### PR TITLE
fix(navigation): remove pinnedByDefault sidebar auto-pin

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -1569,19 +1569,6 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                         })
                         .filter((p): p is FileSystemImport => p !== null)
 
-                    // Auto-pin items the manifest marks `pinnedByDefault` once their flag is on.
-                    for (const product of allProducts) {
-                        if (
-                            product.pinnedByDefault &&
-                            product.flag &&
-                            (featureFlags as Record<string, boolean>)[product.flag] &&
-                            !selectedProductPaths.has(product.path)
-                        ) {
-                            selectedProductPaths.add(product.path)
-                            selectedProducts.push(product)
-                        }
-                    }
-
                     const imports = selectedProducts
                         .filter((f) => !f.flag || (featureFlags as Record<string, boolean>)[f.flag])
                         .map((i) => ({

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -1852,7 +1852,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         href: urls.engineeringAnalytics(),
         flag: FEATURE_FLAGS.ENGINEERING_ANALYTICS,
         tags: ['alpha'],
-        pinnedByDefault: true,
         sceneKey: 'EngineeringAnalytics',
         sceneKeys: [
             'EngineeringAnalytics',
@@ -2177,7 +2176,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         href: urls.replayVision(),
         tags: ['beta'],
         flag: FEATURE_FLAGS.REPLAY_VISION,
-        pinnedByDefault: true,
         sceneKey: 'ReplayVision',
         sceneKeys: ['ReplayVision', 'ReplayVisionScanner'],
     },
@@ -2287,7 +2285,6 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         href: urls.taskTracker(),
         sceneKey: 'TaskTracker',
         flag: FEATURE_FLAGS.TASKS,
-        pinnedByDefault: true,
         sceneKeys: ['TaskTracker'],
     },
     {

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -25514,10 +25514,6 @@
                     "description": "Object's name and folder",
                     "type": "string"
                 },
-                "pinnedByDefault": {
-                    "description": "Auto-include in the user's pinned sidebar when `flag` is on, even without an explicit UserProductList row",
-                    "type": "boolean"
-                },
                 "protocol": {
                     "description": "Protocol of the item, defaults to \"project://\"",
                     "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -4321,8 +4321,6 @@ export interface FileSystemImport extends Omit<FileSystemEntry, 'id'> {
     reasonText?: string | null
     /** Display label override — when set, shown in the nav instead of the last segment of `path` */
     displayLabel?: string
-    /** Auto-include in the user's pinned sidebar when `flag` is on, even without an explicit UserProductList row */
-    pinnedByDefault?: boolean
 }
 
 export interface FileSystemViewLogEntry {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4921,12 +4921,6 @@ class FileSystemImport(BaseModel):
     last_viewed_at: str | None = Field(default=None, description="Timestamp when the file system entry was last viewed")
     meta: dict[str, Any] | None = Field(default=None, description="Metadata")
     path: str = Field(..., description="Object's name and folder")
-    pinnedByDefault: bool | None = Field(
-        default=None,
-        description=(
-            "Auto-include in the user's pinned sidebar when `flag` is on, even without an explicit UserProductList row"
-        ),
-    )
     protocol: str | None = Field(default=None, description='Protocol of the item, defaults to "project://"')
     reason: UserProductListReason | None = Field(
         default=None,

--- a/products/engineering_analytics/manifest.tsx
+++ b/products/engineering_analytics/manifest.tsx
@@ -121,7 +121,6 @@ export const manifest: ProductManifest = {
             href: urls.engineeringAnalytics(),
             flag: FEATURE_FLAGS.ENGINEERING_ANALYTICS,
             tags: ['alpha'],
-            pinnedByDefault: true,
             sceneKey: 'EngineeringAnalytics',
         },
     ],

--- a/products/posthog_ai/manifest.tsx
+++ b/products/posthog_ai/manifest.tsx
@@ -53,9 +53,6 @@ export const manifest: ProductManifest = {
             href: urls.taskTracker(),
             sceneKey: 'TaskTracker',
             flag: FEATURE_FLAGS.TASKS,
-            // Auto-pin into the Tools sidebar for anyone with the flag, so tasks
-            // reached via the Inbox "discuss" flow are findable without typing /tasks.
-            pinnedByDefault: true,
         },
     ],
 }

--- a/products/replay_vision/manifest.tsx
+++ b/products/replay_vision/manifest.tsx
@@ -111,7 +111,6 @@ export const manifest: ProductManifest = {
             href: urls.replayVision(),
             tags: ['beta'],
             flag: FEATURE_FLAGS.REPLAY_VISION,
-            pinnedByDefault: true,
             sceneKey: 'ReplayVision',
             sceneKeys: ['ReplayVision', 'ReplayVisionScanner'],
         },


### PR DESCRIPTION
## Problem

Any product could set `pinnedByDefault` on its nav manifest entry and get force-injected into every user's sidebar whenever its feature flag was on, whether or not the user ever chose it. Teams should not be able to force their product into a user's sidebar, and we don't want them controlling what a person sees there. That's the user's call.

It also produced a visible bug. The sidebar render path honored `pinnedByDefault` but the "edit list" toggle view did not, so an auto-pinned product showed up in the sidebar while reading as un-toggled in the customize view. And un-toggling it never stuck, because the render path re-added it on every render while the flag was on.

## Changes

Removed the `pinnedByDefault` concept entirely:

- the auto-pin injection loop in `getCustomProductTreeItems` (`projectTreeDataLogic.tsx`)
- the `pinnedByDefault` field on the `FileSystemImport` type (`schema-general.ts`)
- its use by Engineering analytics, Replay vision, and Tasks (both `products.tsx` and each product manifest)
- regenerated `frontend/src/queries/schema.json` and `posthog/schema.py`

The sidebar now renders only the products a user has actually added to their list.

> [!NOTE]
> This touches three other teams' products (Replay vision, Engineering analytics, Tasks). They relied on this to stay visible during their beta/launch push and will lose that auto-promotion. Flagging so it's not a surprise.

## How did you test this code?

Ran the frontend TypeScript check (clean for this change; the only error is a pre-existing missing-module in an unrelated `early_access_features` test) and lint/format. I (the agent) did not do manual UI testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Rafa directed this: he noticed Tasks and Engineering analytics showing in his sidebar despite being un-toggled in the edit view, and asked me (Claude Fable 5, in Claude Code) to find the cause and then remove the mechanism. I traced it to the `pinnedByDefault` auto-pin, confirmed the render vs edit-list selector mismatch, and removed the concept end to end.

`products.tsx` is generated from the product manifests, so the pre-commit hook regenerated it from my manifest edits. I reverted a handful of unrelated files that the lint/format run touched (oxfmt/oxlint drift already on master) to keep the diff focused.
