### PR TITLE
fix(data-imports): guard is_table_corrupted's existence check against transient S3 errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -319,9 +319,14 @@ class DeltaTableHelper:
         delta_uri = await self._get_delta_table_uri()
         storage_options = self._get_credentials()
 
-        is_delta = await asyncio.to_thread(
-            deltalake.DeltaTable.is_deltatable, table_uri=delta_uri, storage_options=storage_options
-        )
+        try:
+            is_delta = await asyncio.to_thread(
+                deltalake.DeltaTable.is_deltatable, table_uri=delta_uri, storage_options=storage_options
+            )
+        except Exception:
+            # Same "unknown error is not corrupt" contract as the open below — this existence
+            # check does its own S3 LIST and is just as exposed to a transient network blip.
+            return False
         if not is_delta:
             return False
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -938,25 +938,45 @@ class TestIsTableCorrupted:
 
     @parameterized.expand(
         [
-            # (is_deltatable, open_exception, expected_corrupt) — only DeltaError/FileNotFoundError on a
-            # table whose _delta_log exists count as corrupt; a missing table or an unknown error must NOT,
-            # so we never trigger a destructive revive on a non-existent table or a transient failure.
-            ("not_a_delta_table", False, None, False),
-            ("opens_fine", True, None, False),
-            ("delta_error_is_corrupt", True, deltalake.exceptions.DeltaError("no protocol"), True),
-            ("file_not_found_is_corrupt", True, FileNotFoundError("missing data file"), True),
-            ("unknown_error_not_corrupt", True, ValueError("transient"), False),
+            # (is_deltatable, is_deltatable_exc, open_exception, expected_corrupt) — only
+            # DeltaError/FileNotFoundError on a table whose _delta_log exists count as corrupt; a missing
+            # table, an unknown open error, or a failure of the existence check itself must NOT, so we
+            # never trigger a destructive revive on a non-existent table or a transient failure.
+            ("not_a_delta_table", False, None, None, False),
+            ("opens_fine", True, None, None, False),
+            ("delta_error_is_corrupt", True, None, deltalake.exceptions.DeltaError("no protocol"), True),
+            ("file_not_found_is_corrupt", True, None, FileNotFoundError("missing data file"), True),
+            ("unknown_error_not_corrupt", True, None, ValueError("transient"), False),
+            # The is_deltatable existence check does its own S3 LIST and is just as exposed to a
+            # transient network blip as the open below — it must not escape uncaught.
+            (
+                "is_deltatable_transient_error_not_corrupt",
+                None,
+                OSError("Generic S3 error: connection reset"),
+                None,
+                False,
+            ),
         ]
     )
     @pytest.mark.asyncio
-    async def test_is_table_corrupted(self, _name: str, is_delta: bool, open_exc: Exception | None, expected: bool):
+    async def test_is_table_corrupted(
+        self,
+        _name: str,
+        is_delta: bool | None,
+        is_deltatable_exc: Exception | None,
+        open_exc: Exception | None,
+        expected: bool,
+    ):
         helper = self._helper()
         with (
             patch.object(helper, "_get_delta_table_uri", new=AsyncMock(return_value="s3://b/t")),
             patch.object(helper, "_get_credentials", return_value={}),
             patch(f"{self._MODULE}.deltalake.DeltaTable") as mock_dt,
         ):
-            mock_dt.is_deltatable = MagicMock(return_value=is_delta)
+            if is_deltatable_exc is not None:
+                mock_dt.is_deltatable = MagicMock(side_effect=is_deltatable_exc)
+            else:
+                mock_dt.is_deltatable = MagicMock(return_value=is_delta)
             if open_exc is not None:
                 mock_dt.side_effect = open_exc
             result = await helper.is_table_corrupted()


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `OSError` ("Generic S3 error…") originating from `products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py`, in `is_table_corrupted()`. Sampled events showed transient object-storage failures (connection resets, connect timeouts) escaping this function uncaught, called from `handle_corrupted_delta_log()` which runs before extraction on effectively every sync.

`is_table_corrupted()`'s own docstring states the contract clearly: an unknown/transient failure must never be classified as corruption, so a momentary blip can't trigger a destructive table reset + rebuild. The implementation only honored that contract for the `DeltaTable()` open call. The preceding `DeltaTable.is_deltatable()` existence check — which does its own S3 LIST — sat outside the try/except, so a transient network error there escaped uncaught straight out of the function instead of being treated as "unknown, not corrupted."

The caller (`handle_corrupted_delta_log`) already wraps its call in `try/except` + `capture_exception`, so this wasn't blocking syncs, but it was flooding error tracking with an exception that the code's own design intends to treat as benign.

Note: the related, much higher-volume `vacuum_table`/`compact_table` transient-S3 noise (same error class, different call sites) is already being addressed in [#69306](https://github.com/PostHog/posthog/pull/69306), so this PR is scoped only to the `is_table_corrupted` gap that PR doesn't touch.

## Changes

- Wrap the `DeltaTable.is_deltatable()` existence check in `is_table_corrupted()` with the same "unknown error → not corrupted" handling already applied to the subsequent open call.

## How did you test this code?

- Extended the existing parameterized `TestIsTableCorrupted` suite in `test_delta_table_helper.py` with a case where `is_deltatable()` itself raises an `OSError`, asserting the function still returns `False` (not corrupted) instead of letting the exception propagate.
- Ran the full `test_delta_table_helper.py` file locally (`pytest`) — all pass except 3 pre-existing failures in `TestGetDeltaTableUnrecoverableErrors` that require real network/S3 access unavailable in this environment (confirmed identical failures on `master` before this change).
- `ruff check` / `ruff format --check` clean on both touched files; `mypy` clean on `delta_table_helper.py`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude) triaging a live error-tracking issue. Invoked `/writing-tests` before extending the test suite.

Investigated four related error-tracking issues sharing the same `OSError`/"Generic S3 error" shape across `delta_table_helper.py`. Found an existing open PR ([#69306](https://github.com/PostHog/posthog/pull/69306)) already covers the `vacuum_table`/`compact_table` portion (the majority of the volume), so I left that untouched rather than duplicate it. The remaining issue traced to a distinct bug — the unguarded `is_deltatable()` call in `is_table_corrupted()` — which this PR fixes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*