### PR TITLE
fix(navigation): hide custom product category headers at 5 items or fewer

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3053,9 +3053,9 @@ snapshots:
     layout-project-tree--all-products--light:
         hash: v1.k794b7964.c26cd26dbfc2bd1bd9d0f7d2b3ac7983793e350e6b542b24bd6e7473ad63b83b.uKplxPUSAHj6i9bnJBhUpIuA8Q4lRWdz4_xVGaktDMU
     layout-project-tree--default--dark:
-        hash: v1.k794b7964.8af756d3bb99c51708841e18852de6fbdc6430250eab17eb326c09f6ba42bda9.hCvLj9hzzRgTGh9EiE22hyKuFXUeqyPQFMm_WFilzCs
+        hash: v1.k794b7964.f4f9711fbb4dc3ee399130d90800a85f3340ef956400a0d153ed381c2b745993.TTkQwJ8WWysKBJ6Yfigp_NEJr4p_Mc4QoohX0x2vcvU
     layout-project-tree--default--light:
-        hash: v1.k794b7964.3924f8c86a0f027155ae9596d3e7ac4bf6bc2b048c4243b357a43770046880d2.RXhc3ex_tVwHbhgncJjeJwVrOd0jsQrkJavHArs_xvc
+        hash: v1.k794b7964.517be8bc4b4c90a8bff1d20d055b38e7b46c2f83a6a4642808a1616a06e5901f.2tXnzUt6RcxltdkCCChCwSW9g1XiOtV9uWPJxAY5ukM
     layout-project-tree--narrow-size--dark:
         hash: v1.k794b7964.4984586e16cd8aac358b4514206c944922d8eb00b67c104f98ee385e24e93ed1.DRpmX2SKWmPri2EvJqxmM_hEhNAHrxvPtDCke0RvciM
     layout-project-tree--narrow-size--light:
@@ -5561,7 +5561,7 @@ snapshots:
     scenes-app-dashboards--show-with-post-hog-ai-button-label--narrow--dark:
         hash: v1.k794b7964.4ea07e704d46a0495dbae82890a560c28670e24a9b71c6d63cdb1580151a5121.b_5FvU7MoXFArf7g9EhkXw0JiH3d-_Vmnbm3IR6gIcA
     scenes-app-dashboards--show-with-post-hog-ai-button-label--narrow--light:
-        hash: v1.k794b7964.d96e224f83bfe7ec92a0f61ba319b8c3373189f345f77120be9a12c22116fd02.I40DluW7O4DYLszEDuT88nhoMQtQjVaZUv5R9fkdWNw
+        hash: v1.k794b7964.e6a99deaafbd0220dbe5b084e809b2c09113f273c108b48ec57b6e37720edd52.0BGQiapG0F1x-wxc3GDV0H-f2u2BnuvjmryXRmFAG-U
     scenes-app-dashboards--show-with-post-hog-ai-button-label--superwide--dark:
         hash: v1.k794b7964.68a378f55241be720f381165043d30d595927581e0cb8a397e937bdaa25f78fc.Yk-xHi3W1TbkCiOLeqgTb_kYvzodmeG3UbvGlz56vj4
     scenes-app-dashboards--show-with-post-hog-ai-button-label--superwide--light:
@@ -7111,37 +7111,37 @@ snapshots:
     scenes-app-settings-user--settings-user-reminders-modal--light:
         hash: v1.k794b7964.fbcf3f0f69a5b43c28ea7537ce6f1aab3c21e70f9c2cbb6fdfef4546dadba86c.yYIPurSofuNP1kZXYzNBOa3YU5Zy7VLaSegvGrNZ8Mw
     scenes-app-sidepanels--side-panel-access-control--dark:
-        hash: v1.k794b7964.75d9a0a3295e5934ade86ea12368ce74cf49bb5ce5c09192537e5750585dcd71.50LYrEMMiQ1o7eIwNS3GjeSdu_jZYAYwksuWoubI-78
+        hash: v1.k794b7964.ab76b9589b4b7e1e1ca84725b693b53629f9309f9472966d360b87377f7a7f2c.zbWOHBcSUM1lyU4uwh85J9XpPlcKOJSDMvLJ33AQUAc
     scenes-app-sidepanels--side-panel-access-control--light:
-        hash: v1.k794b7964.e3a4bb21aef674776f6fdf5c87c11008e2cb7584739bc0f74cadf12bafeca954.dB07ACMnoVuyXrf4tlu7YdwsQg0EmuDsR-34tD_V3bw
+        hash: v1.k794b7964.2e00dbb1d898d398ff8f576ba65d9a2f8a6c828bde46df7ce8d82415dbecd4e4.TlXXdgdFnMaqSL3tyrjLvNGm8D4KDazrs0qyy7XuDHc
     scenes-app-sidepanels--side-panel-activity--dark:
-        hash: v1.k794b7964.8b040446695f50e30e55253fa564611abfc8ebb5255d6ef7ef120397129f037f.Qy8aPwN-EIIdZJHUHCSMcqGdPwBziRo0_YeBT8Vhnao
+        hash: v1.k794b7964.7e0a972f5f871f3d297961496d987279afb7492a590651b1c58e9c4b1970d467.kxzi1d-b51DcdDr2BOXtjMvGbfMrz-x5gSbIfA3fHgY
     scenes-app-sidepanels--side-panel-activity--light:
-        hash: v1.k794b7964.6628bf586917018da09ef0fd4dcf677f2ef7613230b6b9da4108b540e405dfb1.jU_GqmGFbCaVdt3zTZmJK24fKZrjayujaHVFPJDMV9U
+        hash: v1.k794b7964.8926af56d8ff83ce86572e5855559ae0430729e1d5e076affa2485ccf3b8a731.vo7CrYreqcAuSOgoDo8VUYQW8gwyDLlB7JZTzDGWfiY
     scenes-app-sidepanels--side-panel-discussion--dark:
-        hash: v1.k794b7964.1fb1a487b07b89e6d81b45cd5a1a9f1e141b9e1e5bac4679dd31606b2e8740b0.19viq6ZN3jDAi-LMIUXealK3LugR8uKWBL77XLRfD8c
+        hash: v1.k794b7964.91d8b06e77607161adbe5f388d2c2bf5349804805a025ef5e034808400da2659.L8ypfATQfuq6LLlmubjBMl2431q7vVCKcF-PbNRAJ5E
     scenes-app-sidepanels--side-panel-discussion--light:
-        hash: v1.k794b7964.7031c913ef187797a2ed6d87e542a50625e2c1d742ba7a1aa018872ebaaeb127.2uVIlBsVBP_jiL-T1CWQ6kek85z7DLQrOf3LpUiOt-U
+        hash: v1.k794b7964.4a35e6ab52e3e1f72b67caaf1069a75529c2a4fe0838c96099f9aac630c315e1.qqhLUdQ13n6oITHLeGeWq7FAemOi46tMEQXLkINsQ6g
     scenes-app-sidepanels--side-panel-exports--dark:
-        hash: v1.k794b7964.d31c7483918a80345d3a6087ab08fdc9957861510be767bf2f2310c8ea24bdc6.2KYblhJKrNwzgQnf5hhqpb2QYRosA7JT5LhJ5FSHfaA
+        hash: v1.k794b7964.fe7a8cd4b30ca44e34d86877cd2acf1e02ecf4ab8fe7e24f4cfc28d18e5d9a7e.mUc1KgNkww7ZJJ6gC5y1fQf95x0TiG-c4_ogL1LavxU
     scenes-app-sidepanels--side-panel-exports--light:
-        hash: v1.k794b7964.4e0558544e54b663466e3cc5471af58787f80e424c1362f19ce241e409fe6896.fn3ZlFCF1Y09Dahd7ELeTIEp-yj6tATjVkPZP0B90tU
+        hash: v1.k794b7964.ff380b03df8cb6ee5daca928d7b9a4222261924bc3dfbdb27ac0fb5269f9ed6a.-vbFJskzjgLHYMTL9V0EHxay4NFZFkkdgyt5Y1_9dfQ
     scenes-app-sidepanels--side-panel-info--dark:
-        hash: v1.k794b7964.75d9a0a3295e5934ade86ea12368ce74cf49bb5ce5c09192537e5750585dcd71.8XUhNuYljbI7mM9GGoyop7uV6QlNr1_1GespCPInHQ4
+        hash: v1.k794b7964.ab76b9589b4b7e1e1ca84725b693b53629f9309f9472966d360b87377f7a7f2c.GcaTLH1M9CtK59oIIJF-yE_WOqjJcZZ5eRUpa01zdjI
     scenes-app-sidepanels--side-panel-info--light:
-        hash: v1.k794b7964.e3a4bb21aef674776f6fdf5c87c11008e2cb7584739bc0f74cadf12bafeca954.TGBluQvOkUZGYgiUG53zuepsY-3nSNdNagFJ5XjqRz0
+        hash: v1.k794b7964.2e00dbb1d898d398ff8f576ba65d9a2f8a6c828bde46df7ce8d82415dbecd4e4.3X8XboxhJHndd-i_hEb1SjJiNNOrx_a6x5xV5xXm5Pc
     scenes-app-sidepanels--side-panel-max--dark:
-        hash: v1.k794b7964.75d9a0a3295e5934ade86ea12368ce74cf49bb5ce5c09192537e5750585dcd71.t9FIPCyPLXcst70dTav9enQ3EXWJvOTuXIafPZ8BxUo
+        hash: v1.k794b7964.ab76b9589b4b7e1e1ca84725b693b53629f9309f9472966d360b87377f7a7f2c.Fnya1jw63b86cgldD5P0qADIjXNHxMU3H4jVbVbDap8
     scenes-app-sidepanels--side-panel-max--light:
-        hash: v1.k794b7964.8982b205095b40e925775e82021f737fcb8dfb066ab2acdebeb747bcf3fc2441.0CaNwy_S3WhrqI5I3hWqwtcxJMU892f2FhNchtDhJCw
+        hash: v1.k794b7964.2f761d3053776fe71e4ded98da3c1298ed674559d620947afe4c5dd862dec04e.6D44uOYc298ot2_QgwUouvdBZUK__ejTwzE9InYoI3M
     scenes-app-sidepanels--side-panel-notebooks--dark:
-        hash: v1.k794b7964.f279c797117b03293ec8b5593b74d75537ebd000a948fe6aaaee0bb045d9fc0a.KQrzGwEsW_pOA72ILXbPY5qz9S-YLNKIIKM3MY-AnrY
+        hash: v1.k794b7964.7a06ad37e572b3198c73710450cc4e28e7c3099fd30858fab60ca5a40ff0a37c.iosKS3MwgnJ6vjBNTWB8jSFlU1_pgnb50eAO5do3zMc
     scenes-app-sidepanels--side-panel-notebooks--light:
-        hash: v1.k794b7964.3b738060f0a82c703258aef096c56bc429d70cf8e6611ce9669fec583ac90e99.yO6ilZ6TPFjWNF_xkrkyGCzR8IpG5MWbPp5atNvGT9A
+        hash: v1.k794b7964.7b25c66c82c3fc40b49a6d31a38da5a8c7629b409d3002f1b0a216a2221e66bb.xsMWO3z7bs3NKggn4rMDNmigeA2iVmLXFuehWuD3Afo
     scenes-app-sidepanels--side-panel-support--dark:
-        hash: v1.k794b7964.220b0da2325a5c600b217d9e06d9ec871e14b5ddaf57f7d63203a8f762fa42bd.7ROM87CPLFyenH0MF2b5iQ6qxAQdMJvf8dETokiYrOM
+        hash: v1.k794b7964.28a02f4270bc87964944d614522f6512c530906de7c72ac635f8154e802943d0.GQNNBUsCcwGYXzNSgZXeGTXZ2RZLL_Q4y2VUodztSfI
     scenes-app-sidepanels--side-panel-support--light:
-        hash: v1.k794b7964.00d74aa61dfc093adbe4517776e510a47cdf75cd7f5931eeab5fb34f8ccfd560.nUFvZsCTBH-oNUaRqLdU0DuOG4x332lN7_IREb8K-n8
+        hash: v1.k794b7964.6f4d33da3ded2438fd7c5bd5b618cc1caf2e355b004b421e78120d33d2c15f8b.6tfLPSZ6q3T8jCH-J6mWbTwIolu2uJ3zyRDL7A3Lpto
     scenes-app-subscriptions-subscription-delivery-history--empty--dark:
         hash: v1.k794b7964.267363ce3a0453be58b96ef2c00446ae4aaf5ed42b02472c495b3c468f25e18f.PmJd-8ou979ieSrNpJQ2DxtM8Tnqs7jtvU6k-2rpr2w
     scenes-app-subscriptions-subscription-delivery-history--empty--light:
@@ -7351,17 +7351,17 @@ snapshots:
     scenes-app-visual-review-run--tracking-only-master-run--light:
         hash: v1.k794b7964.82f2750059b1ef9ab2adb777da603d4d0985b7213235780f24377be11e601a5e.BdVEZ3jDXINsbZgssAvaGfjq_qmGcGOqm2AhdvSYmXg
     scenes-app-web-analytics--web-analytics-dashboard--dark:
-        hash: v1.k794b7964.4943d4f2d8c1f5ee6b3718c290c548b6c455386398425994489f4282f44378d0.KIJ1bXqO1n1C8mT7pkG4JrDAtOoyCapmsZFWaVwgevc
+        hash: v1.k794b7964.b8f3c46ceb7184a09413f1690b14e2aa7a2ab69e0c7d5e4a88831b0ab2c0bc1e.AmbpQANFdxUBMXYgPcyjAdkJx0PgbWYWgUlPMhLe5AM
     scenes-app-web-analytics--web-analytics-dashboard--light:
-        hash: v1.k794b7964.17e5ad5877b77a22efc419c7c20cadd283ecbdbea0881bc46450fa5d9ab49c54.9KTUuD6_GGo5OTbK3oX4mASI7IVxNmke7E6yhvzBQEY
+        hash: v1.k794b7964.125ddde8a36a86a1afca4e0f0087f66233fe71290705cdfc0bdd01f3032e212a.fINztkH45Ovv9xKzbsOvdKe5BnXaJAUdDpf-P3ifyXc
     scenes-app-web-analytics--web-analytics-dashboard-loading--dark:
-        hash: v1.k794b7964.b013feb2079b7ea61e8729fa6dba5eaa004649c6605d055853f0e19c5b364436.EBImZsjSWcoLJsL83AAxzuqFX6hk_vu7QXICQPun8q0
+        hash: v1.k794b7964.0c540b30c4131b7a443a9176ea31b1d148958071fbedec368b688db607e3292d.gXEHVDOq7woSy4fAiUiZVbRUaiPoJYxX3W3nkM49Cw4
     scenes-app-web-analytics--web-analytics-dashboard-loading--light:
-        hash: v1.k794b7964.3e03b4395a4ecfa030b723ba7c0096738911ab6ded9aef857fb5b8a3d1732f13.qL5yYKkJ8OZQns8BF3wXY-bAjQklSsupd2D6Q3N1nVM
+        hash: v1.k794b7964.5c60f267b548fd160974349d81416aff28a67d7ffa5dccb8d089aacb1e508d09.xfEvFiIWkpFanGkg5rZKbB-fMpAXRWy6617NeawKp2Q
     scenes-app-web-analytics--web-analytics-dashboard-metric-cards--dark:
-        hash: v1.k794b7964.31877d6979aba7f0b50bab1fdc625f1f9734e09dd3ac267a7610350f182dd8a4.-DQx-qsS_w-sQucWQkDddaqLhbhvm9xLlYoky3AUSgE
+        hash: v1.k794b7964.badf3caf9ac303168d6991dc3d1f35e1443e1347e8ee3bd208e2302da2f92c00._ZnyJ86nJYoE0_prJTMniCmZUVu1yu0m7VEFA5-hXdk
     scenes-app-web-analytics--web-analytics-dashboard-metric-cards--light:
-        hash: v1.k794b7964.883ee01bd37750a07a948987f6913617492ecd5f12f40f29eef0b2eb89f11ed0.m_z4rlGAD6V9gQkIxWFBs7_9bGI7TfYCxkFVq-TmAHY
+        hash: v1.k794b7964.37b843b19edad6a8cb55c1214386d5910708fda7eadbac15830696a1d3f89742.bfR4KAm2FINsp4lSF840psU3qzPdeuXwqBZOjZ1W_ig
     scenes-app-web-analytics-achievements--daily-only-arm--dark:
         hash: v1.k794b7964.8f024a521e113d8101749768f8d4f49d8dcac1365f43d9b2038c6df0021bac6a.BYx467NAatau4dzb13PnZCTODi-yUho-Vhm_JdtCY9w
     scenes-app-web-analytics-achievements--daily-only-arm--light:

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -1599,7 +1599,7 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                         searchTerm,
                         // With only a few tools pinned, category headers add more noise than structure —
                         // list them in sequence instead.
-                        disableCategories: imports.length < 5,
+                        disableCategories: imports.length <= 5,
                         disabledReason: (item) => getProductAccessDisabledReason(item as FileSystemImport),
                     })
                 }


### PR DESCRIPTION
## Problem

In the left project tree sidebar, the "Custom products" list groups pinned tools under category headers (Analytics, Behavior, AI engineering, etc.). Those headers are meant to disappear when a user has only a handful of items pinned, since with a short list they add noise rather than structure. But they were still showing for users with exactly 5 items.

## Changes

The guard that disables category headers used `imports.length < 5`, which only hid headers at 4 items or fewer. With exactly 5 items the condition was false and headers rendered. Changed it to `<= 5` so "5 items or less" behaves as intended and lists the tools in sequence without headers.

## How did you test this code?

Change is a one-character boundary fix (`<` to `<=`) in `disableCategories`. I (Claude) did not run the app manually. The existing `disableCategories` path in `utils.tsx` already handles the flat-list rendering; only the threshold moved.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Rafael reported that the sidebar was still showing category headers for users at the 5-item mark, and recalled a past PR meant to suppress them. I traced it to an off-by-one in `getCustomProductTreeItems` (`projectTreeDataLogic.tsx`) where `imports.length < 5` excludes the boundary case of exactly 5. Fixed by switching to `<= 5`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
