### PR TITLE
feat(auth): block SSO login into enforced orgs from unverified domains

### DIFF
--- a/frontend/src/scenes/authentication/shared/loginErrorMessages.tsx
+++ b/frontend/src/scenes/authentication/shared/loginErrorMessages.tsx
@@ -32,6 +32,8 @@ export const ERROR_MESSAGES: Record<string, string | JSX.Element> = {
     gitlab_sso_enforced: 'Your organization does not allow this authentication method. Please log in with GitLab.',
     // our catch-all case, so the message is generic
     sso_enforced: "Please log in with your organization's required SSO method.",
+    sso_domain_not_allowed:
+        'Your email address is not on a verified domain for this organization, which requires SSO. Please contact your administrator for access.',
     oauth_cancelled: "Sign in was cancelled. Please try again when you're ready.",
     invalid_invite:
         'This invite link is no longer valid. It may have expired or been revoked. Please ask your administrator for a new invite.',

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -922,6 +922,16 @@ def process_social_domain_jit_provisioning_signup(
     return user
 
 
+def _resolve_invite_organization(invite_id: str) -> Optional[Organization]:
+    """Organization an invite grants access to, or None for legacy team-invite surrogates / missing invites."""
+    try:
+        # nosemgrep: idor-lookup-without-org (invite UUID from server session serves as auth token)
+        invite = OrganizationInvite.objects.select_related("organization").get(id=invite_id)
+    except (OrganizationInvite.DoesNotExist, ValidationError):
+        return None
+    return invite.organization
+
+
 @partial
 def social_create_user(
     strategy: DjangoStrategy,
@@ -947,6 +957,27 @@ def social_create_user(
     if not invite_id and organization_domain_id:
         invite = lookup_invite_for_saml(email, organization_domain_id)
         invite_id = invite.id if invite else None
+
+    # Keep SSO-enforced organizations to their verified domains. If the login email's domain is not a
+    # verified domain of an org that enforces SSO — one the user already belongs to, or the one this
+    # invite targets — block the login. This runs here rather than in the SSO gate (`social_auth_allowed`)
+    # because that gate only sees the email's own domain, not the organization being entered.
+    enforcement_email = user.email if user else email
+    organizations_to_check: list[Organization] = list(user.organizations.all()) if user else []
+    if invite_id:
+        invite_organization = _resolve_invite_organization(invite_id)
+        if invite_organization is not None:
+            organizations_to_check.append(invite_organization)
+    if enforcement_email and organizations_to_check:
+        blocked_organization = OrganizationDomain.objects.find_enforced_org_without_verified_email_domain(
+            enforcement_email, organizations_to_check
+        )
+        if blocked_organization is not None:
+            logger.warning(
+                "social_create_user_blocked_sso_enforced_domain",
+                organization=str(blocked_organization.id),
+            )
+            return redirect("/login?error_code=sso_domain_not_allowed")
 
     if user:
         # If the user is already authenticated, we're looking for outstanding invites for them

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -1207,6 +1207,62 @@ class TestSignupAPI(APIBaseTest):
         self.assertEqual(User.objects.count(), user_count)
         self.assertEqual(Organization.objects.count(), org_count)
 
+    def _org_enforcing_google_sso(self) -> Organization:
+        org = Organization.objects.create(name="Enforced org")
+        org.available_product_features = [
+            {"key": AvailableFeature.SSO_ENFORCEMENT, "name": AvailableFeature.SSO_ENFORCEMENT}
+        ]
+        org.save()
+        OrganizationDomain.objects.create(
+            domain="hogflix.posthog.com",
+            verified_at=timezone.now(),
+            sso_enforcement="google-oauth2",
+            organization=org,
+        )
+        Team.objects.create(organization=org, name="Enforced project")
+        return org
+
+    @mock.patch("posthog.models.organization_domain.get_instance_available_sso_providers")
+    @mock.patch("social_core.backends.base.BaseAuth.request")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
+    @pytest.mark.ee
+    def test_sso_login_blocked_for_member_outside_enforced_verified_domain(
+        self, mock_sso_providers, mock_request, mock_domain_sso_providers
+    ):
+        mock_domain_sso_providers.return_value = {"google-oauth2": True}
+        with self.is_cloud(True):
+            org = self._org_enforcing_google_sso()
+            # Member was invited from outside the verified domain before enforcement was turned on.
+            member = User.objects.create_and_join(
+                organization=org, email="outsider@gmail.com", password=None, first_name="Outsider"
+            )
+
+            response = self._complete_sso_for_email(mock_request, mock_sso_providers, "outsider@gmail.com")
+
+        self.assertRedirects(response, "/login?error_code=sso_domain_not_allowed")
+        # Login refused — no authenticated session — but the membership itself is left untouched.
+        self.assertNotIn("_auth_user_id", self.client.session)
+        self.assertEqual(member.organization_memberships.count(), 1)
+
+    @mock.patch("posthog.models.organization_domain.get_instance_available_sso_providers")
+    @mock.patch("social_core.backends.base.BaseAuth.request")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
+    @pytest.mark.ee
+    def test_sso_login_allowed_for_member_on_enforced_verified_domain(
+        self, mock_sso_providers, mock_request, mock_domain_sso_providers
+    ):
+        mock_domain_sso_providers.return_value = {"google-oauth2": True}
+        with self.is_cloud(True):
+            org = self._org_enforcing_google_sso()
+            User.objects.create_and_join(
+                organization=org, email="insider@hogflix.posthog.com", password=None, first_name="Insider"
+            )
+
+            response = self._complete_sso_for_email(mock_request, mock_sso_providers, "insider@hogflix.posthog.com")
+
+        self.assertRedirects(response, "/")
+        self.assertIn("_auth_user_id", self.client.session)
+
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -1,4 +1,5 @@
 import secrets
+from collections.abc import Iterable
 from typing import Any, Optional
 
 from django.contrib.postgres.fields import ArrayField
@@ -132,16 +133,34 @@ class OrganizationDomainManager(models.Manager):
         if not query:
             return None
 
-        candidate_sso_enforcement = query["sso_enforcement"]
+        return self._active_sso_enforcement(
+            query["sso_enforcement"],
+            query["organization__available_product_features"],
+            organization_id=query["organization_id"],
+            domain=domain,
+        )
 
-        available_product_features = query["organization__available_product_features"]
+    def _active_sso_enforcement(
+        self,
+        candidate_sso_enforcement: str,
+        available_product_features: list[dict[str, Any]],
+        *,
+        organization_id: Any,
+        domain: str | None,
+    ) -> Optional[str]:
+        """
+        Given a domain's configured `sso_enforcement` and its organization's product features, return
+        the provider only if the enforcement is actually active: the org holds an SSO enforcement license
+        and the provider itself is licensed (SAML) or configured on the instance (Google/GitHub/GitLab).
+        Returns None when the setting is present but inert, so callers never enforce a dead configuration.
+        """
         available_product_feature_keys = [feature["key"] for feature in available_product_features]
         # Check organization has a license to enforce SSO
         if AvailableFeature.SSO_ENFORCEMENT not in available_product_feature_keys:
             logger.warning(
                 f"🤑🚪 SSO is enforced for domain {domain} but the organization does not have the proper license.",
                 domain=domain,
-                organization=str(query["organization_id"]),
+                organization=str(organization_id),
             )
             return None
 
@@ -152,7 +171,7 @@ class OrganizationDomainManager(models.Manager):
                 logger.warning(
                     f"🤑🚪 SAML SSO is enforced for domain {domain} but the organization does not have a SAML license.",
                     domain=domain,
-                    organization=str(query["organization_id"]),
+                    organization=str(organization_id),
                 )
                 return None
         else:
@@ -166,6 +185,51 @@ class OrganizationDomainManager(models.Manager):
                 return None
 
         return candidate_sso_enforcement
+
+    def get_active_sso_enforcement_for_organization(self, organization: Organization) -> Optional[str]:
+        """
+        Returns the enforced SSO provider for an organization if any of its verified domains enforce SSO
+        and that enforcement is active (licensed and configured). Unlike `get_sso_enforcement_for_email_address`,
+        this is keyed on the organization rather than an email's domain — it answers "does this org require
+        SSO for its own domains?" so callers can gate who may join or remain a member.
+        """
+        query = (
+            self.verified_domains()
+            .filter(organization=organization)
+            .exclude(sso_enforcement="")
+            .values("sso_enforcement", "organization_id", "organization__available_product_features")
+            .first()
+        )
+        if not query:
+            return None
+        return self._active_sso_enforcement(
+            query["sso_enforcement"],
+            query["organization__available_product_features"],
+            organization_id=query["organization_id"],
+            domain=None,
+        )
+
+    def is_domain_verified_for_organization(self, email: str, organization: Organization) -> bool:
+        """Whether the domain of `email` is a verified domain owned by `organization`."""
+        if "@" not in email:
+            return False
+        domain = email[email.index("@") + 1 :]
+        return self.verified_domains().filter(organization=organization, domain__iexact=domain).exists()
+
+    def find_enforced_org_without_verified_email_domain(
+        self, email: str, organizations: "Iterable[Organization]"
+    ) -> Optional[Organization]:
+        """
+        Return the first organization that enforces SSO but for which `email`'s domain is not one of its
+        verified domains, meaning a login or join for this email into that org should be blocked. Returns
+        None when no organization blocks the email. Used to keep SSO-enforced orgs to their verified domains.
+        """
+        for organization in organizations:
+            if self.get_active_sso_enforcement_for_organization(organization) is None:
+                continue
+            if not self.is_domain_verified_for_organization(email, organization):
+                return organization
+        return None
 
 
 class OrganizationDomain(ModelActivityMixin, UUIDTModel):

--- a/posthog/models/test/test_organization_domain.py
+++ b/posthog/models/test/test_organization_domain.py
@@ -1,0 +1,62 @@
+from posthog.test.base import BaseTest
+from unittest import mock
+
+from django.utils import timezone
+
+from parameterized import parameterized
+
+from posthog.constants import AvailableFeature
+from posthog.models import Organization, OrganizationDomain
+
+SSO_PROVIDERS = {"google-oauth2": True, "github": True, "gitlab": True}
+
+
+@mock.patch("posthog.models.organization_domain.get_instance_available_sso_providers", return_value=SSO_PROVIDERS)
+class TestOrganizationDomainSSOEnforcement(BaseTest):
+    def _org_with_domain(self, *, sso_enforcement: str = "google-oauth2", licensed: bool = True) -> Organization:
+        org = Organization.objects.create(name="Enforced org")
+        if licensed:
+            org.available_product_features = [
+                {"key": AvailableFeature.SSO_ENFORCEMENT, "name": AvailableFeature.SSO_ENFORCEMENT}
+            ]
+            org.save()
+        OrganizationDomain.objects.create(
+            domain="hogflix.posthog.com",
+            organization=org,
+            sso_enforcement=sso_enforcement,
+            verified_at=timezone.now(),
+        )
+        return org
+
+    @parameterized.expand(
+        [
+            # (name, sso_enforcement, licensed, email, expect_blocked)
+            ("blocks_domain_not_verified_for_org", "google-oauth2", True, "outsider@gmail.com", True),
+            ("allows_verified_domain", "google-oauth2", True, "insider@hogflix.posthog.com", False),
+            ("allows_when_enforcement_unlicensed", "google-oauth2", False, "outsider@gmail.com", False),
+            ("allows_when_org_does_not_enforce", "", True, "outsider@gmail.com", False),
+        ]
+    )
+    def test_find_enforced_org_without_verified_email_domain(
+        self, _mock_providers, _name, sso_enforcement, licensed, email, expect_blocked
+    ):
+        org = self._org_with_domain(sso_enforcement=sso_enforcement, licensed=licensed)
+        result = OrganizationDomain.objects.find_enforced_org_without_verified_email_domain(email, [org])
+        self.assertEqual(result, org if expect_blocked else None)
+
+    def test_find_enforced_org_scans_all_memberships(self, _mock_providers):
+        unenforced = Organization.objects.create(name="Open org")
+        enforced = self._org_with_domain()
+        # A member of both orgs whose gmail domain is only unverified in the enforcing one is still blocked.
+        result = OrganizationDomain.objects.find_enforced_org_without_verified_email_domain(
+            "outsider@gmail.com", [unenforced, enforced]
+        )
+        self.assertEqual(result, enforced)
+
+    def test_get_active_sso_enforcement_for_organization_returns_provider(self, _mock_providers):
+        org = self._org_with_domain(sso_enforcement="github")
+        self.assertEqual(OrganizationDomain.objects.get_active_sso_enforcement_for_organization(org), "github")
+
+    def test_get_active_sso_enforcement_ignores_unlicensed_org(self, _mock_providers):
+        org = self._org_with_domain(licensed=False)
+        self.assertIsNone(OrganizationDomain.objects.get_active_sso_enforcement_for_organization(org))


### PR DESCRIPTION
## Problem

An org that turns on **enforce SSO** for its verified domain still lets in members whose email is on a *different*, unverified domain. Invite `random@gmail.com` into a PostHog-Cloud org that enforces Google SSO, and that user logs in with their own Google account and becomes a full member. The enforcement never applies to them.

The reason: enforcement is keyed on the **login email's own domain**, not on the org being entered. `social_auth_allowed` calls `get_sso_enforcement_for_email_address(email)`, which looks up the verified-domain row matching the email's domain. `gmail.com` has no such row, so it returns `None` and the login is allowed. The org's enforcement setting lives on the `posthog.com` row and is simply never consulted for a gmail address.

So "enforce SSO" today means "emails *on* the verified domain must use SSO", not "everyone in this org must be on the verified domain". This closes the first half of that gap at login time. Context: internal discussion on restricting enforced orgs to their verified domains.

## Changes

- New manager helpers on `OrganizationDomain` (`posthog/models/organization_domain.py`):
  - `get_active_sso_enforcement_for_organization(org)` — does this org enforce SSO on any verified domain, respecting license and provider config. Keyed on the org, not an email's domain.
  - `find_enforced_org_without_verified_email_domain(email, orgs)` — the block decision: return the first org that enforces SSO but for which the email's domain is not one of its verified domains.
  - Extracted the existing license/provider validation out of `get_sso_enforcement_for_email_address` into a shared `_active_sso_enforcement` so both paths agree on what "actually enforcing" means (an unlicensed or unconfigured setting is inert and never blocks).
- Enforce it in the social pipeline (`posthog/api/signup.py`, `social_create_user`): resolve the orgs the login actually enters — the user's existing memberships plus the invite target — and redirect to `/login?error_code=sso_domain_not_allowed` if any of them block the email.

  > This lives in `social_create_user`, not in the `social_auth_allowed` gate, on purpose. The gate only sees the email and the backend; the organization being entered isn't known until the invite is resolved one step later. That's the whole reason the original check couldn't catch this.

- Login error copy for the new `sso_domain_not_allowed` code.

The JIT path was already safe (it only auto-joins an org when the email's domain is one of its verified domains), so the only hole was invites.

> [!WARNING]
> **Open question for review — scope of the block.** This blocks on *every* SSO login, so an existing member on an unverified domain is locked out the next time they log in, not just at join. That's the intended strictness, but it has a sharp edge: if someone set up the org with a personal email, verified the company domain, then enabled enforcement, **that owner's own email domain isn't verified for the org and they'd be locked out with no way to disable enforcement**. Options if we want to soften it: exempt org owners/admins from the block, or only block at join time (invite acceptance) rather than every login. Easy to change — say which and it's a small edit.

**Not in this PR (follow-up, stacked):** blocking the invite from being *created* in the first place when the org enforces SSO, so these bad invites never exist. Also out of scope: the password-login path for an already-existing outside-domain member.

## How did you test this code?

Tests. `hogli test posthog/models/test/test_organization_domain.py posthog/api/test/test_signup.py`

- `test_organization_domain.py` (new) covers the decision matrix at the manager level: blocks an unverified domain, allows a verified one, and stays inert when the org is unlicensed or doesn't enforce.
- Two pipeline wiring guards in `test_signup.py`: an existing member on an outside domain is redirected to `sso_domain_not_allowed`, and a member on the verified domain still logs in. These guard against both under-blocking (the original bug) and over-blocking legit members.

I (Claude) couldn't run the suite locally — this branch is in a git worktree without the stack, so I'm relying on CI. Lint-staged ran `ruff` and `ty` clean on commit, and `ci:preflight --strict` passed on push.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Alex directed this; I (Claude Opus 4.8) wrote it. The investigation started from the question of whether an enforced org could still be joined by an arbitrary email — it can. I traced the enforcement path (`social_auth_allowed` → `get_sso_enforcement_for_email_address`) and confirmed the check is keyed on the email's own domain, which is why an outside-domain invite slips through.

Main design decision: **where the check belongs.** The natural instinct is to fix `social_auth_allowed`, but it has no organization context — only the email and backend. The org isn't known until the invite is consumed in `social_create_user`, so that's where the block runs, covering both existing memberships and the invite target. The strict "every login" scope (vs. block-only-at-join) is the reviewer-facing call flagged above.

Skills invoked: `/writing-tests` (test gate), `/pr-writer-alex`. This is PR 1 of a two-PR stack.
