### PR TITLE
feat(replay): extend ml anonymize histogram past 10s

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/metrics.ts
@@ -64,7 +64,9 @@ export class SessionRecordingIngesterMetrics {
         name: 'recording_blob_ingestion_v2_ml_anonymize_duration_ms',
         help: 'Per-message ML mirror anonymize time in ms, by implementation and route',
         labelNames: ['impl', 'route'],
-        buckets: [0, 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, Infinity],
+        // The measured interval includes libuv threadpool queue wait, which under backpressure
+        // reaches tens of seconds — the tail buckets exist so quantiles don't clamp at 10s.
+        buckets: [0, 1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000, Infinity],
     })
 
     private static readonly mlAnonymizeFailed = new Counter({


### PR DESCRIPTION
## Problem

`recording_blob_ingestion_v2_ml_anonymize_duration_ms` has 10s as its top finite bucket. In Grafana the p99 for `route=stream` sits pinned at exactly 10s, and during backpressure windows even p50 clamps there - the real tail is unmeasurable. The measured interval wraps the `await` on the native anonymizer, so it includes libuv threadpool queue wait, which reaches tens of seconds when the pool backs up.

## Changes

Add 30s / 60s / 120s buckets to the histogram. No other behavior change.

## How did you test this code?

Bucket-list-only change to an existing prom-client histogram; prettier clean. No new tests - there is no behavior to regress beyond prom-client bucketing itself.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None; internal metric only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie, follow-up from an ml-mirror lag investigation in a Claude Code session: Grafana quantile panels showed the pinned 10s ceiling on this metric. Companion PR #72872 adds phase spans that separate queue wait from scrub time.
