### PR TITLE
feat(web-analytics): expand sub-30d warming replays to 30 days of buckets

### DIFF
--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -1,3 +1,4 @@
+import re
 import json
 import statistics
 
@@ -87,6 +88,49 @@ def maybe_opt_into_lazy_precompute(query_json: dict) -> dict:
     if query_json.get("useWebAnalyticsPrecompute") is not None:
         return query_json
     return {**query_json, "useWebAnalyticsPrecompute": True}
+
+
+# Warmed bucket depth. ~88% of web analytics requests fit inside 7 days but 93%
+# fit inside 30 (-14d/-28d/-30d/month-start make up the difference); since
+# per-day buckets are immutable and shared across date ranges, building 30 days
+# once covers every narrower request at no recurring cost.
+WARMING_EXPANDED_DATE_FROM = "-30d"
+
+# Relative date_from presets that are always narrower than 30 days. -Nd/-Nh
+# forms are matched by pattern; absolute dates and wider presets (mStart, all,
+# yStart, -90d, …) are left untouched.
+_SUB_30D_DATE_FROM_PRESETS = frozenset({"dStart", "-1dStart", "wStart", "-1wStart"})
+_SUB_30D_DATE_FROM_RE = re.compile(r"^-(\d+)([dh])$")
+
+
+def _is_within_30_days(date_from: str | None) -> bool:
+    if not date_from:
+        return True  # unset falls back to the -7d default
+    if date_from in _SUB_30D_DATE_FROM_PRESETS:
+        return True
+    match = _SUB_30D_DATE_FROM_RE.match(date_from)
+    if not match:
+        return False
+    value, unit = int(match.group(1)), match.group(2)
+    return unit == "h" or value < 30
+
+
+def maybe_expand_warming_date_range(query_json: dict) -> dict:
+    """Deepen a bucket-building replay's date range to WARMING_EXPANDED_DATE_FROM.
+
+    Only date_from moves (earlier), so the built buckets are a strict superset of
+    the requested range. Applies only to shapes on the precompute path: for an
+    opted-out shape the replay's exact result-cache row is the whole value of
+    warming it, so its range must stay faithful.
+    """
+    if query_json.get("kind") not in LAZY_PRECOMPUTE_QUERY_KINDS:
+        return query_json
+    if query_json.get("useWebAnalyticsPrecompute") is not True:
+        return query_json
+    date_range = query_json.get("dateRange") or {}
+    if not _is_within_30_days(date_range.get("date_from")):
+        return query_json
+    return {**query_json, "dateRange": {**date_range, "date_from": WARMING_EXPANDED_DATE_FROM}}
 
 
 def queries_to_keep_fresh(
@@ -238,6 +282,7 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: list[dict]) ->
             tag_queries(team_id=team_id, trigger="webAnalyticsQueryWarming", feature=Feature.CACHE_WARMUP)
 
             query_json = maybe_opt_into_lazy_precompute(query_json)
+            query_json = maybe_expand_warming_date_range(query_json)
 
             # None only for kinds without a get_query_runner branch — the backstop
             # for runnerless kinds the selection doesn't know to exclude yet.

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -96,11 +96,14 @@ def maybe_opt_into_lazy_precompute(query_json: dict) -> dict:
 # once covers every narrower request at no recurring cost.
 WARMING_EXPANDED_DATE_FROM = "-30d"
 
-# Relative date_from presets that are always narrower than 30 days. -Nd/-Nh
-# forms are matched by pattern; absolute dates and wider presets (mStart, all,
-# yStart, -90d, …) are left untouched.
+# Relative date_from presets that are always narrower than 30 days. -Nh/-Nd/-Nw
+# forms are matched by pattern and compared in days; absolute dates and wider
+# presets (mStart, all, yStart, -90d, …) are left untouched. Months/years are
+# deliberately unmatched: -1m can span 31 days, so expanding it would narrow it.
 _SUB_30D_DATE_FROM_PRESETS = frozenset({"dStart", "-1dStart", "wStart", "-1wStart"})
-_SUB_30D_DATE_FROM_RE = re.compile(r"^-(\d+)([dh])$")
+_SUB_30D_DATE_FROM_RE = re.compile(r"^-(\d+)([hdw])$")
+_HOURS_PER_DAY = 24
+_DAYS_PER_WEEK = 7
 
 
 def _is_within_30_days(date_from: str | None) -> bool:
@@ -112,7 +115,11 @@ def _is_within_30_days(date_from: str | None) -> bool:
     if not match:
         return False
     value, unit = int(match.group(1)), match.group(2)
-    return unit == "h" or value < 30
+    if unit == "h":
+        return value < 30 * _HOURS_PER_DAY
+    if unit == "w":
+        return value * _DAYS_PER_WEEK < 30
+    return value < 30
 
 
 def maybe_expand_warming_date_range(query_json: dict) -> dict:

--- a/products/web_analytics/dags/tests/test_cache_warming.py
+++ b/products/web_analytics/dags/tests/test_cache_warming.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 
 from products.web_analytics.dags.cache_warming import (
     get_warmable_queries_op,
+    maybe_expand_warming_date_range,
     maybe_opt_into_lazy_precompute,
     queries_to_keep_fresh,
     warm_queries_op,
@@ -33,6 +34,59 @@ class TestMaybeOptIntoLazyPrecompute(BaseTest):
     )
     def test_leaves_query_untouched(self, _name: str, query: dict) -> None:
         self.assertEqual(maybe_opt_into_lazy_precompute(query), query)
+
+
+class TestMaybeExpandWarmingDateRange(BaseTest):
+    @parameterized.expand(
+        [
+            # Sub-30d ranges deepen to -30d; if these stop expanding, warming
+            # silently builds only ~7 days and every -14d/-28d request
+            # cold-builds inline.
+            ("default_7d", {"date_from": "-7d"}, "-30d"),
+            ("today", {"date_from": "dStart"}, "-30d"),
+            ("hours", {"date_from": "-24h"}, "-30d"),
+            ("no_date_range", None, "-30d"),
+            # Wider or absolute ranges must stay exact — expanding would shrink
+            # or shift what the user actually asked to precompute.
+            ("ninety_days", {"date_from": "-90d"}, "-90d"),
+            ("all_time", {"date_from": "all"}, "all"),
+            ("absolute", {"date_from": "2026-07-01T00:00:00"}, "2026-07-01T00:00:00"),
+            ("month_start", {"date_from": "mStart"}, "mStart"),
+        ]
+    )
+    def test_expansion(self, _name: str, date_range: dict | None, expected_date_from: str) -> None:
+        query: dict = {"kind": "WebOverviewQuery", "useWebAnalyticsPrecompute": True}
+        if date_range is not None:
+            query["dateRange"] = date_range
+
+        result = maybe_expand_warming_date_range(query)
+
+        self.assertEqual(result["dateRange"]["date_from"], expected_date_from)
+
+    def test_preserves_date_to_and_other_range_keys(self) -> None:
+        query = {
+            "kind": "WebStatsTableQuery",
+            "useWebAnalyticsPrecompute": True,
+            "dateRange": {"date_from": "-1dStart", "date_to": "-1dEnd", "explicitDate": True},
+        }
+
+        result = maybe_expand_warming_date_range(query)
+
+        self.assertEqual(result["dateRange"], {"date_from": "-30d", "date_to": "-1dEnd", "explicitDate": True})
+
+    @parameterized.expand(
+        [
+            # An opted-out shape replays on the raw path where the exact
+            # result-cache row is the whole value of warming it.
+            (
+                "opted_out",
+                {"kind": "WebOverviewQuery", "useWebAnalyticsPrecompute": False, "dateRange": {"date_from": "-7d"}},
+            ),
+            ("non_lazy_kind", {"kind": "WebExternalClicksTableQuery", "dateRange": {"date_from": "-7d"}}),
+        ]
+    )
+    def test_leaves_non_precompute_replays_untouched(self, _name: str, query: dict) -> None:
+        self.assertEqual(maybe_expand_warming_date_range(query), query)
 
 
 class TestFleetQuerySelection(BaseTest):

--- a/products/web_analytics/dags/tests/test_cache_warming.py
+++ b/products/web_analytics/dags/tests/test_cache_warming.py
@@ -45,10 +45,14 @@ class TestMaybeExpandWarmingDateRange(BaseTest):
             ("default_7d", {"date_from": "-7d"}, "-30d"),
             ("today", {"date_from": "dStart"}, "-30d"),
             ("hours", {"date_from": "-24h"}, "-30d"),
+            ("weeks", {"date_from": "-2w"}, "-30d"),
             ("no_date_range", None, "-30d"),
             # Wider or absolute ranges must stay exact — expanding would shrink
             # or shift what the user actually asked to precompute.
             ("ninety_days", {"date_from": "-90d"}, "-90d"),
+            ("hours_over_30d", {"date_from": "-1000h"}, "-1000h"),
+            ("weeks_over_30d", {"date_from": "-5w"}, "-5w"),
+            ("one_month_can_be_31d", {"date_from": "-1m"}, "-1m"),
             ("all_time", {"date_from": "all"}, "all"),
             ("absolute", {"date_from": "2026-07-01T00:00:00"}, "2026-07-01T00:00:00"),
             ("month_start", {"date_from": "mStart"}, "mStart"),


### PR DESCRIPTION
## Problem

The cache warmer replays each hot query shape with its exact original date range, so a `-7d` shape builds only 7 days of precompute buckets. Measured against 2 days of production traffic (~464k web analytics queries): ~88% of requests fit inside 7 days, but ~93% fit inside 30 - the difference is `-14d`/`-28d`/`-30d`/month-start requests that today cold-build their missing buckets inline on first read.

Since per-day buckets are immutable and shared across date ranges, building 30 days once covers every narrower request, and the recurring hourly cost is unchanged (only today's bucket refreshes).

## Changes

- New `maybe_expand_warming_date_range`: bucket-building replays (lazy kinds with the precompute opt-in) whose `date_from` is narrower than 30 days get `date_from: "-30d"`. Only `date_from` moves - earlier - so built buckets are a strict superset of the requested range; `date_to` and other range keys are preserved.
- Wider presets (`-90d`, `all`, `yStart`, `mStart`), absolute dates, opted-out shapes, and non-lazy kinds stay exact. For opted-out shapes the replay's exact result-cache row is the whole value of warming, so faithfulness matters there.
- Applied in `warm_queries_op` right after the precompute opt-in injection.

## How did you test this code?

`pytest products/web_analytics/dags/tests/test_cache_warming.py` (19 passed). New parameterized tests cover: sub-30d ranges (relative days/hours/presets/unset) expand to `-30d`; wider/absolute/month-start ranges stay exact (expansion must never shrink or shift coverage); `date_to` and extra range keys survive; opted-out and non-lazy replays are untouched (their exact result-cache row is the point of warming them).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, follow-up to the warming go-live (#72472, #72755). Lucas proposed expanding warmed ranges to cover what analytics queries usually request; the -30d width was chosen from the measured production range distribution (93% coverage; -90d adds only ~1pp for 3x the backfill). Considered canonicalizing every replay to one range - rejected in favor of expand-only (never narrow), keeping wider requests exact.