### PR TITLE
feat(conversations): improve support ticket search when no results

### DIFF
--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -563,6 +563,13 @@ class TestTicketAPI(APIBaseTest):
         self.assertEqual(response.json()["count"], 1)
         self.assertEqual(response.json()["results"][0]["id"], str(self.ticket.id))
 
+    def test_search_with_non_ascii_digit_does_not_error(self, mock_on_commit):
+        # "²" passes str.isdigit() but int() rejects it; it must fall through to text search
+        # rather than 500.
+        response = self.client.get(f"/api/projects/{self.team.id}/conversations/tickets/?search=%C2%B2")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 0)
+
     @parameterized.expand(
         [
             ("anonymous_name", {"anonymous_traits": {"name": "Alice Wonder"}}, "alice"),

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -555,6 +555,14 @@ class TestTicketAPI(APIBaseTest):
         self.assertEqual(response.json()["count"], 1)
         self.assertEqual(response.json()["results"][0]["id"], str(self.ticket.id))
 
+    def test_search_by_ticket_number_with_hash_prefix(self, mock_on_commit):
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/conversations/tickets/?search=%23{self.ticket.ticket_number}"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["id"], str(self.ticket.id))
+
     @parameterized.expand(
         [
             ("anonymous_name", {"anonymous_traits": {"name": "Alice Wonder"}}, "alice"),

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -440,8 +440,10 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
         if search and len(search) <= 200:
             # A leading "#" is how ticket numbers are shown in the UI (e.g. "#1234"), so
             # treat "#1234" the same as "1234" and match the ticket number exactly.
+            # Restrict to ASCII digits: str.isdigit() also accepts characters like "²"
+            # that int() then rejects, which would 500 the request.
             ticket_number_search = search[1:] if search.startswith("#") else search
-            if ticket_number_search.isdigit():
+            if ticket_number_search.isascii() and ticket_number_search.isdigit():
                 queryset = queryset.filter(ticket_number=int(ticket_number_search))
             else:
                 # EXISTS subquery: matches any comment in the ticket's conversation.

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -438,8 +438,11 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
 
         search = self.request.query_params.get("search")
         if search and len(search) <= 200:
-            if search.isdigit():
-                queryset = queryset.filter(ticket_number=int(search))
+            # A leading "#" is how ticket numbers are shown in the UI (e.g. "#1234"), so
+            # treat "#1234" the same as "1234" and match the ticket number exactly.
+            ticket_number_search = search[1:] if search.startswith("#") else search
+            if ticket_number_search.isdigit():
+                queryset = queryset.filter(ticket_number=int(ticket_number_search))
             else:
                 # EXISTS subquery: matches any comment in the ticket's conversation.
                 # Uses the (team_id, scope, item_id) composite index on Comment to

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -17,7 +17,6 @@ import {
 } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
-import { Link } from 'lib/lemon-ui/Link'
 import { useBulkSelection } from 'lib/lemon-ui/LemonTable/useBulkSelection'
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -172,9 +171,12 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
 
     const emptyState =
         searchQuery && hasActiveFilters ? (
-            <Link onClick={() => clearFiltersKeepingSearch()}>
-                You currently have filters applied. Try your search again without filters
-            </Link>
+            <div className="flex flex-col items-center gap-2 py-2">
+                <span>No tickets match your search with the current filters applied.</span>
+                <LemonButton type="secondary" size="small" onClick={() => clearFiltersKeepingSearch()}>
+                    Search again without filters
+                </LemonButton>
+            </div>
         ) : (
             'No tickets'
         )

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -95,8 +95,16 @@ function SupportTicketsBulkActions(): JSX.Element {
 
 export function SupportTicketsTable({ embedded = false }: SupportTicketsTableProps): JSX.Element {
     const logic = useMountedLogic(supportTicketsSceneLogic)
-    const { tickets, ticketsLoading, currentPage, totalCount, sorting, selectedTicketIds, searchQuery, hasActiveFilters } =
-        useValues(logic)
+    const {
+        tickets,
+        ticketsLoading,
+        currentPage,
+        totalCount,
+        sorting,
+        selectedTicketIds,
+        searchQuery,
+        hasActiveFilters,
+    } = useValues(logic)
     const { setCurrentPage, setSorting, setSelectedTicketIds, clearFiltersKeepingSearch } = useActions(logic)
     const { visibleColumns } = useValues(ticketColumnsLogic)
     const { push } = useActions(router)

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -17,6 +17,7 @@ import {
 } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { Link } from 'lib/lemon-ui/Link'
 import { useBulkSelection } from 'lib/lemon-ui/LemonTable/useBulkSelection'
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -95,8 +96,9 @@ function SupportTicketsBulkActions(): JSX.Element {
 
 export function SupportTicketsTable({ embedded = false }: SupportTicketsTableProps): JSX.Element {
     const logic = useMountedLogic(supportTicketsSceneLogic)
-    const { tickets, ticketsLoading, currentPage, totalCount, sorting, selectedTicketIds } = useValues(logic)
-    const { setCurrentPage, setSorting, setSelectedTicketIds } = useActions(logic)
+    const { tickets, ticketsLoading, currentPage, totalCount, sorting, selectedTicketIds, searchQuery, hasActiveFilters } =
+        useValues(logic)
+    const { setCurrentPage, setSorting, setSelectedTicketIds, clearFiltersKeepingSearch } = useActions(logic)
     const { visibleColumns } = useValues(ticketColumnsLogic)
     const { push } = useActions(router)
     const { currentTeam } = useValues(teamLogic)
@@ -168,10 +170,20 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
         toggleRow,
     ])
 
+    const emptyState =
+        searchQuery && hasActiveFilters ? (
+            <Link onClick={() => clearFiltersKeepingSearch()}>
+                You currently have filters applied. Try your search again without filters
+            </Link>
+        ) : (
+            'No tickets'
+        )
+
     return (
         <LemonTable<Ticket>
             dataSource={tickets}
             rowKey="id"
+            emptyState={emptyState}
             loading={ticketsLoading}
             // Keep rows clickable while a background refresh is in flight; the loading overlay
             // otherwise captures pointer events and blocks navigation on every reload.

--- a/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.ts
+++ b/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.ts
@@ -64,6 +64,7 @@ export interface supportTicketsSceneLogicValues {
         dateTo: string | null
     } | null
     dateTo: string | null
+    hasActiveFilters: boolean
     orderBy: string
     priorityFilter: TicketPriority[]
     searchQuery: string
@@ -96,6 +97,9 @@ export interface supportTicketsSceneLogicActions {
         status: TicketStatus
     }
     clearActiveView: () => {
+        value: true
+    }
+    clearFiltersKeepingSearch: () => {
         value: true
     }
     clearSelectedTickets: () => {
@@ -183,6 +187,18 @@ export interface supportTicketsSceneLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
         aiEnabled: (currentTeam: TeamType | null | import('~/types').TeamPublicType) => boolean
         orderBy: (sorting: Sorting | null) => string
+        hasActiveFilters: (
+            statusFilter: TicketStatus[],
+            priorityFilter: TicketPriority[],
+            channelFilter: TicketChannel | 'all',
+            slaFilter: TicketSlaState | 'all',
+            aiTriageResultFilter: AITriageFilterValue[],
+            assigneeFilterEntries: AssigneeFilterEntry[],
+            tagsFilter: string[],
+            tagsExcludeFilter: string[],
+            dateFrom: string | null,
+            dateTo: string | null
+        ) => boolean
         selectedTickets: (tickets: Ticket[], selectedTicketIds: string[]) => Ticket[]
         assigneeFilterEntries: (assigneeFilter: AssigneeFilterEntry[]) => AssigneeFilterEntry[]
         currentFilters: (
@@ -237,6 +253,7 @@ export const supportTicketsSceneLogic = kea<supportTicketsSceneLogicType>([
         setActiveView: (view: SavedTicketView | null) => ({ view }),
         clearActiveView: true,
         resetFilters: true,
+        clearFiltersKeepingSearch: true,
         setDateRangeBeforeView: (dateFrom: string | null, dateTo: string | null) => ({ dateFrom, dateTo }),
         bulkUpdateStatus: (ids: string[], status: TicketStatus) => ({ ids, status }),
         setBulkUpdating: (updating: boolean) => ({ updating }),
@@ -431,6 +448,42 @@ export const supportTicketsSceneLogic = kea<supportTicketsSceneLogicType>([
             (s) => [s.assigneeFilter],
             (assigneeFilter: AssigneeFilterEntry[]): AssigneeFilterEntry[] => normalizeAssigneeFilter(assigneeFilter),
         ],
+        hasActiveFilters: [
+            (s) => [
+                s.statusFilter,
+                s.priorityFilter,
+                s.channelFilter,
+                s.slaFilter,
+                s.aiTriageResultFilter,
+                s.assigneeFilterEntries,
+                s.tagsFilter,
+                s.tagsExcludeFilter,
+                s.dateFrom,
+                s.dateTo,
+            ],
+            (
+                status: TicketStatus[],
+                priority: TicketPriority[],
+                channel: TicketChannel | 'all',
+                sla: TicketSlaState | 'all',
+                aiTriageResult: AITriageFilterValue[],
+                assignee: AssigneeFilterEntry[],
+                tags: string[],
+                tagsExclude: string[],
+                dateFrom: string | null,
+                dateTo: string | null
+            ): boolean =>
+                status.length > 0 ||
+                priority.length > 0 ||
+                channel !== 'all' ||
+                sla !== 'all' ||
+                aiTriageResult.length > 0 ||
+                assignee.length > 0 ||
+                tags.length > 0 ||
+                tagsExclude.length > 0 ||
+                dateFrom !== null ||
+                dateTo !== null,
+        ],
         currentFilters: [
             (s) => [
                 s.statusFilter,
@@ -606,6 +659,17 @@ export const supportTicketsSceneLogic = kea<supportTicketsSceneLogicType>([
             actions.applyViewFilters({
                 ...DEFAULT_TICKET_FILTERS,
                 ...(dateRangeBeforeView ?? { dateFrom: null, dateTo: null }),
+            })
+        },
+        clearFiltersKeepingSearch: () => {
+            // Reset every filter to its default but keep the current search text, so the
+            // user can rerun the same search unconstrained (date range included → all time).
+            actions.clearActiveView()
+            actions.applyViewFilters({
+                ...DEFAULT_TICKET_FILTERS,
+                search: values.searchQuery,
+                dateFrom: null,
+                dateTo: null,
             })
         },
         setActiveView: ({ view }) => {

--- a/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.ts
+++ b/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.ts
@@ -187,6 +187,8 @@ export interface supportTicketsSceneLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
         aiEnabled: (currentTeam: TeamType | null | import('~/types').TeamPublicType) => boolean
         orderBy: (sorting: Sorting | null) => string
+        selectedTickets: (tickets: Ticket[], selectedTicketIds: string[]) => Ticket[]
+        assigneeFilterEntries: (assigneeFilter: AssigneeFilterEntry[]) => AssigneeFilterEntry[]
         hasActiveFilters: (
             statusFilter: TicketStatus[],
             priorityFilter: TicketPriority[],
@@ -199,8 +201,6 @@ export interface supportTicketsSceneLogicMeta {
             dateFrom: string | null,
             dateTo: string | null
         ) => boolean
-        selectedTickets: (tickets: Ticket[], selectedTicketIds: string[]) => Ticket[]
-        assigneeFilterEntries: (assigneeFilter: AssigneeFilterEntry[]) => AssigneeFilterEntry[]
         currentFilters: (
             statusFilter: TicketStatus[],
             priorityFilter: TicketPriority[],


### PR DESCRIPTION
## Problem

In the Support tickets scene, search is scoped by whatever filters are currently applied, so a search can return nothing even when a matching ticket exists (e.g. it falls outside the active date range or a status filter). The empty table gave no hint that filters were the cause. Separately, ticket numbers are shown as `#1234`, but pasting `#1234` into search matched nothing because the `#` broke the numeric-lookup path. Raised in [this Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1784712903051889?thread_ts=1784712903.051889&cid=C075D3C5HST).

**Why:** Support staff searched for a ticket, got zero results with no explanation, and couldn't find a known ticket by its displayed `#`-prefixed number.

## Changes

- When a search returns no rows and any filters are active, the empty table now renders a link that reruns the same search with all filters cleared (date range reset to all time).
- Searching for `#1234` now strips the leading `#` and matches ticket number `1234` exactly, the same as searching `1234`.

<img width="1312" height="360" alt="CleanShot 2026-07-22 at 11 07 04" src="https://github.com/user-attachments/assets/ec8e1515-69c1-461d-9aa8-28a502d1ab19" />


## How did you test this code?

Added a backend test (`test_search_by_ticket_number_with_hash_prefix`) covering the `#`-prefixed ticket-number lookup. The empty-state link is wired through the scene logic (`hasActiveFilters` selector + `clearFiltersKeepingSearch` action). I was not able to run the full test suite or frontend typecheck in this environment (deps not installed).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from the linked thread. Backend change is a small tweak inside the existing `search` handling in `TicketViewSet.safely_get_queryset` — no new query param, so no serializer/OpenAPI changes. Frontend adds a `hasActiveFilters` selector and a `clearFiltersKeepingSearch` action to the existing kea logic and passes an `emptyState` to the tickets `LemonTable`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1784712903051889?thread_ts=1784712903.051889&cid=C075D3C5HST)*
