### PR TITLE
fix(databricks): surface an actionable error for a missing SQL warehouse

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/source.py
@@ -41,6 +41,9 @@ DatabricksErrors = {
     "PERMISSION_DENIED": "Your Databricks credentials don't have permission to access this data. Grant USE CATALOG, USE SCHEMA, and SELECT to the connecting principal, then try again.",
     "INSUFFICIENT_PERMISSIONS": "Your Databricks credentials don't have permission to access this data. Grant USE CATALOG, USE SCHEMA, and SELECT to the connecting principal, then try again.",
     "TABLE_OR_VIEW_NOT_FOUND": "The catalog has no `information_schema` — this usually means it's a legacy `hive_metastore` catalog. The Databricks source requires a Unity Catalog catalog.",
+    # Raised when the SQL warehouse referenced by the HTTP path was mistyped or deleted — a common
+    # setup mistake that otherwise falls through to the generic "could not connect" message.
+    "RESOURCE_DOES_NOT_EXIST": "Can't find the SQL warehouse referenced by the HTTP path. Check the HTTP path points to an existing, running SQL warehouse.",
     "nodename nor servname provided": "Can't resolve the server hostname. Check the server hostname and try again.",
     "Name or service not known": "Can't resolve the server hostname. Check the server hostname and try again.",
     "Failed to resolve": "Can't resolve the server hostname. Check the server hostname and try again.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py
@@ -517,6 +517,7 @@ class TestDatabricksSource:
                 "Error during request to server: : Source IP address: 44.208.188.173 is blocked by Databricks IP ACL for workspace: 1557520918149316. ",
                 "IP access control list",
             ),
+            ("[RESOURCE_DOES_NOT_EXIST] Warehouse abc123 does not exist.", "SQL warehouse"),
             ("something totally unexpected", "Could not connect to Databricks"),
         ],
     )


### PR DESCRIPTION
## Problem

The Databricks source-creation wizard shows a generic "Could not connect to Databricks. Please check all connection details are valid." for a very common setup mistake: an HTTP path pointing at a SQL warehouse that was mistyped or deleted. That message gives the user nothing to act on, and it was the single biggest bucket of Databricks setup failures.

The root cause is drift between two error maps. The sync-time `get_non_retryable_errors` map already recognizes `RESOURCE_DOES_NOT_EXIST` and tells the user their warehouse is gone, but the validate-time `DatabricksErrors` map (used during source creation) never got the same entry. So a bad warehouse in the HTTP path was recognized during sync but fell through to the generic catch-all at create time.

## Changes

- Add `RESOURCE_DOES_NOT_EXIST` to the validate-time error map with a message that points the user at the HTTP path field.
- Extend the existing `test_validate_credentials_maps_connection_errors` parameterized test with a case for it.

## How did you test this code?

Extended the existing parameterized `test_validate_credentials_maps_connection_errors` test with a `RESOURCE_DOES_NOT_EXIST` case. It catches the regression where that mapping is dropped or mis-keyed and a wrong/deleted warehouse silently reverts to the generic message. Ran the test locally, all 7 cases pass. Also ran ruff check and format over the touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged a day of Databricks warehouse-source-creation failures and found they were all the generic "could not connect" fallback. Comparing the validate-time and sync-time error maps surfaced the missing `RESOURCE_DOES_NOT_EXIST` entry as a concrete, minimal fix. I kept the change to a single mapping plus one parameterized test case rather than broadening the reused message from the sync map, since that map's wording tells users to "resync" which is wrong in the create flow. Invoked the `/writing-tests` skill before adding the test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
