### PR TITLE
perf(experiments): improve performance for session_context request by reducing builds of HogQL database

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
@@ -7,7 +7,6 @@ import { IconCollapse, IconExpand, IconExternal, IconMinus, IconWarning } from '
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
-import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTag, LemonTagType } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -219,8 +218,7 @@ export function PlayerSidebarExperimentsSection(): JSX.Element | null {
     const experimentContextLogic = sessionRecordingExperimentContextLogic({
         sessionRecordingId: logicProps.sessionRecordingId,
     })
-    const { seenItems, enrolledItems, hasExperimentContext, expandedExperimentIds, experimentContextLoading } =
-        useValues(experimentContextLogic)
+    const { seenItems, enrolledItems, hasExperimentContext, expandedExperimentIds } = useValues(experimentContextLogic)
     const { setExperimentExpanded } = useActions(experimentContextLogic)
     const { location } = useValues(router)
 
@@ -249,21 +247,6 @@ export function PlayerSidebarExperimentsSection(): JSX.Element | null {
             setExperimentExpanded(currentExpandableId, true)
         }
     }, [currentExpandableId, currentMetricCount, setExperimentExpanded])
-
-    // The context takes a few seconds to resolve (several ClickHouse scans server-side), so show
-    // the box with placeholder rows while it loads instead of popping the whole section in late.
-    if (experimentContextLoading) {
-        return (
-            <div
-                className="rounded border bg-surface-primary px-2 py-1 flex flex-col gap-y-1"
-                data-attr="replay-experiment-context-overview-loading"
-            >
-                <h4 className="font-semibold text-xs mb-0">Experiments</h4>
-                <LemonSkeleton className="h-4 w-2/3" />
-                <LemonSkeleton className="h-4 w-1/2" />
-            </div>
-        )
-    }
 
     if (!hasExperimentContext) {
         return null

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
@@ -7,6 +7,7 @@ import { IconCollapse, IconExpand, IconExternal, IconMinus, IconWarning } from '
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTag, LemonTagType } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -218,7 +219,8 @@ export function PlayerSidebarExperimentsSection(): JSX.Element | null {
     const experimentContextLogic = sessionRecordingExperimentContextLogic({
         sessionRecordingId: logicProps.sessionRecordingId,
     })
-    const { seenItems, enrolledItems, hasExperimentContext, expandedExperimentIds } = useValues(experimentContextLogic)
+    const { seenItems, enrolledItems, hasExperimentContext, expandedExperimentIds, experimentContextLoading } =
+        useValues(experimentContextLogic)
     const { setExperimentExpanded } = useActions(experimentContextLogic)
     const { location } = useValues(router)
 
@@ -247,6 +249,21 @@ export function PlayerSidebarExperimentsSection(): JSX.Element | null {
             setExperimentExpanded(currentExpandableId, true)
         }
     }, [currentExpandableId, currentMetricCount, setExperimentExpanded])
+
+    // The context takes a few seconds to resolve (several ClickHouse scans server-side), so show
+    // the box with placeholder rows while it loads instead of popping the whole section in late.
+    if (experimentContextLoading) {
+        return (
+            <div
+                className="rounded border bg-surface-primary px-2 py-1 flex flex-col gap-y-1"
+                data-attr="replay-experiment-context-overview-loading"
+            >
+                <h4 className="font-semibold text-xs mb-0">Experiments</h4>
+                <LemonSkeleton className="h-4 w-2/3" />
+                <LemonSkeleton className="h-4 w-1/2" />
+            </div>
+        )
+    }
 
     if (!hasExperimentContext) {
         return null

--- a/products/experiments/backend/metric_events.py
+++ b/products/experiments/backend/metric_events.py
@@ -28,6 +28,8 @@ from posthog.schema import (
 )
 
 from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
 from posthog.hogql.errors import BaseHogQLError
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
@@ -173,6 +175,7 @@ def scan_session_for_metric_events(
     session_id: str,
     window_start: datetime,
     window_end: datetime,
+    hogql_database: Database | None = None,
 ) -> list[MetricHit]:
     """The metrics with >=1 matching event in the session, sorted by first occurrence.
 
@@ -189,6 +192,10 @@ def scan_session_for_metric_events(
     source dedupe only narrows the query, it must not let a metric-heavy experiment emit an
     unbounded hit list by piling metrics onto one source. `user` threads through to HogQL for
     property-level access control — metric source nodes can carry property filters.
+
+    `hogql_database` optionally carries a prebuilt virtual database (session_context builds
+    one shared across all its scans) — constructing it dominates query wall time on teams with
+    a large warehouse schema, so callers that already hold one should pass it in.
     """
     names_by_uuid: dict[str, str] = {}
     # Metric uuids grouped by identical source nodes: identical sources compile to identical
@@ -285,7 +292,12 @@ def scan_session_for_metric_events(
             ]
         ),
     )
-    response = execute_hogql_query(query, team=team, user=user)
+    # execute_hogql_query treats a passed context as fully caller-owned, so only build one when
+    # there is a shared database to carry; otherwise let the executor construct its default.
+    extra_kwargs: dict[str, HogQLContext] = {}
+    if hogql_database is not None:
+        extra_kwargs["context"] = HogQLContext(team_id=team.pk, user=user, database=hogql_database)
+    response = execute_hogql_query(query, team=team, user=user, **extra_kwargs)
 
     # Aggregation without GROUP BY always yields exactly one row; a metric with no matching
     # events shows count 0 there (and an epoch minIf), so the count guards the timestamps.

--- a/products/experiments/backend/metric_events.py
+++ b/products/experiments/backend/metric_events.py
@@ -25,6 +25,7 @@ from posthog.schema import (
     ExperimentMeanMetric,
     ExperimentRatioMetric,
     ExperimentRetentionMetric,
+    HogQLQueryModifiers,
 )
 
 from posthog.hogql import ast
@@ -54,6 +55,32 @@ MAX_METRIC_EVENT_TIMESTAMPS = 50
 MAX_SCANNED_METRICS = 50
 
 MetricSourceNode = EventsNode | ActionsNode
+
+
+@dataclass(frozen=True)
+class SharedHogQLDatabase:
+    """A HogQL virtual database built once per request and shared across that request's
+    scans, bundled with the modifiers it was built with.
+
+    Sharing the database is sound only while every scan treats it as read-only — the
+    session-context scans run against it concurrently from a thread pool. HogQL mutates a
+    database at query time in exactly two cases: `system.information_schema` queries register
+    hidden external tables on it (`_rows_select` in
+    posthog/hogql/database/schema/information_schema.py), and direct-connection queries make
+    the executor rebuild it. Scans sharing one must therefore stick to plain table reads;
+    everything here reads only `events`. The modifiers travel with the database because the
+    schema depends on them (person-on-events mode changes the events table's person fields):
+    every query against the shared database must execute with these modifiers, never its own.
+    """
+
+    database: Database
+    modifiers: HogQLQueryModifiers
+
+    def fresh_context(self, team: Team, user: User) -> HogQLContext:
+        """A per-query context carrying the shared database, so `execute_hogql_query` reuses
+        it instead of building its own. Contexts accumulate per-query state during printing
+        and must never be shared between queries — the database can be."""
+        return HogQLContext(team_id=team.pk, user=user, database=self.database)
 
 
 @dataclass(frozen=True)
@@ -175,7 +202,7 @@ def scan_session_for_metric_events(
     session_id: str,
     window_start: datetime,
     window_end: datetime,
-    hogql_database: Database | None = None,
+    shared_hogql: SharedHogQLDatabase | None = None,
 ) -> list[MetricHit]:
     """The metrics with >=1 matching event in the session, sorted by first occurrence.
 
@@ -193,9 +220,10 @@ def scan_session_for_metric_events(
     unbounded hit list by piling metrics onto one source. `user` threads through to HogQL for
     property-level access control — metric source nodes can carry property filters.
 
-    `hogql_database` optionally carries a prebuilt virtual database (session_context builds
+    `shared_hogql` optionally carries a prebuilt virtual database (session_context builds
     one shared across all its scans) — constructing it dominates query wall time on teams with
-    a large warehouse schema, so callers that already hold one should pass it in.
+    a large warehouse schema, so callers that already hold one should pass it in, along with
+    the modifiers it was built with.
     """
     names_by_uuid: dict[str, str] = {}
     # Metric uuids grouped by identical source nodes: identical sources compile to identical
@@ -294,9 +322,10 @@ def scan_session_for_metric_events(
     )
     # execute_hogql_query treats a passed context as fully caller-owned, so only build one when
     # there is a shared database to carry; otherwise let the executor construct its default.
-    extra_kwargs: dict[str, HogQLContext] = {}
-    if hogql_database is not None:
-        extra_kwargs["context"] = HogQLContext(team_id=team.pk, user=user, database=hogql_database)
+    extra_kwargs: dict[str, HogQLContext | HogQLQueryModifiers] = {}
+    if shared_hogql is not None:
+        extra_kwargs["context"] = shared_hogql.fresh_context(team, user)
+        extra_kwargs["modifiers"] = shared_hogql.modifiers
     response = execute_hogql_query(query, team=team, user=user, **extra_kwargs)
 
     # Aggregation without GROUP BY always yields exactly one row; a metric with no matching

--- a/products/experiments/backend/session_context.py
+++ b/products/experiments/backend/session_context.py
@@ -36,7 +36,6 @@ import pydantic
 from posthog.schema import ExperimentEventExposureConfig, ExperimentExposureCriteria
 
 from posthog.hogql import ast
-from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.errors import BaseHogQLError
 from posthog.hogql.modifiers import create_default_modifiers_for_team
@@ -57,6 +56,7 @@ from products.experiments.backend.hogql_queries.exposure_query_logic import (
 from products.experiments.backend.metric_events import (
     MetricEventSource,
     MetricHit,
+    SharedHogQLDatabase,
     resolve_metric_events,
     scan_session_for_metric_events,
 )
@@ -201,14 +201,23 @@ def _compute_session_experiment_context(
     # Every scan below goes through HogQL, and constructing the virtual database dominates this
     # endpoint's wall time on teams with a large warehouse schema — several seconds per query,
     # paid once per query, while ClickHouse itself answers in well under a second. Build the
-    # database once here and share it across all the scans: it is read-only after construction
-    # (each query still gets its own HogQLContext, which printing does mutate). Postgres
-    # foreign-key lazy joins are skipped — these queries only ever read the events table.
-    hogql_database = Database.create_for(
-        team=team,
-        user=user,
-        modifiers=create_default_modifiers_for_team(team),
-        build_postgres_foreign_keys=False,
+    # database once here and share it across all the scans, including across the thread pool
+    # below. Sound only while every scan sticks to plain table reads — SharedHogQLDatabase
+    # documents the two query shapes that mutate a database at query time, and
+    # test_uncached_request_shares_one_readonly_hogql_database pins that these scans don't.
+    # The build modifiers travel with the database so every scan queries the schema it was
+    # built for; no scan may pass its own modifiers. Postgres foreign-key lazy joins are
+    # skipped — the single most expensive build step, and these queries only ever read the
+    # events table.
+    hogql_modifiers = create_default_modifiers_for_team(team)
+    shared_hogql = SharedHogQLDatabase(
+        database=Database.create_for(
+            team=team,
+            user=user,
+            modifiers=hogql_modifiers,
+            build_postgres_foreign_keys=False,
+        ),
+        modifiers=hogql_modifiers,
     )
 
     # Flag evaluations are variant evidence for every experiment — the replay shows exactly
@@ -218,7 +227,7 @@ def _compute_session_experiment_context(
         _query_flag_evaluations,
         team,
         user,
-        hogql_database,
+        shared_hogql,
         session_id,
         window_start,
         window_end,
@@ -233,7 +242,7 @@ def _compute_session_experiment_context(
         _query_exposure_event_branches,
         team,
         user,
-        hogql_database,
+        shared_hogql,
         session_id,
         window_start,
         window_end,
@@ -241,7 +250,7 @@ def _compute_session_experiment_context(
     )
     candidate_keys = {experiment.feature_flag.key for experiment in candidates}
     query_stamped = partial(
-        _query_stamped_flag_properties, team, user, hogql_database, session_id, candidate_keys, window_start, window_end
+        _query_stamped_flag_properties, team, user, shared_hogql, session_id, candidate_keys, window_start, window_end
     )
 
     # The three scans are independent given the pre-rescue candidate set (only the rescue
@@ -281,9 +290,7 @@ def _compute_session_experiment_context(
     if rescued_keys:
         candidates += list(overlapping.filter(feature_flag__key__in=sorted(rescued_keys)))
         stamped.update(
-            _query_stamped_flag_properties(
-                team, user, hogql_database, session_id, rescued_keys, window_start, window_end
-            )
+            _query_stamped_flag_properties(team, user, shared_hogql, session_id, rescued_keys, window_start, window_end)
         )
 
     surfaced: list[tuple[Experiment, str, list[str], Optional[datetime]]] = []
@@ -335,7 +342,7 @@ def _compute_session_experiment_context(
                     session_id=session_id,
                     window_start=window_start,
                     window_end=window_end,
-                    hogql_database=hogql_database,
+                    shared_hogql=shared_hogql,
                 )
             }
     except Exception:
@@ -402,17 +409,10 @@ def _variant_keys_from_filters(filters: Optional[dict]) -> set[str]:
     return {variant["key"] for variant in multivariate.get("variants", []) if variant.get("key")}
 
 
-def _hogql_context(team: Team, user: User, database: Database) -> HogQLContext:
-    """A fresh per-query context carrying the shared prebuilt database, so
-    `execute_hogql_query` reuses it instead of building its own. Contexts must not be shared
-    between queries (printing accumulates per-query state on them); the database can be."""
-    return HogQLContext(team_id=team.pk, user=user, database=database)
-
-
 def _query_flag_evaluations(
     team: Team,
     user: User,
-    database: Database,
+    shared_hogql: SharedHogQLDatabase,
     session_id: str,
     window_start: datetime,
     window_end: datetime,
@@ -455,7 +455,9 @@ def _query_flag_evaluations(
             "max_rows": ast.Constant(value=MAX_EXPOSURE_ROWS),
         },
     )
-    response = execute_hogql_query(query, team=team, user=user, context=_hogql_context(team, user, database))
+    response = execute_hogql_query(
+        query, team=team, user=user, context=shared_hogql.fresh_context(team, user), modifiers=shared_hogql.modifiers
+    )
 
     exposures: dict[str, list[tuple[str, datetime]]] = {}
     for flag_key, variant, first_seen in response.results or []:
@@ -468,7 +470,7 @@ def _query_flag_evaluations(
 def _query_exposure_event_branches(
     team: Team,
     user: User,
-    database: Database,
+    shared_hogql: SharedHogQLDatabase,
     session_id: str,
     window_start: datetime,
     window_end: datetime,
@@ -536,7 +538,9 @@ def _query_exposure_event_branches(
     # No set-level LIMIT here: the printer emits it directly after the last branch's own
     # LIMIT, which ClickHouse rejects as a syntax error. The per-branch limits above are
     # the backstop; total output is already bounded by each flag's defined variants.
-    response = execute_hogql_query(query, team=team, user=user, context=_hogql_context(team, user, database))
+    response = execute_hogql_query(
+        query, team=team, user=user, context=shared_hogql.fresh_context(team, user), modifiers=shared_hogql.modifiers
+    )
 
     exposures: dict[int, list[tuple[str, datetime]]] = {}
     for experiment_id, variant, first_seen in response.results or []:
@@ -549,7 +553,7 @@ def _query_exposure_event_branches(
 def _query_stamped_flag_properties(
     team: Team,
     user: User,
-    database: Database,
+    shared_hogql: SharedHogQLDatabase,
     session_id: str,
     flag_keys: set[str],
     window_start: datetime,
@@ -591,7 +595,9 @@ def _query_stamped_flag_properties(
             ]
         ),
     )
-    response = execute_hogql_query(query, team=team, user=user, context=_hogql_context(team, user, database))
+    response = execute_hogql_query(
+        query, team=team, user=user, context=shared_hogql.fresh_context(team, user), modifiers=shared_hogql.modifiers
+    )
 
     row = response.results[0] if response.results else [[] for _ in sorted_keys]
     return {key: [value for value in row[index] if value] for index, key in enumerate(sorted_keys)}

--- a/products/experiments/backend/session_context.py
+++ b/products/experiments/backend/session_context.py
@@ -36,7 +36,10 @@ import pydantic
 from posthog.schema import ExperimentEventExposureConfig, ExperimentExposureCriteria
 
 from posthog.hogql import ast
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
 from posthog.hogql.errors import BaseHogQLError
+from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
@@ -195,6 +198,19 @@ def _compute_session_experiment_context(
         # No overlapping experiment defines variants, so nothing could surface a variant seen.
         return []
 
+    # Every scan below goes through HogQL, and constructing the virtual database dominates this
+    # endpoint's wall time on teams with a large warehouse schema — several seconds per query,
+    # paid once per query, while ClickHouse itself answers in well under a second. Build the
+    # database once here and share it across all the scans: it is read-only after construction
+    # (each query still gets its own HogQLContext, which printing does mutate). Postgres
+    # foreign-key lazy joins are skipped — these queries only ever read the events table.
+    hogql_database = Database.create_for(
+        team=team,
+        user=user,
+        modifiers=create_default_modifiers_for_team(team),
+        build_postgres_foreign_keys=False,
+    )
+
     # Flag evaluations are variant evidence for every experiment — the replay shows exactly
     # what the session was served, whatever the exposure criteria say — and double as the
     # exposure moment for experiments with the default criteria shape.
@@ -202,6 +218,7 @@ def _compute_session_experiment_context(
         _query_flag_evaluations,
         team,
         user,
+        hogql_database,
         session_id,
         window_start,
         window_end,
@@ -216,6 +233,7 @@ def _compute_session_experiment_context(
         _query_exposure_event_branches,
         team,
         user,
+        hogql_database,
         session_id,
         window_start,
         window_end,
@@ -223,7 +241,7 @@ def _compute_session_experiment_context(
     )
     candidate_keys = {experiment.feature_flag.key for experiment in candidates}
     query_stamped = partial(
-        _query_stamped_flag_properties, team, user, session_id, candidate_keys, window_start, window_end
+        _query_stamped_flag_properties, team, user, hogql_database, session_id, candidate_keys, window_start, window_end
     )
 
     # The three scans are independent given the pre-rescue candidate set (only the rescue
@@ -262,7 +280,11 @@ def _compute_session_experiment_context(
     rescued_keys = evidenced_keys - candidate_keys
     if rescued_keys:
         candidates += list(overlapping.filter(feature_flag__key__in=sorted(rescued_keys)))
-        stamped.update(_query_stamped_flag_properties(team, user, session_id, rescued_keys, window_start, window_end))
+        stamped.update(
+            _query_stamped_flag_properties(
+                team, user, hogql_database, session_id, rescued_keys, window_start, window_end
+            )
+        )
 
     surfaced: list[tuple[Experiment, str, list[str], Optional[datetime]]] = []
     for experiment in candidates:
@@ -313,6 +335,7 @@ def _compute_session_experiment_context(
                     session_id=session_id,
                     window_start=window_start,
                     window_end=window_end,
+                    hogql_database=hogql_database,
                 )
             }
     except Exception:
@@ -379,9 +402,17 @@ def _variant_keys_from_filters(filters: Optional[dict]) -> set[str]:
     return {variant["key"] for variant in multivariate.get("variants", []) if variant.get("key")}
 
 
+def _hogql_context(team: Team, user: User, database: Database) -> HogQLContext:
+    """A fresh per-query context carrying the shared prebuilt database, so
+    `execute_hogql_query` reuses it instead of building its own. Contexts must not be shared
+    between queries (printing accumulates per-query state on them); the database can be."""
+    return HogQLContext(team_id=team.pk, user=user, database=database)
+
+
 def _query_flag_evaluations(
     team: Team,
     user: User,
+    database: Database,
     session_id: str,
     window_start: datetime,
     window_end: datetime,
@@ -424,7 +455,7 @@ def _query_flag_evaluations(
             "max_rows": ast.Constant(value=MAX_EXPOSURE_ROWS),
         },
     )
-    response = execute_hogql_query(query, team=team, user=user)
+    response = execute_hogql_query(query, team=team, user=user, context=_hogql_context(team, user, database))
 
     exposures: dict[str, list[tuple[str, datetime]]] = {}
     for flag_key, variant, first_seen in response.results or []:
@@ -437,6 +468,7 @@ def _query_flag_evaluations(
 def _query_exposure_event_branches(
     team: Team,
     user: User,
+    database: Database,
     session_id: str,
     window_start: datetime,
     window_end: datetime,
@@ -504,7 +536,7 @@ def _query_exposure_event_branches(
     # No set-level LIMIT here: the printer emits it directly after the last branch's own
     # LIMIT, which ClickHouse rejects as a syntax error. The per-branch limits above are
     # the backstop; total output is already bounded by each flag's defined variants.
-    response = execute_hogql_query(query, team=team, user=user)
+    response = execute_hogql_query(query, team=team, user=user, context=_hogql_context(team, user, database))
 
     exposures: dict[int, list[tuple[str, datetime]]] = {}
     for experiment_id, variant, first_seen in response.results or []:
@@ -517,6 +549,7 @@ def _query_exposure_event_branches(
 def _query_stamped_flag_properties(
     team: Team,
     user: User,
+    database: Database,
     session_id: str,
     flag_keys: set[str],
     window_start: datetime,
@@ -558,7 +591,7 @@ def _query_stamped_flag_properties(
             ]
         ),
     )
-    response = execute_hogql_query(query, team=team, user=user)
+    response = execute_hogql_query(query, team=team, user=user, context=_hogql_context(team, user, database))
 
     row = response.results[0] if response.results else [[] for _ in sorted_keys]
     return {key: [value for value in row[index] if value] for index, key in enumerate(sorted_keys)}

--- a/products/experiments/backend/test/test_session_context_api.py
+++ b/products/experiments/backend/test/test_session_context_api.py
@@ -9,6 +9,8 @@ from django.core.cache import cache
 
 from rest_framework import status
 
+from posthog.hogql.database.database import Database
+
 from posthog.constants import AvailableFeature
 from posthog.models import PropertyDefinition, Team, User
 from posthog.models.personal_api_key import PersonalAPIKey
@@ -620,6 +622,33 @@ class TestSessionExperimentContext(ClickhouseTestMixin, APILicensedTest):
             second = self._get_session_context()
         compute.assert_not_called()
         assert second.json() == first.json()
+
+    def test_uncached_request_builds_hogql_database_once(self) -> None:
+        # Building the HogQL virtual database costs seconds on teams with a large warehouse
+        # schema, so the endpoint builds one and shares it across every scan (exposures,
+        # stamped properties, metric events). A scan that quietly builds its own would
+        # reintroduce the multi-second latency this endpoint used to have.
+        self._create_recording()
+        metric = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "uuid": "33333333-3333-3333-3333-333333333333",
+            "name": "Purchases",
+            "source": {"kind": "EventsNode", "event": "purchase"},
+        }
+        self._create_experiment(metrics=[metric])
+        self._create_session_event(properties={"$feature_flag": "checkout-cta", "$feature_flag_response": "test"})
+        self._create_session_event(event="purchase", timestamp="2026-01-01T10:09:00Z")
+        flush_persons_and_events()
+
+        with patch.object(Database, "create_for", wraps=Database.create_for) as create_for:
+            response = self._get_session_context()
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        assert [result["flag_key"] for result in results] == ["checkout-cta"]
+        assert results[0]["metrics_in_session"][0]["metric_uuid"] == metric["uuid"]
+        assert create_for.call_count == 1
 
     def test_recording_not_found_is_not_cached(self) -> None:
         # A recording can 404 while still ingesting; that answer must not stick for the TTL.

--- a/products/experiments/backend/test/test_session_context_api.py
+++ b/products/experiments/backend/test/test_session_context_api.py
@@ -10,6 +10,7 @@ from django.core.cache import cache
 from rest_framework import status
 
 from posthog.hogql.database.database import Database
+from posthog.hogql.database.models import Table, TableNode
 
 from posthog.constants import AvailableFeature
 from posthog.models import PropertyDefinition, Team, User
@@ -29,6 +30,14 @@ from ee.models.rbac.access_control import AccessControl
 RECORDING_START = datetime(2026, 1, 1, 10, 0, 0, tzinfo=UTC)
 RECORDING_END = datetime(2026, 1, 1, 10, 30, 0, tzinfo=UTC)
 SESSION_ID = str(uuid7(unix_ms_time=int(RECORDING_START.timestamp() * 1000)))
+
+
+def _hogql_table_tree(node: TableNode) -> dict[str, Any]:
+    table = node.table
+    return {
+        "fields": sorted(table.fields) if isinstance(table, Table) else None,
+        "children": {name: _hogql_table_tree(child) for name, child in node.children.items()},
+    }
 
 
 @freeze_time("2026-01-02T12:00:00Z")
@@ -623,11 +632,14 @@ class TestSessionExperimentContext(ClickhouseTestMixin, APILicensedTest):
         compute.assert_not_called()
         assert second.json() == first.json()
 
-    def test_uncached_request_builds_hogql_database_once(self) -> None:
+    def test_uncached_request_shares_one_readonly_hogql_database(self) -> None:
         # Building the HogQL virtual database costs seconds on teams with a large warehouse
         # schema, so the endpoint builds one and shares it across every scan (exposures,
-        # stamped properties, metric events). A scan that quietly builds its own would
-        # reintroduce the multi-second latency this endpoint used to have.
+        # stamped properties, metric events) — concurrently, in production. Two regressions
+        # pinned: a scan quietly building its own database (reintroduces the multi-second
+        # latency), and a scan mutating the shared one (e.g. an information_schema-touching
+        # query registers hidden external tables on it — a silent data race across the
+        # production thread pool).
         self._create_recording()
         metric = {
             "kind": "ExperimentMetric",
@@ -641,7 +653,15 @@ class TestSessionExperimentContext(ClickhouseTestMixin, APILicensedTest):
         self._create_session_event(event="purchase", timestamp="2026-01-01T10:09:00Z")
         flush_persons_and_events()
 
-        with patch.object(Database, "create_for", wraps=Database.create_for) as create_for:
+        built: list[tuple[Database, dict[str, Any]]] = []
+        original_create_for = Database.create_for
+
+        def _capturing_create_for(*args: Any, **kwargs: Any) -> Database:
+            database = original_create_for(*args, **kwargs)
+            built.append((database, _hogql_table_tree(database.tables)))
+            return database
+
+        with patch.object(Database, "create_for", side_effect=_capturing_create_for) as create_for:
             response = self._get_session_context()
 
         assert response.status_code == status.HTTP_200_OK
@@ -649,6 +669,8 @@ class TestSessionExperimentContext(ClickhouseTestMixin, APILicensedTest):
         assert [result["flag_key"] for result in results] == ["checkout-cta"]
         assert results[0]["metrics_in_session"][0]["metric_uuid"] == metric["uuid"]
         assert create_for.call_count == 1
+        database, tree_before_scans = built[0]
+        assert _hogql_table_tree(database.tables) == tree_before_scans
 
     def test_recording_not_found_is_not_cached(self) -> None:
         # A recording can 404 while still ingesting; that answer must not stick for the TTL.


### PR DESCRIPTION
## Problem

Follow-up to #72838 since the replay player's experiments box (`GET /api/projects/:id/experiments/session_context/`) was still taking 11–13s after that fix shipped (down from ~19s).

Analysis showed that the bottleneck now is `create_hogql_database`, each of the endpoint's 4 HogQL queries built the full virtual database from Postgres, which takes several seconds per build on a team with a large warehouse schema (`warehouse_foreign_keys` is about half of it), and the three "concurrent" scans building it simultaneously slowed each other down further (GIL-bound work in threads).

(usage of endpoint not rolled out yet, behind feature flag)

## Changes

- **Build the HogQL virtual database once per uncached request** and share it across all scans (flag evaluations, exposure branches, stamped properties + rescue, metric scan). Each query gets a fresh `HogQLContext` carrying the shared database — contexts accumulate per-query state and can't be shared; the database must stay read-only. Same pattern as `marketing_analytics_base_query_runner.py`, except here the scans run concurrently against it.
- **The sharing invariants are enforced, not assumed.** `SharedHogQLDatabase` bundles the database with the modifiers it was built with, and every scan executes with those modifiers — so a scan passing its own can't silently query a mismatched schema. The read-only invariant is pinned by the regression test (HogQL mutates a database at query time only for `system.information_schema` queries and direct-connection queries; these scans read only `events`), and the comments name those mutation paths instead of asserting read-onlyness bare.
- **Skip Postgres foreign-key lazy joins** in that build (`build_postgres_foreign_keys=False`): these queries only ever read the `events` table, and the FK build is the single most expensive step.

This should take it from 11–13s to 3s. The 5-minute per-viewer response cache from #72838 still makes reopening a recording instant.

## How did you test this code?

- Locally against seeded data
- Existing `test_session_context_api.py` and `test_metric_events.py` suites cover the endpoint behavior end to end through the public interface; the sandbox has no ClickHouse, so CI runs them (same as #72838).
- New test `test_uncached_request_shares_one_readonly_hogql_database`: catches two regressions no existing test observes — a scan quietly building its own database again (e.g. a new query added without threading the shared context through, reintroducing the multi-second latency), and a scan mutating the shared database (a silent data race across the production thread pool).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code (PostHog Code cloud task). Skills invoked: /writing-tests.
- Diagnosed from production data rather than assumptions: pulled the OTel trace of an actual 11.2s request via PostHog's own APM (`posthog-web-django-granian` service), which attributed ~9s to four `create_hogql_database` builds and ~2.3s to ClickHouse. Pre-merge traces of the same endpoint (16.8s / 21.2s) vs the post-merge trace confirm #72838 shipped and helped, but mostly by parallelizing three of the database builds.
- Review hardening (from a human-driven review pass): the shared-database sharing invariants (read-only, matching modifiers) were initially comment-only assumptions; they are now pinned by the regression test and carried structurally by `SharedHogQLDatabase`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
