### PR TITLE
fix(replay-vision): quality tab fixes from testing round

### DIFF
--- a/frontend/src/lib/lemon-ui/PaginationControl/types.ts
+++ b/frontend/src/lib/lemon-ui/PaginationControl/types.ts
@@ -21,6 +21,12 @@ export interface PaginationManual extends PaginationBase {
     onForward?: () => void
     /** Previous page navigation handler. */
     onBackward?: () => void
+    /**
+     * Set to false to stop page changes from being pushed to the URL as a `page` search param.
+     * Only for tables whose page state lives entirely in their own logic: handler-less controlled
+     * tables navigate exclusively through that URL param, so they must keep the default.
+     */
+    useUrl?: boolean
 }
 
 export type PaginationState<T> = {

--- a/frontend/src/lib/lemon-ui/PaginationControl/usePagination.test.ts
+++ b/frontend/src/lib/lemon-ui/PaginationControl/usePagination.test.ts
@@ -1,0 +1,31 @@
+import { act, renderHook } from '@testing-library/react'
+import { router } from 'kea-router'
+
+import { initKeaTests } from '~/test/init'
+
+import { usePagination } from './usePagination'
+
+const DATA = ['a', 'b', 'c']
+
+describe('usePagination', () => {
+    beforeEach(() => {
+        initKeaTests()
+        router.actions.push('/table')
+    })
+
+    it('setCurrentPage pushes the page into the URL by default', () => {
+        const { result } = renderHook(() =>
+            usePagination(DATA, { controlled: true, pageSize: 1, currentPage: 1, entryCount: 3 })
+        )
+        act(() => result.current.setCurrentPage(2))
+        expect(router.values.searchParams.page).toBe(2)
+    })
+
+    it('setCurrentPage leaves the URL alone when useUrl is false', () => {
+        const { result } = renderHook(() =>
+            usePagination(DATA, { controlled: true, pageSize: 1, currentPage: 1, entryCount: 3, useUrl: false })
+        )
+        act(() => result.current.setCurrentPage(2))
+        expect(router.values.searchParams.page).toBeUndefined()
+    })
+})

--- a/frontend/src/lib/lemon-ui/PaginationControl/usePagination.ts
+++ b/frontend/src/lib/lemon-ui/PaginationControl/usePagination.ts
@@ -15,9 +15,14 @@ export function usePagination<T>(
     const { location, searchParams, hashParams } = useValues(router)
     const { push } = useActions(router)
 
+    const syncPageToUrl = !(pagination?.controlled && pagination.useUrl === false)
     const setCurrentPage = useCallback(
-        (newPage: number) => push(location.pathname, { ...searchParams, [currentPageParam]: newPage }, hashParams),
-        [location, searchParams, hashParams, push] // oxlint-disable-line react-hooks/exhaustive-deps
+        (newPage: number) => {
+            if (syncPageToUrl) {
+                push(location.pathname, { ...searchParams, [currentPageParam]: newPage }, hashParams)
+            }
+        },
+        [location, searchParams, hashParams, push, syncPageToUrl] // oxlint-disable-line react-hooks/exhaustive-deps
     )
 
     const entryCount: number | null = pagination?.controlled ? pagination.entryCount || null : dataSource.length

--- a/products/replay_vision/backend/prompt_suggestions.py
+++ b/products/replay_vision/backend/prompt_suggestions.py
@@ -227,11 +227,16 @@ def _build_user_content(
 
 def _gemini_client() -> GeminiClient:
     # The generate endpoint runs inline in a web worker, so a hung provider call must time out.
-    return genai.Client(
-        api_key=settings.REPLAY_VISION_GEMINI_API_KEY or settings.GEMINI_API_KEY,
-        posthog_client=posthoganalytics.default_client,
-        http_options={"timeout": _MODEL_CALL_TIMEOUT_MS},
-    )
+    try:
+        return genai.Client(
+            api_key=settings.REPLAY_VISION_GEMINI_API_KEY or settings.GEMINI_API_KEY,
+            posthog_client=posthoganalytics.default_client,
+            http_options={"timeout": _MODEL_CALL_TIMEOUT_MS},
+        )
+    except Exception as e:
+        # A missing or malformed API key raises at construction. Wrap it so the API returns
+        # the friendly 400 instead of a 500.
+        raise PromptSuggestionError("model client unavailable") from e
 
 
 def _parse_llm_output(text: str) -> dict[str, Any]:

--- a/products/replay_vision/backend/prompt_suggestions.py
+++ b/products/replay_vision/backend/prompt_suggestions.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from django.conf import settings
 from django.db import transaction
+from django.db.models import Count, Q
 from django.db.models.fields.json import KeyTextTransform
 from django.utils import timezone
 
@@ -620,7 +621,16 @@ def generate_prompt_suggestion(
     # The change list is the source of truth for "did anything meaningful change": dict equality trips on
     # keys a proposer always injects (e.g. a defaulted allow_inconclusive) that the stored config never had.
     status = SuggestionStatus.NO_CHANGE if not changes else SuggestionStatus.PENDING
-    up = len([o for o in observations if _label(o).is_correct])
+    # Count the full rated set, not the capped briefing slice: the agent can page through every rated
+    # session via its tools, and the UI shows these next to chart totals computed over all ratings.
+    label_counts = ReplayObservation.objects.filter(
+        team_id=scanner.team_id,
+        scanner_id=scanner.id,
+        status=ObservationStatus.SUCCEEDED,
+        label__isnull=False,
+    ).aggregate(up=Count("id", filter=Q(label__is_correct=True)), total=Count("id"))
+    up = label_counts["up"] or 0
+    down = (label_counts["total"] or 0) - up
     with transaction.atomic():
         # Serialize per scanner: a manual generate racing the sweep refresh must not leave two pending rows.
         ReplayScanner.objects.select_for_update().filter(team_id=scanner.team_id, pk=scanner.pk).first()
@@ -639,7 +649,7 @@ def generate_prompt_suggestion(
             rationale=str(llm_output.get("rationale", "")).strip(),
             status=status,
             based_on_up=up,
-            based_on_down=len(observations) - up,
+            based_on_down=down,
             labels_fingerprint=labels_fingerprint(scanner),
             scanner_version=scanner.scanner_version,
             created_by=user,

--- a/products/replay_vision/backend/proposers/monitor.py
+++ b/products/replay_vision/backend/proposers/monitor.py
@@ -36,7 +36,10 @@ class MonitorProposer:
         return _SYSTEM_PROMPT
 
     def grounding(self, scanner: "ReplayScanner") -> str:
-        return ""
+        # The schema requires echoing allow_inconclusive, so the briefing must state the current value.
+        # Without it the model guesses and writes rationales claiming flag changes that are no-ops.
+        allow = bool((scanner.scanner_config or {}).get("allow_inconclusive", False))
+        return f"Current allow_inconclusive: {str(allow).lower()}."
 
     def to_config_patch(self, llm_output: dict[str, Any], base_config: dict[str, Any]) -> dict[str, Any]:
         config = dict(base_config)

--- a/products/replay_vision/backend/proposers/scorer.py
+++ b/products/replay_vision/backend/proposers/scorer.py
@@ -45,7 +45,12 @@ class ScorerProposer:
         return _SYSTEM_PROMPT
 
     def grounding(self, scanner: "ReplayScanner") -> str:
-        return ""
+        # The schema requires echoing the scale, so the briefing must state the current one.
+        scale = (scanner.scanner_config or {}).get("scale") or {}
+        if not scale:
+            return ""
+        label = f" ({scale['label']})" if scale.get("label") else ""
+        return f"Current scale: {scale.get('min')} to {scale.get('max')}{label}."
 
     def to_config_patch(self, llm_output: dict[str, Any], base_config: dict[str, Any]) -> dict[str, Any]:
         config = dict(base_config)

--- a/products/replay_vision/backend/proposers/summarizer.py
+++ b/products/replay_vision/backend/proposers/summarizer.py
@@ -38,7 +38,9 @@ class SummarizerProposer:
         return _SYSTEM_PROMPT
 
     def grounding(self, scanner: "ReplayScanner") -> str:
-        return ""
+        # The schema requires echoing the length, so the briefing must state the current one.
+        length = (scanner.scanner_config or {}).get("length", "medium")
+        return f"Current summary length: {length}."
 
     def to_config_patch(self, llm_output: dict[str, Any], base_config: dict[str, Any]) -> dict[str, Any]:
         config = dict(base_config)

--- a/products/replay_vision/backend/tag_suggestions.py
+++ b/products/replay_vision/backend/tag_suggestions.py
@@ -301,11 +301,16 @@ def _generate(*, user_content: str, team_id: int, distinct_id: str) -> _LlmSugge
     # Inline the key resolution (rather than importing the temporal helper) to keep this off the temporal import path.
     api_key = settings.REPLAY_VISION_GEMINI_API_KEY or settings.GEMINI_API_KEY
     # Runs inline on the interactive request path, so a hung provider call must time out.
-    client = genai.Client(
-        api_key=api_key,
-        posthog_client=posthoganalytics.default_client,
-        http_options={"timeout": _MODEL_CALL_TIMEOUT_MS},
-    )
+    try:
+        client = genai.Client(
+            api_key=api_key,
+            posthog_client=posthoganalytics.default_client,
+            http_options={"timeout": _MODEL_CALL_TIMEOUT_MS},
+        )
+    except Exception as e:
+        # A missing or malformed API key raises at construction. Wrap it so the API returns
+        # the friendly 503 instead of a 500.
+        raise SuggestionError("model client unavailable") from e
     config = GenerateContentConfig(
         system_instruction=_SYSTEM_PROMPT,
         response_mime_type="application/json",

--- a/products/replay_vision/backend/tests/test_prompt_suggestions_api.py
+++ b/products/replay_vision/backend/tests/test_prompt_suggestions_api.py
@@ -100,6 +100,20 @@ class TestPromptSuggestions(_VisionAPITestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertFalse(ReplayScannerPromptSuggestion.objects.exists())
 
+    def test_based_on_counts_cover_all_ratings_beyond_briefing_cap(self) -> None:
+        # The briefing is capped to the most recent rated sessions, but based_on_* is shown in the UI
+        # next to chart totals over ALL ratings, and the agent can page through the full set via tools.
+        self._create_rated_observation("sess-1", True)
+        self._create_rated_observation("sess-2", True)
+        self._create_rated_observation("sess-3", False, "should be yes")
+
+        with patch("products.replay_vision.backend.prompt_suggestions._MAX_RATED_SESSIONS", 2):
+            resp = self.client.post(self._suggestions_url("generate/"))
+
+        self.assertEqual(resp.status_code, 200, resp.json())
+        self.assertEqual(resp.json()["based_on_up"], 2)
+        self.assertEqual(resp.json()["based_on_down"], 1)
+
     def test_generate_returns_friendly_error_when_model_client_unavailable(self) -> None:
         # A missing/malformed Gemini key raises at client construction, before any model call.
         # Run the real generation paths so the failure propagates as it would in production.

--- a/products/replay_vision/backend/tests/test_prompt_suggestions_api.py
+++ b/products/replay_vision/backend/tests/test_prompt_suggestions_api.py
@@ -100,6 +100,26 @@ class TestPromptSuggestions(_VisionAPITestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertFalse(ReplayScannerPromptSuggestion.objects.exists())
 
+    def test_generate_returns_friendly_error_when_model_client_unavailable(self) -> None:
+        # A missing/malformed Gemini key raises at client construction, before any model call.
+        # Run the real generation paths so the failure propagates as it would in production.
+        self._create_rated_observation("sess-1", False, "should be yes")
+        self.agentic_patcher.stop()
+        self.generate_patcher.stop()
+        try:
+            with patch(
+                "products.replay_vision.backend.prompt_suggestions.genai.Client",
+                side_effect=ValueError("Missing key inputs argument!"),
+            ):
+                resp = self.client.post(self._suggestions_url("generate/"))
+        finally:
+            self.mock_agentic = self.agentic_patcher.start()
+            self.mock_generate = self.generate_patcher.start()
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("Couldn't generate a suggestion right now", resp.json()["detail"])
+        self.assertFalse(ReplayScannerPromptSuggestion.objects.exists())
+
     def test_quality_flag_off_hides_endpoints(self) -> None:
         # `replay-vision-quality` gates the sub-feature even when product-level `replay-vision` is on.
         self._create_rated_observation("sess-1", True)

--- a/products/replay_vision/backend/tests/test_proposers.py
+++ b/products/replay_vision/backend/tests/test_proposers.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 
-from products.replay_vision.backend.models.replay_scanner import ScannerType
+from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerType
 from products.replay_vision.backend.proposers import get_proposer
 from products.replay_vision.backend.proposers.base import ConfigChange
 from products.replay_vision.backend.tests.test_api import _VisionAPITestCase
@@ -190,6 +190,26 @@ def test_summarizer_patch_defends_against_missing_or_invalid_length() -> None:
         proposer.to_config_patch({"suggested_prompt": "p2", "length": "epic", "rationale": "r"}, base)["length"]
         == "long"
     )
+
+
+@pytest.mark.parametrize(
+    "scanner_type,config,expected",
+    [
+        ("monitor", {"prompt": "p"}, "allow_inconclusive: false"),
+        ("monitor", {"prompt": "p", "allow_inconclusive": True}, "allow_inconclusive: true"),
+        ("scorer", {"prompt": "p", "scale": {"min": 1, "max": 5, "label": "frustration"}}, "1 to 5 (frustration)"),
+        ("scorer", {"prompt": "p", "scale": {"min": 0, "max": 10}}, "0 to 10."),
+        ("summarizer", {"prompt": "p"}, "length: medium"),
+        ("summarizer", {"prompt": "p", "length": "long"}, "length: long"),
+    ],
+)
+def test_grounding_states_current_type_specific_config(
+    scanner_type: str, config: dict[str, Any], expected: str
+) -> None:
+    # The output schemas force the model to echo these fields, so the briefing must state their
+    # current values. Without them the model guesses and writes rationales claiming no-op changes.
+    scanner = ReplayScanner(scanner_config=config)
+    assert expected in get_proposer(scanner_type).grounding(scanner)
 
 
 class TestClassifierGrounding(_VisionAPITestCase):

--- a/products/replay_vision/backend/tests/test_tag_suggestions.py
+++ b/products/replay_vision/backend/tests/test_tag_suggestions.py
@@ -127,6 +127,17 @@ class TestSuggestTagsEndpoint(_VisionAPITestCase):
         # The raw error must not leak to the client.
         assert "model down" not in resp.content.decode()
 
+    @patch(
+        "products.replay_vision.backend.tag_suggestions.genai.Client",
+        side_effect=ValueError("Missing key inputs argument!"),
+    )
+    def test_client_construction_failure_is_a_clean_503(self, _mock):
+        # A missing/malformed Gemini key raises at construction, before any model call.
+        # It must wrap into SuggestionError so the endpoint 503s instead of 500ing.
+        resp = self.client.post(self.suggest_url, data={"prompt": "categorize by intent"}, format="json")
+
+        assert resp.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
     def test_unknown_scanner_id_is_not_found(self):
         resp = self.client.post(
             self.suggest_url,

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerQualityTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerQualityTab.tsx
@@ -44,10 +44,11 @@ import { OBSERVATION_CREDITS_BY_MODEL } from '../types'
 import { ConfigChangeCards } from './ConfigChangeCards'
 import { versionTag } from './ScannerObservationsTable'
 
-const RATED_FILTER_OPTIONS: { value: RatedFilterValue; label: string }[] = [
-    { value: 'unrated', label: 'Unrated' },
-    { value: 'rated', label: 'Rated' },
-    { value: 'all', label: 'All' },
+// data-attr must live on each option: LemonSegmentedButton renders no element of its own that takes one.
+const RATED_FILTER_OPTIONS: { value: RatedFilterValue; label: string; 'data-attr': string }[] = [
+    { value: 'unrated', label: 'Unrated', 'data-attr': 'vision-quality-rated-filter-unrated' },
+    { value: 'rated', label: 'Rated', 'data-attr': 'vision-quality-rated-filter-rated' },
+    { value: 'all', label: 'All', 'data-attr': 'vision-quality-rated-filter-all' },
 ]
 
 const SUGGESTION_STATUS_TAGS: Record<string, { type: LemonTagType; label: string; tooltip: string }> = {
@@ -242,7 +243,12 @@ function SuggestionEvaluationPanel({
                                 title: 'Session',
                                 key: 'session',
                                 render: (_, result) => (
-                                    <Link to={urls.replaySingle(result.session_id)} className="font-mono">
+                                    // New tab like the results table links, so reviewers keep their place.
+                                    <Link
+                                        to={urls.replaySingle(result.session_id)}
+                                        target="_blank"
+                                        className="font-mono"
+                                    >
                                         {result.session_id.slice(0, 8)}…
                                     </Link>
                                 ),
@@ -575,16 +581,18 @@ function VersionBadgeBridge({
 
 type ChartMode = 'session' | 'rating'
 
-const CHART_MODE_OPTIONS: { value: ChartMode; label: string; tooltip: string }[] = [
+const CHART_MODE_OPTIONS: { value: ChartMode; label: string; tooltip: string; 'data-attr': string }[] = [
     {
         value: 'session',
         label: 'By session day',
         tooltip: 'Ratings placed on the day the session was scanned: how scanner quality trends over time',
+        'data-attr': 'vision-quality-chart-mode-session',
     },
     {
         value: 'rating',
         label: 'By rating day',
         tooltip: "Ratings placed on the day they were given or changed: the team's rating activity",
+        'data-attr': 'vision-quality-chart-mode-rating',
     },
 ]
 
@@ -644,13 +652,7 @@ function RatingsOverTimePanel({ scannerId }: { scannerId: string }): JSX.Element
                         : `last ${LABEL_CHART_DAYS} days`}
                 </span>
                 <div className="ml-auto">
-                    <LemonSegmentedButton
-                        size="xsmall"
-                        value={mode}
-                        onChange={setMode}
-                        options={CHART_MODE_OPTIONS}
-                        data-attr="vision-quality-chart-mode"
-                    />
+                    <LemonSegmentedButton size="xsmall" value={mode} onChange={setMode} options={CHART_MODE_OPTIONS} />
                 </div>
             </div>
             {versionAccuracy.length > 0 && (
@@ -951,7 +953,6 @@ export function ScannerQualityTab({ scannerId }: { scannerId: string }): JSX.Ele
                             value={ratedFilter}
                             onChange={setRatedFilter}
                             options={RATED_FILTER_OPTIONS}
-                            data-attr="vision-quality-rated-filter"
                         />
                     </div>
                 </div>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerQualityTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerQualityTab.tsx
@@ -971,6 +971,9 @@ export function ScannerQualityTab({ scannerId }: { scannerId: string }): JSX.Ele
                         entryCount: total,
                         onForward: () => setPage(page + 1),
                         onBackward: () => setPage(page - 1),
+                        // Page state lives in scannerQualityLogic; without this the control also pushes a
+                        // `page` URL param that nothing reads and that goes stale on filter or tab changes.
+                        useUrl: false,
                     }}
                     sorting={sort}
                     onSort={(next) => setSort(next)}


### PR DESCRIPTION
## Problem

A robust testing round of the Replay Vision quality tab surfaced five bugs:

1. When the Gemini client can't be constructed (missing or malformed API key), the error escapes the friendly error wrapping. `POST .../prompt_suggestions/generate/` returns a 500 instead of its designed 400, and `POST .../scanners/suggest_tags/` returns a 500 instead of its designed 503. The provider *call* is wrapped in both places, but client *construction* was not.
2. The evaluation panel's per-session replay links open in the same tab, unlike every other session link on the quality tab (which open in a new tab so reviewers keep their place in the list).
3. The `data-attr` props on the rated filter and chart mode `LemonSegmentedButton`s never reach the DOM. The component only forwards per-option `data-attr`, so `vision-quality-rated-filter` and `vision-quality-chart-mode` were invisible to autocapture and analytics.
4. `based_on_up`/`based_on_down` on prompt suggestions were computed from the capped 20-session briefing slice, so the UI shows "Based on 16 thumbs up · 4 thumbs down" right next to a ratings chart totaling all 71 ratings. The agent can page through every rated session via its tools, and staleness already fingerprints the full set, so the capped counts both confuse and undersell.
5. The proposer output schemas force the model to echo a type-specific config field (`allow_inconclusive` for monitors, `scale` for scorers, `length` for summarizers) whose current value the briefing never states. The system prompt even instructs "return the current value", which was impossible. The model guessed, producing rationales that claim changes that are no-ops (observed live: "Disabled inconclusive verdicts" on a scanner where they were already off).

Plus one shared-component wart found from the quality tab: in controlled mode, `PaginationControl` invokes both the caller's `onForward`/`onBackward` *and* `setCurrentPage`, which pushes a `page` search param that `usePagination` never reads back in controlled mode. On the quality tab that param goes stale on every filter reset and tab switch (`?tab=configuration&page=2`).

## Changes

- Wrap `genai.Client(...)` construction in `prompt_suggestions._gemini_client` and `tag_suggestions._generate`, raising the module's own suggestion error so the existing endpoint handling produces the friendly 400/503.
- Add `target="_blank"` to the evaluation panel's session links.
- Move the segmented-button `data-attr`s onto each option (`vision-quality-rated-filter-{unrated,rated,all}`, `vision-quality-chart-mode-{session,rating}`) and drop the dead component-level props.
- Compute `based_on_up`/`based_on_down` from an aggregate over the full rated set instead of the briefing slice.
- Give the monitor, scorer, and summarizer proposers a `grounding()` that states the current value of the field their schema forces the model to echo.
- Add an opt-in `useUrl: false` on `PaginationManual` that skips the URL push in `usePagination.setCurrentPage`, and set it on the quality tab table.

> [!NOTE]
> The pagination fix is deliberately opt-in rather than a controlled-mode behavior change. I surveyed every controlled table in the app: a dozen scenes (experiments, feature flags, cohorts, saved insights, several AI observability scenes) have **no** `onForward`/`onBackward` and navigate *exclusively* through that URL push read back via `urlToAction` — skipping the push in controlled mode would break their pagination outright, and no existing test simulates a pagination click, so CI would stay green. `ActivityLog` additionally reads the param for deep links despite having handlers. Cleaning up the redundant pushes in self-driving tables app-wide is a follow-up for another day.

## How did you test this code?

- New test `test_generate_returns_friendly_error_when_model_client_unavailable`: runs the real generation paths with `genai.Client` patched to raise at construction, asserts the 400 with the friendly message and that nothing is persisted. Catches the regression where a bad key 500s the generate endpoint. No existing test exercised an unmocked construction failure.
- New test `test_client_construction_failure_is_a_clean_503`: same failure mode through the `suggest_tags` endpoint, asserting the 503. The existing `test_model_failure_is_a_clean_503` only covers an already-wrapped `SuggestionError`.
- New test `test_based_on_counts_cover_all_ratings_beyond_briefing_cap`: shrinks the briefing cap to 2, rates 3 sessions, asserts counts cover all 3. Catches the counts silently reverting to the capped slice.
- New parameterized `test_grounding_states_current_type_specific_config` (6 cases): asserts each proposer's briefing states the current `allow_inconclusive`/`scale`/`length`. Catches a grounding reverting to empty, which reintroduces the forced-guess rationale bug.
- New `usePagination.test.ts` (2 cases): default still pushes `page` to the URL (the contract the handler-less tables depend on), and `useUrl: false` leaves the URL alone.
- All new backend tests were verified to **fail against the unfixed code** before the fix. Full affected suites pass (`test_prompt_suggestions_api`, `test_tag_suggestions`, `test_proposers`: 88 tests).
- No tests for the two small frontend fixes (links, data-attrs): asserting an anchor attribute would be a change-detector test. Verified live in the local app instead: per-option `data-attr`s render in the DOM, evaluation links carry `target="_blank" rel="noopener noreferrer"`, and paging the quality tab table no longer writes `?page=` while pagination keeps working.
- Frontend typecheck, repo-wide mypy, ruff, and `hogli ci:preflight --fix` all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, nothing documented changes beyond error codes and internal briefing content.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code found these bugs during a live end-to-end testing round of the quality tab (unit suites, live UI walkthrough via Playwright, and exercising suggestion generation and evaluation against a local scanner with 71 rated observations). The 500s were reproduced live by clicking "Regenerate" with no Gemini key configured, and the no-op rationale was observed on a real generation once a key was added. Skills invoked: `/writing-tests` (gating each new test), `/run-posthog` (driving the local stack). Decisions: skipped wrapping the third `genai.Client` construction in `feedback_themes.py` (all callers already wrap it best-effort, it can't 500), and rejected a blanket controlled-mode pagination fix after a codebase survey showed a dozen scenes depend on the URL push for navigation, in favor of the opt-in `useUrl: false`.
