### PR TITLE
fix(postgres): recognize more non-retryable connection rejections

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -372,6 +372,13 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             "could not translate host name": None,
             "timeout expired connection to server at": None,
             "password authentication failed for user": None,
+            # Some providers (observed on a Neon-style pooler) report the same auth rejection without
+            # libpq's "for user" wording, putting the role on its own line instead: "password
+            # authentication failed\nuser \"<role>\"". The key above requires "for user" right after
+            # "failed", so it doesn't substring-match this variant and Temporal keeps retrying a
+            # credential mismatch only the customer can fix. Match the stable, wording-independent
+            # fragment shared by both forms.
+            "password authentication failed": None,
             # AWS RDS Proxy reports bad credentials with its own wording instead of PostgreSQL's
             # "password authentication failed for user" — it validates against Secrets Manager and
             # returns "The password that was provided for the role <role> is wrong." None of the
@@ -410,7 +417,25 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             # Marking it non-retryable would permanently disable syncs on a transient blip. A
             # genuinely unsupported-SSL source fails at connect time with a different message and is
             # caught via "SSLRequiredError" / "SSL/TLS connection is required".
-            "Address not in tenant allow_list": None,
+            # A Neon-style proxy rejects the connection because PostHog's egress IP isn't on the
+            # project's configured IP allow list (EADDRNOTALLOWED). Deterministic until the customer
+            # updates the allow list, so retrying just re-hits the same rejection. NB: the raw message
+            # lowercases "address" ("... FATAL:  (EADDRNOTALLOWED) address not in tenant allow_list:
+            # ..."), unlike the capitalized key this replaced, which never matched production traffic.
+            "address not in tenant allow_list": (
+                "Your database provider rejected the connection because PostHog's IP address is not on "
+                'its configured allow list ("address not in tenant allow_list"). Add PostHog\'s egress IP '
+                "addresses to your database provider's IP allow list, then re-enable the sync."
+            ),
+            # A Neon-style proxy rejects the connection for a specific branch/compute endpoint —
+            # observed when the branch is archived, suspended, or otherwise restricted from external
+            # connections. Deterministic until the customer changes the branch's connection settings.
+            "connection not allowed for branch": (
+                "Your database provider rejected the connection for this branch or compute endpoint "
+                '("connection not allowed for branch"). This usually means the branch is archived, '
+                "suspended, or restricted from external connections. Check your database provider's "
+                "dashboard for this branch's connection settings, then re-enable the sync."
+            ),
             "FATAL: no such database": None,
             "does not exist": None,
             "timestamp too small": None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -699,6 +699,79 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Real production wording (a Neon-style proxy) lowercases "address", unlike the
+            # capitalized key this replaced, which never matched production traffic. Host/IP, port,
+            # and the allow-listed IP tuple are volatile and excluded from the match.
+            'connection failed: connection to server at "203.0.113.10", port 5432 failed: FATAL:  '
+            "(EADDRNOTALLOWED) address not in tenant allow_list: {203, 0, 113, 99}\n"
+            'connection to server at "203.0.113.10", port 5432 failed: FATAL:  (ESSLREQUIRED) SSL '
+            "connection is required for user: postgres",
+        ],
+    )
+    def test_ip_not_in_tenant_allow_list_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        assert "address not in tenant allow_list" in non_retryable
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"IP-not-in-allow-list error should be non-retryable: {error_msg}"
+
+    def test_ip_not_in_tenant_allow_list_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = (
+            'connection failed: connection to server at "203.0.113.10", port 5432 failed: FATAL:  '
+            "(EADDRNOTALLOWED) address not in tenant allow_list: {203, 0, 113, 99}"
+        )
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "IP-not-in-allow-list error should surface an actionable message"
+        assert "allow list" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # A Neon-style proxy rejects the connection for a specific branch before the SSL-required
+            # fallback attempt is even tried. Host/IP, port, and the branch id are volatile.
+            'connection failed: connection to server at "203.0.113.20", port 6432 failed: FATAL:  '
+            "connection not allowed for branch abc123xyz\n"
+            'connection to server at "203.0.113.20", port 6432 failed: FATAL:  SSL/TLS required',
+        ],
+    )
+    def test_branch_connection_not_allowed_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        assert "connection not allowed for branch" in non_retryable
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Branch connection restriction error should be non-retryable: {error_msg}"
+
+    def test_branch_connection_not_allowed_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = (
+            'connection failed: connection to server at "203.0.113.20", port 6432 failed: FATAL:  '
+            "connection not allowed for branch abc123xyz"
+        )
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "Branch connection restriction error should surface an actionable message"
+        assert "branch" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Observed on a Neon-style pooler: the role is reported on its own line instead of
+            # libpq's "for user" wording, so it doesn't substring-match "password authentication
+            # failed for user". Host/IP, port, and the role id are volatile.
+            'connection failed: connection to server at "203.0.113.30", port 5432 failed: FATAL:  '
+            'password authentication failed\nuser "11111111-2222-3333-4444-555555555555"',
+        ],
+    )
+    def test_password_authentication_failed_without_for_user_wording_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        assert "password authentication failed" in non_retryable
+        assert "password authentication failed for user" not in error_msg
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, (
+            f"Password auth failure without 'for user' wording should be non-retryable: {error_msg}"
+        )
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "Cannot build decimal array from values",
             "ValueError: Cannot build decimal array from values",
         ],


### PR DESCRIPTION
## Problem

Error tracking flagged two high-volume `OperationalError` issues from the Postgres data-warehouse import source, both rooted in `_connect_with_options_fallback` (`postgres.py`):

- [Connection failed: SSL connection has been closed unexpectedly](https://us.posthog.com/project/2/error_tracking/019efe0e-e115-7f90-b6a0-39f476ba6801)
- [Connection failed: SSL connection has been closed unexpectedly](https://us.posthog.com/project/2/error_tracking/019efe0f-36d3-7950-97c9-c91b3e752da4)

Error tracking groups by stack frame, not exact message, so both issues bundle several distinct underlying causes. The bare "SSL connection has been closed unexpectedly" message is genuinely transient (already deliberately excluded from `get_non_retryable_errors`, with a comment explaining why) and needs no change.

Digging into a larger sample of events under the same two issues turned up a few connection-rejection messages from a Neon-style Postgres proxy that PostHog's classifier never recognizes, so they retry forever and keep generating error-tracking noise:

- An IP-allow-list rejection (`EADDRNOTALLOWED ... address not in tenant allow_list`) — the classifier already has a key for this, but it's spelled `Address not in tenant allow_list` (capital `A`), which never matches the real message (lowercase `address`). Looks like a typo that shipped without test coverage.
- A branch/compute-endpoint connection restriction (`connection not allowed for branch ...`) — no key at all.
- A password-auth rejection where the role is reported on its own line instead of libpq's `for user` wording — doesn't match the existing `password authentication failed for user` key.

All three are deterministic, customer-side conditions (bad IP allow-list config, a restricted/archived branch, bad credentials) where retrying can't help — the same pattern already handled for SASL/PAM/RDS-proxy wording variants elsewhere in this file.

## Changes

- Fixed the case-mismatched `address not in tenant allow_list` key so it actually matches production traffic, and gave it a customer-facing message.
- Added a `connection not allowed for branch` key with a customer-facing message.
- Added a `password authentication failed` key (without the `for user` suffix) alongside the existing one, to catch the wording variant that omits it.

Scoped to `get_non_retryable_errors` only — no changes to retry/backoff behavior for genuinely transient errors, and no changes to the general (non-Postgres) retry policy.

## How did you test this code?

Added parameterized test cases to `TestPostgresSourceNonRetryableErrors` in `test_postgres.py` (using sanitized, non-production example values):

- `test_ip_not_in_tenant_allow_list_is_non_retryable` / `..._returns_friendly_message` — locks in the case fix so this key can't silently regress back to never matching.
- `test_branch_connection_not_allowed_is_non_retryable` / `..._returns_friendly_message` — covers the new branch-restriction key.
- `test_password_authentication_failed_without_for_user_wording_is_non_retryable` — covers the wording variant that skips "for user".

Ran the full `test_postgres.py` suite locally: `TestPostgresSourceNonRetryableErrors` passes (117/117); the rest of the file's failures are pre-existing environment issues (tests that need a live Postgres instance not available in this sandbox), unrelated to this change. Also ran `ruff check`, `ruff format --check`, and a repo-wide `mypy` — all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal retry-classification logic, no user-facing/documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error-tracking MCP tools (issue + event lookups) to pull the stack traces and a larger sample of events for both linked issues, then read `postgres.py`/`source.py` to understand `get_non_retryable_errors` and the existing Neon/Supabase/RDS-proxy wording-variant precedent in this file. No skills were invoked for the investigation itself; `/writing-tests` was invoked before adding the new test cases, per this repo's mandatory-skill rule.

Decision: the reported issues' representative message ("SSL connection has been closed unexpectedly" alone) is correctly retryable and already documented as such — no change there. The actual fix targets three other message variants bundled under the same two fingerprints that were silently escaping non-retryable classification (one via a case-sensitivity bug, two via missing wording variants), which is what's actually driving these issues' volume.

Searched open PRs (by error type, key phrases, and the maintainer's own recent PRs) for a duplicate fix; found none addressing this specific classification gap.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*