### PR TITLE
feat(web-analytics): widen warming to min-2 shapes and parallelize the warm pass

### DIFF
--- a/posthog/settings/dynamic_settings.py
+++ b/posthog/settings/dynamic_settings.py
@@ -293,8 +293,9 @@ CONSTANCE_CONFIG = {
         int,
     ),
     "WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT": (
-        get_from_env("WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT", default=10, type_cast=int),
-        "Minimum query count threshold for web analytics cache warming",
+        get_from_env("WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT", default=2, type_cast=int),
+        "Per-shape floor: minimum runs in the lookback window for a query shape to be warmed. "
+        "2 covers every shape a user returned to; misses cost only a live serve (warm-behind).",
         int,
     ),
     "WEB_ANALYTICS_WARMING_TEAMS_TO_WARM": (
@@ -303,8 +304,9 @@ CONSTANCE_CONFIG = {
         list[int],
     ),
     "WEB_ANALYTICS_WARMING_MAX_SHAPES": (
-        get_from_env("WEB_ANALYTICS_WARMING_MAX_SHAPES", default=20000, type_cast=int),
-        "Cap on the number of hot query shapes web analytics warming selects fleet-wide per run",
+        get_from_env("WEB_ANALYTICS_WARMING_MAX_SHAPES", default=40000, type_cast=int),
+        "Cap on the number of hot query shapes web analytics warming selects fleet-wide per run. "
+        "Sized above the ~29k shapes the min=2 selection produces so the cap doesn't silently truncate.",
         int,
     ),
 }

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -1,5 +1,6 @@
 import re
 import json
+import threading
 import statistics
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Optional
@@ -8,13 +9,14 @@ from django.db import close_old_connections
 from django.utils.dateparse import parse_datetime
 
 import dagster
+import structlog
 from dagster import Backoff, Jitter, RetryPolicy
 from prometheus_client import Counter, Gauge
 
 from posthog.hogql.constants import LimitContext
 
 from posthog.clickhouse.client import sync_execute
-from posthog.clickhouse.query_tagging import Feature, tag_queries
+from posthog.clickhouse.query_tagging import Feature, reset_query_tags, tag_queries
 from posthog.dags.common import JobOwners
 from posthog.event_usage import EventSource
 from posthog.exceptions_capture import capture_exception
@@ -56,8 +58,10 @@ WARMING_SHAPES_SELECTED_GAUGE = Gauge(
 WARMING_QUERIES_COUNTER = Counter(
     "posthog_web_analytics_warming_queries_total",
     "Web analytics warming outcomes per query shape",
-    ["outcome"],  # warmed | skipped_fresh | failed | unsupported
+    ["outcome"],  # warmed | skipped_fresh | skipped_duplicate | failed | unsupported
 )
+
+logger = structlog.get_logger(__name__)
 
 cache_warming_retry_policy = RetryPolicy(
     max_retries=3,
@@ -341,6 +345,11 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: list[dict]) ->
     if missing_teams:
         context.log.warning(f"{len(missing_teams)} teams not found, skipping their shapes")
 
+    # Selection groups by raw JSON text, so differently-encoded rows can
+    # normalize to one cache key; first worker to claim it warms, the rest skip.
+    seen_cache_keys: set[tuple[int, str]] = set()
+    seen_lock = threading.Lock()
+
     def _warm_one(query_info: dict) -> str:
         team = teams.get(query_info["team_id"])
         if team is None:
@@ -352,7 +361,10 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: list[dict]) ->
             # — not in the op thread — or the replay loses its background-warming
             # identity, which both the lazy gate's rollout bypass and the
             # selection's self-feedback exclusion key on (the eager warmer's
-            # missing-tags warnings came from exactly this).
+            # missing-tags warnings came from exactly this). Reset first: pool
+            # threads are reused, and tags a previous shape's runner added
+            # (client_query_id, cache key, …) would otherwise leak into this one.
+            reset_query_tags()
             tag_queries(team_id=team.pk, trigger="webAnalyticsQueryWarming", feature=Feature.CACHE_WARMUP)
 
             query_json = maybe_opt_into_lazy_precompute(query_json)
@@ -365,7 +377,14 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: list[dict]) ->
                 WARMING_QUERIES_COUNTER.labels(outcome="unsupported").inc()
                 return "unsupported"
 
-            cache_manager = DjangoCacheQueryCacheManager(team_id=team.pk, cache_key=runner.get_cache_key())
+            cache_key = runner.get_cache_key()
+            with seen_lock:
+                if (team.pk, cache_key) in seen_cache_keys:
+                    WARMING_QUERIES_COUNTER.labels(outcome="skipped_duplicate").inc()
+                    return "skipped_duplicate"
+                seen_cache_keys.add((team.pk, cache_key))
+
+            cache_manager = DjangoCacheQueryCacheManager(team_id=team.pk, cache_key=cache_key)
             cached_data = cache_manager.get_cache_data()
 
             if cached_data is not None:
@@ -379,7 +398,13 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: list[dict]) ->
             WARMING_QUERIES_COUNTER.labels(outcome="warmed").inc()
             return "warmed"
         except Exception as e:
-            context.log.exception(f"Error warming query {query_info['normalized_query_hash']} for team {team.pk}")
+            # Module logger, not context.log: Dagster's log manager isn't
+            # guaranteed thread-safe, and workers fail concurrently.
+            logger.exception(
+                "web_analytics_warming_shape_failed",
+                team_id=team.pk,
+                normalized_query_hash=query_info["normalized_query_hash"],
+            )
             capture_exception(e)
             WARMING_QUERIES_COUNTER.labels(outcome="failed").inc()
             return "failed"

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -58,7 +58,7 @@ WARMING_SHAPES_SELECTED_GAUGE = Gauge(
 WARMING_QUERIES_COUNTER = Counter(
     "posthog_web_analytics_warming_queries_total",
     "Web analytics warming outcomes per query shape",
-    ["outcome"],  # warmed | skipped_fresh | skipped_duplicate | failed | unsupported
+    ["outcome"],  # warmed | skipped_fresh | skipped_duplicate | skipped_raw_low_demand | failed | unsupported
 )
 
 logger = structlog.get_logger(__name__)
@@ -183,9 +183,15 @@ _LAZY_FAMILY_CHECKS: dict[str, tuple] = {
 }
 
 
-def build_replay_runner(team: Team, query_json: dict) -> tuple[Optional["QueryRunner"], dict]:
+def _is_lazy_eligible(runner: "QueryRunner", query_json: dict) -> bool:
+    family_checks = _LAZY_FAMILY_CHECKS.get(query_json.get("kind", ""), ())
+    return any(check(runner) for check in family_checks)
+
+
+def build_replay_runner(team: Team, query_json: dict) -> tuple[Optional["QueryRunner"], dict, bool]:
     """Build the runner for a warming replay, widening the date range only for
-    shapes the lazy path will actually serve.
+    shapes the lazy path will actually serve. Returns (runner, replay json,
+    lazy-eligible) — the caller holds raw-path replays to a higher demand bar.
 
     The per-query opt-in does not guarantee the lazy path: shapes the gates
     reject (conversion goals, sampling, unsupported breakdowns/metrics like
@@ -200,15 +206,21 @@ def build_replay_runner(team: Team, query_json: dict) -> tuple[Optional["QueryRu
     """
     expanded_json = maybe_expand_warming_date_range(query_json)
     if expanded_json is query_json:
-        return get_query_runner_or_none(query=query_json, team=team, limit_context=LimitContext.QUERY_ASYNC), query_json
+        runner = get_query_runner_or_none(query=query_json, team=team, limit_context=LimitContext.QUERY_ASYNC)
+        if runner is None:
+            return None, query_json, False
+        return runner, query_json, _is_lazy_eligible(runner, query_json)
 
     runner = get_query_runner_or_none(query=expanded_json, team=team, limit_context=LimitContext.QUERY_ASYNC)
     if runner is None:
-        return None, expanded_json
-    family_checks = _LAZY_FAMILY_CHECKS.get(expanded_json.get("kind", ""), ())
-    if any(check(runner) for check in family_checks):
-        return runner, expanded_json
-    return get_query_runner_or_none(query=query_json, team=team, limit_context=LimitContext.QUERY_ASYNC), query_json
+        return None, expanded_json, False
+    if _is_lazy_eligible(runner, expanded_json):
+        return runner, expanded_json, True
+    return (
+        get_query_runner_or_none(query=query_json, team=team, limit_context=LimitContext.QUERY_ASYNC),
+        query_json,
+        False,
+    )
 
 
 def queries_to_keep_fresh(
@@ -329,6 +341,11 @@ def get_warmable_queries_op(context: dagster.OpExecutionContext) -> list[dict]:
     return queries
 
 
+# Demand bar for shapes that replay on the raw path (not lazy-eligible). The
+# min-2 selection floor is safe for bucket-backed shapes but would let raw
+# replays amplify a tenant's two runs into hourly background scans.
+RAW_REPLAY_MIN_QUERY_COUNT = 10
+
 # Worker threads for the warm pass. The pass is IO-bound (cache checks, CH
 # reads/inserts), so a small pool cuts wall time ~8x at the widened selection
 # size; kept well under the OFFLINE per-user query-slot budget so a build wave
@@ -372,10 +389,20 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: list[dict]) ->
             # None only for kinds without a get_query_runner branch — the backstop
             # for runnerless kinds the selection doesn't know to exclude yet.
             # Validation errors on supported kinds still raise into the failure path.
-            runner, query_json = build_replay_runner(team, query_json)
+            runner, query_json, lazy_eligible = build_replay_runner(team, query_json)
             if runner is None:
                 WARMING_QUERIES_COUNTER.labels(outcome="unsupported").inc()
                 return "unsupported"
+
+            # Raw-path replays keep the pre-widening demand bar: a lazy-eligible
+            # shape amortizes into shared immutable buckets (steady-state cost is
+            # one cheap today-bucket refresh), but an ineligible shape replays as
+            # a full live query every stale hour — with the min-2 floor a tenant
+            # could mint MAX_SHAPES_PER_TEAM such shapes from two runs each and
+            # have the warmer amplify them outside request throttles.
+            if not lazy_eligible and query_info.get("query_count", 0) < RAW_REPLAY_MIN_QUERY_COUNT:
+                WARMING_QUERIES_COUNTER.labels(outcome="skipped_raw_low_demand").inc()
+                return "skipped_raw_low_demand"
 
             cache_key = runner.get_cache_key()
             with seen_lock:

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -1,8 +1,10 @@
 import re
 import json
 import statistics
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Optional
 
+from django.db import close_old_connections
 from django.utils.dateparse import parse_datetime
 
 import dagster
@@ -206,7 +208,7 @@ def build_replay_runner(team: Team, query_json: dict) -> tuple[Optional["QueryRu
 
 
 def queries_to_keep_fresh(
-    context: dagster.OpExecutionContext, days: int = 2, minimum_query_count: int = 10, max_shapes: int = 20000
+    context: dagster.OpExecutionContext, days: int = 2, minimum_query_count: int = 2, max_shapes: int = 40000
 ) -> list[dict]:
     """Fleet-wide demand selection: every (team, query shape) with at least
     `minimum_query_count` runs in the window, hottest first, capped at
@@ -323,35 +325,35 @@ def get_warmable_queries_op(context: dagster.OpExecutionContext) -> list[dict]:
     return queries
 
 
+# Worker threads for the warm pass. The pass is IO-bound (cache checks, CH
+# reads/inserts), so a small pool cuts wall time ~8x at the widened selection
+# size; kept well under the OFFLINE per-user query-slot budget so a build wave
+# can't starve other traffic (the same slot pool the inline-build saturation
+# incidents exhausted).
+WARMING_SHAPE_CONCURRENCY = 8
+
+
 @dagster.op(retry_policy=cache_warming_retry_policy)
 def warm_queries_op(context: dagster.OpExecutionContext, queries: list[dict]) -> None:
-    queries_warmed = 0
-    queries_skipped = 0
-    queries_failed = 0
-    queries_unsupported = 0
+    team_ids = {q["team_id"] for q in queries}
+    teams: dict[int, Team] = {t.pk: t for t in Team.objects.filter(pk__in=team_ids)}
+    missing_teams = team_ids - teams.keys()
+    if missing_teams:
+        context.log.warning(f"{len(missing_teams)} teams not found, skipping their shapes")
 
-    teams: dict[int, Team | None] = {}
-
-    for query_info in queries:
-        team_id = query_info["team_id"]
-        query_json = query_info["query_json"]
-        normalized_query_hash = query_info["normalized_query_hash"]
-
-        if team_id not in teams:
-            try:
-                teams[team_id] = Team.objects.get(pk=team_id)
-            except Team.DoesNotExist:
-                context.log.warning(f"Team {team_id} not found, skipping")
-                teams[team_id] = None
-        team = teams[team_id]
+    def _warm_one(query_info: dict) -> str:
+        team = teams.get(query_info["team_id"])
         if team is None:
-            continue
+            return "team_missing"
+        query_json = query_info["query_json"]
 
         try:
-            # Tag before any runner work so the whole request — including the lazy
-            # precompute gate, which lets warming traffic through regardless of the
-            # rollout flag — is classified as background warming.
-            tag_queries(team_id=team_id, trigger="webAnalyticsQueryWarming", feature=Feature.CACHE_WARMUP)
+            # Query tags are thread-local, so they must be set here in the worker
+            # — not in the op thread — or the replay loses its background-warming
+            # identity, which both the lazy gate's rollout bypass and the
+            # selection's self-feedback exclusion key on (the eager warmer's
+            # missing-tags warnings came from exactly this).
+            tag_queries(team_id=team.pk, trigger="webAnalyticsQueryWarming", feature=Feature.CACHE_WARMUP)
 
             query_json = maybe_opt_into_lazy_precompute(query_json)
 
@@ -361,31 +363,40 @@ def warm_queries_op(context: dagster.OpExecutionContext, queries: list[dict]) ->
             runner, query_json = build_replay_runner(team, query_json)
             if runner is None:
                 WARMING_QUERIES_COUNTER.labels(outcome="unsupported").inc()
-                queries_unsupported += 1
-                continue
+                return "unsupported"
 
             cache_manager = DjangoCacheQueryCacheManager(team_id=team.pk, cache_key=runner.get_cache_key())
             cached_data = cache_manager.get_cache_data()
 
             if cached_data is not None:
                 last_refresh = parse_datetime(cached_data["last_refresh"])
-                is_stale = runner._is_stale(last_refresh)
-
-                if not is_stale:
+                if not runner._is_stale(last_refresh):
                     WARMING_QUERIES_COUNTER.labels(outcome="skipped_fresh").inc()
-                    queries_skipped += 1
-                    continue
+                    return "skipped_fresh"
 
             # TODO: We shouldn't try to run a query if it failed last run
             runner.run(analytics_props={"source": EventSource.CACHE_WARMING})
             WARMING_QUERIES_COUNTER.labels(outcome="warmed").inc()
-            queries_warmed += 1
-
+            return "warmed"
         except Exception as e:
-            context.log.exception(f"Error warming query {normalized_query_hash} for team {team_id}")
+            context.log.exception(f"Error warming query {query_info['normalized_query_hash']} for team {team.pk}")
             capture_exception(e)
             WARMING_QUERIES_COUNTER.labels(outcome="failed").inc()
-            queries_failed += 1
+            return "failed"
+        finally:
+            # Pool threads hold their own Django connections; drop expired ones so
+            # a long pass doesn't accumulate stale connections per thread.
+            close_old_connections()
+
+    outcomes: dict[str, int] = {}
+    with ThreadPoolExecutor(max_workers=WARMING_SHAPE_CONCURRENCY) as pool:
+        for outcome in pool.map(_warm_one, queries):
+            outcomes[outcome] = outcomes.get(outcome, 0) + 1
+
+    queries_warmed = outcomes.get("warmed", 0)
+    queries_skipped = outcomes.get("skipped_fresh", 0)
+    queries_failed = outcomes.get("failed", 0)
+    queries_unsupported = outcomes.get("unsupported", 0)
 
     context.log.info(
         f"Warmed {queries_warmed} queries ({queries_skipped} already fresh, "

--- a/products/web_analytics/dags/tests/test_cache_warming.py
+++ b/products/web_analytics/dags/tests/test_cache_warming.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 
 from posthog.clickhouse.query_tagging import Feature, reset_query_tags, tag_queries
 
+from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import is_background_warming_request
 from products.web_analytics.dags.cache_warming import (
     build_replay_runner,
     get_warmable_queries_op,
@@ -218,6 +219,31 @@ class TestFleetQuerySelection(BaseTest):
 
 
 class TestWarmQueriesOp(BaseTest):
+    def test_worker_threads_carry_warming_tags(self) -> None:
+        # Query tags are thread-local. If tagging moves back to the op thread,
+        # pool workers replay untagged and two things silently break: the lazy
+        # gate's rollout bypass (buckets stop building for non-enrolled teams)
+        # and the selection's self-feedback exclusion.
+        seen: list[bool] = []
+
+        def capture_tags(**kwargs) -> None:
+            seen.append(is_background_warming_request())
+            return None
+
+        with patch("products.web_analytics.dags.cache_warming.get_query_runner_or_none", side_effect=capture_tags):
+            warm_queries_op(
+                dagster.build_op_context(),
+                [
+                    {
+                        "team_id": self.team.pk,
+                        "query_json": {"kind": "WebOverviewQuery", "properties": []},
+                        "normalized_query_hash": "h",
+                    }
+                ],
+            )
+
+        self.assertEqual(seen, [True])
+
     @patch("products.web_analytics.dags.cache_warming.capture_exception")
     def test_kind_without_runner_is_not_an_error(self, mock_capture: MagicMock) -> None:
         # Selection is by kind prefix, so kinds get_query_runner can't build

--- a/products/web_analytics/dags/tests/test_cache_warming.py
+++ b/products/web_analytics/dags/tests/test_cache_warming.py
@@ -119,9 +119,10 @@ class TestBuildReplayRunner(BaseTest):
             "dateRange": {"date_from": "-7d"},
         }
 
-        runner, used_json = build_replay_runner(self.team, query)
+        runner, used_json, lazy_eligible = build_replay_runner(self.team, query)
 
         self.assertIsNotNone(runner)
+        self.assertTrue(lazy_eligible)
         self.assertEqual(used_json["dateRange"]["date_from"], "-30d")
 
     @parameterized.expand(
@@ -148,9 +149,10 @@ class TestBuildReplayRunner(BaseTest):
             **extra,
         }
 
-        runner, used_json = build_replay_runner(self.team, query)
+        runner, used_json, lazy_eligible = build_replay_runner(self.team, query)
 
         self.assertIsNotNone(runner)
+        self.assertFalse(lazy_eligible)
         self.assertEqual(used_json["dateRange"]["date_from"], "-7d")
 
     def test_outside_warming_context_gate_fails_closed(self) -> None:
@@ -162,9 +164,10 @@ class TestBuildReplayRunner(BaseTest):
             "dateRange": {"date_from": "-7d"},
         }
 
-        runner, used_json = build_replay_runner(self.team, query)
+        runner, used_json, lazy_eligible = build_replay_runner(self.team, query)
 
         self.assertIsNotNone(runner)
+        self.assertFalse(lazy_eligible)
         self.assertEqual(used_json["dateRange"]["date_from"], "-7d")
 
 
@@ -219,6 +222,44 @@ class TestFleetQuerySelection(BaseTest):
 
 
 class TestWarmQueriesOp(BaseTest):
+    @parameterized.expand(
+        [
+            # A raw-path (not lazy-eligible) shape below the pre-widening demand
+            # bar must not replay: with the min-2 selection floor, two runs of an
+            # expensive ineligible shape would otherwise become hourly background
+            # scans outside the tenant's request throttles.
+            ("raw_low_demand_skipped", False, 2, 0),
+            ("raw_high_demand_warms", False, 10, 1),
+            ("lazy_low_demand_warms", True, 2, 1),
+        ]
+    )
+    def test_raw_replays_keep_higher_demand_bar(
+        self, _name: str, lazy_eligible: bool, query_count: int, expected_runs: int
+    ) -> None:
+        runner = MagicMock()
+        runner.get_cache_key.return_value = f"key-{_name}"
+        with (
+            patch(
+                "products.web_analytics.dags.cache_warming.build_replay_runner",
+                return_value=(runner, {}, lazy_eligible),
+            ),
+            patch("products.web_analytics.dags.cache_warming.DjangoCacheQueryCacheManager") as mock_cm,
+        ):
+            mock_cm.return_value.get_cache_data.return_value = None
+            warm_queries_op(
+                dagster.build_op_context(),
+                [
+                    {
+                        "team_id": self.team.pk,
+                        "query_json": {"kind": "WebOverviewQuery", "properties": []},
+                        "query_count": query_count,
+                        "normalized_query_hash": "h",
+                    }
+                ],
+            )
+
+        self.assertEqual(runner.run.call_count, expected_runs)
+
     def test_duplicate_cache_keys_warm_once(self) -> None:
         # Selection groups by raw JSON text, so two encodings of one query can
         # both be selected; replaying both wastes ClickHouse capacity and
@@ -226,7 +267,7 @@ class TestWarmQueriesOp(BaseTest):
         runner = MagicMock()
         runner.get_cache_key.return_value = "same-key"
         with (
-            patch("products.web_analytics.dags.cache_warming.build_replay_runner", return_value=(runner, {})),
+            patch("products.web_analytics.dags.cache_warming.build_replay_runner", return_value=(runner, {}, True)),
             patch("products.web_analytics.dags.cache_warming.DjangoCacheQueryCacheManager") as mock_cm,
         ):
             mock_cm.return_value.get_cache_data.return_value = None

--- a/products/web_analytics/dags/tests/test_cache_warming.py
+++ b/products/web_analytics/dags/tests/test_cache_warming.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import dagster
 from parameterized import parameterized
 
-from posthog.clickhouse.query_tagging import Feature, reset_query_tags, tag_queries
+from posthog.clickhouse.query_tagging import Feature, get_query_tags, reset_query_tags, tag_queries
 
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import is_background_warming_request
 from products.web_analytics.dags.cache_warming import (
@@ -219,6 +219,64 @@ class TestFleetQuerySelection(BaseTest):
 
 
 class TestWarmQueriesOp(BaseTest):
+    def test_duplicate_cache_keys_warm_once(self) -> None:
+        # Selection groups by raw JSON text, so two encodings of one query can
+        # both be selected; replaying both wastes ClickHouse capacity and
+        # double-counts warmed outcomes.
+        runner = MagicMock()
+        runner.get_cache_key.return_value = "same-key"
+        with (
+            patch("products.web_analytics.dags.cache_warming.build_replay_runner", return_value=(runner, {})),
+            patch("products.web_analytics.dags.cache_warming.DjangoCacheQueryCacheManager") as mock_cm,
+        ):
+            mock_cm.return_value.get_cache_data.return_value = None
+            warm_queries_op(
+                dagster.build_op_context(),
+                [
+                    {
+                        "team_id": self.team.pk,
+                        "query_json": {"kind": "WebOverviewQuery", "properties": []},
+                        "normalized_query_hash": "a",
+                    },
+                    {
+                        "team_id": self.team.pk,
+                        "query_json": {"properties": [], "kind": "WebOverviewQuery"},
+                        "normalized_query_hash": "b",
+                    },
+                ],
+            )
+
+        self.assertEqual(runner.run.call_count, 1)
+
+    def test_reused_threads_do_not_leak_tags_between_shapes(self) -> None:
+        # Pool threads are reused and tag_queries merges rather than replaces:
+        # without the per-shape reset, tags a previous shape's runner added
+        # (client_query_id here) bleed into the next shape's queries.
+        leaked: list = []
+        calls = {"n": 0}
+
+        def fake_runner_or_none(**kwargs) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                tag_queries(client_query_id="polluted")
+            else:
+                leaked.append(get_query_tags().client_query_id)
+            return None
+
+        shape = {"team_id": self.team.pk, "query_json": {"kind": "WebOverviewQuery", "properties": []}}
+        with (
+            patch("products.web_analytics.dags.cache_warming.WARMING_SHAPE_CONCURRENCY", 1),
+            patch(
+                "products.web_analytics.dags.cache_warming.get_query_runner_or_none", side_effect=fake_runner_or_none
+            ),
+        ):
+            warm_queries_op(
+                dagster.build_op_context(),
+                [{**shape, "normalized_query_hash": "a"}, {**shape, "normalized_query_hash": "b"}],
+            )
+
+        self.assertEqual(leaked, [None])
+
     def test_worker_threads_carry_warming_tags(self) -> None:
         # Query tags are thread-local. If tagging moves back to the op thread,
         # pool workers replay untagged and two things silently break: the lazy


### PR DESCRIPTION
## Problem

Two follow-ups to the demand-driven warmer now that #72959 made misses harmless (live serve + warm-behind):

1. The selection threshold (10 runs in 2 days) warms only ~1.3k shapes across ~214 teams. Measured against production traffic, dropping the floor to 2 runs covers ~29k shapes across ~4k teams — every shape a user actually came back to — and with serve-live-warm-behind the only cost of a broader net is background compute, while every extra warmed shape converts a future live serve into a bucket read.
2. `warm_queries_op` processes shapes strictly sequentially. At the widened selection size a cold pass would take hours; the pass is IO-bound, so a small thread pool cuts wall time ~8x.

## Changes

- `WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT` default 10 → 2 and `WEB_ANALYTICS_WARMING_MAX_SHAPES` 20000 → 40000 (sized above the ~29k the min-2 selection produces so the cap doesn't silently truncate). Code defaults, not instance-setting flips — both remain tunable via instance settings.
- `warm_queries_op` runs shapes through a `ThreadPoolExecutor` (8 workers, mirroring the eager warmer's pool pattern): teams prefetched in one query, per-shape outcomes aggregated from the pool, `close_old_connections()` per task.
- Query tagging moved **inside the worker**: tags are thread-local, and tagging in the op thread would silently strip the background-warming identity from every replay — breaking both the lazy gate's rollout bypass (buckets stop building for non-enrolled teams) and the selection's self-feedback exclusion. This is the failure mode behind the eager warmer's known `sync_execute called with missing query tags` warnings.

## How did you test this code?

`pytest products/web_analytics/dags/tests/test_cache_warming.py` (28 passed). New test: worker threads observe `is_background_warming_request() == True` — catches the thread-local-tags regression above, which no existing test covered (the old sequential op tagged in the op thread and happened to work).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session; Lucas asked for the min-2 default (in code, not instance-setting flips) and the warm-pass parallelization after #72959 removed the inline-build risk. Concurrency of 8 chosen to stay well under the OFFLINE per-user query-slot budget; the eager warmer's ThreadPoolExecutor pattern (contained worker exceptions, connection hygiene) was reused, with the thread-local tagging bug it exhibits fixed here rather than inherited. Commit is unsigned: the GPG signing agent was unavailable in this session.