### PR TITLE
feat(cdp): emit per-type bounce sub-metrics for SES bounces

### DIFF
--- a/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -350,7 +350,8 @@ describe('EmailTrackingService', () => {
                 })
 
                 const metrics = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-                expect(metrics).toHaveLength(1)
+                // Permanent bounces emit the rollup plus the hard-only sub-metric
+                expect(metrics.map((m) => m.value.metric_name)).toEqual(['email_bounced', 'email_bounced_hard'])
                 expect(metrics[0].value).toMatchObject({
                     team_id: team.id,
                     metric_name: 'email_bounced',
@@ -364,7 +365,8 @@ describe('EmailTrackingService', () => {
 
                 await waitForExpect(() => {
                     const metrics = mockProducerObserver.getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
-                    expect(metrics).toHaveLength(1)
+                    // Permanent bounces emit the rollup plus the hard-only sub-metric
+                    expect(metrics.map((m) => m.value.metric_name)).toEqual(['email_bounced', 'email_bounced_hard'])
                     expect(metrics[0].value).toMatchObject({
                         team_id: team.id,
                         metric_name: 'email_bounced',

--- a/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
@@ -351,7 +351,7 @@ describe('SesWebhookHandler', () => {
         const result = await handler.handleWebhook({ body, headers: {} })
         expect(result.status).toBe(200)
         // Transient bounces must NOT emit email_bounced_hard — AWS's account rate excludes them
-        expect(result.metrics?.map((m) => m.metricName)).toEqual(['email_bounced'])
+        expect(result.metrics?.map((m) => m.metricName)).toEqual(['email_bounced', 'email_bounced_transient'])
         expect(result.metrics?.[0].distinctId).toBe('user-123')
         expect(result.hardBounceRecipients).toEqual([])
         expect(result.transientBounceRecipients).toEqual([

--- a/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
@@ -324,7 +324,8 @@ describe('SesWebhookHandler', () => {
         ]
         const result = await handler.handleWebhook({ body, headers: {} })
         expect(result.status).toBe(200)
-        expect(result.metrics?.[0].metricName).toBe('email_bounced')
+        // Hard bounces emit both the catch-all metric and the AWS-comparable hard-only one
+        expect(result.metrics?.map((m) => m.metricName)).toEqual(['email_bounced', 'email_bounced_hard'])
         expect(result.metrics?.[0].distinctId).toBe('user-123')
         expect(result.hardBounceRecipients).toEqual([
             { teamId: '1', emailAddresses: ['to@example.com'], diagnostic: 'bad' },
@@ -349,7 +350,8 @@ describe('SesWebhookHandler', () => {
         ]
         const result = await handler.handleWebhook({ body, headers: {} })
         expect(result.status).toBe(200)
-        expect(result.metrics?.[0].metricName).toBe('email_bounced')
+        // Transient bounces must NOT emit email_bounced_hard — AWS's account rate excludes them
+        expect(result.metrics?.map((m) => m.metricName)).toEqual(['email_bounced'])
         expect(result.metrics?.[0].distinctId).toBe('user-123')
         expect(result.hardBounceRecipients).toEqual([])
         expect(result.transientBounceRecipients).toEqual([

--- a/nodejs/src/cdp/services/messaging/helpers/ses.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.ts
@@ -153,6 +153,13 @@ export type SesEventRecord = z.infer<typeof SesEventRecordSchema>
 
 // email_sent is recorded synchronously in email.service.ts when the email is sent,
 // so we don't record it again from SES Send webhooks to avoid double counting.
+const BOUNCE_TYPE_TO_METRIC_NAME: Record<'Permanent' | 'Transient' | 'Undetermined', MinimalAppMetric['metric_name']> =
+    {
+        Permanent: 'email_bounced_hard',
+        Transient: 'email_bounced_transient',
+        Undetermined: 'email_bounced_undetermined',
+    }
+
 const EVENT_TYPE_TO_METRIC_NAME: Partial<Record<SesEventRecord['eventType'], MinimalAppMetric['metric_name']>> = {
     Open: 'email_opened',
     Click: 'email_link_clicked',
@@ -594,18 +601,19 @@ export class SesWebhookHandler {
                     timestamp,
                 })
 
-                // email_bounced counts every bounce type, but AWS's account bounce rate — the
-                // number the email reputation feature is calibrated against — counts only hard
-                // (Permanent) bounces. Emit those additionally under their own metric so
-                // reputation can match AWS without changing email_bounced for its consumers.
-                if (rec.eventType === 'Bounce' && rec.bounce.bounceType === 'Permanent') {
+                // email_bounced stays the catch-all rollup; each bounce additionally emits a
+                // per-type sub-metric (hard + transient + undetermined = email_bounced). AWS's
+                // account bounce rate — what the email reputation feature calibrates against —
+                // counts only hard (Permanent) bounces, so reputation reads email_bounced_hard;
+                // the others exist for diagnosis (transient spikes are a leading indicator).
+                if (rec.eventType === 'Bounce') {
                     metrics.push({
                         functionId,
                         invocationId,
                         actionId,
                         parentRunId,
                         distinctId,
-                        metricName: 'email_bounced_hard',
+                        metricName: BOUNCE_TYPE_TO_METRIC_NAME[rec.bounce.bounceType],
                         properties,
                         timestamp,
                     })

--- a/nodejs/src/cdp/services/messaging/helpers/ses.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.ts
@@ -593,6 +593,23 @@ export class SesWebhookHandler {
                     properties,
                     timestamp,
                 })
+
+                // email_bounced counts every bounce type, but AWS's account bounce rate — the
+                // number the email reputation feature is calibrated against — counts only hard
+                // (Permanent) bounces. Emit those additionally under their own metric so
+                // reputation can match AWS without changing email_bounced for its consumers.
+                if (rec.eventType === 'Bounce' && rec.bounce.bounceType === 'Permanent') {
+                    metrics.push({
+                        functionId,
+                        invocationId,
+                        actionId,
+                        parentRunId,
+                        distinctId,
+                        metricName: 'email_bounced_hard',
+                        properties,
+                        timestamp,
+                    })
+                }
             }
 
             // Allowlist actionId before interpolating into the [Action:…] rich-log token,

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -237,6 +237,8 @@ export type MinimalAppMetric = {
         | 'email_link_clicked'
         | 'email_bounced'
         | 'email_bounced_hard'
+        | 'email_bounced_transient'
+        | 'email_bounced_undetermined'
         | 'email_bounce_prevented'
         | 'email_suppressed'
         | 'email_blocked'

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -236,6 +236,7 @@ export type MinimalAppMetric = {
         | 'email_opened'
         | 'email_link_clicked'
         | 'email_bounced'
+        | 'email_bounced_hard'
         | 'email_bounce_prevented'
         | 'email_suppressed'
         | 'email_blocked'


### PR DESCRIPTION
## Problem

`email_bounced` counts every SES bounce type in one metric, but AWS's account-level bounce rate - the number the email reputation feature ([#72545](https://github.com/PostHog/posthog/pull/72545)) calibrates its thresholds against - counts **hard (Permanent) bounces only**. Transient traffic (greylisting, mailbox-full) therefore inflates our measured rate relative to what AWS actually holds against the shared sending account: a sender with 1.5% hard + 1% transient reads 2.5% on our score while AWS sees 1.5%.

## Changes

Every SES bounce now emits **one sub-metric by `bounceType` in addition to** the unchanged `email_bounced` rollup:

- `Permanent` → `email_bounced_hard`
- `Transient` → `email_bounced_transient`
- `Undetermined` → `email_bounced_undetermined`

So `hard + transient + undetermined = email_bounced` exactly. Purely additive: every existing `email_bounced` consumer (workflow Metrics tab, exports) is unaffected, and none of the sub-metrics surface in the Metrics UI (it renders from an explicit allowlist). The reputation evaluator reads `email_bounced_hard` (change already on #72545); transient/undetermined exist for diagnosis - a transient spike is a leading indicator of slipping sender reputation.

Deploy-order note: this should merge and deploy **ahead of** the evaluator going live - hard-bounce data only accumulates from this deploy forward, and the evaluator's send-volume window can reach back up to 30 days, so low-volume senders' scores undercount bounces until their window is covered by post-deploy data (high-volume senders are accurate within a day). Undercounting is the tolerable direction while the score is visibility-only.

(Previously folded into #72543; pulled back out because the migration-vs-service-code CI check correctly rejects mixing a migration with service changes in one PR.)

## How did you test this code?

I'm an agent; checks actually run: extended the two existing SES webhook bounce tests to pin the split (Permanent emits `['email_bounced', 'email_bounced_hard']`, Transient emits `['email_bounced', 'email_bounced_transient']` - the exact regressions that would mis-calibrate reputation), full ses.test.ts suite (44 tests) green, Node tsc clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Additive sub-metrics chosen over changing `email_bounced` semantics (would break every current consumer) after review discussion on #72545; three explicit buckets over folding Undetermined into transient so the sum invariant is exact.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
