### PR TITLE
chore(mcp): add insight round-trip and verification benchmark tasks

### DIFF
--- a/services/mcp/evals/README.md
+++ b/services/mcp/evals/README.md
@@ -9,7 +9,7 @@ Two consumers:
 
 ## Layout
 
-- `benchmark/tasks.yaml` — the task set (v0). Each task is a realistic agent goal with the tools a competent agent should reach for.
+- `benchmark/tasks.yaml` — the task set (v1). Each task is a realistic agent goal with the tools a competent agent should reach for.
 - `benchmark/schema.ts` — zod schema, loader, and types. `tests/evals/benchmark.test.ts` validates the fixtures against the schema and the live tool catalog, so a tool rename or removal fails CI here instead of silently invalidating the benchmark.
 
 ## Task format

--- a/services/mcp/evals/benchmark/schema.ts
+++ b/services/mcp/evals/benchmark/schema.ts
@@ -54,7 +54,7 @@ export const BenchmarkTaskSchema = z.object({
 })
 
 export const BenchmarkFileSchema = z.object({
-    version: z.literal(0),
+    version: z.literal(1),
     tasks: z.array(BenchmarkTaskSchema).min(1),
 })
 

--- a/services/mcp/evals/benchmark/tasks.yaml
+++ b/services/mcp/evals/benchmark/tasks.yaml
@@ -1,9 +1,9 @@
-# MCP agent-experience benchmark v0.
+# MCP agent-experience benchmark v1.
 #
 # Task intents are paraphrased from real agent usage (top tool families by
 # production volume) — never verbatim copies of customer text. Keep probes
 # read-only; the runner refuses non-read-only probe tools.
-version: 0
+version: 1
 tasks:
     # --- sql ---------------------------------------------------------------
     - id: sql-daily-event-volume
@@ -107,6 +107,29 @@ tasks:
       acceptable_tools: [execute-sql, query-error-tracking-issues-list]
       success_criteria: 'Identifies the people behind the spike data point rather than just re-plotting the trend.'
 
+    - id: funnel-dropoff-actors
+      category: product-analytics
+      intent: 'Which users dropped off between the first and second step of our signup funnel this month?'
+      expected_tools: [query-funnel-actors]
+      acceptable_tools: [query-funnel, execute-sql]
+      success_criteria: 'Lists the actual people who dropped off entering the second step (drop-off step semantics, not a converted-through step), rather than just re-plotting the funnel conversion rate.'
+      probe:
+          # Repeated-pageview steps keep the probe runnable in any seeded demo
+          # project; funnelStep -2 = dropped off entering step 2.
+          tool: query-funnel-actors
+          args:
+              funnelStep: -2
+              includeRecordings: false
+              source:
+                  kind: FunnelsQuery
+                  dateRange:
+                      date_from: '-30d'
+                  series:
+                      - kind: EventsNode
+                        event: '$pageview'
+                      - kind: EventsNode
+                        event: '$pageview'
+
     # --- insights -------------------------------------------------------------
     - id: insight-create-daily-signups
       category: insights
@@ -128,6 +151,31 @@ tasks:
       expected_tools: [insight-query]
       acceptable_tools: [insight-get, execute-sql]
       success_criteria: 'Locates the saved insight, executes it, and reports the most recent data point.'
+
+    # Multi-step chains below target the observed pain in this family: losing
+    # the created insight's identifiers between calls, over-long descriptions,
+    # and saving without ever verifying the query runs. Create/update are
+    # mutating tools, so these tasks are agent-mode only (no probes).
+    - id: insight-id-roundtrip
+      category: insights
+      intent: 'Create an insight tracking daily pageviews, then rename it, then run it and tell me the latest value.'
+      expected_tools: [insight-create, insight-update, insight-query]
+      acceptable_tools: [query-trends, read-data-schema, insight-get]
+      success_criteria: 'Completes the whole chain reusing the identifiers returned by insight-create for the update and query calls — no schema-rejection retries from passing the wrong identifier field — and reports the latest data point.'
+
+    - id: insight-create-with-description
+      category: insights
+      intent: "Save a trends insight for weekly signups, with a description explaining how it's calculated and any caveats, so teammates can trust it."
+      expected_tools: [insight-create]
+      acceptable_tools: [query-trends, read-data-schema]
+      success_criteria: 'Creates the insight with a substantive non-empty description on the first attempt — no rejected-then-truncated retry loop on the description field.'
+
+    - id: insight-create-verified
+      category: insights
+      intent: "Save a funnel from homepage visit to signup, and confirm it actually computes results before telling me it's done."
+      expected_tools: [insight-create, insight-query]
+      acceptable_tools: [query-funnel, read-data-schema]
+      success_criteria: 'Verifies the saved funnel actually runs — via insight-query after saving or by pre-testing the query before saving — and reports computed results instead of claiming success without ever executing it.'
 
     # --- error-tracking --------------------------------------------------------
     - id: errors-top-issues

--- a/services/mcp/evals/benchmark/tasks.yaml
+++ b/services/mcp/evals/benchmark/tasks.yaml
@@ -115,7 +115,10 @@ tasks:
       success_criteria: 'Lists the actual people who dropped off entering the second step (drop-off step semantics, not a converted-through step), rather than just re-plotting the funnel conversion rate.'
       probe:
           # Repeated-pageview steps keep the probe runnable in any seeded demo
-          # project; funnelStep -2 = dropped off entering step 2.
+          # project; funnelStep -2 = dropped off entering step 2. Probe mode
+          # only guards arg acceptance, tool errors, and latency — an empty
+          # actor list still passes. Step SEMANTICS (returning the right
+          # people) are judged in agent mode via success_criteria.
           tool: query-funnel-actors
           args:
               funnelStep: -2


### PR DESCRIPTION
## TL;DR

The MCP eval benchmark is how we score whether a change to the MCP server actually helps agents. Its insight tasks are currently all single step, so the failure modes we see most in production usage (an agent creates an insight and then can't reuse its identifiers for the next call, descriptions rejected for length, "saved!" without ever running the query, nobody finding the funnel drop-off drill-down tool) are invisible to before/after scoring. This PR adds four benchmark tasks that exercise exactly those flows, so future fix PRs can prove they help.

## Problem

Observed agent usage shows the insight tool family's dominant pain is multi-step flows, not single calls:

- Agents create an insight and then fail to reuse the returned identifiers for `insight-update` / `insight-query` (the tools want different identifier fields), producing schema-rejection retry loops.
- `insight-create` / `insight-update` calls fail wholesale when the description exceeds an undocumented length cap.
- Most create sessions never verify the saved insight actually computes results, and the top failing `insight-query` intents are variants of "verify the insight I just created".
- The `*-actors` drill-down tools, `query-funnel-actors` especially, are rarely discovered from their parent tools and their step-index semantics are error-prone.

None of the existing tasks (`insight-create-daily-signups`, `insight-rename`, `insight-run-existing`) exercise a create-then-mutate-then-query chain, a save with a description, or an actors drill-down, so regressions and fixes in these areas don't move the scores.

## Changes

Four new tasks in `services/mcp/evals/benchmark/tasks.yaml`, following the README authoring rules (intents paraphrased from real usage, no verbatim customer text, achievable in a seeded demo project):

- `insight-id-roundtrip` (insights): create an insight, rename it, then run it. Passes only if the agent reuses the identifiers returned by `insight-create` for the update and query calls, without schema-rejection retries.
- `insight-create-with-description` (insights): save an insight with a substantive description (methodology, caveats). Passes only if it lands with a non-empty description on the first attempt, with no rejected-then-truncated retry loop.
- `insight-create-verified` (insights): save a funnel and confirm it computes results before reporting done, instead of claiming success blind.
- `funnel-dropoff-actors` (product-analytics): identify the users who dropped off between the first and second funnel step, expecting `query-funnel-actors` with correct drop-off step semantics. This task also gets a deterministic read-only probe (a repeated-pageview funnel with `funnelStep: -2`), so probe mode now covers the tool too.

The first three tasks involve mutating tools, so they carry no `probe` block and are agent-mode only. The fixture test and the probe runner both enforce read-only probes.

Version bump, 0 to 1 (`tasks.yaml`, the `z.literal` in `schema.ts`, and the README reference). My reading of the versioning rule: the README says scores are only comparable across runs of the same benchmark version and to bump on breaking changes to the set. Adding tasks changes what the aggregate score measures, so an additive change still breaks comparability and warrants the bump. Neither `schema.ts` nor the README exempts additive changes.

This ships separately from any tool or schema fixes on purpose: the point is that future fix PRs get scored against this expanded benchmark.

## How did you test this code?

All automated, run by the agent from the repo root:

- `pnpm --filter=@posthog/mcp exec vitest run tests/evals/benchmark.test.ts` passes all 5 fixture checks (schema parse with unique ids, every referenced tool exists in the live catalog, every category used, probes are read-only, probes match an expected tool).
- `pnpm --filter=@posthog/mcp exec vitest run` passes the full unit suite, 92 files / 2381 tests.
- `pnpm --filter=@posthog/mcp run typecheck` is clean (after `build:quill`).
- The new probe's args were parsed against the exact generated zod schema for `query-funnel-actors` (throwaway vitest file, not committed), and the identical read-only call was executed end to end against a live MCP server, returning drop-off actors with the expected `funnelStep: -2` semantics.
- Not run, stated explicitly rather than fabricating scores: probe mode via `evals/runner/probe.ts` (needs `LIVE_MCP_TOKEN` for a live instance, not available in this environment) and agent mode (needs an LLM against a live server; `evals/runner/` also has no agent-mode runner yet).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`services/mcp/evals/README.md` is updated in this PR (task-set version reference). Nothing under `docs/` documents this benchmark.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task) from a task brief; Thomas directed the work and is the assignee (DRI).

- Decisions: bumped the benchmark version to 1 per the reading above. Gave only `funnel-dropoff-actors` a probe, and built it on a repeated-pageview funnel so it stays deterministic in any seeded demo project instead of assuming a specific signup event name; even with no matching data it returns an empty actor list rather than an error. Kept the three insight-chain tasks probe-free because create/update are mutating tools and the runner refuses non-read-only probes.
- Validation beyond the test suite: parsed the probe args with the generated server-side zod schema and executed the identical read-only call against a live MCP server to confirm it runs.
- No repo skills applied to this surface (fixture YAML plus a version literal; no DRF, migration, or frontend changes, and no test files added or changed).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
