### PR TITLE
fix(data-management): skip managed viewset kinds the frontend doesn't recognize

### DIFF
--- a/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetCard.tsx
+++ b/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetCard.tsx
@@ -42,12 +42,18 @@ export function DataWarehouseManagedViewsetCard({
     resourceType,
     displayDocsLink = true,
     displayConfigLink = true,
-}: DataWarehouseManagedViewsetCardProps): JSX.Element {
+}: DataWarehouseManagedViewsetCardProps): JSX.Element | null {
     const { currentTeam } = useValues(teamLogic)
     const { toggleViewset } = useActions(dataWarehouseManagedViewsetsLogic({ type }))
     const { togglingViewset, toggleResultLoading } = useValues(dataWarehouseManagedViewsetsLogic({ type }))
 
-    const { title, description, docsUrl, configUrl, icon } = VIEWSET_DESCRIPTIONS[kind]
+    const viewsetInfo = VIEWSET_DESCRIPTIONS[kind]
+
+    if (!viewsetInfo) {
+        return null
+    }
+
+    const { title, description, docsUrl, configUrl, icon } = viewsetInfo
     const isEnabled = !!currentTeam?.managed_viewsets?.[kind]
     const isToggling = togglingViewset === kind && toggleResultLoading
 

--- a/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetsScene.tsx
+++ b/frontend/src/scenes/data-management/managed-viewsets/DataWarehouseManagedViewsetsScene.tsx
@@ -85,14 +85,16 @@ export function DataWarehouseManagedViewsetsScene(): JSX.Element | null {
             />
 
             <div className="space-y-4">
-                {(Object.keys(managedViewsets) as DataWarehouseManagedViewsetKind[]).map((kind) => (
-                    <DataWarehouseManagedViewsetCard
-                        key={kind}
-                        resourceType={RESOURCE_TYPES_MAP[kind]}
-                        type="DataWarehouseManagedViewsetsScene"
-                        kind={kind}
-                    />
-                ))}
+                {(Object.keys(managedViewsets) as DataWarehouseManagedViewsetKind[])
+                    .filter((kind) => kind in RESOURCE_TYPES_MAP)
+                    .map((kind) => (
+                        <DataWarehouseManagedViewsetCard
+                            key={kind}
+                            resourceType={RESOURCE_TYPES_MAP[kind]}
+                            type="DataWarehouseManagedViewsetsScene"
+                            kind={kind}
+                        />
+                    ))}
             </div>
 
             <DataWarehouseManagedViewsetImpactModal


### PR DESCRIPTION
## Problem

Follow-up to [#72873](https://github.com/PostHog/posthog/pull/72873): after that fix landed, the `/data-management/managed-viewsets` page still crashed in production with:

```
TypeError: Cannot destructure property 'title' of 'I[s]' as it is undefined.
```

Root cause: the backend recently added a second `DataWarehouseManagedViewSetKind` value, `engineering_analytics` (landed in an unrelated commit that happened to touch the shared enum file). The team serializer returns every known kind in `managed_viewsets`, so every team's payload now includes `engineering_analytics` alongside `revenue_analytics`. The frontend's `VIEWSET_DESCRIPTIONS`, `RESOURCE_TYPES_MAP`, and `VIEWSET_TITLES` registries only have a `revenue_analytics` entry, so the scene rendered a `DataWarehouseManagedViewsetCard` for `engineering_analytics` and `VIEWSET_DESCRIPTIONS['engineering_analytics']` was `undefined` — the destructure at the top of the card threw and took down the whole page.

Note: the `engineering_analytics` product hasn't registered a view provider on the backend yet, so there isn't real content to show for it regardless — the correct behavior today is to not render anything for it until that product ships its own frontend integration.

## Changes

- `DataWarehouseManagedViewsetCard.tsx`: guard the `VIEWSET_DESCRIPTIONS[kind]` lookup and return `null` for an unrecognized kind instead of destructuring `undefined`.
- `DataWarehouseManagedViewsetsScene.tsx`: filter the list of kinds to render down to ones present in `RESOURCE_TYPES_MAP`, so a card is never mounted for a kind the frontend doesn't have UI copy for.

Both fixes are defensive and additive — when a future PR adds real frontend support for `engineering_analytics` (or any other kind), these guards stop being relevant rather than needing to be removed.

## How did I test this code?

Code review only. `node_modules` weren't available in this environment to run typecheck/lint. The change is a straightforward defensive guard (early-return on missing map entry, `.filter()` before `.map()`) with no changes to component signatures other than widening return types to `JSX.Element | null`, which is a standard React pattern.

## 🤖 Agent context

**Autonomy:** Fully autonomous

The user reported that after merging [#72873](https://github.com/PostHog/posthog/pull/72873) (which fixed a null-`currentTeam` crash on this same page), a *different* error was still occurring in production with the exact message above. I dispatched exploration to rule out `SceneTitleSection` / `ProductSetupButton` (both are null-safe and not the cause), then traced the destructure to `DataWarehouseManagedViewsetCard.tsx`'s `VIEWSET_DESCRIPTIONS[kind]` lookup, and confirmed via `git log`/`grep` that `products/warehouse_sources/backend/types.py` gained an `ENGINEERING_ANALYTICS` choice on `master` (commit `52ed57ff`) that the frontend registries never picked up. Fixed by guarding the lookup and filtering unknown kinds before render.
