### PR TITLE
fix(data-imports): retry connection errors in the shared REST client

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -352,7 +352,15 @@ class RESTClient:
         except ChunkedEncodingError as e:
             raise RESTClientRetryableError(self._redact(f"Connection broken while reading response: {e}")) from e
         except RequestsConnectionError as e:
-            raise RESTClientRetryableError(self._redact(f"Connection error: {e}")) from e
+            # Unlike ChunkedEncodingError, a ConnectionError's message (e.g. urllib3's "Max
+            # retries exceeded with url: ...") embeds the full request URL including the query
+            # string. `_redact` only replaces a secret's raw value, not the percent-encoded form
+            # a query-param API key takes there — so build the message from `_safe_url` (scheme/
+            # host/path only) rather than the raw exception text, the same way the 5xx path below
+            # avoids leaking an encoded credential into the persisted `latest_error`.
+            raise RESTClientRetryableError(
+                self._redact(f"Connection error ({type(e).__name__}) for {_safe_url(prepared.url or '')}")
+            ) from e
 
         # With redirects disabled, a 3xx is not an error to `raise_for_status` and would fall
         # through to JSON parsing; reject it explicitly so a redirect can't smuggle the request

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -10,6 +10,7 @@ from requests import Request, Response, Session
 from requests.auth import AuthBase
 from requests.exceptions import (
     ChunkedEncodingError,
+    ConnectionError as RequestsConnectionError,
     HTTPError,
     JSONDecodeError as RequestsJSONDecodeError,
 )
@@ -340,11 +341,18 @@ class RESTClient:
         # retryable-error type so it propagates immediately rather than being retried.
         self._check_allowed_host(prepared.url)
         # `send` reads the body eagerly (stream=False), so a connection dropped mid-stream
-        # surfaces here as ChunkedEncodingError. Reissue it like a truncated/partial body below.
+        # surfaces here as ChunkedEncodingError. A connection that never got established at all —
+        # egress proxy refusing/resetting the connection, a connect timeout — surfaces as
+        # ConnectionError (already retried a few times inside urllib3's own adapter-level policy,
+        # but that budget is short). Both are transient network failures, so reissue them like a
+        # truncated/partial body below rather than letting them skip this retry loop and fail the
+        # whole sync on one bad connection attempt.
         try:
             response = self.session.send(prepared, allow_redirects=self._allow_redirects)
         except ChunkedEncodingError as e:
             raise RESTClientRetryableError(self._redact(f"Connection broken while reading response: {e}")) from e
+        except RequestsConnectionError as e:
+            raise RESTClientRetryableError(self._redact(f"Connection error: {e}")) from e
 
         # With redirects disabled, a 3xx is not an error to `raise_for_status` and would fall
         # through to JSON parsing; reject it explicitly so a redirect can't smuggle the request

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_exception_redaction.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_exception_redaction.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 from requests import Response
+from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
@@ -45,6 +46,28 @@ def _make_client(secret: str, MockSession: MagicMock) -> MagicMock:
 
     mock_session.prepare_request.side_effect = _prep
     return mock_session
+
+
+def _make_client_with_credentialed_url(secret: str, MockSession: MagicMock) -> MagicMock:
+    # Unlike `_make_client`, the prepared URL itself carries the query-encoded credential — this
+    # is what a real `session.prepare_request()` produces once the auth hook injects the query
+    # param, and it's what `_send_request` sees when a connection error fires before any response.
+    mock_session = MockSession.return_value
+    mock_session.headers = {}
+    prepared = MagicMock()
+    prepared.url = f"https://api.example.com/items?api_key={quote(secret, safe='')}"
+    mock_session.prepare_request.return_value = prepared
+    return mock_session
+
+
+def _make_connection_error(secret: str) -> RequestsConnectionError:
+    # Mirrors urllib3's real "Max retries exceeded with url: ..." message shape, which embeds the
+    # full request URL (query string included) in the exception text itself.
+    url = f"https://api.example.com/items?api_key={quote(secret, safe='')}"
+    return RequestsConnectionError(
+        f"HTTPSConnectionPool(host='api.example.com', port=443): Max retries exceeded with url: {url} "
+        "(Caused by ProxyError('Cannot connect to proxy.'))"
+    )
 
 
 class TestExceptionRedaction:
@@ -102,6 +125,25 @@ class TestExceptionRedaction:
         assert secret not in message
         assert quote(secret, safe="") not in message
         assert "?" not in message
+
+    @parameterized.expand([("raw", SECRET), ("reserved_chars", SPECIAL_SECRET)])
+    @patch(f"{MODULE}.make_tracked_session")
+    def test_connection_error_drops_query_so_no_secret_leaks(self, _name: str, secret: str, MockSession) -> None:
+        mock_session = _make_client_with_credentialed_url(secret, MockSession)
+        mock_session.send.side_effect = _make_connection_error(secret)
+        client = RESTClient(
+            base_url="https://api.example.com",
+            auth=APIKeyAuth(api_key=secret, name="api_key", location="query"),
+            max_retry_attempts=1,
+        )
+        with pytest.raises(RESTClientRetryableError) as excinfo:
+            list(client.paginate(path="/items"))
+        message = str(excinfo.value)
+        # Neither the raw nor the percent-encoded secret survives; the query is dropped entirely.
+        assert secret not in message
+        assert quote(secret, safe="") not in message
+        assert "?" not in message
+        assert "api.example.com/items" in message
 
     @patch(f"{MODULE}.make_tracked_session")
     def test_no_auth_still_reports_host_and_path(self, MockSession) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -482,7 +482,7 @@ class TestRESTClient:
         # the request rather than letting it skip this retry loop and fail the import.
         mock_session = MockSession.return_value
         mock_session.headers = {}
-        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.prepare_request.return_value = MagicMock(url="https://api.example.com/items")
 
         ok = _make_response({"results": [{"id": 1}]})
         mock_session.send.side_effect = [
@@ -503,7 +503,7 @@ class TestRESTClient:
     def test_send_request_raises_retryable_after_persistent_connection_error(self, MockSession, mock_sleep) -> None:
         mock_session = MockSession.return_value
         mock_session.headers = {}
-        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.prepare_request.return_value = MagicMock(url="https://api.example.com/items")
 
         mock_session.send.side_effect = ProxyError("Cannot connect to proxy.")
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -6,7 +6,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from requests import Response
-from requests.exceptions import ChunkedEncodingError
+from requests.exceptions import ChunkedEncodingError, ProxyError
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.exceptions import (
@@ -465,6 +465,47 @@ class TestRESTClient:
         mock_session.send.side_effect = ChunkedEncodingError(
             "Connection broken: InvalidChunkLength(got length b'', 0 bytes read)"
         )
+
+        client = RESTClient(base_url="https://api.example.com")
+        with pytest.raises(RESTClientRetryableError):
+            list(client.paginate(path="/items", paginator=SinglePagePaginator()))
+
+        assert mock_session.send.call_count == 5
+
+    @patch("tenacity.nap.time.sleep")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+    )
+    def test_send_request_retries_connection_error_then_succeeds(self, MockSession, mock_sleep) -> None:
+        # A proxy refusing/resetting the connection before a request is ever sent surfaces as
+        # requests.exceptions.ProxyError (a ConnectionError subclass); it's transient, so reissue
+        # the request rather than letting it skip this retry loop and fail the import.
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+
+        ok = _make_response({"results": [{"id": 1}]})
+        mock_session.send.side_effect = [
+            ProxyError("Cannot connect to proxy."),
+            ok,
+        ]
+
+        client = RESTClient(base_url="https://api.example.com")
+        pages = list(client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator()))
+
+        assert pages == [[{"id": 1}]]
+        assert mock_session.send.call_count == 2
+
+    @patch("tenacity.nap.time.sleep")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+    )
+    def test_send_request_raises_retryable_after_persistent_connection_error(self, MockSession, mock_sleep) -> None:
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+
+        mock_session.send.side_effect = ProxyError("Cannot connect to proxy.")
 
         client = RESTClient(base_url="https://api.example.com")
         with pytest.raises(RESTClientRetryableError):


### PR DESCRIPTION
## Problem

An error-tracking issue caught a Paddle sync (Products endpoint) failing with:

```
ProxyError('Cannot connect to proxy.', RemoteDisconnected('Remote end closed connection without response'))
```

The stack trace traces this to the shared `RESTClient._send_request` in
`products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py`
— not Paddle-specific code. `session.send()` raises `requests.exceptions.ConnectionError`
(the parent class of `ProxyError`) when the connection to the configured egress proxy
can't be established or is reset. That exception isn't one of the types the surrounding
`tenacity`-based retry loop reissues (only `RESTClientRetryableError`), so it skips the
5-attempt/backoff retry the loop gives to other transient failures (429s, 5xxs, malformed
bodies, mid-stream `ChunkedEncodingError`) and fails the whole sync after just urllib3's
short built-in adapter retry.

This is a transient infrastructure blip, not a customer credential/config problem, so it
belongs in the "give it the existing retry budget" bucket rather than `NonRetryableErrors`.

## Changes

- Catch `requests.exceptions.ConnectionError` in `RESTClient._send_request` alongside the
  existing `ChunkedEncodingError` handling, and reissue it as `RESTClientRetryableError` so
  it gets the same tenacity-driven retry-with-backoff every other source built on
  `RESTClient` already relies on.

This is shared code, so every REST-based data warehouse source benefits, not just Paddle.

## How did you test this code?

Added two tests to `test_rest_client.py`, mirroring the existing `ChunkedEncodingError`
coverage:

- `test_send_request_retries_connection_error_then_succeeds` — a `ProxyError` on the first
  attempt followed by a successful response completes the page. Catches a regression where
  connection errors stop being reissued and a single proxy blip fails the whole sync.
- `test_send_request_raises_retryable_after_persistent_connection_error` — a `ProxyError` on
  every attempt exhausts the 5-attempt budget and raises `RESTClientRetryableError`. Catches
  a regression where a genuinely broken connection retries forever instead of failing loud
  after the normal budget.

Ran the full `test_rest_client.py` suite (32 passed) and the Paddle source suite (26 passed).
`ruff check`/`ruff format` clean, `hogli ci:preflight --fix` clean, and a full-repo
`mypy --cache-fine-grained .` run passed with no new errors.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal retry-classification fix, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude) while triaging a live error-tracking issue for a
`ProxyError` in the Paddle data-imports sync. I confirmed the issue via PostHog's error
tracking MCP tools (stack trace, exception chain, occurrence count), traced the failure to
`RESTClient._send_request`, and confirmed via the full stack trace that the exception
originates from `session.send()` inside that shared method rather than anywhere
Paddle-specific. I checked open PRs (including the maintainer's own recent ones) for
overlapping fixes — none touch this retry gap; the closest matches (#70276, #70575, #70389)
address error-tracking noise suppression or different subsystems entirely, not this retry
classification. I chose to extend the retry classification (matching the existing
`ChunkedEncodingError` precedent) over adding this error to `NonRetryableErrors`, since it's
a transient infrastructure blip rather than a customer credential/config problem. Invoked
`/writing-tests` before adding the regression tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*