### PR TITLE
feat(alerts): support selecting Slack workspaces for alerts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4754,6 +4754,10 @@ snapshots:
         hash: v1.k794b7964.3f137bbf7a90843202ca75d89d5dec7f102945cf55f2c4532ccac3b4e8073c9b.phN1IPBCANIC0EsrGxopacxr96qniH5DnAm-ZnKVUz0
     products-alerts-shared-components--notifications--light:
         hash: v1.k794b7964.240b6085693c57e601cf978fe479a2cb6124c80c7cd743f44ff61744e94c90bb.v4D0nGdwscIlnUoeTqwHQsyEggk4eOm3GBGvgvFkXII
+    products-alerts-shared-components--notifications-multiple-slack-workspaces--dark:
+        hash: v1.k794b7964.44080ef3cc8fb24fb5ad535ee387b4911358d8804045747939750530be5c6235.7UCJ4oJX1LEan-IVOu2iA5Hzz14HQQoZENCw_SMOxss
+    products-alerts-shared-components--notifications-multiple-slack-workspaces--light:
+        hash: v1.k794b7964.7af987b36145b9e49adca1cbc6d1a4616ae94866476f72bc510ab96d286e4133.3H70LHwnl5IAqi3fUW4lQZZ7UT9o23krCbiAdBvWpvY
     products-alerts-shared-components--quiet-hours--dark:
         hash: v1.k794b7964.3a4e054512c5b607cf75f1cc3e6dd2212333d05e4fb89274b580b47f01e5aeaf.nPp2_jJIgcpjkQgHQA63v-eqzVox-oIfDi3SQKPdRis
     products-alerts-shared-components--quiet-hours--light:

--- a/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/IntegrationChoice.tsx
@@ -23,6 +23,7 @@ export type IntegrationConfigureProps = {
     schema?: { requiredScopes?: string }
     integration?: string
     beforeRedirect?: () => void
+    allowClear?: boolean
 }
 
 export function IntegrationChoice({
@@ -32,6 +33,7 @@ export function IntegrationChoice({
     integration,
     redirectUrl,
     beforeRedirect,
+    allowClear = true,
 }: IntegrationConfigureProps): JSX.Element | null {
     const { integrationsLoading, integrations, newIntegrationModalKind, slackAvailable } = useValues(integrationsLogic)
     const { newGoogleCloudKey, openNewIntegrationModal, closeNewIntegrationModal, deleteIntegration } =
@@ -139,7 +141,7 @@ export function IntegrationChoice({
                             label: 'Manage integrations',
                             sideIcon: <IconExternal />,
                         },
-                        value
+                        value && allowClear
                             ? {
                                   onClick: () => onChange?.(null),
                                   label: 'Clear selection',

--- a/products/alerts/frontend/components/AlertComponents.stories.tsx
+++ b/products/alerts/frontend/components/AlertComponents.stories.tsx
@@ -314,8 +314,7 @@ function MultipleSlackWorkspacesStory(): JSX.Element {
         },
     })
 
-    // Preselect a workspace + channel so the "add notification" picker opens with real data
-    // instead of an empty "Select a channel..." state.
+    // Preselect a workspace + channel so the picker doesn't open empty.
     const { setSelectedSlackIntegrationId, setSlackChannelValue } = useActions(
         alertNotificationLogic({ alertId: 'alert-1' })
     )

--- a/products/alerts/frontend/components/AlertComponents.stories.tsx
+++ b/products/alerts/frontend/components/AlertComponents.stories.tsx
@@ -258,26 +258,64 @@ const STORY_SLACK_CHANNELS: Record<string, { id: string; name: string }[]> = {
     ],
 }
 
+const STORY_EXISTING_HOG_FUNCTIONS = [
+    {
+        id: 'hf1',
+        type: 'internal_destination',
+        name: 'Alert: Slack #alerts',
+        description: '',
+        created_by: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        enabled: true,
+        hog: '',
+        template_id: 'template-slack',
+        inputs: {
+            slack_workspace: { value: 1 },
+            channel: { value: 'C100|#alerts' },
+        },
+    },
+    {
+        id: 'hf2',
+        type: 'internal_destination',
+        name: 'Alert: Slack #acme-alerts',
+        description: '',
+        created_by: null,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+        enabled: true,
+        hog: '',
+        template_id: 'template-slack',
+        inputs: {
+            slack_workspace: { value: 2 },
+            channel: { value: 'C200|#acme-alerts' },
+        },
+    },
+]
+
 function MultipleSlackWorkspacesStory(): JSX.Element {
     useStorybookMocks({
         get: {
             '/api/environments/:team_id/integrations': { results: STORY_SLACK_WORKSPACES, count: 2 },
-            '/api/environments/:team_id/integrations/:id/channels': (req, res, ctx) => {
-                const channels = (STORY_SLACK_CHANNELS[String(req.params.id)] ?? []).map((channel) => ({
+            '/api/environments/:team_id/integrations/:id/channels': ({ params }) => {
+                const channels = (STORY_SLACK_CHANNELS[String(params.id)] ?? []).map((channel) => ({
                     ...channel,
                     is_private: false,
                     is_ext_shared: false,
                     is_member: true,
                 }))
-                return res(ctx.json({ channels, lastRefreshedAt: '2026-01-01T00:00:00Z' }))
+                return [200, { channels, lastRefreshedAt: '2026-01-01T00:00:00Z' }]
             },
-            '/api/environments/:team_id/hog_functions': { results: [], count: 0 },
+            '/api/environments/:team_id/hog_functions': {
+                results: STORY_EXISTING_HOG_FUNCTIONS,
+                count: STORY_EXISTING_HOG_FUNCTIONS.length,
+            },
         },
     })
 
     return (
         <div className="max-w-2xl border rounded bg-surface-primary p-4">
-            <InlineAlertNotifications />
+            <InlineAlertNotifications alertId="alert-1" />
         </div>
     )
 }

--- a/products/alerts/frontend/components/AlertComponents.stories.tsx
+++ b/products/alerts/frontend/components/AlertComponents.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { kea, path, useValues } from 'kea'
+import { kea, path, useActions, useValues } from 'kea'
 import { Form, forms } from 'kea-forms'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import type { LemonSegmentedButtonOption, LemonSelectOptions } from '@posthog/lemon-ui'
 import { LemonCheckbox, LemonInput, LemonSegmentedButton } from '@posthog/lemon-ui'
@@ -12,6 +12,7 @@ import { useStorybookMocks } from '~/mocks/browser'
 import { AlertCalculationInterval } from '~/queries/schema/schema-general'
 import { IntegrationType } from '~/types'
 
+import { alertNotificationLogic } from 'products/alerts/frontend/logic/alertNotificationLogic'
 import type { ScheduleRestriction } from 'products/alerts/frontend/types'
 import { InlineAlertNotifications } from 'products/alerts/frontend/views/InlineAlertNotifications'
 
@@ -312,6 +313,16 @@ function MultipleSlackWorkspacesStory(): JSX.Element {
             },
         },
     })
+
+    // Preselect a workspace + channel so the "add notification" picker opens with real data
+    // instead of an empty "Select a channel..." state.
+    const { setSelectedSlackIntegrationId, setSlackChannelValue } = useActions(
+        alertNotificationLogic({ alertId: 'alert-1' })
+    )
+    useEffect(() => {
+        setSelectedSlackIntegrationId(2)
+        setSlackChannelValue('C201|#acme-eng')
+    }, [setSelectedSlackIntegrationId, setSlackChannelValue])
 
     return (
         <div className="max-w-2xl border rounded bg-surface-primary p-4">

--- a/products/alerts/frontend/components/AlertComponents.stories.tsx
+++ b/products/alerts/frontend/components/AlertComponents.stories.tsx
@@ -273,7 +273,7 @@ const STORY_EXISTING_HOG_FUNCTIONS = [
         template_id: 'template-slack',
         inputs: {
             slack_workspace: { value: 1 },
-            channel: { value: 'C100|#alerts' },
+            channel: { value: 'C100' },
         },
     },
     {
@@ -289,7 +289,7 @@ const STORY_EXISTING_HOG_FUNCTIONS = [
         template_id: 'template-slack',
         inputs: {
             slack_workspace: { value: 2 },
-            channel: { value: 'C200|#acme-alerts' },
+            channel: { value: 'C200' },
         },
     },
 ]
@@ -298,13 +298,15 @@ function MultipleSlackWorkspacesStory(): JSX.Element {
     useStorybookMocks({
         get: {
             '/api/environments/:team_id/integrations': { results: STORY_SLACK_WORKSPACES, count: 2 },
-            '/api/environments/:team_id/integrations/:id/channels': ({ params }) => {
-                const channels = (STORY_SLACK_CHANNELS[String(params.id)] ?? []).map((channel) => ({
+            '/api/environments/:team_id/integrations/:id/channels': ({ params, request }) => {
+                const channelId = new URL(request.url).searchParams.get('channel_id')
+                const allChannels = (STORY_SLACK_CHANNELS[String(params.id)] ?? []).map((channel) => ({
                     ...channel,
                     is_private: false,
                     is_ext_shared: false,
                     is_member: true,
                 }))
+                const channels = channelId ? allChannels.filter((channel) => channel.id === channelId) : allChannels
                 return [200, { channels, lastRefreshedAt: '2026-01-01T00:00:00Z' }]
             },
             '/api/environments/:team_id/hog_functions': {

--- a/products/alerts/frontend/components/AlertComponents.stories.tsx
+++ b/products/alerts/frontend/components/AlertComponents.stories.tsx
@@ -8,9 +8,12 @@ import { LemonCheckbox, LemonInput, LemonSegmentedButton } from '@posthog/lemon-
 
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 
+import { useStorybookMocks } from '~/mocks/browser'
 import { AlertCalculationInterval } from '~/queries/schema/schema-general'
+import { IntegrationType } from '~/types'
 
 import type { ScheduleRestriction } from 'products/alerts/frontend/types'
+import { InlineAlertNotifications } from 'products/alerts/frontend/views/InlineAlertNotifications'
 
 import { AlertAdvancedOptions } from './AlertAdvancedOptions'
 import { AlertDefinitionRow, AlertNextEvaluationStatus, AlertTimezoneNotice } from './AlertDefinition'
@@ -225,6 +228,60 @@ function NotificationsStory(): JSX.Element {
     )
 }
 
+const STORY_SLACK_WORKSPACES: IntegrationType[] = [
+    {
+        id: 1,
+        kind: 'slack',
+        display_name: 'PostHog',
+        icon_url: '/static/services/slack.png',
+        config: { team: { id: 'T11111', name: 'PostHog' } },
+        created_at: '2026-01-01T00:00:00Z',
+    },
+    {
+        id: 2,
+        kind: 'slack',
+        display_name: 'Acme Workspace',
+        icon_url: '/static/services/slack.png',
+        config: { team: { id: 'T99999', name: 'Acme Workspace' } },
+        created_at: '2026-01-01T00:00:00Z',
+    },
+]
+
+const STORY_SLACK_CHANNELS: Record<string, { id: string; name: string }[]> = {
+    '1': [
+        { id: 'C100', name: 'alerts' },
+        { id: 'C101', name: 'general' },
+    ],
+    '2': [
+        { id: 'C200', name: 'acme-alerts' },
+        { id: 'C201', name: 'acme-eng' },
+    ],
+}
+
+function MultipleSlackWorkspacesStory(): JSX.Element {
+    useStorybookMocks({
+        get: {
+            '/api/environments/:team_id/integrations': { results: STORY_SLACK_WORKSPACES, count: 2 },
+            '/api/environments/:team_id/integrations/:id/channels': (req, res, ctx) => {
+                const channels = (STORY_SLACK_CHANNELS[String(req.params.id)] ?? []).map((channel) => ({
+                    ...channel,
+                    is_private: false,
+                    is_ext_shared: false,
+                    is_member: true,
+                }))
+                return res(ctx.json({ channels, lastRefreshedAt: '2026-01-01T00:00:00Z' }))
+            },
+            '/api/environments/:team_id/hog_functions': { results: [], count: 0 },
+        },
+    })
+
+    return (
+        <div className="max-w-2xl border rounded bg-surface-primary p-4">
+            <InlineAlertNotifications />
+        </div>
+    )
+}
+
 function QuietHoursStory(): JSX.Element {
     const [scheduleRestriction, setScheduleRestriction] = useState<ScheduleRestriction | null>({
         blocked_windows: [{ start: '22:00', end: '07:00' }],
@@ -296,5 +353,6 @@ export const EditorLoading: Story = {
 export const Definition: Story = { render: () => <DefinitionStory /> }
 export const AdvancedOptions: Story = { render: () => <AdvancedOptionsStory /> }
 export const Notifications: Story = { render: () => <NotificationsStory /> }
+export const NotificationsMultipleSlackWorkspaces: Story = { render: () => <MultipleSlackWorkspacesStory /> }
 export const QuietHours: Story = { render: () => <QuietHoursStory /> }
 export const EvaluationHistory: Story = { render: () => <EvaluationHistoryStory /> }

--- a/products/alerts/frontend/components/AlertNotificationDestinationEditor.tsx
+++ b/products/alerts/frontend/components/AlertNotificationDestinationEditor.tsx
@@ -11,6 +11,7 @@ import {
     LemonTagType,
 } from '@posthog/lemon-ui'
 
+import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
 
 import { IntegrationType } from '~/types'
@@ -66,7 +67,9 @@ interface AlertNotificationDestinationEditorProps<NotificationType extends strin
     }
     slack: {
         notificationType: NotificationType
+        integrations?: IntegrationType[]
         integration?: IntegrationType
+        onIntegrationChange?: (integrationId: number | null) => void
         channelValue: string | null
         onChannelValueChange: (value: string | null) => void
     }
@@ -211,11 +214,26 @@ export function AlertNotificationDestinationEditor<NotificationType extends stri
     if (notificationType.value === slack.notificationType) {
         if (slack.integration) {
             slackDestinationInput = (
-                <SlackChannelPicker
-                    value={slack.channelValue ?? undefined}
-                    onChange={slack.onChannelValueChange}
-                    integration={slack.integration}
-                />
+                <div className="space-y-3">
+                    {(slack.integrations?.length ?? 0) > 1 ? (
+                        <div className="space-y-1">
+                            <div className="text-sm font-medium">Slack workspace</div>
+                            <IntegrationChoice
+                                integration="slack"
+                                value={slack.integration.id}
+                                onChange={slack.onIntegrationChange}
+                            />
+                        </div>
+                    ) : null}
+                    <div className="space-y-1">
+                        <div className="text-sm font-medium">Channel</div>
+                        <SlackChannelPicker
+                            value={slack.channelValue ?? undefined}
+                            onChange={slack.onChannelValueChange}
+                            integration={slack.integration}
+                        />
+                    </div>
+                </div>
             )
         } else {
             slackDestinationInput = <SlackNotConfiguredBanner />

--- a/products/alerts/frontend/components/AlertNotificationDestinationEditor.tsx
+++ b/products/alerts/frontend/components/AlertNotificationDestinationEditor.tsx
@@ -33,8 +33,8 @@ interface AlertNotificationDestinationButtonAction {
 
 export interface AlertNotificationDestinationView {
     key: string
-    title: string
-    detail?: string | null
+    title: ReactNode
+    detail?: ReactNode
     tags?: { label: string; type?: LemonTagType }[]
     viewAction?: AlertNotificationDestinationIconAction | AlertNotificationDestinationButtonAction
     onDelete: () => void

--- a/products/alerts/frontend/components/AlertNotificationDestinationEditor.tsx
+++ b/products/alerts/frontend/components/AlertNotificationDestinationEditor.tsx
@@ -216,23 +216,28 @@ export function AlertNotificationDestinationEditor<NotificationType extends stri
             slackDestinationInput = (
                 <div className="space-y-3">
                     {(slack.integrations?.length ?? 0) > 1 ? (
-                        <div className="space-y-1">
-                            <div className="text-sm font-medium">Slack workspace</div>
+                        <fieldset className="space-y-1">
+                            <legend className="text-sm font-medium">Slack workspace</legend>
                             <IntegrationChoice
                                 integration="slack"
                                 value={slack.integration.id}
-                                onChange={slack.onIntegrationChange}
+                                onChange={(integrationId) => {
+                                    if (integrationId !== slack.integration?.id) {
+                                        slack.onIntegrationChange?.(integrationId)
+                                    }
+                                }}
+                                allowClear={false}
                             />
-                        </div>
+                        </fieldset>
                     ) : null}
-                    <div className="space-y-1">
-                        <div className="text-sm font-medium">Channel</div>
+                    <fieldset className="space-y-1">
+                        <legend className="text-sm font-medium">Channel</legend>
                         <SlackChannelPicker
                             value={slack.channelValue ?? undefined}
                             onChange={slack.onChannelValueChange}
                             integration={slack.integration}
                         />
-                    </div>
+                    </fieldset>
                 </div>
             )
         } else {

--- a/products/alerts/frontend/logic/alertNotificationLogic.test.ts
+++ b/products/alerts/frontend/logic/alertNotificationLogic.test.ts
@@ -3,7 +3,7 @@ import { expectLogic } from 'kea-test-utils'
 import api from 'lib/api'
 
 import { initKeaTests } from '~/test/init'
-import { HogFunctionType } from '~/types'
+import { HogFunctionType, IntegrationType } from '~/types'
 
 import {
     ALERT_NOTIFICATION_TYPE_DISCORD,
@@ -32,6 +32,15 @@ describe('alertNotificationLogic', () => {
         listSpy.mockRestore()
     })
 
+    const makeSlackIntegration = (id: number): IntegrationType => ({
+        id,
+        kind: 'slack',
+        display_name: `Workspace ${id}`,
+        icon_url: '',
+        config: {},
+        created_at: '2026-01-01T00:00:00Z',
+    })
+
     it('clears staged inputs when the destination type changes', async () => {
         logic = alertNotificationLogic({ alertId: 'alert-123' })
         logic.mount()
@@ -51,6 +60,26 @@ describe('alertNotificationLogic', () => {
         logic.actions.setSlackChannelValue('C456|#alerts')
         logic.actions.setSelectedType(ALERT_NOTIFICATION_TYPE_WEBHOOK)
         await expectLogic(logic).toMatchValues({ slackChannelValue: null })
+    })
+
+    it('clears the channel when an integrations refresh removes the selected workspace', async () => {
+        logic = alertNotificationLogic({ alertId: 'alert-123' })
+        logic.mount()
+
+        const firstWorkspace = makeSlackIntegration(1)
+        const secondWorkspace = makeSlackIntegration(2)
+        logic.actions.loadIntegrationsSuccess([firstWorkspace, secondWorkspace])
+        await expectLogic(logic).toMatchValues({ selectedSlackIntegrationId: 1 })
+
+        logic.actions.setSelectedSlackIntegrationId(2)
+        logic.actions.setSlackChannelValue('C123|#general')
+        logic.actions.loadIntegrationsSuccess([firstWorkspace])
+
+        await expectLogic(logic).toMatchValues({
+            selectedSlackIntegrationId: 1,
+            selectedSlackIntegration: firstWorkspace,
+            slackChannelValue: null,
+        })
     })
 
     it('creates a Discord destination HogFunction end-to-end', async () => {

--- a/products/alerts/frontend/logic/alertNotificationLogic.test.ts
+++ b/products/alerts/frontend/logic/alertNotificationLogic.test.ts
@@ -45,6 +45,10 @@ describe('alertNotificationLogic', () => {
         // A staged Slack channel is cleared the same way.
         logic.actions.setSlackChannelValue('C123|#general')
         await expectLogic(logic).toMatchValues({ slackChannelValue: 'C123|#general' })
+        logic.actions.setSelectedSlackIntegrationId(2)
+        await expectLogic(logic).toMatchValues({ slackChannelValue: null })
+
+        logic.actions.setSlackChannelValue('C456|#alerts')
         logic.actions.setSelectedType(ALERT_NOTIFICATION_TYPE_WEBHOOK)
         await expectLogic(logic).toMatchValues({ slackChannelValue: null })
     })

--- a/products/alerts/frontend/logic/alertNotificationLogic.test.ts
+++ b/products/alerts/frontend/logic/alertNotificationLogic.test.ts
@@ -8,6 +8,7 @@ import { HogFunctionType, IntegrationType } from '~/types'
 import {
     ALERT_NOTIFICATION_TYPE_DISCORD,
     ALERT_NOTIFICATION_TYPE_MICROSOFT_TEAMS,
+    ALERT_NOTIFICATION_TYPE_SLACK,
     ALERT_NOTIFICATION_TYPE_WEBHOOK,
 } from 'products/alerts/frontend/logic/alertNotifications'
 
@@ -79,6 +80,36 @@ describe('alertNotificationLogic', () => {
             selectedSlackIntegrationId: 1,
             selectedSlackIntegration: firstWorkspace,
             slackChannelValue: null,
+        })
+    })
+
+    it('drops staged Slack notifications for a workspace removed by an integrations refresh', async () => {
+        logic = alertNotificationLogic({ alertId: 'alert-123' })
+        logic.mount()
+
+        const firstWorkspace = makeSlackIntegration(1)
+        const secondWorkspace = makeSlackIntegration(2)
+        logic.actions.loadIntegrationsSuccess([firstWorkspace, secondWorkspace])
+
+        logic.actions.addPendingNotification({
+            type: ALERT_NOTIFICATION_TYPE_SLACK,
+            slackWorkspaceId: 2,
+            slackChannelId: 'C1',
+            slackChannelName: 'general',
+        })
+        logic.actions.addPendingNotification({
+            type: ALERT_NOTIFICATION_TYPE_WEBHOOK,
+            webhookUrl: 'https://example.com',
+        })
+        await expectLogic(logic).toMatchValues({ pendingNotifications: [expect.anything(), expect.anything()] })
+
+        logic.actions.loadIntegrationsSuccess([firstWorkspace])
+
+        // The staged Slack destination pointed at the now-removed workspace 2 is dropped;
+        // saving it would create a HogFunction referencing a dead integration. The webhook
+        // notification doesn't reference a workspace, so it's untouched.
+        await expectLogic(logic).toMatchValues({
+            pendingNotifications: [{ type: ALERT_NOTIFICATION_TYPE_WEBHOOK, webhookUrl: 'https://example.com' }],
         })
     })
 

--- a/products/alerts/frontend/logic/alertNotificationLogic.ts
+++ b/products/alerts/frontend/logic/alertNotificationLogic.ts
@@ -189,11 +189,11 @@ export interface alertNotificationLogicActions {
     setPendingNotifications: (notifications: PendingAlertNotification[]) => {
         notifications: PendingAlertNotification[]
     }
-    setSelectedType: (selectedType: AlertNotificationType) => {
-        selectedType: AlertNotificationType
-    }
     setSelectedSlackIntegrationId: (selectedSlackIntegrationId: number | null) => {
         selectedSlackIntegrationId: number | null
+    }
+    setSelectedType: (selectedType: AlertNotificationType) => {
+        selectedType: AlertNotificationType
     }
     setSlackChannelValue: (slackChannelValue: string | null) => {
         slackChannelValue: string | null

--- a/products/alerts/frontend/logic/alertNotificationLogic.ts
+++ b/products/alerts/frontend/logic/alertNotificationLogic.ts
@@ -43,6 +43,8 @@ export interface alertNotificationLogicValues {
     existingHogFunctionsLoading: boolean
     firstSlackIntegration: IntegrationType | undefined
     pendingNotifications: PendingAlertNotification[]
+    selectedSlackIntegration: IntegrationType | undefined
+    selectedSlackIntegrationId: number | null
     selectedType: AlertNotificationType
     slackChannelValue: string | null
     webhookUrl: string
@@ -191,6 +193,9 @@ export interface alertNotificationLogicActions {
     setSelectedType: (selectedType: AlertNotificationType) => {
         selectedType: AlertNotificationType
     }
+    setSelectedSlackIntegrationId: (selectedSlackIntegrationId: number | null) => {
+        selectedSlackIntegrationId: number | null
+    }
     setSlackChannelValue: (slackChannelValue: string | null) => {
         slackChannelValue: string | null
     }
@@ -204,6 +209,10 @@ export interface alertNotificationLogicMeta {
     key: string
     __keaTypeGenInternalSelectorTypes: {
         firstSlackIntegration: (slackIntegrations: IntegrationType[] | undefined) => IntegrationType | undefined
+        selectedSlackIntegration: (
+            slackIntegrations: IntegrationType[] | undefined,
+            selectedSlackIntegrationId: number | null
+        ) => IntegrationType | undefined
     }
 }
 
@@ -232,6 +241,9 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
         deleteExistingHogFunction: (hogFunction: HogFunctionType) => ({ hogFunction }),
         createPendingHogFunctions: (alertId: string, alertName?: string) => ({ alertId, alertName }),
         setSelectedType: (selectedType: AlertNotificationType) => ({ selectedType }),
+        setSelectedSlackIntegrationId: (selectedSlackIntegrationId: number | null) => ({
+            selectedSlackIntegrationId,
+        }),
         setSlackChannelValue: (slackChannelValue: string | null) => ({ slackChannelValue }),
         setWebhookUrl: (webhookUrl: string) => ({ webhookUrl }),
     }),
@@ -252,6 +264,13 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
                 setSlackChannelValue: (_, { slackChannelValue }) => slackChannelValue,
                 // Reset the input when switching destination type so stale values don't carry over.
                 setSelectedType: () => null,
+                setSelectedSlackIntegrationId: () => null,
+            },
+        ],
+        selectedSlackIntegrationId: [
+            null as number | null,
+            {
+                setSelectedSlackIntegrationId: (_, { selectedSlackIntegrationId }) => selectedSlackIntegrationId,
             },
         ],
         webhookUrl: [
@@ -281,6 +300,15 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
         firstSlackIntegration: [
             (s) => [s.slackIntegrations],
             (slackIntegrations: IntegrationType[] | undefined): IntegrationType | undefined => slackIntegrations?.[0],
+        ],
+        selectedSlackIntegration: [
+            (s) => [s.slackIntegrations, s.selectedSlackIntegrationId],
+            (
+                slackIntegrations: IntegrationType[] | undefined,
+                selectedSlackIntegrationId: number | null
+            ): IntegrationType | undefined =>
+                slackIntegrations?.find((integration) => integration.id === selectedSlackIntegrationId) ??
+                slackIntegrations?.[0],
         ],
     }),
 

--- a/products/alerts/frontend/logic/alertNotificationLogic.ts
+++ b/products/alerts/frontend/logic/alertNotificationLogic.ts
@@ -41,7 +41,6 @@ export interface alertNotificationLogicValues {
     currentProjectId: number | null // projectLogic
     existingHogFunctions: HogFunctionType[]
     existingHogFunctionsLoading: boolean
-    firstSlackIntegration: IntegrationType | undefined
     pendingNotifications: PendingAlertNotification[]
     selectedSlackIntegration: IntegrationType | undefined
     selectedSlackIntegrationId: number | null
@@ -208,7 +207,6 @@ export interface alertNotificationLogicActions {
 export interface alertNotificationLogicMeta {
     key: string
     __keaTypeGenInternalSelectorTypes: {
-        firstSlackIntegration: (slackIntegrations: IntegrationType[] | undefined) => IntegrationType | undefined
         selectedSlackIntegration: (
             slackIntegrations: IntegrationType[] | undefined,
             selectedSlackIntegrationId: number | null
@@ -296,19 +294,13 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
     }),
 
     selectors({
-        // Use first available Slack integration to determine if Slack should be the default notification type
-        firstSlackIntegration: [
-            (s) => [s.slackIntegrations],
-            (slackIntegrations: IntegrationType[] | undefined): IntegrationType | undefined => slackIntegrations?.[0],
-        ],
         selectedSlackIntegration: [
             (s) => [s.slackIntegrations, s.selectedSlackIntegrationId],
             (
                 slackIntegrations: IntegrationType[] | undefined,
                 selectedSlackIntegrationId: number | null
             ): IntegrationType | undefined =>
-                slackIntegrations?.find((integration) => integration.id === selectedSlackIntegrationId) ??
-                slackIntegrations?.[0],
+                slackIntegrations?.find((integration) => integration.id === selectedSlackIntegrationId),
         ],
     }),
 
@@ -332,8 +324,16 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
     })),
 
     listeners(({ actions, values, props }) => ({
-        loadIntegrationsSuccess: () => {
-            if (!values.firstSlackIntegration) {
+        loadIntegrationsSuccess: ({ integrations }) => {
+            const availableSlackIntegrations = integrations.filter((integration) => integration.kind === 'slack')
+            const selectedIntegrationIsAvailable = availableSlackIntegrations.some(
+                (integration) => integration.id === values.selectedSlackIntegrationId
+            )
+
+            if (!selectedIntegrationIsAvailable) {
+                actions.setSelectedSlackIntegrationId(availableSlackIntegrations[0]?.id ?? null)
+            }
+            if (availableSlackIntegrations.length === 0) {
                 actions.setSelectedType(ALERT_NOTIFICATION_TYPE_WEBHOOK)
             }
         },

--- a/products/alerts/frontend/logic/alertNotificationLogic.ts
+++ b/products/alerts/frontend/logic/alertNotificationLogic.ts
@@ -352,11 +352,7 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
                         actions.loadExistingHogFunctions()
                         return
                     }
-                    // Capture only a delete that actually landed: the callback runs after the API
-                    // call resolves and not at all on failure, and we skip it on undo. Mirrors the
-                    // create event, which always carries a known type — so skip an unrecognized
-                    // template rather than emit a null type that can't be classified. A
-                    // delete-then-undo still counts once — acceptable for optimistic-undo analytics.
+                    // Skip on undo and on unrecognized templates so this only counts confirmed deletes with a known type.
                     if (type) {
                         posthog.capture('insight alert destination deleted', {
                             alert_id: props.alertId,
@@ -380,10 +376,7 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
                 })
             )
 
-            // Capture one event per destination that was actually created, tagged with its type,
-            // so adoption of each destination (Slack/Discord/Teams/webhook) is measurable. The
-            // destination is a separate HogFunction, so no `alert created`/`alert updated` event
-            // records it — this is the only signal that ties a destination type to an alert.
+            // No `alert created`/`alert updated` event captures destination type, so this is emitted per created destination instead.
             results.forEach((result, i) => {
                 if (result.status === 'fulfilled') {
                     posthog.capture('insight alert destination created', {
@@ -403,7 +396,6 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
             if (failures.length > 0) {
                 const labelForType = (type: AlertNotificationType): string =>
                     ALERT_NOTIFICATION_TYPE_OPTIONS.find((option) => option.value === type)?.label ?? type
-                // Log each failure with its destination type + API error so the cause is diagnosable later.
                 failures.forEach(({ result, notification }) => {
                     console.error(
                         `Failed to create ${labelForType(notification.type)} alert notification`,

--- a/products/alerts/frontend/logic/alertNotificationLogic.ts
+++ b/products/alerts/frontend/logic/alertNotificationLogic.ts
@@ -336,6 +336,18 @@ export const alertNotificationLogic = kea<alertNotificationLogicType>([
             if (availableSlackIntegrations.length === 0) {
                 actions.setSelectedType(ALERT_NOTIFICATION_TYPE_WEBHOOK)
             }
+
+            // Drop any staged Slack notifications pointing at a workspace that's no longer
+            // connected — saving them would create a destination referencing a dead integration.
+            const availableIds = new Set(availableSlackIntegrations.map((integration) => integration.id))
+            const stillValidPending = values.pendingNotifications.filter(
+                (notification) =>
+                    notification.type !== ALERT_NOTIFICATION_TYPE_SLACK ||
+                    availableIds.has(notification.slackWorkspaceId)
+            )
+            if (stillValidPending.length !== values.pendingNotifications.length) {
+                actions.setPendingNotifications(stillValidPending)
+            }
         },
         deleteExistingHogFunction: async ({ hogFunction }) => {
             // Resolve the type from the closure up front — after the delete the HogFunction is

--- a/products/alerts/frontend/views/InlineAlertNotifications.tsx
+++ b/products/alerts/frontend/views/InlineAlertNotifications.tsx
@@ -63,11 +63,6 @@ function getHogFunctionDestination(
     const inputs = hogFunction.inputs as SlackDestinationInputs | null | undefined
     const channelValue = inputs?.channel?.value
     if (channelValue) {
-        // `channel.value` comes from loosely-typed backend JSON written by several producers
-        // (inline alerts, error tracking alerts, logs alerting, MCP) — guard before splitting it.
-        if (typeof channelValue !== 'string') {
-            return { type: 'Slack', detail: null }
-        }
         // Destinations from before `slack_workspace` existed belonged to the single workspace
         // that was the only option at the time, so fall back to it for those legacy rows.
         const workspaceId = inputs?.slack_workspace?.value ?? slackIntegrations?.[0]?.id

--- a/products/alerts/frontend/views/InlineAlertNotifications.tsx
+++ b/products/alerts/frontend/views/InlineAlertNotifications.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { ReactNode } from 'react'
+import { ReactNode, useEffect } from 'react'
 
 import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
 import { urls } from 'scenes/urls'
@@ -28,8 +28,7 @@ function resolveSlackChannelName(channelValue: string, slackChannels: SlackChann
     return slackChannels.find((channel) => channel.id === channelId)?.name ?? null
 }
 
-// Existing destinations can belong to any connected workspace, not just the one currently
-// selected in the picker, so each row resolves its own channel name from its own workspace.
+// Each destination can belong to a different workspace than the one selected in the picker.
 function SlackDestinationChannel({
     workspaceId,
     channelValue,
@@ -37,14 +36,21 @@ function SlackDestinationChannel({
     workspaceId: number
     channelValue: string
 }): JSX.Element {
-    const { slackChannels } = useValues(slackIntegrationLogic({ id: workspaceId }))
+    const logic = slackIntegrationLogic({ id: workspaceId })
+    const { slackChannels } = useValues(logic)
+    const { loadSlackChannelById } = useActions(logic)
+    const channelId = channelValue.split('|')[0]
+
+    // Load just this one channel rather than the full (paginated) list — the picker's own
+    // bulk load may not include it, and we already know exactly which channel we need.
+    useEffect(() => {
+        loadSlackChannelById(channelId)
+    }, [loadSlackChannelById, channelId])
+
     const channelName = resolveSlackChannelName(channelValue, slackChannels)
     return <>{channelName ? `#${channelName}` : 'channel'}</>
 }
 
-// Written by every producer of this destination (inline alerts, error tracking alerts, logs
-// alerting, MCP) as `{value: int}` / `{value: str}`. Destinations from before `slack_workspace`
-// existed simply lack the key — that's the only real-world gap, not a type mismatch.
 interface SlackDestinationInputs {
     slack_workspace?: { value: number }
     channel?: { value: string }
@@ -57,11 +63,18 @@ function getHogFunctionDestination(
     const inputs = hogFunction.inputs as SlackDestinationInputs | null | undefined
     const channelValue = inputs?.channel?.value
     if (channelValue) {
-        const workspaceId = inputs?.slack_workspace?.value
-        const workspaceName = slackIntegrations?.find((integration) => integration.id === workspaceId)?.display_name
-        if (workspaceId === undefined) {
-            return { type: 'Slack', detail: workspaceName ?? null }
+        // `channel.value` comes from loosely-typed backend JSON written by several producers
+        // (inline alerts, error tracking alerts, logs alerting, MCP) — guard before splitting it.
+        if (typeof channelValue !== 'string') {
+            return { type: 'Slack', detail: null }
         }
+        // Destinations from before `slack_workspace` existed belonged to the single workspace
+        // that was the only option at the time, so fall back to it for those legacy rows.
+        const workspaceId = inputs?.slack_workspace?.value ?? slackIntegrations?.[0]?.id
+        if (workspaceId === undefined) {
+            return { type: 'Slack', detail: null }
+        }
+        const workspaceName = slackIntegrations?.find((integration) => integration.id === workspaceId)?.display_name
         return {
             type: 'Slack',
             detail: (

--- a/products/alerts/frontend/views/InlineAlertNotifications.tsx
+++ b/products/alerts/frontend/views/InlineAlertNotifications.tsx
@@ -42,18 +42,24 @@ function SlackDestinationChannel({
     return <>{channelName ? `#${channelName}` : 'channel'}</>
 }
 
+// Written by every producer of this destination (inline alerts, error tracking alerts, logs
+// alerting, MCP) as `{value: int}` / `{value: str}`. Destinations from before `slack_workspace`
+// existed simply lack the key — that's the only real-world gap, not a type mismatch.
+interface SlackDestinationInputs {
+    slack_workspace?: { value: number }
+    channel?: { value: string }
+}
+
 function getHogFunctionDestination(
     hogFunction: HogFunctionType,
     slackIntegrations: IntegrationType[] | undefined
 ): { type: string; detail: ReactNode } {
-    const channelValue = hogFunction.inputs?.channel?.value
+    const inputs = hogFunction.inputs as SlackDestinationInputs | null | undefined
+    const channelValue = inputs?.channel?.value
     if (channelValue) {
-        const workspaceId = hogFunction.inputs?.slack_workspace?.value
-        const workspaceName =
-            typeof workspaceId === 'number'
-                ? slackIntegrations?.find((integration) => integration.id === workspaceId)?.display_name
-                : undefined
-        if (typeof channelValue !== 'string' || typeof workspaceId !== 'number') {
+        const workspaceId = inputs?.slack_workspace?.value
+        const workspaceName = slackIntegrations?.find((integration) => integration.id === workspaceId)?.display_name
+        if (workspaceId === undefined) {
             return { type: 'Slack', detail: workspaceName ?? null }
         }
         return {

--- a/products/alerts/frontend/views/InlineAlertNotifications.tsx
+++ b/products/alerts/frontend/views/InlineAlertNotifications.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { useEffect } from 'react'
 
 import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
 import { urls } from 'scenes/urls'
@@ -144,13 +143,6 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
 
     const slackLogic = slackIntegrationLogic({ id: selectedSlackIntegration?.id ?? 0 })
     const { slackChannels } = useValues(slackLogic)
-    const { loadAllSlackChannels } = useActions(slackLogic)
-
-    useEffect(() => {
-        if (selectedSlackIntegration) {
-            loadAllSlackChannels()
-        }
-    }, [selectedSlackIntegration?.id, loadAllSlackChannels, selectedSlackIntegration])
 
     const buildPendingNotification = (): PendingAlertNotification | null => {
         if (selectedType === ALERT_NOTIFICATION_TYPE_SLACK) {

--- a/products/alerts/frontend/views/InlineAlertNotifications.tsx
+++ b/products/alerts/frontend/views/InlineAlertNotifications.tsx
@@ -1,10 +1,10 @@
 import { useActions, useValues } from 'kea'
-import { ReactNode, useEffect } from 'react'
+import { ReactNode, useEffect, useState } from 'react'
 
-import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
+import api from 'lib/api'
 import { urls } from 'scenes/urls'
 
-import { HogFunctionType, IntegrationType, SlackChannelType } from '~/types'
+import { HogFunctionType, IntegrationType } from '~/types'
 
 import {
     AlertNotificationDestinationEditor,
@@ -23,31 +23,24 @@ import {
 
 import { ALERT_NOTIFICATION_TYPE_OPTIONS, alertNotificationLogic } from '../logic/alertNotificationLogic'
 
-function resolveSlackChannelName(channelValue: string, slackChannels: SlackChannelType[]): string | null {
-    const channelId = channelValue.split('|')[0]
-    return slackChannels.find((channel) => channel.id === channelId)?.name ?? null
-}
+// Fetched directly rather than through slackIntegrationLogic's loader: that loader keeps a
+// single last-result slot per workspace, so multiple destination rows in the same workspace
+// looking up different channels concurrently would cancel each other's requests.
+function SlackDestinationChannel({ workspaceId, channelId }: { workspaceId: number; channelId: string }): JSX.Element {
+    const [channelName, setChannelName] = useState<string | null>(null)
 
-// Each destination can belong to a different workspace than the one selected in the picker.
-function SlackDestinationChannel({
-    workspaceId,
-    channelValue,
-}: {
-    workspaceId: number
-    channelValue: string
-}): JSX.Element {
-    const logic = slackIntegrationLogic({ id: workspaceId })
-    const { slackChannels } = useValues(logic)
-    const { loadSlackChannelById } = useActions(logic)
-    const channelId = channelValue.split('|')[0]
-
-    // Load just this one channel rather than the full (paginated) list — the picker's own
-    // bulk load may not include it, and we already know exactly which channel we need.
     useEffect(() => {
-        loadSlackChannelById(channelId)
-    }, [loadSlackChannelById, channelId])
+        let cancelled = false
+        api.integrations.slackChannelsById(workspaceId, channelId).then((res) => {
+            if (!cancelled) {
+                setChannelName(res.channels[0]?.name ?? null)
+            }
+        })
+        return () => {
+            cancelled = true
+        }
+    }, [workspaceId, channelId])
 
-    const channelName = resolveSlackChannelName(channelValue, slackChannels)
     return <>{channelName ? `#${channelName}` : 'channel'}</>
 }
 
@@ -61,11 +54,13 @@ function getHogFunctionDestination(
     slackIntegrations: IntegrationType[] | undefined
 ): { type: string; detail: ReactNode } {
     const inputs = hogFunction.inputs as SlackDestinationInputs | null | undefined
-    const channelValue = inputs?.channel?.value
-    if (channelValue) {
-        // Destinations from before `slack_workspace` existed belonged to the single workspace
-        // that was the only option at the time, so fall back to it for those legacy rows.
-        const workspaceId = inputs?.slack_workspace?.value ?? slackIntegrations?.[0]?.id
+    const channelId = inputs?.channel?.value
+    if (channelId) {
+        // Destinations from before `slack_workspace` existed can only be safely attributed to a
+        // workspace when exactly one is connected — with 2+, there's no way to know which one it
+        // was created against, so guessing would risk showing the wrong workspace/channel.
+        const workspaceId =
+            inputs?.slack_workspace?.value ?? (slackIntegrations?.length === 1 ? slackIntegrations[0].id : undefined)
         if (workspaceId === undefined) {
             return { type: 'Slack', detail: null }
         }
@@ -75,7 +70,7 @@ function getHogFunctionDestination(
             detail: (
                 <>
                     {workspaceName ?? 'Unknown workspace'} ·{' '}
-                    <SlackDestinationChannel workspaceId={workspaceId} channelValue={channelValue} />
+                    <SlackDestinationChannel workspaceId={workspaceId} channelId={channelId} />
                 </>
             ),
         }

--- a/products/alerts/frontend/views/InlineAlertNotifications.tsx
+++ b/products/alerts/frontend/views/InlineAlertNotifications.tsx
@@ -1,9 +1,10 @@
 import { useActions, useValues } from 'kea'
+import { ReactNode } from 'react'
 
 import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
 import { urls } from 'scenes/urls'
 
-import { HogFunctionType, SlackChannelType } from '~/types'
+import { HogFunctionType, IntegrationType, SlackChannelType } from '~/types'
 
 import {
     AlertNotificationDestinationEditor,
@@ -27,17 +28,43 @@ function resolveSlackChannelName(channelValue: string, slackChannels: SlackChann
     return slackChannels.find((channel) => channel.id === channelId)?.name ?? null
 }
 
+// Existing destinations can belong to any connected workspace, not just the one currently
+// selected in the picker, so each row resolves its own channel name from its own workspace.
+function SlackDestinationChannel({
+    workspaceId,
+    channelValue,
+}: {
+    workspaceId: number
+    channelValue: string
+}): JSX.Element {
+    const { slackChannels } = useValues(slackIntegrationLogic({ id: workspaceId }))
+    const channelName = resolveSlackChannelName(channelValue, slackChannels)
+    return <>{channelName ? `#${channelName}` : 'channel'}</>
+}
+
 function getHogFunctionDestination(
     hogFunction: HogFunctionType,
-    slackChannels: SlackChannelType[]
-): { type: string; detail: string | null } {
+    slackIntegrations: IntegrationType[] | undefined
+): { type: string; detail: ReactNode } {
     const channelValue = hogFunction.inputs?.channel?.value
-    if (channelValue && typeof channelValue === 'string') {
-        const channelName = resolveSlackChannelName(channelValue, slackChannels)
-        return { type: 'Slack', detail: channelName ? `#${channelName}` : null }
-    }
     if (channelValue) {
-        return { type: 'Slack', detail: null }
+        const workspaceId = hogFunction.inputs?.slack_workspace?.value
+        const workspaceName =
+            typeof workspaceId === 'number'
+                ? slackIntegrations?.find((integration) => integration.id === workspaceId)?.display_name
+                : undefined
+        if (typeof channelValue !== 'string' || typeof workspaceId !== 'number') {
+            return { type: 'Slack', detail: workspaceName ?? null }
+        }
+        return {
+            type: 'Slack',
+            detail: (
+                <>
+                    {workspaceName ?? 'Unknown workspace'} ·{' '}
+                    <SlackDestinationChannel workspaceId={workspaceId} channelValue={channelValue} />
+                </>
+            ),
+        }
     }
     if (hogFunction.template_id === 'template-discord') {
         const webhookUrl = hogFunction.inputs?.webhookUrl?.value
@@ -54,10 +81,17 @@ function getHogFunctionDestination(
     return { type: hogFunction.name, detail: null }
 }
 
-function getNotificationLabel(notification: PendingAlertNotification): string {
+function getNotificationLabel(
+    notification: PendingAlertNotification,
+    slackIntegrations: IntegrationType[] | undefined
+): string {
     switch (notification.type) {
-        case ALERT_NOTIFICATION_TYPE_SLACK:
-            return `Slack: #${notification.slackChannelName ?? 'channel'}`
+        case ALERT_NOTIFICATION_TYPE_SLACK: {
+            const workspaceName = slackIntegrations?.find(
+                (integration) => integration.id === notification.slackWorkspaceId
+            )?.display_name
+            return `Slack: ${workspaceName ?? 'Unknown workspace'} · #${notification.slackChannelName ?? 'channel'}`
+        }
         case ALERT_NOTIFICATION_TYPE_DISCORD:
             return `Discord: ${notification.webhookUrl}`
         case ALERT_NOTIFICATION_TYPE_MICROSOFT_TEAMS:
@@ -141,9 +175,6 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
         setWebhookUrl,
     } = useActions(logic)
 
-    const slackLogic = slackIntegrationLogic({ id: selectedSlackIntegration?.id ?? 0 })
-    const { slackChannels } = useValues(slackLogic)
-
     const buildPendingNotification = (): PendingAlertNotification | null => {
         if (selectedType === ALERT_NOTIFICATION_TYPE_SLACK) {
             if (!slackChannelValue || !selectedSlackIntegration) {
@@ -183,7 +214,7 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
     }
 
     const existingDestinations: AlertNotificationDestinationView[] = existingHogFunctions.map((hogFunction) => {
-        const destination = getHogFunctionDestination(hogFunction, slackChannels)
+        const destination = getHogFunctionDestination(hogFunction, slackIntegrations)
         return {
             key: hogFunction.id,
             title: destination.type,
@@ -204,7 +235,7 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
     const pendingDestinations: PendingAlertNotificationDestinationView[] = pendingNotifications.map(
         (notification, index) => ({
             key: `${notification.type}-${index}`,
-            label: getNotificationLabel(notification),
+            label: getNotificationLabel(notification, slackIntegrations),
             status: '(pending, click Save to apply)',
             onRemove: () => removePendingNotification(index),
         })

--- a/products/alerts/frontend/views/InlineAlertNotifications.tsx
+++ b/products/alerts/frontend/views/InlineAlertNotifications.tsx
@@ -126,7 +126,8 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
         existingHogFunctions,
         existingHogFunctionsLoading,
         pendingNotifications,
-        firstSlackIntegration,
+        slackIntegrations,
+        selectedSlackIntegration,
         selectedType,
         slackChannelValue,
         webhookUrl,
@@ -136,29 +137,30 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
         removePendingNotification,
         deleteExistingHogFunction,
         setSelectedType,
+        setSelectedSlackIntegrationId,
         setSlackChannelValue,
         setWebhookUrl,
     } = useActions(logic)
 
-    const slackLogic = slackIntegrationLogic({ id: firstSlackIntegration?.id ?? 0 })
+    const slackLogic = slackIntegrationLogic({ id: selectedSlackIntegration?.id ?? 0 })
     const { slackChannels } = useValues(slackLogic)
     const { loadAllSlackChannels } = useActions(slackLogic)
 
     useEffect(() => {
-        if (firstSlackIntegration) {
+        if (selectedSlackIntegration) {
             loadAllSlackChannels()
         }
-    }, [firstSlackIntegration?.id, loadAllSlackChannels, firstSlackIntegration])
+    }, [selectedSlackIntegration?.id, loadAllSlackChannels, selectedSlackIntegration])
 
     const buildPendingNotification = (): PendingAlertNotification | null => {
         if (selectedType === ALERT_NOTIFICATION_TYPE_SLACK) {
-            if (!slackChannelValue || !firstSlackIntegration) {
+            if (!slackChannelValue || !selectedSlackIntegration) {
                 return null
             }
             const [channelId, channelLabel] = slackChannelValue.split('|')
             return {
                 type: ALERT_NOTIFICATION_TYPE_SLACK,
-                slackWorkspaceId: firstSlackIntegration.id,
+                slackWorkspaceId: selectedSlackIntegration.id,
                 slackChannelId: channelId,
                 slackChannelName: channelLabel?.replace('#', '') ?? channelId,
             }
@@ -233,7 +235,9 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
             }}
             slack={{
                 notificationType: ALERT_NOTIFICATION_TYPE_SLACK,
-                integration: firstSlackIntegration,
+                integrations: slackIntegrations,
+                integration: selectedSlackIntegration,
+                onIntegrationChange: setSelectedSlackIntegrationId,
                 channelValue: slackChannelValue,
                 onChannelValueChange: setSlackChannelValue,
             }}
@@ -242,7 +246,7 @@ export function InlineAlertNotifications({ alertId }: InlineAlertNotificationsPr
                 onClick: handleAdd,
                 disabledReason: getAddDisabledReason(
                     selectedType,
-                    Boolean(firstSlackIntegration),
+                    Boolean(selectedSlackIntegration),
                     slackChannelValue,
                     webhookUrl
                 ),


### PR DESCRIPTION
## Problem

Alert notifications always used the first Slack integration, so projects with multiple Slack workspaces could not choose where an alert should be sent.

## Changes

<img width="1400" height="1282" alt="CleanShot 2026-07-22 at 14 12 25@2x" src="https://github.com/user-attachments/assets/1d2dcecb-503a-4de1-83bf-11a67b72b8ec" />


- Add workspace selection to the inline alert destination editor when multiple Slack integrations exist.
- Clear the selected channel when switching workspaces.
- Keep the alert-specific destination templates and filters intact.

## How did you test this code?

- Added regression coverage for clearing the Slack channel when the workspace changes.
- Automated tests and type generation could not run because this checkout has no `node_modules`, `hogli`, or `flox`.
- `git diff --check` passed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No matching documentation describes this selector.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change using `/adopting-generated-api-types` and `/writing-tests`. The shared workflow-style picker could not replace alert destinations directly because alerts require their own HogFunction subtemplates and event filters, so the existing inline alert editor now reuses the workspace selection pattern instead.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*