### PR TITLE
fix(toolbar): allow toolbar auth during impersonation sessions

### DIFF
--- a/frontend/src/toolbar/bar/toolbarLogic.ts
+++ b/frontend/src/toolbar/bar/toolbarLogic.ts
@@ -196,12 +196,12 @@ export interface toolbarLogicActions {
     } // toolbarConfigLogic
     setOAuthTokens: (
         accessToken: string,
-        refreshToken: string,
+        refreshToken: string | null,
         clientId: string
     ) => {
         accessToken: string
         clientId: string
-        refreshToken: string
+        refreshToken: string | null
     } // toolbarConfigLogic
     completeGracefulExit: () => {
         value: true

--- a/frontend/src/toolbar/toolbarAuth.ts
+++ b/frontend/src/toolbar/toolbarAuth.ts
@@ -90,7 +90,16 @@ export async function withTokenRefresh(
 
     // `response?.status` (not `response.status`) so a non-Response value from a customer-page
     // `fetch` wrapper can't throw here — callers that don't route through `safeFetch` stay safe too.
-    if (response?.status !== 401 || !accessToken || !refreshToken || !clientId || !uiHost) {
+    if (response?.status !== 401 || !accessToken || !clientId || !uiHost) {
+        return response
+    }
+
+    // Refresh-less tokens (impersonation-minted, refresh-less by design) can't be refreshed —
+    // a 401 means the short-lived access token has expired, so prompt the user to re-authenticate.
+    if (!refreshToken) {
+        toolbarLogger.warn('auth', 'Access token expired and no refresh token available, re-authentication required')
+        lemonToast.error('Please re-authenticate to continue using the toolbar.')
+        toolbarConfigLogic.actions.tokenExpired()
         return response
     }
 

--- a/frontend/src/toolbar/toolbarConfigLogic.test.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.test.ts
@@ -439,6 +439,25 @@ describe('toolbar toolbarConfigLogic', () => {
             })
         })
 
+        it('restores a stored access token that has no refresh token (impersonation)', () => {
+            localStorage.setItem(
+                OAUTH_LOCALSTORAGE_KEY,
+                JSON.stringify({
+                    accessToken: 'stored-access',
+                    clientId: 'stored-client',
+                    uiHost: 'http://localhost',
+                })
+            )
+            const logic = toolbarConfigLogic.build({ apiURL: 'http://localhost' })
+            logic.mount()
+
+            expectLogic(logic).toMatchValues({
+                accessToken: 'stored-access',
+                refreshToken: null,
+                isAuthenticated: true,
+            })
+        })
+
         it('discards stored OAuth tokens when uiHost does not match', () => {
             localStorage.setItem(
                 OAUTH_LOCALSTORAGE_KEY,
@@ -908,6 +927,29 @@ describe('toolbar toolbarConfigLogic', () => {
             expect(logic.values.isAuthenticated).toBe(false)
         })
 
+        it('calls tokenExpired on 401 when there is no refresh token, without attempting a refresh', async () => {
+            const logic = toolbarConfigLogic.build({
+                apiURL: 'http://localhost',
+                accessToken: 'imp-access',
+                clientId: 'client-id',
+            })
+            logic.mount()
+
+            let refreshAttempted = false
+            ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+                if (url.includes('toolbar_oauth_refresh')) {
+                    refreshAttempted = true
+                }
+                return Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({}) })
+            })
+
+            await toolbarFetch('/api/projects/@current/actions/')
+
+            expect(refreshAttempted).toBe(false)
+            expect(logic.values.accessToken).toBeNull()
+            expect(logic.values.isAuthenticated).toBe(false)
+        })
+
         it('does not retry when response is not 401', async () => {
             const logic = toolbarConfigLogic.build({
                 apiURL: 'http://localhost',
@@ -1025,6 +1067,32 @@ describe('toolbar toolbarConfigLogic', () => {
             expect(tokenExchangeCall[0]).toBe('https://us.posthog.com/oauth/token/')
             const body = new URLSearchParams(tokenExchangeCall[1].body)
             expect(body.get('redirect_uri')).toBe('https://us.posthog.com/toolbar_oauth/callback')
+        })
+
+        it('authenticates when the token response has no refresh token (impersonation)', async () => {
+            window.history.pushState({}, '', '/#__posthog_toolbar=code:abc,client_id:xyz')
+            ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+                if (typeof url === 'string' && url.endsWith('/toolbar_oauth/check')) {
+                    return Promise.resolve({ ok: true, status: 200 })
+                }
+                // Impersonation-minted tokens are refresh-less by design.
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: () => Promise.resolve({ access_token: 'imp-access', expires_in: 1800 }),
+                })
+            })
+
+            const logic = toolbarConfigLogic.build({
+                posthog: { config: { ui_host: 'https://us.posthog.com' } } as any,
+            } as any)
+            logic.mount()
+
+            await expectLogic(logic).delay(0).toMatchValues({
+                accessToken: 'imp-access',
+                refreshToken: null,
+                isAuthenticated: true,
+            })
         })
 
         it('does not trigger temporaryToken migration during code exchange', async () => {

--- a/frontend/src/toolbar/toolbarConfigLogic.ts
+++ b/frontend/src/toolbar/toolbarConfigLogic.ts
@@ -103,12 +103,12 @@ export interface toolbarConfigLogicActions {
     }
     setOAuthTokens: (
         accessToken: string,
-        refreshToken: string,
+        refreshToken: string | null,
         clientId: string
     ) => {
         accessToken: string
         clientId: string
-        refreshToken: string
+        refreshToken: string | null
     }
     showButton: () => {
         value: true
@@ -156,7 +156,7 @@ export const toolbarConfigLogic = kea<toolbarConfigLogicType>([
         showButton: true,
         hideButton: true,
         persistConfig: true,
-        setOAuthTokens: (accessToken: string, refreshToken: string, clientId: string) => ({
+        setOAuthTokens: (accessToken: string, refreshToken: string | null, clientId: string) => ({
             accessToken,
             refreshToken,
             clientId,
@@ -572,7 +572,7 @@ export function canonicalizeApiHost(candidate: string | undefined | null): strin
 // ---------------------------------------------------------------------------
 
 type TokenActions = {
-    setOAuthTokens: (accessToken: string, refreshToken: string, clientId: string) => void
+    setOAuthTokens: (accessToken: string, refreshToken: string | null, clientId: string) => void
     setAuthStatus: (status: 'idle' | 'checking' | 'authenticating' | 'error') => void
 }
 type CheckActions = TokenActions & {
@@ -605,14 +605,17 @@ function restoreOAuthTokens(
         return
     }
     const { accessToken, refreshToken, clientId, uiHost: storedUiHost } = parsed as Record<string, unknown>
-    // Validate every field is a non-empty string — guards against a third-party script
+    // Validate the required fields are non-empty strings — guards against a third-party script
     // writing garbage (or an older version writing a different shape) that would later
-    // blow up on fetch header construction.
+    // blow up on fetch header construction. refreshToken is optional (impersonation-minted
+    // tokens are refresh-less); when present it must be a non-empty string, otherwise it's
+    // normalized to null below.
+    const storedRefreshToken = asNonEmptyString(refreshToken)
+    const refreshTokenValid = refreshToken == null || storedRefreshToken !== null
     if (
         typeof accessToken !== 'string' ||
         !accessToken ||
-        typeof refreshToken !== 'string' ||
-        !refreshToken ||
+        !refreshTokenValid ||
         typeof clientId !== 'string' ||
         !clientId
     ) {
@@ -657,7 +660,7 @@ function restoreOAuthTokens(
         localStorage.removeItem(OAUTH_LOCALSTORAGE_KEY)
         return
     }
-    actions.setOAuthTokens(accessToken, refreshToken, clientId)
+    actions.setOAuthTokens(accessToken, storedRefreshToken, clientId)
 }
 
 /**
@@ -871,9 +874,14 @@ async function exchangeCodeForTokens(
         const data = await res.json().catch(() => null)
         const access = asNonEmptyString(data?.access_token)
         const refresh = asNonEmptyString(data?.refresh_token)
-        if (access && refresh) {
+        // A refresh token is optional: impersonation-minted tokens are refresh-less by design
+        // (they can't outlive the admin's impersonation session), so require only the access
+        // token here. Without a refresh token the short-lived access token is used until it
+        // expires, at which point the user re-authenticates.
+        if (access) {
             toolbarPosthogJS.capture('toolbar oauth exchange', {
                 status: 'success',
+                has_refresh_token: !!refresh,
                 duration_ms: Math.round(performance.now() - startTime),
             })
             actions.setOAuthTokens(access, refresh, clientId)


### PR DESCRIPTION
## Problem

PostHog staff can't use the toolbar while impersonating a user. Clicking authenticate fails with `[PostHog Toolbar][auth] Token exchange failed` in the console, and the page just refreshes back to its unauthenticated state. This worked under the old toolbar auth mechanism (a directly-minted `temporaryToken`) but broke after the move to OAuth. Raised in a support thread by staff hitting it during impersonation.

The root cause is a mismatch between backend and frontend. Impersonation-minted OAuth tokens are deliberately refresh-less: the backend caps their lifetime to the impersonation idle timeout and omits the `refresh_token` so a token can't outlive the admin's impersonation session. But the toolbar's token exchange treated a response without a `refresh_token` as a failure, even on a 200. So the exchange succeeds server-side, the toolbar throws it away, and the session never authenticates.

## Changes

Made the refresh token optional across the toolbar auth flow, so a refresh-less (impersonation) session works while a normal session keeps rotating tokens exactly as before:

- Token exchange now succeeds on an access token alone. A `has_refresh_token` flag is added to the success telemetry so we can tell the two paths apart.
- `restoreOAuthTokens` accepts a stored access token with no refresh token (still rejects malformed shapes).
- On a 401 with no refresh token, the toolbar can't refresh, so it now prompts re-authentication instead of silently returning the failed response.
- `setOAuthTokens` and the related types accept `refreshToken: string | null`.

This keeps the security property intact: impersonation tokens stay short-lived and refresh-less, so when the access token expires the user simply re-authenticates.

> [!NOTE]
> This does not touch the separate `_impersonation_ai_processing_block` gate on the OAuth authorize step, which can 403 an impersonated authorize for orgs that haven't approved AI data processing. Users hitting *this* bug got past authorize (they reached token exchange), so that gate isn't what they were hitting.

## How did you test this code?

Added three Jest cases to `toolbarConfigLogic.test.ts`, each guarding a distinct branch of the change (no existing test exercised a refresh-less token):

- token exchange with an access token and no refresh token authenticates (`refreshToken` ends up null, `isAuthenticated` true) — the exact regression reported.
- a stored access token with no refresh token restores from localStorage.
- a 401 with no refresh token fires `tokenExpired` and does not attempt a refresh.

Ran the full toolbar suite locally: `jest frontend/src/toolbar/toolbarConfigLogic.test.ts` — 162 passed. TypeScript check is clean for the changed files. I (the agent) did not do manual in-browser testing of a live impersonation session.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via the PostHog Slack app) investigated a staff report that the toolbar can't authenticate during impersonation. I traced the OAuth flow end-to-end with the Explore agent, then confirmed the root cause by reading `exchangeCodeForTokens` in `toolbarConfigLogic.ts` (requires both tokens) against `OAuthValidator._should_skip_refresh_token` / `save_bearer_token` in `posthog/api/oauth/views.py` (drops the refresh token for impersonation-minted grants).

I considered changing the backend to issue a refresh token during impersonation, but rejected it: the refresh-less, short-lived shape is an intentional security boundary. The correct fix lives on the client. Invoked the `/writing-tests` skill before adding tests and kept the set to three cases that each catch a real regression.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08M011SBCM/p1784571320823079?thread_ts=1784571320.823079&cid=C08M011SBCM)*
