### PR TITLE
feat(dashboards): add interval and breakdown to tile filter overrides

### DIFF
--- a/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
+++ b/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
@@ -1,34 +1,57 @@
 // scenes/dashboard/TileFiltersOverride.tsx
 import './TileFiltersOverride.scss'
 
-import { useActions, useValues } from 'kea'
+import { BindLogic, useActions, useValues } from 'kea'
 
 import { IconCalendar } from '@posthog/icons'
-import { LemonSwitch } from '@posthog/lemon-ui'
+import { LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { getProjectEventExistence } from 'lib/utils/getAppContext'
+import { TaxonomicBreakdownFilter } from 'scenes/insights/filters/BreakdownFilter/TaxonomicBreakdownFilter'
+import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { groupsModel } from '~/models/groupsModel'
-import type { DashboardTile, QueryBasedInsightModel } from '~/types'
+import { BreakdownFilter, NodeKind } from '~/queries/schema/schema-general'
+import { isInsightQueryWithBreakdown, isInsightQueryWithSeries, isInsightVizNode } from '~/queries/utils'
+import type { DashboardTile, InsightLogicProps, IntervalType, QueryBasedInsightModel } from '~/types'
 
 import { tileLogic } from './tileLogic'
 
 export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedInsightModel> }): JSX.Element {
     const { overrides } = useValues(tileLogic)
-    const { setDates, setProperties, setIgnoreDashboardFilters } = useActions(tileLogic)
+    const { setDates, setProperties, setBreakdown, setInterval, setIgnoreDashboardFilters } = useActions(tileLogic)
     const { groupsTaxonomicTypes } = useValues(groupsModel)
 
     const { hasPageview, hasScreen } = getProjectEventExistence()
+
+    const query = tile.insight?.query
+    const querySource = isInsightVizNode(query) ? query.source : query
+    const supportsInterval = isInsightQueryWithSeries(querySource ?? undefined)
+    const supportsBreakdown = isInsightQueryWithBreakdown(querySource)
+
+    // The breakdown picker needs a mounted insightLogic. Bind a throwaway one, like DashboardEditBar,
+    // keyed per tile so it can't collide with the edit bar's `dashboardItemId: 'new'` binding.
+    const breakdownInsightProps: InsightLogicProps = {
+        dashboardItemId: `new-tile-override-${tile.id}`,
+        cachedInsight: null,
+        query: {
+            kind: NodeKind.InsightVizNode,
+            source: {
+                kind: NodeKind.TrendsQuery,
+                series: [],
+            },
+        },
+    }
 
     return (
         <div className="space-y-4 tile-filters-override">
             <div>
                 <p className="text-sm text-muted mb-4">
                     Set custom filters for this tile. Property filters apply on top of the dashboard's, while the tile's
-                    date range and breakdown replace the dashboard's.
+                    date range, interval, and breakdown replace the dashboard's.
                 </p>
             </div>
 
@@ -48,7 +71,7 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                 </div>
 
                 <div>
-                    <label className="text-sm font-medium mb-2 block">Date Range</label>
+                    <label className="text-sm font-medium mb-2 block">Date range</label>
                     <DateFilter
                         showCustom
                         showExplicitDateToggle
@@ -62,6 +85,27 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                                 <span className="hide-when-small"> {key}</span>
                             </>
                         )}
+                    />
+                </div>
+
+                <div>
+                    <label className="text-sm font-medium mb-2 block">Interval</label>
+                    <LemonSelect<IntervalType | null>
+                        size="small"
+                        value={overrides.interval ?? null}
+                        dropdownMatchSelectWidth={false}
+                        disabledReason={
+                            supportsInterval ? undefined : "This insight type doesn't support an interval override"
+                        }
+                        onChange={(interval) => setInterval(interval)}
+                        options={[
+                            { value: null, label: 'inherit' },
+                            { value: 'hour', label: 'hour' },
+                            { value: 'day', label: 'day' },
+                            { value: 'week', label: 'week' },
+                            { value: 'month', label: 'month' },
+                        ]}
+                        data-attr="tile-override-interval"
                     />
                 </div>
 
@@ -87,6 +131,37 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                             TaxonomicFilterGroupType.DataWarehousePersonProperties,
                         ]}
                     />
+                </div>
+
+                <div>
+                    <label className="text-sm font-medium mb-2 block">Breakdown</label>
+                    <BindLogic logic={insightLogic} props={breakdownInsightProps}>
+                        <TaxonomicBreakdownFilter
+                            insightProps={breakdownInsightProps}
+                            breakdownFilter={overrides.breakdown_filter}
+                            isTrends={false}
+                            isFunnels={false}
+                            showLabel={false}
+                            disabledReason={
+                                supportsBreakdown ? undefined : "This insight type doesn't support a breakdown override"
+                            }
+                            updateBreakdownFilter={(breakdown_filter) => {
+                                let newBreakdownFilter: BreakdownFilter | null = breakdown_filter
+                                // taxonomicBreakdownFilterLogic can generate an empty breakdown_filter object
+                                if (
+                                    breakdown_filter &&
+                                    !breakdown_filter.breakdown_type &&
+                                    !breakdown_filter.breakdowns
+                                ) {
+                                    newBreakdownFilter = null
+                                }
+                                setBreakdown(newBreakdownFilter)
+                            }}
+                            updateDisplay={() => {}}
+                            disablePropertyInfo
+                            size="small"
+                        />
+                    </BindLogic>
                 </div>
             </div>
         </div>

--- a/frontend/src/scenes/dashboard/tileLogic.test.ts
+++ b/frontend/src/scenes/dashboard/tileLogic.test.ts
@@ -1,0 +1,43 @@
+import { initKeaTests } from '~/test/init'
+
+import { tileLogic } from './tileLogic'
+
+describe('tileLogic', () => {
+    let logic: ReturnType<typeof tileLogic.build>
+
+    beforeEach(() => {
+        initKeaTests()
+        logic = tileLogic({ dashboardId: 1, tileId: 2, filtersOverrides: { date_from: '-7d' } })
+        logic.mount()
+    })
+
+    it('stores interval and breakdown overrides on top of the initial ones', () => {
+        logic.actions.setInterval('week')
+        logic.actions.setBreakdown({ breakdown: '$browser', breakdown_type: 'event' })
+
+        expect(logic.values.overrides).toEqual({
+            date_from: '-7d',
+            interval: 'week',
+            breakdown_filter: { breakdown: '$browser', breakdown_type: 'event' },
+        })
+    })
+
+    it('removes the key when an override is cleared, rather than persisting null', () => {
+        logic.actions.setInterval('week')
+        logic.actions.setBreakdown({ breakdown: '$browser', breakdown_type: 'event' })
+
+        logic.actions.setInterval(null)
+        logic.actions.setBreakdown(null)
+
+        expect(logic.values.overrides).toEqual({ date_from: '-7d' })
+    })
+
+    it('resetOverrides wipes every override', () => {
+        logic.actions.setInterval('day')
+        logic.actions.setBreakdown({ breakdown: '$browser', breakdown_type: 'event' })
+
+        logic.actions.resetOverrides()
+
+        expect(logic.values.overrides).toEqual({})
+    })
+})

--- a/frontend/src/scenes/dashboard/tileLogic.tsx
+++ b/frontend/src/scenes/dashboard/tileLogic.tsx
@@ -1,7 +1,7 @@
 import { MakeLogicType, actions, kea, key, path, props, reducers } from 'kea'
 
 import { BreakdownFilter, TileFilters } from '~/queries/schema/schema-general'
-import { AnyPropertyFilter } from '~/types'
+import { AnyPropertyFilter, IntervalType } from '~/types'
 
 export interface TileLogicProps {
     dashboardId: number
@@ -34,6 +34,9 @@ export interface tileLogicActions {
     setIgnoreDashboardFilters: (ignoreDashboardFilters: boolean) => {
         ignoreDashboardFilters: boolean
     }
+    setInterval: (interval: IntervalType | null | undefined) => {
+        interval: IntervalType | null | undefined
+    }
     setProperties: (properties: AnyPropertyFilter[] | null | undefined) => {
         properties: AnyPropertyFilter[] | null | undefined
     }
@@ -63,6 +66,7 @@ export const tileLogic = kea<tileLogicType>([
         }),
         setProperties: (properties: AnyPropertyFilter[] | null | undefined) => ({ properties }),
         setBreakdown: (breakdown_filter: BreakdownFilter | null | undefined) => ({ breakdown_filter }),
+        setInterval: (interval: IntervalType | null | undefined) => ({ interval }),
         setIgnoreDashboardFilters: (ignoreDashboardFilters: boolean) => ({ ignoreDashboardFilters }),
         resetOverrides: true,
     })),
@@ -99,7 +103,24 @@ export const tileLogic = kea<tileLogicType>([
                     }
                     return newState
                 },
-                setBreakdown: (state, { breakdown_filter }) => ({ ...state, breakdown_filter }),
+                setBreakdown: (state, { breakdown_filter }) => {
+                    const newState = { ...state }
+                    if (breakdown_filter) {
+                        newState.breakdown_filter = breakdown_filter
+                    } else {
+                        delete newState.breakdown_filter
+                    }
+                    return newState
+                },
+                setInterval: (state, { interval }) => {
+                    const newState = { ...state }
+                    if (interval) {
+                        newState.interval = interval
+                    } else {
+                        delete newState.interval
+                    }
+                    return newState
+                },
                 setIgnoreDashboardFilters: (state, { ignoreDashboardFilters }) => {
                     const newState = { ...state }
                     if (ignoreDashboardFilters) {


### PR DESCRIPTION
## TL;DR

Each dashboard tile can now override the interval and breakdown, not just the date range and properties. Eli5: one chart on a dashboard can say "group me by week, split me by browser" while the rest of the dashboard stays as is.

## Problem

The per-tile "Override tile filters" modal only exposed a date range, property filters, and the "Ignore dashboard filters" toggle. The `TileFilters` schema, `DashboardTile.filters_overrides` storage, and the backend merge (`merge_filters_by_priority`) already support per-tile `interval` and `breakdown_filter`, and the dashboard-level edit bar ships both controls. The modal copy even promised breakdown replacement without offering the control.

## Changes

- `TileFiltersOverride.tsx`: adds an interval select and a breakdown picker, mirroring `DashboardEditBar` (same components, same empty-breakdown normalization). Each control disables with a reason when the tile's insight type doesn't support it.
- `tileLogic.tsx`: new `setInterval` action. `setBreakdown` and `setInterval` delete the key on clear instead of storing null, so cleared overrides leave no stale keys in the saved JSON. Clearing means inherit; fully detaching a tile stays with the existing "Ignore dashboard filters" toggle.
- No backend changes.

No screenshots, the sandbox can't run the app.

## How did you test this code?

- New `frontend/src/scenes/dashboard/tileLogic.test.ts` (3 tests, ran locally, all pass). It catches the regression where clearing an override stores null instead of removing the key, which would persist stale keys in `filters_overrides`. Nothing tested tileLogic before.
- Tile-level interval/breakdown merge behavior is already covered by `test_merge_filters_by_priority.py` and `test_dashboard_filters_overrides.py`.
- I (or, actually Claude) ran jest, oxlint/oxfmt, and kea typegen locally. The full `typescript:check` was still running when this draft opened, any findings get a follow-up push.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No doc under `docs/` covers tile filter overrides.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). The session started as a /grill-me interview that pinned scope before any code: frontend-only (schema, storage, and merge already shipped), mirror the edit bar controls, disable with reason per insight type, clear equals inherit, no feature flag. Skills invoked: /writing-tests. Rejected along the way: binding the breakdown picker to the tile's real insight (couples the modal to insight state) and a backend tri-state force-off for breakdown (out of the agreed scope).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
