### PR TITLE
fix(data-imports): capture and propagate context for OSError in get_delta_table

### DIFF
--- a/posthog/temporal/common/posthog_client.py
+++ b/posthog/temporal/common/posthog_client.py
@@ -15,6 +15,7 @@ from temporalio.worker import (
 )
 
 from posthog.egress.transport.transport import EgressBudgetExhausted
+from posthog.exceptions_capture import ambient_exception_properties
 from posthog.temporal.common.interceptor import ALL_TASK_QUEUES
 from posthog.temporal.common.logger import get_write_only_logger
 
@@ -75,6 +76,11 @@ class _PostHogClientActivityInboundInterceptor(ActivityInboundInterceptor):
             activity_info = activity.info()
             capture_kwargs = {
                 "properties": {
+                    # Ambient properties (e.g. warehouse-sources JobContext) first so the explicit
+                    # Temporal fields below win on collision — this is the last chance to attach
+                    # them, since an exception reaching here escaped uncaught past any inner
+                    # capture_exception() call that would otherwise have merged them in.
+                    **ambient_exception_properties(),
                     "temporal.execution_type": "activity",
                     "module": input.fn.__module__ + "." + input.fn.__qualname__,
                     "temporal.activity.attempt": activity_info.attempt,
@@ -110,6 +116,9 @@ class _PostHogClientWorkflowInterceptor(WorkflowInboundInterceptor):
                 workflow_info = workflow.info()
                 capture_kwargs = {
                     "properties": {
+                        # See the matching comment in _PostHogClientActivityInboundInterceptor:
+                        # ambient properties first so the explicit Temporal fields below win.
+                        **ambient_exception_properties(),
                         "temporal.execution_type": "workflow",
                         "module": input.run_fn.__module__ + "." + input.run_fn.__qualname__,
                         "temporal.workflow.task_queue": workflow_info.task_queue,

--- a/posthog/temporal/tests/common/test_error_tracking.py
+++ b/posthog/temporal/tests/common/test_error_tracking.py
@@ -15,6 +15,7 @@ from temporalio.exceptions import ApplicationError, CancelledError
 from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.egress.github.transport import GitHubEgressBudgetExhausted
+from posthog.exceptions_capture import bind_exception_context
 from posthog.temporal.common.posthog_client import PostHogClientInterceptor
 
 
@@ -78,6 +79,33 @@ class OptionallyFailingWorkflowWithPropertiesToLog:
 async def failing_activity_with_properties_to_log(inputs: OptionallyFailingInputsWithPropertiesToLog) -> None:
     if inputs.fail:
         raise ValueError("Activity failed!")
+
+
+@activity.defn
+async def failing_activity_with_ambient_context(inputs: OptionallyFailingInputs) -> None:
+    if inputs.fail:
+        # Fire-and-forget binding, mirroring how e.g. warehouse-sources' JobContext attaches
+        # sync context: no `with` block, so it stays bound for the rest of this activity
+        # attempt (including an exception that escapes uncaught to the interceptor below).
+        bind_exception_context(warehouse_sources_source_type="Stripe")
+        raise ValueError("Activity failed!")
+
+
+@workflow.defn
+class FailingWorkflowWithAmbientContext:
+    @workflow.run
+    async def run(self, inputs: OptionallyFailingInputs) -> None:
+        await workflow.execute_activity(
+            failing_activity_with_ambient_context,
+            inputs,
+            start_to_close_timeout=dt.timedelta(minutes=1),
+            heartbeat_timeout=dt.timedelta(seconds=5),
+            retry_policy=RetryPolicy(
+                initial_interval=dt.timedelta(seconds=1),
+                maximum_interval=dt.timedelta(seconds=1),
+                maximum_attempts=1,
+            ),
+        )
 
 
 @activity.defn
@@ -195,6 +223,39 @@ async def test_exception_capture(fail: bool, capture_additional_properties: bool
 
         else:
             mock_ph_capture.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ambient_exception_context_reaches_top_level_capture(temporal_client: Client):
+    """An exception that escapes an activity uncaught (nothing inside called capture_exception)
+    must still carry ambient exception context bound earlier in the same activity attempt — e.g.
+    warehouse-sources' JobContext, which attaches sync/job identity via bind_exception_context so a
+    generic pipeline failure can be attributed to the source that produced it."""
+    task_queue = "TEST-TASK-QUEUE"
+    workflow_id = str(uuid.uuid4())
+
+    with patch("posthog.temporal.common.posthog_client.capture_exception") as mock_ph_capture:
+        async with Worker(
+            temporal_client,
+            task_queue=task_queue,
+            workflows=[FailingWorkflowWithAmbientContext],
+            activities=[failing_activity_with_ambient_context],
+            interceptors=[PostHogClientInterceptor()],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            with pytest.raises(WorkflowFailureError):
+                await temporal_client.execute_workflow(
+                    "FailingWorkflowWithAmbientContext",
+                    OptionallyFailingInputs(fail=True),
+                    id=workflow_id,
+                    task_queue=task_queue,
+                    retry_policy=RetryPolicy(maximum_attempts=1),
+                )
+
+        assert mock_ph_capture.call_count == 1
+        activity_call = mock_ph_capture.call_args_list[0]
+        assert activity_call[1]["properties"]["warehouse_sources_source_type"] == "Stripe"
+        assert activity_call[1]["properties"]["temporal.execution_type"] == "activity"
 
 
 @pytest.mark.asyncio

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -281,9 +281,18 @@ class DeltaTableHelper:
         delta_uri = await self._get_delta_table_uri()
         storage_options = self._get_credentials()
 
-        is_delta = await asyncio.to_thread(
-            deltalake.DeltaTable.is_deltatable, table_uri=delta_uri, storage_options=storage_options
-        )
+        try:
+            is_delta = await asyncio.to_thread(
+                deltalake.DeltaTable.is_deltatable, table_uri=delta_uri, storage_options=storage_options
+            )
+        except Exception as e:
+            # Mirrors the DeltaTable() open below: capture before propagating. Callers range from
+            # best-effort maintenance to the main write path, so this can't safely swallow the
+            # error and report "no table" here — that would trip should_overwrite_table for a
+            # table that actually exists, risking data loss.
+            capture_exception(e)
+            raise
+
         if is_delta:
             try:
                 return await asyncio.to_thread(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -379,6 +379,32 @@ class TestGetDeltaTableUnrecoverableErrors:
                 s3._rm.assert_not_awaited()
                 assert helper.is_first_sync is False
 
+    @pytest.mark.asyncio
+    async def test_is_deltatable_failure_is_captured_and_reraised(self):
+        """The `is_deltatable` existence check is a separate S3 call from the DeltaTable() open
+        handled above, and callers span best-effort maintenance to the main write path, so a
+        failure here can't be swallowed as "no table" (that would trip should_overwrite_table and
+        wipe an existing table) — it must be captured for visibility and reraised."""
+        helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
+        delta_uri = "s3://bucket/team_id/job_id/t"
+
+        module = "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.delta_table_helper"
+        with (
+            patch.object(helper, "_get_delta_table_uri", AsyncMock(return_value=delta_uri)),
+            patch(f"{module}.deltalake.DeltaTable") as mock_delta_table,
+            patch(f"{module}.capture_exception") as mock_capture,
+        ):
+            mock_delta_table.is_deltatable.side_effect = OSError(
+                "Generic S3 error: Received redirect without LOCATION, this normally indicates "
+                "an incorrectly configured region"
+            )
+
+            with pytest.raises(OSError, match="Received redirect without LOCATION"):
+                await helper.get_delta_table()
+
+            mock_capture.assert_called_once()
+            assert helper.is_first_sync is False
+
 
 class TestWriteToDeltalakeCommitMetadataPassThrough:
     """Covers that commit_metadata is forwarded to deltalake.write_deltalake as CommitProperties."""


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `OSError` ("Generic S3 error: Received redirect without LOCATION, this normally indicates an incorrectly configured region") originating from `get_delta_table()` in the shared warehouse-sources Delta pipeline code (`products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py`). The stack trace bottoms out in delta-rs's `DeltaTable.is_deltatable()` call, reached from the main per-batch write path (`pipeline.py`'s `_process_pa_table`), not just a maintenance step — so a failure here fails the sync itself, not just error-tracking noise.

Digging in surfaced two related gaps:

1. **Unguarded existence check.** `is_deltatable()` is the only S3 call inside `get_delta_table()` without a try/except — the `DeltaTable()` open three lines below it already wraps failures with `capture_exception` plus repair logic for known-corrupt signatures. `is_deltatable()`'s failures instead propagated bare, with no chance to attach context before hitting the generic Temporal boundary.
2. **Lost sync/job context on uncaught exceptions.** The Temporal client interceptor (`posthog/temporal/common/posthog_client.py`) that captures exceptions escaping uncaught to the activity/workflow boundary imports `capture_exception` directly from `posthoganalytics`, bypassing the ambient exception context (`posthog.exceptions_capture`) that subsystems like warehouse-sources' `JobContext` rely on to attach `warehouse_sources_source_type`, `warehouse_sources_schema_name`, etc. Since this exact `OSError` propagates uncaught all the way to that boundary, its captured event was missing exactly the properties needed to attribute it to a source/schema — which is what made this issue require digging through source instead of just reading properties off the event.

I checked for existing overlapping fixes: [#73136](https://github.com/PostHog/posthog/pull/73136) guards `is_table_corrupted()`'s own separate `is_deltatable()` call, and [#73139](https://github.com/PostHog/posthog/pull/73139) reclassifies transient S3/credential errors in the maintenance path — both are distinct call sites/callers from the one here (`get_delta_table()`'s check on the main write path), so this isn't a duplicate.

I didn't extend `NonRetryableErrors` or change retry policy — the message suggests a region/endpoint misconfiguration, but I can't confirm from code alone whether it's a persistent condition or something that resolves once infra is fixed, and treating a real (if rare) failure as non-retryable risks masking a genuine bug. Leaving it retryable, now with proper capture and full context so it's easy to keep tracking (and ideally more actionable next time it fires).

## Changes

- `delta_table_helper.py`: wrap the `is_deltatable()` call in `get_delta_table()` with the same "capture, then propagate" handling as the `DeltaTable()` open beside it. It re-raises rather than swallowing into "table doesn't exist", since callers span best-effort maintenance to the main write path, and misreporting "no table" here would incorrectly trip a fresh-sync overwrite on a table that actually exists.
- `posthog_client.py`: merge ambient exception context (`posthog.exceptions_capture.ambient_exception_properties()`) into the properties captured by both the activity and workflow interceptors, so any subsystem's `bind_exception_context`/`bind_job_context` binding survives an exception that escapes uncaught all the way to this boundary — not just ones caught and re-captured deeper in the stack.

## How did you test this code?

- Extended `TestGetDeltaTableUnrecoverableErrors` in `test_delta_table_helper.py` with a case where `is_deltatable()` itself raises the observed `OSError`, asserting `capture_exception` is called and the table is *not* treated as a fresh sync (`is_first_sync` stays `False`) — guards against a future "fix" that silently swallows this into first-sync mode and risks overwriting real data.
- Added a real-worker test to `test_error_tracking.py` (extending the existing `PostHogClientInterceptor` test suite there) where an activity binds ambient exception context via `bind_exception_context` (mirroring how `JobContext` does it) and then raises uncaught — asserts the property reaches the interceptor's `capture_exception` call. This is the regression that would have caught the missing-properties gap.
- `ruff check` / `ruff format --check` clean on all four touched files.
- `uv run mypy --cache-fine-grained .` repo-wide: clean (16,716 files, no issues).
- Ran the full `test_delta_table_helper.py` suite locally: 66 passed; the 4 cases in `TestGetDeltaTableUnrecoverableErrors` (3 pre-existing + my new one) need a live `objectstorage` endpoint this sandbox doesn't have — confirmed identical failures on unmodified `master`, consistent with the same gap noted in #73136.
- Couldn't run `test_error_tracking.py`'s new/existing cases here — they need a real Temporal test-server (`temporal:7233`), unavailable in this sandbox; same requirement as every other test already in that file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal pipeline error-handling change, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged via PostHog's error-tracking MCP tools (issue details, sampled `$exception` events with stack traces, and a HogQL query grouping occurrences by `source_id`/`schema_id` since the properties the issue promised — `warehouse_sources_*` — turned out to be entirely absent from the actual events, which is what led to finding gap #2 above). Read `delta_table_helper.py`, `job_context.py`, `pipeline.py`, and `posthog_client.py` to trace the exact call path and confirm the missing-properties defect.

Searched open PRs (by error text, module path, and the maintainer's own queue) before writing any code, per the triage instructions, to rule out duplicates against #73136 and #73139.

Invoked `/writing-tests` before adding both test cases.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*