### PR TITLE
fix(data-warehouse): explain CSV quote handling in self-managed source form

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/components/SelfManagedSourceForm.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/components/SelfManagedSourceForm.tsx
@@ -120,23 +120,30 @@ export function SelfManagedSourceForm({ onUpdate }: Props): JSX.Element {
                     )}
                 </LemonField>
                 {isCsvFormat && (
-                    <LemonField
-                        name={['options', 'csv_allow_double_quotes']}
-                        label="CSV quote handling"
-                        className="mb-4 w-max"
-                    >
-                        {({ value, onChange }) => (
-                            <LemonSelect
-                                data-attr="csv-quote-handling"
-                                options={[
-                                    { label: 'RFC 4180 double quotes', value: true },
-                                    { label: 'Literal quotes', value: false },
-                                ]}
-                                value={value ?? false}
-                                onChange={onChange}
-                            />
-                        )}
-                    </LemonField>
+                    <>
+                        <LemonField
+                            name={['options', 'csv_allow_double_quotes']}
+                            label="CSV quote handling"
+                            className="w-max"
+                        >
+                            {({ value, onChange }) => (
+                                <LemonSelect
+                                    data-attr="csv-quote-handling"
+                                    options={[
+                                        { label: 'RFC 4180 double quotes', value: true },
+                                        { label: 'Literal quotes', value: false },
+                                    ]}
+                                    value={value ?? false}
+                                    onChange={onChange}
+                                />
+                            )}
+                        </LemonField>
+                        <div className="mb-4 text-xs text-secondary">
+                            Pick RFC 4180 if your CSV wraps values in double quotes (the usual way to keep commas inside
+                            a field). If import fails with a column count mismatch, switching to RFC 4180 usually fixes
+                            it.
+                        </div>
+                    </>
                 )}
                 <LemonField name={['credential', 'access_key']} label={ProviderMappings[provider].accessKeyLabel}>
                     {({ value = '', onChange }) => (


### PR DESCRIPTION
## Problem

The self-managed data-warehouse source form (S3 / GCS / Cloudflare R2 / Azure) shows a **CSV quote handling** dropdown with two options — "RFC 4180 double quotes" and "Literal quotes" — and no explanation of what they mean or when to pick which. It defaults to literal quotes.

Users importing ordinary quoted CSVs (fields wrapped in double quotes so they can contain commas) leave it on the default and only find out something is wrong much later, when queries against the table fail with an opaque ClickHouse column-count-mismatch / "structure could not be extracted" error. Recovering means guessing, asking the AI assistant, or re-creating the source — friction that showed up repeatedly in onboarding sessions.

## Changes

Added a short helper note under the field, in the same `text-secondary` style the other fields in this form already use, telling users to pick RFC 4180 when their CSV wraps values in double quotes and that switching to RFC 4180 usually resolves a column count mismatch on import.

Copy-only change. No behaviour, default, or schema changes.

## How did you test this code?

Formatted the touched file with oxfmt. This is a static copy addition inside an existing conditional block; no automated tests were added as there is no behavioural change to assert. I (the agent) did not run the app manually.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Identified from a review of data-warehouse new-source onboarding sessions: several users importing CSVs from their own object storage hit column-count-mismatch errors and had to discover on their own that the RFC 4180 quote option fixes them. The safe, self-contained fix is to explain the field inline rather than change the default (which would alter import behaviour for existing flows). No skills were required for this copy change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
