### PR TITLE
fix(data-warehouse): tolerate string team ids from the control plane

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -3018,7 +3018,14 @@ def _reconcile_earliest_event_dates_with_cp(backfills: list[DuckgresServerTeam])
             teams = managed_warehouse._teams_from_response(managed_warehouse.list_teams(org_id, require_enabled=False))
             if teams is None:
                 continue
-            cp_dates = {row.get("team_id"): row.get("earliest_event_date") for row in teams}
+            # Coerce team ids to int: a control plane serializing them as JSON strings
+            # would otherwise make every team look unknown and silently skip the repair.
+            cp_dates = {}
+            for row in teams:
+                try:
+                    cp_dates[int(row["team_id"])] = row.get("earliest_event_date")
+                except (KeyError, TypeError, ValueError):
+                    continue
             for bf in rows:
                 if bf.team_id not in cp_dates:
                     continue

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -931,6 +931,8 @@ class TestEarliestEventDateReconcile:
         [
             # CP has no date for the team -> re-push
             ("cp_missing_date", {"team_id": 1, "earliest_event_date": None}, True),
+            # A CP serializing team_id as a string must not make the team look unknown
+            ("cp_string_team_id", {"team_id": "1", "earliest_event_date": None}, True),
             # CP has a stale date -> re-push
             ("cp_stale_date", {"team_id": 1, "earliest_event_date": "2019-01-01"}, True),
             # CP already converged -> nothing to do

--- a/products/data_warehouse/backend/presentation/views/managed_warehouse.py
+++ b/products/data_warehouse/backend/presentation/views/managed_warehouse.py
@@ -198,9 +198,17 @@ def _get_project_team_row(*, organization_id: UUID | str, team_id: int) -> dict 
     if not status.is_success(resp.status_code) or not isinstance(resp.data, dict):
         raise RuntimeError("Failed to read the organization's managed warehouse team rows")
     for row in resp.data.get("teams") or []:
-        if isinstance(row, dict) and row.get("team_id") == team_id:
+        if isinstance(row, dict) and _row_team_id(row) == team_id:
             return row
     return None
+
+
+def _row_team_id(row: dict) -> int | None:
+    """A control-plane row's team id as int, tolerating a string serialization."""
+    try:
+        return int(row["team_id"])
+    except (KeyError, TypeError, ValueError):
+        return None
 
 
 def configure_project_reader(
@@ -639,7 +647,7 @@ def team_onboarding_state(organization_id: UUID | str, team_id: int) -> dict:
     try:
         teams = _teams_from_response(list_teams(organization_id, require_enabled=False))
         if teams is not None:
-            duckgres_team = next((row for row in teams if row.get("team_id") == team_id), None)
+            duckgres_team = next((row for row in teams if _row_team_id(row) == team_id), None)
             if duckgres_team is None and has_django_row:
                 duckgres_team = _push_grandfathered_team(organization_id, team_id, table_suffix)
             elif duckgres_team is not None and not has_django_row:


### PR DESCRIPTION
## Problem

Review feedback on #72827: if the control plane ever serializes `team_id` as a JSON string, the sensor's reconciliation map is keyed by strings (`"42"`) while Django team ids are ints (`42`) — every team then looks unknown and the repair is silently skipped. Our control plane marshals `team_id` as a JSON number today (Go `int64`), so this is defensive, but the failure mode is silent, so it's worth closing.

## Changes

- The reconcile pass coerces `team_id` to int when building its lookup map; rows without a usable id are skipped.
- The adapter's two row-lookup sites (`_get_project_team_row`, `team_onboarding_state`) get the same coercion via a shared `_row_team_id` helper — same latent pattern, same fix.

## How did you test this code?

Automated only: new `cp_string_team_id` case in the parameterized reconcile test (string id must still repair); full `test_events_backfill_to_duckling.py` + `test_managed_warehouse.py` suites green locally (291 passed); ruff clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, addressing post-merge review feedback on #72827. Verified against production control-plane responses that team_id is currently a JSON number, so the change is hardening, not a live bug fix. Skills invoked: /writing-tests.
