### PR TITLE
fix(mysql): retry a connection reset during metadata discovery

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -564,21 +564,43 @@ def _is_transient_vitess_reparent(e: BaseException) -> bool:
     return _VITESS_REPARENT_TOKEN in " ".join(str(arg) for arg in e.args)
 
 
+def _is_transient_metadata_query_reset(e: BaseException) -> bool:
+    """Return True if a metadata query's connection was reset mid-query — a transient blip.
+
+    `_is_transient_connect_drop` already retries this same 2013 code when it fires inside
+    `connect()` (a socket close while reading the server greeting); this predicate covers the
+    sibling case where the connection was already established and the reset landed once a real
+    query was in flight — e.g. `get_table_metadata`'s small `information_schema.columns` lookup.
+    A bare `ConnectionResetError` payload means the socket itself was reset (an overloaded
+    server, a proxy/load-balancer cycling its backend, a momentary network blip), not the
+    bad-plan filesort-timeout symptom `_is_bad_plan_error` also keys on this code for — that one
+    only applies to the streaming data query, which has its own FORCE INDEX fallback. Match the
+    stable strerror phrase, not the volatile host.
+    """
+    if not isinstance(e, pymysql.err.OperationalError):
+        return False
+    code = e.args[0] if e.args else None
+    if code != _LOST_CONNECTION_DURING_QUERY_CODE:
+        return False
+    return _CONNECTION_RESET_TOKEN in " ".join(str(arg) for arg in e.args)
+
+
 def _retry_on_transient_tablet_unavailable(
     operation: Callable[[], _T],
     logger: FilteringBoundLogger,
     *,
     max_attempts: int = _MAX_CONNECT_ATTEMPTS,
 ) -> _T:
-    """Run `operation`, retrying a transient Vitess tablet-unavailable error.
+    """Run `operation`, retrying a transient error hit during metadata discovery.
 
     Mirrors `_connect_with_transient_retry`, but covers the metadata queries that run on
     a freshly opened connection: reconnecting alone doesn't help when the vtgate
     handshake succeeds and only the first query hits an unavailable tablet, so retry the
     whole operation (which reopens the connection) with a bounded backoff instead of
     failing sync setup on the first blip and surfacing it as captured error-tracking
-    noise. Non-transient errors re-raise immediately because the predicates only match
-    the gRPC `Unavailable` status or a mid-reparent primary — both self-healing.
+    noise. Non-transient errors re-raise immediately — the predicates only match the gRPC
+    `Unavailable` status, a mid-reparent primary, or a plain peer-reset connection drop,
+    all self-healing.
     """
     attempt = 0
     while True:
@@ -586,10 +608,14 @@ def _retry_on_transient_tablet_unavailable(
             return operation()
         except pymysql.err.OperationalError as e:
             attempt += 1
-            if attempt >= max_attempts or not (_is_transient_tablet_unavailable(e) or _is_transient_vitess_reparent(e)):
+            if attempt >= max_attempts or not (
+                _is_transient_tablet_unavailable(e)
+                or _is_transient_vitess_reparent(e)
+                or _is_transient_metadata_query_reset(e)
+            ):
                 raise
             logger.warning(
-                "Transient MySQL tablet-unavailable error during metadata discovery; retrying",
+                "Transient MySQL error during metadata discovery; retrying",
                 attempt=attempt,
                 max_attempts=max_attempts,
                 exc_info=e,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -30,6 +30,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysq
     _is_transient_connect_gone_away,
     _is_transient_connect_reset,
     _is_transient_connect_timeout,
+    _is_transient_metadata_query_reset,
     _is_transient_packet_sequence_error,
     _is_transient_tablet_unavailable,
     _is_transient_vitess_dial_timeout,
@@ -1450,6 +1451,36 @@ class TestIsTransientVitessReparent:
         assert not _is_transient_vitess_reparent(ValueError("reparent operation in progress"))
 
 
+class TestIsTransientMetadataQueryReset:
+    def test_matches_connection_reset_mid_query(self):
+        # A peer reset landing on an already-open connection while a metadata query (e.g.
+        # `get_table_metadata`'s information_schema lookup) was in flight — an overloaded
+        # server or a proxy/load-balancer cycling its backend, not a bad query plan.
+        assert _is_transient_metadata_query_reset(
+            pymysql.err.OperationalError(
+                2013, "Lost connection to MySQL server during query ([Errno 104] Connection reset by peer)"
+            )
+        )
+
+    @pytest.mark.parametrize(
+        "code,message",
+        [
+            # Same code without the peer-reset signature is the bad-plan/filesort-timeout
+            # symptom `_is_bad_plan_error` handles instead — must not be absorbed here.
+            (2013, "Lost connection to MySQL server during query"),
+            (1045, "Access denied for user"),
+        ],
+    )
+    def test_does_not_match_other_errors(self, code, message):
+        assert not _is_transient_metadata_query_reset(pymysql.err.OperationalError(code, message))
+
+    def test_does_not_match_error_without_args(self):
+        assert not _is_transient_metadata_query_reset(pymysql.err.OperationalError())
+
+    def test_does_not_match_non_operational_error(self):
+        assert not _is_transient_metadata_query_reset(ConnectionResetError("[Errno 104] Connection reset by peer"))
+
+
 class TestRetryOnTransientTabletUnavailable:
     @staticmethod
     def _unavailable() -> pymysql.err.OperationalError:
@@ -1483,6 +1514,17 @@ class TestRetryOnTransientTabletUnavailable:
             "there may be a reparent operation in progress",
         )
         operation = MagicMock(side_effect=[reparent, "ok"])
+
+        assert _retry_on_transient_tablet_unavailable(operation, MagicMock()) == "ok"
+
+        assert operation.call_count == 2
+
+    def test_retries_metadata_query_connection_reset_then_succeeds(self, mocker):
+        mocker.patch("products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.time.sleep")
+        reset = pymysql.err.OperationalError(
+            2013, "Lost connection to MySQL server during query ([Errno 104] Connection reset by peer)"
+        )
+        operation = MagicMock(side_effect=[reset, "ok"])
 
         assert _retry_on_transient_tablet_unavailable(operation, MagicMock()) == "ok"
 


### PR DESCRIPTION
## Problem

Error tracking [flagged](https://us.posthog.com/project/2/error_tracking/019f87f1-7a7e-7402-83b0-bc47bdf45ddf) an `OperationalError(2013, 'Lost connection to MySQL server during query ([Errno 104] Connection reset by peer)')` raised from `get_table_metadata` during MySQL sync setup, wrapping a plain `ConnectionResetError`. The peer reset the socket while a small `information_schema.columns` lookup was in flight, mid `build_pipeline` -> `_discover_metadata`.

This module already retries the equivalent drop when it happens at `connect()` time (`_is_transient_connect_drop`), and retries Vitess-specific transient errors during metadata discovery (`_retry_on_transient_tablet_unavailable`), but a generic peer-reset hitting an already-open connection during a metadata query fell through both and failed sync setup on the first blip.

## Changes

Added `_is_transient_metadata_query_reset`, matching the same 2013 code + `Connection reset by peer` signature already used for the connect-time case, and wired it into `_retry_on_transient_tablet_unavailable`'s retry predicate so metadata discovery retries this transient blip (bounded backoff, reopening the connection) instead of failing the whole activity on the first hit.

This is a fixable-bug case, not user/upstream error: a bare peer reset (overloaded server, proxy/load-balancer cycling its backend, momentary network blip) is exactly the class of transient infrastructure error this source already retries elsewhere — it should stay retryable, just handled locally rather than escalating to error-tracking noise.

## How did you test this code?

Added `TestIsTransientMetadataQueryReset` (predicate unit tests: matches the peer-reset signature, doesn't match the same code without that signature — the bad-plan/filesort-timeout case `_is_bad_plan_error` handles instead — doesn't match other codes or non-`OperationalError`s) and a `test_retries_metadata_query_connection_reset_then_succeeds` case in `TestRetryOnTransientTabletUnavailable` asserting the retry wrapper now recovers from this error and returns the operation's result.

Ran the full MySQL source test suite locally: `232 passed`. Ran `ruff check`/`ruff format --check` and `mypy` on the changed file — all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude, via PostHog Code) investigated an error-tracking issue for the MySQL data-warehouse source, confirmed the stack trace originates in `products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py`, read the surrounding retry helpers to find the closest existing precedent, and extended that precedent to cover this specific transient class rather than widening `NonRetryableErrors` (this isn't a user/upstream error) or touching the broader retry policy.
