### PR TITLE
fix(mcp): regenerate types for members_can_see_org_members

### DIFF
--- a/services/mcp/src/generated/platform_features/api.ts
+++ b/services/mcp/src/generated/platform_features/api.ts
@@ -35,6 +35,12 @@ export const PartialUpdateBody = /* @__PURE__ */ zod.object({
             'When True, organization members (below admin) are allowed to create new projects. Admins and owners can always create projects.'
         ),
     members_can_use_personal_api_keys: zod.boolean().optional(),
+    members_can_see_org_members: zod
+        .boolean()
+        .optional()
+        .describe(
+            'When False, members (below admin) only see themselves in the members list and only project members in access control.'
+        ),
     allow_publicly_shared_resources: zod.boolean().optional(),
     is_ai_data_processing_approved: zod.boolean().nullish(),
     is_ai_training_opted_in: zod

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -540,6 +540,7 @@ const OrganizationEnforce2faSchema = PartialUpdateParams.extend(
         members_can_invite: true,
         members_can_create_projects: true,
         members_can_use_personal_api_keys: true,
+        members_can_see_org_members: true,
         allow_publicly_shared_resources: true,
         is_ai_data_processing_approved: true,
         is_ai_training_opted_in: true,


### PR DESCRIPTION
## Problem

Master's **Validate OpenAPI types** job fails on every commit since #72704 merged: the PR added `members_can_see_org_members` to the Organization serializer, and the PR-branch bot regenerated `services/mcp/src/api/generated.ts` — but not the per-product MCP files. Incident: "OpenAPI types out of date: members_can_see_org_members field" (High).

## Changes

Regenerated via the same steps CI runs (`build:openapi-schema` → MCP generators):

- `services/mcp/src/generated/platform_features/api.ts` — field added to the Zod schema
- `services/mcp/src/tools/generated/platform_features.ts` — field added to the tool schema

Generated files only, no hand edits — 7 added lines, both containing exactly the new field.

## How did you test this code?

Ran the generation from a clean master checkout; diff contains only the missing field. CI's Validate OpenAPI types job on this PR is the real verification.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Human-driven (agent-assisted) — Claude Code (Fable 5), directed by @a-lider. Master-CI fix for the type drift left by #72704; merge unblocks the deploy train past that commit.
