### PR TITLE
fix(replay): show nested filter properties in scanner config view

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerConfigReadonly.tsx
@@ -14,6 +14,7 @@ import { LemonCard, LemonSwitch, LemonTag } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
 import { UniversalFilterButton } from 'lib/components/UniversalFilters/UniversalFilterButton'
+import { isEntityFilter } from 'lib/components/UniversalFilters/utils'
 import { dayjs } from 'lib/dayjs'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
 import { humanFriendlyDurationFilter } from 'scenes/session-recordings/filters/DurationFilter'
@@ -24,7 +25,7 @@ import {
 import { filtersFromUniversalFilterGroups } from 'scenes/session-recordings/utils'
 
 import { RecordingsQuery } from '~/queries/schema/schema-general'
-import { FilterLogicalOperator } from '~/types'
+import { FilterLogicalOperator, UniversalFilterValue } from '~/types'
 
 import { BooleanTag } from '../../components/BooleanTag'
 import { CardHeader } from '../../components/CardHeader'
@@ -46,6 +47,28 @@ const SCANNER_TYPES: ScannerType[] = ['monitor', 'classifier', 'scorer', 'summar
 
 function Multiline({ value }: { value: string | null | undefined }): JSX.Element {
     return <div className="whitespace-pre-wrap text-sm">{value || <span className="text-muted">—</span>}</div>
+}
+
+/**
+ * Renders one recording filter chip. Event/action filters keep the page/URL they match in nested
+ * `properties`, so surface those as their own chips — otherwise the read-only view only shows the
+ * event name (e.g. "$pageview") with no way to see which page is selected.
+ */
+function FilterChip({ filter }: { filter: UniversalFilterValue }): JSX.Element {
+    const nestedProperties = isEntityFilter(filter) ? (filter.properties ?? []) : []
+
+    if (nestedProperties.length === 0) {
+        return <UniversalFilterButton filter={filter} />
+    }
+
+    return (
+        <div className="flex flex-wrap items-center gap-1.5 border rounded p-1">
+            <UniversalFilterButton filter={filter} />
+            {nestedProperties.map((property, i) => (
+                <UniversalFilterButton key={i} filter={property} />
+            ))}
+        </div>
+    )
 }
 
 /** Renders an option set as tags with the chosen value emphasized and the rest greyed/struck through. */
@@ -321,7 +344,7 @@ export function ScannerConfigReadonly({ scanner }: { scanner: ReplayScanner }): 
                                                 <span className="text-xs">Match {matchWord} of</span>
                                             )}
                                             {filters.map((filter, i) => (
-                                                <UniversalFilterButton key={i} filter={filter} />
+                                                <FilterChip key={i} filter={filter} />
                                             ))}
                                         </div>
                                     )}


### PR DESCRIPTION
## Problem

On a Replay Vision scanner's **Configuration** tab, recording filters are shown read-only. For an event/action condition (e.g. a `$pageview` for one page), the matched page/URL lives in the event's nested `properties`. The read-only chip rendered only the event name with a filter-count badge, and the chip wasn't wired to open anything — so there was no way to see *which* page a condition was filtering to without going through the separate "Edit scanner" flow.

Reported in Slack: a `$pageview` filter for a single page showed as just `$pageview` with no way to click in and see the selected page.

## Changes

Surface each entity filter's nested property filters as their own chips in the read-only configuration view (via a small `FilterChip` helper), so the selected page/URL renders inline (e.g. `$pageview` alongside `Current URL = /your-page`) instead of being hidden behind an inert count badge.

## How did you test this code?

I (the agent) could not run the frontend toolchain in this environment (no `node_modules`, so no typecheck/lint/dev server). The change is small and reuses the existing `UniversalFilterButton`; `AnyPropertyFilter` is assignable to `UniversalFilterValue`, so the nested-property chips are type-correct. Please verify visually against a scanner whose query has a `$pageview` (or similar) condition with a URL property.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Investigated by cloning the repo and tracing the Configuration tab down to `ScannerConfigReadonly.tsx` → `UniversalFilterButton`: entity filters are non-editable by design (`isEditableFilter` returns `false` for `type: 'events'`), and the read-only view never rendered their nested `properties`. Chose the minimal read-only fix (render nested property chips) rather than making the chip open an editor, since inline editing on this tab isn't the intended flow. No skills were required for this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1784762171739909)*
