### PR TITLE
fix(llm-gateway): normalize GLM thinking requests

### DIFF
--- a/services/llm-gateway/src/llm_gateway/glm_routing.py
+++ b/services/llm-gateway/src/llm_gateway/glm_routing.py
@@ -47,6 +47,35 @@ from llm_gateway.modal import (
 
 LlmCall = Callable[..., Awaitable[Any]]
 
+GLM_REASONING_EFFORTS: frozenset[str] = frozenset({"high", "max"})
+
+
+def normalize_glm_anthropic_request(request_data: dict[str, Any]) -> dict[str, Any]:
+    """Make Claude runtime reasoning settings valid for GLM's Anthropic surface."""
+    normalized = dict(request_data)
+    output_config = normalized.get("output_config")
+    effort = output_config.get("effort") if isinstance(output_config, dict) else None
+
+    if effort in GLM_REASONING_EFFORTS:
+        normalized["thinking"] = {"type": "adaptive"}
+
+    thinking = normalized.get("thinking")
+    thinking_type = thinking.get("type") if isinstance(thinking, dict) else None
+    if thinking_type not in {"enabled", "adaptive"}:
+        context_management = normalized.get("context_management")
+        if isinstance(context_management, dict) and isinstance(context_management.get("edits"), list):
+            edits = [
+                edit
+                for edit in context_management["edits"]
+                if not isinstance(edit, dict) or edit.get("type") != "clear_thinking_20251015"
+            ]
+            if edits:
+                normalized["context_management"] = {**context_management, "edits": edits}
+            else:
+                normalized.pop("context_management", None)
+
+    return normalized
+
 
 async def _route_to_modal(model: str, user: AuthenticatedUser, product: str, settings: Settings) -> bool:
     if not is_modal_served_model(model) or not is_modal_configured(settings):
@@ -140,7 +169,7 @@ async def send_glm_anthropic_messages(
     product: str,
 ) -> dict[str, Any] | StreamingResponse:
     return await _send_glm_request(
-        request_data,
+        normalize_glm_anthropic_request(request_data),
         user,
         is_streaming,
         product,

--- a/services/llm-gateway/tests/test_glm_routing.py
+++ b/services/llm-gateway/tests/test_glm_routing.py
@@ -96,21 +96,29 @@ async def test_normalizes_supported_reasoning_effort_for_anthropic_requests(effo
     }
 
 
-def test_drops_clear_thinking_when_thinking_is_not_enabled() -> None:
+@pytest.mark.parametrize(
+    ("edits", "expected_context_management"),
+    [
+        ([{"type": "clear_thinking_20251015", "keep": "all"}], None),
+        (
+            [
+                {"type": "clear_thinking_20251015", "keep": "all"},
+                {"type": "clear_tool_uses_20250919"},
+            ],
+            {"edits": [{"type": "clear_tool_uses_20250919"}]},
+        ),
+    ],
+)
+def test_drops_clear_thinking_when_thinking_is_not_enabled(
+    edits: list[dict[str, str]], expected_context_management: dict[str, Any] | None
+) -> None:
     request = {
         "model": GLM_MODEL,
         "messages": [{"role": "user", "content": "hi"}],
-        "context_management": {
-            "edits": [
-                {"type": "clear_thinking_20251015", "keep": "all"},
-                {"type": "clear_tool_uses_20250919"},
-            ]
-        },
+        "context_management": {"edits": edits},
     }
 
-    assert normalize_glm_anthropic_request(request)["context_management"] == {
-        "edits": [{"type": "clear_tool_uses_20250919"}]
-    }
+    assert normalize_glm_anthropic_request(request).get("context_management") == expected_context_management
 
 
 async def test_routes_to_modal_when_fraction_one_without_flag_roundtrip() -> None:

--- a/services/llm-gateway/tests/test_glm_routing.py
+++ b/services/llm-gateway/tests/test_glm_routing.py
@@ -8,6 +8,7 @@ from llm_gateway.api.handler import ProviderError
 from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.config import Settings
 from llm_gateway.glm_routing import (
+    normalize_glm_anthropic_request,
     send_glm_anthropic_messages,
     send_glm_chat_completions,
     send_glm_responses,
@@ -46,6 +47,7 @@ async def _send(
     flag: bool | None = None,
     send_fn: Any = send_glm_anthropic_messages,
     product: str = PRODUCT,
+    request_data: dict[str, Any] | None = None,
 ) -> tuple[Any, AsyncMock]:
     evaluate = AsyncMock(return_value=flag)
     with (
@@ -54,7 +56,7 @@ async def _send(
         patch("llm_gateway.glm_routing.evaluate_flag", evaluate),
     ):
         result = await send_fn(
-            {"model": GLM_MODEL, "messages": [{"role": "user", "content": "hi"}]},
+            request_data or {"model": GLM_MODEL, "messages": [{"role": "user", "content": "hi"}]},
             _user(),
             False,
             product,
@@ -74,6 +76,41 @@ async def test_routes_to_cloudflare_by_default() -> None:
     # The public model id must reach handle_llm_request unchanged — it drives metrics and the
     # unsupported-model gate.
     assert handle.call_args.kwargs["model"] == GLM_MODEL
+
+
+@pytest.mark.parametrize("effort", ["high", "max"])
+async def test_normalizes_supported_reasoning_effort_for_anthropic_requests(effort: str) -> None:
+    request = {
+        "model": GLM_MODEL,
+        "messages": [{"role": "user", "content": "hi"}],
+        "output_config": {"effort": effort},
+        "context_management": {"edits": [{"type": "clear_thinking_20251015", "keep": "all"}]},
+    }
+    handle = AsyncMock(return_value={"ok": True})
+
+    await _send(_settings(), handle, request_data=request)
+
+    assert handle.call_args.kwargs["request_data"] == {
+        **request,
+        "thinking": {"type": "adaptive"},
+    }
+
+
+def test_drops_clear_thinking_when_thinking_is_not_enabled() -> None:
+    request = {
+        "model": GLM_MODEL,
+        "messages": [{"role": "user", "content": "hi"}],
+        "context_management": {
+            "edits": [
+                {"type": "clear_thinking_20251015", "keep": "all"},
+                {"type": "clear_tool_uses_20250919"},
+            ]
+        },
+    }
+
+    assert normalize_glm_anthropic_request(request)["context_management"] == {
+        "edits": [{"type": "clear_tool_uses_20250919"}]
+    }
 
 
 async def test_routes_to_modal_when_fraction_one_without_flag_roundtrip() -> None:


### PR DESCRIPTION
## Problem

**Why:** GLM 5.2 cloud runs can send the `clear_thinking_20251015` context strategy without an enabled thinking configuration, which the Anthropic-compatible API rejects. GLM supports `high` and `max` reasoning effort, so the gateway should preserve those settings in a valid request shape.

## Changes

- Normalize GLM Anthropic requests with high or max effort to adaptive thinking.
- Remove orphaned clear-thinking edits while preserving other context-management strategies.