### PR TITLE
fix(data-imports): handle epoch-number cursors on datetime incremental fields

### DIFF
--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -577,6 +577,8 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
         ):
             if isinstance(value, datetime):
                 return value.isoformat()
+            elif isinstance(value, int | float) and not isinstance(value, bool):
+                return value
             else:
                 return str(value)
         return str(value)
@@ -640,6 +642,8 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
         ):
             if isinstance(last_value_py, datetime):
                 last_value_json = last_value_py.isoformat()
+            elif isinstance(last_value_py, int | float) and not isinstance(last_value_py, bool):
+                last_value_json = last_value_py
             else:
                 last_value_json = str(last_value_py)
         else:
@@ -707,6 +711,11 @@ def process_incremental_value(value: Any | None, field_type: IncrementalFieldTyp
         if isinstance(value, datetime):
             return value
 
+        # Some sources (e.g. Stripe `created`) expose datetime cursors as Unix-epoch numbers.
+        # dateutil can't parse a non-string, so pass epochs through unchanged for the source query.
+        if isinstance(value, int | float) and not isinstance(value, bool):
+            return value
+
         return parser.parse(value)
 
     if field_type == IncrementalFieldType.Date:
@@ -714,6 +723,9 @@ def process_incremental_value(value: Any | None, field_type: IncrementalFieldTyp
             return value.date()
 
         if isinstance(value, date):
+            return value
+
+        if isinstance(value, int | float) and not isinstance(value, bool):
             return value
 
         return parser.parse(value).date()
@@ -736,6 +748,10 @@ def apply_incremental_lookback(
         return value
 
     if field_type in (IncrementalFieldType.DateTime, IncrementalFieldType.Timestamp, IncrementalFieldType.Date):
+        # Epoch-number cursors (e.g. Stripe `created`) are in seconds, so shift them directly since
+        # timedelta subtraction only supports datetime/date operands.
+        if isinstance(value, int | float) and not isinstance(value, bool):
+            return value - lookback_seconds
         return value - timedelta(seconds=lookback_seconds)
 
     return value

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -772,6 +772,11 @@ class TestStagedIncrementalCursor:
             schema.stage_incremental_field_value("run-1", 1718377611)
         assert schema.sync_type_config["incremental_staged"]["last_value"] == 1718377611
 
+    def test_update_incremental_field_value_keeps_epoch_number_for_datetime_field(self) -> None:
+        schema = self._make_schema(incremental_field_type=IncrementalFieldType.DateTime)
+        schema.update_incremental_field_value(1718377611, save=False)
+        assert schema.sync_type_config["incremental_field_last_value"] == 1718377611
+
     def test_stage_writes_earliest_value(self) -> None:
         schema = self._make_schema()
         with patch.object(schema, "save"):

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -706,6 +706,24 @@ def test_process_incremental_value_xid_returns_value_as_is() -> None:
 
 
 @pytest.mark.parametrize(
+    "value,field_type,expected",
+    [
+        # Unix-epoch cursors (e.g. Stripe `created`) arrive as numbers on datetime-typed fields;
+        # dateutil raised "Parser must be a string or character stream, not int" before this passthrough.
+        (1718377611, IncrementalFieldType.DateTime, 1718377611),
+        (1718377611, IncrementalFieldType.Timestamp, 1718377611),
+        (1718377611, IncrementalFieldType.Date, 1718377611),
+        (1718377611.5, IncrementalFieldType.DateTime, 1718377611.5),
+        (datetime(2024, 6, 14, 15, 33, 31), IncrementalFieldType.DateTime, datetime(2024, 6, 14, 15, 33, 31)),
+        ("2024-06-14T15:33:31", IncrementalFieldType.DateTime, datetime(2024, 6, 14, 15, 33, 31)),
+        ("2024-06-14", IncrementalFieldType.Date, date(2024, 6, 14)),
+    ],
+)
+def test_process_incremental_value_datetime_handles_epoch_numbers(value, field_type, expected) -> None:
+    assert process_incremental_value(value, field_type) == expected
+
+
+@pytest.mark.parametrize(
     "value,field_type,lookback_seconds,expected",
     [
         (datetime(2026, 6, 14, 15, 33, 31), IncrementalFieldType.Timestamp, 3600, datetime(2026, 6, 14, 14, 33, 31)),
@@ -718,6 +736,8 @@ def test_process_incremental_value_xid_returns_value_as_is() -> None:
         (datetime(2026, 6, 14, 15, 33, 31), IncrementalFieldType.Timestamp, -5, datetime(2026, 6, 14, 15, 33, 31)),
         (100, IncrementalFieldType.Integer, 3600, 100),
         (100, IncrementalFieldType.Numeric, 3600, 100),
+        # Epoch-second cursor on a datetime field shifts directly instead of crashing on int - timedelta.
+        (1718377611, IncrementalFieldType.DateTime, 3600, 1718374011),
         ("abc123", IncrementalFieldType.ObjectID, 3600, "abc123"),
         (None, IncrementalFieldType.Timestamp, 3600, None),
         (datetime(2026, 6, 14, 15, 33, 31), None, 3600, datetime(2026, 6, 14, 15, 33, 31)),
@@ -743,6 +763,14 @@ class TestStagedIncrementalCursor:
             schema.stage_incremental_field_value("run-1", 42)
         staged = schema.sync_type_config["incremental_staged"]
         assert staged == {"run_uuid": "run-1", "last_value": 42}
+
+    def test_stage_keeps_epoch_number_for_datetime_field(self) -> None:
+        # A datetime-typed epoch cursor must round-trip as a number, not "1718377611", so the next
+        # run's read-back doesn't feed a numeric string into dateutil and crash.
+        schema = self._make_schema(incremental_field_type=IncrementalFieldType.DateTime)
+        with patch.object(schema, "save"):
+            schema.stage_incremental_field_value("run-1", 1718377611)
+        assert schema.sync_type_config["incremental_staged"]["last_value"] == 1718377611
 
     def test_stage_writes_earliest_value(self) -> None:
         schema = self._make_schema()


### PR DESCRIPTION
## Problem

Data warehouse imports were throwing `TypeError: Parser must be a string or character stream, not int` from shared pipeline code, surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019e5faa-efcd-72c3-8445-91f97f285240)). It's a high-volume, growing error affecting many syncs.

The crash originates in `process_incremental_value` in `products/warehouse_sources/backend/models/external_data_schema.py`. Some sources expose a datetime incremental field whose underlying value is a Unix-epoch **number**, not a string or `datetime`. Stripe is the clearest case: its `created` cursor is declared with `type: DateTime` but `field_type: Integer`, and the raw value is an epoch integer.

On the write path, `get_incremental_field_value` computes the new watermark by running every value in the incremental column through `process_incremental_value`. For a datetime-typed field it went straight to `dateutil.parser.parse(value)`, and dateutil refuses a non-string:

```
_process_pa_table → update_incremental_field_values → get_incremental_field_value
  → process_incremental_value → dateutil.parser.parse(<int>)  # TypeError
```

Stripe already guards the *read-back* path with `_coerce_incremental_cursor`, but the *write* path had no such protection, so the watermark could never be computed and every batch of every incremental run crashed and retried.

## Changes

Treat Unix-epoch numbers as valid cursors for datetime-typed incremental fields, end to end:

- `process_incremental_value`: for `DateTime` / `Timestamp` / `Date`, pass an `int`/`float` value through unchanged instead of parsing it. `dateutil` can't parse a number, and the epoch is exactly what the source query needs.
- `_serialize_incremental_value` and `update_incremental_field_value`: keep an epoch number as a JSON number rather than stringifying it, so the next run's read-back doesn't feed a numeric string like `"1718377611"` back into `dateutil` (which also raises). This mirrors the existing Integer/Numeric branches.
- `apply_incremental_lookback`: shift an epoch cursor directly (`value - lookback_seconds`) since `timedelta` subtraction only works on `datetime`/`date`.

`bool` is excluded from the numeric checks since it is a subclass of `int`.

> [!NOTE]
> No migration or data backfill is needed. Affected schemas never successfully stored a watermark (the write path crashed first), so there are no legacy numeric-string cursors to convert.

## How did you test this code?

I (Claude) added unit tests in `products/warehouse_sources/backend/tests/test_models.py`, all at the pure-function layer:

- `test_process_incremental_value_datetime_handles_epoch_numbers` — parameterized over int/float epochs for DateTime/Timestamp/Date plus the existing datetime/string cases. Catches a regression of the exact `TypeError` in this issue; no existing test passed a number to a datetime field.
- A `TestStagedIncrementalCursor` case asserting a datetime-typed epoch cursor stages as a number, not `"1718377611"` — guards the read-back crash the serialization change prevents.
- An epoch-int case added to `test_apply_incremental_lookback` — guards `int - timedelta` crashing once epochs reach that path.

```
33 passed (1 unrelated DB-backed test errored: no Postgres in the sandbox)
```

`ruff check` and `ruff format --check` are clean on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above using the PostHog MCP tools, then traced the stack from the import activity into `process_incremental_value`. Confirmed the data shape by inspecting the Stripe source settings (`type: DateTime`, `field_type: Integer`, `field: created`) and its query binding (`created[gt] = <watermark>`, expecting an epoch int).

Considered converting epochs to `datetime` instead of passing them through, but rejected it: the source query (and Stripe's `_coerce_incremental_cursor`) needs the epoch number, and the seconds/millis unit is ambiguous. Passthrough keeps the watermark comparable to the source column and round-trips cleanly. Kept the change scoped to the epoch-cursor class rather than touching global retry or capture behavior. Invoked the `/writing-tests` skill before adding tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
