### PR TITLE
fix(data-imports): stop tracking self-recovering proxy tunnel errors in salesforce

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/source.py
@@ -75,6 +75,19 @@ class SalesforceSource(ResumableSource[SalesforceSourceConfig, SalesforceResumeC
             "expired access/refresh token": "Your Salesforce connection has expired or been revoked. Please reconnect the source.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `salesforce_refresh_access_token` builds its own tracked session rather than going
+        # through the shared REST client, so a proxy CONNECT failure during token refresh isn't
+        # retried in-process beyond `DEFAULT_RETRY`'s few attempts before it re-raises here. Once
+        # Temporal retries the whole activity the failure is transient and self-recovering (same
+        # class of egress-proxy blip already classified this way for ClickHouse), so don't
+        # surface it as tracked exception noise.
+        return {
+            "Tunnel connection failed: 502",
+            "Tunnel connection failed: 503",
+            "Tunnel connection failed: 504",
+        }
+
     def get_schemas(
         self,
         config: SalesforceSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_salesforce_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_salesforce_source.py
@@ -32,6 +32,28 @@ class TestSalesforceSourceNonRetryableErrors:
             f"'{error_message}' must not match a non-retryable pattern"
         )
 
+    @pytest.mark.parametrize(
+        "error_message",
+        [
+            "Tunnel connection failed: 502 Bad gateway",
+            "Tunnel connection failed: 503 Service Unavailable",
+            "Tunnel connection failed: 504 Gateway Timeout",
+            "HTTPSConnectionPool(host='example.my.salesforce.com', port=443): Max retries exceeded "
+            "with url: /services/oauth2/token (Caused by ProxyError('Cannot connect to proxy.', "
+            "OSError('Tunnel connection failed: 502 Bad gateway')))",
+        ],
+    )
+    def test_token_refresh_proxy_tunnel_failure_is_retryable(self, error_message):
+        # salesforce_refresh_access_token builds its own tracked session, so a proxy CONNECT
+        # failure during token refresh surfaces here as a bare OSError/ProxyError once
+        # DEFAULT_RETRY's in-process attempts are exhausted. It's an egress-proxy blip Temporal's
+        # activity retry recovers from, so it must stay out of error tracking as noise.
+        retryable_errors = self.source.get_retryable_errors()
+
+        assert any(pattern in error_message for pattern in retryable_errors), (
+            f"Expected '{error_message}' to match a retryable pattern"
+        )
+
 
 class TestSalesforceSourceVersions:
     def setup_method(self):


### PR DESCRIPTION
## Problem

Error tracking has been flooded by an `OSError: Tunnel connection failed: 502 Bad gateway` (wrapped in a `ProxyError`/`MaxRetryError` chain) from the Salesforce data warehouse source, all originating in `salesforce_refresh_access_token` in `products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/auth.py`, which calls out to Salesforce's OAuth token endpoint through the shared egress transport.

This isn't a bug: it's an egress-proxy blip during token refresh.
- The shared tracked session's `DEFAULT_RETRY` policy already retries a few times in-process before giving up (urllib3 classifies this as an "other" retry, not gated by the `allowed_methods` restriction that would otherwise skip POST requests).
- Once those attempts are exhausted, the error is re-raised, Temporal retries the whole import activity, and the sync self-recovers.

It stayed correctly *retryable* (it's not in `get_non_retryable_errors`), but `SalesforceSource` had no `get_retryable_errors()` override, so `_handle_import_error` logged it at `exception` level on every occurrence, minting an error-tracking issue for a non-bug.

## Changes

- Added `SalesforceSource.get_retryable_errors()` matching `"Tunnel connection failed: 502/503/504"`, so `_handle_import_error` logs it at `warning` instead of `exception` before re-raising for Temporal's retry — the same pattern already used by the ClickHouse, Matomo, and MySQL sources for this exact class of transient transport failure.

## How did you test this code?

Added a parameterized test in `test_salesforce_source.py` covering the bare status-coded messages (502/503/504) and the full chained exception string as it's actually raised, asserting they match `get_retryable_errors()`. This guards against the proxy-tunnel error reverting to tracked exception noise if the pattern is dropped.

Ran the full `test_salesforce_source.py` file (10 passed), `ruff check` and `ruff format --check` clean on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude) triaging a live error-tracking issue. Pulled the issue's stack trace and sample events via the PostHog MCP error-tracking tools, confirmed the failure is scoped to two Salesforce sources' OAuth token refresh across ~20k occurrences, and traced why the retry chain still surfaces `MaxRetryError`/`ProxyError` despite the `DEFAULT_RETRY` policy's `allowed_methods` restriction (connection-class errors bypass that check in urllib3's `Retry.increment`). Checked open PRs for duplicates: found a draft PR proposing a broader exception-type-based classifier in `_handle_import_error`, but it predates the current per-source `get_retryable_errors()` mechanism (now the established convention per the ClickHouse/Matomo/MySQL sources) and doesn't apply against current master, so this isn't a duplicate. Invoked `/writing-tests` before adding the regression test.