### PR TITLE
feat(llm-gateway): accept caller trace id, protect gateway-owned event properties

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -24,6 +24,7 @@ from llm_gateway.request_context import (
     RequestContext,
     get_posthog_flags,
     get_posthog_properties,
+    get_posthog_trace_id,
     get_request_id,
     set_auth_user,
     set_effort,
@@ -232,6 +233,7 @@ async def handle_llm_request(
             product=product,
             posthog_properties=get_posthog_properties(),
             posthog_flags=get_posthog_flags(),
+            posthog_trace_id=get_posthog_trace_id(),
         )
     )
     set_auth_user(user)

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -17,6 +17,7 @@ from llm_gateway.request_context import (
     get_effort,
     get_posthog_flags,
     get_posthog_properties,
+    get_posthog_trace_id,
     get_product,
     get_time_to_first_token,
 )
@@ -77,9 +78,12 @@ def _apply_owned_event_properties(properties: dict[str, Any], product: str, team
 
     `ai_product`, `$ai_billable`, and `$ai_effort` are gateway-derived (effort via
     `ProviderConfig.extract_effort`) and must not be spoofable via headers, so we re-assert them
-    here and drop `$ai_effort` when the gateway found none. `team_id`, in contrast, is a
-    deliberate caller override (e.g. a shared-key caller attributing to a customer team); we only
-    fall back to the key owner's team when no override was supplied.
+    here and drop `$ai_effort` when the gateway found none. Other gateway-derived keys
+    (`$ai_input`, `$ai_model`, `$group_1`, ...) are protected by the caller-property merge,
+    which uses `setdefault` so a caller header can add a new property but not overwrite a value
+    the gateway already set. `team_id`, in contrast, is a deliberate caller override (e.g.
+    a shared-key caller attributing to a customer team); we only fall back to the key owner's
+    team when no override was supplied.
     """
     properties["ai_product"] = product
     properties["$ai_billable"] = _is_product_billable(product)
@@ -187,9 +191,11 @@ class PostHogCallback(InstrumentedCallback):
         auth_user = get_auth_user()
         product = get_product()
 
-        # Anthropic's metadata.user_id is co-opted as a trace id by Claude Code
-        # (see _normalize_trace_id), and Claude Code sends a JSON blob there.
-        trace_id = _normalize_trace_id(metadata.get("user_id"))
+        # The explicit x-posthog-trace-id header is honored verbatim so the caller's
+        # stored id matches for joins. Absent it, Claude Code's JSON blob in Anthropic's
+        # metadata.user_id needs normalizing (see _normalize_trace_id), which also mints
+        # a random id when nothing is supplied.
+        trace_id = get_posthog_trace_id() or _normalize_trace_id(metadata.get("user_id"))
         if auth_user is None:
             distinct_id = end_user_id or str(uuid4())
         else:
@@ -247,10 +253,14 @@ class PostHogCallback(InstrumentedCallback):
         if reasoning_tokens is not None:
             properties["$ai_reasoning_tokens"] = reasoning_tokens
 
+        # Caller `x-posthog-property-*` values enrich the event but must not overwrite
+        # gateway-derived keys. setdefault lets a caller add its own property (e.g.
+        # `$ai_span_name`, which the gateway never derives) while a value the gateway
+        # already set (`$ai_input`, `$ai_trace_id`, `$group_1`, ...) always wins.
         posthog_properties = get_posthog_properties() or {}
         if isinstance(posthog_properties, dict):
             for key, value in posthog_properties.items():
-                properties[key] = value
+                properties.setdefault(key, value)
 
         posthog_flags = get_posthog_flags() or {}
         if isinstance(posthog_flags, dict):
@@ -311,9 +321,11 @@ class PostHogCallback(InstrumentedCallback):
         auth_user = get_auth_user()
         product = get_product()
 
-        # Anthropic's metadata.user_id is co-opted as a trace id by Claude Code
-        # (see _normalize_trace_id), and Claude Code sends a JSON blob there.
-        trace_id = _normalize_trace_id(metadata.get("user_id"))
+        # The explicit x-posthog-trace-id header is honored verbatim so the caller's
+        # stored id matches for joins. Absent it, Claude Code's JSON blob in Anthropic's
+        # metadata.user_id needs normalizing (see _normalize_trace_id), which also mints
+        # a random id when nothing is supplied.
+        trace_id = get_posthog_trace_id() or _normalize_trace_id(metadata.get("user_id"))
         if auth_user is None:
             distinct_id = end_user_id or str(uuid4())
         else:
@@ -337,10 +349,14 @@ class PostHogCallback(InstrumentedCallback):
             "$group_1": self._region_url,
         }
 
+        # Caller `x-posthog-property-*` values enrich the event but must not overwrite
+        # gateway-derived keys. setdefault lets a caller add its own property (e.g.
+        # `$ai_span_name`, which the gateway never derives) while a value the gateway
+        # already set (`$ai_input`, `$ai_trace_id`, `$group_1`, ...) always wins.
         posthog_properties = get_posthog_properties() or {}
         if isinstance(posthog_properties, dict):
             for key, value in posthog_properties.items():
-                properties[key] = value
+                properties.setdefault(key, value)
 
         posthog_flags = get_posthog_flags() or {}
         if isinstance(posthog_flags, dict):

--- a/services/llm-gateway/src/llm_gateway/request_context.py
+++ b/services/llm-gateway/src/llm_gateway/request_context.py
@@ -19,6 +19,11 @@ POSTHOG_PROPERTY_PREFIX = "x-posthog-property-"
 POSTHOG_FLAG_PREFIX = "x-posthog-flag-"
 POSTHOG_PROVIDER_HEADER = "x-posthog-provider"
 POSTHOG_USE_BEDROCK_FALLBACK_HEADER = "x-posthog-use-bedrock-fallback"
+# Caller-stamped trace id for the captured $ai_generation (the id the caller
+# joins ratings/feedback on). Values over the cap are treated as absent, so the
+# gateway derives its own id rather than capturing a truncated one.
+POSTHOG_TRACE_ID_HEADER = "x-posthog-trace-id"
+_MAX_TRACE_ID_HEADER_LENGTH = 256
 
 _VALID_PROVIDERS = ("anthropic", "bedrock", "cloudflare")
 
@@ -29,6 +34,7 @@ class RequestContext:
     product: str = "llm_gateway"
     posthog_properties: dict[str, str] | None = None
     posthog_flags: dict[str, str] | None = None
+    posthog_trace_id: str | None = None
 
 
 request_context_var: ContextVar[RequestContext | None] = ContextVar("request_context", default=None)
@@ -76,19 +82,21 @@ def set_posthog_flags(flags: dict[str, str] | None) -> None:
     request_context_var.set(replace(ctx, posthog_flags=flags))
 
 
-def set_posthog_context(
-    properties: dict[str, str] | None = None,
-    flags: dict[str, str] | None = None,
-) -> None:
-    ctx = request_context_var.get()
-    if ctx is None:
-        return
-    request_context_var.set(replace(ctx, posthog_properties=properties, posthog_flags=flags))
-
-
 def get_posthog_flags() -> dict[str, str] | None:
     ctx = request_context_var.get()
     return ctx.posthog_flags if ctx else None
+
+
+def set_posthog_trace_id(trace_id: str | None) -> None:
+    ctx = request_context_var.get()
+    if ctx is None:
+        return
+    request_context_var.set(replace(ctx, posthog_trace_id=trace_id))
+
+
+def get_posthog_trace_id() -> str | None:
+    ctx = request_context_var.get()
+    return ctx.posthog_trace_id if ctx else None
 
 
 def _extract_headers_with_prefix(request: Request, prefix: str) -> dict[str, str]:
@@ -138,14 +146,32 @@ def extract_posthog_use_bedrock_fallback_from_headers(request: Request) -> bool 
     )
 
 
+def extract_posthog_trace_id_from_headers(request: Request) -> str | None:
+    trace_id = request.headers.get(POSTHOG_TRACE_ID_HEADER)
+    if trace_id is None:
+        return None
+    trace_id = trace_id.strip()
+    if not trace_id:
+        return None
+    if len(trace_id) > _MAX_TRACE_ID_HEADER_LENGTH:
+        # Drop and fall back to the derived id rather than truncate to a different
+        # value; log so a caller whose join comes back empty has something to find.
+        logger.warning("posthog_trace_id_header_too_long", length=len(trace_id))
+        return None
+    return trace_id
+
+
 def apply_posthog_context_from_headers(request: Request) -> None:
     properties = extract_posthog_properties_from_headers(request)
     flags = extract_posthog_flags_from_headers(request)
+    trace_id = extract_posthog_trace_id_from_headers(request)
 
     if properties:
         set_posthog_properties(properties)
     if flags:
         set_posthog_flags(flags)
+    if trace_id:
+        set_posthog_trace_id(trace_id)
 
 
 def set_throttle_context(runner: ThrottleRunner, context: ThrottleContext) -> None:

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -313,6 +313,127 @@ class TestPostHogCallback:
             assert _is_uuid(props["$ai_trace_id"])
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("event_method", ["_on_success", "_on_failure"])
+    async def test_trace_id_header_wins_over_metadata_user_id(
+        self,
+        event_method: str,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        """A caller-stamped x-posthog-trace-id beats the metadata.user_id derivation,
+        on both the success and the error event, so a caller that stores the id it
+        sent can join ratings/feedback onto the captured generation."""
+        _, mock_client = mock_posthog_client
+        header_trace_id = "0e3c1c81-8bcc-40d8-9e28-1ed92b3a7c3a"
+        kwargs = {
+            "standard_logging_object": standard_logging_object,
+            "litellm_params": {"metadata": {"user_id": "trace-id-123"}},
+        }
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="llm_gateway"),
+            patch("llm_gateway.callbacks.posthog.get_posthog_trace_id", return_value=header_trace_id),
+        ):
+            await getattr(callback, event_method)(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            # a UUID header value passes through verbatim
+            assert props["$ai_trace_id"] == header_trace_id
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("header_value", ["not-a-uuid", "0E3C1C81-8BCC-40D8-9E28-1ED92B3A7C3A"])
+    async def test_trace_id_header_stored_verbatim(
+        self,
+        header_value: str,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        """The explicit header is the caller's join key, so it is stored byte-for-byte
+        rather than canonicalized/hashed: an uppercase UUID stays uppercase and a
+        non-UUID stays as-is, so the caller's stored id matches `$ai_trace_id`."""
+        _, mock_client = mock_posthog_client
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="llm_gateway"),
+            patch("llm_gateway.callbacks.posthog.get_posthog_trace_id", return_value=header_value),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            assert props["$ai_trace_id"] == header_value
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("event_method", ["_on_success", "_on_failure"])
+    async def test_caller_property_cannot_override_gateway_derived_keys(
+        self,
+        event_method: str,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        """A caller `x-posthog-property-*` value adds enrichment the gateway doesn't
+        derive (`$ai_span_name`) but cannot overwrite a gateway-owned key: spoofed
+        `$ai_trace_id` and `$ai_model` lose to the derived values on both events."""
+        _, mock_client = mock_posthog_client
+        header_trace_id = "0e3c1c81-8bcc-40d8-9e28-1ed92b3a7c3a"
+        kwargs = {"standard_logging_object": standard_logging_object, "litellm_params": {}}
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="llm_gateway"),
+            patch("llm_gateway.callbacks.posthog.get_posthog_trace_id", return_value=header_trace_id),
+            patch(
+                "llm_gateway.callbacks.posthog.get_posthog_properties",
+                return_value={
+                    "$ai_trace_id": "spoofed",
+                    "$ai_model": "spoofed",
+                    "$ai_span_name": "slack_nudge_classifier",
+                },
+            ),
+        ):
+            await getattr(callback, event_method)(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            # gateway-derived keys win over the caller's spoofed values...
+            assert props["$ai_trace_id"] == header_trace_id
+            assert props["$ai_model"] != "spoofed"
+            # ...but a key the gateway never sets is preserved as caller enrichment.
+            assert props["$ai_span_name"] == "slack_nudge_classifier"
+
+    @pytest.mark.asyncio
+    async def test_absent_trace_id_header_keeps_metadata_derivation(
+        self,
+        callback: PostHogCallback,
+        auth_user: AuthenticatedUser,
+        standard_logging_object: dict,
+        mock_posthog_client: tuple,
+    ) -> None:
+        """Without the header, the Claude Code metadata.user_id path is unchanged."""
+        _, mock_client = mock_posthog_client
+        kwargs = {
+            "standard_logging_object": standard_logging_object,
+            "litellm_params": {"metadata": {"user_id": "trace-id-123"}},
+        }
+
+        with (
+            patch("llm_gateway.callbacks.posthog.get_auth_user", return_value=auth_user),
+            patch("llm_gateway.callbacks.posthog.get_product", return_value="llm_gateway"),
+            patch("llm_gateway.callbacks.posthog.get_posthog_trace_id", return_value=None),
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+            props = mock_client.capture.call_args.kwargs["properties"]
+            assert props["$ai_trace_id"] == _normalize_trace_id("trace-id-123")
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("method_name", ["_on_success", "_on_failure"])
     async def test_oauth_uses_auth_user_distinct_id_not_end_user_id(
         self, callback: PostHogCallback, method_name: str, mock_posthog_client: tuple

--- a/services/llm-gateway/tests/test_openai.py
+++ b/services/llm-gateway/tests/test_openai.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from llm_gateway.main import RequestLoggingMiddleware
-from llm_gateway.request_context import get_posthog_properties
+from llm_gateway.request_context import get_posthog_properties, get_posthog_trace_id
 from tests.conftest import create_test_app
 
 DANGEROUS_PARAMS: list[tuple[str, str]] = [
@@ -91,6 +91,10 @@ class TestChatCompletionsEndpoint:
         assert data["object"] == "chat.completion"
         assert data["usage"]["total_tokens"] == 15
 
+    # Both the unprefixed route and the `/{product}/...` route the Django callers
+    # (surveys) actually use must carry the trace id and caller properties to the
+    # request context the capture callback reads.
+    @pytest.mark.parametrize("path", ["/v1/chat/completions", "/django/v1/chat/completions"])
     @patch("llm_gateway.api.openai.litellm.acompletion")
     def test_posthog_property_headers_reach_request_context(
         self,
@@ -98,6 +102,7 @@ class TestChatCompletionsEndpoint:
         mock_db_pool: MagicMock,
         valid_request_body: dict,
         mock_openai_response: dict,
+        path: str,
     ) -> None:
         # Build a prod-like app: RequestLoggingMiddleware establishes the base RequestContext
         # that apply_posthog_context_from_headers mutates. The shared conftest app omits it.
@@ -122,23 +127,29 @@ class TestChatCompletionsEndpoint:
 
         def _capture(*args: Any, **kwargs: Any) -> MagicMock:
             captured["properties"] = get_posthog_properties()
+            captured["trace_id"] = get_posthog_trace_id()
             return mock_response
 
         mock_completion.side_effect = _capture
 
         with TestClient(app) as client:
             response = client.post(
-                "/v1/chat/completions",
+                path,
                 json=valid_request_body,
                 headers={
                     "Authorization": "Bearer phx_test_key",
                     "x-posthog-property-team_id": "42",
-                    "x-posthog-property-$ai_billable": "false",
+                    "x-posthog-property-$ai_span_name": "survey_summary",
+                    "x-posthog-trace-id": "0e3c1c81-8bcc-40d8-9e28-1ed92b3a7c3a",
                 },
             )
 
         assert response.status_code == 200
-        assert captured["properties"] == {"team_id": "42", "$ai_billable": "false"}
+        # All caller property headers reach the context, including `$`-prefixed enrichment
+        # the gateway doesn't derive; the capture callback's setdefault merge is what stops
+        # a caller from overwriting gateway-owned keys.
+        assert captured["properties"] == {"team_id": "42", "$ai_span_name": "survey_summary"}
+        assert captured["trace_id"] == "0e3c1c81-8bcc-40d8-9e28-1ed92b3a7c3a"
 
     @pytest.mark.parametrize(
         "error_status,error_message,error_type",

--- a/services/llm-gateway/tests/test_request_context.py
+++ b/services/llm-gateway/tests/test_request_context.py
@@ -8,6 +8,7 @@ from llm_gateway.request_context import (
     apply_posthog_context_from_headers,
     get_posthog_flags,
     get_posthog_properties,
+    get_posthog_trace_id,
     record_cost,
     request_context_var,
     set_request_context,
@@ -24,6 +25,16 @@ def make_mock_user() -> MagicMock:
     user.application_id = None
     user.auth_method = "api_key"
     return user
+
+
+def make_mock_request(headers: list[tuple[str, str]]) -> MagicMock:
+    """Mock a Starlette request whose headers support items() and case-insensitive get()."""
+    lowered = {name.lower(): value for name, value in headers}
+    request = MagicMock()
+    request.headers = MagicMock()
+    request.headers.items.return_value = headers
+    request.headers.get.side_effect = lambda name, default=None: lowered.get(name.lower(), default)
+    return request
 
 
 class TestRecordCost:
@@ -99,13 +110,13 @@ class TestApplyPosthogContextFromHeaders:
         request_context_var.set(None)
 
     def test_sets_properties_and_flags_from_headers(self) -> None:
-        request = MagicMock()
-        request.headers = MagicMock()
-        request.headers.items.return_value = [
-            ("X-POSTHOG-PROPERTY-VARIANT", "memes"),
-            ("X-POSTHOG-FLAG-EXPERIMENT", "test"),
-            ("Content-Type", "application/json"),
-        ]
+        request = make_mock_request(
+            [
+                ("X-POSTHOG-PROPERTY-VARIANT", "memes"),
+                ("X-POSTHOG-FLAG-EXPERIMENT", "test"),
+                ("Content-Type", "application/json"),
+            ]
+        )
         set_request_context(RequestContext(request_id="req-123"))
 
         apply_posthog_context_from_headers(request)
@@ -114,9 +125,7 @@ class TestApplyPosthogContextFromHeaders:
         assert get_posthog_flags() == {"experiment": "test"}
 
     def test_leaves_existing_context_unchanged_without_matching_headers(self) -> None:
-        request = MagicMock()
-        request.headers = MagicMock()
-        request.headers.items.return_value = [("Content-Type", "application/json")]
+        request = make_mock_request([("Content-Type", "application/json")])
         set_request_context(
             RequestContext(
                 request_id="req-123",
@@ -131,12 +140,12 @@ class TestApplyPosthogContextFromHeaders:
         assert get_posthog_flags() == {"existing": "flag"}
 
     def test_updates_only_properties_preserves_existing_flags(self) -> None:
-        request = MagicMock()
-        request.headers = MagicMock()
-        request.headers.items.return_value = [
-            ("X-POSTHOG-PROPERTY-VARIANT", "memes"),
-            ("Content-Type", "application/json"),
-        ]
+        request = make_mock_request(
+            [
+                ("X-POSTHOG-PROPERTY-VARIANT", "memes"),
+                ("Content-Type", "application/json"),
+            ]
+        )
         set_request_context(
             RequestContext(
                 request_id="req-123",
@@ -151,12 +160,12 @@ class TestApplyPosthogContextFromHeaders:
         assert get_posthog_flags() == {"existing": "flag"}
 
     def test_updates_only_flags_preserves_existing_properties(self) -> None:
-        request = MagicMock()
-        request.headers = MagicMock()
-        request.headers.items.return_value = [
-            ("X-POSTHOG-FLAG-EXPERIMENT", "test"),
-            ("Content-Type", "application/json"),
-        ]
+        request = make_mock_request(
+            [
+                ("X-POSTHOG-FLAG-EXPERIMENT", "test"),
+                ("Content-Type", "application/json"),
+            ]
+        )
         set_request_context(
             RequestContext(
                 request_id="req-123",
@@ -169,3 +178,66 @@ class TestApplyPosthogContextFromHeaders:
 
         assert get_posthog_properties() == {"existing": "property"}
         assert get_posthog_flags() == {"experiment": "test"}
+
+    def test_passes_through_dollar_prefixed_property_keys(self) -> None:
+        # `$`-prefixed keys the gateway does not derive (e.g. `$ai_span_name`) are
+        # legitimate caller enrichment and must survive extraction; the capture
+        # callback protects derived keys via a setdefault merge, not by stripping here.
+        request = make_mock_request(
+            [
+                ("X-POSTHOG-PROPERTY-$ai_span_name", "slack_nudge_classifier"),
+                ("X-POSTHOG-PROPERTY-team_id", "42"),
+                ("X-POSTHOG-PROPERTY-ai_stage", "draft"),
+            ]
+        )
+        set_request_context(RequestContext(request_id="req-123"))
+
+        apply_posthog_context_from_headers(request)
+
+        assert get_posthog_properties() == {
+            "$ai_span_name": "slack_nudge_classifier",
+            "team_id": "42",
+            "ai_stage": "draft",
+        }
+
+    def test_sets_trace_id_from_header(self) -> None:
+        request = make_mock_request([("X-PostHog-Trace-Id", "0e3c1c81-8bcc-40d8-9e28-1ed92b3a7c3a")])
+        set_request_context(RequestContext(request_id="req-123"))
+
+        apply_posthog_context_from_headers(request)
+
+        assert get_posthog_trace_id() == "0e3c1c81-8bcc-40d8-9e28-1ed92b3a7c3a"
+
+    def test_accepts_trace_id_header_at_length_cap(self) -> None:
+        at_cap = "x" * 256
+        request = make_mock_request([("X-PostHog-Trace-Id", at_cap)])
+        set_request_context(RequestContext(request_id="req-123"))
+
+        apply_posthog_context_from_headers(request)
+
+        assert get_posthog_trace_id() == at_cap
+
+    def test_trims_surrounding_whitespace_from_trace_id_header(self) -> None:
+        request = make_mock_request([("X-PostHog-Trace-Id", "  0e3c1c81-8bcc-40d8-9e28-1ed92b3a7c3a  ")])
+        set_request_context(RequestContext(request_id="req-123"))
+
+        apply_posthog_context_from_headers(request)
+
+        assert get_posthog_trace_id() == "0e3c1c81-8bcc-40d8-9e28-1ed92b3a7c3a"
+
+    def test_trace_id_absent_without_header(self) -> None:
+        request = make_mock_request([("Content-Type", "application/json")])
+        set_request_context(RequestContext(request_id="req-123"))
+
+        apply_posthog_context_from_headers(request)
+
+        assert get_posthog_trace_id() is None
+
+    @pytest.mark.parametrize("value", ["", "   ", "x" * 257])
+    def test_trace_id_blank_or_oversized_header_treated_as_absent(self, value: str) -> None:
+        request = make_mock_request([("X-PostHog-Trace-Id", value)])
+        set_request_context(RequestContext(request_id="req-123"))
+
+        apply_posthog_context_from_headers(request)
+
+        assert get_posthog_trace_id() is None


### PR DESCRIPTION
## Problem

Callers of the Python LLM gateway have no supported way to correlate their own records with the captured `$ai_generation`: the OpenAI route derives `$ai_trace_id` internally. And the property merge runs caller-last with no protection, so any `x-posthog-property-$ai_*` header silently overwrites gateway-derived fields (`$ai_input`, `$ai_model`, token counts, `$ai_trace_id`).

## Changes

- Accept an `x-posthog-trace-id` request header (stripped, capped at 256 chars) and use it as `$ai_trace_id` on both success and failure captures. Stored verbatim so a caller's saved id matches the join; the `metadata.user_id` derivation still applies when the header is absent.
- Make the caller-property merge use `setdefault`, so a caller can add its own properties (e.g. `$ai_span_name`, which the gateway never derives) but cannot overwrite a value the gateway already set.
- Carry the trace id through the `handle_llm_request` context rebuild.
- Log when an over-256 trace-id header is dropped, so a caller whose join comes back empty has a signal. Delete the unused `set_posthog_context` helper.

First consumer: the surveys gateway helper (#72670), so survey summary ratings can join the generation they rate.

## Verification

llm-gateway suite (1342 passed), ruff, format. Route-level coverage on both `/v1/chat/completions` and `/{product}/v1/chat/completions`; callback tests pin header-wins, verbatim storage, the unchanged `metadata.user_id` fallback, and that a caller `$ai_trace_id`/`$ai_model` property loses to the derived value while `$ai_span_name` passes through.

## Known gaps

Low: a caller can still set `$set`/`$set_once` and, when the gateway computes no cost, `$ai_total_cost_usd`, since the gateway does not set those before the merge. Both are pre-existing (unchanged from master); tracked separately.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Opus 4.8) wrote this under my direction. Requires human review.
