### PR TITLE
fix(insights): show tooltip with full header name when truncated

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -109,33 +109,36 @@ function getCellTitle(cell: TableDataCell<any>): string | undefined {
 
 // Header labels are clamped to a few lines with a CSS ellipsis when they don't fit. The full text stays
 // in the DOM, so we compare the rendered box against the content and reveal the full name on hover only
-// when it's actually cut off.
+// when it's actually cut off. The tooltip prefers the explicit label but falls back to the rendered text,
+// so titles rendered from JSX (e.g. a human-readable property name) show their label, not a raw column key.
 function ColumnHeaderTitle({
     formattedTitle,
     fullTitle,
     children,
 }: {
     formattedTitle: React.ReactNode
-    fullTitle: string
+    fullTitle?: string
     children?: React.ReactNode
 }): JSX.Element {
     const titleRef = useRef<HTMLSpanElement>(null)
-    const [isTruncated, setIsTruncated] = useState(false)
+    const [tooltip, setTooltip] = useState<string | undefined>(undefined)
 
     const detectTruncation = useCallback((): void => {
         const el = titleRef.current
-        if (el) {
-            setIsTruncated(el.scrollHeight - el.clientHeight > 1 || el.scrollWidth - el.clientWidth > 1)
+        if (!el) {
+            return
         }
-    }, [])
+        const isTruncated = el.scrollHeight - el.clientHeight > 1 || el.scrollWidth - el.clientWidth > 1
+        setTooltip(isTruncated ? fullTitle || el.textContent || undefined : undefined)
+    }, [fullTitle])
 
     useLayoutEffect(() => {
         detectTruncation()
-    }, [detectTruncation, fullTitle])
+    }, [detectTruncation])
 
     return (
         <div className="flex items-center gap-1">
-            <Tooltip title={isTruncated ? fullTitle : undefined}>
+            <Tooltip title={tooltip}>
                 <span ref={titleRef} onMouseEnter={detectTruncation}>
                     {formattedTitle}
                 </span>
@@ -173,7 +176,7 @@ export const Table = (props: TableProps): JSX.Element => {
             const { title, ...columnMeta } = renderColumnMeta(column.name, props.query, props.context)
             const columnTitle = settings?.display?.label || title || column.name
             const formattedTitle = typeof columnTitle === 'string' ? formatColumnTitle(columnTitle) : columnTitle
-            const fullColumnTitle = typeof columnTitle === 'string' ? columnTitle : column.name
+            const fullColumnTitle = typeof columnTitle === 'string' ? columnTitle : undefined
 
             const computeConditionalFormattingBackground = (data: TableDataCell<any>[]): string | undefined => {
                 const cell = data[index]

--- a/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Table.tsx
@@ -2,7 +2,7 @@ import '../../DataTable/DataTable.scss'
 
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import React from 'react'
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 import { IconPin, IconPinFilled } from '@posthog/icons'
 import { LemonBanner, LemonTable, LemonTableColumn, Tooltip } from '@posthog/lemon-ui'
@@ -107,6 +107,44 @@ function getCellTitle(cell: TableDataCell<any>): string | undefined {
     return undefined
 }
 
+// Header labels are clamped to a few lines with a CSS ellipsis when they don't fit. The full text stays
+// in the DOM, so we compare the rendered box against the content and reveal the full name on hover only
+// when it's actually cut off.
+function ColumnHeaderTitle({
+    formattedTitle,
+    fullTitle,
+    children,
+}: {
+    formattedTitle: React.ReactNode
+    fullTitle: string
+    children?: React.ReactNode
+}): JSX.Element {
+    const titleRef = useRef<HTMLSpanElement>(null)
+    const [isTruncated, setIsTruncated] = useState(false)
+
+    const detectTruncation = useCallback((): void => {
+        const el = titleRef.current
+        if (el) {
+            setIsTruncated(el.scrollHeight - el.clientHeight > 1 || el.scrollWidth - el.clientWidth > 1)
+        }
+    }, [])
+
+    useLayoutEffect(() => {
+        detectTruncation()
+    }, [detectTruncation, fullTitle])
+
+    return (
+        <div className="flex items-center gap-1">
+            <Tooltip title={isTruncated ? fullTitle : undefined}>
+                <span ref={titleRef} onMouseEnter={detectTruncation}>
+                    {formattedTitle}
+                </span>
+            </Tooltip>
+            {children}
+        </div>
+    )
+}
+
 export const Table = (props: TableProps): JSX.Element => {
     const { isDarkModeOn } = useValues(themeLogic)
 
@@ -135,6 +173,7 @@ export const Table = (props: TableProps): JSX.Element => {
             const { title, ...columnMeta } = renderColumnMeta(column.name, props.query, props.context)
             const columnTitle = settings?.display?.label || title || column.name
             const formattedTitle = typeof columnTitle === 'string' ? formatColumnTitle(columnTitle) : columnTitle
+            const fullColumnTitle = typeof columnTitle === 'string' ? columnTitle : column.name
 
             const computeConditionalFormattingBackground = (data: TableDataCell<any>[]): string | undefined => {
                 const cell = data[index]
@@ -211,8 +250,7 @@ export const Table = (props: TableProps): JSX.Element => {
                 // (rows become the original columns), so only offer it in the normal orientation.
                 sorter: isTransposed ? undefined : (a, b) => compareTableCells(a[index], b[index]),
                 title: (
-                    <div className="flex items-center gap-1">
-                        <span>{formattedTitle}</span>
+                    <ColumnHeaderTitle formattedTitle={formattedTitle} fullTitle={fullColumnTitle}>
                         {isPinningEnabled && (
                             <Tooltip title={isColumnPinned(column.name) ? 'Unpin column' : 'Pin column'}>
                                 <span
@@ -230,7 +268,7 @@ export const Table = (props: TableProps): JSX.Element => {
                                 </span>
                             </Tooltip>
                         )}
-                    </div>
+                    </ColumnHeaderTitle>
                 ),
                 render: (_, data, recordIndex: number, rowCount: number) => {
                     const cell = data[index]


### PR DESCRIPTION
## Problem

SQL and HogQL table insights clamp long column headers to a few lines with a CSS ellipsis. Once a header is cut off there's no way to read its full name — you just get the truncated text with no tooltip.

## Changes

Column headers in the data visualization table now reveal the full header name in a tooltip on hover, but only when the label is actually truncated. The check compares the rendered box against the content (the full text always stays in the DOM), so short headers that fit render exactly as before.

![SQL table insight header tooltip on a truncated column](https://raw.githubusercontent.com/PostHog/pr-assets/56c4dc75871e91a70d84373df6b2b27d181c3926/2026/07/bbaef0d1-bfda-4b9b-a089-952d09278492.png)

_Rendered from the component's actual clamp CSS and Tooltip design tokens in headless Chromium. I (Claude) couldn't run the full PostHog app in this sandbox, so this is a faithful reproduction of the header clamp + tooltip, not a capture of the running app._

## How did you test this code?

I (Claude) couldn't run the app or the frontend toolchain in this environment (no `node_modules`), so I performed no manual or automated runs of the real app. I verified the behavior two ways:

- Traced the render paths: short headers stay non-truncated, so `Tooltip` is a passthrough and the DOM is unchanged from before — the existing `SQLTableConditionalFormatting` story only has short labels, so its snapshot is unaffected.
- Built a faithful standalone reproduction from the component's real clamp CSS and Tooltip tokens, and confirmed the truncation math (`scrollHeight 78 > clientHeight 59`) is what drives the tooltip — that's the screenshot above.

Truncation detection mirrors the existing `EditableField` pattern (`scroll*` vs `client*` size), extended to also catch the multi-line clamp these headers use.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — internal UI affordance only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Xander asked for a tooltip that reveals the full header name when a table insight's header is truncated with an ellipsis, and for a screenshot of it in the description. I (Claude) traced the three table renderers: the trends `InsightsTable` already reveals full breakdown names through `PropertyKeyInfo`'s native `title`, and the events `DataTable` doesn't truncate headers at all. The real gap was the SQL/HogQL `DataVisualizationTable`, whose headers are line-clamped with `text-overflow: ellipsis` and had no tooltip.

I gated the tooltip on real truncation (measured once after layout, plus lazily on hover) rather than always showing it, so non-truncated headers behave exactly as before. I kept the change local to the data-viz table rather than touching the shared `LemonTable`, which would have risked double tooltips on breakdown headers that already have one.

This supersedes #73114 (same change, moved to an `xljones/`-prefixed branch). No repo skills were needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
