### PR TITLE
feat(data-warehouse): measure per-source table sizes during imports

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/batcher.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/batcher.py
@@ -6,6 +6,10 @@ import pyarrow as pa
 import pyarrow.compute as pc
 from structlog.types import FilteringBoundLogger
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.table_stats import (
+    record_table_stats,
+    table_payload_bytes,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.utils import table_from_py_list
 
 DEFAULT_CHUNK_SIZE_BYTES: int = 200 * 1024 * 1024  # 200 MiB
@@ -40,51 +44,12 @@ def _max_offset_pressure(table: pa.Table) -> int:
     return max((_column_offset_pressure(table.column(name)) for name in table.column_names), default=0)
 
 
-def _column_payload_bytes(col: pa.ChunkedArray) -> int:
-    """Slice-accurate in-memory payload bytes: value bytes + offset buffer (string/binary/list)
-    or col_length * byte_width (fixed-width); nested/other types return 0. Avoids `.nbytes` (wrong for slices)."""
-    col_type = col.type
-    col_length = len(col)
-    if pa.types.is_string(col_type) or pa.types.is_binary(col_type):
-        payload = int(pc.sum(pc.binary_length(col)).as_py() or 0)
-        return payload + col_length * 4  # value bytes + 32-bit offsets
-    if pa.types.is_large_string(col_type) or pa.types.is_large_binary(col_type):
-        # 64-bit offsets can't overflow (the offset guard skips them) but still hold real payload.
-        payload = int(pc.sum(pc.binary_length(col)).as_py() or 0)
-        return payload + col_length * 8
-    if pa.types.is_list(col_type):
-        elements = int(pc.sum(pc.list_value_length(col)).as_py() or 0)
-        return elements + col_length * 4
-    if pa.types.is_struct(col_type):
-        # Recurse into child fields so a nested struct (e.g. a Mongo document carried under `data`) is
-        # counted instead of undercounting to 0 — otherwise the per-table byte split never sees the
-        # payload that actually drives the merge's memory. `flatten()` yields one ChunkedArray per field.
-        # Guarded like the fixed-width branch below: an unexpected flatten failure degrades to 0 rather
-        # than propagating and breaking size accounting for the whole table.
-        try:
-            return sum(_column_payload_bytes(child) for child in col.flatten())
-        except Exception:
-            return 0
-    # Fixed-width primitives expose bit_width; variable-length / other nested types raise -> 0.
-    # Known limitation: map and sub-byte bool columns still undercount to 0 (we bound large string/JSON
-    # and struct payloads, the actual OOM drivers).
-    try:
-        bit_width = col_type.bit_width
-    except (ValueError, AttributeError):
-        return 0
-    return col_length * (bit_width // 8)
-
-
-def _table_payload_bytes(table: pa.Table) -> int:
-    return sum(_column_payload_bytes(table.column(name)) for name in table.column_names)
-
-
 def _split_table(table: pa.Table, *, offset_limit: int, bytes_limit: int) -> list[pa.Table]:
     """Row-halve `table` (zero-copy slices) until every slice is under both the per-column offset limit
     and the total-bytes limit. `num_rows <= 1` is the base case, so a lone oversized row is yielded as-is."""
     if table.num_rows <= 1:
         return [table]
-    if _max_offset_pressure(table) <= offset_limit and _table_payload_bytes(table) <= bytes_limit:
+    if _max_offset_pressure(table) <= offset_limit and table_payload_bytes(table) <= bytes_limit:
         return [table]
 
     mid = table.num_rows // 2
@@ -104,6 +69,9 @@ class Batcher:
     _chunk_size_bytes: int
     _max_column_offset_bytes: int
     _max_table_bytes: int
+    _source_type: Optional[str]
+    _team_id: Optional[int]
+    _schema_name: Optional[str]
 
     def __init__(
         self,
@@ -112,6 +80,9 @@ class Batcher:
         chunk_size_bytes: Optional[int] = None,
         max_column_offset_bytes: Optional[int] = None,
         max_table_bytes: Optional[int] = None,
+        source_type: Optional[str] = None,
+        team_id: Optional[int] = None,
+        schema_name: Optional[str] = None,
     ) -> None:
         self._logger = logger
 
@@ -119,6 +90,12 @@ class Batcher:
         self._chunk_size_bytes = chunk_size_bytes or DEFAULT_CHUNK_SIZE_BYTES
         self._max_column_offset_bytes = max_column_offset_bytes or DEFAULT_MAX_COLUMN_OFFSET_BYTES
         self._max_table_bytes = max_table_bytes or DEFAULT_MAX_TABLE_BYTES
+        # When set, each materialised table is measured under `stage="batcher"`. Left None by
+        # source-internal batchers (e.g. apify), whose output is measured when it reaches the
+        # pipeline's own batcher — so this only records once, with the real source_type.
+        self._source_type = source_type
+        self._team_id = team_id
+        self._schema_name = schema_name
 
         self._buffer = []
         self._buffer_size_bytes = 0
@@ -128,16 +105,27 @@ class Batcher:
         """Split `table` so no yielded chunk overflows a 32-bit offset column or exceeds
         the per-table Arrow-payload cap (keeping the loader's per-batch merge bounded)."""
         chunks = _split_table(table, offset_limit=self._max_column_offset_bytes, bytes_limit=self._max_table_bytes)
-        if len(chunks) > 1:
-            payload_bytes = _table_payload_bytes(table)
-            if payload_bytes > self._max_table_bytes:
-                self._logger.info(
-                    "batcher_split_by_bytes",
-                    payload_bytes=payload_bytes,
-                    bytes_limit=self._max_table_bytes,
-                    chunk_count=len(chunks),
-                    row_count=table.num_rows,
-                )
+        payload_bytes = table_payload_bytes(table)
+        if self._source_type is not None:
+            # The materialised table is the true in-memory peak (an unbounded source yields one giant
+            # list -> one giant table here, before the split into bounded chunks).
+            record_table_stats(
+                source_type=self._source_type,
+                stage="batcher",
+                num_rows=table.num_rows,
+                payload_bytes=payload_bytes,
+                logger=self._logger,
+                team_id=self._team_id,
+                schema_name=self._schema_name,
+            )
+        if len(chunks) > 1 and payload_bytes > self._max_table_bytes:
+            self._logger.info(
+                "batcher_split_by_bytes",
+                payload_bytes=payload_bytes,
+                bytes_limit=self._max_table_bytes,
+                chunk_count=len(chunks),
+                row_count=table.num_rows,
+            )
         self._ready = deque(chunks)
 
     def _estimate_size(self, obj: Any) -> int:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/pipeline.py
@@ -60,6 +60,9 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.person_property_row_sink import (
     PersonPropertyRowSink,
 )
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.table_stats import (
+    record_source_item_stats,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
     PipelineResult,
     ResumableData,
@@ -202,6 +205,9 @@ class PipelineNonDLT(Generic[ResumableData]):
             self._logger,
             chunk_size=source_response.chunk_size,
             chunk_size_bytes=source_response.chunk_size_bytes,
+            source_type=self._source.source_type,
+            team_id=self._job.team_id,
+            schema_name=self._schema.name,
         )
         self._internal_schema = HogQLSchema()
         self._cdp_producer = CDPProducer(
@@ -284,6 +290,14 @@ class PipelineNonDLT(Generic[ResumableData]):
 
             async for item in async_iterate(self._resource.items()):
                 py_table = None
+
+                record_source_item_stats(
+                    item,
+                    source_type=self._source.source_type,
+                    logger=self._logger,
+                    team_id=self._job.team_id,
+                    schema_name=self._schema.name,
+                )
 
                 self._batcher.batch(item)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/table_stats.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/table_stats.py
@@ -12,17 +12,31 @@ buffer for a zero-copy slice) — the `Batcher` produces zero-copy slices, so `.
 over-count there.
 """
 
+import os
 from typing import Any, Optional
 
 import pyarrow as pa
 import pyarrow.compute as pc
+import posthoganalytics
 from structlog.types import FilteringBoundLogger
 from temporalio import activity
 
-# Any single table whose in-memory Arrow payload crosses this is logged with the team/schema/source
-# context needed to reproduce it. The metrics below capture the full distribution; this surfaces the
-# specific offenders to fix.
+from posthog.utils import get_machine_id
+
+# Any single table whose in-memory Arrow payload crosses this is logged and captured as a PostHog
+# event with the pod/team/schema/source context needed to reproduce it. The metrics below capture the
+# full distribution; this surfaces the specific offenders to fix. Event volume is bounded because it
+# only fires on the outliers (a paginating source can call record_table_stats thousands of times per
+# sync — one event each would flood ingestion; the histograms carry that full distribution instead).
 OUTLIER_TABLE_BYTES: int = 512 * 1024 * 1024  # 512 MiB
+
+# The event a large table emits. Tagged with pod/host, source_type, schema_name, team_id, rows, bytes.
+LARGE_TABLE_EVENT = "data_import_large_table"
+
+
+def _pod_name() -> Optional[str]:
+    """The k8s pod name (== the container hostname) so events can be sliced by pod/host."""
+    return os.environ.get("HOSTNAME")
 
 
 def _column_payload_bytes(col: pa.ChunkedArray) -> int:
@@ -71,8 +85,9 @@ def record_table_stats(
     """Record row/byte size for one source table, keyed on `(source_type, stage)`.
 
     Safe outside an activity (unit tests construct the pipeline/batcher directly): the Temporal meter
-    is only touched inside an activity context; the outlier log still fires. Metric labels are kept to
-    `source_type` + `stage` (bounded cardinality) — `team_id`/`schema_name` ride the outlier log only.
+    is only touched inside an activity context; the outlier log + event still fire. Metric labels are
+    kept to `source_type` + `stage` (bounded cardinality); `pod`/`team_id`/`schema_name` ride the
+    outlier log and the PostHog event only.
     """
     resolved_source_type = source_type or "unknown"
     if activity.in_activity():
@@ -85,15 +100,38 @@ def record_table_stats(
                 "data_import_table_bytes", "In-memory Arrow payload of one source table", "By"
             ).record(max(payload_bytes, 0))
     if payload_bytes is not None and payload_bytes >= OUTLIER_TABLE_BYTES:
+        pod_name = _pod_name()
         logger.warning(
-            "data_import_large_table",
+            LARGE_TABLE_EVENT,
             source_type=resolved_source_type,
             stage=stage,
             payload_bytes=payload_bytes,
             num_rows=num_rows,
             team_id=team_id,
             schema_name=schema_name,
+            pod_name=pod_name,
         )
+        # Long-lived Temporal worker, so posthoganalytics' background flush thread stays alive
+        # (unlike the Celery pitfall) — this matches capture_repartition_event. Best-effort: a
+        # telemetry failure must never fail the import.
+        try:
+            machine_id = get_machine_id()
+            posthoganalytics.capture(
+                distinct_id=machine_id,
+                event=LARGE_TABLE_EVENT,
+                properties={
+                    "source_type": resolved_source_type,
+                    "stage": stage,
+                    "num_rows": num_rows,
+                    "payload_bytes": payload_bytes,
+                    "team_id": team_id,
+                    "schema_name": schema_name,
+                    "pod_name": pod_name,
+                    "machine_id": machine_id,
+                },
+            )
+        except Exception:
+            logger.debug("Failed to capture data_import_large_table event", exc_info=True)
 
 
 def record_source_item_stats(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/table_stats.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/table_stats.py
@@ -1,0 +1,130 @@
+"""Per-table size telemetry for the data-import pipelines.
+
+Emits how much data each source pulls into the pod, tagged by `(source_type, stage)`, so an
+unbounded source materialisation shows up as a high, chunk-size-insensitive tail per source. Two
+stages are recorded because a source can bypass the shared `Batcher` (e.g. yielding `pa.Table`s
+directly, or a future extract path): `stage="pipeline"` is the raw item off `resource.items()` (the
+catch-all, every source), `stage="batcher"` is the materialised Arrow table (the true in-memory
+peak). Bytes are optional because a list item's Arrow size isn't known until it's materialised.
+
+`table_payload_bytes` is slice-accurate (unlike `pa.Table.nbytes`, which reports the full shared
+buffer for a zero-copy slice) — the `Batcher` produces zero-copy slices, so `.nbytes` would
+over-count there.
+"""
+
+from typing import Any, Optional
+
+import pyarrow as pa
+import pyarrow.compute as pc
+from structlog.types import FilteringBoundLogger
+from temporalio import activity
+
+# Any single table whose in-memory Arrow payload crosses this is logged with the team/schema/source
+# context needed to reproduce it. The metrics below capture the full distribution; this surfaces the
+# specific offenders to fix.
+OUTLIER_TABLE_BYTES: int = 512 * 1024 * 1024  # 512 MiB
+
+
+def _column_payload_bytes(col: pa.ChunkedArray) -> int:
+    """Slice-accurate in-memory payload bytes: value bytes + offset buffer (string/binary/list)
+    or col_length * byte_width (fixed-width); nested/other types return 0. Avoids `.nbytes` (wrong for slices)."""
+    col_type = col.type
+    col_length = len(col)
+    if pa.types.is_string(col_type) or pa.types.is_binary(col_type):
+        payload = int(pc.sum(pc.binary_length(col)).as_py() or 0)
+        return payload + col_length * 4  # value bytes + 32-bit offsets
+    if pa.types.is_large_string(col_type) or pa.types.is_large_binary(col_type):
+        payload = int(pc.sum(pc.binary_length(col)).as_py() or 0)
+        return payload + col_length * 8
+    if pa.types.is_list(col_type):
+        elements = int(pc.sum(pc.list_value_length(col)).as_py() or 0)
+        return elements + col_length * 4
+    if pa.types.is_struct(col_type):
+        # Recurse into child fields so a nested struct (e.g. a Mongo document under `data`) is counted
+        # instead of undercounting to 0. A flatten failure degrades to 0 rather than breaking accounting.
+        try:
+            return sum(_column_payload_bytes(child) for child in col.flatten())
+        except Exception:
+            return 0
+    # Fixed-width primitives expose bit_width; variable-length / other nested types raise -> 0.
+    try:
+        bit_width = col_type.bit_width
+    except (ValueError, AttributeError):
+        return 0
+    return col_length * (bit_width // 8)
+
+
+def table_payload_bytes(table: pa.Table) -> int:
+    return sum(_column_payload_bytes(table.column(name)) for name in table.column_names)
+
+
+def record_table_stats(
+    *,
+    source_type: Optional[str],
+    stage: str,
+    num_rows: int,
+    payload_bytes: Optional[int],
+    logger: FilteringBoundLogger,
+    team_id: Optional[int] = None,
+    schema_name: Optional[str] = None,
+) -> None:
+    """Record row/byte size for one source table, keyed on `(source_type, stage)`.
+
+    Safe outside an activity (unit tests construct the pipeline/batcher directly): the Temporal meter
+    is only touched inside an activity context; the outlier log still fires. Metric labels are kept to
+    `source_type` + `stage` (bounded cardinality) — `team_id`/`schema_name` ride the outlier log only.
+    """
+    resolved_source_type = source_type or "unknown"
+    if activity.in_activity():
+        meter = activity.metric_meter().with_additional_attributes(
+            {"source_type": resolved_source_type, "stage": stage}
+        )
+        meter.create_histogram("data_import_table_rows", "Row count of one source table").record(max(num_rows, 0))
+        if payload_bytes is not None:
+            meter.create_histogram(
+                "data_import_table_bytes", "In-memory Arrow payload of one source table", "By"
+            ).record(max(payload_bytes, 0))
+    if payload_bytes is not None and payload_bytes >= OUTLIER_TABLE_BYTES:
+        logger.warning(
+            "data_import_large_table",
+            source_type=resolved_source_type,
+            stage=stage,
+            payload_bytes=payload_bytes,
+            num_rows=num_rows,
+            team_id=team_id,
+            schema_name=schema_name,
+        )
+
+
+def record_source_item_stats(
+    item: Any,
+    *,
+    source_type: Optional[str],
+    logger: FilteringBoundLogger,
+    team_id: Optional[int] = None,
+    schema_name: Optional[str] = None,
+) -> None:
+    """Measure one raw item yielded by a source (the `stage="pipeline"` catch-all, before batching).
+
+    Every source flows through here regardless of whether it uses the shared `Batcher`. Row count is
+    always known; Arrow bytes only for a `pa.Table` item — a list/dict isn't materialised yet, so its
+    bytes are recorded at `stage="batcher"` instead.
+    """
+    if isinstance(item, pa.Table):
+        num_rows = item.num_rows
+        payload_bytes: Optional[int] = table_payload_bytes(item)
+    elif isinstance(item, list):
+        num_rows = len(item)
+        payload_bytes = None
+    else:  # a single dict row
+        num_rows = 1
+        payload_bytes = None
+    record_table_stats(
+        source_type=source_type,
+        stage="pipeline",
+        num_rows=num_rows,
+        payload_bytes=payload_bytes,
+        logger=logger,
+        team_id=team_id,
+        schema_name=schema_name,
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_batcher.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_batcher.py
@@ -7,10 +7,12 @@ from parameterized import parameterized
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import (
     Batcher,
     _column_offset_pressure,
-    _column_payload_bytes,
     _max_offset_pressure,
     _split_table,
-    _table_payload_bytes,
+)
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.table_stats import (
+    _column_payload_bytes,
+    table_payload_bytes,
 )
 
 
@@ -225,9 +227,9 @@ def test_table_payload_bytes_is_slice_accurate():
     # buffer for a zero-copy slice and would make the byte-driven split non-converging.
     table = pa.table({"val": ["aaaa", "bbbb", "cccc", "dddd"]})
 
-    full = _table_payload_bytes(table)
-    first_half = _table_payload_bytes(table.slice(0, 2))
-    second_half = _table_payload_bytes(table.slice(2, 2))
+    full = table_payload_bytes(table)
+    first_half = table_payload_bytes(table.slice(0, 2))
+    second_half = table_payload_bytes(table.slice(2, 2))
 
     assert first_half < full
     assert first_half == second_half  # equal-sized rows here
@@ -241,7 +243,7 @@ def test_split_table_splits_on_bytes_when_offset_is_under_limit():
 
     assert len(result) > 1
     for slice_table in result:
-        assert _table_payload_bytes(slice_table) <= 14 or slice_table.num_rows <= 1
+        assert table_payload_bytes(slice_table) <= 14 or slice_table.num_rows <= 1
     assert pa.concat_tables(result).equals(table)
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_table_stats.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_table_stats.py
@@ -11,7 +11,10 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     record_table_stats,
 )
 
-_STATS = "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.table_stats.record_table_stats"
+_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.table_stats"
+_STATS = f"{_MODULE}.record_table_stats"
+_CAPTURE = f"{_MODULE}.posthoganalytics.capture"
+_POD = f"{_MODULE}._pod_name"
 _BATCHER_STATS = (
     "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher.record_table_stats"
 )
@@ -33,29 +36,53 @@ class TestRecordTableStats:
             )
         )
 
-    def test_outlier_log_fires_at_threshold(self):
+    def test_outlier_logs_and_captures_event_with_full_tags(self):
         logger = mock.MagicMock()
-        record_table_stats(
-            source_type="Stripe",
-            stage="batcher",
-            num_rows=10,
-            payload_bytes=OUTLIER_TABLE_BYTES,
-            logger=logger,
-            team_id=7,
-            schema_name="charges",
-        )
+        with mock.patch(_CAPTURE) as capture, mock.patch(_POD, return_value="warehouse-sources-load-abc123"):
+            record_table_stats(
+                source_type="Stripe",
+                stage="batcher",
+                num_rows=10,
+                payload_bytes=OUTLIER_TABLE_BYTES,
+                logger=logger,
+                team_id=7,
+                schema_name="charges",
+            )
         logger.warning.assert_called_once()
         assert logger.warning.call_args.args[0] == "data_import_large_table"
-        assert logger.warning.call_args.kwargs["team_id"] == 7
-        assert logger.warning.call_args.kwargs["schema_name"] == "charges"
+
+        capture.assert_called_once()
+        assert capture.call_args.kwargs["event"] == "data_import_large_table"
+        assert capture.call_args.kwargs["distinct_id"]  # machine id used as distinct_id
+        props = capture.call_args.kwargs["properties"]
+        assert props["source_type"] == "Stripe"
+        assert props["stage"] == "batcher"
+        assert props["team_id"] == 7
+        assert props["schema_name"] == "charges"
+        assert props["num_rows"] == 10
+        assert props["payload_bytes"] == OUTLIER_TABLE_BYTES
+        assert props["pod_name"] == "warehouse-sources-load-abc123"
+
+    def test_capture_failure_is_swallowed(self):
+        # A telemetry failure must never fail the import.
+        with mock.patch(_CAPTURE, side_effect=RuntimeError("boom")):
+            record_table_stats(
+                source_type="Stripe",
+                stage="batcher",
+                num_rows=10,
+                payload_bytes=OUTLIER_TABLE_BYTES,
+                logger=mock.MagicMock(),
+            )
 
     @parameterized.expand([("below_threshold", OUTLIER_TABLE_BYTES - 1), ("bytes_unknown", None)])
-    def test_no_outlier_log(self, _name, payload_bytes):
+    def test_no_outlier_log_or_event(self, _name, payload_bytes):
         logger = mock.MagicMock()
-        record_table_stats(
-            source_type="Stripe", stage="pipeline", num_rows=10, payload_bytes=payload_bytes, logger=logger
-        )
+        with mock.patch(_CAPTURE) as capture:
+            record_table_stats(
+                source_type="Stripe", stage="pipeline", num_rows=10, payload_bytes=payload_bytes, logger=logger
+            )
         logger.warning.assert_not_called()
+        capture.assert_not_called()
 
 
 class TestRecordSourceItemStats:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_table_stats.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_table_stats.py
@@ -1,0 +1,106 @@
+from unittest import mock
+
+import pyarrow as pa
+from parameterized import parameterized
+from temporalio.testing import ActivityEnvironment
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import Batcher
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.table_stats import (
+    OUTLIER_TABLE_BYTES,
+    record_source_item_stats,
+    record_table_stats,
+)
+
+_STATS = "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.table_stats.record_table_stats"
+_BATCHER_STATS = (
+    "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher.record_table_stats"
+)
+
+
+class TestRecordTableStats:
+    def test_safe_outside_activity_context(self):
+        # The pipeline/batcher are constructed directly in unit tests, so this must not touch the
+        # Temporal meter (which requires an activity) — it should simply no-op the metric.
+        record_table_stats(
+            source_type="Stripe", stage="batcher", num_rows=5, payload_bytes=100, logger=mock.MagicMock()
+        )
+
+    def test_records_metrics_inside_activity(self):
+        # Exercises the real meter path (guards against a wrong create_histogram signature).
+        ActivityEnvironment().run(
+            lambda: record_table_stats(
+                source_type="Stripe", stage="pipeline", num_rows=5, payload_bytes=100, logger=mock.MagicMock()
+            )
+        )
+
+    def test_outlier_log_fires_at_threshold(self):
+        logger = mock.MagicMock()
+        record_table_stats(
+            source_type="Stripe",
+            stage="batcher",
+            num_rows=10,
+            payload_bytes=OUTLIER_TABLE_BYTES,
+            logger=logger,
+            team_id=7,
+            schema_name="charges",
+        )
+        logger.warning.assert_called_once()
+        assert logger.warning.call_args.args[0] == "data_import_large_table"
+        assert logger.warning.call_args.kwargs["team_id"] == 7
+        assert logger.warning.call_args.kwargs["schema_name"] == "charges"
+
+    @parameterized.expand([("below_threshold", OUTLIER_TABLE_BYTES - 1), ("bytes_unknown", None)])
+    def test_no_outlier_log(self, _name, payload_bytes):
+        logger = mock.MagicMock()
+        record_table_stats(
+            source_type="Stripe", stage="pipeline", num_rows=10, payload_bytes=payload_bytes, logger=logger
+        )
+        logger.warning.assert_not_called()
+
+
+class TestRecordSourceItemStats:
+    def test_pa_table_reports_rows_and_bytes(self):
+        item = pa.table({"a": [1, 2, 3], "s": ["xx", "yy", "zz"]})
+        with mock.patch(_STATS) as recorded:
+            record_source_item_stats(item, source_type="Stripe", logger=mock.MagicMock())
+        kwargs = recorded.call_args.kwargs
+        assert kwargs["stage"] == "pipeline"
+        assert kwargs["num_rows"] == 3
+        assert kwargs["payload_bytes"] is not None and kwargs["payload_bytes"] > 0
+
+    @parameterized.expand(
+        [
+            ("list_of_rows", [{"a": 1}, {"a": 2}], 2),
+            ("single_dict_row", {"a": 1}, 1),
+        ]
+    )
+    def test_unmaterialized_item_reports_rows_only(self, _name, item, expected_rows):
+        with mock.patch(_STATS) as recorded:
+            record_source_item_stats(item, source_type="Stripe", logger=mock.MagicMock())
+        kwargs = recorded.call_args.kwargs
+        assert kwargs["num_rows"] == expected_rows
+        # Arrow size is unknown before materialisation; the batcher stage records it instead.
+        assert kwargs["payload_bytes"] is None
+
+
+class TestBatcherStatsEmission:
+    def test_emits_batcher_stage_when_source_type_set(self):
+        with mock.patch(_BATCHER_STATS) as recorded:
+            batcher = Batcher(logger=mock.MagicMock(), source_type="Stripe", team_id=1, schema_name="charges")
+            batcher.batch(pa.table({"a": [1, 2, 3]}))
+            batcher.get_table()
+        recorded.assert_called_once()
+        kwargs = recorded.call_args.kwargs
+        assert kwargs["source_type"] == "Stripe"
+        assert kwargs["stage"] == "batcher"
+        assert kwargs["num_rows"] == 3
+        assert kwargs["payload_bytes"] is not None
+
+    def test_silent_when_source_type_absent(self):
+        # Source-internal batchers leave source_type None; their output is measured when it reaches
+        # the pipeline's own batcher, so this must not double-count.
+        with mock.patch(_BATCHER_STATS) as recorded:
+            batcher = Batcher(logger=mock.MagicMock())
+            batcher.batch(pa.table({"a": [1, 2, 3]}))
+            batcher.get_table()
+        recorded.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -55,6 +55,9 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     PersonPropertyRowSink,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.pipeline import async_iterate
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.table_stats import (
+    record_source_item_stats,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
     PipelineResult,
     ResumableData,
@@ -218,6 +221,9 @@ class PipelineV3(Generic[ResumableData]):
             self._logger,
             chunk_size=source_response.chunk_size,
             chunk_size_bytes=source_response.chunk_size_bytes,
+            source_type=self._source.source_type if self._source else None,
+            team_id=self._job.team_id,
+            schema_name=self._schema.name,
         )
         self._internal_schema = HogQLSchema()
         self._cdp_producer = CDPProducer(
@@ -319,6 +325,14 @@ class PipelineV3(Generic[ResumableData]):
 
             async for item in async_iterate(self._resource.items()):
                 py_table = None
+
+                record_source_item_stats(
+                    item,
+                    source_type=source_type,
+                    logger=self._logger,
+                    team_id=self._job.team_id,
+                    schema_name=self._schema.name,
+                )
 
                 self._batcher.batch(item)
 


### PR DESCRIPTION
## Problem

The data-warehouse temporal workers still spike to ~29 GB and OOM even with delta-rs merge spill enabled, because the peak isn't in the (spillable) merge — it's the in-memory PyArrow table a source materialises before the merge (`table_from_py_list`). The batcher caps each *output* chunk at 256 MiB, but the peak is one line earlier: a source that yields a giant list in a single `yield` materialises the whole thing at once, and `_split_table` then hands out zero-copy slices that keep the full table resident until the last one drains.

We had no way to see *which* sources do this — the per-source manual `Batcher(chunk_size=2000, …)` patches on a handful of sources are the tell that this was being spotted by hand, not measured.

## Changes

Adds per-table size telemetry to the import pipelines so an unbounded source materialisation shows up as a high, chunk-size-insensitive tail per `source_type`.

- New `table_stats.py` helper: `record_table_stats(...)` emits two Temporal histograms — `data_import_table_rows` and `data_import_table_bytes` — labelled `(source_type, stage)`, plus a `data_import_large_table` warning log (carrying `team_id`/`schema_name`) for any table over 512 MiB of Arrow payload. Metric labels are kept to `source_type` + `stage` to bound cardinality; team/schema ride the log only.
- Recorded from **two** places, because a source can bypass the shared `Batcher` (e.g. yielding `pa.Table`s directly, or a future extract path):
  - `stage="pipeline"` — the raw item off `resource.items()`, the catch-all that sees every source. Wired into both the v2 (`pipeline/pipeline.py`) and v3 (`pipeline_v3/pipeline.py`) run loops. Rows always; Arrow bytes only for `pa.Table` items (a list/dict isn't materialised yet).
  - `stage="batcher"` — the materialised Arrow table in `Batcher._set_ready`, the true in-memory peak. Only emitted when the batcher was given a `source_type` (the pipeline-configured one), so source-internal batchers don't double-count.
- The slice-accurate byte helpers (`table_payload_bytes` / `_column_payload_bytes`) move from `batcher.py` into `table_stats.py` so both call sites share one implementation; `batcher.py` imports them back.
- The emit is a no-op outside an activity context (`activity.in_activity()` guard), so unit tests that construct the pipeline/batcher directly don't touch the meter.
- **PostHog event:** an outlier table (> 512 MiB Arrow payload) also emits a `data_import_large_table` PostHog event tagged with **pod name/host** (`HOSTNAME`), `source_type`, `schema_name`, `team_id`, `num_rows`, `payload_bytes`, `stage`, and `machine_id` — so the offenders are queryable in PostHog, not just Grafana. It's gated to the outlier path on purpose: `record_table_stats` fires per table/chunk, so a paginating source would otherwise emit thousands of events per sync — the histograms carry the full distribution, the event carries the specific offenders. Uses `posthoganalytics.capture(distinct_id=get_machine_id())` like `capture_repartition_event` (safe here — the Temporal worker is long-lived, unlike the Celery pitfall), and swallows any capture failure so telemetry never fails an import.

Once this is in, finding the offenders is a Grafana query — rank `source_type` by `max`/`p99` of `data_import_table_bytes`; bounded sources sit under the ~256 MiB chunk budget, unbounded ones show a flat high tail — and the `data_import_large_table` log/event gives the exact `(pod, source_type, schema, team)` to reproduce. No behaviour change; this only measures.

## How did you test this code?

New `test_table_stats.py`:

- `record_table_stats` is safe outside an activity (no meter access), and its real meter path runs under `ActivityEnvironment` (guards against a wrong `create_histogram` signature).
- Outlier log fires at/above the 512 MiB threshold with `team_id`/`schema_name`, and stays silent below it and when bytes are unknown.
- `record_source_item_stats` reports rows+bytes for a `pa.Table` and rows-only for list/dict items (parameterized).
- `Batcher` emits `stage="batcher"` with the right `source_type`/rows when a `source_type` is set, and stays silent (no double-count) when it isn't.
- An outlier logs **and** captures the `data_import_large_table` event with the full tag set (asserts `pod_name`, `source_type`, `schema_name`, `team_id`, rows, bytes); below the threshold (or when bytes are unknown) neither fires; and a `capture` that raises is swallowed.

Ran locally: `test_table_stats.py` + the existing `test_batcher.py` (updated for the moved helpers) — 47 passed. Both pipeline modules import cleanly. `ruff` clean; `hogli ci:preflight` green.

## Docs update

None — internal telemetry, no user-facing surface.
