### PR TITLE
feat(conversations): tint customer message bubbles in ticket view

### DIFF
--- a/products/conversations/frontend/components/Chat/Message.tsx
+++ b/products/conversations/frontend/components/Chat/Message.tsx
@@ -91,7 +91,11 @@ export function Message({
                     <div className="max-w-full min-w-80">
                         <div
                             className={`border py-2 px-3 rounded-lg ${
-                                isPrivate ? 'bg-warning-highlight border-warning' : 'bg-surface-primary'
+                                isPrivate
+                                    ? 'bg-warning-highlight border-warning'
+                                    : isCustomer
+                                      ? 'bg-surface-secondary'
+                                      : 'bg-surface-primary'
                             } [&_img]:max-h-64 [&_.SupportEditor__image]:max-h-64`}
                         >
                             {isPrivate && (


### PR DESCRIPTION
## Problem

In the support ticket thread, customer messages and staff/AI replies looked nearly identical, distinguished only by alignment. It's easy to lose track of who said what.

## Changes

Customer message bubbles now use a subtle neutral background (`bg-surface-secondary`) so they stand out from staff/AI replies. Private notes keep their existing warning styling.

<img width="623" height="702" alt="Screenshot 2026-07-22 at 11 17 34" src="https://github.com/user-attachments/assets/3723c25f-ad54-4881-a871-96e952d3a963" />
<img width="625" height="720" alt="Screenshot 2026-07-22 at 11 18 26" src="https://github.com/user-attachments/assets/f6606023-4f5b-4180-acb9-fa36f1df57ae" />


## How did you test this code?

Manually, against seeded local tickets. No automated tests — this is a one-line styling tweak.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

One-line CSS change to `Message.tsx`. No skills invoked. Color token chosen with the DRI after comparing neutral/blue/accent options; neutral gray was picked.