### PR TITLE
feat(workflows): decrypt hog flow secret inputs in the worker

### DIFF
--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -356,7 +356,7 @@ export function createCdpCoreServices(
     const valkeyShadow = createCdpValkeyShadowPools(config, redisName)
 
     const hogFunctionManager = new HogFunctionManagerService(deps.postgres, deps.pubSub, deps.encryptedFields)
-    const hogFlowManager = new HogFlowManagerService(deps.postgres, deps.pubSub)
+    const hogFlowManager = new HogFlowManagerService(deps.postgres, deps.pubSub, deps.encryptedFields)
 
     const hogWatcherConfig = {
         hogCostTimingLowerMs: config.CDP_WATCHER_HOG_COST_TIMING_LOWER_MS,

--- a/nodejs/src/cdp/schema/hogflow.ts
+++ b/nodejs/src/cdp/schema/hogflow.ts
@@ -273,6 +273,10 @@ export const HogFlowSchema = z.object({
         'exit_only_at_end',
     ]),
     actions: z.array(HogFlowActionSchema),
+    // Secret function inputs, split out of `actions` and stored Fernet-encrypted at rest, keyed by
+    // action id then input key. Decrypted by the manager and merged back into `action.config.inputs`
+    // before execution; never present on the plaintext `actions` blob.
+    encrypted_inputs: z.record(z.string(), z.record(z.string(), CyclotronInputSchema)).optional().nullable(),
     abort_action: z.string().optional(),
     edges: z.array(HogFlowEdgeSchema),
     variables: z.array(CyclotronJobInputSchemaTypeSchema).optional().nullable(),

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -473,9 +473,14 @@ export class HogFlowExecutorService {
                     timestamp: DateTime.now(),
                 })
             }
+            // Deliberately an allowlisted context, not the full action/invocation: an action's
+            // config.inputs can hold decrypted secrets (API keys, auth headers) that the encrypted_inputs
+            // split keeps out of storage, and dumping them here would put them straight into worker logs.
             logger.debug('🦔', `[HogFlowActionRunner] Running action ${currentAction.type}`, {
-                action: currentAction,
-                invocation,
+                hogFlowId: invocation.hogFlow.id,
+                invocationId: invocation.id,
+                actionId: currentAction.id,
+                actionType: currentAction.type,
             })
 
             const handler = this.actionHandlers[currentAction.type]

--- a/nodejs/src/cdp/services/hogflows/hogflow-manager.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-manager.service.test.ts
@@ -25,7 +25,7 @@ describe('HogFlowManager', () => {
     beforeEach(async () => {
         hub = await createHub()
         await resetTestDatabase()
-        manager = new HogFlowManagerService(hub.postgres, hub.pubSub)
+        manager = new HogFlowManagerService(hub.postgres, hub.pubSub, hub.encryptedFields)
 
         const team = await getTeam(hub.postgres, 2)
 
@@ -179,6 +179,62 @@ describe('HogFlowManager', () => {
             const result = await manager.getHogFlowIdsForTeams([teamId1])
             expect(result[teamId1]).toHaveLength(1)
             expect(result[teamId1]).not.toContain(hogFlows[0].id)
+        })
+    })
+
+    describe('encrypted inputs', () => {
+        it('decrypts and merges secret inputs into the matching action before execution', async () => {
+            const flow = await insertHogFlow(
+                hub.postgres,
+                new FixtureHogFlowBuilder()
+                    .withName('Flow with secret webhook')
+                    .withTeamId(teamId1)
+                    .withStatus('active')
+                    .withWorkflow({
+                        actions: {
+                            trigger: { type: 'trigger', config: { type: 'event', filters: {} } },
+                            send_webhook: {
+                                type: 'function',
+                                config: {
+                                    template_id: 'template-webhook',
+                                    inputs: { url: { value: 'https://example.com' } },
+                                },
+                            },
+                            exit: { type: 'exit', config: {} },
+                        },
+                        edges: [
+                            { from: 'trigger', to: 'send_webhook', type: 'continue' },
+                            { from: 'send_webhook', to: 'exit', type: 'continue' },
+                        ],
+                    })
+                    .build()
+            )
+
+            // The API stores secret inputs Fernet-encrypted, stripped out of the plaintext `actions`.
+            await hub.postgres.query(
+                PostgresUse.COMMON_WRITE,
+                `UPDATE posthog_hogflow SET encrypted_inputs = $2 WHERE id = $1`,
+                [
+                    flow.id,
+                    hub.encryptedFields.encrypt(
+                        JSON.stringify({ send_webhook: { api_key: { value: 'super-secret-key' } } })
+                    ),
+                ],
+                'testKey'
+            )
+            manager['onHogFlowsReloaded'](teamId1, [flow.id])
+
+            const loaded = await manager.getHogFlow(flow.id)
+            const action = loaded?.actions.find((a) => a.id === 'send_webhook')
+            expect(action).not.toBeUndefined()
+
+            // Secret folded back in alongside the untouched plaintext input, keyed by action id.
+            expect((action!.config as { inputs: Record<string, unknown> }).inputs).toEqual({
+                url: { value: 'https://example.com' },
+                api_key: { value: 'super-secret-key' },
+            })
+            // The ciphertext blob never rides along on the in-memory flow.
+            expect(loaded).not.toHaveProperty('encrypted_inputs')
         })
     })
 })

--- a/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-manager.service.ts
@@ -1,9 +1,13 @@
 import { HogFlow } from '~/cdp/schema/hogflow'
 import { PostgresRouter, PostgresUse } from '~/common/utils/db/postgres'
+import { parseJSON } from '~/common/utils/json-parse'
 import { LazyLoader } from '~/common/utils/lazy-loader'
 import { logger } from '~/common/utils/logger'
+import { captureException } from '~/common/utils/posthog'
 import { PubSub } from '~/common/utils/pubsub'
 import { Team } from '~/types'
+
+import { EncryptedFields } from '../../utils/encryption-utils'
 
 // TODO: Make sure we only have fields we truly need
 const HOG_FLOW_FIELDS = [
@@ -21,6 +25,7 @@ const HOG_FLOW_FIELDS = [
     'exit_condition',
     'edges',
     'actions',
+    'encrypted_inputs',
     'abort_action',
     'billable_action_types',
     'variables',
@@ -35,7 +40,8 @@ export class HogFlowManagerService {
 
     constructor(
         private postgres: PostgresRouter,
-        private pubSub: PubSub
+        private pubSub: PubSub,
+        private encryptedFields: EncryptedFields
     ) {
         // The reload-hog-flows pub/sub below is the primary invalidation; these ages bound how
         // stale a worker can run when it misses the publish (pod restart, Redis blip). Live edits
@@ -181,8 +187,51 @@ export class HogFlowManagerService {
                     }
                 }
             }
+            this.mergeEncryptedInputs(item)
             acc[item.id] = item
             return acc
         }, {})
+    }
+
+    // Decrypts `encrypted_inputs` and folds each action's secret inputs back into
+    // `action.config.inputs` so the executor sees a whole config. Encrypted values win over any
+    // (legacy) plaintext still present in `actions`, so a row mid-migration keeps working either way.
+    private mergeEncryptedInputs(item: HogFlow): void {
+        const raw = item.encrypted_inputs as unknown
+
+        let decrypted: Record<string, Record<string, unknown>> | undefined
+        if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+            // The sql lib occasionally hands back an already-parsed object
+            decrypted = raw as Record<string, Record<string, unknown>>
+        } else if (typeof raw === 'string' && raw) {
+            try {
+                const plaintext = this.encryptedFields.decrypt(raw)
+                if (plaintext) {
+                    decrypted = parseJSON(plaintext)
+                }
+            } catch (error) {
+                logger.warn('[HogFlowManager]', 'Could not decrypt encrypted inputs - preserving original value', {
+                    error: error instanceof Error ? error.message : 'Unknown error',
+                })
+                captureException(error)
+            }
+        }
+
+        // Drop the encrypted blob from the in-memory flow either way - downstream reads inputs off
+        // `action.config.inputs`, and this keeps the ciphertext out of anything that logs the flow.
+        delete item.encrypted_inputs
+
+        if (!decrypted) {
+            return
+        }
+
+        for (const action of item.actions ?? []) {
+            const actionSecrets = decrypted[action.id]
+            if (!actionSecrets || !('config' in action)) {
+                continue
+            }
+            const config = action.config as { inputs?: Record<string, unknown> }
+            config.inputs = { ...config.inputs, ...actionSecrets }
+        }
     }
 }


### PR DESCRIPTION
## Problem

Stacked on #72880. Once the API starts splitting a function action's secret inputs into `HogFlow.encrypted_inputs`, those values are no longer present in the plaintext `actions` blob. The nodejs worker reads `action.config.inputs.<key>.value` straight from `actions`, so without this change every function/email/sms step would execute with the secret missing.

This teaches the worker to fetch, decrypt, and re-merge the encrypted column - the same thing `HogFunctionManagerService` already does for `HogFunction.encrypted_inputs`. Part of #72835.

## Changes

In `HogFlowManagerService`:

- `encrypted_inputs` added to `HOG_FLOW_FIELDS`, `EncryptedFields` injected into the constructor.
- `mergeEncryptedInputs` decrypts the column and folds each action's secrets back into `action.config.inputs`, keyed by action id.

Two deliberate properties:

- **Encrypted wins, plaintext is the fallback.** `{ ...action.config.inputs, ...decrypted[action.id] }` - a row mid-migration (secret still in `actions`, column null) keeps working, and once the API strips `actions` the encrypted value is authoritative.
- **The ciphertext blob is dropped off the in-memory flow** after merging, so it never rides along into anything that logs the flow.

> [!NOTE]
> Read-only and a no-op until the API writes the column. Deploy order: #72880 (migration) must be applied first - this PR's `SELECT` references `encrypted_inputs`, so the column has to exist. The API-side split/mask is a later, flag-gated PR.

## How did you test this code?

Added one case to `hogflow-manager.service.test.ts`: a flow row with a Fernet-encrypted `encrypted_inputs` has its secret merged into the matching action's `config.inputs` on fetch (keyed by action id, alongside an untouched plaintext input), and the ciphertext is not present on the returned flow.

It catches the regression where someone drops `encrypted_inputs` from the `SELECT` or the merge - which would silently execute steps with missing secrets. The null/legacy path is already covered by every existing fixture (none set the column), so I did not duplicate it. The pre-existing "returns the hog flow" snapshot passed unchanged, which confirms the merge/delete does not alter the returned shape when there are no secrets.

Ran locally: `env -u DEBUG NODE_ENV=test pnpm exec jest src/cdp/services/hogflows/hogflow-manager.service.test.ts` - 6/6 pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude (Claude Code) wrote it. Chose to decrypt-and-merge in the manager (rather than threading `encrypted_inputs` through `buildHogFunction`) so the executor path is untouched and the in-memory flow looks exactly as it does today. Salvaged the shape from an earlier stale attempt (#49947) that took the same worker approach.

Invoked the `/writing-tests` skill before adding the test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
