### PR TITLE
fix(funnels): report malformed correlation properties instead of silent drop

### DIFF
--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -2,7 +2,10 @@ import json
 import datetime
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
-from posthog.models.property import Property
+import posthoganalytics
+
+from posthog.exceptions_capture import capture_exception
+from posthog.models.property import Property, PropertyValidationError
 
 if TYPE_CHECKING:
     from posthog.models.entity import Entity
@@ -395,7 +398,24 @@ class FunnelCorrelationActorsMixin(BaseParamMixin):
                     try:
                         new_prop = Property(**prop_params)
                         _properties.append(new_prop)
-                    except:
+                    except (PropertyValidationError, ValidationError, TypeError) as e:
+                        # PropertyValidationError covers every failure Property.__init__ itself
+                        # raises; ValidationError covers validate_group_type_index's own DRF
+                        # error; TypeError covers `Property(**prop_params)` failing to unpack
+                        # prop_params as a mapping before __init__ even runs.
+                        # Report structure only — never the property's own value/event_filters
+                        # — since those can carry real user data.
+                        prop_dict = prop_params if isinstance(prop_params, dict) else {}
+                        with posthoganalytics.new_context():
+                            posthoganalytics.set_capture_exception_code_variables_context(False)
+                            capture_exception(
+                                e,
+                                additional_properties={
+                                    "property_type": prop_dict.get("type"),
+                                    "property_fields": sorted(prop_dict.keys()) or None,
+                                    "context": "funnel_correlation_property_values",
+                                },
+                            )
                         continue
             return _properties
         return None


### PR DESCRIPTION
## Problem

`FunnelCorrelationMixin.correlation_property_values` in `posthog/models/filters/mixins/funnel.py` has a bare `except: continue` that silently drops any property that fails to construct, with zero visibility.

This is the same pattern recently fixed in the sibling `PropertyMixin._parse_properties` in `posthog/models/filters/mixins/property.py`.

Fixes #72470

## Changes

Applied the same fix pattern from `PropertyMixin._parse_properties`:
- Catch specific exception types: `PropertyValidationError`, `ValidationError`, `TypeError`
- Report via `capture_exception` with structure-only metadata (property type and field names, never the actual values since those can carry real user data)
- Added `"context": "funnel_correlation_property_values"` to distinguish from the sibling fix

## How did you test this code?

- Verified syntax with `python3 -m py_compile`
- The fix mirrors the tested pattern from `PropertyMixin._parse_properties`
- Maintains backward compatibility (still drops malformed properties, just reports them now)
