### PR TITLE
feat(slack_app): allow disabling local dev email override under DEBUG

### DIFF
--- a/posthog/settings/__init__.py
+++ b/posthog/settings/__init__.py
@@ -75,6 +75,11 @@ SITE_URL: str = os.getenv("SITE_URL", "http://localhost:8010").rstrip("/")
 NGROK_URL: str | None = os.getenv("NGROK_URL", None)
 INSTANCE_TAG: str = os.getenv("INSTANCE_TAG", "none")
 
+# Local dev only (DEBUG): force this email when resolving Slack users instead of
+# hitting Slack's users.info API, so it matches the seeded fixture user. Set it
+# empty to use the real Slack email while keeping DEBUG on. Ignored outside DEBUG.
+SLACK_APP_LOCAL_DEV_EMAIL: str = os.getenv("SLACK_APP_LOCAL_DEV_EMAIL", "test@posthog.com")
+
 # Vapi voice-AI integration (used by user_interviews to host public interview pages).
 VAPI_PUBLIC_KEY: str = os.getenv("VAPI_PUBLIC_KEY", "")
 VAPI_ASSISTANT_ID: str = os.getenv("VAPI_ASSISTANT_ID", "")

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -64,6 +64,7 @@ from products.slack_app.backend.feature_flags import (
     is_slack_app_queue_workflow_enabled,
     is_slack_app_untagged_thread_followups_enabled,
 )
+from products.slack_app.backend.helpers import local_dev_slack_email
 from products.slack_app.backend.models import SlackChannel, SlackThreadTaskMapping
 from products.slack_app.backend.services import inbox_interactivity
 from products.slack_app.backend.services.integration_resolver import (
@@ -122,7 +123,6 @@ HANDLED_EVENT_TYPES = [
 # The notifications Slack app (`slack`) install carries every scope the coding-agent flow
 # needs, so both surfaces share one kind.
 SLACK_INTEGRATION_KIND = "slack"
-LOCAL_DEV_SLACK_EMAIL = "test@posthog.com"
 
 # Onboarding-on-join dedupe TTL: just long enough to absorb Slack retries and
 # a near-simultaneous cross-region race during cutover. A real re-add after
@@ -350,13 +350,13 @@ def resolve_slack_user(
             return SlackUserContext(user=linked_user, slack_email=None)
 
         slack_email = get_slack_email_for_user(integration, slack_user_id)
-        if settings.DEBUG:
+        if (dev_email := local_dev_slack_email()) is not None:
             # Local dev: match the seeded test fixture user regardless of what
             # Slack returns. Applied here rather than in the shared helper so
             # other callers (e.g. `resolve_posthog_user_from_event` from the
             # channel-approval path) can still drive the helper with stubbed
             # Slack responses in tests.
-            slack_email = LOCAL_DEV_SLACK_EMAIL
+            slack_email = dev_email
 
         if not slack_email:
             logger.exception("slack_app_no_user_email", slack_user_id=slack_user_id)

--- a/products/slack_app/backend/helpers.py
+++ b/products/slack_app/backend/helpers.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+
+
+def local_dev_slack_email() -> str | None:
+    """Return the seeded fixture email to force during local dev, or None.
+
+    Lets local setups skip Slack's users.info lookup and match the seeded test
+    user. Returns None outside DEBUG, or when the email is set empty, so callers
+    can treat it as "no override" and fall through to the real Slack email.
+    """
+    if not settings.DEBUG:
+        return None
+    return settings.SLACK_APP_LOCAL_DEV_EMAIL.strip() or None

--- a/products/slack_app/backend/services/integration_resolver.py
+++ b/products/slack_app/backend/services/integration_resolver.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass, field
 from typing import Literal
 
-from django.conf import settings
 from django.db.models import Q
 
 import structlog
@@ -10,6 +9,7 @@ from posthog.models.integration import Integration
 from posthog.models.user import User
 from posthog.user_permissions import UserPermissions
 
+from products.slack_app.backend.helpers import local_dev_slack_email
 from products.slack_app.backend.models import SlackSettings, SlackThreadTaskMapping
 
 logger = structlog.get_logger(__name__)
@@ -227,11 +227,7 @@ def resolve_user_for_workspace(
     # The user resolver lives in api.py alongside the Slack-API helpers it
     # depends on (``get_slack_user_info`` etc). Inline-imported to break the
     # cycle until those helpers are factored out into a shared module.
-    from products.slack_app.backend.api import (
-        LOCAL_DEV_SLACK_EMAIL,
-        get_slack_email_for_user,
-        resolve_posthog_user_from_event,
-    )
+    from products.slack_app.backend.api import get_slack_email_for_user, resolve_posthog_user_from_event
 
     if not slack_user_id:
         logger.warning(
@@ -248,7 +244,7 @@ def resolve_user_for_workspace(
     # In local dev, match the seeded user the single-integration resolver also
     # uses. Keep this at the resolver layer so lower-level callers like channel
     # approval can still exercise real or stubbed Slack emails under DEBUG.
-    slack_email = LOCAL_DEV_SLACK_EMAIL if settings.DEBUG else None
+    slack_email = local_dev_slack_email()
 
     # Pass slack_email=None outside local dev so the linked-user path
     # short-circuits before users.info; the resolver fetches lazily on the


### PR DESCRIPTION
Gate the local-dev Slack email override behind `SLACK_APP_LOCAL_DEV_EMAIL` (defaults to the seeded fixture). Set it empty to resolve the real Slack email while `DEBUG` stays on.

![screenshot](TODO)
