### PR TITLE
fix(tasks): authenticate custom image security scans

### DIFF
--- a/products/tasks/backend/temporal/build_image/activities.py
+++ b/products/tasks/backend/temporal/build_image/activities.py
@@ -108,7 +108,7 @@ def _judge_spec_safety(spec_yaml: str, team_id: int, repository: str = "") -> Sc
         if repository
         else ""
     )
-    client = get_llm_client(product="posthog_code", team_id=team_id)
+    client = get_llm_client(product="django", team_id=team_id)
     response = client.chat.completions.create(
         model=SCAN_JUDGE_MODEL,
         messages=[

--- a/products/tasks/backend/temporal/build_image/test_activities.py
+++ b/products/tasks/backend/temporal/build_image/test_activities.py
@@ -36,7 +36,7 @@ def test_security_scan_uses_glm_json_output(mock_get_llm_client: MagicMock) -> N
 
     assert result.passed is True
     assert result.findings == [{"severity": "low", "detail": "Pinned development tool"}]
-    mock_get_llm_client.assert_called_once_with(product="posthog_code", team_id=42)
+    mock_get_llm_client.assert_called_once_with(product="django", team_id=42)
     request = mock_get_llm_client.return_value.chat.completions.create.call_args.kwargs
     assert request["model"] == SCAN_JUDGE_MODEL
     assert request["response_format"] == {"type": "json_object"}


### PR DESCRIPTION
## Problem

Custom image security scans use a server-side gateway key, but were routed through the OAuth-only `posthog_code` product. This caused scans to fail with a 403 before image builds could begin.

## Changes

Route the GLM 5.2 security scan through the existing server-authenticated `django` gateway product. Team attribution and structured JSON verdicts remain unchanged.
