### PR TITLE
fix(data-imports): stop tracking transient S3 credential errors in delta maintenance

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -17,6 +17,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.l
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.cdp_producer import CDPProducer
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.delta_table_helper import (
     DeltaTableHelper,
+    is_transient_object_store_error,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.person_property_row_sink import (
     PersonPropertyRowSink,
@@ -682,6 +683,9 @@ async def run_pre_write_defensive_compact(
     the CDC post-load path in `common/load.py` writes the same watermark, and both merge
     via `update_sync_type_config_keys` under a row lock. Wrapped in try/except so a
     maintenance failure never blocks the actual sync; the original error path is unaffected.
+    A transient object-store error (see `is_transient_object_store_error`) is logged at
+    warning instead of captured — the next sync's maintenance pass retries it from scratch,
+    so it isn't a bug in this function, just a temporary blip talking to our own S3 bucket.
 
     Used by both `PipelineNonDLT.run` (v2) and `PipelineV3.run` to keep the behaviour
     identical across pipelines without each having to know how to look up `partition_count`
@@ -705,5 +709,8 @@ async def run_pre_write_defensive_compact(
                 schema.id, schema.team_id, updates={"last_vacuum_version": new_version}
             )
     except Exception as e:
+        if is_transient_object_store_error(e):
+            await logger.awarning(f"Pre-write maintenance skipped: transient object-store error: {e}")
+            return
         capture_exception(e)
         await logger.aexception(f"Pre-write maintenance failed: {e}", exc_info=e)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -166,6 +166,38 @@ class TestRunPreWriteDefensiveCompact:
         mock_capture.assert_called_once()
         logger.aexception.assert_awaited_once()
 
+    @parameterized.expand(
+        [
+            (
+                "credentials_loading",
+                "Operation not supported: an error occurred while loading credentials: dispatch failure: timeout",
+            ),
+            (
+                "credential_provider_not_enabled",
+                "Operation not supported: the credential provider was not enabled: no providers in chain provided credentials",
+            ),
+            (
+                "generic_s3_error",
+                "Generic S3 error: Error getting list response body: operation timed out",
+            ),
+        ]
+    )
+    @pytest.mark.asyncio
+    async def test_logs_transient_object_store_error_without_capturing(self, _name: str, error_message: str):
+        # A transient blip talking to our own delta S3 bucket (credential-provider or connectivity
+        # errors from delta-rs) isn't a bug in this function — it shouldn't flood error tracking the
+        # way an actual maintenance bug does (see test_swallows_maintenance_failure above).
+        helper = MagicMock(run_maintenance=AsyncMock(side_effect=OSError(error_message)))
+        logger = MagicMock(aexception=AsyncMock(), awarning=AsyncMock())
+
+        schema = MagicMock(partition_count=5, sync_type_config={})
+        with patch(f"{_EXTRACT_MODULE}.capture_exception") as mock_capture:
+            await run_pre_write_defensive_compact(helper, schema, MagicMock(partition_count=None), logger)
+
+        mock_capture.assert_not_called()
+        logger.awarning.assert_awaited_once()
+        logger.aexception.assert_not_awaited()
+
 
 class TestReportHeartbeatTimeoutRecording(BaseTest):
     def _schema(self) -> ExternalDataSchema:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -50,6 +50,21 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 DEFAULT_COMPACT_FILES_PER_PARTITION_THRESHOLD = 200
 DEFAULT_COMPACT_TOTAL_FILES_THRESHOLD = 5000
 
+# Substrings of the `OSError`s delta-rs's Rust `object_store` crate raises from
+# `DeltaTable.is_deltatable()` when it can't reach or authenticate against our own S3-backed
+# data-warehouse bucket (IMDS/STS blips, dispatch timeouts) — not a customer credential problem.
+# Transient and self-recovering: the next maintenance pass re-lists from scratch, so these
+# shouldn't be treated the same as a bug in our maintenance logic.
+TRANSIENT_OBJECT_STORE_ERRORS = (
+    "an error occurred while loading credentials",
+    "the credential provider was not enabled",
+    "Generic S3 error",
+)
+
+
+def is_transient_object_store_error(error: BaseException) -> bool:
+    return isinstance(error, OSError) and any(needle in str(error) for needle in TRANSIENT_OBJECT_STORE_ERRORS)
+
 
 def _delta_merge_spill_kwargs() -> dict[str, int]:
     """delta-rs `merge` kwargs that let DataFusion spill to disk instead of OOMing on large merges.


### PR DESCRIPTION
## Problem

Error tracking surfaced a high-volume `OSError` originating from `get_delta_table()` in the shared warehouse-sources Delta pipeline code (`pipelines/pipeline/delta_table_helper.py`), reached via the pre-write defensive-compaction maintenance step (`pipelines/common/extract.py`'s `run_pre_write_defensive_compact`).

The stack trace bottoms out in delta-rs's Rust `object_store` crate call `DeltaTable.is_deltatable(...)`, which lists our own internal data-warehouse S3 bucket before every pre-write compaction check. When that call hits a transient credential-provider or connectivity blip (S3 connect timeouts, expired STS tokens, dispatch/tunnel failures, `Generic S3 error` list/read failures), the resulting `OSError` propagates up into `run_pre_write_defensive_compact`'s `except` block.

That function's own docstring already says maintenance failures are wrapped in try/except "so a maintenance failure never blocks the actual sync" — the sync itself is unaffected. But every occurrence still went through `capture_exception`, so a single infra-side S3/credential blip repeated across every affected sync run generated a large volume of near-identical error-tracking issues for something that was already handled as non-fatal.

This isn't a customer-facing bug: it's PostHog's own IAM/instance credentials talking to PostHog's own storage, and it's already non-blocking by design. The only thing missing was classifying it as such before deciding whether to send it to error tracking.

## Changes

- Add `is_transient_object_store_error()` in `delta_table_helper.py`: matches the `OSError` substrings delta-rs/`object_store` uses for credential-loading and generic S3 connectivity failures.
- In `run_pre_write_defensive_compact`, route those specific errors to a `logger.awarning` and skip `capture_exception`, instead of the previous blanket `capture_exception` + `logger.aexception` for every exception. Any other exception (a genuine bug in the maintenance step) is still captured and logged as an exception exactly as before — nothing here widens what's swallowed beyond this transient-connectivity class.

## How did you test this code?

Added a parameterized case group to `TestRunPreWriteDefensiveCompact` in `pipelines/common/test/test_extract.py` covering the three observed transient-error message shapes (credential-loading failure, credential-provider-not-enabled, generic S3 error) — asserts `capture_exception` is not called and a warning is logged instead. The existing `test_swallows_maintenance_failure` case (an unrelated `RuntimeError`) already guards that non-transient errors keep going through `capture_exception`, so the classifier can't be broadened to hide real bugs.

Ran locally:
- `pytest pipelines/common/test/test_extract.py` (new + existing cases pass)
- `pytest pipelines/pipeline/test/test_delta_table_helper.py` (no regressions vs. pre-existing sandbox-only failures unrelated to this change — those need a live object-storage endpoint this environment doesn't have)
- `ruff check` / `ruff format --check` on changed files
- `uv run mypy --cache-fine-grained .` repo-wide: clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal pipeline error-handling change, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools: pulled the issue, its stack trace, and sampled exception events across four related error-tracking issues that all fingerprint to the same `get_delta_table` → `is_deltatable` call site with different underlying S3/credential-provider error text. Read the shared pipeline code (`delta_table_helper.py`, `extract.py`) to confirm the call site is unguarded and that the enclosing function already treats failures as best-effort/non-blocking, which is why the fix is to stop over-reporting rather than change retry semantics.

Invoked `/writing-tests` before adding the parameterized test cases.

Checked for a duplicate fix: PR [#69306](https://github.com/PostHog/posthog/pull/69306) ("swallow transient S3 errors in delta maintenance") looked related by title but addresses a different call site — retrying/swallowing errors from `vacuum_table`/`compact_table`'s own S3 delete/list calls — and its error-text classifier doesn't cover the credential-loading error shapes seen here, so it wouldn't have caught this class of issue. No overlap with the change in this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
