### PR TITLE
feat(ingestion): merge-event rate overflow condition via pluggable strategies

### DIFF
--- a/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.test.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.test.ts
@@ -4,7 +4,7 @@ import { HealthCheckResultOk } from '~/types'
 import { MainLaneOverflowRedirect, MainLaneOverflowRedirectConfig } from './main-lane-overflow-redirect'
 import { OverflowEventBatch } from './overflow-redirect-service'
 import { OverflowRedisRepository } from './overflow-redis-repository'
-import { EventRateOverflowStrategy } from './overflow-strategy'
+import { EventRateOverflowStrategy, MergeEventRateOverflowStrategy } from './overflow-strategy'
 
 const createMockRepository = (): jest.Mocked<OverflowRedisRepository> => ({
     batchCheck: jest.fn().mockResolvedValue(new Map()),
@@ -214,6 +214,51 @@ describe('MainLaneOverflowRedirect', () => {
 
             expect(result.size).toBe(0)
         })
+    })
+
+    describe('merge event rate strategy', () => {
+        const createMergeAwareService = (): MainLaneOverflowRedirect =>
+            createService({
+                strategies: [
+                    { strategy: new EventRateOverflowStrategy(), bucketCapacity: 100, replenishRate: 1 },
+                    { strategy: new MergeEventRateOverflowStrategy(), bucketCapacity: 3, replenishRate: 0.01 },
+                ],
+            })
+
+        const createBatchWithEvents = (
+            token: string,
+            distinctId: string,
+            eventNames: (string | undefined)[]
+        ): OverflowEventBatch => ({
+            key: { token, distinctId },
+            eventHeaders: eventNames.map((event) => createTestEventHeaders({ token, distinct_id: distinctId, event })),
+            firstTimestamp: Date.now(),
+        })
+
+        it.each(['$identify', '$create_alias', '$merge_dangerously'])(
+            'redirects a key whose %s rate exceeds the merge bucket while under the event bucket',
+            async (eventName) => {
+                const mergeAwareService = createMergeAwareService()
+                const batch = [createBatchWithEvents('token1', 'user1', Array(5).fill(eventName))]
+
+                const result = await mergeAwareService.handleEventBatch(batch)
+
+                expect(result.has('token1:user1')).toBe(true)
+            }
+        )
+
+        it.each([['$pageview'], [undefined]])(
+            'does not count non-merge events (%s) against the merge bucket',
+            async (eventName) => {
+                const mergeAwareService = createMergeAwareService()
+                // 50 events: over the merge bucket capacity (3) but under the event bucket (100)
+                const batch = [createBatchWithEvents('token1', 'user1', Array(50).fill(eventName))]
+
+                const result = await mergeAwareService.handleEventBatch(batch)
+
+                expect(result.size).toBe(0)
+            }
+        )
     })
 
     describe('healthCheck', () => {

--- a/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.test.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.test.ts
@@ -4,7 +4,7 @@ import { HealthCheckResultOk } from '~/types'
 import { MainLaneOverflowRedirect, MainLaneOverflowRedirectConfig } from './main-lane-overflow-redirect'
 import { OverflowEventGroup } from './overflow-redirect-service'
 import { OverflowRedisRepository } from './overflow-redis-repository'
-import { EventRateOverflowStrategy, MergeEventRateOverflowStrategy } from './overflow-strategy'
+import { eventRateStrategy, mergeEventRateStrategy } from './overflow-strategy'
 
 const createMockRepository = (): jest.Mocked<OverflowRedisRepository> => ({
     batchCheck: jest.fn().mockResolvedValue(new Map()),
@@ -34,7 +34,7 @@ describe('MainLaneOverflowRedirect', () => {
         return new MainLaneOverflowRedirect({
             redisRepository: mockRepository,
             localCacheTTLSeconds: 60,
-            strategies: [{ strategy: new EventRateOverflowStrategy(), bucketCapacity: 10, replenishRate: 1 }],
+            strategies: [{ ...eventRateStrategy(), bucketCapacity: 10, replenishRate: 1 }],
             overflowType: 'events',
             ...overrides,
         })
@@ -222,8 +222,8 @@ describe('MainLaneOverflowRedirect', () => {
         const createMergeAwareService = (): MainLaneOverflowRedirect =>
             createService({
                 strategies: [
-                    { strategy: new EventRateOverflowStrategy(), bucketCapacity: 100, replenishRate: 1 },
-                    { strategy: new MergeEventRateOverflowStrategy(), bucketCapacity: 3, replenishRate: 0.01 },
+                    { ...eventRateStrategy(), bucketCapacity: 100, replenishRate: 1 },
+                    { ...mergeEventRateStrategy(), bucketCapacity: 3, replenishRate: 0.01 },
                 ],
             })
 

--- a/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.test.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.test.ts
@@ -1,8 +1,10 @@
+import { createTestEventHeaders } from '~/tests/helpers/event-headers'
 import { HealthCheckResultOk } from '~/types'
 
 import { MainLaneOverflowRedirect, MainLaneOverflowRedirectConfig } from './main-lane-overflow-redirect'
 import { OverflowEventBatch } from './overflow-redirect-service'
 import { OverflowRedisRepository } from './overflow-redis-repository'
+import { EventRateOverflowStrategy } from './overflow-strategy'
 
 const createMockRepository = (): jest.Mocked<OverflowRedisRepository> => ({
     batchCheck: jest.fn().mockResolvedValue(new Map()),
@@ -18,7 +20,7 @@ const createBatch = (
     firstTimestamp: number = Date.now()
 ): OverflowEventBatch => ({
     key: { token, distinctId },
-    eventCount,
+    eventHeaders: Array.from({ length: eventCount }, () => createTestEventHeaders({ token, distinct_id: distinctId })),
     firstTimestamp,
 })
 
@@ -30,8 +32,7 @@ describe('MainLaneOverflowRedirect', () => {
         return new MainLaneOverflowRedirect({
             redisRepository: mockRepository,
             localCacheTTLSeconds: 60,
-            bucketCapacity: 10,
-            replenishRate: 1,
+            strategies: [{ strategy: new EventRateOverflowStrategy(), bucketCapacity: 10, replenishRate: 1 }],
             overflowType: 'events',
             ...overrides,
         })

--- a/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.test.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.test.ts
@@ -2,7 +2,7 @@ import { createTestEventHeaders } from '~/tests/helpers/event-headers'
 import { HealthCheckResultOk } from '~/types'
 
 import { MainLaneOverflowRedirect, MainLaneOverflowRedirectConfig } from './main-lane-overflow-redirect'
-import { OverflowEventBatch } from './overflow-redirect-service'
+import { OverflowEventGroup } from './overflow-redirect-service'
 import { OverflowRedisRepository } from './overflow-redis-repository'
 import { EventRateOverflowStrategy, MergeEventRateOverflowStrategy } from './overflow-strategy'
 
@@ -13,14 +13,16 @@ const createMockRepository = (): jest.Mocked<OverflowRedisRepository> => ({
     healthCheck: jest.fn().mockResolvedValue(new HealthCheckResultOk()),
 })
 
-const createBatch = (
+const createGroup = (
     token: string,
     distinctId: string,
     eventCount: number = 1,
     firstTimestamp: number = Date.now()
-): OverflowEventBatch => ({
+): OverflowEventGroup => ({
     key: { token, distinctId },
-    eventHeaders: Array.from({ length: eventCount }, () => createTestEventHeaders({ token, distinct_id: distinctId })),
+    headersPerEvent: Array.from({ length: eventCount }, () =>
+        createTestEventHeaders({ token, distinct_id: distinctId })
+    ),
     firstTimestamp,
 })
 
@@ -45,7 +47,7 @@ describe('MainLaneOverflowRedirect', () => {
 
     describe('handleEventBatch', () => {
         it('returns empty set when no events exceed rate limit', async () => {
-            const batch = [createBatch('token1', 'user1', 5)]
+            const batch = [createGroup('token1', 'user1', 5)]
 
             const result = await service.handleEventBatch(batch)
 
@@ -54,7 +56,7 @@ describe('MainLaneOverflowRedirect', () => {
 
         it('returns keys that exceed rate limit', async () => {
             // Bucket capacity is 10, so 15 events should exceed
-            const batch = [createBatch('token1', 'user1', 15)]
+            const batch = [createGroup('token1', 'user1', 15)]
 
             const result = await service.handleEventBatch(batch)
 
@@ -63,7 +65,7 @@ describe('MainLaneOverflowRedirect', () => {
         })
 
         it('flags newly rate-limited keys in Redis', async () => {
-            const batch = [createBatch('token1', 'user1', 15)]
+            const batch = [createGroup('token1', 'user1', 15)]
 
             await service.handleEventBatch(batch)
 
@@ -71,7 +73,7 @@ describe('MainLaneOverflowRedirect', () => {
         })
 
         it('checks Redis for keys not in local cache', async () => {
-            const batch = [createBatch('token1', 'user1', 5)]
+            const batch = [createGroup('token1', 'user1', 5)]
 
             await service.handleEventBatch(batch)
 
@@ -81,7 +83,7 @@ describe('MainLaneOverflowRedirect', () => {
         it('returns keys that are already flagged in Redis', async () => {
             mockRepository.batchCheck.mockResolvedValue(new Map([['token1:user1', true]]))
 
-            const batch = [createBatch('token1', 'user1', 1)]
+            const batch = [createGroup('token1', 'user1', 1)]
 
             const result = await service.handleEventBatch(batch)
 
@@ -93,14 +95,14 @@ describe('MainLaneOverflowRedirect', () => {
             // First call: Redis says key is flagged
             mockRepository.batchCheck.mockResolvedValue(new Map([['token1:user1', true]]))
 
-            const batch1 = [createBatch('token1', 'user1', 1)]
+            const batch1 = [createGroup('token1', 'user1', 1)]
             await service.handleEventBatch(batch1)
 
             // Reset mock
             mockRepository.batchCheck.mockClear()
 
             // Second call: should use cache, not repository
-            const batch2 = [createBatch('token1', 'user1', 1)]
+            const batch2 = [createGroup('token1', 'user1', 1)]
             const result = await service.handleEventBatch(batch2)
 
             expect(result.size).toBe(1)
@@ -112,7 +114,7 @@ describe('MainLaneOverflowRedirect', () => {
             // First call: key not in Redis
             mockRepository.batchCheck.mockResolvedValue(new Map([['token1:user1', false]]))
 
-            const batch1 = [createBatch('token1', 'user1', 1)]
+            const batch1 = [createGroup('token1', 'user1', 1)]
             await service.handleEventBatch(batch1)
 
             // Reset mock
@@ -120,7 +122,7 @@ describe('MainLaneOverflowRedirect', () => {
             mockRepository.batchCheck.mockResolvedValue(new Map([['token1:user1', true]]))
 
             // Second call: should use cache (null), not check repository again
-            const batch2 = [createBatch('token1', 'user1', 1)]
+            const batch2 = [createGroup('token1', 'user1', 1)]
             await service.handleEventBatch(batch2)
 
             expect(mockRepository.batchCheck).not.toHaveBeenCalled()
@@ -135,8 +137,8 @@ describe('MainLaneOverflowRedirect', () => {
             )
 
             const batch = [
-                createBatch('token1', 'user1', 5), // Below limit
-                createBatch('token1', 'user2', 15), // Exceeds limit
+                createGroup('token1', 'user1', 5), // Below limit
+                createGroup('token1', 'user2', 15), // Exceeds limit
             ]
 
             const result = await service.handleEventBatch(batch)
@@ -148,9 +150,9 @@ describe('MainLaneOverflowRedirect', () => {
 
         it('batches all keys in a single batchCheck call', async () => {
             const batch = [
-                createBatch('token1', 'user1', 1),
-                createBatch('token1', 'user2', 1),
-                createBatch('token2', 'user1', 1),
+                createGroup('token1', 'user1', 1),
+                createGroup('token1', 'user2', 1),
+                createGroup('token2', 'user1', 1),
             ]
 
             await service.handleEventBatch(batch)
@@ -170,7 +172,7 @@ describe('MainLaneOverflowRedirect', () => {
             // Simulate repository fail-open by returning the default "not flagged" result
             mockRepository.batchCheck.mockResolvedValue(new Map([['token1:user1', false]]))
 
-            const batch = [createBatch('token1', 'user1', 5)]
+            const batch = [createGroup('token1', 'user1', 5)]
 
             const result = await service.handleEventBatch(batch)
 
@@ -180,7 +182,7 @@ describe('MainLaneOverflowRedirect', () => {
         it('still redirects based on rate limit even when batchFlag is a no-op', async () => {
             // Even if batchFlag does nothing (e.g. repository fail-open), the local
             // rate limit decision still causes a redirect for this batch
-            const batch = [createBatch('token1', 'user1', 15)]
+            const batch = [createGroup('token1', 'user1', 15)]
 
             const result = await service.handleEventBatch(batch)
 
@@ -192,12 +194,12 @@ describe('MainLaneOverflowRedirect', () => {
     describe('rate limiting behavior', () => {
         it('rate limit state persists across batches', async () => {
             // First batch: consume 8 of 10 tokens
-            const batch1 = [createBatch('token1', 'user1', 8)]
+            const batch1 = [createGroup('token1', 'user1', 8)]
             const result1 = await service.handleEventBatch(batch1)
             expect(result1.size).toBe(0)
 
             // Second batch: consume 3 more tokens (total 11, exceeds 10)
-            const batch2 = [createBatch('token1', 'user1', 3)]
+            const batch2 = [createGroup('token1', 'user1', 3)]
             const result2 = await service.handleEventBatch(batch2)
             expect(result2.size).toBe(1)
             expect(result2.has('token1:user1')).toBe(true)
@@ -205,11 +207,11 @@ describe('MainLaneOverflowRedirect', () => {
 
         it('different keys have independent rate limits', async () => {
             // Exhaust tokens for user1
-            const batch1 = [createBatch('token1', 'user1', 15)]
+            const batch1 = [createGroup('token1', 'user1', 15)]
             await service.handleEventBatch(batch1)
 
             // user2 should still have tokens
-            const batch2 = [createBatch('token1', 'user2', 5)]
+            const batch2 = [createGroup('token1', 'user2', 5)]
             const result = await service.handleEventBatch(batch2)
 
             expect(result.size).toBe(0)
@@ -225,13 +227,15 @@ describe('MainLaneOverflowRedirect', () => {
                 ],
             })
 
-        const createBatchWithEvents = (
+        const createGroupWithEvents = (
             token: string,
             distinctId: string,
             eventNames: (string | undefined)[]
-        ): OverflowEventBatch => ({
+        ): OverflowEventGroup => ({
             key: { token, distinctId },
-            eventHeaders: eventNames.map((event) => createTestEventHeaders({ token, distinct_id: distinctId, event })),
+            headersPerEvent: eventNames.map((event) =>
+                createTestEventHeaders({ token, distinct_id: distinctId, event })
+            ),
             firstTimestamp: Date.now(),
         })
 
@@ -239,7 +243,7 @@ describe('MainLaneOverflowRedirect', () => {
             'redirects a key whose %s rate exceeds the merge bucket while under the event bucket',
             async (eventName) => {
                 const mergeAwareService = createMergeAwareService()
-                const batch = [createBatchWithEvents('token1', 'user1', Array(5).fill(eventName))]
+                const batch = [createGroupWithEvents('token1', 'user1', Array(5).fill(eventName))]
 
                 const result = await mergeAwareService.handleEventBatch(batch)
 
@@ -252,7 +256,7 @@ describe('MainLaneOverflowRedirect', () => {
             async (eventName) => {
                 const mergeAwareService = createMergeAwareService()
                 // 50 events: over the merge bucket capacity (3) but under the event bucket (100)
-                const batch = [createBatchWithEvents('token1', 'user1', Array(50).fill(eventName))]
+                const batch = [createGroupWithEvents('token1', 'user1', Array(50).fill(eventName))]
 
                 const result = await mergeAwareService.handleEventBatch(batch)
 
@@ -274,7 +278,7 @@ describe('MainLaneOverflowRedirect', () => {
         it('clears local cache', async () => {
             // Populate cache
             mockRepository.batchCheck.mockResolvedValue(new Map([['token1:user1', true]]))
-            await service.handleEventBatch([createBatch('token1', 'user1', 1)])
+            await service.handleEventBatch([createGroup('token1', 'user1', 1)])
 
             await service.shutdown()
 
@@ -282,7 +286,7 @@ describe('MainLaneOverflowRedirect', () => {
             // Next call should check repository again
             mockRepository.batchCheck.mockClear()
             mockRepository.batchCheck.mockResolvedValue(new Map([['token1:user1', false]]))
-            await service.handleEventBatch([createBatch('token1', 'user1', 1)])
+            await service.handleEventBatch([createGroup('token1', 'user1', 1)])
 
             expect(mockRepository.batchCheck).toHaveBeenCalled()
         })

--- a/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.ts
@@ -12,7 +12,7 @@ import {
     overflowRedirectRateLimitDecisions,
     overflowRedirectSourceEventsTotal,
 } from './metrics'
-import { OverflowEventBatch, OverflowRedirectService } from './overflow-redirect-service'
+import { OverflowEventGroup, OverflowRedirectService } from './overflow-redirect-service'
 import { OverflowRedisRepository, OverflowType, memberKey } from './overflow-redis-repository'
 import { OverflowStrategy, OverflowStrategyEntry, overflowStrategyLabel } from './overflow-strategy'
 
@@ -77,32 +77,32 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
         this.localCache.set(key, value)
     }
 
-    async handleEventBatch(batch: OverflowEventBatch[]): Promise<Set<string>> {
+    async handleEventBatch(batch: OverflowEventGroup[]): Promise<Set<string>> {
         const type = this.overflowType
         const toRedirect = new Set<string>()
         const redirectSource = new Map<string, 'redis' | 'rate_limiter'>()
-        const needsRateLimitCheck: OverflowEventBatch[] = []
+        const needsRateLimitCheck: OverflowEventGroup[] = []
 
         // Step 1: Check local cache
-        const needsRedisCheck: OverflowEventBatch[] = []
+        const needsRedisCheck: OverflowEventGroup[] = []
 
-        for (const event of batch) {
-            const cacheKey = this.localCacheKey(type, event.key.token, event.key.distinctId)
+        for (const group of batch) {
+            const cacheKey = this.localCacheKey(type, group.key.token, group.key.distinctId)
             const cached = this.getCachedValue(cacheKey)
 
             if (cached === true) {
                 // Already flagged (cached from previous Redis lookup) - redirect
-                const mKey = memberKey(event.key.token, event.key.distinctId)
+                const mKey = memberKey(group.key.token, group.key.distinctId)
                 toRedirect.add(mKey)
                 redirectSource.set(mKey, 'redis')
                 overflowRedirectCacheHitsTotal.labels(type, 'hit_flagged').inc()
             } else if (cached === false) {
                 // Known not in Redis - check rate limit only
-                needsRateLimitCheck.push(event)
+                needsRateLimitCheck.push(group)
                 overflowRedirectCacheHitsTotal.labels(type, 'hit_not_flagged').inc()
             } else {
                 // Cache miss - need to check Redis
-                needsRedisCheck.push(event)
+                needsRedisCheck.push(group)
                 overflowRedirectCacheHitsTotal.labels(type, 'miss').inc()
             }
         }
@@ -114,9 +114,9 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
                 needsRedisCheck.map((e) => e.key)
             )
 
-            for (const event of needsRedisCheck) {
-                const mKey = memberKey(event.key.token, event.key.distinctId)
-                const cacheKey = this.localCacheKey(type, event.key.token, event.key.distinctId)
+            for (const group of needsRedisCheck) {
+                const mKey = memberKey(group.key.token, group.key.distinctId)
+                const cacheKey = this.localCacheKey(type, group.key.token, group.key.distinctId)
 
                 if (redisResults.get(mKey)) {
                     // Flagged in Redis - redirect
@@ -126,7 +126,7 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
                 } else {
                     // Not in Redis - cache false and check rate limit
                     this.setCachedValue(cacheKey, false)
-                    needsRateLimitCheck.push(event)
+                    needsRateLimitCheck.push(group)
                 }
             }
         }
@@ -135,24 +135,24 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
         overflowRedirectCacheSize.set(this.localCache.size)
 
         // Step 3: Check rate limiter for unflagged keys
-        const newlyFlagged: OverflowEventBatch[] = []
+        const newlyFlagged: OverflowEventGroup[] = []
 
-        for (const event of needsRateLimitCheck) {
-            const rateLimitKey = memberKey(event.key.token, event.key.distinctId)
+        for (const group of needsRateLimitCheck) {
+            const rateLimitKey = memberKey(group.key.token, group.key.distinctId)
 
             // Consume from every strategy (no short-circuit) so buckets drain
             // consistently; any exhausted bucket flags the key.
             let allowed = true
             for (const { label, strategy, limiter } of this.strategies) {
                 let tokens = 0
-                for (const headers of event.eventHeaders) {
+                for (const headers of group.headersPerEvent) {
                     tokens += strategy.countTokens(headers)
                 }
                 if (tokens === 0) {
                     continue
                 }
 
-                if (limiter.consume(rateLimitKey, tokens, event.firstTimestamp)) {
+                if (limiter.consume(rateLimitKey, tokens, group.firstTimestamp)) {
                     overflowRedirectRateLimitDecisions.labels(type, label, 'allowed').inc()
                 } else {
                     allowed = false
@@ -162,7 +162,7 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
 
             if (!allowed) {
                 // Rate limit exceeded - needs to be flagged
-                newlyFlagged.push(event)
+                newlyFlagged.push(group)
                 toRedirect.add(rateLimitKey)
                 redirectSource.set(rateLimitKey, 'rate_limiter')
             }
@@ -172,8 +172,8 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
         if (newlyFlagged.length > 0) {
             // Update local cache BEFORE Redis write to prevent race condition where
             // a subsequent batch could check the rate limiter again before Redis completes
-            for (const event of newlyFlagged) {
-                const cacheKey = this.localCacheKey(type, event.key.token, event.key.distinctId)
+            for (const group of newlyFlagged) {
+                const cacheKey = this.localCacheKey(type, group.key.token, group.key.distinctId)
                 this.setCachedValue(cacheKey, true)
             }
             overflowRedirectCacheSize.set(this.localCache.size)
@@ -193,16 +193,16 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
         let redirectedEvents = 0
         let passedEvents = 0
         const eventsBySource = new Map<'redis' | 'rate_limiter', number>()
-        for (const event of batch) {
-            const mKey = memberKey(event.key.token, event.key.distinctId)
+        for (const group of batch) {
+            const mKey = memberKey(group.key.token, group.key.distinctId)
             if (toRedirect.has(mKey)) {
-                redirectedEvents += event.eventHeaders.length
+                redirectedEvents += group.headersPerEvent.length
                 const source = redirectSource.get(mKey)
                 if (source) {
-                    eventsBySource.set(source, (eventsBySource.get(source) ?? 0) + event.eventHeaders.length)
+                    eventsBySource.set(source, (eventsBySource.get(source) ?? 0) + group.headersPerEvent.length)
                 }
             } else {
-                passedEvents += event.eventHeaders.length
+                passedEvents += group.headersPerEvent.length
             }
         }
         overflowRedirectEventsTotal.labels(type, 'redirected').inc(redirectedEvents)

--- a/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.ts
@@ -14,7 +14,7 @@ import {
 } from './metrics'
 import { OverflowEventGroup, OverflowRedirectService } from './overflow-redirect-service'
 import { OverflowRedisRepository, OverflowType, memberKey } from './overflow-redis-repository'
-import { OverflowStrategy, OverflowStrategyEntry } from './overflow-strategy'
+import { OverflowStrategyEntry } from './overflow-strategy'
 
 export interface MainLaneOverflowRedirectConfig {
     redisRepository: OverflowRedisRepository
@@ -45,7 +45,11 @@ const DEFAULT_LOCAL_CACHE_MAX_SIZE = 1_000_000
  */
 export class MainLaneOverflowRedirect implements OverflowRedirectService {
     private localCache: LRUCache<string, boolean>
-    private strategies: { label: string; strategy: OverflowStrategy; limiter: MemoryRateLimiter }[]
+    private strategies: {
+        label: string
+        countTokens: OverflowStrategyEntry['countTokens']
+        limiter: MemoryRateLimiter
+    }[]
     private redisRepository: OverflowRedisRepository
     private overflowType: OverflowType
 
@@ -56,9 +60,8 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
             ttl: config.localCacheTTLSeconds * 1000,
         })
         this.strategies = config.strategies.map((entry) => ({
-            // The class name is the metrics label: renaming a strategy renames its label.
-            label: entry.strategy.constructor.name,
-            strategy: entry.strategy,
+            label: entry.label,
+            countTokens: entry.countTokens,
             limiter: new MemoryRateLimiter(entry.bucketCapacity, entry.replenishRate),
         }))
         this.overflowType = config.overflowType
@@ -144,10 +147,10 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
             // Consume from every strategy (no short-circuit) so buckets drain
             // consistently; any exhausted bucket flags the key.
             let allowed = true
-            for (const { label, strategy, limiter } of this.strategies) {
+            for (const { label, countTokens, limiter } of this.strategies) {
                 let tokens = 0
                 for (const headers of group.headersPerEvent) {
-                    tokens += strategy.countTokens(headers)
+                    tokens += countTokens(headers)
                 }
                 if (tokens === 0) {
                     continue

--- a/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.ts
@@ -14,14 +14,15 @@ import {
 } from './metrics'
 import { OverflowEventBatch, OverflowRedirectService } from './overflow-redirect-service'
 import { OverflowRedisRepository, OverflowType, memberKey } from './overflow-redis-repository'
+import { OverflowStrategy, OverflowStrategyEntry, overflowStrategyLabel } from './overflow-strategy'
 
 export interface MainLaneOverflowRedirectConfig {
     redisRepository: OverflowRedisRepository
     localCacheTTLSeconds: number
     /** Max entries in the in-memory flagged/not-flagged cache before LRU eviction. */
     localCacheMaxSize?: number
-    bucketCapacity: number
-    replenishRate: number
+    /** Overflow conditions to enforce; a key is redirected when any strategy's bucket is exhausted. */
+    strategies: OverflowStrategyEntry[]
     /** Redis keyspace this service operates on. Fixed per pipeline. */
     overflowType: OverflowType
 }
@@ -44,7 +45,7 @@ const DEFAULT_LOCAL_CACHE_MAX_SIZE = 1_000_000
  */
 export class MainLaneOverflowRedirect implements OverflowRedirectService {
     private localCache: LRUCache<string, boolean>
-    private rateLimiter: MemoryRateLimiter
+    private strategies: { label: string; strategy: OverflowStrategy; limiter: MemoryRateLimiter }[]
     private redisRepository: OverflowRedisRepository
     private overflowType: OverflowType
 
@@ -54,7 +55,11 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
             max: config.localCacheMaxSize ?? DEFAULT_LOCAL_CACHE_MAX_SIZE,
             ttl: config.localCacheTTLSeconds * 1000,
         })
-        this.rateLimiter = new MemoryRateLimiter(config.bucketCapacity, config.replenishRate)
+        this.strategies = config.strategies.map((entry) => ({
+            label: overflowStrategyLabel(entry.strategy),
+            strategy: entry.strategy,
+            limiter: new MemoryRateLimiter(entry.bucketCapacity, entry.replenishRate),
+        }))
         this.overflowType = config.overflowType
     }
 
@@ -134,16 +139,32 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
 
         for (const event of needsRateLimitCheck) {
             const rateLimitKey = memberKey(event.key.token, event.key.distinctId)
-            const allowed = this.rateLimiter.consume(rateLimitKey, event.eventCount, event.firstTimestamp)
+
+            // Consume from every strategy (no short-circuit) so buckets drain
+            // consistently; any exhausted bucket flags the key.
+            let allowed = true
+            for (const { label, strategy, limiter } of this.strategies) {
+                let tokens = 0
+                for (const headers of event.eventHeaders) {
+                    tokens += strategy.countTokens(headers)
+                }
+                if (tokens === 0) {
+                    continue
+                }
+
+                if (limiter.consume(rateLimitKey, tokens, event.firstTimestamp)) {
+                    overflowRedirectRateLimitDecisions.labels(type, label, 'allowed').inc()
+                } else {
+                    allowed = false
+                    overflowRedirectRateLimitDecisions.labels(type, label, 'exceeded').inc()
+                }
+            }
 
             if (!allowed) {
                 // Rate limit exceeded - needs to be flagged
                 newlyFlagged.push(event)
                 toRedirect.add(rateLimitKey)
                 redirectSource.set(rateLimitKey, 'rate_limiter')
-                overflowRedirectRateLimitDecisions.labels(type, 'exceeded').inc()
-            } else {
-                overflowRedirectRateLimitDecisions.labels(type, 'allowed').inc()
             }
         }
 
@@ -175,13 +196,13 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
         for (const event of batch) {
             const mKey = memberKey(event.key.token, event.key.distinctId)
             if (toRedirect.has(mKey)) {
-                redirectedEvents += event.eventCount
+                redirectedEvents += event.eventHeaders.length
                 const source = redirectSource.get(mKey)
                 if (source) {
-                    eventsBySource.set(source, (eventsBySource.get(source) ?? 0) + event.eventCount)
+                    eventsBySource.set(source, (eventsBySource.get(source) ?? 0) + event.eventHeaders.length)
                 }
             } else {
-                passedEvents += event.eventCount
+                passedEvents += event.eventHeaders.length
             }
         }
         overflowRedirectEventsTotal.labels(type, 'redirected').inc(redirectedEvents)

--- a/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/main-lane-overflow-redirect.ts
@@ -14,7 +14,7 @@ import {
 } from './metrics'
 import { OverflowEventGroup, OverflowRedirectService } from './overflow-redirect-service'
 import { OverflowRedisRepository, OverflowType, memberKey } from './overflow-redis-repository'
-import { OverflowStrategy, OverflowStrategyEntry, overflowStrategyLabel } from './overflow-strategy'
+import { OverflowStrategy, OverflowStrategyEntry } from './overflow-strategy'
 
 export interface MainLaneOverflowRedirectConfig {
     redisRepository: OverflowRedisRepository
@@ -56,7 +56,8 @@ export class MainLaneOverflowRedirect implements OverflowRedirectService {
             ttl: config.localCacheTTLSeconds * 1000,
         })
         this.strategies = config.strategies.map((entry) => ({
-            label: overflowStrategyLabel(entry.strategy),
+            // The class name is the metrics label: renaming a strategy renames its label.
+            label: entry.strategy.constructor.name,
             strategy: entry.strategy,
             limiter: new MemoryRateLimiter(entry.bucketCapacity, entry.replenishRate),
         }))

--- a/nodejs/src/ingestion/common/overflow-redirect/metrics.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/metrics.ts
@@ -43,7 +43,8 @@ export const overflowRedirectCacheSize = new Gauge({
 export const overflowRedirectRateLimitDecisions = new Counter({
     name: 'overflow_redirect_rate_limit_decisions_total',
     help: 'Total number of rate limit decisions',
-    labelNames: ['type', 'decision'], // decision: 'allowed' | 'exceeded'
+    // strategy: overflowStrategyLabel of the strategy that decided (e.g. 'event_rate')
+    labelNames: ['type', 'strategy', 'decision'], // decision: 'allowed' | 'exceeded'
 })
 
 // Redirect source metrics - tracks WHERE the redirect decision came from

--- a/nodejs/src/ingestion/common/overflow-redirect/metrics.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/metrics.ts
@@ -43,7 +43,7 @@ export const overflowRedirectCacheSize = new Gauge({
 export const overflowRedirectRateLimitDecisions = new Counter({
     name: 'overflow_redirect_rate_limit_decisions_total',
     help: 'Total number of rate limit decisions',
-    // strategy: overflowStrategyLabel of the strategy that decided (e.g. 'event_rate')
+    // strategy: class name of the strategy that decided (e.g. 'EventRateOverflowStrategy')
     labelNames: ['type', 'strategy', 'decision'], // decision: 'allowed' | 'exceeded'
 })
 

--- a/nodejs/src/ingestion/common/overflow-redirect/metrics.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/metrics.ts
@@ -43,7 +43,7 @@ export const overflowRedirectCacheSize = new Gauge({
 export const overflowRedirectRateLimitDecisions = new Counter({
     name: 'overflow_redirect_rate_limit_decisions_total',
     help: 'Total number of rate limit decisions',
-    // strategy: class name of the strategy that decided (e.g. 'EventRateOverflowStrategy')
+    // strategy: OverflowStrategy.label of the strategy that decided (e.g. 'event_rate')
     labelNames: ['type', 'strategy', 'decision'], // decision: 'allowed' | 'exceeded'
 })
 

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect.test.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect.test.ts
@@ -1,3 +1,4 @@
+import { createTestEventHeaders } from '~/tests/helpers/event-headers'
 import { HealthCheckResultError, HealthCheckResultOk } from '~/types'
 
 import { OverflowLaneOverflowRedirect } from './overflow-lane-overflow-redirect'
@@ -18,7 +19,7 @@ const createBatch = (
     firstTimestamp: number = Date.now()
 ): OverflowEventBatch => ({
     key: { token, distinctId },
-    eventCount,
+    eventHeaders: Array.from({ length: eventCount }, () => createTestEventHeaders({ token, distinct_id: distinctId })),
     firstTimestamp,
 })
 

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect.test.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect.test.ts
@@ -2,7 +2,7 @@ import { createTestEventHeaders } from '~/tests/helpers/event-headers'
 import { HealthCheckResultError, HealthCheckResultOk } from '~/types'
 
 import { OverflowLaneOverflowRedirect } from './overflow-lane-overflow-redirect'
-import { OverflowEventBatch } from './overflow-redirect-service'
+import { OverflowEventGroup } from './overflow-redirect-service'
 import { OverflowRedisRepository } from './overflow-redis-repository'
 
 const createMockRepository = (): jest.Mocked<OverflowRedisRepository> => ({
@@ -12,14 +12,16 @@ const createMockRepository = (): jest.Mocked<OverflowRedisRepository> => ({
     healthCheck: jest.fn().mockResolvedValue(new HealthCheckResultOk()),
 })
 
-const createBatch = (
+const createGroup = (
     token: string,
     distinctId: string,
     eventCount: number = 1,
     firstTimestamp: number = Date.now()
-): OverflowEventBatch => ({
+): OverflowEventGroup => ({
     key: { token, distinctId },
-    eventHeaders: Array.from({ length: eventCount }, () => createTestEventHeaders({ token, distinct_id: distinctId })),
+    headersPerEvent: Array.from({ length: eventCount }, () =>
+        createTestEventHeaders({ token, distinct_id: distinctId })
+    ),
     firstTimestamp,
 })
 
@@ -37,7 +39,7 @@ describe('OverflowLaneOverflowRedirect', () => {
 
     describe('handleEventBatch', () => {
         it('always returns empty set (no redirects from overflow lane)', async () => {
-            const batch = [createBatch('token1', 'user1', 100), createBatch('token1', 'user2', 100)]
+            const batch = [createGroup('token1', 'user1', 100), createGroup('token1', 'user2', 100)]
 
             const result = await service.handleEventBatch(batch)
 
@@ -45,7 +47,7 @@ describe('OverflowLaneOverflowRedirect', () => {
         })
 
         it('refreshes TTL for all keys in batch', async () => {
-            const batch = [createBatch('token1', 'user1'), createBatch('token1', 'user2')]
+            const batch = [createGroup('token1', 'user1'), createGroup('token1', 'user2')]
 
             await service.handleEventBatch(batch)
 
@@ -61,7 +63,7 @@ describe('OverflowLaneOverflowRedirect', () => {
                 overflowType: 'recordings',
             })
 
-            await recordingsService.handleEventBatch([createBatch('token1', 'session1')])
+            await recordingsService.handleEventBatch([createGroup('token1', 'session1')])
 
             expect(mockRepository.batchRefreshTTL).toHaveBeenCalledWith('recordings', [
                 { token: 'token1', distinctId: 'session1' },
@@ -77,9 +79,9 @@ describe('OverflowLaneOverflowRedirect', () => {
 
         it('sends all keys in a single batchRefreshTTL call', async () => {
             const batch = [
-                createBatch('token1', 'user1'),
-                createBatch('token1', 'user2'),
-                createBatch('token2', 'user1'),
+                createGroup('token1', 'user1'),
+                createGroup('token1', 'user2'),
+                createGroup('token2', 'user1'),
             ]
 
             await service.handleEventBatch(batch)
@@ -98,7 +100,7 @@ describe('OverflowLaneOverflowRedirect', () => {
             // The repository layer handles Redis errors internally (fail-open)
             // From the service perspective, batchRefreshTTL completes without error
             // and the service still returns an empty set (no redirects from overflow lane)
-            const batch = [createBatch('token1', 'user1')]
+            const batch = [createGroup('token1', 'user1')]
 
             const result = await service.handleEventBatch(batch)
 

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect.ts
@@ -2,7 +2,7 @@ import { Component } from '~/ingestion/common/scopes'
 import { HealthCheckResult } from '~/types'
 
 import { overflowRedirectEventsTotal, overflowRedirectKeysTotal } from './metrics'
-import { OverflowEventBatch, OverflowRedirectService } from './overflow-redirect-service'
+import { OverflowEventGroup, OverflowRedirectService } from './overflow-redirect-service'
 import { OverflowRedisRepository, OverflowType } from './overflow-redis-repository'
 
 export interface OverflowLaneOverflowRedirectConfig {
@@ -34,7 +34,7 @@ export class OverflowLaneOverflowRedirect implements OverflowRedirectService {
         this.overflowType = config.overflowType
     }
 
-    async handleEventBatch(batch: OverflowEventBatch[]): Promise<Set<string>> {
+    async handleEventBatch(batch: OverflowEventGroup[]): Promise<Set<string>> {
         const type = this.overflowType
 
         // Refresh TTL for all keys in the batch
@@ -49,7 +49,7 @@ export class OverflowLaneOverflowRedirect implements OverflowRedirectService {
         overflowRedirectKeysTotal.labels(type, 'passed').inc(batch.length)
 
         // Record event-level metrics - sum up all event counts
-        const totalEvents = batch.reduce((sum, event) => sum + event.eventHeaders.length, 0)
+        const totalEvents = batch.reduce((sum, group) => sum + group.headersPerEvent.length, 0)
         overflowRedirectEventsTotal.labels(type, 'passed').inc(totalEvents)
 
         // Never redirect from overflow lane - return empty set

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect.ts
@@ -49,7 +49,7 @@ export class OverflowLaneOverflowRedirect implements OverflowRedirectService {
         overflowRedirectKeysTotal.labels(type, 'passed').inc(batch.length)
 
         // Record event-level metrics - sum up all event counts
-        const totalEvents = batch.reduce((sum, event) => sum + event.eventCount, 0)
+        const totalEvents = batch.reduce((sum, event) => sum + event.eventHeaders.length, 0)
         overflowRedirectEventsTotal.labels(type, 'passed').inc(totalEvents)
 
         // Never redirect from overflow lane - return empty set

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-redirect-service.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-redirect-service.ts
@@ -1,4 +1,4 @@
-import { HealthCheckResult } from '~/types'
+import { EventHeaders, HealthCheckResult } from '~/types'
 
 // Re-export OverflowType so consumers of the interface
 // don't need to know about the repository layer
@@ -11,7 +11,8 @@ export interface OverflowEventKey {
 
 export interface OverflowEventBatch {
     key: OverflowEventKey
-    eventCount: number
+    /** Headers of each event for this key in the batch; strategies count their tokens from these. */
+    eventHeaders: EventHeaders[]
     firstTimestamp: number
 }
 

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-redirect-service.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-redirect-service.ts
@@ -9,10 +9,10 @@ export interface OverflowEventKey {
     distinctId: string
 }
 
-export interface OverflowEventBatch {
+export interface OverflowEventGroup {
     key: OverflowEventKey
     /** Headers of each event for this key in the batch; strategies count their tokens from these. */
-    eventHeaders: EventHeaders[]
+    headersPerEvent: EventHeaders[]
     firstTimestamp: number
 }
 
@@ -32,7 +32,7 @@ export interface OverflowRedirectService {
      *
      * @returns Set of keys (token:distinctId) that should be redirected to overflow
      */
-    handleEventBatch(batch: OverflowEventBatch[]): Promise<Set<string>>
+    handleEventBatch(batch: OverflowEventGroup[]): Promise<Set<string>>
 
     /**
      * Health check for the service

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.test.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.test.ts
@@ -1,3 +1,5 @@
+import { createTestEventHeaders } from '~/tests/helpers/event-headers'
+
 import {
     EventRateOverflowStrategy,
     MergeEventRateOverflowStrategy,
@@ -5,6 +7,30 @@ import {
 } from './overflow-strategy'
 
 describe('overflow strategies', () => {
+    describe('EventRateOverflowStrategy', () => {
+        it.each([['$pageview'], ['$identify'], [undefined]])('counts every event (%s) as one token', (event) => {
+            const strategy = new EventRateOverflowStrategy()
+
+            expect(strategy.countTokens(createTestEventHeaders({ event }))).toBe(1)
+        })
+    })
+
+    describe('MergeEventRateOverflowStrategy', () => {
+        it.each([
+            ['$identify', 1],
+            ['$create_alias', 1],
+            ['$merge_dangerously', 1],
+            ['$pageview', 0],
+            ['identify', 0],
+            ['$Identify', 0],
+            [undefined, 0],
+        ])('counts %s as %i tokens', (event, expected) => {
+            const strategy = new MergeEventRateOverflowStrategy()
+
+            expect(strategy.countTokens(createTestEventHeaders({ event }))).toBe(expected)
+        })
+    })
+
     describe('createAnalyticsOverflowStrategies', () => {
         const baseConfig = {
             eventBucketCapacity: 1000,

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.test.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.test.ts
@@ -3,13 +3,14 @@ import { createTestEventHeaders } from '~/tests/helpers/event-headers'
 import {
     EventRateOverflowStrategy,
     MergeEventRateOverflowStrategy,
+    OverflowStrategy,
     createAnalyticsOverflowStrategies,
 } from './overflow-strategy'
 
 describe('overflow strategies', () => {
     describe('EventRateOverflowStrategy', () => {
         it.each([['$pageview'], ['$identify'], [undefined]])('counts every event (%s) as one token', (event) => {
-            const strategy = new EventRateOverflowStrategy()
+            const strategy: OverflowStrategy = new EventRateOverflowStrategy()
 
             expect(strategy.countTokens(createTestEventHeaders({ event }))).toBe(1)
         })

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.test.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.test.ts
@@ -1,0 +1,44 @@
+import {
+    EventRateOverflowStrategy,
+    MergeEventRateOverflowStrategy,
+    createAnalyticsOverflowStrategies,
+    overflowStrategyLabel,
+} from './overflow-strategy'
+
+describe('overflow strategies', () => {
+    describe('createAnalyticsOverflowStrategies', () => {
+        const baseConfig = {
+            eventBucketCapacity: 1000,
+            eventReplenishRate: 1,
+            mergeEventBucketCapacity: 50,
+            mergeEventReplenishRate: 0.1,
+        }
+
+        it('includes the merge strategy when its capacity is positive', () => {
+            const strategies = createAnalyticsOverflowStrategies(baseConfig)
+
+            expect(strategies).toHaveLength(2)
+            expect(strategies[0].strategy).toBeInstanceOf(EventRateOverflowStrategy)
+            expect(strategies[1].strategy).toBeInstanceOf(MergeEventRateOverflowStrategy)
+        })
+
+        it('omits the merge strategy entirely when its capacity is 0', () => {
+            // A 0-capacity bucket would deny everything, so the strategy must be
+            // omitted, not included with capacity 0
+            const strategies = createAnalyticsOverflowStrategies({ ...baseConfig, mergeEventBucketCapacity: 0 })
+
+            expect(strategies).toHaveLength(1)
+            expect(strategies[0].strategy).toBeInstanceOf(EventRateOverflowStrategy)
+        })
+    })
+
+    describe('overflowStrategyLabel', () => {
+        // These labels are a metrics contract: dashboards filter on them
+        it.each([
+            [new EventRateOverflowStrategy(), 'event_rate'],
+            [new MergeEventRateOverflowStrategy(), 'merge_event_rate'],
+        ])('derives a stable snake_case label from the class name (%#)', (strategy, expected) => {
+            expect(overflowStrategyLabel(strategy)).toBe(expected)
+        })
+    })
+})

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.test.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.test.ts
@@ -2,7 +2,6 @@ import {
     EventRateOverflowStrategy,
     MergeEventRateOverflowStrategy,
     createAnalyticsOverflowStrategies,
-    overflowStrategyLabel,
 } from './overflow-strategy'
 
 describe('overflow strategies', () => {
@@ -29,16 +28,6 @@ describe('overflow strategies', () => {
 
             expect(strategies).toHaveLength(1)
             expect(strategies[0].strategy).toBeInstanceOf(EventRateOverflowStrategy)
-        })
-    })
-
-    describe('overflowStrategyLabel', () => {
-        // These labels are a metrics contract: dashboards filter on them
-        it.each([
-            [new EventRateOverflowStrategy(), 'event_rate'],
-            [new MergeEventRateOverflowStrategy(), 'merge_event_rate'],
-        ])('derives a stable snake_case label from the class name (%#)', (strategy, expected) => {
-            expect(overflowStrategyLabel(strategy)).toBe(expected)
         })
     })
 })

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.test.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.test.ts
@@ -1,22 +1,15 @@
 import { createTestEventHeaders } from '~/tests/helpers/event-headers'
 
-import {
-    EventRateOverflowStrategy,
-    MergeEventRateOverflowStrategy,
-    OverflowStrategy,
-    createAnalyticsOverflowStrategies,
-} from './overflow-strategy'
+import { createAnalyticsOverflowStrategies, eventRateStrategy, mergeEventRateStrategy } from './overflow-strategy'
 
 describe('overflow strategies', () => {
-    describe('EventRateOverflowStrategy', () => {
+    describe('eventRateStrategy', () => {
         it.each([['$pageview'], ['$identify'], [undefined]])('counts every event (%s) as one token', (event) => {
-            const strategy: OverflowStrategy = new EventRateOverflowStrategy()
-
-            expect(strategy.countTokens(createTestEventHeaders({ event }))).toBe(1)
+            expect(eventRateStrategy().countTokens(createTestEventHeaders({ event }))).toBe(1)
         })
     })
 
-    describe('MergeEventRateOverflowStrategy', () => {
+    describe('mergeEventRateStrategy', () => {
         it.each([
             ['$identify', 1],
             ['$create_alias', 1],
@@ -26,9 +19,7 @@ describe('overflow strategies', () => {
             ['$Identify', 0],
             [undefined, 0],
         ])('counts %s as %i tokens', (event, expected) => {
-            const strategy = new MergeEventRateOverflowStrategy()
-
-            expect(strategy.countTokens(createTestEventHeaders({ event }))).toBe(expected)
+            expect(mergeEventRateStrategy().countTokens(createTestEventHeaders({ event }))).toBe(expected)
         })
     })
 
@@ -43,9 +34,7 @@ describe('overflow strategies', () => {
         it('includes the merge strategy when its capacity is positive', () => {
             const strategies = createAnalyticsOverflowStrategies(baseConfig)
 
-            expect(strategies).toHaveLength(2)
-            expect(strategies[0].strategy).toBeInstanceOf(EventRateOverflowStrategy)
-            expect(strategies[1].strategy).toBeInstanceOf(MergeEventRateOverflowStrategy)
+            expect(strategies.map((s) => s.label)).toEqual(['event_rate', 'merge_event_rate'])
         })
 
         it('omits the merge strategy entirely when its capacity is 0', () => {
@@ -53,8 +42,7 @@ describe('overflow strategies', () => {
             // omitted, not included with capacity 0
             const strategies = createAnalyticsOverflowStrategies({ ...baseConfig, mergeEventBucketCapacity: 0 })
 
-            expect(strategies).toHaveLength(1)
-            expect(strategies[0].strategy).toBeInstanceOf(EventRateOverflowStrategy)
+            expect(strategies.map((s) => s.label)).toEqual(['event_rate'])
         })
     })
 })

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.ts
@@ -28,6 +28,52 @@ export class EventRateOverflowStrategy implements OverflowStrategy {
     }
 }
 
+/** Events that can trigger a person merge - the expensive person-processing path. */
+const MERGE_EVENT_NAMES = new Set(['$identify', '$create_alias', '$merge_dangerously'])
+
+export function isMergeEvent(eventName: string | undefined): boolean {
+    return eventName !== undefined && MERGE_EVENT_NAMES.has(eventName)
+}
+
+/**
+ * Counts only person-merge events, so merge-heavy actors overflow at a
+ * dedicated (much lower) rate than the overall event rate. Events without an
+ * event name header are not counted (fail open).
+ */
+export class MergeEventRateOverflowStrategy implements OverflowStrategy {
+    countTokens(headers: EventHeaders): number {
+        return isMergeEvent(headers.event) ? 1 : 0
+    }
+}
+
+/**
+ * Strategy set for the analytics events pipeline: overall event rate, plus a
+ * merge-event rate condition when enabled (a merge bucket capacity of 0
+ * disables it - the strategy is omitted entirely rather than denying all).
+ */
+export function createAnalyticsOverflowStrategies(config: {
+    eventBucketCapacity: number
+    eventReplenishRate: number
+    mergeEventBucketCapacity: number
+    mergeEventReplenishRate: number
+}): OverflowStrategyEntry[] {
+    const strategies: OverflowStrategyEntry[] = [
+        {
+            strategy: new EventRateOverflowStrategy(),
+            bucketCapacity: config.eventBucketCapacity,
+            replenishRate: config.eventReplenishRate,
+        },
+    ]
+    if (config.mergeEventBucketCapacity > 0) {
+        strategies.push({
+            strategy: new MergeEventRateOverflowStrategy(),
+            bucketCapacity: config.mergeEventBucketCapacity,
+            replenishRate: config.mergeEventReplenishRate,
+        })
+    }
+    return strategies
+}
+
 /**
  * Metrics label for a strategy, derived from its class name
  * (e.g. EventRateOverflowStrategy -> event_rate). The class name is thereby

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.ts
@@ -73,15 +73,3 @@ export function createAnalyticsOverflowStrategies(config: {
     }
     return strategies
 }
-
-/**
- * Metrics label for a strategy, derived from its class name
- * (e.g. EventRateOverflowStrategy -> event_rate). The class name is thereby
- * part of the metrics contract: renaming a strategy renames its label.
- */
-export function overflowStrategyLabel(strategy: OverflowStrategy): string {
-    return strategy.constructor.name
-        .replace(/OverflowStrategy$/, '')
-        .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
-        .toLowerCase()
-}

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.ts
@@ -1,0 +1,41 @@
+import { EventHeaders } from '~/types'
+
+/**
+ * A pluggable overflow condition for the main-lane overflow redirect.
+ *
+ * Strategies are pure classifiers: they only decide how many tokens an event
+ * consumes from their bucket. All state (the token buckets, keyed on
+ * token:distinct_id) is owned by the redirect service, one bucket set per
+ * strategy. A key is redirected to overflow when any strategy's bucket is
+ * exhausted.
+ */
+export interface OverflowStrategy {
+    /** Tokens this event consumes from the strategy's bucket; 0 = not counted. */
+    countTokens(headers: EventHeaders): number
+}
+
+/** Pairs a strategy with the limits for its token buckets. */
+export interface OverflowStrategyEntry {
+    strategy: OverflowStrategy
+    bucketCapacity: number
+    replenishRate: number
+}
+
+/** Counts every event: the overall event-rate overflow condition. */
+export class EventRateOverflowStrategy implements OverflowStrategy {
+    countTokens(): number {
+        return 1
+    }
+}
+
+/**
+ * Metrics label for a strategy, derived from its class name
+ * (e.g. EventRateOverflowStrategy -> event_rate). The class name is thereby
+ * part of the metrics contract: renaming a strategy renames its label.
+ */
+export function overflowStrategyLabel(strategy: OverflowStrategy): string {
+    return strategy.constructor.name
+        .replace(/OverflowStrategy$/, '')
+        .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+        .toLowerCase()
+}

--- a/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.ts
+++ b/nodejs/src/ingestion/common/overflow-redirect/overflow-strategy.ts
@@ -3,30 +3,29 @@ import { EventHeaders } from '~/types'
 /**
  * A pluggable overflow condition for the main-lane overflow redirect.
  *
- * Strategies are pure classifiers: they only decide how many tokens an event
- * consumes from their bucket. All state (the token buckets, keyed on
- * token:distinct_id) is owned by the redirect service, one bucket set per
- * strategy. A key is redirected to overflow when any strategy's bucket is
- * exhausted.
+ * A strategy is a metrics label plus a pure token-counting function. All state
+ * (the token buckets, keyed on token:distinct_id) is owned by the redirect
+ * service, one bucket set per strategy. A key is redirected to overflow when
+ * any strategy's bucket is exhausted.
  */
 export interface OverflowStrategy {
+    /** Metrics label, e.g. 'event_rate'. Renaming it renames the Prometheus series. */
+    label: string
     /** Tokens this event consumes from the strategy's bucket; 0 = not counted. */
-    countTokens(headers: EventHeaders): number
+    countTokens: (headers: EventHeaders) => number
 }
 
 /** Pairs a strategy with the limits for its token buckets. */
-export interface OverflowStrategyEntry {
-    strategy: OverflowStrategy
+export interface OverflowStrategyEntry extends OverflowStrategy {
     bucketCapacity: number
     replenishRate: number
 }
 
 /** Counts every event: the overall event-rate overflow condition. */
-export class EventRateOverflowStrategy implements OverflowStrategy {
-    countTokens(): number {
-        return 1
-    }
-}
+export const eventRateStrategy = (): OverflowStrategy => ({
+    label: 'event_rate',
+    countTokens: () => 1,
+})
 
 /** Events that can trigger a person merge - the expensive person-processing path. */
 const MERGE_EVENT_NAMES = new Set(['$identify', '$create_alias', '$merge_dangerously'])
@@ -40,11 +39,10 @@ export function isMergeEvent(eventName: string | undefined): boolean {
  * dedicated (much lower) rate than the overall event rate. Events without an
  * event name header are not counted (fail open).
  */
-export class MergeEventRateOverflowStrategy implements OverflowStrategy {
-    countTokens(headers: EventHeaders): number {
-        return isMergeEvent(headers.event) ? 1 : 0
-    }
-}
+export const mergeEventRateStrategy = (): OverflowStrategy => ({
+    label: 'merge_event_rate',
+    countTokens: (headers) => (isMergeEvent(headers.event) ? 1 : 0),
+})
 
 /**
  * Strategy set for the analytics events pipeline: overall event rate, plus a
@@ -59,14 +57,14 @@ export function createAnalyticsOverflowStrategies(config: {
 }): OverflowStrategyEntry[] {
     const strategies: OverflowStrategyEntry[] = [
         {
-            strategy: new EventRateOverflowStrategy(),
+            ...eventRateStrategy(),
             bucketCapacity: config.eventBucketCapacity,
             replenishRate: config.eventReplenishRate,
         },
     ]
     if (config.mergeEventBucketCapacity > 0) {
         strategies.push({
-            strategy: new MergeEventRateOverflowStrategy(),
+            ...mergeEventRateStrategy(),
             bucketCapacity: config.mergeEventBucketCapacity,
             replenishRate: config.mergeEventReplenishRate,
         })

--- a/nodejs/src/ingestion/common/steps/event-preprocessing/overflow-lane-ttl-refresh-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/overflow-lane-ttl-refresh-step.test.ts
@@ -47,8 +47,16 @@ describe('createOverflowLaneTTLRefreshStep', () => {
         await step(events)
 
         expect(service.handleEventBatch).toHaveBeenCalledWith([
-            { key: { token: 'token1', distinctId: 'user1' }, eventCount: 2, firstTimestamp: baseTime.getTime() },
-            { key: { token: 'token1', distinctId: 'user2' }, eventCount: 1, firstTimestamp: baseTime.getTime() },
+            {
+                key: { token: 'token1', distinctId: 'user1' },
+                eventHeaders: [events[0].headers, events[1].headers],
+                firstTimestamp: baseTime.getTime(),
+            },
+            {
+                key: { token: 'token1', distinctId: 'user2' },
+                eventHeaders: [events[2].headers],
+                firstTimestamp: baseTime.getTime(),
+            },
         ])
     })
 

--- a/nodejs/src/ingestion/common/steps/event-preprocessing/overflow-lane-ttl-refresh-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/overflow-lane-ttl-refresh-step.test.ts
@@ -49,12 +49,12 @@ describe('createOverflowLaneTTLRefreshStep', () => {
         expect(service.handleEventBatch).toHaveBeenCalledWith([
             {
                 key: { token: 'token1', distinctId: 'user1' },
-                eventHeaders: [events[0].headers, events[1].headers],
+                headersPerEvent: [events[0].headers, events[1].headers],
                 firstTimestamp: baseTime.getTime(),
             },
             {
                 key: { token: 'token1', distinctId: 'user2' },
-                eventHeaders: [events[2].headers],
+                headersPerEvent: [events[2].headers],
                 firstTimestamp: baseTime.getTime(),
             },
         ])

--- a/nodejs/src/ingestion/common/steps/event-preprocessing/overflow-lane-ttl-refresh-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/overflow-lane-ttl-refresh-step.ts
@@ -1,5 +1,5 @@
 import {
-    OverflowEventBatch,
+    OverflowEventGroup,
     OverflowRedirectService,
 } from '~/ingestion/common/overflow-redirect/overflow-redirect-service'
 import { PipelineResult, ok } from '~/ingestion/framework/results'
@@ -28,7 +28,7 @@ export function createOverflowLaneTTLRefreshStep<T extends OverflowLaneTTLRefres
         // Group events by token:distinct_id for batch TTL refresh
         const keyStats = new Map<
             string,
-            { token: string; distinctId: string; eventHeaders: EventHeaders[]; firstTimestamp: number }
+            { token: string; distinctId: string; headersPerEvent: EventHeaders[]; firstTimestamp: number }
         >()
 
         for (const { headers, event } of inputs) {
@@ -39,23 +39,23 @@ export function createOverflowLaneTTLRefreshStep<T extends OverflowLaneTTLRefres
 
             const existing = keyStats.get(eventKey)
             if (existing) {
-                existing.eventHeaders.push(headers)
+                existing.headersPerEvent.push(headers)
             } else {
-                keyStats.set(eventKey, { token, distinctId, eventHeaders: [headers], firstTimestamp: timestamp })
+                keyStats.set(eventKey, { token, distinctId, headersPerEvent: [headers], firstTimestamp: timestamp })
             }
         }
 
-        const batches: OverflowEventBatch[] = Array.from(keyStats.values()).map(
-            ({ token, distinctId, eventHeaders, firstTimestamp }) => ({
+        const groups: OverflowEventGroup[] = Array.from(keyStats.values()).map(
+            ({ token, distinctId, headersPerEvent, firstTimestamp }) => ({
                 key: { token, distinctId },
-                eventHeaders,
+                headersPerEvent,
                 firstTimestamp,
             })
         )
 
         // TTL refresh doesn't affect routing, so attach it as a pipeline side effect
         // instead of blocking the pipeline on a Redis write.
-        const refreshPromise = overflowRedirectService.handleEventBatch(batches)
+        const refreshPromise = overflowRedirectService.handleEventBatch(groups)
 
         return Promise.resolve(inputs.map((input) => ok(input, [refreshPromise])))
     }

--- a/nodejs/src/ingestion/common/steps/event-preprocessing/overflow-lane-ttl-refresh-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/overflow-lane-ttl-refresh-step.ts
@@ -26,7 +26,10 @@ export function createOverflowLaneTTLRefreshStep<T extends OverflowLaneTTLRefres
         }
 
         // Group events by token:distinct_id for batch TTL refresh
-        const keyStats = new Map<string, { token: string; distinctId: string; count: number; firstTimestamp: number }>()
+        const keyStats = new Map<
+            string,
+            { token: string; distinctId: string; eventHeaders: EventHeaders[]; firstTimestamp: number }
+        >()
 
         for (const { headers, event } of inputs) {
             const token = headers.token ?? ''
@@ -36,16 +39,16 @@ export function createOverflowLaneTTLRefreshStep<T extends OverflowLaneTTLRefres
 
             const existing = keyStats.get(eventKey)
             if (existing) {
-                existing.count++
+                existing.eventHeaders.push(headers)
             } else {
-                keyStats.set(eventKey, { token, distinctId, count: 1, firstTimestamp: timestamp })
+                keyStats.set(eventKey, { token, distinctId, eventHeaders: [headers], firstTimestamp: timestamp })
             }
         }
 
         const batches: OverflowEventBatch[] = Array.from(keyStats.values()).map(
-            ({ token, distinctId, count, firstTimestamp }) => ({
+            ({ token, distinctId, eventHeaders, firstTimestamp }) => ({
                 key: { token, distinctId },
-                eventCount: count,
+                eventHeaders,
                 firstTimestamp,
             })
         )

--- a/nodejs/src/ingestion/common/steps/event-preprocessing/rate-limit-to-overflow-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/rate-limit-to-overflow-step.test.ts
@@ -112,8 +112,16 @@ describe('createRateLimitToOverflowStep', () => {
             await step(events)
 
             expect(service.handleEventBatch).toHaveBeenCalledWith([
-                { key: { token: 'token1', distinctId: 'user1' }, eventCount: 2, firstTimestamp: baseTime.getTime() },
-                { key: { token: 'token2', distinctId: 'user2' }, eventCount: 1, firstTimestamp: baseTime.getTime() },
+                {
+                    key: { token: 'token1', distinctId: 'user1' },
+                    eventHeaders: [events[0].headers, events[1].headers],
+                    firstTimestamp: baseTime.getTime(),
+                },
+                {
+                    key: { token: 'token2', distinctId: 'user2' },
+                    eventHeaders: [events[2].headers],
+                    firstTimestamp: baseTime.getTime(),
+                },
             ])
         })
 
@@ -360,8 +368,14 @@ describe('createSkipCookielessRateLimitToOverflowStep', () => {
 
         expect(service.handleEventBatch).toHaveBeenCalledWith(
             expect.arrayContaining([
-                expect.objectContaining({ key: { token: 'token1', distinctId: 'user1' }, eventCount: 1 }),
-                expect.objectContaining({ key: { token: 'token1', distinctId: 'user2' }, eventCount: 1 }),
+                expect.objectContaining({
+                    key: { token: 'token1', distinctId: 'user1' },
+                    eventHeaders: [events[0].headers],
+                }),
+                expect.objectContaining({
+                    key: { token: 'token1', distinctId: 'user2' },
+                    eventHeaders: [events[2].headers],
+                }),
             ])
         )
         const batches = (service.handleEventBatch as jest.Mock).mock.calls[0][0]

--- a/nodejs/src/ingestion/common/steps/event-preprocessing/rate-limit-to-overflow-step.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/rate-limit-to-overflow-step.test.ts
@@ -114,12 +114,12 @@ describe('createRateLimitToOverflowStep', () => {
             expect(service.handleEventBatch).toHaveBeenCalledWith([
                 {
                     key: { token: 'token1', distinctId: 'user1' },
-                    eventHeaders: [events[0].headers, events[1].headers],
+                    headersPerEvent: [events[0].headers, events[1].headers],
                     firstTimestamp: baseTime.getTime(),
                 },
                 {
                     key: { token: 'token2', distinctId: 'user2' },
-                    eventHeaders: [events[2].headers],
+                    headersPerEvent: [events[2].headers],
                     firstTimestamp: baseTime.getTime(),
                 },
             ])
@@ -370,11 +370,11 @@ describe('createSkipCookielessRateLimitToOverflowStep', () => {
             expect.arrayContaining([
                 expect.objectContaining({
                     key: { token: 'token1', distinctId: 'user1' },
-                    eventHeaders: [events[0].headers],
+                    headersPerEvent: [events[0].headers],
                 }),
                 expect.objectContaining({
                     key: { token: 'token1', distinctId: 'user2' },
-                    eventHeaders: [events[2].headers],
+                    headersPerEvent: [events[2].headers],
                 }),
             ])
         )

--- a/nodejs/src/ingestion/common/steps/event-preprocessing/rate-limit-to-overflow-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/rate-limit-to-overflow-step.ts
@@ -1,7 +1,7 @@
 import { OVERFLOW_OUTPUT, OverflowOutput } from '~/common/outputs'
 import { COOKIELESS_SENTINEL_VALUE } from '~/ingestion/common/cookieless/cookieless-manager'
 import {
-    OverflowEventBatch,
+    OverflowEventGroup,
     OverflowRedirectService,
 } from '~/ingestion/common/overflow-redirect/overflow-redirect-service'
 import { PipelineResult, ok, redirect } from '~/ingestion/framework/results'
@@ -30,7 +30,7 @@ async function applyOverflowRedirect<T extends { headers: EventHeaders }>(
     const perInputKeys: (string | null)[] = []
     const keyStats = new Map<
         string,
-        { token: string; distinctId: string; eventHeaders: EventHeaders[]; firstTimestamp: number }
+        { token: string; distinctId: string; headersPerEvent: EventHeaders[]; firstTimestamp: number }
     >()
 
     for (const input of inputs) {
@@ -46,9 +46,9 @@ async function applyOverflowRedirect<T extends { headers: EventHeaders }>(
         const timestamp = input.headers.now?.getTime() ?? Date.now()
         const existing = keyStats.get(eventKey)
         if (existing) {
-            existing.eventHeaders.push(input.headers)
+            existing.headersPerEvent.push(input.headers)
         } else {
-            keyStats.set(eventKey, { ...derived, eventHeaders: [input.headers], firstTimestamp: timestamp })
+            keyStats.set(eventKey, { ...derived, headersPerEvent: [input.headers], firstTimestamp: timestamp })
         }
     }
 
@@ -56,14 +56,14 @@ async function applyOverflowRedirect<T extends { headers: EventHeaders }>(
         return inputs.map((input) => ok(input))
     }
 
-    const batches: OverflowEventBatch[] = Array.from(keyStats.values()).map(
-        ({ token, distinctId, eventHeaders, firstTimestamp }) => ({
+    const groups: OverflowEventGroup[] = Array.from(keyStats.values()).map(
+        ({ token, distinctId, headersPerEvent, firstTimestamp }) => ({
             key: { token, distinctId },
-            eventHeaders,
+            headersPerEvent,
             firstTimestamp,
         })
     )
-    const keysToRedirect = await overflowRedirectService.handleEventBatch(batches)
+    const keysToRedirect = await overflowRedirectService.handleEventBatch(groups)
 
     return inputs.map((input, index) => {
         const eventKey = perInputKeys[index]

--- a/nodejs/src/ingestion/common/steps/event-preprocessing/rate-limit-to-overflow-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/rate-limit-to-overflow-step.ts
@@ -28,7 +28,10 @@ async function applyOverflowRedirect<T extends { headers: EventHeaders }>(
     }
 
     const perInputKeys: (string | null)[] = []
-    const keyStats = new Map<string, { token: string; distinctId: string; count: number; firstTimestamp: number }>()
+    const keyStats = new Map<
+        string,
+        { token: string; distinctId: string; eventHeaders: EventHeaders[]; firstTimestamp: number }
+    >()
 
     for (const input of inputs) {
         const derived = deriveKey(input)
@@ -43,9 +46,9 @@ async function applyOverflowRedirect<T extends { headers: EventHeaders }>(
         const timestamp = input.headers.now?.getTime() ?? Date.now()
         const existing = keyStats.get(eventKey)
         if (existing) {
-            existing.count++
+            existing.eventHeaders.push(input.headers)
         } else {
-            keyStats.set(eventKey, { ...derived, count: 1, firstTimestamp: timestamp })
+            keyStats.set(eventKey, { ...derived, eventHeaders: [input.headers], firstTimestamp: timestamp })
         }
     }
 
@@ -54,9 +57,9 @@ async function applyOverflowRedirect<T extends { headers: EventHeaders }>(
     }
 
     const batches: OverflowEventBatch[] = Array.from(keyStats.values()).map(
-        ({ token, distinctId, count, firstTimestamp }) => ({
+        ({ token, distinctId, eventHeaders, firstTimestamp }) => ({
             key: { token, distinctId },
-            eventCount: count,
+            eventHeaders,
             firstTimestamp,
         })
     )

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -173,6 +173,10 @@ export type IngestionConsumerConfig = {
     // Event overflow config
     EVENT_OVERFLOW_BUCKET_CAPACITY: number
     EVENT_OVERFLOW_BUCKET_REPLENISH_RATE: number
+    // Merge-event ($identify, $create_alias, $merge_dangerously) overflow rate,
+    // per token:distinct_id. A capacity of 0 disables the condition.
+    MERGE_EVENT_OVERFLOW_BUCKET_CAPACITY: number
+    MERGE_EVENT_OVERFLOW_BUCKET_REPLENISH_RATE: number
 
     // Stateful overflow config
     INGESTION_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS: number
@@ -290,6 +294,8 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         // Event overflow config
         EVENT_OVERFLOW_BUCKET_CAPACITY: 1000,
         EVENT_OVERFLOW_BUCKET_REPLENISH_RATE: 1.0,
+        MERGE_EVENT_OVERFLOW_BUCKET_CAPACITY: 0,
+        MERGE_EVENT_OVERFLOW_BUCKET_REPLENISH_RATE: 1.0,
 
         // Stateful overflow config
         INGESTION_STATEFUL_OVERFLOW_REDIS_TTL_SECONDS: 300,

--- a/nodejs/src/ingestion/ingestion-consumer.test.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.test.ts
@@ -302,7 +302,7 @@ describe('IngestionConsumer', () => {
             })
 
             it('should emit to overflow if token and distinct_id are overflowed', async () => {
-                ;(ingester['overflowRedirectService'] as any)['rateLimiter'].consume(
+                ;(ingester['overflowRedirectService'] as any)['strategies'][0]['limiter'].consume(
                     `${team.api_token}:overflow-distinct-id`,
                     1000,
                     now()

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -60,7 +60,7 @@ import { MainLaneOverflowRedirect } from './common/overflow-redirect/main-lane-o
 import { OverflowLaneOverflowRedirect } from './common/overflow-redirect/overflow-lane-overflow-redirect'
 import { OverflowRedirectService } from './common/overflow-redirect/overflow-redirect-service'
 import { RedisOverflowRepository } from './common/overflow-redirect/overflow-redis-repository'
-import { EventRateOverflowStrategy } from './common/overflow-redirect/overflow-strategy'
+import { createAnalyticsOverflowStrategies } from './common/overflow-redirect/overflow-strategy'
 import { AiEventSubpipelineFactory } from './common/subpipelines/ai-subpipeline.contract'
 import { IngestionConsumerConfig, IngestionOutputsConfig } from './config'
 
@@ -190,13 +190,12 @@ export class IngestionConsumer {
             this.overflowRedirectService = new MainLaneOverflowRedirect({
                 redisRepository: overflowRedisRepository,
                 localCacheTTLSeconds: this.config.INGESTION_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS,
-                strategies: [
-                    {
-                        strategy: new EventRateOverflowStrategy(),
-                        bucketCapacity: this.config.EVENT_OVERFLOW_BUCKET_CAPACITY,
-                        replenishRate: this.config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
-                    },
-                ],
+                strategies: createAnalyticsOverflowStrategies({
+                    eventBucketCapacity: this.config.EVENT_OVERFLOW_BUCKET_CAPACITY,
+                    eventReplenishRate: this.config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
+                    mergeEventBucketCapacity: this.config.MERGE_EVENT_OVERFLOW_BUCKET_CAPACITY,
+                    mergeEventReplenishRate: this.config.MERGE_EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
+                }),
                 overflowType: 'events',
             })
         }

--- a/nodejs/src/ingestion/ingestion-consumer.ts
+++ b/nodejs/src/ingestion/ingestion-consumer.ts
@@ -60,6 +60,7 @@ import { MainLaneOverflowRedirect } from './common/overflow-redirect/main-lane-o
 import { OverflowLaneOverflowRedirect } from './common/overflow-redirect/overflow-lane-overflow-redirect'
 import { OverflowRedirectService } from './common/overflow-redirect/overflow-redirect-service'
 import { RedisOverflowRepository } from './common/overflow-redirect/overflow-redis-repository'
+import { EventRateOverflowStrategy } from './common/overflow-redirect/overflow-strategy'
 import { AiEventSubpipelineFactory } from './common/subpipelines/ai-subpipeline.contract'
 import { IngestionConsumerConfig, IngestionOutputsConfig } from './config'
 
@@ -189,8 +190,13 @@ export class IngestionConsumer {
             this.overflowRedirectService = new MainLaneOverflowRedirect({
                 redisRepository: overflowRedisRepository,
                 localCacheTTLSeconds: this.config.INGESTION_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS,
-                bucketCapacity: this.config.EVENT_OVERFLOW_BUCKET_CAPACITY,
-                replenishRate: this.config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
+                strategies: [
+                    {
+                        strategy: new EventRateOverflowStrategy(),
+                        bucketCapacity: this.config.EVENT_OVERFLOW_BUCKET_CAPACITY,
+                        replenishRate: this.config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
+                    },
+                ],
                 overflowType: 'events',
             })
         }

--- a/nodejs/src/ingestion/pipelines/ai/consumer.ts
+++ b/nodejs/src/ingestion/pipelines/ai/consumer.ts
@@ -28,7 +28,7 @@ import { DisabledOverflowRedirectComponent } from '~/ingestion/common/overflow-r
 import { MainLaneOverflowRedirectComponent } from '~/ingestion/common/overflow-redirect/main-lane-overflow-redirect'
 import { OverflowLaneOverflowRedirectComponent } from '~/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect'
 import { RedisOverflowRepositoryComponent } from '~/ingestion/common/overflow-redirect/overflow-redis-repository'
-import { EventRateOverflowStrategy } from '~/ingestion/common/overflow-redirect/overflow-strategy'
+import { eventRateStrategy } from '~/ingestion/common/overflow-redirect/overflow-strategy'
 import { Scope, extend } from '~/ingestion/common/scopes'
 import { PromiseSchedulerComponent } from '~/ingestion/common/utils/promise-scheduler'
 import { IngestionConsumerConfig, IngestionOutputsConfig } from '~/ingestion/config'
@@ -123,7 +123,7 @@ export function createAiConsumer(config: AiConsumerConfig, sharedScope: AiShared
                           localCacheTTLSeconds: config.INGESTION_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS,
                           strategies: [
                               {
-                                  strategy: new EventRateOverflowStrategy(),
+                                  ...eventRateStrategy(),
                                   bucketCapacity: config.EVENT_OVERFLOW_BUCKET_CAPACITY,
                                   replenishRate: config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
                               },

--- a/nodejs/src/ingestion/pipelines/ai/consumer.ts
+++ b/nodejs/src/ingestion/pipelines/ai/consumer.ts
@@ -28,6 +28,7 @@ import { DisabledOverflowRedirectComponent } from '~/ingestion/common/overflow-r
 import { MainLaneOverflowRedirectComponent } from '~/ingestion/common/overflow-redirect/main-lane-overflow-redirect'
 import { OverflowLaneOverflowRedirectComponent } from '~/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect'
 import { RedisOverflowRepositoryComponent } from '~/ingestion/common/overflow-redirect/overflow-redis-repository'
+import { EventRateOverflowStrategy } from '~/ingestion/common/overflow-redirect/overflow-strategy'
 import { Scope, extend } from '~/ingestion/common/scopes'
 import { PromiseSchedulerComponent } from '~/ingestion/common/utils/promise-scheduler'
 import { IngestionConsumerConfig, IngestionOutputsConfig } from '~/ingestion/config'
@@ -120,8 +121,13 @@ export function createAiConsumer(config: AiConsumerConfig, sharedScope: AiShared
                     ? new MainLaneOverflowRedirectComponent({
                           redisRepository: container.overflowRedisRepository,
                           localCacheTTLSeconds: config.INGESTION_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS,
-                          bucketCapacity: config.EVENT_OVERFLOW_BUCKET_CAPACITY,
-                          replenishRate: config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
+                          strategies: [
+                              {
+                                  strategy: new EventRateOverflowStrategy(),
+                                  bucketCapacity: config.EVENT_OVERFLOW_BUCKET_CAPACITY,
+                                  replenishRate: config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
+                              },
+                          ],
                           overflowType: 'ai',
                       })
                     : new DisabledOverflowRedirectComponent()

--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.ts
@@ -20,7 +20,7 @@ import { MainLaneOverflowRedirect } from '~/ingestion/common/overflow-redirect/m
 import { OverflowLaneOverflowRedirect } from '~/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect'
 import { OverflowRedirectService } from '~/ingestion/common/overflow-redirect/overflow-redirect-service'
 import { RedisOverflowRepository } from '~/ingestion/common/overflow-redirect/overflow-redis-repository'
-import { EventRateOverflowStrategy } from '~/ingestion/common/overflow-redirect/overflow-strategy'
+import { eventRateStrategy } from '~/ingestion/common/overflow-redirect/overflow-strategy'
 import { IngestionLane, IngestionOverflowMode } from '~/ingestion/config'
 import { TopHog } from '~/ingestion/framework/tophog'
 import { PluginEvent } from '~/plugin-scaffold'
@@ -146,7 +146,7 @@ export class ErrorTrackingConsumer {
                 localCacheTTLSeconds: config.statefulOverflowLocalCacheTTLSeconds,
                 strategies: [
                     {
-                        strategy: new EventRateOverflowStrategy(),
+                        ...eventRateStrategy(),
                         bucketCapacity: config.overflowBucketCapacity,
                         replenishRate: config.overflowBucketReplenishRate,
                     },

--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.ts
@@ -20,6 +20,7 @@ import { MainLaneOverflowRedirect } from '~/ingestion/common/overflow-redirect/m
 import { OverflowLaneOverflowRedirect } from '~/ingestion/common/overflow-redirect/overflow-lane-overflow-redirect'
 import { OverflowRedirectService } from '~/ingestion/common/overflow-redirect/overflow-redirect-service'
 import { RedisOverflowRepository } from '~/ingestion/common/overflow-redirect/overflow-redis-repository'
+import { EventRateOverflowStrategy } from '~/ingestion/common/overflow-redirect/overflow-strategy'
 import { IngestionLane, IngestionOverflowMode } from '~/ingestion/config'
 import { TopHog } from '~/ingestion/framework/tophog'
 import { PluginEvent } from '~/plugin-scaffold'
@@ -143,8 +144,13 @@ export class ErrorTrackingConsumer {
             this.overflowRedirectService = new MainLaneOverflowRedirect({
                 redisRepository: overflowRedisRepository,
                 localCacheTTLSeconds: config.statefulOverflowLocalCacheTTLSeconds,
-                bucketCapacity: config.overflowBucketCapacity,
-                replenishRate: config.overflowBucketReplenishRate,
+                strategies: [
+                    {
+                        strategy: new EventRateOverflowStrategy(),
+                        bucketCapacity: config.overflowBucketCapacity,
+                        replenishRate: config.overflowBucketReplenishRate,
+                    },
+                ],
                 overflowType: 'errortracking',
             })
         }

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -70,6 +70,7 @@ import { MainLaneOverflowRedirect } from '../ingestion/common/overflow-redirect/
 import { OverflowLaneOverflowRedirect } from '../ingestion/common/overflow-redirect/overflow-lane-overflow-redirect'
 import { OverflowRedirectService } from '../ingestion/common/overflow-redirect/overflow-redirect-service'
 import { RedisOverflowRepository } from '../ingestion/common/overflow-redirect/overflow-redis-repository'
+import { EventRateOverflowStrategy } from '../ingestion/common/overflow-redirect/overflow-strategy'
 import {
     DatabaseConnectionConfig,
     IngestionConsumerConfig,
@@ -323,8 +324,13 @@ export class IngestionApiServer implements NodeServer {
             overflowRedirectService = new MainLaneOverflowRedirect({
                 redisRepository: overflowRedisRepository,
                 localCacheTTLSeconds: this.config.INGESTION_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS,
-                bucketCapacity: this.config.EVENT_OVERFLOW_BUCKET_CAPACITY,
-                replenishRate: this.config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
+                strategies: [
+                    {
+                        strategy: new EventRateOverflowStrategy(),
+                        bucketCapacity: this.config.EVENT_OVERFLOW_BUCKET_CAPACITY,
+                        replenishRate: this.config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
+                    },
+                ],
                 overflowType: 'events',
             })
         }

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -70,7 +70,7 @@ import { MainLaneOverflowRedirect } from '../ingestion/common/overflow-redirect/
 import { OverflowLaneOverflowRedirect } from '../ingestion/common/overflow-redirect/overflow-lane-overflow-redirect'
 import { OverflowRedirectService } from '../ingestion/common/overflow-redirect/overflow-redirect-service'
 import { RedisOverflowRepository } from '../ingestion/common/overflow-redirect/overflow-redis-repository'
-import { EventRateOverflowStrategy } from '../ingestion/common/overflow-redirect/overflow-strategy'
+import { createAnalyticsOverflowStrategies } from '../ingestion/common/overflow-redirect/overflow-strategy'
 import {
     DatabaseConnectionConfig,
     IngestionConsumerConfig,
@@ -324,13 +324,12 @@ export class IngestionApiServer implements NodeServer {
             overflowRedirectService = new MainLaneOverflowRedirect({
                 redisRepository: overflowRedisRepository,
                 localCacheTTLSeconds: this.config.INGESTION_STATEFUL_OVERFLOW_LOCAL_CACHE_TTL_SECONDS,
-                strategies: [
-                    {
-                        strategy: new EventRateOverflowStrategy(),
-                        bucketCapacity: this.config.EVENT_OVERFLOW_BUCKET_CAPACITY,
-                        replenishRate: this.config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
-                    },
-                ],
+                strategies: createAnalyticsOverflowStrategies({
+                    eventBucketCapacity: this.config.EVENT_OVERFLOW_BUCKET_CAPACITY,
+                    eventReplenishRate: this.config.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
+                    mergeEventBucketCapacity: this.config.MERGE_EVENT_OVERFLOW_BUCKET_CAPACITY,
+                    mergeEventReplenishRate: this.config.MERGE_EVENT_OVERFLOW_BUCKET_REPLENISH_RATE,
+                }),
                 overflowType: 'events',
             })
         }


### PR DESCRIPTION
## Problem

A single `token:distinct_id` sending a burst of person-merge events (`$identify`, `$create_alias`, `$merge_dangerously`) is far more expensive to ingest than the same volume of regular events, and can cause pipeline lag well before the overall event-rate overflow condition trips.
The main-lane overflow redirect only supported one condition, a hardcoded event-rate token bucket.

## Changes

Best reviewed commit by commit:

**1. `refactor(ingestion)`: pluggable overflow strategies (behavior-neutral)**

- New `OverflowStrategy` interface in `overflow-redirect/overflow-strategy.ts`. A strategy is a pure classifier (`countTokens(headers)`); the redirect service owns all state and keeps one `MemoryRateLimiter` per strategy. A key redirects when any strategy's bucket is exhausted.
- `MainLaneOverflowRedirectConfig` takes `strategies: OverflowStrategyEntry[]` (strategy + bucket capacity + replenish rate) instead of a single `bucketCapacity`/`replenishRate` pair. All existing wiring (analytics, ingestion API server, error tracking, AI) passes a single `EventRateOverflowStrategy`, so behavior is unchanged.
- The per-key group passed to the service now carries `headersPerEvent` instead of a pre-aggregated `eventCount`, so strategies can count their own tokens from headers. Cache, Redis flagging, and overflow-lane TTL refresh are untouched.
- `overflow_redirect_rate_limit_decisions_total` gains a `strategy` label (the strategy class name), so dashboards can see which condition trips keys.

**2. `feat(ingestion)`: merge-event rate condition**

- `MergeEventRateOverflowStrategy` counts only `$identify`, `$create_alias`, and `$merge_dangerously`, classified from the Kafka `event` header, so it runs in the existing pre-body-parse step. Events without the header are not counted (fail open).
- New config: `MERGE_EVENT_OVERFLOW_BUCKET_CAPACITY` (default 0 = disabled) and `MERGE_EVENT_OVERFLOW_BUCKET_REPLENISH_RATE`. When capacity is 0 the strategy is omitted entirely rather than added with an always-empty bucket.
- Wired into the analytics pipelines only (ingestion consumer + ingestion API server). Error tracking and AI keep event-rate only.

**3–4. naming and label cleanups from review**

- `OverflowEventBatch` → `OverflowEventGroup` (each element is one key's group of events within a batch), loop vars `event` → `group`, field named `headersPerEvent`.
- Metrics label is the raw strategy class name, no derivation helper.

> [!NOTE]
> Redirect granularity is unchanged: flagging stays per `token:distinct_id`, so once a key exceeds the merge rate all of its events go to overflow, preserving per-distinct-id ordering. The strategy keys on the header distinct id, which is the merge target for `$identify`, so many-anon-ids-into-one-identity storms are caught. One-anon-into-many-identities spreads across keys and would need a token-level bucket, out of scope here.

## How did you test this code?

Ran the touched jest suites locally, all passing: `overflow-redirect/*` (strategy, main lane, overflow lane, detector), `rate-limit-to-overflow-step`, `overflow-lane-ttl-refresh-step`, `errortracking/error-tracking-consumer`, `ai/pipeline`. `tsc --noEmit` clean on touched files.

New tests and the regression each catches:

- main lane merge cases: a key over the merge bucket but under the event bucket must redirect (catches the merge strategy not being consulted, or a broken event-name set), and non-merge or missing event names must not consume the merge bucket (catches over-counting that would overflow normal traffic).
- `createAnalyticsOverflowStrategies` gating: capacity 0 must omit the strategy, since a present-but-empty bucket would deny every key (that regression would redirect all analytics traffic to overflow).

Not tested by me (Claude): the full `ingestion-consumer.test.ts` integration suite needs the local dev stack (Kafka/Postgres/Redis), which wasn't running in this session. CI runs it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (investigation + implementation session). Skills invoked: /writing-tests.
Design decisions made with the driver during the session: strategies are pure classifiers (declarative entry of strategy + limits) rather than owning their own state or a `consume` method, so the service keeps all bucket state and lifecycle; the metrics label is the plain strategy class name (a snake_case derivation helper was considered and dropped as unnecessary); the per-key group carries headers per event instead of a count so strategies stay header-driven and the step stays strategy-agnostic; merge limiting is off by default (capacity 0) and enabled per deployment via env.