### PR TITLE
fix(warehouse_sources): avoid ArrowNotImplementedError on empty composite-PK take

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -164,9 +164,10 @@ def _enrich_cdc_rows(
                             for j in range(existing_rows.num_rows)
                             if tuple(arr[j] for arr in ex_pk_arrays) in enrich_key_set
                         ]
-                        existing_rows = existing_rows.take(match_indices)
+                        # Explicit int64 so an empty result doesn't infer a null-typed index array.
+                        existing_rows = existing_rows.take(pa.array(match_indices, type=pa.int64()))
                     else:
-                        existing_rows = existing_rows.take([])
+                        existing_rows = existing_rows.take(pa.array([], type=pa.int64()))
 
                 # For SCD2 tables, keep only "current" rows (valid_to IS NULL) so we
                 # enrich with the most recent state rather than a historical one.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/test_processor.py
@@ -540,6 +540,80 @@ class TestEnrichCdcRows:
 
             assert result.column("big").to_pylist() == ["current-toast"]
 
+    def test_composite_pk_delete_enrichment_with_no_matching_existing_row(self):
+        # Existing row shares the first PK component ("id") with the incoming DELETE
+        # but not the full composite key, so `match_indices` narrows to empty. This
+        # used to crash with ArrowNotImplementedError: `Table.take([])` infers a
+        # null-typed indices array, and pyarrow has no take kernel for (string, null).
+        with tempfile.TemporaryDirectory() as path:
+            write_deltalake(
+                path,
+                pa.table(
+                    {
+                        "id": pa.array([1], pa.int64()),
+                        "tenant": pa.array(["a"], pa.string()),
+                        "name": pa.array(["existing"], pa.string()),
+                    }
+                ),
+                mode="overwrite",
+            )
+
+            batch = pa.table(
+                {
+                    "id": pa.array([1], pa.int64()),
+                    "tenant": pa.array(["z"], pa.string()),
+                    "name": pa.array([None], pa.string()),
+                    CDC_OP_COLUMN: pa.array(["D"], pa.string()),
+                    TOAST_OMITTED_COLUMN: pa.array([None], pa.list_(pa.string())),
+                }
+            )
+            result = _enrich_cdc_rows(
+                batch,
+                primary_keys=["id", "tenant"],
+                cdc_write_mode="incremental_merge",
+                existing_delta_table=DeltaTable(path),
+                batch_index=0,
+            )
+
+            assert TOAST_OMITTED_COLUMN not in result.column_names
+            assert result.column("name").to_pylist() == [None]
+
+    def test_composite_pk_delete_enrichment_when_existing_table_lacks_a_pk_column(self):
+        # The existing Delta table predates a composite key gaining a second PK
+        # column ("tenant"), so it can't be exactly matched. Same bug as above but
+        # via the `else` branch, which also called `.take([])` unconditionally.
+        with tempfile.TemporaryDirectory() as path:
+            write_deltalake(
+                path,
+                pa.table(
+                    {
+                        "id": pa.array([1], pa.int64()),
+                        "name": pa.array(["existing"], pa.string()),
+                    }
+                ),
+                mode="overwrite",
+            )
+
+            batch = pa.table(
+                {
+                    "id": pa.array([1], pa.int64()),
+                    "tenant": pa.array(["z"], pa.string()),
+                    "name": pa.array([None], pa.string()),
+                    CDC_OP_COLUMN: pa.array(["D"], pa.string()),
+                    TOAST_OMITTED_COLUMN: pa.array([None], pa.list_(pa.string())),
+                }
+            )
+            result = _enrich_cdc_rows(
+                batch,
+                primary_keys=["id", "tenant"],
+                cdc_write_mode="incremental_merge",
+                existing_delta_table=DeltaTable(path),
+                batch_index=0,
+            )
+
+            assert TOAST_OMITTED_COLUMN not in result.column_names
+            assert result.column("name").to_pylist() == [None]
+
     def test_marker_dropped_when_enrichment_cannot_run(self):
         # First-ever CDC batch: no existing Delta table to fill from. The value is
         # unknowable (stays null) but the transport marker must never reach the write.


### PR DESCRIPTION
## Problem

Error tracking caught an `ArrowNotImplementedError` in the data warehouse import pipeline: `Function 'array_take' has no kernel matching input types (string, null)`, raised from `pyarrow.lib._Tabular.take` inside `_enrich_cdc_rows` in [`processor.py`](https://github.com/PostHog/posthog/blob/master/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py).

That function narrows a composite-primary-key match down to a plain Python list of row indices, then calls `existing_rows.take(match_indices)`. When the list ends up empty (or the `else` branch's explicit `.take([])`), pyarrow infers the indices array as `null`-typed, and there's no `array_take` kernel for `(<column type>, null)`. This crashed CDC enrichment for any composite-PK sync where an incoming DELETE or TOAST-omitted row's composite key had no exact match against the existing Delta table state, which is a normal, expected outcome, not a data-integrity problem.

## Changes

Explicitly type the indices array as `int64` before calling `.take()`, matching the existing precedent already used in the Gitea and GitHub sources (`table.take(pa.array(sorted(...), type=pa.int64()))`). An `int64` array of length 0 has a working `take` kernel, so the empty-match case now returns an empty table instead of raising.

## How did you test this code?

Added `TestEnrichCdcRows.test_composite_pk_delete_enrichment_with_no_matching_existing_row`, which reproduces the exact crash: an existing Delta row shares the first PK component with an incoming composite-PK DELETE but not the full key, so the narrowing step produces an empty index list. Verified the test fails with the original code (`ArrowNotImplementedError: Function 'array_take' has no kernel matching input types (int64, null)`) and passes with the fix.

Ran the full `test_processor.py` suite (26 passed), `ruff check`/`ruff format --check`, and a repo-wide `mypy` run (clean, 16695 files) since the change touches type-sensitive pyarrow code.

## Docs update

Not applicable — internal pipeline bugfix, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude, via PostHog Code) triaged this from an error-tracking webhook alert, read the full stack trace and a sample `$exception` event via the PostHog MCP error-tracking tools, then traced the call path into `_enrich_cdc_rows`. I reproduced the exact pyarrow behavior locally (`Table.take([])` inferring a `null`-typed array) before writing the fix, confirmed no open PR already addressed it, and confirmed the regression test fails without the fix and passes with it.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*