### PR TITLE
feat(workflows): block email sends for suspended teams in the email worker

### DIFF
--- a/nodejs/src/cdp/services/managers/team-workflows-config.service.ts
+++ b/nodejs/src/cdp/services/managers/team-workflows-config.service.ts
@@ -1,5 +1,6 @@
 import { PostgresRouter, PostgresUse } from '~/common/utils/db/postgres'
 import { LazyLoader } from '~/common/utils/lazy-loader'
+import { logger } from '~/common/utils/logger'
 
 // Mirrors EmailTrackingConsentMode in products/workflows/backend/models/team_workflows_config.py
 export type EmailTrackingConsentMode = 'off' | 'opt_out' | 'opt_in'
@@ -7,11 +8,13 @@ export type EmailTrackingConsentMode = 'off' | 'opt_out' | 'opt_in'
 export type TeamWorkflowsConfig = {
     capture_workflows_engagement_events: boolean
     email_tracking_consent_mode: EmailTrackingConsentMode
+    email_sending_suspended: boolean
 }
 
 const DEFAULT_CONFIG: TeamWorkflowsConfig = {
     capture_workflows_engagement_events: false,
     email_tracking_consent_mode: 'off',
+    email_sending_suspended: false,
 }
 
 /**
@@ -45,14 +48,30 @@ export class TeamWorkflowsConfigService {
         return config.email_tracking_consent_mode
     }
 
+    /**
+     * Team-level kill switch, set by staff when a team's sender reputation puts shared SES
+     * deliverability at risk. Fails open: a lookup error must never block legitimate sends.
+     */
+    public async isEmailSendingSuspended(teamId: number): Promise<boolean> {
+        try {
+            const config = await this.get(teamId)
+            return config.email_sending_suspended
+        } catch (error) {
+            logger.error('[TeamWorkflowsConfig] Failed to check email sending suspension', { teamId, error })
+            return false
+        }
+    }
+
     private async fetchConfigs(teamIds: string[]): Promise<Record<string, TeamWorkflowsConfig>> {
         const result = await this.postgres.query<{
             team_id: number
             capture_workflows_engagement_events: boolean
             email_tracking_consent_mode: EmailTrackingConsentMode
+            email_sending_suspended: boolean
         }>(
             PostgresUse.COMMON_READ,
-            `SELECT team_id, capture_workflows_engagement_events, email_tracking_consent_mode
+            `SELECT team_id, capture_workflows_engagement_events, email_tracking_consent_mode,
+                    email_sending_suspended_at IS NOT NULL AS email_sending_suspended
              FROM workflows_teamworkflowsconfig
              WHERE team_id = ANY($1)`,
             [teamIds.map(Number)],
@@ -67,6 +86,7 @@ export class TeamWorkflowsConfigService {
             configs[String(row.team_id)] = {
                 capture_workflows_engagement_events: row.capture_workflows_engagement_events,
                 email_tracking_consent_mode: row.email_tracking_consent_mode ?? 'off',
+                email_sending_suspended: row.email_sending_suspended,
             }
         }
         return configs

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -504,6 +504,43 @@ describe('EmailService', () => {
             })
         })
 
+        describe('team suspension enforcement at send time', () => {
+            // Guards the reputation kill switch: while a team is suspended, no send path may
+            // reach SES — including editor test sends, which count against the tenant too.
+            it('does not call SES while the team is suspended and records email_suspended', async () => {
+                jest.spyOn(service['teamWorkflowsConfigService'], 'isEmailSendingSuspended').mockResolvedValue(true)
+                sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
+
+                const result = await service.executeSendEmail(invocation)
+
+                expect(sendEmailSpy).not.toHaveBeenCalled()
+                expect(result.metrics.map((m) => m.metric_name)).toEqual(['email_suspended'])
+                expect(invocation.state.vmState?.stack).toEqual([{ success: false }])
+            })
+
+            it('blocks editor test sends while suspended without recording metrics', async () => {
+                jest.spyOn(service['teamWorkflowsConfigService'], 'isEmailSendingSuspended').mockResolvedValue(true)
+                sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
+
+                const result = await service.executeSendEmail(invocation, true)
+
+                expect(sendEmailSpy).not.toHaveBeenCalled()
+                expect(result.metrics).toEqual([])
+            })
+
+            it('fails open when the suspension lookup errors', async () => {
+                // The config lookup rejecting must never block a legitimate send. Rejects once:
+                // the suspension check is the first config read; later reads use the real loader.
+                jest.spyOn(service['teamWorkflowsConfigService'], 'get').mockRejectedValueOnce(new Error('pg down'))
+                sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
+
+                const result = await service.executeSendEmail(invocation)
+
+                expect(sendEmailSpy).toHaveBeenCalledTimes(1)
+                expect(result.metrics.map((m) => m.metric_name)).toContain('email_sent')
+            })
+        })
+
         it('should include cc addresses in SES destination', async () => {
             sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
             invocation.queueParameters = createEmailParams({

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -181,6 +181,26 @@ export class EmailService {
         let trackingEnabled = true
 
         try {
+            // Team-level kill switch: staff suspend all workflow email for a team whose sender
+            // reputation endangers shared SES deliverability. Same choke-point placement as the
+            // suppression check below so no upstream route can bypass it. Test sends are blocked
+            // too — they hit SES and count against the tenant all the same.
+            if (await this.teamWorkflowsConfigService.isEmailSendingSuspended(invocation.teamId)) {
+                addLog('warn', 'Skipping send: email sending is suspended for this project')
+                if (!isTest) {
+                    result.metrics.push({
+                        team_id: invocation.teamId,
+                        app_source_id: invocation.parentRunId ?? invocation.functionId,
+                        instance_id: invocation.state.actionId || invocation.id,
+                        metric_kind: 'email',
+                        metric_name: 'email_suspended',
+                        count: 1,
+                    })
+                }
+                result.invocation.state.vmState?.stack.push({ success: false })
+                return result
+            }
+
             // Wrong-team references deliberately read as not-found so an ID's existence on another team can't be probed
             if (!integration || integration.team_id !== invocation.teamId) {
                 throw new Error(

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -241,6 +241,7 @@ export type MinimalAppMetric = {
         | 'email_bounced_undetermined'
         | 'email_bounce_prevented'
         | 'email_suppressed'
+        | 'email_suspended'
         | 'email_blocked'
         | 'email_spam'
         | 'email_unsubscribed'

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -47,6 +47,7 @@ export type EmailMetric =
     | 'email_blocked'
     | 'email_spam'
     | 'email_untracked'
+    | 'email_suspended'
 
 export type PushMetric = 'push_sent' | 'push_skipped' | 'push_failed'
 
@@ -110,6 +111,7 @@ export const METRIC_COLORS: Record<string, string> = {
     Blocked: getColorVar('data-color-8'),
     'Marked as spam': getColorVar('data-color-9'),
     Untracked: getColorVar('data-color-10'),
+    Suspended: getColorVar('data-color-11'),
     Skipped: getColorVar('data-color-2'),
     // Workflow run + batch-job metrics
     Success: getColorVar('success'),
@@ -231,6 +233,13 @@ export const WORKFLOW_EMAIL_METRICS: Record<
         color: METRIC_COLORS['Untracked'],
         metricNames: ['email_untracked'],
     },
+    email_suspended: {
+        name: 'Suspended',
+        description:
+            'Total number of emails that were not sent because email sending is suspended for this project. Check the Reputation tab for details.',
+        color: METRIC_COLORS['Suspended'],
+        metricNames: ['email_suspended'],
+    },
 }
 
 // Push has no delivery-receipt channel like email's SES webhook (FCM/APNs respond synchronously), so
@@ -276,6 +285,8 @@ export const EMAIL_METRIC_INVOCATION_FILTERS: Partial<
     // MX-validation skips log "Skipping send: …" at INFO (see HogFunctionHandler in the plugin server).
     email_bounce_prevented: { search: 'Skipping send', levels: ['INFO'] },
     email_blocked: { search: 'Complaint', levels: ['WARN', 'ERROR'] },
+    // Suspension skips log "Skipping send: email sending is suspended …" at WARN (EmailService).
+    email_suspended: { search: 'Skipping send', levels: ['WARN'] },
 }
 
 // Build the router search params that point the Invocations tab at the runs behind the given email
@@ -314,6 +325,7 @@ const EMAIL_METRICS: EmailMetric[] = [
     'email_blocked',
     'email_spam',
     'email_untracked',
+    'email_suspended',
 ]
 
 const PUSH_METRICS: PushMetric[] = ['push_sent', 'push_skipped', 'push_failed']

--- a/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
+++ b/products/workflows/frontend/Workflows/workflowMetricsSummaryLogic.ts
@@ -236,7 +236,7 @@ export const WORKFLOW_EMAIL_METRICS: Record<
     email_suspended: {
         name: 'Suspended',
         description:
-            'Total number of emails that were not sent because email sending is suspended for this project. Check the Reputation tab for details.',
+            'Total number of emails that were not sent because email sending is suspended for this project. Contact support to get sending re-enabled.',
         color: METRIC_COLORS['Suspended'],
         metricNames: ['email_suspended'],
     },


### PR DESCRIPTION
## Problem

Second piece of phase A enforcement for workflow email reputation (stacked on #72891). When staff suspend a team's email sending because its bounce or complaint rates put shared SES deliverability at risk, the CDP email worker has to actually stop the sends.

## Changes

- `TeamWorkflowsConfigService` now also selects `email_sending_suspended_at IS NOT NULL` and exposes `isEmailSendingSuspended(teamId)`. It fails open – a lookup error must never block legitimate sends (same contract as the suppression list check). Propagation is the loader's existing 2 min TTL + 30s jitter, so a flipped switch reaches all worker pods within ~2.5 minutes.
- `EmailService.executeSendEmail` gets a suspension guard at the same choke point as the suppression check, so no upstream route (workflow action or email destination hog function) can bypass it. Blocked sends log at WARN, emit an `email_suspended` app metric, and push `{success: false}` to the VM stack. Editor test sends are blocked too – they hit SES and count against the tenant all the same – but skip the metric, matching existing test-send behavior.
- `email_suspended` is wired into the workflow email metrics UI (`WORKFLOW_EMAIL_METRICS`, colors, invocation drill-down filter) so blocked sends are visible per workflow with a friendly label instead of a raw metric name.

## How did you test this code?

- `email.service.test.ts`: full suite passes locally (56/56). New tests cover the regressions nothing else catches: suspended team never reaches SES and records `email_suspended`; editor test sends are blocked without metrics; a rejecting config lookup fails open and the send proceeds.
- `workflowMetricsSummaryLogic.test.ts` passes (29/29).
- nodejs `tsc --noEmit` clean for changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Skills invoked: /writing-tests. Stacked on #72891 because the nodejs Jest schema is generated from the branch's Django models, so the enforcement tests need the new columns present. The guard runs before integration validation deliberately – suspension dominates any other send-time error, and the check is one cached lookup so ordering costs nothing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*