### PR TITLE
fix(access-control): sort settings table rows alphabetically by feature

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6947,9 +6947,9 @@ snapshots:
     scenes-app-settings-authentication-domains--one-unverified-domain--light:
         hash: v1.k794b7964.b1ae6dbc8feb673159fcc13f4a8fd5ee856c63ad1204e839a1b55ef70d109c81.W5sqRIJDHcdkKlYg4ghfwpbKS2FmlQKF_N-1C83h9Mg
     scenes-app-settings-environment--settings-environment-access-control--dark:
-        hash: v1.k794b7964.f371f0993dc42cd074258604780e8a90dcc80dd7319a2a0e15fd007f910bec43.XcwFTTHCfVcHpz1rc4P3qWgeboGmLt4lWDPKbdI9UVE
+        hash: v1.k794b7964.e21dd62aa9b6fe56d56eb25335fc9381ebe50dd2fdbbfb7210ba3eff53873cca.X07uD_OyuY0vaAAq7Wr44wgawmba7-iuAe4D0fn0h2A
     scenes-app-settings-environment--settings-environment-access-control--light:
-        hash: v1.k794b7964.2bf13d938e2e771c04106ea1c77873ff914ff2c19d3328f74810d8f56812d2bd.ILHlhbk7257G41f-oFgJ_cT-IKHaNd4zaL5XdEmpUVw
+        hash: v1.k794b7964.cb89513904c4aadf57bb62efabd5b07c88ce3217ebf6c6beab3653f5f5269870.JIBr0t6f_OJj9gyjcmWsclA7lrz4ajWJPdwsevFBvV4
     scenes-app-settings-environment--settings-environment-autocapture--dark:
         hash: v1.k794b7964.2183cf0082a1556d6df553572df4ab3813c96288a8b9a80e669c005908230c3e.-ybX8d6KyxaSa-yJDVccZm2CkK8Fl8qLSbw9jGhSIx4
     scenes-app-settings-environment--settings-environment-autocapture--light:

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/ResourceAccessControlsV2/accessControlsLogic.ts
@@ -967,19 +967,21 @@ export const accessControlsLogic = kea<accessControlsLogicType>([
                 resources: APIScopeObject[],
                 featureFlags: import('lib/logic/featureFlagLogic').FeatureFlagsSet
             ): { key: APIScopeObject; label: string }[] => {
-                if (defaults) {
-                    return Object.keys(defaults.resource_access_levels)
-                        .filter((resource) => isResourceRolledOut(resource as AccessControlResourceType, featureFlags))
-                        .map((resource) => ({
-                            key: resource as APIScopeObject,
-                            label: toSentenceCase(pluralizeResource(resource as APIScopeObject)),
-                        }))
-                }
-                // Fallback to list of all resources while loading
-                return resources.map((resource) => ({
-                    key: resource,
-                    label: toSentenceCase(pluralizeResource(resource)),
-                }))
+                const rows = defaults
+                    ? Object.keys(defaults.resource_access_levels)
+                          .filter((resource) =>
+                              isResourceRolledOut(resource as AccessControlResourceType, featureFlags)
+                          )
+                          .map((resource) => ({
+                              key: resource as APIScopeObject,
+                              label: toSentenceCase(pluralizeResource(resource as APIScopeObject)),
+                          }))
+                    : // Fallback to list of all resources while loading
+                      resources.map((resource) => ({
+                          key: resource,
+                          label: toSentenceCase(pluralizeResource(resource)),
+                      }))
+                return rows.sort((a, b) => a.label.localeCompare(b.label))
             },
         ],
 


### PR DESCRIPTION
## Problem

The Access control settings table (Settings → Access control → Defaults) lists one row per feature, but the rows followed a hand-maintained, non-alphabetical order inherited from the backend resource list — making it hard to scan or find a specific feature.

## Changes

- Sort the `resourceKeys` selector in `accessControlsLogic.ts` alphabetically by the displayed feature label.
- Since the "Feature" filter dropdown and the grouped access rule modal both derive their lists from this same selector, they now render alphabetically too, for consistency.

## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check` — no errors.
- `pnpm --filter=@posthog/frontend fix` (oxlint + oxfmt) — clean.
- Ran the existing Jest suite for this directory (`accessControlsLogic.test.ts`, `resourcesAccessControlLogic.test.ts`, `groupedAccessControlRuleModalLogic.test.ts`, `helpers.test.ts`) — all 60 tests pass. No existing test asserted row order, so no test needed updating.
- Did not manually test in a running browser session (no interactive dev environment available in this session) — the change is a single `.sort()` call on an existing, already-tested data selector.

Tested change manually locally as well

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal UI ordering change, no documented behavior affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: PostHog Code (Claude Sonnet 5), autonomous cloud task.
- Located the table via the `Explore` sub-agent, which traced the render path from `AccessControlDefaultSettings.tsx`'s `LemonTable` down to the `resourceKeys` selector in `accessControlsLogic.ts`, and confirmed the backend `ACCESS_CONTROL_RESOURCES` tuple order was the root cause of the non-alphabetical rows.
- Chose to sort by the rendered `label` (e.g. "Feature flags") rather than the raw `key` (e.g. `feature_flag`), since sorting by key wouldn't necessarily match visual alphabetical order once pluralization/label overrides are applied.
- Sorted in the shared kea selector rather than at each render site, since multiple UI surfaces (main table, filter dropdown, rule modal) consume the same selector.