### PR TITLE
feat(replay): add concerrency per batch to ml-mirror sessions scrubbing

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.test.ts
@@ -1,0 +1,12 @@
+import { resolveMlAnonymizeMaxConcurrency } from './config'
+
+describe('resolveMlAnonymizeMaxConcurrency', () => {
+    it.each([
+        ['explicit value passes through verbatim, even above the pool', 8, 3, 4, 8],
+        ['sentinel resolves to available CPUs when below the pool', 0, 3, 4, 3],
+        ['sentinel is capped by the threadpool size', 0, 16, 4, 4],
+        ['sentinel never resolves below 1', -1, 0, 0, 1],
+    ])('%s', (_name, configured, cpus, poolSize, expected) => {
+        expect(resolveMlAnonymizeMaxConcurrency(configured, cpus, poolSize)).toBe(expected)
+    })
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
@@ -36,6 +36,14 @@ export type MlMirrorConfig = {
     // Scrub-phase budget. Sized so scrub + 2x the S3 write timeout stays under Kafka's max.poll.interval.ms
     // (300s), or a hung sidecar/S3 evicts us mid-batch and livelocks.
     SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_BATCH_SCRUB_MS: number
+
+    /**
+     * Cap on sessions scrubbed concurrently per pod. Each in-flight scrub occupies one libuv
+     * threadpool thread (UV_THREADPOOL_SIZE, default 4, shared with the recorder's snappy
+     * compression), so keep this below the pool size. Per-session event order is preserved at any
+     * setting; 1 restores fully sequential scrubbing.
+     */
+    SESSION_RECORDING_ML_ANONYMIZE_MAX_CONCURRENCY: number
 }
 
 export function getDefaultMlMirrorConfig(): MlMirrorConfig {
@@ -61,5 +69,6 @@ export function getDefaultMlMirrorConfig(): MlMirrorConfig {
         SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_RETRIES: 3,
         SESSION_RECORDING_ML_IMAGE_SCRUB_S3_WRITE_TIMEOUT_MS: 30 * 1000,
         SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_BATCH_SCRUB_MS: 120 * 1000,
+        SESSION_RECORDING_ML_ANONYMIZE_MAX_CONCURRENCY: 3,
     }
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
@@ -40,11 +40,10 @@ export type MlMirrorConfig = {
     SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_BATCH_SCRUB_MS: number
 
     /**
-     * Cap on sessions scrubbed concurrently per pod. Each in-flight scrub occupies one libuv
+     * Cap on messages scrubbed concurrently per pod. Each in-flight scrub occupies one libuv
      * threadpool thread (UV_THREADPOOL_SIZE, default 4, shared with the recorder's snappy
      * compression). <= 0 (the default) resolves to min(available CPUs, threadpool size); an
-     * explicit positive value is used verbatim. Per-session event order is preserved at any
-     * setting; 1 restores fully sequential scrubbing.
+     * explicit positive value is used verbatim; 1 restores fully sequential scrubbing.
      */
     SESSION_RECORDING_ML_ANONYMIZE_MAX_CONCURRENCY: number
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
@@ -1,3 +1,5 @@
+import os from 'node:os'
+
 export type MlMirrorConfig = {
     /** S3 key prefix under the bucket for the block-metadata Parquet dataset (used by the sink). */
     SESSION_RECORDING_ML_METADATA_PREFIX: string
@@ -40,7 +42,8 @@ export type MlMirrorConfig = {
     /**
      * Cap on sessions scrubbed concurrently per pod. Each in-flight scrub occupies one libuv
      * threadpool thread (UV_THREADPOOL_SIZE, default 4, shared with the recorder's snappy
-     * compression), so keep this below the pool size. Per-session event order is preserved at any
+     * compression). <= 0 (the default) resolves to min(available CPUs, threadpool size); an
+     * explicit positive value is used verbatim. Per-session event order is preserved at any
      * setting; 1 restores fully sequential scrubbing.
      */
     SESSION_RECORDING_ML_ANONYMIZE_MAX_CONCURRENCY: number
@@ -69,6 +72,23 @@ export function getDefaultMlMirrorConfig(): MlMirrorConfig {
         SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_RETRIES: 3,
         SESSION_RECORDING_ML_IMAGE_SCRUB_S3_WRITE_TIMEOUT_MS: 30 * 1000,
         SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_BATCH_SCRUB_MS: 120 * 1000,
-        SESSION_RECORDING_ML_ANONYMIZE_MAX_CONCURRENCY: 3,
+        SESSION_RECORDING_ML_ANONYMIZE_MAX_CONCURRENCY: 0,
     }
+}
+
+const DEFAULT_UV_THREADPOOL_SIZE = 4
+
+/**
+ * `os.availableParallelism()` respects cgroup CPU limits, so in-container this sees the pod's
+ * cores, not the node's.
+ */
+export function resolveMlAnonymizeMaxConcurrency(
+    configured: number,
+    availableParallelism: number = os.availableParallelism(),
+    uvThreadpoolSize: number = parseInt(process.env.UV_THREADPOOL_SIZE ?? '', 10) || DEFAULT_UV_THREADPOOL_SIZE
+): number {
+    if (configured > 0) {
+        return configured
+    }
+    return Math.max(1, Math.min(availableParallelism, uvThreadpoolSize))
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-anonymize-concurrency.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-anonymize-concurrency.test.ts
@@ -1,0 +1,218 @@
+import { DateTime } from 'luxon'
+import { Message } from 'node-rdkafka'
+
+import { EventIngestionRestrictionManager } from '~/common/utils/event-ingestion-restrictions'
+import { PromiseScheduler } from '~/common/utils/promise-scheduler'
+import { createApplyEventRestrictionsStep, createParseHeadersStep } from '~/ingestion/common/steps/event-preprocessing'
+import { TopHogRegistry } from '~/ingestion/framework/extensions/tophog'
+import { ok } from '~/ingestion/framework/results'
+import { runSessionReplayPipeline } from '~/ingestion/pipelines/sessionreplay'
+import { ParsedMessageData } from '~/ingestion/pipelines/sessionreplay/kafka/types'
+import { createParseAndAnonymizeMessageStep } from '~/ingestion/pipelines/sessionreplay/parse-and-anonymize-step'
+import { SessionBatchRecorder } from '~/ingestion/pipelines/sessionreplay/sessions/session-batch-recorder'
+import { SessionFilter } from '~/ingestion/pipelines/sessionreplay/sessions/session-filter'
+import { SessionTracker } from '~/ingestion/pipelines/sessionreplay/sessions/session-tracker'
+import { RetentionResolution, RetentionService } from '~/ingestion/pipelines/sessionreplay/shared/retention-service'
+import { SessionMap, SessionSet } from '~/ingestion/pipelines/sessionreplay/shared/session-map'
+import { TeamService } from '~/ingestion/pipelines/sessionreplay/shared/teams/team-service'
+import { createMockKeyStore } from '~/ingestion/pipelines/sessionreplay/shared/test-helpers'
+import { TeamForReplay } from '~/ingestion/pipelines/sessionreplay/teams/types'
+import { createMockIngestionOutputs } from '~/tests/helpers/mock-ingestion-outputs'
+
+import { createMlMirrorReplayPipeline } from './ml-mirror-pipeline'
+
+jest.mock('~/ingestion/common/steps/event-preprocessing', () => ({
+    createParseHeadersStep: jest.fn(),
+    createApplyEventRestrictionsStep: jest.fn(),
+}))
+jest.mock('~/ingestion/pipelines/sessionreplay/parse-and-anonymize-step', () => ({
+    createParseAndAnonymizeMessageStep: jest.fn(),
+}))
+
+const mockCreateParseHeadersStep = createParseHeadersStep as jest.Mock
+const mockCreateApplyEventRestrictionsStep = createApplyEventRestrictionsStep as jest.Mock
+const mockCreateParseAndAnonymizeMessageStep = createParseAndAnonymizeMessageStep as jest.Mock
+
+describe('ml-mirror anonymize concurrency', () => {
+    const now = DateTime.now()
+
+    const retentionService = {
+        resolveSessionRetentions: jest.fn().mockImplementation((sessions: SessionSet) => {
+            const resolutions = new SessionMap<RetentionResolution>()
+            for (const s of sessions) {
+                resolutions.set(s.teamId, s.sessionId, { resolved: true, retentionPeriod: '30d' })
+            }
+            return Promise.resolve(resolutions)
+        }),
+    } as unknown as RetentionService
+    const sessionTracker = {
+        hasSeen: jest.fn().mockImplementation((sessions: SessionSet) => {
+            const map = new SessionMap<boolean>()
+            for (const { teamId, sessionId } of sessions) {
+                map.set(teamId, sessionId, true)
+            }
+            return Promise.resolve(map)
+        }),
+        markSeen: jest.fn().mockResolvedValue(undefined),
+    } as unknown as SessionTracker
+    const sessionFilter = {
+        handleNewSessions: jest.fn().mockResolvedValue(new SessionSet()),
+        isBlocked: jest.fn().mockResolvedValue(new SessionSet()),
+    } as unknown as SessionFilter
+    const keyStore = createMockKeyStore()
+    const teamService = {
+        getTeamByToken: jest.fn().mockResolvedValue({
+            teamId: 1,
+            consoleLogIngestionEnabled: false,
+            aiTrainingOptedIn: true,
+        } satisfies TeamForReplay),
+        getRetentionPeriodByTeamId: jest.fn().mockResolvedValue(30),
+    } as unknown as TeamService
+
+    let recordMock: jest.Mock
+    let promiseScheduler: PromiseScheduler
+    // Per `${sessionId}:${offset}`: a promise the mocked scrub awaits before completing.
+    let scrubGates: Map<string, Promise<void>>
+    let scrubStarts: Set<string>
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        recordMock = jest.fn().mockResolvedValue(undefined)
+        promiseScheduler = new PromiseScheduler()
+        scrubGates = new Map()
+        scrubStarts = new Set()
+
+        mockCreateParseHeadersStep.mockReturnValue((input: { message: Message }) => {
+            const headers: Record<string, string> = {}
+            for (const header of input.message.headers || []) {
+                for (const [key, value] of Object.entries(header)) {
+                    headers[key] = Buffer.isBuffer(value) ? value.toString() : (value as string)
+                }
+            }
+            return Promise.resolve(ok({ ...input, headers }))
+        })
+        mockCreateApplyEventRestrictionsStep.mockReturnValue((input: unknown) => Promise.resolve(ok(input)))
+        mockCreateParseAndAnonymizeMessageStep.mockReturnValue(
+            async (input: { message: Message; headers: Record<string, string> }) => {
+                const scrubKey = `${input.headers.session_id}:${input.message.offset}`
+                scrubStarts.add(scrubKey)
+                await (scrubGates.get(scrubKey) ?? Promise.resolve())
+                const parsedMessage: ParsedMessageData = {
+                    metadata: {
+                        partition: input.message.partition,
+                        topic: input.message.topic,
+                        rawSize: input.message.size,
+                        offset: input.message.offset,
+                        timestamp: input.message.timestamp!,
+                    },
+                    distinct_id: 'user-123',
+                    session_id: input.headers.session_id,
+                    token: input.headers.token,
+                    eventsByWindowId: {},
+                    preSerialized: {
+                        lines: Buffer.from('["window-1",{}]\n'),
+                        events: [],
+                        consoleLogCount: 0,
+                        consoleWarnCount: 0,
+                        consoleErrorCount: 0,
+                    },
+                    eventsRange: { start: now, end: now },
+                    snapshot_source: null,
+                    snapshot_library: null,
+                }
+                return ok({ ...input, parsedMessage })
+            }
+        )
+    })
+
+    function buildPipeline(): ReturnType<typeof createMlMirrorReplayPipeline> {
+        return createMlMirrorReplayPipeline(
+            {
+                outputs: createMockIngestionOutputs(),
+                eventIngestionRestrictionManager: {} as unknown as EventIngestionRestrictionManager,
+                overflowMode: 'disabled',
+                promiseScheduler,
+                teamService,
+                retentionService,
+                sessionTracker,
+                sessionFilter,
+                keyStore,
+                sessionKeyResolutionMaxConcurrency: 20,
+                topHog: {
+                    registerSum: jest.fn().mockReturnValue({ record: jest.fn() }),
+                    registerMax: jest.fn().mockReturnValue({ record: jest.fn() }),
+                    registerAverage: jest.fn().mockReturnValue({ record: jest.fn() }),
+                } as unknown as TopHogRegistry,
+                isDebugLoggingEnabled: () => false,
+            },
+            { anonymizeMaxConcurrency: 2 }
+        )
+    }
+
+    function message(sessionId: string, offset: number): Message {
+        return {
+            partition: 0,
+            offset,
+            topic: 'test-topic',
+            value: Buffer.from('irrelevant, the scrub step is mocked'),
+            key: Buffer.from('k'),
+            timestamp: Date.now(),
+            headers: [
+                { token: Buffer.from('test-token') },
+                { session_id: Buffer.from(sessionId) },
+                { distinct_id: Buffer.from('user-123') },
+            ],
+            size: 10,
+        } as unknown as Message
+    }
+
+    function recordedOffsets(sessionId: string): number[] {
+        return recordMock.mock.calls
+            .filter((call) => call[0].message.session_id === sessionId)
+            .map((call) => call[0].message.metadata.offset)
+    }
+
+    async function until(condition: () => boolean): Promise<void> {
+        for (let i = 0; i < 5000 && !condition(); i++) {
+            await new Promise(setImmediate)
+        }
+        if (!condition()) {
+            throw new Error('condition not reached while a scrub gate was held')
+        }
+    }
+
+    it('scrubs sessions concurrently while preserving within-session order', async () => {
+        let releaseScrubA!: () => void
+        let releaseScrubB!: () => void
+        scrubGates.set('sess-a:1', new Promise<void>((resolve) => (releaseScrubA = resolve)))
+        scrubGates.set('sess-b:3', new Promise<void>((resolve) => (releaseScrubB = resolve)))
+
+        const recorder = {
+            record: recordMock,
+            getRetention: jest.fn().mockReturnValue(undefined),
+        } as unknown as SessionBatchRecorder
+        const run = runSessionReplayPipeline(
+            buildPipeline(),
+            [message('sess-a', 1), message('sess-a', 2), message('sess-b', 3)],
+            recorder,
+            promiseScheduler
+        )
+
+        try {
+            // Both sessions' scrubs are in flight at once — sequential processing never starts the
+            // second scrub while the first is gated, so this is the concurrency proof.
+            await until(() => scrubStarts.has('sess-a:1') && scrubStarts.has('sess-b:3'))
+            // Within a session order is preserved: the second message must not start (let alone
+            // record) while the session's first scrub is still gated.
+            expect(scrubStarts.has('sess-a:2')).toBe(false)
+            expect(recordedOffsets('sess-a')).toEqual([])
+        } finally {
+            releaseScrubA()
+            releaseScrubB()
+        }
+        await run
+
+        expect(recordedOffsets('sess-a')).toEqual([1, 2])
+        expect(recordedOffsets('sess-b')).toEqual([3])
+    })
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-anonymize-concurrency.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-anonymize-concurrency.test.ts
@@ -12,7 +12,10 @@ import { createParseAndAnonymizeMessageStep } from '~/ingestion/pipelines/sessio
 import { SessionBatchRecorder } from '~/ingestion/pipelines/sessionreplay/sessions/session-batch-recorder'
 import { SessionFilter } from '~/ingestion/pipelines/sessionreplay/sessions/session-filter'
 import { SessionTracker } from '~/ingestion/pipelines/sessionreplay/sessions/session-tracker'
-import { RetentionResolution, RetentionService } from '~/ingestion/pipelines/sessionreplay/shared/retention-service'
+import {
+    RetentionResolution,
+    RetentionService,
+} from '~/ingestion/pipelines/sessionreplay/shared/retention/retention-service'
 import { SessionMap, SessionSet } from '~/ingestion/pipelines/sessionreplay/shared/session-map'
 import { TeamService } from '~/ingestion/pipelines/sessionreplay/shared/teams/team-service'
 import { createMockKeyStore } from '~/ingestion/pipelines/sessionreplay/shared/test-helpers'

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-anonymize-concurrency.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-anonymize-concurrency.test.ts
@@ -184,11 +184,11 @@ describe('ml-mirror anonymize concurrency', () => {
         }
     }
 
-    it('scrubs sessions concurrently while preserving within-session order', async () => {
-        let releaseScrubA!: () => void
-        let releaseScrubB!: () => void
-        scrubGates.set('sess-a:1', new Promise<void>((resolve) => (releaseScrubA = resolve)))
-        scrubGates.set('sess-b:3', new Promise<void>((resolve) => (releaseScrubB = resolve)))
+    it('scrubs messages concurrently, including messages of the same session', async () => {
+        let releaseFirstScrub!: () => void
+        let releaseSecondScrub!: () => void
+        scrubGates.set('sess-a:1', new Promise<void>((resolve) => (releaseFirstScrub = resolve)))
+        scrubGates.set('sess-a:2', new Promise<void>((resolve) => (releaseSecondScrub = resolve)))
 
         const recorder = {
             record: recordMock,
@@ -202,20 +202,18 @@ describe('ml-mirror anonymize concurrency', () => {
         )
 
         try {
-            // Both sessions' scrubs are in flight at once — sequential processing never starts the
-            // second scrub while the first is gated, so this is the concurrency proof.
-            await until(() => scrubStarts.has('sess-a:1') && scrubStarts.has('sess-b:3'))
-            // Within a session order is preserved: the second message must not start (let alone
-            // record) while the session's first scrub is still gated.
-            expect(scrubStarts.has('sess-a:2')).toBe(false)
-            expect(recordedOffsets('sess-a')).toEqual([])
+            // Both of sess-a's scrubs are in flight at once — sequential processing never starts
+            // the second scrub while the first is gated, and per-session grouping never starts a
+            // session's second message while its first is gated.
+            await until(() => scrubStarts.has('sess-a:1') && scrubStarts.has('sess-a:2'))
         } finally {
-            releaseScrubA()
-            releaseScrubB()
+            releaseFirstScrub()
+            releaseSecondScrub()
         }
         await run
 
-        expect(recordedOffsets('sess-a')).toEqual([1, 2])
+        // No ordering guarantees, so only membership is asserted.
+        expect(recordedOffsets('sess-a').sort()).toEqual([1, 2])
         expect(recordedOffsets('sess-b')).toEqual([3])
     })
 })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.test.ts
@@ -128,20 +128,23 @@ describe('ml-mirror-pipeline', () => {
     })
 
     function buildPipeline(): ReturnType<typeof createMlMirrorReplayPipeline> {
-        return createMlMirrorReplayPipeline({
-            outputs,
-            eventIngestionRestrictionManager: {} as unknown as EventIngestionRestrictionManager,
-            overflowMode: 'disabled',
-            promiseScheduler,
-            teamService: mockTeamService,
-            retentionService,
-            sessionTracker,
-            sessionFilter,
-            keyStore,
-            sessionKeyResolutionMaxConcurrency: 20,
-            topHog,
-            isDebugLoggingEnabled: () => false,
-        })
+        return createMlMirrorReplayPipeline(
+            {
+                outputs,
+                eventIngestionRestrictionManager: {} as unknown as EventIngestionRestrictionManager,
+                overflowMode: 'disabled',
+                promiseScheduler,
+                teamService: mockTeamService,
+                retentionService,
+                sessionTracker,
+                sessionFilter,
+                keyStore,
+                sessionKeyResolutionMaxConcurrency: 20,
+                topHog,
+                isDebugLoggingEnabled: () => false,
+            },
+            { anonymizeMaxConcurrency: 4 }
+        )
     }
 
     function message(sessionId: string): Message {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.ts
@@ -22,7 +22,15 @@ import { createResolveKeyStep } from '~/ingestion/pipelines/sessionreplay/sessio
 import { createTeamFilterStep } from '~/ingestion/pipelines/sessionreplay/team-filter-step'
 import { createValidateSessionReplayHeadersStep } from '~/ingestion/pipelines/sessionreplay/validate-headers-step'
 
-export function createMlMirrorReplayPipeline(config: SessionReplayPipelineConfig): SessionReplayPipeline {
+export interface MlMirrorPipelineOptions {
+    /** Cap on sessions scrubbed concurrently; each in-flight scrub occupies a libuv threadpool thread. */
+    anonymizeMaxConcurrency: number
+}
+
+export function createMlMirrorReplayPipeline(
+    config: SessionReplayPipelineConfig,
+    mlOptions: MlMirrorPipelineOptions
+): SessionReplayPipeline {
     const {
         outputs,
         eventIngestionRestrictionManager,
@@ -112,38 +120,48 @@ export function createMlMirrorReplayPipeline(config: SessionReplayPipelineConfig
                                 b
                                     .teamAware((b) =>
                                         b
-                                            .sequentially((b) => {
-                                                // The native Rust addon fuses parse+anonymize in one step.
-                                                const parsed = b.pipe(
-                                                    topHogWrapper(createParseAndAnonymizeMessageStep(), [
-                                                        timer('parse_time_ms_by_session_id', (input) => ({
-                                                            token: input.headers.token ?? 'unknown',
-                                                            session_id: input.headers.session_id ?? 'unknown',
-                                                        })),
-                                                    ])
-                                                )
-                                                return parsed.pipe(
-                                                    topHogWrapper(
-                                                        createRecordSessionEventStep({
-                                                            isDebugLoggingEnabled,
-                                                        }),
-                                                        [
-                                                            sum(
-                                                                'message_size_by_session_id',
-                                                                (input) => ({
-                                                                    token: input.parsedMessage.token ?? 'unknown',
-                                                                    session_id: input.parsedMessage.session_id,
+                                            // Scrub sessions concurrently — a slow scrub (large full snapshot,
+                                            // image blur) must not stall the whole batch. Grouping by session
+                                            // keeps events in order within a session, which block-line appends
+                                            // require; each in-flight scrub occupies a libuv threadpool thread.
+                                            .concurrentlyPerGroup(
+                                                (element) => `${element.team.teamId}:${element.headers.session_id}`,
+                                                (group) =>
+                                                    group.sequentially((b) => {
+                                                        // The native Rust addon fuses parse+anonymize in one step.
+                                                        const parsed = b.pipe(
+                                                            topHogWrapper(createParseAndAnonymizeMessageStep(), [
+                                                                timer('parse_time_ms_by_session_id', (input) => ({
+                                                                    token: input.headers.token ?? 'unknown',
+                                                                    session_id: input.headers.session_id ?? 'unknown',
+                                                                })),
+                                                            ])
+                                                        )
+                                                        return parsed.pipe(
+                                                            topHogWrapper(
+                                                                createRecordSessionEventStep({
+                                                                    isDebugLoggingEnabled,
                                                                 }),
-                                                                (input) => input.parsedMessage.metadata.rawSize
-                                                            ),
-                                                            timer('consume_time_ms_by_session_id', (input) => ({
-                                                                token: input.parsedMessage.token ?? 'unknown',
-                                                                session_id: input.parsedMessage.session_id,
-                                                            })),
-                                                        ]
-                                                    )
-                                                )
-                                            })
+                                                                [
+                                                                    sum(
+                                                                        'message_size_by_session_id',
+                                                                        (input) => ({
+                                                                            token:
+                                                                                input.parsedMessage.token ?? 'unknown',
+                                                                            session_id: input.parsedMessage.session_id,
+                                                                        }),
+                                                                        (input) => input.parsedMessage.metadata.rawSize
+                                                                    ),
+                                                                    timer('consume_time_ms_by_session_id', (input) => ({
+                                                                        token: input.parsedMessage.token ?? 'unknown',
+                                                                        session_id: input.parsedMessage.session_id,
+                                                                    })),
+                                                                ]
+                                                            )
+                                                        )
+                                                    }),
+                                                { maxConcurrency: mlOptions.anonymizeMaxConcurrency }
+                                            )
                                             .gather()
                                     )
                                     .handleIngestionWarnings(outputs)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.ts
@@ -120,10 +120,6 @@ export function createMlMirrorReplayPipeline(
                                 b
                                     .teamAware((b) =>
                                         b
-                                            // Scrub sessions concurrently — a slow scrub (large full snapshot,
-                                            // image blur) must not stall the whole batch. Grouping by session
-                                            // keeps events in order within a session, which block-line appends
-                                            // require; each in-flight scrub occupies a libuv threadpool thread.
                                             .concurrentlyPerGroup(
                                                 (element) => `${element.team.teamId}:${element.headers.session_id}`,
                                                 (group) =>

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.ts
@@ -120,42 +120,41 @@ export function createMlMirrorReplayPipeline(
                                 b
                                     .teamAware((b) =>
                                         b
-                                            .concurrentlyPerGroup(
-                                                (element) => `${element.team.teamId}:${element.headers.session_id}`,
-                                                (group) =>
-                                                    group.sequentially((b) => {
-                                                        // The native Rust addon fuses parse+anonymize in one step.
-                                                        const parsed = b.pipe(
-                                                            topHogWrapper(createParseAndAnonymizeMessageStep(), [
-                                                                timer('parse_time_ms_by_session_id', (input) => ({
-                                                                    token: input.headers.token ?? 'unknown',
-                                                                    session_id: input.headers.session_id ?? 'unknown',
-                                                                })),
-                                                            ])
-                                                        )
-                                                        return parsed.pipe(
-                                                            topHogWrapper(
-                                                                createRecordSessionEventStep({
-                                                                    isDebugLoggingEnabled,
-                                                                }),
-                                                                [
-                                                                    sum(
-                                                                        'message_size_by_session_id',
-                                                                        (input) => ({
-                                                                            token:
-                                                                                input.parsedMessage.token ?? 'unknown',
-                                                                            session_id: input.parsedMessage.session_id,
-                                                                        }),
-                                                                        (input) => input.parsedMessage.metadata.rawSize
-                                                                    ),
-                                                                    timer('consume_time_ms_by_session_id', (input) => ({
+                                            // Downstream consumers don't require event order within a
+                                            // session's block, so scrubbing is free to complete out of order.
+                                            .concurrently(
+                                                (b) => {
+                                                    // The native Rust addon fuses parse+anonymize in one step.
+                                                    const parsed = b.pipe(
+                                                        topHogWrapper(createParseAndAnonymizeMessageStep(), [
+                                                            timer('parse_time_ms_by_session_id', (input) => ({
+                                                                token: input.headers.token ?? 'unknown',
+                                                                session_id: input.headers.session_id ?? 'unknown',
+                                                            })),
+                                                        ])
+                                                    )
+                                                    return parsed.pipe(
+                                                        topHogWrapper(
+                                                            createRecordSessionEventStep({
+                                                                isDebugLoggingEnabled,
+                                                            }),
+                                                            [
+                                                                sum(
+                                                                    'message_size_by_session_id',
+                                                                    (input) => ({
                                                                         token: input.parsedMessage.token ?? 'unknown',
                                                                         session_id: input.parsedMessage.session_id,
-                                                                    })),
-                                                                ]
-                                                            )
+                                                                    }),
+                                                                    (input) => input.parsedMessage.metadata.rawSize
+                                                                ),
+                                                                timer('consume_time_ms_by_session_id', (input) => ({
+                                                                    token: input.parsedMessage.token ?? 'unknown',
+                                                                    session_id: input.parsedMessage.session_id,
+                                                                })),
+                                                            ]
                                                         )
-                                                    }),
+                                                    )
+                                                },
                                                 { maxConcurrency: mlOptions.anonymizeMaxConcurrency }
                                             )
                                             .gather()

--- a/nodejs/src/servers/ingestion-session-replay-ml-mirror-server.ts
+++ b/nodejs/src/servers/ingestion-session-replay-ml-mirror-server.ts
@@ -153,7 +153,10 @@ export class IngestionSessionReplayMlMirrorServer implements NodeServer {
             featureStore: new SessionFeatureStore(outputs, false),
             keyStore,
             encryptor: new CleartextRecordingEncryptor(keyStore),
-            createPipeline: (pipelineConfig) => createMlMirrorReplayPipeline(pipelineConfig),
+            createPipeline: (pipelineConfig) =>
+                createMlMirrorReplayPipeline(pipelineConfig, {
+                    anonymizeMaxConcurrency: this.config.SESSION_RECORDING_ML_ANONYMIZE_MAX_CONCURRENCY,
+                }),
             // Isolate the mirror's session tracker/filter keys from the main lane. Sharing them would let
             // the cleartext mirror mark a session seen without the main lane's KMS key, so the main lane
             // would then fetch a missing key and record cleartext.

--- a/nodejs/src/servers/ingestion-session-replay-ml-mirror-server.ts
+++ b/nodejs/src/servers/ingestion-session-replay-ml-mirror-server.ts
@@ -19,7 +19,11 @@ import {
     SessionRecordingIngester,
     SessionRecordingIngesterCollaborators,
 } from '~/ingestion/pipelines/sessionreplay/consumer'
-import { MlMirrorConfig, getDefaultMlMirrorConfig } from '~/ingestion/pipelines/sessionreplay/ml-mirror/config'
+import {
+    MlMirrorConfig,
+    getDefaultMlMirrorConfig,
+    resolveMlAnonymizeMaxConcurrency,
+} from '~/ingestion/pipelines/sessionreplay/ml-mirror/config'
 import { MlBlockMetadataSink } from '~/ingestion/pipelines/sessionreplay/ml-mirror/ml-block-metadata-sink'
 import { createMlMirrorReplayPipeline } from '~/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline'
 import { resolvePseudonymKey } from '~/ingestion/pipelines/sessionreplay/ml-mirror/pseudonym-key'
@@ -155,7 +159,9 @@ export class IngestionSessionReplayMlMirrorServer implements NodeServer {
             encryptor: new CleartextRecordingEncryptor(keyStore),
             createPipeline: (pipelineConfig) =>
                 createMlMirrorReplayPipeline(pipelineConfig, {
-                    anonymizeMaxConcurrency: this.config.SESSION_RECORDING_ML_ANONYMIZE_MAX_CONCURRENCY,
+                    anonymizeMaxConcurrency: resolveMlAnonymizeMaxConcurrency(
+                        this.config.SESSION_RECORDING_ML_ANONYMIZE_MAX_CONCURRENCY
+                    ),
                 }),
             // Isolate the mirror's session tracker/filter keys from the main lane. Sharing them would let
             // the cleartext mirror mark a session seen without the main lane's KMS key, so the main lane


### PR DESCRIPTION
## Problem

The ml-mirror lane's fused parse+anonymize step runs strictly sequentially within each batch, and the consumer runs one batch at a time. APM traces show the consequence directly: a single slow scrub (a large full snapshot, inline image blur) stalls the entire pod - one production batch spent 5.2s of its 7.1s wall time inside one message's scrub while 3 of the 4 libuv threadpool threads sat idle. During the mid-July lag incident this is how individual partitions fell days behind while the median partition stayed at zero.

Serialization also starves the autoscaler: a latency-bound pod caps its own CPU below the HPA's 45% target no matter how far behind it falls, so the fleet never scales toward maxPods.

## Changes

```mermaid
flowchart LR
    Batch[batch] --> G1{{scrub → record}}
    Batch --> G2{{scrub → record}}
    Batch --> G3{{scrub → record}}
    G1 --> Gather[gather → warnings → results]
    G2 --> Gather
    G3 --> Gather
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class G1,G2,G3 phBlue;
    class Batch,Gather phYellow;
```

- The parse+anonymize+record stage now runs via `concurrently` with bounded fan-out and no ordering constraints - downstream consumers don't require event order within a session's block, so even two messages of the same session scrub in parallel. (An earlier revision grouped by session to preserve within-session order; dropped once we established nothing downstream needs it.)
- New `SESSION_RECORDING_ML_ANONYMIZE_MAX_CONCURRENCY`: an explicit positive value is used verbatim; <= 0 (the default) auto-sizes to min(available CPUs, UV_THREADPOOL_SIZE) - availableParallelism respects cgroup limits, so current prod-us pods (3 cores, pool 4) resolve to 3 and the 2-core overflow lane to 2. Each in-flight scrub occupies one libuv threadpool thread (default pool: 4, shared with snappy compression) and the pods have 3 dedicated cores. Setting it to 1 restores the old sequential behavior as a rollback lever.
- Concurrent `record()` calls are safe, including for the same session: the recorder's check-then-create of per-session state and the block-line append run synchronously before its first await, so calls never interleave mid-mutation.

> [!NOTE]
> Companion observability PRs: #72872 (phase spans, including threadpool queue wait) and #72875 (histogram buckets past 10s). Together they show whether 3 is the right concurrency and when to raise UV_THREADPOOL_SIZE / CPU in charts.

## How did you test this code?

- New `ml-mirror-anonymize-concurrency.test.ts` with the scrub step mocked behind controllable gates. It requires **two scrubs of the same session to be in flight simultaneously** - neither sequential processing nor per-session grouping can satisfy that. Red-green verified at each revision: the first draft asserted only cross-session completion order, which even the old sequential code passed (the upstream key-resolution stage already emits unordered), so it was rewritten around in-flight assertions.
- All 13 ml-mirror Jest suites plus the ml-mirror server suite pass; tsc reports no errors in the changed files.
- Not done: no load/staging verification of throughput; that's the scrub-saturation and consumer-lag panels post-deploy.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None; internal pipeline behavior, config documented in code.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie, third PR from the ml-mirror lag investigation (APM traces + Grafana). Design choices: bounded `concurrently` over raising `concurrentBatches` because the recorder tags one batch at a time; started as per-session `concurrentlyPerGroup` until Robbie confirmed within-session order is not required downstream, at which point the grouping only cost concurrency. Skills invoked: /writing-tests.


