### PR TITLE
fix(aio): guard trace comment quote-insert against unmounted logic

### DIFF
--- a/products/ai_observability/frontend/ConversationDisplay/MessageActionsMenu.tsx
+++ b/products/ai_observability/frontend/ConversationDisplay/MessageActionsMenu.tsx
@@ -41,6 +41,11 @@ export const MessageActionsMenu = ({ content, traceId }: MessageActionsMenuProps
     }
 
     const insertQuoteIntoEditor = (quotedContent: string, retries = 0): void => {
+        // The logic can be unmounted before this deferred callback runs (e.g. the user navigates
+        // away or switches traces), so bail out rather than reading `.values` off a torn-down store.
+        if (!commentsLogicInstance.isMounted()) {
+            return
+        }
         // Access editor via .values to get the latest value at retry time, not render time
         const editor = commentsLogicInstance.values.richContentEditor
         if (editor) {

--- a/products/ai_observability/frontend/text-view/components/LineWithNumber.tsx
+++ b/products/ai_observability/frontend/text-view/components/LineWithNumber.tsx
@@ -64,6 +64,11 @@ export function LineWithNumber({
     }
 
     const insertQuoteIntoEditor = (quotedContent: string, retries = 0): void => {
+        // The logic can be unmounted before this deferred callback runs (e.g. the user navigates
+        // away or switches traces), so bail out rather than reading `.values` off a torn-down store.
+        if (!commentsLogicInstance.isMounted()) {
+            return
+        }
         const editor = commentsLogicInstance.values.richContentEditor
         if (editor) {
             editor.clear()


### PR DESCRIPTION
## Problem

Clicking "Start discussion" on a message inside an LLM trace occasionally logs a Kea error:

`[KEA] Can not find path "scenes.notebooks.Notebook.commentsLogic.LLMTrace-<traceId>" in the store.`

The action opens the discussion side panel and then, on a `setTimeout` retry loop (~1s), reaches back into `commentsLogic` to grab the rich-text editor so it can insert the quoted message. If the `commentsLogic` instance for that trace gets unmounted before the loop finishes — the user navigates away, switches traces, or the message list re-renders — the pending callback still reads `.values` off a store path that no longer exists, throwing the error. It's harmless (caught, not a crash), but noisy, and the quoted text silently fails to insert in that window.

## Changes

Guard the deferred `insertQuoteIntoEditor` callback with `commentsLogicInstance.isMounted()` so it bails out cleanly when the logic has been torn down, rather than reading `.values` off it. Applied to both `MessageActionsMenu.tsx` and `LineWithNumber.tsx`, which share the same retry pattern.

## How did you test this code?

No automated test added — the bug is a lifecycle timing race that's awkward to reproduce deterministically at a level that would catch a regression the existing suite doesn't. The fix is a one-line guard using Kea's standard `isMounted()` on a built logic (same pattern used in `frontend/src/kea-disposables.ts`). I was not able to run the frontend typecheck in this environment (`node_modules` not installed).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from an error-tracking alert. Traced the Kea store-path error to the `setTimeout` retry loop in the AI observability trace comment flow, confirmed the same pattern in two components, and guarded the deferred read with `isMounted()`. No skills required for this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1784729848925399?thread_ts=1784729848.925399&cid=C0A006STKHR)*
