### PR TITLE
feat(cymbal): set posthog-flutter wire-order cutoff

### DIFF
--- a/rust/cymbal/src/modes/processing/normalization.rs
+++ b/rust/cymbal/src/modes/processing/normalization.rs
@@ -107,6 +107,9 @@ fn lib_rules() -> &'static [LibRule] {
                     // but each module reports its own version stream.
                     "posthog-android" => Some(Version::new(3, 56, 0)),
                     "posthog-server" => Some(Version::new(2, 9, 0)),
+                    // posthog-flutter ships its Dart flip in 5.33.0 and raises
+                    // its Android SDK floor to the canonical 3.56.0 release.
+                    "posthog-flutter" => Some(Version::new(5, 33, 0)),
                     // `posthog-java` is the tombstoned legacy SDK: it will
                     // never ship the flip, so no cutoff, ever.
                     _ => None,
@@ -327,12 +330,13 @@ mod test {
     }
 
     #[test]
-    fn android_and_server_cutoffs_gate_normalization_by_version() {
-        // Both modules flip in one release train but carry separate version
-        // streams; each gate keys on its own module's version.
+    fn android_server_and_flutter_cutoffs_gate_normalization_by_version() {
+        // Android and server flip in one release train; Flutter follows with
+        // its own wrapper release. Each gate keys on its reported version.
         for (lib, below, at) in [
             ("posthog-android", "3.55.2", "3.56.0"),
             ("posthog-server", "2.8.1", "2.9.0"),
+            ("posthog-flutter", "5.32.1", "5.33.0"),
         ] {
             for version in [Some(below), Some("1.0.0"), Some("garbage"), None] {
                 let mut list: ExceptionList =


### PR DESCRIPTION
## Problem

`posthog-flutter` payloads are currently normalized as legacy crash-first stacks at every version. PostHog/posthog-flutter#467 will make Flutter's Dart path canonical and raise the Android SDK floor to `3.56.0`, whose shared throwable coercer is also canonical. Apple-native exceptions are already canonical.

Cymbal must stop reversing events from that Flutter release onward while preserving legacy fingerprint lookup for older issues.

## Changes

- set `posthog-flutter`'s `canonical_since` cutoff to `5.33.0`
- cover the version boundary in the existing Android/server cutoff regression test
- keep reverse-order legacy fingerprint reconstruction after the cutoff

## Rollout

- [ ] Confirm `5.33.0` is still the next unclaimed Flutter minor immediately before merge. PostHog/posthog-flutter#495 also carries a minor changeset; if it releases first, update this cutoff and PostHog/posthog-flutter#467 to `5.34.0`.
- [ ] Merge and deploy this Cymbal cutoff.
- [ ] Merge and release PostHog/posthog-flutter#467.

Known limitation: already-published Flutter `5.32.1` accepts the dynamic Android range `[3.55.0,4.0.0)`, so some fresh builds can resolve canonical Android `3.56.0` while still reporting Flutter `5.32.1`. A Flutter-version cutoff cannot distinguish those builds. The new Flutter release raises the lower bound and establishes a reliable boundary going forward.

## Tests

- `cargo fmt --all --check`
- `cargo test -p cymbal modes::processing::normalization::test::android_server_and_flutter_cutoffs_gate_normalization_by_version --lib`
