### PR TITLE
feat(insights): blue-purple palette for the insight icon set

### DIFF
--- a/frontend/src/lib/lemon-ui/icons/icons.tsx
+++ b/frontend/src/lib/lemon-ui/icons/icons.tsx
@@ -429,13 +429,15 @@ export function IconTableChart(props: LemonIconProps): JSX.Element {
 
 /*
  * Insight type icon set. Drawn at the same visual weight as the left-nav icon family
- * (~1.5-1.75 unit strokes, slim bars) and colored the way each insight's chart actually renders:
- * series blue `--data-color-1` (#1d4aff) for most, the real lifecycle status colors for Lifecycle,
- * and the PostHog brand trio for SQL. Colors are fixed hex on purpose (the glyphs stay chart-true
- * rather than following `currentColor`); structural parts (SQL brackets, lifecycle axis) still
- * follow `currentColor` so they theme.
+ * (~1.5-1.75 unit strokes, slim bars) and colored with one shared blue→purple ramp across
+ * every glyph: primary element blue, secondary purple, tertiary light violet. The three
+ * stops are PostHog series colors (`--data-color-1`, `-2`, `-14`). Colors are fixed hex on
+ * purpose (the glyphs keep this palette rather than following `currentColor`); structural
+ * parts (SQL brackets, lifecycle axis) still follow `currentColor` so they theme.
  */
-const INSIGHT_BLUE = '#1d4aff' // --data-color-1, the default series color
+const INSIGHT_BLUE = '#1d4aff' // --data-color-1
+const INSIGHT_PURPLE = '#7f26d9' // --data-color-2 (dark variant, the more vivid purple)
+const INSIGHT_VIOLET = '#a56eff' // --data-color-14
 
 /** SQL insights: curly brackets (matching `IconBrackets` from `@posthog/icons`) wrapping a bar chart. */
 export function IconBracketsChart(props: LemonIconProps): JSX.Element {
@@ -447,8 +449,8 @@ export function IconBracketsChart(props: LemonIconProps): JSX.Element {
                 d="M4 4.75C4 3.784 4.784 3 5.75 3h2.5a.75.75 0 0 1 0 1.5h-2.5a.25.25 0 0 0-.25.25V11c0 .372-.116.716-.314 1 .198.284.314.628.314 1v6.25c0 .138.112.25.25.25h2.5a.75.75 0 0 1 0 1.5h-2.5A1.75 1.75 0 0 1 4 19.25V13a.25.25 0 0 0-.25-.25h-1a.75.75 0 0 1 0-1.5h1A.25.25 0 0 0 4 11V4.75Zm11-1a.75.75 0 0 1 .75-.75h2.5c.966 0 1.75.784 1.75 1.75V11c0 .138.112.25.25.25h1a.75.75 0 0 1 0 1.5h-1A.25.25 0 0 0 20 13v6.25A1.75 1.75 0 0 1 18.25 21h-2.5a.75.75 0 0 1 0-1.5h2.5a.25.25 0 0 0 .25-.25V13c0-.372.116-.716.314-1a1.742 1.742 0 0 1-.314-1V4.75a.25.25 0 0 0-.25-.25h-2.5a.75.75 0 0 1-.75-.75Z"
                 fill="currentColor"
             />
-            <rect x="6.75" y="13.5" width="3" height="4" rx="0.5" fill="#f9bd2b" />
-            <rect x="10.5" y="10.5" width="3" height="7" rx="0.5" fill="#f54e00" />
+            <rect x="6.75" y="13.5" width="3" height="4" rx="0.5" fill={INSIGHT_VIOLET} />
+            <rect x="10.5" y="10.5" width="3" height="7" rx="0.5" fill={INSIGHT_PURPLE} />
             <rect x="14.25" y="7.5" width="3" height="10" rx="0.5" fill={INSIGHT_BLUE} />
         </LemonIconBase>
     )
@@ -469,21 +471,21 @@ export function IconInsightFunnels(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
             <rect x="3.75" y="4.25" width="16.5" height="4.25" rx="0.75" fill={INSIGHT_BLUE} />
-            <rect x="3.75" y="9.9" width="11" height="4.25" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="3.75" y="15.55" width="5.75" height="4.25" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="3.75" y="9.9" width="11" height="4.25" rx="0.75" fill={INSIGHT_PURPLE} />
+            <rect x="3.75" y="15.55" width="5.75" height="4.25" rx="0.75" fill={INSIGHT_VIOLET} />
         </LemonIconBase>
     )
 }
 
-/** Retention insights: the cohort triangle, fading as periods pass. */
+/** Retention insights: the cohort triangle, hue stepping blue→purple→violet across periods. */
 export function IconInsightRetention(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
             <rect x="3.75" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
-            <rect x="9.3" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="14.85" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="9.3" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_PURPLE} />
+            <rect x="14.85" y="3.75" width="4.4" height="4.4" rx="1" fill={INSIGHT_VIOLET} />
             <rect x="3.75" y="9.3" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
-            <rect x="9.3" y="9.3" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="9.3" y="9.3" width="4.4" height="4.4" rx="1" fill={INSIGHT_PURPLE} />
             <rect x="3.75" y="14.85" width="4.4" height="4.4" rx="1" fill={INSIGHT_BLUE} />
         </LemonIconBase>
     )
@@ -493,11 +495,11 @@ export function IconInsightRetention(props: LemonIconProps): JSX.Element {
 export function IconInsightUserPaths(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <path d="M6.6 8.25 C10.5 8.25 12 7.6 17.4 7.6" stroke={INSIGHT_BLUE} strokeWidth="4.5" opacity="0.4" />
-            <path d="M6.6 15 C10.5 15 12.5 16.4 17.4 16.4" stroke={INSIGHT_BLUE} strokeWidth="3.25" opacity="0.25" />
+            <path d="M6.6 8.25 C10.5 8.25 12 7.6 17.4 7.6" stroke={INSIGHT_PURPLE} strokeWidth="4.5" opacity="0.45" />
+            <path d="M6.6 15 C10.5 15 12.5 16.4 17.4 16.4" stroke={INSIGHT_VIOLET} strokeWidth="3.25" opacity="0.45" />
             <rect x="3.75" y="4.5" width="2.9" height="15" rx="0.7" fill={INSIGHT_BLUE} />
-            <rect x="17.35" y="4.5" width="2.9" height="6.25" rx="0.7" fill={INSIGHT_BLUE} />
-            <rect x="17.35" y="13.25" width="2.9" height="6.25" rx="0.7" fill={INSIGHT_BLUE} />
+            <rect x="17.35" y="4.5" width="2.9" height="6.25" rx="0.7" fill={INSIGHT_PURPLE} />
+            <rect x="17.35" y="13.25" width="2.9" height="6.25" rx="0.7" fill={INSIGHT_VIOLET} />
         </LemonIconBase>
     )
 }
@@ -507,42 +509,42 @@ export function IconInsightStickiness(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
             <rect x="3.75" y="4.5" width="2.9" height="15" rx="0.7" fill={INSIGHT_BLUE} />
-            <rect x="8.4" y="9" width="2.9" height="10.5" rx="0.7" fill={INSIGHT_BLUE} />
-            <rect x="13.05" y="12.5" width="2.9" height="7" rx="0.7" fill={INSIGHT_BLUE} />
-            <rect x="17.7" y="15.5" width="2.9" height="4" rx="0.7" fill={INSIGHT_BLUE} />
+            <rect x="8.4" y="9" width="2.9" height="10.5" rx="0.7" fill={INSIGHT_PURPLE} />
+            <rect x="13.05" y="12.5" width="2.9" height="7" rx="0.7" fill={INSIGHT_VIOLET} />
+            <rect x="17.7" y="15.5" width="2.9" height="4" rx="0.7" fill={INSIGHT_VIOLET} fillOpacity="0.6" />
         </LemonIconBase>
     )
 }
 
-/** Lifecycle insights: new/returning/resurrecting above the axis, dormant below, in the chart's real status colors. */
+/** Lifecycle insights: bars above the axis blue→purple→violet, dormant dipping below in purple. */
 export function IconInsightLifecycle(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
             <path d="M3.75 12.1h16.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-            <rect x="3.9" y="5" width="2.6" height="6.25" rx="0.65" fill="#1d4aff" />
-            <rect x="8.3" y="6.75" width="2.6" height="4.5" rx="0.65" fill="#388600" />
-            <rect x="12.7" y="13" width="2.6" height="4.5" rx="0.65" fill="#db3707" />
-            <rect x="17.1" y="5.75" width="2.6" height="5.5" rx="0.65" fill="#a56eff" />
+            <rect x="3.9" y="5" width="2.6" height="6.25" rx="0.65" fill={INSIGHT_BLUE} />
+            <rect x="8.3" y="6.75" width="2.6" height="4.5" rx="0.65" fill={INSIGHT_VIOLET} />
+            <rect x="12.7" y="13" width="2.6" height="4.5" rx="0.65" fill={INSIGHT_PURPLE} />
+            <rect x="17.1" y="5.75" width="2.6" height="5.5" rx="0.65" fill={INSIGHT_BLUE} fillOpacity="0.6" />
         </LemonIconBase>
     )
 }
 
-/** Calendar heatmap insights: a day-by-hour intensity matrix. */
+/** Calendar heatmap insights: a day-by-hour matrix, intensity mapped along blue→purple→violet. */
 export function IconInsightCalendarHeatmap(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
-            <rect x="3.55" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.35" />
-            <rect x="8.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="3.55" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_VIOLET} />
+            <rect x="8.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
             <rect x="12.55" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
-            <rect x="17.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="3.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="17.05" y="5.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
+            <rect x="3.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
             <rect x="8.05" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
-            <rect x="12.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="17.05" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="12.55" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
+            <rect x="17.05" y="9.85" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_VIOLET} />
             <rect x="3.55" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} />
-            <rect x="8.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="12.55" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.35" />
-            <rect x="17.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_BLUE} fillOpacity="0.6" />
+            <rect x="8.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
+            <rect x="12.55" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_VIOLET} />
+            <rect x="17.05" y="14.35" width="3.4" height="3.4" rx="0.9" fill={INSIGHT_PURPLE} />
         </LemonIconBase>
     )
 }
@@ -560,26 +562,26 @@ export function IconInsightNumber(props: LemonIconProps): JSX.Element {
     )
 }
 
-/** Table insights: a solid header row above label/value rows fading down the ranking. */
+/** Table insights: a solid header row above label/value rows stepping blue→purple→violet. */
 export function IconInsightTable(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
             <rect x="3.75" y="4.5" width="16.5" height="3.6" rx="0.75" fill={INSIGHT_BLUE} />
-            <rect x="3.75" y="10" width="5" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="10.25" y="10" width="10" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <rect x="3.75" y="15.5" width="5" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.35" />
-            <rect x="10.25" y="15.5" width="10" height="3.6" rx="0.75" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <rect x="3.75" y="10" width="5" height="3.6" rx="0.75" fill={INSIGHT_PURPLE} />
+            <rect x="10.25" y="10" width="10" height="3.6" rx="0.75" fill={INSIGHT_PURPLE} />
+            <rect x="3.75" y="15.5" width="5" height="3.6" rx="0.75" fill={INSIGHT_VIOLET} />
+            <rect x="10.25" y="15.5" width="10" height="3.6" rx="0.75" fill={INSIGHT_VIOLET} />
         </LemonIconBase>
     )
 }
 
-/** Pie insights: breakdown slices fading like the chart's series shades. */
+/** Pie insights: breakdown slices in the blue→purple→violet ramp, largest slice blue. */
 export function IconInsightPie(props: LemonIconProps): JSX.Element {
     return (
         <LemonIconBase {...props}>
             <path d="M12 12 L12 3.75 A8.25 8.25 0 0 1 12 20.25 Z" fill={INSIGHT_BLUE} />
-            <path d="M12 12 L12 20.25 A8.25 8.25 0 0 1 4.16 9.44 Z" fill={INSIGHT_BLUE} fillOpacity="0.6" />
-            <path d="M12 12 L4.16 9.44 A8.25 8.25 0 0 1 12 3.75 Z" fill={INSIGHT_BLUE} fillOpacity="0.35" />
+            <path d="M12 12 L12 20.25 A8.25 8.25 0 0 1 4.16 9.44 Z" fill={INSIGHT_PURPLE} />
+            <path d="M12 12 L4.16 9.44 A8.25 8.25 0 0 1 12 3.75 Z" fill={INSIGHT_VIOLET} />
         </LemonIconBase>
     )
 }


### PR DESCRIPTION
## TL;DR

Option B of two. The insight icon set gets one shared palette: a blue→purple→violet ramp across every glyph, including the SQL bars. Answers the review question — should the whole set be red/yellow/blue, or all purple tones? This is the purple answer. The trio answer is the sibling PR.

Blue is the current set; purple ramp is this PR (light, 16 px, dark):

![purple comparison](https://raw.githubusercontent.com/PostHog/pr-assets/2db1118235174c6041205eab0e4d64560e5abbe0/2026/07/a3cde4cf-8960-46e2-aa60-40f90c943a6d.png)

## Problem

Review feedback on the icon set ([#72732](https://github.com/PostHog/posthog/pull/72732)): the coloring is split. Most glyphs are blue with opacity fades (plus lifecycle's own status colors), but the SQL icon introduces the red/yellow/blue brand trio. One or the other, not both. This PR keeps everything in blue/purple tones and pulls the SQL icon in with it.

## Changes

One shared ramp in `frontend/src/lib/lemon-ui/icons/icons.tsx`: primary element blue (`#1d4aff`, `--data-color-1`), secondary purple (`#7f26d9`, `--data-color-2`), tertiary light violet (`#a56eff`, `--data-color-14`). All three are PostHog series colors.

- Funnel, retention, stickiness, table, pie, calendar heatmap: opacity fades replaced by the discrete blue→purple→violet stops.
- Paths: flow ribbons purple and violet, sinks purple/violet.
- Lifecycle: drops the green/red status colors; above-axis bars blue/violet, dormant dips below in purple.
- SQL icon: the red/yellow/blue bars become blue/purple/violet, matching the rest.
- Single-element glyphs (trends line, number digits, world map globe) stay blue.

Structural parts (SQL brackets, lifecycle axis) still follow `currentColor` so they theme.

> [!NOTE]
> Alternative to [the brand-trio PR](https://github.com/PostHog/posthog/pull/73004). Both branch off [#72732](https://github.com/PostHog/posthog/pull/72732); merge one, close the other. This PR targets that branch so the diff is only the recolor.

## How did you test this code?

No logic change — fill colors only. I (Claude via PostHog Code) rendered the set against the current blue version at 40 px, 16 px, and on dark (image above) to confirm the ramp stays distinct at menu size and in dark mode (the violet is the risk at small sizes; it holds). The icons show in the `Lemon UI/Icons` storybook, so CI visual snapshots will pick them up.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed. No doc shows the insight type icons.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude), driven by Thomas. The review left an open palette question on the icon-set PR; rather than guess, I built both answers as separate PRs off that branch so they can be compared side by side. This is the blue/purple one. The three stops are all real PostHog series tokens (`--data-color-1/-2/-14`) so the ramp stays on-brand; violet was chosen as the third stop over a darker purple to keep the lightest step legible at 16 px. No skills invoked — pure icon geometry/color.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*