### PR TITLE
refactor(query): split cache serving into load and per-state dispatch

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1376,6 +1376,9 @@ R = TypeVar("R", bound=BaseModel)
 # CR (for CachedResponse) must be R extended with CachedQueryResponseMixin
 # Unfortunately inheritance is also not a thing here, because we lose this info in the schema.ts->.json->.py journey
 CR = TypeVar("CR", bound=GenericCachedQueryResponse)
+# SR (for ServableResponse): anything the cache-serving path can return directly — a cached result
+# or an explicit miss
+SR = TypeVar("SR", bound=GenericCachedQueryResponse | CacheMissResponse)
 
 
 class QueryRunner(ABC, Generic[Q, R, CR]):
@@ -1547,8 +1550,47 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         user: Optional[User] = None,
         analytics_props: Optional[AnalyticsProps] = None,
     ) -> Optional[CR | CacheMissResponse]:
+        """Serve the query from cache when the execution mode allows it.
+
+        Returns None when the caller should proceed to a blocking calculation."""
+        cached_response = self._load_cached_response(cache_manager)
+        served: Optional[CR | CacheMissResponse]
+
+        if isinstance(cached_response, CacheMissResponse):
+            count_query_cache_hit(self.team.pk, hit="miss", trigger="")
+            served = self._handle_cache_miss(execution_mode, cached_response, cache_manager, user, analytics_props)
+        else:
+            # Apply current query's custom_name values to cached response
+            # (custom_name is excluded from cache key, so cached values may be stale)
+            cached_response, custom_names_modified = self.apply_series_custom_names(cached_response)
+
+            if custom_names_modified:
+                # Update cache with patched response so subsequent requests get the updated names
+                cache_manager.set_cache_data(
+                    response=cached_response.model_dump(),
+                    target_age=cached_response.cache_target_age,
+                )
+
+            if not self._is_stale_for_request(last_refresh=last_refresh_from_cached_result(cached_response)):
+                count_query_cache_hit(self.team.pk, hit="hit", trigger=cached_response.calculation_trigger or "")
+                # We have a valid result that's fresh enough, let's return it
+                return self._attach_async_query_status(cached_response, cache_manager)
+
+            count_query_cache_hit(self.team.pk, hit="stale", trigger=cached_response.calculation_trigger or "")
+            served = self._handle_stale_cache(execution_mode, cached_response, cache_manager, user, analytics_props)
+
+        if served is None:
+            # Nothing useful out of cache, nor async query status. A recomputation follows, so the
+            # cached raw results (if any) must not leak onto the fresh response.
+            self.raw_cached_results_bytes = None
+        return served
+
+    def _load_cached_response(self, cache_manager: QueryCacheManagerBase) -> CR | CacheMissResponse:
+        """Fetch and parse the cached response, mapping anything unusable to a CacheMissResponse.
+
+        When serving raw cached results, also stashes the unparsed results payload on
+        self.raw_cached_results_bytes."""
         CachedResponse: type[CR] = self.cached_response_type
-        cached_response: CR | CacheMissResponse
         cached_response_candidate: Optional[dict]
         self.raw_cached_results_bytes = None
         raw_results: Optional[bytes] = None
@@ -1559,7 +1601,7 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             # model-typed results, e.g. retention, validating a `[]` placeholder would bypass
             # the schema-drift check that triggers recomputation) AND neither the query nor
             # the cached results carry custom series names — otherwise
-            # apply_series_custom_names below must be able to patch the parsed results.
+            # apply_series_custom_names must be able to patch the parsed results.
             split_candidate = cache_manager.get_cache_data_split()
             if split_candidate is None:
                 cached_response_candidate = None
@@ -1588,82 +1630,76 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
                 cached_response = CachedResponse(**cached_response_candidate)
                 if raw_results is not None:
                     self.raw_cached_results_bytes = raw_results
+                return cached_response
             except Exception as e:
                 capture_exception(Exception(f"Error parsing cached response: {e}"))
-                cached_response = CacheMissResponse(cache_key=cache_manager.cache_key)
-        elif cached_response_candidate is None:
-            cached_response = CacheMissResponse(cache_key=cache_manager.cache_key)
-        else:
-            # Whatever's in cache is malformed, so let's treat is as non-existent
-            cached_response = CacheMissResponse(cache_key=cache_manager.cache_key)
+                return CacheMissResponse(cache_key=cache_manager.cache_key)
+        if cached_response_candidate is not None:
+            # Whatever's in cache is malformed, so let's treat it as non-existent
             capture_exception(
-                ValueError(f"Cached response is of unexpected type {type(cached_response)}, ignoring it"),
+                ValueError(f"Cached response is of unexpected type {type(cached_response_candidate)}, ignoring it"),
                 {"cache_key": cache_manager.cache_key},
             )
+        return CacheMissResponse(cache_key=cache_manager.cache_key)
 
-        if isinstance(cached_response, CachedResponse):
-            # Apply current query's custom_name values to cached response
-            # (custom_name is excluded from cache key, so cached values may be stale)
-            cached_response, custom_names_modified = self.apply_series_custom_names(cached_response)
-
-            if custom_names_modified:
-                # Update cache with patched response so subsequent requests get the updated names
-                cache_manager.set_cache_data(
-                    response=cached_response.model_dump(),
-                    target_age=cached_response.cache_target_age,
-                )
-
-            if not self._is_stale_for_request(last_refresh=last_refresh_from_cached_result(cached_response)):
-                count_query_cache_hit(self.team.pk, hit="hit", trigger=cached_response.calculation_trigger or "")
-                # We have a valid result that's fresh enough, let's return it
-                cached_response.query_status = self.get_async_query_status(cache_key=cache_manager.cache_key)
-                return cached_response
-
-            count_query_cache_hit(self.team.pk, hit="stale", trigger=cached_response.calculation_trigger or "")
-            # We have a stale result. If we aren't allowed to calculate, let's still return it
-            # – otherwise let's proceed to calculation
-            if execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
-                cached_response.query_status = self.get_async_query_status(cache_key=cache_manager.cache_key)
-                return cached_response
-            elif execution_mode in (
-                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
-                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
-            ):
-                # We're allowed to calculate, but we'll do it asynchronously and attach the query status
-                cached_response.query_status = self.enqueue_async_calculation(
-                    cache_manager=cache_manager, user=user, refresh_requested=True, analytics_props=analytics_props
-                )
-                return cached_response
-            elif execution_mode == ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE:
-                # We're allowed to calculate if the lazy check fails, but we'll do it asynchronously
-                assert isinstance(cached_response, CachedResponse)
-                if self._is_stale_for_request(last_refresh=last_refresh_from_cached_result(cached_response), lazy=True):
-                    cached_response.query_status = self.enqueue_async_calculation(
-                        cache_manager=cache_manager, user=user, analytics_props=analytics_props
-                    )
-                cached_response.query_status = self.get_async_query_status(cache_key=cache_manager.cache_key)
-                return cached_response
-        else:
-            count_query_cache_hit(self.team.pk, hit="miss", trigger="")
-            # We have no cached result. If we aren't allowed to calculate, let's return the cache miss
-            # – otherwise let's proceed to calculation
-            if execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
-                cached_response.query_status = self.get_async_query_status(cache_key=cache_manager.cache_key)
-                return cached_response
-            elif execution_mode in (
-                ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
-                ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE,
-            ):
-                # We're allowed to calculate, but we'll do it asynchronously
-                cached_response.query_status = self.enqueue_async_calculation(
-                    cache_manager=cache_manager, user=user, analytics_props=analytics_props
-                )
-                return cached_response
-
-        # Nothing useful out of cache, nor async query status. A recomputation follows, so the
-        # cached raw results (if any) must not leak onto the fresh response.
-        self.raw_cached_results_bytes = None
+    def _handle_stale_cache(
+        self,
+        execution_mode: ExecutionMode,
+        cached_response: CR,
+        cache_manager: QueryCacheManagerBase,
+        user: Optional[User],
+        analytics_props: Optional[AnalyticsProps],
+    ) -> Optional[CR]:
+        """We have a stale result. Serve it, kicking off an async recalculation when the mode
+        allows one — or return None to proceed to a blocking recalculation."""
+        if execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
+            # We aren't allowed to calculate, let's still return the stale result
+            return self._attach_async_query_status(cached_response, cache_manager)
+        if execution_mode in (
+            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+        ):
+            # We're allowed to calculate, but we'll do it asynchronously and attach the query status
+            cached_response.query_status = self.enqueue_async_calculation(
+                cache_manager=cache_manager, user=user, refresh_requested=True, analytics_props=analytics_props
+            )
+            return cached_response
+        if execution_mode == ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE:
+            # We're allowed to calculate if the lazy check fails, but we'll do it asynchronously
+            if self._is_stale_for_request(last_refresh=last_refresh_from_cached_result(cached_response), lazy=True):
+                self.enqueue_async_calculation(cache_manager=cache_manager, user=user, analytics_props=analytics_props)
+            return self._attach_async_query_status(cached_response, cache_manager)
+        # A blocking mode: recalculate synchronously
         return None
+
+    def _handle_cache_miss(
+        self,
+        execution_mode: ExecutionMode,
+        miss_response: CacheMissResponse,
+        cache_manager: QueryCacheManagerBase,
+        user: Optional[User],
+        analytics_props: Optional[AnalyticsProps],
+    ) -> Optional[CacheMissResponse]:
+        """We have no cached result. Serve the miss, kicking off an async calculation when the
+        mode allows one — or return None to proceed to a blocking calculation."""
+        if execution_mode == ExecutionMode.CACHE_ONLY_NEVER_CALCULATE:
+            # We aren't allowed to calculate, let's return the cache miss
+            return self._attach_async_query_status(miss_response, cache_manager)
+        if execution_mode in (
+            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+            ExecutionMode.EXTENDED_CACHE_CALCULATE_ASYNC_IF_STALE,
+        ):
+            # We're allowed to calculate, but we'll do it asynchronously
+            miss_response.query_status = self.enqueue_async_calculation(
+                cache_manager=cache_manager, user=user, analytics_props=analytics_props
+            )
+            return miss_response
+        # A blocking mode: calculate synchronously
+        return None
+
+    def _attach_async_query_status(self, response: SR, cache_manager: QueryCacheManagerBase) -> SR:
+        response.query_status = self.get_async_query_status(cache_key=cache_manager.cache_key)
+        return response
 
     def _call_with_rate_limits(self, *, dashboard_id: Optional[int]) -> tuple[R, float]:
         """Execute calculate() with all rate limiters applied.


### PR DESCRIPTION
## Problem

`handle_cache_and_async_logic` in `query_runner.py` has grown into a ~130-line method doing four jobs at once: fetching and parsing the cached payload (with the raw-bytes fast path), patching custom series names, the freshness check, and two parallel execution-mode ladders whose implicit fall-through means "go run a blocking calculation".

Anything that hooks into the serve-or-calculate decision has to weave itself through both ladders. The query failure breaker in #72777 ended up touching five separate points inside this one method, which was the signal that the structure needs simplifying before more gets added to it.

## Changes

Pure structural refactor of the cache-serving path, no behavior change:

- `_load_cached_response` owns fetch + parse + raw-bytes handling, and maps anything unusable (missing, malformed, schema drift) to a `CacheMissResponse`
- `_handle_stale_cache` and `_handle_cache_miss` each own one dispatch decision, with an explicit contract: return a response to serve, or `None` to proceed to a blocking calculation
- `_attach_async_query_status` replaces the repeated `query_status = self.get_async_query_status(...)` + return boilerplate (five copies)
- `handle_cache_and_async_logic` itself is now ~35 lines that read as the flow: load, then hit? patch names, fresh? serve. Otherwise resolve stale or miss

Only intended observable delta: the malformed-cache telemetry message now reports the actual cached value's type. It previously logged `type(cached_response)` right after `cached_response` had been reassigned to the replacement `CacheMissResponse`, so it always said `CacheMissResponse`.

## How did you test this code?

No new tests, this is a behavior-preserving refactor pinned by the existing suite. `posthog/hogql_queries/test/test_query_runner.py` (89 tests) passes, covering cache hit/stale/miss across every execution mode through `run()`. Repo-wide `uv run mypy --cache-fine-grained .` is clean (16,597 files).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, internal refactor with no user-facing or API change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Extracted by Claude (PostHog Code) as a precursor to #72777 after Andy flagged that the caching logic should be simplified before more behavior is layered onto it. The alternative considered was a declarative mode-to-policy table, rejected as more indirection than the two mirrored resolvers it would replace. #72777 will be rebased onto this branch so the breaker integrates through the new seams (one veto point per resolver instead of five inline blocks).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*