### PR TITLE
feat(conversations): attribute Teams support replies to the agent

### DIFF
--- a/products/conversations/backend/api/tests/test_teams_formatting.py
+++ b/products/conversations/backend/api/tests/test_teams_formatting.py
@@ -4,6 +4,7 @@ from parameterized import parameterized
 
 from products.conversations.backend.teams_formatting import (
     append_teams_attribution,
+    build_teams_reply_html,
     rich_content_to_teams_html,
     teams_html_to_content_and_rich_content,
 )
@@ -280,3 +281,19 @@ class TestAppendTeamsAttribution(SimpleTestCase):
         result = append_teams_attribution("<p>Hello</p>", "<script>alert(1)</script>")
         assert "<script>" not in result
         assert "&lt;script&gt;" in result
+
+
+class TestBuildTeamsReplyHtml(SimpleTestCase):
+    def test_renders_rich_content_then_footer(self):
+        rich = {
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "All fixed now."}]}],
+        }
+        assert build_teams_reply_html(rich, "All fixed now.", "Xander Jones") == (
+            "<p>All fixed now.</p><p><i>Xander Jones via SupportHog</i></p>"
+        )
+
+    def test_falls_back_to_plain_content_with_footer(self):
+        assert build_teams_reply_html(None, "All fixed now.", "Xander Jones") == (
+            "All fixed now.<p><i>Xander Jones via SupportHog</i></p>"
+        )

--- a/products/conversations/backend/api/tests/test_teams_formatting.py
+++ b/products/conversations/backend/api/tests/test_teams_formatting.py
@@ -3,6 +3,7 @@ from django.test import SimpleTestCase
 from parameterized import parameterized
 
 from products.conversations.backend.teams_formatting import (
+    append_teams_attribution,
     rich_content_to_teams_html,
     teams_html_to_content_and_rich_content,
 )
@@ -264,3 +265,18 @@ class TestRichContentToTeamsHtml(SimpleTestCase):
         }
         result = rich_content_to_teams_html(rich)
         assert result == "<p><i><b>wow</b></i></p>"
+
+
+class TestAppendTeamsAttribution(SimpleTestCase):
+    def test_appends_italic_footer(self):
+        assert append_teams_attribution("<p>Hello</p>", "Xander Jones") == (
+            "<p>Hello</p><p><i>Xander Jones via SupportHog</i></p>"
+        )
+
+    def test_no_author_leaves_reply_untouched(self):
+        assert append_teams_attribution("<p>Hello</p>", "") == "<p>Hello</p>"
+
+    def test_escapes_author_name(self):
+        result = append_teams_attribution("<p>Hello</p>", "<script>alert(1)</script>")
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result

--- a/products/conversations/backend/api/tests/test_teams_formatting.py
+++ b/products/conversations/backend/api/tests/test_teams_formatting.py
@@ -270,7 +270,7 @@ class TestRichContentToTeamsHtml(SimpleTestCase):
 
 class TestAppendTeamsAttribution(SimpleTestCase):
     def test_appends_italic_footer(self):
-        assert append_teams_attribution("<p>Hello</p>", "Xander Jones") == (
+        assert append_teams_attribution("<p>Hello</p>", "Max Hedgehog") == (
             "<p>Hello</p><p><i>Max Hedgehog via SupportHog</i></p>"
         )
 

--- a/products/conversations/backend/api/tests/test_teams_formatting.py
+++ b/products/conversations/backend/api/tests/test_teams_formatting.py
@@ -271,7 +271,7 @@ class TestRichContentToTeamsHtml(SimpleTestCase):
 class TestAppendTeamsAttribution(SimpleTestCase):
     def test_appends_italic_footer(self):
         assert append_teams_attribution("<p>Hello</p>", "Xander Jones") == (
-            "<p>Hello</p><p><i>Xander Jones via SupportHog</i></p>"
+            "<p>Hello</p><p><i>Max Hedgehog via SupportHog</i></p>"
         )
 
     def test_no_author_leaves_reply_untouched(self):
@@ -289,11 +289,11 @@ class TestBuildTeamsReplyHtml(SimpleTestCase):
             "type": "doc",
             "content": [{"type": "paragraph", "content": [{"type": "text", "text": "All fixed now."}]}],
         }
-        assert build_teams_reply_html(rich, "All fixed now.", "Xander Jones") == (
-            "<p>All fixed now.</p><p><i>Xander Jones via SupportHog</i></p>"
+        assert build_teams_reply_html(rich, "All fixed now.", "Max Hedgehog") == (
+            "<p>All fixed now.</p><p><i>Max Hedgehog via SupportHog</i></p>"
         )
 
     def test_falls_back_to_plain_content_with_footer(self):
-        assert build_teams_reply_html(None, "All fixed now.", "Xander Jones") == (
-            "All fixed now.<p><i>Xander Jones via SupportHog</i></p>"
+        assert build_teams_reply_html(None, "All fixed now.", "Max Hedgehog") == (
+            "All fixed now.<p><i>Max Hedgehog via SupportHog</i></p>"
         )

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -97,7 +97,7 @@ from products.conversations.backend.teams import (
     post_teams_channel_message_via_graph,
 )
 from products.conversations.backend.teams_attachments import extract_teams_graph_images
-from products.conversations.backend.teams_formatting import append_teams_attribution, rich_content_to_teams_html
+from products.conversations.backend.teams_formatting import build_teams_reply_html
 
 from .support_slack import SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES
 
@@ -1000,8 +1000,7 @@ def post_reply_to_teams(
         logger.warning("teams_reply_no_bot_token", team_id=team_id)
         return
 
-    reply_html = rich_content_to_teams_html(rich_content, content)
-    reply_html = append_teams_attribution(reply_html, author_name)
+    reply_html = build_teams_reply_html(rich_content, content, author_name)
     display_text = f"{author_name}: {content[:200]}" if author_name else content[:200]
 
     payload: dict[str, Any] = {
@@ -1070,8 +1069,7 @@ def post_reply_to_teams_via_graph(
         logger.warning("teams_graph_reply_team_not_found", team_id=team_id)
         return
 
-    reply_html = rich_content_to_teams_html(rich_content, content)
-    reply_html = append_teams_attribution(reply_html, author_name)
+    reply_html = build_teams_reply_html(rich_content, content, author_name)
 
     status, _message_id = post_teams_channel_message_via_graph(
         team=team,

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -97,7 +97,7 @@ from products.conversations.backend.teams import (
     post_teams_channel_message_via_graph,
 )
 from products.conversations.backend.teams_attachments import extract_teams_graph_images
-from products.conversations.backend.teams_formatting import rich_content_to_teams_html
+from products.conversations.backend.teams_formatting import append_teams_attribution, rich_content_to_teams_html
 
 from .support_slack import SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES
 
@@ -1001,6 +1001,7 @@ def post_reply_to_teams(
         return
 
     reply_html = rich_content_to_teams_html(rich_content, content)
+    reply_html = append_teams_attribution(reply_html, author_name)
     display_text = f"{author_name}: {content[:200]}" if author_name else content[:200]
 
     payload: dict[str, Any] = {
@@ -1070,8 +1071,7 @@ def post_reply_to_teams_via_graph(
         return
 
     reply_html = rich_content_to_teams_html(rich_content, content)
-    if author_name:
-        reply_html = f"<p><b>{html_mod.escape(author_name)}</b></p>{reply_html}"
+    reply_html = append_teams_attribution(reply_html, author_name)
 
     status, _message_id = post_teams_channel_message_via_graph(
         team=team,

--- a/products/conversations/backend/teams_formatting.py
+++ b/products/conversations/backend/teams_formatting.py
@@ -86,6 +86,16 @@ def rich_content_to_teams_html(rich_content: JSON | None, fallback_content: str 
     return "".join(parts) or html_mod.escape(fallback_content)
 
 
+def build_teams_reply_html(rich_content: JSON | None, content: str, author_name: str) -> str:
+    """Render a support agent's reply to Teams-ready HTML, with the attribution footer.
+
+    Single entry point shared by both outbound reply paths (bot connector and Graph)
+    so their formatting can't drift.
+    """
+    reply_html = rich_content_to_teams_html(rich_content, content)
+    return append_teams_attribution(reply_html, author_name)
+
+
 def append_teams_attribution(reply_html: str, author_name: str) -> str:
     """Append a subtle "{name} via SupportHog" footer to an outbound Teams reply.
 
@@ -93,6 +103,8 @@ def append_teams_attribution(reply_html: str, author_name: str) -> str:
     shows up from a nameless "SupportHog" and customers can't tell which agent answered.
     The footer makes the sender clear. Both outbound paths (bot connector and Graph)
     render the common inline HTML tags, so the same italic markup works for each.
+
+    Keep the footer markup here only -- it's the single place to restyle attribution.
     """
     if not author_name:
         return reply_html

--- a/products/conversations/backend/teams_formatting.py
+++ b/products/conversations/backend/teams_formatting.py
@@ -86,6 +86,20 @@ def rich_content_to_teams_html(rich_content: JSON | None, fallback_content: str 
     return "".join(parts) or html_mod.escape(fallback_content)
 
 
+def append_teams_attribution(reply_html: str, author_name: str) -> str:
+    """Append a subtle "{name} via SupportHog" footer to an outbound Teams reply.
+
+    A Teams bot's display name is fixed in the app manifest, so every reply otherwise
+    shows up from a nameless "SupportHog" and customers can't tell which agent answered.
+    The footer makes the sender clear. Both outbound paths (bot connector and Graph)
+    render the common inline HTML tags, so the same italic markup works for each.
+    """
+    if not author_name:
+        return reply_html
+    footer = f"<p><i>{html_mod.escape(author_name)} via SupportHog</i></p>"
+    return f"{reply_html}{footer}"
+
+
 def _render_node(node: JSON) -> str:
     node_type = node.get("type", "")
 


### PR DESCRIPTION
## Problem

Support replies sent back into a Microsoft Teams thread showed up from a nameless "SupportHog", so customers couldn't tell which agent had answered — and in at least one case appeared to miss the reply entirely because it looked like an automated bot message. A Teams bot's display name is fixed in the app manifest and can't be overridden per-message, so we can't rename the sender; the fix is to attribute the reply in the message body instead.

Raised in a support Slack thread: https://posthog.slack.com/archives/C090RCG671C/p1784708626116489?thread_ts=1784708626.116489&cid=C090RCG671C

## Changes

Add a shared `append_teams_attribution` helper that appends a subtle italic `{name} via SupportHog` footer to outbound Teams replies, and wire both outbound paths through it:

- **Standard channels** (bot connector, `post_reply_to_teams`) previously rendered no author in the visible body — the name only went into the hidden `summary` field. Now it shows the footer.
- **Shared channels** (Graph, `post_reply_to_teams_via_graph`) already prepended a bold author name; switched to the same footer for consistency.

The author name is escaped, and replies with no author (e.g. AI bot) are left untouched.

## How did you test this code?

Added unit tests in `test_teams_formatting.py` covering the footer output, the no-author passthrough, and HTML escaping of the author name. Verified the helper output directly with a standalone Python run. I (the agent) could not run the Django test suite or exercise a live Teams thread in this environment, so the end-to-end path against Teams has not been manually verified.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) from a support Slack thread. The investigation traced the two outbound Teams reply paths in `products/conversations/backend` and found the attribution inconsistency between them (Graph path already named the author, bot-connector path did not). Chose a shared footer over the existing bold-header approach to keep the attribution subtle, per the requester's suggestion. No repo skills were required for this change.
