### PR TITLE
fix(mysql): stop tracking self-recovering lost-connection errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/source.py
@@ -281,6 +281,14 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             "ordinal not in range(256)": "One of your connection details contains an invisible or unsupported character (for example a zero-width space pasted in from another app). Retype the affected field — host, database, user, or password — by hand instead of pasting it, then re-enable the sync.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_connect_with_transient_retry` already retries this exact drop in-process (see
+        # `_is_transient_connect_drop` in mysql.py) before re-raising once its attempt budget is
+        # exhausted; the streaming path's FORCE INDEX fallback does the same for a mid-query drop
+        # (see `_is_bad_plan_error`). Either way, Temporal retries the whole activity next and the
+        # failure is transient and self-recovering, so don't surface it as tracked exception noise.
+        return {"Lost connection to MySQL server during query"}
+
     def reconcile_schema_metadata(
         self,
         source: "ExternalDataSource",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1922,6 +1922,22 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "OperationalError: (2013, 'Lost connection to MySQL server during query')",
+            "Lost connection to MySQL server during query",
+        ],
+    )
+    def test_transient_lost_connection_is_classified_retryable(self, source, error_msg):
+        # Already retried in-process (connect-time and streaming-query FORCE INDEX fallback); once
+        # exhausted it re-raises for Temporal to retry the whole activity. Without this
+        # classification `_handle_import_error` logs it at `exception` on every occurrence,
+        # flooding error tracking with a self-recovering failure.
+        retryable = source.get_retryable_errors()
+        is_retryable = any(pattern in error_msg for pattern in retryable)
+        assert is_retryable, f"Transient lost-connection error should be classified retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # MySQL error 1135: the server reached the connection but couldn't spawn an OS thread
             # to service it (errno 11 EAGAIN). This is a transient, server-side resource exhaustion
             # — it clears as concurrent connections close — so it must keep retrying, just like


### PR DESCRIPTION
## Problem

Error tracking has been flooded by an `OperationalError: (2013, 'Lost connection to MySQL server during query')` from the MySQL/MariaDB import source — tens of thousands of occurrences over the past couple of months, all originating in `_connect_with_transient_retry` in `products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py`.

This isn't a bug: the source already retries this exact drop in-process before giving up —
- At connect time, `_connect_with_transient_retry` retries a transient `2013` drop (no SSL signature) up to `_MAX_CONNECT_ATTEMPTS` times (`_is_transient_connect_drop`).
- Mid-stream, the same code is retried once via the `FORCE INDEX` fallback (`_is_bad_plan_error`).

Once those in-process retries are exhausted, the error is re-raised, Temporal retries the whole activity, and the sync usually recovers on its own. It stayed correctly *retryable* (it's not in `get_non_retryable_errors`), but `_handle_import_error` still logged it at `exception` level on every occurrence, so it kept showing up as tracked noise instead of a handled, self-recovering condition.

## Changes

- Added `MySQLSource.get_retryable_errors()` matching `"Lost connection to MySQL server during query"`, so `_handle_import_error` logs it at `warning` instead of `exception` before re-raising for Temporal's retry — the same pattern already used by the ClickHouse and Matomo sources.

## How did you test this code?

Added a parameterized test, `test_transient_lost_connection_is_classified_retryable`, asserting both the raw and Temporal-wrapped message forms are recognized by `get_retryable_errors()`. Ran the full `test_mysql.py` non/retryable-error suite locally — all 35 cases pass.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from a live error-tracking issue (source: MySQL, exception `OperationalError`, message `(2013, 'Lost connection to MySQL server during query')`) plus a second issue in the same message/fingerprint class. Pulled the stack trace and event samples via PostHog's error-tracking MCP tools, which confirmed the top in-app frame in every sampled event was `_connect_with_transient_retry` — i.e. the connect-time transient-retry path, not a genuine bug.

Read through `mysql.py`'s existing transient-vs-non-retryable classification (there's an extensive, well-documented taxonomy already in place for this source) and confirmed the code already treats this exact drop as retryable — it just wasn't suppressed from error-tracking capture. Found the existing `get_retryable_errors()` hook (documented in `products/warehouse_sources/backend/temporal/data_imports/sources/README.md`, already used by the ClickHouse and Matomo sources for the identical "retries internally, still self-recovering" pattern) and used it here rather than inventing a new mechanism.

Searched open PRs (by exception type, message phrase, module path, and the maintainer's own open PRs) — found no existing fix for this.