### PR TITLE
fix(data-imports): treat all incompatible Delta casts as schema changes

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -745,6 +745,37 @@ def test_evolve_pyarrow_schema_whole_valued_floats_cast_into_stored_integer_colu
     assert evolved_table.column("val").to_pylist() == [10, 20]
 
 
+@pytest.mark.parametrize(
+    "delta_type, incoming_column",
+    [
+        # Non-numeric text arriving for a column stored as int (Failed to parse string).
+        (pa.int32(), pa.array(["80", "80-150"], type=pa.string())),
+        # Non-boolean text arriving for a column stored as bool (Failed to parse value).
+        (pa.bool_(), pa.array(["true", "processed"], type=pa.string())),
+        # A value that overflows the stored decimal precision (Cannot convert ... overflow).
+        (pa.decimal128(3, 1), pa.array([1.0, 999999999.0], type=pa.float64())),
+    ],
+)
+def test_evolve_pyarrow_schema_incompatible_cast_raises_actionable_error(
+    delta_type: pa.DataType, incoming_column: pa.Array
+):
+    """Incoming data that can't be cast into the stored Delta type — non-numeric text into a
+    numeric/boolean column, or a value that overflows the stored decimal precision — raises the
+    actionable reset-and-re-sync error rather than a raw pyarrow ArrowInvalid that gets retried."""
+    arrow_table = pa.table(
+        {
+            "id": pa.array([1, 2], type=pa.int64()),
+            "val": incoming_column,
+        }
+    )
+    delta_schema = deltalake.Schema.from_arrow(
+        pa.schema([pa.field("id", pa.int64(), nullable=False), pa.field("val", delta_type, nullable=True)])
+    )
+
+    with pytest.raises(SchemaColumnTypeChangedException, match="Source column type changed"):
+        evolve_pyarrow_schema(arrow_table, delta_schema)
+
+
 def test_evolve_pyarrow_schema_with_struct_containing_datetime_and_decimal():
     """Test that evolve_pyarrow_schema can handle struct columns with non-JSON-serializable types."""
     metadata_struct_type = pa.struct(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
@@ -293,26 +293,24 @@ def evolve_pyarrow_schema(incoming_table: pa.Table, delta_schema: deltalake.Sche
                 try:
                     casted_column = incoming_column.cast(delta_field.type).combine_chunks()
                 except pa.ArrowInvalid as e:
-                    # A narrowing cast overflowed. The usual causes are the source column's type
-                    # being widened upstream (e.g. Postgres `integer` → `bigint`) after the Delta
-                    # column was created with the narrower type, or an integer-created column now
-                    # receiving fractional values — e.g. a price field whose first-synced rows were
-                    # all whole numbers, later failing with "ArrowInvalid: Float value 19.990000
-                    # was truncated converting to int64". delta-rs cannot widen an existing column
-                    # in place, so retrying is futile — surface an actionable error telling the
-                    # user to reset and fully re-sync the table. Whole-valued floats/decimals still
-                    # cast into an integer column losslessly, so this only fires on genuine data loss.
-                    if pa.types.is_integer(delta_field.type) and (
-                        pa.types.is_integer(incoming_column.type)
-                        or pa.types.is_floating(incoming_column.type)
-                        or pa.types.is_decimal(incoming_column.type)
-                    ):
-                        raise SchemaColumnTypeChangedException(
-                            f"Source column type changed: '{delta_field.name}' has values that no longer "
-                            f"fit its stored type {delta_field.type} (incoming data is now "
-                            f"{incoming_column.type}). Reset and fully re-sync this table to adopt the new type."
-                        ) from e
-                    raise
+                    # Reaching this cast already means the incoming type differs from the stored
+                    # Delta type (see the guard above) and the timestamp path didn't apply, so a
+                    # failure here is a deterministic, unretryable incompatibility: the source
+                    # column's type changed under a table created with a narrower type. Common
+                    # shapes are an integer column widened upstream (Postgres `integer` → `bigint`),
+                    # an integer-created column now receiving fractional values ("Float value 19.99
+                    # was truncated converting to int64"), non-numeric text arriving for a numeric
+                    # column ("Failed to parse string: '80-150' as a scalar of type int32"), or a
+                    # value that overflows the stored decimal precision. delta-rs cannot change a
+                    # column's type in place, so retrying is futile — surface an actionable error
+                    # telling the user to reset and fully re-sync. Lossless widening (e.g. a
+                    # whole-valued float into an integer column) still casts fine and never reaches
+                    # here.
+                    raise SchemaColumnTypeChangedException(
+                        f"Source column type changed: '{delta_field.name}' has values that no longer "
+                        f"fit its stored type {delta_field.type} (incoming data is now "
+                        f"{incoming_column.type}). Reset and fully re-sync this table to adopt the new type."
+                    ) from e
 
                 incoming_table = incoming_table.set_column(
                     incoming_table.schema.get_field_index(delta_field.name),

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -39,6 +39,9 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     SourceInputs,
     SourceResponse,
 )
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.utils import (
+    SchemaColumnTypeChangedException,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_sync import PipelineInputs
 from products.warehouse_sources.backend.temporal.data_imports.row_tracking import setup_row_tracking
 from products.warehouse_sources.backend.temporal.data_imports.sources import SourceRegistry
@@ -337,6 +340,13 @@ async def _handle_import_error(
     # contract by type so every REST-based source stops immediately, rather than depending on each
     # source listing the message in get_non_retryable_errors.
     if isinstance(error, RESTClientNonRetryableError):
+        await handle_non_retryable_error(job_inputs, error_msg, logger, error)
+
+    # Raised in shared pipeline code when incoming data can't be cast into the stored (narrower)
+    # Delta column type. delta-rs can't change a column's type in place, so this fails identically
+    # on every retry regardless of source — classify it non-retryable by type here rather than
+    # relying on each source listing the message in get_non_retryable_errors.
+    if isinstance(error, SchemaColumnTypeChangedException):
         await handle_non_retryable_error(job_inputs, error_msg, logger, error)
 
     non_retryable_errors = source_cls.get_non_retryable_errors()

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -5,6 +5,9 @@ from datetime import datetime
 import pytest
 from unittest import mock
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.utils import (
+    SchemaColumnTypeChangedException,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import SimpleSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
     RESTClientNonRetryableError,
@@ -163,6 +166,39 @@ async def test_rest_client_non_retryable_error_routes_through_handler_without_so
     # get_non_retryable_errors doesn't list the message, so any REST-based source stops instead of
     # retrying the deterministic failure to the activity max and minting error-tracking noise.
     error = RESTClientNonRetryableError("Non-JSON response from https://api.example.com/v1/data/leads")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with (
+        mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
+        mock.patch.object(module, "handle_non_retryable_error", new=mock.AsyncMock()) as handle_mock,
+    ):
+        handle_mock.side_effect = NonRetryableException()
+        with pytest.raises(NonRetryableException):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    handle_mock.assert_awaited_once()
+    assert handle_mock.await_args is not None
+    assert handle_mock.await_args.args[3] is error
+    logger.aexception.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_schema_column_type_changed_routes_through_handler_without_source_opt_in():
+    # SchemaColumnTypeChangedException is raised in shared pipeline code when incoming data can't be
+    # cast into the stored Delta column type — a deterministic failure that only a reset and re-sync
+    # fixes. It must be non-retryable by type for every source, not just the SQL sources that list
+    # "Source column type changed" in get_non_retryable_errors, so non-SQL sources stop retrying it.
+    error = SchemaColumnTypeChangedException(
+        "Source column type changed: 'val' has values that no longer fit its stored type int32 "
+        "(incoming data is now string). Reset and fully re-sync this table to adopt the new type."
+    )
     source = mock.MagicMock(spec=SimpleSource)
     source.get_non_retryable_errors.return_value = {}
     source.get_retryable_errors.return_value = set()


### PR DESCRIPTION
## Problem

The data-warehouse import pipeline is throwing a large, growing volume of retryable `ArrowInvalid` exceptions from shared code in `evolve_pyarrow_schema` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019efe10-1e4c-7fa1-ae5e-d46af4b51325), and its older sibling [019ed03f](https://us.posthog.com/project/2/error_tracking/019ed03f-6b97-7c81-b88a-4ae3d9a067b7)). They all originate at the same line - casting an incoming column into the stored Delta column type - and share a root cause: the incoming data no longer fits the type the table was created with.

We already handle one shape of this: a numeric value that doesn't fit an integer column raises a `SchemaColumnTypeChangedException` telling the user to reset and re-sync, which is classified non-retryable. But the handler only fired when the target was an integer column and the source was numeric. The other shapes fell through to a bare re-raise:

- non-numeric text into a numeric column (`Failed to parse string: '80-150' as a scalar of type int32`)
- a value that overflows the stored decimal precision (`Cannot convert 999999999.0 to Decimal128(...): overflow`)
- non-boolean text into a boolean column (`Failed to parse value: processed`)

Because those surfaced as a plain `ArrowInvalid`, Temporal retried them to the activity max on every scheduled sync, generating the noise. None of them are retryable - delta-rs can't change a column's type in place, so only a reset and full re-sync fixes them.

## Changes

- **`evolve_pyarrow_schema`**: any `ArrowInvalid` from the cast now raises the actionable `SchemaColumnTypeChangedException`. Reaching that cast already means the incoming type differs from the stored type and the timestamp path didn't apply, so the failure is always a deterministic incompatibility. Lossless widening (for example a whole-valued float into an integer column) still casts fine and never reaches the handler, so this doesn't swallow benign data.
- **Shared V2 error handling**: `_handle_import_error` now classifies `SchemaColumnTypeChangedException` as non-retryable by type, the same way it already does for `RESTClientNonRetryableError`. Previously only SQL sources caught it, via a message match in `get_non_retryable_errors`; a non-SQL source hit the generic re-raise and kept retrying. V3 already matches "Source column type changed" in its non-retryable patterns, and V3 runs the same `evolve_pyarrow_schema`, so it's covered by the first change.

> [!NOTE]
> This keeps the error visible but bounded (a few attempts per run) rather than suppressing it. It's a real, user-actionable condition - the user must reset and re-sync the affected table - not benign control-flow, so it stays in error tracking, just no longer as an unbounded retry flood.

## How did you test this code?

Automated tests only (I did not run the pipeline end to end):

- Added a parametrized `test_evolve_pyarrow_schema_incompatible_cast_raises_actionable_error` covering the three previously-unhandled shapes (text into int, text into bool, float overflowing a decimal). These regress to a raw `ArrowInvalid` if the broadened handler is reverted - nothing existing caught them, since the existing `..._integer_overflow_...` test only exercises integer targets with numeric sources.
- Added `test_schema_column_type_changed_routes_through_handler_without_source_opt_in`, mirroring the existing `RESTClientNonRetryableError` test, to lock in the shared-layer non-retryable classification for sources that don't list the message.
- Ran both files: `test_pipeline_utils.py` and `test_import_data_sync.py`, 127 passed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged and authored by Claude (Claude Code) from the error-tracking issue: pulled the stack trace and representative events via the PostHog error-tracking tools, traced the failure to `evolve_pyarrow_schema`, confirmed the two issues share a root cause, and checked the V2/V3 non-retryable wiring before choosing a general fix over a per-source patch. Invoked the `/writing-tests` skill before adding tests. Decision worth flagging for review: I removed the `is_integer` target guard entirely rather than adding string as another special case, on the reasoning that every path reaching that cast is an unreconcilable type mismatch - please sanity-check that there's no cast in that branch we'd rather keep retryable.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
