### PR TITLE
fix(customer-analytics): raise jest timeout for expanded-row stories

### DIFF
--- a/common/storybook/.storybook/test-runner.ts
+++ b/common/storybook/.storybook/test-runner.ts
@@ -42,6 +42,12 @@ declare module 'storybook/internal/types' {
             /** Timeout in ms for waitForSelector. Defaults to Playwright's context timeout (PLAYWRIGHT_TIMEOUT_MS). */
             waitForSelectorTimeout?: number
             /**
+             * Override the per-test Jest timeout (ms) for stories whose render legitimately needs
+             * longer than the default. Use sparingly — a slow story is usually a bug, not a budget
+             * problem. Still scaled by the viewport-widths multiplier. Defaults to JEST_TIMEOUT_MS.
+             */
+            jestTimeout?: number
+            /**
              * By default we wait for images to have width as an indication the page is ready for screenshot testing
              * Some stories have broken images on purpose to test what the UI does
              * in those cases set `allowImagesWithoutWidth` to `true`
@@ -142,8 +148,8 @@ export default {
             route.fulfill({ status: 200, contentType: 'text/html', body: EMBED_STUB_HTML })
         )
         const storyContext = await getStoryContext(page, context)
-        const { viewport, viewportWidths } = storyContext.parameters?.testOptions ?? {}
-        applyStoryTimeouts(page, viewportWidths)
+        const { viewport, viewportWidths, jestTimeout } = storyContext.parameters?.testOptions ?? {}
+        applyStoryTimeouts(page, viewportWidths, jestTimeout)
         const effectiveViewport = viewportWidths?.length
             ? VIEWPORT_WIDTHS[viewportWidths[0]]
             : viewport || DEFAULT_VIEWPORT
@@ -153,7 +159,7 @@ export default {
     async postVisit(page, context) {
         ATTEMPT_COUNT_PER_ID[context.id] = (ATTEMPT_COUNT_PER_ID[context.id] || 0) + 1
         const storyContext = await getStoryContext(page, context)
-        const { viewport, viewportWidths } = storyContext.parameters?.testOptions ?? {}
+        const { viewport, viewportWidths, jestTimeout } = storyContext.parameters?.testOptions ?? {}
         const effectiveViewport = viewportWidths?.length
             ? VIEWPORT_WIDTHS[viewportWidths[0]]
             : viewport || DEFAULT_VIEWPORT
@@ -175,7 +181,7 @@ export default {
         const { snapshotBrowsers = ['chromium'] } = storyContext.parameters?.testOptions ?? {}
 
         // Keep timeouts scaled in postVisit too, as retries can run through this path multiple times.
-        applyStoryTimeouts(page, viewportWidths)
+        applyStoryTimeouts(page, viewportWidths, jestTimeout)
         const currentBrowser = browserContext.browser()!.browserType().name() as SupportedBrowserName
         if (snapshotBrowsers.includes(currentBrowser)) {
             if (viewportWidths?.length) {
@@ -576,10 +582,10 @@ async function waitForPageReady(page: Page, skipNetworkIdle = false): Promise<vo
         .catch(() => undefined)
 }
 
-function applyStoryTimeouts(page: Page, viewportWidths?: ViewportWidthName[]): void {
+function applyStoryTimeouts(page: Page, viewportWidths?: ViewportWidthName[], jestTimeout?: number): void {
     // Multi-width stories effectively run several snapshots inside one smoke test.
     const timeoutMultiplier = viewportWidths?.length || 1
-    jest.setTimeout(JEST_TIMEOUT_MS * timeoutMultiplier)
+    jest.setTimeout((jestTimeout ?? JEST_TIMEOUT_MS) * timeoutMultiplier)
     page.context().setDefaultTimeout(PLAYWRIGHT_TIMEOUT_MS * timeoutMultiplier)
 }
 

--- a/products/customer_analytics/frontend/components/Accounts/AccountsTab.stories.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsTab.stories.tsx
@@ -139,9 +139,14 @@ async function expandAndOpenTab(canvasElement: HTMLElement, tab: 'Usage' | 'Spen
 // The snapshot fires well after `play` (page-ready waits, forced reflows, a dispatched resize),
 // and the meta-level waitForSelector is satisfied by a collapsed table. Gating the snapshot on the
 // expanded-row content turns a lost expansion into a retry instead of a flaky collapsed capture.
+// The 60s waitForSelector can eat the whole default 60s Jest budget on its own, leaving no room
+// for the surrounding page-ready waits, reflows, and the two theme snapshots — so under CI load
+// the test hits the Jest timeout even when the expansion eventually renders. Give it a 120s Jest
+// budget so the selector wait has headroom instead of racing the test timeout.
 const EXPANDED_ROW_TEST_OPTIONS = {
     waitForSelector: ['[data-attr="accounts-refresh"]', '[data-attr="account-expansion"]'],
     waitForSelectorTimeout: 60000,
+    jestTimeout: 120000,
 }
 
 function mockAccountsQuery(rows: AccountRow[]): (info: MockResolverInfo) => Promise<[number, unknown] | undefined> {


### PR DESCRIPTION
## Problem

The `Scenes-App/Customer Analytics/Accounts` expanded-row stories (`RowExpandedWithNote`, `RowExpandedLinksDisabled`, and the other `RowExpanded*` stories that share the same test options) have been flaking in visual-regression CI by exceeding the Jest per-test timeout.

These stories set `waitForSelectorTimeout: 60000` on `[data-attr="account-expansion"]`, which equals the default 60s Jest per-test budget (`JEST_TIMEOUT_MS`). Under CI load the selector wait can consume nearly the whole budget on its own, leaving no headroom for the surrounding page-ready waits, reflows, and the two (light + dark) theme snapshots — so the test hits the Jest timeout even when the expansion eventually renders.

Reported via [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1784765081715409?thread_ts=1784765081.715409&cid=C09ADEV3AJD).

## Changes

- Add an optional `jestTimeout` testOption to the storybook test-runner (`common/storybook/.storybook/test-runner.ts`), threaded through `applyStoryTimeouts` in both `preVisit` and `postVisit` and still scaled by the viewport-widths multiplier.
- Set `jestTimeout: 120000` on the shared `EXPANDED_ROW_TEST_OPTIONS` in `AccountsTab.stories.tsx`, so the 60s selector wait has room to spare instead of racing the test timeout.

## How did you test this code?

No manual run performed by the agent. This is a test-infrastructure timeout change; correctness is in the wiring — the new `jestTimeout` is read from `testOptions` and passed to `jest.setTimeout` via `applyStoryTimeouts`. The existing `waitForSelectorTimeout` (60s) is unchanged, so the story still fails fast if the expansion genuinely never renders; only the outer Jest budget is widened.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app agent in response to a report of repeated VR-test timeouts on the Accounts expanded-row stories. Traced the timeout to the interaction between the story's 60s `waitForSelectorTimeout` and the test-runner's hard 60s `JEST_TIMEOUT_MS`; chose to add a per-story `jestTimeout` override rather than bump the global default, so only the genuinely slow stories get the extra budget.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1784765081715409?thread_ts=1784765081.715409&cid=C09ADEV3AJD)*
