### PR TITLE
feat(signals): enable scout-metadata-get mcp tool

### DIFF
--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -508,7 +508,21 @@ tools:
             another owner). Pass `search` to narrow a large roster. Strictly team-scoped.
     scout-metadata-get:
         operation: signals_scout_metadata_get
-        enabled: false
+        enabled: true
+        scopes:
+            - signal_scout:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get scout enrollment, banner, and run limits
+        description: >
+            Return this project's scout metadata: whether it is enrolled to run scouts, the current announcement
+            banner (e.g. an early-access run-limit notice, or null when unset), and the enforced run limits with
+            current usage — `max_runs_per_tick`, `max_runs_per_day` (null = unbounded), `runs_today`, and
+            `runs_remaining_today`. Limits reflect what the scout coordinator actually applies at dispatch, so use
+            this to size an enabled scout troop against the project's real daily run budget rather than assuming a
+            value. Read-only and side-effect free.
     scout-project-profile-get:
         operation: signals_scout_project_profile_get
         enabled: true

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -517,12 +517,12 @@ tools:
             idempotent: true
         title: Get scout enrollment, banner, and run limits
         description: >
-            Return this project's scout metadata: whether it is enrolled to run scouts, the current announcement
-            banner (e.g. an early-access run-limit notice, or null when unset), and the enforced run limits with
-            current usage — `max_runs_per_tick`, `max_runs_per_day` (null = unbounded), `runs_today`, and
-            `runs_remaining_today`. Limits reflect what the scout coordinator actually applies at dispatch, so use
-            this to size an enabled scout troop against the project's real daily run budget rather than assuming a
-            value. Read-only and side-effect free.
+            Return this project's scout metadata: whether it is enrolled to run scouts, the current announcement banner
+            (e.g. an early-access run-limit notice, or null when unset), and the enforced run limits with current usage
+            — `max_runs_per_tick`, `max_runs_per_day` (null = unbounded), `runs_today`, and `runs_remaining_today`.
+            Limits reflect what the scout coordinator actually applies at dispatch, so use this to size an enabled scout
+            troop against the project's real daily run budget rather than assuming a value. Read-only and side-effect
+            free.
     scout-project-profile-get:
         operation: signals_scout_project_profile_get
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -7730,6 +7730,20 @@
             "readOnlyHint": true
         }
     },
+    "scout-metadata-get": {
+        "description": "Return this project's scout metadata: whether it is enrolled to run scouts, the current announcement banner (e.g. an early-access run-limit notice, or null when unset), and the enforced run limits with current usage — `max_runs_per_tick`, `max_runs_per_day` (null = unbounded), `runs_today`, and `runs_remaining_today`. Limits reflect what the scout coordinator actually applies at dispatch, so use this to size an enabled scout troop against the project's real daily run budget rather than assuming a value. Read-only and side-effect free.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Get scout enrollment, banner, and run limits",
+        "title": "Get scout enrollment, banner, and run limits",
+        "required_scopes": ["signal_scout:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "scout-project-profile-get": {
         "description": "Return a deterministic snapshot of \"what's true about this project\" — products in use, product intents (stuck onboardings), connected integrations, warehouse sources, signal source configs (split enabled/disabled), and existing inbox report counts. Singleton per team; the response reflects either the newest non-expired cached profile or a freshly-built one. Read this once at the start of a run (right after `skill-get`) to orient on the team in one tool call instead of paginating through `inbox-source-configs-list` / `inbox-reports-list` / `read-data-schema` / `advanced-activity-logs-list`. Distinct from `scout-scratchpad-search`: profile is ground truth from authoritative tables; scratchpad is the scout's inferred learnings.",
         "category": "Signals",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -8293,6 +8293,20 @@
             "readOnlyHint": true
         }
     },
+    "scout-metadata-get": {
+        "description": "Return this project's scout metadata: whether it is enrolled to run scouts, the current announcement banner (e.g. an early-access run-limit notice, or null when unset), and the enforced run limits with current usage — `max_runs_per_tick`, `max_runs_per_day` (null = unbounded), `runs_today`, and `runs_remaining_today`. Limits reflect what the scout coordinator actually applies at dispatch, so use this to size an enabled scout troop against the project's real daily run budget rather than assuming a value. Read-only and side-effect free.",
+        "category": "Signals",
+        "feature": "signals",
+        "summary": "Get scout enrollment, banner, and run limits",
+        "title": "Get scout enrollment, banner, and run limits",
+        "required_scopes": ["signal_scout:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "scout-project-profile-get": {
         "description": "Return a deterministic snapshot of \"what's true about this project\" — products in use, product intents (stuck onboardings), connected integrations, warehouse sources, signal source configs (split enabled/disabled), and existing inbox report counts. Singleton per team; the response reflects either the newest non-expired cached profile or a freshly-built one. Read this once at the start of a run (right after `skill-get`) to orient on the team in one tool call instead of paginating through `inbox-source-configs-list` / `inbox-reports-list` / `read-data-schema` / `advanced-activity-logs-list`. Distinct from `scout-scratchpad-search`: profile is ground truth from authoritative tables; scratchpad is the scout's inferred learnings.",
         "category": "Signals",

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 34 enabled ops
+ * PostHog API - MCP 35 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -533,6 +533,18 @@ export const SignalsScoutMembersListQueryParams = /* @__PURE__ */ zod.object({
         .optional()
         .describe(
             "Case-insensitive substring filter over member email and first/last name. Use it to narrow a large project's roster to the owner you're trying to match instead of pulling every member."
+        ),
+})
+
+/**
+ * Return the project's scout metadata: whether it is enrolled, the current announcement banner (e.g. an alpha run-limit notice, or null when unset), and the enforced run limits with current usage. Limits reflect what the coordinator actually applies at dispatch, so a user can see the real throttle rather than what they assume they set. All values come from the `signals-scout` flag payload, so the banner and caps can change with no deploy.
+ * @summary Get scout metadata
+ */
+export const SignalsScoutMetadataGetParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
         ),
 })
 

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -746,6 +746,22 @@ const scoutMembersList = (): ToolBase<typeof ScoutMembersListSchema, WithPostHog
     },
 })
 
+const ScoutMetadataGetSchema = z.object({})
+
+const scoutMetadataGet = (): ToolBase<typeof ScoutMetadataGetSchema, Schemas.ScoutMetadata> => ({
+    name: 'scout-metadata-get',
+    schema: ScoutMetadataGetSchema,
+    // eslint-disable-next-line no-unused-vars
+    handler: async (context: Context, params: z.infer<typeof ScoutMetadataGetSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.ScoutMetadata>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/scout/metadata/current/`,
+        })
+        return result
+    },
+})
+
 const ScoutProjectProfileGetSchema = SignalsScoutProjectProfileGetQueryParams
 
 const scoutProjectProfileGet = (): ToolBase<typeof ScoutProjectProfileGetSchema, Schemas.ProjectProfile> => ({
@@ -1457,6 +1473,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'scout-emit-report': scoutEmitReport,
     'scout-emit-signal': scoutEmitSignal,
     'scout-members-list': scoutMembersList,
+    'scout-metadata-get': scoutMetadataGet,
     'scout-project-profile-get': scoutProjectProfileGet,
     'scout-run-now': scoutRunNow,
     'scout-runs-emission-reports': scoutRunsEmissionReports,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-metadata-get.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/scout-metadata-get.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {},
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Scout runs are budgeted per project (enforced by the scout coordinator from the `signals-scout` flag payload, currently 24 runs a day by default during early access). The read-only metadata endpoint that reports the enforced limits (`signals_scout_metadata_get` – enrollment, announcement banner, `max_runs_per_day`, `runs_today`, `runs_remaining_today`) already exists and backs the UI, but its MCP tool was left `enabled: false`, so agents – in particular the self-driving setup wizard configuring a scout troop – can't read the project's real run budget and would have to hardcode assumptions that drift when the flag is retuned.

## Changes

- Flip `scout-metadata-get` to `enabled: true` in `products/signals/mcp/tools.yaml`, with `signal_scout:read` scope, read-only/idempotent annotations, and an agent-facing description that points at sizing a troop against the real budget.
- Regenerated MCP artifacts via `hogli build:openapi` (tool definitions JSON, generated signals API + tool handler).

No backend changes – the endpoint, serializer, and scope already exist (`SignalScoutMetadataViewSet.current`, `required_scopes=["signal_scout:read"]`).

## How did you test this code?

- `hogli build:openapi` regenerates cleanly; the generated handler hits `/signals/scout/metadata/current/` and types the response as `Schemas.ScoutMetadata`, matching the existing viewset.
- No new runtime logic – config + codegen only. I did not manually test the tool against a live MCP server.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code in a session driven by Andy. Skills invoked: /implementing-mcp-tools. Companion PRs update the self-driving wizard guidance (wizard and context-mill repos) to read this tool and size the scout troop against the project's daily run budget instead of assuming a value.
