### PR TITLE
fix(data-imports): stop tracking expected schema-type-change failures

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -241,6 +241,14 @@ class BatchConsumerAdapter(Protocol):
         the run's terminal state."""
         ...
 
+    def is_expected_user_error(self, err: Exception) -> bool:
+        """Whether the failure is an expected upstream/customer condition rather than a bug in
+        our pipeline (e.g. a source column whose type changed and no longer fits the stored
+        type — only a reset and full re-sync resolves it). The run still fails with the error's
+        actionable message, but the engine keeps these out of error tracking. Orthogonal to
+        ``is_retryable_error``: an error can be both non-retryable and expected."""
+        ...
+
     async def after_batch_processed(
         self,
         conn: psycopg.AsyncConnection[Any],
@@ -923,14 +931,25 @@ class BatchConsumer:
         if not self._adapter.is_retryable_error(err):
             # Deterministic failures do not benefit from retrying. Preserve their
             # messages, except for explicitly classified permanent apply errors.
-            logger.exception(
-                self._event("batch_failed_non_retryable"),
-                batch_id=batch.id,
-                run_uuid=batch.run_uuid,
-                attempt=attempt,
-            )
-            capture_exception(err)
             reason = f"permanent apply error: {err}" if isinstance(err, PermanentBatchApplyError) else str(err)
+            if self._adapter.is_expected_user_error(err):
+                # Expected upstream/customer condition — the run fails with an actionable
+                # message; there is nothing for us to fix, so keep it out of error tracking.
+                logger.warning(
+                    self._event("batch_failed_expected_user_error"),
+                    batch_id=batch.id,
+                    run_uuid=batch.run_uuid,
+                    attempt=attempt,
+                    error=str(err),
+                )
+            else:
+                logger.exception(
+                    self._event("batch_failed_non_retryable"),
+                    batch_id=batch.id,
+                    run_uuid=batch.run_uuid,
+                    attempt=attempt,
+                )
+                capture_exception(err)
             await self._fail_run(batch, reason=reason, conn=lock_conn)
         elif attempt >= self._config.max_attempts:
             reason = f"max retries exceeded: {err}"

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
@@ -475,6 +475,11 @@ class DuckgresBatchConsumerAdapter:
     def is_retryable_error(self, err: Exception) -> bool:
         return not isinstance(err, PermanentBatchApplyError)
 
+    def is_expected_user_error(self, err: Exception) -> bool:
+        # The duckgres sink applies already-validated Delta batches; it has no expected
+        # customer-actionable failures of its own to keep out of error tracking.
+        return False
+
 
 class DuckgresBatchConsumer(SharedBatchConsumer):
     """The shared engine plus the sink's lease-safety overrides, kept out of the

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -83,6 +83,16 @@ NON_RETRYABLE_ERROR_PATTERNS: tuple[str, ...] = (
     "ExternalDataJob matching query does not exist",
 )
 
+# Subset of the non-retryable errors that are expected upstream/customer conditions rather than
+# pipeline bugs. The run still fails with an actionable message, but the engine skips
+# error-tracking capture for these so they don't drown real bugs. Kept deliberately narrow.
+EXPECTED_USER_ERROR_PATTERNS: tuple[str, ...] = (
+    # a source column's type changed upstream and no longer fits the stored Delta column
+    # (SchemaColumnTypeChangedException) — delta-rs can't widen in place, so the fix is a
+    # user-driven reset and full re-sync, not a code change
+    "Source column type changed",
+)
+
 # How long an "alive" job-status lookup stays cached before re-checking the app DB.
 # Dead results never expire — a terminal job never comes back to life — and eviction
 # drops alive entries first, so a dead verdict survives until the cache overflows
@@ -462,6 +472,10 @@ class DeltaBatchConsumerAdapter:
     def is_retryable_error(self, err: Exception) -> bool:
         message = str(err)
         return not any(pattern in message for pattern in NON_RETRYABLE_ERROR_PATTERNS)
+
+    def is_expected_user_error(self, err: Exception) -> bool:
+        message = str(err)
+        return any(pattern in message for pattern in EXPECTED_USER_ERROR_PATTERNS)
 
     async def after_batch_processed(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -176,6 +176,37 @@ class TestProcessSingle:
         states = [call[1]["job_state"] for call in mock_status.call_args_list]
         assert SourceBatchStatus.State.WAITING_RETRY not in states
 
+    @pytest.mark.parametrize(
+        ("message", "expect_capture"),
+        [
+            # Expected upstream/customer condition (a source column's type changed and no longer
+            # fits the stored type): the run fails with an actionable message but stays out of
+            # error tracking.
+            ("Source column type changed: 'price' has values that no longer fit its stored type int64", False),
+            # A genuine non-retryable failure must still surface so real bugs aren't hidden.
+            ("20009.59 is too large to store in a Decimal128 of precision 24.", True),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_expected_user_error_skips_error_tracking(self, message: str, expect_capture: bool):
+        consumer = _make_consumer(max_attempts=3)
+        batch = _make_batch(latest_attempt=0)
+        consumer._process_batch = AsyncMock(side_effect=ValueError(message))
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status_unless_failed",
+                new_callable=AsyncMock,
+            ),
+            patch.object(consumer, "_fail_run", new_callable=AsyncMock) as mock_fail,
+            patch.object(batch_consumer_module, "capture_exception") as mock_capture,
+        ):
+            await consumer._process_single(batch)
+
+        mock_fail.assert_called_once()
+        assert mock_fail.call_args[1]["reason"] == message  # run still fails with the actionable message
+        assert mock_capture.called is expect_capture
+
     @pytest.mark.asyncio
     async def test_max_attempts_exceeded_fails_run(self):
         consumer = _make_consumer(max_attempts=3)


### PR DESCRIPTION
## Problem

Error tracking is flooded with a `SchemaColumnTypeChangedException` issue coming out of the shared data-imports pipeline ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f65a6-fa4c-7a61-acac-eef73986fa6d)). It fires when a source column's type changes upstream and no longer fits the column type already stored in the Delta table, e.g. a metric column created as `int64` from whole-valued rows that later starts arriving as `double` (`Float value 0.037736 was truncated converting to int64`).

This is not a bug in our pipeline. delta-rs can't widen an existing column in place, so the only fix is a user-driven reset and full re-sync, which is exactly what the exception message tells the customer to do. The run already fails non-retryably (the message is matched in the v3 delta consumer's `NON_RETRYABLE_ERROR_PATTERNS`), so there is no retry storm. The only problem is that the v3 delta consumer still calls `capture_exception` on it, so an expected customer condition shows up as a large, spiking error-tracking issue and drowns real bugs.

## Changes

Give the batch consumer adapter a new `is_expected_user_error` hook, mirroring the existing `is_retryable_error`. When a non-retryable failure is classified as an expected upstream/customer condition, the shared engine skips error-tracking capture and logs at `warning` instead of `exception`. The run still fails with the same actionable `latest_error`, so the customer sees no change in behavior.

The classification is deliberately narrow: the delta adapter matches only the `Source column type changed` condition. Every other non-retryable error (decimal overflow, missing primary key, deleted schema/job) keeps capturing as before, so genuine bugs stay visible. The duckgres adapter returns `False` (its sink applies already-validated Delta batches and has no expected customer-actionable failures of its own).

> [!NOTE]
> Complementary to #71105, which tries to avoid the exception entirely for webhook-only sources by widening the stored column in place. That path can't help API sources (where reset + re-sync is the correct remedy), and it doesn't touch the v3 consumer's capture. This PR stops the surviving failures from being tracked as noise.

## How did you test this code?

Automated only (I'm an agent, no manual/staging run):

- Added a parameterized regression test `test_expected_user_error_skips_error_tracking` in `postgres_queue/test_consumer.py`. It drives `_process_single` to a non-retryable failure and asserts that the schema-type-change condition does **not** call `capture_exception` while still failing the run with the actionable message, and that a genuine non-retryable error (decimal overflow) **does** still capture. This catches three regressions no existing test covered: re-adding unconditional capture, dropping the pattern, and over-broadening suppression to all non-retryable errors.
- Ran the affected suites: `TestProcessSingle` and `TestIsRetryableError` (14 passed) and the duckgres consumer suite (24 passed; 3 pre-existing errors need a live Postgres and are unrelated to this change).
- `mypy` clean on the three changed modules; `ruff` format + check clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged the error-tracking issue with the PostHog MCP tools, traced the raise site (`evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`) up through the v3 delta consumer to the `capture_exception` call in the shared engine's `_handle_batch_failure`, and confirmed via the events that all occurrences carried empty `warehouse_sources_*` context props, which pins the capture to the delta-consumer process rather than the v2 sync activity.

Considered making the exception itself non-capturing, but the cleanest seam is the adapter (it already owns `is_retryable_error`), so the engine stays generic and each sink decides what counts as expected. Kept the pattern list tight to avoid hiding real bugs. Invoked the `/writing-tests` skill before adding the test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
