### PR TITLE
fix(langfuse): treat 404 responses as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/source.py
@@ -103,6 +103,10 @@ Find your project API keys in your Langfuse **Project settings > API Keys**. Set
         return {
             "401 Client Error": "Invalid Langfuse API keys. Check the project public key and secret key, and make sure the host matches your Langfuse data region.",
             "403 Client Error": "Your Langfuse API keys do not have access to this resource. Check the keys and try again.",
+            # Every LANGFUSE_ENDPOINTS path is a collection route (no resource id in the URL), so a
+            # 404 here means the route itself doesn't exist on this host - typically a self-hosted
+            # instance running a Langfuse version that predates this endpoint. Retrying never helps.
+            "404 Client Error": "This Langfuse endpoint was not found on your host. Self-hosted instances on an older Langfuse version may not support it yet - upgrade your instance or remove this table from the sync.",
             HOST_NOT_ALLOWED_ERROR: "The Langfuse host is not allowed. Please use a publicly reachable instance URL.",
             HTTP_NOT_ALLOWED_ERROR: "The Langfuse host must use HTTPS. Please update the host to use https://.",
             RESPONSE_LIMIT_ERROR: "The Langfuse host returned a response that was too large or too slow to download. Check that the host points at a real Langfuse instance.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/tests/test_langfuse_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/tests/test_langfuse_source.py
@@ -53,7 +53,9 @@ class TestLangfuseSource:
         assert secret_key_field.secret is True
         assert secret_key_field.required is True
 
-    @pytest.mark.parametrize("expected_key", ["401 Client Error", "403 Client Error", RESPONSE_LIMIT_ERROR])
+    @pytest.mark.parametrize(
+        "expected_key", ["401 Client Error", "403 Client Error", "404 Client Error", RESPONSE_LIMIT_ERROR]
+    )
     def test_non_retryable_errors(self, expected_key):
         assert expected_key in self.source.get_non_retryable_errors()
 


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `HTTPError: 404 Client Error: Not Found` from the Langfuse data warehouse source's `fetch_page`, on the `observations` (v2) endpoint. Every endpoint in `LANGFUSE_ENDPOINTS` is a collection route with no resource id in the URL, so a 404 there can only mean the route itself doesn't exist on the customer's Langfuse host - typically a self-hosted instance running a version that predates that API path. Since 404 wasn't in `get_non_retryable_errors`, Temporal kept retrying the whole activity even though the outcome could never change.

## Changes

- Add a `"404 Client Error"` entry to `LangfuseSource.get_non_retryable_errors()` (mirroring the existing `401`/`403` entries) with a friendly message pointing at an outdated/self-hosted instance.

## How did you test this code?

- Ran the existing Langfuse source test suite (`uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/tests/test_langfuse_source.py`) - 21 passed, including a new parametrized case asserting `"404 Client Error"` is recognized as non-retryable.
- `ruff check` / `ruff format --check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - internal retry-classification change, no user-facing behavior or docs to update.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (this session), triaging a live error-tracking issue for the Langfuse warehouse source.
- Confirmed the stack trace resolves into `products/warehouse_sources/backend/temporal/data_imports/sources/langfuse/langfuse.py` (`fetch_page`, `raise_for_status()`), not just a serialized log context.
- Checked open PRs (including the maintainer's own) for overlap - #72039 addresses a separate 422 deep-pagination issue on `traces`, not this 404 classification.
- Reasoned that since every synced endpoint is a collection route, a 404 can't be resource-specific - it's a stable "this route doesn't exist here" signal, so non-retryable is the right classification per the existing `401`/`403` pattern in this file.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*