### PR TITLE
feat(signals): support idempotent emission

### DIFF
--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -7,6 +7,7 @@ import pydantic
 import structlog
 import temporalio
 import posthoganalytics
+from temporalio.common import WorkflowIDReusePolicy
 
 from posthog.event_usage import groups
 from posthog.helpers.tiktoken_encoding import LLM_TOKEN_COUNT_PROXY_MODEL, get_tiktoken_encoding_for_model
@@ -206,6 +207,7 @@ async def emit_signal(
     weight: float = 0.5,
     extra: dict | None = None,
     remediation: SignalRemediation | None = None,
+    idempotency_key: str | None = None,
 ) -> None:
     """
     Emit a signal for grouping and potential report generation, fire-and-forget.
@@ -231,6 +233,8 @@ async def emit_signal(
             (`human` + `agent` combined). When set, the signal is treated as actionable: the guidance
             is surfaced to the research agent as authoritative direction, which it follows instead of
             investigating from scratch. Not required by any existing source.
+        idempotency_key: Optional stable key for callers that may retry. Repeated calls with
+            the same key, source product, and source type start at most one emitter workflow.
 
     Example:
         await emit_signal(
@@ -243,6 +247,9 @@ async def emit_signal(
             extra={"html_url": "https://github.com/posthog/posthog/issues/12345", "number": 12345, ...},
         )
     """
+    if idempotency_key is not None and not idempotency_key.strip():
+        raise ValueError("idempotency_key must not be empty")
+
     # Deferred: the temporal package imports the facade back (reingestion -> emit_signal), so
     # importing these workflows at module scope forms a circular import and drags the whole
     # temporal stack onto the Django startup path. Resolved lazily at call time instead.
@@ -355,13 +362,26 @@ async def emit_signal(
 
     # Fire-and-forget: the emitter workflow will submit the signal to the buffer
     # via update, blocking if the buffer is full (backpressure).
-    await client.start_workflow(
-        SignalEmitterWorkflow.run,
-        SignalEmitterInput(team_id=team.id, signal=signal_input),
-        id=SignalEmitterWorkflow.workflow_id_for(team.id),
-        task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
-        run_timeout=timedelta(minutes=10),
+    emitter_idempotency_key = (
+        f"{source_product}:{source_type}:{idempotency_key}" if idempotency_key is not None else None
     )
+    try:
+        await client.start_workflow(
+            SignalEmitterWorkflow.run,
+            SignalEmitterInput(team_id=team.id, signal=signal_input),
+            id=SignalEmitterWorkflow.workflow_id_for(team.id, emitter_idempotency_key),
+            task_queue=settings.VIDEO_EXPORT_TASK_QUEUE,
+            run_timeout=timedelta(minutes=10),
+            id_reuse_policy=(
+                WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY
+                if emitter_idempotency_key is not None
+                else WorkflowIDReusePolicy.ALLOW_DUPLICATE
+            ),
+        )
+    except temporalio.exceptions.WorkflowAlreadyStartedError:
+        if emitter_idempotency_key is None:
+            raise
+        return
 
     # Fire the analytics event only after the signal is definitively queued so
     # Temporal/connection failures don't inflate the "signals emitted" metric.

--- a/products/signals/backend/temporal/emitter.py
+++ b/products/signals/backend/temporal/emitter.py
@@ -1,4 +1,5 @@
 import uuid
+import hashlib
 from dataclasses import dataclass
 from datetime import timedelta
 
@@ -23,12 +24,14 @@ class SignalEmitterWorkflow:
     Ephemeral per-signal workflow that submits a signal to the buffer workflow
     via update. The update blocks if the buffer is full, providing backpressure.
 
-    emit_signal() starts this fire-and-forget with a unique ID per signal.
+    emit_signal() starts this fire-and-forget with either a unique ID or a caller-provided
+    idempotency key.
     """
 
     @staticmethod
-    def workflow_id_for(team_id: int) -> str:
-        return f"signal-emitter-{team_id}-{uuid.uuid4()}"
+    def workflow_id_for(team_id: int, idempotency_key: str | None = None) -> str:
+        suffix = hashlib.sha256(idempotency_key.encode()).hexdigest() if idempotency_key else str(uuid.uuid4())
+        return f"signal-emitter-{team_id}-{suffix}"
 
     @temporalio.workflow.run
     async def run(self, input: SignalEmitterInput) -> None:

--- a/products/signals/backend/test/test_api.py
+++ b/products/signals/backend/test/test_api.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pydantic
 import temporalio.exceptions
+from temporalio.common import WorkflowIDReusePolicy
 
 from products.signals.backend.contracts import SignalRemediation
 from products.signals.backend.facade.api import (
@@ -180,6 +181,46 @@ class TestEmitSignalValidation:
             )
 
         assert client.start_workflow.await_count == 2
+
+    async def test_emit_signal_treats_an_existing_idempotent_emitter_as_success(self, team_stub):
+        client = AsyncMock()
+        client.start_workflow.side_effect = [
+            temporalio.exceptions.WorkflowAlreadyStartedError("already started", "buffer-signals-1"),
+            temporalio.exceptions.WorkflowAlreadyStartedError("already started", "signal-emitter-1-stable"),
+        ]
+
+        with (
+            patch("products.signals.backend.facade.api.async_connect", return_value=client),
+            patch.object(SignalSourceConfig, "is_source_enabled", return_value=True),
+        ):
+            await emit_signal(
+                team=team_stub,
+                source_product="github",
+                source_type="issue",
+                source_id="test-id-1",
+                description="A valid signal",
+                extra=GITHUB_ISSUE_EXTRA,
+                idempotency_key="notification-1",
+            )
+
+        emitter_call = client.start_workflow.call_args_list[1]
+        assert emitter_call.kwargs["id"] == SignalEmitterWorkflow.workflow_id_for(
+            team_stub.id, "github:issue:notification-1"
+        )
+        assert emitter_call.kwargs["id_reuse_policy"] == WorkflowIDReusePolicy.ALLOW_DUPLICATE_FAILED_ONLY
+
+    @pytest.mark.parametrize("idempotency_key", ["", "   "])
+    async def test_emit_signal_rejects_empty_idempotency_keys(self, team_stub, idempotency_key):
+        with pytest.raises(ValueError, match="idempotency_key must not be empty"):
+            await emit_signal(
+                team=team_stub,
+                source_product="github",
+                source_type="issue",
+                source_id="test-id-1",
+                description="A valid signal",
+                extra=GITHUB_ISSUE_EXTRA,
+                idempotency_key=idempotency_key,
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Retrying callers of `emit_signal` cannot currently prevent duplicate signal-emitter workflows because every call receives a random workflow ID.

```mermaid
flowchart LR
    A[Retrying caller] --> B[emit_signal]
    B --> C[Random workflow ID]
    C --> D[Duplicate emitter workflows]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B phBlue;
    class C,D phGray;
```

```mermaid
flowchart LR
    A[Retrying caller] --> B[emit_signal]
    B --> C[Stable hashed workflow ID]
    C --> D[One emitter workflow]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,D phYellow;
    class B phBlue;
    class C phGray;
```

## Changes

- Add an optional `idempotency_key` to the Signals facade.
- Derive a stable, namespaced emitter workflow ID when the key is provided.
- Treat active or successfully completed emitters as success while allowing retries after failed executions.
- Preserve random workflow IDs for existing callers that do not opt in.

## How did you test this code?

- `uv run pytest -q products/signals/backend/test/test_api.py` – 17 passed. The added regression verifies stable emitter IDs, duplicate-start handling, the failed-execution-only reuse policy, and rejection of empty keys.
- `uv run ruff check products/signals/backend/facade/api.py products/signals/backend/temporal/emitter.py products/signals/backend/test/test_api.py`
- `uv run ty check products/signals/backend/facade/api.py products/signals/backend/temporal/emitter.py`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation changes are required.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the pi coding agent using the `pr` skill. The API remains backward compatible: only callers that provide an idempotency key receive deterministic workflow IDs and duplicate rejection.


