### PR TITLE
fix(cymbal): use native roots for Temporal Cloud

### DIFF
--- a/rust/cymbal/src/modes/notifications/config.rs
+++ b/rust/cymbal/src/modes/notifications/config.rs
@@ -88,9 +88,6 @@ pub struct NotificationsConfig {
     #[envconfig(from = "TEMPORAL_CLIENT_KEY", default = "")]
     pub temporal_client_key: String,
 
-    #[envconfig(from = "TEMPORAL_CLIENT_ROOT_CA")]
-    pub temporal_client_root_ca: Option<String>,
-
     #[envconfig(from = "TEMPORAL_SECRET_KEY", default = "")]
     pub temporal_secret_key: String,
 

--- a/rust/cymbal/src/modes/notifications/temporal.rs
+++ b/rust/cymbal/src/modes/notifications/temporal.rs
@@ -63,7 +63,10 @@ impl IssueCreatedWorkflowStarter {
             namespace: config.temporal_namespace.clone(),
             client_cert: config.temporal_client_cert.clone(),
             client_key: config.temporal_client_key.clone(),
-            server_root_ca_cert: config.temporal_client_root_ca.clone(),
+            // Temporal Cloud's server certificate chains to a public CA. Match the
+            // Python workers and use native roots rather than the injected CA,
+            // which is not the server certificate issuer.
+            server_root_ca_cert: None,
             payload_encryption_key: config.temporal_secret_key.clone(),
             identity: "cymbal-notifications".to_string(),
         })


### PR DESCRIPTION
## Problem

Cymbal notifications fails at startup when issue-created workflow routing is enabled:

```text
invalid peer certificate: UnknownIssuer
```

The Rust client was treating the injected `TEMPORAL_CLIENT_ROOT_CA` as the server trust root. This replaces the SDK's native root store, but that certificate is not the issuer of Temporal Cloud's public server certificate. PostHog's Python Temporal workers do not pass this injected value to the client and rely on native roots.

## Changes

- Match the Python workers by using native roots for Temporal Cloud server verification.
- Continue using the existing client certificate and key for mTLS authentication.
- Remove the unused root CA field from Cymbal's notifications configuration.

## How did you test this code?

- `cargo fmt --all -- --check`
- `cargo check -p cymbal`
- `cargo test -p cymbal modes::notifications::temporal --lib` – 3 passed
- `cargo clippy -p cymbal --all-targets --no-deps -- -D warnings`

I could not perform a live Temporal Cloud connection test locally. The deployed connection failure is specifically in server certificate verification, before workflow starts.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

This internal TLS configuration fix does not require documentation changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with OpenAI Codex in pi after diagnosing the deployed Temporal connection error. No repo-specific implementation skill was invoked. The fix keeps custom CA support in the shared Temporal client, but Cymbal intentionally uses native roots to match Python worker behavior.
