### PR TITLE
fix(replay-vision): apply scanner conditions to on-demand recordings browser

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/ScannerRunTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerRunTab.tsx
@@ -7,9 +7,11 @@ import { LemonButton, LemonInput, LemonTable, Link } from '@posthog/lemon-ui'
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { humanFriendlyDuration } from 'lib/utils/durations'
+import { recordingsQueryToUniversalFilters } from 'scenes/session-recordings/filters/recordingsQueryConversions'
 import { ReplayFiltersTab } from 'scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed'
 import {
     SessionRecordingPlaylistLogicProps,
+    getDefaultFilters,
     sessionRecordingsPlaylistLogic,
 } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
 import { urls } from 'scenes/urls'
@@ -251,9 +253,16 @@ function RecordingsList({ scannerId }: { scannerId: string }): JSX.Element {
 
 /** Browse and filter recordings, then fire this scanner against any of them. */
 function ScanFromRecordings({ scannerId }: { scannerId: string }): JSX.Element {
+    const { scanner } = useValues(replayScannerLogic({ id: scannerId }))
+    // Seed the browser with the scanner's own scan conditions so it previews the recordings this scanner
+    // actually runs against, not just the latest recordings. Only the condition dimensions
+    // (events/actions/properties/duration/test accounts) live on the scanner query, so overlay those onto
+    // the default recent-recordings date range and sort order. The user can still widen or clear the filters.
+    const scannerConditions = recordingsQueryToUniversalFilters(scanner?.query)
     const logicProps: SessionRecordingPlaylistLogicProps = {
         logicKey: `vision-run-${scannerId}`,
         updateSearchParams: false,
+        filters: { ...getDefaultFilters(), ...scannerConditions },
     }
     return (
         <div className="border rounded p-4 bg-surface-primary space-y-3">


### PR DESCRIPTION
## Problem

When you create a Replay Vision scanner and open its **On-demand** tab to "scan recent recordings", the "Pick from your recordings" browser ignored the scan conditions you set on the scanner. It just showed the latest recordings, so the preview didn't reflect the sessions the scanner will actually run against.

## Changes

`ScanFromRecordings` mounted `sessionRecordingsPlaylistLogic` without a `filters` prop, so the logic fell back to its default (recent recordings, empty filter group).

Now it seeds the browser's initial filters from the scanner's own `query`. Only the condition dimensions (events, actions, properties, duration, test accounts) live on the scanner query, so those are overlaid onto the default recent-recordings date range and sort order. That gives you "recent recordings matching this scanner's conditions" rather than "all recent recordings". The filter bar stays editable, so you can still widen or clear it.

Note: the playlist logic persists filters per scanner, so this seeds the first time you open the tab for a scanner. After you manually change the filters, your choice sticks.

## How did you test this code?

I (the PostHog Slack app agent) did not run the app or the frontend typecheck — this environment has no installed `node_modules`. I verified statically that:

- `recordingsQueryToUniversalFilters` accepts `RecordingsQuery | null | undefined` and returns only the condition dimensions, which is why the fix overlays it onto `getDefaultFilters()` rather than passing it raw (the logic uses `props.filters` verbatim, with no merge against defaults).
- The scanner detail scene guards rendering until `scanner` is loaded, so `scanner.query` is available when this component mounts.
- Import ordering matches the oxfmt convention already used in `ScannerTriggers.tsx`.

Worth a manual pass by the team: open a scanner's On-demand tab and confirm the browser is pre-filtered to the scanner's conditions.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Cory Slater from a Slack thread while dogfooding Replay Vision scanners for Error Tracking. Authored by the PostHog Slack app agent (Claude). No repo skills were required for this change; I used the Explore agent to locate the On-demand tab wiring, then traced how `sessionRecordingsPlaylistLogic` seeds its initial filters.

I first considered passing `recordingsQueryToUniversalFilters(scanner.query)` straight in as `props.filters`, but that helper drops `date_from`/`date_to`/`order`, and the logic uses `props.filters` without merging defaults — so the raw version would have left the preview with no date range or sort. Overlaying the conversion onto `getDefaultFilters()` keeps a sane recent-recordings window while applying the scanner's conditions.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1784755285263609?thread_ts=1784755285.263609&cid=C03PB072FMJ)*
