### PR TITLE
chore(cohorts): add seeder entry to deploy matrix

### DIFF
--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -150,6 +150,9 @@ jobs:
                     - release: cohort-event-shuffler
                       digest_key: cohort-event-shuffler
                       values_key: image
+                    - release: cohort-seeder
+                      digest_key: cohort-seeder
+                      values_key: image
                     - release: cohort-stream-processor
                       digest_key: cohort-stream-processor
                       values_key: image


### PR DESCRIPTION
## Problem

The `cohort-seeder` image builds and pushes to ghcr, but it has no row in the deploy matrix, so no `commit_state_update` dispatch fires and `state/cohort-seeder.yaml` in charts never auto updates. The app would stay pinned forever at its hand seeded digest.

## Changes

Add a `cohort-seeder` row to the deploy matrix in `.github/workflows/rust-docker-build.yml`, mirroring the `cohort-event-shuffler` and `cohort-stream-processor` rows (`release`, `digest_key`, `values_key: image`). This wires the release dispatch so master builds move the charts state pin.

The build side (`.github/rust-images.yml`), CI test side (`ci-rust.yml`), and cargo workspace (`Cargo.toml`) already knew about the seeder, so this row was the only gap on the release path.

## How did you test this code?

`actionlint` passes on the workflow and the deploy matrix parses with `cohort-seeder` placed between its two siblings. No runtime code changed. The dispatch only fires from the canonical deploy repo on master, so it cannot be exercised from a branch.

## Docs update

No.