### PR TITLE
fix(warehouse_sources): stop retrying Databricks IP ACL rejections

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/source.py
@@ -44,6 +44,7 @@ DatabricksErrors = {
     "nodename nor servname provided": "Can't resolve the server hostname. Check the server hostname and try again.",
     "Name or service not known": "Can't resolve the server hostname. Check the server hostname and try again.",
     "Failed to resolve": "Can't resolve the server hostname. Check the server hostname and try again.",
+    "is blocked by Databricks IP ACL for workspace": "PostHog's IP address is blocked by your Databricks workspace's IP access control list. Add PostHog's IP addresses to the workspace's IP ACL, then try again.",
 }
 
 
@@ -179,6 +180,9 @@ class DatabricksSource(SQLSource[DatabricksSourceConfig], ValidateDatabaseHostMi
             "INSUFFICIENT_PERMISSIONS": "Your Databricks credentials don't have permission to access this data. Grant USE CATALOG, USE SCHEMA, and SELECT to the connecting principal, then resync.",
             # Raised when the SQL warehouse referenced by the HTTP path was deleted.
             "RESOURCE_DOES_NOT_EXIST": "The SQL warehouse referenced by the HTTP path no longer exists. Update the HTTP path to a running SQL warehouse, then resync.",
+            # Workspace-level IP ACL rejection — a customer-side network config that retrying can
+            # never satisfy. Match the stable phrase, ignoring the appended IP and workspace id.
+            "is blocked by Databricks IP ACL for workspace": "PostHog's IP address is blocked by your Databricks workspace's IP access control list. Add PostHog's IP addresses to the workspace's IP ACL, then resync.",
         }
 
     def validate_credentials(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py
@@ -473,6 +473,9 @@ class TestDatabricksSource:
             "[SCHEMA_NOT_FOUND] The schema 'analytics' cannot be found.",
             "PERMISSION_DENIED: User does not have USE SCHEMA on Schema 'analytics'.",
             "[TABLE_OR_VIEW_NOT_FOUND] The table or view `main`.`information_schema`.`columns` cannot be found.",
+            # Workspace IP ACL rejection — matched on the stable phrase, ignoring the appended IP
+            # address and workspace id.
+            "Error during request to server: : Source IP address: 44.208.188.173 is blocked by Databricks IP ACL for workspace: 1557520918149316. ",
         ],
     )
     def test_permanent_failures_are_non_retryable(self, source, error_msg):
@@ -509,6 +512,10 @@ class TestDatabricksSource:
             (
                 "[TABLE_OR_VIEW_NOT_FOUND] The table or view `information_schema`.`columns` cannot be found.",
                 "Unity Catalog",
+            ),
+            (
+                "Error during request to server: : Source IP address: 44.208.188.173 is blocked by Databricks IP ACL for workspace: 1557520918149316. ",
+                "IP access control list",
             ),
             ("something totally unexpected", "Could not connect to Databricks"),
         ],


### PR DESCRIPTION
## Problem

Databricks error tracking surfaced a `RequestError` from the Databricks source: `Source IP address ... is blocked by Databricks IP ACL for workspace: ...`. This is raised when a customer's Databricks workspace has an IP access control list that doesn't allowlist PostHog's egress IPs — a network-config choice on the customer's side, not something we can fix by retrying.

## Changes

- Added the stable, non-volatile phrase `is blocked by Databricks IP ACL for workspace` to `DatabricksSource.get_non_retryable_errors()` so sync/import stops retrying on this rejection, following the same pattern used for other permanent auth/config errors on this source (and mirroring Stripe's IP-allowlist handling).
- Added the same phrase to the `DatabricksErrors` map used by `validate_credentials`, so the connection-test flow surfaces an actionable message instead of the generic "Could not connect to Databricks" fallback.
- Matched on the phrase between the IP address and the workspace id — both of which are volatile per request — so the match stays stable across different customers and IPs.

## How did you test this code?

Extended the existing parameterized tests rather than adding new ones:
- `test_permanent_failures_are_non_retryable` in `test_databricks.py` — added a case with the redacted IP ACL message, asserting it's classified non-retryable. Catches a regression where this error keeps getting retried forever against a workspace that will never accept our IP.
- `test_validate_credentials_maps_connection_errors` — added a case asserting `validate_credentials` returns the actionable IP ACL message instead of the generic fallback.

Ran `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py` (71 passed), `uv run ruff check` and `uv run ruff format --check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — no user-facing config or workflow change, just error classification.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (Sonnet 5), triaging a PostHog error tracking issue for the Databricks warehouse source.
- Confirmed the error's stack trace has in-app frames in `source.py::validate_credentials` and `databricks.py::connect`, and read through the Databricks connector's call path to `_handle_request_error` in `databricks.sql.backend.thrift_backend` to understand where the error originates.
- Decision: classified as a user/upstream error (customer's Databricks IP ACL config), not a code bug — extended `NonRetryableErrors` rather than changing retry/backoff behavior, following the precedent in `stripe/source.py`.
- Searched open PRs (by keyword and by the source-code author) for a duplicate fix; found none.