### PR TITLE
fix(insights): let table display bleed to the card edges

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2317,9 +2317,9 @@ snapshots:
     exporter-trends--trends-pie-insight-legend--light:
         hash: v1.k794b7964.2eee29146a4cd703a88df5986742cf2bfe804374e9b46e04f3a065acb3bb0d8f.vDNDFJu83-A5zpZF5hhUW1uHl36Hd18AwHbnNLrLnOA
     exporter-trends--trends-table-insight--dark:
-        hash: v1.k794b7964.92191f5d6ed09bce9843b2168a0ae277493e522cfb6bd52fd7a5b91397d91fa5.2VnfYOZnlJzHQtD34o5Rws-OY7mm8onFWP_ZIfiPj-8
+        hash: v1.k794b7964.d2351308c6493ff330fef71e6af5d43c0a52ef28004f39d7112c49cb9ba6b4d4.vVRXq4GJ2nofvbBEpopRDL3DsKgpTC2fL5H4KNEdjMU
     exporter-trends--trends-table-insight--light:
-        hash: v1.k794b7964.fbfe6112e758938dcdce47ad87f44b5a12846796ae55ffebbc7f5c1f2b796fa3.cjdnak6QmLsWypy7NBfjJLFAJPHwao2i6QwqgqIvjpc
+        hash: v1.k794b7964.249fa82816a002cc5dd7af1b232914f0a1a638365d47cd51c8cff80a1fe91958.gJ72UIUwBqI7vOSBJqnbpJzbA9WurFHjhYIhLRjl3v0
     exporter-trends--trends-world-map-insight--dark:
         hash: v1.k794b7964.9db49f05cafcb9471da9287819b17a7c76eb7c28f0de19dc53501063d8a4b47d.Or90JHFX4C_EH0id0iP_FCW07ZXb280MhNhhWtXvgQQ
     exporter-trends--trends-world-map-insight--light:
@@ -6303,9 +6303,9 @@ snapshots:
     scenes-app-insights-loading-messages--loading-messages--light:
         hash: v1.k794b7964.8127887a8cefedcd7ed93385885d6847022c7fa290f01ba60c42deb1216aa9b8.7DnuefE-HifUz5vzz32GzJAmV6eG8Or-yMF3OpaDuw8
     scenes-app-insights-mcp-missing-capability--mcp-missing-capability--dark:
-        hash: v1.k794b7964.f250895219333202c28d21570219a9430aa10b41a3851e0c1c4dbda4f46d4f78.m8QqxDmzk6Rif-oSNHNpYIIn0wvVDHCVYB63cime7eE
+        hash: v1.k794b7964.0437dd655c7b78ec6e051f8a966a3db0aacaa698bbd575887696f03b1d277fc6.xBIh6OnGCQTM0zftdVNaO6ig0h-4oLpd3bIDgixmAzw
     scenes-app-insights-mcp-missing-capability--mcp-missing-capability--light:
-        hash: v1.k794b7964.f16f9a878965f2a9c65430ae15d8f28aa5e42cf06d164c2d8a34bcbb825403bf.V9V7xTdOK4Ae-b5Ks5E5oZCMfBIxv_HImZRcJUFOMLc
+        hash: v1.k794b7964.27c8a5311feed5b8811a92f4651a5437b1776718dd951ac103c986a320c912e7.zv4ZV2Lh4TbIBWDm-5xZh6P6s6R55ut_-jDmzNAt7b0
     scenes-app-insights-side-panel-actions--saved-data-visualization--dark:
         hash: v1.k794b7964.3911a695d4b7b073bd0bfbaa183acb078d81df968e2cfecd18f84bc1c181bb66.2Hh9UrgF9n3vN3ZVif3FKqyz4F9mFROKhyLIEflEvDY
     scenes-app-insights-side-panel-actions--saved-data-visualization--light:

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.scss
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.scss
@@ -262,8 +262,11 @@
     }
 }
 
-// Drop the viz padding so the Metric sparkline can bleed to the card edges.
-.InsightVizDisplay__content:has(.Metric) {
+// Drop the viz padding for displays that bleed to the card edges: the Metric sparkline, and the
+// results table, whose full-width header and row separators would otherwise stop short of the border.
+.InsightVizDisplay__content:has(.Metric),
+.InsightVizDisplay__content:has(.TrendsInsight--ActionsTable),
+.InsightVizDisplay__content:has(.InsightCard__viz--ActionsTable) {
     padding: 0;
 }
 


### PR DESCRIPTION
## TL;DR

When you view an insight as a table, the table floats inside its card with a small gap on every side, so its lines stop before the card border and it looks cropped. This change makes the table reach the card edges again.

## Problem

Insights rendered with the "Table" chart type sit 0.5rem inside the card border. The header and row separators end short of the edge, and extra white space shows below the last row:

![before](https://raw.githubusercontent.com/PostHog/pr-assets/7ff5d784712a2d6816cf4c6223720e83c9be2185/2026/07/d431fd62-4a8a-4552-9f72-aaa5101b29ce.png)

`.InsightVizDisplay__content` gained `padding: 0.5rem` in #28880, which replaced child margins that caused a scrollbar. Before that, the table display had `margin: 0` and bled to the edges. #63907 later restored edge-to-edge rendering for the Metric display with a `:has(.Metric)` override, but the table never got the same treatment.

## Changes

Extend the padding override to the table display's wrapper classes: `TrendsInsight--ActionsTable` for the insight scene and `InsightCard__viz--ActionsTable` for embedded surfaces. The table's own cell padding (doubled on first and last cells) keeps the content clear of the border.

> [!NOTE]
> This also removes the inset on dashboard tiles, exports, and notebook nodes, which render the same wrapper. Tables there now sit flush with the card, matching SQL insight and web analytics tables.

## How did you test this code?

CSS-only change, so no automated tests. I (or, actually, Claude) verified the selectors against the class chain in `Trends.tsx` and `InsightVizDisplay.tsx`, and mirrored the `:has(.Metric)` override that already works in the same file. The task sandbox has no dev stack, so no manual UI check ran. The Storybook exporter story `TrendsTableInsight` renders the embedded variant for review.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs cover this spacing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code cloud task) wrote this from a bug report with the screenshot above. It traced the inset to #28880, which moved child margins into parent padding and took the table display along. It chose the smallest fix: extend the `:has()` padding override that #63907 added for the Metric display. It rejected removing the parent padding outright (that would bring back the scrollbar #28880 fixed) and a TSX-side conditional class (the CSS pattern already exists in this file). Retention's grid table keeps its padding on purpose: it has no full-width separators, so the breathing room reads as intended. No repo skills applied to a CSS-only change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
