### PR TITLE
fix(mcp-analytics): fall back to lemon date picker behind quill flag

### DIFF
--- a/products/mcp_analytics/frontend/components/McpDateFilter.tsx
+++ b/products/mcp_analytics/frontend/components/McpDateFilter.tsx
@@ -10,7 +10,9 @@ import {
 } from '@posthog/quill-components'
 import { Button, Popover, PopoverContent, PopoverTrigger } from '@posthog/quill-primitives'
 
+import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { dayjs } from 'lib/dayjs'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 
 // Quick ranges that translate to PostHog relative date strings, so queries stay
 // rolling ("-7d" re-resolves on every load). Minute-level ranges are omitted on
@@ -63,7 +65,18 @@ interface McpDateFilterProps {
     dataAttr: string
 }
 
-export function McpDateFilter({ dateFrom, dateTo, onChange, dataAttr }: McpDateFilterProps): JSX.Element {
+export function McpDateFilter(props: McpDateFilterProps): JSX.Element {
+    // Quill's DateTimePicker is still behind the QUILL_DATE_PICKER flag; fall back to the LemonUI
+    // DateFilter everywhere else so the picker matches the rest of the app until quill is fully rolled out.
+    const quillEnabled = useFeatureFlag('QUILL_DATE_PICKER')
+    return quillEnabled ? <McpDateFilterQuill {...props} /> : <McpDateFilterLemon {...props} />
+}
+
+function McpDateFilterLemon({ dateFrom, dateTo, onChange }: McpDateFilterProps): JSX.Element {
+    return <DateFilter dateFrom={dateFrom} dateTo={dateTo} onChange={(from, to) => onChange(from, to)} />
+}
+
+function McpDateFilterQuill({ dateFrom, dateTo, onChange, dataAttr }: McpDateFilterProps): JSX.Element {
     const [open, setOpen] = useState(false)
     const value = toPickerValue(dateFrom, dateTo)
 


### PR DESCRIPTION
## Problem

The date picker in MCP Analytics was showing the in-progress quill `DateTimePicker` for everyone the product is enabled for — the gray header/footer, auto-open tooltip, and a trigger button that's neither fully quill nor lemon. That quill picker isn't ready for general use yet; the rest of the app still shows the LemonUI picker unless the `quill-date-picker` flag is on.

## Changes

`McpDateFilter` imported and rendered quill's `DateTimePicker` unconditionally, so it never respected the `QUILL_DATE_PICKER` rollout that gates the shared `lib/components/DatePicker` seam. It now checks that same flag: quill picker when on, LemonUI `DateFilter` when off (the default). No behavior change for anyone already on the flag.

## Why

MCP Analytics should show the standard lemon date picker like the rest of the app until quill is fully rolled out, instead of a half-finished picker.

## How did you test this code?

Ran `pnpm --filter=@posthog/frontend typescript:check` (passes) and formatted with oxfmt. No automated tests added — this is a small flag-gating change on presentation. I did not run the app manually.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Traced the MCP Analytics date-picker call sites to the bespoke `McpDateFilter` wrapper, confirmed it hardcoded the quill picker and bypassed the `QUILL_DATE_PICKER` seam used elsewhere, and gated it on that flag with a LemonUI `DateFilter` fallback (a range picker matching the component's `dateFrom`/`dateTo` string contract, since the shared `lib/components/DatePicker` seam is single-date only).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1784656144936889?thread_ts=1784656144.936889&cid=C0B3E1Y576X)*