### PR TITLE
fix(tasks): use autocomplete for creator in loop admin

### DIFF
--- a/products/tasks/backend/admin.py
+++ b/products/tasks/backend/admin.py
@@ -178,7 +178,7 @@ class LoopAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     )
-    autocomplete_fields = ("team", "created_by")
+    autocomplete_fields = ("team", "created_by", "creator")
     raw_id_fields = ("sandbox_environment",)
 
     def get_queryset(self, request: HttpRequest):


### PR DESCRIPTION
## Problem

Opening a Loop's change page in Django admin never finishes loading.
`LoopAdmin` configures widgets for `team`, `created_by` and `sandbox_environment`, but the `creator` FK (added alongside the admin in #70604) was never listed in `autocomplete_fields`, `raw_id_fields` or `readonly_fields`.
Django falls back to a plain `<select>` for it, which queries every row of `posthog_user` and renders each one as an `<option>`, so the page hangs on any install with a real user table.

## Changes

Adds `creator` to `autocomplete_fields` on `LoopAdmin`, matching how `created_by` (same target model) is already handled.
Kept it editable rather than readonly so an admin can repair a creator nulled out by `SET_NULL` after a user deletion.

## How did you test this code?

I (or, actually Claude) verified `UserAdmin` defines the `search_fields` that autocomplete requires and ran `manage.py check --tag admin`, which passes with no issues.
No manual load of a production admin page was done.
No test added: a one-line admin widget config isn't a realistic regression target beyond Django's own system checks.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A, internal admin only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and authored with Claude Code.
Starting from a report that the Loop admin page loads forever, Claude enumerated the FKs on `Loop`, found `creator` was the only one without a widget config and confirmed via git history that it shipped in the same PR as `LoopAdmin`.
Considered making `creator` readonly since the model treats it as immutable, but chose autocomplete so support can still fix a nulled creator.
No skills were invoked.
