### PR TITLE
fix(data-imports): skip warehouse enrichment when LLM gateway unset

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/enrich_table_semantics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/enrich_table_semantics.py
@@ -22,6 +22,8 @@ import dataclasses
 from datetime import timedelta
 from typing import Any
 
+from django.conf import settings
+
 import posthoganalytics
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
@@ -407,6 +409,23 @@ def enrich_table_semantics_sync(team_id: int, schema_id: uuid.UUID) -> dict[str,
         log.info("warehouse_enrichment.done", canonical=canonical_count, ai=0, llm_called=False)
         emit_completed("done", canonical_annotations=canonical_count, ai_annotations=0, llm_called=False)
         return {"status": "done", "canonical_annotations": canonical_count, "ai_annotations": 0}
+
+    # The LLM pass needs the internal gateway. Where it isn't configured (e.g. a worker without the
+    # gateway env), get_llm_client raises a ValueError that the broad except below would capture on
+    # every sync — an expected environment condition, not a per-table failure. Skip the AI pass instead:
+    # canonical descriptions above are already persisted and don't need the gateway, and a later sync
+    # fills in the rest once it's available.
+    if not settings.LLM_GATEWAY_URL or not settings.LLM_GATEWAY_API_KEY:
+        log.info("warehouse_enrichment.skipped", reason="llm_gateway_not_configured", canonical=canonical_count)
+        emit_completed(
+            "skipped", reason="llm_gateway_not_configured", canonical_annotations=canonical_count, ai_annotations=0
+        )
+        return {
+            "status": "skipped",
+            "reason": "llm_gateway_not_configured",
+            "canonical_annotations": canonical_count,
+            "ai_annotations": 0,
+        }
 
     # 2) LLM pass for everything still undescribed. Known descriptions (canonical + existing) give the
     # model context about neighbouring columns without re-describing them.

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_enrich_table_semantics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_enrich_table_semantics.py
@@ -5,6 +5,8 @@ from typing import Any
 import pytest
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
+
 from temporalio.testing import ActivityEnvironment
 
 from posthog.models import Organization, Team
@@ -707,6 +709,37 @@ class TestEnrichTableSemanticsSync:
         annotations = _annotations(team, table)
         assert annotations["amount"].description == "charge amount in cents"
         assert annotations["currency"].description == "ISO currency code"
+
+    @override_settings(LLM_GATEWAY_URL="", LLM_GATEWAY_API_KEY="")
+    def test_skips_llm_pass_without_capturing_when_gateway_not_configured(self):
+        # Where the LLM gateway env isn't set, get_llm_client raises — an expected config condition,
+        # not a per-table bug. The AI pass must skip without capturing an exception, while canonical
+        # descriptions (which need no gateway) still persist.
+        team = _team()
+        schema, table = _make_schema(
+            team,
+            columns=[
+                {"name": "amount", "data_type": "Int64", "is_nullable": False},
+                {"name": "status", "data_type": "String", "is_nullable": True},
+            ],
+        )
+        canonical = {"Charge": {"columns": {"amount": "charge amount in cents"}}}
+        with (
+            patch.object(enrich, "enrichment_enabled", return_value=True),
+            patch.object(enrich, "get_canonical_descriptions_for_source", return_value=canonical),
+            patch.object(enrich, "_generate_descriptions") as mock_llm,
+            patch.object(enrich, "capture_exception") as mock_capture,
+        ):
+            result = enrich_table_semantics_sync(team.pk, schema.id)
+
+        mock_llm.assert_not_called()
+        mock_capture.assert_not_called()
+        assert result["status"] == "skipped"
+        assert result["reason"] == "llm_gateway_not_configured"
+        # Canonical description still landed; the un-canonical column was not enriched.
+        annotations = _annotations(team, table)
+        assert annotations["amount"].description == "charge amount in cents"
+        assert "status" not in annotations
 
     def test_partial_status_when_llm_fails(self):
         team = _team()


### PR DESCRIPTION
## Problem

The data warehouse semantic-enrichment activity (`enrich_table_semantics`) runs after every sync to draft table and column descriptions for PostHog AI. Its optional LLM pass goes through `get_llm_client`, which raises `ValueError: LLM_GATEWAY_URL and LLM_GATEWAY_API_KEY must be configured` in any environment where the internal LLM gateway isn't set up.

The activity already degrades gracefully when the LLM call fails, but it does so by catching the error and calling `capture_exception` on it. So in environments without the gateway, this expected config condition gets reported to error tracking on every sync that reaches the LLM pass. It's a recurring, non-actionable exception with no per-table root cause. Reported by error tracking: https://us.posthog.com/project/2/error_tracking/019efee6-45ae-79c2-8263-52a01d6577c2

## Changes

Gate the LLM pass on the gateway actually being configured, the same precheck `products/conversations/backend/slack.py` already uses. When `LLM_GATEWAY_URL` or `LLM_GATEWAY_API_KEY` is unset, skip the AI pass and return a `skipped` / `llm_gateway_not_configured` status instead of letting `get_llm_client` raise into the broad `except` that captures it.

The gate sits after the canonical (documentation-sourced) descriptions are persisted, so those still land without a gateway, and a later sync fills in the AI descriptions once one is available. The real LLM-failure path (network errors, gateway 5xx, unparseable responses) is untouched and still captured.

> [!NOTE]
> This is a "stop tracking an expected condition" change, not a retry-policy change. It follows the same pattern as #69763 in the sibling data-modeling view enrichment.

## How did you test this code?

Added `test_skips_llm_pass_without_capturing_when_gateway_not_configured` to the sync test suite. With the gateway unset it asserts the LLM call and `capture_exception` are both never invoked, the result is `skipped` / `llm_gateway_not_configured`, and canonical descriptions still persist while un-canonical columns are left for a later run. No existing test covered this path — `test_partial_status_when_llm_fails` mocks a generic failure and asserts capture *does* happen, which is the opposite case.

I (Claude) ran the full `TestEnrichTableSemanticsSync` suite locally against Postgres + ClickHouse; it passes. I did not run the change against a live import.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the shared data-imports pipeline. The stack trace pointed at `enrich_table_semantics_sync` → `_generate_descriptions` → `get_llm_client`, which raises when the gateway env isn't configured. Confirmed via error tracking that it's a steady, high-volume, handled `ValueError` with no per-table cause — an environment condition, not a bug in the conversion/schema-evolution path.

Considered two fixes: catching the specific `ValueError` in the existing `except`, versus a preventive gate before the LLM call. Chose the gate — it matches the existing `conversations` precedent, avoids the wasted prompt-building work, and produces a clean telemetry status instead of a swallowed exception. Kept it strictly scoped so genuine LLM failures stay visible.

Skills invoked: `/writing-tests`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
