### PR TITLE
fix(langsmith): scope runs/query to the workspace's tracing projects

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/langsmith.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/langsmith.py
@@ -60,6 +60,13 @@ MAX_CURSOR_BYTES = 8 * 1024
 # make hitting this in one attempt take days.
 MAX_PAGES_PER_RUN = 50_000
 
+# Cap the total bytes of session ids accumulated while scoping the runs query. `host` is
+# user-controlled and returns arbitrary `id` strings on every project page, so without a cumulative
+# cap a host could return unboundedly many (or oversized) ids across thousands of pages — well
+# before MAX_PAGES_PER_RUN trips — and exhaust a shared import worker's memory. ~58k real UUIDs'
+# worth, far beyond any legitimate workspace's tracing-project count.
+MAX_SESSION_IDS_BYTES = 2 * 1024 * 1024
+
 
 class LangSmithRetryableError(Exception):
     pass
@@ -337,6 +344,7 @@ def _list_session_ids(
     """
     config = LANGSMITH_ENDPOINTS["projects"]
     ids: list[str] = []
+    ids_bytes = 0
     offset = 0
     pages = 0
     while True:
@@ -345,7 +353,17 @@ def _list_session_ids(
         rows = data if isinstance(data, list) else []
         if not rows:
             break
-        ids.extend(row["id"] for row in rows if row.get("id"))
+        for row in rows:
+            row_id = row.get("id")
+            if not row_id:
+                continue
+            ids.append(row_id)
+            ids_bytes += len(row_id.encode())
+            if ids_bytes > MAX_SESSION_IDS_BYTES:
+                raise LangSmithResponseTooLargeError(
+                    f"LangSmith returned an oversized set of tracing-project ids "
+                    f"(> {MAX_SESSION_IDS_BYTES} bytes) while scoping the runs query"
+                )
         if len(rows) < config.page_size:
             break
         offset += config.page_size

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/langsmith.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/langsmith.py
@@ -323,6 +323,42 @@ def _fetch_page(
         return json.loads(raw) if raw else None
 
 
+def _list_session_ids(
+    session: requests.Session,
+    headers: dict[str, str],
+    base_url: str,
+    logger: FilteringBoundLogger,
+) -> list[str]:
+    """Collect every tracing-project (session) id in the workspace.
+
+    runs/query rejects a request that doesn't scope to at least one of session/id/parent_run/
+    trace/reference_example; this sync pulls runs across every project, so it scopes by every
+    session id in the workspace instead of narrowing to one.
+    """
+    config = LANGSMITH_ENDPOINTS["projects"]
+    ids: list[str] = []
+    offset = 0
+    pages = 0
+    while True:
+        url = f"{base_url}{config.path}?{urlencode({'limit': config.page_size, 'offset': offset})}"
+        data = _fetch_page(session, url, headers, logger)
+        rows = data if isinstance(data, list) else []
+        if not rows:
+            break
+        ids.extend(row["id"] for row in rows if row.get("id"))
+        if len(rows) < config.page_size:
+            break
+        offset += config.page_size
+        # Same hostile-host guard as the other paginators: a host returning a full page forever
+        # must not hold the worker until the activity timeout.
+        pages += 1
+        if pages >= MAX_PAGES_PER_RUN:
+            raise LangSmithPageLimitError(
+                f"LangSmith session listing hit the {MAX_PAGES_PER_RUN}-page limit while scoping the runs query"
+            )
+    return ids
+
+
 def _get_runs_rows(
     session: requests.Session,
     headers: dict[str, str],
@@ -350,6 +386,13 @@ def _get_runs_rows(
         start = _resolve_window_start(config, should_use_incremental_field, db_incremental_field_last_value)
         window_start = _format_datetime(start) if start is not None else None
 
+    # runs/query requires at least one of session/id/parent_run/trace/reference_example in the
+    # body (a 400 otherwise) — there's no such thing as an unscoped query across a workspace.
+    session_ids = _list_session_ids(session, headers, base_url, logger)
+    if not session_ids:
+        logger.debug("LangSmith: no tracing projects in workspace, nothing to sync for runs")
+        return
+
     body: dict[str, Any] = {
         "limit": config.page_size,
         "select": RUNS_SELECT_FIELDS,
@@ -357,6 +400,7 @@ def _get_runs_rows(
         # window bound. The watermark still only persists at job end (sort_mode="desc") since we
         # can't verify the ordering guarantee across every LangSmith deployment.
         "order": "asc",
+        "session": session_ids,
     }
     if window_start:
         body["start_time"] = window_start

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/tests/test_langsmith.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/tests/test_langsmith.py
@@ -296,6 +296,18 @@ class TestOffsetPagination:
 
 
 class TestPaginationAbuseGuards:
+    def test_oversized_session_id_accumulation_raises(self):
+        # A host controls both the count and size of session ids returned while scoping the runs
+        # query; without a cumulative cap, accumulating every id would let a hostile host exhaust a
+        # shared worker's memory well before MAX_PAGES_PER_RUN ever trips.
+        manager = FakeManager()
+        huge_id = "x" * 50_000
+        page_size = LANGSMITH_ENDPOINTS["projects"].page_size
+
+        with mock.patch(_FETCH_PAGE, return_value=[{"id": huge_id} for _ in range(page_size)]):
+            with pytest.raises(LangSmithResponseTooLargeError):
+                _collect(get_rows("key", BASE_URL, "runs", logger, manager, 1))  # type: ignore[arg-type]
+
     def test_repeated_runs_cursor_raises(self):
         # A host that hands back a cursor it already gave us would loop forever; the walk must bail
         # instead of spinning until the week-long activity timeout.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/tests/test_langsmith.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langsmith/tests/test_langsmith.py
@@ -66,6 +66,21 @@ def _run(run_id: str) -> dict[str, Any]:
     return {"id": run_id, "start_time": "2026-06-01T00:00:00Z"}
 
 
+SESSION_IDS_PAGE = [{"id": "session-1"}]
+
+
+def _with_session_page(fake_fetch):
+    """Wrap a runs/query-only fake_fetch so the preceding sessions-listing GET (json_body=None)
+    is answered separately from the runs/query POSTs the wrapped function expects to see."""
+
+    def wrapped(session, url, headers, log, json_body=None):
+        if json_body is None:
+            return SESSION_IDS_PAGE
+        return fake_fetch(session, url, headers, log, json_body=json_body)
+
+    return wrapped
+
+
 class TestNormalizeBaseUrl:
     @pytest.mark.parametrize(
         "raw,expected",
@@ -146,7 +161,7 @@ class TestRunsPagination:
             bodies.append(json_body)
             return pages[len(bodies) - 1]
 
-        with mock.patch(_FETCH_PAGE, side_effect=fake_fetch):
+        with mock.patch(_FETCH_PAGE, side_effect=_with_session_page(fake_fetch)):
             rows = _collect(
                 get_rows("key", BASE_URL, "runs", logger, manager, 1, True, watermark)  # type: ignore[arg-type]
             )
@@ -164,11 +179,44 @@ class TestRunsPagination:
     def test_terminates_on_empty_page_and_missing_cursors(self):
         manager = FakeManager()
 
-        with mock.patch(_FETCH_PAGE, return_value={"runs": [], "cursors": {"next": "dangling"}}) as fetch:
+        def fake_fetch(session, url, headers, log, json_body=None):
+            return {"runs": [], "cursors": {"next": "dangling"}}
+
+        with mock.patch(_FETCH_PAGE, side_effect=_with_session_page(fake_fetch)) as fetch:
+            rows = _collect(get_rows("key", BASE_URL, "runs", logger, manager, 1))  # type: ignore[arg-type]
+
+        assert rows == []
+        # One call to list sessions, one to runs/query.
+        assert fetch.call_count == 2
+
+    def test_no_sessions_in_workspace_skips_runs_query_entirely(self):
+        # runs/query requires a session/id/parent_run/trace/reference_example scope; with no
+        # tracing projects there's nothing to scope to, so the sync must not call it at all
+        # (an empty `session: []` would 400 the same way the unscoped call used to).
+        manager = FakeManager()
+
+        with mock.patch(_FETCH_PAGE, return_value=[]) as fetch:
             rows = _collect(get_rows("key", BASE_URL, "runs", logger, manager, 1))  # type: ignore[arg-type]
 
         assert rows == []
         assert fetch.call_count == 1
+
+    def test_runs_query_is_always_scoped_to_a_session(self):
+        # Regression test: runs/query used to send limit/select/order (and start_time) with no
+        # session/id/parent_run/trace/reference_example, which LangSmith rejects with a 400
+        # ("At least one of 'session', 'id', 'parent_run', 'trace' or 'reference_example' must be
+        # specified"). Every request must carry the workspace's session ids.
+        manager = FakeManager()
+        bodies: list[dict[str, Any]] = []
+
+        def fake_fetch(session, url, headers, log, json_body=None):
+            bodies.append(json_body)
+            return {"runs": [_run("a")], "cursors": {"next": None}}
+
+        with mock.patch(_FETCH_PAGE, side_effect=_with_session_page(fake_fetch)):
+            _collect(get_rows("key", BASE_URL, "runs", logger, manager, 1))  # type: ignore[arg-type]
+
+        assert bodies[0]["session"] == [row["id"] for row in SESSION_IDS_PAGE]
 
     def test_resume_pins_cursor_and_window(self):
         manager = FakeManager(resume=LangSmithResumeConfig(cursor="c9", window_start="2026-01-01T00:00:00.000000Z"))
@@ -178,7 +226,7 @@ class TestRunsPagination:
             bodies.append(json_body)
             return {"runs": [_run("x")], "cursors": {"next": None}}
 
-        with mock.patch(_FETCH_PAGE, side_effect=fake_fetch):
+        with mock.patch(_FETCH_PAGE, side_effect=_with_session_page(fake_fetch)):
             _collect(get_rows("key", BASE_URL, "runs", logger, manager, 1, True, datetime.now(UTC)))  # type: ignore[arg-type]
 
         # The interrupted run's window is replayed, not recomputed from the new watermark — a
@@ -193,7 +241,7 @@ class TestRunsPagination:
         big_page = {"runs": [_run(f"r{i}") for i in range(2500)], "cursors": {"next": "c2"}}
         last_page = {"runs": [_run("tail")], "cursors": {"next": None}}
 
-        with mock.patch(_FETCH_PAGE, side_effect=[big_page, last_page]):
+        with mock.patch(_FETCH_PAGE, side_effect=[SESSION_IDS_PAGE, big_page, last_page]):
             rows = _collect(get_rows("key", BASE_URL, "runs", logger, manager, 1))  # type: ignore[arg-type]
 
         assert len(rows) == 2501
@@ -256,7 +304,7 @@ class TestPaginationAbuseGuards:
         def fake_fetch(session, url, headers, log, json_body=None):
             return {"runs": [_run("a")], "cursors": {"next": "loop"}}
 
-        with mock.patch(_FETCH_PAGE, side_effect=fake_fetch):
+        with mock.patch(_FETCH_PAGE, side_effect=_with_session_page(fake_fetch)):
             with pytest.raises(LangSmithRepeatedCursorError):
                 _collect(get_rows("key", BASE_URL, "runs", logger, manager, 1))  # type: ignore[arg-type]
 
@@ -269,7 +317,7 @@ class TestPaginationAbuseGuards:
         def fake_fetch(session, url, headers, log, json_body=None):
             return {"runs": [_run("a")], "cursors": {"next": big_cursor}}
 
-        with mock.patch(_FETCH_PAGE, side_effect=fake_fetch):
+        with mock.patch(_FETCH_PAGE, side_effect=_with_session_page(fake_fetch)):
             with pytest.raises(LangSmithResponseTooLargeError):
                 _collect(get_rows("key", BASE_URL, "runs", logger, manager, 1))  # type: ignore[arg-type]
 
@@ -286,7 +334,7 @@ class TestPaginationAbuseGuards:
             return {"runs": [_run(f"r{counter['n']}")], "cursors": {"next": f"c{counter['n']}"}}
 
         rows: list[dict[str, Any]] = []
-        with mock.patch(_MAX_PAGES, 3), mock.patch(_FETCH_PAGE, side_effect=fake_fetch):
+        with mock.patch(_MAX_PAGES, 3), mock.patch(_FETCH_PAGE, side_effect=_with_session_page(fake_fetch)):
             with pytest.raises(LangSmithPageLimitError):
                 for table in get_rows("key", BASE_URL, "runs", logger, manager, 1):  # type: ignore[arg-type]
                     rows.extend(table.to_pylist())


### PR DESCRIPTION
## Problem

The LangSmith `runs` table sync was failing for every workspace with:

```
HTTPError: 400 Client Error: Bad Request for url: https://api.smith.langchain.com/api/v1/runs/query
```

Caught by [error tracking](https://us.posthog.com/project/2/error_tracking/019f874b-88cf-7c61-a6c2-bd7f51ec2264). The response body (visible in worker logs, not captured by the exception) was:

```json
{"detail":"At least one of 'session', 'id', 'parent_run', 'trace' or 'reference_example' must be specified"}
```

`runs/query` was called with only `limit`/`select`/`order`/`start_time` — no scope at all — which LangSmith's API rejects outright. This wasn't transient: the same activity retried 7 times and got the identical 400 every time, since retrying an unscoped request can never succeed.

## Changes

- Added `_list_session_ids`, which pages through `GET /api/v1/sessions` (the same endpoint the `projects` table already syncs) to collect every tracing-project id in the workspace.
- `_get_runs_rows` now fetches those ids before building the request body and sends them as the `session` filter, satisfying LangSmith's scoping requirement.
- If a workspace has no tracing projects yet, the sync now skips the `runs/query` call entirely instead of sending an empty scope that would 400 the same way.

## How did you test this code?

- Ran the existing `test_langsmith.py` / `test_langsmith_source.py` suites (56 tests, all passing) after updating the mocks that model the request sequence to account for the new sessions-listing call.
- Added `test_runs_query_is_always_scoped_to_a_session` — regression test asserting every `runs/query` body carries the workspace's session ids (this is exactly the scenario that 400'd in production).
- Added `test_no_sessions_in_workspace_skips_runs_query_entirely` — covers the new empty-workspace short-circuit.
- `ruff check`/`format`, and a full-repo `mypy --cache-fine-grained` run, both clean.
- Didn't run this against a live LangSmith account (no test credentials in this environment); verified the root cause against the actual failing request logged by the worker and against LangSmith's public OpenAPI schema for `/runs/query`.

## Docs update

N/A — no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (PostHog Code), triaging an error-tracking webhook for the LangSmith warehouse source.
- Skill invoked: `/writing-tests` before adding/modifying test coverage.
- Investigation: confirmed the stack trace originates in `_fetch_page` in this source's own code (not a caller), then found the actual LangSmith response body by searching the `temporal-worker-data-warehouse` service logs for the log line this code already emits before raising — that revealed the real validation error, which isn't captured on the exception itself.
- Decision: treated as a fixable bug rather than adding to `NonRetryableErrors`, since the request was malformed on our side (missing a required scope) rather than a customer credential/config problem — every retry failed identically because retrying can't fix a structurally invalid request.
- Checked LangSmith's public OpenAPI schema (`https://api.smith.langchain.com/openapi.json`) to confirm `session` accepts an array of tracing-project ids and that the existing `projects` schema's endpoint (`GET /api/v1/sessions`) is the right source for them.