### PR TITLE
chore(stripe): de-flake account-request expiry test on slow shards

### DIFF
--- a/ee/partners/stripe/api/provisioning/test/test_account_requests.py
+++ b/ee/partners/stripe/api/provisioning/test/test_account_requests.py
@@ -1,9 +1,6 @@
-from datetime import timedelta
-
 from unittest.mock import patch
 
 from django.core.cache import cache
-from django.utils import timezone
 
 from parameterized import parameterized
 
@@ -20,7 +17,10 @@ def _account_request(email: str, **overrides) -> dict:
         "id": "acctreq_test",
         "email": email,
         "scopes": ["query:read"],
-        "expires_at": (timezone.now() + timedelta(minutes=10)).isoformat(),
+        # Static, not now()+delta: @parameterized.expand builds the invalid-request cases at
+        # collection time, so a relative expiry can lapse before a slow shard reaches them and
+        # trip the "expired" check ahead of the field validation each case actually asserts.
+        "expires_at": "2999-01-01T00:00:00+00:00",
         "orchestrator": {"type": "stripe", "stripe": {"account": "acct_test"}},
     }
     body.update(overrides)


### PR DESCRIPTION
## Problem

The Core Django CI shard is intermittently red on master:

```
ee/partners/stripe/api/provisioning/test/test_account_requests.py::
  TestAccountRequests::test_invalid_requests_are_rejected_{5,6,7,8}
→ 4 failed, 1945 passed
```

Root cause is a wall-clock time-bomb in the test fixture, not the product code. `_account_request()` defaulted `expires_at` to `now() + 10 minutes`, and the `@parameterized.expand([...])` case list is evaluated **at collection time**. This Core shard takes ~12.5 min and reaches these cases ~76% through, so by the time they execute the baked-in timestamp has already lapsed. `AccountRequestSerializer.validate()` checks expiry *before* the field validations, so the request is rejected as `expired` and never reaches the check each case is asserting. Cases 0–4 are unaffected: the missing-email check runs first, and the expiry-focused cases set their own timestamps.