### PR TITLE
fix(data-warehouse): stabilize elasticsearch numeric column types

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/elasticsearch.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/elasticsearch.py
@@ -21,6 +21,14 @@ MAX_RETRY_ATTEMPTS = 5
 # get_non_retryable_errors without the two strings silently drifting apart.
 NON_JSON_RESPONSE_ERROR = "Elasticsearch returned a non-JSON response"
 
+# Elasticsearch numeric types whose _source JSON alternates between whole (40) and fractional
+# (40.5) representations across documents. Left alone, that makes a column infer as int64 on one
+# scroll page and double on the next, which PyArrow/Delta refuse to merge ("incompatible types:
+# int64 vs double"). Coercing these fields to float up front pins the type deterministically.
+# Integer types (long/integer/short/byte) are excluded on purpose: they're always whole in JSON,
+# and widening a large `long` id to float64 would silently lose precision past 2^53.
+_ES_FLOAT_TYPES = frozenset({"float", "double", "half_float", "scaled_float"})
+
 
 class ElasticsearchRetryableError(Exception):
     pass
@@ -91,6 +99,74 @@ def list_indices(host: str, auth: ElasticsearchAuth) -> list[str]:
     return sorted(index for index in indices if index and not index.startswith("."))
 
 
+def _collect_float_paths(properties: dict[str, Any], prefix: str, paths: set[str]) -> None:
+    """Walk an Elasticsearch mapping's `properties` tree, recording dotted paths of float-typed fields."""
+    for name, spec in properties.items():
+        if not isinstance(spec, dict):
+            continue
+        path = f"{prefix}{name}"
+        if spec.get("type") in _ES_FLOAT_TYPES:
+            paths.add(path)
+        sub_properties = spec.get("properties")
+        if isinstance(sub_properties, dict):
+            _collect_float_paths(sub_properties, f"{path}.", paths)
+
+
+def get_float_field_paths(session: requests.Session, base_url: str, index: str) -> set[str]:
+    """Dotted paths of fields the index mapping types as floating point.
+
+    Best-effort: a mapping we can't read (permissions, non-JSON body) yields no paths, so the sync
+    behaves as before rather than failing on the mapping lookup alone.
+    """
+    try:
+        response = session.get(f"{base_url}/{quote(index)}/_mapping", timeout=REQUEST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        body = response.json()
+    except (requests.exceptions.RequestException, requests.exceptions.JSONDecodeError, ValueError):
+        return set()
+
+    paths: set[str] = set()
+    # Shape: {"<index>": {"mappings": {"properties": {...}}}}. An alias resolves to several indices,
+    # so union every block's float paths.
+    if isinstance(body, dict):
+        for index_block in body.values():
+            properties = ((index_block or {}).get("mappings") or {}).get("properties")
+            if isinstance(properties, dict):
+                _collect_float_paths(properties, "", paths)
+    return paths
+
+
+def _to_float(value: Any) -> Any:
+    # bool is an int subclass but never a numeric field value here — leave it untouched.
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return float(value)
+    if isinstance(value, list):
+        return [_to_float(item) for item in value]
+    return value
+
+
+def _coerce_path(obj: Any, parts: list[str]) -> None:
+    key = parts[0]
+    if isinstance(obj, list):
+        for item in obj:
+            _coerce_path(item, parts)
+        return
+    if not isinstance(obj, dict) or key not in obj:
+        return
+    if len(parts) == 1:
+        obj[key] = _to_float(obj[key])
+    else:
+        _coerce_path(obj[key], parts[1:])
+
+
+def coerce_float_fields(doc: dict[str, Any], float_paths: set[str]) -> None:
+    """Rewrite whole-number values under float-typed fields to float, in place."""
+    for path in float_paths:
+        _coerce_path(doc, path.split("."))
+
+
 def get_rows(
     host: str,
     auth: ElasticsearchAuth,
@@ -99,6 +175,7 @@ def get_rows(
 ) -> Iterator[list[dict[str, Any]]]:
     session = _get_session(auth)
     base_url = normalize_host(host)
+    float_paths = get_float_field_paths(session, base_url, index)
 
     @retry(
         retry=retry_if_exception_type((ElasticsearchRetryableError, requests.ReadTimeout, requests.ConnectionError)),
@@ -133,6 +210,10 @@ def get_rows(
         while True:
             hits = ((data.get("hits") or {}).get("hits")) or []
             items = [{**(hit.get("_source") or {}), "_id": hit["_id"]} for hit in hits]
+
+            if float_paths:
+                for item in items:
+                    coerce_float_fields(item, float_paths)
 
             if items:
                 yield items

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/tests/test_elasticsearch.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/tests/test_elasticsearch.py
@@ -8,7 +8,9 @@ import requests
 from products.warehouse_sources.backend.temporal.data_imports.sources.elasticsearch.elasticsearch import (
     PAGE_SIZE,
     ElasticsearchAuth,
+    coerce_float_fields,
     elasticsearch_source,
+    get_float_field_paths,
     get_rows,
     hostname_of,
     list_indices,
@@ -170,6 +172,121 @@ class TestGetRows:
         assert (
             list(get_rows("https://es.example.com", ElasticsearchAuth(api_key="k"), "orders", mock.MagicMock())) == []
         )
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_float_typed_fields_are_coerced_across_rows(self, mock_session):
+        # A float-typed field whose docs mix whole (40) and fractional (40.5) values must all
+        # arrive as floats so the column infers a single Arrow type; the long id stays an int.
+        mock_session.return_value.headers = {}
+        mock_session.return_value.get.return_value = _response(
+            {"orders": {"mappings": {"properties": {"amount": {"type": "float"}, "id": {"type": "long"}}}}}
+        )
+        mock_session.return_value.post.return_value = _response(
+            _scroll_page(
+                [
+                    {"_id": "1", "_source": {"amount": 40, "id": 100}},
+                    {"_id": "2", "_source": {"amount": 40.5, "id": 200}},
+                ]
+            )
+        )
+
+        batches = list(get_rows("https://es.example.com", ElasticsearchAuth(api_key="k"), "orders", mock.MagicMock()))
+
+        assert batches == [
+            [
+                {"amount": 40.0, "id": 100, "_id": "1"},
+                {"amount": 40.5, "id": 200, "_id": "2"},
+            ]
+        ]
+        assert [type(row["amount"]) for row in batches[0]] == [float, float]
+        assert [type(row["id"]) for row in batches[0]] == [int, int]
+
+
+class TestFloatFieldPaths:
+    @pytest.mark.parametrize(
+        "mappings, expected",
+        [
+            # Scalar float types are collected; integer/keyword types are not.
+            (
+                {
+                    "properties": {
+                        "threshold_amount": {"type": "float"},
+                        "total_hours_worked": {"type": "double"},
+                        "ratio": {"type": "half_float"},
+                        "price": {"type": "scaled_float", "scaling_factor": 100},
+                        "id": {"type": "long"},
+                        "count": {"type": "integer"},
+                        "name": {"type": "keyword"},
+                    }
+                },
+                {"threshold_amount", "total_hours_worked", "ratio", "price"},
+            ),
+            # Nested object properties are walked and reported as dotted paths.
+            (
+                {
+                    "properties": {
+                        "payroll": {
+                            "properties": {
+                                "rate": {"type": "double"},
+                                "employee_id": {"type": "long"},
+                            }
+                        }
+                    }
+                },
+                {"payroll.rate"},
+            ),
+            ({"properties": {}}, set()),
+            ({}, set()),
+        ],
+    )
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_collects_float_typed_paths(self, mock_session, mappings, expected):
+        mock_session.return_value.headers = {}
+        session = mock_session.return_value
+        session.get.return_value = _response({"orders": {"mappings": mappings}})
+
+        assert get_float_field_paths(session, "https://es.example.com", "orders") == expected
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_unreadable_mapping_yields_no_paths(self, mock_session):
+        mock_session.return_value.headers = {}
+        session = mock_session.return_value
+        session.get.side_effect = requests.exceptions.ConnectionError("boom")
+
+        assert get_float_field_paths(session, "https://es.example.com", "orders") == set()
+
+
+class TestCoerceFloatFields:
+    @pytest.mark.parametrize(
+        "doc, float_paths, expected",
+        [
+            # Whole numbers under float fields become floats; ints under non-float fields stay ints.
+            (
+                {"amount": 40, "id": 12345678901234567, "name": "x"},
+                {"amount"},
+                {"amount": 40.0, "id": 12345678901234567, "name": "x"},
+            ),
+            # Already-float values are untouched, missing paths are ignored.
+            ({"amount": 40.5}, {"amount", "missing"}, {"amount": 40.5}),
+            # Nested and array-of-scalar float fields are coerced element-wise.
+            (
+                {"payroll": {"rate": 20}, "readings": [1, 2, 3]},
+                {"payroll.rate", "readings"},
+                {"payroll": {"rate": 20.0}, "readings": [1.0, 2.0, 3.0]},
+            ),
+            # Arrays of nested objects are traversed.
+            (
+                {"lines": [{"cost": 5}, {"cost": 6}]},
+                {"lines.cost"},
+                {"lines": [{"cost": 5.0}, {"cost": 6.0}]},
+            ),
+            # Booleans are ints in Python but must not be coerced to float.
+            ({"flag": True}, {"flag"}, {"flag": True}),
+        ],
+    )
+    def test_coercion(self, doc, float_paths, expected):
+        coerce_float_fields(doc, float_paths)
+        assert doc == expected
 
 
 class TestElasticsearchSourceResponse:


### PR DESCRIPTION
## Problem

The Elasticsearch warehouse source has a high sync failure rate.
Looking at the [error-rate-by-source insight](https://us.posthog.com/project/2/insights/CCaTSaIl), Elasticsearch failures over the last 30 days are almost entirely two errors:

```
ArrowTypeError: Unable to merge: Field total_hours_worked has incompatible types: int64 vs double
Source column type changed: 'threshold_amount' has values that no longer fit its stored type int64 (incoming data is now double)
```

Both are the same root cause.
Elasticsearch's `_source` is schemaless JSON, so a field the index maps as floating point (`float` / `double` / `scaled_float`) still comes back as `40` for whole-number documents and `40.5` for fractional ones.
The importer infers Arrow types per scroll page, so one page infers `int64` and the next `double`:

- Within a run, PyArrow/delta-rs refuse to merge the two pages (`Unable to merge`).
- Across runs, a column created `int64` from an all-whole first run can't take a later fractional value (`no longer fit its stored type`), which is unrecoverable without a reset.

The column's type was non-deterministic, so a sync's success depended on which values happened to land in which page.

## Changes

Before scrolling an index, fetch its `_mapping` (Elasticsearch's authoritative field types), collect the dotted paths of every floating-point-typed field, and coerce those values to `float` as each document is read.
That pins each numeric column to one stable Arrow type, within and across runs.

A couple of deliberate choices:

- Only mapping-declared float types are coerced. Integer types (`long` / `integer` / ...) stay ints on purpose, since downcasting a large `long` id to `float64` would silently lose precision past 2^53.
- The mapping lookup is best-effort. If it fails (permissions, non-JSON body) it returns no paths and the sync behaves exactly as before, rather than failing on the lookup itself.

Nested objects and arrays of scalars/objects are handled, and booleans (an `int` subclass in Python) are left alone.

> [!NOTE]
> Tables already stuck in the `no longer fit its stored type` state need a one-time reset and full re-sync, as the error message already instructs.
> After that the column is created as `double` and stays stable. This PR prevents recurrence and fixes fresh syncs.

## How did you test this code?

Added parameterized unit tests in `test_elasticsearch.py` (pure functions, no DB):

- `TestFloatFieldPaths` - mapping parsing extracts float-typed paths including nested ones, excludes integer/keyword types, and returns nothing for an unreadable mapping. Catches a regression where mapping parsing stops recursing or starts matching integer types (either reintroduces the bug or downcasts `long` ids).
- `TestCoerceFloatFields` - int-under-float becomes float, ints under non-float fields stay ints, nested/array/array-of-object fields are traversed, booleans are untouched.
- `TestGetRows::test_float_typed_fields_are_coerced_across_rows` - end-to-end: mixed `40` / `40.5` docs all arrive as `float` while a `long` id stays `int`. This is the direct guard for the merge failure.

All 51 tests in the elasticsearch suite pass locally. `ruff check` / `ruff format` clean, and `mypy --cache-fine-grained` clean on the changed module.
I (Claude) invoked the `/writing-tests` skill to gate the test additions.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
