### PR TITLE
fix(tasks): allowlist api-settable origin_product values

### DIFF
--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
@@ -13,7 +13,7 @@ import {
     ClaudeRuntimeAdapterEnumApi,
     OriginProductEnumApi,
     ReasoningEffortEnumApi,
-    type TaskWriteApi,
+    type TaskCreateApi,
     TaskExecutionModeEnumApi,
 } from 'products/tasks/frontend/generated/api.schemas'
 
@@ -490,7 +490,7 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
             stream.actions.startOptimisticRun(description)
 
             try {
-                const taskData: TaskWriteApi = {
+                const taskData: TaskCreateApi = {
                     title: '',
                     description,
                     origin_product: OriginProductEnumApi.PosthogAi,

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -404,11 +404,6 @@ class TaskWriteSerializer(serializers.Serializer):
         allow_blank=True,
         help_text="Free-form description of the work to be done. Used as the prompt passed to the agent.",
     )
-    origin_product = serializers.ChoiceField(
-        choices=tasks_facade.TaskOriginProduct.choices,
-        required=False,
-        help_text="PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).",
-    )
     repository = serializers.CharField(
         max_length=255,
         required=False,
@@ -591,17 +586,6 @@ class TaskWriteSerializer(serializers.Serializer):
             raise serializers.ValidationError("User integration must belong to the authenticated user")
         return value
 
-    def validate_origin_product(self, value):
-        """Reject internal-only origins that are set by server-side flows, never by API callers."""
-        if value == tasks_facade.TaskOriginProduct.IMAGE_BUILDER:
-            raise serializers.ValidationError("origin_product 'image_builder' is reserved for image-builder sessions")
-        if value == tasks_facade.TaskOriginProduct.EXPERIMENTS:
-            # Experiments tasks are team-readable, so letting API callers pick this origin
-            # would let them expose an arbitrary task to the whole team. The experiments
-            # flow creates its tasks server-side through the facade, never through here.
-            raise serializers.ValidationError("origin_product 'experiments' is reserved for the experiments flow")
-        return value
-
     def validate_repository(self, value):
         """Validate repository configuration"""
         if not value:
@@ -630,6 +614,10 @@ class TaskWriteSerializer(serializers.Serializer):
     def validate(self, attrs: dict) -> dict:
         if "runtime" in self.initial_data and "runtime" not in self.fields:
             raise serializers.ValidationError({"runtime": "Runtime cannot be changed after task creation."})
+        if "origin_product" in self.initial_data and "origin_product" not in self.fields:
+            raise serializers.ValidationError(
+                {"origin_product": "origin_product cannot be changed after task creation."}
+            )
 
         rel = attrs.get("signal_report_task_relationship")
         if rel is not None:
@@ -651,7 +639,32 @@ class TaskWriteSerializer(serializers.Serializer):
         return attrs
 
 
+# Origins that traced API clients actually send (the Code desktop/mobile app, web
+# surfaces, support-desk clients). Every other origin is stamped by server-side flows
+# that create tasks through the facade/ORM, never through this serializer.
+API_CREATABLE_ORIGIN_PRODUCTS: frozenset[str] = frozenset(
+    {
+        tasks_facade.TaskOriginProduct.USER_CREATED,
+        tasks_facade.TaskOriginProduct.SIGNAL_REPORT,
+        tasks_facade.TaskOriginProduct.ERROR_TRACKING,
+        tasks_facade.TaskOriginProduct.SESSION_SUMMARIES,
+        tasks_facade.TaskOriginProduct.POSTHOG_AI,
+        tasks_facade.TaskOriginProduct.HOGDESK,
+        tasks_facade.TaskOriginProduct.SUPPORT_QUEUE,
+    }
+)
+
+
 class TaskCreateSerializer(TaskWriteSerializer):
+    origin_product = serializers.ChoiceField(
+        choices=tasks_facade.TaskOriginProduct.choices,
+        required=False,
+        help_text=(
+            "PostHog product or surface that created this task (e.g. error_tracking, hogdesk, user_created). "
+            "Defaults to user_created. Origins reserved for server-side flows are rejected, and the value "
+            "cannot be changed after creation."
+        ),
+    )
     sandbox_environment_id = serializers.UUIDField(
         required=False,
         default=None,
@@ -671,6 +684,19 @@ class TaskCreateSerializer(TaskWriteSerializer):
         required=False,
         help_text="Agent protocol and harness used for this task's runs. Defaults to ACP when omitted.",
     )
+
+    def validate_origin_product(self, value: str) -> str:
+        """Allow only origins that traced API clients send; everything else is reserved for server-side flows."""
+        if value == tasks_facade.TaskOriginProduct.IMAGE_BUILDER:
+            raise serializers.ValidationError("origin_product 'image_builder' is reserved for image-builder sessions")
+        if value == tasks_facade.TaskOriginProduct.EXPERIMENTS:
+            # Experiments tasks are team-readable, so letting API callers pick this origin
+            # would let them expose an arbitrary task to the whole team. The experiments
+            # flow creates its tasks server-side through the facade, never through here.
+            raise serializers.ValidationError("origin_product 'experiments' is reserved for the experiments flow")
+        if value not in API_CREATABLE_ORIGIN_PRODUCTS:
+            raise serializers.ValidationError(f"origin_product '{value}' is reserved for server-side flows")
+        return value
 
 
 class TaskRunSetOutputRequestSerializer(serializers.Serializer):

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -619,23 +619,8 @@ class TaskWriteSerializer(serializers.Serializer):
                 {"origin_product": "origin_product cannot be changed after task creation."}
             )
 
-        rel = attrs.get("signal_report_task_relationship")
-        if rel is not None:
-            if not attrs.get("signal_report"):
-                raise serializers.ValidationError(
-                    {"signal_report_task_relationship": "Requires signal_report when set."}
-                )
-            if attrs.get("origin_product") != tasks_facade.TaskOriginProduct.SIGNAL_REPORT:
-                raise serializers.ValidationError(
-                    {"signal_report_task_relationship": ("Requires origin_product signal_report when set.")}
-                )
-        if (
-            attrs.get("origin_product") == tasks_facade.TaskOriginProduct.SIGNAL_REPORT
-            and attrs.get("github_user_integration") is not None
-        ):
-            raise serializers.ValidationError(
-                {"github_user_integration": "Signal report tasks use the team GitHub integration."}
-            )
+        if attrs.get("signal_report_task_relationship") is not None and not attrs.get("signal_report"):
+            raise serializers.ValidationError({"signal_report_task_relationship": "Requires signal_report when set."})
         return attrs
 
 
@@ -697,6 +682,26 @@ class TaskCreateSerializer(TaskWriteSerializer):
         if value not in API_CREATABLE_ORIGIN_PRODUCTS:
             raise serializers.ValidationError(f"origin_product '{value}' is reserved for server-side flows")
         return value
+
+    # origin_product is create-only, so origin-dependent cross-field rules can only bind here;
+    # on update they would always read origin_product as absent and misfire.
+    def validate(self, attrs: dict) -> dict:
+        attrs = super().validate(attrs)
+        if (
+            attrs.get("signal_report_task_relationship") is not None
+            and attrs.get("origin_product") != tasks_facade.TaskOriginProduct.SIGNAL_REPORT
+        ):
+            raise serializers.ValidationError(
+                {"signal_report_task_relationship": "Requires origin_product signal_report when set."}
+            )
+        if (
+            attrs.get("origin_product") == tasks_facade.TaskOriginProduct.SIGNAL_REPORT
+            and attrs.get("github_user_integration") is not None
+        ):
+            raise serializers.ValidationError(
+                {"github_user_integration": "Signal report tasks use the team GitHub integration."}
+            )
+        return attrs
 
 
 class TaskRunSetOutputRequestSerializer(serializers.Serializer):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1454,7 +1454,7 @@ class TestTaskAPI(BaseTaskAPITest):
             {"origin_product": "signal_report"},
             format="json",
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         task.refresh_from_db()
         self.assertEqual(task.origin_product, Task.OriginProduct.USER_CREATED)
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1472,6 +1472,20 @@ class TestTaskAPI(BaseTaskAPITest):
         task.refresh_from_db()
         self.assertIsNone(task.signal_report_id)
 
+    def test_patch_cannot_set_signal_report_relationship(self):
+        from products.signals.backend.models import SignalReport
+
+        report = SignalReport.objects.create(team=self.team)
+        task = self.create_task("Mine")
+        response = self.client.patch(
+            f"/api/projects/@current/tasks/{task.id}/",
+            {"signal_report": str(report.id), "signal_report_task_relationship": "implementation"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        task.refresh_from_db()
+        self.assertIsNone(task.signal_report_id)
+
     def test_update_task(self):
         task = self.create_task("Original Task")
 

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -6,10 +6,44 @@ from django.test import SimpleTestCase
 
 from parameterized import parameterized
 
+from products.tasks.backend.models import Task
 from products.tasks.backend.presentation.serializers import (
+    API_CREATABLE_ORIGIN_PRODUCTS,
+    TaskCreateSerializer,
     TaskRunCreateRequestSerializer,
     TaskRunLivingArtifactCreateRequestSerializer,
+    TaskWriteSerializer,
 )
+
+_RESERVED_ORIGIN_MESSAGES = {
+    "image_builder": "origin_product 'image_builder' is reserved for image-builder sessions",
+    "experiments": "origin_product 'experiments' is reserved for the experiments flow",
+}
+
+
+class TestTaskOriginProductValidation(SimpleTestCase):
+    @parameterized.expand(
+        [(value,) for value in sorted(set(Task.OriginProduct.values) - API_CREATABLE_ORIGIN_PRODUCTS)]
+    )
+    def test_create_rejects_reserved_origin(self, origin: str) -> None:
+        serializer = TaskCreateSerializer(data={"origin_product": origin})
+
+        assert not serializer.is_valid()
+        expected = _RESERVED_ORIGIN_MESSAGES.get(origin, f"origin_product '{origin}' is reserved for server-side flows")
+        assert str(serializer.errors["origin_product"][0]) == expected
+
+    @parameterized.expand([(value,) for value in sorted(API_CREATABLE_ORIGIN_PRODUCTS)])
+    def test_create_accepts_client_origin(self, origin: str) -> None:
+        serializer = TaskCreateSerializer(data={"origin_product": origin})
+
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["origin_product"] == origin
+
+    def test_update_rejects_origin_product(self) -> None:
+        serializer = TaskWriteSerializer(data={"origin_product": Task.OriginProduct.USER_CREATED}, partial=True)
+
+        assert not serializer.is_valid()
+        assert str(serializer.errors["origin_product"][0]) == "origin_product cannot be changed after task creation."
 
 
 class TestTaskRunLivingArtifactCreateRequestSerializer(SimpleTestCase):

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -1351,26 +1351,6 @@ export interface TaskCreateApi {
     title_manually_set?: boolean
     /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
     description?: string
-    /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-     *
-     * * `onboarding` - Onboarding
-     * * `error_tracking` - Error Tracking
-     * * `eval_clusters` - Eval Clusters
-     * * `user_created` - User Created
-     * * `automation` - Automation
-     * * `slack` - Slack
-     * * `support_queue` - Support Queue
-     * * `session_summaries` - Session Summaries
-     * * `posthog_ai` - PostHog AI
-     * * `experiments` - Experiments
-     * * `signal_report` - Signal Report
-     * * `signals_scout` - Signals Scout
-     * * `support_reply` - Support Reply
-     * * `hogdesk` - HogDesk
-     * * `review_hog` - ReviewHog
-     * * `image_builder` - Image Builder
-     * * `loop` - Loop */
-    origin_product?: OriginProductEnumApi
     /**
      * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
      * @maxLength 255
@@ -1452,6 +1432,26 @@ export interface TaskCreateApi {
      * @nullable
      */
     channel?: string | null
+    /** PostHog product or surface that created this task (e.g. error_tracking, hogdesk, user_created). Defaults to user_created. Origins reserved for server-side flows are rejected, and the value cannot be changed after creation.
+     *
+     * * `onboarding` - Onboarding
+     * * `error_tracking` - Error Tracking
+     * * `eval_clusters` - Eval Clusters
+     * * `user_created` - User Created
+     * * `automation` - Automation
+     * * `slack` - Slack
+     * * `support_queue` - Support Queue
+     * * `session_summaries` - Session Summaries
+     * * `posthog_ai` - PostHog AI
+     * * `experiments` - Experiments
+     * * `signal_report` - Signal Report
+     * * `signals_scout` - Signals Scout
+     * * `support_reply` - Support Reply
+     * * `hogdesk` - HogDesk
+     * * `review_hog` - ReviewHog
+     * * `image_builder` - Image Builder
+     * * `loop` - Loop */
+    origin_product?: OriginProductEnumApi
     /**
      * Sandbox environment selected for matching a pre-warmed cloud run. Not persisted on the task.
      * @nullable
@@ -1486,26 +1486,6 @@ export interface TaskWriteApi {
     title_manually_set?: boolean
     /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
     description?: string
-    /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-     *
-     * * `onboarding` - Onboarding
-     * * `error_tracking` - Error Tracking
-     * * `eval_clusters` - Eval Clusters
-     * * `user_created` - User Created
-     * * `automation` - Automation
-     * * `slack` - Slack
-     * * `support_queue` - Support Queue
-     * * `session_summaries` - Session Summaries
-     * * `posthog_ai` - PostHog AI
-     * * `experiments` - Experiments
-     * * `signal_report` - Signal Report
-     * * `signals_scout` - Signals Scout
-     * * `support_reply` - Support Reply
-     * * `hogdesk` - HogDesk
-     * * `review_hog` - ReviewHog
-     * * `image_builder` - Image Builder
-     * * `loop` - Loop */
-    origin_product?: OriginProductEnumApi
     /**
      * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
      * @maxLength 255
@@ -1606,26 +1586,6 @@ export interface PatchedTaskWriteApi {
     title_manually_set?: boolean
     /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
     description?: string
-    /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-     *
-     * * `onboarding` - Onboarding
-     * * `error_tracking` - Error Tracking
-     * * `eval_clusters` - Eval Clusters
-     * * `user_created` - User Created
-     * * `automation` - Automation
-     * * `slack` - Slack
-     * * `support_queue` - Support Queue
-     * * `session_summaries` - Session Summaries
-     * * `posthog_ai` - PostHog AI
-     * * `experiments` - Experiments
-     * * `signal_report` - Signal Report
-     * * `signals_scout` - Signals Scout
-     * * `support_reply` - Support Reply
-     * * `hogdesk` - HogDesk
-     * * `review_hog` - ReviewHog
-     * * `image_builder` - Image Builder
-     * * `loop` - Loop */
-    origin_product?: OriginProductEnumApi
     /**
      * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
      * @maxLength 255

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -1015,33 +1015,6 @@ export const TasksCreateBody = /* @__PURE__ */ zod
             .string()
             .optional()
             .describe('Free-form description of the work to be done. Used as the prompt passed to the agent.'),
-        origin_product: zod
-            .enum([
-                'onboarding',
-                'error_tracking',
-                'eval_clusters',
-                'user_created',
-                'automation',
-                'slack',
-                'support_queue',
-                'session_summaries',
-                'posthog_ai',
-                'experiments',
-                'signal_report',
-                'signals_scout',
-                'support_reply',
-                'hogdesk',
-                'review_hog',
-                'image_builder',
-                'loop',
-            ])
-            .describe(
-                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop'
-            )
-            .optional()
-            .describe(
-                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop'
-            ),
         repository: zod
             .string()
             .max(tasksCreateBodyRepositoryMax)
@@ -1121,6 +1094,33 @@ export const TasksCreateBody = /* @__PURE__ */ zod
                 "When true, the cloud run agent pushes its work and opens a draft pull request on completion without waiting for an explicit ask. Write-only and not persisted on the task: persisted into the reused warm Run's state when creation activates one, so resumes of that Run honor it. Ignored when no warm Run is reused — cold creation takes it via the run start endpoint instead."
             ),
         channel: zod.uuid().nullish().describe('Channel this task is owned by (the channel it was kicked off in).'),
+        origin_product: zod
+            .enum([
+                'onboarding',
+                'error_tracking',
+                'eval_clusters',
+                'user_created',
+                'automation',
+                'slack',
+                'support_queue',
+                'session_summaries',
+                'posthog_ai',
+                'experiments',
+                'signal_report',
+                'signals_scout',
+                'support_reply',
+                'hogdesk',
+                'review_hog',
+                'image_builder',
+                'loop',
+            ])
+            .describe(
+                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop'
+            )
+            .optional()
+            .describe(
+                'PostHog product or surface that created this task (e.g. error_tracking, hogdesk, user_created). Defaults to user_created. Origins reserved for server-side flows are rejected, and the value cannot be changed after creation.\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop'
+            ),
         sandbox_environment_id: zod
             .uuid()
             .nullish()
@@ -1169,33 +1169,6 @@ export const TasksUpdateBody = /* @__PURE__ */ zod
             .string()
             .optional()
             .describe('Free-form description of the work to be done. Used as the prompt passed to the agent.'),
-        origin_product: zod
-            .enum([
-                'onboarding',
-                'error_tracking',
-                'eval_clusters',
-                'user_created',
-                'automation',
-                'slack',
-                'support_queue',
-                'session_summaries',
-                'posthog_ai',
-                'experiments',
-                'signal_report',
-                'signals_scout',
-                'support_reply',
-                'hogdesk',
-                'review_hog',
-                'image_builder',
-                'loop',
-            ])
-            .describe(
-                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop'
-            )
-            .optional()
-            .describe(
-                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop'
-            ),
         repository: zod
             .string()
             .max(tasksUpdateBodyRepositoryMax)
@@ -1308,33 +1281,6 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod
             .string()
             .optional()
             .describe('Free-form description of the work to be done. Used as the prompt passed to the agent.'),
-        origin_product: zod
-            .enum([
-                'onboarding',
-                'error_tracking',
-                'eval_clusters',
-                'user_created',
-                'automation',
-                'slack',
-                'support_queue',
-                'session_summaries',
-                'posthog_ai',
-                'experiments',
-                'signal_report',
-                'signals_scout',
-                'support_reply',
-                'hogdesk',
-                'review_hog',
-                'image_builder',
-                'loop',
-            ])
-            .describe(
-                '\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop'
-            )
-            .optional()
-            .describe(
-                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n\* `onboarding` - Onboarding\n\* `error_tracking` - Error Tracking\n\* `eval_clusters` - Eval Clusters\n\* `user_created` - User Created\n\* `automation` - Automation\n\* `slack` - Slack\n\* `support_queue` - Support Queue\n\* `session_summaries` - Session Summaries\n\* `posthog_ai` - PostHog AI\n\* `experiments` - Experiments\n\* `signal_report` - Signal Report\n\* `signals_scout` - Signals Scout\n\* `support_reply` - Support Reply\n\* `hogdesk` - HogDesk\n\* `review_hog` - ReviewHog\n\* `image_builder` - Image Builder\n\* `loop` - Loop'
-            ),
         repository: zod
             .string()
             .max(tasksPartialUpdateBodyRepositoryMax)

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -52716,26 +52716,6 @@ export namespace Schemas {
       title_manually_set?: boolean;
       /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
       description?: string;
-      /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-       *
-       * * `onboarding` - Onboarding
-       * * `error_tracking` - Error Tracking
-       * * `eval_clusters` - Eval Clusters
-       * * `user_created` - User Created
-       * * `automation` - Automation
-       * * `slack` - Slack
-       * * `support_queue` - Support Queue
-       * * `session_summaries` - Session Summaries
-       * * `posthog_ai` - PostHog AI
-       * * `experiments` - Experiments
-       * * `signal_report` - Signal Report
-       * * `signals_scout` - Signals Scout
-       * * `support_reply` - Support Reply
-       * * `hogdesk` - HogDesk
-       * * `review_hog` - ReviewHog
-       * * `image_builder` - Image Builder
-       * * `loop` - Loop */
-      origin_product?: OriginProductEnum;
       /**
          * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
          * @maxLength 255
@@ -66883,26 +66863,6 @@ export namespace Schemas {
       title_manually_set?: boolean;
       /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
       description?: string;
-      /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-       *
-       * * `onboarding` - Onboarding
-       * * `error_tracking` - Error Tracking
-       * * `eval_clusters` - Eval Clusters
-       * * `user_created` - User Created
-       * * `automation` - Automation
-       * * `slack` - Slack
-       * * `support_queue` - Support Queue
-       * * `session_summaries` - Session Summaries
-       * * `posthog_ai` - PostHog AI
-       * * `experiments` - Experiments
-       * * `signal_report` - Signal Report
-       * * `signals_scout` - Signals Scout
-       * * `support_reply` - Support Reply
-       * * `hogdesk` - HogDesk
-       * * `review_hog` - ReviewHog
-       * * `image_builder` - Image Builder
-       * * `loop` - Loop */
-      origin_product?: OriginProductEnum;
       /**
          * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
          * @maxLength 255
@@ -66984,6 +66944,26 @@ export namespace Schemas {
          * @nullable
          */
       channel?: string | null;
+      /** PostHog product or surface that created this task (e.g. error_tracking, hogdesk, user_created). Defaults to user_created. Origins reserved for server-side flows are rejected, and the value cannot be changed after creation.
+       *
+       * * `onboarding` - Onboarding
+       * * `error_tracking` - Error Tracking
+       * * `eval_clusters` - Eval Clusters
+       * * `user_created` - User Created
+       * * `automation` - Automation
+       * * `slack` - Slack
+       * * `support_queue` - Support Queue
+       * * `session_summaries` - Session Summaries
+       * * `posthog_ai` - PostHog AI
+       * * `experiments` - Experiments
+       * * `signal_report` - Signal Report
+       * * `signals_scout` - Signals Scout
+       * * `support_reply` - Support Reply
+       * * `hogdesk` - HogDesk
+       * * `review_hog` - ReviewHog
+       * * `image_builder` - Image Builder
+       * * `loop` - Loop */
+      origin_product?: OriginProductEnum;
       /**
          * Sandbox environment selected for matching a pre-warmed cloud run. Not persisted on the task.
          * @nullable
@@ -67864,26 +67844,6 @@ export namespace Schemas {
       title_manually_set?: boolean;
       /** Free-form description of the work to be done. Used as the prompt passed to the agent. */
       description?: string;
-      /** PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).
-       *
-       * * `onboarding` - Onboarding
-       * * `error_tracking` - Error Tracking
-       * * `eval_clusters` - Eval Clusters
-       * * `user_created` - User Created
-       * * `automation` - Automation
-       * * `slack` - Slack
-       * * `support_queue` - Support Queue
-       * * `session_summaries` - Session Summaries
-       * * `posthog_ai` - PostHog AI
-       * * `experiments` - Experiments
-       * * `signal_report` - Signal Report
-       * * `signals_scout` - Signals Scout
-       * * `support_reply` - Support Reply
-       * * `hogdesk` - HogDesk
-       * * `review_hog` - ReviewHog
-       * * `image_builder` - Image Builder
-       * * `loop` - Loop */
-      origin_product?: OriginProductEnum;
       /**
          * Target GitHub repository in `organization/repo` format (e.g. `posthog/posthog-js`).
          * @maxLength 255

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -835,33 +835,6 @@ export const TasksCreateBody = /* @__PURE__ */ zod
             .string()
             .optional()
             .describe('Free-form description of the work to be done. Used as the prompt passed to the agent.'),
-        origin_product: zod
-            .enum([
-                'onboarding',
-                'error_tracking',
-                'eval_clusters',
-                'user_created',
-                'automation',
-                'slack',
-                'support_queue',
-                'session_summaries',
-                'posthog_ai',
-                'experiments',
-                'signal_report',
-                'signals_scout',
-                'support_reply',
-                'hogdesk',
-                'review_hog',
-                'image_builder',
-                'loop',
-            ])
-            .describe(
-                '* `onboarding` - Onboarding\n* `error_tracking` - Error Tracking\n* `eval_clusters` - Eval Clusters\n* `user_created` - User Created\n* `automation` - Automation\n* `slack` - Slack\n* `support_queue` - Support Queue\n* `session_summaries` - Session Summaries\n* `posthog_ai` - PostHog AI\n* `experiments` - Experiments\n* `signal_report` - Signal Report\n* `signals_scout` - Signals Scout\n* `support_reply` - Support Reply\n* `hogdesk` - HogDesk\n* `review_hog` - ReviewHog\n* `image_builder` - Image Builder\n* `loop` - Loop'
-            )
-            .optional()
-            .describe(
-                'PostHog product or surface that created this task (e.g. error_tracking, slack, user_created).\n\n* `onboarding` - Onboarding\n* `error_tracking` - Error Tracking\n* `eval_clusters` - Eval Clusters\n* `user_created` - User Created\n* `automation` - Automation\n* `slack` - Slack\n* `support_queue` - Support Queue\n* `session_summaries` - Session Summaries\n* `posthog_ai` - PostHog AI\n* `experiments` - Experiments\n* `signal_report` - Signal Report\n* `signals_scout` - Signals Scout\n* `support_reply` - Support Reply\n* `hogdesk` - HogDesk\n* `review_hog` - ReviewHog\n* `image_builder` - Image Builder\n* `loop` - Loop'
-            ),
         repository: zod
             .string()
             .max(tasksCreateBodyRepositoryMax)
@@ -942,6 +915,33 @@ export const TasksCreateBody = /* @__PURE__ */ zod
                 "When true, the cloud run agent pushes its work and opens a draft pull request on completion without waiting for an explicit ask. Write-only and not persisted on the task: persisted into the reused warm Run's state when creation activates one, so resumes of that Run honor it. Ignored when no warm Run is reused — cold creation takes it via the run start endpoint instead."
             ),
         channel: zod.string().nullish().describe('Channel this task is owned by (the channel it was kicked off in).'),
+        origin_product: zod
+            .enum([
+                'onboarding',
+                'error_tracking',
+                'eval_clusters',
+                'user_created',
+                'automation',
+                'slack',
+                'support_queue',
+                'session_summaries',
+                'posthog_ai',
+                'experiments',
+                'signal_report',
+                'signals_scout',
+                'support_reply',
+                'hogdesk',
+                'review_hog',
+                'image_builder',
+                'loop',
+            ])
+            .describe(
+                '* `onboarding` - Onboarding\n* `error_tracking` - Error Tracking\n* `eval_clusters` - Eval Clusters\n* `user_created` - User Created\n* `automation` - Automation\n* `slack` - Slack\n* `support_queue` - Support Queue\n* `session_summaries` - Session Summaries\n* `posthog_ai` - PostHog AI\n* `experiments` - Experiments\n* `signal_report` - Signal Report\n* `signals_scout` - Signals Scout\n* `support_reply` - Support Reply\n* `hogdesk` - HogDesk\n* `review_hog` - ReviewHog\n* `image_builder` - Image Builder\n* `loop` - Loop'
+            )
+            .optional()
+            .describe(
+                'PostHog product or surface that created this task (e.g. error_tracking, hogdesk, user_created). Defaults to user_created. Origins reserved for server-side flows are rejected, and the value cannot be changed after creation.\n\n* `onboarding` - Onboarding\n* `error_tracking` - Error Tracking\n* `eval_clusters` - Eval Clusters\n* `user_created` - User Created\n* `automation` - Automation\n* `slack` - Slack\n* `support_queue` - Support Queue\n* `session_summaries` - Session Summaries\n* `posthog_ai` - PostHog AI\n* `experiments` - Experiments\n* `signal_report` - Signal Report\n* `signals_scout` - Signals Scout\n* `support_reply` - Support Reply\n* `hogdesk` - HogDesk\n* `review_hog` - ReviewHog\n* `image_builder` - Image Builder\n* `loop` - Loop'
+            ),
         sandbox_environment_id: zod
             .string()
             .nullish()

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -329,7 +329,6 @@ const loopsRunsRetrieve = (): ToolBase<typeof LoopsRunsRetrieveSchema, WithPostH
 
 const TasksCreateSchema = TasksCreateBody.omit({
     title_manually_set: true,
-    origin_product: true,
     github_integration: true,
     github_user_integration: true,
     signal_report: true,
@@ -346,6 +345,7 @@ const TasksCreateSchema = TasksCreateBody.omit({
     pending_user_artifact_ids: true,
     auto_publish: true,
     channel: true,
+    origin_product: true,
     sandbox_environment_id: true,
     custom_image_id: true,
     runtime: true,


### PR DESCRIPTION
## Problem

`Task.origin_product` drives task visibility rules and usage attribution, and it is about to carry more weight as cloud-run usage gets attributed by origin. Today the create API only rejects two values (`image_builder`, `experiments`), so any caller with `task:write` can stamp a task with any other origin, including ones that belong exclusively to server-side flows (`loop`, `slack`, `signals_scout`, and so on). That allows misattributed tasks and opting into other products' visibility semantics. On update, `origin_product` was accepted and then silently dropped by the facade, a 200 that looks like success.

## Changes

Flips `validate_origin_product` from a blocklist to an allowlist of origins that traced API clients actually send, and makes the field explicitly immutable at the API boundary.

- `origin_product` moves from `TaskWriteSerializer` to `TaskCreateSerializer`, mirroring the existing `runtime` split, so PATCH/PUT no longer advertise the field and reject it with a 400.
- Create keeps the two documented rejections (`image_builder`, `experiments`) with their existing messages and rationale, and now also rejects every origin not in the allowlist.
- The facade's silent drop on update stays as a second layer. Server-side creation flows (facade/ORM) never pass through this serializer and are untouched.
- One-line type annotation fix in `taskTrackerSceneLogic.ts` (`TaskWriteApi` to `TaskCreateApi`) so the generated-type refresh keeps typechecking.

> [!WARNING]
> Behavior change for API callers: creating a task with a reserved origin now returns 400 (previously accepted), and PATCHing `origin_product` returns 400 (previously 200 with the value silently ignored).

The allowlist, with the caller that justifies each entry. Tasks team: please veto anything here that should not be client-settable.

| Origin | Who sends it |
|---|---|
| `user_created` | The default. PostHog Code desktop and mobile apps, plus internal automation clients (they send it explicitly or omit the field) |
| `signal_report` | Code desktop and mobile report-kickoff flows, and the web inbox ([inboxTaskKickoffLogic.ts](https://github.com/PostHog/posthog/blob/cc906a25ee8ddd30458a3c11d0d6d40890150396/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts#L83), [scoutFleetLogic.ts](https://github.com/PostHog/posthog/blob/cc906a25ee8ddd30458a3c11d0d6d40890150396/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts#L643)) |
| `error_tracking` | Issue "create task" flow ([IssueTasks.tsx](https://github.com/PostHog/posthog/blob/cc906a25ee8ddd30458a3c11d0d6d40890150396/products/error_tracking/frontend/components/IssueTasks.tsx#L175)) |
| `session_summaries` | Notebook task-create node ([NotebookNodeTaskCreate.tsx](https://github.com/PostHog/posthog/blob/cc906a25ee8ddd30458a3c11d0d6d40890150396/frontend/src/scenes/notebooks/Nodes/NotebookNodeTaskCreate.tsx#L32)) |
| `posthog_ai` | Task tracker scene ([taskTrackerSceneLogic.ts](https://github.com/PostHog/posthog/blob/cc906a25ee8ddd30458a3c11d0d6d40890150396/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts#L496)) |
| `hogdesk` | The internal support-desk client creates tasks from a ticket's Code chat through this API (already pinned by an existing API test) |
| `support_queue` | The support team's Zendesk-addon variant of the support-desk client still sends this. Most veto-able entry: if that client is retired or migrated, this should move to the reserved list |

Reserved (no API caller found, all created server-side): `onboarding`, `eval_clusters`, `automation`, `slack`, `experiments`, `signals_scout`, `support_reply`, `review_hog`, `image_builder`, `loop`. Excluding an origin without a traced caller is the safe direction: a 400 for an unadvertised value is recoverable, silent misattribution is not.

## How did you test this code?

- New serializer-level `SimpleTestCase` matrix in `test_presentation_serializers.py` classifies all 17 enum values. Reserved values assert the exact rejection message (catches re-opening a reserved origin, and catches dropping the documented `image_builder`/`experiments` rationales); allowed values assert validity (catches dropping a live client's origin). The reserved set is derived as enum minus allowlist, so a future enum member is API-rejected by default and automatically covered.
- `test_update_rejects_origin_product` pins the new update guard at the serializer level, and the endpoint test `test_patch_cannot_change_origin_product` now expects 400 and asserts the stored value is untouched (wiring guard for the PATCH path).
- Existing endpoint tests (`image_builder`/`experiments` 400s, hogdesk 201 round-trip, omitted-field default to `user_created`) pass unchanged as create-path wiring guards.
- I (well, Claude) could not run the Django suite in this sandbox (no database available). Ran the repo-pinned ruff and Python syntax checks locally and rely on CI for test execution. Generated API types were not regenerated here either; the openapi-types CI job should auto-commit the refresh.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No `docs/` change needed: the docs mentioning `origin_product` describe server-side facade creation, which is unchanged. The API-facing contract lives in the field's `help_text`, updated here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via PostHog Code. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`. The allowlist was derived empirically by tracing every caller of the task-create endpoint across this repo's frontends and PostHog's client apps, then excluding any origin without a traceable API caller. Chose the `runtime`-style serializer split for immutability (over a `partial`-aware guard) so the PATCH schema stops advertising the field, and kept the full enum `choices` on the create field so the two documented rejection messages stay reachable ahead of the allowlist check.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
