### PR TITLE
fix(data-imports): stop looping forever when delta table reset fails

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -40,7 +40,6 @@ if TYPE_CHECKING:
     from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
     from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
     from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-    from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_sync import PipelineInputs
     from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.import_data_sync import (
         ImportDataActivityInputs,
     )
@@ -190,7 +189,9 @@ def report_heartbeat_timeout(inputs: "ImportDataActivityInputs", logger: Filteri
 
 
 async def handle_non_retryable_error(
-    job_inputs: "PipelineInputs",
+    team_id: int,
+    source_id: str,
+    run_id: str,
     error_msg: str,
     logger: FilteringBoundLogger,
     error: Exception,
@@ -200,9 +201,7 @@ async def handle_non_retryable_error(
             await logger.adebug(f"Failed to get Redis client for non-retryable error tracking. error={error_msg}")
             raise NonRetryableException() from error
 
-        retry_key = build_non_retryable_errors_redis_key(
-            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id
-        )
+        retry_key = build_non_retryable_errors_redis_key(team_id, source_id, run_id)
         attempts = await redis_client.incr(retry_key)
 
         if attempts <= NON_RETRYABLE_ERROR_RETRY_LIMIT:
@@ -491,7 +490,19 @@ async def handle_corrupted_delta_log(
         update_sync_type_config_keys,
     )
 
-    await delta_table_helper.reset_table()
+    try:
+        await delta_table_helper.reset_table()
+    except Exception as e:
+        # A reset that can't even complete (e.g. the storage backend rejects the delete) leaves the
+        # revive markers in place, so an unguarded re-raise here would repeat this exact same failing
+        # reset on every subsequent sync attempt forever. Give up after a few identical failures
+        # instead of looping — same policy as any other non-retryable import error.
+        capture_exception(e)
+        await logger.aexception(
+            f"handle_corrupted_delta_log: reset_table failed, schema_id={schema.id}: {e}", exc_info=e
+        )
+        await handle_non_retryable_error(schema.team_id, str(job.pipeline_id), str(job.id), str(e), logger, e)
+
     await database_sync_to_async_pool(schema.update_sync_type_config_for_reset_pipeline)()
     # Refresh the in-memory config from the persisted result — this schema object keeps saving
     # `sync_type_config` for the rest of the run (incremental staging, partition bookkeeping), and

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -20,6 +20,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.e
     resolve_primary_keys,
     run_pre_write_defensive_compact,
 )
+from products.warehouse_sources.backend.temporal.data_imports.util import NonRetryableException
 
 _EXTRACT_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract"
 
@@ -268,6 +269,37 @@ class TestHandleCorruptedDeltaLog:
         assert ph.capture.call_args.kwargs["event"] == "warehouse_delta_revived"
         assert ph.capture.call_args.kwargs["properties"]["outcome"] == "reset_rebuild"
         assert ph.capture.call_args.kwargs["properties"]["made_non_billable"] is True
+
+    def test_reset_failure_routes_through_non_retryable_handler(self, team):
+        # A reset that can't even complete (e.g. the storage backend rejects the delete) must not
+        # propagate unguarded — the revive markers would stay set, so every subsequent sync would
+        # repeat the exact same failing reset forever. It must go through the same give-up-after-
+        # N-attempts policy as any other import error, rather than looping and flooding error tracking.
+        schema, job = self._schema_and_job(team)
+        reset_error = RuntimeError("An error occurred (InvalidAccessKeyId) when calling ListObjectsV2")
+        helper = MagicMock(
+            is_table_corrupted=AsyncMock(return_value=True), reset_table=AsyncMock(side_effect=reset_error)
+        )
+
+        with (
+            patch(f"{_EXTRACT_MODULE}.posthoganalytics"),
+            patch(
+                f"{_EXTRACT_MODULE}.handle_non_retryable_error",
+                new=AsyncMock(side_effect=NonRetryableException()),
+            ) as handle_mock,
+        ):
+            with pytest.raises(NonRetryableException):
+                async_to_sync(handle_corrupted_delta_log)(schema, job, helper, self._logger())
+
+        handle_mock.assert_awaited_once()
+        assert handle_mock.await_args.args[0] == schema.team_id
+        assert handle_mock.await_args.args[1] == str(job.pipeline_id)
+        assert handle_mock.await_args.args[2] == str(job.id)
+        assert handle_mock.await_args.args[-1] is reset_error
+        # The reset itself failed, so the non-billable flip (which only happens after a successful
+        # reset) must never be reached.
+        job.refresh_from_db()
+        assert job.billable is True
 
     def test_revive_marker_resets_readable_table(self, team):
         # A hollow table — log opens fine but references data files gone from S3 — is invisible to

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -292,6 +292,7 @@ class TestHandleCorruptedDeltaLog:
                 async_to_sync(handle_corrupted_delta_log)(schema, job, helper, self._logger())
 
         handle_mock.assert_awaited_once()
+        assert handle_mock.await_args is not None
         assert handle_mock.await_args.args[0] == schema.team_id
         assert handle_mock.await_args.args[1] == str(job.pipeline_id)
         assert handle_mock.await_args.args[2] == str(job.id)

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -233,7 +233,9 @@ async def import_data_activity_sync(inputs: ImportDataActivityInputs) -> Pipelin
                 # fails identically on every attempt — there is nothing to retry. Treat it as
                 # non-retryable so the job gives up cleanly instead of crash-looping and spamming
                 # error tracking. Mirrors the skip in `sync_new_schemas_activity`.
-                await handle_non_retryable_error(job_inputs, str(e), logger, e)
+                await handle_non_retryable_error(
+                    job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, str(e), logger, e
+                )
 
             resumable_source_manager: ResumableSourceManager | None = None
             try:
@@ -337,11 +339,15 @@ async def _handle_import_error(
     # contract by type so every REST-based source stops immediately, rather than depending on each
     # source listing the message in get_non_retryable_errors.
     if isinstance(error, RESTClientNonRetryableError):
-        await handle_non_retryable_error(job_inputs, error_msg, logger, error)
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
 
     non_retryable_errors = source_cls.get_non_retryable_errors()
     if any(match in error_msg for match in non_retryable_errors):
-        await handle_non_retryable_error(job_inputs, error_msg, logger, error)
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
 
     retryable_errors = source_cls.get_retryable_errors()
     if any(match in error_msg for match in retryable_errors):

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -99,7 +99,7 @@ async def test_non_retryable_setup_error_routes_through_handler():
             await import_data_activity_sync(_inputs())
 
     handle_mock.assert_awaited_once()
-    assert handle_mock.await_args.args[3] is error
+    assert handle_mock.await_args.args[5] is error
 
 
 @pytest.mark.asyncio
@@ -129,7 +129,7 @@ async def test_unparseable_config_routes_through_handler():
             await import_data_activity_sync(_inputs())
 
     handle_mock.assert_awaited_once()
-    assert handle_mock.await_args.args[3] is error
+    assert handle_mock.await_args.args[5] is error
     source.source_for_pipeline.assert_not_called()
 
 
@@ -182,7 +182,7 @@ async def test_rest_client_non_retryable_error_routes_through_handler_without_so
 
     handle_mock.assert_awaited_once()
     assert handle_mock.await_args is not None
-    assert handle_mock.await_args.args[3] is error
+    assert handle_mock.await_args.args[5] is error
     logger.aexception.assert_not_awaited()
 
 


### PR DESCRIPTION
## Problem

[Error tracking](https://us.posthog.com/project/2/error_tracking/019edb40-46d9-7023-a41b-cd80ef4c389a) surfaced a `ClientError: InvalidAccessKeyId` (root-caused through a `PermissionError`/`OSError` chain) repeating thousands of times over several weeks for the same import job, originating in `delta_table_helper.py`'s `reset_table()`.

Tracing the call path (`handle_corrupted_delta_log` in `products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py`), the corrupted-delta-log revival flow's final "reset + rebuild" step calls `delta_table_helper.reset_table()` without a try/except - unlike its sibling salvage step just above it, which is defensively wrapped. When the reset itself can't complete (the storage delete fails), the exception propagates unguarded, and because it propagates before the revive markers (`delta_revive_required` / `repartition_pending` / `repartition_swap`) get cleared, the next sync attempt re-enters the exact same revival path and repeats the identical failing reset. Nothing bounds that loop, which is why the same job kept re-emitting this exception indefinitely and flooding error tracking with duplicate signal.

## Changes

- `handle_corrupted_delta_log`: wrap the reset+rebuild `reset_table()` call in a try/except. On failure, route it through the same give-up-after-N-attempts policy (`handle_non_retryable_error`) already used for every other non-retryable import error, instead of letting it retry unbounded.
- `handle_non_retryable_error`: takes explicit `team_id` / `source_id` / `run_id` instead of a whole `PipelineInputs` object, since the corrupted-log path only has an `ExternalDataJob` / `ExternalDataSchema` on hand, not a `PipelineInputs`. Updated the three existing call sites in `import_data_sync.py` accordingly.

This is a shared pipeline-layer fix (not source-specific) since the failure originates in the Delta/S3 storage layer, not any particular connector.

## How did you test this code?

Added `test_reset_failure_routes_through_non_retryable_handler` to `TestHandleCorruptedDeltaLog` in `test_extract.py` - reproduces a `reset_table()` failure during the corrupted-log revival path and asserts it now routes through `handle_non_retryable_error` (with the correct team/source/run identifiers) instead of propagating raw, and that the non-billable flip is never reached when reset itself fails.

Ran locally (agent):
- `ruff check` / `ruff format` on all four changed files - clean
- `mypy` on the two changed production files - no issues
- `pytest` on `workflow_activities/tests/test_import_data_sync.py` (updated call-site assertions) - 10/10 passed

I could not run the DB-backed `test_extract.py::TestHandleCorruptedDeltaLog` suite in this sandbox (no Postgres/Redis available, no Docker daemon) - I traced the new test manually against the modified code instead.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - internal pipeline error-handling fix, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools (issue details, sampled exception events with full stack traces, and HogQL breakdowns by sync-context properties) to confirm the failure's shape and scope, then read through the pipeline source to trace the call path from the Temporal activity into `delta_table_helper.py` and `common/extract.py`.

Ruled out a duplicate fix by searching open PRs (by exception type, module path, and error text) and scanning the maintainer's own open PRs - none address this call path.

Decision: this is a pipeline-layer bug (the reset step lacks the same defensive wrapping as its sibling salvage step), not a user/upstream credentials problem to leave permanently retrying, and not a benign/expected condition to suppress from tracking - so it's fixed at the shared pipeline layer with a regression test, rather than widening any source's `NonRetryableErrors` list.

Ran `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*