### PR TITLE
fix(intercom): treat companies scroll cursor expiry as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/source.py
@@ -63,6 +63,15 @@ class IntercomSource(SimpleSource[IntercomSourceConfig], OAuthMixin):
             "Intercom access token not found": "Intercom OAuth access token is missing. Please reconnect your Intercom account.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # The `companies` table walks Intercom's companies Scroll API (`_iter_companies` in
+        # intercom.py). The scroll cursor expires mid-walk on idle timeout or when a
+        # concurrent sync steals the workspace's single scroll slot, and the continuation
+        # then 404s (see `_is_scroll_expired`). `companies` is full-refresh, so a fresh
+        # Temporal attempt opens a new scroll and restarts cleanly — transient and
+        # self-recovering, not a real bug.
+        return {"Not Found for url: https://api.intercom.io/companies/scroll"}
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/tests/test_intercom_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/intercom/tests/test_intercom_source.py
@@ -62,6 +62,21 @@ class TestIntercomSource:
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert any(key in error_msg for key in non_retryable_errors)
 
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            "404 Client Error: Not Found for url: https://api.intercom.io/companies/scroll?scroll_param=c77e46e6-6344-4ada-a0c7-fba26d6af725",
+            "404 Client Error: Not Found for url: https://api.intercom.io/companies/scroll",
+        ],
+    )
+    def test_companies_scroll_expiry_is_retryable(self, error_msg):
+        # A companies scroll cursor expiring mid-walk (idle timeout, or a concurrent sync
+        # stealing the workspace's single scroll slot) 404s on continuation. `companies` is
+        # full-refresh, so a fresh Temporal attempt restarts cleanly — this should stay out
+        # of error tracking as noise rather than be flagged as a real failure.
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(key in error_msg for key in retryable_errors)
+
     def test_get_schemas_covers_all_endpoints(self):
         schemas = self.source.get_schemas(self.config, self.team_id)
 


### PR DESCRIPTION
## Problem

Error tracking flagged a recurring `HTTPError: 404 Client Error: Not Found for url: https://api.intercom.io/companies/scroll?scroll_param=...` from the Intercom warehouse source ([issue](https://us.posthog.com/project/2/error_tracking/019eef73-bd06-7703-bc39-fde03918b5b3)).

The `companies` table walks Intercom's companies Scroll API (`_iter_companies` in `intercom.py`). The scroll cursor can be invalidated mid-walk — it expires after roughly a minute idle, and Intercom only allows one open scroll per workspace, so a concurrent sync can steal the slot. The next continuation request then 404s.

This is already a known, documented condition in the source (`_is_scroll_expired`, and the docstring on `_company_segments_generator` explaining the design), and it's already handled correctly at the retry level: `companies` is a full-refresh table, so letting the error surface and having Temporal retry the whole activity is safe — a fresh attempt opens a new scroll and restarts cleanly. Nothing was broken.

The gap was purely on the observability side: this transient, self-recovering condition wasn't in `IntercomSource.get_retryable_errors()`, so it was logged at `exception` level and picked up by error tracking as noise instead of `warning` level like other sources' internally-retried transient errors (see `ClickHouseSource`, `MatomoSource`, `MixpanelSource`, `TwelveDataSource`).

## Changes

- Add `IntercomSource.get_retryable_errors()` matching the companies-scroll 404, following the existing pattern used by other sources for transient/self-recovering failures.

## How did you test this code?

Added two parametrized cases to `test_intercom_source.py::TestIntercomSource` asserting the real 404 message (with and without the volatile `scroll_param` value) matches the new retryable marker — guards against the marker string and the raised message drifting apart. Ran the full `test_intercom_source.py` suite (21 passed) plus `ruff check`/`ruff format --check` on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (Sonnet 5), triaging a real error tracking issue delivered by webhook.
- Investigated the issue via PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`), read the full stack trace and source code, and confirmed the failure is a documented, already-correctly-retried transient condition — not a functional bug. Ruled out marking it non-retryable (that would stop legitimate retries) and ruled out any code path change (the existing restart/backoff logic elsewhere in the file already covers this class of error for the `company_segments` substream; the `companies` streaming endpoint intentionally lets it surface so Temporal retries the whole activity).
- Searched open PRs (by exception type, source path, and the maintainer's own open PRs) — found #71657 (Intercom API version support) touches the same files but not this error path; no duplicate found.
- Skills invoked: `/writing-tests` before adding the parametrized test cases.