### PR TITLE
fix(mem0): follow relative pagination links from the events endpoint

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/mem0.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/mem0.py
@@ -10,7 +10,7 @@ it is redacted from logs and raised error messages.
 import dataclasses
 from datetime import UTC, date, datetime
 from typing import Any, Optional
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
@@ -97,18 +97,23 @@ def _build_memories_filters(incremental_field: str, cutoff: str | None) -> dict[
 
 
 def _ensure_mem0_origin(url: str) -> str:
-    """Refuse pagination/resume URLs that leave the Mem0 API origin.
+    """Resolve a pagination/resume URL against the Mem0 API origin, refusing any that leave it.
 
-    The session carries the API key on every request, so following an off-origin ``next`` link
-    (from a tampered response, or a poisoned resume-state entry) would send the credential to an
-    arbitrary host. Rejects any URL whose scheme or host differs from the Mem0 API origin —
-    including an ``http://`` downgrade to the same host.
+    Mem0's ``next`` links are sometimes relative (e.g. ``/v1/events/?page=2``); resolving them
+    against the API base yields the absolute URL the request must target. The session carries the
+    API key on every request, so following an off-origin link (from a tampered response, or a
+    poisoned resume-state entry) would send the credential to an arbitrary host. Rejects any URL
+    that resolves to a scheme or host other than the Mem0 API origin — including a scheme-relative
+    ``//other-host`` link or an ``http://`` downgrade to the same host.
     """
-    parsed = urlparse(url)
+    resolved = urljoin(MEM0_BASE_URL, url)
+    parsed = urlparse(resolved)
     expected = urlparse(MEM0_BASE_URL)
     if parsed.scheme != expected.scheme or parsed.netloc != expected.netloc:
-        raise ValueError(f"Refusing to follow a pagination URL off the Mem0 API origin: {url}")
-    return url
+        raise ValueError(
+            f"Refusing to follow a pagination URL off the Mem0 API origin: {parsed.scheme}://{parsed.netloc}"
+        )
+    return resolved
 
 
 class Mem0OriginPinnedPaginator(JSONResponsePaginator):
@@ -118,12 +123,12 @@ class Mem0OriginPinnedPaginator(JSONResponsePaginator):
     def update_state(self, response: Any, data: Optional[list[Any]] = None) -> None:
         super().update_state(response, data)
         if self._has_next_page and self._next_url is not None:
-            _ensure_mem0_origin(self._next_url)
+            self._next_url = _ensure_mem0_origin(self._next_url)
 
     def set_resume_state(self, state: dict[str, Any]) -> None:
         next_url = state.get("next_url")
         if next_url is not None:
-            _ensure_mem0_origin(next_url)
+            state = {**state, "next_url": _ensure_mem0_origin(next_url)}
         super().set_resume_state(state)
 
 
@@ -311,8 +316,7 @@ def _events_resource(
     if resume is not None and resume.next_url:
         # Validate the seeded resume URL before it is ever requested (poisoned resume state must
         # not receive the credentialed request); the paginator re-checks on seed too.
-        _ensure_mem0_origin(resume.next_url)
-        initial_paginator_state = {"next_url": resume.next_url}
+        initial_paginator_state = {"next_url": _ensure_mem0_origin(resume.next_url)}
 
     rest_config: RESTAPIConfig = {
         "client": client,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/test_mem0.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/test_mem0.py
@@ -259,6 +259,21 @@ class TestEventsRows:
         assert prepared[1].url == next_url
         manager.save_state.assert_called_once_with(Mem0ResumeConfig(endpoint=EVENTS_ENDPOINT, next_url=next_url))
 
+    def test_follows_relative_next_urls(self):
+        # Mem0's /v1/events/ envelope returns a relative `next` link; it must resolve against the
+        # API origin rather than be rejected as off-origin.
+        absolute_next = f"{MEM0_BASE_URL}/v1/events/?page=2"
+        manager = _manager()
+        rows, prepared = _run(
+            EVENTS_ENDPOINT,
+            [_response([{"id": "e1"}], next_url="/v1/events/?page=2"), _response([{"id": "e2"}], next_url=None)],
+            manager,
+        )
+
+        assert rows == [{"id": "e1"}, {"id": "e2"}]
+        assert prepared[1].url == absolute_next
+        manager.save_state.assert_called_once_with(Mem0ResumeConfig(endpoint=EVENTS_ENDPOINT, next_url=absolute_next))
+
     def test_resumes_from_the_saved_next_url(self):
         saved_url = f"{MEM0_BASE_URL}/v1/events/?page=5"
         manager = _manager(Mem0ResumeConfig(endpoint=EVENTS_ENDPOINT, next_url=saved_url))


### PR DESCRIPTION
## Problem

The Mem0 data warehouse source crashes when paginating the `/v1/events/` endpoint. That endpoint returns a **relative** `next` link (e.g. `/v1/events/?page=2`), but the source's origin-pinning guard `_ensure_mem0_origin` ran `urlparse` directly on the link. A relative URL has no scheme or host, so the guard read them as empty, decided the link had left the Mem0 API origin, and raised:

```
ValueError: Refusing to follow a pagination URL off the Mem0 API origin: /v1/events/?page=2
```

The sync fetched page 1 fine and then died the moment it tried to follow the next link. The guard exists for a real reason (the session carries the API key on every request, so an off-origin `next` link would leak the credential), but a same-origin relative link is exactly the safe case it was wrongly rejecting.

Observed in error tracking: [issue 019f8947-9643-7f40-b3d0-c33d567f8227](https://us.posthog.com/project/2/error_tracking/019f8947-9643-7f40-b3d0-c33d567f8227). Top in-app frame is `_ensure_mem0_origin` in `mem0.py`, so the failure originates in our code, not upstream.

## Changes

This is a fixable bug in our code, not a user or upstream error, so I fixed the guard rather than marking anything non-retryable.

`_ensure_mem0_origin` now resolves the URL against `MEM0_BASE_URL` with `urljoin` before validating, and returns the resolved absolute URL. The paginator stores that resolved value, so both the follow-up request and the saved resume checkpoint use an absolute URL (a relative one would otherwise fail later at request-prepare time).

The security property is unchanged. A relative link can only resolve back onto the API origin, while every off-origin shape still resolves to a foreign scheme or host and is refused:

- absolute off-origin (`https://evil.example.com/...`)
- scheme-relative (`//evil.example.com/...`)
- scheme downgrade (`http://api.mem0.ai/...`)
- lookalike host (`https://api.mem0.ai.evil.example.com/...`)

## How did you test this code?

Automated tests only (I did not run a live Mem0 sync).

- Added `test_follows_relative_next_urls` to `TestEventsRows`: the events endpoint returns a relative `next` link and the sync must follow it, request the resolved absolute URL, and checkpoint the absolute URL. This is the exact regression from the error above; no existing test covered a relative `next` (they all used absolute URLs, which is why this shipped).
- The existing off-origin refusal cases (absolute, scheme-relative, http downgrade, lookalike host) still pass, confirming the guard was loosened for relative links only.
- Ran the full mem0 suite: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/mem0/tests/` — 49 passed. Lint (`ruff check`) and format (`ruff format`) clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected — internal pagination fix, no user-facing behavior or config change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking alert and fixed by Claude (Opus 4.8). No human drove the work, so the PR is left unassigned for the owning team to triage.

Skills invoked: `/writing-tests` (to gate the new regression test).

Decision path: confirmed the crashing frame was our own `_ensure_mem0_origin` via the error-tracking issue, traced the call path through the shared `rest_source` paginator, and confirmed the memories endpoint returns absolute `next` links (works today) while events returns relative ones (crashes). Considered fixing at the shared paginator layer but scoped it to the mem0 guard, since that guard is where the rejection happens and returning the resolved absolute URL there also keeps the downstream request and resume checkpoint valid.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
