### PR TITLE
fix(cli): strip CSS source map references

### DIFF
--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -260,11 +260,21 @@ impl MinifiedSourceFile {
     }
 
     pub fn get_sourcemap_reference(&self) -> Result<Option<String>> {
-        let patterns = ["//# sourceMappingURL=", "//@ sourceMappingURL="];
-        let Some(found) = self.get_comment_value(&patterns) else {
-            return Ok(None);
-        };
-        Ok(Some(urlencoding::decode(&found)?.into_owned()))
+        let found = self.inner.content.lines().rev().find_map(|line| {
+            let line = line.trim();
+            ["//# sourceMappingURL=", "//@ sourceMappingURL="]
+                .iter()
+                .find_map(|prefix| line.strip_prefix(prefix))
+                .or_else(|| {
+                    line.strip_prefix("/*# sourceMappingURL=")
+                        .and_then(|reference| reference.strip_suffix("*/"))
+                        .map(str::trim_end)
+                })
+        });
+
+        Ok(found
+            .map(|reference| urlencoding::decode(reference).map(|decoded| decoded.into_owned()))
+            .transpose()?)
     }
 
     pub fn remove_sourcemap_reference(&mut self) -> bool {
@@ -354,6 +364,7 @@ fn trailing_sourcemap_reference_range(content: &str) -> Option<std::ops::Range<u
         }
         if trimmed_line.starts_with("//# sourceMappingURL=")
             || trimmed_line.starts_with("//@ sourceMappingURL=")
+            || (trimmed_line.starts_with("/*# sourceMappingURL=") && trimmed_line.ends_with("*/"))
         {
             return Some(line_start..line_end);
         }
@@ -541,6 +552,19 @@ mod tests {
 
         assert!(source.remove_sourcemap_reference());
         assert_eq!(source.inner.content, "console.log(1);\r\n");
+    }
+
+    #[test]
+    fn remove_sourcemap_reference_strips_css_comment() {
+        let mut source =
+            minified_source(".app { color: black; }\n/*# sourceMappingURL=app.css.map */\n");
+
+        assert_eq!(
+            source.get_sourcemap_reference().unwrap(),
+            Some("app.css.map".to_string())
+        );
+        assert!(source.remove_sourcemap_reference());
+        assert_eq!(source.inner.content, ".app { color: black; }\n");
     }
 
     #[test]

--- a/cli/src/sourcemaps/plain/inject.rs
+++ b/cli/src/sourcemaps/plain/inject.rs
@@ -21,3 +21,7 @@ pub fn is_javascript_file(entry: &DirEntry) -> bool {
             .extension()
             .is_some_and(|ext| ext == "js" || ext == "mjs" || ext == "cjs")
 }
+
+pub fn is_stylesheet_file(entry: &DirEntry) -> bool {
+    entry.file_type().is_file() && entry.path().extension().is_some_and(|ext| ext == "css")
+}

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -21,7 +21,7 @@ use crate::{
         args::{FileSelectionArgs, ReleaseArgs, UploadConcurrencyArgs, UploadConflictArgs},
         content::MinifiedSourceFile,
         inject::get_release_for_maps,
-        plain::inject::is_javascript_file,
+        plain::inject::{is_javascript_file, is_stylesheet_file},
         source_pairs::read_pairs,
     },
     utils::files::{delete_files, FileSelection},
@@ -175,9 +175,34 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
     upload_result?;
 
     if args.delete_after {
-        remove_sourcemap_references(source_paths)
-            .context("While stripping sourcemap references")?;
-        delete_files(sourcemap_paths).context("While deleting sourcemaps")?;
+        let stylesheet_selection = FileSelection::try_from(args.file_selection.clone())?;
+        let stylesheet_pairs = read_pairs(
+            stylesheet_selection.into_iter().filter(is_stylesheet_file),
+            &args.public_path_prefix,
+        );
+        let stylesheet_source_paths = stylesheet_pairs
+            .iter()
+            .map(|pair| pair.source.inner.path.clone())
+            .collect::<Vec<_>>();
+        let stylesheet_sourcemap_paths = stylesheet_pairs
+            .iter()
+            .map(|pair| pair.sourcemap.inner.path.clone())
+            .collect::<Vec<_>>();
+
+        remove_sourcemap_references(
+            source_paths
+                .into_iter()
+                .chain(stylesheet_source_paths)
+                .collect(),
+        )
+        .context("While stripping sourcemap references")?;
+        delete_files(
+            sourcemap_paths
+                .into_iter()
+                .chain(stylesheet_sourcemap_paths)
+                .collect(),
+        )
+        .context("While deleting sourcemaps")?;
     }
 
     Ok(())

--- a/cli/tests/_cases/stylesheet/app.css
+++ b/cli/tests/_cases/stylesheet/app.css
@@ -1,0 +1,2 @@
+.app { color: black; }
+/*# sourceMappingURL=app.css.map */

--- a/cli/tests/_cases/stylesheet/app.css.map
+++ b/cli/tests/_cases/stylesheet/app.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":[],"names":[],"mappings":""}

--- a/cli/tests/sourcemap.rs
+++ b/cli/tests/sourcemap.rs
@@ -1,6 +1,8 @@
 use posthog_cli::{
     sourcemaps::{
-        content::SourceMapContent, inject::inject_pairs, plain::inject::is_javascript_file,
+        content::SourceMapContent,
+        inject::inject_pairs,
+        plain::inject::{is_javascript_file, is_stylesheet_file},
         source_pairs::SourcePair,
     },
     utils::files::FileSelection,
@@ -61,6 +63,23 @@ fn test_search_without_multiple_files() {
     )
     .expect("Failed to read pairs");
     assert_eq!(pairs.len(), 2);
+}
+
+#[test]
+fn test_stylesheet_pair_is_discoverable_for_cleanup() {
+    let selection = FileSelection::from_roots(vec![get_case_path("stylesheet")])
+        .include(vec![])
+        .expect("Failed to select stylesheet fixture");
+    let pairs = posthog_cli::sourcemaps::source_pairs::read_pairs(
+        selection.into_iter().filter(is_stylesheet_file),
+        &None,
+    );
+
+    assert_eq!(pairs.len(), 1);
+    assert_eq!(
+        pairs[0].source.inner.path,
+        get_case_path("stylesheet/app.css")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Closes PostHog/posthog-js#4546

`deleteAfterUpload` only discovers JavaScript source-map pairs. CSS bundles with a trailing `sourceMappingURL` comment keep their comment and sidecar map after a successful upload.

## Changes

- discover CSS source-map pairs during the delete-after cleanup path
- recognize and remove trailing CSS source-map comments
- delete the associated CSS sidecar maps with the existing cleanup

## How did you test this code?

- `cargo test --manifest-path cli/Cargo.toml --lib`
- `cargo test --manifest-path cli/Cargo.toml --test sourcemap`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets -- -D warnings`
- Added a CSS fixture that proves stylesheet pairs are discovered for cleanup and a regression test that proves the CSS comment is removed.

I did not run a live upload because it requires a configured PostHog project and would mutate remote project data.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update: this restores the existing `deleteAfterUpload` cleanup behavior for CSS artifacts.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this focused CLI fix under human direction. I used the repository `/writing-tests` skill to add only the two regressions needed: CSS comment stripping and CSS source-map-pair discovery. The upload set remains JavaScript-only; CSS is visited solely after a successful upload when deletion is already requested.