### PR TITLE
feat(experiments): polish replay experiment sidebar and dropdown

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4967,9 +4967,9 @@ snapshots:
     replay-overview-tab--wide-overview-tab--light:
         hash: v1.k794b7964.deb71477c91ae3fb89eaa9c6c9a45e665db4fa8363df4de30b3737c655930825.n5T9fmKBWN7qXDwbX9sYPEtdRgVYiaUgrJfvtail2tg
     replay-overview-tab-experiments--default--dark:
-        hash: v1.k794b7964.84ba0a1ff57ca5b14b54715912350609faee2d5c65f9ea6c5ade055b33ddcc81.D2N4NQPNCpcUXsQkvrjeq_XDQ8L98D6paPPsajdYWgQ
+        hash: v1.k794b7964.d8d0a5076deebd369360b47f2ae86bbd0645d082ba0e271202ae5dfc9fdbe71f._l-QzxbiRIMLOQNEH2rreVSC-AoglFfLN8V-qdtKe1M
     replay-overview-tab-experiments--default--light:
-        hash: v1.k794b7964.4d37d89ed1aeb7e8d0d037a9c468e2f36986abb9b6b07d712bab94dfbaf35148.pGSFsm8IUjIcH3ffC3Iw0NRrCJcbWB2L2eBAvjxxPFs
+        hash: v1.k794b7964.75111a9a147dfe4dad586d19e47092c919f6a27173e6409223104337f9acb08d.kdrOerNCwGkoznYgvK6S_Y6dat9EJ-mIbVwjcrHKD14
     replay-overview-tab-experiments--empty--dark:
         hash: v1.k794b7964.13e51a486b40a1455fde0075af333e3dff21f25491d06cc59ab10c24200eb1d2.Fn0OHVeRm39HLB3-xcZUZavR375CxuNraJZdmfxTS-U
     replay-overview-tab-experiments--empty--light:

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReplayTab.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReplayTab.tsx
@@ -1,10 +1,20 @@
 import { useActions, useValues } from 'kea'
 
-import { IconChevronDown } from '@posthog/icons'
+import { IconChevronDown, IconInfo } from '@posthog/icons'
 import { LemonBanner, LemonSegmentedButton } from '@posthog/lemon-ui'
-import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from '@posthog/quill'
+import {
+    DropdownMenu,
+    DropdownMenuCheckboxItem,
+    DropdownMenuContent,
+    DropdownMenuGroup,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@posthog/quill'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { SessionRecordingsPlaylist } from 'scenes/session-recordings/playlist/SessionRecordingsPlaylist'
 
 import { Experiment } from '~/types'
@@ -39,6 +49,12 @@ export function ExperimentReplayTab({ experiment }: { experiment: Experiment }):
         return <LemonBanner type="warning">{EXPOSURE_UNLINKABLE_REASON}</LemonBanner>
     }
 
+    // Selectable metrics render as checkboxes. Unlinkable ones move to a labelled section that
+    // explains once, via a section tooltip, why they can't be matched — instead of repeating the
+    // same reason on every row.
+    const linkableMetricOptions = metricOptions.filter((option) => !option.unlinkable)
+    const unlinkableMetricOptions = metricOptions.filter((option) => option.unlinkable)
+
     return (
         <div data-attr="experiment-recordings-tab">
             <div className="mb-2 flex flex-wrap gap-2">
@@ -69,29 +85,44 @@ export function ExperimentReplayTab({ experiment }: { experiment: Experiment }):
                                 : 'Metric events'}
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="start" className="min-w-fit max-w-100">
-                            {metricOptions.map((option) => (
+                            {linkableMetricOptions.map((option) => (
                                 <DropdownMenuCheckboxItem
                                     key={option.uuid}
                                     checked={effectiveMetricUuids.includes(option.uuid)}
                                     onCheckedChange={(checked: boolean) => setMetricSelected(option.uuid, checked)}
                                     closeOnClick={false}
-                                    disabled={option.unlinkable}
                                     data-attr="experiment-recordings-metric-option"
                                 >
-                                    {option.unlinkable ? (
-                                        // Disabled items get pointer-events: none, so a tooltip can't
-                                        // explain them — the reason renders inline instead.
-                                        <span className="flex flex-col items-start text-left">
-                                            <span>{option.name}</span>
-                                            <span className="text-muted whitespace-normal">
-                                                {METRIC_UNLINKABLE_REASON}
-                                            </span>
-                                        </span>
-                                    ) : (
-                                        option.name
-                                    )}
+                                    {option.name}
                                 </DropdownMenuCheckboxItem>
                             ))}
+                            {unlinkableMetricOptions.length > 0 && (
+                                <>
+                                    {linkableMetricOptions.length > 0 && <DropdownMenuSeparator />}
+                                    {/* Quill's DropdownMenuLabel renders a Base UI GroupLabel, which must
+                                        live inside a DropdownMenuGroup or it throws at render. */}
+                                    <DropdownMenuGroup>
+                                        <DropdownMenuLabel inset className="flex items-center gap-1">
+                                            Can't match to recordings
+                                            <Tooltip title={METRIC_UNLINKABLE_REASON}>
+                                                <IconInfo className="size-3 shrink-0" />
+                                            </Tooltip>
+                                        </DropdownMenuLabel>
+                                        {unlinkableMetricOptions.map((option) => (
+                                            // Informational only — not selectable. The section label above
+                                            // carries the single shared explanation.
+                                            <DropdownMenuItem
+                                                key={option.uuid}
+                                                inset
+                                                disabled
+                                                data-attr="experiment-recordings-metric-option"
+                                            >
+                                                {option.name}
+                                            </DropdownMenuItem>
+                                        ))}
+                                    </DropdownMenuGroup>
+                                </>
+                            )}
                         </DropdownMenuContent>
                     </DropdownMenu>
                 )}

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
@@ -1,6 +1,8 @@
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import { useEffect } from 'react'
 
-import { IconCollapse, IconExpand, IconExternal, IconWarning } from '@posthog/icons'
+import { IconCollapse, IconExpand, IconExternal, IconMinus, IconWarning } from '@posthog/icons'
 
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -46,10 +48,6 @@ function VariantTag({ item }: { item: ExperimentSessionContextItemApi }): JSX.El
         </Tooltip>
     )
 }
-
-// Above this many in-bounds occurrences the per-event seek chips collapse behind a toggle so a
-// busy metric doesn't flood the sidebar.
-const INLINE_METRIC_EVENT_LIMIT = 6
 
 function MetricEventChips({
     seekPoints,
@@ -98,18 +96,6 @@ function MetricHitRow({
             <span className="truncate">{hit.metric_name}</span>
             {seekPoints.length === 0 ? (
                 <span className="pl-3 text-muted">Fired outside the recording</span>
-            ) : seekPoints.length > INLINE_METRIC_EVENT_LIMIT ? (
-                <LemonCollapse
-                    embedded
-                    size="small"
-                    panels={[
-                        {
-                            key: 'events',
-                            header: `${seekPoints.length} events`,
-                            content: <MetricEventChips seekPoints={seekPoints} onSeek={onSeek} />,
-                        },
-                    ]}
-                />
             ) : (
                 <MetricEventChips seekPoints={seekPoints} onSeek={onSeek} />
             )}
@@ -144,16 +130,38 @@ function OpenExperimentButton({ item }: { item: ExperimentSessionContextItemApi 
 const OUT_OF_WINDOW_TOOLTIP =
     "The exposure was captured just outside this recording's playable range, so there's no moment to jump to."
 
-// Position of the exposure within the recording, so the list's chronological order is legible rather than
-// implied. Deliberately always relative (not the player's Relative/UTC/device setting like the inspector's
-// ItemTimeDisplay): "where in this recording" is the whole point here, and an absolute date would not fit
-// the sidebar's width. An exposure captured before the recording starts clamps to zero — the row's tooltip
-// is what explains that it landed outside the playable range.
-function ExposureTime({ timeInRecording }: { timeInRecording: number }): JSX.Element {
+// The person's counted first exposure may lie in an earlier session (the experiment analysis counts
+// exposure per person across the whole run window), so an in-session metric event can precede this one.
+const EXPOSURE_CAVEAT =
+    'They may have been enrolled in an earlier session, so metric events can fire before this moment.'
+
+function ExposureTime({
+    timeInRecording,
+    onSeek,
+    outOfWindow,
+}: {
+    timeInRecording: number
+    onSeek?: () => void
+    outOfWindow?: boolean
+}): JSX.Element {
+    const label = colonDelimitedDuration(Math.max(0, timeInRecording) / 1000, null)
+    if (onSeek) {
+        return (
+            <Tooltip title={`Jump to the first exposure in this session. ${EXPOSURE_CAVEAT}`}>
+                <Link
+                    className="text-xs tabular-nums shrink-0 min-w-10 text-right"
+                    onClick={onSeek}
+                    data-attr="replay-experiment-context-jump-to-first-exposure"
+                >
+                    {label}
+                </Link>
+            </Tooltip>
+        )
+    }
     return (
-        <span className="text-secondary text-xs tabular-nums shrink-0 min-w-10 text-right">
-            {colonDelimitedDuration(Math.max(0, timeInRecording) / 1000, null)}
-        </span>
+        <Tooltip title={outOfWindow ? OUT_OF_WINDOW_TOOLTIP : `First exposure in this session. ${EXPOSURE_CAVEAT}`}>
+            <span className="text-secondary text-xs tabular-nums shrink-0 min-w-10 text-right">{label}</span>
+        </Tooltip>
     )
 }
 
@@ -168,43 +176,32 @@ function ExperimentContextRow({
     onSeek?: () => void
     outOfWindow?: boolean
     timeInRecording?: number | null
-    // Leading slot rendered before the timestamp — the metric-events expand toggle, or an empty
-    // spacer of the same width so the timestamp and name columns line up across rows.
+    // Leading slot rendered before the timestamp — the metric-events expand toggle, or a same-width
+    // spacer so the timestamp and name columns line up across rows.
     leading?: JSX.Element | null
 }): JSX.Element {
-    let name: JSX.Element
-    if (onSeek) {
-        name = (
-            <Link
-                title="Jump to when this session matched the experiment's exposure criteria"
-                onClick={onSeek}
-                data-attr="replay-experiment-context-jump-to-first-exposure"
-            >
-                {item.experiment_name}
-            </Link>
-        )
-    } else if (outOfWindow) {
-        name = (
-            <Tooltip title={OUT_OF_WINDOW_TOOLTIP}>
-                <span>{item.experiment_name}</span>
-            </Tooltip>
-        )
-    } else {
-        name = <span>{item.experiment_name}</span>
-    }
-
-    // The name lives in its own flex-1 truncate box so the variant tag and open-experiment icon
-    // stay right-aligned whether the name is a plain span or a Link (a Link with no `to` renders a
-    // button wrapped in a non-flex span, which would otherwise let its tag hug the text).
+    // The name is a plain label in its own flex-1 truncate box (keeping the variant tag and
+    // open-experiment icon right-aligned). Seeking lives on the timestamp; opening the experiment on
+    // the icon — so the name identifies the row rather than pretending to be a control.
     return (
         <div className="flex flex-row items-center gap-x-2 min-w-0">
             {leading}
-            {timeInRecording != null ? <ExposureTime timeInRecording={timeInRecording} /> : null}
-            <div className="flex-1 min-w-0 truncate">{name}</div>
+            {timeInRecording != null ? (
+                <ExposureTime timeInRecording={timeInRecording} onSeek={onSeek} outOfWindow={outOfWindow} />
+            ) : null}
+            <div className="flex-1 min-w-0 truncate">{item.experiment_name}</div>
             <VariantTag item={item} />
             <OpenExperimentButton item={item} />
         </div>
     )
+}
+
+// The experiments scene keeps /experiments/<numeric id> in the path even while the player is embedded
+// in its recordings tab, so the experiment the viewer came from is recoverable from the route. Returns
+// null off that scene (the generic replay page), where there's no experiment to pin.
+function experimentIdFromPath(pathname: string): number | null {
+    const match = pathname.match(/\/experiments\/(\d+)/)
+    return match ? Number(match[1]) : null
 }
 
 export function PlayerSidebarExperimentsSection(): JSX.Element | null {
@@ -215,6 +212,26 @@ export function PlayerSidebarExperimentsSection(): JSX.Element | null {
     })
     const { seenItems, enrolledItems, hasExperimentContext, expandedExperimentIds } = useValues(experimentContextLogic)
     const { setExperimentExpanded } = useActions(experimentContextLogic)
+    const { location } = useValues(router)
+
+    // The experiment the viewer arrived from: their recordings tab keeps the URL on /experiments/<id>
+    // while the player is embedded, so we can pin it and default-expand its metrics. Null on the
+    // generic replay page, where there's no experiment context.
+    const currentExperimentId = experimentIdFromPath(location.pathname)
+    const currentItem =
+        currentExperimentId != null
+            ? ([...seenItems, ...enrolledItems].find((item) => item.experiment_id === currentExperimentId) ?? null)
+            : null
+
+    // Default-expand the current experiment's metrics on load so they're visible right away. Depending
+    // on the identity + metric count (not the expand set) keeps a manual collapse afterwards sticky.
+    const currentExpandableId = currentItem?.experiment_id
+    const currentMetricCount = currentItem?.metrics_in_session.length ?? 0
+    useEffect(() => {
+        if (currentExpandableId != null && currentMetricCount > 0) {
+            setExperimentExpanded(currentExpandableId, true)
+        }
+    }, [currentExpandableId, currentMetricCount, setExperimentExpanded])
 
     if (!hasExperimentContext) {
         return null
@@ -239,6 +256,93 @@ export function PlayerSidebarExperimentsSection(): JSX.Element | null {
     // one experiment has an expand toggle; with nothing expandable, keep the list flush-left.
     const anySeenExpandable = seenItems.some((seenItem) => seenItem.metrics_in_session.length > 0)
 
+    // One seen experiment rendered in full: its timestamp seek control, the expand toggle (or the
+    // no-metrics marker), and — when expanded — its metric hits. Extracted so the pinned "current"
+    // experiment reuses the exact same treatment as the list rows below it.
+    const renderSeenRow = (item: ExperimentSessionContextItemApi): JSX.Element => {
+        const exposedAtMs = item.first_exposure_timestamp ? dayjs(item.first_exposure_timestamp).valueOf() : null
+        const canSeek = isWithinRecording(exposedAtMs)
+        // Distinguish "seen but outside the window" (worth a tooltip) from "bounds not known yet"
+        // (transient, no tooltip) so we never explain a non-jump we can't actually vouch for.
+        const outOfWindow =
+            exposedAtMs != null &&
+            recordingStartMs != null &&
+            recordingEndMs != null &&
+            (exposedAtMs < recordingStartMs || exposedAtMs > recordingEndMs)
+        const hasMetrics = item.metrics_in_session.length > 0
+        const isExpanded = expandedExperimentIds.includes(item.experiment_id)
+        return (
+            <div key={item.experiment_id} className="flex flex-col gap-y-0.5 min-w-0">
+                <ExperimentContextRow
+                    item={item}
+                    onSeek={canSeek && exposedAtMs != null ? () => seekToTimestamp(exposedAtMs) : undefined}
+                    outOfWindow={outOfWindow}
+                    timeInRecording={
+                        exposedAtMs != null && recordingStartMs != null ? exposedAtMs - recordingStartMs : null
+                    }
+                    leading={
+                        // -me-1.5 pulls the timestamp back toward the toggle so the icon and time read
+                        // as one column (and line up better with the expanded metrics), without
+                        // tightening the timestamp-to-name gap.
+                        anySeenExpandable ? (
+                            <div className="shrink-0 flex w-[1.625rem] items-center justify-center -me-1.5">
+                                {hasMetrics ? (
+                                    <LemonButton
+                                        size="xsmall"
+                                        icon={isExpanded ? <IconCollapse /> : <IconExpand />}
+                                        onClick={() => setExperimentExpanded(item.experiment_id, !isExpanded)}
+                                        tooltip={
+                                            isExpanded
+                                                ? 'Hide metric events'
+                                                : `Show metric events (${item.metrics_in_session.length})`
+                                        }
+                                        data-attr="replay-experiment-context-expand-metrics"
+                                    />
+                                ) : (
+                                    // Same component and size as the expand button so the marker has an
+                                    // identical box, border, and tooltip hover target. disabledReason keeps
+                                    // it hoverable (LemonButton disables via aria-disabled, not the native
+                                    // attribute) while signalling there's nothing to expand.
+                                    <LemonButton
+                                        size="xsmall"
+                                        icon={<IconMinus />}
+                                        disabledReason="No experiment metric fired in this session"
+                                        data-attr="replay-experiment-context-no-metrics"
+                                    />
+                                )}
+                            </div>
+                        ) : undefined
+                    }
+                />
+                {isExpanded && hasMetrics ? (
+                    <div className="flex flex-col gap-y-0.5">
+                        {item.metrics_in_session.map((hit) => (
+                            <MetricHitRow
+                                key={hit.metric_uuid}
+                                hit={hit}
+                                recordingStartMs={recordingStartMs}
+                                isWithinRecording={isWithinRecording}
+                                onSeek={seekToTimestamp}
+                            />
+                        ))}
+                    </div>
+                ) : null}
+            </div>
+        )
+    }
+
+    const otherSeenItems = currentItem
+        ? seenItems.filter((item) => item.experiment_id !== currentItem.experiment_id)
+        : seenItems
+    const otherEnrolledItems = currentItem
+        ? enrolledItems.filter((item) => item.experiment_id !== currentItem.experiment_id)
+        : enrolledItems
+    // Pin the current experiment only when there are other experiments to stand out from — a lone
+    // "Viewing" row is just clutter. Otherwise it stays inline in the normal lists below.
+    const pinnedItem = currentItem && (otherSeenItems.length > 0 || otherEnrolledItems.length > 0) ? currentItem : null
+    const listSeenItems = pinnedItem ? otherSeenItems : seenItems
+    const listEnrolledItems = pinnedItem ? otherEnrolledItems : enrolledItems
+
     return (
         <div
             className="rounded border bg-surface-primary px-2 py-1 flex flex-col gap-y-1"
@@ -246,77 +350,38 @@ export function PlayerSidebarExperimentsSection(): JSX.Element | null {
         >
             <h4 className="font-semibold text-xs mb-0">Experiments</h4>
 
-            {seenItems.map((item) => {
-                const exposedAtMs = item.first_exposure_timestamp
-                    ? dayjs(item.first_exposure_timestamp).valueOf()
-                    : null
-                const canSeek = isWithinRecording(exposedAtMs)
-                // Distinguish "seen but outside the window" (worth a tooltip) from "bounds not known
-                // yet" (transient, no tooltip) so we never explain a non-jump we can't actually vouch for.
-                const outOfWindow =
-                    exposedAtMs != null &&
-                    recordingStartMs != null &&
-                    recordingEndMs != null &&
-                    (exposedAtMs < recordingStartMs || exposedAtMs > recordingEndMs)
-                const hasMetrics = item.metrics_in_session.length > 0
-                const isExpanded = expandedExperimentIds.includes(item.experiment_id)
-                return (
-                    <div key={item.experiment_id} className="flex flex-col gap-y-0.5 min-w-0">
-                        <ExperimentContextRow
-                            item={item}
-                            onSeek={canSeek && exposedAtMs != null ? () => seekToTimestamp(exposedAtMs) : undefined}
-                            outOfWindow={outOfWindow}
-                            timeInRecording={
-                                exposedAtMs != null && recordingStartMs != null ? exposedAtMs - recordingStartMs : null
-                            }
-                            leading={
-                                anySeenExpandable ? (
-                                    <div className="shrink-0 flex w-[1.625rem] justify-center">
-                                        {hasMetrics ? (
-                                            <LemonButton
-                                                size="xsmall"
-                                                icon={isExpanded ? <IconCollapse /> : <IconExpand />}
-                                                onClick={() => setExperimentExpanded(item.experiment_id, !isExpanded)}
-                                                tooltip={
-                                                    isExpanded
-                                                        ? 'Hide metric events'
-                                                        : `Show metric events (${item.metrics_in_session.length})`
-                                                }
-                                                data-attr="replay-experiment-context-expand-metrics"
-                                            />
-                                        ) : null}
-                                    </div>
-                                ) : undefined
-                            }
-                        />
-                        {isExpanded && hasMetrics ? (
-                            <div className="flex flex-col gap-y-0.5">
-                                {item.metrics_in_session.map((hit) => (
-                                    <MetricHitRow
-                                        key={hit.metric_uuid}
-                                        hit={hit}
-                                        recordingStartMs={recordingStartMs}
-                                        isWithinRecording={isWithinRecording}
-                                        onSeek={seekToTimestamp}
-                                    />
-                                ))}
-                            </div>
-                        ) : null}
-                    </div>
-                )
-            })}
+            {pinnedItem ? (
+                <div className="flex flex-col gap-y-0.5" data-attr="replay-experiment-context-current">
+                    <span className="text-[0.625rem] font-semibold uppercase tracking-wider text-secondary">
+                        Viewing
+                    </span>
+                    {pinnedItem.first_exposure_timestamp != null ? (
+                        renderSeenRow(pinnedItem)
+                    ) : (
+                        <ExperimentContextRow item={pinnedItem} />
+                    )}
+                </div>
+            ) : null}
 
-            {enrolledItems.length > 0 ? (
+            {pinnedItem && listSeenItems.length > 0 ? (
+                <span className="text-[0.625rem] font-semibold uppercase tracking-wider text-muted">
+                    Other experiments in this session
+                </span>
+            ) : null}
+
+            {listSeenItems.map((item) => renderSeenRow(item))}
+
+            {listEnrolledItems.length > 0 ? (
                 <LemonCollapse
                     embedded
                     size="small"
                     panels={[
                         {
                             key: 'enrolled',
-                            header: `Also enrolled, not exposed in this session (${enrolledItems.length})`,
+                            header: `Also enrolled, not exposed in this session (${listEnrolledItems.length})`,
                             content: (
                                 <div className="flex flex-col gap-y-1">
-                                    {enrolledItems.map((item) => (
+                                    {listEnrolledItems.map((item) => (
                                         <ExperimentContextRow key={item.experiment_id} item={item} />
                                     ))}
                                 </div>

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { IconCollapse, IconExpand, IconExternal, IconMinus, IconWarning } from '@posthog/icons'
 
@@ -49,6 +49,11 @@ function VariantTag({ item }: { item: ExperimentSessionContextItemApi }): JSX.El
     )
 }
 
+// A busy metric can carry up to the API's 50-event cap; rendering them all inline floods the narrow
+// sidebar. Show a sample of seek points and note the rest as a static count (no inline expansion —
+// the full picture lives on the recordings tab's metric filter and the experiment's own analysis).
+const MAX_INLINE_METRIC_EVENTS = 15
+
 function MetricEventChips({
     seekPoints,
     onSeek,
@@ -56,9 +61,11 @@ function MetricEventChips({
     seekPoints: { ms: number; offsetSeconds: number }[]
     onSeek: (timestampMs: number) => void
 }): JSX.Element {
+    const shown = seekPoints.slice(0, MAX_INLINE_METRIC_EVENTS)
+    const hiddenCount = seekPoints.length - shown.length
     return (
         <div className="flex flex-row flex-wrap gap-1 pl-3">
-            {seekPoints.map(({ ms, offsetSeconds }) => (
+            {shown.map(({ ms, offsetSeconds }) => (
                 <Link
                     key={ms}
                     className="font-mono tabular-nums"
@@ -69,6 +76,7 @@ function MetricEventChips({
                     {colonDelimitedDuration(offsetSeconds, 2)}
                 </Link>
             ))}
+            {hiddenCount > 0 ? <span className="text-muted">+{hiddenCount} more</span> : null}
         </div>
     )
 }
@@ -223,12 +231,19 @@ export function PlayerSidebarExperimentsSection(): JSX.Element | null {
             ? ([...seenItems, ...enrolledItems].find((item) => item.experiment_id === currentExperimentId) ?? null)
             : null
 
-    // Default-expand the current experiment's metrics on load so they're visible right away. Depending
-    // on the identity + metric count (not the expand set) keeps a manual collapse afterwards sticky.
+    // Default-expand the current experiment's metrics on load so they're visible right away — but only
+    // once per experiment. Auto-expanding again on a later metric-count change (e.g. a context refetch)
+    // would silently reopen a row the viewer deliberately collapsed, so a ref tracks who's been done.
     const currentExpandableId = currentItem?.experiment_id
     const currentMetricCount = currentItem?.metrics_in_session.length ?? 0
+    const autoExpandedIds = useRef<Set<number>>(new Set())
     useEffect(() => {
-        if (currentExpandableId != null && currentMetricCount > 0) {
+        if (
+            currentExpandableId != null &&
+            currentMetricCount > 0 &&
+            !autoExpandedIds.current.has(currentExpandableId)
+        ) {
+            autoExpandedIds.current.add(currentExpandableId)
             setExperimentExpanded(currentExpandableId, true)
         }
     }, [currentExpandableId, currentMetricCount, setExperimentExpanded])


### PR DESCRIPTION
## Problem

Follow-up UX polish on the replay player in experiments context shipped in #72240 
(not rolled out yet, behind feature flag)

## Changes

Recordings tab, "Metric events" filter:
- Group the dropdown — selectable metrics as checkboxes; server-side metrics that can't match recordings collapse into one labelled section that states the reason once, instead of repeating it on every row

Player sidebar, Experiments box:
- Pin and label the experiment you arrived from ("Viewing"), only when there are others to stand out from
- Mark experiments that fired no metric events in the session
- Move "jump to exposure" onto the timestamp; fold the exposure caveat into its tooltip
- Show a metric's events inline instead of behind a second collapse; expand the viewed experiment by default
- Tighten the toggle-to-timestamp spacing

## How did you test this code?

Frontend only. I (Claude) ran oxlint and oxfmt on both files. The author verified both surfaces visually in the local app against seeded demo data. No automated tests added.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @mp-hog. Two decisions worth flagging: for "which experiment am I viewing" in the sidebar I compared pin-to-top vs highlight-in-place and chose pin + caption; for the metric dropdown I replaced the per-row repeated "can't match" reason with a single labelled section (a Base UI GroupLabel, which must sit inside a DropdownMenuGroup). No backend, migration, or generated-type changes.
