### PR TITLE
fix(vercel): stop tracking self-recovering Vercel API errors as bugs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/source.py
@@ -104,6 +104,12 @@ To sync resources owned by a team, also enter the team's ID (found under **Team 
             "404 Client Error: Not Found for url: https://api.vercel.com/v1/billing/charges": "Vercel couldn't find billing data for the configured team. Check that the Team ID is correct and that your access token's user still belongs to that team, then reconnect.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # A 429 or 5xx is retried internally by `_fetch_page`/`_open_billing_stream`; if those
+        # retries still exhaust, the failure is transient and self-recovering, so let Temporal
+        # retry the activity without surfacing it as tracked exception noise.
+        return {"Vercel API error (retryable)"}
+
     def get_schemas(
         self,
         config: VercelSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
@@ -126,6 +126,18 @@ class TestVercelSource:
         non_retryable = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable)
 
+    @parameterized.expand(
+        [
+            ("server_error", "Vercel API error (retryable): status=500, url=https://api.vercel.com/v1/billing/charges"),
+            ("rate_limit", "Vercel API error (retryable): status=429, url=https://api.vercel.com/v6/deployments"),
+        ]
+    )
+    def test_retryable_errors_match_known_failures(self, _name: str, observed_error: str) -> None:
+        # Matches the message `_fetch_page`/`_open_billing_stream` raise after their internal
+        # retry loop exhausts; keeps this benign, self-recovering failure out of error tracking.
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(key in observed_error for key in retryable_errors)
+
     def test_get_resumable_source_manager_binds_data_class(self) -> None:
         manager = self.source.get_resumable_source_manager(_source_inputs("deployments"))
         assert isinstance(manager, ResumableSourceManager)


### PR DESCRIPTION
## Problem

Error tracking surfaced a `VercelRetryableError` (a 500 from Vercel's `billing/charges` endpoint) as a tracked exception for the Vercel data warehouse source.

The Vercel source already retries `429`/`5xx` responses internally (`_fetch_page`/`_open_billing_stream`, exponential backoff, 5 attempts). Once those internal retries are exhausted, the error is re-raised and Temporal retries the whole sync activity — the failure is transient and self-recovering. But `VercelSource` never overrode `get_retryable_errors()`, the mechanism this codebase already uses for exactly this case (see Matomo, Intercom, and several other sources), so the error fell through to the default path that logs at `exception` level and pollutes error tracking with noise instead of a real bug.

## Changes

- Add `get_retryable_errors()` to `VercelSource`, matching the stable `"Vercel API error (retryable)"` prefix both retry-raising call sites use. This keeps the per-request URL/status out of the match (avoiding over/under-matching on volatile parts) while covering both the paginated-endpoint and billing-stream code paths.
- No change to retry/backoff behavior itself — the source's own retry policy was already reasonable for a transient upstream 500.

## How did you test this code?

Added 2 parameterized cases to `test_retryable_errors_match_known_failures` in `test_vercel_source.py`, covering the 500 and 429 messages the source actually raises after exhausting its internal retries — this is the regression the existing suite didn't catch (nothing asserted `get_retryable_errors()` classifies these). Ran the full `test_vercel_source.py` suite locally (`uv run pytest ... -q`): 20 passed. Also ran `ruff check` and `ruff format --check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) triaged a `VercelRetryableError` reported by error tracking for the Vercel data warehouse source, read the stack trace and the `_open_billing_stream`/`_fetch_page` implementations, and confirmed the underlying 500 is a genuine transient upstream error that the source already retries. Rather than adding a `NonRetryableErrors` entry (which would stop syncing), I found the codebase already has a purpose-built mechanism for this — `get_retryable_errors()` — used by several other sources (Matomo, Intercom, Meta Ads) for identical self-recovering-but-noisy failures, and applied the same pattern here. No skills were invoked for this change beyond confirming test conventions from `CLAUDE.md`.