### PR TITLE
chore(insights): throwaway prototype of insight type switcher variants

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
+++ b/frontend/src/queries/nodes/InsightViz/EditorFilters.tsx
@@ -23,6 +23,7 @@ import { RetentionOptions } from 'scenes/insights/EditorFilters/RetentionOptions
 import { SamplingDeprecationNotice } from 'scenes/insights/EditorFilters/SamplingDeprecationNotice'
 import { WebAnalyticsEditorFilters } from 'scenes/insights/EditorFilters/WebAnalyticsEditorFilters'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { SidebarTypeCardPrototype } from 'scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { FunnelVizType } from 'scenes/insights/views/Funnels/FunnelVizType'
 import { userLogic } from 'scenes/userLogic'
@@ -383,6 +384,8 @@ export function EditorFilters({ query, showing, embedded }: EditorFiltersProps):
 
     return (
         <EditorFiltersShell query={query} showing={showing} embedded={embedded}>
+            {/* PROTOTYPE(insight-type-switcher): inert unless the URL has ?variant=sidebar; throwaway */}
+            {!embedded && <SidebarTypeCardPrototype />}
             <div className="flex flex-col gap-3">
                 {allFilterGroups.map((editorFilterGroup) => (
                     <EditorFilterGroup

--- a/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
@@ -48,6 +48,8 @@ import { CORE_TYPES, EXTRA_TYPES, ExtraTypeEntry } from './SidebarTypeCardProtot
  *              carousel of sketch cards with descriptions, where the display menu's groups
  *              are the top level (time series, total value, world map, calendar heatmap,
  *              funnel, retention, ...) with display suboptions
+ *   sidebar-viz-grid : G's tinted card filled with L's viz-first options as a sketch grid,
+ *              all nine visible at once with "View as" suboptions below
  *
  * The real six types switch for real (same setActiveView as the tab strip, carry-over intact).
  * Extra entries (calendar heatmap, SQL, examples) are display-only, there to show how each
@@ -301,6 +303,7 @@ const VARIANTS = [
     { key: 'sidebar-list', name: 'Sidebar visual: quiet list' },
     { key: 'sidebar-compact', name: 'Sidebar visual: compact selects' },
     { key: 'sidebar-section', name: 'Sidebar: native section, viz carousel' },
+    { key: 'sidebar-viz-grid', name: 'Sidebar: viz grid (G card, L options)' },
 ] as const
 
 export function InsightTypeSwitcherPrototype({ insightLogicProps }: VariantProps): JSX.Element {

--- a/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useEffect, useState } from 'react'
 
-import { IconChevronDown, IconChevronLeft, IconChevronRight, IconCorrelationAnalysis, IconGraph } from '@posthog/icons'
+import { IconChevronDown, IconChevronLeft, IconChevronRight } from '@posthog/icons'
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonCard } from 'lib/lemon-ui/LemonCard'
@@ -12,12 +12,12 @@ import { LemonSelect, LemonSelectOptions } from 'lib/lemon-ui/LemonSelect'
 import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { insightNavLogic } from 'scenes/insights/InsightNav/insightNavLogic'
-import { INSIGHT_TYPES_METADATA, QUERY_TYPES_METADATA } from 'scenes/saved-insights/insightTypesMetadata'
+import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/insightTypesMetadata'
 
-import { NodeKind } from '~/queries/schema/schema-general'
 import { InsightLogicProps, InsightType } from '~/types'
 
 import { InsightsNav } from '../InsightsNav'
+import { CORE_TYPES, EXTRA_TYPES, ExtraTypeEntry } from './SidebarTypeCardPrototype'
 
 /**
  * THROWAWAY PROTOTYPE: do not ship, do not extend.
@@ -27,71 +27,20 @@ import { InsightsNav } from '../InsightsNav'
  * the editor (or to browse adjacent tabs), while a minority converts an already-configured
  * insight and relies on the config carry-over in insightNavLogic.
  *
- * Four variants of the type switcher on the real insight editor route (edit mode), switchable
+ * Five variants of the type switcher on the real insight editor route (edit mode), switchable
  * via `?variant=` or the floating bar at the bottom (arrow keys cycle too):
  *   tabs     : baseline: today's tab strip
  *   dropdown : one compact type select where the tabs sat
  *   hybrid   : Trends + Funnels stay as tabs, everything else behind a "More types" menu
  *   palette  : no persistent strip: a type chip that opens a searchable picker dialog
+ *   sidebar  : nothing in the header at all: a type + view card above the filters in the left
+ *              sidebar (see SidebarTypeCardPrototype.tsx, rendered from EditorFilters)
  *
  * The real six types switch for real (same setActiveView as the tab strip, carry-over intact).
  * Extra entries (calendar heatmap, SQL, examples) are display-only, there to show how each
  * variant copes with a longer type list. The winning variant gets rebuilt properly (quill
  * Select/Combobox, kea logic, analytics); everything in this folder gets deleted.
  */
-
-const CORE_TYPES: InsightType[] = [
-    InsightType.TRENDS,
-    InsightType.FUNNELS,
-    InsightType.RETENTION,
-    InsightType.PATHS,
-    InsightType.STICKINESS,
-    InsightType.LIFECYCLE,
-]
-
-interface ExtraTypeEntry {
-    key: string
-    name: string
-    description: string
-    icon: React.ComponentType<any>
-    tag: string
-    disabledReason: string
-}
-
-const EXTRA_TYPES: ExtraTypeEntry[] = [
-    {
-        key: 'CALENDAR_HEATMAP',
-        name: 'Calendar heatmap',
-        description: QUERY_TYPES_METADATA[NodeKind.CalendarHeatmapQuery].description ?? '',
-        icon: QUERY_TYPES_METADATA[NodeKind.CalendarHeatmapQuery].icon,
-        tag: 'Beta',
-        disabledReason: 'Real query type without a tab slot today. Display-only in this prototype',
-    },
-    {
-        key: 'SQL',
-        name: 'SQL',
-        description: INSIGHT_TYPES_METADATA[InsightType.SQL].description ?? '',
-        icon: INSIGHT_TYPES_METADATA[InsightType.SQL].icon,
-        tag: 'Editor',
-        disabledReason: 'Would open the SQL editor. Display-only in this prototype',
-    },
-    {
-        key: 'EXAMPLE_SANKEY',
-        name: 'Sankey flow',
-        description: 'Example future type, here to show how the list scales.',
-        icon: IconGraph,
-        tag: 'Example',
-        disabledReason: 'Example future type. Display-only in this prototype',
-    },
-    {
-        key: 'EXAMPLE_ANOMALY',
-        name: 'Anomaly detection',
-        description: 'Example future type, here to show how the list scales.',
-        icon: IconCorrelationAnalysis,
-        tag: 'Example',
-        disabledReason: 'Example future type. Display-only in this prototype',
-    },
-]
 
 interface VariantProps {
     insightLogicProps: InsightLogicProps
@@ -331,6 +280,7 @@ const VARIANTS = [
     { key: 'dropdown', name: 'Compact dropdown' },
     { key: 'hybrid', name: 'Hot-path tabs + More' },
     { key: 'palette', name: 'Chip + searchable picker' },
+    { key: 'sidebar', name: 'Sidebar type + view card' },
 ] as const
 
 export function InsightTypeSwitcherPrototype({ insightLogicProps }: VariantProps): JSX.Element {

--- a/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
@@ -41,6 +41,9 @@ import { CORE_TYPES, EXTRA_TYPES, ExtraTypeEntry } from './SidebarTypeCardProtot
  *              under trends, retention splits recurring vs first time)
  *   sidebar-modes     : sidebar, no regrouping: the six types in a select plus a uniform
  *              mode row surfacing each type's buried subtype picker
+ *   sidebar-sketches / sidebar-list / sidebar-compact : visual alternatives of the sidebar
+ *              card; same grouping as sidebar-families, only the looks change (sketch
+ *              gallery, quiet indented list, two bare selects)
  *
  * The real six types switch for real (same setActiveView as the tab strip, carry-over intact).
  * Extra entries (calendar heatmap, SQL, examples) are display-only, there to show how each
@@ -290,6 +293,9 @@ const VARIANTS = [
     { key: 'sidebar-questions', name: 'Sidebar: question families' },
     { key: 'sidebar-families', name: 'Sidebar: shared-editor families' },
     { key: 'sidebar-modes', name: 'Sidebar: flat + mode row' },
+    { key: 'sidebar-sketches', name: 'Sidebar visual: sketch gallery' },
+    { key: 'sidebar-list', name: 'Sidebar visual: quiet list' },
+    { key: 'sidebar-compact', name: 'Sidebar visual: compact selects' },
 ] as const
 
 export function InsightTypeSwitcherPrototype({ insightLogicProps }: VariantProps): JSX.Element {

--- a/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
@@ -44,6 +44,9 @@ import { CORE_TYPES, EXTRA_TYPES, ExtraTypeEntry } from './SidebarTypeCardProtot
  *   sidebar-sketches / sidebar-list / sidebar-compact : visual alternatives of the sidebar
  *              card; same grouping as sidebar-families, only the looks change (sketch
  *              gallery, quiet indented list, two bare selects)
+ *   sidebar-section : a native "Visualization" section styled like General/Filters; the
+ *              display menu's groups become the top level (time series, total value, world
+ *              map, calendar heatmap, funnel, retention, ...) with display suboptions
  *
  * The real six types switch for real (same setActiveView as the tab strip, carry-over intact).
  * Extra entries (calendar heatmap, SQL, examples) are display-only, there to show how each
@@ -296,6 +299,7 @@ const VARIANTS = [
     { key: 'sidebar-sketches', name: 'Sidebar visual: sketch gallery' },
     { key: 'sidebar-list', name: 'Sidebar visual: quiet list' },
     { key: 'sidebar-compact', name: 'Sidebar visual: compact selects' },
+    { key: 'sidebar-section', name: 'Sidebar: native section, viz-first' },
 ] as const
 
 export function InsightTypeSwitcherPrototype({ insightLogicProps }: VariantProps): JSX.Element {

--- a/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
@@ -35,6 +35,12 @@ import { CORE_TYPES, EXTRA_TYPES, ExtraTypeEntry } from './SidebarTypeCardProtot
  *   palette  : no persistent strip: a type chip that opens a searchable picker dialog
  *   sidebar  : nothing in the header at all: a type + view card above the filters in the left
  *              sidebar (see SidebarTypeCardPrototype.tsx, rendered from EditorFilters)
+ *   sidebar-questions : sidebar families grouped by the question asked (stickiness and
+ *              lifecycle under retention)
+ *   sidebar-families  : sidebar families grouped by shared setup (stickiness and lifecycle
+ *              under trends, retention splits recurring vs first time)
+ *   sidebar-modes     : sidebar, no regrouping: the six types in a select plus a uniform
+ *              mode row surfacing each type's buried subtype picker
  *
  * The real six types switch for real (same setActiveView as the tab strip, carry-over intact).
  * Extra entries (calendar heatmap, SQL, examples) are display-only, there to show how each
@@ -281,6 +287,9 @@ const VARIANTS = [
     { key: 'hybrid', name: 'Hot-path tabs + More' },
     { key: 'palette', name: 'Chip + searchable picker' },
     { key: 'sidebar', name: 'Sidebar type + view card' },
+    { key: 'sidebar-questions', name: 'Sidebar: question families' },
+    { key: 'sidebar-families', name: 'Sidebar: shared-editor families' },
+    { key: 'sidebar-modes', name: 'Sidebar: flat + mode row' },
 ] as const
 
 export function InsightTypeSwitcherPrototype({ insightLogicProps }: VariantProps): JSX.Element {

--- a/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
@@ -1,0 +1,407 @@
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import { useEffect, useState } from 'react'
+
+import { IconChevronDown, IconChevronLeft, IconChevronRight, IconCorrelationAnalysis, IconGraph } from '@posthog/icons'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonCard } from 'lib/lemon-ui/LemonCard'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { LemonSelect, LemonSelectOptions } from 'lib/lemon-ui/LemonSelect'
+import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { insightNavLogic } from 'scenes/insights/InsightNav/insightNavLogic'
+import { INSIGHT_TYPES_METADATA, QUERY_TYPES_METADATA } from 'scenes/saved-insights/insightTypesMetadata'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { InsightLogicProps, InsightType } from '~/types'
+
+import { InsightsNav } from '../InsightsNav'
+
+/**
+ * THROWAWAY PROTOTYPE: do not ship, do not extend.
+ *
+ * Question: can the insight type tab strip be replaced with something that scales to more
+ * insight types? Usage data says the strip is mostly used to pick a type right after opening
+ * the editor (or to browse adjacent tabs), while a minority converts an already-configured
+ * insight and relies on the config carry-over in insightNavLogic.
+ *
+ * Four variants of the type switcher on the real insight editor route (edit mode), switchable
+ * via `?variant=` or the floating bar at the bottom (arrow keys cycle too):
+ *   tabs     : baseline: today's tab strip
+ *   dropdown : one compact type select where the tabs sat
+ *   hybrid   : Trends + Funnels stay as tabs, everything else behind a "More types" menu
+ *   palette  : no persistent strip: a type chip that opens a searchable picker dialog
+ *
+ * The real six types switch for real (same setActiveView as the tab strip, carry-over intact).
+ * Extra entries (calendar heatmap, SQL, examples) are display-only, there to show how each
+ * variant copes with a longer type list. The winning variant gets rebuilt properly (quill
+ * Select/Combobox, kea logic, analytics); everything in this folder gets deleted.
+ */
+
+const CORE_TYPES: InsightType[] = [
+    InsightType.TRENDS,
+    InsightType.FUNNELS,
+    InsightType.RETENTION,
+    InsightType.PATHS,
+    InsightType.STICKINESS,
+    InsightType.LIFECYCLE,
+]
+
+interface ExtraTypeEntry {
+    key: string
+    name: string
+    description: string
+    icon: React.ComponentType<any>
+    tag: string
+    disabledReason: string
+}
+
+const EXTRA_TYPES: ExtraTypeEntry[] = [
+    {
+        key: 'CALENDAR_HEATMAP',
+        name: 'Calendar heatmap',
+        description: QUERY_TYPES_METADATA[NodeKind.CalendarHeatmapQuery].description ?? '',
+        icon: QUERY_TYPES_METADATA[NodeKind.CalendarHeatmapQuery].icon,
+        tag: 'Beta',
+        disabledReason: 'Real query type without a tab slot today. Display-only in this prototype',
+    },
+    {
+        key: 'SQL',
+        name: 'SQL',
+        description: INSIGHT_TYPES_METADATA[InsightType.SQL].description ?? '',
+        icon: INSIGHT_TYPES_METADATA[InsightType.SQL].icon,
+        tag: 'Editor',
+        disabledReason: 'Would open the SQL editor. Display-only in this prototype',
+    },
+    {
+        key: 'EXAMPLE_SANKEY',
+        name: 'Sankey flow',
+        description: 'Example future type, here to show how the list scales.',
+        icon: IconGraph,
+        tag: 'Example',
+        disabledReason: 'Example future type. Display-only in this prototype',
+    },
+    {
+        key: 'EXAMPLE_ANOMALY',
+        name: 'Anomaly detection',
+        description: 'Example future type, here to show how the list scales.',
+        icon: IconCorrelationAnalysis,
+        tag: 'Example',
+        disabledReason: 'Example future type. Display-only in this prototype',
+    },
+]
+
+interface VariantProps {
+    insightLogicProps: InsightLogicProps
+}
+
+function coreOption(type: InsightType): {
+    value: string
+    label: string
+    icon: JSX.Element
+    labelInMenu: JSX.Element
+} {
+    const meta = INSIGHT_TYPES_METADATA[type]
+    const Icon = meta.icon
+    return {
+        value: type,
+        label: meta.name,
+        icon: <Icon />,
+        labelInMenu: (
+            <div className="flex max-w-md flex-col py-0.5">
+                <span className="font-semibold">{meta.name}</span>
+                <span className="text-secondary text-xs">{meta.description}</span>
+            </div>
+        ),
+    }
+}
+
+function extraOption(entry: ExtraTypeEntry): {
+    value: string
+    label: string
+    icon: JSX.Element
+    disabledReason: string
+    labelInMenu: JSX.Element
+} {
+    const Icon = entry.icon
+    return {
+        value: entry.key,
+        label: entry.name,
+        icon: <Icon />,
+        disabledReason: entry.disabledReason,
+        labelInMenu: (
+            <div className="flex max-w-md flex-col py-0.5">
+                <span className="flex items-center gap-2 font-semibold">
+                    {entry.name}
+                    <LemonTag size="small" type="muted">
+                        {entry.tag}
+                    </LemonTag>
+                </span>
+                <span className="text-secondary text-xs">{entry.description}</span>
+            </div>
+        ),
+    }
+}
+
+/** Variant B: the whole strip collapses into one compact select. */
+function DropdownVariant({ insightLogicProps }: VariantProps): JSX.Element {
+    const { activeView } = useValues(insightNavLogic(insightLogicProps))
+    const { setActiveView } = useActions(insightNavLogic(insightLogicProps))
+
+    const options: LemonSelectOptions<string> = [
+        { title: 'Insight type', options: CORE_TYPES.map(coreOption) },
+        { title: 'More types', options: EXTRA_TYPES.map(extraOption) },
+    ]
+
+    return (
+        <div className="mb-2 flex items-center gap-2">
+            <LemonSelect
+                size="small"
+                value={activeView as string}
+                onChange={(value) => value && setActiveView(value as InsightType)}
+                options={options}
+                dropdownMatchSelectWidth={false}
+                data-attr="prototype-insight-type-dropdown"
+            />
+        </div>
+    )
+}
+
+/** Variant C: the dominant pair stays one click away, the long tail moves behind "More types". */
+function HybridVariant({ insightLogicProps }: VariantProps): JSX.Element {
+    const { activeView } = useValues(insightNavLogic(insightLogicProps))
+    const { setActiveView } = useActions(insightNavLogic(insightLogicProps))
+
+    const primary: InsightType[] = [InsightType.TRENDS, InsightType.FUNNELS]
+    const tabTypes = primary.includes(activeView) ? primary : [...primary, activeView]
+    const moreOptions: LemonSelectOptions<string | null> = [
+        {
+            title: 'More types',
+            options: [
+                ...CORE_TYPES.filter((type) => !primary.includes(type)).map(coreOption),
+                ...EXTRA_TYPES.map(extraOption),
+            ],
+        },
+    ]
+
+    return (
+        <div className="flex items-center gap-2 [&_.LemonTabs]:![--lemon-tabs-margin-bottom:0]">
+            <LemonTabs
+                activeKey={activeView}
+                onChange={(view) => setActiveView(view)}
+                tabs={tabTypes.map((type) => ({ key: type, label: INSIGHT_TYPES_METADATA[type].name }))}
+            />
+            <LemonSelect<string | null>
+                size="small"
+                placeholder="More types"
+                value={null}
+                onChange={(value) => value && setActiveView(value as InsightType)}
+                options={moreOptions}
+                dropdownMatchSelectWidth={false}
+                data-attr="prototype-insight-type-more"
+            />
+        </div>
+    )
+}
+
+/** Variant D: no persistent strip at all: a chip that opens a searchable picker dialog. */
+function PaletteVariant({ insightLogicProps }: VariantProps): JSX.Element {
+    const { activeView } = useValues(insightNavLogic(insightLogicProps))
+    const { setActiveView } = useActions(insightNavLogic(insightLogicProps))
+    const [isOpen, setIsOpen] = useState(false)
+    const [search, setSearch] = useState('')
+
+    const activeMeta = INSIGHT_TYPES_METADATA[activeView] ?? INSIGHT_TYPES_METADATA[InsightType.TRENDS]
+    const ActiveIcon = activeMeta.icon
+
+    const entries = [
+        ...CORE_TYPES.map((type) => ({
+            key: type as string,
+            name: INSIGHT_TYPES_METADATA[type].name,
+            description: INSIGHT_TYPES_METADATA[type].description ?? '',
+            icon: INSIGHT_TYPES_METADATA[type].icon,
+            tag: null as string | null,
+        })),
+        ...EXTRA_TYPES.map((entry) => ({
+            key: entry.key,
+            name: entry.name,
+            description: entry.description,
+            icon: entry.icon,
+            tag: entry.tag,
+        })),
+    ]
+    const filtered = entries.filter((entry) =>
+        `${entry.name} ${entry.description}`.toLowerCase().includes(search.toLowerCase())
+    )
+
+    const close = (): void => {
+        setIsOpen(false)
+        setSearch('')
+    }
+
+    return (
+        <div className="mb-2 flex items-center gap-2">
+            <LemonButton
+                type="secondary"
+                size="small"
+                icon={<ActiveIcon />}
+                sideIcon={<IconChevronDown />}
+                onClick={() => setIsOpen(true)}
+                data-attr="prototype-insight-type-chip"
+            >
+                {activeMeta.name}
+            </LemonButton>
+            <LemonModal
+                isOpen={isOpen}
+                onClose={close}
+                title="Change insight type"
+                description="Your configuration carries over where the new type supports it."
+                width={720}
+            >
+                <div className="flex flex-col gap-4">
+                    <LemonInput
+                        type="search"
+                        autoFocus
+                        fullWidth
+                        placeholder="Search insight types…"
+                        value={search}
+                        onChange={setSearch}
+                    />
+                    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                        {filtered.map((entry) => {
+                            const EntryIcon = entry.icon
+                            const isSelectable = entry.tag === null
+                            const content = (
+                                <>
+                                    <span className="shrink-0 text-xl">
+                                        <EntryIcon />
+                                    </span>
+                                    <div className="min-w-0">
+                                        <div className="flex items-center gap-2 font-semibold">
+                                            {entry.name}
+                                            {entry.tag && (
+                                                <LemonTag size="small" type="muted">
+                                                    {entry.tag}
+                                                </LemonTag>
+                                            )}
+                                        </div>
+                                        <div className="text-secondary text-xs">{entry.description}</div>
+                                    </div>
+                                </>
+                            )
+                            return isSelectable ? (
+                                <LemonCard
+                                    key={entry.key}
+                                    focused={entry.key === activeView}
+                                    onClick={() => {
+                                        setActiveView(entry.key as InsightType)
+                                        close()
+                                    }}
+                                    className="flex cursor-pointer items-start gap-3 p-3"
+                                    data-attr={`prototype-insight-type-card-${entry.key.toLowerCase()}`}
+                                >
+                                    {content}
+                                </LemonCard>
+                            ) : (
+                                <LemonCard
+                                    key={entry.key}
+                                    hoverEffect={false}
+                                    className="flex items-start gap-3 p-3 opacity-60"
+                                >
+                                    {content}
+                                </LemonCard>
+                            )
+                        })}
+                        {filtered.length === 0 && (
+                            <div className="text-secondary col-span-full p-4 text-center">
+                                No matching insight types
+                            </div>
+                        )}
+                    </div>
+                </div>
+            </LemonModal>
+        </div>
+    )
+}
+
+const VARIANTS = [
+    { key: 'tabs', name: 'Baseline: tab strip' },
+    { key: 'dropdown', name: 'Compact dropdown' },
+    { key: 'hybrid', name: 'Hot-path tabs + More' },
+    { key: 'palette', name: 'Chip + searchable picker' },
+] as const
+
+export function InsightTypeSwitcherPrototype({ insightLogicProps }: VariantProps): JSX.Element {
+    const { location, searchParams, hashParams } = useValues(router)
+    const { activeView } = useValues(insightNavLogic(insightLogicProps))
+
+    const requested = typeof searchParams.variant === 'string' ? searchParams.variant : 'tabs'
+    const index = Math.max(
+        0,
+        VARIANTS.findIndex((variant) => variant.key === requested)
+    )
+    const variant = VARIANTS[index]
+
+    const setVariant = (key: string): void => {
+        router.actions.replace(location.pathname, { ...searchParams, variant: key }, hashParams)
+    }
+    const cycle = (delta: number): void => {
+        setVariant(VARIANTS[(index + delta + VARIANTS.length) % VARIANTS.length].key)
+    }
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent): void => {
+            if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+                return
+            }
+            const target = event.target as HTMLElement | null
+            // Leave arrow keys alone inside inputs, menus, and modals, where they navigate.
+            if (
+                target?.closest(
+                    'input, textarea, select, [contenteditable="true"], [role="menu"], [role="listbox"], [role="dialog"], .Popover'
+                )
+            ) {
+                return
+            }
+            cycle(event.key === 'ArrowRight' ? 1 : -1)
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => window.removeEventListener('keydown', onKeyDown)
+    })
+
+    return (
+        <>
+            {variant.key === 'tabs' && (
+                <div className="[&_.LemonTabs]:![--lemon-tabs-margin-bottom:0]">
+                    <InsightsNav />
+                </div>
+            )}
+            {variant.key === 'dropdown' && <DropdownVariant insightLogicProps={insightLogicProps} />}
+            {variant.key === 'hybrid' && <HybridVariant insightLogicProps={insightLogicProps} />}
+            {variant.key === 'palette' && <PaletteVariant insightLogicProps={insightLogicProps} />}
+
+            {process.env.NODE_ENV !== 'production' && (
+                <div className="border-primary bg-surface-primary fixed bottom-4 left-1/2 z-[1000] flex -translate-x-1/2 items-center gap-1 rounded-full border py-1 pr-2 pl-1 shadow-lg">
+                    <LemonButton
+                        size="xsmall"
+                        icon={<IconChevronLeft />}
+                        onClick={() => cycle(-1)}
+                        tooltip="Previous variant (←)"
+                    />
+                    <span className="text-xs font-semibold whitespace-nowrap">
+                        {String.fromCharCode(65 + index)} · {variant.name}
+                    </span>
+                    <LemonButton
+                        size="xsmall"
+                        icon={<IconChevronRight />}
+                        onClick={() => cycle(1)}
+                        tooltip="Next variant (→)"
+                    />
+                    <LemonTag type="highlight">{INSIGHT_TYPES_METADATA[activeView]?.name ?? activeView}</LemonTag>
+                </div>
+            )}
+        </>
+    )
+}

--- a/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/InsightTypeSwitcherPrototype.tsx
@@ -44,9 +44,10 @@ import { CORE_TYPES, EXTRA_TYPES, ExtraTypeEntry } from './SidebarTypeCardProtot
  *   sidebar-sketches / sidebar-list / sidebar-compact : visual alternatives of the sidebar
  *              card; same grouping as sidebar-families, only the looks change (sketch
  *              gallery, quiet indented list, two bare selects)
- *   sidebar-section : a native "Visualization" section styled like General/Filters; the
- *              display menu's groups become the top level (time series, total value, world
- *              map, calendar heatmap, funnel, retention, ...) with display suboptions
+ *   sidebar-section : a native "Visualization" section styled like General/Filters; a
+ *              carousel of sketch cards with descriptions, where the display menu's groups
+ *              are the top level (time series, total value, world map, calendar heatmap,
+ *              funnel, retention, ...) with display suboptions
  *
  * The real six types switch for real (same setActiveView as the tab strip, carry-over intact).
  * Extra entries (calendar heatmap, SQL, examples) are display-only, there to show how each
@@ -299,7 +300,7 @@ const VARIANTS = [
     { key: 'sidebar-sketches', name: 'Sidebar visual: sketch gallery' },
     { key: 'sidebar-list', name: 'Sidebar visual: quiet list' },
     { key: 'sidebar-compact', name: 'Sidebar visual: compact selects' },
-    { key: 'sidebar-section', name: 'Sidebar: native section, viz-first' },
+    { key: 'sidebar-section', name: 'Sidebar: native section, viz carousel' },
 ] as const
 
 export function InsightTypeSwitcherPrototype({ insightLogicProps }: VariantProps): JSX.Element {

--- a/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
@@ -43,6 +43,7 @@ import {
     EditorFilterProps,
     FunnelVizType,
     InsightEditorFilterGroup,
+    InsightLogicProps,
     InsightType,
     PathType,
 } from '~/types'
@@ -71,6 +72,8 @@ import {
  *                          display menu's groups are the top level (time series, total value,
  *                          world map, calendar heatmap, funnel, retention, ...) and the
  *                          display options are suboptions
+ *   sidebar-viz-grid  (M): G's tinted card filled with L's viz-first options: all nine as a
+ *                          sketch grid visible at once, with "View as" suboptions below
  *
  * Type switches go through setActiveView (config carry-over intact); mode switches go through
  * updateInsightFilter on the live query. Rendered from EditorFilters, inert (null) unless the
@@ -864,25 +867,19 @@ function CalendarHeatmapSketch(): JSX.Element {
     )
 }
 
-function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX.Element {
+interface VizRowsResult {
+    rows: VisRow[]
+    activeRow: VisRow | undefined
+}
+
+/** L's option set wired to the live query, shared by the viz-first variants (L carousel, M grid). */
+function useVizRows(insightProps: InsightLogicProps): VizRowsResult {
     const { activeView } = useValues(insightNavLogic(insightProps))
     const { setActiveView } = useActions(insightNavLogic(insightProps))
     const { display, funnelsFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
     const { featureFlags } = useValues(featureFlagLogic)
     const apply = updateInsightFilter as unknown as ApplyInsightFilter
-
-    const scrollRef = useRef<HTMLDivElement | null>(null)
-    const scrollByCards = (direction: 1 | -1): void => {
-        scrollRef.current?.scrollBy({ left: direction * 150, behavior: 'smooth' })
-    }
-
-    useEffect(() => {
-        // Bring the active card into view when the section mounts.
-        scrollRef.current
-            ?.querySelector<HTMLElement>('[aria-pressed="true"]')
-            ?.scrollIntoView({ block: 'nearest', inline: 'center' })
-    }, [])
 
     const trendsDisplay = activeView === InsightType.TRENDS ? (display ?? ChartDisplayType.ActionsLineGraph) : null
     const isTotalValue = TOTAL_VALUE_DISPLAYS.some((option) => option.value === trendsDisplay)
@@ -1028,6 +1025,24 @@ function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX
 
     const activeRow = rows.find((row) => row.active)
 
+    return { rows, activeRow }
+}
+
+function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX.Element {
+    const { rows, activeRow } = useVizRows(insightProps)
+
+    const scrollRef = useRef<HTMLDivElement | null>(null)
+    const scrollByCards = (direction: 1 | -1): void => {
+        scrollRef.current?.scrollBy({ left: direction * 150, behavior: 'smooth' })
+    }
+
+    useEffect(() => {
+        // Bring the active card into view when the section mounts.
+        scrollRef.current
+            ?.querySelector<HTMLElement>('[aria-pressed="true"]')
+            ?.scrollIntoView({ block: 'nearest', inline: 'center' })
+    }, [])
+
     return (
         <div>
             <div className="-mt-1 mb-1 flex items-center justify-end gap-0.5">
@@ -1109,6 +1124,63 @@ function PrototypeVisualizationSection(): JSX.Element {
     )
 }
 
+/** Variant M: G's tinted family card, filled with L's viz-first options as a sketch grid. */
+function VizGridCard(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { rows, activeRow } = useVizRows(insightProps)
+
+    return (
+        <CardShell>
+            <CardLabel>Visualization</CardLabel>
+            <div className="mt-2 grid grid-cols-2 gap-1.5">
+                {rows.map((row) => {
+                    const Sketch = row.sketch
+                    const card = (
+                        <button
+                            key={row.key}
+                            type="button"
+                            aria-pressed={row.active}
+                            onClick={row.disabledReason || row.active ? undefined : row.onSelect}
+                            className={clsx(
+                                'rounded-md border p-1.5 text-left transition-colors',
+                                row.active
+                                    ? 'border-accent bg-surface-primary shadow-sm'
+                                    : 'hover:bg-surface-primary border-transparent',
+                                row.disabledReason ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+                            )}
+                            data-attr={`prototype-insight-viz-grid-${row.key}`}
+                        >
+                            <Sketch />
+                            <div
+                                className={clsx(
+                                    'mt-1 text-xs font-semibold',
+                                    row.active ? 'text-accent' : 'text-primary'
+                                )}
+                            >
+                                {row.label}
+                            </div>
+                        </button>
+                    )
+                    return row.disabledReason ? (
+                        <Tooltip key={row.key} title={row.disabledReason} placement="top">
+                            {card}
+                        </Tooltip>
+                    ) : (
+                        card
+                    )
+                })}
+            </div>
+            {activeRow && <div className="text-secondary mt-2 text-xs">{activeRow.description}</div>}
+            {activeRow && activeRow.subs.length > 0 && (
+                <div className="mt-2">
+                    <CardLabel>View as</CardLabel>
+                    <SubChips options={activeRow.subs} dataAttrPrefix={`prototype-insight-viz-grid-${activeRow.key}`} />
+                </div>
+            )}
+        </CardShell>
+    )
+}
+
 /** Routes the sidebar card variants; inert unless the URL requests one. */
 export function SidebarTypeCardPrototype(): JSX.Element | null {
     const { searchParams } = useValues(router)
@@ -1137,6 +1209,9 @@ export function SidebarTypeCardPrototype(): JSX.Element | null {
     }
     if (variant === 'sidebar-section') {
         return <PrototypeVisualizationSection />
+    }
+    if (variant === 'sidebar-viz-grid') {
+        return <VizGridCard />
     }
     return null
 }

--- a/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
@@ -1,0 +1,217 @@
+import clsx from 'clsx'
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+
+import { IconCorrelationAnalysis, IconGraph } from '@posthog/icons'
+
+import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightNavLogic } from 'scenes/insights/InsightNav/insightNavLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { INSIGHT_TYPES_METADATA, QUERY_TYPES_METADATA } from 'scenes/saved-insights/insightTypesMetadata'
+
+import { NodeKind } from '~/queries/schema/schema-general'
+import { ChartDisplayType, FunnelVizType, InsightType } from '~/types'
+
+/**
+ * THROWAWAY PROTOTYPE: variant E of the insight type switcher, see InsightTypeSwitcherPrototype.tsx.
+ *
+ * A type + view card that sits above the filters in the left editor sidebar, styled to stand
+ * out from the filter sections below it: tinted accent card, an icon tile row for the type,
+ * the selected type's name and description, and a "View as" subtype control where the type
+ * has one (trends and stickiness: display, funnels: viz type).
+ *
+ * Lives in its own file so EditorFilters can import it without pulling in InsightsNav and the
+ * saved-insights scene. Rendered from EditorFilters, but inert (null) unless the URL has
+ * `?variant=sidebar`.
+ */
+
+export interface ExtraTypeEntry {
+    key: string
+    name: string
+    description: string
+    icon: React.ComponentType<any>
+    tag: string
+    disabledReason: string
+}
+
+export const CORE_TYPES: InsightType[] = [
+    InsightType.TRENDS,
+    InsightType.FUNNELS,
+    InsightType.RETENTION,
+    InsightType.PATHS,
+    InsightType.STICKINESS,
+    InsightType.LIFECYCLE,
+]
+
+export const EXTRA_TYPES: ExtraTypeEntry[] = [
+    {
+        key: 'CALENDAR_HEATMAP',
+        name: 'Calendar heatmap',
+        description: QUERY_TYPES_METADATA[NodeKind.CalendarHeatmapQuery].description ?? '',
+        icon: QUERY_TYPES_METADATA[NodeKind.CalendarHeatmapQuery].icon,
+        tag: 'Beta',
+        disabledReason: 'Real query type without a tab slot today. Display-only in this prototype',
+    },
+    {
+        key: 'SQL',
+        name: 'SQL',
+        description: INSIGHT_TYPES_METADATA[InsightType.SQL].description ?? '',
+        icon: INSIGHT_TYPES_METADATA[InsightType.SQL].icon,
+        tag: 'Editor',
+        disabledReason: 'Would open the SQL editor. Display-only in this prototype',
+    },
+    {
+        key: 'EXAMPLE_SANKEY',
+        name: 'Sankey flow',
+        description: 'Example future type, here to show how the list scales.',
+        icon: IconGraph,
+        tag: 'Example',
+        disabledReason: 'Example future type. Display-only in this prototype',
+    },
+    {
+        key: 'EXAMPLE_ANOMALY',
+        name: 'Anomaly detection',
+        description: 'Example future type, here to show how the list scales.',
+        icon: IconCorrelationAnalysis,
+        tag: 'Example',
+        disabledReason: 'Example future type. Display-only in this prototype',
+    },
+]
+
+interface SubtypeOption {
+    value: string
+    label: string
+}
+
+const TRENDS_VIEWS: SubtypeOption[] = [
+    { value: ChartDisplayType.ActionsLineGraph, label: 'Line' },
+    { value: ChartDisplayType.ActionsBar, label: 'Bar' },
+    { value: ChartDisplayType.BoldNumber, label: 'Number' },
+    { value: ChartDisplayType.ActionsTable, label: 'Table' },
+    { value: ChartDisplayType.ActionsPie, label: 'Pie' },
+]
+
+const STICKINESS_VIEWS: SubtypeOption[] = [
+    { value: ChartDisplayType.ActionsLineGraph, label: 'Line' },
+    { value: ChartDisplayType.ActionsBar, label: 'Bar' },
+]
+
+const FUNNEL_VIEWS: SubtypeOption[] = [
+    { value: FunnelVizType.Steps, label: 'Steps' },
+    { value: FunnelVizType.TimeToConvert, label: 'Time to convert' },
+    { value: FunnelVizType.Trends, label: 'Trends' },
+]
+
+function TypeTile({
+    name,
+    icon: Icon,
+    selected,
+    onClick,
+    disabledReason,
+}: {
+    name: string
+    icon: React.ComponentType<any>
+    selected: boolean
+    onClick?: () => void
+    disabledReason?: string
+}): JSX.Element {
+    return (
+        <Tooltip title={disabledReason ? `${name}: ${disabledReason}` : name} placement="top">
+            <button
+                type="button"
+                aria-pressed={selected}
+                aria-label={name}
+                onClick={disabledReason ? undefined : onClick}
+                className={clsx(
+                    'flex h-8 w-8 items-center justify-center rounded-md border text-base transition-colors',
+                    selected
+                        ? 'border-accent bg-surface-primary text-accent shadow-sm'
+                        : 'text-secondary border-transparent',
+                    disabledReason ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
+                    !disabledReason && !selected && 'hover:bg-surface-primary hover:text-primary'
+                )}
+                data-attr={`prototype-insight-type-tile-${name.toLowerCase().replace(/\s+/g, '-')}`}
+            >
+                <Icon />
+            </button>
+        </Tooltip>
+    )
+}
+
+/** Variant E: the type + view card above the filters in the left editor sidebar. */
+export function SidebarTypeCardPrototype(): JSX.Element | null {
+    const { searchParams } = useValues(router)
+    const { insightProps } = useValues(insightLogic)
+    const { activeView } = useValues(insightNavLogic(insightProps))
+    const { setActiveView } = useActions(insightNavLogic(insightProps))
+    const { display, funnelsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    if (searchParams.variant !== 'sidebar') {
+        return null
+    }
+
+    const meta = INSIGHT_TYPES_METADATA[activeView] ?? INSIGHT_TYPES_METADATA[InsightType.TRENDS]
+
+    let viewOptions: SubtypeOption[] | null = null
+    let viewValue: string | null = null
+    let onViewChange: ((value: string) => void) | null = null
+    if (activeView === InsightType.TRENDS || activeView === InsightType.STICKINESS) {
+        viewOptions = activeView === InsightType.TRENDS ? TRENDS_VIEWS : STICKINESS_VIEWS
+        viewValue = (display as string | undefined) ?? ChartDisplayType.ActionsLineGraph
+        onViewChange = (value) => updateInsightFilter({ display: value as ChartDisplayType })
+    } else if (activeView === InsightType.FUNNELS) {
+        viewOptions = FUNNEL_VIEWS
+        viewValue = (funnelsFilter?.funnelVizType as string | undefined) ?? FunnelVizType.Steps
+        onViewChange = (value) => updateInsightFilter({ funnelVizType: value as FunnelVizType })
+    }
+
+    return (
+        <div
+            className="border-accent bg-accent-highlight-secondary mb-3 rounded-lg border p-3"
+            data-attr="prototype-insight-type-sidebar-card"
+        >
+            <div className="text-accent text-[0.625rem] font-semibold tracking-wide uppercase">Insight type</div>
+            <div className="mt-2 flex flex-wrap gap-1">
+                {CORE_TYPES.map((type) => (
+                    <TypeTile
+                        key={type}
+                        name={INSIGHT_TYPES_METADATA[type].name}
+                        icon={INSIGHT_TYPES_METADATA[type].icon}
+                        selected={type === activeView}
+                        onClick={() => setActiveView(type)}
+                    />
+                ))}
+                <div className="border-accent mx-1 my-1 w-px self-stretch border-l opacity-40" />
+                {EXTRA_TYPES.map((entry) => (
+                    <TypeTile
+                        key={entry.key}
+                        name={entry.name}
+                        icon={entry.icon}
+                        selected={false}
+                        disabledReason={entry.disabledReason}
+                    />
+                ))}
+            </div>
+            <div className="mt-2">
+                <div className="text-sm font-semibold">{meta.name}</div>
+                <div className="text-secondary text-xs">{meta.description}</div>
+            </div>
+            {viewOptions && onViewChange && (
+                <div className="mt-3">
+                    <div className="text-accent text-[0.625rem] font-semibold tracking-wide uppercase">View as</div>
+                    <LemonSegmentedButton
+                        size="xsmall"
+                        fullWidth
+                        className="mt-1"
+                        value={viewValue ?? undefined}
+                        onChange={(value) => onViewChange(value)}
+                        options={viewOptions.map((option) => ({ value: option.value, label: option.label }))}
+                    />
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
@@ -11,7 +11,18 @@ import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightNavLogic } from 'scenes/insights/InsightNav/insightNavLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
-import { INSIGHT_TYPES_METADATA, QUERY_TYPES_METADATA } from 'scenes/saved-insights/insightTypesMetadata'
+import {
+    FunnelSketch,
+    GenericInsightSketch,
+    PathsSketch,
+    RetentionSketch,
+    TrendsSketch,
+} from 'scenes/saved-insights/InsightTypeSketch'
+import {
+    INSIGHT_TYPES_METADATA,
+    InsightTypeMetadata,
+    QUERY_TYPES_METADATA,
+} from 'scenes/saved-insights/insightTypesMetadata'
 
 import { NodeKind } from '~/queries/schema/schema-general'
 import { ChartDisplayType, FunnelVizType, InsightType, PathType } from '~/types'
@@ -29,6 +40,12 @@ import { ChartDisplayType, FunnelVizType, InsightType, PathType } from '~/types'
  *                          splits into recurring vs first time; paths picks its event scope
  *   sidebar-modes     (H): no regrouping; the six types in a select plus a uniform "Mode" row
  *                          surfacing each type's buried subtype picker
+ *   sidebar-sketches  (I): visual alternative; plain surface card where the hand-drawn chart
+ *                          sketches carry the weight (same grouping as G)
+ *   sidebar-list      (J): visual alternative; no card chrome, families as quiet rows with
+ *                          methods indented under the active one (same grouping as G)
+ *   sidebar-compact   (K): visual alternative; family and method as two bare selects on one
+ *                          row, no decoration at all (same grouping as G)
  *
  * Type switches go through setActiveView (config carry-over intact); mode switches go through
  * updateInsightFilter on the live query. Rendered from EditorFilters, inert (null) unless the
@@ -409,7 +426,16 @@ function FamilyTile({
     )
 }
 
-function FamilyCard({ grouping }: { grouping: 'questions' | 'config' }): JSX.Element {
+interface FamilySelection {
+    families: FamilyDef[]
+    family: FamilyDef
+    subs: SubOption[]
+    activeMeta: InsightTypeMetadata
+    selectFamily: (candidate: FamilyDef) => void
+}
+
+/** Shared state for the family-based variants: the active family, its method row, and the switch action. */
+function useFamilySelection(grouping: 'questions' | 'config'): FamilySelection {
     const { insightProps } = useValues(insightLogic)
     const { activeView } = useValues(insightNavLogic(insightProps))
     const { setActiveView } = useActions(insightNavLogic(insightProps))
@@ -467,6 +493,18 @@ function FamilyCard({ grouping }: { grouping: 'questions' | 'config' }): JSX.Ele
 
     const activeMeta = INSIGHT_TYPES_METADATA[activeView] ?? INSIGHT_TYPES_METADATA[InsightType.TRENDS]
 
+    const selectFamily = (candidate: FamilyDef): void => {
+        if (!candidate.types.includes(activeView)) {
+            setActiveView(candidate.types[0])
+        }
+    }
+
+    return { families, family, subs, activeMeta, selectFamily }
+}
+
+function FamilyCard({ grouping }: { grouping: 'questions' | 'config' }): JSX.Element {
+    const { families, family, subs, activeMeta, selectFamily } = useFamilySelection(grouping)
+
     return (
         <CardShell>
             <CardLabel>Insight type</CardLabel>
@@ -480,11 +518,7 @@ function FamilyCard({ grouping }: { grouping: 'questions' | 'config' }): JSX.Ele
                             hint={candidate.hint}
                             icon={Icon}
                             selected={candidate.key === family.key}
-                            onClick={() => {
-                                if (!candidate.types.includes(activeView)) {
-                                    setActiveView(candidate.types[0])
-                                }
-                            }}
+                            onClick={() => selectFamily(candidate)}
                         />
                     )
                 })}
@@ -570,6 +604,184 @@ function FlatModesCard(): JSX.Element {
     )
 }
 
+// --- Variants I, J, K: visual alternatives. Same shared-setup grouping as G; only the looks change. ---
+
+const FAMILY_SKETCHES: Record<string, () => JSX.Element> = {
+    trends: TrendsSketch,
+    funnel: FunnelSketch,
+    retention: RetentionSketch,
+    paths: PathsSketch,
+}
+
+function MutedLabel({ children }: { children: React.ReactNode }): JSX.Element {
+    return <div className="text-secondary text-[0.625rem] font-semibold tracking-wide uppercase">{children}</div>
+}
+
+/** Variant I: sketch gallery. A plain surface card where the chart sketches carry the visual weight. */
+function SketchGalleryCard(): JSX.Element {
+    const { families, family, subs, activeMeta, selectFamily } = useFamilySelection('config')
+
+    return (
+        <div
+            className="border-primary bg-surface-primary mb-3 rounded-lg border p-3"
+            data-attr="prototype-insight-type-sketch-card"
+        >
+            <MutedLabel>Insight type</MutedLabel>
+            <div className="mt-2 grid grid-cols-2 gap-1.5">
+                {families.map((candidate) => {
+                    const Sketch = FAMILY_SKETCHES[candidate.key] ?? GenericInsightSketch
+                    const selected = candidate.key === family.key
+                    return (
+                        <button
+                            key={candidate.key}
+                            type="button"
+                            aria-pressed={selected}
+                            onClick={() => selectFamily(candidate)}
+                            className={clsx(
+                                'cursor-pointer rounded-md border p-1.5 text-left transition-colors',
+                                selected
+                                    ? 'border-accent bg-accent-highlight-secondary shadow-sm'
+                                    : 'border-primary hover:border-accent'
+                            )}
+                            data-attr={`prototype-insight-sketch-${candidate.key}`}
+                        >
+                            <Sketch />
+                            <div
+                                className={clsx(
+                                    'mt-1 text-xs font-semibold',
+                                    selected ? 'text-accent' : 'text-primary'
+                                )}
+                            >
+                                {candidate.name}
+                            </div>
+                        </button>
+                    )
+                })}
+            </div>
+            <div className="mt-3">
+                <MutedLabel>Method</MutedLabel>
+                <SubChips options={subs} dataAttrPrefix="prototype-insight-sketch-method" />
+            </div>
+            <div className="text-secondary mt-2 text-xs">{activeMeta.description}</div>
+        </div>
+    )
+}
+
+/** Variant J: quiet list. No card chrome; families as rows, methods indented under the active one. */
+function QuietListCard(): JSX.Element {
+    const { families, family, subs, activeMeta, selectFamily } = useFamilySelection('config')
+
+    return (
+        <div className="border-primary mb-3 border-b pb-3" data-attr="prototype-insight-type-list">
+            <MutedLabel>Insight type</MutedLabel>
+            <div className="mt-1 flex flex-col">
+                {families.map((candidate) => {
+                    const Icon = INSIGHT_TYPES_METADATA[candidate.types[0]].icon
+                    const selected = candidate.key === family.key
+                    return (
+                        <div key={candidate.key}>
+                            <button
+                                type="button"
+                                aria-pressed={selected}
+                                onClick={() => selectFamily(candidate)}
+                                className={clsx(
+                                    'flex w-full cursor-pointer items-center gap-2 rounded px-1.5 py-1 text-left text-sm transition-colors',
+                                    selected
+                                        ? 'text-primary font-semibold'
+                                        : 'text-secondary hover:bg-surface-primary hover:text-primary'
+                                )}
+                                data-attr={`prototype-insight-list-${candidate.key}`}
+                            >
+                                <Icon className={clsx(selected && 'text-accent')} />
+                                {candidate.name}
+                            </button>
+                            {selected && (
+                                <div className="border-primary mt-0.5 mb-1 ml-3 flex flex-col gap-0.5 border-l pl-3">
+                                    {subs.map((option) => {
+                                        const row = (
+                                            <button
+                                                key={option.key}
+                                                type="button"
+                                                aria-pressed={option.active}
+                                                onClick={option.disabledReason ? undefined : option.onSelect}
+                                                className={clsx(
+                                                    'w-fit rounded px-1 py-0.5 text-left text-xs transition-colors',
+                                                    option.active
+                                                        ? 'text-accent font-semibold'
+                                                        : 'text-secondary hover:text-primary',
+                                                    option.disabledReason
+                                                        ? 'cursor-not-allowed opacity-50'
+                                                        : 'cursor-pointer'
+                                                )}
+                                                data-attr={`prototype-insight-list-method-${option.key.toLowerCase()}`}
+                                            >
+                                                {option.label}
+                                            </button>
+                                        )
+                                        return option.disabledReason ? (
+                                            <Tooltip key={option.key} title={option.disabledReason} placement="right">
+                                                {row}
+                                            </Tooltip>
+                                        ) : (
+                                            row
+                                        )
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                    )
+                })}
+            </div>
+            <div className="text-secondary mt-1 text-xs">{activeMeta.description}</div>
+        </div>
+    )
+}
+
+/** Variant K: compact toolbar. Family and method as two bare selects on one row, no decoration. */
+function CompactSelectsCard(): JSX.Element {
+    const { families, family, subs, selectFamily } = useFamilySelection('config')
+
+    const familyOptions: LemonSelectOptions<string> = families.map((candidate) => {
+        const Icon = INSIGHT_TYPES_METADATA[candidate.types[0]].icon
+        return { value: candidate.key, label: candidate.name, icon: <Icon /> }
+    })
+    const methodOptions: LemonSelectOptions<string | null> = subs.map((option) => ({
+        value: option.key,
+        label: option.label,
+        disabledReason: option.disabledReason,
+    }))
+    const methodValue = subs.find((option) => option.active)?.key ?? null
+
+    return (
+        <div className="mb-3 flex flex-wrap items-center gap-1.5" data-attr="prototype-insight-type-compact">
+            <LemonSelect
+                size="small"
+                value={family.key}
+                onChange={(value) => {
+                    const candidate = families.find((entry) => entry.key === value)
+                    if (candidate) {
+                        selectFamily(candidate)
+                    }
+                }}
+                options={familyOptions}
+                dropdownMatchSelectWidth={false}
+                data-attr="prototype-insight-compact-family"
+            />
+            <LemonSelect<string | null>
+                size="small"
+                placeholder="Method"
+                value={methodValue}
+                onChange={(value) => {
+                    subs.find((option) => option.key === value)?.onSelect?.()
+                }}
+                options={methodOptions}
+                dropdownMatchSelectWidth={false}
+                data-attr="prototype-insight-compact-method"
+            />
+        </div>
+    )
+}
+
 /** Routes the sidebar card variants; inert unless the URL requests one. */
 export function SidebarTypeCardPrototype(): JSX.Element | null {
     const { searchParams } = useValues(router)
@@ -586,6 +798,15 @@ export function SidebarTypeCardPrototype(): JSX.Element | null {
     }
     if (variant === 'sidebar-modes') {
         return <FlatModesCard />
+    }
+    if (variant === 'sidebar-sketches') {
+        return <SketchGalleryCard />
+    }
+    if (variant === 'sidebar-list') {
+        return <QuietListCard />
+    }
+    if (variant === 'sidebar-compact') {
+        return <CompactSelectsCard />
     }
     return null
 }

--- a/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
@@ -1,8 +1,9 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
+import { useEffect, useRef } from 'react'
 
-import { IconCorrelationAnalysis, IconGlobe, IconGraph } from '@posthog/icons'
+import { IconChevronLeft, IconChevronRight, IconCorrelationAnalysis, IconGraph } from '@posthog/icons'
 
 import {
     FEATURE_FLAGS,
@@ -10,7 +11,6 @@ import {
     RETENTION_FIRST_OCCURRENCE_MATCHING_FILTERS,
     RETENTION_RECURRING,
 } from 'lib/constants'
-import { Icon123 } from 'lib/lemon-ui/icons'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
 import { LemonSelect, LemonSelectOptions } from 'lib/lemon-ui/LemonSelect'
@@ -22,9 +22,13 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import {
     FunnelSketch,
     GenericInsightSketch,
+    LifecycleSketch,
+    NumberSketch,
     PathsSketch,
     RetentionSketch,
+    StickinessSketch,
     TrendsSketch,
+    WorldMapSketch,
 } from 'scenes/saved-insights/InsightTypeSketch'
 import {
     INSIGHT_TYPES_METADATA,
@@ -63,9 +67,10 @@ import {
  *   sidebar-compact   (K): visual alternative; family and method as two bare selects on one
  *                          row, no decoration at all (same grouping as G)
  *   sidebar-section   (L): a native "Visualization" section styled exactly like General and
- *                          Filters, with the display menu's groups promoted to the top level
- *                          (time series, total value, world map, calendar heatmap, funnel,
- *                          retention, ...) and the display options as suboptions
+ *                          Filters; a carousel of sketch cards with descriptions, where the
+ *                          display menu's groups are the top level (time series, total value,
+ *                          world map, calendar heatmap, funnel, retention, ...) and the
+ *                          display options are suboptions
  *
  * Type switches go through setActiveView (config carry-over intact); mode switches go through
  * updateInsightFilter on the live query. Rendered from EditorFilters, inert (null) unless the
@@ -829,11 +834,34 @@ const LINE_BAR_DISPLAYS: SubtypeOption[] = [
 interface VisRow {
     key: string
     label: string
-    icon: React.ComponentType<any>
+    description: string
+    sketch: () => JSX.Element
     active: boolean
     onSelect: () => void
     disabledReason?: string
     subs: SubOption[]
+}
+
+/** No hand-drawn heatmap sketch exists yet, so this draws a minimal one in the same style. */
+function CalendarHeatmapSketch(): JSX.Element {
+    return (
+        <svg viewBox="0 0 160 88" className="h-auto w-full" fill="none" aria-hidden="true">
+            {Array.from({ length: 7 }, (_, col) =>
+                Array.from({ length: 4 }, (_, rowIndex) => (
+                    <rect
+                        key={`${col}-${rowIndex}`}
+                        x={12 + col * 20}
+                        y={8 + rowIndex * 19}
+                        width={16}
+                        height={15}
+                        rx={3}
+                        fill="var(--data-color-1)"
+                        opacity={((col * 4 + rowIndex) % 5) * 0.2 + 0.15}
+                    />
+                ))
+            )}
+        </svg>
+    )
 }
 
 function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX.Element {
@@ -843,6 +871,18 @@ function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
     const { featureFlags } = useValues(featureFlagLogic)
     const apply = updateInsightFilter as unknown as ApplyInsightFilter
+
+    const scrollRef = useRef<HTMLDivElement | null>(null)
+    const scrollByCards = (direction: 1 | -1): void => {
+        scrollRef.current?.scrollBy({ left: direction * 150, behavior: 'smooth' })
+    }
+
+    useEffect(() => {
+        // Bring the active card into view when the section mounts.
+        scrollRef.current
+            ?.querySelector<HTMLElement>('[aria-pressed="true"]')
+            ?.scrollIntoView({ block: 'nearest', inline: 'center' })
+    }, [])
 
     const trendsDisplay = activeView === InsightType.TRENDS ? (display ?? ChartDisplayType.ActionsLineGraph) : null
     const isTotalValue = TOTAL_VALUE_DISPLAYS.some((option) => option.value === trendsDisplay)
@@ -874,7 +914,8 @@ function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX
         {
             key: 'time-series',
             label: 'Time series',
-            icon: INSIGHT_TYPES_METADATA[InsightType.TRENDS].icon,
+            description: 'Values over time, as lines or bars.',
+            sketch: TrendsSketch,
             active:
                 trendsDisplay !== null &&
                 !isTotalValue &&
@@ -886,7 +927,8 @@ function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX
         {
             key: 'total-value',
             label: 'Total value',
-            icon: Icon123,
+            description: 'One combined value for the whole period.',
+            sketch: NumberSketch,
             active: isTotalValue,
             onSelect: () => setTrendsDisplay(ChartDisplayType.BoldNumber),
             subs: displaySubsFor(TOTAL_VALUE_DISPLAYS, ChartDisplayType.BoldNumber),
@@ -894,7 +936,8 @@ function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX
         {
             key: 'world-map',
             label: 'World map',
-            icon: IconGlobe,
+            description: 'Values per country on a map.',
+            sketch: WorldMapSketch,
             active: trendsDisplay === ChartDisplayType.WorldMap,
             onSelect: () => setTrendsDisplay(ChartDisplayType.WorldMap),
             subs: [],
@@ -902,7 +945,8 @@ function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX
         {
             key: 'calendar-heatmap',
             label: 'Calendar heatmap',
-            icon: QUERY_TYPES_METADATA[NodeKind.CalendarHeatmapQuery].icon,
+            description: 'Values broken down by day and hour.',
+            sketch: CalendarHeatmapSketch,
             active: trendsDisplay === ChartDisplayType.CalendarHeatmap,
             onSelect: () => setTrendsDisplay(ChartDisplayType.CalendarHeatmap),
             disabledReason: heatmapEnabled
@@ -913,7 +957,8 @@ function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX
         {
             key: 'funnel',
             label: 'Funnel',
-            icon: INSIGHT_TYPES_METADATA[InsightType.FUNNELS].icon,
+            description: 'How many users complete a sequence of steps.',
+            sketch: FunnelSketch,
             active: activeView === InsightType.FUNNELS,
             onSelect: () => setActiveView(InsightType.FUNNELS),
             subs: [
@@ -946,7 +991,8 @@ function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX
         {
             key: 'retention',
             label: 'Retention',
-            icon: INSIGHT_TYPES_METADATA[InsightType.RETENTION].icon,
+            description: 'How many users come back after an initial action.',
+            sketch: RetentionSketch,
             active: activeView === InsightType.RETENTION,
             onSelect: () => setActiveView(InsightType.RETENTION),
             subs: displaySubsFor(LINE_BAR_DISPLAYS, ChartDisplayType.ActionsLineGraph),
@@ -954,7 +1000,8 @@ function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX
         {
             key: 'paths',
             label: 'User paths',
-            icon: INSIGHT_TYPES_METADATA[InsightType.PATHS].icon,
+            description: 'The journeys users take through your product.',
+            sketch: PathsSketch,
             active: activeView === InsightType.PATHS,
             onSelect: () => setActiveView(InsightType.PATHS),
             subs: [],
@@ -962,7 +1009,8 @@ function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX
         {
             key: 'stickiness',
             label: 'Stickiness',
-            icon: INSIGHT_TYPES_METADATA[InsightType.STICKINESS].icon,
+            description: 'How often users repeat an action.',
+            sketch: StickinessSketch,
             active: activeView === InsightType.STICKINESS,
             onSelect: () => setActiveView(InsightType.STICKINESS),
             subs: displaySubsFor(LINE_BAR_DISPLAYS, ChartDisplayType.ActionsLineGraph),
@@ -970,38 +1018,78 @@ function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX
         {
             key: 'lifecycle',
             label: 'Lifecycle',
-            icon: INSIGHT_TYPES_METADATA[InsightType.LIFECYCLE].icon,
+            description: 'New, returning, resurrected, and dormant users.',
+            sketch: LifecycleSketch,
             active: activeView === InsightType.LIFECYCLE,
             onSelect: () => setActiveView(InsightType.LIFECYCLE),
             subs: [],
         },
     ]
 
+    const activeRow = rows.find((row) => row.active)
+
     return (
-        <div className="flex flex-col gap-0.5">
-            {rows.map((row) => {
-                const RowIcon = row.icon
-                return (
-                    <div key={row.key}>
-                        <LemonButton
-                            fullWidth
-                            size="small"
-                            active={row.active}
-                            icon={<RowIcon />}
-                            onClick={row.active ? undefined : row.onSelect}
-                            disabledReason={row.disabledReason}
+        <div>
+            <div className="-mt-1 mb-1 flex items-center justify-end gap-0.5">
+                <LemonButton
+                    size="xsmall"
+                    icon={<IconChevronLeft />}
+                    onClick={() => scrollByCards(-1)}
+                    tooltip="Scroll left"
+                />
+                <LemonButton
+                    size="xsmall"
+                    icon={<IconChevronRight />}
+                    onClick={() => scrollByCards(1)}
+                    tooltip="Scroll right"
+                />
+            </div>
+            <div ref={scrollRef} className="flex snap-x gap-1.5 overflow-x-auto pb-1">
+                {rows.map((row) => {
+                    const Sketch = row.sketch
+                    const card = (
+                        <button
+                            key={row.key}
+                            type="button"
+                            aria-pressed={row.active}
+                            onClick={row.disabledReason || row.active ? undefined : row.onSelect}
+                            className={clsx(
+                                'w-[8.75rem] shrink-0 snap-start rounded-md border p-1.5 text-left transition-colors',
+                                row.active
+                                    ? 'border-accent bg-accent-highlight-secondary shadow-sm'
+                                    : 'border-primary hover:border-accent',
+                                row.disabledReason ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+                            )}
                             data-attr={`prototype-insight-vis-${row.key}`}
                         >
-                            {row.label}
-                        </LemonButton>
-                        {row.active && row.subs.length > 0 && (
-                            <div className="border-primary mt-0.5 mb-1 ml-3.5 border-l pl-2">
-                                <SubChips options={row.subs} dataAttrPrefix={`prototype-insight-vis-${row.key}`} />
+                            <Sketch />
+                            <div
+                                className={clsx(
+                                    'mt-1 text-xs font-semibold',
+                                    row.active ? 'text-accent' : 'text-primary'
+                                )}
+                            >
+                                {row.label}
                             </div>
-                        )}
-                    </div>
-                )
-            })}
+                            <div className="text-secondary mt-0.5 text-[0.6875rem] leading-tight">
+                                {row.description}
+                            </div>
+                        </button>
+                    )
+                    return row.disabledReason ? (
+                        <Tooltip key={row.key} title={row.disabledReason} placement="top">
+                            {card}
+                        </Tooltip>
+                    ) : (
+                        card
+                    )
+                })}
+            </div>
+            {activeRow && activeRow.subs.length > 0 && (
+                <div className="mt-1.5">
+                    <SubChips options={activeRow.subs} dataAttrPrefix={`prototype-insight-vis-${activeRow.key}`} />
+                </div>
+            )}
         </div>
     )
 }

--- a/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
@@ -2,12 +2,20 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconCorrelationAnalysis, IconGraph } from '@posthog/icons'
+import { IconCorrelationAnalysis, IconGlobe, IconGraph } from '@posthog/icons'
 
-import { RETENTION_FIRST_OCCURRENCE_MATCHING_FILTERS, RETENTION_RECURRING } from 'lib/constants'
+import {
+    FEATURE_FLAGS,
+    FunnelLayout,
+    RETENTION_FIRST_OCCURRENCE_MATCHING_FILTERS,
+    RETENTION_RECURRING,
+} from 'lib/constants'
+import { Icon123 } from 'lib/lemon-ui/icons'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
 import { LemonSelect, LemonSelectOptions } from 'lib/lemon-ui/LemonSelect'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightNavLogic } from 'scenes/insights/InsightNav/insightNavLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
@@ -24,8 +32,16 @@ import {
     QUERY_TYPES_METADATA,
 } from 'scenes/saved-insights/insightTypesMetadata'
 
+import { EditorFilterGroup } from '~/queries/nodes/InsightViz/EditorFilterGroup'
 import { NodeKind } from '~/queries/schema/schema-general'
-import { ChartDisplayType, FunnelVizType, InsightType, PathType } from '~/types'
+import {
+    ChartDisplayType,
+    EditorFilterProps,
+    FunnelVizType,
+    InsightEditorFilterGroup,
+    InsightType,
+    PathType,
+} from '~/types'
 
 /**
  * THROWAWAY PROTOTYPE: variants E to H of the insight type switcher, see InsightTypeSwitcherPrototype.tsx.
@@ -46,6 +62,10 @@ import { ChartDisplayType, FunnelVizType, InsightType, PathType } from '~/types'
  *                          methods indented under the active one (same grouping as G)
  *   sidebar-compact   (K): visual alternative; family and method as two bare selects on one
  *                          row, no decoration at all (same grouping as G)
+ *   sidebar-section   (L): a native "Visualization" section styled exactly like General and
+ *                          Filters, with the display menu's groups promoted to the top level
+ *                          (time series, total value, world map, calendar heatmap, funnel,
+ *                          retention, ...) and the display options as suboptions
  *
  * Type switches go through setActiveView (config carry-over intact); mode switches go through
  * updateInsightFilter on the live query. Rendered from EditorFilters, inert (null) unless the
@@ -782,6 +802,225 @@ function CompactSelectsCard(): JSX.Element {
     )
 }
 
+// --- Variant L: a native "Visualization" section among General/Filters ---
+// The top level is what you see (the display menu's groups promoted), not the query type:
+// time series and total value and world map and calendar heatmap are all trends underneath.
+
+const TIME_SERIES_DISPLAYS: SubtypeOption[] = [
+    { value: ChartDisplayType.ActionsLineGraph, label: 'Line chart' },
+    { value: ChartDisplayType.ActionsAreaGraph, label: 'Area chart' },
+    { value: ChartDisplayType.ActionsUnstackedBar, label: 'Bar chart' },
+    { value: ChartDisplayType.ActionsBar, label: 'Stacked bar' },
+    { value: ChartDisplayType.ActionsLineGraphCumulative, label: 'Line (cumulative)' },
+]
+
+const TOTAL_VALUE_DISPLAYS: SubtypeOption[] = [
+    { value: ChartDisplayType.BoldNumber, label: 'Number' },
+    { value: ChartDisplayType.ActionsPie, label: 'Pie chart' },
+    { value: ChartDisplayType.ActionsBarValue, label: 'Bar chart' },
+    { value: ChartDisplayType.ActionsTable, label: 'Table' },
+]
+
+const LINE_BAR_DISPLAYS: SubtypeOption[] = [
+    { value: ChartDisplayType.ActionsLineGraph, label: 'Line chart' },
+    { value: ChartDisplayType.ActionsBar, label: 'Bar chart' },
+]
+
+interface VisRow {
+    key: string
+    label: string
+    icon: React.ComponentType<any>
+    active: boolean
+    onSelect: () => void
+    disabledReason?: string
+    subs: SubOption[]
+}
+
+function PrototypeVisualizationOptions({ insightProps }: EditorFilterProps): JSX.Element {
+    const { activeView } = useValues(insightNavLogic(insightProps))
+    const { setActiveView } = useActions(insightNavLogic(insightProps))
+    const { display, funnelsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const { featureFlags } = useValues(featureFlagLogic)
+    const apply = updateInsightFilter as unknown as ApplyInsightFilter
+
+    const trendsDisplay = activeView === InsightType.TRENDS ? (display ?? ChartDisplayType.ActionsLineGraph) : null
+    const isTotalValue = TOTAL_VALUE_DISPLAYS.some((option) => option.value === trendsDisplay)
+
+    // Switching the type rebuilds the query in the same tick, so a display update aimed at a
+    // not-yet-active trends query has to wait for the rebuilt query to land.
+    const setTrendsDisplay = (value: ChartDisplayType): void => {
+        if (activeView === InsightType.TRENDS) {
+            apply({ display: value })
+        } else {
+            setActiveView(InsightType.TRENDS)
+            window.setTimeout(() => apply({ display: value }), 0)
+        }
+    }
+
+    const displaySubsFor = (views: SubtypeOption[], fallback: ChartDisplayType): SubOption[] =>
+        views.map((view) => ({
+            key: view.value,
+            label: view.label,
+            active: (display ?? fallback) === view.value,
+            onSelect: () => apply({ display: view.value }),
+        }))
+
+    const funnelViz = funnelsFilter?.funnelVizType ?? FunnelVizType.Steps
+    const funnelLayout = funnelsFilter?.layout ?? FunnelLayout.vertical
+    const heatmapEnabled = !!featureFlags[FEATURE_FLAGS.CALENDAR_HEATMAP_INSIGHT]
+
+    const rows: VisRow[] = [
+        {
+            key: 'time-series',
+            label: 'Time series',
+            icon: INSIGHT_TYPES_METADATA[InsightType.TRENDS].icon,
+            active:
+                trendsDisplay !== null &&
+                !isTotalValue &&
+                trendsDisplay !== ChartDisplayType.WorldMap &&
+                trendsDisplay !== ChartDisplayType.CalendarHeatmap,
+            onSelect: () => setTrendsDisplay(ChartDisplayType.ActionsLineGraph),
+            subs: displaySubsFor(TIME_SERIES_DISPLAYS, ChartDisplayType.ActionsLineGraph),
+        },
+        {
+            key: 'total-value',
+            label: 'Total value',
+            icon: Icon123,
+            active: isTotalValue,
+            onSelect: () => setTrendsDisplay(ChartDisplayType.BoldNumber),
+            subs: displaySubsFor(TOTAL_VALUE_DISPLAYS, ChartDisplayType.BoldNumber),
+        },
+        {
+            key: 'world-map',
+            label: 'World map',
+            icon: IconGlobe,
+            active: trendsDisplay === ChartDisplayType.WorldMap,
+            onSelect: () => setTrendsDisplay(ChartDisplayType.WorldMap),
+            subs: [],
+        },
+        {
+            key: 'calendar-heatmap',
+            label: 'Calendar heatmap',
+            icon: QUERY_TYPES_METADATA[NodeKind.CalendarHeatmapQuery].icon,
+            active: trendsDisplay === ChartDisplayType.CalendarHeatmap,
+            onSelect: () => setTrendsDisplay(ChartDisplayType.CalendarHeatmap),
+            disabledReason: heatmapEnabled
+                ? undefined
+                : 'Behind the calendar-heatmap-insight feature flag; enable it to try this',
+            subs: [],
+        },
+        {
+            key: 'funnel',
+            label: 'Funnel',
+            icon: INSIGHT_TYPES_METADATA[InsightType.FUNNELS].icon,
+            active: activeView === InsightType.FUNNELS,
+            onSelect: () => setActiveView(InsightType.FUNNELS),
+            subs: [
+                {
+                    key: 'left-to-right',
+                    label: 'Left to right',
+                    active: funnelViz === FunnelVizType.Steps && funnelLayout === FunnelLayout.vertical,
+                    onSelect: () => apply({ funnelVizType: FunnelVizType.Steps, layout: FunnelLayout.vertical }),
+                },
+                {
+                    key: 'top-to-bottom',
+                    label: 'Top to bottom',
+                    active: funnelViz === FunnelVizType.Steps && funnelLayout === FunnelLayout.horizontal,
+                    onSelect: () => apply({ funnelVizType: FunnelVizType.Steps, layout: FunnelLayout.horizontal }),
+                },
+                {
+                    key: 'funnel-trends',
+                    label: 'Trends',
+                    active: funnelViz === FunnelVizType.Trends,
+                    onSelect: () => apply({ funnelVizType: FunnelVizType.Trends }),
+                },
+                {
+                    key: 'time-to-convert',
+                    label: 'Time to convert',
+                    active: funnelViz === FunnelVizType.TimeToConvert,
+                    onSelect: () => apply({ funnelVizType: FunnelVizType.TimeToConvert }),
+                },
+            ],
+        },
+        {
+            key: 'retention',
+            label: 'Retention',
+            icon: INSIGHT_TYPES_METADATA[InsightType.RETENTION].icon,
+            active: activeView === InsightType.RETENTION,
+            onSelect: () => setActiveView(InsightType.RETENTION),
+            subs: displaySubsFor(LINE_BAR_DISPLAYS, ChartDisplayType.ActionsLineGraph),
+        },
+        {
+            key: 'paths',
+            label: 'User paths',
+            icon: INSIGHT_TYPES_METADATA[InsightType.PATHS].icon,
+            active: activeView === InsightType.PATHS,
+            onSelect: () => setActiveView(InsightType.PATHS),
+            subs: [],
+        },
+        {
+            key: 'stickiness',
+            label: 'Stickiness',
+            icon: INSIGHT_TYPES_METADATA[InsightType.STICKINESS].icon,
+            active: activeView === InsightType.STICKINESS,
+            onSelect: () => setActiveView(InsightType.STICKINESS),
+            subs: displaySubsFor(LINE_BAR_DISPLAYS, ChartDisplayType.ActionsLineGraph),
+        },
+        {
+            key: 'lifecycle',
+            label: 'Lifecycle',
+            icon: INSIGHT_TYPES_METADATA[InsightType.LIFECYCLE].icon,
+            active: activeView === InsightType.LIFECYCLE,
+            onSelect: () => setActiveView(InsightType.LIFECYCLE),
+            subs: [],
+        },
+    ]
+
+    return (
+        <div className="flex flex-col gap-0.5">
+            {rows.map((row) => {
+                const RowIcon = row.icon
+                return (
+                    <div key={row.key}>
+                        <LemonButton
+                            fullWidth
+                            size="small"
+                            active={row.active}
+                            icon={<RowIcon />}
+                            onClick={row.active ? undefined : row.onSelect}
+                            disabledReason={row.disabledReason}
+                            data-attr={`prototype-insight-vis-${row.key}`}
+                        >
+                            {row.label}
+                        </LemonButton>
+                        {row.active && row.subs.length > 0 && (
+                            <div className="border-primary mt-0.5 mb-1 ml-3.5 border-l pl-2">
+                                <SubChips options={row.subs} dataAttrPrefix={`prototype-insight-vis-${row.key}`} />
+                            </div>
+                        )}
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+function PrototypeVisualizationSection(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const group: InsightEditorFilterGroup = {
+        title: 'Visualization',
+        defaultExpanded: true,
+        editorFilters: [{ key: 'prototype-visualization', component: PrototypeVisualizationOptions }],
+    }
+
+    return (
+        <div className="mb-3">
+            <EditorFilterGroup editorFilterGroup={group} insightProps={insightProps} />
+        </div>
+    )
+}
+
 /** Routes the sidebar card variants; inert unless the URL requests one. */
 export function SidebarTypeCardPrototype(): JSX.Element | null {
     const { searchParams } = useValues(router)
@@ -807,6 +1046,9 @@ export function SidebarTypeCardPrototype(): JSX.Element | null {
     }
     if (variant === 'sidebar-compact') {
         return <CompactSelectsCard />
+    }
+    if (variant === 'sidebar-section') {
+        return <PrototypeVisualizationSection />
     }
     return null
 }

--- a/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
+++ b/frontend/src/scenes/insights/InsightNav/prototype/SidebarTypeCardPrototype.tsx
@@ -4,7 +4,9 @@ import { router } from 'kea-router'
 
 import { IconCorrelationAnalysis, IconGraph } from '@posthog/icons'
 
+import { RETENTION_FIRST_OCCURRENCE_MATCHING_FILTERS, RETENTION_RECURRING } from 'lib/constants'
 import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
+import { LemonSelect, LemonSelectOptions } from 'lib/lemon-ui/LemonSelect'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightNavLogic } from 'scenes/insights/InsightNav/insightNavLogic'
@@ -12,19 +14,25 @@ import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { INSIGHT_TYPES_METADATA, QUERY_TYPES_METADATA } from 'scenes/saved-insights/insightTypesMetadata'
 
 import { NodeKind } from '~/queries/schema/schema-general'
-import { ChartDisplayType, FunnelVizType, InsightType } from '~/types'
+import { ChartDisplayType, FunnelVizType, InsightType, PathType } from '~/types'
 
 /**
- * THROWAWAY PROTOTYPE: variant E of the insight type switcher, see InsightTypeSwitcherPrototype.tsx.
+ * THROWAWAY PROTOTYPE: variants E to H of the insight type switcher, see InsightTypeSwitcherPrototype.tsx.
  *
- * A type + view card that sits above the filters in the left editor sidebar, styled to stand
- * out from the filter sections below it: tinted accent card, an icon tile row for the type,
- * the selected type's name and description, and a "View as" subtype control where the type
- * has one (trends and stickiness: display, funnels: viz type).
+ * All four render a card above the filters in the left editor sidebar (tinted accent card so it
+ * stands out from the filter sections) and differ in how they structure the type choice:
+ *   sidebar           (E): flat icon tile row for the six types + a "View as" display row
+ *   sidebar-questions (F): four families grouped by the question you ask; stickiness and
+ *                          lifecycle live under retention; the sub row picks the method
+ *   sidebar-families  (G): four families grouped by shared setup; stickiness and lifecycle
+ *                          live under trends (same series editor, lossless switch); retention
+ *                          splits into recurring vs first time; paths picks its event scope
+ *   sidebar-modes     (H): no regrouping; the six types in a select plus a uniform "Mode" row
+ *                          surfacing each type's buried subtype picker
  *
- * Lives in its own file so EditorFilters can import it without pulling in InsightsNav and the
- * saved-insights scene. Rendered from EditorFilters, but inert (null) unless the URL has
- * `?variant=sidebar`.
+ * Type switches go through setActiveView (config carry-over intact); mode switches go through
+ * updateInsightFilter on the live query. Rendered from EditorFilters, inert (null) unless the
+ * URL has a matching ?variant=.
  */
 
 export interface ExtraTypeEntry {
@@ -104,6 +112,134 @@ const FUNNEL_VIEWS: SubtypeOption[] = [
     { value: FunnelVizType.Trends, label: 'Trends' },
 ]
 
+const PATH_SCOPES: { key: string; label: string; value: PathType[] }[] = [
+    { key: 'pages', label: 'Pages', value: [PathType.PageView] },
+    { key: 'screens', label: 'Screens', value: [PathType.Screen] },
+    { key: 'custom-events', label: 'Custom events', value: [PathType.CustomEvent] },
+    { key: 'all', label: 'All events', value: [PathType.PageView, PathType.Screen, PathType.CustomEvent] },
+]
+
+// --- Shared building blocks ---
+
+function CardShell({ children }: { children: React.ReactNode }): JSX.Element {
+    return (
+        <div
+            className="border-accent bg-accent-highlight-secondary mb-3 rounded-lg border p-3"
+            data-attr="prototype-insight-type-sidebar-card"
+        >
+            {children}
+        </div>
+    )
+}
+
+function CardLabel({ children }: { children: React.ReactNode }): JSX.Element {
+    return <div className="text-accent text-[0.625rem] font-semibold tracking-wide uppercase">{children}</div>
+}
+
+interface SubOption {
+    key: string
+    label: string
+    active?: boolean
+    onSelect?: () => void
+    disabledReason?: string
+}
+
+function SubChips({ options, dataAttrPrefix }: { options: SubOption[]; dataAttrPrefix: string }): JSX.Element {
+    return (
+        <div className="mt-1 flex flex-wrap gap-1">
+            {options.map((option) => {
+                const chip = (
+                    <button
+                        key={option.key}
+                        type="button"
+                        aria-pressed={option.active}
+                        onClick={option.disabledReason ? undefined : option.onSelect}
+                        className={clsx(
+                            'rounded-md border px-2 py-1 text-xs font-medium transition-colors',
+                            option.active
+                                ? 'border-accent bg-surface-primary text-accent shadow-sm'
+                                : 'text-secondary border-transparent',
+                            option.disabledReason ? 'cursor-not-allowed opacity-40' : 'cursor-pointer',
+                            !option.disabledReason && !option.active && 'hover:bg-surface-primary hover:text-primary'
+                        )}
+                        data-attr={`${dataAttrPrefix}-${option.key.toLowerCase()}`}
+                    >
+                        {option.label}
+                    </button>
+                )
+                return option.disabledReason ? (
+                    <Tooltip key={option.key} title={option.disabledReason} placement="top">
+                        {chip}
+                    </Tooltip>
+                ) : (
+                    chip
+                )
+            })}
+        </div>
+    )
+}
+
+type ApplyInsightFilter = (insightFilter: Record<string, unknown>) => void
+
+function funnelVizSubs(current: FunnelVizType | undefined, apply: ApplyInsightFilter): SubOption[] {
+    const active = current ?? FunnelVizType.Steps
+    return FUNNEL_VIEWS.map((view) => ({
+        key: view.value,
+        label: view.label,
+        active: active === view.value,
+        onSelect: () => apply({ funnelVizType: view.value }),
+    }))
+}
+
+function retentionTypeSubs(current: string | undefined, apply: ApplyInsightFilter): SubOption[] {
+    const active = current ?? RETENTION_RECURRING
+    return [
+        {
+            key: 'recurring',
+            label: 'Recurring',
+            active: active === RETENTION_RECURRING,
+            onSelect: () => apply({ retentionType: RETENTION_RECURRING }),
+        },
+        {
+            key: 'first-time',
+            label: 'First time',
+            active: active === RETENTION_FIRST_OCCURRENCE_MATCHING_FILTERS,
+            onSelect: () => apply({ retentionType: RETENTION_FIRST_OCCURRENCE_MATCHING_FILTERS }),
+        },
+    ]
+}
+
+function pathScopeSubs(current: PathType[] | undefined, apply: ApplyInsightFilter): SubOption[] {
+    const activeKey = [...(current ?? [PathType.PageView])].sort().join(',')
+    return PATH_SCOPES.map((scope) => ({
+        key: scope.key,
+        label: scope.label,
+        active: activeKey === [...scope.value].sort().join(','),
+        onSelect: () => apply({ includeEventTypes: scope.value }),
+    }))
+}
+
+function displaySubs(views: SubtypeOption[], current: string | undefined, apply: ApplyInsightFilter): SubOption[] {
+    const active = current ?? ChartDisplayType.ActionsLineGraph
+    return views.map((view) => ({
+        key: view.value,
+        label: view.label,
+        active: active === view.value,
+        onSelect: () => apply({ display: view.value }),
+    }))
+}
+
+function exampleSub(extraKey: string): SubOption {
+    const entry = EXTRA_TYPES.find((candidate) => candidate.key === extraKey)
+    return {
+        key: extraKey,
+        label: entry?.name ?? extraKey,
+        disabledReason: entry?.disabledReason ?? 'Display-only in this prototype',
+    }
+}
+
+// --- Variant E: flat tile row + "View as" display row ---
+
 function TypeTile({
     name,
     icon: Icon,
@@ -140,18 +276,12 @@ function TypeTile({
     )
 }
 
-/** Variant E: the type + view card above the filters in the left editor sidebar. */
-export function SidebarTypeCardPrototype(): JSX.Element | null {
-    const { searchParams } = useValues(router)
+function TypeAndViewCard(): JSX.Element {
     const { insightProps } = useValues(insightLogic)
     const { activeView } = useValues(insightNavLogic(insightProps))
     const { setActiveView } = useActions(insightNavLogic(insightProps))
     const { display, funnelsFilter } = useValues(insightVizDataLogic(insightProps))
     const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
-
-    if (searchParams.variant !== 'sidebar') {
-        return null
-    }
 
     const meta = INSIGHT_TYPES_METADATA[activeView] ?? INSIGHT_TYPES_METADATA[InsightType.TRENDS]
 
@@ -169,11 +299,8 @@ export function SidebarTypeCardPrototype(): JSX.Element | null {
     }
 
     return (
-        <div
-            className="border-accent bg-accent-highlight-secondary mb-3 rounded-lg border p-3"
-            data-attr="prototype-insight-type-sidebar-card"
-        >
-            <div className="text-accent text-[0.625rem] font-semibold tracking-wide uppercase">Insight type</div>
+        <CardShell>
+            <CardLabel>Insight type</CardLabel>
             <div className="mt-2 flex flex-wrap gap-1">
                 {CORE_TYPES.map((type) => (
                     <TypeTile
@@ -201,7 +328,7 @@ export function SidebarTypeCardPrototype(): JSX.Element | null {
             </div>
             {viewOptions && onViewChange && (
                 <div className="mt-3">
-                    <div className="text-accent text-[0.625rem] font-semibold tracking-wide uppercase">View as</div>
+                    <CardLabel>View as</CardLabel>
                     <LemonSegmentedButton
                         size="xsmall"
                         fullWidth
@@ -212,6 +339,253 @@ export function SidebarTypeCardPrototype(): JSX.Element | null {
                     />
                 </div>
             )}
-        </div>
+        </CardShell>
     )
+}
+
+// --- Variants F and G: family tiles + method row, two competing groupings ---
+
+interface FamilyDef {
+    key: string
+    name: string
+    hint: string
+    types: InsightType[]
+}
+
+const QUESTION_FAMILIES: FamilyDef[] = [
+    { key: 'trends', name: 'Trends', hint: 'How much and how often?', types: [InsightType.TRENDS] },
+    { key: 'funnel', name: 'Funnel', hint: 'Do users convert?', types: [InsightType.FUNNELS] },
+    {
+        key: 'retention',
+        name: 'Retention',
+        hint: 'Do users come back?',
+        types: [InsightType.RETENTION, InsightType.STICKINESS, InsightType.LIFECYCLE],
+    },
+    { key: 'paths', name: 'Paths', hint: 'Where do users go?', types: [InsightType.PATHS] },
+]
+
+const CONFIG_FAMILIES: FamilyDef[] = [
+    {
+        key: 'trends',
+        name: 'Trends',
+        hint: 'Series over time',
+        types: [InsightType.TRENDS, InsightType.STICKINESS, InsightType.LIFECYCLE],
+    },
+    { key: 'funnel', name: 'Funnel', hint: 'A sequence of steps', types: [InsightType.FUNNELS] },
+    { key: 'retention', name: 'Retention', hint: 'Cohorts coming back', types: [InsightType.RETENTION] },
+    { key: 'paths', name: 'Paths', hint: 'Flows between events', types: [InsightType.PATHS] },
+]
+
+function FamilyTile({
+    name,
+    hint,
+    icon: Icon,
+    selected,
+    onClick,
+}: {
+    name: string
+    hint: string
+    icon: React.ComponentType<any>
+    selected: boolean
+    onClick: () => void
+}): JSX.Element {
+    return (
+        <button
+            type="button"
+            aria-pressed={selected}
+            onClick={onClick}
+            className={clsx(
+                'flex cursor-pointer flex-col items-start gap-0.5 rounded-md border p-2 text-left transition-colors',
+                selected ? 'border-accent bg-surface-primary shadow-sm' : 'hover:bg-surface-primary border-transparent'
+            )}
+            data-attr={`prototype-insight-family-${name.toLowerCase()}`}
+        >
+            <span className={clsx('flex items-center gap-1.5 text-sm font-semibold', selected && 'text-accent')}>
+                <Icon />
+                {name}
+            </span>
+            <span className="text-secondary text-xs">{hint}</span>
+        </button>
+    )
+}
+
+function FamilyCard({ grouping }: { grouping: 'questions' | 'config' }): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { activeView } = useValues(insightNavLogic(insightProps))
+    const { setActiveView } = useActions(insightNavLogic(insightProps))
+    const { funnelsFilter, retentionFilter, pathsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const apply = updateInsightFilter as unknown as ApplyInsightFilter
+
+    const families = grouping === 'questions' ? QUESTION_FAMILIES : CONFIG_FAMILIES
+    const family = families.find((candidate) => candidate.types.includes(activeView)) ?? families[0]
+
+    const typeSub = (type: InsightType, label: string): SubOption => ({
+        key: type,
+        label,
+        active: activeView === type,
+        onSelect: () => setActiveView(type),
+    })
+
+    let subs: SubOption[]
+    if (family.key === 'funnel') {
+        subs = funnelVizSubs(funnelsFilter?.funnelVizType, apply)
+    } else if (family.key === 'retention') {
+        subs =
+            grouping === 'questions'
+                ? [
+                      typeSub(InsightType.RETENTION, 'Retention curve'),
+                      typeSub(InsightType.STICKINESS, 'Stickiness'),
+                      typeSub(InsightType.LIFECYCLE, 'Lifecycle'),
+                  ]
+                : retentionTypeSubs(retentionFilter?.retentionType, apply)
+    } else if (family.key === 'paths') {
+        subs =
+            grouping === 'config'
+                ? [...pathScopeSubs(pathsFilter?.includeEventTypes, apply), exampleSub('EXAMPLE_SANKEY')]
+                : [{ key: 'paths', label: 'User paths', active: true }, exampleSub('EXAMPLE_SANKEY')]
+    } else {
+        subs =
+            grouping === 'questions'
+                ? [
+                      {
+                          key: 'volume',
+                          label: 'Volume',
+                          active: activeView === InsightType.TRENDS,
+                          onSelect: () => setActiveView(InsightType.TRENDS),
+                      },
+                      exampleSub('CALENDAR_HEATMAP'),
+                      exampleSub('EXAMPLE_ANOMALY'),
+                  ]
+                : [
+                      typeSub(InsightType.TRENDS, 'Volume'),
+                      typeSub(InsightType.STICKINESS, 'Stickiness'),
+                      typeSub(InsightType.LIFECYCLE, 'Lifecycle'),
+                      exampleSub('CALENDAR_HEATMAP'),
+                  ]
+    }
+
+    const activeMeta = INSIGHT_TYPES_METADATA[activeView] ?? INSIGHT_TYPES_METADATA[InsightType.TRENDS]
+
+    return (
+        <CardShell>
+            <CardLabel>Insight type</CardLabel>
+            <div className="mt-2 grid grid-cols-2 gap-1.5">
+                {families.map((candidate) => {
+                    const Icon = INSIGHT_TYPES_METADATA[candidate.types[0]].icon
+                    return (
+                        <FamilyTile
+                            key={candidate.key}
+                            name={candidate.name}
+                            hint={candidate.hint}
+                            icon={Icon}
+                            selected={candidate.key === family.key}
+                            onClick={() => {
+                                if (!candidate.types.includes(activeView)) {
+                                    setActiveView(candidate.types[0])
+                                }
+                            }}
+                        />
+                    )
+                })}
+            </div>
+            <div className="mt-3">
+                <CardLabel>Method</CardLabel>
+                <SubChips options={subs} dataAttrPrefix="prototype-insight-method" />
+            </div>
+            <div className="text-secondary mt-2 text-xs">{activeMeta.description}</div>
+            <div className="border-primary text-secondary mt-3 border-t pt-2 text-[0.625rem]">
+                {grouping === 'questions'
+                    ? 'Grouped by question. Stickiness and lifecycle live under retention. SQL and custom queries move to the New insight menu.'
+                    : 'Grouped by shared setup. Stickiness and lifecycle live under trends and keep your series when you switch. SQL and custom queries move to the New insight menu.'}
+            </div>
+        </CardShell>
+    )
+}
+
+// --- Variant H: flat six types in a select + a uniform mode row, no regrouping ---
+
+function FlatModesCard(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { activeView } = useValues(insightNavLogic(insightProps))
+    const { setActiveView } = useActions(insightNavLogic(insightProps))
+    const { display, funnelsFilter, retentionFilter, pathsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+    const apply = updateInsightFilter as unknown as ApplyInsightFilter
+
+    const typeOptions: LemonSelectOptions<string> = [
+        {
+            title: 'Insight type',
+            options: CORE_TYPES.map((type) => {
+                const meta = INSIGHT_TYPES_METADATA[type]
+                const Icon = meta.icon
+                return { value: type as string, label: meta.name, icon: <Icon /> }
+            }),
+        },
+        {
+            title: 'More types',
+            options: EXTRA_TYPES.map((entry) => {
+                const Icon = entry.icon
+                return { value: entry.key, label: entry.name, icon: <Icon />, disabledReason: entry.disabledReason }
+            }),
+        },
+    ]
+
+    let modeSubs: SubOption[] | null = null
+    if (activeView === InsightType.TRENDS) {
+        modeSubs = displaySubs(TRENDS_VIEWS, display ?? undefined, apply)
+    } else if (activeView === InsightType.STICKINESS) {
+        modeSubs = displaySubs(STICKINESS_VIEWS, display ?? undefined, apply)
+    } else if (activeView === InsightType.FUNNELS) {
+        modeSubs = funnelVizSubs(funnelsFilter?.funnelVizType, apply)
+    } else if (activeView === InsightType.RETENTION) {
+        modeSubs = retentionTypeSubs(retentionFilter?.retentionType, apply)
+    } else if (activeView === InsightType.PATHS) {
+        modeSubs = pathScopeSubs(pathsFilter?.includeEventTypes, apply)
+    }
+
+    const activeMeta = INSIGHT_TYPES_METADATA[activeView] ?? INSIGHT_TYPES_METADATA[InsightType.TRENDS]
+
+    return (
+        <CardShell>
+            <CardLabel>Insight type</CardLabel>
+            <div className="mt-1">
+                <LemonSelect
+                    size="small"
+                    fullWidth
+                    value={activeView as string}
+                    onChange={(value) => value && setActiveView(value as InsightType)}
+                    options={typeOptions}
+                    data-attr="prototype-insight-type-flat-select"
+                />
+            </div>
+            {modeSubs && (
+                <div className="mt-3">
+                    <CardLabel>Mode</CardLabel>
+                    <SubChips options={modeSubs} dataAttrPrefix="prototype-insight-mode" />
+                </div>
+            )}
+            <div className="text-secondary mt-2 text-xs">{activeMeta.description}</div>
+        </CardShell>
+    )
+}
+
+/** Routes the sidebar card variants; inert unless the URL requests one. */
+export function SidebarTypeCardPrototype(): JSX.Element | null {
+    const { searchParams } = useValues(router)
+    const variant = typeof searchParams.variant === 'string' ? searchParams.variant : ''
+
+    if (variant === 'sidebar') {
+        return <TypeAndViewCard />
+    }
+    if (variant === 'sidebar-questions') {
+        return <FamilyCard grouping="questions" />
+    }
+    if (variant === 'sidebar-families') {
+        return <FamilyCard grouping="config" />
+    }
+    if (variant === 'sidebar-modes') {
+        return <FlatModesCard />
+    }
+    return null
 }

--- a/frontend/src/scenes/insights/InsightSceneHeader.tsx
+++ b/frontend/src/scenes/insights/InsightSceneHeader.tsx
@@ -11,7 +11,7 @@ import { urls } from 'scenes/urls'
 import { InsightShortId, InsightLogicProps, ItemMode } from '~/types'
 
 import { insightDataLogic } from './insightDataLogic'
-import { InsightsNav } from './InsightNav/InsightsNav'
+import { InsightTypeSwitcherPrototype } from './InsightNav/prototype/InsightTypeSwitcherPrototype'
 import { InsightPageHeader } from './InsightPageHeader'
 
 export interface InsightSceneHeaderProps {
@@ -44,9 +44,8 @@ export function InsightSceneHeader({ insightLogicProps }: InsightSceneHeaderProp
             )}
 
             {insightMode === ItemMode.Edit && (
-                <div className="[&_.LemonTabs]:![--lemon-tabs-margin-bottom:0]">
-                    <InsightsNav />
-                </div>
+                /* PROTOTYPE(insight-type-switcher): swaps the tab strip for switchable variants; throwaway, see the prototype file */
+                <InsightTypeSwitcherPrototype insightLogicProps={insightLogicProps} />
             )}
 
             {showDebugPanel && insight?.id && (


### PR DESCRIPTION
## TL;DR

A throwaway prototype. It puts thirteen different insight type switchers on the real insight editor. Open any insight in edit mode and flip between them with the floating bar at the bottom (or `?variant=` in the URL). A to D try different header controls. E to H move the switcher into the left sidebar as a card above the filters and test what the top-level and sub-level type choice should be. I to K keep one structure and try three different looks for it. L and M make the visualization (not the query type) the top level: L as a carousel in native section chrome, M as a G-style sketch grid. Pick a winner, then we rebuild it properly and delete this branch.

> [!WARNING]
> Do not merge. This branch exists to click through, compare, and throw away.

## Problem

The insight editor shows one tab per insight type. The strip is full: new query kinds (calendar heatmap, for example) get no slot, and every future type makes it worse.

Usage analysis of the tab strip showed:

- Most type switches happen right after the editor opens, before the user configures anything. The strip mostly works as navigation, not conversion.
- Switches cluster between neighboring tabs, and users often bounce back to a type they just left. That reads as browsing the strip, not deliberate choice.
- A minority does convert an already-configured insight (most often between trends and funnels, or a saved insight viewed as another type) and relies on the config carry-over.

So the strip can shrink to something that scales, as long as in-editor switching (with carry-over) survives in some form.

## Changes

- `InsightSceneHeader` renders `InsightTypeSwitcherPrototype` instead of `InsightsNav` in edit mode; `EditorFilters` renders `SidebarTypeCardPrototype` above the filter sections. Both are inert unless the URL requests a matching variant.
- Header variants:
  - **A `tabs`**: baseline, today's strip
  - **B `dropdown`**: one compact select where the tabs sat
  - **C `hybrid`**: Trends and Funnels stay as tabs, the rest behind "More types"
  - **D `palette`**: a type chip opens a searchable picker dialog
- Sidebar structure variants (nothing in the header; a tinted card above the filters):
  - **E `sidebar`**: flat icon tile row for the six types + a "View as" display row
  - **F `sidebar-questions`**: four families grouped by the question you ask; stickiness and lifecycle become retention methods
  - **G `sidebar-families`**: four families grouped by shared setup; stickiness and lifecycle become trends methods (same series editor, so switching keeps your setup); retention splits into recurring vs first time; paths picks its event scope
  - **H `sidebar-modes`**: no regrouping; the six types in a select plus a uniform "Mode" row surfacing each type's buried subtype picker
- Sidebar visual variants (same grouping as G; only the looks change):
  - **I `sidebar-sketches`**: a plain surface card where the hand-drawn chart sketches from the New insight menu carry the visual weight
  - **J `sidebar-list`**: no card chrome at all; families as quiet text rows, methods indented under the active one
  - **K `sidebar-compact`**: family and method as two bare selects on one row, zero decoration
- Visualization-first variants:
  - **L `sidebar-section`**: a "Visualization" section that reuses `EditorFilterGroup`, so it looks exactly like General and Filters. Inside, a horizontally scrolling carousel of sketch cards (chart preview + name + one-line description, arrows + scroll snap). The display menu's groups are the top level: time series (line / area / bar / stacked bar / cumulative), total value (number / pie / bar / table), world map, calendar heatmap (a real trends display type, dimmed when its flag is off), funnel (left to right / top to bottom / trends / time to convert), retention (line / bar), user paths, stickiness (line / bar), lifecycle. The active card's suboptions show as chips below the carousel
  - **M `sidebar-viz-grid`**: G's tinted card filled with L's option set: all nine visualization options as a sketch grid visible at once (no carousel), the active option's description and "View as" chips below
- Sub-level switches drive the real query: type changes go through `setActiveView` (config carry-over intact), display and mode changes through `updateInsightFilter`. Future types (SQL, two invented examples) appear display-only where shown, to test how each structure absorbs growth.
- The floating bar hides in production builds. The branch is still not meant to merge.

No screenshots: the point is clicking through it locally.

## How did you test this code?

- `oxlint` and `oxfmt` on the touched files: clean.
- Full `tsgo --noEmit`: no errors in the touched files. The few remaining errors in this environment come from unbuilt workspace packages, unrelated to this change.
- I (Claude, via PostHog Code) could not run the app in this environment, so the variants are untested in a browser. To try them: `hogli start`, open an insight in edit mode, and use the bottom bar.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Throwaway prototype, no docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code session), directed by @thmsobrmlr, following an analysis of how users switch insight types in the editor.
- Skills invoked: `/prototype` (UI branch: variants on the real route behind `?variant=` with a floating switcher bar) and `querying-posthog-data` for the preceding analysis.
- Decisions: the variants use the editor's existing Lemon components so they read against the surrounding UI; the winning variant should be rebuilt with quill (`Select`/`Combobox`) per design-system guidance. Real types switch for real to keep carry-over judgeable. F and G share one component with two family definitions so the taxonomy is the only variable between them; H is the no-regroup control. I, J, and K reuse G's grouping through a shared hook so the visual shell is the only variable. L follows Thomas's spec (display-menu groups promoted to the top level, native section chrome, sketch card carousel). M combines G's card shell with L's option set through a shared `useVizRows` hook, so L vs M isolates carousel vs grid.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
