### PR TITLE
feat(conversations): independent tabbed buffers for reply vs internal note

### DIFF
--- a/products/conversations/frontend/components/Chat/ChatView.tsx
+++ b/products/conversations/frontend/components/Chat/ChatView.tsx
@@ -30,11 +30,15 @@ export interface ChatViewProps {
     unreadCustomerCount?: number
     /** Whether to show delivery status on team messages */
     showDeliveryStatus?: boolean
-    /** Draft content to restore (for tab persistence) */
+    /** Draft content to restore (for tab persistence) — the public reply body */
     draftContent?: JSONContent | null
-    /** Called when draft content changes */
+    /** Called when the public reply draft changes */
     onDraftChange?: (content: JSONContent | null) => void
-    /** Whether the private note checkbox is checked */
+    /** Separate draft body for the internal note tab */
+    privateDraftContent?: JSONContent | null
+    /** Called when the internal note draft changes */
+    onPrivateDraftChange?: (content: JSONContent | null) => void
+    /** Whether the internal-note tab is the active one */
     isPrivate?: boolean
     /** Called when private checkbox changes */
     onPrivateChange?: (isPrivate: boolean) => void
@@ -74,6 +78,8 @@ export function ChatView({
     showDeliveryStatus = false,
     draftContent,
     onDraftChange,
+    privateDraftContent,
+    onPrivateDraftChange,
     isPrivate,
     onPrivateChange,
     extraActions,
@@ -117,6 +123,8 @@ export function ChatView({
                     showPrivateOption={showPrivateOption}
                     draftContent={draftContent}
                     onDraftChange={onDraftChange}
+                    privateDraftContent={privateDraftContent}
+                    onPrivateDraftChange={onPrivateDraftChange}
                     isPrivate={isPrivate}
                     onPrivateChange={onPrivateChange}
                     extraActions={extraActions}

--- a/products/conversations/frontend/components/Chat/ChatView.tsx
+++ b/products/conversations/frontend/components/Chat/ChatView.tsx
@@ -34,13 +34,13 @@ export interface ChatViewProps {
     draftContent?: JSONContent | null
     /** Called when the public reply draft changes */
     onDraftChange?: (content: JSONContent | null) => void
-    /** Separate draft body for the internal note tab */
+    /** Separate draft body for the private note tab */
     privateDraftContent?: JSONContent | null
-    /** Called when the internal note draft changes */
+    /** Called when the private note draft changes */
     onPrivateDraftChange?: (content: JSONContent | null) => void
-    /** Whether the internal-note tab is the active one */
+    /** Whether the private-note tab is the active one */
     isPrivate?: boolean
-    /** Called when private checkbox changes */
+    /** Called when the active tab changes */
     onPrivateChange?: (isPrivate: boolean) => void
     /** Extra actions rendered next to the send button in MessageInput */
     extraActions?: React.ReactNode

--- a/products/conversations/frontend/components/Chat/MessageInput.test.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.test.tsx
@@ -10,13 +10,24 @@ import type { TicketStatus } from '../../types'
 import { MessageInput } from './MessageInput'
 
 // The real SupportEditor pulls in tiptap, mentions, and uploads; the behavior under test is
-// MessageInput's own wiring, which only needs an editor exposing getJSON().
+// MessageInput's own wiring, which only needs an editor exposing the buffer API. The mock is
+// stateful so tab switches (setContent) and stash-on-switch (getJSON) can be asserted.
+const mockEditorHolder: { current: any } = { current: null }
 jest.mock('../Editor', () => {
     const React = jest.requireActual<typeof import('react')>('react')
     return {
         SupportEditor: ({ onCreate }: { onCreate: (editor: unknown) => void }) => {
             React.useEffect(() => {
-                onCreate({ getJSON: () => ({ type: 'doc' }), clear: () => {} })
+                // getJSON is stable so callers can assert on it; emptiness is driven by
+                // MessageInput's own state (seeded from the active draft prop), not the editor.
+                mockEditorHolder.current = {
+                    getJSON: () => ({ type: 'doc' }),
+                    setContent: jest.fn(),
+                    clear: jest.fn(),
+                    isEmpty: () => false,
+                    focus: jest.fn(),
+                }
+                onCreate(mockEditorHolder.current)
                 // eslint-disable-next-line react-hooks/exhaustive-deps
             }, [])
             return React.createElement('div')
@@ -30,6 +41,8 @@ const SEND_AND_SET_STATUS_OPTIONS: { value: TicketStatus; statusLabel: string }[
     { value: 'on_hold', statusLabel: 'on hold' },
     { value: 'resolved', statusLabel: 'resolved' },
 ]
+
+const NON_EMPTY_DOC = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'x' }] }] }
 
 describe('MessageInput send-and-set-status dropdown', () => {
     beforeEach(() => {
@@ -58,7 +71,8 @@ describe('MessageInput send-and-set-status dropdown', () => {
                     onPrivateChange={jest.fn()}
                     draftMode={false}
                     onDraftModeChange={jest.fn()}
-                    draftContent={{ type: 'doc', content: [] }}
+                    draftContent={NON_EMPTY_DOC}
+                    privateDraftContent={NON_EMPTY_DOC}
                     sendAndSetStatusOptions={SEND_AND_SET_STATUS_OPTIONS}
                 />
             </Provider>
@@ -75,5 +89,74 @@ describe('MessageInput send-and-set-status dropdown', () => {
         await userEvent.click(screen.getByText(`${verb} and set pending`))
         expect(onSendMessage).toHaveBeenCalledTimes(1)
         expect(onSendMessage).toHaveBeenCalledWith('hello', { type: 'doc' }, isPrivate, expect.any(Function), 'pending')
+    })
+})
+
+describe('MessageInput reply/internal-note tabs', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+        mockEditorHolder.current = null
+    })
+
+    it('stashes the current tab body and switches active tab on tab change', async () => {
+        const onDraftChange = jest.fn()
+        const onPrivateDraftChange = jest.fn()
+        const onPrivateChange = jest.fn()
+
+        render(
+            <Provider>
+                <MessageInput
+                    onSendMessage={jest.fn()}
+                    messageSending={false}
+                    showPrivateOption
+                    isPrivate={false}
+                    onPrivateChange={onPrivateChange}
+                    draftContent={NON_EMPTY_DOC}
+                    onDraftChange={onDraftChange}
+                    privateDraftContent={null}
+                    onPrivateDraftChange={onPrivateDraftChange}
+                />
+            </Provider>
+        )
+
+        await userEvent.click(screen.getByText('Internal note'))
+
+        // The reply body in the editor is stashed to the public buffer, and the active tab flips.
+        expect(onDraftChange).toHaveBeenCalledWith(mockEditorHolder.current.getJSON())
+        expect(onPrivateDraftChange).not.toHaveBeenCalled()
+        expect(onPrivateChange).toHaveBeenCalledWith(true)
+    })
+
+    it('clears only the sent tab and preserves the other draft', async () => {
+        const onSendMessage = jest.fn((_c, _r, _p, onSuccess: () => void) => onSuccess())
+        const onDraftChange = jest.fn()
+        const onPrivateDraftChange = jest.fn()
+
+        render(
+            <Provider>
+                <MessageInput
+                    onSendMessage={onSendMessage}
+                    messageSending={false}
+                    showPrivateOption
+                    isPrivate={false}
+                    onPrivateChange={jest.fn()}
+                    draftContent={NON_EMPTY_DOC}
+                    onDraftChange={onDraftChange}
+                    privateDraftContent={NON_EMPTY_DOC}
+                    onPrivateDraftChange={onPrivateDraftChange}
+                />
+            </Provider>
+        )
+
+        await userEvent.click(screen.getByRole('button', { name: 'Send' }))
+
+        // The reply buffer is cleared; the internal-note buffer is never touched.
+        expect(onSendMessage).toHaveBeenCalledWith('hello', { type: 'doc' }, false, expect.any(Function), undefined)
+        expect(onDraftChange).toHaveBeenLastCalledWith(null)
+        expect(onPrivateDraftChange).not.toHaveBeenCalled()
     })
 })

--- a/products/conversations/frontend/components/Chat/MessageInput.test.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.test.tsx
@@ -53,8 +53,8 @@ describe('MessageInput send-and-set-status dropdown', () => {
         cleanup()
     })
 
-    // Guards the private-note flag through the dropdown path: dropping it would deliver an
-    // internal note to the customer as a real reply.
+    // Guards the private-note flag through the dropdown path: dropping it would deliver a
+    // private note to the customer as a real reply.
     test.each<[string, boolean, string]>([
         ['regular mode', false, 'Send'],
         ['private note mode', true, 'Attach'],
@@ -92,7 +92,7 @@ describe('MessageInput send-and-set-status dropdown', () => {
     })
 })
 
-describe('MessageInput reply/internal-note tabs', () => {
+describe('MessageInput reply/private-note tabs', () => {
     beforeEach(() => {
         initKeaTests()
     })
@@ -123,7 +123,7 @@ describe('MessageInput reply/internal-note tabs', () => {
             </Provider>
         )
 
-        await userEvent.click(screen.getByText('Internal note'))
+        await userEvent.click(screen.getByText('Private note'))
 
         // The reply body in the editor is stashed to the public buffer, and the active tab flips.
         expect(onDraftChange).toHaveBeenCalledWith(mockEditorHolder.current.getJSON())
@@ -154,7 +154,7 @@ describe('MessageInput reply/internal-note tabs', () => {
 
         await userEvent.click(screen.getByRole('button', { name: 'Send' }))
 
-        // The reply buffer is cleared; the internal-note buffer is never touched.
+        // The reply buffer is cleared; the private-note buffer is never touched.
         expect(onSendMessage).toHaveBeenCalledWith('hello', { type: 'doc' }, false, expect.any(Function), undefined)
         expect(onDraftChange).toHaveBeenLastCalledWith(null)
         expect(onPrivateDraftChange).not.toHaveBeenCalled()

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -23,18 +23,18 @@ export interface MessageInputProps {
     placeholder?: string
     buttonText?: string
     minRows?: number
-    /** Whether to show the reply / internal-note tab switch */
+    /** Whether to show the reply / private-note tab switch */
     showPrivateOption?: boolean
     /** Public reply draft content to restore (from parent logic for tab persistence) */
     draftContent?: JSONContent | null
     /** Called when the public reply draft changes */
     onDraftChange?: (content: JSONContent | null) => void
-    /** Internal-note draft content, kept separate from the public reply so the two
+    /** Private-note draft content, kept separate from the public reply so the two
      *  tabs never overwrite each other. Only used when showPrivateOption is set. */
     privateDraftContent?: JSONContent | null
-    /** Called when the internal-note draft changes */
+    /** Called when the private-note draft changes */
     onPrivateDraftChange?: (content: JSONContent | null) => void
-    /** Whether the internal-note tab is the active one (from parent logic for tab persistence) */
+    /** Whether the private-note tab is the active one (from parent logic for tab persistence) */
     isPrivate?: boolean
     /** Called when the active tab changes */
     onPrivateChange?: (isPrivate: boolean) => void
@@ -85,7 +85,7 @@ export function MessageInput({
 
     // The editor only ever holds the active tab's body; the other tab's body lives
     // in the parent (draftContent / privateDraftContent) and is swapped into the
-    // editor on a tab change so the reply and the internal note never overwrite
+    // editor on a tab change so the reply and the private note never overwrite
     // each other.
     const activeDraftContent = isPrivate ? privateDraftContent : draftContent
 
@@ -143,7 +143,7 @@ export function MessageInput({
                     () => {
                         // Clear only the tab that was just sent; the other tab's draft
                         // is deliberately preserved so sending a reply never discards an
-                        // in-progress internal note (or vice versa), and the active tab
+                        // in-progress private note (or vice versa), and the active tab
                         // stays put.
                         editorRef.current?.clear()
                         setIsEmpty(true)
@@ -236,7 +236,7 @@ export function MessageInput({
             label: (
                 <span className="inline-flex items-center gap-1.5">
                     <IconLock className="text-sm" />
-                    Internal note
+                    Private note
                     {!isPrivate && privateHasDraft ? draftDot : null}
                 </span>
             ),

--- a/products/conversations/frontend/components/Chat/MessageInput.tsx
+++ b/products/conversations/frontend/components/Chat/MessageInput.tsx
@@ -2,7 +2,8 @@ import { JSONContent } from '@tiptap/core'
 import { useEffect, useRef, useState } from 'react'
 
 import { IconLock } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonSegmentedButton, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
+import type { LemonSegmentedButtonOption } from '@posthog/lemon-ui'
 
 import { RichContentEditorType } from 'lib/components/RichContentEditor/types'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
@@ -22,15 +23,20 @@ export interface MessageInputProps {
     placeholder?: string
     buttonText?: string
     minRows?: number
-    /** Whether to show the "Send as private" checkbox */
+    /** Whether to show the reply / internal-note tab switch */
     showPrivateOption?: boolean
-    /** Draft content to restore (from parent logic for tab persistence) */
+    /** Public reply draft content to restore (from parent logic for tab persistence) */
     draftContent?: JSONContent | null
-    /** Called when draft content changes */
+    /** Called when the public reply draft changes */
     onDraftChange?: (content: JSONContent | null) => void
-    /** Whether the private note checkbox is checked (from parent logic for tab persistence) */
+    /** Internal-note draft content, kept separate from the public reply so the two
+     *  tabs never overwrite each other. Only used when showPrivateOption is set. */
+    privateDraftContent?: JSONContent | null
+    /** Called when the internal-note draft changes */
+    onPrivateDraftChange?: (content: JSONContent | null) => void
+    /** Whether the internal-note tab is the active one (from parent logic for tab persistence) */
     isPrivate?: boolean
-    /** Called when private checkbox changes */
+    /** Called when the active tab changes */
     onPrivateChange?: (isPrivate: boolean) => void
     /** Extra actions rendered next to the send button */
     extraActions?: React.ReactNode
@@ -57,6 +63,8 @@ export function MessageInput({
     showPrivateOption = false,
     draftContent,
     onDraftChange,
+    privateDraftContent,
+    onPrivateDraftChange,
     isPrivate: controlledIsPrivate,
     onPrivateChange,
     extraActions,
@@ -67,20 +75,54 @@ export function MessageInput({
     sendAndSetStatusOptions,
     unsavedTicketChanges,
 }: MessageInputProps): JSX.Element {
-    const [isEmpty, setIsEmpty] = useState(!draftContent)
     const [isUploading, setIsUploading] = useState(false)
     const [localIsPrivate, setLocalIsPrivate] = useState(false)
     const editorRef = useRef<RichContentEditorType | null>(null)
 
-    useEffect(() => {
-        setIsEmpty(!draftContent)
-    }, [draftContent])
-
-    // Support controlled or uncontrolled isPrivate
+    // Support controlled or uncontrolled active-tab state
     const isPrivate = controlledIsPrivate ?? localIsPrivate
     const setIsPrivate = onPrivateChange ?? setLocalIsPrivate
 
+    // The editor only ever holds the active tab's body; the other tab's body lives
+    // in the parent (draftContent / privateDraftContent) and is swapped into the
+    // editor on a tab change so the reply and the internal note never overwrite
+    // each other.
+    const activeDraftContent = isPrivate ? privateDraftContent : draftContent
+
+    const [isEmpty, setIsEmpty] = useState(!activeDraftContent)
+
+    // Keep isEmpty aligned with the active buffer — covers both external draft
+    // updates and tab switches (which change which buffer is active).
+    useEffect(() => {
+        setIsEmpty(!activeDraftContent)
+    }, [activeDraftContent])
+
     const sendVerb = isPrivate ? 'Attach' : 'Send'
+
+    // Empty doc mirrors SupportEditor's default so setContent clears the editor cleanly.
+    const EMPTY_DOC: JSONContent = { type: 'doc', content: [{ type: 'paragraph' }] }
+
+    const handleTabChange = (nextIsPrivate: boolean): void => {
+        if (nextIsPrivate === isPrivate) {
+            return
+        }
+        const editor = editorRef.current
+        if (editor) {
+            // Stash whatever is in the editor into the outgoing tab's buffer, then
+            // load the incoming tab's buffer (empty doc when it has no draft yet).
+            const current = editor.isEmpty?.() ? null : editor.getJSON()
+            if (isPrivate) {
+                onPrivateDraftChange?.(current)
+            } else {
+                onDraftChange?.(current)
+            }
+            const incoming = nextIsPrivate ? privateDraftContent : draftContent
+            editor.setContent?.(incoming ?? EMPTY_DOC)
+            setIsEmpty(!incoming)
+            editor.focus?.()
+        }
+        setIsPrivate(nextIsPrivate)
+    }
 
     const handleSubmit = (statusAfterSend?: TicketStatus): void => {
         // These guard the Cmd+Enter path, which bypasses the (disabled) button.
@@ -99,13 +141,16 @@ export function MessageInput({
                     richContent,
                     isPrivate,
                     () => {
+                        // Clear only the tab that was just sent; the other tab's draft
+                        // is deliberately preserved so sending a reply never discards an
+                        // in-progress internal note (or vice versa), and the active tab
+                        // stays put.
                         editorRef.current?.clear()
                         setIsEmpty(true)
-                        onDraftChange?.(null)
-                        if (onPrivateChange) {
-                            onPrivateChange(false)
+                        if (isPrivate) {
+                            onPrivateDraftChange?.(null)
                         } else {
-                            setLocalIsPrivate(false)
+                            onDraftChange?.(null)
                         }
                     },
                     statusAfterSend
@@ -149,8 +194,15 @@ export function MessageInput({
 
     const handleUpdate = (empty: boolean): void => {
         setIsEmpty(empty)
-        if (onDraftChange && editorRef.current) {
-            onDraftChange(empty ? null : editorRef.current.getJSON())
+        if (!editorRef.current) {
+            return
+        }
+        // Route edits to the active tab's buffer so each tab keeps its own body.
+        const json = empty ? null : editorRef.current.getJSON()
+        if (isPrivate) {
+            onPrivateDraftChange?.(json)
+        } else {
+            onDraftChange?.(json)
         }
     }
 
@@ -163,14 +215,42 @@ export function MessageInput({
                 ? 'Uploading image...'
                 : undefined
 
+    // A dot on the inactive tab flags an in-progress draft there, so the other
+    // buffer stays discoverable. The active tab's content is visible, so no dot.
+    const publicHasDraft = isPrivate ? !!draftContent : !isEmpty
+    const privateHasDraft = isPrivate ? !isEmpty : !!privateDraftContent
+    const draftDot = <span className="w-1.5 h-1.5 rounded-full bg-accent" aria-hidden />
+    const tabOptions: LemonSegmentedButtonOption<'reply' | 'note'>[] = [
+        {
+            value: 'reply',
+            label: (
+                <span className="inline-flex items-center gap-1.5">
+                    Reply
+                    {isPrivate && publicHasDraft ? draftDot : null}
+                </span>
+            ),
+        },
+        {
+            value: 'note',
+            tooltip: 'Private notes are only visible to your team, not to the customer.',
+            label: (
+                <span className="inline-flex items-center gap-1.5">
+                    <IconLock className="text-sm" />
+                    Internal note
+                    {!isPrivate && privateHasDraft ? draftDot : null}
+                </span>
+            ),
+        },
+    ]
+
     return (
         <div>
             <SupportEditor
-                initialContent={draftContent}
+                initialContent={activeDraftContent}
                 placeholder={placeholder}
                 onCreate={(editor) => {
                     editorRef.current = editor
-                    if (draftContent) {
+                    if (activeDraftContent) {
                         setIsEmpty(false)
                     }
                 }}
@@ -189,20 +269,12 @@ export function MessageInput({
             />
             <div className="flex justify-between items-center mt-2">
                 {showPrivateOption ? (
-                    <Tooltip title="Private notes are only visible to your team, not to the customer.">
-                        <span>
-                            <LemonCheckbox
-                                checked={isPrivate}
-                                onChange={setIsPrivate}
-                                label={
-                                    <span className="inline-flex items-center gap-1">
-                                        <IconLock className="text-sm" />
-                                        Attach as private note
-                                    </span>
-                                }
-                            />
-                        </span>
-                    </Tooltip>
+                    <LemonSegmentedButton
+                        size="small"
+                        value={isPrivate ? 'note' : 'reply'}
+                        onChange={(value) => handleTabChange(value === 'note')}
+                        options={tabOptions}
+                    />
                 ) : (
                     <div />
                 )}

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -89,6 +89,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
         unsavedTicketChanges,
         ticketUpdating,
         draftContent,
+        draftPrivateContent,
         draftIsPrivate,
         draftModeEnabled,
         replyRecipientDescription,
@@ -109,6 +110,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
         updateTicket,
         loadOlderMessages,
         setDraftContent,
+        setDraftPrivateContent,
         setDraftIsPrivate,
         setDraftModeEnabled,
         dismissKnowledgeGap,
@@ -219,6 +221,8 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                         showDeliveryStatus={ticket?.channel_source === 'widget'}
                         draftContent={draftContent}
                         onDraftChange={setDraftContent}
+                        privateDraftContent={draftPrivateContent}
+                        onPrivateDraftChange={setDraftPrivateContent}
                         isPrivate={draftIsPrivate}
                         onPrivateChange={setDraftIsPrivate}
                         draftMode={draftModeEnabled}

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -178,6 +178,7 @@ export interface supportTicketSceneLogicValues {
     chatMessages: ChatMessage[]
     chatPanelWidth: (desiredSize: number | null) => number
     draftContent: JSONContent | null
+    draftPrivateContent: JSONContent | null
     draftIsPrivate: boolean
     draftModeEnabled: boolean
     emailReplyBlockedReason: EmailReplyBlockedReason | null
@@ -316,6 +317,9 @@ export interface supportTicketSceneLogicActions {
         assignee: TicketAssignee
     }
     setDraftContent: (content: JSONContent | null) => {
+        content: JSONContent | null
+    }
+    setDraftPrivateContent: (content: JSONContent | null) => {
         content: JSONContent | null
     }
     setDraftIsPrivate: (isPrivate: boolean) => {
@@ -483,8 +487,11 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         loadKnowledgeGaps: true,
         dismissKnowledgeGap: (suggestionId: string) => ({ suggestionId }),
 
-        // Draft message state (persists across tab switches)
+        // Draft message state (persists across tab switches). The public reply and the
+        // private note keep independent bodies so switching the composer tab never
+        // clobbers the other draft.
         setDraftContent: (content: JSONContent | null) => ({ content }),
+        setDraftPrivateContent: (content: JSONContent | null) => ({ content }),
         setDraftIsPrivate: (isPrivate: boolean) => ({ isPrivate }),
         // Per-ticket draft mode override, seeded from the browser-local default on open
         setDraftModeEnabled: (enabled: boolean) => ({ enabled }),
@@ -680,6 +687,12 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             null as JSONContent | null,
             {
                 setDraftContent: (_, { content }) => content,
+            },
+        ],
+        draftPrivateContent: [
+            null as JSONContent | null,
+            {
+                setDraftPrivateContent: (_, { content }) => content,
             },
         ],
         draftIsPrivate: [


### PR DESCRIPTION
## Problem

Support agents routinely draft a public reply **and** a private note for the same ticket at the same time. The composer's "Attach as private note" checkbox only flipped where a **single shared** editor body was sent (public vs. private), so keeping both in flight was impossible — starting the note meant losing the reply you'd already typed, and vice versa.

## Changes

Replace the checkbox with a **Reply / Private note** tab switch, and give each tab its own independent draft buffer so switching never clobbers the other.

- `supportTicketSceneLogic` now holds a second draft buffer (`draftPrivateContent`) alongside the existing public `draftContent`; both persist across tab switches like before.
- `MessageInput` renders a `LemonSegmentedButton` (Reply / Private note) instead of the checkbox. The editor only ever holds the active tab's body; on a tab change it stashes the current body into the outgoing buffer and swaps in the incoming one. Edits are routed to the active buffer.
- Sending clears only the tab that was sent and preserves the other's draft; the active tab stays put.
- An inactive tab shows a dot when it holds an in-progress draft, so the other buffer stays discoverable.
- Non-`showPrivateOption` consumers (new-ticket and customer-view composers) are unaffected — no tabs, single buffer, same behavior as before.

The tab label is **"Private note"** (matching the product's existing terminology — the send toast, the `is_private` flag), not "Internal note". The active tab still drives the warning tint and the send-button verb (`Send` vs `Attach`), including the send-and-set-status dropdown.

**Reply tab active** — the private note tab carries a draft dot:

![Reply tab active (light) — private note tab shows a draft dot](https://raw.githubusercontent.com/PostHog/pr-assets/83b2b6821fe28c930e4b4d5bab61f94f35737c9c/2026/07/8c1cbf1d-b554-4a8b-8ab3-15799bd464a2.png)

**Private note tab active** — its own separate body, warning surface, `Attach`, and the reply tab keeps its draft dot:

![Private note tab active (light) — separate body, warning surface, reply tab keeps its draft dot](https://raw.githubusercontent.com/PostHog/pr-assets/08aef1c9c5ea5185f89806b3fe2367f155ec2c6a/2026/07/63559db4-1814-48da-af3c-b17782a856f8.png)

<details>
<summary>Dark theme</summary>

![Reply tab active (dark)](https://raw.githubusercontent.com/PostHog/pr-assets/4d8e7e720c81c21be43d440056a8f8212f48e023/2026/07/45bd7068-38b5-4a48-b514-46acb1e52468.png)

![Private note tab active (dark)](https://raw.githubusercontent.com/PostHog/pr-assets/6d9bef7bba6d6cb1a12232bfb5cd2658a53d2e9c/2026/07/da4a8a94-76ec-4025-b3a1-3f25dd6b7a88.png)

</details>

## How did you test this code?

- Added unit tests in `MessageInput.test.tsx`: the send-and-set-status dropdown preserves the private flag in both modes (existing, updated for the two-buffer props), switching tabs stashes the current body and flips the active tab without touching the other buffer, and sending clears only the sent tab's buffer.
- Ran `jest` for `MessageInput` (4 passing) and `supportTicketSceneLogic` (29 passing).
- Type-checked with `tsgo --noEmit` (no new errors in `products/conversations`) and linted the changed files with `oxlint` (clean).
- Screenshots above were captured from a Storybook render of the real component (a throwaway story, not included in this PR).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Human-driven (agent-assisted) — requested by @xander in the Conversations support channel.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1784712664489389?thread_ts=1784712664.489389&cid=C075D3C5HST)*
