### PR TITLE
chore(dev): fix gemini api key env var name in .env.local.example

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -10,7 +10,7 @@
 # Required to run Max and other AI features against real providers.
 # OPENAI_API_KEY=op://General/sbadkrbtbdgev4mjm4xtuirfoy/credential
 # ANTHROPIC_API_KEY=op://General/4n2rpvrjbmlkvpd464dekedzmy/credential
-# GOOGLE_API_KEY=op://General/53ir3ynk3e4h6ic4q4ftcph76i/credential
+# GEMINI_API_KEY=op://General/53ir3ynk3e4h6ic4q4ftcph76i/credential
 # INKEEP_API_KEY=op://General/y5mqpg2xnmzosdqocob5phlgni/credential
 # AZURE_INFERENCE_ENDPOINT=op://General/yw6efvcz5ooxx5fgll3kyang5a/username
 # AZURE_INFERENCE_CREDENTIAL=op://General/yw6efvcz5ooxx5fgll3kyang5a/credential


### PR DESCRIPTION
## Problem

`.env.local.example` offers a 1Password reference for `GOOGLE_API_KEY`, but nothing in the repo reads that env var. The backend reads `GEMINI_API_KEY` (`ee/settings.py`), and every Gemini client passes `api_key=settings.GEMINI_API_KEY` explicitly, so the SDK's implicit `GOOGLE_API_KEY` fallback never applies either. Anyone who uncommented the example line got a silent no-op and Gemini-backed features (wizard, surveys AI, replay vision, session moments, product tours, LLM analytics summaries) still failed with "GEMINI_API_KEY is not set".

The 1Password item the line points to is the Gemini local-dev key, so only the env var name is wrong.

## Changes

Renames the example line from `GOOGLE_API_KEY` to `GEMINI_API_KEY`, keeping the same `op://` reference.

## How did you test this code?

Comment-only change to an example file, no code paths affected. I verified with a repo-wide search that `GOOGLE_API_KEY` has no consumers (Python, services, plugin-server, dags) and that `GEMINI_API_KEY` is what `ee/settings.py` reads, and confirmed the referenced 1Password item is the Gemini local-dev credential.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference `GOOGLE_API_KEY`, nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Fable 5) investigated whether `GEMINI_API_KEY` was covered by the existing 1Password `op://` prefill flow, found the misnamed example line, and made this one-line fix. Verification was a repo-wide search for consumers of both env vars plus a metadata-only lookup (title, no secret) of the referenced 1Password item to confirm it holds the Gemini key.
