### PR TITLE
fix(data-imports): bucket non-integer numerical partition keys instead of crashing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -970,6 +970,29 @@ def test_append_partition_key_numerical_handles_null_key():
     assert partitioned_table.column(PARTITION_KEY).to_pylist() == ["1", "2", "null", "4"]
 
 
+def test_append_partition_key_numerical_handles_non_int_key():
+    # Numerical mode is persisted per source and passed back in on later batches, skipping the
+    # detection guard that requires an integer key column. If the source's key column has since
+    # changed type, the values arrive as strings and used to crash the batch on `str // int`.
+    # Numeric strings must keep their original bucket; non-numeric ones fall into the null bucket.
+    table = pa.table({"id": pa.array(["250", "10", "not-a-number"], type=pa.string())})
+
+    result = append_partition_key_to_table(
+        table=table,
+        partition_count=None,
+        partition_size=100,
+        partition_keys=["id"],
+        partition_mode="numerical",
+        partition_format=None,
+        logger=cast(FilteringBoundLogger, structlog.get_logger()),
+    )
+
+    assert result is not None
+    partitioned_table, mode, _, _ = result
+    assert mode == "numerical"
+    assert partitioned_table.column(PARTITION_KEY).to_pylist() == ["2", "0", "null"]
+
+
 def _mock_schema(**overrides: Any) -> MagicMock:
     schema = MagicMock()
     schema.partition_count = overrides.get("partition_count")

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
@@ -672,8 +672,19 @@ def append_partition_key_to_table(
 
                 if key_value is None:
                     partition_array.append(NULL_NUMERICAL_PARTITION)
-                else:
+                elif isinstance(key_value, int):
                     partition_array.append(str(key_value // partition_size))
+                else:
+                    # A persisted "numerical" mode can outlive the integer key column that
+                    # justified it (e.g. the source's key column changed type mid-sync). Coerce
+                    # numeric values back to int so rows keep their original bucket; anything that
+                    # isn't integer-like lands in the null bucket instead of crashing the sync.
+                    try:
+                        coerced_key_value = int(key_value)
+                    except (TypeError, ValueError):
+                        partition_array.append(NULL_NUMERICAL_PARTITION)
+                    else:
+                        partition_array.append(str(coerced_key_value // partition_size))
             elif mode == "datetime":
                 key = normalized_partition_keys[0]
                 date = row[key]


### PR DESCRIPTION
## Problem

The data-warehouse import pipeline is throwing a `TypeError: unsupported operand type(s) for //: 'str' and 'int'` (and previously `'NoneType' and 'int'`) from `append_partition_key_to_table` in shared pipeline code. It fires on every batch of an affected sync, so it retries indefinitely without ever making progress.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019efe39-e35d-7e53-a3ab-6a4f026b3d7b

Root cause: numerical partition mode is only *selected* when the key column is detected as an integer. But once selected, the mode is persisted on the schema and passed back in on later batches, which skips the whole detection block. If the source's key column then changes type, the values arrive as strings (or other non-int types) and the numerical branch does `key_value // partition_size` on them, which blows up.

The `None` case was already handled. This closes the remaining gap for non-integer values.

## Changes

In the numerical branch of `append_partition_key_to_table`:

- Integers keep their exact existing behavior.
- Non-int values are coerced with `int(...)` so a numeric string keeps the *same* bucket it would have had as an int, preserving partition consistency with already-written data.
- Anything that isn't integer-like falls into the existing null bucket instead of crashing the sync.

```diff
                 if key_value is None:
                     partition_array.append(NULL_NUMERICAL_PARTITION)
-                else:
-                    partition_array.append(str(key_value // partition_size))
+                elif isinstance(key_value, int):
+                    partition_array.append(str(key_value // partition_size))
+                else:
+                    try:
+                        coerced_key_value = int(key_value)
+                    except (TypeError, ValueError):
+                        partition_array.append(NULL_NUMERICAL_PARTITION)
+                    else:
+                        partition_array.append(str(coerced_key_value // partition_size))
```

This is our bug, not a user/upstream one: retrying can't help because every batch hits the same rows, so marking it non-retryable would just hide a fixable data-shape mismatch. Fixing the shared code resolves the whole class.

## How did you test this code?

Added `test_append_partition_key_numerical_handles_non_int_key`: with a persisted `numerical` mode and a string key column, numeric strings bucket to their integer partition and a non-numeric value lands in the null bucket. Without the fix this test raises `TypeError`; no existing test covered persisted numerical mode with a non-integer column (the existing tests cover `None` and the `partition_size=None` path that never reaches the numerical branch).

Ran locally:

```
uv run pytest .../test_pipeline_utils.py::test_append_partition_key_numerical_handles_non_int_key \
  .../test_pipeline_utils.py::test_append_partition_key_numerical_handles_null_key \
  .../test_pipeline_utils.py::test_append_partition_key_to_table_does_not_type_error
# 5 passed
```

I (Claude) did not run the full pipeline against a live source.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the linked error-tracking issue: pulled the stack trace and sampled events (all live occurrences show `str // int`), traced the call path `_process_pa_table` → `setup_partitioning` → `append_partition_key_to_table`, and confirmed the persisted-mode path skips type detection. Checked open PRs first — #72145 handles only the `None` case (already on master) and #72250 is datetime-mode, so neither covers this. Invoked `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
