### PR TITLE
fix(code): include repository in task deep links

### DIFF
--- a/frontend/src/lib/components/AgentPromptButton/AgentPromptButton.test.ts
+++ b/frontend/src/lib/components/AgentPromptButton/AgentPromptButton.test.ts
@@ -1,0 +1,10 @@
+import { buildPostHogCodeDeepLink } from './AgentPromptButton'
+
+describe('AgentPromptButton', () => {
+    it.each([
+        ['with a repository', 'posthog/posthog', 'posthog-code://new?prompt=fix%20this&repo=posthog%2Fposthog'],
+        ['without a repository', undefined, 'posthog-code://new?prompt=fix%20this'],
+    ])('builds a PostHog Code deep link %s', (_, repository, expected) => {
+        expect(buildPostHogCodeDeepLink('fix this', repository)).toBe(expected)
+    })
+})

--- a/frontend/src/lib/components/AgentPromptButton/AgentPromptButton.tsx
+++ b/frontend/src/lib/components/AgentPromptButton/AgentPromptButton.tsx
@@ -100,6 +100,11 @@ function openDeepLink(buildDeepLink: (prompt: string) => string): (prompt: strin
     return (prompt: string) => window.open(buildDeepLink(prompt), '_blank')
 }
 
+export function buildPostHogCodeDeepLink(prompt: string, repository?: string): string {
+    const repoParam = repository ? `&repo=${encodeURIComponent(repository)}` : ''
+    return `posthog-code://new?prompt=${encodeURIComponent(prompt)}${repoParam}`
+}
+
 const AGENTS: AgentDef[] = [
     {
         key: 'posthog-ai',
@@ -113,7 +118,7 @@ const AGENTS: AgentDef[] = [
         name: 'PostHog Code',
         logo: <IconLogomark className="size-4 shrink-0" />,
         verb: 'Open',
-        open: openDeepLink((p) => `posthog-code://new?prompt=${encodeURIComponent(p)}`),
+        open: (prompt, { repository }) => window.open(buildPostHogCodeDeepLink(prompt, repository), '_blank'),
     },
     {
         key: 'claude-code',


### PR DESCRIPTION
## Problem

PostHog Code task links opened without repository context, so the desktop app could fall back to a previously selected repository.

**Why:** Actions that already know the target repository should open in the correct workspace reliably.

## Changes

Forward the repository slug in PostHog Code deep links while preserving links that do not have repository context.