### PR TITLE
feat(mcp): add property-definition-update tool

### DIFF
--- a/frontend/src/lib/agentScopes.generated.ts
+++ b/frontend/src/lib/agentScopes.generated.ts
@@ -95,6 +95,7 @@ export const AGENT_USE_CASE_SCOPES = [
     'project:read',
     'project:write',
     'property_definition:read',
+    'property_definition:write',
     'query:read',
     'replay_scanner:read',
     'replay_scanner:write',

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -7355,6 +7355,20 @@
             "readOnlyHint": true
         }
     },
+    "property-definition-update": {
+        "description": "Update property definition metadata. Can update description, tags, property type (DateTime, String, Numeric, Boolean, Duration), and mark status as verified or hidden. Use the exact property name like '$browser' or 'plan_type'. Pass 'type' to target event, person, group, or session properties (defaults to event); for group properties also pass 'groupTypeIndex'.",
+        "category": "Events & properties",
+        "feature": "events",
+        "summary": "Update a property definition's metadata.",
+        "title": "Update property definition",
+        "required_scopes": ["property_definition:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "proxy-create": {
         "description": "Create a new managed reverse proxy for a custom domain. Provide the domain (e.g. 'e.example.com') that will proxy requests to PostHog. The response includes the CNAME target — the user must add a CNAME DNS record pointing their domain to this target. Once DNS propagates, the proxy is automatically verified and an SSL certificate is issued. The proxy starts in 'waiting' status until DNS is verified.",
         "category": "Reverse proxy",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -7356,7 +7356,7 @@
         }
     },
     "property-definition-update": {
-        "description": "Update property definition metadata. Can update description, tags, property type (DateTime, String, Numeric, Boolean, Duration), and mark status as verified or hidden. Use the exact property name like '$browser' or 'plan_type'. Pass 'type' to target event, person, group, or session properties (defaults to event); for group properties also pass 'groupTypeIndex'.",
+        "description": "Update property definition metadata. Can update description, tags, property type (DateTime, String, Numeric, Boolean, Duration), and mark status as verified or hidden. Use the exact property name like '$browser' or 'plan_type'. Pass 'type' to target event, person, group, or session properties (defaults to event); for group properties also pass 'groupTypeIndex'. Note: passing 'tags' replaces the property's entire tag list rather than merging, so include any existing tags you want to keep.",
         "category": "Events & properties",
         "feature": "events",
         "summary": "Update a property definition's metadata.",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -436,7 +436,7 @@
         }
     },
     "property-definition-update": {
-        "description": "Update property definition metadata. Can update description, tags, property type (DateTime, String, Numeric, Boolean, Duration), and mark status as verified or hidden. Use the exact property name like '$browser' or 'plan_type'. Pass 'type' to target event, person, group, or session properties (defaults to event); for group properties also pass 'groupTypeIndex'.",
+        "description": "Update property definition metadata. Can update description, tags, property type (DateTime, String, Numeric, Boolean, Duration), and mark status as verified or hidden. Use the exact property name like '$browser' or 'plan_type'. Pass 'type' to target event, person, group, or session properties (defaults to event); for group properties also pass 'groupTypeIndex'. Note: passing 'tags' replaces the property's entire tag list rather than merging, so include any existing tags you want to keep.",
         "category": "Events & properties",
         "feature": "events",
         "summary": "Update a property definition's metadata.",

--- a/services/mcp/schema/tool-definitions.json
+++ b/services/mcp/schema/tool-definitions.json
@@ -435,6 +435,20 @@
             "readOnlyHint": false
         }
     },
+    "property-definition-update": {
+        "description": "Update property definition metadata. Can update description, tags, property type (DateTime, String, Numeric, Boolean, Duration), and mark status as verified or hidden. Use the exact property name like '$browser' or 'plan_type'. Pass 'type' to target event, person, group, or session properties (defaults to event); for group properties also pass 'groupTypeIndex'.",
+        "category": "Events & properties",
+        "feature": "events",
+        "summary": "Update a property definition's metadata.",
+        "title": "Update property definition",
+        "required_scopes": ["property_definition:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
     "path-cleaning-rules-update": {
         "description": "Safely add, replace, remove, or reorder a project's path cleaning rules (Team.path_cleaning_filters) without hand-managing the whole list. Reads the current rules, applies your ordered operations, auto-numbers them, and (unless confirm:true) returns a PREVIEW of the resulting rules — plus how they rewrite any sample_paths — without saving. Path cleaning normalizes $pathname/$entry_pathname so pages sharing a template (/users/123, /users/456) collapse into one row (/users/<id>) in Web analytics, Paths, and apply_path_cleaning HogQL. Prefer this over project-settings-update for path cleaning: it avoids clobbering existing rules and renumbering by hand. Rules apply sequentially (order matters) and globally wherever cleaning is enabled, changing historical numbers — surface the preview to the user, then re-run with confirm:true.",
         "category": "Web analytics",

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -758,6 +758,87 @@
                 }
             }
         },
+        "PropertyDefinitionUpdateInputSchema": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "Description explaining what the property represents",
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "Tags to organize properties by product area (e.g. \"checkout\", \"onboarding\") or user journey stage (e.g. \"acquisition\", \"activation\", \"monetization\", \"retention\")",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "property_type": {
+                    "description": "The data type of the property. Controls how the property is parsed, displayed, and filtered.",
+                    "type": "string",
+                    "enum": ["DateTime", "String", "Numeric", "Boolean", "Duration"]
+                },
+                "verified": {
+                    "description": "Mark as verified to indicate the property is correctly instrumented and safe to use",
+                    "type": "boolean"
+                },
+                "hidden": {
+                    "description": "Mark property as no longer used. Hides it from the UI while preserving historical data",
+                    "type": "boolean"
+                }
+            }
+        },
+        "PropertyDefinitionUpdateSchema": {
+            "type": "object",
+            "properties": {
+                "propertyName": {
+                    "type": "string",
+                    "description": "The exact name of the property to update (e.g. \"$browser\", \"plan_type\")"
+                },
+                "type": {
+                    "default": "event",
+                    "description": "Which property taxonomy the property belongs to. Defaults to \"event\" (event properties).",
+                    "type": "string",
+                    "enum": ["event", "person", "group", "session"]
+                },
+                "groupTypeIndex": {
+                    "description": "Required when type is \"group\": the zero-based index of the group type the property belongs to.",
+                    "type": "integer",
+                    "minimum": -9007199254740991,
+                    "maximum": 9007199254740991
+                },
+                "data": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "description": "Description explaining what the property represents",
+                            "type": "string"
+                        },
+                        "tags": {
+                            "description": "Tags to organize properties by product area (e.g. \"checkout\", \"onboarding\") or user journey stage (e.g. \"acquisition\", \"activation\", \"monetization\", \"retention\")",
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "property_type": {
+                            "description": "The data type of the property. Controls how the property is parsed, displayed, and filtered.",
+                            "type": "string",
+                            "enum": ["DateTime", "String", "Numeric", "Boolean", "Duration"]
+                        },
+                        "verified": {
+                            "description": "Mark as verified to indicate the property is correctly instrumented and safe to use",
+                            "type": "boolean"
+                        },
+                        "hidden": {
+                            "description": "Mark property as no longer used. Hides it from the UI while preserving historical data",
+                            "type": "boolean"
+                        }
+                    },
+                    "description": "The property definition data to update"
+                }
+            },
+            "required": ["propertyName", "data"]
+        },
         "ReadDataSchemaSchema": {
             "type": "object",
             "properties": {

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -766,7 +766,7 @@
                     "type": "string"
                 },
                 "tags": {
-                    "description": "Tags to organize properties by product area (e.g. \"checkout\", \"onboarding\") or user journey stage (e.g. \"acquisition\", \"activation\", \"monetization\", \"retention\")",
+                    "description": "Tags to organize properties by product area (e.g. \"checkout\", \"onboarding\") or user journey stage (e.g. \"acquisition\", \"activation\", \"monetization\", \"retention\"). Warning: this REPLACES the property's entire tag list, it does not merge. To keep existing tags, include them alongside the new ones; to remove a tag, omit it. Omit this field entirely to leave tags unchanged.",
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -814,7 +814,7 @@
                             "type": "string"
                         },
                         "tags": {
-                            "description": "Tags to organize properties by product area (e.g. \"checkout\", \"onboarding\") or user journey stage (e.g. \"acquisition\", \"activation\", \"monetization\", \"retention\")",
+                            "description": "Tags to organize properties by product area (e.g. \"checkout\", \"onboarding\") or user journey stage (e.g. \"acquisition\", \"activation\", \"monetization\", \"retention\"). Warning: this REPLACES the property's entire tag list, it does not merge. To keep existing tags, include them alongside the new ones; to remove a tag, omit it. Omit this field entirely to leave tags unchanged.",
                             "type": "array",
                             "items": {
                                 "type": "string"

--- a/services/mcp/src/api/client.ts
+++ b/services/mcp/src/api/client.ts
@@ -717,6 +717,73 @@ export class ApiClient {
                 }
             },
 
+            updatePropertyDefinition: async ({
+                projectId,
+                propertyName,
+                type,
+                groupTypeIndex,
+                data,
+            }: {
+                projectId: string
+                propertyName: string
+                type?: 'event' | 'person' | 'group' | 'session'
+                groupTypeIndex?: number
+                data: {
+                    description?: string
+                    tags?: string[]
+                    property_type?: 'DateTime' | 'String' | 'Numeric' | 'Boolean' | 'Duration'
+                    verified?: boolean
+                    hidden?: boolean
+                }
+            }): Promise<Result<ApiPropertyDefinition>> => {
+                try {
+                    // Property definitions have no by-name lookup endpoint, so resolve the id via the
+                    // list endpoint: `properties` does an exact-name match, and `type` disambiguates a
+                    // name that exists across taxonomies (e.g. an event property and a person property).
+                    const findParams = getSearchParamsFromRecord({
+                        properties: propertyName,
+                        type: type ?? 'event',
+                        group_type_index: groupTypeIndex,
+                    })
+                    const findUrl = `${this.baseUrl}/api/projects/${projectId}/property_definitions/?${findParams}`
+
+                    const findResponse = await this.fetch(findUrl)
+
+                    if (!findResponse.ok) {
+                        throw new Error(`Failed to find property definition: ${findResponse.statusText}`)
+                    }
+
+                    const findData = (await findResponse.json()) as { results: ApiPropertyDefinition[] }
+                    const propertyDef = findData.results.find((def) => def.name === propertyName)
+
+                    if (!propertyDef) {
+                        return {
+                            success: false,
+                            error: new Error(
+                                `Property definition not found: ${propertyName} (type: ${type ?? 'event'})`
+                            ),
+                        }
+                    }
+
+                    const updateUrl = `${this.baseUrl}/api/projects/${projectId}/property_definitions/${propertyDef.id}/`
+
+                    const updateResponse = await this.fetch(updateUrl, {
+                        method: 'PATCH',
+                        body: JSON.stringify(data),
+                    })
+
+                    if (!updateResponse.ok) {
+                        throw new Error(`Failed to update property definition: ${updateResponse.statusText}`)
+                    }
+
+                    const responseData = (await updateResponse.json()) as ApiPropertyDefinition
+
+                    return { success: true, data: responseData }
+                } catch (error) {
+                    return { success: false, error: error as Error }
+                }
+            },
+
             updatePathCleaningFilters: async ({
                 projectId,
                 filters,

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -438,6 +438,42 @@ export const EventDefinitionUpdateSchema = z.object({
     data: EventDefinitionUpdateInputSchema.describe('The event definition data to update'),
 })
 
+export const PropertyDefinitionUpdateInputSchema = z.object({
+    description: z.string().optional().describe('Description explaining what the property represents'),
+    tags: z
+        .array(z.string())
+        .optional()
+        .describe(
+            'Tags to organize properties by product area (e.g. "checkout", "onboarding") or user journey stage (e.g. "acquisition", "activation", "monetization", "retention")'
+        ),
+    property_type: z
+        .enum(['DateTime', 'String', 'Numeric', 'Boolean', 'Duration'])
+        .optional()
+        .describe('The data type of the property. Controls how the property is parsed, displayed, and filtered.'),
+    verified: z
+        .boolean()
+        .optional()
+        .describe('Mark as verified to indicate the property is correctly instrumented and safe to use'),
+    hidden: z
+        .boolean()
+        .optional()
+        .describe('Mark property as no longer used. Hides it from the UI while preserving historical data'),
+})
+
+export const PropertyDefinitionUpdateSchema = z.object({
+    propertyName: z.string().describe('The exact name of the property to update (e.g. "$browser", "plan_type")'),
+    type: z
+        .enum(['event', 'person', 'group', 'session'])
+        .default('event')
+        .describe('Which property taxonomy the property belongs to. Defaults to "event" (event properties).'),
+    groupTypeIndex: z
+        .number()
+        .int()
+        .optional()
+        .describe('Required when type is "group": the zero-based index of the group type the property belongs to.'),
+    data: PropertyDefinitionUpdateInputSchema.describe('The property definition data to update'),
+})
+
 const PathCleaningAliasField = z
     .string()
     .describe(

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -444,7 +444,7 @@ export const PropertyDefinitionUpdateInputSchema = z.object({
         .array(z.string())
         .optional()
         .describe(
-            'Tags to organize properties by product area (e.g. "checkout", "onboarding") or user journey stage (e.g. "acquisition", "activation", "monetization", "retention")'
+            'Tags to organize properties by product area (e.g. "checkout", "onboarding") or user journey stage (e.g. "acquisition", "activation", "monetization", "retention"). Warning: this REPLACES the property\'s entire tag list, it does not merge. To keep existing tags, include them alongside the new ones; to remove a tag, omit it. Omit this field entirely to leave tags unchanged.'
         ),
     property_type: z
         .enum(['DateTime', 'String', 'Numeric', 'Boolean', 'Duration'])

--- a/services/mcp/src/tools/index.ts
+++ b/services/mcp/src/tools/index.ts
@@ -44,6 +44,7 @@ import getProjects from './projects/getProjects'
 import setActiveProject from './projects/setActive'
 import updateEventDefinition from './projects/updateEventDefinition'
 import updatePathCleaning from './projects/updatePathCleaning'
+import updatePropertyDefinition from './projects/updatePropertyDefinition'
 // Replay
 import sessionRecordingSummarize from './replay/sessionRecordingSummarize'
 // Skills (deprecation aliases for the llma-skill-* → skill-* rename)
@@ -72,6 +73,7 @@ export const TOOL_MAP: Record<string, () => ToolBase<ZodObjectAny>> = {
     'projects-get': getProjects,
     'switch-project': setActiveProject,
     'event-definition-update': updateEventDefinition,
+    'property-definition-update': updatePropertyDefinition,
 
     // Feature flags (get-definition-by-key is hand-written; get-definition by numeric id is codegen)
     'feature-flag-get-definition-by-key': featureFlagGetDefinitionByKey,

--- a/services/mcp/src/tools/projects/updatePropertyDefinition.ts
+++ b/services/mcp/src/tools/projects/updatePropertyDefinition.ts
@@ -30,7 +30,7 @@ export const updatePropertyDefinitionHandler: ToolBase<typeof schema, Result>['h
 
     return {
         ...result.data,
-        url: `${context.api.getProjectBaseUrl(projectId)}/data-management/properties/${encodeURIComponent(result.data.name)}`,
+        url: `${context.api.getProjectBaseUrl(projectId)}/data-management/properties/${encodeURIComponent(result.data.id)}`,
     }
 }
 

--- a/services/mcp/src/tools/projects/updatePropertyDefinition.ts
+++ b/services/mcp/src/tools/projects/updatePropertyDefinition.ts
@@ -1,0 +1,43 @@
+import type { z } from 'zod'
+
+import type { ApiPropertyDefinition } from '@/schema/api'
+import { PropertyDefinitionUpdateSchema } from '@/schema/tool-inputs'
+import type { Context, ToolBase } from '@/tools/types'
+
+const schema = PropertyDefinitionUpdateSchema
+
+type Params = z.infer<typeof schema>
+
+type Result = ApiPropertyDefinition & { url: string }
+
+export const updatePropertyDefinitionHandler: ToolBase<typeof schema, Result>['handler'] = async (
+    context: Context,
+    params: Params
+) => {
+    const projectId = await context.stateManager.getProjectId()
+
+    const result = await context.api.projects().updatePropertyDefinition({
+        projectId,
+        propertyName: params.propertyName,
+        type: params.type,
+        groupTypeIndex: params.groupTypeIndex,
+        data: params.data,
+    })
+
+    if (!result.success) {
+        throw new Error(`Failed to update property definition: ${result.error.message}`)
+    }
+
+    return {
+        ...result.data,
+        url: `${context.api.getProjectBaseUrl(projectId)}/data-management/properties/${encodeURIComponent(result.data.name)}`,
+    }
+}
+
+const tool = (): ToolBase<typeof schema, Result> => ({
+    name: 'property-definition-update',
+    schema,
+    handler: updatePropertyDefinitionHandler,
+})
+
+export default tool

--- a/services/mcp/tests/tools/projects.integration.test.ts
+++ b/services/mcp/tests/tools/projects.integration.test.ts
@@ -158,7 +158,8 @@ describe('Projects', { concurrent: false }, () => {
 
             expect(propertyDef.description).toBe(testDescription)
             expect(propertyDef.name).toBe('$browser')
-            expect(propertyDef.url).toContain('/data-management/properties/')
+            // The definition-detail route is keyed by id, not name, so the link must carry the id
+            expect(propertyDef.url).toContain(`/data-management/properties/${propertyDef.id}`)
         })
 
         it('should update property definition tags', async () => {

--- a/services/mcp/tests/tools/projects.integration.test.ts
+++ b/services/mcp/tests/tools/projects.integration.test.ts
@@ -15,6 +15,7 @@ import {
 import getProjectsTool from '@/tools/projects/getProjects'
 import setActiveProjectTool from '@/tools/projects/setActive'
 import updateEventDefinitionTool from '@/tools/projects/updateEventDefinition'
+import updatePropertyDefinitionTool from '@/tools/projects/updatePropertyDefinition'
 import type { Context } from '@/tools/types'
 
 describe('Projects', { concurrent: false }, () => {
@@ -137,6 +138,77 @@ describe('Projects', { concurrent: false }, () => {
             await expect(
                 updateTool.handler(context, {
                     eventName: nonExistentEvent,
+                    data: { description: 'test' },
+                })
+            ).rejects.toThrow()
+        })
+    })
+
+    describe('property-definition-update tool', () => {
+        const updateTool = updatePropertyDefinitionTool()
+
+        it('should update property definition description', async () => {
+            const testDescription = `Test description ${uuidv4()}`
+            const result = await updateTool.handler(context, {
+                propertyName: '$browser',
+                type: 'event',
+                data: { description: testDescription },
+            })
+            const propertyDef = parseToolResponse(result)
+
+            expect(propertyDef.description).toBe(testDescription)
+            expect(propertyDef.name).toBe('$browser')
+            expect(propertyDef.url).toContain('/data-management/properties/')
+        })
+
+        it('should update property definition tags', async () => {
+            const testTag = `test-tag-${uuidv4().slice(0, 8)}`
+            const result = await updateTool.handler(context, {
+                propertyName: '$browser',
+                type: 'event',
+                data: { tags: [testTag] },
+            })
+            const propertyDef = parseToolResponse(result)
+
+            expect(propertyDef.tags).toContain(testTag)
+        })
+
+        it('should update verified status', async () => {
+            const result = await updateTool.handler(context, {
+                propertyName: '$browser',
+                type: 'event',
+                data: { verified: true },
+            })
+            const propertyDef = parseToolResponse(result)
+
+            expect(propertyDef.verified).toBe(true)
+        })
+
+        it('should update multiple fields at once', async () => {
+            const testDescription = `Multi-field test ${uuidv4()}`
+            const testTag = `multi-tag-${uuidv4().slice(0, 8)}`
+            const result = await updateTool.handler(context, {
+                propertyName: '$browser',
+                type: 'event',
+                data: {
+                    description: testDescription,
+                    tags: [testTag],
+                    verified: true,
+                },
+            })
+            const propertyDef = parseToolResponse(result)
+
+            expect(propertyDef.description).toBe(testDescription)
+            expect(propertyDef.tags).toContain(testTag)
+            expect(propertyDef.verified).toBe(true)
+        })
+
+        it('should throw error for non-existent property', async () => {
+            const nonExistentProperty = `non-existent-property-${uuidv4()}`
+            await expect(
+                updateTool.handler(context, {
+                    propertyName: nonExistentProperty,
+                    type: 'event',
                     data: { description: 'test' },
                 })
             ).rejects.toThrow()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/property-definition-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/property-definition-update.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "data": {
+            "description": "The property definition data to update",
+            "properties": {
+                "description": {
+                    "description": "Description explaining what the property represents",
+                    "type": "string"
+                },
+                "hidden": {
+                    "description": "Mark property as no longer used. Hides it from the UI while preserving historical data",
+                    "type": "boolean"
+                },
+                "property_type": {
+                    "description": "The data type of the property. Controls how the property is parsed, displayed, and filtered.",
+                    "enum": ["DateTime", "String", "Numeric", "Boolean", "Duration"],
+                    "type": "string"
+                },
+                "tags": {
+                    "description": "Tags to organize properties by product area (e.g. \"checkout\", \"onboarding\") or user journey stage (e.g. \"acquisition\", \"activation\", \"monetization\", \"retention\")",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "verified": {
+                    "description": "Mark as verified to indicate the property is correctly instrumented and safe to use",
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "groupTypeIndex": {
+            "description": "Required when type is \"group\": the zero-based index of the group type the property belongs to.",
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+        },
+        "propertyName": {
+            "description": "The exact name of the property to update (e.g. \"$browser\", \"plan_type\")",
+            "type": "string"
+        },
+        "type": {
+            "default": "event",
+            "description": "Which property taxonomy the property belongs to. Defaults to \"event\" (event properties).",
+            "enum": ["event", "person", "group", "session"],
+            "type": "string"
+        }
+    },
+    "required": ["propertyName", "data"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/property-definition-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/property-definition-update.json
@@ -18,7 +18,7 @@
                     "type": "string"
                 },
                 "tags": {
-                    "description": "Tags to organize properties by product area (e.g. \"checkout\", \"onboarding\") or user journey stage (e.g. \"acquisition\", \"activation\", \"monetization\", \"retention\")",
+                    "description": "Tags to organize properties by product area (e.g. \"checkout\", \"onboarding\") or user journey stage (e.g. \"acquisition\", \"activation\", \"monetization\", \"retention\"). Warning: this REPLACES the property's entire tag list, it does not merge. To keep existing tags, include them alongside the new ones; to remove a tag, omit it. Omit this field entirely to leave tags unchanged.",
                     "items": {
                         "type": "string"
                     },


### PR DESCRIPTION
## Problem

The PostHog MCP already lets agents update **event** definition metadata via `event-definition-update`, but there was no equivalent for **property** definitions — the only property tools were read-only. Users who wanted to curate their property taxonomy (descriptions, types, verified/hidden status) over MCP had no way to do it. This was raised in a support thread after a customer successfully used `event-definition-update` and asked why properties couldn't be updated the same way.

## Changes

Adds a `property-definition-update` MCP tool that mirrors `event-definition-update`:

- Updates `description`, `tags`, `property_type` (DateTime / String / Numeric / Boolean / Duration), and `verified` / `hidden` status.
- Takes an exact property name plus a `type` (event / person / group / session, defaulting to event) to target the right property, with `groupTypeIndex` for group properties.
- Property definitions have no `by_name` lookup endpoint, so the client resolves the id via the list endpoint (exact-name `properties` filter + `type`) before issuing the PATCH.

New handler in `src/tools/projects/updatePropertyDefinition.ts`, an `updatePropertyDefinition` method on the API client, input schemas in `tool-inputs.ts`, registration in `index.ts`, and the tool definition (scope `property_definition:write`). Regenerated `schema/tool-inputs.json`.

## How did you test this code?

Added integration tests in `tests/tools/projects.integration.test.ts` covering description, tags, verified, multi-field updates, and the not-found error path — parallel to the existing event-definition-update tests.

I (the agent) was not able to run the MCP toolchain (typecheck / lint / integration tests) in this environment because monorepo dependencies were not installed; CI will exercise them. The regenerated `tool-inputs.json` was produced with the pinned zod version and verified to add only the two new schema entries with no churn to existing ones.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app agent from a Slack thread. The work followed the existing `event-definition-update` tool as a template end to end (handler, client method, schema, tool definition, tests). Backend behavior was confirmed against `posthog/taxonomy/property_definition_api.py` and the EE serializer to pick the id-resolution approach (`properties` exact-name filter + `type`) and the writable field set. `tool-inputs.json` was regenerated and hand-verified to contain only additive changes.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BALLBBKAB/p1784740653682329)*
