### PR TITLE
fix(playwright): log in via request client to avoid navigation race

### DIFF
--- a/playwright/utils/playwright-setup.ts
+++ b/playwright/utils/playwright-setup.ts
@@ -273,40 +273,27 @@ export class PlaywrightSetup {
         return workspace
     }
 
+    // Login via the context's request client rather than an in-page fetch: the app on
+    // /login can trigger a full navigation at any time, destroying an in-flight
+    // page.evaluate. Cookies from the response propagate to the browser context.
     async login(page: Page, workspace: PlaywrightWorkspaceSetupResult): Promise<void> {
-        await page.goto(`${this.baseURL}/login`)
-        await page.waitForLoadState('networkidle')
-        await page.evaluate(
-            async ({ email, password }) => {
-                const maxAttempts = 3
-                for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-                    try {
-                        const res = await fetch('/api/login/', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify({ email, password }),
-                        })
-                        if (res.ok) {
-                            return
-                        }
-                        if (attempt === maxAttempts || res.status < 500) {
-                            throw new Error(`Login failed with status ${res.status}`)
-                        }
-                    } catch (e) {
-                        if (attempt === maxAttempts) {
-                            throw e
-                        }
-                    }
-                    await new Promise((r) => setTimeout(r, 500 * attempt))
+        const maxAttempts = 3
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                const res = await page.request.post(`${this.baseURL}/api/login/`, {
+                    data: { email: workspace.user_email, password: LOGIN_PASSWORD },
+                })
+                if (res.ok()) {
+                    return
                 }
-            },
-            {
-                email: workspace.user_email,
-                password: LOGIN_PASSWORD,
+                throw new Error(`Login failed with status ${res.status()}`)
+            } catch (e) {
+                if (attempt === maxAttempts) {
+                    throw e
+                }
             }
-        )
+            await this.delay(500 * attempt)
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

`PlaywrightSetup.login()` POSTs `/api/login/` through an in-page `fetch` inside `page.evaluate` while sitting on `/login`. The app is free to trigger a full navigation at any moment, which destroys the execution context mid-evaluate and fails whatever spec is logging in. This is currently the top flake in the E2E suite on master (same `Execution context was destroyed` error at `playwright-setup.ts:279` in 5 of the last ~11 red runs, e.g. [29925512825](https://github.com/PostHog/posthog/actions/runs/29925512825), [29920516003](https://github.com/PostHog/posthog/actions/runs/29920516003)).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Log in via `page.request.post('/api/login/')` instead of an in-page fetch, so no execution context is involved and no navigation can race it
- Session cookies from the response propagate to the browser context, so subsequent `page.goto` is authenticated (same as before)
- Keep the 3-attempt retry from #64763
- Drop the `goto('/login')` + `networkidle` round trip, saving a page load per login

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Validated the mechanism against a local dev server with a playwright script: `page.request.post('/api/login/')` returns 200 (no CSRF needed for anonymous login), and `/api/users/@me/` then returns 200 both via the request client and via in-page fetch after `page.goto('/')`. Couldn't run the e2e suite locally (needs an `E2E_TESTING=1` stack); the full suite runs on CI once this is marked ready for review.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Claude) while investigating master playwright flakiness. Skills invoked: `debugging-ci-failures`, `fixing-flaky-tests`. Evidence for the root cause: the failure artifact's screenshot/page snapshot shows the bare app-shell spinner, i.e. a fresh document mid-load right after a full navigation. The sibling flake in `dashboards.spec.ts` (tile lookup) is separately addressed by #72882. The race itself is CI-load-dependent and wasn't reproducible locally, so validation of the fix is the mechanism check above plus the structural argument (no execution context left to destroy).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
