### PR TITLE
feat(code): channel artifact list/get endpoints

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -57,6 +57,7 @@ from products.tasks.backend.models import (
     SandboxEnvironment,
     SandboxSnapshot,
     Task,
+    TaskArtifact,
     TaskAutomation,
     TaskRun,
     TaskThreadMessage,
@@ -4953,13 +4954,22 @@ def _channel_feed_message_to_dto(message: ChannelFeedMessage) -> contracts.Chann
     )
 
 
+def _live_channel(channel_id: str | UUID, team_id: int) -> Channel | None:
+    """The channel row if it exists on the team and isn't deleted, regardless of requester."""
+    return Channel.objects.select_related("created_by").filter(id=channel_id, team_id=team_id, deleted=False).first()
+
+
+def _channel_visible_to(channel: Channel, user_id: int | None) -> bool:
+    """Whether the requester may read a live channel: public channels are team-visible,
+    personal ones owner-only."""
+    return channel.channel_type != Channel.ChannelType.PERSONAL or channel.created_by_id == user_id
+
+
 def _visible_channel(channel_id: str | UUID, team_id: int, user_id: int | None) -> Channel | None:
     """A channel the requester may read: any live public channel on the team, or their
     own personal channel. ``None`` when it's missing or someone else's personal channel."""
-    channel = Channel.objects.select_related("created_by").filter(id=channel_id, team_id=team_id, deleted=False).first()
-    if channel is None:
-        return None
-    if channel.channel_type == Channel.ChannelType.PERSONAL and channel.created_by_id != user_id:
+    channel = _live_channel(channel_id, team_id)
+    if channel is None or not _channel_visible_to(channel, user_id):
         return None
     return channel
 
@@ -5017,6 +5027,55 @@ def create_channel_feed_message(
     message = ChannelFeedMessage.objects.create(**fields)
     # Fresh row: author lazy-loads once for the DTO.
     return _channel_feed_message_to_dto(message)
+
+
+def list_channel_artifacts(
+    channel_id: str | UUID, team_id: int, user_id: int | None, *, limit: int = 100
+) -> list[dict] | None:
+    """A channel's artifacts — task-created and channel-owned alike — most recently
+    updated first. ``None`` when the channel isn't visible. Active artifacts only."""
+    from products.tasks.backend.logic.services.living_artifacts import (  # noqa: PLC0415 — keep storage deps off the api import path
+        serialize_task_artifact,
+    )
+
+    if _visible_channel(channel_id, team_id, user_id) is None:
+        return None
+    artifacts = (
+        TaskArtifact.objects.for_team(team_id)
+        .filter(channel_id=channel_id, status=TaskArtifact.Status.ACTIVE)
+        .order_by("-updated_at")[:limit]
+    )
+    return [serialize_task_artifact(artifact) for artifact in artifacts]
+
+
+def get_task_artifact(team_id: int, user_id: int | None, *, artifact_id: str | UUID) -> dict | None:
+    """An artifact by id, with its current content when the adapter can read it.
+    The artifact's live channel is its home and its access control (public → team,
+    personal → owner only); the task is provenance, governing only when there is no live
+    channel — so moving an artifact into a private channel actually hides it, even from
+    people who can still see the task it came from. ``None`` when missing or not visible."""
+    from products.tasks.backend.logic.services.living_artifacts import (  # noqa: PLC0415 — keep storage deps off the api import path
+        open_task_artifact,
+        serialize_task_artifact,
+    )
+
+    artifact = TaskArtifact.objects.for_team(team_id).filter(id=artifact_id).first()
+    if artifact is None:
+        return None
+    channel = _live_channel(artifact.channel_id, team_id) if artifact.channel_id is not None else None
+    if channel is not None:
+        visible = _channel_visible_to(channel, user_id)
+    else:
+        visible = artifact.task_id is not None and _visible_task(artifact.task_id, team_id, user_id) is not None
+    if not visible:
+        return None
+    serialized = serialize_task_artifact(artifact)
+    try:
+        serialized["content"] = open_task_artifact(artifact)
+    except ValueError:
+        # Reference-only adapters (github_pr) have no read path; location is the artifact.
+        serialized["content"] = None
+    return serialized
 
 
 def _thread_message_to_dto(message: TaskThreadMessage) -> contracts.TaskThreadMessageDTO:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1437,6 +1437,18 @@ class ChannelFeedMessageWriteSerializer(serializers.Serializer):
         return value
 
 
+class ChannelArtifactListQuerySerializer(serializers.Serializer):
+    """Query parameters for listing a channel's living artifacts."""
+
+    limit = serializers.IntegerField(
+        required=False,
+        default=100,
+        min_value=1,
+        max_value=500,
+        help_text="Maximum number of artifacts to return (most recently updated first).",
+    )
+
+
 class TaskMentionQuerySerializer(serializers.Serializer):
     """Query parameters for listing mentions."""
 

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -2249,6 +2249,46 @@ class TaskRunLivingArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewS
         return Response(serializer.data)
 
 
+class TaskArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    """
+    Flat read API for task artifacts: an artifact is reachable by bare id, with
+    visibility derived from its owners (channel or task), so a client holding an id
+    doesn't need the owning run to open it.
+    """
+
+    authentication_classes = [
+        SessionAuthentication,
+        PersonalAPIKeyAuthentication,
+        OAuthAccessTokenAuthentication,
+    ]
+    permission_classes = [IsAuthenticated, APIScopePermission]
+    scope_object = "task"
+    http_method_names = ["get", "head", "options"]
+    serializer_class = TaskRunLivingArtifactResponseSerializer
+
+    @validated_request(
+        responses={
+            200: OpenApiResponse(
+                response=TaskRunLivingArtifactOpenResponseSerializer,
+                description="Living artifact with current readable content",
+            ),
+            404: OpenApiResponse(description="Artifact not found"),
+        },
+        summary="Open a living artifact",
+        description="A stable artifact handle plus the current content when the adapter supports reads.",
+        operation_id="tasks_artifacts_retrieve",
+    )
+    def retrieve(self, request, pk=None, **kwargs):
+        try:
+            UUID(str(pk))
+        except (ValueError, TypeError):
+            raise NotFound("Artifact not found")
+        artifact = tasks_facade.get_task_artifact(self.team_id, getattr(request.user, "id", None), artifact_id=pk)
+        if artifact is None:
+            raise NotFound("Artifact not found")
+        return Response(TaskRunLivingArtifactOpenResponseSerializer(artifact).data)
+
+
 @extend_schema(tags=["code-invites"])
 class CodeInviteViewSet(viewsets.ViewSet):
     """API for redeeming PostHog Code invite codes."""

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -15,12 +15,15 @@ from posthog.permissions import APIScopePermission
 
 from products.tasks.backend.facade import api as tasks_facade
 from products.tasks.backend.presentation.serializers import (
+    ChannelArtifactListQuerySerializer,
     ChannelFeedMessageSerializer,
     ChannelFeedMessageWriteSerializer,
     ChannelSerializer,
     ChannelWriteSerializer,
     TaskMentionQuerySerializer,
     TaskMentionSerializer,
+    TaskRunLivingArtifactResponseSerializer,
+    TaskRunLivingArtifactsResponseSerializer,
     TaskThreadMessageSerializer,
     TaskThreadMessageWriteSerializer,
 )
@@ -163,6 +166,64 @@ class ChannelFeedMessageViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet)
         if message == "full":
             raise ValidationError("This channel's feed is full.")
         return Response(ChannelFeedMessageSerializer(message).data, status=status.HTTP_201_CREATED)
+
+
+class ChannelArtifactViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    """
+    Read API for a channel's artifacts — the durable outputs of the channel's work
+    (canvases, documents, PRs), whether created by its tasks' runs or owned by the channel
+    directly. Writes stay on the run-scoped API until channel-owned creation has a consumer.
+    """
+
+    authentication_classes = [
+        SessionAuthentication,
+        PersonalAPIKeyAuthentication,
+        OAuthAccessTokenAuthentication,
+    ]
+    permission_classes = [IsAuthenticated, APIScopePermission]
+    scope_object = "task"
+    http_method_names = ["get", "head", "options"]
+    serializer_class = TaskRunLivingArtifactResponseSerializer
+
+    def _channel_id(self) -> str:
+        channel_id = self.kwargs.get("parent_lookup_channel_id")
+        if not channel_id:
+            raise NotFound("Channel ID is required")
+        try:
+            UUID(channel_id)
+        except (ValueError, TypeError):
+            raise NotFound("Channel not found")
+        return channel_id
+
+    def _user_id(self) -> int | None:
+        return getattr(self.request.user, "id", None)
+
+    @validated_request(
+        query_serializer=ChannelArtifactListQuerySerializer,
+        responses={
+            200: OpenApiResponse(
+                response=TaskRunLivingArtifactsResponseSerializer,
+                description="Living artifacts attached to this channel",
+            ),
+            404: OpenApiResponse(description="Channel not found"),
+        },
+        summary="List a channel's living artifacts",
+        description=(
+            "The channel's durable outputs — artifacts created by its tasks' runs or owned by the "
+            "channel directly — most recently updated first."
+        ),
+        operation_id="tasks_channels_artifacts_list",
+    )
+    def list(self, request, *args, **kwargs):
+        artifacts = tasks_facade.list_channel_artifacts(
+            self._channel_id(),
+            self.team_id,
+            self._user_id(),
+            limit=request.validated_query_data["limit"],
+        )
+        if artifacts is None:
+            raise NotFound("Channel not found")
+        return Response(TaskRunLivingArtifactsResponseSerializer({"artifacts": artifacts}).data)
 
 
 class TaskMentionViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):

--- a/products/tasks/backend/routes.py
+++ b/products/tasks/backend/routes.py
@@ -29,6 +29,13 @@ def register_routes(routers: RouterRegistry) -> None:
         "project_task_channel_feed",
         ["team_id", "channel_id"],
     )
+    project_task_channels_router.register(
+        r"artifacts",
+        channels.ChannelArtifactViewSet,
+        "project_task_channel_artifacts",
+        ["team_id", "channel_id"],
+    )
+    routers.projects.register(r"task_artifacts", tasks.TaskArtifactViewSet, "project_task_artifacts", ["team_id"])
     routers.projects.register(r"task_mentions", channels.TaskMentionViewSet, "project_task_mentions", ["team_id"])
     routers.projects.register(r"task_automations", tasks.TaskAutomationViewSet, "project_task_automations", ["team_id"])
     routers.projects.register(r"loops", loops.LoopViewSet, "project_loops", ["team_id"])

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -10,7 +10,7 @@ from rest_framework.test import APIClient
 
 from posthog.models import Organization, OrganizationMembership, Team, User
 
-from products.tasks.backend.models import Channel, ChannelFeedMessage, Task, TaskRun, TaskThreadMessage
+from products.tasks.backend.models import Channel, ChannelFeedMessage, Task, TaskArtifact, TaskRun, TaskThreadMessage
 
 
 class ChannelsAPITestCase(TestCase):
@@ -498,3 +498,167 @@ class ChannelFeedMessageAPITestCase(TestCase):
         # Same org, wrong team in the URL — the channel must not resolve.
         response = self.client.get(f"/api/projects/{other_team.id}/task_channels/{channel_id}/feed/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class ChannelArtifactsAPITestCase(ChannelTaskAPITestCase):
+    def _artifacts_url(self, channel_id) -> str:
+        return f"/api/projects/{self.team.id}/task_channels/{channel_id}/artifacts/"
+
+    def _artifact(self, **overrides) -> TaskArtifact:
+        fields: dict = {
+            "team": self.team,
+            "task": self.task,
+            "channel": self.channel,
+            "created_by": self.author,
+            "name": "Findings",
+            "artifact_type": TaskArtifact.ArtifactType.DOCUMENT,
+            "adapter": TaskArtifact.Adapter.SLACK_MESSAGE,
+            "versions": [{"version": 1, "content": "v1 body"}],
+        }
+        fields.update(overrides)
+        # Direct instantiation sidesteps the fail-closed TeamScopedManager (see setUp).
+        artifact = TaskArtifact(**fields)
+        artifact.save()
+        return artifact
+
+    def test_list_returns_channel_artifacts_newest_first(self):
+        task_owned = self._artifact(name="Task doc")
+        channel_owned = self._artifact(name="Channel note", task=None)
+
+        response = self.author_client.get(self._artifacts_url(self.channel.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        artifacts = response.json()["artifacts"]
+        self.assertEqual([a["id"] for a in artifacts], [str(channel_owned.id), str(task_owned.id)])
+        self.assertEqual([a["channel_id"] for a in artifacts], [str(self.channel.id)] * 2)
+        self.assertIsNone(artifacts[0]["task_id"])
+        self.assertEqual(artifacts[1]["task_id"], str(self.task.id))
+
+    def test_list_is_visible_to_the_team(self):
+        self._artifact()
+        response = self.peer_client.get(self._artifacts_url(self.channel.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()["artifacts"]), 1)
+
+    def test_list_is_scoped_to_the_channel(self):
+        mine = self._artifact()
+        other_channel = Channel(team=self.team, name="mobile", created_by=self.author)
+        other_channel.save()
+        self._artifact(channel=other_channel, task=None)
+
+        artifacts = self.author_client.get(self._artifacts_url(self.channel.id)).json()["artifacts"]
+        self.assertEqual([a["id"] for a in artifacts], [str(mine.id)])
+
+    def test_list_excludes_failed_artifacts(self):
+        active = self._artifact()
+        self._artifact(status=TaskArtifact.Status.FAILED)
+
+        artifacts = self.author_client.get(self._artifacts_url(self.channel.id)).json()["artifacts"]
+        self.assertEqual([a["id"] for a in artifacts], [str(active.id)])
+
+    def test_list_respects_limit(self):
+        self._artifact(name="oldest")
+        middle = self._artifact(name="middle")
+        newest = self._artifact(name="newest")
+
+        response = self.author_client.get(self._artifacts_url(self.channel.id), {"limit": 2})
+        self.assertEqual([a["id"] for a in response.json()["artifacts"]], [str(newest.id), str(middle.id)])
+
+        invalid = self.author_client.get(self._artifacts_url(self.channel.id), {"limit": 0})
+        self.assertEqual(invalid.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unknown_channel_is_404(self):
+        for channel_ref in ("00000000-0000-0000-0000-000000000000", "not-a-uuid"):
+            response = self.author_client.get(self._artifacts_url(channel_ref))
+            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_personal_channel_artifacts_are_owner_only(self):
+        # Listing channels provisions the requester's personal channel.
+        self.author_client.get(f"/api/projects/{self.team.id}/task_channels/")
+        personal = Channel.objects.unscoped().get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
+        self._artifact(channel=personal, task=None)
+
+        mine = self.author_client.get(self._artifacts_url(personal.id))
+        self.assertEqual(mine.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(mine.json()["artifacts"]), 1)
+
+        peer = self.peer_client.get(self._artifacts_url(personal.id))
+        self.assertEqual(peer.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_artifacts_are_team_scoped(self):
+        self._artifact()
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        # Same org, wrong team in the URL — the channel must not resolve.
+        response = self.author_client.get(f"/api/projects/{other_team.id}/task_channels/{self.channel.id}/artifacts/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def _task_artifact_url(self, artifact_ref) -> str:
+        return f"/api/projects/{self.team.id}/task_artifacts/{artifact_ref}/"
+
+    def test_retrieve_returns_current_content(self):
+        artifact = self._artifact(
+            versions=[{"version": 1, "content": "v1 body"}, {"version": 2, "content": "v2 body"}],
+            current_version=2,
+        )
+
+        response = self.author_client.get(self._task_artifact_url(artifact.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        body = response.json()
+        self.assertEqual(body["id"], str(artifact.id))
+        self.assertEqual(body["content"], "v2 body")
+        self.assertEqual(body["current_version"], 2)
+        self.assertEqual(body["channel_id"], str(self.channel.id))
+
+    def test_retrieve_public_channel_artifact_is_team_visible(self):
+        artifact = self._artifact()
+        response = self.peer_client.get(self._task_artifact_url(artifact.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_retrieve_channel_is_the_access_control(self):
+        # An artifact moved into a personal channel goes dark for everyone but the
+        # channel owner — even for people who can still see the task it came from.
+        self.author_client.get(f"/api/projects/{self.team.id}/task_channels/")
+        personal = Channel.objects.unscoped().get(team=self.team, channel_type=Channel.ChannelType.PERSONAL)
+        artifact = self._artifact(channel=personal)
+
+        self.assertEqual(self.author_client.get(self._task_artifact_url(artifact.id)).status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            self.peer_client.get(self._task_artifact_url(artifact.id)).status_code, status.HTTP_404_NOT_FOUND
+        )
+
+    def test_retrieve_falls_back_to_task_visibility_without_a_live_channel(self):
+        unstamped = self._artifact(channel=None)
+        response = self.peer_client.get(self._task_artifact_url(unstamped.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        stamped = self._artifact()
+        self.channel.deleted = True
+        self.channel.save()
+        response = self.author_client.get(self._task_artifact_url(stamped.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_retrieve_reference_artifact_has_no_content(self):
+        # github_pr rows are pure references: no readable content, location is the artifact.
+        artifact = self._artifact(
+            name="Fix login redirect",
+            artifact_type=TaskArtifact.ArtifactType.GITHUB_PR,
+            adapter=TaskArtifact.Adapter.GITHUB_PR,
+            versions=[],
+            location={"url": "https://github.com/posthog/posthog/pull/1"},
+        )
+
+        response = self.author_client.get(self._task_artifact_url(artifact.id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        body = response.json()
+        self.assertIsNone(body["content"])
+        self.assertEqual(body["location"], {"url": "https://github.com/posthog/posthog/pull/1"})
+
+    def test_retrieve_missing_artifact_is_404(self):
+        artifact = self._artifact()
+
+        for artifact_ref in ("00000000-0000-0000-0000-000000000000", "not-a-uuid"):
+            response = self.author_client.get(self._task_artifact_url(artifact_ref))
+            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, artifact_ref)
+
+        other_team = Team.objects.create(organization=self.organization, name="Other Team")
+        cross_team = self.author_client.get(f"/api/projects/{other_team.id}/task_artifacts/{artifact.id}/")
+        self.assertEqual(cross_team.status_code, status.HTTP_404_NOT_FOUND)

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -828,6 +828,121 @@ export interface PatchedSandboxEnvironmentWriteApi {
     custom_image_id?: string | null
 }
 
+export type TaskRunLivingArtifactOpenResponseApiVersionsItem = { [key: string]: unknown }
+
+/**
+ * * `slack_message` - slack_message
+ * * `slack_canvas` - slack_canvas
+ * * `document` - document
+ * * `spreadsheet` - spreadsheet
+ * * `dashboard` - dashboard
+ * * `file` - file
+ * * `github_pr` - github_pr
+ */
+export type ArtifactTypeEnumApi = (typeof ArtifactTypeEnumApi)[keyof typeof ArtifactTypeEnumApi]
+
+export const ArtifactTypeEnumApi = {
+    SlackMessage: 'slack_message',
+    SlackCanvas: 'slack_canvas',
+    Document: 'document',
+    Spreadsheet: 'spreadsheet',
+    Dashboard: 'dashboard',
+    File: 'file',
+    GithubPr: 'github_pr',
+} as const
+
+/**
+ * * `slack_message` - slack_message
+ * * `slack_canvas` - slack_canvas
+ * * `slack_file` - slack_file
+ * * `document_connector` - document_connector
+ * * `github_pr` - github_pr
+ */
+export type AdapterEnumApi = (typeof AdapterEnumApi)[keyof typeof AdapterEnumApi]
+
+export const AdapterEnumApi = {
+    SlackMessage: 'slack_message',
+    SlackCanvas: 'slack_canvas',
+    SlackFile: 'slack_file',
+    DocumentConnector: 'document_connector',
+    GithubPr: 'github_pr',
+} as const
+
+/**
+ * * `active` - active
+ * * `failed` - failed
+ */
+export type TaskArtifactStatusEnumApi = (typeof TaskArtifactStatusEnumApi)[keyof typeof TaskArtifactStatusEnumApi]
+
+export const TaskArtifactStatusEnumApi = {
+    Active: 'active',
+    Failed: 'failed',
+} as const
+
+export interface TaskRunLivingArtifactOpenResponseApi {
+    /** Stable living artifact id. Use this id when editing the artifact. */
+    id: string
+    /** Task id this living artifact belongs to. */
+    task_id: string
+    /** Task run id that created or currently owns this artifact. */
+    run_id: string
+    /**
+     * Channel this artifact belongs to, stamped from its task at create.
+     * @nullable
+     */
+    channel_id?: string | null
+    /** Project id that owns this artifact. */
+    team_id: number
+    /** Human-readable artifact name. */
+    name: string
+    /** Artifact format or delivery surface, such as document, spreadsheet, slack_canvas, file, or slack_message.
+     *
+     * * `slack_message` - slack_message
+     * * `slack_canvas` - slack_canvas
+     * * `document` - document
+     * * `spreadsheet` - spreadsheet
+     * * `dashboard` - dashboard
+     * * `file` - file
+     * * `github_pr` - github_pr */
+    artifact_type: ArtifactTypeEnumApi
+    /** Adapter that currently stores or edits the artifact.
+     *
+     * * `slack_message` - slack_message
+     * * `slack_canvas` - slack_canvas
+     * * `slack_file` - slack_file
+     * * `document_connector` - document_connector
+     * * `github_pr` - github_pr */
+    adapter: AdapterEnumApi
+    /** Current registry status for the artifact.
+     *
+     * * `active` - active
+     * * `failed` - failed */
+    status: TaskArtifactStatusEnumApi
+    /** Adapter-specific location, such as S3 key or Slack canvas id. */
+    location: unknown
+    /** Adapter-specific metadata for external storage and source tracking. */
+    metadata: unknown
+    /** Current version number for the artifact. */
+    current_version: number
+    /** Chronological version records for this artifact. */
+    versions: TaskRunLivingArtifactOpenResponseApiVersionsItem[]
+    /**
+     * ISO timestamp when created.
+     * @nullable
+     */
+    created_at?: string | null
+    /**
+     * ISO timestamp when last updated.
+     * @nullable
+     */
+    updated_at?: string | null
+    /**
+     * Current artifact content when the adapter can read it directly.
+     * @nullable
+     */
+    content?: string | null
+}
+
 /**
  * Detail/create/update/run response for a task automation.
  */
@@ -977,6 +1092,81 @@ export interface ChannelWriteApi {
      * @maxLength 128
      */
     name: string
+}
+
+export type TaskRunLivingArtifactResponseApiVersionsItem = { [key: string]: unknown }
+
+export interface TaskRunLivingArtifactResponseApi {
+    /** Stable living artifact id. Use this id when editing the artifact. */
+    id: string
+    /** Task id this living artifact belongs to. */
+    task_id: string
+    /** Task run id that created or currently owns this artifact. */
+    run_id: string
+    /**
+     * Channel this artifact belongs to, stamped from its task at create.
+     * @nullable
+     */
+    channel_id?: string | null
+    /** Project id that owns this artifact. */
+    team_id: number
+    /** Human-readable artifact name. */
+    name: string
+    /** Artifact format or delivery surface, such as document, spreadsheet, slack_canvas, file, or slack_message.
+     *
+     * * `slack_message` - slack_message
+     * * `slack_canvas` - slack_canvas
+     * * `document` - document
+     * * `spreadsheet` - spreadsheet
+     * * `dashboard` - dashboard
+     * * `file` - file
+     * * `github_pr` - github_pr */
+    artifact_type: ArtifactTypeEnumApi
+    /** Adapter that currently stores or edits the artifact.
+     *
+     * * `slack_message` - slack_message
+     * * `slack_canvas` - slack_canvas
+     * * `slack_file` - slack_file
+     * * `document_connector` - document_connector
+     * * `github_pr` - github_pr */
+    adapter: AdapterEnumApi
+    /** Current registry status for the artifact.
+     *
+     * * `active` - active
+     * * `failed` - failed */
+    status: TaskArtifactStatusEnumApi
+    /** Adapter-specific location, such as S3 key or Slack canvas id. */
+    location: unknown
+    /** Adapter-specific metadata for external storage and source tracking. */
+    metadata: unknown
+    /** Current version number for the artifact. */
+    current_version: number
+    /** Chronological version records for this artifact. */
+    versions: TaskRunLivingArtifactResponseApiVersionsItem[]
+    /**
+     * ISO timestamp when created.
+     * @nullable
+     */
+    created_at?: string | null
+    /**
+     * ISO timestamp when last updated.
+     * @nullable
+     */
+    updated_at?: string | null
+}
+
+export interface TaskRunLivingArtifactsResponseApi {
+    /** Living artifacts for this task run. */
+    artifacts: TaskRunLivingArtifactResponseApi[]
+}
+
+export interface PaginatedTaskRunLivingArtifactsResponseListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: TaskRunLivingArtifactsResponseApi[]
 }
 
 export type ChannelFeedMessageDTOApiPayload = { [key: string]: unknown }
@@ -2758,121 +2948,6 @@ export interface StreamReadTokenResponseApi {
 }
 
 /**
- * * `slack_message` - slack_message
- * * `slack_canvas` - slack_canvas
- * * `document` - document
- * * `spreadsheet` - spreadsheet
- * * `dashboard` - dashboard
- * * `file` - file
- * * `github_pr` - github_pr
- */
-export type ArtifactTypeEnumApi = (typeof ArtifactTypeEnumApi)[keyof typeof ArtifactTypeEnumApi]
-
-export const ArtifactTypeEnumApi = {
-    SlackMessage: 'slack_message',
-    SlackCanvas: 'slack_canvas',
-    Document: 'document',
-    Spreadsheet: 'spreadsheet',
-    Dashboard: 'dashboard',
-    File: 'file',
-    GithubPr: 'github_pr',
-} as const
-
-/**
- * * `slack_message` - slack_message
- * * `slack_canvas` - slack_canvas
- * * `slack_file` - slack_file
- * * `document_connector` - document_connector
- * * `github_pr` - github_pr
- */
-export type AdapterEnumApi = (typeof AdapterEnumApi)[keyof typeof AdapterEnumApi]
-
-export const AdapterEnumApi = {
-    SlackMessage: 'slack_message',
-    SlackCanvas: 'slack_canvas',
-    SlackFile: 'slack_file',
-    DocumentConnector: 'document_connector',
-    GithubPr: 'github_pr',
-} as const
-
-/**
- * * `active` - active
- * * `failed` - failed
- */
-export type TaskArtifactStatusEnumApi = (typeof TaskArtifactStatusEnumApi)[keyof typeof TaskArtifactStatusEnumApi]
-
-export const TaskArtifactStatusEnumApi = {
-    Active: 'active',
-    Failed: 'failed',
-} as const
-
-export type TaskRunLivingArtifactResponseApiVersionsItem = { [key: string]: unknown }
-
-export interface TaskRunLivingArtifactResponseApi {
-    /** Stable living artifact id. Use this id when editing the artifact. */
-    id: string
-    /** Task id this living artifact belongs to. */
-    task_id: string
-    /** Task run id that created or currently owns this artifact. */
-    run_id: string
-    /**
-     * Channel this artifact belongs to, stamped from its task at create.
-     * @nullable
-     */
-    channel_id?: string | null
-    /** Project id that owns this artifact. */
-    team_id: number
-    /** Human-readable artifact name. */
-    name: string
-    /** Artifact format or delivery surface, such as document, spreadsheet, slack_canvas, file, or slack_message.
-     *
-     * * `slack_message` - slack_message
-     * * `slack_canvas` - slack_canvas
-     * * `document` - document
-     * * `spreadsheet` - spreadsheet
-     * * `dashboard` - dashboard
-     * * `file` - file
-     * * `github_pr` - github_pr */
-    artifact_type: ArtifactTypeEnumApi
-    /** Adapter that currently stores or edits the artifact.
-     *
-     * * `slack_message` - slack_message
-     * * `slack_canvas` - slack_canvas
-     * * `slack_file` - slack_file
-     * * `document_connector` - document_connector
-     * * `github_pr` - github_pr */
-    adapter: AdapterEnumApi
-    /** Current registry status for the artifact.
-     *
-     * * `active` - active
-     * * `failed` - failed */
-    status: TaskArtifactStatusEnumApi
-    /** Adapter-specific location, such as S3 key or Slack canvas id. */
-    location: unknown
-    /** Adapter-specific metadata for external storage and source tracking. */
-    metadata: unknown
-    /** Current version number for the artifact. */
-    current_version: number
-    /** Chronological version records for this artifact. */
-    versions: TaskRunLivingArtifactResponseApiVersionsItem[]
-    /**
-     * ISO timestamp when created.
-     * @nullable
-     */
-    created_at?: string | null
-    /**
-     * ISO timestamp when last updated.
-     * @nullable
-     */
-    updated_at?: string | null
-}
-
-export interface TaskRunLivingArtifactsResponseApi {
-    /** Living artifacts for this task run. */
-    artifacts: TaskRunLivingArtifactResponseApi[]
-}
-
-/**
  * Optional metadata to persist with the living artifact.
  */
 export type TaskRunLivingArtifactCreateRequestApiMetadata = { [key: string]: unknown }
@@ -2919,72 +2994,6 @@ export interface TaskRunLivingArtifactCreateRequestApi {
     source_storage_path?: string
     /** Optional metadata to persist with the living artifact. */
     metadata?: TaskRunLivingArtifactCreateRequestApiMetadata
-}
-
-export type TaskRunLivingArtifactOpenResponseApiVersionsItem = { [key: string]: unknown }
-
-export interface TaskRunLivingArtifactOpenResponseApi {
-    /** Stable living artifact id. Use this id when editing the artifact. */
-    id: string
-    /** Task id this living artifact belongs to. */
-    task_id: string
-    /** Task run id that created or currently owns this artifact. */
-    run_id: string
-    /**
-     * Channel this artifact belongs to, stamped from its task at create.
-     * @nullable
-     */
-    channel_id?: string | null
-    /** Project id that owns this artifact. */
-    team_id: number
-    /** Human-readable artifact name. */
-    name: string
-    /** Artifact format or delivery surface, such as document, spreadsheet, slack_canvas, file, or slack_message.
-     *
-     * * `slack_message` - slack_message
-     * * `slack_canvas` - slack_canvas
-     * * `document` - document
-     * * `spreadsheet` - spreadsheet
-     * * `dashboard` - dashboard
-     * * `file` - file
-     * * `github_pr` - github_pr */
-    artifact_type: ArtifactTypeEnumApi
-    /** Adapter that currently stores or edits the artifact.
-     *
-     * * `slack_message` - slack_message
-     * * `slack_canvas` - slack_canvas
-     * * `slack_file` - slack_file
-     * * `document_connector` - document_connector
-     * * `github_pr` - github_pr */
-    adapter: AdapterEnumApi
-    /** Current registry status for the artifact.
-     *
-     * * `active` - active
-     * * `failed` - failed */
-    status: TaskArtifactStatusEnumApi
-    /** Adapter-specific location, such as S3 key or Slack canvas id. */
-    location: unknown
-    /** Adapter-specific metadata for external storage and source tracking. */
-    metadata: unknown
-    /** Current version number for the artifact. */
-    current_version: number
-    /** Chronological version records for this artifact. */
-    versions: TaskRunLivingArtifactOpenResponseApiVersionsItem[]
-    /**
-     * ISO timestamp when created.
-     * @nullable
-     */
-    created_at?: string | null
-    /**
-     * ISO timestamp when last updated.
-     * @nullable
-     */
-    updated_at?: string | null
-    /**
-     * Current artifact content when the adapter can read it directly.
-     * @nullable
-     */
-    content?: string | null
 }
 
 /**
@@ -3509,6 +3518,19 @@ export type TaskAutomationsListParams = {
 export type TaskChannelsListParams = {
     /**
      * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type TasksChannelsArtifactsListParams = {
+    /**
+     * Maximum number of artifacts to return (most recently updated first).
+     * @minimum 1
+     * @maximum 500
      */
     limit?: number
     /**

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -35,6 +35,7 @@ import type {
     PaginatedTaskDetailDTOListApi,
     PaginatedTaskMentionDTOListApi,
     PaginatedTaskRunDetailDTOListApi,
+    PaginatedTaskRunLivingArtifactsResponseListApi,
     PaginatedTaskSummaryDTOListApi,
     PaginatedTaskThreadMessageDTOListApi,
     PatchedChannelWriteApi,
@@ -96,6 +97,7 @@ import type {
     TaskThreadMessageDTOApi,
     TaskThreadMessageWriteApi,
     TaskWriteApi,
+    TasksChannelsArtifactsListParams,
     TasksListParams,
     TasksRepositoryReadinessRetrieveParams,
     TasksRunsListParams,
@@ -602,6 +604,25 @@ export const sandboxDestroy = async (projectId: string, id: string, options?: Re
     })
 }
 
+export const getTasksArtifactsRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/task_artifacts/${id}/`
+}
+
+/**
+ * A stable artifact handle plus the current content when the adapter supports reads.
+ * @summary Open a living artifact
+ */
+export const tasksArtifactsRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<TaskRunLivingArtifactOpenResponseApi> => {
+    return apiMutator<TaskRunLivingArtifactOpenResponseApi>(getTasksArtifactsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
 export const getTaskAutomationsListUrl = (projectId: string, params?: TaskAutomationsListParams) => {
     const normalizedParams = new URLSearchParams()
 
@@ -773,6 +794,45 @@ export const taskChannelsCreate = async (
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(channelWriteApi),
     })
+}
+
+export const getTasksChannelsArtifactsListUrl = (
+    projectId: string,
+    channelId: string,
+    params?: TasksChannelsArtifactsListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/task_channels/${channelId}/artifacts/?${stringifiedParams}`
+        : `/api/projects/${projectId}/task_channels/${channelId}/artifacts/`
+}
+
+/**
+ * The channel's durable outputs — artifacts created by its tasks' runs or owned by the channel directly — most recently updated first.
+ * @summary List a channel's living artifacts
+ */
+export const tasksChannelsArtifactsList = async (
+    projectId: string,
+    channelId: string,
+    params?: TasksChannelsArtifactsListParams,
+    options?: RequestInit
+): Promise<PaginatedTaskRunLivingArtifactsResponseListApi> => {
+    return apiMutator<PaginatedTaskRunLivingArtifactsResponseListApi>(
+        getTasksChannelsArtifactsListUrl(projectId, channelId, params),
+        {
+            ...options,
+            method: 'GET',
+        }
+    )
 }
 
 export const getTaskChannelsFeedListUrl = (

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -229,6 +229,12 @@ tools:
     tasks-active-wizard-run-retrieve:
         operation: tasks_active_wizard_run_retrieve
         enabled: false
+    tasks-artifacts-retrieve:
+        operation: tasks_artifacts_retrieve
+        enabled: false
+    tasks-channels-artifacts-list:
+        operation: tasks_channels_artifacts_list
+        enabled: false
     tasks-create:
         operation: tasks_create
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -44667,6 +44667,93 @@ export namespace Schemas {
     }
 
     /**
+     * * `active` - active
+     * * `failed` - failed
+     */
+    export type TaskArtifactStatusEnum = typeof TaskArtifactStatusEnum[keyof typeof TaskArtifactStatusEnum];
+
+
+    export const TaskArtifactStatusEnum = {
+      Active: 'active',
+      Failed: 'failed',
+    } as const;
+
+    export type TaskRunLivingArtifactResponseVersionsItem = { [key: string]: unknown };
+
+    export interface TaskRunLivingArtifactResponse {
+      /** Stable living artifact id. Use this id when editing the artifact. */
+      id: string;
+      /** Task id this living artifact belongs to. */
+      task_id: string;
+      /** Task run id that created or currently owns this artifact. */
+      run_id: string;
+      /**
+         * Channel this artifact belongs to, stamped from its task at create.
+         * @nullable
+         */
+      channel_id?: string | null;
+      /** Project id that owns this artifact. */
+      team_id: number;
+      /** Human-readable artifact name. */
+      name: string;
+      /** Artifact format or delivery surface, such as document, spreadsheet, slack_canvas, file, or slack_message.
+       *
+       * * `slack_message` - slack_message
+       * * `slack_canvas` - slack_canvas
+       * * `document` - document
+       * * `spreadsheet` - spreadsheet
+       * * `dashboard` - dashboard
+       * * `file` - file
+       * * `github_pr` - github_pr */
+      artifact_type: ArtifactTypeEnum;
+      /** Adapter that currently stores or edits the artifact.
+       *
+       * * `slack_message` - slack_message
+       * * `slack_canvas` - slack_canvas
+       * * `slack_file` - slack_file
+       * * `document_connector` - document_connector
+       * * `github_pr` - github_pr */
+      adapter: AdapterEnum;
+      /** Current registry status for the artifact.
+       *
+       * * `active` - active
+       * * `failed` - failed */
+      status: TaskArtifactStatusEnum;
+      /** Adapter-specific location, such as S3 key or Slack canvas id. */
+      location: unknown;
+      /** Adapter-specific metadata for external storage and source tracking. */
+      metadata: unknown;
+      /** Current version number for the artifact. */
+      current_version: number;
+      /** Chronological version records for this artifact. */
+      versions: TaskRunLivingArtifactResponseVersionsItem[];
+      /**
+         * ISO timestamp when created.
+         * @nullable
+         */
+      created_at?: string | null;
+      /**
+         * ISO timestamp when last updated.
+         * @nullable
+         */
+      updated_at?: string | null;
+    }
+
+    export interface TaskRunLivingArtifactsResponse {
+      /** Living artifacts for this task run. */
+      artifacts: TaskRunLivingArtifactResponse[];
+    }
+
+    export interface PaginatedTaskRunLivingArtifactsResponseList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: TaskRunLivingArtifactsResponse[];
+    }
+
+    /**
      * * `not_started` - Not Started
      * * `queued` - Queued
      * * `in_progress` - In Progress
@@ -66482,18 +66569,6 @@ export namespace Schemas {
     }
 
     /**
-     * * `active` - active
-     * * `failed` - failed
-     */
-    export type TaskArtifactStatusEnum = typeof TaskArtifactStatusEnum[keyof typeof TaskArtifactStatusEnum];
-
-
-    export const TaskArtifactStatusEnum = {
-      Active: 'active',
-      Failed: 'failed',
-    } as const;
-
-    /**
      * Request body for creating or updating a task automation.
      */
     export interface TaskAutomationWrite {
@@ -67287,72 +67362,6 @@ export namespace Schemas {
          * @nullable
          */
       content?: string | null;
-    }
-
-    export type TaskRunLivingArtifactResponseVersionsItem = { [key: string]: unknown };
-
-    export interface TaskRunLivingArtifactResponse {
-      /** Stable living artifact id. Use this id when editing the artifact. */
-      id: string;
-      /** Task id this living artifact belongs to. */
-      task_id: string;
-      /** Task run id that created or currently owns this artifact. */
-      run_id: string;
-      /**
-         * Channel this artifact belongs to, stamped from its task at create.
-         * @nullable
-         */
-      channel_id?: string | null;
-      /** Project id that owns this artifact. */
-      team_id: number;
-      /** Human-readable artifact name. */
-      name: string;
-      /** Artifact format or delivery surface, such as document, spreadsheet, slack_canvas, file, or slack_message.
-       *
-       * * `slack_message` - slack_message
-       * * `slack_canvas` - slack_canvas
-       * * `document` - document
-       * * `spreadsheet` - spreadsheet
-       * * `dashboard` - dashboard
-       * * `file` - file
-       * * `github_pr` - github_pr */
-      artifact_type: ArtifactTypeEnum;
-      /** Adapter that currently stores or edits the artifact.
-       *
-       * * `slack_message` - slack_message
-       * * `slack_canvas` - slack_canvas
-       * * `slack_file` - slack_file
-       * * `document_connector` - document_connector
-       * * `github_pr` - github_pr */
-      adapter: AdapterEnum;
-      /** Current registry status for the artifact.
-       *
-       * * `active` - active
-       * * `failed` - failed */
-      status: TaskArtifactStatusEnum;
-      /** Adapter-specific location, such as S3 key or Slack canvas id. */
-      location: unknown;
-      /** Adapter-specific metadata for external storage and source tracking. */
-      metadata: unknown;
-      /** Current version number for the artifact. */
-      current_version: number;
-      /** Chronological version records for this artifact. */
-      versions: TaskRunLivingArtifactResponseVersionsItem[];
-      /**
-         * ISO timestamp when created.
-         * @nullable
-         */
-      created_at?: string | null;
-      /**
-         * ISO timestamp when last updated.
-         * @nullable
-         */
-      updated_at?: string | null;
-    }
-
-    export interface TaskRunLivingArtifactsResponse {
-      /** Living artifacts for this task run. */
-      artifacts: TaskRunLivingArtifactResponse[];
     }
 
     export interface TaskRunRelayMessageRequest {
@@ -79218,6 +79227,19 @@ export namespace Schemas {
     export type TaskChannelsListParams = {
     /**
      * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type TasksChannelsArtifactsListParams = {
+    /**
+     * Maximum number of artifacts to return (most recently updated first).
+     * @minimum 1
+     * @maximum 500
      */
     limit?: number;
     /**


### PR DESCRIPTION
## Problem

_PR 3/n, on a quest to clean up the task<>channel<>artifact relationship -- see more details in_ [_https://github.com/PostHog/posthog/pull/72681_](https://github.com/PostHog/posthog/pull/72681)

current problem: we need to support querying all artifacts for a channel, and a specific artifact

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->

<!-- Closes #ISSUE_ID -->

## Changes

adds two new artifact-related endpoints:

- `GET /task_channels/:id/artifacts/`
    - list all artifacts for a given channel
    - gated on channel visibility
    - will eventually replace [this series of fetches](https://github.com/PostHog/code/blob/c8ec5c8ef/packages/ui/src/features/canvas/components/WebsiteChannelArtifacts.tsx#L63-L100) required to get a channel's artifacts
- `GET /task_artifacts/:id/`
    - fetch a specific artifact
    - visibility gate uses channel precedence:
        - if the artifact has an attached channel, channel must be visible
        - otherwise, associated task must be visible

<!-- If there are frontend changes, please include screenshots. -->

<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

automated testing

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->

<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->

<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with_ [_PostHog coding conventions_](https://posthog.com/docs/contribute/coding-conventions) _for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** **Human-driven (agent-assisted)**

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->