### PR TITLE
fix(tasks): acknowledge cloud task messages asynchronously

### DIFF
--- a/products/tasks/backend/logic/services/agent_command.py
+++ b/products/tasks/backend/logic/services/agent_command.py
@@ -285,6 +285,7 @@ def send_user_message(
     timeout: int = COMMAND_TIMEOUT_SECONDS,
     message_id: str | None = None,
     steer: bool = False,
+    wait_for_completion: bool = True,
 ) -> CommandResult:
     """Send a user_message command to the sandbox agent.
 
@@ -301,6 +302,8 @@ def send_user_message(
         params["messageId"] = message_id
     if steer:
         params["steer"] = True
+    if not wait_for_completion:
+        params["waitForCompletion"] = False
     return send_agent_command(
         task_run,
         method="user_message",

--- a/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/activities/forward_pending_message.py
@@ -128,6 +128,7 @@ def forward_pending_user_message(run_id: str) -> None:
             auth_token=auth_token,
             timeout=PENDING_MESSAGE_TIMEOUT_SECONDS,
             message_id=pending_message_id,
+            wait_for_completion=False,
         )
         logger.info(
             "forward_pending_message_attempted",

--- a/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_forward_pending_message.py
@@ -101,6 +101,7 @@ class TestForwardPendingUserMessage(TestCase):
         forward_pending_user_message(str(run.id))
 
         mock_send.assert_called_once()
+        assert mock_send.call_args.kwargs["wait_for_completion"] is False
         assert mock_send.call_args[0][1] == "fix the tests"
         assert mock_send.call_args.kwargs["message_id"]
         run.refresh_from_db()


### PR DESCRIPTION
## Problem

Cloud task startup currently waits for the agent's full first turn before confirming message delivery. A long turn can exceed the sandbox tunnel timeout, causing a healthy run to be marked failed and its sandbox to be removed.

## Changes

Request the asynchronous message acknowledgement introduced by [PostHog/code#3711](https://github.com/PostHog/code/pull/3711). The task workflow can clear the pending message after acceptance while turn progress and completion continue through the existing event stream.

> [!NOTE]
> Deploy the linked agent change before this PR. Older agents ignore the opt-in field and retain the current synchronous behavior.

## How did you test this code?

- Extended the existing delivery test to verify the workflow opts into asynchronous acknowledgement. This guards against reintroducing full-turn blocking during startup.
- Ran Ruff lint and format checks on all changed files.
- The database-backed test suite could not start locally because this environment has no Docker or reachable Postgres service. Pytest collection and non-database cases completed before the database setup failures.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation change. This corrects internal message-delivery behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex investigated task lifecycle telemetry and session logs, then implemented the smallest protocol change that separates message acceptance from turn completion. I used the `/querying-posthog-data`, `/writing-tests`, and `/setup-web-tests` skills. A blanket 504-as-success approach was rejected because a tunnel timeout does not prove the sandbox received the message.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
