### PR TITLE
chore(ci): add no-ci label to skip heavy CI on draft PRs

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -92,7 +92,8 @@ on:
         # still skip drafts. Ready PRs run the full matrices — the merge gate —
         # and ready_for_review re-triggers them when a PR leaves draft. Add the
         # `run-ci-backend` label (labeled/unlabeled re-trigger) to force the full
-        # matrices on a draft. Mirrors canonical.
+        # matrices on a draft; the `no-ci` label silences the workflow on a draft
+        # entirely. Mirrors canonical.
         types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 concurrency:
     # PRs: one active run per branch, cancel stale. Push: per-SHA so master
@@ -186,9 +187,14 @@ jobs:
     # See .github/actions/paths-filter/README.md for filter semantics
     changes:
         # Root of the `needs` graph: skipped when `sample` says skip (or is itself skipped
-        # at percent 0/unset), which cascades the whole workflow off.
+        # at percent 0/unset), which cascades the whole workflow off. Also skipped on
+        # draft PRs labeled `no-ci`, mirroring canonical.
         needs: sample
-        if: needs.sample.outputs.sampled == 'true'
+        if: >-
+            needs.sample.outputs.sampled == 'true'
+            && (github.event_name != 'pull_request'
+                || github.event.pull_request.draft != true
+                || !contains(github.event.pull_request.labels.*.name, 'no-ci'))
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 5
         name: Determine need to run backend and migration checks

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -19,6 +19,9 @@ on:
         # it when a PR leaves draft. To force the full matrices on a draft, add the
         # `run-ci-backend` label — labeled/unlabeled re-trigger the run so the matrices
         # start without needing a new push. Cheap checks still run on drafts.
+        # The `no-ci` label does the opposite: it silences this workflow on a draft
+        # entirely (prototypes/spikes), until the label is removed or the PR is
+        # marked ready for review.
         # The `test-new-events-schema` label opts a PR into the doubled matrices that
         # rerun everything with CLICKHOUSE_HOGQL_USE_NEW_EVENTS_SCHEMA=true; unlabeled
         # PRs run legacy-schema only (master runs always cover both).
@@ -78,6 +81,13 @@ jobs:
     changes:
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 5
+        # A draft PR labeled `no-ci` skips this workflow entirely (prototypes):
+        # every other job needs this one, and the gates treat skipped as success.
+        # ready_for_review re-runs everything, so the merge gate is unaffected.
+        if: >-
+            github.event_name != 'pull_request'
+            || github.event.pull_request.draft != true
+            || !contains(github.event.pull_request.labels.*.name, 'no-ci')
         name: Determine need to run backend and migration checks
         # Set job outputs to values from filter step
         outputs:
@@ -3355,7 +3365,8 @@ jobs:
     test-selection-verdict:
         needs: [django, turbo-tests, changes, select-tests]
         name: Test selection verdict
-        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        # changes is skipped on no-ci drafts — no tests ran, nothing to verdict.
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && needs.changes.result != 'skipped' }}
         runs-on: ubuntu-latest
         timeout-minutes: 10
         permissions:

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -5,7 +5,9 @@ on:
         # (the merge gate). ready_for_review re-triggers the full run on the
         # current head when a PR leaves draft. To force the full matrix on a
         # draft, add the `run-ci-frontend` label — labeled/unlabeled re-trigger
-        # the run so it starts without needing a new push.
+        # the run so it starts without needing a new push. The `no-ci` label does
+        # the opposite: it silences this workflow on a draft entirely (prototypes),
+        # until the label is removed or the PR is marked ready for review.
         types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     push:
         branches:
@@ -31,6 +33,13 @@ jobs:
     changes:
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        # A draft PR labeled `no-ci` skips this workflow entirely (prototypes):
+        # every other job needs this one, and the gates treat skipped as success.
+        # ready_for_review re-runs everything, so the merge gate is unaffected.
+        if: >-
+            github.event_name != 'pull_request'
+            || github.event.pull_request.draft != true
+            || !contains(github.event.pull_request.labels.*.name, 'no-ci')
         name: Determine need to run frontend checks
         # A snapshot-only bot push (Visual Review auto-commits frontend/snapshots.yml after
         # approval) skips ci-storybook and ci-e2e-playwright (the snapshot-baseline-dependent

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -7,6 +7,8 @@ on:
         # Draft PRs run build + unit tests only; the integration tests (which boot
         # the full PostHog backend and trigger on any Python change) run when the
         # PR is marked ready for review — that full run is the merge gate.
+        # The `no-ci` label silences this workflow on a draft entirely (prototypes).
+        # No labeled/unlabeled triggers here, so it takes effect from the next push.
         types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
@@ -24,6 +26,13 @@ jobs:
     changes:
         runs-on: ubuntu-24.04
         timeout-minutes: 5
+        # A draft PR labeled `no-ci` skips this workflow entirely (prototypes):
+        # every other job needs this one, and the gates treat skipped as success.
+        # ready_for_review re-runs everything, so the merge gate is unaffected.
+        if: >-
+            github.event_name != 'pull_request'
+            || github.event.pull_request.draft != true
+            || !contains(github.event.pull_request.labels.*.name, 'no-ci')
         name: Determine need to run MCP checks
         outputs:
             mcp: ${{ steps.filter.outputs.mcp || 'true' }}

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -6,6 +6,8 @@ on:
         # matrix as the merge gate. To force the full matrix on a draft, add the
         # `run-ci-frontend` label —
         # labeled/unlabeled re-trigger the run so it starts without needing a push.
+        # The `no-ci` label does the opposite: it silences this workflow on a draft
+        # entirely (prototypes), until it is removed or the PR is marked ready.
         types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     push:
         branches:
@@ -24,6 +26,13 @@ jobs:
     changes:
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        # A draft PR labeled `no-ci` skips this workflow entirely (prototypes):
+        # every other job needs this one, and the gates treat skipped as success.
+        # ready_for_review re-runs everything, so the merge gate is unaffected.
+        if: >-
+            github.event_name != 'pull_request'
+            || github.event.pull_request.draft != true
+            || !contains(github.event.pull_request.labels.*.name, 'no-ci')
         name: Determine need to run storybook checks
         # Set job outputs to values from filter step
         outputs:


### PR DESCRIPTION
**TL;DR:** Put the `no-ci` label on a **draft** PR and the four heavy CI suites (backend, frontend, storybook, MCP) stop running on it. Remove the label or mark the PR ready for review and full CI comes back. Meant for prototypes that don't need CI on every push.

## Problem

Prototype and spike PRs burn runner credits on every push even though nobody needs the results yet.
Drafts already narrow the heavy suites, but a narrowed backend + frontend + storybook run per push is still real cost on a PR that may never merge.

**Why:** asked as "is there an easy way to add a no-ci label for things like prototypes?"

## Changes

- A draft PR carrying the `no-ci` label now skips Backend CI, Frontend CI, Storybook, and MCP CI entirely.
- The guard is one `if:` on each workflow's `changes` entry job. Every other job `needs` it, so skipping it skips the whole workflow, and the "Tests Pass" gates already treat skipped as success (the same state a docs-only or fork PR produces today).
- Backend CI's `test-selection-verdict` telemetry job now also skips when `changes` was skipped, since no tests ran and there is nothing to verdict.
- I created the `no-ci` label on the repo: "Skip backend/frontend/storybook/MCP CI on this draft PR (prototypes). No effect on ready PRs."

Safety and scope:

> [!NOTE]
> The label is draft-only by design. All four guarded workflows re-trigger on `ready_for_review`, so marking a muted PR ready runs full CI before it can merge. The label can never produce a mergeable PR with green-but-empty checks.

- Only workflows that already trigger on `ready_for_review` got the guard. ci-python, ci-nodejs, ci-rust, the container builds, and turbo don't re-run on ready today, so muting them via label would let a muted draft go ready with stale green aggregators. They can join later by adding the `ready_for_review` trigger type first.
- ci-e2e-playwright already skips drafts entirely, and MCP integration tests were already draft-gated, so nothing to do there.
- Backend/frontend/storybook trigger on `labeled`/`unlabeled`, so the label takes effect immediately and cancels the in-flight run via the concurrency group. MCP CI picks it up on the next push.
- Zero-config alternative that already exists: GitHub natively skips all `push`/`pull_request` workflows when the PR's head commit message contains `[no ci]` or `[skip ci]`. That mutes everything and saves the run dispatches too, but it's per-commit. The label is per-PR and reversible without rewriting history.

## How did you test this code?

- `bin/hogli lint:workflows` passes (6 checks, 103 workflows).
- `actionlint` on the four edited files reports only the two findings already present on master (`job.check_run_id` in ci-storybook, `node24` in the vendored paths-filter under actionlint 1.7.7). No new findings.
- I (Claude) traced every `always()` / `!cancelled()` gate in the guarded workflows (`django_tests`, `frontend_tests`, `visual_regression_tests`, `vr-complete`, MCP's aggregator) to confirm a skipped `changes` job reads as pass, not failure. ci-rust and container-images-ci already skip `changes` on fork PRs, which exercises this exact state in production today.
- Live check on this PR: since `pull_request` runs use the PR's own workflow definitions, flipping the `no-ci` label on this draft demonstrates the skip end to end.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No `docs/` page covers CI labels. Following the `run-ci-backend` / `run-ci-frontend` precedent, the behavior is documented in the workflow trigger comments and the label description.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude (PostHog Code cloud task) from a question by the assignee. Skill invoked: `/authoring-ci-workflows`.
- Rejected a central hook in the vendored paths-filter action (forcing all filter outputs to `false` on labeled PRs would make the filter lie about which paths changed, a trap for any future non-gating consumer). Explicit per-workflow guards match the existing label conventions.
- Rejected guarding workflows without a `ready_for_review` trigger: their aggregators report success on the muted run, and with no re-run on ready, a muted draft could go ready and merge on stale green checks.
- Found and avoided a trap in rust-docker-build: skipping its `affected` job makes `build-images` fall back to building every image (the `workflow_dispatch` escape hatch), the opposite of no-ci. That workflow is deliberately out of scope.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
