### PR TITLE
feat(data-warehouse): add MCP tools for person-property sources

### DIFF
--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -1643,9 +1643,18 @@ def update_custom_property_source(
     return _to_custom_property_source_view(source, user_access_control)
 
 
-def delete_custom_property_source(*, team_id: int, source_id: str) -> bool:
-    """Delete a team-scoped source. Returns False when none matched (→ 404)."""
-    deleted, _ = CustomPropertySource.objects.for_team(team_id).filter(id=source_id).delete()
+def delete_custom_property_source(
+    *, team_id: int, source_id: str, user_access_control: "UserAccessControl | None" = None
+) -> bool:
+    """Delete a team-scoped source. Returns False when none matched (→ 404). Deleting a person source
+    permanently stops its billable warehouse-driven updates, so it requires the caller's warehouse-source
+    editor access (→ 403 via ``ResourceForbiddenError``), matching create/update/sync/backfill."""
+    source = CustomPropertySource.objects.for_team(team_id).filter(id=source_id).first()
+    if source is None:
+        return False
+    if source.external_data_schema_id is not None:
+        _assert_warehouse_source_editor(team_id, source.external_data_schema_id, user_access_control)
+    deleted, _ = source.delete()
     return deleted > 0
 
 

--- a/products/customer_analytics/backend/facade/custom_property_source_person_test.py
+++ b/products/customer_analytics/backend/facade/custom_property_source_person_test.py
@@ -181,6 +181,20 @@ class TestPersonCustomPropertySource(TeamScopedTestMixin, APIBaseTest):
                 user_access_control=self._uac(allowed=False),
             )
 
+    def test_delete_person_source_requires_warehouse_source_editor(self):
+        # Deleting a person source permanently stops its billable warehouse-driven updates, so it needs
+        # external_data_source editor access, not account-scope editor alone.
+        source = self._create(user_access_control=self._uac(allowed=True))
+        with self.assertRaises(api.ResourceForbiddenError):
+            api.delete_custom_property_source(
+                team_id=self.team.id, source_id=source.id, user_access_control=self._uac(allowed=False)
+            )
+        assert CustomPropertySource.objects.filter(id=source.id).exists()
+        assert api.delete_custom_property_source(
+            team_id=self.team.id, source_id=source.id, user_access_control=self._uac(allowed=True)
+        )
+        assert not CustomPropertySource.objects.filter(id=source.id).exists()
+
     def test_disabling_source_does_not_require_warehouse_source_editor(self):
         # Disabling never triggers a backfill, so it must not demand warehouse editor access.
         source = self._create(user_access_control=self._uac(allowed=True))

--- a/products/customer_analytics/backend/presentation/views/serializers.py
+++ b/products/customer_analytics/backend/presentation/views/serializers.py
@@ -307,6 +307,22 @@ class CustomPropertyReferenceSerializer(DataclassSerializer):
         fields = ["id", "name", "status", "type"]
 
 
+class CustomPropertySyncTriggerResponseSerializer(serializers.Serializer):
+    """Response of the person-property sync/backfill trigger actions."""
+
+    status = serializers.ChoiceField(
+        choices=[("triggered", "triggered"), ("started", "started"), ("already_running", "already_running")],
+        help_text=(
+            "'triggered' (sync now started the warehouse sync), 'started' (a new backfill began), or "
+            "'already_running' (a backfill for this table was already in flight, so this was a no-op)."
+        ),
+    )
+    already_running = serializers.BooleanField(
+        required=False,
+        help_text="Backfill only: true when a backfill for this table was already running and this call coalesced.",
+    )
+
+
 class CustomPropertySyncRunSerializer(DataclassSerializer):
     """One person-property sync or backfill run. Read-only: runs are created by the sync/backfill
     pipeline, never through the API."""

--- a/products/customer_analytics/backend/presentation/views/views.py
+++ b/products/customer_analytics/backend/presentation/views/views.py
@@ -48,6 +48,7 @@ from products.customer_analytics.backend.presentation.views.serializers import (
     CustomPropertySourceSerializer,
     CustomPropertySourceUpdateSerializer,
     CustomPropertySyncRunSerializer,
+    CustomPropertySyncTriggerResponseSerializer,
     CustomPropertyValueSerializer,
     CustomPropertyValueSuggestionsResponseSerializer,
     CustomPropertyValueWriteSerializer,
@@ -537,7 +538,11 @@ class CustomPropertySourceViewSet(
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @extend_schema(request=None, responses={202: OpenApiTypes.OBJECT})
+    @extend_schema(
+        operation_id="custom_property_sources_sync",
+        request=None,
+        responses={202: CustomPropertySyncTriggerResponseSerializer},
+    )
     @action(methods=["POST"], detail=True)
     def sync(self, request: Request, *args, **kwargs) -> Response:
         """Person sources only: trigger the underlying warehouse schema's sync now. This re-runs a
@@ -554,7 +559,11 @@ class CustomPropertySourceViewSet(
             raise ValidationError("This action is only available for enabled person-property sources.")
         return Response({"status": "triggered"}, status=status.HTTP_202_ACCEPTED)
 
-    @extend_schema(request=None, responses={202: OpenApiTypes.OBJECT})
+    @extend_schema(
+        operation_id="custom_property_sources_backfill",
+        request=None,
+        responses={202: CustomPropertySyncTriggerResponseSerializer},
+    )
     @action(methods=["POST"], detail=True)
     def backfill(self, request: Request, *args, **kwargs) -> Response:
         """Person sources only: start a backfill that reads the whole warehouse table and populates
@@ -575,7 +584,10 @@ class CustomPropertySourceViewSet(
             status=status.HTTP_202_ACCEPTED,
         )
 
-    @extend_schema(responses={200: CustomPropertySyncRunSerializer(many=True)})
+    @extend_schema(
+        operation_id="custom_property_sources_runs_list",
+        responses={200: CustomPropertySyncRunSerializer(many=True)},
+    )
     @action(methods=["GET"], detail=True)
     def runs(self, request: Request, *args, **kwargs) -> Response:
         """Person sources only: the source's sync/backfill run history, newest first. Gated on the

--- a/products/customer_analytics/backend/presentation/views/views.py
+++ b/products/customer_analytics/backend/presentation/views/views.py
@@ -533,7 +533,14 @@ class CustomPropertySourceViewSet(
         return self.update(request, *args, **kwargs)
 
     def destroy(self, request: Request, *args, **kwargs) -> Response:
-        deleted = api.delete_custom_property_source(team_id=self.team_id, source_id=self.kwargs["pk"])
+        try:
+            deleted = api.delete_custom_property_source(
+                team_id=self.team_id,
+                source_id=self.kwargs["pk"],
+                user_access_control=_warehouse_scoped_uac(self),
+            )
+        except api.ResourceForbiddenError:
+            raise PermissionDenied()
         if not deleted:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/products/customer_analytics/backend/test/test_views.py
+++ b/products/customer_analytics/backend/test/test_views.py
@@ -2009,6 +2009,52 @@ class TestCustomPropertySourceViewSet(APIBaseTest):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content
 
+    def _create_person_source(self):
+        definition, schema = self._person_definition_and_schema()
+        created = self.client.post(
+            self.endpoint,
+            {
+                "definition": str(definition.id),
+                "external_data_schema": str(schema.id),
+                "column_property_map": {"plan": "plan_tier"},
+                "key_column": "distinct_id",
+            },
+            format="json",
+        )
+        assert created.status_code == status.HTTP_201_CREATED, created.content
+        return created.json()["id"]
+
+    @patch("posthoganalytics.feature_enabled", return_value=False)
+    def test_person_source_actions_are_flag_gated(self, _flag):
+        # Regression: sync/backfill must 400 when WAREHOUSE_PERSON_PROPERTIES is off. The gate lives in
+        # the facade; a viewset refactor that dropped it would ship an ungated (billable) trigger.
+        source_id = self._create_person_source()
+        for action in ("sync", "backfill"):
+            response = self.client.post(f"{self.endpoint}{source_id}/{action}/")
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, (action, response.content)
+
+    @patch("products.warehouse_sources.backend.facade.temporal.start_person_property_backfill", return_value=True)
+    @patch("products.warehouse_sources.backend.facade.temporal.trigger_schema_sync")
+    @patch("posthoganalytics.feature_enabled", return_value=True)
+    def test_person_source_actions_when_enabled(self, _flag, mock_trigger_sync, mock_start_backfill):
+        # Wiring guard: the actions route through the facade to the temporal seam, return the typed
+        # response, and the backfill pre-creates a running run the runs feed then surfaces.
+        source_id = self._create_person_source()
+
+        synced = self.client.post(f"{self.endpoint}{source_id}/sync/")
+        assert synced.status_code == status.HTTP_202_ACCEPTED, synced.content
+        assert synced.json()["status"] == "triggered"
+        mock_trigger_sync.assert_called_once()
+
+        backfilled = self.client.post(f"{self.endpoint}{source_id}/backfill/")
+        assert backfilled.status_code == status.HTTP_202_ACCEPTED, backfilled.content
+        assert backfilled.json() == {"status": "started", "already_running": False}
+        mock_start_backfill.assert_called_once()
+
+        runs = self.client.get(f"{self.endpoint}{source_id}/runs/")
+        assert runs.status_code == status.HTTP_200_OK
+        assert any(run["status"] == "running" for run in runs.json()["results"])
+
 
 class TestAccountNotesViewSet(APIBaseTest):
     def setUp(self):

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -939,6 +939,34 @@ export interface PatchedCustomPropertySourceUpdateApi {
     is_enabled?: boolean
 }
 
+/**
+ * * `triggered` - triggered
+ * * `started` - started
+ * * `already_running` - already_running
+ */
+export type CustomPropertySyncTriggerResponseStatusEnumApi =
+    (typeof CustomPropertySyncTriggerResponseStatusEnumApi)[keyof typeof CustomPropertySyncTriggerResponseStatusEnumApi]
+
+export const CustomPropertySyncTriggerResponseStatusEnumApi = {
+    Triggered: 'triggered',
+    Started: 'started',
+    AlreadyRunning: 'already_running',
+} as const
+
+/**
+ * Response of the person-property sync/backfill trigger actions.
+ */
+export interface CustomPropertySyncTriggerResponseApi {
+    /** 'triggered' (sync now started the warehouse sync), 'started' (a new backfill began), or 'already_running' (a backfill for this table was already in flight, so this was a no-op).
+     *
+     * * `triggered` - triggered
+     * * `started` - started
+     * * `already_running` - already_running */
+    status: CustomPropertySyncTriggerResponseStatusEnumApi
+    /** Backfill only: true when a backfill for this table was already running and this call coalesced. */
+    already_running?: boolean
+}
+
 export interface PaginatedCustomPropertySyncRunListApi {
     count: number
     /** @nullable */
@@ -1334,8 +1362,6 @@ export type CustomPropertySourcesListParams = {
     offset?: number
 }
 
-export type CustomPropertySourcesBackfillCreate202 = { [key: string]: unknown }
-
 export type CustomPropertySourcesRunsListParams = {
     /**
      * Number of results to return per page.
@@ -1346,8 +1372,6 @@ export type CustomPropertySourcesRunsListParams = {
      */
     offset?: number
 }
-
-export type CustomPropertySourcesSyncCreate202 = { [key: string]: unknown }
 
 export type CustomerJourneysListParams = {
     /**

--- a/products/customer_analytics/frontend/generated/api.ts
+++ b/products/customer_analytics/frontend/generated/api.ts
@@ -27,10 +27,9 @@ import type {
     CustomPropertyDefinitionsValuesRetrieveParams,
     CustomPropertySourceApi,
     CustomPropertySourceUpdateApi,
-    CustomPropertySourcesBackfillCreate202,
     CustomPropertySourcesListParams,
     CustomPropertySourcesRunsListParams,
-    CustomPropertySourcesSyncCreate202,
+    CustomPropertySyncTriggerResponseApi,
     CustomPropertyValueApi,
     CustomPropertyValueSuggestionsResponseApi,
     CustomPropertyValueWriteApi,
@@ -875,7 +874,7 @@ export const customPropertySourcesDestroy = async (
     })
 }
 
-export const getCustomPropertySourcesBackfillCreateUrl = (projectId: string, id: string) => {
+export const getCustomPropertySourcesBackfillUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/custom_property_sources/${id}/backfill/`
 }
 
@@ -883,18 +882,15 @@ export const getCustomPropertySourcesBackfillCreateUrl = (projectId: string, id:
  * Person sources only: start a backfill that reads the whole warehouse table and populates
  * person properties for historical rows. Coalesces if one is already running for the table.
  */
-export const customPropertySourcesBackfillCreate = async (
+export const customPropertySourcesBackfill = async (
     projectId: string,
     id: string,
     options?: RequestInit
-): Promise<CustomPropertySourcesBackfillCreate202> => {
-    return apiMutator<CustomPropertySourcesBackfillCreate202>(
-        getCustomPropertySourcesBackfillCreateUrl(projectId, id),
-        {
-            ...options,
-            method: 'POST',
-        }
-    )
+): Promise<CustomPropertySyncTriggerResponseApi> => {
+    return apiMutator<CustomPropertySyncTriggerResponseApi>(getCustomPropertySourcesBackfillUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+    })
 }
 
 export const getCustomPropertySourcesRunsListUrl = (
@@ -936,7 +932,7 @@ export const customPropertySourcesRunsList = async (
     )
 }
 
-export const getCustomPropertySourcesSyncCreateUrl = (projectId: string, id: string) => {
+export const getCustomPropertySourcesSyncUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/custom_property_sources/${id}/sync/`
 }
 
@@ -944,12 +940,12 @@ export const getCustomPropertySourcesSyncCreateUrl = (projectId: string, id: str
  * Person sources only: trigger the underlying warehouse schema's sync now. This re-runs a
  * real (billable) warehouse sync; the incremental person-property update runs off it.
  */
-export const customPropertySourcesSyncCreate = async (
+export const customPropertySourcesSync = async (
     projectId: string,
     id: string,
     options?: RequestInit
-): Promise<CustomPropertySourcesSyncCreate202> => {
-    return apiMutator<CustomPropertySourcesSyncCreate202>(getCustomPropertySourcesSyncCreateUrl(projectId, id), {
+): Promise<CustomPropertySyncTriggerResponseApi> => {
+    return apiMutator<CustomPropertySyncTriggerResponseApi>(getCustomPropertySourcesSyncUrl(projectId, id), {
         ...options,
         method: 'POST',
     })

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
@@ -17,12 +17,12 @@ import {
     customPropertyDefinitionsDestroy,
     customPropertyDefinitionsList,
     customPropertyDefinitionsPartialUpdate,
-    customPropertySourcesBackfillCreate,
+    customPropertySourcesBackfill,
     customPropertySourcesCreate,
     customPropertySourcesDestroy,
     customPropertySourcesPartialUpdate,
     customPropertySourcesRunsList,
-    customPropertySourcesSyncCreate,
+    customPropertySourcesSync,
 } from 'products/customer_analytics/frontend/generated/api'
 import type {
     CustomPropertyDefinitionApi,
@@ -866,7 +866,7 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
         triggerSync: async ({ sourceId }) => {
             actions.addTriggeringSource({ sourceId })
             try {
-                await customPropertySourcesSyncCreate(String(values.currentProjectId), sourceId)
+                await customPropertySourcesSync(String(values.currentProjectId), sourceId)
                 lemonToast.success('Sync triggered — it may take a few minutes to run')
                 actions.loadDefinitions()
                 actions.pollRunsStatus({ sourceId })
@@ -880,7 +880,7 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
         triggerBackfill: async ({ sourceId }) => {
             actions.addTriggeringSource({ sourceId })
             try {
-                const response = await customPropertySourcesBackfillCreate(String(values.currentProjectId), sourceId)
+                const response = await customPropertySourcesBackfill(String(values.currentProjectId), sourceId)
                 const alreadyRunning = (response as { already_running?: boolean } | undefined)?.already_running
                 lemonToast.success(
                     alreadyRunning

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -467,30 +467,132 @@ tools:
     custom-property-definitions-values-retrieve:
         operation: custom_property_definitions_values_retrieve
         enabled: false
-    custom-property-sources-backfill-create:
-        operation: custom_property_sources_backfill_create
-        enabled: false
+    custom-property-sources-backfill:
+        operation: custom_property_sources_backfill
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Backfill a warehouse person-property source
+        description: >
+            Person-property sources only: start a backfill that reads the whole warehouse table and
+            populates person properties for its historical rows. Backfill is per table — one call
+            refreshes every enabled person property mapped from that table — and it coalesces if one
+            is already running for the table (the response's `already_running` is then true). Returns
+            400 for a source that is not an enabled person-property source.
+        feature_flag: warehouse-person-properties
     custom-property-sources-create:
         operation: custom_property_sources_create
-        enabled: false
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create custom property source
+        description: >
+            Bind a custom property definition to a data source. Account sources read a materialized
+            view (`saved_query` + `source_column`); person sources read a synced warehouse table
+            (`external_data_schema` + `column_property_map` mapping warehouse columns to person
+            properties, plus `key_column` = the person's distinct_id column). One source per definition.
+        feature_flag: customer-analytics-csp
     custom-property-sources-destroy:
         operation: custom_property_sources_destroy
-        enabled: false
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Delete custom property source
+        description: >
+            Delete a custom property source by id, stopping its sync. Values already written stay on
+            the accounts/people but stop updating. The definition itself is not deleted.
+        feature_flag: customer-analytics-csp
     custom-property-sources-list:
         operation: custom_property_sources_list
-        enabled: false
+        enabled: true
+        scopes:
+            - account:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List custom property sources
+        description: >
+            List custom property sources for the project, newest first. Each source binds a definition
+            to a data source and reports its sync status (`last_synced_at`, `last_sync_error`) and, for
+            person sources, the schedule (`next_sync_at`, `sync_frequency_interval_seconds`) and the
+            most recent run (`latest_run`).
+        feature_flag: customer-analytics-csp
     custom-property-sources-partial-update:
         operation: custom_property_sources_partial_update
-        enabled: false
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Update custom property source
+        description: >
+            Update the editable fields of a custom property source (`key_column`, `is_enabled`).
+            Re-enabling a disabled source resets its failure count. The definition binding, warehouse
+            schema, and column map are create-only and cannot be changed here.
+        feature_flag: customer-analytics-csp
     custom-property-sources-retrieve:
         operation: custom_property_sources_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - account:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get custom property source
+        description: >
+            Fetch a single custom property source by id, including its binding, sync status, and (for
+            person sources) schedule and latest run.
+        feature_flag: customer-analytics-csp
     custom-property-sources-runs-list:
         operation: custom_property_sources_runs_list
-        enabled: false
-    custom-property-sources-sync-create:
-        operation: custom_property_sources_sync_create
-        enabled: false
+        enabled: true
+        scopes:
+            - account:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List person-property source runs
+        description: >
+            Person-property sources only: the source's sync/backfill run history, newest first. Each
+            run reports `trigger` (scheduled/manual/backfill), `status` (running/completed/failed), the
+            funnel counts (`rows_read`, `changed`, `existing` = person profiles affected, `produced`,
+            `skipped_missing_person`), `error`, and timestamps.
+        feature_flag: warehouse-person-properties
+    custom-property-sources-sync:
+        operation: custom_property_sources_sync
+        enabled: true
+        scopes:
+            - account:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Sync a warehouse person-property source now
+        description: >
+            Person-property sources only: trigger the underlying warehouse schema's sync now. This
+            re-runs a real (billable) warehouse sync, and the incremental person-property update rides
+            off it. It does not reset the schema's recurring sync schedule. Returns 400 for a source
+            that is not an enabled person-property source.
+        feature_flag: warehouse-person-properties
     custom-property-sources-update:
         operation: custom_property_sources_update
         enabled: false

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -478,11 +478,10 @@ tools:
             idempotent: false
         title: Backfill a warehouse person-property source
         description: >
-            Person-property sources only: start a backfill that reads the whole warehouse table and
-            populates person properties for its historical rows. Backfill is per table — one call
-            refreshes every enabled person property mapped from that table — and it coalesces if one
-            is already running for the table (the response's `already_running` is then true). Returns
-            400 for a source that is not an enabled person-property source.
+            Person-property sources only: start a backfill that reads the whole warehouse table and populates person
+            properties for its historical rows. Backfill is per table — one call refreshes every enabled person property
+            mapped from that table — and it coalesces if one is already running for the table (the response's
+            `already_running` is then true). Returns 400 for a source that is not an enabled person-property source.
         feature_flag: warehouse-person-properties
     custom-property-sources-create:
         operation: custom_property_sources_create
@@ -495,10 +494,10 @@ tools:
             idempotent: false
         title: Create custom property source
         description: >
-            Bind a custom property definition to a data source. Account sources read a materialized
-            view (`saved_query` + `source_column`); person sources read a synced warehouse table
-            (`external_data_schema` + `column_property_map` mapping warehouse columns to person
-            properties, plus `key_column` = the person's distinct_id column). One source per definition.
+            Bind a custom property definition to a data source. Account sources read a materialized view (`saved_query`
+            + `source_column`); person sources read a synced warehouse table (`external_data_schema` +
+            `column_property_map` mapping warehouse columns to person properties, plus `key_column` = the person's
+            distinct_id column). One source per definition.
         feature_flag: customer-analytics-csp
     custom-property-sources-destroy:
         operation: custom_property_sources_destroy
@@ -511,8 +510,8 @@ tools:
             idempotent: true
         title: Delete custom property source
         description: >
-            Delete a custom property source by id, stopping its sync. Values already written stay on
-            the accounts/people but stop updating. The definition itself is not deleted.
+            Delete a custom property source by id, stopping its sync. Values already written stay on the accounts/people
+            but stop updating. The definition itself is not deleted.
         feature_flag: customer-analytics-csp
     custom-property-sources-list:
         operation: custom_property_sources_list
@@ -526,10 +525,9 @@ tools:
         list: true
         title: List custom property sources
         description: >
-            List custom property sources for the project, newest first. Each source binds a definition
-            to a data source and reports its sync status (`last_synced_at`, `last_sync_error`) and, for
-            person sources, the schedule (`next_sync_at`, `sync_frequency_interval_seconds`) and the
-            most recent run (`latest_run`).
+            List custom property sources for the project, newest first. Each source binds a definition to a data source
+            and reports its sync status (`last_synced_at`, `last_sync_error`) and, for person sources, the schedule
+            (`next_sync_at`, `sync_frequency_interval_seconds`) and the most recent run (`latest_run`).
         feature_flag: customer-analytics-csp
     custom-property-sources-partial-update:
         operation: custom_property_sources_partial_update
@@ -542,9 +540,9 @@ tools:
             idempotent: true
         title: Update custom property source
         description: >
-            Update the editable fields of a custom property source (`key_column`, `is_enabled`).
-            Re-enabling a disabled source resets its failure count. The definition binding, warehouse
-            schema, and column map are create-only and cannot be changed here.
+            Update the editable fields of a custom property source (`key_column`, `is_enabled`). Re-enabling a disabled
+            source resets its failure count. The definition binding, warehouse schema, and column map are create-only
+            and cannot be changed here.
         feature_flag: customer-analytics-csp
     custom-property-sources-retrieve:
         operation: custom_property_sources_retrieve
@@ -557,8 +555,8 @@ tools:
             idempotent: true
         title: Get custom property source
         description: >
-            Fetch a single custom property source by id, including its binding, sync status, and (for
-            person sources) schedule and latest run.
+            Fetch a single custom property source by id, including its binding, sync status, and (for person sources)
+            schedule and latest run.
         feature_flag: customer-analytics-csp
     custom-property-sources-runs-list:
         operation: custom_property_sources_runs_list
@@ -572,10 +570,10 @@ tools:
         list: true
         title: List person-property source runs
         description: >
-            Person-property sources only: the source's sync/backfill run history, newest first. Each
-            run reports `trigger` (scheduled/manual/backfill), `status` (running/completed/failed), the
-            funnel counts (`rows_read`, `changed`, `existing` = person profiles affected, `produced`,
-            `skipped_missing_person`), `error`, and timestamps.
+            Person-property sources only: the source's sync/backfill run history, newest first. Each run reports
+            `trigger` (scheduled/manual/backfill), `status` (running/completed/failed), the funnel counts (`rows_read`,
+            `changed`, `existing` = person profiles affected, `produced`, `skipped_missing_person`), `error`, and
+            timestamps.
         feature_flag: warehouse-person-properties
     custom-property-sources-sync:
         operation: custom_property_sources_sync
@@ -588,10 +586,9 @@ tools:
             idempotent: false
         title: Sync a warehouse person-property source now
         description: >
-            Person-property sources only: trigger the underlying warehouse schema's sync now. This
-            re-runs a real (billable) warehouse sync, and the incremental person-property update rides
-            off it. It does not reset the schema's recurring sync schedule. Returns 400 for a source
-            that is not an enabled person-property source.
+            Person-property sources only: trigger the underlying warehouse schema's sync now. This re-runs a real
+            (billable) warehouse sync, and the incremental person-property update rides off it. It does not reset the
+            schema's recurring sync schedule. Returns 400 for a source that is not an enabled person-property source.
         feature_flag: warehouse-person-properties
     custom-property-sources-update:
         operation: custom_property_sources_update

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2079,6 +2079,126 @@
         },
         "feature_flag": "customer-analytics-csp"
     },
+    "custom-property-sources-backfill": {
+        "description": "Person-property sources only: start a backfill that reads the whole warehouse table and populates person properties for its historical rows. Backfill is per table — one call refreshes every enabled person property mapped from that table — and it coalesces if one is already running for the table (the response's `already_running` is then true). Returns 400 for a source that is not an enabled person-property source.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Backfill a warehouse person-property source",
+        "title": "Backfill a warehouse person-property source",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "warehouse-person-properties"
+    },
+    "custom-property-sources-create": {
+        "description": "Bind a custom property definition to a data source. Account sources read a materialized view (`saved_query` + `source_column`); person sources read a synced warehouse table (`external_data_schema` + `column_property_map` mapping warehouse columns to person properties, plus `key_column` = the person's distinct_id column). One source per definition.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Create custom property source",
+        "title": "Create custom property source",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "custom-property-sources-destroy": {
+        "description": "Delete a custom property source by id, stopping its sync. Values already written stay on the accounts/people but stop updating. The definition itself is not deleted.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Delete custom property source",
+        "title": "Delete custom property source",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "custom-property-sources-list": {
+        "description": "List custom property sources for the project, newest first. Each source binds a definition to a data source and reports its sync status (`last_synced_at`, `last_sync_error`) and, for person sources, the schedule (`next_sync_at`, `sync_frequency_interval_seconds`) and the most recent run (`latest_run`).",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List custom property sources",
+        "title": "List custom property sources",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "custom-property-sources-partial-update": {
+        "description": "Update the editable fields of a custom property source (`key_column`, `is_enabled`). Re-enabling a disabled source resets its failure count. The definition binding, warehouse schema, and column map are create-only and cannot be changed here.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Update custom property source",
+        "title": "Update custom property source",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "custom-property-sources-retrieve": {
+        "description": "Fetch a single custom property source by id, including its binding, sync status, and (for person sources) schedule and latest run.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Get custom property source",
+        "title": "Get custom property source",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "custom-property-sources-runs-list": {
+        "description": "Person-property sources only: the source's sync/backfill run history, newest first. Each run reports `trigger` (scheduled/manual/backfill), `status` (running/completed/failed), the funnel counts (`rows_read`, `changed`, `existing` = person profiles affected, `produced`, `skipped_missing_person`), `error`, and timestamps.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List person-property source runs",
+        "title": "List person-property source runs",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "warehouse-person-properties"
+    },
+    "custom-property-sources-sync": {
+        "description": "Person-property sources only: trigger the underlying warehouse schema's sync now. This re-runs a real (billable) warehouse sync, and the incremental person-property update rides off it. It does not reset the schema's recurring sync schedule. Returns 400 for a source that is not an enabled person-property source.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Sync a warehouse person-property source now",
+        "title": "Sync a warehouse person-property source now",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "warehouse-person-properties"
+    },
     "dashboard-create": {
         "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
         "category": "Dashboards",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2108,6 +2108,126 @@
         },
         "feature_flag": "customer-analytics-csp"
     },
+    "custom-property-sources-backfill": {
+        "description": "Person-property sources only: start a backfill that reads the whole warehouse table and populates person properties for its historical rows. Backfill is per table — one call refreshes every enabled person property mapped from that table — and it coalesces if one is already running for the table (the response's `already_running` is then true). Returns 400 for a source that is not an enabled person-property source.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Backfill a warehouse person-property source",
+        "title": "Backfill a warehouse person-property source",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "warehouse-person-properties"
+    },
+    "custom-property-sources-create": {
+        "description": "Bind a custom property definition to a data source. Account sources read a materialized view (`saved_query` + `source_column`); person sources read a synced warehouse table (`external_data_schema` + `column_property_map` mapping warehouse columns to person properties, plus `key_column` = the person's distinct_id column). One source per definition.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Create custom property source",
+        "title": "Create custom property source",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "custom-property-sources-destroy": {
+        "description": "Delete a custom property source by id, stopping its sync. Values already written stay on the accounts/people but stop updating. The definition itself is not deleted.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Delete custom property source",
+        "title": "Delete custom property source",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "custom-property-sources-list": {
+        "description": "List custom property sources for the project, newest first. Each source binds a definition to a data source and reports its sync status (`last_synced_at`, `last_sync_error`) and, for person sources, the schedule (`next_sync_at`, `sync_frequency_interval_seconds`) and the most recent run (`latest_run`).",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List custom property sources",
+        "title": "List custom property sources",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "custom-property-sources-partial-update": {
+        "description": "Update the editable fields of a custom property source (`key_column`, `is_enabled`). Re-enabling a disabled source resets its failure count. The definition binding, warehouse schema, and column map are create-only and cannot be changed here.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Update custom property source",
+        "title": "Update custom property source",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "custom-property-sources-retrieve": {
+        "description": "Fetch a single custom property source by id, including its binding, sync status, and (for person sources) schedule and latest run.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Get custom property source",
+        "title": "Get custom property source",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "customer-analytics-csp"
+    },
+    "custom-property-sources-runs-list": {
+        "description": "Person-property sources only: the source's sync/backfill run history, newest first. Each run reports `trigger` (scheduled/manual/backfill), `status` (running/completed/failed), the funnel counts (`rows_read`, `changed`, `existing` = person profiles affected, `produced`, `skipped_missing_person`), `error`, and timestamps.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "List person-property source runs",
+        "title": "List person-property source runs",
+        "required_scopes": ["account:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "warehouse-person-properties"
+    },
+    "custom-property-sources-sync": {
+        "description": "Person-property sources only: trigger the underlying warehouse schema's sync now. This re-runs a real (billable) warehouse sync, and the incremental person-property update rides off it. It does not reset the schema's recurring sync schedule. Returns 400 for a source that is not an enabled person-property source.",
+        "category": "Customer analytics",
+        "feature": "customer_analytics",
+        "summary": "Sync a warehouse person-property source now",
+        "title": "Sync a warehouse person-property source now",
+        "required_scopes": ["account:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "warehouse-person-properties"
+    },
     "dashboard-create": {
         "description": "Create a new dashboard. Provide a name and optional description, tags, and pinned status. Can also create from a template or duplicate an existing dashboard. The returned tiles omit insight results to save context — use dashboard-insights-run to fetch the actual data for each insight. To add widget tiles after creation, see dashboard-widget-catalog-list for available widget types and dashboard-widgets-batch-add to add them.",
         "category": "Dashboards",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16704,6 +16704,34 @@ export namespace Schemas {
     }
 
     /**
+     * * `triggered` - triggered
+     * * `started` - started
+     * * `already_running` - already_running
+     */
+    export type CustomPropertySyncTriggerResponseStatusEnum = typeof CustomPropertySyncTriggerResponseStatusEnum[keyof typeof CustomPropertySyncTriggerResponseStatusEnum];
+
+
+    export const CustomPropertySyncTriggerResponseStatusEnum = {
+      Triggered: 'triggered',
+      Started: 'started',
+      AlreadyRunning: 'already_running',
+    } as const;
+
+    /**
+     * Response of the person-property sync/backfill trigger actions.
+     */
+    export interface CustomPropertySyncTriggerResponse {
+      /** 'triggered' (sync now started the warehouse sync), 'started' (a new backfill began), or 'already_running' (a backfill for this table was already in flight, so this was a no-op).
+       *
+       * * `triggered` - triggered
+       * * `started` - started
+       * * `already_running` - already_running */
+      status: CustomPropertySyncTriggerResponseStatusEnum;
+      /** Backfill only: true when a backfill for this table was already running and this call coalesced. */
+      already_running?: boolean;
+    }
+
+    /**
      * An account's current value for a custom property (read shape).
      */
     export interface CustomPropertyValue {
@@ -73274,8 +73302,6 @@ export namespace Schemas {
     offset?: number;
     };
 
-    export type CustomPropertySourcesBackfillCreate202 = { [key: string]: unknown };
-
     export type CustomPropertySourcesRunsListParams = {
     /**
      * Number of results to return per page.
@@ -73286,8 +73312,6 @@ export namespace Schemas {
      */
     offset?: number;
     };
-
-    export type CustomPropertySourcesSyncCreate202 = { [key: string]: unknown };
 
     export type CustomerJourneysListParams = {
     /**

--- a/services/mcp/src/generated/customer_analytics/api.ts
+++ b/services/mcp/src/generated/customer_analytics/api.ts
@@ -750,7 +750,8 @@ export const CustomPropertySourcesBackfillParams = /* @__PURE__ */ zod.object({
 })
 
 /**
- * Person sources only: the source's sync/backfill run history, newest first.
+ * Person sources only: the source's sync/backfill run history, newest first. Gated on the
+ * caller's warehouse-source viewer access, since the runs expose its row counts and sync errors.
  */
 export const CustomPropertySourcesRunsListParams = /* @__PURE__ */ zod.object({
     id: zod.string(),

--- a/services/mcp/src/generated/customer_analytics/api.ts
+++ b/services/mcp/src/generated/customer_analytics/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 29 enabled ops
+ * PostHog API - MCP 37 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -604,6 +604,173 @@ export const CustomPropertyDefinitionsPartialUpdateBody = /* @__PURE__ */ zod
     )
 
 export const CustomPropertyDefinitionsDestroyParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const CustomPropertySourcesListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const CustomPropertySourcesListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+export const CustomPropertySourcesCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const customPropertySourcesCreateBodySourceColumnMax = 400
+
+export const customPropertySourcesCreateBodyKeyColumnMax = 400
+
+export const customPropertySourcesCreateBodyIsEnabledDefault = true
+
+export const CustomPropertySourcesCreateBody = /* @__PURE__ */ zod
+    .object({
+        definition: zod
+            .string()
+            .describe('UUID of the custom property definition this source feeds. One source per definition.'),
+        saved_query: zod
+            .string()
+            .nullish()
+            .describe(
+                'Account sources only: UUID of the data-warehouse saved query (materialized view) to read values from. Mutually exclusive with external_data_schema.'
+            ),
+        external_data_schema: zod
+            .string()
+            .nullish()
+            .describe(
+                'Person sources only: UUID of the warehouse schema (raw incremental table) to read from. Mutually exclusive with saved_query.'
+            ),
+        source_column: zod
+            .string()
+            .max(customPropertySourcesCreateBodySourceColumnMax)
+            .nullish()
+            .describe('Account sources only: column in the view whose value is written to the property.'),
+        column_property_map: zod
+            .unknown()
+            .optional()
+            .describe(
+                'Person sources only: {warehouse_column: person_property_name} mapping the columns this source writes onto the person.'
+            ),
+        key_column: zod
+            .string()
+            .max(customPropertySourcesCreateBodyKeyColumnMax)
+            .describe(
+                "Column whose value identifies the target: an account's external_id for account sources, or the person's distinct_id for person sources."
+            ),
+        is_enabled: zod
+            .boolean()
+            .default(customPropertySourcesCreateBodyIsEnabledDefault)
+            .describe(
+                'Whether the source syncs. Auto-disabled after repeated failures or a missing view; re-enabling resets the failure count.'
+            ),
+    })
+    .describe(
+        "Binds a materialized data-warehouse view column to a custom property definition; the view's\nvalues are synced onto matching accounts on each materialization."
+    )
+
+export const CustomPropertySourcesRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const CustomPropertySourcesPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const customPropertySourcesPartialUpdateBodySourceColumnMax = 400
+
+export const customPropertySourcesPartialUpdateBodyKeyColumnMax = 400
+
+export const CustomPropertySourcesPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        source_column: zod
+            .string()
+            .max(customPropertySourcesPartialUpdateBodySourceColumnMax)
+            .optional()
+            .describe('Column in the view whose value is written to the property.'),
+        key_column: zod
+            .string()
+            .max(customPropertySourcesPartialUpdateBodyKeyColumnMax)
+            .optional()
+            .describe("Column in the view whose value matches an account's external_id."),
+        is_enabled: zod
+            .boolean()
+            .optional()
+            .describe('Whether the source syncs; re-enabling it resets the failure count.'),
+    })
+    .describe(
+        "Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so\nthey are intentionally absent — only these reach the facade's update."
+    )
+
+export const CustomPropertySourcesDestroyParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Person sources only: start a backfill that reads the whole warehouse table and populates
+ * person properties for historical rows. Coalesces if one is already running for the table.
+ */
+export const CustomPropertySourcesBackfillParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Person sources only: the source's sync/backfill run history, newest first.
+ */
+export const CustomPropertySourcesRunsListParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const CustomPropertySourcesRunsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * Person sources only: trigger the underlying warehouse schema's sync now. This re-runs a
+ * real (billable) warehouse sync; the incremental person-property update runs off it.
+ */
+export const CustomPropertySourcesSyncParams = /* @__PURE__ */ zod.object({
     id: zod.string(),
     project_id: zod
         .string()

--- a/services/mcp/src/tools/generated/customer_analytics.ts
+++ b/services/mcp/src/tools/generated/customer_analytics.ts
@@ -35,6 +35,16 @@ import {
     CustomPropertyDefinitionsPartialUpdateBody,
     CustomPropertyDefinitionsPartialUpdateParams,
     CustomPropertyDefinitionsRetrieveParams,
+    CustomPropertySourcesBackfillParams,
+    CustomPropertySourcesCreateBody,
+    CustomPropertySourcesDestroyParams,
+    CustomPropertySourcesListQueryParams,
+    CustomPropertySourcesPartialUpdateBody,
+    CustomPropertySourcesPartialUpdateParams,
+    CustomPropertySourcesRetrieveParams,
+    CustomPropertySourcesRunsListParams,
+    CustomPropertySourcesRunsListQueryParams,
+    CustomPropertySourcesSyncParams,
     GroupsTypesMetricsCreateBody,
     GroupsTypesMetricsCreateParams,
     GroupsTypesMetricsDestroyParams,
@@ -636,6 +646,187 @@ const customPropertyDefinitionsRetrieve = (): ToolBase<
     },
 })
 
+const CustomPropertySourcesBackfillSchema = CustomPropertySourcesBackfillParams.omit({ project_id: true })
+
+const customPropertySourcesBackfill = (): ToolBase<typeof CustomPropertySourcesBackfillSchema, unknown> => ({
+    name: 'custom-property-sources-backfill',
+    schema: CustomPropertySourcesBackfillSchema,
+    handler: async (context: Context, params: z.infer<typeof CustomPropertySourcesBackfillSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/custom_property_sources/${encodeURIComponent(String(params.id))}/backfill/`,
+        })
+        return result
+    },
+})
+
+const CustomPropertySourcesCreateSchema = CustomPropertySourcesCreateBody
+
+const customPropertySourcesCreate = (): ToolBase<
+    typeof CustomPropertySourcesCreateSchema,
+    Schemas.CustomPropertySource
+> => ({
+    name: 'custom-property-sources-create',
+    schema: CustomPropertySourcesCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof CustomPropertySourcesCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.definition !== undefined) {
+            body['definition'] = params.definition
+        }
+        if (params.saved_query !== undefined) {
+            body['saved_query'] = params.saved_query
+        }
+        if (params.external_data_schema !== undefined) {
+            body['external_data_schema'] = params.external_data_schema
+        }
+        if (params.source_column !== undefined) {
+            body['source_column'] = params.source_column
+        }
+        if (params.column_property_map !== undefined) {
+            body['column_property_map'] = params.column_property_map
+        }
+        if (params.key_column !== undefined) {
+            body['key_column'] = params.key_column
+        }
+        if (params.is_enabled !== undefined) {
+            body['is_enabled'] = params.is_enabled
+        }
+        const result = await context.api.request<Schemas.CustomPropertySource>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/custom_property_sources/`,
+            body,
+        })
+        return result
+    },
+})
+
+const CustomPropertySourcesDestroySchema = CustomPropertySourcesDestroyParams.omit({ project_id: true })
+
+const customPropertySourcesDestroy = (): ToolBase<typeof CustomPropertySourcesDestroySchema, unknown> => ({
+    name: 'custom-property-sources-destroy',
+    schema: CustomPropertySourcesDestroySchema,
+    handler: async (context: Context, params: z.infer<typeof CustomPropertySourcesDestroySchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'DELETE',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/custom_property_sources/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const CustomPropertySourcesListSchema = CustomPropertySourcesListQueryParams
+
+const customPropertySourcesList = (): ToolBase<
+    typeof CustomPropertySourcesListSchema,
+    WithPostHogUrl<Schemas.PaginatedCustomPropertySourceList>
+> => ({
+    name: 'custom-property-sources-list',
+    schema: CustomPropertySourcesListSchema,
+    handler: async (context: Context, params: z.infer<typeof CustomPropertySourcesListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedCustomPropertySourceList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/custom_property_sources/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        return await withPostHogUrl(context, result, '/customer-analytics')
+    },
+})
+
+const CustomPropertySourcesPartialUpdateSchema = CustomPropertySourcesPartialUpdateParams.omit({
+    project_id: true,
+}).extend(CustomPropertySourcesPartialUpdateBody.shape)
+
+const customPropertySourcesPartialUpdate = (): ToolBase<
+    typeof CustomPropertySourcesPartialUpdateSchema,
+    Schemas.CustomPropertySource
+> => ({
+    name: 'custom-property-sources-partial-update',
+    schema: CustomPropertySourcesPartialUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof CustomPropertySourcesPartialUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.source_column !== undefined) {
+            body['source_column'] = params.source_column
+        }
+        if (params.key_column !== undefined) {
+            body['key_column'] = params.key_column
+        }
+        if (params.is_enabled !== undefined) {
+            body['is_enabled'] = params.is_enabled
+        }
+        const result = await context.api.request<Schemas.CustomPropertySource>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/custom_property_sources/${encodeURIComponent(String(params.id))}/`,
+            body,
+        })
+        return result
+    },
+})
+
+const CustomPropertySourcesRetrieveSchema = CustomPropertySourcesRetrieveParams.omit({ project_id: true })
+
+const customPropertySourcesRetrieve = (): ToolBase<
+    typeof CustomPropertySourcesRetrieveSchema,
+    Schemas.CustomPropertySource
+> => ({
+    name: 'custom-property-sources-retrieve',
+    schema: CustomPropertySourcesRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof CustomPropertySourcesRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.CustomPropertySource>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/custom_property_sources/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const CustomPropertySourcesRunsListSchema = CustomPropertySourcesRunsListParams.omit({ project_id: true }).extend(
+    CustomPropertySourcesRunsListQueryParams.shape
+)
+
+const customPropertySourcesRunsList = (): ToolBase<
+    typeof CustomPropertySourcesRunsListSchema,
+    WithPostHogUrl<Schemas.PaginatedCustomPropertySyncRunList>
+> => ({
+    name: 'custom-property-sources-runs-list',
+    schema: CustomPropertySourcesRunsListSchema,
+    handler: async (context: Context, params: z.infer<typeof CustomPropertySourcesRunsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedCustomPropertySyncRunList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/custom_property_sources/${encodeURIComponent(String(params.id))}/runs/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        return await withPostHogUrl(context, result, '/customer-analytics')
+    },
+})
+
+const CustomPropertySourcesSyncSchema = CustomPropertySourcesSyncParams.omit({ project_id: true })
+
+const customPropertySourcesSync = (): ToolBase<typeof CustomPropertySourcesSyncSchema, unknown> => ({
+    name: 'custom-property-sources-sync',
+    schema: CustomPropertySourcesSyncSchema,
+    handler: async (context: Context, params: z.infer<typeof CustomPropertySourcesSyncSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/custom_property_sources/${encodeURIComponent(String(params.id))}/sync/`,
+        })
+        return result
+    },
+})
+
 const UsageMetricsCreateSchema = GroupsTypesMetricsCreateParams.omit({ project_id: true })
     .extend(GroupsTypesMetricsCreateBody.shape)
     .extend({
@@ -823,6 +1014,14 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'custom-property-definitions-list': customPropertyDefinitionsList,
     'custom-property-definitions-partial-update': customPropertyDefinitionsPartialUpdate,
     'custom-property-definitions-retrieve': customPropertyDefinitionsRetrieve,
+    'custom-property-sources-backfill': customPropertySourcesBackfill,
+    'custom-property-sources-create': customPropertySourcesCreate,
+    'custom-property-sources-destroy': customPropertySourcesDestroy,
+    'custom-property-sources-list': customPropertySourcesList,
+    'custom-property-sources-partial-update': customPropertySourcesPartialUpdate,
+    'custom-property-sources-retrieve': customPropertySourcesRetrieve,
+    'custom-property-sources-runs-list': customPropertySourcesRunsList,
+    'custom-property-sources-sync': customPropertySourcesSync,
     'usage-metrics-create': usageMetricsCreate,
     'usage-metrics-destroy': usageMetricsDestroy,
     'usage-metrics-list': usageMetricsList,

--- a/services/mcp/tests/unit/tool-filtering.test.ts
+++ b/services/mcp/tests/unit/tool-filtering.test.ts
@@ -819,9 +819,10 @@ describe('Tool Filtering - Feature Flags', () => {
                 'stamphog',
                 'product-data-catalog',
                 'loops',
+                'warehouse-person-properties',
             ])
         )
-        expect(flags).toHaveLength(23)
+        expect(flags).toHaveLength(24)
     })
 
     it('every loops tool is gated on the loops flag', () => {


### PR DESCRIPTION
> [!NOTE]
> Stacked on #72843 (base branch `tom/dwh-person-props-management-ui`). Review that first — this diff is only the MCP + API-layer changes on top of it.

## Problem

#72843 added the person-property management API (sync / backfill / runs actions on `CustomPropertySourceViewSet`, plus the source CRUD), but none of it is reachable by agents through MCP, and the two trigger actions returned an untyped object. This PR closes both gaps: it exposes the management surface as MCP tools and tightens the API layer so the generated tool schemas are correct.

## Changes

- **Typed the trigger responses.** `sync` and `backfill` returned `OpenApiTypes.OBJECT` (an opaque object downstream). They now use a small `CustomPropertySyncTriggerResponseSerializer` (`status`, and `already_running` for backfill), and all three actions get explicit `operation_id`s so the generated tool keys and client function names stay stable.
- **Enabled MCP tools** for the custom-property source CRUD (create / list / retrieve / partial-update / destroy) plus the three new actions (`sync`, `backfill`, `runs`), in `products/customer_analytics/mcp/tools.yaml`.
- **Flag-gated the tools.** The person-property-specific actions (`sync` / `backfill` / `runs`) are gated on `warehouse-person-properties`, so they're hidden at MCP init when the flag is off (matching where the backend gates). The shared source CRUD is gated on `customer-analytics-csp`, matching the existing definitions tools.
- **Flag-gating tests.** New viewset tests assert the actions 400 when the flag is off and route correctly (with the temporal seam mocked) when it's on — which doubles as an explicit guard that the whole surface is behind the flag.

## How did you test this code?

Run locally against a 3.13.13 venv + Postgres:

- `TestCustomPropertySourceViewSet` — 5 pass, including the two new cases: `test_person_source_actions_are_flag_gated` (flag off → 400 for sync and backfill) and `test_person_source_actions_when_enabled` (202 + typed body, temporal seam mocked, and the backfill's running placeholder shows up in the runs feed). These guard the flag gate and the viewset→facade→temporal wiring, neither of which an existing test covered.
- `pnpm --filter=@posthog/mcp lint-tool-names` passes; `hogli build:openapi` regenerates the customer_analytics OpenAPI/MCP artifacts and the three tools appear in the generated `customer_analytics.ts` tool map; `ruff` clean.

No app click-through, so no screenshots — this is API + tool-definition plumbing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Nothing under `docs/` covers these tools yet; the tool descriptions live in `tools.yaml`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Tom) directed this; Claude Code (Opus 4.8) implemented it. Skills invoked: `/implementing-mcp-tools` (the scaffold → enable → build flow, and the native `feature_flag` gating) and `/improving-drf-endpoints` (typed responses + explicit operation_ids so the generated schemas aren't `z.object({})`). Decision worth flagging: the shared source CRUD is gated on `customer-analytics-csp` rather than `warehouse-person-properties`, because those endpoints also manage account sources — over-gating them on the warehouse flag would have hidden account-source management too; the person-specific actions carry the warehouse flag, and the API still backstops person-source creation with a 400 when the flag is off.
