### PR TITLE
fix(cli): raise empty sourcemap wrapper threshold

### DIFF
--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -7,9 +7,14 @@ use tracing::{debug, info, warn};
 /// Sibling-JS size below which an empty sourcemap is treated as a harmless
 /// bundler-generated wrapper (e.g. Turbopack App Router page entries,
 /// webpack re-export shims). Observed wrapper files in the wild are
-/// under 1 KiB; 2 KiB leaves comfortable headroom for tools that inject
-/// extra glue (PostHog chunk-id IIFE, etc.) without misclassifying real code.
-const WRAPPER_JS_SIZE_THRESHOLD_BYTES: usize = 2048;
+/// under 1 KiB; Turbopack App Router wrappers can reach roughly 3 KiB after
+/// the PostHog chunk-id injection. 4 KiB keeps those harmless wrappers quiet
+/// while still flagging larger empty sourcemaps for investigation.
+const WRAPPER_JS_SIZE_THRESHOLD_BYTES: usize = 4096;
+
+fn is_empty_sourcemap_wrapper(js_size: usize) -> bool {
+    js_size < WRAPPER_JS_SIZE_THRESHOLD_BYTES
+}
 
 use crate::{
     api::{
@@ -113,7 +118,7 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
     for pair in &empty_pairs {
         let js_size = pair.source.inner.content.len();
         let map_path = pair.sourcemap.inner.path.display();
-        if js_size < WRAPPER_JS_SIZE_THRESHOLD_BYTES {
+        if is_empty_sourcemap_wrapper(js_size) {
             empty_skipped_wrapper += 1;
             debug!(
                 "Skipping {}: sourcemap is empty and sibling JS is {} bytes — bundler-generated wrapper, nothing to symbolicate",
@@ -194,4 +199,19 @@ fn remove_sourcemap_references(paths: Vec<PathBuf>) -> Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_empty_sourcemap_wrapper;
+
+    #[test]
+    fn treats_turbopack_page_wrapper_as_harmless_empty_sourcemap() {
+        assert!(is_empty_sourcemap_wrapper(2864));
+    }
+
+    #[test]
+    fn keeps_a_four_kib_empty_sourcemap_suspect() {
+        assert!(!is_empty_sourcemap_wrapper(4096));
+    }
 }


### PR DESCRIPTION
## Problem

Closes #70235.

Next.js 16 Turbopack App Router server page wrappers can exceed the CLI's 2 KiB empty-sourcemap cutoff after PostHog chunk-ID injection. Those harmless wrappers are reported as a likely bundler misconfiguration.

## Changes

- Raise the empty-sourcemap wrapper cutoff to 4 KiB.
- Keep a 4 KiB empty sourcemap classified as suspicious.
- Add focused regressions for both sides of that boundary.

## How did you test this code?

- Added a regression for a 2,864-byte Turbopack wrapper. It fails with the former 2 KiB cutoff and passes with this change.
- Added a boundary regression showing a 4 KiB empty sourcemap remains suspicious.
- Ran `cargo test --manifest-path cli/Cargo.toml --lib sourcemaps::plain::upload::tests`.
- Ran `cargo fmt --manifest-path cli/Cargo.toml -- --check`, `cargo clippy --manifest-path cli/Cargo.toml --lib -- -D warnings`, and `cargo build --manifest-path cli/Cargo.toml`.

The tests exercise the same classification helper called by the upload path after source-pair generation. I did not run a networked upload because it requires external project credentials and this change does not alter upload transport.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed. This is an internal warning-classification threshold with focused code comments and tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex desktop authored this small Rust fix with human-directed scope. It used `gh` for collision checks and Cargo for validation. The repository-provided `/writing-tests` skill was invoked for the regression design.

The selected boundary is intentionally narrow: a real 2,864-byte wrapper reproduces the false warning, while 4 KiB stays on the suspicious side. No upload transport or non-empty-sourcemap behavior changed.
