### PR TITLE
fix(toolbar): accept relative api_host reverse-proxy configs

### DIFF
--- a/frontend/src/toolbar/toolbarConfigLogic.test.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.test.ts
@@ -1396,6 +1396,11 @@ describe('toolbar toolbarConfigLogic', () => {
             ['https://host@evil.com/path', null],
             ['//evil.com', null], // protocol-relative would hijack the origin
             ['/\\evil.com', null], // backslash protocol-relative
+            // tab/newline/CR are stripped by the URL parser, turning these into
+            // protocol-relative refs that would otherwise hijack the origin
+            ['/\t/evil.com', null],
+            ['/\n/evil.com', null],
+            ['/\r/evil.com', null],
             ['', null],
             [undefined, null],
             ['not a url', null], // non-path garbage is not treated as relative

--- a/frontend/src/toolbar/toolbarConfigLogic.test.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.test.ts
@@ -1323,6 +1323,18 @@ describe('toolbar toolbarConfigLogic', () => {
             expect(logic.values.apiHost).toBe('https://proxy.example.com/ingest')
         })
 
+        it('resolves a relative reverse-proxy api_host against the current origin', () => {
+            // posthog-js commonly points api_host at a relative reverse-proxy path
+            // like /ingest (Next.js/Vercel rewrites). The toolbar must keep that
+            // prefix rather than reject it and fall back to the bare origin.
+            const logic = toolbarConfigLogic.build({
+                posthog: { config: { api_host: '/ingest' } } as any,
+            } as any)
+            logic.mount()
+            expect(logic.values.apiHost).toBe(`${window.location.origin}/ingest`)
+            expect(logic.values.apiHostResolution.source).toBe('posthog_api_host')
+        })
+
         it.each([
             ['apiURL', { apiURL: '' }],
             ['api_host', { apiURL: '', posthog: { config: { api_host: '' } } as any }],
@@ -1375,13 +1387,18 @@ describe('toolbar toolbarConfigLogic', () => {
             ['https://proxy.example.com/ingest/', 'https://proxy.example.com/ingest'],
             ['https://us.i.posthog.com', 'https://us.i.posthog.com'],
             ['https://us.i.posthog.com/', 'https://us.i.posthog.com'],
+            // relative reverse-proxy configs resolve against the current origin
+            ['/ingest', `${window.location.origin}/ingest`],
+            ['/ingest/', `${window.location.origin}/ingest`],
             // rejected
             ['javascript:alert(1)', null],
             ['https://user:pass@host/path', null],
             ['https://host@evil.com/path', null],
+            ['//evil.com', null], // protocol-relative would hijack the origin
+            ['/\\evil.com', null], // backslash protocol-relative
             ['', null],
             [undefined, null],
-            ['not a url', null],
+            ['not a url', null], // non-path garbage is not treated as relative
         ])('canonicalizeApiHost(%p) === %p', (input, expected) => {
             expect(canonicalizeApiHost(input as any)).toBe(expected)
         })

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -544,16 +544,22 @@ export function canonicalizeUiHost(candidate: string | undefined | null): string
 
 /**
  * Sanitize an apiHost candidate. Like canonicalizeUiHost, but preserves the URL
- * path so reverse-proxy deployments (e.g. `https://proxy/ingest`) keep working
- * — apiHost is concatenated with `/static/toolbar.css` and `/i/v1/logs`, so the
- * path prefix must survive. Query and fragment are still dropped.
+ * path so reverse-proxy deployments keep working, whether configured absolutely
+ * (`https://proxy/ingest`) or as a relative path (`/ingest`, resolved against the
+ * current origin). apiHost is concatenated with `/static/toolbar.css` and
+ * `/i/v1/logs`, so the path prefix must survive. Query and fragment are dropped.
  */
 export function canonicalizeApiHost(candidate: string | undefined | null): string | null {
     if (!candidate) {
         return null
     }
     try {
-        const parsed = new URL(candidate)
+        // Path-absolute values like "/ingest" are relative reverse-proxy configs;
+        // resolve them against the current origin. Protocol-relative refs
+        // ("//evil.com", "/\evil.com") are excluded so they can't hijack the origin:
+        // they fall through to base-less parsing and are rejected, as is any non-path garbage.
+        const trimmed = candidate.trim()
+        const parsed = /^\/(?![/\\])/.test(trimmed) ? new URL(trimmed, window.location.origin) : new URL(candidate)
         if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
             return null
         }

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -556,10 +556,17 @@ export function canonicalizeApiHost(candidate: string | undefined | null): strin
     try {
         // Path-absolute values like "/ingest" are relative reverse-proxy configs;
         // resolve them against the current origin. Protocol-relative refs
-        // ("//evil.com", "/\evil.com") are excluded so they can't hijack the origin:
-        // they fall through to base-less parsing and are rejected, as is any non-path garbage.
+        // ("//evil.com", "/\evil.com") fall through to base-less parsing and are
+        // rejected, as is any non-path garbage.
         const trimmed = candidate.trim()
-        const parsed = /^\/(?![/\\])/.test(trimmed) ? new URL(trimmed, window.location.origin) : new URL(candidate)
+        const isPathAbsolute = /^\/(?![/\\])/.test(trimmed)
+        const parsed = isPathAbsolute ? new URL(trimmed, window.location.origin) : new URL(candidate)
+        // The regex can't see tab/newline/CR that the WHATWG parser strips mid-string,
+        // so "/\t/evil.com" would normalize to a network-path ref and hijack the origin.
+        // Verify the resolved origin instead of trusting the textual guard.
+        if (isPathAbsolute && parsed.origin !== window.location.origin) {
+            return null
+        }
         if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
             return null
         }


### PR DESCRIPTION
## Problem

The toolbar logged `[PostHog Toolbar][config] Invalid posthog.config.api_host, rejected` on every load when `api_host` is a relative reverse-proxy path like `/ingest` (the standard posthog-js Next.js/Vercel rewrite pattern). `canonicalizeApiHost` parsed candidates with `new URL(candidate)` and no base, which throws on any relative URL, so a valid config was rejected and `apiHost` fell back to `window.location.origin`, dropping the `/ingest` prefix.

The warning is the main symptom. For a same-origin relative proxy nothing functional breaks (CSS loads from the baked-in `__POSTHOG_TOOLBAR_PUBLIC_PATH__`, API calls use the token-bound `uiHost`, and the origin is unchanged), but a valid config looks broken in the console and gets mislabeled `fallback_rejected` in our own telemetry.

## Changes

Resolve path-absolute values (`/ingest`) against `window.location.origin` so relative proxy configs work like the absolute form (`https://proxy/ingest`) already did. Protocol-relative refs (`//evil.com`, `/\evil.com`) and non-path garbage stay rejected, so there's no origin-hijack regression. `canonicalizeUiHost` is left strict on purpose: `ui_host` is token-bound and never legitimately relative.

## How did you test this code?

Unit tests in `toolbarConfigLogic.test.ts`: parameterized `canonicalizeApiHost` cases (`/ingest`, trailing-slash normalization, protocol-relative and garbage rejection) plus a selector test asserting a relative `api_host` resolves to `origin + path` with `source: posthog_api_host` instead of `fallback_rejected`. The prior suite only covered absolute URLs, so it missed this. I (Claude, via PostHog Code) ran `hogli test frontend/src/toolbar/toolbarConfigLogic.test.ts` (164/164 pass) and oxlint on the changed files. No manual toolbar-on-live-site run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed: relative `api_host` is already documented as supported in posthog-js; this just makes the toolbar honor it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Opus 4.8) via PostHog Code, directed by @xljones. I traced the warning to `canonicalizeApiHost`'s base-less `new URL()`. I considered relaxing `canonicalizeUiHost` too but rejected it (security-sensitive, no valid relative use case), and chose a path-absolute guard (`/^\/(?![/\\])/`) over passing a base unconditionally, since an unconditional base would resolve `//evil.com` cross-origin and turn garbage into same-origin paths. No repo skills were needed for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
