### PR TITLE
fix(data-warehouse): include unreleased sources in public source configs

### DIFF
--- a/products/data_warehouse/backend/presentation/views/public_source_configs.py
+++ b/products/data_warehouse/backend/presentation/views/public_source_configs.py
@@ -14,7 +14,7 @@ logger = structlog.get_logger(__name__)
 
 
 @functools.cache
-def build_source_configs(*, include_tables: bool = True, include_unreleased: bool = True) -> dict[str, dict]:
+def build_source_configs(*, include_tables: bool = True) -> dict[str, dict]:
     """Build the source-config catalog returned by both the public endpoint and the wizard.
 
     Each entry is the source's ``SourceConfig`` augmented with ``supportsColumnSelection`` and,
@@ -23,10 +23,6 @@ def build_source_configs(*, include_tables: bool = True, include_unreleased: boo
     in-app wizard skips it because nothing in the app reads it and it is ~40% of the payload.
     Kept in one place so the two endpoints can never drift (see ``test_matches_wizard_response``).
 
-    When ``include_unreleased`` is false, sources marked ``unreleasedSource`` are omitted. The
-    authenticated wizard keeps them so the app can render "coming soon" entries; the public,
-    unauthenticated catalog drops them so unreleased connector metadata isn't disclosed early.
-
     The catalog is deploy-static (it only changes when source code ships), so the result is
     memoized per process — callers must treat it as read-only.
     """
@@ -34,10 +30,7 @@ def build_source_configs(*, include_tables: bool = True, include_unreleased: boo
 
     results: dict[str, dict] = {}
     for source_type, source in sources.items():
-        source_config = source.get_source_config
-        if not include_unreleased and source_config.unreleasedSource:
-            continue
-        config = source_config.model_dump()
+        config = source.get_source_config.model_dump()
         config["supportsColumnSelection"] = bool(source.supports_column_selection)
         config["versions"] = list(source.supported_versions)
         config["defaultVersion"] = source.default_version
@@ -84,6 +77,5 @@ class PublicSourceConfigViewSet(viewsets.ViewSet):
     def list(self, request: Request) -> Response:
         # Results are deploy-static (they only change when source code ships), so this is a
         # safe candidate for caching if the endpoint ever gets hot; today it is fetched only
-        # at posthog.com build time. Unreleased sources are excluded so their connector
-        # metadata isn't disclosed to unauthenticated callers before release.
-        return Response(status=status.HTTP_200_OK, data=build_source_configs(include_unreleased=False))
+        # at posthog.com build time.
+        return Response(status=status.HTTP_200_OK, data=build_source_configs())

--- a/products/data_warehouse/backend/tests/api/test_public_source_configs.py
+++ b/products/data_warehouse/backend/tests/api/test_public_source_configs.py
@@ -19,9 +19,8 @@ class TestPublicSourceConfigs(APIBaseTest):
         assert "fields" in first_config
 
     def test_matches_wizard_response(self):
-        """Public endpoint returns the same data as the authenticated /wizard endpoint for released
-        sources, plus the docs-only `tables` catalog the wizard deliberately omits to keep its
-        payload small. Unreleased sources are wizard-only (see test_excludes_unreleased_sources)."""
+        """Public endpoint returns the same data as the authenticated /wizard endpoint, plus the
+        docs-only `tables` catalog the wizard deliberately omits to keep its payload small."""
         response = self.client.get("/api/public_source_configs/")
         assert response.status_code == status.HTTP_200_OK
 
@@ -31,24 +30,11 @@ class TestPublicSourceConfigs(APIBaseTest):
         wizard_data = wizard_response.json()
         assert not any("tables" in config for config in wizard_data.values())
 
-        # The public catalog omits unreleased sources, so compare against the wizard restricted
-        # to released ones.
-        wizard_released = {st: config for st, config in wizard_data.items() if not config.get("unreleasedSource")}
-
         public_without_tables = {
             source_type: {k: v for k, v in config.items() if k != "tables"}
             for source_type, config in response.json().items()
         }
-        assert public_without_tables == wizard_released
-
-    def test_excludes_unreleased_sources(self):
-        """Unreleased connector metadata must not be disclosed to unauthenticated callers, but the
-        authenticated wizard still exposes it so the app can render "coming soon" entries."""
-        public = self.client.get("/api/public_source_configs/").json()
-        assert not any(config.get("unreleasedSource") for config in public.values())
-
-        wizard = self.client.get("/api/environments/@current/external_data_sources/wizard/").json()
-        assert any(config.get("unreleasedSource") for config in wizard.values())
+        assert public_without_tables == wizard_data
 
     def test_accessible_without_authentication(self):
         self.client.logout()


### PR DESCRIPTION
## Problem

PR #72669 (scaffolding 379 unimplemented sources) also added an `include_unreleased` gate that made the public, unauthenticated `/api/public_source_configs/` endpoint drop every source marked `unreleasedSource`. That gate was not intended. It halved the catalog that downstream consumers of the public endpoint see (from the full registered set of ~1250 down to ~570 released sources).

## Changes

Revert the gate. `build_source_configs` goes back to just `include_tables`, and the public endpoint returns all registered sources again, matching the authenticated wizard. `test_matches_wizard_response` is restored to compare the public endpoint against the full wizard response, and the added `test_excludes_unreleased_sources` is removed. The 379 scaffolded sources from #72669 are untouched.

Both changed files are now byte-for-byte identical to their pre-#72669 state.

> [!NOTE]
> This re-exposes unreleased connector metadata on the public unauthenticated endpoint. That is the pre-#72669 behaviour and is what's intended here.

## How did you test this code?

I did not run the Django suite locally in this environment. I verified with `git diff` that both `public_source_configs.py` and `test_public_source_configs.py` are byte-identical to their state before #72669 (which passed CI). CI on this PR runs the restored `test_matches_wizard_response`.