### PR TITLE
feat(conversations): show filtered ticket count next to the search bar

### DIFF
--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.test.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.test.tsx
@@ -131,8 +131,11 @@ describe('SupportTicketsTableFilters count', () => {
         })
     }
 
-    it('shows a pluralized count of tickets matching the current query', async () => {
-        setCount(42)
+    it.each([
+        ['pluralizes the count of tickets matching the current query', 42, '42 tickets'],
+        ['uses the singular noun for a single ticket', 1, '1 ticket'],
+    ])('%s', async (_name, count, expected) => {
+        setCount(count)
 
         render(
             <Provider>
@@ -140,18 +143,6 @@ describe('SupportTicketsTableFilters count', () => {
             </Provider>
         )
 
-        expect(await screen.findByText('42 tickets')).toBeInTheDocument()
-    })
-
-    it('uses the singular noun for a single ticket', async () => {
-        setCount(1)
-
-        render(
-            <Provider>
-                <SupportTicketsTableFilters />
-            </Provider>
-        )
-
-        expect(await screen.findByText('1 ticket')).toBeInTheDocument()
+        expect(await screen.findByText(expected)).toBeInTheDocument()
     })
 })

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.test.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.test.tsx
@@ -8,7 +8,7 @@ import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
 import { Ticket } from '../../types'
-import { SupportTicketsTable } from './SupportTicketsScene'
+import { SupportTicketsTable, SupportTicketsTableFilters } from './SupportTicketsScene'
 import { supportTicketsSceneLogic } from './supportTicketsSceneLogic'
 
 const TICKET: Ticket = {
@@ -96,5 +96,62 @@ describe('SupportTicketsTable selection', () => {
 
         await waitFor(() => expect(getRowCheckbox()).not.toBeChecked())
         expect(logic.values.selectedTicketIds).toEqual([])
+    })
+})
+
+describe('SupportTicketsTableFilters count', () => {
+    let logic: ReturnType<typeof supportTicketsSceneLogic.build>
+    let mockCount = 0
+
+    beforeEach(() => {
+        mockCount = 0
+        useMocks({
+            get: {
+                '/api/projects/:team_id/conversations/tickets/': () => [200, { results: [TICKET], count: mockCount }],
+                '/api/organizations/:organization_id/members/': () => [200, { results: [] }],
+                '/api/projects/:team_id/tags': () => [200, []],
+            },
+        })
+        initKeaTests()
+        logic = supportTicketsSceneLogic()
+        logic.mount()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        cleanup()
+    })
+
+    // Set the count directly so the assertion doesn't race the debounced loadTickets; keep the
+    // mock in sync so a background reload can't reset the value out from under the assertion.
+    function setCount(count: number): void {
+        mockCount = count
+        act(() => {
+            logic.actions.setTotalCount(count)
+        })
+    }
+
+    it('shows a pluralized count of tickets matching the current query', async () => {
+        setCount(42)
+
+        render(
+            <Provider>
+                <SupportTicketsTableFilters />
+            </Provider>
+        )
+
+        expect(await screen.findByText('42 tickets')).toBeInTheDocument()
+    })
+
+    it('uses the singular noun for a single ticket', async () => {
+        setCount(1)
+
+        render(
+            <Provider>
+                <SupportTicketsTableFilters />
+            </Provider>
+        )
+
+        expect(await screen.findByText('1 ticket')).toBeInTheDocument()
     })
 })

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -305,10 +305,7 @@ export function SupportTicketsTableFilters({ embedded = false }: SupportTicketsT
                         controls so it reads as the filtered count rather than an all-time total.
                         Hidden until the first load resolves; dims on subsequent background refreshes. */}
                     <span
-                        className={clsx(
-                            'text-secondary text-sm whitespace-nowrap',
-                            ticketsLoading && 'opacity-50'
-                        )}
+                        className={clsx('text-secondary text-sm whitespace-nowrap', ticketsLoading && 'opacity-50')}
                         aria-live="polite"
                     >
                         {ticketsLoading && totalCount === 0 ? null : pluralize(totalCount, 'ticket')}

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -14,11 +14,13 @@ import {
     LemonSelect,
     LemonTable,
     LemonTableColumns,
+    Tooltip,
 } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { useBulkSelection } from 'lib/lemon-ui/LemonTable/useBulkSelection'
 import { newInternalTab } from 'lib/utils/newInternalTab'
+import { pluralize } from 'lib/utils/strings'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -260,6 +262,8 @@ export function SupportTicketsTableFilters({ embedded = false }: SupportTicketsT
         dateFrom,
         dateTo,
         ticketsLoading,
+        totalCount,
+        hasActiveFilters,
     } = useValues(logic)
     const {
         setSearchQuery,
@@ -290,6 +294,26 @@ export function SupportTicketsTableFilters({ embedded = false }: SupportTicketsT
                     size="small"
                     className="min-w-64"
                 />
+                <Tooltip
+                    title={
+                        hasActiveFilters || searchQuery
+                            ? 'Tickets matching the current filters, search, and view — not the total across all tickets'
+                            : 'Tickets in the current view'
+                    }
+                >
+                    {/* Count of tickets matching the current query, shown next to the search/filter
+                        controls so it reads as the filtered count rather than an all-time total.
+                        Hidden until the first load resolves; dims on subsequent background refreshes. */}
+                    <span
+                        className={clsx(
+                            'text-secondary text-sm whitespace-nowrap',
+                            ticketsLoading && 'opacity-50'
+                        )}
+                        aria-live="polite"
+                    >
+                        {ticketsLoading && totalCount === 0 ? null : pluralize(totalCount, 'ticket')}
+                    </span>
+                </Tooltip>
                 <DateFilter
                     dateFrom={dateFrom}
                     dateTo={dateTo}


### PR DESCRIPTION
## Problem

Support agents want to know how many tickets are in their current view at all times, without scrolling to the pagination footer. We wanted this to be unambiguous that it reflects the current filters, search, and saved view rather than the all-time ticket total.

## Changes

Adds a live ticket count to the support tickets filter row, right next to the search input (same placement as the feature flags list).

- It reads from the existing `totalCount` selector, so it's the server total for the current filters/search/view, not just the loaded page.
- Sitting inline with the search and filter controls makes it read as the filtered count. A tooltip spells it out, and switches its wording when filters or a search are active ("matching the current filters, search, and view — not the total across all tickets").
- Uses `pluralize`, so it renders "1 ticket" / "1,234 tickets".
- Hidden until the first load resolves, and dims during background refreshes (via the existing `ticketsLoading`), matching the feature flags pattern.

This started as a change in the standalone hogdesk prototype and moved here to the real product, and per feedback landed next to the search bar rather than in the `#` column header.

## How did you test this code?

Added two unit tests to `SupportTicketsScene.test.tsx` covering the new count: it renders the pluralized count for the current query, and uses the singular noun for a single ticket. These guard against the count regressing to a hidden/blank state or mis-pluralizing.

I (the agent) ran locally:
- `jest --testPathPattern='SupportTicketsScene.test'` — 4 passed (2 existing + 2 new)
- `oxlint` on both changed files — clean

I did not run the full type-check or exercise it manually in a browser.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Luke directed this from a Slack thread; I (the PostHog Slack app, running Claude) implemented it. I first built it in the hogdesk prototype as a count in the `#` column header, then Luke redirected it to `posthog/posthog` and asked for the feature-flags style placement next to the search bar. I matched the existing `FeatureFlagFilters` count pattern (inline `text-secondary` count, dim-while-loading), reused the existing `totalCount`/`hasActiveFilters` selectors rather than adding new state, and added a tooltip because the explicit requirement was that the number must not be mistaken for an all-time total.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1784803252311559?thread_ts=1784803252.311559&cid=C075D3C5HST)*
