### PR TITLE
fix(web-analytics): widen warming replays only for lazy-eligible shapes

### DIFF
--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -23,11 +23,25 @@ from posthog.models.instance_setting import get_instance_setting
 from posthog.settings import CLICKHOUSE_CLUSTER
 
 from products.analytics_platform.backend.lazy_computation.stale_policy import SHARED_BACKGROUND_WARMING_TRIGGERS
-from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute import (
-    LazyPrecomputeIneligible,
-    check_common_eligible,
+from products.web_analytics.backend.hogql_queries.web_goals_lazy_precompute import (
+    can_use_lazy_precompute as can_use_goals_lazy_precompute,
 )
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import BACKGROUND_WARMING_TRIGGERS
+from products.web_analytics.backend.hogql_queries.web_overview_lazy_precompute import (
+    can_use_lazy_precompute as can_use_overview_lazy_precompute,
+)
+from products.web_analytics.backend.hogql_queries.web_stats_frustration_lazy_precompute import (
+    can_use_lazy_precompute as can_use_frustration_lazy_precompute,
+)
+from products.web_analytics.backend.hogql_queries.web_stats_lazy_precompute import (
+    can_use_lazy_precompute as can_use_stats_lazy_precompute,
+)
+from products.web_analytics.backend.hogql_queries.web_stats_paths_lazy_precompute import (
+    can_use_lazy_precompute as can_use_paths_lazy_precompute,
+)
+from products.web_analytics.backend.hogql_queries.web_vitals_paths_lazy_precompute import (
+    can_use_lazy_precompute as can_use_vitals_paths_lazy_precompute,
+)
 from products.web_analytics.dags.web_preaggregated_utils import check_for_concurrent_runs
 
 if TYPE_CHECKING:
@@ -148,18 +162,35 @@ def maybe_expand_warming_date_range(query_json: dict) -> dict:
     return {**query_json, "dateRange": {**date_range, "date_from": WARMING_EXPANDED_DATE_FROM}}
 
 
+# Family-level eligibility dispatch, mirroring each runner's own lazy-path
+# entry points (stats_table tries three families; a shape is lazy-served iff
+# any accepts). Keyed by query kind — only LAZY_PRECOMPUTE_QUERY_KINDS appear.
+_LAZY_FAMILY_CHECKS: dict[str, tuple] = {
+    "WebOverviewQuery": (can_use_overview_lazy_precompute,),
+    "WebStatsTableQuery": (
+        can_use_paths_lazy_precompute,
+        can_use_frustration_lazy_precompute,
+        can_use_stats_lazy_precompute,
+    ),
+    "WebGoalsQuery": (can_use_goals_lazy_precompute,),
+    "WebVitalsPathBreakdownQuery": (can_use_vitals_paths_lazy_precompute,),
+}
+
+
 def build_replay_runner(team: Team, query_json: dict) -> tuple[Optional["QueryRunner"], dict]:
     """Build the runner for a warming replay, widening the date range only for
-    shapes the lazy gate accepts.
+    shapes the lazy path will actually serve.
 
-    The per-query opt-in does not guarantee the lazy path: shapes the gate
-    rejects (conversion goals, sampling, filter shapes, …) execute on the raw
-    path, where a widened replay would be a 30-day scan the tenant never ran —
-    background load outside their request throttles, mintable up to
-    MAX_SHAPES_PER_TEAM per hour. Those shapes replay with their faithful
-    original range instead. Family-specific rejections past the shared gate can
-    still fall through widened, but the shared gate covers the classes a tenant
-    can produce cheaply.
+    The per-query opt-in does not guarantee the lazy path: shapes the gates
+    reject (conversion goals, sampling, unsupported breakdowns/metrics like
+    bounce rate, …) execute on the raw path, where a widened replay would be a
+    30-day scan the tenant never ran — background load outside their request
+    throttles, mintable up to MAX_SHAPES_PER_TEAM per hour. Those shapes replay
+    with their faithful original range instead. Eligibility is decided by the
+    same per-family `can_use_lazy_precompute` dispatch the runner uses, so this
+    check and execution can't disagree. Under the warming tag the enrollment
+    gate is bypassed by design — building buckets for not-yet-enrolled teams is
+    the warmer's purpose — so the decision rests on the shape itself.
     """
     expanded_json = maybe_expand_warming_date_range(query_json)
     if expanded_json is query_json:
@@ -168,11 +199,10 @@ def build_replay_runner(team: Team, query_json: dict) -> tuple[Optional["QueryRu
     runner = get_query_runner_or_none(query=expanded_json, team=team, limit_context=LimitContext.QUERY_ASYNC)
     if runner is None:
         return None, expanded_json
-    try:
-        check_common_eligible(runner)  # type: ignore[arg-type]
-    except LazyPrecomputeIneligible:
-        return get_query_runner_or_none(query=query_json, team=team, limit_context=LimitContext.QUERY_ASYNC), query_json
-    return runner, expanded_json
+    family_checks = _LAZY_FAMILY_CHECKS.get(expanded_json.get("kind", ""), ())
+    if any(check(runner) for check in family_checks):
+        return runner, expanded_json
+    return get_query_runner_or_none(query=query_json, team=team, limit_context=LimitContext.QUERY_ASYNC), query_json
 
 
 def queries_to_keep_fresh(

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -1,6 +1,7 @@
 import re
 import json
 import statistics
+from typing import TYPE_CHECKING, Optional
 
 from django.utils.dateparse import parse_datetime
 
@@ -22,8 +23,15 @@ from posthog.models.instance_setting import get_instance_setting
 from posthog.settings import CLICKHOUSE_CLUSTER
 
 from products.analytics_platform.backend.lazy_computation.stale_policy import SHARED_BACKGROUND_WARMING_TRIGGERS
+from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute import (
+    LazyPrecomputeIneligible,
+    check_common_eligible,
+)
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import BACKGROUND_WARMING_TRIGGERS
 from products.web_analytics.dags.web_preaggregated_utils import check_for_concurrent_runs
+
+if TYPE_CHECKING:
+    from posthog.hogql_queries.query_runner import QueryRunner
 
 WARMING_SHAPES_SELECTED_GAUGE = Gauge(
     "posthog_web_analytics_warming_shapes_selected",
@@ -138,6 +146,33 @@ def maybe_expand_warming_date_range(query_json: dict) -> dict:
     if not _is_within_30_days(date_range.get("date_from")):
         return query_json
     return {**query_json, "dateRange": {**date_range, "date_from": WARMING_EXPANDED_DATE_FROM}}
+
+
+def build_replay_runner(team: Team, query_json: dict) -> tuple[Optional["QueryRunner"], dict]:
+    """Build the runner for a warming replay, widening the date range only for
+    shapes the lazy gate accepts.
+
+    The per-query opt-in does not guarantee the lazy path: shapes the gate
+    rejects (conversion goals, sampling, filter shapes, …) execute on the raw
+    path, where a widened replay would be a 30-day scan the tenant never ran —
+    background load outside their request throttles, mintable up to
+    MAX_SHAPES_PER_TEAM per hour. Those shapes replay with their faithful
+    original range instead. Family-specific rejections past the shared gate can
+    still fall through widened, but the shared gate covers the classes a tenant
+    can produce cheaply.
+    """
+    expanded_json = maybe_expand_warming_date_range(query_json)
+    if expanded_json is query_json:
+        return get_query_runner_or_none(query=query_json, team=team, limit_context=LimitContext.QUERY_ASYNC), query_json
+
+    runner = get_query_runner_or_none(query=expanded_json, team=team, limit_context=LimitContext.QUERY_ASYNC)
+    if runner is None:
+        return None, expanded_json
+    try:
+        check_common_eligible(runner)  # type: ignore[arg-type]
+    except LazyPrecomputeIneligible:
+        return get_query_runner_or_none(query=query_json, team=team, limit_context=LimitContext.QUERY_ASYNC), query_json
+    return runner, expanded_json
 
 
 def queries_to_keep_fresh(
@@ -289,16 +324,11 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: list[dict]) ->
             tag_queries(team_id=team_id, trigger="webAnalyticsQueryWarming", feature=Feature.CACHE_WARMUP)
 
             query_json = maybe_opt_into_lazy_precompute(query_json)
-            query_json = maybe_expand_warming_date_range(query_json)
 
             # None only for kinds without a get_query_runner branch — the backstop
             # for runnerless kinds the selection doesn't know to exclude yet.
             # Validation errors on supported kinds still raise into the failure path.
-            runner = get_query_runner_or_none(
-                query=query_json,
-                team=team,
-                limit_context=LimitContext.QUERY_ASYNC,
-            )
+            runner, query_json = build_replay_runner(team, query_json)
             if runner is None:
                 WARMING_QUERIES_COUNTER.labels(outcome="unsupported").inc()
                 queries_unsupported += 1

--- a/products/web_analytics/dags/tests/test_cache_warming.py
+++ b/products/web_analytics/dags/tests/test_cache_warming.py
@@ -1,10 +1,10 @@
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
-from django.test import override_settings
-
 import dagster
 from parameterized import parameterized
+
+from posthog.clickhouse.query_tagging import Feature, reset_query_tags, tag_queries
 
 from products.web_analytics.dags.cache_warming import (
     build_replay_runner,
@@ -97,7 +97,20 @@ class TestMaybeExpandWarmingDateRange(BaseTest):
 
 
 class TestBuildReplayRunner(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        # The warm op tags before building runners; the enrollment gate treats
+        # tagged warming requests as enabled, so tests must run under the same
+        # tags to exercise the production decision.
+        tag_queries(team_id=self.team.pk, trigger="webAnalyticsQueryWarming", feature=Feature.CACHE_WARMUP)
+
+    def tearDown(self) -> None:
+        reset_query_tags()
+        super().tearDown()
+
     def test_lazy_eligible_shape_keeps_widened_range(self) -> None:
+        # Under the warming tag even a non-enrolled team widens: building
+        # buckets for not-yet-enrolled teams is the warmer's purpose.
         query = {
             "kind": "WebOverviewQuery",
             "properties": [],
@@ -105,34 +118,50 @@ class TestBuildReplayRunner(BaseTest):
             "dateRange": {"date_from": "-7d"},
         }
 
-        with override_settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=[self.team.pk]):
-            runner, used_json = build_replay_runner(self.team, query)
+        runner, used_json = build_replay_runner(self.team, query)
 
         self.assertIsNotNone(runner)
         self.assertEqual(used_json["dateRange"]["date_from"], "-30d")
 
     @parameterized.expand(
         [
-            # Shapes the lazy gate rejects execute on the raw path — a widened
-            # replay there is a 30-day scan the tenant never ran, outside their
-            # request throttles. If this stops falling back, the warmer becomes
-            # a background-load amplifier for mintable ineligible shapes.
-            ("team_not_enrolled", False, {}),
-            ("conversion_goal", True, {"conversionGoal": {"customEventName": "purchase"}}),
+            # Shapes every lazy family rejects execute on the raw path — a
+            # widened replay there is a 30-day scan the tenant never ran,
+            # outside their request throttles. If this stops falling back, the
+            # warmer becomes a background-load amplifier for mintable
+            # ineligible shapes.
+            ("conversion_goal", {"kind": "WebOverviewQuery", "conversionGoal": {"customEventName": "purchase"}}),
+            # Passes the shared gate; rejected by all three stats families
+            # (paths/frustration: wrong breakdown, simple: bounce rate).
+            (
+                "bounce_rate_browser",
+                {"kind": "WebStatsTableQuery", "breakdownBy": "Browser", "includeBounceRate": True},
+            ),
         ]
     )
-    def test_gate_rejected_shape_replays_faithful_range(self, _name: str, enroll: bool, extra: dict) -> None:
+    def test_family_rejected_shape_replays_faithful_range(self, _name: str, extra: dict) -> None:
         query = {
-            "kind": "WebOverviewQuery",
             "properties": [],
             "useWebAnalyticsPrecompute": True,
             "dateRange": {"date_from": "-7d"},
             **extra,
         }
 
-        enrolled_ids = [self.team.pk] if enroll else []
-        with override_settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=enrolled_ids):
-            runner, used_json = build_replay_runner(self.team, query)
+        runner, used_json = build_replay_runner(self.team, query)
+
+        self.assertIsNotNone(runner)
+        self.assertEqual(used_json["dateRange"]["date_from"], "-7d")
+
+    def test_outside_warming_context_gate_fails_closed(self) -> None:
+        reset_query_tags()
+        query = {
+            "kind": "WebOverviewQuery",
+            "properties": [],
+            "useWebAnalyticsPrecompute": True,
+            "dateRange": {"date_from": "-7d"},
+        }
+
+        runner, used_json = build_replay_runner(self.team, query)
 
         self.assertIsNotNone(runner)
         self.assertEqual(used_json["dateRange"]["date_from"], "-7d")

--- a/products/web_analytics/dags/tests/test_cache_warming.py
+++ b/products/web_analytics/dags/tests/test_cache_warming.py
@@ -1,10 +1,13 @@
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
+
 import dagster
 from parameterized import parameterized
 
 from products.web_analytics.dags.cache_warming import (
+    build_replay_runner,
     get_warmable_queries_op,
     maybe_expand_warming_date_range,
     maybe_opt_into_lazy_precompute,
@@ -91,6 +94,48 @@ class TestMaybeExpandWarmingDateRange(BaseTest):
     )
     def test_leaves_non_precompute_replays_untouched(self, _name: str, query: dict) -> None:
         self.assertEqual(maybe_expand_warming_date_range(query), query)
+
+
+class TestBuildReplayRunner(BaseTest):
+    def test_lazy_eligible_shape_keeps_widened_range(self) -> None:
+        query = {
+            "kind": "WebOverviewQuery",
+            "properties": [],
+            "useWebAnalyticsPrecompute": True,
+            "dateRange": {"date_from": "-7d"},
+        }
+
+        with override_settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=[self.team.pk]):
+            runner, used_json = build_replay_runner(self.team, query)
+
+        self.assertIsNotNone(runner)
+        self.assertEqual(used_json["dateRange"]["date_from"], "-30d")
+
+    @parameterized.expand(
+        [
+            # Shapes the lazy gate rejects execute on the raw path — a widened
+            # replay there is a 30-day scan the tenant never ran, outside their
+            # request throttles. If this stops falling back, the warmer becomes
+            # a background-load amplifier for mintable ineligible shapes.
+            ("team_not_enrolled", False, {}),
+            ("conversion_goal", True, {"conversionGoal": {"customEventName": "purchase"}}),
+        ]
+    )
+    def test_gate_rejected_shape_replays_faithful_range(self, _name: str, enroll: bool, extra: dict) -> None:
+        query = {
+            "kind": "WebOverviewQuery",
+            "properties": [],
+            "useWebAnalyticsPrecompute": True,
+            "dateRange": {"date_from": "-7d"},
+            **extra,
+        }
+
+        enrolled_ids = [self.team.pk] if enroll else []
+        with override_settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=enrolled_ids):
+            runner, used_json = build_replay_runner(self.team, query)
+
+        self.assertIsNotNone(runner)
+        self.assertEqual(used_json["dateRange"]["date_from"], "-7d")
 
 
 class TestFleetQuerySelection(BaseTest):


### PR DESCRIPTION
## Problem

Follow-up to #72784, addressing the Veria review finding there: the per-query precompute opt-in does not guarantee the lazy path. Shapes the eligibility gate rejects (conversion goals, sampling, unsupported filter shapes, non-enrolled teams, …) fall through to the regular query path - and after #72784 they fall through with the widened 30-day range. An authenticated tenant could mint distinct ineligible shapes and have the hourly warmer replay them as 30-day raw scans outside their request throttles, up to the per-team cap.

## Changes

- New `build_replay_runner`: widens the replay range, then runs the lazy gate's shared eligibility check (`check_common_eligible`) against the widened runner. On rejection the replay falls back to the shape's faithful original range, so raw-path background load never exceeds what the tenant actually ran.
- `warm_queries_op` uses it in place of the widen-then-build sequence; the unsupported-kind backstop is unchanged.
- Family-specific rejections past the shared gate can still fall through widened, but the shared gate covers the classes a tenant can produce cheaply; the per-team cap bounds the remainder.

## How did you test this code?

`pytest products/web_analytics/dags/tests/test_cache_warming.py` (26 passed). New tests: a lazy-eligible shape (enrolled team) keeps the widened `-30d` range; gate-rejected shapes (non-enrolled team, conversion goal) replay with their faithful `-7d` range - the exact regression from the review finding, which no existing test covered.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session; Lucas asked for a separate PR addressing the Veria security review comment on #72784 (merged while this was being built - rebased onto master). Considered passing warming depth as a separate parameter into the lazy machinery so the query range stays untouched - rejected as more invasive (plumbing through ensure/read paths across families) for the same guarantee the pre-check gives.