### PR TITLE
fix(onboarding): selecting conversations as a product during onboarding doesn't enable it

### DIFF
--- a/frontend/src/scenes/onboarding/legacy/onboardingFlowUtils.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingFlowUtils.ts
@@ -7,6 +7,35 @@ const STEP_KEY_TITLE_OVERRIDES: Partial<Record<OnboardingStepKey, string>> = {
     [OnboardingStepKey.LINK_DATA]: 'Import data',
 }
 
+/**
+ * Step keys that can join the flow asynchronously after it first builds: `plans`
+ * appears once billing loads, `invite_teammates` once org invite permissions
+ * resolve, and `link_data` is appended for product-analytics primaries. A URL
+ * requesting one of these must not be self-corrected away just because the step
+ * isn't in the flow yet.
+ */
+const ASYNC_APPENDED_STEP_KEYS: string[] = [
+    OnboardingStepKey.PLANS,
+    OnboardingStepKey.INVITE_TEAMMATES,
+    OnboardingStepKey.LINK_DATA,
+]
+
+/**
+ * Whether a requested step id might still be emitted into the flow once async data
+ * (billing, org membership) loads. Product-provided steps (install, configure, …)
+ * are contributed synchronously the moment the flow builds, so a bare product-level
+ * step key missing from a built flow will never appear — e.g. `?step=install` for a
+ * product whose provider emits no install step — and must be self-corrected instead
+ * of leaving the host on a spinner forever.
+ *
+ * A `?` or `&` means query params fused into the step value (a mangled URL) — never
+ * treat that as pending. Namespaced ids (`install:logs`) are conservatively treated
+ * as pending: they include the namespaced forms of the async-appended steps
+ * (`plans:<product>`), which must keep waiting for billing.
+ */
+export const mayStepAppearLater = (stepId: string): boolean =>
+    !/[?&]/.test(stepId) && (ASYNC_APPENDED_STEP_KEYS.includes(stepId) || stepId.includes(':'))
+
 export const stepKeyToTitle = (stepKey?: OnboardingStepKey): undefined | string => {
     if (!stepKey) {
         return undefined

--- a/frontend/src/scenes/onboarding/legacy/onboardingFlowUtils.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingFlowUtils.ts
@@ -22,19 +22,15 @@ const ASYNC_APPENDED_STEP_KEYS: string[] = [
 
 /**
  * Whether a requested step id might still be emitted into the flow once async data
- * (billing, org membership) loads. Product-provided steps (install, configure, …)
- * are contributed synchronously the moment the flow builds, so a bare product-level
- * step key missing from a built flow will never appear — e.g. `?step=install` for a
- * product whose provider emits no install step — and must be self-corrected instead
- * of leaving the host on a spinner forever.
- *
- * A `?` or `&` means query params fused into the step value (a mangled URL) — never
- * treat that as pending. Namespaced ids (`install:logs`) are conservatively treated
- * as pending: they include the namespaced forms of the async-appended steps
- * (`plans:<product>`), which must keep waiting for billing.
+ * (billing, org membership) loads. Product-provided steps are contributed synchronously
+ * the moment the flow builds, so anything else missing from a built flow will never
+ * appear and must be self-corrected instead of leaving the host on a spinner forever.
+ * Namespaced ids (`plans:conversations`) are pending only when their prefix is an
+ * async-appended key; a `?` or `&` means query params fused into the step value
+ * (a mangled URL) — never pending.
  */
 export const mayStepAppearLater = (stepId: string): boolean =>
-    !/[?&]/.test(stepId) && (ASYNC_APPENDED_STEP_KEYS.includes(stepId) || stepId.includes(':'))
+    !/[?&]/.test(stepId) && ASYNC_APPENDED_STEP_KEYS.includes(stepId.split(':')[0])
 
 export const stepKeyToTitle = (stepKey?: OnboardingStepKey): undefined | string => {
     if (!stepKey) {

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
@@ -730,16 +730,31 @@ describe('onboardingLogic — flow composition', () => {
             expect(router.values.searchParams.step).toBe('install')
         })
 
-        it('keeps waiting on ?step=plans while billing has not loaded (async-appended step)', async () => {
-            // `plans` joins the flow only after billing loads; reconciling it away would
-            // permanently lose the requested step (e.g. the post-upgrade round-trip
-            // landing before billing settles).
-            router.actions.push('/onboarding/conversations?step=plans')
+        it.each(['plans', 'plans:conversations'])(
+            'keeps waiting on ?step=%s while billing has not loaded (async-appended step)',
+            async (step) => {
+                // `plans` joins the flow only after billing loads; reconciling it away would
+                // permanently lose the requested step (e.g. the post-upgrade round-trip
+                // landing before billing settles). The namespaced form must wait too.
+                router.actions.push(`/onboarding/conversations?step=${step}`)
+                await expectLogic(logic).toDispatchActions(['setStepId'])
+                await new Promise((resolve) => setTimeout(resolve, 0))
+                expect(logic.values.stepId).toBe(step)
+                expect(logic.values.currentFlowStep).toBeNull()
+                expect(router.values.searchParams.step).toBe(step)
+            }
+        )
+
+        it('self-corrects a namespaced step id that is not in the flow and never will be', async () => {
+            // A stale bookmark or edited `?with=` list can request a namespaced id
+            // (`install:llm_analytics`) for a product that isn't selected. Product steps are
+            // contributed synchronously, so it can never appear — reconcile instead of spinning.
+            router.actions.push('/onboarding/web_analytics?step=install:llm_analytics')
             await expectLogic(logic).toDispatchActions(['setStepId'])
             await new Promise((resolve) => setTimeout(resolve, 0))
-            expect(logic.values.stepId).toBe('plans')
-            expect(logic.values.currentFlowStep).toBeNull()
-            expect(router.values.searchParams.step).toBe('plans')
+            expect(logic.values.stepId).toBe('')
+            expect(logic.values.currentFlowStep?.id).toBe('install:web_analytics')
+            expect(router.values.searchParams.step).toBeUndefined()
         })
 
         it('leaves a resolvable bare ?step=install untouched for a product that has an install step', async () => {

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
@@ -493,7 +493,10 @@ describe('onboardingLogic — flow composition', () => {
     describe('completeOnboarding — conversations enablement', () => {
         // Conversations has no onboarding steps, so enablement rides on completion. It must
         // fire for BOTH slots: as primary, and as a secondary (where the visited-step credit
-        // can never cover it because it contributes no steps to visit).
+        // can never cover it because it contributes no steps to visit). The enable must also be
+        // part of the SAME team PATCH as the completion fields: the team endpoint saves the full
+        // row from a possibly-stale instance, so a separately-dispatched enable is silently
+        // reverted whenever the completion PATCH commits after it.
         it.each([
             ['primary', (): void => logic.actions.setProductKey(ProductKey.CONVERSATIONS)],
             [
@@ -503,14 +506,22 @@ describe('onboardingLogic — flow composition', () => {
                     logic.actions.setSecondaryProductKeys([ProductKey.CONVERSATIONS])
                 },
             ],
-        ])('enables conversations on completion when selected as %s', async (_slot, setup) => {
+        ])('enables conversations atomically with completion when selected as %s', async (_slot, setup) => {
             setup()
             await expectLogic(logic, () => {
                 logic.actions.completeOnboarding()
             }).toDispatchActions([
-                (action) =>
-                    action.type === logic.actionTypes.updateCurrentTeam &&
-                    (action.payload as Record<string, unknown>)?.conversations_enabled === true,
+                (action) => {
+                    if (action.type !== logic.actionTypes.updateCurrentTeam) {
+                        return false
+                    }
+                    const payload = action.payload as Record<string, unknown>
+                    return (
+                        payload?.conversations_enabled === true &&
+                        payload?.completed_snippet_onboarding === true &&
+                        !!payload?.has_completed_onboarding_for
+                    )
+                },
             ])
         })
 

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
@@ -490,6 +490,54 @@ describe('onboardingLogic — flow composition', () => {
         })
     })
 
+    describe('completeOnboarding — conversations enablement', () => {
+        // Conversations has no onboarding steps, so enablement rides on completion. It must
+        // fire for BOTH slots: as primary, and as a secondary (where the visited-step credit
+        // can never cover it because it contributes no steps to visit).
+        it.each([
+            ['primary', (): void => logic.actions.setProductKey(ProductKey.CONVERSATIONS)],
+            [
+                'secondary',
+                (): void => {
+                    logic.actions.setProductKey(ProductKey.PRODUCT_ANALYTICS)
+                    logic.actions.setSecondaryProductKeys([ProductKey.CONVERSATIONS])
+                },
+            ],
+        ])('enables conversations on completion when selected as %s', async (_slot, setup) => {
+            setup()
+            await expectLogic(logic, () => {
+                logic.actions.completeOnboarding()
+            }).toDispatchActions([
+                (action) =>
+                    action.type === logic.actionTypes.updateCurrentTeam &&
+                    (action.payload as Record<string, unknown>)?.conversations_enabled === true,
+            ])
+        })
+
+        it('does not touch conversations_enabled when conversations was not selected', async () => {
+            // Guards against the enable becoming unconditional — that would silently turn
+            // Support on for every team completing any product's onboarding.
+            logic.actions.setProductKey(ProductKey.PRODUCT_ANALYTICS)
+            const patches: Record<string, unknown>[] = []
+            await expectLogic(logic, () => {
+                logic.actions.completeOnboarding()
+            }).toDispatchActions([
+                (action) => {
+                    if (action.type === logic.actionTypes.updateCurrentTeam) {
+                        patches.push(action.payload as Record<string, unknown>)
+                    }
+                    // The completion PATCH (has_completed_onboarding_for) is the tail of the
+                    // synchronous completion path — stop matching there.
+                    return (
+                        action.type === logic.actionTypes.updateCurrentTeam &&
+                        !!(action.payload as Record<string, unknown>)?.has_completed_onboarding_for
+                    )
+                },
+            ])
+            expect(patches.some((patch) => 'conversations_enabled' in (patch ?? {}))).toBe(false)
+        })
+    })
+
     describe('completeContextOnboarding', () => {
         it('persists both onboarding completion signals', async () => {
             await expectLogic(logic, () => {

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
@@ -626,6 +626,19 @@ describe('onboardingLogic — flow composition', () => {
             expect(router.values.searchParams.step).toBeUndefined()
         })
 
+        it('resolves ?step=install via a secondary product when conversations is picked with others', async () => {
+            // The most common real-world selection shape: conversations alongside another
+            // product. The flow then contains the secondary's install step and the bare key
+            // loose-matches it — reconciliation must not fire, and loose matching must not
+            // be scoped to the primary product's own steps.
+            router.actions.push('/onboarding/conversations?step=install&with=logs')
+            await expectLogic(logic).toDispatchActions(['setStepId'])
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            expect(logic.values.stepId).toBe('install')
+            expect(logic.values.currentFlowStep?.id).toBe('install:logs')
+            expect(router.values.searchParams.step).toBe('install')
+        })
+
         it('keeps waiting on ?step=plans while billing has not loaded (async-appended step)', async () => {
             // `plans` joins the flow only after billing loads; reconciling it away would
             // permanently lose the requested step (e.g. the post-upgrade round-trip

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
@@ -10,7 +10,7 @@ import { organizationLogic } from 'scenes/organizationLogic'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { OnboardingStepKey, type OrganizationType } from '~/types'
+import { AccessControlLevel, OnboardingStepKey, type OrganizationType } from '~/types'
 
 import { onboardingLogic } from './onboardingLogic'
 import { INSTALL_DEDUP_KEYS } from './types'
@@ -491,12 +491,9 @@ describe('onboardingLogic — flow composition', () => {
     })
 
     describe('completeOnboarding — conversations enablement', () => {
-        // Conversations has no onboarding steps, so enablement rides on completion. It must
-        // fire for BOTH slots: as primary, and as a secondary (where the visited-step credit
-        // can never cover it because it contributes no steps to visit). The enable must also be
-        // part of the SAME team PATCH as the completion fields: the team endpoint saves the full
-        // row from a possibly-stale instance, so a separately-dispatched enable is silently
-        // reverted whenever the completion PATCH commits after it.
+        // Conversations has no onboarding steps, so enablement rides on completion, for both
+        // slots, and must travel in the SAME team PATCH as the completion fields: a
+        // separately-dispatched enable is silently reverted by the concurrent completion PATCH.
         it.each([
             ['primary', (): void => logic.actions.setProductKey(ProductKey.CONVERSATIONS)],
             [
@@ -539,6 +536,41 @@ describe('onboardingLogic — flow composition', () => {
                     }
                     // The completion PATCH (has_completed_onboarding_for) is the tail of the
                     // synchronous completion path — stop matching there.
+                    return (
+                        action.type === logic.actionTypes.updateCurrentTeam &&
+                        !!(action.payload as Record<string, unknown>)?.has_completed_onboarding_for
+                    )
+                },
+            ])
+            expect(patches.some((patch) => 'conversations_enabled' in (patch ?? {}))).toBe(false)
+        })
+
+        it('omits conversations_enabled for non-admin members so completion still succeeds', async () => {
+            // The field is admin-gated server-side; including it 403s the whole completion PATCH,
+            // which would block the member from completing onboarding at all.
+            logic.unmount()
+            initKeaTests(
+                true,
+                {
+                    ...MOCK_DEFAULT_TEAM,
+                    effective_membership_level: OrganizationMembershipLevel.Member,
+                    user_access_level: AccessControlLevel.Member,
+                },
+                MOCK_DEFAULT_PROJECT,
+                MOCK_DEFAULT_ORGANIZATION
+            )
+            logic = onboardingLogic()
+            logic.mount()
+            logic.actions.setProductKey(ProductKey.PRODUCT_ANALYTICS)
+            logic.actions.setSecondaryProductKeys([ProductKey.CONVERSATIONS])
+            const patches: Record<string, unknown>[] = []
+            await expectLogic(logic, () => {
+                logic.actions.completeOnboarding()
+            }).toDispatchActions([
+                (action) => {
+                    if (action.type === logic.actionTypes.updateCurrentTeam) {
+                        patches.push(action.payload as Record<string, unknown>)
+                    }
                     return (
                         action.type === logic.actionTypes.updateCurrentTeam &&
                         !!(action.payload as Record<string, unknown>)?.has_completed_onboarding_for

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.test.ts
@@ -1,13 +1,16 @@
+import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_PROJECT, MOCK_DEFAULT_TEAM } from 'lib/api.mock'
+
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { SetupTaskId } from 'lib/components/ProductSetup'
-import { FEATURE_FLAGS } from 'lib/constants'
+import { FEATURE_FLAGS, OrganizationMembershipLevel } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { organizationLogic } from 'scenes/organizationLogic'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
-import { OnboardingStepKey } from '~/types'
+import { OnboardingStepKey, type OrganizationType } from '~/types'
 
 import { onboardingLogic } from './onboardingLogic'
 import { INSTALL_DEDUP_KEYS } from './types'
@@ -606,6 +609,70 @@ describe('onboardingLogic — flow composition', () => {
                     payload: { subscribedDuringOnboarding: true } as any,
                 },
             ])
+        })
+    })
+
+    describe('unresolvable step reconciliation', () => {
+        it('self-corrects ?step=install to the first available step for a product with no install step', async () => {
+            // Conversations' provider emits no product steps, but product selection and
+            // setup-task links route to `?step=install` unconditionally. The requested
+            // step will never exist — the URL must reconcile to flow[0] instead of
+            // leaving `currentFlowStep` null (an infinite spinner with no escape button).
+            router.actions.push('/onboarding/conversations?step=install')
+            await expectLogic(logic).toDispatchActions(['setStepId'])
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            expect(logic.values.stepId).toBe('')
+            expect(logic.values.currentFlowStep?.id).toBe('invite_teammates:conversations')
+            expect(router.values.searchParams.step).toBeUndefined()
+        })
+
+        it('keeps waiting on ?step=plans while billing has not loaded (async-appended step)', async () => {
+            // `plans` joins the flow only after billing loads; reconciling it away would
+            // permanently lose the requested step (e.g. the post-upgrade round-trip
+            // landing before billing settles).
+            router.actions.push('/onboarding/conversations?step=plans')
+            await expectLogic(logic).toDispatchActions(['setStepId'])
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            expect(logic.values.stepId).toBe('plans')
+            expect(logic.values.currentFlowStep).toBeNull()
+            expect(router.values.searchParams.step).toBe('plans')
+        })
+
+        it('leaves a resolvable bare ?step=install untouched for a product that has an install step', async () => {
+            router.actions.push('/onboarding/web_analytics?step=install')
+            await expectLogic(logic).toDispatchActions(['setStepId'])
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            expect(logic.values.stepId).toBe('install')
+            expect(logic.values.currentFlowStep?.id).toBe('install:web_analytics')
+            expect(router.values.searchParams.step).toBe('install')
+        })
+
+        it('reconciles an unresolvable step when the flow builds after the URL was parsed', async () => {
+            // A member without invite rights gets an empty conversations flow until an
+            // async input (org permissions, billing) contributes a shared step. The
+            // setStepId listener can't reconcile against an empty flow, so the flow
+            // subscription must pick it up once steps exist.
+            logic.unmount()
+            initKeaTests(true, MOCK_DEFAULT_TEAM, MOCK_DEFAULT_PROJECT, {
+                ...MOCK_DEFAULT_ORGANIZATION,
+                members_can_invite: false,
+                membership_level: OrganizationMembershipLevel.Member,
+            })
+            logic = onboardingLogic()
+            logic.mount()
+
+            router.actions.push('/onboarding/conversations?step=install')
+            await expectLogic(logic).toDispatchActions(['setStepId'])
+            expect(logic.values.flow).toEqual([])
+            expect(logic.values.stepId).toBe('install')
+
+            organizationLogic.actions.loadCurrentOrganizationSuccess({
+                ...MOCK_DEFAULT_ORGANIZATION,
+                members_can_invite: true,
+            } as OrganizationType)
+            await new Promise((resolve) => setTimeout(resolve, 0))
+            expect(logic.values.stepId).toBe('')
+            expect(logic.values.currentFlowStep?.id).toBe('invite_teammates:conversations')
         })
     })
 

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
@@ -731,23 +731,6 @@ export const onboardingLogic = kea<onboardingLogicType>([
             // but don't fire an additional `onboarding completed` analytics event.
             eventUsageLogic.actions.reportOnboardingCompleted(primary)
             props.onCompleteOnboarding?.(primary)
-            // Error Tracking has a side-effect tied to onboarding completion (set up in the
-            // legacy view): turn on autocapture_exceptions_opt_in. Preserved here.
-            if (primary === ProductKey.ERROR_TRACKING) {
-                teamLogic.actions.updateCurrentTeam({ autocapture_exceptions_opt_in: true })
-            }
-            // Support has no onboarding screen; enable the product on completion so it's live
-            // on arrival. Selecting it in either slot is the consent signal: its provider emits
-            // zero steps, so the visited-step crediting below can never cover it and a secondary
-            // selection would otherwise be dropped entirely. The field is project-admin-gated
-            // server-side, so for non-admins this PATCH is rejected (onboarding is effectively
-            // always driven by an owner or an admin-level delegation invite).
-            if (
-                primary === ProductKey.CONVERSATIONS ||
-                values.secondaryProductKeys.includes(ProductKey.CONVERSATIONS)
-            ) {
-                teamLogic.actions.updateCurrentTeam({ conversations_enabled: true })
-            }
             // Only mark a product as fully onboarded when the user actually visited at
             // least one of its steps. Without this guard, a hand-crafted URL with an
             // arbitrary `?with=...` list would silently flip every secondary's flag on
@@ -793,9 +776,6 @@ export const onboardingLogic = kea<onboardingLogicType>([
                     tickedTaskIds.add(id)
                 }
             }
-            if (setup && tickedTaskIds.size > 0) {
-                setup.actions.markTaskAsCompleted(Array.from(tickedTaskIds))
-            }
             for (const productKey of visitedProducts) {
                 actions.recordProductIntentOnboardingComplete({ product_type: productKey as ProductKey })
             }
@@ -804,17 +784,44 @@ export const onboardingLogic = kea<onboardingLogicType>([
             for (const productKey of visitedProducts) {
                 completedMap[productKey] = true
             }
+            // Every completion-time team change rides in ONE PATCH. The team endpoint saves the
+            // full row from the instance it read, so concurrent team PATCHes silently revert each
+            // other's fields — a separately-dispatched enable loses whenever this PATCH commits
+            // last. Keep both completion signals in sync so every bootstrapped team shape prevents
+            // sceneLogic from redirecting a completed user back into onboarding after refresh.
+            const completionPatch: Partial<TeamType> = {
+                completed_snippet_onboarding: true,
+                has_completed_onboarding_for: completedMap,
+            }
+            // Error Tracking has a side-effect tied to onboarding completion (set up in the
+            // legacy view): turn on autocapture_exceptions_opt_in. Preserved here.
+            if (primary === ProductKey.ERROR_TRACKING) {
+                completionPatch.autocapture_exceptions_opt_in = true
+            }
+            // Support has no onboarding screen; enable the product on completion so it's live
+            // on arrival. Selecting it in either slot is the consent signal: its provider emits
+            // zero steps, so the visited-step crediting above can never cover it and a secondary
+            // selection would otherwise be dropped entirely. The field is project-admin-gated
+            // server-side, so for non-admins this PATCH is rejected (onboarding is effectively
+            // always driven by an owner or an admin-level delegation invite).
+            if (
+                primary === ProductKey.CONVERSATIONS ||
+                values.secondaryProductKeys.includes(ProductKey.CONVERSATIONS)
+            ) {
+                completionPatch.conversations_enabled = true
+            }
             try {
-                // Keep both completion signals in sync so every bootstrapped team shape prevents
-                // sceneLogic from redirecting a completed user back into onboarding after refresh.
-                await teamLogic.asyncActions.updateCurrentTeam({
-                    completed_snippet_onboarding: true,
-                    has_completed_onboarding_for: completedMap,
-                })
+                await teamLogic.asyncActions.updateCurrentTeam(completionPatch)
                 setQuickstartAsDefaultHomepageOnce(previouslyOnboardedMap)
             } catch {
                 // The completion update failed, so leave the user's homepage untouched
                 lemonToast.error("Couldn't save onboarding progress. Please try again.")
+            }
+            // Tick setup tasks only after the completion PATCH settles: the tick issues its own
+            // team PATCH (onboarding_tasks), and firing it concurrently makes it read a stale row
+            // and wipe the fields written above.
+            if (setup && tickedTaskIds.size > 0) {
+                setup.actions.markTaskAsCompleted(Array.from(tickedTaskIds))
             }
         },
         completeContextOnboarding: async () => {

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
@@ -1,5 +1,6 @@
 import { MakeLogicType, actions, connect, kea, listeners, path, props, reducers, selectors } from 'kea'
 import { actionToUrl, router, urlToAction } from 'kea-router'
+import { subscriptions } from 'kea-subscriptions'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -38,7 +39,7 @@ import type {
     UserType,
 } from '../../../types'
 import { onboardingEventUsageLogic } from '../onboardingEventUsageLogic'
-import { arraysEqual, parseProductsParam, stepKeyToTitle } from './onboardingFlowUtils'
+import { arraysEqual, mayStepAppearLater, parseProductsParam, stepKeyToTitle } from './onboardingFlowUtils'
 import { appendSharedTrailingSteps } from './sharedSteps'
 import { onboardingProviderRegistry } from './stepProviderRegistry'
 import { type OnboardingFlowContext, type OnboardingStepDescriptor } from './types'
@@ -890,24 +891,19 @@ export const onboardingLogic = kea<onboardingLogicType>([
             // the 4th arg here, not the 2nd — that was the breakpoint function.
             const previousStepId = selectors.stepId(previousState)
 
-            // URL self-correction: if the user navigated to a stepId we can't resolve
-            // (typo'd bookmark, deprecated step name, secondary product not in `?with=`),
-            // `currentFlowStep` returns null and the host shows a spinner forever.
-            // Reconcile by falling through to flow[0].
+            // URL self-correction: if the user navigated to a stepId the flow can't resolve
+            // (typo'd bookmark, deprecated step name, secondary product not in `?with=`, or
+            // a step key the selected product's flow never emits — e.g. `?step=install` for
+            // a product whose provider contributes no install step), `currentFlowStep`
+            // returns null and the host shows a spinner forever. Reconcile by falling
+            // through to flow[0].
             //
-            // Important: only self-correct when the stepId is genuinely unknown — NOT when
-            // it's a valid OnboardingStepKey that simply hasn't been emitted into the flow
-            // yet. Steps like `plans` are appended async (after billing loads) by
-            // `appendSharedTrailingSteps`; self-correcting too eagerly here would clobber
-            // the URL before the flow settles, leaving the user on `flow[0]` even after
-            // billing arrives.
-            // A `?` or `&` means query params fused into the step value (a mangled URL) — never
-            // treat that as a valid namespaced id, or self-correction skips it and the host
-            // spins forever waiting for a step that can't resolve.
-            const isKnownStepKey = (id: string): boolean =>
-                !/[?&]/.test(id) &&
-                (Object.values(OnboardingStepKey).includes(id as OnboardingStepKey) || id.includes(':'))
-            if (stepId && values.flow.length > 0 && !isKnownStepKey(stepId)) {
+            // Important: only self-correct when the step can never resolve — NOT when it's
+            // one of the async-appended step keys that simply hasn't been emitted into the
+            // flow yet (`plans` arrives only after billing loads; see `mayStepAppearLater`).
+            // Self-correcting those too eagerly would clobber the URL before the flow
+            // settles, leaving the user on `flow[0]` even after billing arrives.
+            if (stepId && values.flow.length > 0 && !mayStepAppearLater(stepId)) {
                 const exact = values.flow.find((step) => step.id === stepId)
                 const loose = exact ? null : values.flow.find((step) => step.stepKey === stepId)
                 if (!exact && !loose) {
@@ -980,6 +976,21 @@ export const onboardingLogic = kea<onboardingLogicType>([
             }
         },
     })),
+    subscriptions(({ actions, values }) => ({
+        flow: (flow: OnboardingStepDescriptor[]): void => {
+            // The setStepId listener can only self-correct at dispatch time. When the flow
+            // was still empty then (e.g. billing hadn't loaded and the product contributes
+            // no steps of its own), re-run the reconciliation once steps exist so a step
+            // that can never resolve falls through to flow[0] instead of spinning forever.
+            const stepId = values.stepId
+            if (!stepId || flow.length === 0 || mayStepAppearLater(stepId)) {
+                return
+            }
+            if (!flow.some((step) => step.id === stepId || step.stepKey === stepId)) {
+                actions.setStepId('')
+            }
+        },
+    })),
     actionToUrl(({ values, actions }) => ({
         setStepId: ({ stepId }) => {
             // `success`/`upgraded` are billing-callback signals consumed once; keeping them in
@@ -1005,17 +1016,14 @@ export const onboardingLogic = kea<onboardingLogicType>([
             // through urlToAction and re-dispatches setStepId(bogus), looping
             // indefinitely. Stripping unresolvable stepIds here keeps the URL
             // self-consistent with the reducer state.
-            // Mirror the `setStepId` listener's `isKnownStepKey` heuristic. Billing-gated
-            // steps (plans, invite_teammates, link_data) are appended async after billing
-            // loads, so they may not be in `flow` when the URL push lands. Stripping them
-            // from the URL would re-fire `setStepId('')` and permanently lose the request.
-            const isKnownStepKey =
-                !/[?&]/.test(stepId) &&
-                (Object.values(OnboardingStepKey).includes(stepId as OnboardingStepKey) || stepId.includes(':'))
+            // Mirror the `setStepId` listener's heuristic. Async-appended steps (plans,
+            // invite_teammates, link_data) may not be in `flow` when the URL push lands.
+            // Stripping them from the URL would re-fire `setStepId('')` and permanently
+            // lose the request.
             const stepResolves =
                 !stepId ||
                 values.flow.length === 0 ||
-                isKnownStepKey ||
+                mayStepAppearLater(stepId) ||
                 !!values.flow.find((s) => s.id === stepId || s.stepKey === stepId)
             // The first tuple element must be a bare pathname: kea-router joins the tuple by
             // string concatenation (`path + '?' + search`), so a query embedded here would get a

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
@@ -736,8 +736,16 @@ export const onboardingLogic = kea<onboardingLogicType>([
             if (primary === ProductKey.ERROR_TRACKING) {
                 teamLogic.actions.updateCurrentTeam({ autocapture_exceptions_opt_in: true })
             }
-            // Support has no onboarding screen; enable the product on completion so it's live on arrival.
-            if (primary === ProductKey.CONVERSATIONS) {
+            // Support has no onboarding screen; enable the product on completion so it's live
+            // on arrival. Selecting it in either slot is the consent signal: its provider emits
+            // zero steps, so the visited-step crediting below can never cover it and a secondary
+            // selection would otherwise be dropped entirely. The field is project-admin-gated
+            // server-side, so for non-admins this PATCH is rejected (onboarding is effectively
+            // always driven by an owner or an admin-level delegation invite).
+            if (
+                primary === ProductKey.CONVERSATIONS ||
+                values.secondaryProductKeys.includes(ProductKey.CONVERSATIONS)
+            ) {
                 teamLogic.actions.updateCurrentTeam({ conversations_enabled: true })
             }
             // Only mark a product as fully onboarded when the user actually visited at

--- a/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
+++ b/frontend/src/scenes/onboarding/legacy/onboardingLogic.tsx
@@ -784,29 +784,26 @@ export const onboardingLogic = kea<onboardingLogicType>([
             for (const productKey of visitedProducts) {
                 completedMap[productKey] = true
             }
-            // Every completion-time team change rides in ONE PATCH. The team endpoint saves the
-            // full row from the instance it read, so concurrent team PATCHes silently revert each
-            // other's fields — a separately-dispatched enable loses whenever this PATCH commits
-            // last. Keep both completion signals in sync so every bootstrapped team shape prevents
-            // sceneLogic from redirecting a completed user back into onboarding after refresh.
+            // One PATCH for every completion-time team change: concurrent team PATCHes silently
+            // revert each other's fields, and both completion signals must stay in sync so
+            // sceneLogic doesn't redirect a completed user back into onboarding after refresh.
             const completionPatch: Partial<TeamType> = {
                 completed_snippet_onboarding: true,
                 has_completed_onboarding_for: completedMap,
             }
-            // Error Tracking has a side-effect tied to onboarding completion (set up in the
-            // legacy view): turn on autocapture_exceptions_opt_in. Preserved here.
             if (primary === ProductKey.ERROR_TRACKING) {
                 completionPatch.autocapture_exceptions_opt_in = true
             }
-            // Support has no onboarding screen; enable the product on completion so it's live
-            // on arrival. Selecting it in either slot is the consent signal: its provider emits
-            // zero steps, so the visited-step crediting above can never cover it and a secondary
-            // selection would otherwise be dropped entirely. The field is project-admin-gated
-            // server-side, so for non-admins this PATCH is rejected (onboarding is effectively
-            // always driven by an owner or an admin-level delegation invite).
+            // Support has no steps of its own, so selection in either slot is the consent signal.
+            // Skipped for non-admins: `conversations_enabled` is an admin-gated field, and sending
+            // it would 403 the entire completion PATCH.
+            const isTeamAdmin =
+                (!!values.currentTeam?.effective_membership_level &&
+                    values.currentTeam.effective_membership_level >= OrganizationMembershipLevel.Admin) ||
+                values.currentTeam?.user_access_level === 'admin'
             if (
-                primary === ProductKey.CONVERSATIONS ||
-                values.secondaryProductKeys.includes(ProductKey.CONVERSATIONS)
+                isTeamAdmin &&
+                (primary === ProductKey.CONVERSATIONS || values.secondaryProductKeys.includes(ProductKey.CONVERSATIONS))
             ) {
                 completionPatch.conversations_enabled = true
             }
@@ -817,9 +814,8 @@ export const onboardingLogic = kea<onboardingLogicType>([
                 // The completion update failed, so leave the user's homepage untouched
                 lemonToast.error("Couldn't save onboarding progress. Please try again.")
             }
-            // Tick setup tasks only after the completion PATCH settles: the tick issues its own
-            // team PATCH (onboarding_tasks), and firing it concurrently makes it read a stale row
-            // and wipe the fields written above.
+            // Ticking tasks issues its own team PATCH; fired concurrently with the one above it
+            // would read a stale row and wipe the fields just written.
             if (setup && tickedTaskIds.size > 0) {
                 setup.actions.markTaskAsCompleted(Array.from(tickedTaskIds))
             }


### PR DESCRIPTION
## Problem

Selecting Support (Conversations) during onboarding silently did nothing, in two different ways:

1. **Picked alone: endless spinner.** Product selection routes to `?step=install`, but Conversations intentionally has no product steps (`steps: () => []`; it's enabled on completion instead), so nothing matches and the flow host spins forever. The URL self-correction that should rescue this skipped every *valid* step key on the theory it might be appended later, but only `plans`, `invite_teammates`, and `link_data` ever join a flow asynchronously. The same trap applies to any product whose flow lacks the requested step. In our telemetry essentially nobody completed onboarding from this state.

2. **Picked alongside another product: the selection was dropped.** The enable-on-completion side effect only fired when Conversations was the *primary* product, and with zero steps it never earned visited-step credit either. The secondary slot is by far the most common way users pick Conversations (roughly 20 to 1 over primary), and nothing downstream knew they had asked for it.

Both bugs are in the `legacy/` flow, which is the live default onboarding (the `onboarding-flow-variant` flag resolves everyone to it).

## Changes

**Spinner:** narrow the "may this step still appear later" predicate to the step keys that genuinely join the flow asynchronously (`mayStepAppearLater` in `onboardingFlowUtils.ts`), use it in both the `setStepId` self-correction and the `actionToUrl` guard, and add a `flow` subscription so a step requested before the flow builds still reconciles. Unresolvable step URLs now self-correct to the first available step instead of spinning.

**Enablement:** `completeOnboarding` enables Conversations when it was selected in either slot, and the flag rides in the **same team PATCH as the completion fields**. Manual testing showed a separately-dispatched enable gets silently reverted: the team endpoint saves the full row from the instance it read, so concurrent team PATCHes lose updates nondeterministically. Error Tracking's completion-time `autocapture_exceptions_opt_in`, which has had the same latent race, moves into that single PATCH too, and the setup-task tick now fires only after it settles. For non-admin members the Conversations flag is omitted from the PATCH: it is an admin-gated field, and including it would make the server reject the entire completion request, blocking the member from completing onboarding at all.

> [!NOTE]
> The step reconciliation fires only when the requested step has neither an exact nor a loose match in a built flow, so multi-product selections are untouched. A secondary Conversations is enabled but deliberately **not** marked as onboarded in `has_completed_onboarding_for`, preserving the guard against hand-crafted `?with=` URLs crediting products the user never saw.

## How did you test this code?

Added 8 cases to `onboardingLogic.test.ts`, each catching a distinct regression no existing test covers: five for step reconciliation (solo `?step=install` self-corrects, multi-product resolves via the loose match, async `plans` still waits for billing, resolvable keys stay in the URL, late-building flows reconcile) and three for enablement (enabled as primary, enabled as secondary, untouched when not selected). The enablement tests assert the flag arrives in the same `updateCurrentTeam` payload as the completion fields, which is the assertion that catches the revert race. Full onboarding scene suite passes (12 suites); lint and format pass.

Manually verified on a local dev stack across fresh projects, checking outcomes in the database and Team activity log rather than just the UI: solo selection self-corrects and completing enables Support; a secondary selection enables Support with the onboarding-credit rules intact; a control run without Conversations leaves the flag untouched. Also enumerated every `conversations_enabled` write path in the repo to confirm nothing else consumes the onboarding selection.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed: bug fix in internal onboarding routing and completion side effects; no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude across two sessions directed by @christiaan-ph, starting from a user stuck on Conversations onboarding. The first session traced the routing chain (`productSelectionLogic` → `onboardingLogic` → `OnboardingFlowHost`) and shipped the spinner fix plus either-slot enablement. A follow-up session (2026-07-22) independently re-verified the claims against master and telemetry, then manual testing on a local stack exposed the lost-update race (the enable PATCH being reverted by the concurrent completion PATCH, diagnosed via the Team activity log), leading to the atomic-PATCH fix, the setup-task reordering, and the same-payload test assertions. Skills invoked: `/writing-tests`.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
