### PR TITLE
feat(replay): allow group properties in vision scanner filters

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
@@ -22,6 +22,7 @@ import {
 import { RecordingsUniversalFilterAddFilterPopover } from 'scenes/session-recordings/filters/RecordingsUniversalFiltersEmbed'
 import { defaultRecordingDurationFilter } from 'scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic'
 
+import { groupsModel } from '~/models/groupsModel'
 import { AndOrFilterSelect } from '~/queries/nodes/InsightViz/PropertyGroupFilters/AndOrFilterSelect'
 import { RecordingsQuery } from '~/queries/schema/schema-general'
 import { RecordingUniversalFilters, UniversalFiltersGroup } from '~/types'
@@ -32,7 +33,8 @@ import { SAMPLING_MODE_OPTIONS, SamplingMode } from '../types'
 import { ScannerQuotaForecast } from './ScannerQuotaForecast'
 
 // Mirrors the recordings list taxonomy, including suggested filters so the search bar surfaces them.
-const SCANNER_FILTER_TYPES: TaxonomicFilterGroupType[] = [
+// Group properties are appended per-project from groupsModel (see scannerFilterTypes below).
+const SCANNER_BASE_FILTER_TYPES: TaxonomicFilterGroupType[] = [
     TaxonomicFilterGroupType.SuggestedFilters,
     TaxonomicFilterGroupType.Replay,
     TaxonomicFilterGroupType.Events,
@@ -73,9 +75,11 @@ function ScannerFilterGroup(): JSX.Element {
 export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Element {
     const { scanner } = useValues(replayScannerLogic({ id: scannerId }))
     const { featureFlags } = useValues(featureFlagLogic)
+    const { groupsTaxonomicTypes } = useValues(groupsModel)
     const categoryDropdownVariant = resolveCategoryDropdownVariant(
         featureFlags[FEATURE_FLAGS.TAXONOMIC_FILTER_CATEGORY_DROPDOWN]
     )
+    const scannerFilterTypes = [...SCANNER_BASE_FILTER_TYPES, ...groupsTaxonomicTypes]
 
     if (!scanner) {
         return <div className="text-muted">Loading…</div>
@@ -208,7 +212,7 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
                             <UniversalFilters
                                 rootKey={`replay-scanner-${scanner.id}`}
                                 group={universal.filter_group}
-                                taxonomicGroupTypes={SCANNER_FILTER_TYPES}
+                                taxonomicGroupTypes={scannerFilterTypes}
                                 onChange={(filterGroup) => applyUniversal({ ...universal, filter_group: filterGroup })}
                             >
                                 {universal.filter_group.values.length > 0 &&
@@ -216,7 +220,7 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
                                         <UniversalFilters
                                             rootKey={`replay-scanner-${scanner.id}.nested`}
                                             group={universal.filter_group.values[0]}
-                                            taxonomicGroupTypes={SCANNER_FILTER_TYPES}
+                                            taxonomicGroupTypes={scannerFilterTypes}
                                             onChange={(nestedGroup) =>
                                                 applyUniversal({
                                                     ...universal,
@@ -232,7 +236,7 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
                                         >
                                             <RecordingsUniversalFilterAddFilterPopover
                                                 categoryDropdownVariant={categoryDropdownVariant}
-                                                taxonomicGroupTypes={SCANNER_FILTER_TYPES}
+                                                taxonomicGroupTypes={scannerFilterTypes}
                                             />
                                         </UniversalFilters>
                                     )}


### PR DESCRIPTION
## Problem

Group analytics users (and folks scanning their book of business) can't filter Replay Vision scanners by group properties. The scanner setup "Recording filters" step is the one place in the app where you set up which sessions a scanner watches, but its Taxonomic filter didn't offer group properties as a filter category.

There's no technical reason for this. The scanner query is a `RecordingsQuery`, the same type the main recordings playlist filters produce, and group properties are valid filters there. The scanner's own "Run" tab (which reuses the shared recordings filter component) already surfaces them. The setup step just hand-rolled its own taxonomic group list and left group properties out.

Raised in [this Slack thread](https://posthog.slack.com/archives/C0B7TE4R8GH/p1784752743191689?thread_ts=1784752743.191689&cid=C0B7TE4R8GH).

## Changes

`ScannerTriggers.tsx` now appends the project's group taxonomic types (from `groupsModel`) to the Taxonomic filter's group list, so each configured group type shows up as a filterable category. This mirrors how the recordings list builds its filter taxonomy.

Everything else in the list stays as-is. Group properties are appended after the existing categories, so nothing in the top positions moves.

## How did you test this code?

I (Claude, via the PostHog Slack app) ran the frontend typecheck (`pnpm --filter=@posthog/frontend typescript:check`) and lint/format fix — both clean. I did not run the app manually or add automated tests; this is a small consumer-side config change (which group types the existing filter component is told to render).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a Slack request asking whether there was any technical limitation preventing Replay Vision scanners from filtering on group properties. Confirmed there isn't: the setup step's `SCANNER_FILTER_TYPES` array simply omitted group properties, diverging from the main recordings playlist filters and the scanner's own Run tab (both of which spread `groupsTaxonomicTypes` from `groupsModel`). Fix mirrors that existing pattern rather than introducing anything new.

Invoked the `/modifying-taxonomic-filter` skill. This is a consumer call-site change (which `taxonomicGroupTypes` are passed in), not a change to the TaxonomicFilter component, its ordering, promotion, or enum, so no cross-variant mirroring was required.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B7TE4R8GH/p1784752743191689?thread_ts=1784752743.191689&cid=C0B7TE4R8GH)*
