### PR TITLE
feat(replay): report ml-mirror anonymizer rust phase timings as APM spans

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize-timing-spans.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize-timing-spans.ts
@@ -1,0 +1,75 @@
+import { Span, SpanStatusCode, context, trace } from '@opentelemetry/api'
+
+import type { AnonymizeTimings } from '@posthog/replay-anonymizer'
+
+import { defaultConfig } from '~/common/config/config'
+
+const tracer = trace.getTracer('replay-anonymizer')
+
+const NS_PER_MS = 1e6
+
+export interface AnonymizeOutcome {
+    route: string | null
+    /** The dlq/drop reason when the addon failed, else null. */
+    failureReason: string | null
+}
+
+/**
+ * Materialize the addon's phase timings as retroactive child spans of the current step span. The
+ * addon runs on the libuv threadpool where no OTel context exists, so it reports nanosecond phase
+ * boundaries instead and this converts them to spans after the fact — including on failures and
+ * contained panics, where `lastOp` names the op that was running when processing stopped.
+ */
+export function recordAnonymizeTimingSpans(
+    callStartEpochMs: number,
+    timings: AnonymizeTimings | null | undefined,
+    outcome: AnonymizeOutcome
+): void {
+    if (!timings || defaultConfig.DISABLE_OPENTELEMETRY_TRACING) {
+        return
+    }
+    const parent = context.active()
+    const taskStartMs = timings.taskStartEpochMs
+
+    const emit = (name: string, startMs: number, endMs: number, decorate?: (span: Span) => void): void => {
+        const span = tracer.startSpan(name, { startTime: startMs }, parent)
+        decorate?.(span)
+        span.end(Math.max(endMs, startMs))
+    }
+
+    // SystemTime (Rust) and performance.timeOrigin (JS) are both wall clock; clamp so minor skew
+    // can't produce a negative queue span.
+    emit('anonymize.queueWait', callStartEpochMs, Math.max(taskStartMs, callStartEpochMs))
+
+    if (timings.decompressStartNs !== null && timings.decompressEndNs !== null) {
+        emit(
+            'anonymize.decompress',
+            taskStartMs + timings.decompressStartNs / NS_PER_MS,
+            taskStartMs + timings.decompressEndNs / NS_PER_MS
+        )
+    }
+
+    if (timings.scrubStartNs !== null) {
+        const startMs = taskStartMs + timings.scrubStartNs / NS_PER_MS
+        // A missing end boundary means the outer panic guard fired mid-scrub; the await settling
+        // "now" is the closest observable end.
+        const endMs =
+            timings.scrubEndNs !== null
+                ? taskStartMs + timings.scrubEndNs / NS_PER_MS
+                : performance.timeOrigin + performance.now()
+        emit('anonymize.scrub', startMs, endMs, (span) => {
+            span.setAttributes({
+                'anonymize.route': outcome.route ?? '',
+                'anonymize.cv_total_ms': timings.cvTotalNs / NS_PER_MS,
+                'anonymize.cv_count': timings.cvCount,
+                'anonymize.blur_total_ms': timings.blurTotalNs / NS_PER_MS,
+                'anonymize.blur_count': timings.blurCount,
+                'anonymize.last_op': timings.lastOp,
+            })
+            if (outcome.failureReason) {
+                span.setStatus({ code: SpanStatusCode.ERROR, message: outcome.failureReason })
+                span.setAttribute('anonymize.failure_reason', outcome.failureReason)
+            }
+        })
+    }
+}

--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize-timing-spans.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize-timing-spans.ts
@@ -16,9 +16,12 @@ export interface AnonymizeOutcome {
 
 /**
  * Materialize the addon's phase timings as retroactive child spans of the current step span. The
- * addon runs on the libuv threadpool where no OTel context exists, so it reports nanosecond phase
- * boundaries instead and this converts them to spans after the fact — including on failures and
- * contained panics, where `lastOp` names the op that was running when processing stopped.
+ * addon runs on the libuv threadpool where no OTel context exists, so it reports monotonic offsets
+ * instead and this converts them to spans after the fact. All offsets are anchored on the caller's
+ * clock at the moment of the addon call, so no cross-clock (JS vs Rust wall time) skew is possible.
+ *
+ * A phase that started but never ended (contained panic) still gets a span, ended at "now"; on
+ * failure the deepest emitted span carries the reason and the `lastOp` that was in flight.
  */
 export function recordAnonymizeTimingSpans(
     callStartEpochMs: number,
@@ -29,47 +32,58 @@ export function recordAnonymizeTimingSpans(
         return
     }
     const parent = context.active()
-    const taskStartMs = timings.taskStartEpochMs
+    const at = (offsetNs: number): number => callStartEpochMs + offsetNs / NS_PER_MS
+    const nowMs = (): number => performance.timeOrigin + performance.now()
 
-    const emit = (name: string, startMs: number, endMs: number, decorate?: (span: Span) => void): void => {
-        const span = tracer.startSpan(name, { startTime: startMs }, parent)
-        decorate?.(span)
-        span.end(Math.max(endMs, startMs))
+    const decorateFailure = (span: Span): void => {
+        span.setAttribute('anonymize.last_op', timings.lastOp)
+        if (outcome.failureReason) {
+            span.setStatus({ code: SpanStatusCode.ERROR, message: outcome.failureReason })
+            span.setAttribute('anonymize.failure_reason', outcome.failureReason)
+        }
     }
 
-    // SystemTime (Rust) and performance.timeOrigin (JS) are both wall clock; clamp so minor skew
-    // can't produce a negative queue span.
-    emit('anonymize.queueWait', callStartEpochMs, Math.max(taskStartMs, callStartEpochMs))
-
-    if (timings.decompressStartNs !== null && timings.decompressEndNs !== null) {
-        emit(
-            'anonymize.decompress',
-            taskStartMs + timings.decompressStartNs / NS_PER_MS,
-            taskStartMs + timings.decompressEndNs / NS_PER_MS
-        )
+    interface PhaseSpan {
+        name: string
+        startMs: number
+        endMs: number
+        decorate?: (span: Span) => void
     }
+    const phases: PhaseSpan[] = []
 
-    if (timings.scrubStartNs !== null) {
-        const startMs = taskStartMs + timings.scrubStartNs / NS_PER_MS
-        // A missing end boundary means the outer panic guard fired mid-scrub; the await settling
-        // "now" is the closest observable end.
-        const endMs =
-            timings.scrubEndNs !== null
-                ? taskStartMs + timings.scrubEndNs / NS_PER_MS
-                : performance.timeOrigin + performance.now()
-        emit('anonymize.scrub', startMs, endMs, (span) => {
-            span.setAttributes({
-                'anonymize.route': outcome.route ?? '',
-                'anonymize.cv_total_ms': timings.cvTotalNs / NS_PER_MS,
-                'anonymize.cv_count': timings.cvCount,
-                'anonymize.blur_total_ms': timings.blurTotalNs / NS_PER_MS,
-                'anonymize.blur_count': timings.blurCount,
-                'anonymize.last_op': timings.lastOp,
-            })
-            if (outcome.failureReason) {
-                span.setStatus({ code: SpanStatusCode.ERROR, message: outcome.failureReason })
-                span.setAttribute('anonymize.failure_reason', outcome.failureReason)
-            }
+    if (timings.taskStartNs !== null) {
+        phases.push({ name: 'anonymize.queueWait', startMs: callStartEpochMs, endMs: at(timings.taskStartNs) })
+    }
+    if (timings.decompressStartNs !== null) {
+        phases.push({
+            name: 'anonymize.decompress',
+            startMs: at(timings.decompressStartNs),
+            endMs: timings.decompressEndNs !== null ? at(timings.decompressEndNs) : nowMs(),
         })
     }
+    if (timings.scrubStartNs !== null) {
+        phases.push({
+            name: 'anonymize.scrub',
+            startMs: at(timings.scrubStartNs),
+            endMs: timings.scrubEndNs !== null ? at(timings.scrubEndNs) : nowMs(),
+            decorate: (span) => {
+                span.setAttributes({
+                    'anonymize.route': outcome.route ?? '',
+                    'anonymize.cv_total_ms': timings.cvTotalNs / NS_PER_MS,
+                    'anonymize.cv_count': timings.cvCount,
+                    'anonymize.blur_total_ms': timings.blurTotalNs / NS_PER_MS,
+                    'anonymize.blur_count': timings.blurCount,
+                })
+            },
+        })
+    }
+
+    phases.forEach((phase, i) => {
+        const span = tracer.startSpan(phase.name, { startTime: phase.startMs }, parent)
+        phase.decorate?.(span)
+        if (i === phases.length - 1) {
+            decorateFailure(span)
+        }
+        span.end(Math.max(phase.endMs, phase.startMs))
+    })
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/shared-fixtures.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/shared-fixtures.test.ts
@@ -189,8 +189,8 @@ describeAddon('native rust addon matches the shared fixtures', () => {
             const result = await rustAddon!.anonymizeKafkaPayload(payloadOf('w', [fullSnapshot]))
             expect(result.failed).toBe(false)
             const t = result.timings!
-            expect(t.taskStartEpochMs).toBeGreaterThan(0)
-            expect(t.decompressStartNs).not.toBeNull()
+            expect(t.taskStartNs).not.toBeNull()
+            expect(t.decompressStartNs).toBeGreaterThanOrEqual(t.taskStartNs!)
             expect(t.decompressEndNs).toBeGreaterThanOrEqual(t.decompressStartNs!)
             expect(t.scrubStartNs).toBeGreaterThanOrEqual(t.decompressEndNs!)
             expect(t.scrubEndNs).toBeGreaterThanOrEqual(t.scrubStartNs!)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/shared-fixtures.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/shared-fixtures.test.ts
@@ -183,5 +183,31 @@ describeAddon('native rust addon matches the shared fixtures', () => {
             const decoded = unzstdLatin1(line[1].data.texts) as { value: string }[]
             expect(decoded[0].value).toBe('keep ******')
         })
+
+        it('reports ordered phase timings with cv op totals on success', async () => {
+            rustAddon!.initAnonymizer({ text: ['keep'], url: [] })
+            const result = await rustAddon!.anonymizeKafkaPayload(payloadOf('w', [fullSnapshot]))
+            expect(result.failed).toBe(false)
+            const t = result.timings!
+            expect(t.taskStartEpochMs).toBeGreaterThan(0)
+            expect(t.decompressStartNs).not.toBeNull()
+            expect(t.decompressEndNs).toBeGreaterThanOrEqual(t.decompressStartNs!)
+            expect(t.scrubStartNs).toBeGreaterThanOrEqual(t.decompressEndNs!)
+            expect(t.scrubEndNs).toBeGreaterThanOrEqual(t.scrubStartNs!)
+            // The cv full snapshot forces at least one timed de/recompression op.
+            expect(t.cvCount).toBeGreaterThanOrEqual(1)
+            expect(t.lastOp).toBe('done')
+        })
+
+        it('still reports timings when the payload fails, naming the phase that died', async () => {
+            rustAddon!.initAnonymizer({ text: [], url: [] })
+            // Gzip magic bytes followed by garbage: decompression starts, then fails.
+            const result = await rustAddon!.anonymizeKafkaPayload(Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0xde, 0xad]))
+            expect(result.failed).toBe(true)
+            const t = result.timings!
+            expect(t.decompressStartNs).not.toBeNull()
+            expect(t.scrubStartNs).toBeNull()
+            expect(t.lastOp).toBe('decompress')
+        })
     })
 })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/parse-and-anonymize-step.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/parse-and-anonymize-step.ts
@@ -7,6 +7,7 @@ import { logger } from '~/common/utils/logger'
 import { normalizeSessionId } from '~/common/utils/utils'
 import { dlq, drop, ok } from '~/ingestion/framework/results'
 import { ProcessingStep } from '~/ingestion/framework/steps'
+import { recordAnonymizeTimingSpans } from '~/ingestion/pipelines/sessionreplay/anonymize-timing-spans'
 import { ParsedMessageData } from '~/ingestion/pipelines/sessionreplay/kafka/types'
 import { SessionRecordingIngesterMetrics } from '~/ingestion/pipelines/sessionreplay/metrics'
 
@@ -62,6 +63,7 @@ export function createParseAndAnonymizeMessageStep<T extends ParseMessageStepInp
         )
 
         const t0 = performance.now()
+        const callStartEpochMs = performance.timeOrigin + t0
         let result
         try {
             result = await getRustAnonymizer().anonymizeKafkaPayload(message.value, contentEncoding)
@@ -72,6 +74,10 @@ export function createParseAndAnonymizeMessageStep<T extends ParseMessageStepInp
             return drop('anonymize_failed')
         }
         SessionRecordingIngesterMetrics.observeMlAnonymizeDuration('rust', performance.now() - t0, result.route ?? '')
+        recordAnonymizeTimingSpans(callStartEpochMs, result.timings, {
+            route: result.route,
+            failureReason: result.failed ? (result.reason ?? 'anonymize_failed') : null,
+        })
 
         if (result.failed) {
             if (result.reason && DLQ_REASONS.has(result.reason)) {

--- a/rust/replay-anonymizer-node/src/index.ts
+++ b/rust/replay-anonymizer-node/src/index.ts
@@ -39,17 +39,13 @@ export interface AnonymizeMeta {
 }
 
 /**
- * Phase timings for one {@link anonymizeKafkaPayload} call, measured on the threadpool task.
- * Reported on success AND failure (including contained panics), so slow or crashing payloads can
- * be debugged from the same telemetry. Offsets are nanoseconds from `taskStartEpochMs`; a `null`
- * boundary means the phase was never reached.
+ * Phase timings for one {@link anonymizeKafkaPayload} call, reported on success and failure alike
+ * (including contained panics). All offsets are monotonic nanoseconds from the moment the addon
+ * was invoked on the JS thread; a `null` boundary means the phase was never reached.
  */
 export interface AnonymizeTimings {
-    /**
-     * Wall-clock time the threadpool picked the task up (epoch ms). The gap from when the caller
-     * invoked the addon to this is the libuv threadpool queue wait.
-     */
-    taskStartEpochMs: number
+    /** Threadpool pickup — this offset IS the libuv queue wait. */
+    taskStartNs: number | null
     decompressStartNs: number | null
     decompressEndNs: number | null
     scrubStartNs: number | null
@@ -62,7 +58,7 @@ export interface AnonymizeTimings {
     blurCount: number
     /**
      * The op in flight when processing stopped: `done` on success, else the phase or op
-     * (`decompress` | `scrub` | `cv` | `blur` | `serialize_meta`) that was running.
+     * (`queued` | `decompress` | `scrub` | `cv` | `blur` | `serialize_meta`) that was running.
      */
     lastOp: string
 }

--- a/rust/replay-anonymizer-node/src/index.ts
+++ b/rust/replay-anonymizer-node/src/index.ts
@@ -38,6 +38,35 @@ export interface AnonymizeMeta {
     events: AnonymizeEventMeta[]
 }
 
+/**
+ * Phase timings for one {@link anonymizeKafkaPayload} call, measured on the threadpool task.
+ * Reported on success AND failure (including contained panics), so slow or crashing payloads can
+ * be debugged from the same telemetry. Offsets are nanoseconds from `taskStartEpochMs`; a `null`
+ * boundary means the phase was never reached.
+ */
+export interface AnonymizeTimings {
+    /**
+     * Wall-clock time the threadpool picked the task up (epoch ms). The gap from when the caller
+     * invoked the addon to this is the libuv threadpool queue wait.
+     */
+    taskStartEpochMs: number
+    decompressStartNs: number | null
+    decompressEndNs: number | null
+    scrubStartNs: number | null
+    scrubEndNs: number | null
+    /** Accumulated cv de/recompression time across all events in the message. */
+    cvTotalNs: number
+    cvCount: number
+    /** Accumulated image blur/pixelate time (cache misses only). */
+    blurTotalNs: number
+    blurCount: number
+    /**
+     * The op in flight when processing stopped: `done` on success, else the phase or op
+     * (`decompress` | `scrub` | `cv` | `blur` | `serialize_meta`) that was running.
+     */
+    lastOp: string
+}
+
 export interface AnonymizeKafkaPayloadResult {
     /** True if the message could not be anonymized — the caller must drop or DLQ it (fail-closed). */
     failed: boolean
@@ -58,6 +87,8 @@ export interface AnonymizeKafkaPayloadResult {
      * whole-message parse fallback fired; the label is an A/B / fallback-rate signal.
      */
     route: 'stream' | 'tree' | null
+    /** Phase timings; present on success and failure alike. `null` only if serialization failed. */
+    timings: AnonymizeTimings | null
 }
 
 /** Initialize the process-wide allow lists. Call once at startup before {@link anonymizeKafkaPayload}. */
@@ -73,9 +104,19 @@ export function initAnonymizer(allow: AllowListsInput): void {
  *
  * `cv` payloads re-emit as zstd; the reader dispatches on magic bytes.
  */
-export function anonymizeKafkaPayload(
+export async function anonymizeKafkaPayload(
     payload: Buffer,
     contentEncoding?: string | null
 ): Promise<AnonymizeKafkaPayloadResult> {
-    return native.anonymizeKafkaPayload(payload, contentEncoding ?? undefined)
+    const result = await native.anonymizeKafkaPayload(payload, contentEncoding ?? undefined)
+    // Timings are best-effort telemetry: a malformed timings blob must never fail the message.
+    let timings: AnonymizeTimings | null = null
+    if (typeof result.timings === 'string') {
+        try {
+            timings = JSON.parse(result.timings)
+        } catch {
+            timings = null
+        }
+    }
+    return { ...result, timings }
 }

--- a/rust/replay-anonymizer-node/src/lib.rs
+++ b/rust/replay-anonymizer-node/src/lib.rs
@@ -46,8 +46,7 @@ fn init_anonymizer(mut cx: FunctionContext) -> JsResult<JsNull> {
 /// unclassified error (panic, missing init) that the caller must treat as `anonymize_failed`.
 type TaskOutcome = Result<Result<(Vec<u8>, String, &'static str), (&'static str, String)>, String>;
 
-/// The outcome plus the JSON phase timings, which are reported on every arm — success, classified
-/// failure, and panic — so slow or crashing payloads can be debugged from the same telemetry.
+/// The outcome plus the JSON phase timings, reported on every arm including panics.
 type TaskResult = (TaskOutcome, Option<String>);
 
 fn anonymize_kafka_payload_ffi(mut cx: FunctionContext) -> JsResult<JsPromise> {
@@ -60,11 +59,13 @@ fn anonymize_kafka_payload_ffi(mut cx: FunctionContext) -> JsResult<JsPromise> {
         .argument_opt(1)
         .and_then(|v| v.downcast::<JsString, _>(&mut cx).ok())
         .map(|s| s.value(&mut cx));
+    // Created on the JS thread so every offset shares one monotonic origin: the task-start mark
+    // becomes the threadpool queue wait, and no wall clock is involved.
+    let timings = PhaseTimings::new();
     let promise = cx
         .task(move || -> TaskResult {
-            // The sink lives outside the catch_unwind so whatever phases completed before a panic
-            // still reach the caller — errored messages carry timings too.
-            let timings = PhaseTimings::new();
+            timings.task_started();
+            // The sink stays outside the catch_unwind so partial timings survive a panic.
             // Contain any panic on untrusted input so it fails closed (the caller drops the message)
             // rather than risking process abort.
             let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/rust/replay-anonymizer-node/src/lib.rs
+++ b/rust/replay-anonymizer-node/src/lib.rs
@@ -11,7 +11,7 @@ use std::sync::RwLock;
 
 use neon::prelude::*;
 use neon::types::buffer::TypedArray;
-use posthog_replay_anonymizer::{snapshot, AllowLists, FailKind};
+use posthog_replay_anonymizer::{snapshot, AllowLists, FailKind, PhaseTimings};
 use serde::Deserialize;
 
 // The fail-closed contract depends on `catch_unwind` containing panics on untrusted input. Under
@@ -46,6 +46,10 @@ fn init_anonymizer(mut cx: FunctionContext) -> JsResult<JsNull> {
 /// unclassified error (panic, missing init) that the caller must treat as `anonymize_failed`.
 type TaskOutcome = Result<Result<(Vec<u8>, String, &'static str), (&'static str, String)>, String>;
 
+/// The outcome plus the JSON phase timings, which are reported on every arm — success, classified
+/// failure, and panic — so slow or crashing payloads can be debugged from the same telemetry.
+type TaskResult = (TaskOutcome, Option<String>);
+
 fn anonymize_kafka_payload_ffi(mut cx: FunctionContext) -> JsResult<JsPromise> {
     // One copy on the event loop: the buffer's bytes move into the task (they can't be borrowed
     // across threads, and simd-json needs a mutable scratch anyway). Decompression happens inside
@@ -57,38 +61,60 @@ fn anonymize_kafka_payload_ffi(mut cx: FunctionContext) -> JsResult<JsPromise> {
         .and_then(|v| v.downcast::<JsString, _>(&mut cx).ok())
         .map(|s| s.value(&mut cx));
     let promise = cx
-        .task(move || -> TaskOutcome {
+        .task(move || -> TaskResult {
+            // The sink lives outside the catch_unwind so whatever phases completed before a panic
+            // still reach the caller — errored messages carry timings too.
+            let timings = PhaseTimings::new();
             // Contain any panic on untrusted input so it fails closed (the caller drops the message)
             // rather than risking process abort.
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 let guard = ALLOW
                     .read()
                     .map_err(|_| "allow lists lock poisoned".to_string())?;
                 let allow = guard.as_ref().ok_or_else(|| {
                     "anonymizer not initialized (call initAnonymizer first)".to_string()
                 })?;
+                timings.decompress_started();
                 let mut payload =
                     match snapshot::decompress_payload(raw, content_encoding.as_deref()) {
                         Ok(p) => p,
                         Err(f) => return Ok(Err((f.kind.reason(), f.detail))),
                     };
-                match snapshot::anonymize_kafka_payload_opts(
+                timings.decompress_finished();
+                timings.scrub_started();
+                let scrubbed = snapshot::anonymize_kafka_payload_timed(
                     allow,
                     &mut payload,
                     snapshot::AnonymizeOpts::default(),
-                ) {
+                    Some(&timings),
+                );
+                timings.scrub_finished();
+                match scrubbed {
                     Ok(out) => {
+                        timings.mark("serialize_meta");
                         let meta = serde_json::to_string(&out.meta)
                             .map_err(|e| format!("serialize meta: {e}"))?;
+                        timings.mark("done");
                         Ok(Ok((out.lines, meta, out.route.as_str())))
                     }
                     Err(f) => Ok(Err((f.kind.reason(), f.detail))),
                 }
             }))
-            .unwrap_or_else(|_| Err("panic while anonymizing".to_string()))
+            .unwrap_or_else(|_| Err("panic while anonymizing".to_string()));
+            (outcome, serde_json::to_string(&timings.snapshot()).ok())
         })
-        .promise(|mut cx, result: TaskOutcome| {
+        .promise(|mut cx, (result, timings_json): TaskResult| {
             let obj = cx.empty_object();
+            match timings_json {
+                Some(json) => {
+                    let timings = cx.string(json);
+                    obj.set(&mut cx, "timings", timings)?;
+                }
+                None => {
+                    let null = cx.null();
+                    obj.set(&mut cx, "timings", null)?;
+                }
+            }
             let set_failure = |cx: &mut TaskContext<'_>,
                                obj: &Handle<'_, JsObject>,
                                reason: &str,

--- a/rust/replay-anonymizer/src/context.rs
+++ b/rust/replay-anonymizer/src/context.rs
@@ -12,6 +12,7 @@ use anyhow::{bail, Result};
 
 use crate::allow_lists::AllowLists;
 use crate::blur::{blur_image_data_uri, pixelate_raw_rgba};
+use crate::timings::PhaseTimings;
 
 /// Cumulative decompressed-bytes budget across all cv payloads in one message: the per-payload
 /// `compression::MAX_DECOMPRESSED_BYTES` cap bounds each field, this bounds their sum so many high-ratio
@@ -25,14 +26,28 @@ pub struct Ctx<'a> {
     // key: the original data URI (data-image blur), or `raw:{w}x{h}:{base64}` (raw RGBA pixelate).
     // value: the blurred result, or `None` when blurring failed (caller falls back to a blank pixel).
     blur_cache: RefCell<HashMap<String, Option<String>>>,
+    timings: Option<&'a PhaseTimings>,
 }
 
 impl<'a> Ctx<'a> {
     pub fn new(allow: &'a AllowLists) -> Self {
+        Self::with_timings(allow, None)
+    }
+
+    pub fn with_timings(allow: &'a AllowLists, timings: Option<&'a PhaseTimings>) -> Self {
         Self {
             allow,
             cv_budget: Cell::new(CV_MESSAGE_DECOMPRESSION_BUDGET),
             blur_cache: RefCell::new(HashMap::new()),
+            timings,
+        }
+    }
+
+    /// Time an op into the sink when one is attached; transparent otherwise.
+    fn timed<T>(&self, op: &'static str, f: impl FnOnce() -> T) -> T {
+        match self.timings {
+            Some(t) => t.time_op(op, f),
+            None => f(),
         }
     }
 
@@ -47,7 +62,7 @@ impl<'a> Ctx<'a> {
     /// codecs directly. Magic-byte dispatch (gzip or zstd, unknown fails closed) lives in
     /// [`crate::compression::decompress_by_magic`]; this layers the cumulative budget on top.
     pub fn decompress_cv(&self, raw: &[u8]) -> Result<Vec<u8>> {
-        let out = crate::compression::decompress_by_magic(raw)?;
+        let out = self.timed("cv", || crate::compression::decompress_by_magic(raw))?;
         match self.cv_budget.get().checked_sub(out.len()) {
             Some(rest) => self.cv_budget.set(rest),
             None => bail!("message exceeds the cumulative cv decompression budget"),
@@ -59,11 +74,12 @@ impl<'a> Ctx<'a> {
     // borrow-free, so a future blur helper that re-entered `Ctx` still couldn't double-borrow-panic.
 
     /// Blur a data-image URI, memoized on the URI. `None` → caller falls back to a blank/placeholder.
+    /// Only cache misses are timed — the hit path is a map lookup, not blur work.
     pub fn blur_data_uri(&self, original: &str) -> Option<String> {
         if let Some(hit) = self.blur_cache.borrow().get(original) {
             return hit.clone();
         }
-        let result = blur_image_data_uri(original);
+        let result = self.timed("blur", || blur_image_data_uri(original));
         self.blur_cache
             .borrow_mut()
             .insert(original.to_string(), result.clone());
@@ -76,7 +92,7 @@ impl<'a> Ctx<'a> {
         if let Some(hit) = self.blur_cache.borrow().get(&key) {
             return hit.clone();
         }
-        let result = pixelate_raw_rgba(rgba_base64, width, height);
+        let result = self.timed("blur", || pixelate_raw_rgba(rgba_base64, width, height));
         self.blur_cache.borrow_mut().insert(key, result.clone());
         result
     }

--- a/rust/replay-anonymizer/src/context.rs
+++ b/rust/replay-anonymizer/src/context.rs
@@ -43,7 +43,6 @@ impl<'a> Ctx<'a> {
         }
     }
 
-    /// Time an op into the sink when one is attached; transparent otherwise.
     fn timed<T>(&self, op: &'static str, f: impl FnOnce() -> T) -> T {
         match self.timings {
             Some(t) => t.time_op(op, f),
@@ -74,7 +73,6 @@ impl<'a> Ctx<'a> {
     // borrow-free, so a future blur helper that re-entered `Ctx` still couldn't double-borrow-panic.
 
     /// Blur a data-image URI, memoized on the URI. `None` → caller falls back to a blank/placeholder.
-    /// Only cache misses are timed — the hit path is a map lookup, not blur work.
     pub fn blur_data_uri(&self, original: &str) -> Option<String> {
         if let Some(hit) = self.blur_cache.borrow().get(original) {
             return hit.clone();

--- a/rust/replay-anonymizer/src/lib.rs
+++ b/rust/replay-anonymizer/src/lib.rs
@@ -50,6 +50,7 @@ pub mod scan;
 pub mod snapshot;
 #[doc(hidden)]
 pub mod text;
+pub mod timings;
 #[cfg(feature = "typed-parse")]
 pub mod typed;
 mod unwind;
@@ -65,9 +66,10 @@ pub use event::{
     anonymize_message,
 };
 pub use snapshot::{
-    anonymize_kafka_payload, anonymize_kafka_payload_opts, AnonymizeOpts, AnonymizedMessage,
-    FailKind, Failure, Route,
+    anonymize_kafka_payload, anonymize_kafka_payload_opts, anonymize_kafka_payload_timed,
+    AnonymizeOpts, AnonymizedMessage, FailKind, Failure, Route,
 };
+pub use timings::{PhaseTimings, PhaseTimingsSnapshot};
 #[cfg(feature = "typed-parse")]
 pub use typed::{parse_scrubbed_event, parse_scrubbed_event_with_ctx};
 

--- a/rust/replay-anonymizer/src/snapshot.rs
+++ b/rust/replay-anonymizer/src/snapshot.rs
@@ -38,6 +38,7 @@ use crate::json::{
     reject_if_too_deep,
 };
 use crate::scan::{self, Span};
+use crate::timings::PhaseTimings;
 
 /// Why a payload could not be anonymized; maps onto the TS pipeline's dlq/drop reasons so the fused
 /// step classifies failures exactly like the TS parse step does.
@@ -223,18 +224,30 @@ pub fn anonymize_kafka_payload_opts(
     payload: &mut [u8],
     opts: AnonymizeOpts,
 ) -> SResult<AnonymizedMessage> {
-    contain_panics(|| anonymize_kafka_payload_opts_impl(allow, payload, opts))
+    anonymize_kafka_payload_timed(allow, payload, opts, None)
+}
+
+/// [`anonymize_kafka_payload_opts`] with a phase-timing sink. The sink must be owned by the caller
+/// outside any `catch_unwind` boundary so partial timings survive a contained panic.
+pub fn anonymize_kafka_payload_timed(
+    allow: &AllowLists,
+    payload: &mut [u8],
+    opts: AnonymizeOpts,
+    timings: Option<&PhaseTimings>,
+) -> SResult<AnonymizedMessage> {
+    contain_panics(|| anonymize_kafka_payload_opts_impl(allow, payload, opts, timings))
 }
 
 fn anonymize_kafka_payload_opts_impl(
     allow: &AllowLists,
     payload: &mut [u8],
     opts: AnonymizeOpts,
+    timings: Option<&PhaseTimings>,
 ) -> SResult<AnonymizedMessage> {
     if let Some((distinct_id_span, data_span)) = scan_outer_envelope(payload) {
         // Resolve distinct_id to an owned string first — the unescape below rewrites the buffer.
         let Ok(distinct_id) = scan::unescape(payload, distinct_id_span) else {
-            return anonymize_kafka_payload_via_parse(allow, payload, opts);
+            return anonymize_kafka_payload_via_parse(allow, payload, opts, timings);
         };
         let distinct_id = distinct_id.into_owned();
         // Point of no return: the in-place unescape consumes the buffer, so failures past here are
@@ -252,9 +265,9 @@ fn anonymize_kafka_payload_opts_impl(
                 "invalid utf-8 in data string",
             ));
         }
-        return anonymize_snapshot_data_opts(allow, &distinct_id, inner, opts);
+        return anonymize_snapshot_data_inner(allow, &distinct_id, inner, opts, timings);
     }
-    anonymize_kafka_payload_via_parse(allow, payload, opts)
+    anonymize_kafka_payload_via_parse(allow, payload, opts, timings)
 }
 
 /// Locate the `distinct_id` + `data` string spans by scanning the outer object. `None` means "let
@@ -329,6 +342,7 @@ fn anonymize_kafka_payload_via_parse(
     allow: &AllowLists,
     payload: &mut [u8],
     opts: AnonymizeOpts,
+    timings: Option<&PhaseTimings>,
 ) -> SResult<AnonymizedMessage> {
     reject_if_too_deep(payload, "kafka payload")
         .map_err(|e| Failure::new(FailKind::InvalidJson, e.to_string()))?;
@@ -354,7 +368,7 @@ fn anonymize_kafka_payload_via_parse(
     };
     // Rare path (the scanner bailed): one owned copy buys the in-place processing a mutable buffer.
     let mut data_bytes = data.as_bytes().to_vec();
-    anonymize_snapshot_data_opts(allow, distinct_id, &mut data_bytes, opts)
+    anonymize_snapshot_data_inner(allow, distinct_id, &mut data_bytes, opts, timings)
 }
 
 /// Anonymize the inner `$snapshot_items` event JSON (the payload's `data` string). The buffer is
@@ -374,18 +388,26 @@ pub fn anonymize_snapshot_data_opts(
     inner: &mut [u8],
     opts: AnonymizeOpts,
 ) -> SResult<AnonymizedMessage> {
-    contain_panics(|| {
-        // No whole-message depth pre-pass here: the byte walk bounds its own recursion and declines
-        // past its limit, and every recursive parse below is preceded by a span-local
-        // reject_if_too_deep — so the common all-walked path never pays a depth scan at all.
-        let ctx = Ctx::new(allow);
-        match stream_message(&ctx, distinct_id, inner, opts)? {
-            Some(msg) => Ok(msg),
-            // Escaped/duplicate envelope keys: only a real parse resolves them, and nothing was
-            // consumed before the signal, so the tree path re-reads the intact buffer.
-            None => anonymize_via_tree_mut(&ctx, distinct_id, inner),
-        }
-    })
+    contain_panics(|| anonymize_snapshot_data_inner(allow, distinct_id, inner, opts, None))
+}
+
+fn anonymize_snapshot_data_inner(
+    allow: &AllowLists,
+    distinct_id: &str,
+    inner: &mut [u8],
+    opts: AnonymizeOpts,
+    timings: Option<&PhaseTimings>,
+) -> SResult<AnonymizedMessage> {
+    // No whole-message depth pre-pass here: the byte walk bounds its own recursion and declines
+    // past its limit, and every recursive parse below is preceded by a span-local
+    // reject_if_too_deep — so the common all-walked path never pays a depth scan at all.
+    let ctx = Ctx::with_timings(allow, timings);
+    match stream_message(&ctx, distinct_id, inner, opts)? {
+        Some(msg) => Ok(msg),
+        // Escaped/duplicate envelope keys: only a real parse resolves them, and nothing was
+        // consumed before the signal, so the tree path re-reads the intact buffer.
+        None => anonymize_via_tree_mut(&ctx, distinct_id, inner),
+    }
 }
 
 const MAX_FAIL_DETAIL: usize = 200;

--- a/rust/replay-anonymizer/src/snapshot.rs
+++ b/rust/replay-anonymizer/src/snapshot.rs
@@ -227,8 +227,8 @@ pub fn anonymize_kafka_payload_opts(
     anonymize_kafka_payload_timed(allow, payload, opts, None)
 }
 
-/// [`anonymize_kafka_payload_opts`] with a phase-timing sink. The sink must be owned by the caller
-/// outside any `catch_unwind` boundary so partial timings survive a contained panic.
+/// [`anonymize_kafka_payload_opts`] with a phase-timing sink, which the caller should own outside
+/// any `catch_unwind` boundary so partial timings survive a contained panic.
 pub fn anonymize_kafka_payload_timed(
     allow: &AllowLists,
     payload: &mut [u8],

--- a/rust/replay-anonymizer/src/timings.rs
+++ b/rust/replay-anonymizer/src/timings.rs
@@ -1,15 +1,12 @@
-//! Phase-timing sink for the snapshot pipeline: contiguous phase boundaries (decompress, scrub)
-//! plus accumulated in-scrub op totals (cv de/recompression, image blur).
+//! Phase-timing sink for the snapshot pipeline: contiguous phase boundaries plus accumulated
+//! in-scrub op totals (cv de/recompression, image blur), all as nanosecond offsets from one
+//! monotonic origin captured when the sink is created.
 //!
-//! The sink is `Cell`-based and owned by the caller *outside* any `catch_unwind` boundary, so
-//! whatever phases completed before a panic are still readable afterwards — the addon reports
-//! timings on the failure path too, which is how a panicking payload gets debugged.
-//!
-//! `last_op` is the in-flight marker: each op sets it on entry and restores `"scrub"` on a clean
-//! exit, so after a panic it names the op that was running.
+//! `Cell`-based so the caller can own it outside a `catch_unwind` boundary: whatever completed
+//! before a panic is still readable, and `last_op` names the op that was in flight.
 
 use std::cell::Cell;
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use std::time::Instant;
 
 use serde::Serialize;
 
@@ -17,7 +14,7 @@ const UNSET: u64 = u64::MAX;
 
 pub struct PhaseTimings {
     origin: Instant,
-    origin_epoch_ms: f64,
+    task_start_ns: Cell<u64>,
     decompress_start_ns: Cell<u64>,
     decompress_end_ns: Cell<u64>,
     scrub_start_ns: Cell<u64>,
@@ -29,13 +26,11 @@ pub struct PhaseTimings {
     last_op: Cell<&'static str>,
 }
 
-/// Plain serializable view of a [`PhaseTimings`]; field names match the TS `AnonymizeTimings`.
+/// Serializable view of a [`PhaseTimings`]; field names match the TS `AnonymizeTimings`.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PhaseTimingsSnapshot {
-    /// Wall-clock time the task started (when the sink was created), epoch milliseconds.
-    pub task_start_epoch_ms: f64,
-    /// Phase boundaries as nanosecond offsets from `task_start_epoch_ms`; `None` = never reached.
+    pub task_start_ns: Option<u64>,
     pub decompress_start_ns: Option<u64>,
     pub decompress_end_ns: Option<u64>,
     pub scrub_start_ns: Option<u64>,
@@ -52,10 +47,7 @@ impl PhaseTimings {
     pub fn new() -> Self {
         Self {
             origin: Instant::now(),
-            origin_epoch_ms: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_secs_f64() * 1000.0)
-                .unwrap_or(0.0),
+            task_start_ns: Cell::new(UNSET),
             decompress_start_ns: Cell::new(UNSET),
             decompress_end_ns: Cell::new(UNSET),
             scrub_start_ns: Cell::new(UNSET),
@@ -64,12 +56,17 @@ impl PhaseTimings {
             cv_count: Cell::new(0),
             blur_total_ns: Cell::new(0),
             blur_count: Cell::new(0),
-            last_op: Cell::new("start"),
+            last_op: Cell::new("queued"),
         }
     }
 
     fn now_ns(&self) -> u64 {
         u64::try_from(self.origin.elapsed().as_nanos()).unwrap_or(u64::MAX - 1)
+    }
+
+    /// Marks the threadpool pickup; the offset from the sink's creation is the queue wait.
+    pub fn task_started(&self) {
+        self.task_start_ns.set(self.now_ns());
     }
 
     pub fn decompress_started(&self) {
@@ -94,9 +91,8 @@ impl PhaseTimings {
         self.last_op.set(op);
     }
 
-    /// Time one in-scrub op, accumulating into the `total`/`count` pair named by `op` ("cv" or
-    /// "blur"). Restores the `"scrub"` marker only on clean exit — a panic inside `f` leaves
-    /// `last_op` naming the op that died.
+    /// Times one in-scrub op into the `cv` or `blur` totals. Restores the `"scrub"` marker only on
+    /// clean exit, so after a panic `last_op` names the op that died.
     pub(crate) fn time_op<T>(&self, op: &'static str, f: impl FnOnce() -> T) -> T {
         let (total, count) = match op {
             "cv" => (&self.cv_total_ns, &self.cv_count),
@@ -115,7 +111,7 @@ impl PhaseTimings {
     pub fn snapshot(&self) -> PhaseTimingsSnapshot {
         let opt = |c: &Cell<u64>| Some(c.get()).filter(|&v| v != UNSET);
         PhaseTimingsSnapshot {
-            task_start_epoch_ms: self.origin_epoch_ms,
+            task_start_ns: opt(&self.task_start_ns),
             decompress_start_ns: opt(&self.decompress_start_ns),
             decompress_end_ns: opt(&self.decompress_end_ns),
             scrub_start_ns: opt(&self.scrub_start_ns),
@@ -137,6 +133,7 @@ mod tests {
     #[test]
     fn accumulates_ops_and_phase_boundaries() {
         let t = PhaseTimings::new();
+        t.task_started();
         t.decompress_started();
         t.decompress_finished();
         t.scrub_started();
@@ -146,6 +143,7 @@ mod tests {
         t.scrub_finished();
 
         let snap = t.snapshot();
+        assert!(snap.task_start_ns.unwrap() <= snap.decompress_start_ns.unwrap());
         assert!(snap.decompress_start_ns.unwrap() <= snap.decompress_end_ns.unwrap());
         assert!(snap.scrub_start_ns.unwrap() <= snap.scrub_end_ns.unwrap());
         assert_eq!(snap.cv_count, 1);
@@ -156,6 +154,7 @@ mod tests {
     #[test]
     fn survives_a_panic_and_names_the_op_in_flight() {
         let t = PhaseTimings::new();
+        t.task_started();
         t.decompress_started();
         t.decompress_finished();
         t.scrub_started();

--- a/rust/replay-anonymizer/src/timings.rs
+++ b/rust/replay-anonymizer/src/timings.rs
@@ -1,0 +1,179 @@
+//! Phase-timing sink for the snapshot pipeline: contiguous phase boundaries (decompress, scrub)
+//! plus accumulated in-scrub op totals (cv de/recompression, image blur).
+//!
+//! The sink is `Cell`-based and owned by the caller *outside* any `catch_unwind` boundary, so
+//! whatever phases completed before a panic are still readable afterwards — the addon reports
+//! timings on the failure path too, which is how a panicking payload gets debugged.
+//!
+//! `last_op` is the in-flight marker: each op sets it on entry and restores `"scrub"` on a clean
+//! exit, so after a panic it names the op that was running.
+
+use std::cell::Cell;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+
+const UNSET: u64 = u64::MAX;
+
+pub struct PhaseTimings {
+    origin: Instant,
+    origin_epoch_ms: f64,
+    decompress_start_ns: Cell<u64>,
+    decompress_end_ns: Cell<u64>,
+    scrub_start_ns: Cell<u64>,
+    scrub_end_ns: Cell<u64>,
+    cv_total_ns: Cell<u64>,
+    cv_count: Cell<u32>,
+    blur_total_ns: Cell<u64>,
+    blur_count: Cell<u32>,
+    last_op: Cell<&'static str>,
+}
+
+/// Plain serializable view of a [`PhaseTimings`]; field names match the TS `AnonymizeTimings`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PhaseTimingsSnapshot {
+    /// Wall-clock time the task started (when the sink was created), epoch milliseconds.
+    pub task_start_epoch_ms: f64,
+    /// Phase boundaries as nanosecond offsets from `task_start_epoch_ms`; `None` = never reached.
+    pub decompress_start_ns: Option<u64>,
+    pub decompress_end_ns: Option<u64>,
+    pub scrub_start_ns: Option<u64>,
+    pub scrub_end_ns: Option<u64>,
+    pub cv_total_ns: u64,
+    pub cv_count: u32,
+    pub blur_total_ns: u64,
+    pub blur_count: u32,
+    pub last_op: &'static str,
+}
+
+impl PhaseTimings {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            origin: Instant::now(),
+            origin_epoch_ms: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs_f64() * 1000.0)
+                .unwrap_or(0.0),
+            decompress_start_ns: Cell::new(UNSET),
+            decompress_end_ns: Cell::new(UNSET),
+            scrub_start_ns: Cell::new(UNSET),
+            scrub_end_ns: Cell::new(UNSET),
+            cv_total_ns: Cell::new(0),
+            cv_count: Cell::new(0),
+            blur_total_ns: Cell::new(0),
+            blur_count: Cell::new(0),
+            last_op: Cell::new("start"),
+        }
+    }
+
+    fn now_ns(&self) -> u64 {
+        u64::try_from(self.origin.elapsed().as_nanos()).unwrap_or(u64::MAX - 1)
+    }
+
+    pub fn decompress_started(&self) {
+        self.last_op.set("decompress");
+        self.decompress_start_ns.set(self.now_ns());
+    }
+
+    pub fn decompress_finished(&self) {
+        self.decompress_end_ns.set(self.now_ns());
+    }
+
+    pub fn scrub_started(&self) {
+        self.last_op.set("scrub");
+        self.scrub_start_ns.set(self.now_ns());
+    }
+
+    pub fn scrub_finished(&self) {
+        self.scrub_end_ns.set(self.now_ns());
+    }
+
+    pub fn mark(&self, op: &'static str) {
+        self.last_op.set(op);
+    }
+
+    /// Time one in-scrub op, accumulating into the `total`/`count` pair named by `op` ("cv" or
+    /// "blur"). Restores the `"scrub"` marker only on clean exit — a panic inside `f` leaves
+    /// `last_op` naming the op that died.
+    pub(crate) fn time_op<T>(&self, op: &'static str, f: impl FnOnce() -> T) -> T {
+        let (total, count) = match op {
+            "cv" => (&self.cv_total_ns, &self.cv_count),
+            _ => (&self.blur_total_ns, &self.blur_count),
+        };
+        self.last_op.set(op);
+        let start = Instant::now();
+        let out = f();
+        let elapsed = u64::try_from(start.elapsed().as_nanos()).unwrap_or(u64::MAX - 1);
+        total.set(total.get().saturating_add(elapsed));
+        count.set(count.get().saturating_add(1));
+        self.last_op.set("scrub");
+        out
+    }
+
+    pub fn snapshot(&self) -> PhaseTimingsSnapshot {
+        let opt = |c: &Cell<u64>| Some(c.get()).filter(|&v| v != UNSET);
+        PhaseTimingsSnapshot {
+            task_start_epoch_ms: self.origin_epoch_ms,
+            decompress_start_ns: opt(&self.decompress_start_ns),
+            decompress_end_ns: opt(&self.decompress_end_ns),
+            scrub_start_ns: opt(&self.scrub_start_ns),
+            scrub_end_ns: opt(&self.scrub_end_ns),
+            cv_total_ns: self.cv_total_ns.get(),
+            cv_count: self.cv_count.get(),
+            blur_total_ns: self.blur_total_ns.get(),
+            blur_count: self.blur_count.get(),
+            last_op: self.last_op.get(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unwind::contain_unwind;
+
+    #[test]
+    fn accumulates_ops_and_phase_boundaries() {
+        let t = PhaseTimings::new();
+        t.decompress_started();
+        t.decompress_finished();
+        t.scrub_started();
+        t.time_op("cv", || {});
+        t.time_op("blur", || {});
+        t.time_op("blur", || {});
+        t.scrub_finished();
+
+        let snap = t.snapshot();
+        assert!(snap.decompress_start_ns.unwrap() <= snap.decompress_end_ns.unwrap());
+        assert!(snap.scrub_start_ns.unwrap() <= snap.scrub_end_ns.unwrap());
+        assert_eq!(snap.cv_count, 1);
+        assert_eq!(snap.blur_count, 2);
+        assert_eq!(snap.last_op, "scrub");
+    }
+
+    #[test]
+    fn survives_a_panic_and_names_the_op_in_flight() {
+        let t = PhaseTimings::new();
+        t.decompress_started();
+        t.decompress_finished();
+        t.scrub_started();
+        t.time_op("cv", || {});
+        let result = contain_unwind(
+            || -> Result<(), String> {
+                t.time_op("blur", || panic!("image decode exploded"));
+                Ok(())
+            },
+            |m| m,
+        );
+        assert!(result.is_err());
+
+        let snap = t.snapshot();
+        assert!(snap.decompress_end_ns.is_some());
+        assert!(snap.scrub_start_ns.is_some());
+        assert_eq!(snap.scrub_end_ns, None);
+        assert_eq!(snap.cv_count, 1);
+        assert_eq!(snap.last_op, "blur");
+    }
+}


### PR DESCRIPTION
## Problem

The ml-mirror lane's Rust anonymizer (`@posthog/replay-anonymizer`) shows up in APM traces as a single opaque `parseAndAnonymizeMessageStep` span. Production shows a bimodal latency distribution for that step (p50 ~2ms, but ~30% of messages land in a 50-500ms mode, with a tail past 5s), and today there is no way to tell whether a slow message spent its time in payload decompression, the scrub walk, cv de/recompression, or image blur. There is also no visibility into libuv threadpool queue wait, which we need before making scrubs concurrent. When a payload makes the addon panic, we get even less: a drop with no timing at all.

## Changes

The addon now measures phase timings inside the threadpool task and the JS step materializes them as retroactive child spans of the step span, in the same trace.

```mermaid
flowchart LR
    Step[parseAndAnonymizeMessageStep] --> Task{{Rust threadpool task}}
    Task --> Sink[(PhaseTimings sink)]
    Sink --> Spans[anonymize.queueWait / .decompress / .scrub]
    Spans --> Trace[existing batch trace]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Task phBlue;
    class Step,Trace phYellow;
    class Sink,Spans phGray;
```

- `rust/replay-anonymizer/src/timings.rs` (new): `PhaseTimings`, a Cell-based sink recording contiguous phase boundaries (decompress, scrub) plus accumulated op totals (cv de/recompression, image blur, cache misses only) and a `last_op` in-flight marker.
- `Ctx` optionally carries the sink and times `decompress_cv` / `blur_data_uri` / `pixelate_raw`; new `anonymize_kafka_payload_timed` entry point threads it through (existing public API unchanged).
- The Neon addon creates the sink outside its `catch_unwind` and attaches a `timings` JSON blob to the result on every arm: success, classified failure, and panic. A panicking payload reports whatever phases completed plus the op that was running when it died.
- `parse-and-anonymize-step.ts` converts the timings into child spans with explicit timestamps: `anonymize.queueWait` (JS call to task pickup, i.e. libuv threadpool queue wait), `anonymize.decompress`, and `anonymize.scrub` with `cv_total_ms` / `cv_count` / `blur_total_ms` / `blur_count` / `route` / `last_op` attributes. Failures set span status ERROR with the dlq/drop reason.

> [!NOTE]
> Timings are best-effort telemetry: a missing or malformed timings blob never affects message processing, and span emission is skipped when `DISABLE_OPENTELEMETRY_TRACING` is set.

## How did you test this code?

- `cargo test -p posthog-replay-anonymizer` (all suites pass). New tests in `timings.rs` catch two regressions nothing else covers: op totals silently un-wired from `Ctx`, and timings lost across a contained panic (the sink must keep partial phases and name the in-flight op).
- `hogli test nodejs/.../shared-fixtures.test.ts` against the freshly built addon. Two new cases pin the FFI contract: ordered phase boundaries with cv op counts on success, and timings still present on a failing payload (truncated gzip) with `lastOp: decompress`. That failure-arm guarantee is the debugging requirement this PR exists for.
- `hogli test nodejs/.../parse-and-anonymize-step.test.ts` (mocked addon, 14 pass) exercises the timings-absent path since the existing mocks return no `timings` field.
- `cargo clippy` and addon `tsc` clean. `pnpm typescript:check` in nodejs has 15 pre-existing failures (missing local `@posthog/hogvm` artifact, cdp files only), identical with and without this diff.
- Not done: no production/staging verification of the emitted spans; that happens on deploy by checking the trace view for `anonymize.*` children under `parseAndAnonymizeMessageStep`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None; internal telemetry only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie in a Claude Code session investigating ml-mirror consumer lag with the PostHog APM MCP tools. The trace analysis showed the anonymize step is the dominant per-batch cost with a heavy-tailed second mode, and that nothing attributes time below the FFI boundary. We considered full OTel inside the addon (tracing-opentelemetry + OTLP exporter with context propagation over FFI) but chose caller-materialized spans: no second export pipeline in the process, and it is the only design that can measure threadpool queue wait. Skills invoked: /writing-tests. The `simplify` pass was not run; the diff is small and shaped by the existing fail-closed patterns in the addon.
