### PR TITLE
fix(cdp): use endpoint-specific logo.dev credentials

### DIFF
--- a/nodejs/src/cdp/segment/sync-segment-icons.ts
+++ b/nodejs/src/cdp/segment/sync-segment-icons.ts
@@ -4,12 +4,20 @@ import { join } from 'path'
 import { SEGMENT_DESTINATIONS } from './segment-templates'
 
 // Script to store the segment icons in the static folder
+const logoDevPublishableKey = process.env.LOGO_DEV_PUBLISHABLE_KEY ?? process.env.LOGO_DEV_TOKEN
+
+if (!logoDevPublishableKey?.startsWith('pk_')) {
+    throw new Error('Set LOGO_DEV_PUBLISHABLE_KEY to a logo.dev publishable key')
+}
 
 void SEGMENT_DESTINATIONS.map(async ({ template }) => {
     const iconId = template.icon_url?.replace('/static/services/', '')
 
     // eslint-disable-next-line no-restricted-globals
-    const res = await fetch(`https://img.logo.dev/${iconId}?token=${process.env.LOGO_DEV_TOKEN}`)
+    const res = await fetch(`https://img.logo.dev/${iconId}?token=${logoDevPublishableKey}`)
+    if (!res.ok || !res.headers.get('content-type')?.startsWith('image/')) {
+        throw new Error(`logo.dev returned an invalid image response for ${iconId} (${res.status})`)
+    }
     const buffer = await res.arrayBuffer()
 
     // Ensure directory exists

--- a/posthog/cdp/services/icons.py
+++ b/posthog/cdp/services/icons.py
@@ -1,17 +1,23 @@
 import re
 from base64 import b64encode
+from typing import NoReturn, cast
 
 from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponse
 
-from rest_framework.exceptions import NotFound
+import requests
+import structlog
+from rest_framework import status
+from rest_framework.exceptions import APIException, NotFound
 
 from posthog.egress.limiter.outbound import get_outbound_rate_limiter
 from posthog.egress.limiter.policies import Priority, RatePolicy, register_policy
 from posthog.egress.logodev.transport import LogoDevEgressBudgetExhausted, logodev_request
 
 ICON_CACHE_SECONDS = 60 * 60 * 24
+
+logger = structlog.get_logger(__name__)
 
 # Per-team fairness gate in front of the instance-wide logo.dev account budget. Icon domains and
 # search queries are caller-supplied and only definitive misses are cached, so without a per-team
@@ -53,54 +59,103 @@ _ALLOWED_THEMES: frozenset[str | None] = frozenset({None, "dark", "light"})
 _ALLOWED_FALLBACKS: frozenset[str] = frozenset({"monogram", "404"})
 
 
-class CDPIconsService:
-    @property
-    def supported(self) -> bool:
-        return bool(settings.LOGO_DEV_TOKEN)
+class LogoDevBadGateway(APIException):
+    status_code = status.HTTP_502_BAD_GATEWAY
+    default_detail = "The logo provider returned an invalid response."
+    default_code = "logo_provider_error"
 
+
+class LogoDevUnavailable(APIException):
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_detail = "The logo provider is temporarily unavailable."
+    default_code = "logo_provider_unavailable"
+
+
+def _parse_search_results(payload: object, icon_url_base: str) -> list[dict[str, str]] | None:
+    if not isinstance(payload, list):
+        return None
+
+    results: list[dict[str, str]] = []
+    for raw_item in cast(list[object], payload):
+        if not isinstance(raw_item, dict):
+            continue
+        item = cast(dict[object, object], raw_item)
+        domain = item.get("domain")
+        name = item.get("name")
+        if not isinstance(domain, str) or not isinstance(name, str):
+            continue
+        domain = domain.lower()
+        if len(domain) > _MAX_DOMAIN_LENGTH or not _DOMAIN_RE.match(domain):
+            continue
+        results.append({"id": domain, "name": name, "url": f"{icon_url_base}{domain}"})
+
+    return results
+
+
+def _raise_icon_provider_error(status_code: int) -> NoReturn:
+    logger.warning("logodev_icon_request_failed", status_code=status_code)
+    if status_code == status.HTTP_429_TOO_MANY_REQUESTS or status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR:
+        raise LogoDevUnavailable()
+    raise LogoDevBadGateway()
+
+
+class CDPIconsService:
     def list_icons(self, query: str, icon_url_base: str, *, team_id: int) -> list[dict[str, str]]:
-        if not self.supported:
+        secret_key = settings.LOGO_DEV_SECRET_KEY
+        if not secret_key:
+            return []
+        if not secret_key.startswith("sk_"):
+            logger.warning("logodev_configuration_invalid", credential_type="secret_key")
             return []
 
         cache_key = f"@cdp/list_icons/{b64encode(query.encode()).decode()}"
-        data = cache.get(cache_key)
+        cached_data: list[dict[str, str]] | None = cache.get(cache_key)
 
+        if cached_data is not None:
+            return cached_data
+
+        # Queries are free-text, so cached entries don't bound upstream volume — gate uncached
+        # searches on the caller's team budget before they reach the shared account budget.
+        if not _consume_team_icon_budget(team_id):
+            return []
+        try:
+            # NORMAL: a typeahead search degrades to no results when the shared budget is tight.
+            res = logodev_request(
+                "GET",
+                "https://api.logo.dev/search",
+                source="cdp_icons",
+                priority=Priority.NORMAL,
+                headers={"Authorization": f"Bearer {secret_key}"},
+                params={"q": query},
+                timeout=10,
+            )
+        except LogoDevEgressBudgetExhausted:
+            return []
+        except requests.RequestException:
+            logger.warning("logodev_search_request_failed", failure_type="transport")
+            return []
+
+        if res.status_code != status.HTTP_200_OK:
+            logger.warning("logodev_search_request_failed", status_code=res.status_code)
+            return []
+
+        try:
+            payload: object = res.json()
+        except requests.exceptions.JSONDecodeError:
+            logger.warning("logodev_search_request_failed", failure_type="invalid_json")
+            return []
+
+        data = _parse_search_results(payload, icon_url_base)
         if data is None:
-            # Queries are free-text, so cached entries don't bound upstream volume — gate uncached
-            # searches on the caller's team budget before they reach the shared account budget.
-            if not _consume_team_icon_budget(team_id):
-                return []
-            try:
-                # NORMAL: a typeahead search degrades to no results when the shared budget is tight.
-                res = logodev_request(
-                    "GET",
-                    "https://search.logo.dev/api/icons",
-                    source="cdp_icons",
-                    priority=Priority.NORMAL,
-                    params={"token": settings.LOGO_DEV_TOKEN, "query": query},
-                    timeout=10,
-                )
-            except LogoDevEgressBudgetExhausted:
-                return []
+            logger.warning("logodev_search_request_failed", failure_type="invalid_schema")
+            return []
 
-            data = [
-                {
-                    "id": item["domain"],
-                    "name": item["name"],
-                    "url": f"{icon_url_base}{item['domain']}",
-                }
-                for item in res.json() or []
-            ]
-
-            cache.set(cache_key, data, ICON_CACHE_SECONDS)
-
+        cache.set(cache_key, data, ICON_CACHE_SECONDS)
         return data
 
     def get_icon_http_response(
         self, id: str, theme: str | None = None, fallback: str = "monogram", *, team_id: int
     ) -> HttpResponse:
-        if not self.supported:
-            raise NotFound()
         if theme not in _ALLOWED_THEMES:
             raise ValueError(f"Unsupported logo.dev theme: {theme!r}")
         if fallback not in _ALLOWED_FALLBACKS:
@@ -112,6 +167,13 @@ class CDPIconsService:
         domain = id.lower()
         if len(domain) > _MAX_DOMAIN_LENGTH or not _DOMAIN_RE.match(domain):
             raise NotFound()
+
+        publishable_key = settings.LOGO_DEV_PUBLISHABLE_KEY
+        if not publishable_key:
+            raise LogoDevUnavailable("The logo provider is not configured.")
+        if not publishable_key.startswith("pk_"):
+            logger.warning("logodev_configuration_invalid", credential_type="publishable_key")
+            raise LogoDevUnavailable("The logo provider is configured with an invalid publishable key.")
 
         # Only the *fact* of a definitive miss is ever cached. Logo bytes must not be stored on our
         # infrastructure — logo.dev gates that behind a data-caching license our plan doesn't
@@ -125,10 +187,10 @@ class CDPIconsService:
         # Unique domains bypass the miss cache by construction, so gate the uncached fetch on the
         # caller's team budget. Transient and uncached, like account-budget exhaustion below.
         if not _consume_team_icon_budget(team_id):
-            raise NotFound()
+            raise LogoDevUnavailable()
 
         params = {
-            "token": settings.LOGO_DEV_TOKEN,
+            "token": publishable_key,
             # PNG keeps the logo's transparency — the jpg default flattens it onto a white tile.
             "format": "png",
             "retina": "true",
@@ -149,7 +211,10 @@ class CDPIconsService:
             )
         except LogoDevEgressBudgetExhausted:
             # Transient and uncached — the next render retries once the budget window rolls over.
-            raise NotFound() from None
+            raise LogoDevUnavailable() from None
+        except requests.RequestException:
+            logger.warning("logodev_icon_request_failed", failure_type="transport")
+            raise LogoDevUnavailable() from None
         if res.status_code == 404 and fallback == "404":
             # A definitive "no logo for this domain" — cache the miss so rendering an unknown
             # domain doesn't re-proxy to logo.dev for a day. Other upstream errors are treated
@@ -157,12 +222,13 @@ class CDPIconsService:
             cache.set(miss_cache_key, True, ICON_CACHE_SECONDS)
             raise NotFound()
         if res.status_code != 200:
-            raise NotFound()
+            _raise_icon_provider_error(res.status_code)
         content_type = res.headers.get("Content-Type", "image/png")
         if not content_type.startswith("image/"):
             # A 200 that isn't an image (upstream anomaly, error page) must not be proxied from
             # our origin.
-            raise NotFound()
+            logger.warning("logodev_icon_request_failed", failure_type="non_image_response")
+            raise LogoDevBadGateway()
 
         response = HttpResponse(res.content, content_type=content_type)
         # Public brand assets — browser caching is the only dedup layer, so honor logo.dev's own

--- a/posthog/cdp/test/test_icons.py
+++ b/posthog/cdp/test/test_icons.py
@@ -1,3 +1,4 @@
+import json
 import time
 from itertools import count
 
@@ -9,9 +10,10 @@ from django.test import SimpleTestCase, override_settings
 import requests
 from parameterized import parameterized
 from requests.structures import CaseInsensitiveDict
-from rest_framework.exceptions import NotFound
+from rest_framework import status
+from rest_framework.exceptions import APIException, NotFound
 
-from posthog.cdp.services.icons import CDPIconsService
+from posthog.cdp.services.icons import CDPIconsService, LogoDevBadGateway, LogoDevUnavailable
 from posthog.egress.limiter.outbound import get_outbound_rate_limiter
 
 # Fresh team id per test (and per run) so consuming the real per-team budget never accumulates
@@ -24,6 +26,7 @@ def _response(
     content: bytes = b"",
     content_type: str = "image/png",
     cache_control: str | None = None,
+    url: str = "https://img.logo.dev/linear.app",
 ) -> requests.Response:
     response = requests.models.Response()
     response.status_code = status
@@ -33,12 +36,20 @@ def _response(
         response.headers["Cache-Control"] = cache_control
     prepared = requests.models.PreparedRequest()
     prepared.method = "GET"
-    prepared.url = "https://img.logo.dev/linear.app"
+    prepared.url = url
     response.request = prepared
     return response
 
 
-@override_settings(LOGO_DEV_TOKEN="test-token")
+def _search_response(payload: object) -> requests.Response:
+    return _response(
+        content=json.dumps(payload).encode(),
+        content_type="application/json",
+        url="https://api.logo.dev/search",
+    )
+
+
+@override_settings(LOGO_DEV_PUBLISHABLE_KEY="pk_test", LOGO_DEV_SECRET_KEY="sk_test")
 class TestCDPIconsService(SimpleTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -71,23 +82,32 @@ class TestCDPIconsService(SimpleTestCase):
 
     @parameterized.expand(
         [
-            ("server_error", 500, "image/png"),
-            ("non_image_200", 200, "text/html"),
+            ("unauthorized", 401, "image/png", LogoDevBadGateway, status.HTTP_502_BAD_GATEWAY),
+            ("server_error", 500, "image/png", LogoDevUnavailable, status.HTTP_503_SERVICE_UNAVAILABLE),
+            ("non_image_200", 200, "text/html", LogoDevBadGateway, status.HTTP_502_BAD_GATEWAY),
         ]
     )
-    def test_bad_upstream_response_raises_not_found_and_is_not_cached(
-        self, _name: str, status: int, content_type: str
+    def test_bad_upstream_response_raises_provider_error_and_is_not_cached(
+        self,
+        _name: str,
+        upstream_status: int,
+        content_type: str,
+        expected_exception: type[APIException],
+        expected_status: int,
     ) -> None:
         # A logo.dev error body — or a 200 that isn't an image — must not be proxied through from
-        # our origin, nor mint a 24h miss entry for a transient failure.
+        # our origin, masquerade as a missing logo, or mint a 24h miss entry.
         with (
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
             patch(
-                "requests.request", return_value=_response(status=status, content=b"boom", content_type=content_type)
+                "requests.request",
+                return_value=_response(status=upstream_status, content=b"boom", content_type=content_type),
             ),
         ):
-            with self.assertRaises(NotFound):
+            with self.assertRaises(expected_exception) as raised:
                 self.service.get_icon_http_response("linear.app", team_id=self.team_id)
+
+        assert raised.exception.status_code == expected_status
 
         with (
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
@@ -160,25 +180,26 @@ class TestCDPIconsService(SimpleTestCase):
         assert params["retina"] == "true"
         assert params["fallback"] == "404"
         assert params["theme"] == "dark"
+        assert params["token"] == "pk_test"
 
     @parameterized.expand(
         [
-            ("definitive_miss_is_cached", "404", 1),
-            ("monogram_mode_stays_transient", "monogram", 2),
+            ("definitive_miss_is_cached", "404", NotFound, 1),
+            ("monogram_mode_is_provider_error", "monogram", LogoDevBadGateway, 2),
         ]
     )
-    def test_upstream_404_caching_depends_on_fallback_mode(
-        self, _name: str, fallback: str, expected_calls: int
+    def test_upstream_404_is_only_not_found_and_cached_in_404_fallback_mode(
+        self, _name: str, fallback: str, expected_exception: type[Exception], expected_calls: int
     ) -> None:
         # With fallback="404" a miss is a definitive answer — without negative caching, every
-        # render of an unknown domain would re-proxy to logo.dev. Monogram-mode 404s are
-        # anomalies and must stay transient (uncached), as before.
+        # render of an unknown domain would re-proxy to logo.dev. A monogram-mode 404 is an
+        # upstream anomaly, so it is reported as a provider error and stays transient.
         with (
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
             patch("requests.request", return_value=_response(status=404)) as upstream,
         ):
             for _ in range(2):
-                with self.assertRaises(NotFound):
+                with self.assertRaises(expected_exception):
                     self.service.get_icon_http_response("unknown.example", fallback=fallback, team_id=self.team_id)
 
         assert upstream.call_count == expected_calls
@@ -200,7 +221,7 @@ class TestCDPIconsService(SimpleTestCase):
         assert upstream.call_count == 2
         assert monogram.content == b"monogram-png"
 
-    def test_icon_fetch_degrades_to_not_found_when_budget_exhausted(self) -> None:
+    def test_icon_fetch_reports_unavailable_when_budget_exhausted(self) -> None:
         # The icon id is user-controlled, so the fetch runs on a sheddable lane: an exhausted
         # budget must stop upstream calls, not proceed as an advisory limit. Nothing is cached,
         # so the next render retries once the budget window rolls over.
@@ -208,7 +229,7 @@ class TestCDPIconsService(SimpleTestCase):
             patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=False),
             patch("requests.request") as upstream,
         ):
-            with self.assertRaises(NotFound):
+            with self.assertRaises(LogoDevUnavailable):
                 self.service.get_icon_http_response("linear.app", team_id=self.team_id)
 
         upstream.assert_not_called()
@@ -233,7 +254,56 @@ class TestCDPIconsService(SimpleTestCase):
 
         upstream.assert_not_called()
 
-    def test_icon_fetch_degrades_to_not_found_when_team_budget_exhausted(self) -> None:
+    def test_search_uses_secret_key_and_current_api_contract(self) -> None:
+        # The image CDN and Search API use different hosts, parameter names, and credential types.
+        # Reusing the image contract here previously turned the provider's HTML error into a 500.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch(
+                "requests.request",
+                return_value=_search_response([{"name": "Linear", "domain": "linear.app"}]),
+            ) as upstream,
+        ):
+            icons = self.service.list_icons("linear", icon_url_base="/base?id=", team_id=self.team_id)
+
+        assert icons == [{"id": "linear.app", "name": "Linear", "url": "/base?id=linear.app"}]
+        assert upstream.call_args.args == ("GET", "https://api.logo.dev/search")
+        assert upstream.call_args.kwargs["headers"] == {"Authorization": "Bearer sk_test"}
+        assert upstream.call_args.kwargs["params"] == {"q": "linear"}
+
+    @parameterized.expand(
+        [
+            ("provider_error", _response(status=530, content_type="text/html")),
+            ("invalid_json", _response(content=b"not-json", content_type="text/html")),
+            ("invalid_schema", _search_response({"results": []})),
+        ]
+    )
+    def test_search_provider_failure_degrades_without_caching(
+        self, _name: str, failed_response: requests.Response
+    ) -> None:
+        # Provider failures must not become endpoint 500s or cache an empty result for a day.
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch(
+                "requests.request",
+                side_effect=[failed_response, _search_response([{"name": "Linear", "domain": "linear.app"}])],
+            ) as upstream,
+        ):
+            failed = self.service.list_icons("linear", icon_url_base="/base?id=", team_id=self.team_id)
+            recovered = self.service.list_icons("linear", icon_url_base="/base?id=", team_id=self.team_id)
+
+        assert failed == []
+        assert recovered == [{"id": "linear.app", "name": "Linear", "url": "/base?id=linear.app"}]
+        assert upstream.call_count == 2
+
+    def test_search_transport_failure_degrades_to_empty(self) -> None:
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request", side_effect=requests.ConnectionError),
+        ):
+            assert self.service.list_icons("linear", icon_url_base="/base?id=", team_id=self.team_id) == []
+
+    def test_icon_fetch_reports_unavailable_when_team_budget_exhausted(self) -> None:
         # The account budget is instance-wide, so the per-team gate is what stops one team's
         # arbitrary-domain requests from blanking icons for every other team. Denial must be
         # charged to the calling team's own key, stay uncached, and never reach upstream.
@@ -242,7 +312,7 @@ class TestCDPIconsService(SimpleTestCase):
             patch("requests.request") as upstream,
         ):
             limiter.return_value.consume_sync.return_value = False
-            with self.assertRaises(NotFound):
+            with self.assertRaises(LogoDevUnavailable):
                 self.service.get_icon_http_response("linear.app", team_id=self.team_id)
 
         upstream.assert_not_called()
@@ -256,6 +326,33 @@ class TestCDPIconsService(SimpleTestCase):
 
         assert upstream.call_count == 1
         assert recovered.content == b"png-bytes"
+
+    @parameterized.expand([("missing", ""), ("wrong_type", "sk_wrong_type")])
+    def test_icon_fetch_rejects_invalid_configuration_without_upstream_call(
+        self, _name: str, publishable_key: str
+    ) -> None:
+        with override_settings(LOGO_DEV_PUBLISHABLE_KEY=publishable_key):
+            with patch("requests.request") as upstream:
+                with self.assertRaises(LogoDevUnavailable):
+                    self.service.get_icon_http_response("linear.app", team_id=self.team_id)
+
+        upstream.assert_not_called()
+
+    @parameterized.expand([("missing", ""), ("wrong_type", "pk_wrong_type")])
+    def test_search_rejects_invalid_configuration_without_upstream_call(self, _name: str, secret_key: str) -> None:
+        with override_settings(LOGO_DEV_SECRET_KEY=secret_key):
+            with patch("requests.request") as upstream:
+                assert self.service.list_icons("linear", icon_url_base="/base?id=", team_id=self.team_id) == []
+
+        upstream.assert_not_called()
+
+    def test_icon_transport_failure_reports_unavailable(self) -> None:
+        with (
+            patch("posthog.egress.logodev.transport.consume_logodev_sync", return_value=True),
+            patch("requests.request", side_effect=requests.ConnectionError),
+        ):
+            with self.assertRaises(LogoDevUnavailable):
+                self.service.get_icon_http_response("linear.app", team_id=self.team_id)
 
     def test_search_degrades_to_empty_when_team_budget_exhausted(self) -> None:
         # Search queries are free text — the same per-team gate must cover them or a team could

--- a/posthog/egress/README.md
+++ b/posthog/egress/README.md
@@ -48,7 +48,9 @@ GitHub meters its REST resources on **separate per-installation counters**, so i
 The two search budgets are static because GitHub's search rate limits are fixed regardless of the account's plan tier, so there is no tier to observe (unlike core).
 Budgets stay deliberately under the real ceiling so reactive backoff absorbs drift (clock skew, multi-process races, untracked PAT traffic on the same account).
 
-logo.dev (`logodev/`) meters per account token, and each instance holds exactly one (`LOGO_DEV_TOKEN`), so a single `logodev` domain carries one instance-wide budget under a constant scope.
+logo.dev (`logodev/`) meters per account, so a single `logodev` domain carries one instance-wide budget under a constant scope.
+Image CDN requests use `LOGO_DEV_PUBLISHABLE_KEY` (a `pk_` key) as a query parameter, while Search API requests use `LOGO_DEV_SECRET_KEY` (an `sk_` key) as a bearer token.
+`LOGO_DEV_TOKEN` is a deprecated compatibility fallback for image requests only and is never used to authenticate Search API requests.
 logo.dev publishes no rate-limit numbers, so the budgets are static operator ceilings read from settings at acquire time: `LOGODEV_EGRESS_PER_MINUTE_BUDGET` (default 300) smooths bursts and `LOGODEV_EGRESS_HOURLY_BUDGET` (default 5,000) caps total spend.
 Every logo.dev call runs on a sheddable lane — the icon id is user-controlled, so nothing in this domain runs `CRITICAL`.
 Icon bytes are never stored server-side (logo.dev licenses that separately), so steady-state traffic is deduped only by browser caching (`posthog/cdp/services/icons.py` sets `Cache-Control`) and tracks unique (user, icon) first views per day — raise the settings if that outgrows the defaults.

--- a/posthog/egress/logodev/limiter.py
+++ b/posthog/egress/logodev/limiter.py
@@ -1,7 +1,7 @@
 """logo.dev egress budget.
 
-logo.dev meters usage per account token, and each PostHog instance holds exactly one
-(``settings.LOGO_DEV_TOKEN``), so the whole instance draws from a single shared budget under a
+logo.dev meters usage per account, and each PostHog instance configures the image and Search API
+credentials from that account, so the whole instance draws from a single shared budget under a
 constant scope. logo.dev publishes no hard rate-limit numbers, so the defaults are deliberately
 modest operator ceilings. Icon bytes are never stored server-side (logo.dev gates that behind a
 data-caching license), so upstream volume is deduped only per user, by the browser caching that

--- a/posthog/egress/logodev/transport.py
+++ b/posthog/egress/logodev/transport.py
@@ -1,8 +1,9 @@
 """logo.dev incarnation of the egress transport.
 
 ``logodev_request`` is the one way to call logo.dev from anywhere in the codebase: it gates on the
-instance's shared account budget and records telemetry by construction. The caller owns auth —
-logo.dev takes the token as a ``token`` query parameter, so pass it via ``params``.
+instance's shared account budget and records telemetry by construction. The caller owns the
+endpoint-specific auth: image requests use a publishable key query parameter, while Search API
+requests use a secret key bearer token.
 """
 
 from typing import Any
@@ -59,8 +60,8 @@ def logodev_request(
     timeout: float | tuple[float, float] | None = None,
     **kwargs: Any,
 ) -> requests.Response:
-    """Make a gated, recorded logo.dev request. ``source`` attributes the call to a subsystem; pass
-    the account token via ``params`` (logo.dev's auth is a query parameter, not a header)."""
+    """Make a gated, recorded logo.dev request. ``source`` attributes the call to a subsystem;
+    callers pass the authentication required by their selected logo.dev endpoint."""
     return _logodev_client.request(
         method,
         url,

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -926,7 +926,11 @@ DOMAIN_CONNECT_KEY_ID: str = os.getenv("DOMAIN_CONNECT_KEY_ID", "_dcpubkeyv1")
 ####
 # CDP
 
+# Deprecated compatibility fallback for the image CDN. New deployments should configure the
+# API-specific credentials below so a publishable key can never be reused for authenticated API calls.
 LOGO_DEV_TOKEN = get_from_env("LOGO_DEV_TOKEN", "")
+LOGO_DEV_PUBLISHABLE_KEY = get_from_env("LOGO_DEV_PUBLISHABLE_KEY", LOGO_DEV_TOKEN)
+LOGO_DEV_SECRET_KEY = get_from_env("LOGO_DEV_SECRET_KEY", "")
 
 ####
 # Feature flag billing analytics

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -62,10 +62,11 @@ Domains without a logo return 404 and the UI falls back to a generic server glyp
 
 ### Self-hosted instances
 
-Icon resolution requires the `LOGO_DEV_TOKEN` environment variable and outbound network access to `img.logo.dev`.
-Without the token, which is the default on self-hosted and air-gapped deployments, the icon endpoint returns 404 and the UI falls back to the generic glyph.
+Icon resolution requires a logo.dev publishable key in the `LOGO_DEV_PUBLISHABLE_KEY` environment variable and outbound network access to `img.logo.dev`.
+Without the key, which is the default on self-hosted and air-gapped deployments, the icon endpoint returns 503 and the UI falls back to the generic glyph.
 This is cosmetic only: installing and using MCP servers works the same without icons.
-To show brand icons on a self-hosted instance, create a logo.dev account, generate an API token, and set `LOGO_DEV_TOKEN` in the web service environment.
+To show brand icons on a self-hosted instance, create a logo.dev account, generate a publishable key with the `pk_` prefix, and set `LOGO_DEV_PUBLISHABLE_KEY` in the web service environment.
+`LOGO_DEV_TOKEN` remains a deprecated compatibility fallback for the image CDN only.
 
 ## Auth models
 


### PR DESCRIPTION
## Problem

Logo.dev uses separate credential contracts for its image CDN and Search API. The shared `LOGO_DEV_TOKEN` setting was sent to both endpoints, while icon search also used a legacy host and parsed every response as JSON. This could hide image authentication failures behind 404 responses and turn non-JSON search failures into endpoint 500s.

## Changes

- Add `LOGO_DEV_PUBLISHABLE_KEY` for `img.logo.dev` and `LOGO_DEV_SECRET_KEY` for the Search API, with prefix validation. The deprecated `LOGO_DEV_TOKEN` remains an image-only compatibility fallback.
- Move search to `https://api.logo.dev/search` with the documented `q` parameter and secret-key bearer authentication.
- Treat only a definitive image miss as 404. Provider, configuration, transport, and rate-limit failures now return 502 or 503 and emit structured status/failure metadata without response bodies or credentials.
- Make search failures degrade to an uncached empty result and validate the returned schema before building proxy URLs.
- Update the Segment icon sync script and operator documentation for the split credentials.

Before:

```mermaid
flowchart LR
    Caller[PostHog logo callers] --> Shared[LOGO_DEV_TOKEN]
    Shared --> Image[img.logo.dev]
    Shared --> Legacy[search.logo.dev/api/icons]
    Legacy --> Parse[Unconditional JSON parsing]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Caller phYellow;
    class Shared phGray;
    class Image,Legacy phRed;
    class Parse phBlue;
```

After:

```mermaid
flowchart LR
    Caller[PostHog logo callers] --> Publishable[LOGO_DEV_PUBLISHABLE_KEY]
    Caller --> Secret[LOGO_DEV_SECRET_KEY]
    Publishable --> Image[img.logo.dev]
    Secret --> Search[api.logo.dev/search]
    Image --> Validation[Status and content validation]
    Search --> Validation
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Caller phYellow;
    class Publishable,Secret phGray;
    class Image,Search phRed;
    class Validation phBlue;
```

> [!WARNING]
> Deployments need a logo.dev `pk_` key for image resolution and an `sk_` key for icon search. The legacy setting can only supply the image key.

## How did you test this code?

- `./bin/hogli test posthog/cdp/test/test_icons.py` - 32 passed. The coverage catches the current Search API request contract, credential-type mixups, non-JSON/provider failures, transport failures, and image 404 vs. 502/503 semantics.
- `.flox/cache/venv/bin/ruff check ...` and `ruff format --check ...` on all changed Python files.
- `pnpm --filter=@posthog/nodejs exec prettier --write src/cdp/segment/sync-segment-icons.ts`.
- `pnpm --filter=@posthog/nodejs exec eslint src/cdp/segment/sync-segment-icons.ts`.
- `./bin/hogli ci:preflight --fix` - no failures.
- `.flox/cache/venv/bin/mypy --cache-fine-grained .` - no issues across 16,634 source files.
- `pnpm --filter=@posthog/nodejs typescript:check` could not resolve pre-existing unbuilt workspace package outputs in this worktree. The changed script passed its focused formatter and linter.

No manual UI testing was performed.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated the MCP store self-hosting guide and egress documentation with the new settings, key types, compatibility behavior, and failure status.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex desktop implemented and verified the change in a local worktree; this local task has no shareable session URL. I invoked `/implementing-mcp-tools` and `/writing-tests`. I kept the legacy setting as an image-only migration fallback, while requiring the secret key to be explicit so the two Logo.dev authentication contracts cannot be mixed again.
