### PR TITLE
fix(aio): guard llm taggers logic against unmounted store access

### DIFF
--- a/products/ai_observability/frontend/tags/AIObservabilityTagsScene.tsx
+++ b/products/ai_observability/frontend/tags/AIObservabilityTagsScene.tsx
@@ -39,7 +39,9 @@ export const scene: SceneExport = {
 }
 
 function TaggerMetrics(): JSX.Element {
-    const { chartQuery, totalRuns, taggers, runStatsLoading } = useValues(llmTaggersLogic)
+    // Build the logic instance so this component holds its own mount, rather than
+    // reading the bare reference and assuming an ancestor kept it in the store.
+    const { chartQuery, totalRuns, taggers, runStatsLoading } = useValues(llmTaggersLogic())
 
     const enabledCount = taggers.filter((t) => t.enabled && !t.deleted).length
 

--- a/products/ai_observability/frontend/tags/TagMetrics.tsx
+++ b/products/ai_observability/frontend/tags/TagMetrics.tsx
@@ -5,7 +5,6 @@ import { LemonSkeleton, LemonTag } from '@posthog/lemon-ui'
 import { Query } from '~/queries/Query/Query'
 import { InsightVizNode, NodeKind } from '~/queries/schema/schema-general'
 
-import { llmTaggersLogic } from './llmTaggersLogic'
 import { tagMetricsLogic } from './tagMetricsLogic'
 
 export const TAG_METRICS_COLLECTION_ID = 'tag-metrics'
@@ -50,8 +49,10 @@ function TopTagsCard({ tags }: { tags: { tag: string; count: number }[] }): JSX.
 }
 
 export function TagMetrics(): JSX.Element {
-    const { summaryMetrics, tagStats, tagStatsLoading, enabledTaggerCount, chartQuery } = useValues(tagMetricsLogic)
-    const { taggers } = useValues(llmTaggersLogic)
+    // `taggers` comes through tagMetricsLogic's connect to llmTaggersLogic, so we don't
+    // read the bare llmTaggersLogic reference directly (which can be unmounted here).
+    const { summaryMetrics, tagStats, tagStatsLoading, enabledTaggerCount, chartQuery, taggers } =
+        useValues(tagMetricsLogic)
 
     if (tagStatsLoading) {
         return (


### PR DESCRIPTION
## Problem

The AI observability tags feature threw an unhandled frontend error, surfaced in error tracking:

```
[KEA] Can not find path "products.ai_observability.taggers.llmTaggersLogic" in the store.
```

`TaggerMetrics` (in `AIObservabilityTagsScene.tsx`) and the currently-unrendered `TagMetrics` component both read the bare `llmTaggersLogic` reference via `useValues(llmTaggersLogic)`, assuming an ancestor had mounted it into the Kea store. When that assumption breaks — e.g. during scene teardown on navigation away — the store lookup fails and the component crashes.

## Changes

- `TaggerMetrics`: build the logic instance (`useValues(llmTaggersLogic())`) so the component holds its own mount, matching the pattern already used in the sibling `AIObservabilityTagsContent`.
- `TagMetrics`: read `taggers` through `tagMetricsLogic` (which already exposes it via its `connect` to `llmTaggersLogic`) and drop the redundant bare `llmTaggersLogic` read entirely.

No behavior change — both components render the same values; this only hardens how the logic is accessed.

## How did you test this code?

Ran oxlint on both changed files (passes). The `taggers` value is already part of the generated `tagMetricsLogicValues` type, so the `TagMetrics` change type-checks. No new automated tests added — the fix is a mount-safety change to existing components; I (the agent) did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from an error-tracking alert via the PostHog Slack app. Traced the KEA "path not in store" error to two components reading the bare `llmTaggersLogic` reference instead of a built/connected instance. Considered deleting the unused `TagMetrics` component but kept the change scoped to fixing the anti-pattern. No skills were required for this frontend-only mount-safety fix.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A006STKHR/p1784796195674659?thread_ts=1784796195.674659&cid=C0A006STKHR)*
