### PR TITLE
fix(data-management): guard against null currentTeam in managed viewsets page

### DIFF
--- a/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetCard.tsx
+++ b/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetCard.tsx
@@ -48,7 +48,7 @@ export function DataWarehouseManagedViewsetCard({
     const { togglingViewset, toggleResultLoading } = useValues(dataWarehouseManagedViewsetsLogic({ type }))
 
     const { title, description, docsUrl, configUrl, icon } = VIEWSET_DESCRIPTIONS[kind]
-    const isEnabled = currentTeam!.managed_viewsets![kind]
+    const isEnabled = !!currentTeam?.managed_viewsets?.[kind]
     const isToggling = togglingViewset === kind && toggleResultLoading
 
     return (

--- a/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetsScene.tsx
+++ b/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetsScene.tsx
@@ -36,7 +36,7 @@ export function DataWarehouseManagedViewsetsScene(): JSX.Element {
 
     const { loadCurrentTeam } = useActions(teamLogic)
 
-    if (!featureFlags[FEATURE_FLAGS.REVENUE_ANALYTICS]) {
+    if (!featureFlags[FEATURE_FLAGS.MANAGED_VIEWSETS]) {
         return (
             <SceneContent>
                 <SceneTitleSection
@@ -51,7 +51,11 @@ export function DataWarehouseManagedViewsetsScene(): JSX.Element {
         )
     }
 
-    const managedViewsets = currentTeam!.managed_viewsets!
+    const managedViewsets = currentTeam?.managed_viewsets ?? {}
+
+    if (!managedViewsets || Object.keys(managedViewsets).length === 0) {
+        return null
+    }
 
     const onConfirmDisable = async (): Promise<boolean> => {
         if (!kind) {

--- a/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetsScene.tsx
+++ b/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetsScene.tsx
@@ -27,7 +27,7 @@ const RESOURCE_TYPES_MAP: Record<DataWarehouseManagedViewsetKind, AccessControlR
     revenue_analytics: AccessControlResourceType.RevenueAnalytics,
 }
 
-export function DataWarehouseManagedViewsetsScene(): JSX.Element {
+export function DataWarehouseManagedViewsetsScene(): JSX.Element | null {
     const { currentTeam } = useValues(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { kind, views } = useValues(
@@ -51,11 +51,11 @@ export function DataWarehouseManagedViewsetsScene(): JSX.Element {
         )
     }
 
-    const managedViewsets = currentTeam?.managed_viewsets ?? {}
-
-    if (!managedViewsets || Object.keys(managedViewsets).length === 0) {
+    if (!currentTeam) {
         return null
     }
+
+    const managedViewsets = currentTeam.managed_viewsets ?? {}
 
     const onConfirmDisable = async (): Promise<boolean> => {
         if (!kind) {


### PR DESCRIPTION
## Problem

The managed viewsets page at `/data-management/managed-viewsets` crashed with a runtime error. The scene dereferenced `currentTeam` using non-null assertions (`currentTeam!.managed_viewsets!`) without guarding against `currentTeam` being `null` (while loading) or `managed_viewsets` being `undefined` on `TeamPublicType` (which is `Partial<TeamType>`).

A secondary issue: the tab that shows this scene is gated behind `FEATURE_FLAGS.MANAGED_VIEWSETS`, but the scene component itself checked `FEATURE_FLAGS.REVENUE_ANALYTICS` — a different flag for a different product. Users with `managed-viewsets` enabled but `revenue-analytics` disabled would see the "upcoming feature" placeholder instead of the actual content.

## Changes

- `DataWarehouseManagedViewsetsScene.tsx`: Replaced `currentTeam!.managed_viewsets!` with `currentTeam?.managed_viewsets ?? {}` and added an early return when the data isn't available yet. Fixed the feature flag check from `REVENUE_ANALYTICS` to `MANAGED_VIEWSETS` to match the tab's gate.
- `DataWarehouseManagedViewsetCard.tsx`: Replaced `currentTeam!.managed_viewsets![kind]` with `!!currentTeam?.managed_viewsets?.[kind]` so it safely returns `false` instead of crashing.

## How did I test this code?

Code review only. The fix is a straightforward null-safety change: non-null assertions replaced with optional chaining and fallback values. I verified the types — `currentTeam` is `TeamType | TeamPublicType | null` and `managed_viewsets` is always present on `TeamType` but optional on `TeamPublicType`. The `node_modules` weren't available in this environment to run typecheck or lint, but the change only swaps one valid `FEATURE_FLAGS` key for another and replaces `!` assertions with `?.` chains.

## 🤖 Agent context

**Autonomy:** Fully autonomous

The user reported an error on the `/data-management/managed-viewsets` page. I traced the crash to null dereferences in `DataWarehouseManagedViewsetsScene.tsx` (line 54, `currentTeam!.managed_viewsets!`) and `DataWarehouseManagedViewsetCard.tsx` (line 51, `currentTeam!.managed_viewsets![kind]`), where `currentTeam` can be `null` during loading or when the team object is a `TeamPublicType` missing the `managed_viewsets` field. I also found a feature flag mismatch between the tab gate (`MANAGED_VIEWSETS`) and the scene's internal check (`REVENUE_ANALYTICS`) and corrected it to match.
