### PR TITLE
feat(conversations): include ticket tags in conversation events

### DIFF
--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -294,6 +294,34 @@ class TestConversationEvents(BaseTest):
         assert props["channel_source"] == self.ticket.channel_source
         assert props["status"] == self.ticket.status
         assert props["priority"] == self.ticket.priority
+        # Untagged ticket → an empty list, never None or a missing key.
+        assert props["tags"] == []
+
+    @parameterized.expand(
+        [
+            ("capture_ticket_created", capture_ticket_created, []),
+            ("capture_ticket_status_changed", capture_ticket_status_changed, ["old", "new"]),
+            ("capture_ticket_priority_changed", capture_ticket_priority_changed, [None, "high"]),
+            ("capture_ticket_assigned", capture_ticket_assigned, ["user", "123"]),
+            ("capture_message_sent", capture_message_sent, ["msg-id", "content"]),
+            ("capture_message_received", capture_message_received, ["msg-id", "content"]),
+        ]
+    )
+    @patch("products.conversations.backend.events.capture_internal")
+    def test_all_events_include_sorted_ticket_tags(self, _name, capture_fn, extra_args, mock_capture):
+        from posthog.models import Tag
+
+        for name in ("urgent", "billing"):
+            tag, _ = Tag.objects.get_or_create(name=name, team_id=self.team.id)
+            self.ticket.tagged_items.create(tag=tag)
+
+        if capture_fn is capture_message_sent:
+            capture_message_sent(self.ticket, "msg-id", "content", author=self.user)
+        else:
+            capture_fn(self.ticket, *extra_args)
+
+        props = mock_capture.call_args.kwargs["properties"]
+        assert props["tags"] == ["billing", "urgent"]
 
     @patch("products.conversations.backend.events.capture_internal")
     def test_message_content_truncated_to_1000_chars(self, mock_capture):

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -324,6 +324,14 @@ def _groups_from_org_id(team: Team, organization_id: str) -> dict:
     return {"instance": SITE_URL, "project": str(team.uuid), "organization": organization_id}
 
 
+def _get_ticket_tags(ticket: Ticket) -> list[str]:
+    """Tag names on the ticket, sorted for deterministic event payloads.
+
+    One query per event; capture is per-ticket (never bulk), so no N+1 concern.
+    """
+    return sorted(ticket.tagged_items.values_list("tag__name", flat=True))
+
+
 def _get_ticket_base_properties(ticket: Ticket) -> dict:
     return {
         "ticket_id": str(ticket.id),
@@ -332,6 +340,7 @@ def _get_ticket_base_properties(ticket: Ticket) -> dict:
         "channel_detail": ticket.channel_detail,
         "status": ticket.status,
         "priority": ticket.priority,
+        "tags": _get_ticket_tags(ticket),
     }
 
 


### PR DESCRIPTION
## Problem

Ticket tags never made it onto the `$conversation_*` analytics events. Tags are first-class on tickets (filterable in the ticket list, settable via the API, imported from Zendesk), but the events that power workflow triggers and analytics carried none of that. So you couldn't build a workflow like "auto-resolve pending tickets tagged `billing`", or segment event analytics by tag.

## Changes

Add a sorted `tags` list (the ticket's tag names) to the shared ticket base properties, so all six conversation events carry it:

- `$conversation_ticket_created`
- `$conversation_ticket_status_changed`
- `$conversation_ticket_priority_changed`
- `$conversation_ticket_assigned`
- `$conversation_message_sent`
- `$conversation_message_received`

Tags read through the standard tagging relation (`ticket.tagged_items` → `Tag`), the same source the ticket serializer and external API already use. The list is sorted so payloads are deterministic, and an untagged ticket emits `[]` rather than a missing key or `null`.

Cost is one extra query per event. Capture is always per-ticket (never bulk), so there's no N+1 concern, and I noted that on the helper.

## How did you test this code?

Added tests in `products/conversations/backend/api/tests/test_events.py`:

- Extended `test_all_events_include_base_properties` to assert an untagged ticket emits `tags == []` across all six events. Catches a regression where the key goes missing or comes back `None`.
- New parameterized `test_all_events_include_sorted_ticket_tags` tags a ticket and asserts each of the six events carries the tag names, sorted. Catches a regression where tags stop flowing through or lose their deterministic order.

Ran the full `test_events.py` file locally (94 passed) plus ruff lint/format. No existing test covered tags on these events.
