### PR TITLE
fix(insights): show tooltip with full header name when truncated

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -2,7 +2,7 @@ import '../../DataTable/DataTable.scss'
 
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import React from 'react'
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 import { IconPin, IconPinFilled } from '@posthog/icons'
 import { LemonBanner, LemonTable, LemonTableColumn, Tooltip } from '@posthog/lemon-ui'
@@ -107,6 +107,44 @@ function getCellTitle(cell: TableDataCell<any>): string | undefined {
     return undefined
 }
 
+// Header labels are clamped to a few lines with a CSS ellipsis when they don't fit. The full text stays
+// in the DOM, so we compare the rendered box against the content and reveal the full name on hover only
+// when it's actually cut off.
+function ColumnHeaderTitle({
+    formattedTitle,
+    fullTitle,
+    children,
+}: {
+    formattedTitle: React.ReactNode
+    fullTitle: string
+    children?: React.ReactNode
+}): JSX.Element {
+    const titleRef = useRef<HTMLSpanElement>(null)
+    const [isTruncated, setIsTruncated] = useState(false)
+
+    const detectTruncation = useCallback((): void => {
+        const el = titleRef.current
+        if (el) {
+            setIsTruncated(el.scrollHeight - el.clientHeight > 1 || el.scrollWidth - el.clientWidth > 1)
+        }
+    }, [])
+
+    useLayoutEffect(() => {
+        detectTruncation()
+    }, [detectTruncation, fullTitle])
+
+    return (
+        <div className="flex items-center gap-1">
+            <Tooltip title={isTruncated ? fullTitle : undefined}>
+                <span ref={titleRef} onMouseEnter={detectTruncation}>
+                    {formattedTitle}
+                </span>
+            </Tooltip>
+            {children}
+        </div>
+    )
+}
+
 export const Table = (props: TableProps): JSX.Element => {
     const { isDarkModeOn } = useValues(themeLogic)
 
@@ -135,6 +173,7 @@ export const Table = (props: TableProps): JSX.Element => {
             const { title, ...columnMeta } = renderColumnMeta(column.name, props.query, props.context)
             const columnTitle = settings?.display?.label || title || column.name
             const formattedTitle = typeof columnTitle === 'string' ? formatColumnTitle(columnTitle) : columnTitle
+            const fullColumnTitle = typeof columnTitle === 'string' ? columnTitle : column.name
 
             const computeConditionalFormattingBackground = (data: TableDataCell<any>[]): string | undefined => {
                 const cell = data[index]
@@ -211,8 +250,7 @@ export const Table = (props: TableProps): JSX.Element => {
                 // (rows become the original columns), so only offer it in the normal orientation.
                 sorter: isTransposed ? undefined : (a, b) => compareTableCells(a[index], b[index]),
                 title: (
-                    <div className="flex items-center gap-1">
-                        <span>{formattedTitle}</span>
+                    <ColumnHeaderTitle formattedTitle={formattedTitle} fullTitle={fullColumnTitle}>
                         {isPinningEnabled && (
                             <Tooltip title={isColumnPinned(column.name) ? 'Unpin column' : 'Pin column'}>
                                 <span
@@ -230,7 +268,7 @@ export const Table = (props: TableProps): JSX.Element => {
                                 </span>
                             </Tooltip>
                         )}
-                    </div>
+                    </ColumnHeaderTitle>
                 ),
                 render: (_, data, recordIndex: number, rowCount: number) => {
                     const cell = data[index]


### PR DESCRIPTION
## Problem

SQL and HogQL table insights clamp long column headers to a few lines with a CSS ellipsis. Once a header is cut off there's no way to read its full name — you just get the truncated text with no tooltip.

## Changes

Column headers in the data visualization table now reveal the full header name in a tooltip on hover, but only when the label is actually truncated. The check compares the rendered box against the content (the full text always stays in the DOM), so short headers that fit render exactly as before.

## How did you test this code?

I (Claude) couldn't run the app or the frontend toolchain in this environment (no `node_modules`), so I performed no manual or automated runs. I reasoned through the behavior instead:

- Short headers stay non-truncated, so `Tooltip` is a passthrough and the rendered DOM is unchanged from before — the existing `SQLTableConditionalFormatting` story only has short labels, so its snapshot is unaffected.
- Truncation detection mirrors the existing pattern in `EditableField` (`scroll*` vs `client*` size), extended to also catch the multi-line clamp these headers use.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — internal UI affordance only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Xander asked for a tooltip that reveals the full header name when a table insight's header is truncated with an ellipsis. I (Claude) traced the three table renderers: the trends `InsightsTable` already reveals full breakdown names through `PropertyKeyInfo`'s native `title`, and the events `DataTable` doesn't truncate headers at all. The real gap was the SQL/HogQL `DataVisualizationTable`, whose headers are line-clamped with `text-overflow: ellipsis` and had no tooltip.

I gated the tooltip on real truncation (measured once after layout, plus lazily on hover) rather than always showing it, so non-truncated headers behave exactly as before. I kept the change local to the data-viz table rather than touching the shared `LemonTable`, which would have risked double tooltips on breakdown headers that already have one.

No repo skills were needed for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
