### PR TITLE
feat(metrics): emit per-team ingested counters into posthog metrics

### DIFF
--- a/nodejs/src/ingestion/pipelines/metrics/ingestion-otel-metrics.test.ts
+++ b/nodejs/src/ingestion/pipelines/metrics/ingestion-otel-metrics.test.ts
@@ -1,0 +1,83 @@
+import { metrics as metricsApi } from '@opentelemetry/api'
+import {
+    type DataPoint,
+    InMemoryMetricExporter,
+    MeterProvider,
+    PeriodicExportingMetricReader,
+} from '@opentelemetry/sdk-metrics'
+
+import { recordMetricsIngested, resetMetricsIngestionInstrumentsForTests } from './ingestion-otel-metrics'
+
+describe('ingestion-otel-metrics', () => {
+    let exporter: InMemoryMetricExporter
+    let provider: MeterProvider
+    let reader: PeriodicExportingMetricReader
+
+    beforeEach(() => {
+        // Simulate the real startup-order hazard: a record call may run before a
+        // provider exists (bound to the noop meter), with the provider registered
+        // afterwards. Lazily acquired instruments must still deliver data recorded
+        // after registration.
+        resetMetricsIngestionInstrumentsForTests()
+        recordMetricsIngested(1, 1, 1)
+
+        exporter = new InMemoryMetricExporter(0)
+        reader = new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 60_000 })
+        provider = new MeterProvider({ readers: [reader] })
+        metricsApi.setGlobalMeterProvider(provider)
+        resetMetricsIngestionInstrumentsForTests()
+    })
+
+    afterEach(async () => {
+        await provider.shutdown()
+        metricsApi.disable()
+    })
+
+    const dataPointsFor = <T>(name: string): readonly DataPoint<T>[] =>
+        exporter
+            .getMetrics()
+            .flatMap((rm) => rm.scopeMetrics)
+            .flatMap((sm) => sm.metrics)
+            .filter((m) => m.descriptor.name === name)
+            .flatMap((m) => m.dataPoints as unknown as readonly DataPoint<T>[])
+
+    it.each([
+        ['bytes', 'metrics_ingestion_bytes_ingested_total', 2048],
+        ['records', 'metrics_ingestion_records_ingested_total', 10],
+    ] as const)('emits per-team ingested %s', async (_name, metricName, value) => {
+        recordMetricsIngested(42, 2048, 10)
+
+        await reader.forceFlush()
+
+        const points = dataPointsFor<number>(metricName)
+        expect(points).toHaveLength(1)
+        expect(points[0].attributes).toEqual({ team_id: '42' })
+        expect(points[0].value).toEqual(value)
+    })
+
+    it('skips zero and negative amounts so no empty per-team series are created', async () => {
+        recordMetricsIngested(42, 0, 0)
+        recordMetricsIngested(43, -1, 0)
+
+        await reader.forceFlush()
+
+        const names = ['metrics_ingestion_bytes_ingested_total', 'metrics_ingestion_records_ingested_total']
+        expect(names.map((name) => dataPointsFor(name).length)).toEqual([0, 0])
+    })
+
+    it('swallows a throwing OTel SDK so the consumer background task is never rejected', () => {
+        const throwing = () => {
+            throw new Error('otel exploded')
+        }
+        metricsApi.disable() // the API ignores a second setGlobalMeterProvider without this
+        metricsApi.setGlobalMeterProvider({
+            getMeter: () =>
+                ({
+                    createCounter: () => ({ add: throwing }),
+                }) as any,
+        } as any)
+        resetMetricsIngestionInstrumentsForTests()
+
+        expect(() => recordMetricsIngested(42, 1, 1)).not.toThrow()
+    })
+})

--- a/nodejs/src/ingestion/pipelines/metrics/ingestion-otel-metrics.ts
+++ b/nodejs/src/ingestion/pipelines/metrics/ingestion-otel-metrics.ts
@@ -1,0 +1,61 @@
+import { Attributes, Counter, metrics as metricsApi } from '@opentelemetry/api'
+
+import { createCounterWithExemplars, swallowing } from '~/common/metrics/instruments'
+
+/**
+ * OTLP-pushed per-team ingestion counters, landing in the PostHog metrics product
+ * through the exporter installed by initMetrics (common/metrics/otel-metrics.ts).
+ * They answer "which teams are actually ingesting metrics" — a signal neither the
+ * aggregate prom counters (no team label) nor the app_metrics2 usage rows (billing
+ * store, not queryable as a metric) provide.
+ *
+ * Names mirror the app_metrics2 usage rows (records_ingested/bytes_ingested =
+ * passed quota and rate limiting, headed to storage) rather than the prom
+ * *_allowed_total counters, which already reach the metrics product team-less via
+ * the scrape bridge — reusing those names would mix two label schemas.
+ *
+ * Instruments are acquired lazily on first record: the OTel metrics API has no proxy
+ * provider, so instruments created at module load (before initMetrics runs) would be
+ * bound to the noop meter forever.
+ */
+
+interface MetricsIngestionInstruments {
+    bytesIngested: Counter
+    recordsIngested: Counter
+}
+
+let instruments: MetricsIngestionInstruments | null = null
+
+function getInstruments(): MetricsIngestionInstruments {
+    if (instruments === null) {
+        const meter = metricsApi.getMeter('metrics-ingestion')
+        instruments = {
+            bytesIngested: createCounterWithExemplars(meter, 'metrics_ingestion_bytes_ingested_total', {
+                description: 'Total uncompressed metric bytes ingested (passed quota and rate limiting), by team',
+                unit: 'By',
+            }),
+            recordsIngested: createCounterWithExemplars(meter, 'metrics_ingestion_records_ingested_total', {
+                description: 'Total metric records ingested (passed quota and rate limiting), by team',
+            }),
+        }
+    }
+    return instruments
+}
+
+function addPositive(counter: Counter, value: number, attributes?: Attributes): void {
+    if (value > 0) {
+        counter.add(value, attributes)
+    }
+}
+
+export const recordMetricsIngested = swallowing((teamId: number, bytes: number, records: number): void => {
+    const { bytesIngested, recordsIngested } = getInstruments()
+    const attributes = { team_id: teamId.toString() }
+    addPositive(bytesIngested, bytes, attributes)
+    addPositive(recordsIngested, records, attributes)
+})
+
+/** Test seam: forget cached instruments so a test-installed provider is picked up. */
+export function resetMetricsIngestionInstrumentsForTests(): void {
+    instruments = null
+}

--- a/nodejs/src/ingestion/pipelines/metrics/ingestion-otel-metrics.ts
+++ b/nodejs/src/ingestion/pipelines/metrics/ingestion-otel-metrics.ts
@@ -9,10 +9,12 @@ import { createCounterWithExemplars, swallowing } from '~/common/metrics/instrum
  * aggregate prom counters (no team label) nor the app_metrics2 usage rows (billing
  * store, not queryable as a metric) provide.
  *
- * Names mirror the app_metrics2 usage rows (records_ingested/bytes_ingested =
- * passed quota and rate limiting, headed to storage) rather than the prom
- * *_allowed_total counters, which already reach the metrics product team-less via
- * the scrape bridge — reusing those names would mix two label schemas.
+ * Names mirror the app_metrics2 usage rows (records_ingested/bytes_ingested)
+ * rather than the prom *_allowed_total counters, which already reach the metrics
+ * product team-less via the scrape bridge — reusing those names would mix two
+ * label schemas. The boundary here is stricter than the usage rows: recorded only
+ * after a message is successfully produced to the ClickHouse-bound topic, so
+ * DLQ'd messages never count as ingested.
  *
  * Instruments are acquired lazily on first record: the OTel metrics API has no proxy
  * provider, so instruments created at module load (before initMetrics runs) would be
@@ -31,11 +33,11 @@ function getInstruments(): MetricsIngestionInstruments {
         const meter = metricsApi.getMeter('metrics-ingestion')
         instruments = {
             bytesIngested: createCounterWithExemplars(meter, 'metrics_ingestion_bytes_ingested_total', {
-                description: 'Total uncompressed metric bytes ingested (passed quota and rate limiting), by team',
+                description: 'Total uncompressed metric bytes successfully produced for storage, by team',
                 unit: 'By',
             }),
             recordsIngested: createCounterWithExemplars(meter, 'metrics_ingestion_records_ingested_total', {
-                description: 'Total metric records ingested (passed quota and rate limiting), by team',
+                description: 'Total metric records successfully produced for storage, by team',
             }),
         }
     }

--- a/nodejs/src/ingestion/pipelines/metrics/metrics-ingestion-consumer.ts
+++ b/nodejs/src/ingestion/pipelines/metrics/metrics-ingestion-consumer.ts
@@ -305,6 +305,9 @@ export class MetricsIngestionConsumer {
                             },
                         },
                     ])
+                    // Only after the ClickHouse-bound produce resolves — messages that
+                    // fail and route to the DLQ must not count as ingested.
+                    recordMetricsIngested(message.teamId, message.bytesUncompressed, message.recordCount)
                 } catch (error) {
                     await this.produceToDlq(message, error)
                     throw error
@@ -358,7 +361,6 @@ export class MetricsIngestionConsumer {
             this.queueUsageMetric(teamId, 'records_ingested', stats.recordsAllowed)
             this.queueUsageMetric(teamId, 'bytes_dropped', stats.bytesDropped)
             this.queueUsageMetric(teamId, 'records_dropped', stats.recordsDropped)
-            recordMetricsIngested(teamId, stats.bytesAllowed, stats.recordsAllowed)
         }
 
         // Best-effort: don't let metric failures block ingestion

--- a/nodejs/src/ingestion/pipelines/metrics/metrics-ingestion-consumer.ts
+++ b/nodejs/src/ingestion/pipelines/metrics/metrics-ingestion-consumer.ts
@@ -14,6 +14,7 @@ import { TeamManager } from '~/common/utils/team-manager'
 import { HealthCheckResult, PluginServerService } from '~/types'
 
 import { MetricsIngestionConsumerConfig } from './config'
+import { recordMetricsIngested } from './ingestion-otel-metrics'
 import { METRICS_DLQ_OUTPUT, METRICS_OUTPUT, MetricsDlqOutput, MetricsOutput } from './outputs/outputs'
 import { MetricsRateLimiterService } from './services/metrics-rate-limiter.service'
 import { MetricsIngestionMessage } from './types'
@@ -357,6 +358,7 @@ export class MetricsIngestionConsumer {
             this.queueUsageMetric(teamId, 'records_ingested', stats.recordsAllowed)
             this.queueUsageMetric(teamId, 'bytes_dropped', stats.bytesDropped)
             this.queueUsageMetric(teamId, 'records_dropped', stats.recordsDropped)
+            recordMetricsIngested(teamId, stats.bytesAllowed, stats.recordsAllowed)
         }
 
         // Best-effort: don't let metric failures block ingestion


### PR DESCRIPTION
## Problem

The metrics usage dashboard can tell who visits the Metrics UI, who calls the Metrics MCP tools, and who shows product intent, but nothing confirms a team is actually *sending* metric data. Per-team ingestion volume exists only as `app_metrics2` billing usage rows and team-less prom counters, neither of which is queryable as a metric in the Metrics product itself.

## Changes

Dogfoods the Metrics product to answer "which teams are ingesting metrics":

- New `nodejs/src/ingestion/pipelines/metrics/ingestion-otel-metrics.ts` with two OTLP-pushed counters, recorded through the existing self-push helper (`initMetrics` in `common/metrics/otel-metrics.ts`):
  - `metrics_ingestion_records_ingested_total{team_id}`
  - `metrics_ingestion_bytes_ingested_total{team_id}` (unit `By`)
- Recorded in `MetricsIngestionConsumer.produceValidMetricMessages`, per message, only after the produce to the ClickHouse-bound topic resolves. Messages that fail and route to the DLQ never count as ingested. This consumer is the earliest point in the pipeline where `team_id` exists (the Rust capture layer only sees the raw token).
- The module mirrors the merged logs twin (`nodejs/src/logs/ingestion-otel-metrics.ts`): lazy instrument acquisition, exemplar support, error swallowing, zero-skip.

Names mirror the `app_metrics2` usage row names (`records_ingested`/`bytes_ingested`) rather than the prom `*_allowed_total` counters, which the scrape bridge already pushes team-less; reusing those names would mix two label schemas. The counting boundary here is stricter than the billing rows: post-produce success rather than post-quota, so the metric reflects data that actually reached the storage pipeline (this addressed a review finding, see thread).

> [!NOTE]
> The consumer counts its own OTLP self-pushes, since they flow through this same pipeline. This is bounded (constant data points per export interval, independent of counter values) and matches the existing logs twins. Emission stays off unless `OTEL_METRICS_EXPORT_URL`/`OTEL_METRICS_EXPORT_TOKEN` are set, the same gate as everything else using the helper; enabling it on the metrics-ingestion deployment is charts-side config.

## How did you test this code?

TDD (red first) with 4 jest cases in `ingestion-otel-metrics.test.ts`, each catching a regression no existing test covers:

- the two per-team emission cases catch swapped bytes/records args, wrong metric names, a missing or non-string `team_id` attribute, and instruments created at module load (which would bind to the noop meter forever)
- the zero/negative skip case catches removal of the `addPositive` guard, which would create empty per-team series every export interval
- the swallow case catches loss of the `swallowing()` wrapper, where an OTel throw would reject the consumer's background task

`eslint`, `prettier`, and `tsc --noEmit` clean for the touched files. There is no consumer-level jest test: constructing `MetricsIngestionConsumer` needs Kafka, Redis, and rate-limiter scaffolding, the logs precedent has none either, and the wiring is validated end to end below.

Validated end to end on a local stack (metrics intent, OTLP export env pointed at local capture-logs), twice: once for the original wiring, and again after moving the recording to the post-produce success path. The counters land in `posthog.metrics` every export interval with correct per-team attribution, cumulative values, and correct attribution of a consumer-group backlog drained after a restart.

<details><summary>Observed ClickHouse output (post-fix run)</summary>

```
SELECT timestamp, metric_name, attributes_map_str['team_id__str'] AS team, value
FROM posthog.metrics
WHERE metric_name LIKE 'metrics_ingestion_%_ingested_total'
  AND timestamp > now() - INTERVAL 3 MINUTE ORDER BY timestamp DESC

┌──────────────────timestamp─┬─metric_name──────────────────────────────┬─team─┬───value─┐
│ 2026-07-22 19:03:57.934000 │ metrics_ingestion_bytes_ingested_total   │ 1    │ 1860313 │
│ 2026-07-22 19:03:57.934000 │ metrics_ingestion_bytes_ingested_total   │ 20   │   11305 │
│ 2026-07-22 19:03:57.934000 │ metrics_ingestion_records_ingested_total │ 1    │   10568 │
│ 2026-07-22 19:03:57.934000 │ metrics_ingestion_records_ingested_total │ 20   │      19 │
│ 2026-07-22 19:03:42.933000 │ metrics_ingestion_bytes_ingested_total   │ 1    │ 1700320 │
│ 2026-07-22 19:03:42.933000 │ metrics_ingestion_bytes_ingested_total   │ 20   │   10115 │
│ 2026-07-22 19:03:42.933000 │ metrics_ingestion_records_ingested_total │ 1    │    9666 │
│ 2026-07-22 19:03:42.933000 │ metrics_ingestion_records_ingested_total │ 20   │      17 │
└────────────────────────────┴──────────────────────────────────────────┴──────┴─────────┘
```

Two distinct local teams attributed correctly, values cumulative and increasing.

</details>

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal instrumentation only, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Skills invoked: `/writing-tests`, `/instrumenting-first-party-metrics`.
- Hook point decision: the Rust capture layer (`rust/capture-logs`) has no `team_id` at all, so the metric is emitted from the Node consumer where team identity is resolved, instead of duplicating token-to-team resolution into Rust.
- Initially recorded pre-produce alongside the `app_metrics2` usage rows (same boundary as billing). Greptile flagged that DLQ'd messages would count as ingested; rather than documenting that boundary, the recording moved to per-message post-produce success in `produceValidMetricMessages`, which better matches the metric's purpose.
- Considered and rejected reusing the `*_allowed_total` prom names (label-schema mix with the bridge-pushed aggregates) and a consumer-wiring jest test (needs Kafka/Redis scaffolding; the logs precedent has none and the E2E run covers the wiring).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
