### PR TITLE
fix(cohorts): work around clickhouse 26.3 union distinct dedup loss

### DIFF
--- a/posthog/hogql/constants.py
+++ b/posthog/hogql/constants.py
@@ -196,6 +196,13 @@ class HogQLGlobalSettings(HogQLQuerySettings):
     # [minIf(..., notNullIn(...))]` (THERE_IS_NO_COLUMN). Same bug class as #64487; disabling the rewrite avoids it
     # without touching NULL semantics (unlike transform_null_in).
     optimize_min_inequality_conjunction_chain_length: Optional[int] = 4294967295
+    # A bugfix workaround for UNION/INTERSECT DISTINCT losing deduplication on ClickHouse 26.3.x when
+    # every branch carries an ORDER BY: the planner puts DistinctSortedStreamTransform (adjacent-row
+    # dedup, assumes a globally sorted input) after the Resize that merely concatenates the branches'
+    # independently sorted streams, so cross-branch duplicates survive. 26.6 plans a hash
+    # DistinctTransform instead. Only effective at the outermost statement level (branch-level settings
+    # are ignored for the distinct step), so set it on the executor's global settings, not per SELECT.
+    optimize_distinct_in_order: Optional[bool] = None
     # experimental support for nonequal joins
     allow_experimental_join_condition: Optional[bool] = True
     preferred_block_size_bytes: Optional[int] = None

--- a/posthog/hogql_queries/hogql_cohort_query.py
+++ b/posthog/hogql_queries/hogql_cohort_query.py
@@ -274,7 +274,9 @@ class HogQLCohortQuery:
             modifiers=HogQLQueryModifiers(personsOnEventsMode=PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED),
             team=self.team,
             limit_context=LimitContext.COHORT_CALCULATION,
-            settings=HogQLGlobalSettings(),
+            # OR conditions print as UNION DISTINCT of ORDER BY-ed branches, which loses dedup on
+            # ClickHouse 26.3.x (see HogQLGlobalSettings.optimize_distinct_in_order).
+            settings=HogQLGlobalSettings(optimize_distinct_in_order=False),
         )
 
     def get_query(self) -> SelectQuery | SelectSetQuery:

--- a/products/cohorts/backend/models/sql.py
+++ b/products/cohorts/backend/models/sql.py
@@ -38,13 +38,16 @@ WHERE team_id = %(team_id)s AND cohort_id = %(cohort_id)s AND version = %(versio
 
 # Continually ensure that all previous version rows are deleted and insert persons that match the criteria
 # optimize_aggregation_in_order = 1 is necessary to avoid oom'ing for our biggest clients
+# optimize_distinct_in_order = 0 works around UNION DISTINCT returning duplicates on ClickHouse 26.3.x
+# when branches are sorted (see HogQLGlobalSettings.optimize_distinct_in_order); the embedded
+# {cohort_filter} has its own trailing SETTINGS trimmed, so the workaround must live on this INSERT.
 RECALCULATE_COHORT_BY_ID = """
 INSERT INTO cohortpeople
 SELECT id, %(cohort_id)s as cohort_id, %(team_id)s as team_id, 1 AS sign, %(new_version)s AS version
 FROM (
     {cohort_filter}
 ) as person
-SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'auto'
+SETTINGS optimize_aggregation_in_order = 1, join_algorithm = 'auto', optimize_distinct_in_order = 0
 """
 
 # NOTE: Group by version id to ensure that signs are summed between corresponding rows.


### PR DESCRIPTION
## Problem

- ClickHouse 26.3.x loses UNION DISTINCT dedup when every branch carries an ORDER BY. OR-cohorts print exactly that shape: duplicate `sign=+1` cohortpeople rows in prod, and canary `test_cohort_filter_with_extra` reddened master 2h43m on 2026-07-22 ([run](https://github.com/PostHog/posthog/actions/runs/29886642430)).

| 100k-unique UNION DISTINCT | result | distinct plan |
|---|---|---|
| 26.3.10 (prod US/EU, CI oldest) | 150k rows | `DistinctSortedStreamTransform` after Resize |
| 26.6.1 | 100k rows | hash `DistinctTransform` |

- Reopens [#72289](https://github.com/PostHog/posthog/pull/72289); [#72295](https://github.com/PostHog/posthog/pull/72295) only skipped events_json and deferred this.

> [!NOTE]
> Parked as draft: CH 26.6 is rolling out (EU done, US this week). Dead code once `oldest_supported` bumps — merge only if the US upgrade slips.

## Changes

- `optimize_distinct_in_order=0` on the cohort executor and `RECALCULATE_COHORT_BY_ID` (embedded subquery's SETTINGS gets trimmed, so it must live on the INSERT).
- New optional `HogQLGlobalSettings` field, default `None` — no other query or snapshot changes.

## How did you test this code?

- Same diff as #72289: docker repro on 26.3.10 flips 150k back to 100k at both levels; 49 cohort tests green; canary validates on CI's 26.3.10 shards.
- Re-applied clean; ruff and preflight green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code: confirmed today's master red included the canary post-#72295; root cause proven earlier via `EXPLAIN PIPELINE`. Skills: /debugging-ci-failures.
