### PR TITLE
fix(experiments): align hypothesis edit limit with backend (3000)

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/Info.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/Info.tsx
@@ -232,7 +232,7 @@ export function Info(): JSX.Element {
                                 onChange={(value) => setTempDescription(value)}
                                 placeholder="Add your hypothesis for this test"
                                 minRows={6}
-                                maxLength={400}
+                                maxLength={3000}
                             />
                         </LemonModal>
                     </div>


### PR DESCRIPTION
## Problem

The experiment UI capped the hypothesis field at 400 characters in the "Edit hypothesis" modal, but the backend model and serializer allow 3000 characters — and the experiment creation wizard already uses 3000. As a result, hypotheses created longer than 400 characters (via the wizard or the API/MCP) could not be edited without being truncated. Raised in a Slack thread.

## Changes

Bump the `maxLength` on the "Edit hypothesis" `LemonTextArea` in `ExperimentView/Info.tsx` from 400 to 3000, matching the backend limit and the creation wizard.

**Why:** the UI edit limit was inconsistent with the backend, which accepts far more than 400 characters, causing longer hypotheses to be silently truncated on edit.

## How did you test this code?

No automated tests were added — this is a single-constant UI limit change. Verified by inspection that the backend model (`description = models.CharField(max_length=3000)`), the serializer (`max_length=3000`), and the creation wizard (`AboutStep.tsx`, `maxLength={3000}`) all already use 3000, so this brings the edit modal in line with them.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app after a user reported that the UI restricts the experiment hypothesis to 400 characters while the API accepts more. Traced the field (experiment `description`) through the frontend, serializer, and model; found the backend and the creation wizard both allow 3000 while only the edit modal still capped at 400, and aligned the modal to 3000.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07PXH2GTGV/p1784772485995289)*
