### PR TITLE
fix(tasks): start inbox discuss and detail-page runs in interactive mode

### DIFF
--- a/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
+++ b/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
@@ -7,7 +7,7 @@ import api from 'lib/api'
 import { urls } from 'scenes/urls'
 
 import { OriginProduct } from 'products/posthog_ai/frontend/types/taskTypes'
-import { RunSourceEnumApi } from 'products/tasks/frontend/generated/api.schemas'
+import { RunSourceEnumApi, TaskExecutionModeEnumApi } from 'products/tasks/frontend/generated/api.schemas'
 
 import {
     SIGNAL_REPORT_TASK_DISCUSSION_RELATIONSHIP,
@@ -93,6 +93,10 @@ async function createReportTask(
     await api.tasks.run(task.id, {
         run_source: RunSourceEnumApi.SignalReport,
         signal_report_id: report.id,
+        // Interactive, not the default background: the user lands on the run page right away, and the
+        // agent-server only relays AskUserQuestion (and other approval prompts) to the client on
+        // non-background runs — a background run's questions are parked and never rendered as a form.
+        mode: TaskExecutionModeEnumApi.Interactive,
     })
 
     router.actions.push(urls.taskDetail(task.id))

--- a/products/posthog_ai/frontend/logics/taskLogic.ts
+++ b/products/posthog_ai/frontend/logics/taskLogic.ts
@@ -4,6 +4,8 @@ import { router } from 'kea-router'
 
 import api from 'lib/api'
 
+import { TaskExecutionModeEnumApi } from 'products/tasks/frontend/generated/api.schemas'
+
 import { isApiNotFound, loadErrorMessage } from '../lib/load-error'
 import { phDebugQueryParams } from '../lib/ph-debug'
 import { Task, type TaskUpsertProps } from '../types/taskTypes'
@@ -115,7 +117,10 @@ export const taskLogic = kea<taskLogicType>([
                     }
                 },
                 runTask: async () => {
-                    return await api.tasks.run(props.taskId)
+                    // Interactive, not the default background: this run starts from the detail page the user
+                    // is watching, and the agent-server only relays AskUserQuestion (and other approval
+                    // prompts) to the client on non-background runs.
+                    return await api.tasks.run(props.taskId, { mode: TaskExecutionModeEnumApi.Interactive })
                 },
                 deleteTask: async () => {
                     await api.tasks.delete(props.taskId)


### PR DESCRIPTION
## Problem

Tasks kicked off from the inbox report Discuss / Create PR actions, and re-runs from the task detail page Run button, call the task run endpoint without a `mode`, which defaults to `background`.

The sandbox agent-server only relays `AskUserQuestion` (and other approval prompts) to the client on non-background runs. On a background run the question is parked with a prompt instruction (or on older agent-server builds falls through to an answerless auto-approve), so the interactive question form never renders in the run view and the model can end up answering its own question instead of waiting for the user. Origin: [Slack thread](https://posthog.slack.com/archives/C07R2BCPX2R).

## Changes

Both flows land the user on the live run page, so they now pass `mode: 'interactive'` explicitly, matching what the `/tasks` composer already does:

- `frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts` – Discuss / Create PR from a report
- `products/posthog_ai/frontend/logics/taskLogic.ts` – the Run button on the task detail page (its only caller)

Interactive mode also keeps the event stream open across turns, which these follow-up-style conversations want anyway.

> [!NOTE]
> This is the client-side half. The robust fix (relaying questions on background runs regardless of execution mode) lives in the agent-server and is being planned separately.

## How did you test this code?

Oxlint and oxfmt pass on both files. `typescript:check` fails only on pre-existing master breakage in untouched files (`ai_observability` evaluation types, `registerDataToolRenderers`). No new tests: the only assertable behavior is the mocked request payload, which the generated types already constrain. I did not manually test the inbox flow end to end.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) investigated why the AskQuestion form never displayed for a discuss-origin task: traced the run creation path (run serializer defaults `mode` to background) and the agent-server permission relay (questions are only relayed on non-background runs), confirmed the frontend renders question frames correctly in every permission mode, then applied this minimal client-side fix. A separate implementation plan for the agent-server side (relay questions on background runs with a bounded wait) was produced for the agent repo. Session: https://claude.ai/code/session_01LLpQHnwCh8EB1XxSVVkCP2