### PR TITLE
fix(mcp): document insight description limit and clarify rejection

### DIFF
--- a/products/product_analytics/mcp/tools.yaml
+++ b/products/product_analytics/mcp/tools.yaml
@@ -100,6 +100,9 @@ tools:
                 description: >
                     Dashboard IDs this insight should belong to. This is a full replacement — always include all
                     existing dashboard IDs when adding a new one.
+            description:
+                description: |
+                    Human-readable summary of what the insight shows. Max 400 characters (longer values are rejected).
         response:
             exclude:
                 - result
@@ -201,6 +204,9 @@ tools:
                 description: >
                     Dashboard IDs this insight should belong to. This is a full replacement — always include all
                     existing dashboard IDs when adding a new one.
+            description:
+                description: |
+                    Human-readable summary of what the insight shows. Max 400 characters (longer values are rejected).
         response:
             exclude:
                 - result

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -193,6 +193,15 @@ export function formatInputValidationError(toolName: string, error: z.ZodError):
         if (issue.code === 'unrecognized_keys') {
             return `unexpected ${issue.keys.length > 1 ? 'properties' : 'property'}: ${issue.keys.join(', ')}`
         }
+        // A too-long string names the limit and the input's actual length so the
+        // agent knows how much to trim (zod's default names only the limit).
+        // Surfaces the LENGTH only, never the value: the message is returned to
+        // the caller and recorded as the analytics error_message. `issue.input`
+        // is only present under `reportInput: true`; without it, or for
+        // non-string origins, fall through to zod's limit-naming default.
+        if (issue.code === 'too_big' && issue.origin === 'string' && typeof issue.input === 'string') {
+            return `parameter "${path}" is too long: ${issue.input.length} characters (max ${issue.maximum})`
+        }
         return path ? `parameter "${path}": ${issue.message}` : issue.message
     })
     return `Invalid input for "${toolName}": ${[...new Set(parts)].join('; ')}`

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -201,6 +201,9 @@ const InsightCreateSchema = InsightsCreateBody.omit({
     dashboards: InsightsCreateBody.shape['dashboards'].describe(
         'Dashboard IDs this insight should belong to. This is a full replacement — always include all existing dashboard IDs when adding a new one.'
     ),
+    description: InsightsCreateBody.shape['description'].describe(
+        'Human-readable summary of what the insight shows. Max 400 characters (longer values are rejected).'
+    ),
 })
 
 const insightCreate = (): ToolBase<typeof InsightCreateSchema, WithPostHogUrl<Schemas.Insight>> => ({
@@ -322,6 +325,9 @@ const InsightUpdateSchema = z.preprocess(
             query: InsightQuery.optional(),
             dashboards: InsightsPartialUpdateBody.shape['dashboards'].describe(
                 'Dashboard IDs this insight should belong to. This is a full replacement — always include all existing dashboard IDs when adding a new one.'
+            ),
+            description: InsightsPartialUpdateBody.shape['description'].describe(
+                'Human-readable summary of what the insight shows. Max 400 characters (longer values are rejected).'
             ),
         })
 )

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-create.json
@@ -17,7 +17,8 @@
                 {
                     "type": "null"
                 }
-            ]
+            ],
+            "description": "Human-readable summary of what the insight shows. Max 400 characters (longer values are rejected)."
         },
         "favorited": {
             "type": "boolean"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/insight-update.json
@@ -17,7 +17,8 @@
                 {
                     "type": "null"
                 }
-            ]
+            ],
+            "description": "Human-readable summary of what the insight shows. Max 400 characters (longer values are rejected)."
         },
         "favorited": {
             "type": "boolean"

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -15,6 +15,7 @@ import {
     describeValidationError,
     type ExecInnerCallProperties,
     type ExecToolOptions,
+    formatInputValidationError,
     parseExecCallInnerToolName,
 } from '@/tools/exec'
 import { ExecHelpCatalog } from '@/tools/exec-help'
@@ -514,10 +515,17 @@ describe('exec tool', () => {
                 input: '{"actionId":277664}',
                 expected: /missing required parameter: id/,
             },
+            {
+                // Requires `reportInput: true` at the dispatch site — without it the
+                // message degrades to zod's default, which omits the actual length.
+                case: 'a string over its max length, naming actual length and limit',
+                input: `{"id":1,"description":"${'x'.repeat(401)}"}`,
+                expected: /parameter "description" is too long: 401 characters \(max 400\)/,
+            },
         ])('rejects a call with $case', async ({ input, expected }) => {
             const tool = makeMockTool({
                 name: 'action-get',
-                schema: z.object({ id: z.number() }),
+                schema: z.object({ id: z.number(), description: z.string().max(400).optional() }),
                 handler: async (_ctx, params) => params,
             })
             const exec = createExec([tool])
@@ -1347,6 +1355,34 @@ describe('exec tool', () => {
 
             expect(detail.fields).toContain('projectId:invalid_type')
             expect(JSON.stringify(detail)).not.toContain('not-a-number')
+        })
+    })
+
+    describe('formatInputValidationError', () => {
+        it('names actual length and limit for an over-long string without echoing the value', () => {
+            const schema = z.object({ description: z.string().max(5) })
+            const result = schema.safeParse({ description: 'secret-value' }, { reportInput: true })
+            expect(result.success).toBe(false)
+
+            const message = formatInputValidationError('insight-create', result.error!)
+
+            expect(message).toBe(
+                'Invalid input for "insight-create": parameter "description" is too long: 12 characters (max 5)'
+            )
+            // The message flows into the tool response and analytics error_message,
+            // so it may carry the input's length but never the value itself.
+            expect(message).not.toContain('secret-value')
+        })
+
+        it('falls back to the zod default for a non-string too_big instead of a bogus length', () => {
+            const schema = z.object({ tags: z.array(z.string()).max(2) })
+            const result = schema.safeParse({ tags: ['a', 'b', 'c'] }, { reportInput: true })
+            expect(result.success).toBe(false)
+
+            const message = formatInputValidationError('insight-create', result.error!)
+
+            expect(message).toMatch(/parameter "tags": /)
+            expect(message).not.toContain('undefined')
         })
     })
 })

--- a/services/mcp/tests/unit/insight-description-limit.test.ts
+++ b/services/mcp/tests/unit/insight-description-limit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { formatInputValidationError } from '@/tools/exec'
+import { GENERATED_TOOLS } from '@/tools/generated/product_analytics'
+
+// Minimal valid input per tool: create requires `query`, update requires `id`.
+const cases = [
+    { tool: 'insight-create', base: { query: { source: { kind: 'TrendsQuery' } } } },
+    { tool: 'insight-update', base: { id: 1 } },
+]
+
+// The Insight model caps `description` at 400 characters; these tests keep the
+// advertised limit, the enforced limit, and the rejection message in lockstep.
+describe('insight description 400-character limit', () => {
+    it.each(cases)('$tool accepts a description of exactly 400 characters', ({ tool, base }) => {
+        const schema = GENERATED_TOOLS[tool]!().schema
+
+        expect(schema.safeParse({ ...base, description: 'a'.repeat(400) }).success).toBe(true)
+    })
+
+    it.each(cases)('$tool rejects a 401-character description, naming actual length and limit', ({ tool, base }) => {
+        const { name, schema } = GENERATED_TOOLS[tool]!()
+        const result = schema.safeParse({ ...base, description: 'a'.repeat(401) }, { reportInput: true })
+        expect(result.success).toBe(false)
+
+        const message = formatInputValidationError(name, result.error!)
+
+        expect(message).toContain('parameter "description" is too long: 401 characters (max 400)')
+    })
+
+    it.each(cases)('$tool advertises the 400-character limit on the description param', ({ tool }) => {
+        const inputSchema = z.toJSONSchema(GENERATED_TOOLS[tool]!().schema, { io: 'input' }) as {
+            properties: Record<string, { description?: string }>
+        }
+
+        expect(inputSchema.properties['description']?.description).toMatch(/[Mm]ax 400 characters/)
+    })
+})


### PR DESCRIPTION
## TL;DR

The MCP tools `insight-create` and `insight-update` accept a `description` for the saved insight, but the backend caps it at 400 characters and nothing told agents about that. When an agent wrote a longer description, the whole call was rejected with a generic validation error, and an otherwise-valid create or update (often also carrying a valid `query`, `name`, or `id`) was lost. This PR advertises the 400-character limit in the tools' input schema and makes the rejection message name the offending input's actual length alongside the limit, so agents can self-limit up front and retry precisely when they don't.

## Problem

Agents calling `insight-create` / `insight-update` over MCP frequently exceed the undocumented 400-character cap on `description`. The cap comes from the `Insight` model's `CharField(max_length=400)` and is enforced client-side by the generated zod schema, so the whole call dies before reaching the API. Two gaps compounded:

- the advertised input schema carried `maxLength: 400` in JSON schema but no prose, so agents composing a call had no visible warning
- zod's default `too_big` message names the limit but not the actual length of what was sent, so a retry required guesswork

This is one of the most common input-schema validation failure modes in the Product analytics tool family.

## Changes

- `products/product_analytics/mcp/tools.yaml`: added a `param_overrides.description` entry to both tools stating the field's purpose and "Max 400 characters (longer values are rejected)". Regenerated `services/mcp/src/tools/generated/product_analytics.ts` and the two tool-schema snapshots through the generator pipeline (`hogli build:openapi-schema`, `generate-tools`, `scaffold-yaml --sync-all`), not by hand.
- `services/mcp/src/tools/exec.ts`: `formatInputValidationError` now has a `too_big` branch for string params, producing e.g. `parameter "description" is too long: 512 characters (max 400)`. Both invocation paths (direct tool calls and the exec dispatcher) share this formatter. The message surfaces the input's length only, never its value, and the value-free telemetry descriptors on `ToolInputValidationError` (`fields` / `inputKeys`) are unchanged. Non-string `too_big` issues keep zod's default message, which already names the limit.

Considered and rejected: auto-truncating to 400 with a note in the response. It silently rewrites user-visible content mid-sentence, and the only existing input-normalization layer (schema-level cast helpers) runs at parse time with no way to flag the truncation in the tool response. The backend cap itself is intentionally untouched; changing it is a model/migration decision, and 400 characters is a reasonable size for a summary field.

## How did you test this code?

Automated tests only (vitest, `services/mcp`):

- `tests/unit/insight-description-limit.test.ts` (new): a 400-character description parses on the real generated schemas of both tools, a 401-character one is rejected with a message naming 401 and the 400 limit, and the advertised JSON schema prose for the param mentions the limit. Catches the documented number drifting from the enforced one, a regeneration changing the field shape so the improved message stops firing, and the yaml override being dropped. No existing test covered any of these.
- `tests/unit/exec.test.ts`: one new row in the existing dispatcher rejection table (catches `reportInput: true` being dropped at the dispatch site, which would silently degrade the message), plus direct `formatInputValidationError` tests pinning the exact message format, that the raw input value never appears in it, and the non-string fallback.
- Tool-schema snapshots regenerated; only `insight-create.json` and `insight-update.json` changed, each gaining the new `description` prose next to the existing `maxLength: 400`.

Full `services/mcp` unit suite and `typecheck` pass. `hogli ci:preflight --fix` run; I also reran every `build:openapi` MCP substep (`generate-mcp-types`, `generate-orval-schemas`, `generate-tools`, both scopes generators, `scaffold-yaml --sync-all`) and confirmed zero drift outside the intended files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Nothing under `docs/` documents these tool params; the advertised tool schema (regenerated here) is the shipped documentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude via a PostHog Code cloud task from a task brief; the assignee drove the scope.
- Skills invoked: `/writing-tests`.
- Traced the cap end to end before documenting it: the generated zod `.max(400)` in `services/mcp/src/generated/product_analytics/api.ts` derives from the OpenAPI spec, which DRF derives from `Insight.description`'s `CharField(max_length=400)` in `products/product_analytics/backend/models/insight.py`.
- Chose documented limit plus actionable rejection over silent truncation (see Changes), and kept the rejection telemetry value-free.
- `scaffold-yaml --sync-all` normalized the yaml scalar style of the new overrides; all generated artifacts come from the generators.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
