### PR TITLE
fix(data-warehouse): co-claim consecutive live batches in the duckgres sink

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/jobs_db.py
@@ -286,13 +286,14 @@ class DuckgresBatchQueue:
         is the hard backstop. Teams without a mapping row are uncapped
         (None = no caps at all, for tests/dev).
 
-        Intra-run head-of-line: LIVE batches stay strictly ordered (any
-        unapplied lower batch_index blocks). Backfill CHUNKS relax this so a
-        whole run drains in one claim: a pending predecessor blocks a chunk
-        only when it cannot be returned AHEAD of it in this same fetch (see the
-        gate's inline comments). Co-claimable predecessors sort earlier, land
-        in the same group, and the group is processed strictly in order with a
-        halt on first non-success — so chunk 0's CREATE still applies first.
+        Intra-run head-of-line: a pending predecessor blocks a batch only when
+        it cannot be returned AHEAD of it in this same fetch (see the gate's
+        inline comments) — for LIVE batches and backfill CHUNKS alike, so a
+        run's consecutive delta-succeeded prefix drains in one claim (bounded
+        by ``limit``). Co-claimable predecessors sort earlier, land in the same
+        group, and the group is processed strictly in order with a halt on
+        first non-success — so chunk 0's CREATE (and a live run's lowest
+        batch) still applies first, and nothing ever applies past a gap.
 
         Cross-run head-of-line: a batch is ineligible while an older run (by run
         start time) of the same (team_id, schema_id) still has unapplied,
@@ -420,13 +421,14 @@ class DuckgresBatchQueue:
                                 )
                                 AND a.id IS NULL
                                 AND (
-                                    -- LIVE batches: any unapplied predecessor blocks.
-                                    {LIVE_BATCH_SQL_PREDICATE}
-                                    -- Backfill chunks: block only on predecessors that
-                                    -- cannot be co-claimed AHEAD of this chunk —
-                                    -- not delta-succeeded (fail closed; enqueue_chunks
-                                    -- writes chunks pre-succeeded atomically):
-                                    OR ds_prev.job_state IS DISTINCT FROM 'succeeded'
+                                    -- Both batch kinds co-claim: a predecessor blocks
+                                    -- only when it cannot be returned AHEAD of this
+                                    -- batch in this same fetch (live batches gained
+                                    -- this in 2026-07; one-at-a-time head-of-line
+                                    -- capped a group at ~1 batch per fetch rotation
+                                    -- and could not keep up with a fast producer).
+                                    -- Not delta-succeeded (fail closed):
+                                    ds_prev.job_state IS DISTINCT FROM 'succeeded'
                                     -- sorting later in the fetch order (a reconcile
                                     -- replay re-inserts dropped chunks with a fresh
                                     -- created_at):

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_jobs_db.py
@@ -262,7 +262,11 @@ class TestDuckgresBatchQueueEligibility:
         assert batches[0].latest_attempt == 1
 
     @pytest.mark.asyncio
-    async def test_enforces_prior_batch_apply_order(self, conn):
+    async def test_co_claims_consecutive_live_prefix_in_one_fetch(self, conn):
+        # A live run's delta-succeeded prefix drains in ONE claim (the chunk
+        # co-claim semantics): each fetch-rotation wait amortizes across the
+        # prefix instead of gating every batch — the head-of-line throughput
+        # ceiling behind the 2026-07 team-2 workflow_histories backlog.
         first_id = await _insert_batch(conn, batch_index=0)
         second_id = await _insert_batch(conn, batch_index=1)
         await BatchQueue.update_status(conn, batch_id=first_id, job_state="succeeded", attempt=1)
@@ -270,7 +274,54 @@ class TestDuckgresBatchQueueEligibility:
 
         batches = await DuckgresBatchQueue.get_delta_succeeded_and_lock(conn, owner_token="owner-a")
 
+        assert [batch.batch_index for batch in batches] == [0, 1]
+
+    @pytest.mark.asyncio
+    async def test_live_prefix_stops_at_a_non_delta_succeeded_gap(self, conn):
+        # Only the CONSECUTIVE delta-succeeded prefix is claimable: a gap fails
+        # closed exactly like the chunk gate, so ordering can never skip a hole.
+        first_id = await _insert_batch(conn, batch_index=0)
+        await _insert_batch(conn, batch_index=1)
+        third_id = await _insert_batch(conn, batch_index=2)
+        await BatchQueue.update_status(conn, batch_id=first_id, job_state="succeeded", attempt=1)
+        await BatchQueue.update_status(conn, batch_id=third_id, job_state="succeeded", attempt=1)
+
+        batches = await DuckgresBatchQueue.get_delta_succeeded_and_lock(conn, owner_token="owner-a")
+
         assert [batch.batch_index for batch in batches] == [0]
+
+    @pytest.mark.asyncio
+    async def test_live_batch_blocked_behind_executing_predecessor(self, conn):
+        first_id = await _insert_batch(conn, batch_index=0)
+        second_id = await _insert_batch(conn, batch_index=1)
+        await BatchQueue.update_status(conn, batch_id=first_id, job_state="succeeded", attempt=1)
+        await BatchQueue.update_status(conn, batch_id=second_id, job_state="succeeded", attempt=1)
+        await DuckgresBatchQueue.update_status(conn, batch_id=first_id, job_state="executing", attempt=1)
+
+        batches = await DuckgresBatchQueue.get_delta_succeeded_and_lock(conn, owner_token="owner-a")
+
+        assert batches == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "backoff_seconds,expected_indexes",
+        [
+            (3600, []),  # predecessor inside its backoff window gates the run
+            (0, [0, 1]),  # backoff elapsed: predecessor and successor co-claim
+        ],
+    )
+    async def test_retry_backoff_gates_successor_live_batches(self, conn, backoff_seconds, expected_indexes):
+        first_id = await _insert_batch(conn, batch_index=0)
+        second_id = await _insert_batch(conn, batch_index=1)
+        await BatchQueue.update_status(conn, batch_id=first_id, job_state="succeeded", attempt=1)
+        await BatchQueue.update_status(conn, batch_id=second_id, job_state="succeeded", attempt=1)
+        await DuckgresBatchQueue.update_status(conn, batch_id=first_id, job_state="waiting_retry", attempt=1)
+
+        batches = await DuckgresBatchQueue.get_delta_succeeded_and_lock(
+            conn, owner_token="owner-a", retry_backoff_base_seconds=backoff_seconds
+        )
+
+        assert [b.batch_index for b in batches] == expected_indexes
 
     @pytest.mark.asyncio
     async def test_final_marker_waits_for_matching_data_batch_apply(self, conn):
@@ -280,13 +331,9 @@ class TestDuckgresBatchQueueEligibility:
         await BatchQueue.update_status(conn, batch_id=final_id, job_state="succeeded", attempt=1)
 
         batches = await DuckgresBatchQueue.get_delta_succeeded_and_lock(conn, owner_token="owner-a")
-        assert [str(batch.id) for batch in batches] == [data_id]
-
-        await DuckgresBatchQueue.mark_applied(conn, batch=batches[0])
-        await DuckgresBatchQueue.unlock_for_batches(conn, batches=batches, owner_token="owner-a")
-
-        batches = await DuckgresBatchQueue.get_delta_succeeded_and_lock(conn, owner_token="owner-a")
-        assert [str(batch.id) for batch in batches] == [final_id]
+        # Co-claimed in one fetch, data batch strictly first — the group loop
+        # applies in order and halts before the final on any non-success.
+        assert [str(batch.id) for batch in batches] == [data_id, final_id]
 
     @pytest.mark.asyncio
     async def test_delta_failed_run_is_skipped(self, conn):

--- a/services/mcp/src/generated/platform_features/api.ts
+++ b/services/mcp/src/generated/platform_features/api.ts
@@ -35,6 +35,12 @@ export const PartialUpdateBody = /* @__PURE__ */ zod.object({
             'When True, organization members (below admin) are allowed to create new projects. Admins and owners can always create projects.'
         ),
     members_can_use_personal_api_keys: zod.boolean().optional(),
+    members_can_see_org_members: zod
+        .boolean()
+        .optional()
+        .describe(
+            'When False, members (below admin) only see themselves in the members list and only project members in access control.'
+        ),
     allow_publicly_shared_resources: zod.boolean().optional(),
     is_ai_data_processing_approved: zod.boolean().nullish(),
     is_ai_training_opted_in: zod

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -540,6 +540,7 @@ const OrganizationEnforce2faSchema = PartialUpdateParams.extend(
         members_can_invite: true,
         members_can_create_projects: true,
         members_can_use_personal_api_keys: true,
+        members_can_see_org_members: true,
         allow_publicly_shared_resources: true,
         is_ai_data_processing_approved: true,
         is_ai_training_opted_in: true,


### PR DESCRIPTION
## Problem

Live batches in the duckgres sink are strictly head-of-line: `get_delta_succeeded_and_lock`'s intra-run gate blocks any live batch with an unapplied predecessor, so only a run's head batch is claimable per fetch. Every live batch therefore pays one full fetch-rotation wait before its apply.

Measured in prod during the 2026-07-22 "stuck baseline" investigation (team 2's `workflow_histories` import):

- median dead time between consecutive applies: **129s**; median apply: **25s** (p90 325s, max 501s)
- throughput ceiling ≈ **23 batches/hr** best case, **7/hr observed**, against **74/hr produced**
- result: a ~32h-deep queue, `duckgres_sink_eligible_backlog` pinned at ~1.8K, and `oldest_eligible_age` climbing linearly (1.34d and growing) — while every pod was healthy and applying continuously

~84% of each claim cycle was waiting for the next rotation, not working.

## Fix

Backfill chunks already solved exactly this: a predecessor blocks only when it **cannot be co-claimed ahead of the batch in the same fetch**. This PR drops the live-batch special case (`LIVE_BATCH_SQL_PREDICATE` disjunct) from the intra-run gate so both batch kinds share the identical co-claim conditions:

- the claimable set is the run's **consecutive delta-succeeded prefix** — a gap (non-delta-succeeded, executing, in-backoff, or later-sorting predecessor) still fails closed and blocks everything after it
- co-claimed batches sort in order, land in the same group, and the existing group loop applies them **strictly in order with halt on first non-success** — nothing can apply past a gap or out of order
- cross-run head-of-line, retry backoff, org budgets, lease exclusion, and the blocked/unprimed-schema gates are untouched
- the prefix is bounded by the fetch `limit`, the same bound backfill chunks already operate under

Amortizing the rotation wait takes the measured group from ~7/hr observed to ~(129 + 20×25)/20 ≈ 31s/batch ≈ **114/hr** at p50 apply time — comfortably above the producer.

## How did you test this code?

I'm an agent; checks actually run:

- TDD against the real queue DB: rewrote `test_enforces_prior_batch_apply_order` into `test_co_claims_consecutive_live_prefix_in_one_fetch` and watched it fail on head-only behavior first, plus new failing-first coverage for the gap (`test_live_prefix_stops_at_a_non_delta_succeeded_gap`), executing-predecessor, and retry-backoff cases (mirroring the chunk tests), and updated the final-marker test for same-fetch co-claim.
- Full `test_jobs_db.py`: **53 passed** — including all pre-existing intra-run, cross-run, supersede, budget, and lease tests unchanged.
- `test_consumer.py` + `test_processor.py`: 40 passed.
- `bin/hogli ci:preflight`: staged-file hooks (ruff, format, ty) clean.

## Follow-ups (not in this PR)

- The 300–500s apply outliers (suspect DuckLake commit contention across an org's concurrent groups).
- A per-group progress-rate metric — this incident was indistinguishable from a wedged consumer on the existing gauges, which is what sent the investigation down a zombie-lease path first.

## 🤖 Agent context

Authored by Claude Code (Fable 5) from a production investigation: queue-DB attribution of the eligible backlog → per-batch log timing across the three consumer pods (22 applies/3h, gap/apply split) → the claim-SQL asymmetry between live batches and backfill chunks. The fix deliberately reuses the chunk co-claim conditions verbatim rather than introducing a new mechanism or knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)