### PR TITLE
chore(insights): prototype unsaved-insight notice as a table row

### DIFF
--- a/frontend/src/scenes/saved-insights/ReloadInsightPrototype.tsx
+++ b/frontend/src/scenes/saved-insights/ReloadInsightPrototype.tsx
@@ -1,0 +1,292 @@
+/**
+ * PROTOTYPE — THROWAWAY CODE, do not ship.
+ *
+ * Question: should the "You have an unsaved insight from <date>. Click here" text (ReloadInsight)
+ * become an item in the saved-insights table below it?
+ *
+ * Three variants on the existing /insights route, switchable via `?variant=` or the floating
+ * bottom bar (also ← / → keys):
+ *   A — the draft is a pinned first row in the insights table (default)
+ *   B — the draft is a strip above the table
+ *   C — the draft is a dismissible banner (evolved status quo)
+ *
+ * Run `./bin/start` and open /insights. Caveats: everything is gated to local dev builds;
+ * if no real draft exists in localStorage a sample draft is shown (labelled in the bottom bar);
+ * "Discard" is stubbed with a toast so the demo draft survives; client-side column sorts can
+ * move the pinned row in variant A.
+ */
+import { useValues } from 'kea'
+import { router } from 'kea-router'
+import { useEffect, useMemo } from 'react'
+
+import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { dayjs } from 'lib/dayjs'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { More } from 'lib/lemon-ui/LemonButton/More'
+import { LemonCard } from 'lib/lemon-ui/LemonCard'
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
+import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { useSummarizeInsight } from 'scenes/insights/summarizeInsight'
+import { parseDraftQueryFromLocalStorage } from 'scenes/insights/utils'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
+
+import { Node } from '~/queries/schema/schema-general'
+import { isNodeWithSource } from '~/queries/utils'
+import { AccessControlLevel } from '~/types'
+
+import { QUERY_TYPES_METADATA } from './insightTypesMetadata'
+import { SavedInsightListItem } from './savedInsightsLogic'
+
+// 'development' only (not just "not production"): keeps Jest and Storybook snapshots untouched
+const PROTOTYPE_ENABLED = process.env.NODE_ENV === 'development'
+
+export type DraftPrototypeVariant = 'A' | 'B' | 'C'
+
+export interface DraftQueryPayload {
+    query: Node<Record<string, any>>
+    timestamp: number
+}
+
+const VARIANTS: DraftPrototypeVariant[] = ['A', 'B', 'C']
+const VARIANT_NAMES: Record<DraftPrototypeVariant, string> = {
+    A: 'Row in the table',
+    B: 'Strip above the table',
+    C: 'Dismissible banner',
+}
+
+export const DRAFT_ROW_ID = -1
+
+const SAMPLE_DRAFT_QUERY = {
+    kind: 'InsightVizNode',
+    source: {
+        kind: 'TrendsQuery',
+        series: [{ kind: 'EventsNode', event: '$pageview', name: '$pageview', math: 'total' }],
+    },
+} as unknown as Node<Record<string, any>>
+
+function variantFromSearchParams(searchParams: Record<string, any>): DraftPrototypeVariant {
+    const raw = String(searchParams.variant ?? 'A').toUpperCase()
+    return (VARIANTS as string[]).includes(raw) ? (raw as DraftPrototypeVariant) : 'A'
+}
+
+function cycleVariant(delta: number): void {
+    const current = variantFromSearchParams(router.values.searchParams)
+    const next = VARIANTS[(VARIANTS.indexOf(current) + delta + VARIANTS.length) % VARIANTS.length]
+    router.actions.replace(
+        router.values.location.pathname,
+        { ...router.values.searchParams, variant: next },
+        router.values.hashParams
+    )
+}
+
+function discardDraftStub(): void {
+    lemonToast.info('Prototype: discard is stubbed so the draft stays around for the demo.')
+}
+
+export function isDraftRow(item: SavedInsightListItem): boolean {
+    return item.id === DRAFT_ROW_ID
+}
+
+export function useDraftInsightPrototype(): {
+    variant: DraftPrototypeVariant | null
+    draft: DraftQueryPayload | null
+    isSample: boolean
+    draftRow: SavedInsightListItem | null
+} {
+    const { currentTeamId } = useValues(teamLogic)
+    const { user } = useValues(userLogic)
+    const { searchParams } = useValues(router)
+    const sampleTimestamp = useMemo(() => Date.now() - 3 * 60 * 60 * 1000, [])
+
+    if (!PROTOTYPE_ENABLED) {
+        return { variant: null, draft: null, isSample: false, draftRow: null }
+    }
+
+    const stored = localStorage.getItem(`draft-query-${currentTeamId}`)
+    const parsed = stored ? parseDraftQueryFromLocalStorage(stored) : null
+    const isSample = !parsed?.query
+    const draft: DraftQueryPayload = parsed?.query ? parsed : { query: SAMPLE_DRAFT_QUERY, timestamp: sampleTimestamp }
+
+    const timestampIso = dayjs(draft.timestamp).toISOString()
+    const draftRow = {
+        id: DRAFT_ROW_ID,
+        short_id: 'draft-prototype',
+        name: '',
+        query: draft.query,
+        tags: [],
+        favorited: false,
+        created_by: user ?? null,
+        created_at: timestampIso,
+        last_modified_at: timestampIso,
+        last_modified_by: null,
+        last_viewed_at: null,
+        updated_at: timestampIso,
+        user_access_level: AccessControlLevel.Viewer,
+        saved: false,
+        deleted: false,
+        is_sample: false,
+        order: null,
+        result: null,
+        dashboards: null,
+        dashboard_tiles: null,
+    } as unknown as SavedInsightListItem
+
+    return { variant: variantFromSearchParams(searchParams), draft, isSample, draftRow }
+}
+
+function DraftQueryIcon({
+    query,
+    className,
+}: {
+    query: Node<Record<string, any>>
+    className?: string
+}): JSX.Element | null {
+    const kind = isNodeWithSource(query) ? query.source.kind : query.kind
+    const Icon = QUERY_TYPES_METADATA[kind]?.icon
+    return Icon ? <Icon className={className} /> : null
+}
+
+/** Variant A — name cell of the pinned draft row. */
+export function DraftRowNameCellPrototype({ item }: { item: SavedInsightListItem }): JSX.Element {
+    const summarizeInsight = useSummarizeInsight()
+    return (
+        <div className="flex items-center gap-1">
+            <LemonTableLink
+                to={urls.insightNew({ query: item.query ?? undefined })}
+                title={
+                    <span className="flex items-center gap-2">
+                        <i>{summarizeInsight(item.query) || 'Unsaved insight'}</i>
+                        <LemonTag type="warning" size="small">
+                            Draft
+                        </LemonTag>
+                    </span>
+                }
+                description="Unsaved changes, only stored in this browser"
+            />
+        </div>
+    )
+}
+
+/** Variant A — actions cell of the pinned draft row. */
+export function DraftRowMoreMenuPrototype({ item }: { item: SavedInsightListItem }): JSX.Element {
+    return (
+        <More
+            overlay={
+                <>
+                    <LemonButton to={urls.insightNew({ query: item.query ?? undefined })} fullWidth>
+                        Continue editing
+                    </LemonButton>
+                    <LemonDivider />
+                    <LemonButton status="danger" onClick={discardDraftStub} fullWidth>
+                        Discard draft
+                    </LemonButton>
+                </>
+            }
+        />
+    )
+}
+
+/** Variant B — a draft strip sitting between the filters and the table. */
+export function DraftStripPrototype({ draft, isSample }: { draft: DraftQueryPayload; isSample: boolean }): JSX.Element {
+    const summarizeInsight = useSummarizeInsight()
+    return (
+        <LemonCard hoverEffect={false} className="flex items-center gap-3 p-3 border-warning bg-warning-highlight">
+            <DraftQueryIcon query={draft.query} className="text-secondary text-2xl shrink-0" />
+            <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 font-semibold">
+                    <span className="truncate">{summarizeInsight(draft.query) || 'Unsaved insight'}</span>
+                    <LemonTag type="warning" size="small">
+                        Draft
+                    </LemonTag>
+                </div>
+                <div className="text-secondary text-xs">
+                    Unsaved insight from <TZLabel time={dayjs(draft.timestamp)} />. Only stored in this browser
+                    {isSample ? ' (sample)' : ''}.
+                </div>
+            </div>
+            <LemonButton size="small" onClick={discardDraftStub}>
+                Discard
+            </LemonButton>
+            <LemonButton size="small" type="primary" to={urls.insightNew({ query: draft.query })}>
+                Continue editing
+            </LemonButton>
+        </LemonCard>
+    )
+}
+
+/** Variant C — the current banner shape, upgraded with a proper action and dismiss. */
+export function DraftBannerPrototype({ draft }: { draft: DraftQueryPayload }): JSX.Element {
+    return (
+        <LemonBanner
+            type="info"
+            onClose={discardDraftStub}
+            action={{ children: 'Continue editing', to: urls.insightNew({ query: draft.query }) }}
+        >
+            You have an unsaved insight from <TZLabel time={dayjs(draft.timestamp)} />.
+        </LemonBanner>
+    )
+}
+
+/** Floating bottom-center bar to flip between variants. Hidden in production builds. */
+export function PrototypeSwitcherBar({ note }: { note?: string }): JSX.Element | null {
+    const { searchParams } = useValues(router)
+    const variant = variantFromSearchParams(searchParams)
+
+    useEffect(() => {
+        if (!PROTOTYPE_ENABLED) {
+            return
+        }
+        const onKeyDown = (event: KeyboardEvent): void => {
+            if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+                return
+            }
+            const target = event.target as HTMLElement | null
+            if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+                return
+            }
+            if (event.key === 'ArrowLeft') {
+                cycleVariant(-1)
+            } else if (event.key === 'ArrowRight') {
+                cycleVariant(1)
+            }
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => window.removeEventListener('keydown', onKeyDown)
+    }, [])
+
+    if (!PROTOTYPE_ENABLED) {
+        return null
+    }
+
+    return (
+        <div className="fixed bottom-4 left-1/2 z-[1000] flex -translate-x-1/2 items-center gap-1 rounded-full bg-black/85 px-2 py-1 text-white shadow-xl">
+            <button
+                type="button"
+                aria-label="Previous variant"
+                className="cursor-pointer rounded-full px-1.5 py-0.5 hover:bg-white/20"
+                onClick={() => cycleVariant(-1)}
+            >
+                <IconChevronLeft />
+            </button>
+            <span className="px-1 text-xs font-semibold whitespace-nowrap">
+                Prototype {variant} · {VARIANT_NAMES[variant]}
+                {note ? <span className="font-normal text-white/70"> · {note}</span> : null}
+            </span>
+            <button
+                type="button"
+                aria-label="Next variant"
+                className="cursor-pointer rounded-full px-1.5 py-0.5 hover:bg-white/20"
+                onClick={() => cycleVariant(1)}
+            >
+                <IconChevronRight />
+            </button>
+        </div>
+    )
+}

--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -52,6 +52,16 @@ export * from './insightTypesMetadata'
 import { QUERY_TYPES_METADATA } from './insightTypesMetadata'
 import { NewInsightButton } from './NewInsightMenu'
 import { ReloadInsight } from './ReloadInsight'
+// PROTOTYPE — throwaway draft-notice variants, see ReloadInsightPrototype.tsx
+import {
+    DraftBannerPrototype,
+    DraftRowMoreMenuPrototype,
+    DraftRowNameCellPrototype,
+    DraftStripPrototype,
+    PrototypeSwitcherBar,
+    isDraftRow,
+    useDraftInsightPrototype,
+} from './ReloadInsightPrototype'
 import { SavedInsightListItem, savedInsightsLogic } from './savedInsightsLogic'
 
 export const scene: SceneExport = {
@@ -93,6 +103,7 @@ export function SavedInsights(): JSX.Element {
 
     const { currentProjectId } = useValues(projectLogic)
     const summarizeInsight = useSummarizeInsight()
+    const draftPrototype = useDraftInsightPrototype()
 
     const { tab } = filters
 
@@ -109,6 +120,9 @@ export function SavedInsights(): JSX.Element {
             dataIndex: 'name',
             key: 'name',
             render: function renderName(name: string, insight) {
+                if (isDraftRow(insight)) {
+                    return <DraftRowNameCellPrototype item={insight} />
+                }
                 return (
                     <div className="flex items-center gap-1">
                         <LemonTableLink
@@ -215,6 +229,9 @@ export function SavedInsights(): JSX.Element {
         {
             width: 0,
             render: function Render(_, insight) {
+                if (isDraftRow(insight)) {
+                    return <DraftRowMoreMenuPrototype item={insight} />
+                }
                 return (
                     <More
                         overlay={
@@ -342,11 +359,22 @@ export function SavedInsights(): JSX.Element {
                                 : undefined
                         }
                     />
-                    <ReloadInsight />
+                    {draftPrototype.variant === null ? (
+                        <ReloadInsight />
+                    ) : draftPrototype.variant === 'B' && draftPrototype.draft ? (
+                        <DraftStripPrototype draft={draftPrototype.draft} isSample={draftPrototype.isSample} />
+                    ) : draftPrototype.variant === 'C' && draftPrototype.draft ? (
+                        <DraftBannerPrototype draft={draftPrototype.draft} />
+                    ) : null}
                     <LemonTable
                         loading={insightsLoading}
                         columns={columns}
-                        dataSource={insights.results}
+                        dataSource={
+                            draftPrototype.variant === 'A' && draftPrototype.draftRow
+                                ? [draftPrototype.draftRow, ...insights.results]
+                                : insights.results
+                        }
+                        rowClassName={(record) => (isDraftRow(record) ? 'bg-warning-highlight' : null)}
                         pagination={pagination}
                         noSortingCancellation
                         sorting={sorting}
@@ -371,13 +399,15 @@ export function SavedInsights(): JSX.Element {
                         bulkSelection={{
                             getKey: (insight: SavedInsightListItem): number => insight.id,
                             isRowSelectable: (insight: SavedInsightListItem) =>
-                                accessLevelSatisfied(
-                                    AccessControlResourceType.Insight,
-                                    insight.user_access_level,
-                                    AccessControlLevel.Editor
-                                )
-                                    ? true
-                                    : { disabledReason: "You don't have permission to edit this insight." },
+                                isDraftRow(insight)
+                                    ? { disabledReason: 'This draft only exists in your browser.' }
+                                    : accessLevelSatisfied(
+                                            AccessControlResourceType.Insight,
+                                            insight.user_access_level,
+                                            AccessControlLevel.Editor
+                                        )
+                                      ? true
+                                      : { disabledReason: "You don't have permission to edit this insight." },
                             rowAriaLabel: (insight: SavedInsightListItem) =>
                                 `Select insight ${insight.name || 'Untitled'}`,
                             headerAriaLabel: 'Select all insights on this page',
@@ -425,6 +455,7 @@ export function SavedInsights(): JSX.Element {
                     />
                 </>
             )}
+            <PrototypeSwitcherBar note={draftPrototype.isSample ? 'sample draft' : undefined} />
         </SceneContent>
     )
 }


### PR DESCRIPTION
## TL;DR

Throwaway prototype, not meant to merge as-is. It shows three looks for the "You have an unsaved insight" notice on the insights list page. The main one turns the notice into a draft row pinned to the top of the table. Flip between looks in the browser with the floating bar at the bottom or `?variant=`.

## Problem

The insights list shows an unsaved draft as a plain text line above the table: "You have an unsaved insight from [date]. Click here to view it." It is easy to miss. Question to settle: should the draft be an item in the table below instead?

## Changes

All prototype code lives in `ReloadInsightPrototype.tsx` and only runs in local dev builds (`NODE_ENV === 'development'`). Production keeps the current text line. On `/insights`, switch variants with the floating bottom bar, the left/right arrow keys, or `?variant=`:

- `A` (default): the draft is a pinned, highlighted first row of the table, with the insight icon, summary, a "Draft" tag, timestamps, and a row menu (Continue editing / Discard).
- `B`: the draft is a strip between the filters and the table, with a primary "Continue editing" button.
- `C`: the current banner shape, upgraded with an action button and a dismiss control.

If localStorage has no real draft, a sample draft is shown and labelled in the bottom bar. Discard is stubbed with a toast so the demo draft survives flipping.

## How did you test this code?

Automated checks only, no manual run (the agent environment cannot start the dev stack, so no screenshots):

- oxlint (repo config): clean on both changed files
- oxfmt applied
- `pnpm --filter=@posthog/frontend typescript:check`: no errors in the changed files (the remaining errors are pre-existing, from unbuilt quill workspace packages in the sandbox, all in untouched files)
- `hogli ci:preflight --fix`: pass

To try it: `./bin/start`, open `/insights`, use the bottom bar.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed: dev-only prototype with no user-facing change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built by Claude in a PostHog Code session with the `/prototype` skill (UI branch: several variants on the existing route, plus a floating switcher). Decisions: variant A reuses the real table columns and special-cases only three spots in `SavedInsights.tsx` (name cell, row menu, bulk selection) so the row looks exactly like production; the gate is `NODE_ENV === 'development'` rather than "not production" so Jest and Storybook stay untouched; discard is a stub so the demo data survives. When a variant wins, fold it into the real code properly (real discard, no type casts) and close this PR unmerged; the branch stays as the record of the options.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
