### PR TITLE
fix(tasks): preserve running turns after initial timeout

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
@@ -19,6 +19,8 @@ from products.tasks.backend.temporal.process_task.utils import (
 
 logger = get_logger(__name__)
 
+PENDING_MESSAGE_TIMEOUT_SECONDS = 90
+
 
 def _task_run_log_context(task_run: Any) -> dict[str, Any]:
     task = task_run.task
@@ -124,7 +126,7 @@ def forward_pending_user_message(run_id: str) -> None:
             pending_message,
             artifacts=pending_artifacts or None,
             auth_token=auth_token,
-            timeout=90,
+            timeout=PENDING_MESSAGE_TIMEOUT_SECONDS,
             message_id=pending_message_id,
         )
         logger.info(
@@ -133,17 +135,23 @@ def forward_pending_user_message(run_id: str) -> None:
             has_message=bool(pending_message),
             artifact_count=len(pending_artifacts),
         )
-        if not result.success and result.retryable and result.status_code != 504:
+        if result.turn_in_flight:
+            logger.info(
+                "forward_pending_message_turn_still_running",
+                run_id=run_id,
+                timeout_seconds=PENDING_MESSAGE_TIMEOUT_SECONDS,
+            )
+        elif not result.success and result.retryable and result.status_code != 504:
             result = send_user_message(
                 task_run,
                 pending_message,
                 artifacts=pending_artifacts or None,
                 auth_token=auth_token,
-                timeout=90,
+                timeout=PENDING_MESSAGE_TIMEOUT_SECONDS,
                 message_id=pending_message_id,
             )
 
-        if not result.success and result.retryable:
+        if not result.success and not result.turn_in_flight and result.retryable:
             from products.tasks.backend.logic.services.agent_command import user_facing_agent_error
 
             retryable_delivery_error = result.error or "Retryable pending message delivery failed"
@@ -165,7 +173,7 @@ def forward_pending_user_message(run_id: str) -> None:
         if state.get("interaction_origin") == "slack":
             if result.success:
                 _enqueue_pending_reply_relay(task_run, pending_message_ts, result.data)
-            else:
+            elif not result.turn_in_flight:
                 _enqueue_pending_delivery_failure_relay(task_run, pending_message_ts, result.error)
 
         TaskRun.update_state_atomic(
@@ -178,7 +186,7 @@ def forward_pending_user_message(run_id: str) -> None:
             ],
         )
 
-        if result.success:
+        if result.success or result.turn_in_flight:
             logger.info("forward_pending_message_delivered", run_id=run_id)
         else:
             observe_followup_delivery_failed(task_run, retryable=False)

--- a/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
@@ -126,6 +126,30 @@ class TestForwardPendingUserMessage(TestCase):
 
     @patch("products.tasks.backend.logic.services.connection_token.create_sandbox_connection_token", return_value="jwt")
     @patch("products.tasks.backend.logic.services.agent_command.send_user_message")
+    def test_read_timeout_keeps_running_turn_alive(self, mock_send, mock_token):
+        run = self._make_run(
+            state={
+                "pending_user_message": "fix the tests",
+                "sandbox_url": "https://sandbox.example.com/rpc",
+            }
+        )
+        mock_send.return_value = _command_result(
+            success=False,
+            status_code=504,
+            error="Sandbox request timed out",
+            retryable=True,
+            turn_in_flight=True,
+        )
+
+        forward_pending_user_message(str(run.id))
+
+        mock_send.assert_called_once()
+        run.refresh_from_db()
+        assert "pending_user_message" not in run.state
+        assert "pending_user_message_id" not in run.state
+
+    @patch("products.tasks.backend.logic.services.connection_token.create_sandbox_connection_token", return_value="jwt")
+    @patch("products.tasks.backend.logic.services.agent_command.send_user_message")
     def test_connection_error_retries_with_longer_timeout(self, mock_send, mock_token):
         run = self._make_run(
             state={

--- a/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
@@ -24,7 +24,14 @@ forward_pending_user_message = _module.forward_pending_user_message
 
 
 def _command_result(**kwargs):
-    defaults = {"success": False, "status_code": 0, "error": None, "retryable": False, "data": None}
+    defaults = {
+        "success": False,
+        "status_code": 0,
+        "error": None,
+        "retryable": False,
+        "turn_in_flight": False,
+        "data": None,
+    }
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
 


### PR DESCRIPTION
## Problem

**Why:** Initial task messages can take longer than the synchronous sandbox request window. A read timeout currently fails the workflow even though the sandbox received the message and the agent turn is still running.

## Changes

Treat a read timeout marked as an in-flight turn as successful delivery. Keep the sandbox alive so the existing event relay can report heartbeats and completion, while preserving the current failure behavior when delivery is unknown.