### PR TITLE
fix(aio): fix prompt label picker item indent and clipped validation message

### DIFF
--- a/products/ai_observability/frontend/prompts/PromptLabelPicker.tsx
+++ b/products/ai_observability/frontend/prompts/PromptLabelPicker.tsx
@@ -63,19 +63,23 @@ export function PromptLabelPicker({ version }: { version: number }): JSX.Element
                 data-attr="llma-prompt-label-picker-input"
             />
             <ComboboxContent>
-                <ComboboxEmpty>{validationError ?? 'No matching labels'}</ComboboxEmpty>
+                {/* h-auto + whitespace-normal: validation messages are longer than one line */}
+                <ComboboxEmpty className="h-auto whitespace-normal py-1.5 text-left">
+                    {validationError ?? 'No matching labels'}
+                </ComboboxEmpty>
                 <ComboboxList>
                     {(item: string) => {
+                        // ps-2: no item is ever "selected" here, so skip the check-indicator gutter
                         if (item === createSentinel) {
                             return (
-                                <ComboboxItem key={item} value={item}>
+                                <ComboboxItem key={item} value={item} className="ps-2">
                                     Create label "{trimmed}"
                                 </ComboboxItem>
                             )
                         }
                         const hint = labelHint(item)
                         return (
-                            <ComboboxItem key={item} value={item}>
+                            <ComboboxItem key={item} value={item} className="ps-2">
                                 <span>{item}</span>
                                 {hint ? <span className="text-xs text-secondary">{hint}</span> : null}
                             </ComboboxItem>


### PR DESCRIPTION
## Problem

In the label picker on the prompt view, all rows ("Create label ...", existing labels) render with an empty left gutter, and the label name validation message gets clipped at the popup edge.

## Changes

- `ps-2` on the picker's items: quill's `ComboboxItem` reserves the gutter for a selected-item check, but this picker is action-style and never marks anything selected, so the gutter was always empty.
- `h-auto whitespace-normal` on the empty state so the validation message wraps instead of clipping (it inherits `whitespace-nowrap` and a fixed height from the button-styled `MenuEmpty`).

Left the quill primitives untouched since their defaults are right for selection-style comboboxes.

## How did you test this code?

oxlint and oxfmt on the changed file. Not verified in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Traced the whitespace to the check-indicator gutter in `packages/quill/packages/primitives/src/combobox.css` and the clipping to `MenuEmpty`'s button styling, then chose call-site overrides over primitive changes.
