### PR TITLE
perf(data-warehouse): probe target table for existence instead of information_schema

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from time import sleep as _real_sleep  # captured before any test patches this module's `time`
 from typing import Any, Literal
+from weakref import WeakKeyDictionary
 
 from django.conf import settings
 from django.db import close_old_connections
@@ -648,7 +649,17 @@ def _plan_batch_operation(
     raise PermanentBatchApplyError(f"Unsupported Duckgres sync type: {batch.sync_type}")
 
 
+# Per-connection cache of tables confirmed to exist: the information_schema
+# probe below is expensive on a large, high-churn DuckLake catalog and the sink
+# runs it every non-first batch. Only positive results are cached (a table may
+# be created between batches); GC'd with the connection, so reuse re-checks.
+_existing_tables: WeakKeyDictionary[psycopg.Connection[Any], set[tuple[str, str]]] = WeakKeyDictionary()
+
+
 def _table_exists(conn: psycopg.Connection[Any], duckgres_schema: str, duckgres_table: str) -> bool:
+    known = _existing_tables.setdefault(conn, set())
+    if (duckgres_schema, duckgres_table) in known:
+        return True
     cursor = conn.execute(
         """
         SELECT 1
@@ -659,7 +670,10 @@ def _table_exists(conn: psycopg.Connection[Any], duckgres_schema: str, duckgres_
         """,
         [duckgres_schema, duckgres_table],
     )
-    return cursor.fetchone() is not None
+    exists = cursor.fetchone() is not None
+    if exists:
+        known.add((duckgres_schema, duckgres_table))
+    return exists
 
 
 def _replace_table(conn: psycopg.Connection[Any], duckgres_schema: str, duckgres_table: str, paths: list[str]) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
@@ -649,10 +649,10 @@ def _plan_batch_operation(
     raise PermanentBatchApplyError(f"Unsupported Duckgres sync type: {batch.sync_type}")
 
 
-# Per-connection cache of tables confirmed to exist: the information_schema
-# probe below is expensive on a large, high-churn DuckLake catalog and the sink
-# runs it every non-first batch. Only positive results are cached (a table may
-# be created between batches); GC'd with the connection, so reuse re-checks.
+# Per-connection cache of tables confirmed to exist: the sink checks existence
+# every non-first batch, so cache positive results (a table stays existing for
+# the connection's life — the sink never drops tables mid-run). Only positives
+# are cached (a table may be created between batches); GC'd with the connection.
 _existing_tables: WeakKeyDictionary[psycopg.Connection[Any], set[tuple[str, str]]] = WeakKeyDictionary()
 
 
@@ -660,20 +660,32 @@ def _table_exists(conn: psycopg.Connection[Any], duckgres_schema: str, duckgres_
     known = _existing_tables.setdefault(conn, set())
     if (duckgres_schema, duckgres_table) in known:
         return True
-    cursor = conn.execute(
-        """
-        SELECT 1
-        FROM information_schema.tables
-        WHERE table_schema = %s
-            AND table_name = %s
-        LIMIT 1
-        """,
-        [duckgres_schema, duckgres_table],
-    )
-    exists = cursor.fetchone() is not None
+    exists = _probe_table_exists(conn, duckgres_schema, duckgres_table)
     if exists:
         known.add((duckgres_schema, duckgres_table))
     return exists
+
+
+def _probe_table_exists(conn: psycopg.Connection[Any], duckgres_schema: str, duckgres_table: str) -> bool:
+    """Cheap single-table existence probe (autocommit, so a raised error is inert).
+
+    A `LIMIT 0` reference loads only this table's metadata (~0.1-0.6s even under
+    concurrent snapshot commits); the former `information_schema.tables` check
+    re-materialized the whole catalog (~48s under load on a large catalog).
+    duckgres reports a missing table as a generic XX000 carrying DuckDB's stable
+    "... does not exist" message; anything else is a real error and propagates.
+    """
+    try:
+        conn.execute(
+            sql.SQL("SELECT 1 FROM {}.{} LIMIT 0").format(
+                sql.Identifier(duckgres_schema), sql.Identifier(duckgres_table)
+            )
+        )
+        return True
+    except psycopg.Error as err:
+        if "does not exist" in str(err).lower():
+            return False
+        raise
 
 
 def _replace_table(conn: psycopg.Connection[Any], duckgres_schema: str, duckgres_table: str, paths: list[str]) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
@@ -673,7 +673,9 @@ def _probe_table_exists(conn: psycopg.Connection[Any], duckgres_schema: str, duc
     concurrent snapshot commits); the former `information_schema.tables` check
     re-materialized the whole catalog (~48s under load on a large catalog).
     duckgres reports a missing table as a generic XX000 carrying DuckDB's stable
-    "... does not exist" message; anything else is a real error and propagates.
+    "Table with name X does not exist" catalog message. Match that specifically —
+    a bare "does not exist" would also swallow a missing schema/catalog/secret,
+    wrongly routing a real failure to the create path. Anything else propagates.
     """
     try:
         conn.execute(
@@ -683,7 +685,8 @@ def _probe_table_exists(conn: psycopg.Connection[Any], duckgres_schema: str, duc
         )
         return True
     except psycopg.Error as err:
-        if "does not exist" in str(err).lower():
+        message = str(err).lower()
+        if "table with name" in message and "does not exist" in message:
             return False
         raise
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
@@ -11,6 +11,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     _process_backfill_batch,
     _process_batch,
     _session_cache,
+    _table_exists,
     process_batch,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.jobs_db import (
@@ -730,3 +731,49 @@ class TestLiveSessionReuse:
             process_batch(_make_batch(batch_index=1))
 
         assert self.mock_team.objects.only.return_value.get.call_count == 1
+
+
+def _existence_conn(exists: bool):
+    """A mock connection whose information_schema probe reports table existence."""
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.fetchone.return_value = (1,) if exists else None
+    conn.execute.return_value = cur
+    return conn
+
+
+class TestTableExistsCache:
+    """`information_schema.tables` forces duckgres to materialize its whole-catalog
+    compat view — tens of seconds under concurrent snapshot commits on a large
+    DuckLake catalog (prod, 2026-07). Cache the answer per connection so it is
+    paid at most once per connection, not once per batch."""
+
+    def test_second_check_on_same_connection_skips_the_catalog_query(self):
+        conn = _existence_conn(True)
+        assert _table_exists(conn, "posthog_data_imports_team_1", "customers") is True
+        assert _table_exists(conn, "posthog_data_imports_team_1", "customers") is True
+        # information_schema queried exactly once despite two existence checks.
+        assert conn.execute.call_count == 1
+
+    def test_distinct_tables_each_check_once(self):
+        conn = _existence_conn(True)
+        _table_exists(conn, "s", "a")
+        _table_exists(conn, "s", "b")
+        _table_exists(conn, "s", "a")
+        assert conn.execute.call_count == 2
+
+    def test_separate_connections_do_not_share_the_cache(self):
+        c1, c2 = _existence_conn(True), _existence_conn(True)
+        _table_exists(c1, "s", "t")
+        _table_exists(c2, "s", "t")
+        assert c1.execute.call_count == 1
+        assert c2.execute.call_count == 1
+
+    def test_absent_table_is_not_cached(self):
+        # A negative must be re-checked: the table may be created between batches
+        # (the create path), so caching "does not exist" would wrongly skip a
+        # later insert/merge onto the now-existing table.
+        conn = _existence_conn(False)
+        assert _table_exists(conn, "s", "t") is False
+        assert _table_exists(conn, "s", "t") is False
+        assert conn.execute.call_count == 2

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
@@ -759,9 +759,20 @@ class TestTableExistsProbeAndCache:
 
     def test_other_error_propagates_not_treated_as_absent(self):
         # A transient failure must NOT be read as "table absent" (that would pick
-        # the create path); only DuckDB's "does not exist" means absent.
+        # the create path); only DuckDB's table-missing message means absent.
         conn = MagicMock()
         conn.execute.side_effect = psycopg.errors.InternalError_("flight execute: rpc error: Unavailable")
+        with pytest.raises(psycopg.Error):
+            _table_exists(conn, "s", "t")
+
+    def test_missing_schema_error_propagates_not_treated_as_table_absent(self):
+        # A bare "does not exist" match would swallow a missing schema/catalog/
+        # secret and wrongly pick the create path; only "Table with name ..." is
+        # absent. (Greptile P1.)
+        conn = MagicMock()
+        conn.execute.side_effect = psycopg.errors.InternalError_(
+            "flight execute: ... Catalog Error: Schema with name s does not exist!"
+        )
         with pytest.raises(psycopg.Error):
             _table_exists(conn, "s", "t")
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
@@ -3,6 +3,8 @@ from typing import Any
 import pytest
 from unittest.mock import MagicMock, Mock, patch
 
+import psycopg
+
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.processor import (
     DuckgresColumn,
     _ensure_duckgres_apply_table,
@@ -734,28 +736,42 @@ class TestLiveSessionReuse:
 
 
 def _existence_conn(exists: bool):
-    """A mock connection whose information_schema probe reports table existence."""
+    """A mock connection whose LIMIT-0 probe reports existence: it succeeds when
+    the table exists, and raises duckgres's XX000 "... does not exist" when not."""
     conn = MagicMock()
-    cur = MagicMock()
-    cur.fetchone.return_value = (1,) if exists else None
-    conn.execute.return_value = cur
+    if not exists:
+        conn.execute.side_effect = psycopg.errors.InternalError_(
+            "flight execute: ... Catalog Error: Table with name t does not exist!"
+        )
     return conn
 
 
-class TestTableExistsCache:
-    """`information_schema.tables` forces duckgres to materialize its whole-catalog
-    compat view — tens of seconds under concurrent snapshot commits on a large
-    DuckLake catalog (prod, 2026-07). Cache the answer per connection so it is
-    paid at most once per connection, not once per batch."""
+class TestTableExistsProbeAndCache:
+    """The existence check the sink runs every non-first batch: a cheap
+    single-table LIMIT-0 probe (the whole-catalog information_schema check cost
+    ~48s under concurrent snapshot commits, prod 2026-07), cached per connection."""
 
-    def test_second_check_on_same_connection_skips_the_catalog_query(self):
+    def test_probe_succeeds_means_exists(self):
+        assert _table_exists(_existence_conn(True), "s", "t") is True
+
+    def test_probe_not_found_means_absent(self):
+        assert _table_exists(_existence_conn(False), "s", "t") is False
+
+    def test_other_error_propagates_not_treated_as_absent(self):
+        # A transient failure must NOT be read as "table absent" (that would pick
+        # the create path); only DuckDB's "does not exist" means absent.
+        conn = MagicMock()
+        conn.execute.side_effect = psycopg.errors.InternalError_("flight execute: rpc error: Unavailable")
+        with pytest.raises(psycopg.Error):
+            _table_exists(conn, "s", "t")
+
+    def test_second_check_on_same_connection_skips_the_probe(self):
         conn = _existence_conn(True)
         assert _table_exists(conn, "posthog_data_imports_team_1", "customers") is True
         assert _table_exists(conn, "posthog_data_imports_team_1", "customers") is True
-        # information_schema queried exactly once despite two existence checks.
-        assert conn.execute.call_count == 1
+        assert conn.execute.call_count == 1  # probed once despite two checks
 
-    def test_distinct_tables_each_check_once(self):
+    def test_distinct_tables_each_probe_once(self):
         conn = _existence_conn(True)
         _table_exists(conn, "s", "a")
         _table_exists(conn, "s", "b")


### PR DESCRIPTION
## Problem

The duckgres sink's `_table_exists()` runs `SELECT 1 FROM information_schema.tables` on every non-first batch (via `_plan_batch_operation`, to choose create vs insert/merge). On a large DuckLake catalog this forces duckgres to re-materialize its whole-catalog `information_schema` compat view — every current table and column at the current snapshot.

Traced end to end on the dogfood org's catalog (mw-prod-us, 2026-07): **3,173 tables, 80,235 snapshots, 577,076 `ducklake_column` rows** (88% superseded version history), and the `ducklake_column` index is `(table_id, …)`-leading — so an "all current columns" load can't use it and scans the whole history.

- It's **not a lock** — sampling `pg_stat_activity`/`pg_locks` on the catalog Postgres during live sink activity showed zero blocking. It's *work*: DuckDB caches the catalog and re-loads it whenever the snapshot advances; the sink commits a snapshot **per batch**, so the cache is invalidated on every batch and each check re-scans the bloated catalog.
- Measured under identical concurrent write load: `information_schema.tables` = **1.3s idle → ~48s under load** (44.8–52.1s every iteration, one concurrent writer was enough). This is a **shared per-apply tax paid by every table**, which is why sink throughput was flat (~140/hr) regardless of which table a batch hit — and why neither the earlier session-reuse nor co-claim PRs moved it (the cache is invalidated by *other* sessions' commits).

## Change

Replace the `information_schema` enumeration with a **single-table `LIMIT 0` probe** (`SELECT 1 FROM <schema>.<table> LIMIT 0`). It loads only that one table's metadata via the catalog's `table_id`-indexed single-table path, so it stays cheap even under concurrent snapshot commits:

| under identical concurrent write load | idle | loaded |
|---|---|---|
| `information_schema.tables` (old) | 1.3s | **~48s** |
| `LIMIT 0` probe (new) | 0.11s | **0.59s** (max 0.90s) |

duckgres reports a missing table as a generic `XX000` carrying DuckDB's stable `"... does not exist"` catalog message (verified via psycopg — it is **not** a typed `UndefinedTable`), so the probe matches that message for "absent" and **propagates anything else** — a transient error read as "table absent" would wrongly pick the create path (a benign, self-healing `CREATE`-then-retry, but avoid it). The probe runs on the autocommit connection outside any transaction, so a raised error is inert.

Kept the per-connection positive existence cache (`WeakKeyDictionary`): a table that exists stays existing for the connection's life (the sink never drops tables mid-run), so repeat batches skip the probe entirely and the not-found match only runs on a table's **first encounter per connection**.

## How did you test this code?

I'm an agent; checks actually run:

- TDD: probe-succeeds→exists, probe-not-found→absent, **other-error propagates (not read as absent)**, cache-hit skips the probe, per-table granularity, per-connection isolation, negatives-not-cached — each watched failing first, then passing (`test_processor.py`, 30 total).
- Direct production experiments established causation: idle vs concurrent-load repro (1.3s→48s for `information_schema`, 0.11s→0.59s for the probe), catalog Postgres `pg_locks`/index inspection, and the exact psycopg error signature. All test artifacts (a temporary user, a scratch schema) were removed.
- Pre-commit hooks (ruff/format/ty) clean.

## Follow-ups (separate)

- **Snapshot/version expiry** to shrink the 577k-row catalog — makes even the rare create-path check cheap and helps storage/billing (this is the part of the earlier "compaction helps throughput" idea that's actually true — metadata expiry, not S3 file compaction).
- File compaction remains **storage-only** for throughput.

## 🤖 Agent context

Authored by Claude Code (Fable 5) from a multi-day production investigation. Notably this **corrected an earlier hypothesis**: the throughput bottleneck is not S3 file-count bloat (compaction) but this per-batch `information_schema` re-materialization — established by reproducing the 1.3s→48s swing under concurrent snapshot commits, confirming on the catalog Postgres it's re-read work (not lock contention), and then validating that the single-table probe stays sub-second under the same load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)