### PR TITLE
fix(tasks): create missing branch for cloud task

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -674,15 +674,37 @@ def checkout_branch_in_sandbox(input: CheckoutBranchInSandboxInput) -> CheckoutB
                     extra={"branch": input.branch, "stderr": update_result.stderr},
                 )
 
-        depth_flag = f" --depth {shlex.quote('1')}" if input.shallow_clone else ""
-        fetch_and_checkout = (
-            f"cd {shlex.quote(repo_path)} && "
-            f"git fetch{depth_flag} origin -- {shlex.quote(input.branch)} && "
-            f"git checkout -B {shlex.quote(input.branch)} FETCH_HEAD"
-        )
+        branch = shlex.quote(input.branch)
+        branch_ref = shlex.quote(f"refs/heads/{input.branch}")
+        remote_branch_check = f"cd {shlex.quote(repo_path)} && git ls-remote --exit-code --heads origin {branch_ref}"
+        remote_branch_result = sandbox.execute(remote_branch_check, timeout_seconds=30)
+
+        if remote_branch_result.exit_code == 0:
+            depth_flag = f" --depth {shlex.quote('1')}" if input.shallow_clone else ""
+            checkout_command = (
+                f"cd {shlex.quote(repo_path)} && "
+                f"git fetch{depth_flag} origin -- {branch} && "
+                f"git checkout -B {branch} FETCH_HEAD"
+            )
+        elif remote_branch_result.exit_code == 2:
+            if input.used_snapshot:
+                depth_flag = f" --depth {shlex.quote('1')}" if input.shallow_clone else ""
+                checkout_command = (
+                    f"cd {shlex.quote(repo_path)} && "
+                    f"git fetch{depth_flag} origin -- HEAD && "
+                    f"git checkout -B {branch} FETCH_HEAD"
+                )
+            else:
+                checkout_command = f"cd {shlex.quote(repo_path)} && git checkout -B {branch} HEAD"
+        else:
+            logger.warning(
+                "Failed to check whether remote branch exists",
+                extra={"branch": input.branch, "stderr": remote_branch_result.stderr},
+            )
+            raise RuntimeError(f"Failed to check whether branch {input.branch} exists")
 
         with StepTimer("branch_checkout", used_snapshot=input.used_snapshot) as checkout_timer:
-            result = sandbox.execute(fetch_and_checkout, timeout_seconds=5 * 60)
+            result = sandbox.execute(checkout_command, timeout_seconds=5 * 60)
 
         if result.exit_code != 0:
             logger.warning("Branch checkout failed", extra={"branch": input.branch, "stderr": result.stderr})

--- a/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
@@ -1,16 +1,21 @@
-from typing import Any
+from collections.abc import Callable
+from typing import Any, cast
 
 import pytest
 from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+from products.tasks.backend.logic.services.sandbox import ExecutionResult
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 from products.tasks.backend.temporal.process_task.activities.provision_sandbox import (
+    CheckoutBranchInSandboxInput,
+    CheckoutBranchInSandboxOutput,
     PrepareSandboxForRepositoryOutput,
     _build_environment_variables,
     _build_sandbox_tags,
     _to_modal_domain_allowlist,
+    checkout_branch_in_sandbox,
 )
 
 _PROVISION = "products.tasks.backend.temporal.process_task.activities.provision_sandbox"
@@ -127,6 +132,46 @@ def test_build_sandbox_tags_drops_none_values():
 )
 def test_to_modal_domain_allowlist_resolves_exact_list(allowed_domains, expected):
     assert _to_modal_domain_allowlist(allowed_domains) == expected
+
+
+@patch(f"{_PROVISION}.emit_agent_log")
+@patch(f"{_PROVISION}.Sandbox.get_by_id")
+@pytest.mark.parametrize(
+    "used_snapshot, expected_checkout",
+    [
+        (False, "git checkout -B new-task-branch HEAD"),
+        (True, "git fetch --depth 1 origin -- HEAD && git checkout -B new-task-branch FETCH_HEAD"),
+    ],
+)
+def test_checkout_branch_creates_missing_branch_from_current_default_branch(
+    mock_get_sandbox, _mock_emit_agent_log, used_snapshot, expected_checkout
+):
+    sandbox = mock_get_sandbox.return_value
+
+    def execute(command, **_kwargs):
+        exit_code = 2 if "git ls-remote" in command else 0
+        return ExecutionResult(stdout="", stderr="", exit_code=exit_code)
+
+    sandbox.execute.side_effect = execute
+    activity_body = cast(
+        Callable[[CheckoutBranchInSandboxInput], CheckoutBranchInSandboxOutput],
+        vars(checkout_branch_in_sandbox)["__wrapped__"],
+    )
+
+    activity_body(
+        CheckoutBranchInSandboxInput(
+            context=_context(),
+            sandbox_id="sandbox-123",
+            repository="posthog/posthog",
+            branch="new-task-branch",
+            github_token="token",
+            shallow_clone=True,
+            used_snapshot=used_snapshot,
+        )
+    )
+
+    checkout_command = sandbox.execute.call_args_list[-1].args[0]
+    assert expected_checkout in checkout_command
 
 
 @patch(f"{_PROVISION}.get_git_identity_env_vars", return_value={})


### PR DESCRIPTION
## Problem

Choosing “Use as branch name” in a new cloud task can submit a branch that does not exist on the remote. Sandbox setup currently fetches every selected name as an existing remote branch, so setup fails before the agent starts


https://github.com/user-attachments/assets/4cf61482-fd68-45f9-bc45-8a687a0dc8a9