### PR TITLE
fix(replay-vision): fix word spacing in alert threshold sentence

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
@@ -452,44 +452,48 @@ function ConditionSection({ scannerId }: { scannerId: string }): JSX.Element {
 
             {!everyMatch && (
                 <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm">when the</span>
                     {isScorer ? (
-                        <LemonSelect
-                            size="small"
-                            value={actionForm.alert_metric}
-                            onChange={(value) => {
-                                if (!value) {
-                                    return
-                                }
-                                setActionFormValue('alert_metric', value)
-                                // Count thresholds are always "at least" (the direction control is
-                                // hidden for them), so switching back to count clears any "at most".
-                                if (value === VisionAlertMetricEnumApi.Count) {
-                                    setActionFormValue('alert_direction', VisionAlertDirectionEnumApi.Above)
-                                }
-                            }}
-                            options={[
-                                { value: VisionAlertMetricEnumApi.Count, label: 'number of matches' },
-                                { value: VisionAlertMetricEnumApi.AvgScore, label: 'average score' },
-                            ]}
-                            data-attr="vision-action-alert-metric"
-                        />
+                        <>
+                            <span className="text-sm">when the</span>
+                            <LemonSelect
+                                size="small"
+                                value={actionForm.alert_metric}
+                                onChange={(value) => {
+                                    if (!value) {
+                                        return
+                                    }
+                                    setActionFormValue('alert_metric', value)
+                                    // Count thresholds are always "at least" (the direction control is
+                                    // hidden for them), so switching back to count clears any "at most".
+                                    if (value === VisionAlertMetricEnumApi.Count) {
+                                        setActionFormValue('alert_direction', VisionAlertDirectionEnumApi.Above)
+                                    }
+                                }}
+                                options={[
+                                    { value: VisionAlertMetricEnumApi.Count, label: 'number of matches' },
+                                    { value: VisionAlertMetricEnumApi.AvgScore, label: 'average score' },
+                                ]}
+                                data-attr="vision-action-alert-metric"
+                            />
+                            {isAvg ? (
+                                <LemonSelect
+                                    size="small"
+                                    value={actionForm.alert_direction}
+                                    onChange={(value) => value && setActionFormValue('alert_direction', value)}
+                                    options={[
+                                        { value: VisionAlertDirectionEnumApi.Above, label: 'is at least' },
+                                        { value: VisionAlertDirectionEnumApi.Below, label: 'is at most' },
+                                    ]}
+                                    data-attr="vision-action-alert-direction"
+                                />
+                            ) : (
+                                <span className="text-sm">is at least</span>
+                            )}
+                        </>
                     ) : (
-                        <span className="text-sm">number of matches</span>
-                    )}
-                    {isAvg ? (
-                        <LemonSelect
-                            size="small"
-                            value={actionForm.alert_direction}
-                            onChange={(value) => value && setActionFormValue('alert_direction', value)}
-                            options={[
-                                { value: VisionAlertDirectionEnumApi.Above, label: 'is at least' },
-                                { value: VisionAlertDirectionEnumApi.Below, label: 'is at most' },
-                            ]}
-                            data-attr="vision-action-alert-direction"
-                        />
-                    ) : (
-                        <span className="text-sm">is at least</span>
+                        // One span, not one per word: adjacent flex items get the 8px control
+                        // gap, which reads as doubled spacing between plain words.
+                        <span className="text-sm">when the number of matches is at least</span>
                     )}
                     <LemonInput
                         type="number"


### PR DESCRIPTION
## Problem

In the scanner alert editor, the threshold condition sentence ("when the number of matches is at least ... over ...") renders with doubled spacing between the plain-text words for monitor and classifier scanners.

The row is a `flex flex-wrap items-center gap-2` container where every sentence chunk is its own flex item. That 8px gap is right around the dropdowns and the input, but for non-scorer scanners the "number of matches" and "is at least" chunks are plain text, so consecutive words get button-sized gaps instead of normal ~4px word spacing.

## Changes

For non-scorer scanners, the static text now renders as a single span ("when the number of matches is at least"), so words get natural spacing. Scorers keep the split layout because their middle chunks are real dropdowns (metric and direction), where the flex gap belongs. No behavior changes, all controls and their `data-attr`s are untouched.

## How did you test this code?

Visual-only JSX restructuring with no logic changes. I ran oxfmt and oxlint on the changed file. No new tests: asserting flex-item grouping would test implementation details, and no existing behavior changed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, visual spacing fix only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Arnaud spotted the doubled spacing in a screenshot and asked why; I (Claude Code) traced it to per-word flex items in `ActionEditorScene.tsx` and merged the adjacent plain-text runs for the non-scorer case, leaving the scorer case (where those positions are dropdowns) as is. No repo skills applied (single-file JSX change, no tests or API surface touched).
