### PR TITLE
feat(capture): accept recording sent_at in request body

### DIFF
--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -16,7 +16,7 @@ use chrono::DateTime;
 use common_types::{CapturedEvent, HasEventName};
 use limiters::redis::RedisLimiter;
 use metrics::{counter, histogram};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{json, Value};
 use time::{format_description::well_known::Iso8601, OffsetDateTime};
 use tokio::time::Instant;
@@ -37,6 +37,16 @@ use crate::{
         DataType, OverflowReason, ProcessedEvent, ProcessedEventMetadata, ProcessingContext,
     },
 };
+
+fn deserialize_sent_at<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(match Option::<Value>::deserialize(deserializer)? {
+        Some(Value::String(value)) => Some(value),
+        _ => None,
+    })
+}
 
 /// A recording event optimized for minimal deserialization overhead.
 /// Instead of fully parsing all properties into a HashMap, we only extract
@@ -67,9 +77,13 @@ pub struct RawRecording {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
 
-    /// Request dispatch timestamp, kept untyped so malformed values can fall back to the query.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub sent_at: Option<Value>,
+    /// ISO 8601 request dispatch timestamp.
+    #[serde(
+        default,
+        deserialize_with = "deserialize_sent_at",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub sent_at: Option<String>,
 
     /// Timezone offset
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -129,8 +143,7 @@ pub enum RecordingRequest {
 impl RawRecording {
     pub fn sent_at(&self) -> Option<OffsetDateTime> {
         self.sent_at
-            .as_ref()
-            .and_then(Value::as_str)
+            .as_deref()
             .and_then(|value| OffsetDateTime::parse(value, &Iso8601::DEFAULT).ok())
     }
 

--- a/rust/capture/src/events/recordings.rs
+++ b/rust/capture/src/events/recordings.rs
@@ -18,6 +18,7 @@ use limiters::redis::RedisLimiter;
 use metrics::{counter, histogram};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use time::{format_description::well_known::Iso8601, OffsetDateTime};
 use tokio::time::Instant;
 use tracing::{error, instrument, Span};
 use uuid::Uuid;
@@ -65,6 +66,10 @@ pub struct RawRecording {
     /// Event timestamp
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp: Option<String>,
+
+    /// Request dispatch timestamp, kept untyped so malformed values can fall back to the query.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sent_at: Option<Value>,
 
     /// Timezone offset
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -122,6 +127,13 @@ pub enum RecordingRequest {
 }
 
 impl RawRecording {
+    pub fn sent_at(&self) -> Option<OffsetDateTime> {
+        self.sent_at
+            .as_ref()
+            .and_then(Value::as_str)
+            .and_then(|value| OffsetDateTime::parse(value, &Iso8601::DEFAULT).ok())
+    }
+
     /// Extract the distinct_id, checking both root field and properties
     pub fn extract_distinct_id(&self) -> Option<String> {
         let value = match &self.distinct_id {
@@ -491,6 +503,7 @@ mod tests {
         let json = json!({
             "event": "$snapshot",
             "distinct_id": "user123",
+            "sent_at": "2024-01-02T03:04:05.678Z",
             "properties": {
                 "$session_id": "session-abc",
                 "$window_id": "window-xyz",
@@ -501,11 +514,23 @@ mod tests {
 
         let recording: RawRecording = serde_json::from_value(json).unwrap();
         assert_eq!(recording.event, "$snapshot");
+        assert_eq!(
+            recording.sent_at(),
+            Some(OffsetDateTime::from_unix_timestamp_nanos(1_704_164_645_678_000_000).unwrap())
+        );
         assert_eq!(recording.extract_distinct_id(), Some("user123".to_string()));
         assert_eq!(
             recording.properties.session_id,
             Some(Value::String("session-abc".to_string()))
         );
+
+        let recording: RawRecording = serde_json::from_value(json!({
+            "event": "$snapshot",
+            "sent_at": 1_704_164_645_678_i64,
+            "properties": {}
+        }))
+        .unwrap();
+        assert_eq!(recording.sent_at(), None);
     }
 
     #[test]

--- a/rust/capture/src/payload/recordings.rs
+++ b/rust/capture/src/payload/recordings.rs
@@ -113,7 +113,7 @@ pub async fn handle_recording_payload(
     counter!("capture_events_received_total").increment(events.len() as u64);
 
     let now = state.timesource.current_time();
-    let sent_at = query_params.sent_at();
+    let sent_at = events[0].sent_at().or_else(|| query_params.sent_at());
 
     let context = ProcessingContext {
         sent_at,

--- a/rust/capture/tests/recordings.rs
+++ b/rust/capture/tests/recordings.rs
@@ -69,6 +69,51 @@ async fn it_captures_one_recording() -> Result<()> {
 }
 
 #[tokio::test]
+async fn it_prefers_body_sent_at_and_falls_back_to_query_for_recordings() -> Result<()> {
+    setup_tracing();
+    let token = random_string("token", 16);
+    let main_topic = EphemeralTopic::new().await;
+    let server = ServerHandle::for_recordings(&main_topic).await;
+    let query_sent_at = 1_704_067_200_000_i64;
+
+    for (body_sent_at, expected_sent_at) in [
+        (
+            json!("2024-01-02T03:04:05.678Z"),
+            "2024-01-02T03:04:05.678Z",
+        ),
+        (json!("invalid"), "2024-01-01T00:00:00Z"),
+        (json!(1_704_164_645_678_i64), "2024-01-01T00:00:00Z"),
+    ] {
+        let session_id = Uuid::now_v7().to_string();
+        let recording_events = json!([{
+            "token": token,
+            "event": "$snapshot",
+            "distinct_id": random_string("id", 16),
+            "sent_at": body_sent_at,
+            "properties": {
+                "$session_id": session_id,
+                "$window_id": Uuid::now_v7().to_string(),
+                "$snapshot_data": [],
+            }
+        }]);
+
+        let response = reqwest::Client::new()
+            .post(format!(
+                "http://{:?}/s/?sent_at={query_sent_at}",
+                server.addr
+            ))
+            .body(recording_events.to_string())
+            .send()
+            .await?;
+
+        assert_eq!(StatusCode::OK, response.status());
+        assert_eq!(expected_sent_at, main_topic.next_event()?["sent_at"]);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn it_captures_one_recording_with_user_agent_fallback_for_lib() -> Result<()> {
     setup_tracing();
     let token = random_string("token", 16);


### PR DESCRIPTION
## Problem

The `/s/` session recording endpoint only reads `sent_at` from the query string. Browser clients should be able to keep POST metadata in the request body while older SDKs continue using the existing numeric query parameter.

## Changes

Session recording items now accept an optional ISO 8601 string in the `sent_at` body field, matching `/batch/`. A valid value on the first recording item takes precedence, while `sent_at` and `_` query values remain as fallbacks. A tolerant deserializer ignores invalid or mistyped body values rather than making previously accepted payloads fail hydration.

Before:

```mermaid
flowchart LR
    A[POST /s query sent_at] --> B[Recording processing context]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    class A phYellow;
    class B phBlue;
```

After:

```mermaid
flowchart LR
    A[First recording body sent_at] --> C{Valid ISO value?}
    B[Query sent_at or underscore] --> C
    C --> D[Recording processing context]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A,B phYellow;
    class C phGray;
    class D phBlue;
```

> [!NOTE]
> This PR preserves the established `/s/` body shape, which is a recording object or an array of recording objects. Ideally, `/s/` would eventually use a `/batch/`-style envelope that permits request-level fields such as `sent_at` and `api_key`, and potentially shared recording metadata such as `distinct_id`, without duplicating them across events. That protocol change is intentionally out of scope for this backward-compatible addition.

## How did you test this code?

- `cargo test -p capture --lib events::recordings::tests::test_raw_recording_deserialization`
- `cargo test -p capture --lib payload::recordings::tests`
- `cargo test -p capture --test recordings --no-run`
- `cargo clippy -p capture --all-targets -- -D warnings`
- `hogli ci:preflight --fix`

The added coverage catches regressions where body `sent_at` is ignored, query values override valid body values, or invalid and mistyped body values prevent legacy query fallback. The Kafka-backed integration test compiled locally but could not execute because the local Kafka service was unavailable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed. This is a backward-compatible transport addition for SDKs, and legacy query formats remain supported.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using the `/writing-tests`, `/running-ci-preflight`, and `/pr` skills, with a read-only reviewer agent checking compatibility. The review identified that a plain typed string field would reject body values that were previously ignored, so the implementation uses an optional string contract with tolerant deserialization and parses only valid ISO values.
