### PR TITLE
fix(surveys): scope embedded actions to the serializer's fields

### DIFF
--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -299,6 +299,22 @@ def get_survey_conditions_with_actions(
         else:
             conditions = dict(conditions)
         conditions["actions"] = {"values": action_serializer_class(actions, many=True).data}
+    elif isinstance(conditions, dict) and isinstance(conditions.get("actions"), dict):
+        # The actions M2M didn't resolve (e.g. the referenced actions were deleted) but a stale
+        # actions blob still lives in `conditions`. That stored blob can carry fields this caller's
+        # serializer would never expose — notably `created_by` on the public /surveys and /decide
+        # payload — so project each value down to the serializer's own fields. Never surface more
+        # than the serializer itself would.
+        allowed_fields = getattr(action_serializer_class.Meta, "fields", None)
+        if isinstance(allowed_fields, list | tuple):
+            allowed = set(allowed_fields)
+            values = conditions["actions"].get("values") or []
+            conditions = dict(conditions)
+            conditions["actions"] = {
+                "values": [
+                    {k: v for k, v in value.items() if k in allowed} for value in values if isinstance(value, dict)
+                ]
+            }
     return conditions
 
 

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -305,7 +305,8 @@ def get_survey_conditions_with_actions(
         # serializer would never expose — notably `created_by` on the public /surveys and /decide
         # payload — so project each value down to the serializer's own fields. Never surface more
         # than the serializer itself would.
-        allowed_fields = getattr(action_serializer_class.Meta, "fields", None)
+        meta = getattr(action_serializer_class, "Meta", None)
+        allowed_fields = getattr(meta, "fields", None)
         if isinstance(allowed_fields, list | tuple):
             allowed = set(allowed_fields)
             values = conditions["actions"].get("values") or []

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -4722,7 +4722,6 @@ class TestSurveyWithActions(APIBaseTest):
         assert len(survey.actions.all()) == 0
 
 
-@freeze_time("2024-12-12 00:00:00")
 class TestGetSurveyConditionsActionSanitization(SimpleTestCase):
     def test_public_action_serializer_strips_non_public_fields_from_stale_blob(self) -> None:
         # /decide PII leak guard (no DB): when the actions M2M is empty and
@@ -4761,6 +4760,7 @@ class TestGetSurveyConditionsActionSanitization(SimpleTestCase):
         assert value["name"] == "person subscribed"
 
 
+@freeze_time("2024-12-12 00:00:00")
 class TestSurveyResponseSampling(APIBaseTest):
     def _create_survey_with_sampling_limits(
         self,

--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -15,7 +15,7 @@ from posthog.test.base import (
 )
 from unittest.mock import ANY, MagicMock, patch
 
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 
 from nanoid import generate
 from parameterized import parameterized
@@ -4535,6 +4535,46 @@ class TestSurveyWithActions(APIBaseTest):
             {"key": "plan", "value": "pro", "operator": "exact"}
         ]
 
+    def test_public_serializer_strips_pii_from_stale_actions_blob(self):
+        # When the actions M2M is empty (e.g. the referenced actions were deleted) but conditions
+        # still carries a full actions blob from an editor round-trip, the public serializer must
+        # not surface anything beyond the public action fields — no created_by, team_id, etc. This
+        # is the /decide leak: the blob was served verbatim to unauthenticated clients.
+        from products.surveys.backend.api.survey import SurveyAPISerializer
+
+        survey = Survey.objects.create(
+            team=self.team,
+            name="stale actions blob survey",
+            type="popover",
+            conditions={
+                "actions": {
+                    "values": [
+                        {
+                            "id": 987654321,
+                            "name": "person subscribed",
+                            "steps": [{"event": "$pageview"}],
+                            "created_by": {
+                                "id": 1,
+                                "email": "employee@posthog.com",
+                                "first_name": "Real",
+                                "last_name": "Person",
+                            },
+                            "team_id": self.team.id,
+                            "post_to_slack": True,
+                        }
+                    ]
+                }
+            },
+        )
+        assert survey.actions.count() == 0  # the stale blob is the only source of the actions
+
+        value = SurveyAPISerializer(survey).data["conditions"]["actions"]["values"][0]
+        assert set(value.keys()) <= {"id", "name", "steps"}, value
+        assert "created_by" not in value
+        assert "team_id" not in value
+        assert "post_to_slack" not in value
+        assert value["name"] == "person subscribed"
+
     def test_can_set_associated_actions(self):
         user_subscribed_action = Action.objects.create(
             team=self.team,
@@ -4683,6 +4723,44 @@ class TestSurveyWithActions(APIBaseTest):
 
 
 @freeze_time("2024-12-12 00:00:00")
+class TestGetSurveyConditionsActionSanitization(SimpleTestCase):
+    def test_public_action_serializer_strips_non_public_fields_from_stale_blob(self) -> None:
+        # /decide PII leak guard (no DB): when the actions M2M is empty and
+        # get_survey_conditions_with_actions falls back to a stale conditions blob, it must project
+        # each value down to the caller serializer's own fields, so nothing extra (created_by,
+        # team_id, ...) reaches the public payload.
+        from products.surveys.backend.api.survey import SurveyAPIActionSerializer, get_survey_conditions_with_actions
+
+        class _EmptyActions:
+            def all(self) -> list:
+                return []
+
+        class _StubSurvey:
+            def __init__(self) -> None:
+                self.actions = _EmptyActions()
+                self.conditions = {
+                    "actions": {
+                        "values": [
+                            {
+                                "id": 1,
+                                "name": "person subscribed",
+                                "steps": [{"event": "$pageview"}],
+                                "created_by": {"id": 1, "email": "employee@posthog.com", "first_name": "Real"},
+                                "team_id": 5,
+                                "post_to_slack": True,
+                            }
+                        ]
+                    }
+                }
+
+        conditions = get_survey_conditions_with_actions(_StubSurvey(), SurveyAPIActionSerializer)  # type: ignore[arg-type]
+        assert conditions is not None
+        value = conditions["actions"]["values"][0]
+        assert set(value.keys()) <= {"id", "name", "steps"}, value
+        assert "created_by" not in value
+        assert value["name"] == "person subscribed"
+
+
 class TestSurveyResponseSampling(APIBaseTest):
     def _create_survey_with_sampling_limits(
         self,


### PR DESCRIPTION
## Problem

`get_survey_conditions_with_actions` re-serializes a survey's linked actions from the `actions` M2M when it's populated. But surveys also store an `actions` blob inside `conditions`, and the M2M is set from that blob's IDs. When those IDs don't resolve (e.g. the referenced action was deleted), the M2M ends up empty while the stale blob remains — and the function returned that blob verbatim.

For the public `SurveyAPISerializer` (served on `/api/surveys` and the `/decide` config), that meant the payload could carry fields the serializer never declares, because the stored blob can hold a full action object from an editor round-trip rather than the minimal public shape.

## Changes

- In the M2M-empty fallback, project each stored action value down to the caller serializer's own `Meta.fields`. The public serializer exposes `id`/`name`/`steps`, so the output now matches the serialized shape regardless of what the stale blob held. The authenticated path is unchanged.

## How did you test this code?

Automated. I'm an agent and did not do manual testing.

- Added a DB-free unit test on `get_survey_conditions_with_actions` (`TestGetSurveyConditionsActionSanitization`). Verified it **fails before the fix** (the stale blob's extra fields come through) and **passes after**.
- Added a DB-backed test on the real `SurveyAPISerializer` for a stale-blob survey (`TestSurveyWithActions`). This one I could not run locally — the dev ClickHouse was in a readonly/timeout state — so it's left for CI to confirm.

Regression caught: a survey whose action M2M is empty but whose `conditions` still holds a stored action blob. No existing test exercised that fallback path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom directed this. Authored by Claude Code (Opus 4.8). Skills invoked: `/improving-drf-endpoints` (serializer change) and `/writing-tests` (test value gate).

I traced the fallback to `_associate_actions`, which sets the M2M from the blob's IDs but doesn't strip the blob from `conditions`, so an unresolved ID leaves a stale blob behind. Chose to sanitize at the single read chokepoint (`get_survey_conditions_with_actions`) by projecting to the caller serializer's declared fields, rather than rewriting the stored data or the write path — it's minimal and correct for both the public and authenticated callers. Test-first: unit test failing, applied the fix, green.
