### PR TITLE
feat(workflows): capture usage events and distinct activity types

### DIFF
--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -14,7 +14,6 @@ from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
 import structlog
-import posthoganalytics
 from django_filters import BaseInFilter, CharFilter, FilterSet
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
@@ -51,7 +50,7 @@ from posthog.cdp.validation import (
     generate_template_bytecode,
 )
 from posthog.clickhouse.query_tagging import Feature, tag_queries
-from posthog.event_usage import EventSource, get_event_source
+from posthog.event_usage import EventSource, get_event_source, report_user_action
 from posthog.models import Team
 from posthog.models.filters import Filter
 from posthog.plugins.plugin_server_api import (
@@ -1787,6 +1786,26 @@ class HogFlowViewSet(
             ac_resource_type=self.scope_object,
         )
 
+    def _report_workflow_action(self, event: str, instance: HogFlow, extra_properties: Optional[dict] = None) -> None:
+        # report_user_action injects source and MCP-client properties from the request, so usage is
+        # attributable per channel (web builder vs MCP vs raw API). Capture must never break the request.
+        try:
+            report_user_action(
+                self.request.user,
+                event,
+                {
+                    "workflow_id": str(instance.id),
+                    "workflow_name": instance.name,
+                    "team_id": str(self.team_id),
+                    "organization_id": str(self.organization.id),
+                    **(extra_properties or {}),
+                },
+                team=self.team,
+                request=self.request,
+            )
+        except Exception as e:
+            logger.warning("Failed to capture workflow usage event", event=event, error=str(e))
+
     def perform_create(self, serializer):
         if self._is_mcp_request(self.request) and serializer.validated_data.get("status") == HogFlow.State.ACTIVE:
             raise exceptions.ValidationError(
@@ -1798,26 +1817,14 @@ class HogFlowViewSet(
         log_activity_from_viewset(self, serializer.instance, name=serializer.instance.name, detail_type="standard")
         self._emit_resource_edited(serializer.instance)
 
-        try:
-            # Count edges and actions
-            edges_count = len(serializer.instance.edges) if serializer.instance.edges else 0
-            actions_count = len(serializer.instance.actions) if serializer.instance.actions else 0
-
-            posthoganalytics.capture(
-                distinct_id=str(serializer.context["request"].user.distinct_id),
-                event="hog_flow_created",
-                properties={
-                    "workflow_id": str(serializer.instance.id),
-                    "workflow_name": serializer.instance.name,
-                    # "trigger_type": trigger_type,
-                    "edges_count": edges_count,
-                    "actions_count": actions_count,
-                    "team_id": str(self.team_id),
-                    "organization_id": str(self.organization.id),
-                },
-            )
-        except Exception as e:
-            logger.warning("Failed to capture hog_flow_created event", error=str(e))
+        self._report_workflow_action(
+            "hog_flow_created",
+            serializer.instance,
+            {
+                "edges_count": len(serializer.instance.edges or []),
+                "actions_count": len(serializer.instance.actions or []),
+            },
+        )
 
     def perform_update(self, serializer):
         # Guardrails for MCP/LLM callers (gated on x-posthog-client: mcp; the frontend and raw API are
@@ -1921,25 +1928,21 @@ class HogFlowViewSet(
             and before_update.status == HogFlow.State.DRAFT
             and serializer.instance.status == HogFlow.State.ACTIVE
         ):
-            try:
-                # Count edges and actions
-                edges_count = len(serializer.instance.edges) if serializer.instance.edges else 0
-                actions_count = len(serializer.instance.actions) if serializer.instance.actions else 0
+            self._report_workflow_action(
+                "hog_flow_activated",
+                serializer.instance,
+                {
+                    "edges_count": len(serializer.instance.edges or []),
+                    "actions_count": len(serializer.instance.actions or []),
+                },
+            )
 
-                posthoganalytics.capture(
-                    distinct_id=str(serializer.context["request"].user.distinct_id),
-                    event="hog_flow_activated",
-                    properties={
-                        "workflow_id": str(serializer.instance.id),
-                        "workflow_name": serializer.instance.name,
-                        "edges_count": edges_count,
-                        "actions_count": actions_count,
-                        "team_id": str(self.team_id),
-                        "organization_id": str(self.organization.id),
-                    },
-                )
-            except Exception as e:
-                logger.warning("Failed to capture hog_flow_activated event", error=str(e))
+    def perform_destroy(self, instance: HogFlow) -> None:
+        # Workflow deletes are hard deletes; without this override they leave no trail at all.
+        # Log before delete() nulls the instance pk.
+        log_activity_from_viewset(self, instance, activity="deleted", name=instance.name)
+        self._report_workflow_action("hog_flow_deleted", instance, {"via": "destroy"})
+        instance.delete()
 
     def _refresh_action_redirects(
         self, target: HogFlow, old: HogFlow, new_actions: Optional[list], enabled: bool
@@ -2069,8 +2072,15 @@ class HogFlowViewSet(
 
         if not route_to_draft:
             self._maybe_reschedule_timing_edits(before_update, locked)
-        log_activity_from_viewset(self, locked, name=locked.name, previous=before_update)
+        # Explicit "updated" (the action name "graph" isn't in ACTIVITY_TYPES, which would fall back to
+        # the indistinct "changed" and miss the describer's per-field rendering).
+        log_activity_from_viewset(self, locked, activity="updated", name=locked.name, previous=before_update)
         self._emit_resource_edited(locked)
+        self._report_workflow_action(
+            "hog_flow_graph_updated",
+            locked,
+            {"operations_count": len(operations), "routed_to_draft": route_to_draft},
+        )
 
         return Response(self.get_serializer(locked).data)
 
@@ -2232,8 +2242,9 @@ class HogFlowViewSet(
             locked.save(update_fields=["draft", "draft_updated_at"])
 
         self._maybe_reschedule_timing_edits(before_update, locked)
-        log_activity_from_viewset(self, locked, name=locked.name, previous=before_update)
+        log_activity_from_viewset(self, locked, activity="published", name=locked.name, previous=before_update)
         self._emit_resource_edited(locked)
+        self._report_workflow_action("hog_flow_draft_published", locked)
 
         return Response(
             {
@@ -2263,8 +2274,9 @@ class HogFlowViewSet(
             locked.draft_updated_at = None
             locked.save(update_fields=["draft", "draft_updated_at"])
 
-        log_activity_from_viewset(self, locked, name=locked.name, previous=before_update)
+        log_activity_from_viewset(self, locked, activity="draft_discarded", name=locked.name, previous=before_update)
         self._emit_resource_edited(locked)
+        self._report_workflow_action("hog_flow_draft_discarded", locked)
 
         return Response(self.get_serializer(locked).data)
 
@@ -2616,13 +2628,18 @@ class HogFlowViewSet(
         # object-specific viewer override would otherwise be bulk-deletable. Check each candidate explicitly.
         candidates = list(self.get_queryset().filter(id__in=validated_ids, status="archived"))
         self.user_access_control.preload_object_access_controls(candidates)
-        deletable_ids = [
-            flow.id
+        deletable = [
+            flow
             for flow in candidates
             if self.user_access_control.check_access_level_for_object(flow, required_level="editor")
         ]
 
-        deleted_count, _ = self.get_queryset().filter(id__in=deletable_ids).delete()
+        # Hard deletes must leave a trail, same as the single destroy path.
+        for flow in deletable:
+            log_activity_from_viewset(self, flow, activity="deleted", name=flow.name)
+            self._report_workflow_action("hog_flow_deleted", flow, {"via": "bulk_delete"})
+
+        deleted_count, _ = self.get_queryset().filter(id__in=[flow.id for flow in deletable]).delete()
 
         return Response({"deleted": deleted_count})
 
@@ -2750,6 +2767,7 @@ class HogFlowViewSet(
                 return Response(serializer.errors, status=400)
 
             batch_job = serializer.save()
+            self._report_workflow_action("hog_flow_batch_job_created", hog_flow, {"batch_job_id": str(batch_job.id)})
             return Response(HogFlowBatchJobSerializer(batch_job).data)
         else:
             batch_jobs = HogFlowBatchJob.objects.filter(hog_flow=hog_flow, team=self.team).order_by("-created_at")
@@ -2767,7 +2785,8 @@ class HogFlowViewSet(
         if request.method == "POST":
             serializer = HogFlowScheduleSerializer(data=request.data, context=self.get_serializer_context())
             serializer.is_valid(raise_exception=True)
-            serializer.save(team=self.team, hog_flow=hog_flow)
+            schedule = serializer.save(team=self.team, hog_flow=hog_flow)
+            self._report_workflow_action("hog_flow_schedule_created", hog_flow, {"schedule_id": str(schedule.id)})
             return Response(serializer.data, status=201)
 
         schedules = HogFlowSchedule.objects.filter(hog_flow=hog_flow, team=self.team).order_by("-created_at")
@@ -2794,7 +2813,9 @@ class HogFlowViewSet(
             raise exceptions.NotFound("Schedule not found")
 
         if request.method == "DELETE":
+            schedule_id_str = str(schedule.id)
             schedule.delete()
+            self._report_workflow_action("hog_flow_schedule_deleted", hog_flow, {"schedule_id": schedule_id_str})
             return Response(status=204)
 
         serializer = HogFlowScheduleSerializer(
@@ -2802,6 +2823,7 @@ class HogFlowViewSet(
         )
         serializer.is_valid(raise_exception=True)
         serializer.save()
+        self._report_workflow_action("hog_flow_schedule_updated", hog_flow, {"schedule_id": str(schedule.id)})
         return Response(serializer.data)
 
 

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -2342,8 +2342,9 @@ class HogFlowViewSet(
             locked.draft_updated_at = timezone.now()
             locked.save(update_fields=["draft", "draft_updated_at"])
 
-        log_activity_from_viewset(self, locked, name=locked.name, previous=before_update)
+        log_activity_from_viewset(self, locked, activity="revision_restored", name=locked.name, previous=before_update)
         self._emit_resource_edited(locked)
+        self._report_workflow_action("hog_flow_revision_restored", locked, {"version": revision.version})
 
         return Response(self.get_serializer(locked).data)
 

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -1939,10 +1939,14 @@ class HogFlowViewSet(
 
     def perform_destroy(self, instance: HogFlow) -> None:
         # Workflow deletes are hard deletes; without this override they leave no trail at all.
-        # Log before delete() nulls the instance pk.
-        log_activity_from_viewset(self, instance, activity="deleted", name=instance.name)
+        # The audit row shares the delete's transaction so a failed delete rolls it back; the
+        # usage event fires only after commit. delete() nulls the pk, so stash it for the event.
+        flow_id = instance.id
+        with transaction.atomic():
+            log_activity_from_viewset(self, instance, activity="deleted", name=instance.name)
+            instance.delete()
+        instance.id = flow_id
         self._report_workflow_action("hog_flow_deleted", instance, {"via": "destroy"})
-        instance.delete()
 
     def _refresh_action_redirects(
         self, target: HogFlow, old: HogFlow, new_actions: Optional[list], enabled: bool
@@ -2635,12 +2639,24 @@ class HogFlowViewSet(
             if self.user_access_control.check_access_level_for_object(flow, required_level="editor")
         ]
 
-        # Hard deletes must leave a trail, same as the single destroy path.
-        for flow in deletable:
-            log_activity_from_viewset(self, flow, activity="deleted", name=flow.name)
-            self._report_workflow_action("hog_flow_deleted", flow, {"via": "bulk_delete"})
+        # Hard deletes must leave a trail, same as the single destroy path. Lock the rows so the
+        # audit entries match exactly what this request deletes (a concurrently removed row gets no
+        # entry), and share the delete's transaction so a failed delete rolls its audit rows back.
+        # Usage events fire only after commit.
+        with transaction.atomic():
+            deleted_ids = set(
+                self.get_queryset()
+                .select_for_update()
+                .filter(id__in=[flow.id for flow in deletable])
+                .values_list("id", flat=True)
+            )
+            deleted_count, _ = self.get_queryset().filter(id__in=deleted_ids).delete()
+            deleted_flows = [flow for flow in deletable if flow.id in deleted_ids]
+            for flow in deleted_flows:
+                log_activity_from_viewset(self, flow, activity="deleted", name=flow.name)
 
-        deleted_count, _ = self.get_queryset().filter(id__in=[flow.id for flow in deletable]).delete()
+        for flow in deleted_flows:
+            self._report_workflow_action("hog_flow_deleted", flow, {"via": "bulk_delete"})
 
         return Response({"deleted": deleted_count})
 

--- a/products/workflows/backend/api/hog_flow_template.py
+++ b/products/workflows/backend/api/hog_flow_template.py
@@ -3,7 +3,6 @@ from typing import Optional, cast
 from django.db.models import Q
 
 import structlog
-import posthoganalytics
 from drf_spectacular.utils import extend_schema, extend_schema_field
 from rest_framework import mixins, permissions, serializers, status, viewsets
 from rest_framework.permissions import SAFE_METHODS, BasePermission
@@ -13,6 +12,7 @@ from rest_framework.response import Response
 from posthog.api.log_entries import LogEntryMixin
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.cdp.validation import HogFunctionFiltersSerializer
+from posthog.event_usage import report_user_action
 from posthog.helpers.impersonation import is_impersonated
 from posthog.models import User
 from posthog.models.activity_logging.activity_log import Detail, log_activity
@@ -296,21 +296,22 @@ class HogFlowTemplateViewSet(TeamAndOrgViewSetMixin, LogEntryMixin, viewsets.Mod
         )
 
         try:
-            edges_count = len(serializer.instance.edges) if serializer.instance.edges else 0
-            actions_count = len(serializer.instance.actions) if serializer.instance.actions else 0
-
-            posthoganalytics.capture(
-                distinct_id=str(serializer.context["request"].user.distinct_id),
-                event="hog_flow_template_created",
-                properties={
+            # report_user_action injects source and MCP-client properties so template usage is
+            # attributable per channel (web builder vs MCP vs raw API).
+            report_user_action(
+                serializer.context["request"].user,
+                "hog_flow_template_created",
+                {
                     "workflow_template_id": str(serializer.instance.id),
                     "workflow_template_name": serializer.instance.name,
-                    "edges_count": edges_count,
-                    "actions_count": actions_count,
+                    "edges_count": len(serializer.instance.edges or []),
+                    "actions_count": len(serializer.instance.actions or []),
                     "team_id": str(self.team_id),
                     "organization_id": str(self.organization.id),
                     "scope": serializer.instance.scope if serializer.instance else None,
                 },
+                team=self.team,
+                request=serializer.context["request"],
             )
         except Exception as e:
             logger.warning("Failed to capture hog_flow_template_created event", error=str(e))

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -13,6 +13,7 @@ from posthog.cdp.templates.hog_function_template import sync_template_to_db
 from posthog.cdp.templates.slack.template_slack import template as template_slack
 from posthog.event_usage import EventSource
 from posthog.models import Organization, Team, User
+from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.test.fixtures import create_app_metric2
@@ -3109,6 +3110,21 @@ class TestHogFlowAPI(APIBaseTest):
         assert response.status_code == 200, response.json()
         assert response.json()["deleted"] == 3
         assert HogFlow.objects.filter(id__in=ids).count() == 0
+        assert ActivityLog.objects.filter(scope="HogFlow", activity="deleted", item_id__in=ids).count() == 3
+
+    @patch("products.workflows.backend.api.hog_flow.report_user_action")
+    def test_delete_writes_deleted_activity_and_usage_event(self, mock_report):
+        flow_id = self._create_flow(name="Doomed")
+
+        response = self.client.delete(f"/api/projects/{self.team.id}/hog_flows/{flow_id}")
+        assert response.status_code == 204, response.content
+        assert not HogFlow.objects.filter(id=flow_id).exists()
+
+        entry = ActivityLog.objects.filter(scope="HogFlow", item_id=flow_id).order_by("-created_at").first()
+        assert entry is not None and entry.activity == "deleted"
+        deleted_events = [c for c in mock_report.call_args_list if c.args[1] == "hog_flow_deleted"]
+        assert len(deleted_events) == 1
+        assert deleted_events[0].args[2]["workflow_id"] == flow_id
 
     @parameterized.expand(
         [

--- a/products/workflows/backend/api/test/test_hog_flow_draft_publish.py
+++ b/products/workflows/backend/api/test/test_hog_flow_draft_publish.py
@@ -332,6 +332,10 @@ class TestHogFlowDraftPublish(APIBaseTest):
         trigger = next(a for a in flow.actions if a["type"] == "trigger")
         assert trigger["config"]["filters"].get("bytecode"), "publish must compile trigger filter bytecode"
 
+        # Publish must stay distinguishable from a plain edit in the audit trail
+        entry = ActivityLog.objects.filter(scope="HogFlow", item_id=flow_id).order_by("-created_at").first()
+        assert entry is not None and entry.activity == "published"
+
     @patch(FLAG_PATH, return_value=True)
     def test_publish_with_stale_token_after_draft_reedit_is_rejected_with_409(self, _flag):
         flow_id = self._create_active_flow()
@@ -415,6 +419,9 @@ class TestHogFlowDraftPublish(APIBaseTest):
         flow = HogFlow.objects.get(pk=flow_id)
         assert flow.draft is None
         assert flow.draft_updated_at is None
+
+        entry = ActivityLog.objects.filter(scope="HogFlow", item_id=flow_id).order_by("-created_at").first()
+        assert entry is not None and entry.activity == "draft_discarded"
 
     # ── Test-run from draft ──────────────────────────────────────────
 

--- a/products/workflows/backend/api/test/test_hog_flow_revisions.py
+++ b/products/workflows/backend/api/test/test_hog_flow_revisions.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from parameterized import parameterized
 
 from posthog.cdp.templates.hog_function_template import sync_template_to_db
+from posthog.models.activity_logging.activity_log import ActivityLog
 
 from products.cdp.backend.api.test.test_hog_function_templates import MOCK_NODE_TEMPLATES
 from products.workflows.backend.api.hog_flow import DRAFT_CONTENT_FIELDS
@@ -247,6 +248,10 @@ class TestHogFlowRevisions(APIBaseTest):
         assert flow.draft_updated_at is not None
         draft_urls = [a["config"]["inputs"]["url"]["value"] for a in flow.draft["actions"] if a["type"] == "function"]
         assert draft_urls == ["https://example.com"]
+
+        # Restore must stay distinguishable from a plain edit in the audit trail
+        entry = ActivityLog.objects.filter(scope="HogFlow", item_id=flow_id).order_by("-created_at").first()
+        assert entry is not None and entry.activity == "revision_restored"
 
     @patch(FLAG_PATH, return_value=True)
     def test_rollback_round_trip_restores_live_and_prunes_redirects(self, _flag):

--- a/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.tsx
+++ b/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.tsx
@@ -97,6 +97,18 @@ export function workflowActivityDescriber(logItem: ActivityLogItem, asNotificati
         }
     }
 
+    if (logItem.activity == 'revision_restored') {
+        return {
+            description: (
+                <>
+                    <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> restored a past version
+                    into the staged draft of the {objectNoun}:{' '}
+                    {nameOrLinkToWorkflow(logItem?.item_id, logItem?.detail.name)}
+                </>
+            ),
+        }
+    }
+
     if (logItem.activity == 'draft_discarded') {
         return {
             description: (

--- a/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.tsx
+++ b/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.tsx
@@ -97,7 +97,19 @@ export function workflowActivityDescriber(logItem: ActivityLogItem, asNotificati
         }
     }
 
-    if (logItem.activity == 'updated') {
+    if (logItem.activity == 'draft_discarded') {
+        return {
+            description: (
+                <>
+                    <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> discarded the staged draft
+                    of the {objectNoun}: {nameOrLinkToWorkflow(logItem?.item_id, logItem?.detail.name)}
+                </>
+            ),
+        }
+    }
+
+    if (logItem.activity == 'updated' || logItem.activity == 'published') {
+        const verb = logItem.activity == 'published' ? 'published' : 'updated'
         const changes: JSX.Element[] = []
         for (const change of logItem.detail.changes ?? []) {
             switch (change.field) {
@@ -162,7 +174,7 @@ export function workflowActivityDescriber(logItem: ActivityLogItem, asNotificati
         return {
             description: (
                 <div>
-                    <strong className="ph-no-capture">{name}</strong> updated the {objectNoun}: {workflowName}
+                    <strong className="ph-no-capture">{name}</strong> {verb} the {objectNoun}: {workflowName}
                     <ul className="ml-5 list-disc">
                         {changes.map((c, i) => (
                             <li key={i}>{c}</li>


### PR DESCRIPTION
## Problem

An audit of the workflow APIs (everything shipped in the last two months: the draft → test → publish cycle from #70823, graph ops, batch jobs, schedules) found we have almost no usage visibility:

- `publish`, `discard_draft`, and `graph` fire no product-analytics events, and all three log activity as the generic `"changed"` (their action names aren't in `ACTIVITY_TYPES`), so the activity log can't distinguish a publish from a rename.
- Deleting a workflow (single `DELETE` or `bulk_delete`) left **no trail at all** - no activity log entry, no event, and these are hard deletes.
- `batch_jobs` POST (starts a real send) and the schedule endpoints (durable config) had neither.
- The three events that did exist (`hog_flow_created`, `hog_flow_activated`, `hog_flow_template_created`) used raw `posthoganalytics.capture`, so none carry `source` / MCP-client properties - we can't answer "how many workflows are created or published via MCP vs the web builder", despite the draft cycle being MCP-first.

Part of the #66380 wrap-up.

## Changes

**Backend (`products/workflows/backend/api/`)**

- New `_report_workflow_action` helper on `HogFlowViewSet`, built on `report_user_action` from `posthog/event_usage.py`, which injects `source`, `access_method`, and `mcp_client_*` properties from the request. All new and existing workflow events go through it (never raises; failures log a warning).
- New events: `hog_flow_draft_published`, `hog_flow_draft_discarded`, `hog_flow_graph_updated` (with `operations_count` + `routed_to_draft`), `hog_flow_deleted` (with `via: destroy|bulk_delete`), `hog_flow_batch_job_created`, `hog_flow_schedule_created` / `_updated` / `_deleted`, `hog_flow_revision_restored`.
- Existing `hog_flow_created` / `hog_flow_activated` / `hog_flow_template_created` migrated onto the same pattern - same event names and properties, plus channel attribution.
- Distinct activity types: `publish` → `"published"`, `discard_draft` → `"draft_discarded"`, `graph` → `"updated"` (was `"changed"`; unlocks the describer's per-field change rendering). New `perform_destroy` override and per-flow logging in `bulk_delete` write `"deleted"` entries.

**Frontend**

- `workflowActivityDescriber` renders `"published"` (reusing the per-field change list with a "published" verb) and `"draft_discarded"`; `"deleted"` already had a branch.

> [!NOTE]
> Rebased on master after the revisions stack (#72506/#72572/#72573/#72576) merged. The new `restore_revision` endpoint from #72573 is instrumented too: `hog_flow_revision_restored` event (with the restored `version`) and a distinct `"revision_restored"` activity type, rendered by the describer.

## How did you test this code?

- `pytest products/workflows/backend/api/test/test_hog_flow.py::TestHogFlowAPI` - 159 passed
- `pytest products/workflows/backend/api/test/test_hog_flow_draft_publish.py products/workflows/backend/api/test/test_hog_flow_revisions.py` - 46 passed (post-rebase, on the rewritten publish path)
  - `test_restore_copies_revision_into_draft_without_touching_live` (extended): asserts the distinct `"revision_restored"` activity type - same protection as the publish/discard assertions
- `uv run mypy --cache-fine-grained .` repo-wide - clean; `pnpm --filter=@posthog/frontend typescript:check` - clean
- New/extended tests and the regression each catches:
  - `test_delete_writes_deleted_activity_and_usage_event` (new): deleting a workflow currently leaves zero audit trail; catches the `perform_destroy` override being dropped (e.g. in a future viewset refactor)
  - `test_bulk_delete_archived_workflows` (extended): same for the bulk path - asserts one `"deleted"` activity entry per flow
  - `test_publish_with_confirm_promotes_draft_and_clears_it` / `test_discard_draft_clears_it` (extended): assert the distinct `"published"` / `"draft_discarded"` activity types survive - directly protects against the in-flight publish rewrite reverting them to `"changed"`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Nothing to update: internal instrumentation with no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) at Harley's direction, following an audit of usage-visibility gaps across the workflow APIs. Skills invoked: `/improving-drf-endpoints` (no serializer/schema changes ended up needed - instrumentation only, so no OpenAPI regen) and `/writing-tests` (gated the test additions; the extended-not-new approach for publish/discard came from there). Decisions: standardized on `report_user_action` over raw `posthoganalytics.capture` for channel attribution; kept event property shapes identical for the three pre-existing events; deliberately did not register the `HogFlowTemplate` activity scope (its `log_activity` writes are invisible in the UI today) - that's a separate frontend describer + enum change, flagged as a follow-up on #66380.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
