### PR TITLE
feat(mcp): surface governed metrics in exec search output

### DIFF
--- a/products/data_catalog/backend/tests/test_eval_scorers.py
+++ b/products/data_catalog/backend/tests/test_eval_scorers.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from parameterized import parameterized
+
+from products.data_catalog.evals.scorers import _search_surfaced_metrics
+from products.posthog_ai.eval_harness.log_parser import ToolCall
+
+_METRIC_OUTPUT = '{"matches":[],"governed_metrics":[{"name":"monthly_recurring_revenue"}],"hint":"run it"}'
+
+
+def _tool_call(**overrides: Any) -> ToolCall:
+    defaults: dict[str, Any] = {
+        "name": "search",
+        "input": {},
+        "output": "",
+        "is_error": False,
+        "call_id": "call-1",
+        "position": 0,
+        "raw_name": "exec",
+        "is_exec_unwrapped": True,
+    }
+    defaults.update(overrides)
+    return ToolCall(**defaults)
+
+
+class TestSearchSurfacedMetrics:
+    @parameterized.expand(
+        [
+            ("unwrapped_search_with_metrics", _tool_call(name="search", output=_METRIC_OUTPUT), True),
+            (
+                "wrapped_exec_search_with_metrics",
+                _tool_call(name="exec", input={"command": "search revenue"}, output=_METRIC_OUTPUT),
+                True,
+            ),
+            ("malformed_json_substring_fallback", _tool_call(output='garbage "governed_metrics": [x]'), True),
+            ("search_without_metrics", _tool_call(name="search", output='{"matches":["x"]}'), False),
+            ("errored_search", _tool_call(name="search", output=_METRIC_OUTPUT, is_error=True), False),
+            ("non_search_command", _tool_call(name="info", output=_METRIC_OUTPUT), False),
+        ]
+    )
+    def test_detects_search_that_surfaced_governed_metrics(self, _name: str, call: ToolCall, expected: bool) -> None:
+        assert _search_surfaced_metrics(call) is expected

--- a/products/data_catalog/evals/eval_governed_metrics.py
+++ b/products/data_catalog/evals/eval_governed_metrics.py
@@ -105,6 +105,29 @@ async def eval_governed_metrics(ctx: EvalContext) -> None:
             },
             setup=seed_approved_metric,
         ),
+        # `exec search` now returns matching governed metrics in its output, so the agent can
+        # discover the metric from the search result — no execute-sql catalog query needed —
+        # and run it. Credits the search-surfaced catalog lookup (scorers.py) then the run.
+        SandboxedEvalCase(
+            name="governed_metric_search_first",
+            prompt="Search for our revenue metric and give me the current value.",
+            expected={
+                "metrics_catalog_queried": {},
+                "canonical_metric_run": {
+                    "metric_name": APPROVED_METRIC_NAME,
+                    "outcome": "succeeded",
+                },
+                "governed_behavior_correctness": {
+                    "expected_behavior": (
+                        f"Discovered the approved metric '{APPROVED_METRIC_NAME}' via a catalog search (either the "
+                        "governed_metrics returned by exec search or a system.information_schema.metrics query), ran "
+                        "it through data-catalog-metric-run rather than re-deriving revenue, rechecked the runner's "
+                        "approved and non-drifted response, and reported the canonical value."
+                    )
+                },
+            },
+            setup=seed_approved_metric,
+        ),
         SandboxedEvalCase(
             name="governed_metric_implicit_ranking",
             prompt="give me the top 10 B2C customers by revenue and tell me which tool you used.",

--- a/products/data_catalog/evals/scorers.py
+++ b/products/data_catalog/evals/scorers.py
@@ -67,6 +67,29 @@ def _is_catalog_lookup(call: ToolCall) -> bool:
     return METRICS_CATALOG_MARKER in _query_text(call)
 
 
+def _is_search_command(call: ToolCall) -> bool:
+    if call.name.casefold() == "search":
+        return True
+    if call.name != "exec" or not isinstance(call.input, dict):
+        return False
+    command = call.input.get("command")
+    return isinstance(command, str) and command.strip().partition(" ")[0].casefold() == "search"
+
+
+def _search_surfaced_metrics(call: ToolCall) -> bool:
+    """A successful ``exec search`` whose output surfaced governed metrics — the tool-output
+    path to the catalog that needs no ``execute-sql`` query."""
+    if call.is_error or not _is_search_command(call):
+        return False
+    output = call.output or ""
+    try:
+        payload = json.loads(output)
+    except (json.JSONDecodeError, TypeError):
+        # Fall back to a substring check — exec only emits `governed_metrics` when non-empty.
+        return '"governed_metrics"' in output
+    return bool(isinstance(payload, dict) and payload.get("governed_metrics"))
+
+
 def _is_discovery(call: ToolCall) -> bool:
     return _INFO_SCHEMA in _query_text(call)
 
@@ -110,8 +133,14 @@ class MetricsCatalogQueried(Scorer):
         parser = _parser_for(output)
         if parser is None:
             return Score(name=self._name(), score=None, metadata={"reason": "No raw log"})
-        hits = [c for c in _successful_sql(parser) if _is_catalog_lookup(c)]
-        return Score(name=self._name(), score=1.0 if hits else 0.0, metadata={"catalog_lookups": len(hits)})
+        sql_hits = [c for c in _successful_sql(parser) if _is_catalog_lookup(c)]
+        search_hits = [c for c in parser.get_tool_calls() if _search_surfaced_metrics(c)]
+        found = bool(sql_hits or search_hits)
+        return Score(
+            name=self._name(),
+            score=1.0 if found else 0.0,
+            metadata={"catalog_lookups": len(sql_hits), "search_metric_hits": len(search_hits)},
+        )
 
 
 class MetricsCatalogBeforeAnswer(Scorer):
@@ -133,7 +162,12 @@ class MetricsCatalogBeforeAnswer(Scorer):
         catalog_seen = False
         offenders: list[str] = []
         answer_calls = 0
-        for call in _successful_sql(parser):
+        for call in sorted(parser.get_tool_calls(), key=lambda current: current.position):
+            if _search_surfaced_metrics(call):
+                catalog_seen = True
+                continue
+            if call.name != SQL_TOOL or call.is_error:
+                continue
             if _is_catalog_lookup(call):
                 catalog_seen = True
                 continue
@@ -180,6 +214,9 @@ class MetricsCatalogBeforeDataDiscovery(Scorer):
                     failed_catalog_lookups += 1
                 else:
                     catalog_seen = True
+                continue
+            if _search_surfaced_metrics(call):
+                catalog_seen = True
                 continue
             if catalog_seen or not _is_data_bearing(call):
                 continue

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -56,6 +56,17 @@ export interface GroupType {
     name_plural: string | null
 }
 
+/** The lean projection of a governed-metrics catalog row used by `exec search`.
+ *  Only the fields the search ranking and its run-hint need — the full metric
+ *  (definition, owner, timestamps) is fetched later by `data-catalog-metric-run`. */
+export interface CatalogMetricSummary {
+    name: string
+    display_name: string
+    description: string
+    status: string
+    is_drifted: boolean
+}
+
 // Global search types
 export const SearchableEntitySchema = z.enum([
     'insight',
@@ -1389,5 +1400,21 @@ export class ApiClient {
             throw new Error(result.error.message)
         }
         return result.data
+    }
+
+    async getCatalogMetrics(projectId: string): Promise<CatalogMetricSummary[]> {
+        const result = await this.fetchJson<{ results: CatalogMetricSummary[] }>(
+            `${this.baseUrl}/api/projects/${projectId}/data_catalog/metrics/?limit=100`
+        )
+        if (!result.success) {
+            throw new Error(result.error.message)
+        }
+        return result.data.results.map((m) => ({
+            name: m.name,
+            display_name: m.display_name,
+            description: m.description,
+            status: m.status,
+            is_drifted: m.is_drifted,
+        }))
     }
 }

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -403,6 +403,16 @@ export class ToolExecutor {
                 : tool
         )
 
+        // Only surface governed metrics in `exec search` when the catalog tool is
+        // registered — flag-off orgs get byte-identical output and zero added latency.
+        const catalogEnabled = state.allTools.some((tool) => tool.name === 'data-catalog-metric-run')
+        const catalogMetricsProvider = catalogEnabled
+            ? async () => {
+                  const projectId = await state.context.stateManager.getProjectId()
+                  return projectId ? state.context.stateManager.getOrFetchCatalogMetrics(projectId) : undefined
+              }
+            : undefined
+
         const execTool = createExecTool(
             execTools,
             state.context,
@@ -414,6 +424,7 @@ export class ToolExecutor {
             {
                 isInlineExecUiHost: state.clientProfile.isInlineExecUiHost(),
                 helpCatalog: this.instructionsBuilder.buildExecHelpCatalog(state),
+                ...(catalogMetricsProvider ? { catalogMetricsProvider } : {}),
             }
         )
 

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -1,4 +1,4 @@
-import type { ApiClient, GroupType } from '@/api/client'
+import type { ApiClient, CatalogMetricSummary, GroupType } from '@/api/client'
 import { hasScope } from '@/lib/api'
 import type { ScopedCache } from '@/lib/cache/ScopedCache'
 import {
@@ -382,6 +382,15 @@ export class StateManager {
             cacheKey: `groupTypes:${projectId}` as const,
             fetchedAtKey: `groupTypesFetchedAt:${projectId}` as const,
             fetcher: () => this._api.getGroupTypes(projectId),
+        })
+    }
+
+    async getOrFetchCatalogMetrics(projectId: string): Promise<CatalogMetricSummary[] | undefined> {
+        return this.getOrFetchCached({
+            name: 'catalog_metrics',
+            cacheKey: `catalogMetrics:${projectId}` as const,
+            fetchedAtKey: `catalogMetricsFetchedAt:${projectId}` as const,
+            fetcher: () => this._api.getCatalogMetrics(projectId),
         })
     }
 

--- a/services/mcp/src/templates/sections/exec-tool-blurb.md
+++ b/services/mcp/src/templates/sections/exec-tool-blurb.md
@@ -42,5 +42,5 @@ posthog:exec({ "command": "call --json <tool_name> <json_input>" })
 
 **Not supported:**
 
-- `search` matches tool metadata only, not input schemas.
+- `search` does not match input schemas (it ranks tool metadata, plus governed metrics when the catalog is available).
 - No pattern-based field projection — drill one path at a time.

--- a/services/mcp/src/templates/sections/metric-discovery.md
+++ b/services/mcp/src/templates/sections/metric-discovery.md
@@ -4,7 +4,7 @@ Catalog-first for any named business measure or KPI (revenue-, growth-, engageme
 
 This takes precedence over 'Retrieving data' below: for metric/KPI questions, check the catalog before any `query-*` or `execute-sql` call, even when the question maps to a supported insight type.
 
-Before data calls, search `name`, `display_name`, and `description` with terms/synonyms. `exec search` finds tools, not catalog rows.
+Before data calls, search `name`, `display_name`, and `description` with terms/synonyms. `exec search` also returns matching governed metrics with a ready-to-run hint; the SQL below is the exhaustive lookup.
 
 `SELECT name, display_name, description, status, is_drifted FROM system.information_schema.metrics WHERE name ILIKE '%<term>%' OR display_name ILIKE '%<term>%' OR description ILIKE '%<term>%'`
 

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -1,6 +1,7 @@
 import { stringify as stringifyYaml } from 'yaml'
 import { z } from 'zod'
 
+import type { CatalogMetricSummary } from '@/api/client'
 import { markExecPayload, buildToolResultPayload, estimateResponseTokens } from '@/lib/build-tool-result'
 import { isPostHogCodeConsumer } from '@/lib/client-detection'
 import { findRecoverableApiError, PostHogApiError, ToolInputValidationError } from '@/lib/errors'
@@ -8,6 +9,7 @@ import { estimateTokens } from '@/lib/estimate-tokens'
 import { formatResponse } from '@/lib/response'
 
 import type { ExecHelpCatalog } from './exec-help'
+import { searchCatalogMetrics } from './metric-search'
 import { TOKEN_CHAR_LIMIT, listAvailablePaths, resolveSchemaPath, summarizeSchema } from './schema-utils'
 import { isRegexPattern, searchToolsRanked, searchToolsRegex } from './tool-search'
 import type { ScopeGatedTool } from './toolDefinitions'
@@ -63,7 +65,20 @@ export interface ExecToolOptions {
      * re-homed onto `_meta`. Computed from the client profile at the call site.
      */
     isInlineExecUiHost?: boolean
+    /**
+     * Fetches the org's governed-metrics catalog so `exec search` can surface
+     * matching metrics alongside tool matches. Passed only when the
+     * `data-catalog-metric-run` tool is registered (see `resolveExecTool`), so
+     * flag-off orgs get byte-identical search output and zero added latency.
+     * Fail-soft: a rejected fetch must never break tool search.
+     */
+    catalogMetricsProvider?: () => Promise<CatalogMetricSummary[] | undefined>
 }
+
+/** Steering appended to `exec search` results when governed metrics match — routes
+ *  the agent to the canonical run instead of insights or ad-hoc SQL. */
+const GOVERNED_METRICS_SEARCH_HINT =
+    'Governed metrics match. For an approved, non-drifted metric run: call data-catalog-metric-run {"name": "<name>"} — prefer it over searching insights or deriving with SQL.'
 
 function makeExecSchema(commandReference: string): z.ZodObject<{ command: z.ZodString }> {
     return z.object({
@@ -399,9 +414,33 @@ export function createExecTool(
                             .filter((t): t is ScopeGatedTool => t !== undefined)
                     }
 
+                    // Governed metrics are fetched only when the provider is wired
+                    // (data-catalog tool present). Fail-soft: a metrics API error must
+                    // never break tool search. When a metric hits, an existing hint
+                    // (scopes, truncation) stays primary and the run-hint moves to
+                    // `governed_metrics_hint` so neither clobbers the other.
+                    const catalogMetrics = options.catalogMetricsProvider
+                        ? await options.catalogMetricsProvider().catch(() => undefined)
+                        : undefined
+                    const governedMetrics = catalogMetrics?.length ? searchCatalogMetrics(catalogMetrics, rest) : []
+                    const withGovernedMetrics = (base: Record<string, unknown> & { hint?: string }): string => {
+                        if (governedMetrics.length === 0) {
+                            return JSON.stringify(base)
+                        }
+                        return JSON.stringify(
+                            base.hint
+                                ? {
+                                      ...base,
+                                      governed_metrics: governedMetrics,
+                                      governed_metrics_hint: GOVERNED_METRICS_SEARCH_HINT,
+                                  }
+                                : { ...base, governed_metrics: governedMetrics, hint: GOVERNED_METRICS_SEARCH_HINT }
+                        )
+                    }
+
                     if (gatedMatches.length > 0) {
                         const requiredScopes = [...new Set(gatedMatches.flatMap((t) => t.missingScopes))].sort()
-                        return JSON.stringify({
+                        return withGovernedMetrics({
                             matches,
                             scope_gated_matches: gatedMatches.map((t) => ({
                                 name: t.name,
@@ -413,16 +452,32 @@ export function createExecTool(
                         })
                     }
                     if (matches.length === 0) {
+                        // A metric-only match (e.g. "ARR" hits the metric, no tool) must not
+                        // read as a dead end, so the run-hint replaces "no tools matched".
+                        if (governedMetrics.length > 0) {
+                            return JSON.stringify({
+                                matches: [],
+                                governed_metrics: governedMetrics,
+                                hint: GOVERNED_METRICS_SEARCH_HINT,
+                            })
+                        }
                         return JSON.stringify({
                             matches: [],
                             hint: `No tools matched "${rest}". Run "tools" to see all available tool names.`,
                         })
                     }
                     if (truncatedFrom > 0) {
-                        return JSON.stringify({
+                        return withGovernedMetrics({
                             matches,
                             truncated: true,
                             hint: `Showing the top ${MAX_RANKED_SEARCH_RESULTS} of ${truncatedFrom} matches, ranked by relevance. Use a more specific query to narrow the results.`,
+                        })
+                    }
+                    if (governedMetrics.length > 0) {
+                        return JSON.stringify({
+                            matches,
+                            governed_metrics: governedMetrics,
+                            hint: GOVERNED_METRICS_SEARCH_HINT,
                         })
                     }
                     return JSON.stringify(matches)

--- a/services/mcp/src/tools/metric-search.ts
+++ b/services/mcp/src/tools/metric-search.ts
@@ -1,0 +1,50 @@
+/**
+ * Ranks governed-metrics catalog rows for `exec search` (src/tools/exec.ts).
+ *
+ * A metric question ("what's our ARR?") should surface the governed metric next
+ * to the tool matches, so the agent runs `data-catalog-metric-run` instead of
+ * searching insights or deriving with SQL. This reuses the same field-weighted
+ * token ranking as tool search by projecting each metric onto `SearchableTool`
+ * (`display_name` → `title`), so a metric name hit outranks a description hit.
+ */
+
+import type { CatalogMetricSummary } from '@/api/client'
+
+import { searchToolsRanked } from './tool-search'
+
+/** A governed-metric hit returned in the `exec search` result. Carries `status`
+ *  and `is_drifted` so the model still applies the trust rules — only an
+ *  `approved`, non-drifted metric is canonical. */
+export interface GovernedMetricMatch {
+    name: string
+    display_name: string
+    description: string
+    status: string
+    is_drifted: boolean
+}
+
+const MAX_METRIC_SEARCH_RESULTS = 5
+
+export function searchCatalogMetrics(
+    metrics: readonly CatalogMetricSummary[],
+    query: string,
+    limit: number = MAX_METRIC_SEARCH_RESULTS
+): GovernedMetricMatch[] {
+    const searchable = metrics.map((m) => ({
+        name: m.name,
+        title: m.display_name ?? '',
+        description: m.description ?? '',
+    }))
+    const byName = new Map(metrics.map((m) => [m.name, m]))
+    return searchToolsRanked(searchable, query)
+        .slice(0, limit)
+        .map((match) => byName.get(match.name))
+        .filter((m): m is CatalogMetricSummary => m !== undefined)
+        .map((m) => ({
+            name: m.name,
+            display_name: m.display_name,
+            description: m.description,
+            status: m.status,
+            is_drifted: m.is_drifted,
+        }))
+}

--- a/services/mcp/src/tools/types.ts
+++ b/services/mcp/src/tools/types.ts
@@ -1,6 +1,6 @@
 import type { z } from 'zod'
 
-import type { ApiClient, GroupType } from '@/api/client'
+import type { ApiClient, CatalogMetricSummary, GroupType } from '@/api/client'
 import type { Schemas } from '@/api/generated'
 import type { ScopedCache } from '@/lib/cache/ScopedCache'
 import type { AnalyticsEvent } from '@/lib/posthog/analytics'
@@ -34,6 +34,8 @@ export type State = {
 } & Record<PrefixedString<'session'>, SessionState> &
     Record<PrefixedString<'groupTypes'>, GroupType[] | undefined> &
     Record<PrefixedString<'groupTypesFetchedAt'>, number | undefined> &
+    Record<PrefixedString<'catalogMetrics'>, CatalogMetricSummary[] | undefined> &
+    Record<PrefixedString<'catalogMetricsFetchedAt'>, number | undefined> &
     Record<PrefixedString<'cachedUser'>, CachedUser | undefined> &
     Record<PrefixedString<'cachedUserFetchedAt'>, number | undefined> &
     Record<PrefixedString<'cachedOrg'>, CachedOrg | undefined> &

--- a/services/mcp/tests/unit/__snapshots__/instructions/exec-tool-description.txt
+++ b/services/mcp/tests/unit/__snapshots__/instructions/exec-tool-description.txt
@@ -42,5 +42,5 @@ posthog:exec({ "command": "call --json <tool_name> <json_input>" })
 
 **Not supported:**
 
-- `search` matches tool metadata only, not input schemas.
+- `search` does not match input schemas (it ranks tool metadata, plus governed metrics when the catalog is available).
 - No pattern-based field projection — drill one path at a time.

--- a/services/mcp/tests/unit/exec.test.ts
+++ b/services/mcp/tests/unit/exec.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { parse as parseYaml } from 'yaml'
 import { z } from 'zod'
 
+import type { CatalogMetricSummary } from '@/api/client'
 import { PostHogApiError, ToolInputValidationError } from '@/lib/errors'
 import { estimateTokens } from '@/lib/estimate-tokens'
 import { buildQueryToolsBlock, buildToolDomainsCompact } from '@/lib/instructions'
@@ -1149,6 +1150,56 @@ describe('exec tool', () => {
             await expect(exec.handler(mockContext, { command: 'search [invalid' })).rejects.toThrow(
                 /invalid regex pattern/i
             )
+        })
+    })
+
+    describe('governed metrics in search', () => {
+        const mrr: CatalogMetricSummary = {
+            name: 'monthly_recurring_revenue',
+            display_name: 'MRR',
+            description: 'monthly recurring revenue',
+            status: 'approved',
+            is_drifted: false,
+        }
+        const provider = (): Promise<CatalogMetricSummary[]> => Promise.resolve([mrr])
+
+        it('surfaces a matching governed metric with a run hint when no tool matches', async () => {
+            const exec = createExec([makeMockTool()], undefined, { catalogMetricsProvider: provider })
+            const result = JSON.parse((await exec.handler(mockContext, { command: 'search revenue' })) as string)
+            expect(result.matches).toEqual([])
+            expect(result.governed_metrics).toEqual([mrr])
+            expect(result.hint).toContain('data-catalog-metric-run')
+        })
+
+        it('adds governed metrics alongside tool matches without clobbering them', async () => {
+            const revenueTool = makeMockTool({ name: 'revenue-report', description: 'revenue report' })
+            const exec = createExec([revenueTool], undefined, { catalogMetricsProvider: provider })
+            const result = JSON.parse((await exec.handler(mockContext, { command: 'search revenue' })) as string)
+            expect(result.matches).toContain('revenue-report')
+            expect(result.governed_metrics).toEqual([mrr])
+        })
+
+        it('omits governed metrics when nothing in the catalog matches', async () => {
+            const exec = createExec([makeMockTool()], undefined, { catalogMetricsProvider: provider })
+            // 'mock' matches the tool but no metric — result stays the bare-array shape.
+            const result = JSON.parse((await exec.handler(mockContext, { command: 'search mock' })) as string)
+            expect(result).toEqual(['mock-tool'])
+        })
+
+        it('fails soft when the catalog provider rejects', async () => {
+            const failing = (): Promise<CatalogMetricSummary[]> => Promise.reject(new Error('metrics API down'))
+            const exec = createExec([makeMockTool()], undefined, { catalogMetricsProvider: failing })
+            const result = JSON.parse((await exec.handler(mockContext, { command: 'search mock' })) as string)
+            expect(result).toEqual(['mock-tool'])
+        })
+
+        it('leaves search output unchanged when no provider is wired (flag-off)', async () => {
+            const exec = createExec([makeMockTool()])
+            const result = JSON.parse((await exec.handler(mockContext, { command: 'search revenue' })) as string)
+            expect(result).toEqual({
+                matches: [],
+                hint: 'No tools matched "revenue". Run "tools" to see all available tool names.',
+            })
         })
     })
 

--- a/services/mcp/tests/unit/metric-search.test.ts
+++ b/services/mcp/tests/unit/metric-search.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import type { CatalogMetricSummary } from '@/api/client'
+import { searchCatalogMetrics } from '@/tools/metric-search'
+
+function metric(overrides: Partial<CatalogMetricSummary>): CatalogMetricSummary {
+    return {
+        name: 'a_metric',
+        display_name: 'A metric',
+        description: '',
+        status: 'approved',
+        is_drifted: false,
+        ...overrides,
+    }
+}
+
+describe('searchCatalogMetrics', () => {
+    it('ranks a name hit above a description-only hit and carries the trust fields', () => {
+        const metrics = [
+            metric({ name: 'weekly_signups', display_name: 'Weekly signups', description: 'includes revenue context' }),
+            metric({
+                name: 'monthly_recurring_revenue',
+                display_name: 'MRR',
+                description: 'sum of paid bills',
+                status: 'proposed',
+                is_drifted: true,
+            }),
+        ]
+
+        const results = searchCatalogMetrics(metrics, 'revenue')
+
+        expect(results.map((m) => m.name)).toEqual(['monthly_recurring_revenue', 'weekly_signups'])
+        // The trust state travels with the hit so the model can still reject a proposed/drifted metric.
+        expect(results[0]).toMatchObject({ status: 'proposed', is_drifted: true })
+    })
+
+    it('excludes metrics that match no query token', () => {
+        const metrics = [metric({ name: 'monthly_recurring_revenue', display_name: 'MRR', description: 'paid bills' })]
+        expect(searchCatalogMetrics(metrics, 'retention')).toEqual([])
+    })
+
+    it('caps the number of returned matches', () => {
+        const metrics = Array.from({ length: 8 }, (_, i) =>
+            metric({ name: `revenue_metric_${i}`, display_name: 'rev' })
+        )
+        expect(searchCatalogMetrics(metrics, 'revenue', 5)).toHaveLength(5)
+    })
+})


### PR DESCRIPTION
## Problem

In single-exec mode, agents discover capabilities with `exec search "<terms>"` — but it matched tool metadata only, never catalog rows. A metric question ("what's our ARR?") therefore surfaced no governed metrics, and the agent fell back to searching insights or deriving with SQL. Prompt steering alone can be skipped; putting the signal in **tool output** cannot.

This is PR 2 of a 3-PR stack (builds on the prompt fixes in the base PR).

## Changes

- `exec search` now returns matching governed metrics alongside tool matches, with a ready-to-run hint pointing at `data-catalog-metric-run`. New `metric-search.ts` reuses the existing field-weighted tool ranking (metric `display_name` → `title`); proposed/drifted rows carry their `status`/`is_drifted` so trust rules still apply.
- Cached, fail-soft fetch on `StateManager` (`getOrFetchCatalogMetrics`, 10-min TTL, stale-on-error) via a lean `getCatalogMetrics` client method; a metrics-API error can never break tool search.
- Gated in `resolveExecTool`: the provider is passed only when `data-catalog-metric-run` is registered, so flag-off orgs get **byte-identical** search output and zero added latency.
- Extended the eval scorers to credit an `exec search` whose output surfaced `governed_metrics` (so the catalog-lookup ordering scorers still pass when discovery happens via search, not SQL); added the `governed_metric_search_first` eval.
- Inverted the now-stale "search matches tool metadata only" / "finds tools, not catalog rows" prose.

## How did you test this code?

Automated (run by the agent):
- `pnpm --filter=@posthog/mcp test` — full unit suite green.
- New `metric-search.test.ts` (ranking, trust-field passthrough, cap) and `exec.ts` search-integration tests (metric surfacing with run hint, no-clobber alongside tool matches, fail-soft on provider rejection, flag-off byte-identical, no false positives).
- New Python scorer test (`test_eval_scorers.py`) for the search-surfaced-metrics detection (6 cases incl. malformed-JSON fallback, errored search, non-search command).
- `typescript:check` + `pnpm fix` clean. Sandboxed evals **not** run here (Docker/Modal + credentials required).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None (MCP internal behavior).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.8), from the approved plan. Skills: `/writing-tests`, `/writing-evals`.

Decisions:
- When a governed metric matches but an existing hint is present (scope-gated / truncated results), the run-hint moves to a distinct `governed_metrics_hint` key so neither clobbers the other; the metric-only case (query matches no tool) leads with the run-hint instead of "no tools matched".
- 10-min stale cache is acceptable because `data-catalog-metric-run` re-verifies status/drift server-side at run time.

Note: stack is behind `origin/master` (OpenAPI-drift advisory) — will be cleared by a restack/merge before ready.
