### PR TITLE
fix(data-imports): stop tracking benign worker-shutdown errors

### DIFF
--- a/posthog/temporal/common/posthog_client.py
+++ b/posthog/temporal/common/posthog_client.py
@@ -17,6 +17,7 @@ from temporalio.worker import (
 from posthog.egress.transport.transport import EgressBudgetExhausted
 from posthog.temporal.common.interceptor import ALL_TASK_QUEUES
 from posthog.temporal.common.logger import get_write_only_logger
+from posthog.temporal.common.shutdown import WorkerShuttingDownError
 
 logger = get_write_only_logger()
 
@@ -66,11 +67,14 @@ class _PostHogClientActivityInboundInterceptor(ActivityInboundInterceptor):
         try:
             return await super().execute_activity(input)
         except Exception as e:
-            # Cancellations (worker drain, activity timeout, workflow cancellation) and our own
-            # egress-budget backpressure (a deliberate "defer and retry later" signal that our
-            # rate limiter already records via record_outbound_decision) are expected control flow,
-            # not defects — re-raise without reporting them to error tracking.
-            if temporalio.exceptions.is_cancelled_exception(e) or isinstance(e, EgressBudgetExhausted):
+            # Cancellations (worker drain, activity timeout, workflow cancellation), a cooperative
+            # worker shutdown (raised mid-activity during a deploy, always retried on a fresh
+            # worker), and our own egress-budget backpressure (a deliberate "defer and retry later"
+            # signal that our rate limiter already records via record_outbound_decision) are expected
+            # control flow, not defects — re-raise without reporting them to error tracking.
+            if temporalio.exceptions.is_cancelled_exception(e) or isinstance(
+                e, EgressBudgetExhausted | WorkerShuttingDownError
+            ):
                 raise
             activity_info = activity.info()
             capture_kwargs = {

--- a/posthog/temporal/tests/common/test_error_tracking.py
+++ b/posthog/temporal/tests/common/test_error_tracking.py
@@ -16,6 +16,7 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.egress.github.transport import GitHubEgressBudgetExhausted
 from posthog.temporal.common.posthog_client import PostHogClientInterceptor
+from posthog.temporal.common.shutdown import WorkerShuttingDownError
 
 
 @dataclass
@@ -109,6 +110,24 @@ class EgressBackpressureActivityWorkflow:
     async def run(self, inputs: OptionallyFailingInputs) -> None:
         await workflow.execute_activity(
             egress_backpressure_activity,
+            inputs,
+            start_to_close_timeout=dt.timedelta(minutes=1),
+            heartbeat_timeout=dt.timedelta(seconds=5),
+            retry_policy=RetryPolicy(maximum_attempts=1),
+        )
+
+
+@activity.defn
+async def worker_shutting_down_activity(inputs: OptionallyFailingInputs) -> None:
+    raise WorkerShuttingDownError.from_activity_context()
+
+
+@workflow.defn
+class WorkerShuttingDownActivityWorkflow:
+    @workflow.run
+    async def run(self, inputs: OptionallyFailingInputs) -> None:
+        await workflow.execute_activity(
+            worker_shutting_down_activity,
             inputs,
             start_to_close_timeout=dt.timedelta(minutes=1),
             heartbeat_timeout=dt.timedelta(seconds=5),
@@ -245,6 +264,35 @@ async def test_egress_backpressure_is_not_captured(temporal_client: Client):
             with pytest.raises(WorkflowFailureError):
                 await temporal_client.execute_workflow(
                     "EgressBackpressureActivityWorkflow",
+                    OptionallyFailingInputs(fail=True),
+                    id=workflow_id,
+                    task_queue=task_queue,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                )
+
+        mock_ph_capture.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_worker_shutting_down_is_not_captured(temporal_client: Client):
+    """A cooperative worker shutdown raised mid-activity (during a deploy) is expected control flow
+    that is always retried on a fresh worker, so the interceptor must re-raise it without reporting
+    it to error tracking."""
+    task_queue = "TEST-TASK-QUEUE"
+    workflow_id = str(uuid.uuid4())
+
+    with patch("posthog.temporal.common.posthog_client.capture_exception") as mock_ph_capture:
+        async with Worker(
+            temporal_client,
+            task_queue=task_queue,
+            workflows=[WorkerShuttingDownActivityWorkflow],
+            activities=[worker_shutting_down_activity],
+            interceptors=[PostHogClientInterceptor()],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with pytest.raises(WorkflowFailureError):
+                await temporal_client.execute_workflow(
+                    "WorkerShuttingDownActivityWorkflow",
                     OptionallyFailingInputs(fail=True),
                     id=workflow_id,
                     task_queue=task_queue,


### PR DESCRIPTION
## Problem

The data-warehouse import pipeline surfaces a high volume of `WorkerShuttingDownError` events in [error tracking](https://us.posthog.com/project/2/error_tracking/019ed05f-13b0-7262-a03b-e5303897295f). These are not real failures.

The error is raised by the cooperative shutdown check (`ShutdownMonitor.raise_if_is_worker_shutdown`) when a worker is drained mid-activity, which normally happens during a deploy. Its own docstring says it should always be retried, and Temporal does exactly that on a fresh worker. So the import completes fine, but every drained activity leaves behind a tracked exception. The captured events are all `handled: true` and originate from `posthog/temporal/common/shutdown.py`, across many sources and teams, which is why it lands in shared pipeline code rather than a single connector.

## Changes

The actual capture happens in the shared Temporal activity interceptor (`posthog/temporal/common/posthog_client.py`), which already re-raises expected control flow without reporting it: cancellations (worker drain, timeout, cancel) and our own egress-budget backpressure. I added `WorkerShuttingDownError` to that same bypass.

This is a general fix at the shared layer, so it covers every activity that uses `ShutdownMonitor`, not just data imports. Retry behavior is unchanged: the interceptor still re-raises, so Temporal retries on a fresh worker exactly as before. The change only stops the error-tracking capture.

It is scoped by exception type. `WorkerShuttingDownError` is only ever raised by the shutdown check, so excluding it cannot mask a real bug.

> [!NOTE]
> There is a separate open PR ([#71643](https://github.com/PostHog/posthog/pull/71643)) that introduces a different `WorkerShuttingDownError` class in `posthog/temporal/common/client.py` for a web-worker interpreter-shutdown race in `sync_connect()`. That is an unrelated root cause and capture path. This PR targets the existing `shutdown.py` class raised inside import activities.

## How did you test this code?

Added `test_worker_shutting_down_is_not_captured` to `posthog/temporal/tests/common/test_error_tracking.py`, mirroring the existing `test_cancellation_is_not_captured` and `test_egress_backpressure_is_not_captured` cases. It runs an activity that raises `WorkerShuttingDownError` through a real Worker with the interceptor installed and asserts `capture_exception` is never called. The regression it catches: if someone drops the type from the interceptor bypass, the shutdown noise starts flowing back into error tracking.

These interceptor tests need a live Temporal server (the `temporal_client` fixture), which I could not run in this environment, so I did not run them locally. I verified the import graph loads with no circular import, the `isinstance` union check behaves as expected, and ran ruff lint and format on both files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue with the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`). The stack trace pointed at `raise_if_is_worker_shutdown`; from there I traced the capture to the shared activity interceptor. Invoked the `/writing-tests` skill before adding the test.

Considered fixing at the data-imports layer (`_handle_import_error`) but chose the shared interceptor because it is the single capture point and resolves the whole class of activities cleanly. Confirmed [#71643](https://github.com/PostHog/posthog/pull/71643) addresses a different `WorkerShuttingDownError`, so this is not a duplicate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
