### PR TITLE
chore(batch-exports): cap staging partition fan-out in temporal tests

### DIFF
--- a/products/batch_exports/backend/tests/temporal/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/conftest.py
@@ -6,6 +6,7 @@ import datetime as dt
 import pytest
 
 from django.conf import settings
+from django.test import override_settings
 
 import psycopg
 import pytest_asyncio
@@ -53,6 +54,19 @@ def clickhouse_create_db_and_tables():
     create_clickhouse_tables()  # Create all expected tables
 
     yield
+
+
+@pytest.fixture(autouse=True)
+def reduced_staging_partitions():
+    """Cap CH→S3 staging fan-out at 2 partition files instead of the production default of 10.
+
+    Ten concurrent S3 writers per tiny staging insert, multiplied across xdist workers, contends on
+    the shared CI objectstorage and produces 20s+ staging stalls that trip workflow execution
+    timeouts. Two partitions keep the multi-file read path exercised; tests that assert partition
+    behavior set their own override.
+    """
+    with override_settings(BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS=2):
+        yield
 
 
 @pytest.fixture

--- a/products/batch_exports/backend/tests/temporal/destinations/postgres/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/postgres/test_workflow.py
@@ -115,7 +115,7 @@ async def test_postgres_export_workflow(
                     id=workflow_id,
                     task_queue=settings.BATCH_EXPORTS_TASK_QUEUE,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=10),
+                    execution_timeout=dt.timedelta(seconds=60),
                 )
 
     runs = await afetch_batch_export_runs(batch_export_id=postgres_batch_export.id)
@@ -209,7 +209,7 @@ async def test_postgres_export_workflow_with_integration(
                     id=workflow_id,
                     task_queue=settings.BATCH_EXPORTS_TASK_QUEUE,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=10),
+                    execution_timeout=dt.timedelta(seconds=60),
                 )
 
     runs = await afetch_batch_export_runs(batch_export_id=postgres_batch_export.id)
@@ -295,7 +295,7 @@ async def test_postgres_export_workflow_without_events(
                     id=workflow_id,
                     task_queue=settings.BATCH_EXPORTS_TASK_QUEUE,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=10),
+                    execution_timeout=dt.timedelta(seconds=60),
                 )
 
     runs = await afetch_batch_export_runs(batch_export_id=postgres_batch_export.id)

--- a/products/batch_exports/backend/tests/temporal/destinations/postgres/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/postgres/test_workflow.py
@@ -115,7 +115,7 @@ async def test_postgres_export_workflow(
                     id=workflow_id,
                     task_queue=settings.BATCH_EXPORTS_TASK_QUEUE,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=60),
+                    execution_timeout=dt.timedelta(seconds=10),
                 )
 
     runs = await afetch_batch_export_runs(batch_export_id=postgres_batch_export.id)
@@ -209,7 +209,7 @@ async def test_postgres_export_workflow_with_integration(
                     id=workflow_id,
                     task_queue=settings.BATCH_EXPORTS_TASK_QUEUE,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=60),
+                    execution_timeout=dt.timedelta(seconds=10),
                 )
 
     runs = await afetch_batch_export_runs(batch_export_id=postgres_batch_export.id)
@@ -295,7 +295,7 @@ async def test_postgres_export_workflow_without_events(
                     id=workflow_id,
                     task_queue=settings.BATCH_EXPORTS_TASK_QUEUE,
                     retry_policy=RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=60),
+                    execution_timeout=dt.timedelta(seconds=10),
                 )
 
     runs = await afetch_batch_export_runs(batch_export_id=postgres_batch_export.id)


### PR DESCRIPTION
## Problem

- Master red twice on 2026-07-22: `test_postgres_export_workflow` hits `Workflow timed out` on Temporal shard 8/14, random variant, greens interleaved ([evidence run](https://github.com/PostHog/posthog/actions/runs/29920516205)).
- From `junit-results-backend-temporal-*` artifacts:

| master | Jul 17 | Jul 20 | Jul 21 | Jul 22 |
|---|---|---|---|---|
| pg variants on shard 8 | 0 | 0 | 11 | 13 |
| slowest pg variant | 1.6s (shard 9) | 1.6s (shard 9) | 1.0s | 23.5s |
| pg timeout failures | 0 | 0 | 0 | 24 |

- A pytest-split re-split moved the tests onto shard 8, where staging inserts (prod default: 10 concurrent S3 partition files per ~1s insert, × xdist workers and co-tenant suites) develop a 23–28s tail past the 10s workflow timeout.

## Changes

- Autouse fixture caps `BATCH_EXPORT_CLICKHOUSE_S3_PARTITIONS` at 2 in temporal tests; partition-sensitive tests keep their own overrides.
- Reverts the interim 60s timeout raise — 10s stays as the flake detector.

## How did you test this code?

- Local full stack: postgres workflow suite 24 passed, internal stage suite 41 passed; consumer still reads 2 staged files.
- In progress: 20 CI reruns of shard 8/14 on this branch vs master as live control (baseline 24 failures/~50 runs). Results posted before marking ready.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code: root cause from run logs + junit artifacts; first draft raised the timeout, redone after review pushback. Skills: /debugging-ci-failures, /fixing-flaky-tests.
