### PR TITLE
fix(workflows): name the expected syntax when Liquid appears in a hog-templated input

### DIFF
--- a/posthog/cdp/test/test_validation.py
+++ b/posthog/cdp/test/test_validation.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin, QueryMatchingTest
 
 from parameterized import parameterized
@@ -374,6 +375,42 @@ class TestHogFunctionValidation(ClickhouseTestMixin, APIBaseTest, QueryMatchingT
         assert validated["A"].get("bytecode") is None
         assert validated["A"].get("transpiled") is None
         assert validated["A"].get("value") == "{inputs.X} + A"
+
+    @parameterized.expand(
+        [
+            ("string_input", "string", "Hey {{ person.properties.name }}"),
+            (
+                "email_object_input",
+                "native_email",
+                {
+                    "to": "{{ person.properties.email }}",
+                    "from": "hi@posthog.com",
+                    "subject": "Hello",
+                    "html": "<p>hi</p>",
+                },
+            ),
+        ]
+    )
+    def test_liquid_syntax_in_hog_templated_input_names_the_expected_syntax(self, _name, item_type, value):
+        # Liquid-style {{ ... }} in a hog-templated field is the dominant authoring mistake
+        # behind template errors, and the transpiler's own message ("Placeholders are not
+        # allowed in this context") never names it - agents bisect blind on it. The error
+        # must state the expected single-curly syntax and call out Liquid.
+        inputs_schema = [{"key": "field", "type": item_type, "required": True}]
+        inputs = {"field": {"value": value}}
+
+        with pytest.raises(ValidationError) as ctx:
+            validate_inputs(inputs_schema, inputs)
+        message = str(ctx.value.detail)
+        assert "{person.properties.email}" in message
+        assert "Liquid" in message
+
+    def test_liquid_templated_input_still_accepts_liquid_syntax(self):
+        inputs_schema = [{"key": "field", "type": "string", "required": True, "templating": "liquid"}]
+        inputs = {"field": {"value": "Hey {{ person.properties.name }}"}}
+
+        validated = validate_inputs(inputs_schema, inputs)
+        assert validated["field"]["value"] == "Hey {{ person.properties.name }}"
 
     @parameterized.expand(
         [

--- a/posthog/cdp/validation.py
+++ b/posthog/cdp/validation.py
@@ -223,6 +223,16 @@ def transpile_template_code(obj: Any, compiler: JavaScriptCompiler, is_dwh_sourc
         return json.dumps(obj)
 
 
+def _contains_liquid_style_syntax(value: Any) -> bool:
+    if isinstance(value, str):
+        return "{{" in value
+    if isinstance(value, dict):
+        return any(_contains_liquid_style_syntax(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_contains_liquid_style_syntax(v) for v in value)
+    return False
+
+
 @extend_schema_field({"oneOf": [{"type": "boolean"}, {"type": "string", "enum": ["hog", "liquid"]}]})
 class _TemplatingChoiceField(serializers.ChoiceField):
     """drf-spectacular 0.29 crashes on sorted() with mixed bool/str choice keys."""
@@ -403,6 +413,19 @@ class InputsItemSerializer(serializers.Serializer):
                             if "transpiled" in attrs:
                                 del attrs["transpiled"]
         except Exception as e:
+            # Liquid-style {{ ... }} in a hog-templated field is the dominant authoring mistake
+            # behind transpile failures, and the compiler's own message ("Placeholders are not
+            # allowed in this context") never names it - callers bisect blind without this hint.
+            if _contains_liquid_style_syntax(value):
+                raise serializers.ValidationError(
+                    {
+                        "input": (
+                            "Invalid template: this field uses single-curly templating like "
+                            "{person.properties.email}. Liquid-style {{ ... }} syntax is not "
+                            f"supported here. ({str(e)})"
+                        )
+                    }
+                )
             raise serializers.ValidationError({"input": f"Invalid template: {str(e)}"})
 
         return attrs

--- a/products/workflows/backend/api/test/test_hog_flow.py
+++ b/products/workflows/backend/api/test/test_hog_flow.py
@@ -126,6 +126,21 @@ class TestHogFlowAPI(APIBaseTest):
         assert "actions" in web_response.json()["results"][0]
         assert secret in web_response.content.decode()
 
+    def test_invalid_action_input_error_carries_the_field_message(self):
+        # A programmatic caller sending a broken function input must get back the validator's
+        # actual message (what is wrong with which field), not a bare code: agents retry blind
+        # on "invalid_input" and thrash. Locks the whole pipeline serializer -> exception
+        # handler envelope.
+        hog_flow, _ = self._create_hog_flow_with_action({"template_id": "template-webhook", "inputs": {}})
+
+        response = self.client.post(f"/api/projects/{self.team.id}/hog_flows", hog_flow, HTTP_X_POSTHOG_CLIENT="mcp")
+
+        assert response.status_code == 400, response.json()
+        body = response.json()
+        assert body["type"] == "validation_error"
+        assert "url" in (body["attr"] or ""), body
+        assert "required" in body["detail"].lower(), body
+
     def test_stale_update_is_rejected_with_409(self):
         flow_id = self._create_simple_flow()
         flow = HogFlow.objects.get(pk=flow_id)


### PR DESCRIPTION
## Problem

Liquid-style `{{ person.properties.email }}` in a hog-templated function input fails with the transpiler's raw message: `Invalid template: Placeholders are not allowed in this context`. That message names neither the offending syntax nor the expected one, and double-curly is the natural personalization habit - it IS valid on fields that declare `templating: liquid` (email bodies). Production MCP analytics show agents bisecting blind on exactly this: stripping braces, minimizing payloads, questioning JSON encoding, six calls to discover one syntax rule.

## Changes

When a template transpile fails and the value contains `{{`, the validation error now states the expected single-curly form and calls out Liquid explicitly:

```
Invalid template: this field uses single-curly templating like {person.properties.email}. Liquid-style {{ ... }} syntax is not supported here. (Placeholders are not allowed in this context)
```

Fields that legitimately accept Liquid (`templating: liquid`) are untouched - they skip transpilation entirely, covered by a test.

## How did you test this code?

I am an agent; tests I actually ran: two parameterized cases (string input, email object input) assert the new message names the single-curly syntax and Liquid - both reproduce the exact production failure and fail without the fix; one case asserts `templating: liquid` fields still accept `{{ }}`; one endpoint regression test locks that programmatic callers receive the validator's real field message in the error envelope (nothing previously covered the envelope's detail content). Full `test_validation.py` suite passes (75 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Error-copy change only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Came out of investigating agent retry-storms on workflows-patch-graph in MCP analytics: the original hypothesis (validation detail lost in the error pipeline) was disproven by tests - the envelope delivers real messages - and the reproduced root cause was this one cryptic transpiler message. Skills invoked: /improving-drf-endpoints, /writing-tests.