### PR TITLE
fix(slack_app): post project command replies at channel root for top-level mentions

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/rules.py
+++ b/posthog/temporal/ai/slack_app/activities/rules.py
@@ -124,8 +124,11 @@ def handle_posthog_code_slack_mention_command_activity(
 
     event = inputs.event
     channel = event.get("channel")
-    # Empty anchor posts at the channel root — correct for a slash command invoked outside a thread.
-    thread_ts = event.get("thread_ts") or event.get("ts") or ""
+    # Anchor the reply to the thread only when the command was posted in one. For a top-level
+    # mention (or a slash command outside a thread) the empty anchor posts at the channel root,
+    # where the user actually sees it — a thread-anchored ephemeral is only rendered to someone
+    # already viewing that thread, so it reads as no response.
+    thread_ts = event.get("thread_ts") or ""
     slack_user_id = event.get("user")
     if not channel or not slack_user_id:
         return PostHogCodeSlackMentionCommandResult(status="done")

--- a/products/slack_app/backend/tests/test_mention_command_activity.py
+++ b/products/slack_app/backend/tests/test_mention_command_activity.py
@@ -24,10 +24,10 @@ class TestMentionCommandActivity:
         )
         self.user = User.objects.create_and_join(self.organization, "u@example.com", "pw")
 
-    def _inputs(self, *, command_prefix: str, with_thread: bool) -> PostHogCodeSlackMentionCommandWorkflowInputs:
-        event = {"channel": "C1", "user": "U1", "text": "help"}
-        if with_thread:
-            event["ts"] = "111.1"
+    def _inputs(
+        self, *, command_prefix: str, event_extra: dict[str, str]
+    ) -> PostHogCodeSlackMentionCommandWorkflowInputs:
+        event = {"channel": "C1", "user": "U1", "text": "help", **event_extra}
         return PostHogCodeSlackMentionCommandWorkflowInputs(
             event=event,
             integration_ids=[self.integration.id],
@@ -38,12 +38,15 @@ class TestMentionCommandActivity:
 
     @parameterized.expand(
         [
-            # A slash command outside a thread carries no ``ts``; the reply must
-            # still go out (channel-root anchor) rather than silently no-op on the
-            # guard, and it must speak the ``/posthog`` surface.
-            ("slash_outside_thread", "/posthog", False, ""),
-            # The mention surface always carries a ``ts`` and keeps its copy.
-            ("mention_in_thread", "@PostHog", True, "111.1"),
+            # A slash command outside a thread carries neither ts nor thread_ts; the
+            # reply anchors to the channel root and speaks the ``/posthog`` surface.
+            ("slash_outside_thread", "/posthog", {}, ""),
+            # A top-level mention carries only its own ts (no thread_ts). The reply
+            # must anchor to the channel root, not that ts — a thread-anchored reply
+            # is invisible to a user who isn't already viewing the thread.
+            ("mention_top_level", "@PostHog", {"ts": "111.1"}, ""),
+            # A mention inside a real thread carries thread_ts; the reply threads there.
+            ("mention_in_thread", "@PostHog", {"ts": "222.2", "thread_ts": "111.1"}, "111.1"),
         ]
     )
     @patch("products.slack_app.backend.services.slack_user_info.get_slack_user_info")
@@ -52,7 +55,7 @@ class TestMentionCommandActivity:
         self,
         _name: str,
         command_prefix: str,
-        with_thread: bool,
+        event_extra: dict[str, str],
         expected_thread_ts: str,
         mock_slack_cls,
         mock_info,
@@ -61,7 +64,7 @@ class TestMentionCommandActivity:
         client = mock_slack_cls.return_value.client
 
         result = handle_posthog_code_slack_mention_command_activity(
-            self._inputs(command_prefix=command_prefix, with_thread=with_thread), self.user.id
+            self._inputs(command_prefix=command_prefix, event_extra=event_extra), self.user.id
         )
 
         assert result.status == "done"


### PR DESCRIPTION
## Problem

`@PostHog project` (and the other `project` / `rules` / `help` command replies) gave no visible response when the command was a top-level mention. The reply used the mention's own `ts` as the thread anchor, and Slack only renders a thread-anchored ephemeral to a user who is actively viewing that thread. Posted at the channel root, the user was never in that thread, so it read as the bot ignoring them. See [ticket 64409](https://us.posthog.com/project/2/support/tickets/64409).

## Changes

One line in `handle_posthog_code_slack_mention_command_activity`: anchor the reply to `thread_ts` only when the command was actually posted in a thread. For a top-level mention (or a slash command outside a thread) the anchor is empty, so the reply lands at the channel root where the user sees it.

```diff
-    thread_ts = event.get("thread_ts") or event.get("ts") or ""
+    thread_ts = event.get("thread_ts") or ""
```

The empty-anchor-posts-at-root behavior already existed for the slash surface; this just stops the mention surface from falling back to its own `ts`. It covers every `project` / `rules` / `help` reply on both surfaces and keeps them ephemeral, so it also fixes the original ticket (the "Default set to…" confirmation on `project <id>` now shows even when the project is unchanged) without needing the no-op special-casing from #73021.

The `rules add` picker is untouched — the workflow computes its own thread anchor for the interactive flow.

## How did you test this code?

Corrected the existing parameterized test in `test_mention_command_activity.py`: its "in thread" case only set `ts` (no `thread_ts`), so it was really a top-level mention asserting the old buggy anchor. Split it into a genuine top-level case (`ts` only → root) and a real in-thread case (`thread_ts` set → threads there), plus the existing slash case. The top-level case is the regression guard — if the `or event.get("ts")` fallback comes back, it fails. 3 cases pass locally. Ran `ruff`. Not tested in a live Slack workspace.

<img width="1270" height="921" alt="Screenshot 2026-07-23 at 11 17 15" src="https://github.com/user-attachments/assets/9652e140-3ffa-4513-aaf6-abdc6bf71e6e" />


## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Vojta) directed this. Claude traced the mention → command workflow → `handle_posthog_code_slack_mention_command_activity` → handler path. We first tried making just the `project` show reply a visible `chat_postMessage`, then landed on this smaller root-cause fix: keep everything ephemeral and only drop the thread anchor for top-level mentions, which fixes all the command replies at once. `/writing-tests` was invoked for the test change.
