### PR TITLE
fix(data-imports): handle missing partition key column during schema drift

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -1,5 +1,6 @@
 import uuid
 import decimal
+import hashlib
 import datetime
 from ipaddress import IPv4Address, IPv6Address
 from typing import Any, cast
@@ -16,6 +17,7 @@ from structlog.types import FilteringBoundLogger
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.consts import PARTITION_KEY
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.utils import (
+    NULL_NUMERICAL_PARTITION,
     SchemaColumnTypeChangedException,
     _get_max_decimal_type,
     _to_list_array,
@@ -1421,3 +1423,37 @@ def test_align_incoming_decimals_to_delta_raises_when_integer_overflows():
 
     with pytest.raises(SchemaColumnTypeChangedException):
         align_incoming_decimals_to_delta(arrow_table, delta_schema)
+
+
+@pytest.mark.parametrize(
+    "mode,partition_count,partition_size,partition_format,expected",
+    [
+        # datetime is the reported crash: a persisted `hs_timestamp`/`_creation_time` key that the
+        # source stopped returning fell into `row[key]` and raised a raw KeyError, failing every sync.
+        ("datetime", None, None, "month", "1970-01"),
+        ("numerical", None, 100, None, NULL_NUMERICAL_PARTITION),
+        ("md5", 4, None, None, str(int(hashlib.md5(b"None").hexdigest(), 16) % 4)),
+    ],
+)
+def test_append_partition_key_missing_column_buckets_into_fallback(
+    mode, partition_count, partition_size, partition_format, expected
+):
+    # A persisted partition mode is reused on later batches without re-running detection, so a source
+    # schema drift that drops the partition key column must bucket rows into a catch-all partition
+    # rather than raise a raw KeyError.
+    table = pa.table({"id": pa.array([1, 2, 3], type=pa.int64())})
+
+    result = append_partition_key_to_table(
+        table=table,
+        partition_count=partition_count,
+        partition_size=partition_size,
+        partition_keys=["dropped_field"],
+        partition_mode=mode,
+        partition_format=partition_format,
+        logger=cast(FilteringBoundLogger, structlog.get_logger()),
+    )
+
+    assert result is not None
+    partitioned_table, resolved_mode, _, _ = result
+    assert resolved_mode == mode
+    assert partitioned_table.column(PARTITION_KEY).to_pylist() == [expected, expected, expected]

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
@@ -610,7 +610,9 @@ def append_partition_key_to_table(
             mode = "md5"
 
         # If there is only one primary key and it's a numerical ID, then bucket by the ID itself instead of hashing it
-        is_partition_key_int = pa.types.is_integer(table.field(normalized_partition_keys[0]).type)
+        is_partition_key_int = normalized_partition_keys[0] in table.column_names and pa.types.is_integer(
+            table.field(normalized_partition_keys[0]).type
+        )
         are_incrementing_ints = False
         if is_partition_key_int:
             partition_column = table.column(normalized_partition_keys[0])
@@ -646,6 +648,18 @@ def append_partition_key_to_table(
         else:
             logger.debug(f"append_partition_key_to_table: partitioning mode {mode} selected")
 
+    # A persisted partition mode skips the detection block above, so the partition key column may be
+    # absent from this batch — e.g. the source's schema drifted and stopped returning the field we
+    # previously partitioned on. Reading a missing key per-row would raise a raw KeyError and fail
+    # every sync; instead those rows fall back to a catch-all bucket (via `row.get`). When the missing
+    # field is also the incremental field, the downstream incremental-value check surfaces an
+    # actionable, non-retryable error.
+    missing_partition_keys = [key for key in normalized_partition_keys if key not in table.column_names]
+    if missing_partition_keys:
+        logger.warning(
+            f"append_partition_key_to_table: partition key(s) missing from incoming table, bucketing into fallback: {missing_partition_keys}"
+        )
+
     partition_array: list[str] = []
 
     for batch in table.to_batches():
@@ -653,7 +667,7 @@ def append_partition_key_to_table(
             if mode == "md5":
                 assert partition_count is not None, "append_partition_key_to_table: partition_count is None"
 
-                primary_key_values = [str(row[key]) for key in normalized_partition_keys]
+                primary_key_values = [str(row.get(key)) for key in normalized_partition_keys]
                 delimited_primary_key_value = "|".join(primary_key_values)
 
                 # this hash has no security impact
@@ -666,7 +680,7 @@ def append_partition_key_to_table(
                 assert partition_size is not None, "append_partition_key_to_table: partition_size is None"
 
                 key = normalized_partition_keys[0]
-                key_value = row[key]
+                key_value = row.get(key)
 
                 if key_value is None:
                     partition_array.append(NULL_NUMERICAL_PARTITION)
@@ -685,7 +699,7 @@ def append_partition_key_to_table(
                         partition_array.append(str(coerced_key_value // partition_size))
             elif mode == "datetime":
                 key = normalized_partition_keys[0]
-                date = row[key]
+                date = row.get(key)
 
                 if partition_format is None:
                     partition_format = "week"


### PR DESCRIPTION
## Problem

A data-import pipeline error is firing at high volume from shared code: [`KeyError` in `append_partition_key_to_table`](https://us.posthog.com/project/2/error_tracking/019efe24-f05e-77d2-8890-45caeb24e573). The reported messages are field names like `hs_timestamp` and `_creation_time` (incremental/cursor fields used as partition keys), and it's been recurring right up to today.

Root cause: once a schema has partitioned, its partition mode and keys are persisted and passed back on every later batch. That persisted mode makes `append_partition_key_to_table` skip the detection block that validates the key exists as a column, and go straight to the row loop where `row[key]` assumes the column is still present. When a source's schema drifts and stops returning that field, `row[key]` raises a raw `KeyError` and fails the whole sync.

The closely related [`updated_at` `KeyError`](https://us.posthog.com/project/2/error_tracking/019efe4e-caf2-73d3-b54b-a20cdcf70415) in `get_incremental_field_value` is the same class and is already fixed on master (it raises the actionable `IncrementalFieldMissingFromDataError`). It stopped firing about a week ago, but the partitioning path crashes earlier, so that fix never gets a chance to run for the partition-key case.

## Changes

In `append_partition_key_to_table`:

- Read the partition key with `row.get(key)` instead of `row[key]` in all three modes. A missing column now falls back to the existing catch-all bucket rather than crashing: datetime -> `1970-01`, numerical -> `null`, md5 -> a stable bucket.
- Guard the detection-path column access (`table.field(...)`) with a `column_names` presence check so a first-ever sync with an unexpected key can't crash there either.
- Log a warning when partition keys are missing so schema drift stays visible.

This keeps the fix at the partition layer (an internal file-layout optimization we shouldn't hard-fail on) while letting the real user-actionable signal surface downstream: if the missing field is also the incremental field, `update_incremental_field_values` still raises `IncrementalFieldMissingFromDataError`, which is registered in `Any_Source_Errors` and pauses the schema with guidance instead of retrying forever.

> [!NOTE]
> This is deliberately not a new `NonRetryableErrors` entry. A missing partition key is not something a user configures directly, so failing the sync on it would be too aggressive. Graceful bucketing plus the existing incremental-field check covers both the "just a partition key" and "also the incremental field" cases.

## How did you test this code?

Added `test_append_partition_key_missing_column_buckets_into_fallback`, a parameterized pure-function test covering datetime, numerical, and md5 persisted modes with a table that lacks the partition-key column. It locks in that a dropped column buckets into the fallback partition instead of raising `KeyError` — the exact regression this fixes, which no existing test covered (existing cases only exercise null/non-date values that are present).

```
uv run pytest .../pipeline/test/test_pipeline_utils.py -k "partition" -q
20 passed
```

Ran `ruff check` and `ruff format --check` on both changed files — clean. I (Claude) did not run the full import pipeline end to end.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from PostHog error tracking. I (Claude) pulled the issue, stack trace, and `warehouse_sources_*` context via the PostHog MCP tools, confirmed the related `updated_at` issue shares the root cause and is already handled on master, and checked open PRs (including the maintainer's) to rule out a duplicate — the two nearest ones (#72145 null numerical value, #72250 datetime sentinel) handle present-but-odd values, not a missing column.

Invoked the `/writing-tests` skill before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
