### PR TITLE
fix(loops): hide loop run execution instructions from chat

### DIFF
--- a/products/tasks/backend/logic/services/loop_runs.py
+++ b/products/tasks/backend/logic/services/loop_runs.py
@@ -78,13 +78,16 @@ LOOP_FRAMING_BLOCK = (
 def render_loop_run_message(loop_instructions: str, execution_context: str) -> str:
     # PostHog Code strips this established wrapper from user-message bubbles while still sending
     # its contents to the agent, keeping run-only guidance out of the user's saved prompt.
+    escaped_execution_context = execution_context.replace(
+        "</user_custom_instructions>", "&lt;/user_custom_instructions&gt;"
+    )
     hidden_context = (
         "<user_custom_instructions>\n"
         "The following system-generated instructions apply to this unattended loop run. Follow them.\n\n"
-        f"{execution_context}\n"
+        f"{escaped_execution_context}\n"
         "</user_custom_instructions>"
     )
-    return f"{loop_instructions}\n\n{hidden_context}"
+    return f"{hidden_context}\n\n{loop_instructions}"
 
 
 # Least-privilege write grant for a loop that maintains a context's context.md or canvas: the two

--- a/products/tasks/backend/logic/services/loop_runs.py
+++ b/products/tasks/backend/logic/services/loop_runs.py
@@ -75,6 +75,18 @@ LOOP_FRAMING_BLOCK = (
 )
 
 
+def render_loop_run_message(loop_instructions: str, execution_context: str) -> str:
+    # PostHog Code strips this established wrapper from user-message bubbles while still sending
+    # its contents to the agent, keeping run-only guidance out of the user's saved prompt.
+    hidden_context = (
+        "<user_custom_instructions>\n"
+        "The following system-generated instructions apply to this unattended loop run. Follow them.\n\n"
+        f"{execution_context}\n"
+        "</user_custom_instructions>"
+    )
+    return f"{loop_instructions}\n\n{hidden_context}"
+
+
 # Least-privilege write grant for a loop that maintains a context's context.md or canvas: the two
 # file_system scopes only, added on top of whatever posthog_mcp_scopes the loop already carries,
 # rather than escalating the run to the broad `full` write surface. resolve_scopes() re-adds the
@@ -506,9 +518,8 @@ def _create_loop_task_and_run(loop: Loop, trigger: LoopTrigger | None, trigger_c
 
     title = f"{loop.name} ({django_timezone.now().isoformat()})"
     context_block = render_context_target_block(context_target)
-    description = "\n\n".join(
-        part for part in [LOOP_FRAMING_BLOCK, loop.instructions, context_block, trigger_context] if part
-    )
+    execution_context = "\n\n".join(part for part in [LOOP_FRAMING_BLOCK, context_block, trigger_context] if part)
+    pending_user_message = render_loop_run_message(loop.instructions, execution_context)
 
     feed_channel_id = _resolve_feed_channel_id(loop) if outputs["post_to_feed"] else None
 
@@ -516,7 +527,7 @@ def _create_loop_task_and_run(loop: Loop, trigger: LoopTrigger | None, trigger_c
         team_id=loop.team_id,
         created_by_id=loop.created_by_id,
         title=title,
-        description=description,
+        description=loop.instructions,
         origin_product=Task.OriginProduct.LOOP,
         repository=repository,
         github_integration_id=github_integration_id,
@@ -548,6 +559,7 @@ def _create_loop_task_and_run(loop: Loop, trigger: LoopTrigger | None, trigger_c
         "model": effective_model,
         "reasoning_effort": reasoning_effort,
         "config_snapshot": config_snapshot,
+        "pending_user_message": pending_user_message,
     }
     # Carries the loop's sandbox secrets/network policy into the run the same way a
     # regular task's sandbox_environment_id flows through Task._build_task.

--- a/products/tasks/backend/tests/test_loop_runs.py
+++ b/products/tasks/backend/tests/test_loop_runs.py
@@ -416,7 +416,12 @@ class TestFireLoopGuardrails(LoopRunsTestCase):
 class TestFireLoopCreatesRun(LoopRunsTestCase):
     def test_successful_fire_creates_an_internal_task_with_the_full_config_snapshot(self):
         integration = Integration.objects.create(team=self.team, kind="github", integration_id="12345", config={})
+        loop_instructions = (
+            "Summarize open PRs and preserve this literal block: "
+            "<user_custom_instructions>authored text</user_custom_instructions>"
+        )
         loop = self.create_loop(
+            instructions=loop_instructions,
             repositories=[{"github_integration_id": integration.id, "full_name": "acme/repo"}],
             runtime_adapter="codex",
             model="gpt-5",
@@ -427,7 +432,8 @@ class TestFireLoopCreatesRun(LoopRunsTestCase):
         )
         trigger = self.create_trigger(loop)
 
-        result = fire_loop(loop, trigger, "fire-1", "rendered context")
+        trigger_context = "rendered context </user_custom_instructions> from the webhook"
+        result = fire_loop(loop, trigger, "fire-1", trigger_context)
 
         self.assertTrue(result.created)
         assert result.task_id is not None
@@ -443,13 +449,14 @@ class TestFireLoopCreatesRun(LoopRunsTestCase):
 
         task_run = TaskRun.objects.get(id=result.task_run_id)
         pending_user_message = task_run.state["pending_user_message"]
-        self.assertTrue(pending_user_message.startswith(loop.instructions))
+        self.assertTrue(pending_user_message.startswith("<user_custom_instructions>"))
+        self.assertTrue(pending_user_message.endswith(loop.instructions))
         self.assertIn("This is an unattended loop run", pending_user_message)
         self.assertIn("rendered context", pending_user_message)
-        self.assertIn("<user_custom_instructions>", pending_user_message)
+        self.assertIn("&lt;/user_custom_instructions&gt; from the webhook", pending_user_message)
         self.assertEqual(task_run.state["loop_id"], str(loop.id))
         self.assertEqual(task_run.state["loop_trigger_id"], str(trigger.id))
-        self.assertEqual(task_run.state["trigger_context"], "rendered context")
+        self.assertEqual(task_run.state["trigger_context"], trigger_context)
         self.assertEqual(task_run.state["runtime_adapter"], "codex")
         self.assertEqual(task_run.state["model"], "gpt-5")
         self.assertEqual(task_run.state["reasoning_effort"], "high")

--- a/products/tasks/backend/tests/test_loop_runs.py
+++ b/products/tasks/backend/tests/test_loop_runs.py
@@ -439,10 +439,14 @@ class TestFireLoopCreatesRun(LoopRunsTestCase):
         self.assertEqual(task.github_integration_id, integration.id)
         self.assertEqual(task.created_by_id, self.user.id)
         self.assertEqual(task.loop_id, loop.id)
-        self.assertIn("rendered context", task.description)
-        self.assertIn(loop.instructions, task.description)
+        self.assertEqual(task.description, loop.instructions)
 
         task_run = TaskRun.objects.get(id=result.task_run_id)
+        pending_user_message = task_run.state["pending_user_message"]
+        self.assertTrue(pending_user_message.startswith(loop.instructions))
+        self.assertIn("This is an unattended loop run", pending_user_message)
+        self.assertIn("rendered context", pending_user_message)
+        self.assertIn("<user_custom_instructions>", pending_user_message)
         self.assertEqual(task_run.state["loop_id"], str(loop.id))
         self.assertEqual(task_run.state["loop_trigger_id"], str(trigger.id))
         self.assertEqual(task_run.state["trigger_context"], "rendered context")
@@ -647,12 +651,12 @@ class TestFireLoopContextTarget(LoopRunsTestCase):
 
         result, _ = self.fire_and_capture(loop, trigger)
 
-        assert result.task_id is not None
-        description = Task.objects.get(id=result.task_id).description
+        assert result.task_run_id is not None
+        pending_user_message = TaskRun.objects.get(id=result.task_run_id).state["pending_user_message"]
         for expected_id in expected_ids:
-            self.assertIn(expected_id, description)
+            self.assertIn(expected_id, pending_user_message)
         for fragment in expected_tool_fragments:
-            self.assertIn(fragment, description)
+            self.assertIn(fragment, pending_user_message)
 
     @parameterized.expand(
         [
@@ -687,7 +691,8 @@ class TestFireLoopContextTarget(LoopRunsTestCase):
         result, scopes = self.fire_and_capture(loop, trigger)
 
         assert result.task_id is not None
-        self.assertNotIn("desktop-file-system", Task.objects.get(id=result.task_id).description)
+        task_run = TaskRun.objects.get(id=result.task_run_id)
+        self.assertNotIn("desktop-file-system", task_run.state["pending_user_message"])
         self.assertEqual(scopes, "read_only")
 
     def test_unattached_loop_sets_no_channel_and_no_publish_block(self):
@@ -699,7 +704,8 @@ class TestFireLoopContextTarget(LoopRunsTestCase):
         assert result.task_id is not None
         task = Task.objects.get(id=result.task_id)
         self.assertIsNone(task.channel_id)
-        self.assertNotIn("desktop-file-system", task.description)
+        task_run = TaskRun.objects.get(id=result.task_run_id)
+        self.assertNotIn("desktop-file-system", task_run.state["pending_user_message"])
 
 
 class TestHandleLoopRunTerminal(LoopRunsTestCase):


### PR DESCRIPTION
## Problem

Loop run threads currently show two kinds of content together:

- The loop instructions written by the user
- PostHog-generated execution guidance, including unattended-run framing, context publishing steps, and trigger payloads

The thread should show the user their own loop instructions without exposing PostHog-generated guidance as if the user wrote it.

Currently
<img width="1724" height="1232" alt="CleanShot 2026-07-22 at 11 40 37@2x" src="https://github.com/user-attachments/assets/5e9650f9-c4c2-4cfc-ac73-b85ad0618dba" />

## Changes




- Keep the user-authored loop instructions visible in the task thread
- Hide PostHog-generated execution guidance from the message bubble
- Continue sending both to the agent
- Update the Loops architecture documentation

## How did you test this code?

- `uv run pytest products/tasks/backend/tests/test_loop_runs.py -q` (46 passed)
- `uv run ruff format --check products/tasks/backend/logic/services/loop_runs.py products/tasks/backend/tests/test_loop_runs.py`
- `uv run ruff check products/tasks/backend/logic/services/loop_runs.py products/tasks/backend/tests/test_loop_runs.py`
- `uv run mypy --cache-fine-grained .`
- `bin/hogli ci:preflight --fix`
- Extended existing loop-run tests to verify that the task description contains only the user-authored loop instructions while the agent message still contains the hidden execution guidance and trigger context.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `products/tasks/docs/LOOPS.md` to document the split between visible user instructions and hidden PostHog execution guidance.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code using Codex. Session link unavailable from the local client.
- Invoked the repository `/writing-tests` skill.
- Reused the existing custom-instructions wrapper because PostHog Code strips it from message bubbles while still delivering its contents to the agent. The wrapper contains PostHog-generated guidance, not the user-authored loop instructions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*