### PR TITLE
docs(warehouse): clarify Klaviyo list membership vs subscription consent

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/canonical_descriptions.py
@@ -99,19 +99,37 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "organization": "The organization the profile is associated with.",
             "title": "The profile's job title.",
             "location": "The profile's location details.",
-            "properties": "Custom properties set on the profile.",
+            "properties": (
+                "Custom properties set on the profile. Subscription status lives here in the `$consent` array "
+                "— the communication channels (`sms`, `email`, and/or `push`) the profile is currently "
+                "consented to — not in list membership: a profile can belong to a list without being "
+                "subscribed. `$consent_timestamp` records when the profile consented to receive communication, "
+                "but it is not reliably cleared on unsubscribe, so use `$consent`, not `$consent_timestamp`, "
+                "to tell who is currently subscribed."
+            ),
             "created": "Time at which the profile was created.",
             "updated": "Time at which the profile was last updated.",
             "last_event_date": "Time of the profile's most recent event.",
         },
     },
     "list_profiles": {
-        "description": "A flat join table mapping which profiles belong to which Klaviyo list. Rows for profiles removed from a list are only pruned by a full refresh.",
+        "description": (
+            "A flat join table mapping which profiles belong to which Klaviyo list. Rows for profiles removed "
+            "from a list are only pruned by a full refresh. List membership is not the same as subscription: "
+            "a profile can be on a list without being subscribed to any channel. To tell which channels "
+            "(`sms`, `email`, and/or `push`) a profile is actually subscribed to, check the `$consent` array "
+            "in the profile's `properties` (in the `profiles` table)."
+        ),
         "docs_url": "https://developers.klaviyo.com/en/reference/get_profiles_for_list",
         "columns": {
             "list_id": "Identifier of the list.",
             "profile_id": "Identifier of a profile that is a member of the list.",
-            "joined_group_at": "The datetime when the profile most recently joined the list. Updated if the profile re-joins.",
+            "joined_group_at": (
+                "The datetime when the profile most recently joined the list. Updated if the profile re-joins. "
+                "Joining a list does not mean the profile is subscribed: check the `$consent` array in the "
+                "`profiles` table's `properties` for current subscription status. This timestamp often matches "
+                "the profile's `$consent_timestamp`, but not always — do not treat them as interchangeable."
+            ),
         },
     },
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/source.py
@@ -135,7 +135,9 @@ Make sure to grant the following read permissions:
                 return (
                     "Maps which profiles belong to which list as {list_id, profile_id, joined_group_at} rows. "
                     "Incremental syncs pick up new joins and re-joins; profiles removed from a list are only "
-                    "reflected on a full refresh"
+                    "reflected on a full refresh. List membership is not the same as subscription: check the "
+                    "$consent array in the profiles table's properties column to see which channels (sms, "
+                    "email, push) a profile is currently subscribed to"
                 )
             return None
 


### PR DESCRIPTION
## Problem

Klaviyo warehouse users had nothing telling them that email/SMS/push subscription status doesn't live in list membership. A profile being in a list (what `list_profiles` captures via `joined_group_at`) doesn't mean they're subscribed to any channel. The reliable signal is the `$consent` array nested in a profile's `properties`, which lists the channels (`sms`, `email`, `push`) a profile currently consents to. `$consent_timestamp` (also in `properties`) records when consent was given, but it's unreliable as a live status check since Klaviyo doesn't always clear it on unsubscribe.

The `profiles.properties` annotation just said "Custom properties set on the profile" and nothing documented the `$consent` distinction, so people naturally conflate list membership with consent and query the wrong field. The sync itself is correct; this is a documentation gap.

## Changes

Enriched the in-product column annotations (from `canonical_descriptions.py`) so the distinction shows up right where users build queries:

- `profiles.properties` now explains that subscription status lives in the `$consent` array across all channels (not just email), and warns against relying on `$consent_timestamp`.
- The `list_profiles` table description and its `joined_group_at` column note that membership is separate from subscription, and point at `$consent` in the `profiles` table.
- Mirrored the same note in the `list_profiles` schema `description` in `source.py`.

> [!NOTE]
> The customer-facing page at posthog.com/docs/cdp/sources/klaviyo lives in the separate posthog.com repo and still needs the same clarification. That's a follow-up outside this repo.

## How did you test this code?

Text-only annotation changes. Ran `ruff check` and `ruff format` on both files (clean). Confirmed no existing test asserts on the changed description strings. Cross-checked the `$consent` / `$consent_timestamp` semantics against Klaviyo's own Help Center glossary and public API examples to confirm `$consent` is multi-channel (sms/email/push), not email-only.

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude (via PostHog Code) to draft this after a customer reply confirmed a docs gap around Klaviyo consent semantics, and to double-check the wording against Klaviyo's own documentation before shipping it — the first draft framed `$consent` as an email-only signal, which Claude corrected to cover all three channels after cross-referencing Klaviyo's docs.

Invoked the `/documenting-warehouse-sources` skill to confirm these canonical descriptions (not a hand-written docs page) are the single source of truth the product renders.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*