### PR TITLE
chore(ci): publish PR images to per-image -prs ECR repos

### DIFF
--- a/.github/actions/build-n-cache-image/action.yml
+++ b/.github/actions/build-n-cache-image/action.yml
@@ -86,10 +86,10 @@ runs:
           run: |
               TAGS="posthog/posthog:$COMMIT_SHA"
               if [[ -n "$REGISTRY" ]]; then
-                TAGS="$TAGS,$REGISTRY/posthog-cloud:$COMMIT_SHA"
+                TAGS="$TAGS,$REGISTRY/posthog-cloud-prs:$COMMIT_SHA"
               fi
               if [[ "$PR_NUMBER" != "" ]]; then
-                TAGS="$TAGS,$REGISTRY/posthog-cloud:pr-$PR_NUMBER"
+                TAGS="$TAGS,$REGISTRY/posthog-cloud-prs:pr-$PR_NUMBER"
               fi
               echo "tag=$TAGS" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci-agent-container.yml
+++ b/.github/workflows/ci-agent-container.yml
@@ -116,7 +116,23 @@ jobs:
                       depot_project: 6gmww256q5
                       push_to_ecr: 'false'
 
+        # ECR routing resolved once so the push target can't drift from the digest/smoke
+        # pull target: master → <image> via the master role; else → <image>-prs via the prs role.
+        env:
+            ECR_IMAGE: ${{ github.ref == 'refs/heads/master' && matrix.image || format('{0}-prs', matrix.image) }}
+            ECR_ROLE: ${{ github.ref == 'refs/heads/master' && vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE || vars.AWS_ECR_POSTHOG_PRS_PUBLISH_IAM_ROLE }}
+
         steps:
+            - name: Assert master publish role is configured
+              if: github.ref == 'refs/heads/master'
+              env:
+                  MASTER_ROLE: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+              run: |
+                  if [[ -z "$MASTER_ROLE" ]]; then
+                    echo "::error::AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE is not set — refusing to fall back to the PRS role on master."
+                    exit 1
+                  fi
+
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -134,7 +150,10 @@ jobs:
               uses: ./.github/actions/docker-meta
               with:
                   image-name: ${{ matrix.image }}
-                  aws-role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  # ECR repo + role resolved once at job level (see env above). Unused for the
+                  # push_to_ecr:'false' matrix entry (ghcr-only). ghcr/dockerhub unchanged.
+                  ecr-image-name: ${{ env.ECR_IMAGE }}
+                  aws-role-to-assume: ${{ env.ECR_ROLE }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -166,7 +185,7 @@ jobs:
                   # report the GHCR reference instead so the step summary stays
                   # useful and the smoke-test step downstream has a pullable ref.
                   if [ "$PUSH_TO_ECR" = "true" ]; then
-                      IMAGE_BASE="$ECR_REGISTRY/$IMAGE_NAME"
+                      IMAGE_BASE="$ECR_REGISTRY/$ECR_IMAGE"
                   else
                       IMAGE_BASE="ghcr.io/posthog/$IMAGE_NAME"
                   fi
@@ -210,7 +229,7 @@ jobs:
                   # Mirror the digest-step logic: GHCR-only images smoke-test
                   # against their GHCR ref since there's no ECR copy.
                   if [ "$PUSH_TO_ECR" = "true" ]; then
-                      IMAGE_REF="${ECR_REGISTRY}/${IMAGE_NAME}@${IMAGE_DIGEST}"
+                      IMAGE_REF="${ECR_REGISTRY}/${ECR_IMAGE}@${IMAGE_DIGEST}"
                   else
                       IMAGE_REF="ghcr.io/posthog/${IMAGE_NAME}@${IMAGE_DIGEST}"
                   fi

--- a/.github/workflows/ci-ml-mirror-image-scrub-container.yml
+++ b/.github/workflows/ci-ml-mirror-image-scrub-container.yml
@@ -96,7 +96,23 @@ jobs:
         outputs:
             digest: ${{ steps.build.outputs.digest }}
 
+        # ECR routing resolved once so the push target can't drift from the digest reader:
+        # master → posthog-ml-mirror-image-scrub via the master role; else → the -prs repo via the prs role.
+        env:
+            ECR_IMAGE: ${{ github.ref == 'refs/heads/master' && 'posthog-ml-mirror-image-scrub' || 'posthog-ml-mirror-image-scrub-prs' }}
+            ECR_ROLE: ${{ github.ref == 'refs/heads/master' && vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE || vars.AWS_ECR_POSTHOG_PRS_PUBLISH_IAM_ROLE }}
+
         steps:
+            - name: Assert master publish role is configured
+              if: github.ref == 'refs/heads/master'
+              env:
+                  MASTER_ROLE: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+              run: |
+                  if [[ -z "$MASTER_ROLE" ]]; then
+                    echo "::error::AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE is not set — refusing to fall back to the PRS role on master."
+                    exit 1
+                  fi
+
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -114,7 +130,9 @@ jobs:
               uses: ./.github/actions/docker-meta
               with:
                   image-name: posthog-ml-mirror-image-scrub
-                  aws-role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  # ECR repo + role resolved once at job level (see env above). ghcr/dockerhub unchanged.
+                  ecr-image-name: ${{ env.ECR_IMAGE }}
+                  aws-role-to-assume: ${{ env.ECR_ROLE }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -146,10 +164,10 @@ jobs:
                   COMMIT_SHA: ${{ github.sha }}
               run: |
                   echo "Image digest: $IMAGE_DIGEST"
-                  echo "Full image reference: $IMAGE_REGISTRY/posthog-ml-mirror-image-scrub:$COMMIT_SHA@$IMAGE_DIGEST"
+                  echo "Full image reference: $IMAGE_REGISTRY/$ECR_IMAGE:$COMMIT_SHA@$IMAGE_DIGEST"
                   echo "## Container image built :rocket:" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image reference:** \`$IMAGE_REGISTRY/posthog-ml-mirror-image-scrub:$COMMIT_SHA@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image reference:** \`$IMAGE_REGISTRY/$ECR_IMAGE:$COMMIT_SHA@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "**Image SHA:** \`$COMMIT_SHA@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-nodejs-container.yml
+++ b/.github/workflows/ci-nodejs-container.yml
@@ -87,7 +87,27 @@ jobs:
             contents: read # allow reading the repo contents
             packages: write # allow push to ghcr.io
 
+        # ECR routing resolved once here so the push target (docker-meta) and the
+        # digest pull target read the same value and can't drift: master → posthog-node
+        # via the master role; everything else → posthog-node-prs via the prs role.
+        env:
+            ECR_IMAGE: ${{ github.ref == 'refs/heads/master' && 'posthog-node' || 'posthog-node-prs' }}
+            ECR_ROLE: ${{ github.ref == 'refs/heads/master' && vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE || vars.AWS_ECR_POSTHOG_PRS_PUBLISH_IAM_ROLE }}
+
         steps:
+            # Fail loudly rather than let the role ternary silently fall back to the PRS
+            # role if the master var is unset on master (which would push the prod repo
+            # with a role that can't, giving a confusing access-denied).
+            - name: Assert master publish role is configured
+              if: github.ref == 'refs/heads/master'
+              env:
+                  MASTER_ROLE: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+              run: |
+                  if [[ -z "$MASTER_ROLE" ]]; then
+                    echo "::error::AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE is not set — refusing to fall back to the PRS role on master."
+                    exit 1
+                  fi
+
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -105,7 +125,9 @@ jobs:
               uses: ./.github/actions/docker-meta
               with:
                   image-name: posthog-node
-                  aws-role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  # ECR repo + role resolved once at job level (see env above). ghcr/dockerhub unchanged.
+                  ecr-image-name: ${{ env.ECR_IMAGE }}
+                  aws-role-to-assume: ${{ env.ECR_ROLE }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -133,10 +155,10 @@ jobs:
                   IMAGE_REGISTRY: ${{ steps.docker-meta.outputs.ecr-registry }}
               run: |
                   echo "Image digest: $IMAGE_DIGEST"
-                  echo "Full image reference: $IMAGE_REGISTRY/posthog-node:${{ github.sha }}@$IMAGE_DIGEST"
+                  echo "Full image reference: $IMAGE_REGISTRY/$ECR_IMAGE:${{ github.sha }}@$IMAGE_DIGEST"
                   echo "## Container image built :rocket:" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image reference:** \`$IMAGE_REGISTRY/posthog-node:${{ github.sha }}@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image reference:** \`$IMAGE_REGISTRY/$ECR_IMAGE:${{ github.sha }}@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "**Image SHA:** \`${{ github.sha }}@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci-recording-rasterizer-container.yml
+++ b/.github/workflows/ci-recording-rasterizer-container.yml
@@ -98,7 +98,23 @@ jobs:
         outputs:
             digest: ${{ steps.build.outputs.digest }}
 
+        # ECR routing resolved once so the push target can't drift from the digest reader.
+        # The weekly schedule runs on master, so it lands in the prod repo via the master role.
+        env:
+            ECR_IMAGE: ${{ github.ref == 'refs/heads/master' && 'posthog-recording-rasterizer' || 'posthog-recording-rasterizer-prs' }}
+            ECR_ROLE: ${{ github.ref == 'refs/heads/master' && vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE || vars.AWS_ECR_POSTHOG_PRS_PUBLISH_IAM_ROLE }}
+
         steps:
+            - name: Assert master publish role is configured
+              if: github.ref == 'refs/heads/master'
+              env:
+                  MASTER_ROLE: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+              run: |
+                  if [[ -z "$MASTER_ROLE" ]]; then
+                    echo "::error::AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE is not set — refusing to fall back to the PRS role on master."
+                    exit 1
+                  fi
+
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -116,7 +132,9 @@ jobs:
               uses: ./.github/actions/docker-meta
               with:
                   image-name: posthog-recording-rasterizer
-                  aws-role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  # ECR repo + role resolved once at job level (see env above). ghcr/dockerhub unchanged.
+                  ecr-image-name: ${{ env.ECR_IMAGE }}
+                  aws-role-to-assume: ${{ env.ECR_ROLE }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -146,10 +164,10 @@ jobs:
                   COMMIT_SHA: ${{ github.sha }}
               run: |
                   echo "Image digest: $IMAGE_DIGEST"
-                  echo "Full image reference: $IMAGE_REGISTRY/posthog-recording-rasterizer:$COMMIT_SHA@$IMAGE_DIGEST"
+                  echo "Full image reference: $IMAGE_REGISTRY/$ECR_IMAGE:$COMMIT_SHA@$IMAGE_DIGEST"
                   echo "## Container image built :rocket:" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image reference:** \`$IMAGE_REGISTRY/posthog-recording-rasterizer:$COMMIT_SHA@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image reference:** \`$IMAGE_REGISTRY/$ECR_IMAGE:$COMMIT_SHA@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "**Image SHA:** \`$COMMIT_SHA@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -16,6 +16,10 @@ on:
         paths-ignore:
             - 'rust/**'
             - 'livestream/**'
+    # Break-glass: a manual dispatch must run from master. The ECR publish role
+    # (AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE) is OIDC-trusted only for
+    # refs/heads/master, so a dispatch from any other branch is denied at
+    # AssumeRoleWithWebIdentity — deliberate, so prod images only ship from master.
     workflow_dispatch:
 
 # Serialize runs for the same commit so a push racing a manual re-run/dispatch can't both
@@ -63,7 +67,7 @@ jobs:
                   # PUBLIC_IMAGE_PUSH_PAUSED is set (deploy is unaffected — ECR still pushes).
                   push-to-dockerhub: ${{ vars.PUBLIC_IMAGE_PUSH_PAUSED != 'true' }}
                   push-to-ghcr: ${{ vars.PUBLIC_IMAGE_PUSH_PAUSED != 'true' }}
-                  aws-role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  aws-role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -136,7 +140,7 @@ jobs:
               if: steps.build.outcome == 'failure'
               uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
               with:
-                  role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
                   aws-region: us-east-1
 
             - name: Re-login to Amazon ECR (retry)

--- a/.github/workflows/container-images-ci.yml
+++ b/.github/workflows/container-images-ci.yml
@@ -139,7 +139,8 @@ jobs:
               with:
                   actions-id-token-request-url: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
                   push-image: ${{ github.repository == 'PostHog/posthog' }} # Don't push on forks due to lack of credentials
-                  aws-role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  # PR-only publish role: any branch, but can ONLY push to posthog-cloud-prs (not posthog-cloud).
+                  aws-role-to-assume: ${{ vars.AWS_ECR_POSTHOG_PRS_PUBLISH_IAM_ROLE }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
                   pr-number: ${{ github.event.number }}
@@ -153,7 +154,7 @@ jobs:
                   echo "Image digest: $IMAGE_DIGEST"
                   echo "## Container image built :rocket:" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
-                  echo "**Image reference:** \`$IMAGE_REGISTRY/posthog-cloud@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
+                  echo "**Image reference:** \`$IMAGE_REGISTRY/posthog-cloud-prs@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "**Image SHA:** \`${{ github.sha }}@$IMAGE_DIGEST\`" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/livestream-docker-image.yml
+++ b/.github/workflows/livestream-docker-image.yml
@@ -33,7 +33,23 @@ jobs:
         outputs:
             sha: ${{ steps.push.outputs.digest }}
 
+        # ECR routing resolved once so the push target can't drift from any reader:
+        # master → livestream via the master role; everything else → livestream-prs via the prs role.
+        env:
+            ECR_IMAGE: ${{ github.ref == 'refs/heads/master' && 'livestream' || 'livestream-prs' }}
+            ECR_ROLE: ${{ github.ref == 'refs/heads/master' && vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE || vars.AWS_ECR_POSTHOG_PRS_PUBLISH_IAM_ROLE }}
+
         steps:
+            - name: Assert master publish role is configured
+              if: github.ref == 'refs/heads/master'
+              env:
+                  MASTER_ROLE: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+              run: |
+                  if [[ -z "$MASTER_ROLE" ]]; then
+                    echo "::error::AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE is not set — refusing to fall back to the PRS role on master."
+                    exit 1
+                  fi
+
             - name: Check out livestream code
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -47,7 +63,9 @@ jobs:
               uses: ./.github/actions/docker-meta
               with:
                   image-name: livestream
-                  aws-role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  # ECR repo + role resolved once at job level (see env above). ghcr/legacy paths unchanged.
+                  ecr-image-name: ${{ env.ECR_IMAGE }}
+                  aws-role-to-assume: ${{ env.ECR_ROLE }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Problem

PR and master docker builds push to the same per-image ECR repo, so ephemeral PR images accumulate in the prod repos, and every build uses one broad role that can write any repo from any branch. We want the prod repos to hold only master-built images (so they can be immutable) and PR builds to run with least privilege.

## Changes

Each split image (posthog-cloud, posthog-node, livestream, posthog-agents, posthog-ml-mirror-image-scrub, posthog-recording-rasterizer) now routes its **ECR** push by branch: master → prod repo via a master-only role; anything else (PRs, non-master dispatch) → a dedicated `<name>-prs` repo via an any-branch role. DockerHub and ghcr publishing are unchanged.

Requires two new Actions variables (role ARNs, created in the paired infra change): `AWS_ECR_POSTHOG_PRS_PUBLISH_IAM_ROLE` and `AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE`.

> ⚠️ Blocked on rollout: apply the infra change and set both variables **before** merging — otherwise image builds (and master deploys) fail. Image-build CI on this PR will fail until then.

## How did you test this code?

`hogli lint:workflows` and `actionlint` pass. No runtime test is possible pre-rollout (the role variables don't exist yet); the split routing is verified by reading the plan on the infra side.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code; invoked `/authoring-ci-workflows` and `/gating-production-deploys`. Routing keys on `github.ref` rather than event name, so PRs, non-master `workflow_dispatch`, and the rasterizer's scheduled run all land in the right repo. Consolidated to two shared roles (vs a pair per image) to avoid role sprawl, and fixed the agents smoke-test step to pull from the repo the PR image actually went to.
