### PR TITLE
feat(tasks): make experiment cleanup tasks team-visible

### DIFF
--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -595,6 +595,11 @@ class TaskWriteSerializer(serializers.Serializer):
         """Reject internal-only origins that are set by server-side flows, never by API callers."""
         if value == tasks_facade.TaskOriginProduct.IMAGE_BUILDER:
             raise serializers.ValidationError("origin_product 'image_builder' is reserved for image-builder sessions")
+        if value == tasks_facade.TaskOriginProduct.EXPERIMENTS:
+            # Experiments tasks are team-readable, so letting API callers pick this origin
+            # would let them expose an arbitrary task to the whole team. The experiments
+            # flow creates its tasks server-side through the facade, never through here.
+            raise serializers.ValidationError("origin_product 'experiments' is reserved for the experiments flow")
         return value
 
     def validate_repository(self, value):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -392,6 +392,28 @@ class TestTaskCreatorScoping(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["id"], str(task.id))
 
+    def test_update_experiments_task_owned_by_another_user_returns_404(self):
+        # Experiments tasks are team-readable but stay creator-driven: runs execute
+        # with the creator's credentials, so teammates must not be able to edit,
+        # run, or command them.
+        other_user = self.create_organization_user("experiment-ender")
+        task = Task.objects.create(
+            team=self.team,
+            created_by=other_user,
+            title="Clean up feature flag my-experiment-flag",
+            description="Opened on experiment end",
+            origin_product=Task.OriginProduct.EXPERIMENTS,
+        )
+
+        response = self.client.patch(
+            f"/api/projects/@current/tasks/{task.id}/",
+            {"title": "Hijacked"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        task.refresh_from_db()
+        self.assertEqual(task.title, "Clean up feature flag my-experiment-flag")
+
     def test_retrieve_other_user_non_signal_internal_task_returns_404(self):
         # Non-signal internal tasks created by another user remain private.
         other_user = self.create_organization_user("victim")

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -376,6 +376,22 @@ class TestTaskCreatorScoping(BaseTaskAPITest):
         ids = {r["id"] for r in response.json()["results"]}
         self.assertEqual(ids, {str(run.id)})
 
+    def test_retrieve_experiments_task_owned_by_another_user_is_visible(self):
+        # Flag-cleanup tasks are surfaced on the (team-visible) experiment, so any
+        # team member must be able to open them, not just whoever ended the experiment.
+        other_user = self.create_organization_user("experiment-ender")
+        task = Task.objects.create(
+            team=self.team,
+            created_by=other_user,
+            title="Clean up feature flag my-experiment-flag",
+            description="Opened on experiment end",
+            origin_product=Task.OriginProduct.EXPERIMENTS,
+        )
+
+        response = self.client.get(f"/api/projects/@current/tasks/{task.id}/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["id"], str(task.id))
+
     def test_retrieve_other_user_non_signal_internal_task_returns_404(self):
         # Non-signal internal tasks created by another user remain private.
         other_user = self.create_organization_user("victim")

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1263,13 +1263,19 @@ class TestTaskAPI(BaseTaskAPITest):
         task = Task.objects.get(id=data["id"])
         self.assertEqual(task.origin_product, Task.OriginProduct.HOGDESK)
 
-    def test_create_task_rejects_internal_image_builder_origin(self):
+    @parameterized.expand(
+        [
+            ("image_builder",),
+            ("experiments",),
+        ]
+    )
+    def test_create_task_rejects_internal_origin(self, origin: str):
         response = self.client.post(
             "/api/projects/@current/tasks/",
             {
                 "title": "New Task",
                 "description": "New Description",
-                "origin_product": "image_builder",
+                "origin_product": origin,
                 "repository": "posthog/posthog",
             },
             format="json",

--- a/products/tasks/backend/visibility.py
+++ b/products/tasks/backend/visibility.py
@@ -19,11 +19,15 @@ from products.tasks.backend.models import Channel, Task
 # - HOGDESK: support-desk Code threads. The task is pinned to the support ticket via a
 #   shared ticket tag, so any agent opening the ticket resumes the same thread — it must
 #   be viewable by the whole team, not just the agent who started it.
+# - EXPERIMENTS: flag-cleanup tasks opened when an experiment ends. The experiment (and
+#   the task's status on it) is team-visible, so any team member should be able to open
+#   the task and answer the agent, not just whoever clicked "End experiment".
 TEAM_VISIBLE_ORIGIN_PRODUCTS = [
     Task.OriginProduct.SIGNAL_REPORT,
     Task.OriginProduct.SIGNALS_SCOUT,
     Task.OriginProduct.ONBOARDING,
     Task.OriginProduct.HOGDESK,
+    Task.OriginProduct.EXPERIMENTS,
 ]
 
 

--- a/products/tasks/backend/visibility.py
+++ b/products/tasks/backend/visibility.py
@@ -19,14 +19,22 @@ from products.tasks.backend.models import Channel, Task
 # - HOGDESK: support-desk Code threads. The task is pinned to the support ticket via a
 #   shared ticket tag, so any agent opening the ticket resumes the same thread — it must
 #   be viewable by the whole team, not just the agent who started it.
-# - EXPERIMENTS: flag-cleanup tasks opened when an experiment ends. The experiment (and
-#   the task's status on it) is team-visible, so any team member should be able to open
-#   the task and answer the agent, not just whoever clicked "End experiment".
 TEAM_VISIBLE_ORIGIN_PRODUCTS = [
     Task.OriginProduct.SIGNAL_REPORT,
     Task.OriginProduct.SIGNALS_SCOUT,
     Task.OriginProduct.ONBOARDING,
     Task.OriginProduct.HOGDESK,
+]
+
+# Origin products whose tasks are team-readable but stay creator-driven, like
+# public-channel tasks: teammates can open the task and read what the agent did or
+# asked, but runs execute with the creator's credentials (oauth.py mints tokens from
+# `task.created_by`), so edits, runs, and agent commands stay with the creator.
+# - EXPERIMENTS: flag-cleanup tasks opened when an experiment ends. The experiment
+#   (and the task's status on it) is team-visible, so any team member should be able
+#   to open the task, not just whoever clicked "End experiment".
+TEAM_READABLE_ORIGIN_PRODUCTS = [
+    *TEAM_VISIBLE_ORIGIN_PRODUCTS,
     Task.OriginProduct.EXPERIMENTS,
 ]
 
@@ -53,12 +61,16 @@ def task_control_q(user_id: int | None) -> Q:
 def task_visibility_q(user_id: int | None) -> Q:
     """Filter for tasks visible (readable) to the given user.
 
-    Everything controllable per ``task_control_q``, plus tasks in a public
-    channel: channel feeds are multiplayer, so every team member sees every
-    task filed there. Personal-channel ("#me") tasks stay creator-only via
-    the control rules.
+    Everything controllable per ``task_control_q``, plus team-readable origins
+    and tasks in a public channel: channel feeds are multiplayer, so every team
+    member sees every task filed there. Personal-channel ("#me") tasks stay
+    creator-only via the control rules.
     """
-    return task_control_q(user_id) | Q(channel__channel_type=Channel.ChannelType.PUBLIC, channel__deleted=False)
+    return (
+        task_control_q(user_id)
+        | Q(origin_product__in=TEAM_READABLE_ORIGIN_PRODUCTS)
+        | Q(channel__channel_type=Channel.ChannelType.PUBLIC, channel__deleted=False)
+    )
 
 
 def task_run_visibility_q(user_id: int | None) -> Q:
@@ -66,6 +78,6 @@ def task_run_visibility_q(user_id: int | None) -> Q:
     return (
         Q(task__created_by_id=user_id)
         | Q(task__created_by__isnull=True)
-        | Q(task__origin_product__in=TEAM_VISIBLE_ORIGIN_PRODUCTS)
+        | Q(task__origin_product__in=TEAM_READABLE_ORIGIN_PRODUCTS)
         | Q(task__channel__channel_type=Channel.ChannelType.PUBLIC, task__channel__deleted=False)
     )


### PR DESCRIPTION
## Problem

Tasks with origin `experiments` (the flag-cleanup tasks opened when an experiment ends) are creator-only in the tasks API. The experiment page shows the task's status to the whole team, but only the person who ended the experiment can open the task. In our first dogfood run the agent asked a question in the task thread and nobody but the creator could see it.

## Changes

- Add a `TEAM_READABLE_ORIGIN_PRODUCTS` list, consumed by `task_visibility_q` and `task_run_visibility_q` but not `task_control_q`, and put `EXPERIMENTS` there. Teammates can open the task and read the thread, but edits, runs, and agent commands stay with the creator, since runs execute with the creator's credentials.
- Reject `origin_product="experiments"` in the task create API. The experiments flow creates its tasks server-side through the facade, so API callers picking this origin could only be using it to expose an arbitrary task to the team.

## How did you test this code?

New tests: a teammate can retrieve another user's experiments task (regression: the 404 this PR removes), a teammate's PATCH on it still 404s (regression: control leaking along with visibility), and creating a task with `origin_product="experiments"` returns 400. Ran the visibility and creation test groups locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #69975 and #72558, directed by the assignee. Initially added `EXPERIMENTS` to `TEAM_VISIBLE_ORIGIN_PRODUCTS`, which also grants control; review bots flagged that teammates could then drive the agent with the creator's credentials, and that the origin is client-settable on create. Reworked to a separate read-only list plus an origin guard. Skills invoked: /writing-tests.