### PR TITLE
fix(data-imports): resolve ducklake copy source from the written delta folder

### DIFF
--- a/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
@@ -54,7 +54,6 @@ from posthog.temporal.ducklake.metrics import (
 
 from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 from products.warehouse_sources.backend.facade.pipelines import DUCKGRES_BATCH_SINK_FLAG, is_duckgres_sink_team_member
-from products.warehouse_sources.backend.temporal.data_imports.naming_convention import NamingConvention
 
 LOGGER = get_logger(__name__)
 DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX = "data_imports"
@@ -390,13 +389,12 @@ def cleanup_data_imports_staging_activity(inputs: DuckLakeDataImportsStagingClea
 def _data_imports_source_table_uri(schema: ExternalDataSchema) -> str:
     """S3 URI of the schema's Delta table, matching the folder the loader actually wrote.
 
-    The loader names the folder after the resolved S3 folder (the resource/table leaf), which
-    diverges from ``normalized_name`` for folder-pinned sources (e.g. Postgres ``public.users``
-    → folder ``users``). Reading ``normalized_name`` here points at a prefix with no ``_delta_log``
+    Uses ``normalized_s3_folder_name`` (the resolved folder leaf), which diverges from
+    ``normalized_name`` for folder-pinned sources (e.g. Postgres ``public.users`` → folder
+    ``users``). Reading ``normalized_name`` here points at a prefix with no ``_delta_log``
     and surfaces as "No files in log segment".
     """
-    folder_leaf = NamingConvention.normalize_identifier(schema.resolved_s3_folder_name or schema.name)
-    return f"{settings.BUCKET_URL}/{schema.folder_path()}/{folder_leaf}"
+    return f"{settings.BUCKET_URL}/{schema.folder_path()}/{schema.normalized_s3_folder_name}"
 
 
 def _resolve_data_imports_staging_uri(source_uri: str, *, team_id: int) -> str | None:

--- a/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
@@ -54,6 +54,7 @@ from posthog.temporal.ducklake.metrics import (
 
 from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 from products.warehouse_sources.backend.facade.pipelines import DUCKGRES_BATCH_SINK_FLAG, is_duckgres_sink_team_member
+from products.warehouse_sources.backend.temporal.data_imports.naming_convention import NamingConvention
 
 LOGGER = get_logger(__name__)
 DATA_IMPORTS_DUCKLAKE_WORKFLOW_PREFIX = "data_imports"
@@ -259,7 +260,7 @@ async def prepare_data_imports_ducklake_metadata_activity(
                     source_type=source_type,
                 )
                 continue
-        source_table_uri = f"{settings.BUCKET_URL}/{schema.folder_path()}/{normalized_name}"
+        source_table_uri = _data_imports_source_table_uri(schema)
         staging_uri = await database_sync_to_async(_resolve_data_imports_staging_uri)(
             source_table_uri, team_id=inputs.team_id
         )
@@ -384,6 +385,18 @@ def cleanup_data_imports_staging_activity(inputs: DuckLakeDataImportsStagingClea
     cleanup_staged_files(
         staging_uri=inputs.staging_uri,
     )
+
+
+def _data_imports_source_table_uri(schema: ExternalDataSchema) -> str:
+    """S3 URI of the schema's Delta table, matching the folder the loader actually wrote.
+
+    The loader names the folder after the resolved S3 folder (the resource/table leaf), which
+    diverges from ``normalized_name`` for folder-pinned sources (e.g. Postgres ``public.users``
+    → folder ``users``). Reading ``normalized_name`` here points at a prefix with no ``_delta_log``
+    and surfaces as "No files in log segment".
+    """
+    folder_leaf = NamingConvention.normalize_identifier(schema.resolved_s3_folder_name or schema.name)
+    return f"{settings.BUCKET_URL}/{schema.folder_path()}/{folder_leaf}"
 
 
 def _resolve_data_imports_staging_uri(source_uri: str, *, team_id: int) -> str | None:

--- a/posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py
@@ -5,6 +5,8 @@ from collections.abc import Sequence
 import pytest
 from unittest.mock import MagicMock
 
+from django.conf import settings
+
 import temporalio.worker
 import temporalio.converter
 from temporalio import activity as temporal_activity
@@ -239,6 +241,47 @@ async def test_prepare_data_imports_ducklake_metadata_activity_basic(ateam, monk
     assert metadata.ducklake_schema_name == f"posthog_data_imports_team_{ateam.id}"
     assert metadata.ducklake_table_name == "postgres_customers"
     assert metadata.source_partition_column == "created_at"
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "schema_name,s3_folder_name,expected_leaf",
+    [
+        ("orders", None, "orders"),
+        # Folder-pinned source: the loader wrote the Delta table under the resolved folder
+        # ("users"), not the schema's normalized name ("public_users"). Reading normalized_name
+        # points at a prefix with no _delta_log -> "No files in log segment".
+        ("public.users", "users", "users"),
+    ],
+)
+async def test_prepare_resolves_source_table_uri_from_written_folder(
+    ateam, monkeypatch, schema_name, s3_folder_name, expected_leaf
+):
+    monkeypatch.setattr(ducklake_module, "_fetch_delta_partition_columns", lambda table_uri, *, team_id: [])
+
+    source = await database_sync_to_async(ExternalDataSource.objects.create)(
+        team=ateam,
+        source_id="test_source",
+        connection_id="test_connection",
+        source_type="Postgres",
+        status="Running",
+    )
+    schema = await database_sync_to_async(ExternalDataSchema.objects.create)(
+        team=ateam,
+        name=schema_name,
+        source=source,
+        sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+        s3_folder_name=s3_folder_name,
+    )
+
+    inputs = DataImportsDuckLakeCopyInputs(team_id=ateam.id, job_id="job-uri", schema_ids=[schema.id])
+
+    result = await prepare_data_imports_ducklake_metadata_activity(inputs)
+
+    assert len(result) == 1
+    folder_path = await database_sync_to_async(schema.folder_path)()
+    assert result[0].source_table_uri == f"{settings.BUCKET_URL}/{folder_path}/{expected_leaf}"
 
 
 @pytest.mark.asyncio

--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -131,6 +131,16 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
         return NamingConvention.normalize_identifier(self.name)
 
     @property
+    def normalized_s3_folder_name(self) -> str:
+        """Normalized Delta folder leaf the loader actually wrote the table under.
+
+        Diverges from ``normalized_name`` for folder-pinned rows (e.g. Postgres ``public.users``
+        → folder ``users``); readers that resolve ``normalized_name`` point at a prefix with no
+        ``_delta_log`` and surface "No files in log segment".
+        """
+        return NamingConvention.normalize_identifier(self.resolved_s3_folder_name or self.name)
+
+    @property
     def is_incremental(self):
         return self.sync_type == self.SyncType.INCREMENTAL
 


### PR DESCRIPTION
## Problem

The DuckLake copy workflow for data imports has been failing loudly and repeatedly with `TableNotFoundError: Generic delta kernel error: No files in log segment`, raised from `_get_delta_snapshot_files` while staging a source Delta table. It's the single highest-volume error in the data-warehouse import pipeline right now (error tracking issue [`019edb3c-…`](https://us.posthog.com/project/2/error_tracking/019edb3c-900b-7de1-a8dc-f63a5a82d930), still firing daily).

Root cause is a source-path mismatch. `prepare_data_imports_ducklake_metadata_activity` computed the source Delta URI from `schema.normalized_name`:

```python
source_table_uri = f"{settings.BUCKET_URL}/{schema.folder_path()}/{normalized_name}"
```

But the loader names the Delta folder after the resolved S3 folder leaf (`resolved_s3_folder_name`), not the schema's normalized name. For folder-pinned sources these diverge — a Postgres `public.users` schema normalizes to `public_users`, but its Delta table lives under `users`. So the copy pointed at a prefix that has no `_delta_log`, which delta-rs surfaces as "No files in log segment".

Every other reader already resolves the folder the loader-native way — the person-property backfill and the v3 duckgres backfill both use `normalize_identifier(resolved_s3_folder_name or name)` and explicitly document this exact failure mode. The copy workflow was the last reader still using `normalized_name`.

## Changes

Resolve the source URI from the folder the loader actually wrote, matching the other readers:

```python
folder_leaf = NamingConvention.normalize_identifier(schema.resolved_s3_folder_name or schema.name)
source_table_uri = f"{settings.BUCKET_URL}/{schema.folder_path()}/{folder_leaf}"
```

`staging_uri` and partition detection both derive from `source_table_uri`, so they're fixed by the same change. The destination DuckLake table name and verification queries are unaffected — they legitimately key off the logical schema name.

> [!NOTE]
> The related issue [`019f1e89-…`](https://us.posthog.com/project/2/error_tracking/019f1e89-b374-7f51-adb2-d815a020e9df) is the same error class from the v3 backfill path (`resolve_snapshot_plan`). That path already resolves the folder leaf via `url_pattern` and the issue went silent well before this change, so it's already handled on master — no action needed there. This PR fixes the un-migrated twin in the copy workflow.

This is our bug (shared code mishandling a data shape), not a user/upstream condition, so it's a real fix rather than a `NonRetryableErrors` entry or a capture suppression.

## How did you test this code?

Added a parameterized regression test to `test_prepare_data_imports_ducklake_metadata_activity`-adjacent coverage: `test_prepare_resolves_source_table_uri_from_written_folder` asserts the resolved `source_table_uri` uses the written folder leaf for both a plain schema (`orders` → `orders`) and a folder-pinned one (`public.users` with `s3_folder_name=users` → `users`, not `public_users`). No existing test asserted `source_table_uri`, and all existing cases used schemas where the folder equals the normalized name, so they passed with the bug present.

I (Claude) could not run the DB-backed test locally — the dev stack wouldn't come up in this environment (no docker daemon). I did verify the pure normalization the test hinges on (`normalize_identifier("public.users") == "public_users"`, `"users" == "users"`), confirmed the test file collects both cases, and ran ruff check + format on both files. CI runs the DB-backed assertions.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue by Claude (Claude Code). Traced the stack (`copy_data_imports_to_ducklake_activity` → `stage_delta_table` → `_get_delta_snapshot_files`) to the source-path computation, then cross-checked how the loader writes the folder and how the person-property and v3 backfill readers resolve it. Chose `resolved_s3_folder_name or name` (the schema-native source of truth used by `person_property_sync`) over the `url_pattern` leaf approach, since it doesn't depend on a `DataWarehouseTable` row existing. Skills invoked: `/writing-tests`. Confirmed no duplicate PR (checked the maintainer's open PRs and searched by exception type, message, and module path — #69098 fixes the destination table name, a different root cause).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
