### PR TITLE
fix(auth): restrict SSO-enforced orgs to their verified domains

### DIFF
--- a/frontend/src/scenes/authentication/shared/loginErrorMessages.tsx
+++ b/frontend/src/scenes/authentication/shared/loginErrorMessages.tsx
@@ -32,6 +32,8 @@ export const ERROR_MESSAGES: Record<string, string | JSX.Element> = {
     gitlab_sso_enforced: 'Your organization does not allow this authentication method. Please log in with GitLab.',
     // our catch-all case, so the message is generic
     sso_enforced: "Please log in with your organization's required SSO method.",
+    sso_domain_not_allowed:
+        'Your email address is not on a verified domain for this organization, which requires SSO. Please contact your administrator for access.',
     oauth_cancelled: "Sign in was cancelled. Please try again when you're ready.",
     invalid_invite:
         'This invite link is no longer valid. It may have expired or been revoked. Please ask your administrator for a new invite.',

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -19,7 +19,7 @@ from posthog.constants import INVITE_DAYS_VALIDITY
 from posthog.email import is_email_available
 from posthog.event_usage import report_bulk_invited, report_team_member_invited
 from posthog.helpers.email_utils import EmailNormalizer, validate_display_name, validate_message_body
-from posthog.models import OrganizationInvite, OrganizationMembership
+from posthog.models import OrganizationDomain, OrganizationInvite, OrganizationMembership
 from posthog.models.onboarding_delegation import (
     get_existing_pending_delegation_invite,
     schedule_delegation_side_effects,
@@ -134,6 +134,22 @@ class OrganizationInviteManager:
         ).delete()
 
 
+def validate_invite_target_email_domain(organization_id: UUID | str, email: str) -> None:
+    """
+    When an organization enforces SSO on a verified domain, invites may only go to that domain.
+    Raises ValidationError otherwise. No-op for orgs that don't enforce SSO, so ordinary invites
+    are unaffected. Complements the login-time block by stopping the bad invite from ever existing.
+    """
+    organization = Organization.objects.get(id=organization_id)
+    if OrganizationDomain.objects.get_active_sso_enforcement_for_organization(organization) is None:
+        return
+    if not OrganizationDomain.objects.is_domain_verified_for_organization(email, organization):
+        raise exceptions.ValidationError(
+            "This organization enforces SSO, so invites can only be sent to email addresses on a verified domain.",
+            code="sso_enforced_domain",
+        )
+
+
 class OrganizationInviteSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
     send_email = serializers.BooleanField(write_only=True, default=True)
@@ -165,7 +181,11 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
         extra_kwargs = {"target_email": {"required": True, "allow_null": False}}
 
     def validate_target_email(self, email: str):
-        return EmailNormalizer.normalize(email)
+        email = EmailNormalizer.normalize(email)
+        organization_id = self.context.get("organization_id")
+        if organization_id:
+            validate_invite_target_email_domain(organization_id, email)
+        return email
 
     def validate_first_name(self, value: str) -> str:
         return validate_display_name(value)
@@ -540,6 +560,9 @@ class OrganizationInviteViewSet(
         # has been normalized and the comparison is case-insensitive via the normalizer.
         if bool(user.email) and EmailNormalizer.normalize(user.email) == target_email:
             raise exceptions.ValidationError("You cannot delegate setup to yourself.", code="self_delegation")
+
+        # Delegation grants admin, so it must respect the same verified-domain rule as a normal invite.
+        validate_invite_target_email_domain(self.organization_id, target_email)
 
         # Server-side gate: delegation only makes sense while the *target organization* is
         # still in onboarding. `user.team` points at the caller's current_team (which could

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -134,6 +134,18 @@ class OrganizationInviteManager:
         ).delete()
 
 
+def first_bulk_invite_error(errors: list[Any]) -> exceptions.ValidationError:
+    """
+    A many=True ValidationError carries a list of per-row error dicts, which the exception handler
+    can't flatten into the standard {type, code, detail, attr} shape — clients would see the raw
+    dict repr. Re-raise the first failing row's error so bulk renders identically to single create.
+    """
+    for row_errors in errors:
+        if row_errors:
+            return exceptions.ValidationError(row_errors)
+    return exceptions.ValidationError(errors)
+
+
 def validate_invite_target_email_domain(organization: Organization, email: str) -> None:
     """
     When an organization enforces SSO, invites may only go to emails on one of the org's verified
@@ -698,7 +710,8 @@ class OrganizationInviteViewSet(
                 "session_id": session_id,
             },
         )
-        serializer.is_valid(raise_exception=True)
+        if not serializer.is_valid():
+            raise first_bulk_invite_error(serializer.errors)
         serializer.save()
 
         organization = Organization.objects.get(id=self.organization_id)

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -136,8 +136,8 @@ class OrganizationInviteManager:
 
 def validate_invite_target_email_domain(organization: Organization, email: str) -> None:
     """
-    When an organization enforces SSO on a verified domain, invites may only go to that domain.
-    Raises ValidationError otherwise. No-op for orgs that don't enforce SSO.
+    When an organization enforces SSO, invites may only go to emails on one of the org's verified
+    domains. No-op for orgs that don't enforce SSO.
     """
     if OrganizationDomain.objects.is_email_blocked_by_sso_enforcement(email, organization):
         raise exceptions.ValidationError(
@@ -178,9 +178,7 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
 
     def validate_target_email(self, email: str):
         email = EmailNormalizer.normalize(email)
-        get_organization = self.context.get("get_organization")
-        if get_organization:
-            validate_invite_target_email_domain(get_organization(), email)
+        validate_invite_target_email_domain(self.context["get_organization"](), email)
         return email
 
     def validate_first_name(self, value: str) -> str:

--- a/posthog/api/organization_invite.py
+++ b/posthog/api/organization_invite.py
@@ -134,16 +134,12 @@ class OrganizationInviteManager:
         ).delete()
 
 
-def validate_invite_target_email_domain(organization_id: UUID | str, email: str) -> None:
+def validate_invite_target_email_domain(organization: Organization, email: str) -> None:
     """
     When an organization enforces SSO on a verified domain, invites may only go to that domain.
-    Raises ValidationError otherwise. No-op for orgs that don't enforce SSO, so ordinary invites
-    are unaffected. Complements the login-time block by stopping the bad invite from ever existing.
+    Raises ValidationError otherwise. No-op for orgs that don't enforce SSO.
     """
-    organization = Organization.objects.get(id=organization_id)
-    if OrganizationDomain.objects.get_active_sso_enforcement_for_organization(organization) is None:
-        return
-    if not OrganizationDomain.objects.is_domain_verified_for_organization(email, organization):
+    if OrganizationDomain.objects.is_email_blocked_by_sso_enforcement(email, organization):
         raise exceptions.ValidationError(
             "This organization enforces SSO, so invites can only be sent to email addresses on a verified domain.",
             code="sso_enforced_domain",
@@ -182,9 +178,9 @@ class OrganizationInviteSerializer(serializers.ModelSerializer):
 
     def validate_target_email(self, email: str):
         email = EmailNormalizer.normalize(email)
-        organization_id = self.context.get("organization_id")
-        if organization_id:
-            validate_invite_target_email_domain(organization_id, email)
+        get_organization = self.context.get("get_organization")
+        if get_organization:
+            validate_invite_target_email_domain(get_organization(), email)
         return email
 
     def validate_first_name(self, value: str) -> str:
@@ -562,7 +558,7 @@ class OrganizationInviteViewSet(
             raise exceptions.ValidationError("You cannot delegate setup to yourself.", code="self_delegation")
 
         # Delegation grants admin, so it must respect the same verified-domain rule as a normal invite.
-        validate_invite_target_email_domain(self.organization_id, target_email)
+        validate_invite_target_email_domain(self.organization, target_email)
 
         # Server-side gate: delegation only makes sense while the *target organization* is
         # still in onboarding. `user.team` points at the caller's current_team (which could

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -552,11 +552,10 @@ class InviteSignupSerializer(serializers.Serializer):
                 code="sso_enforced",
             )
 
-        # An org that enforces SSO only admits members on its verified domains. Refuse an invite whose
-        # target email is outside them, even if that email's own domain isn't itself SSO-enforced —
-        # otherwise a pre-existing outside-domain invite could still be accepted with a password.
-        if invite.target_email and OrganizationDomain.objects.find_enforced_org_without_verified_email_domain(
-            invite.target_email, [invite.organization]
+        # The check above keys on the email's own domain; this one keys on the org: an SSO-enforced org
+        # only admits verified-domain members, so a pre-existing outside-domain invite can't be accepted.
+        if invite.target_email and OrganizationDomain.objects.is_email_blocked_by_sso_enforcement(
+            invite.target_email, invite.organization
         ):
             raise serializers.ValidationError(
                 "This organization enforces SSO, so invites can only be accepted from an email address on a verified domain.",
@@ -969,24 +968,20 @@ def social_create_user(
         invite = lookup_invite_for_saml(email, organization_domain_id)
         invite_id = invite.id if invite else None
 
-    # Keep SSO-enforced organizations to their verified domains, enforced at the join boundary: if this
-    # login would add the user to an org via an invite, and that org enforces SSO but the email's domain
-    # is not one of its verified domains, refuse the join. Only the invite target is checked — existing
-    # memberships are left alone, so nobody already in an org is locked out. JIT is already safe (it only
-    # joins an org whose verified domain matches the email). This lives here, not in the SSO gate
-    # (`social_auth_allowed`), because that gate only sees the email's own domain, not the org being joined.
+    # Refuse joining an SSO-enforced org via invite when the email's domain isn't verified for that org.
+    # Existing memberships are not re-checked. Can't live in `social_auth_allowed` — it never sees the org.
     enforcement_email = user.email if user else email
     invite_organization = _resolve_invite_organization(invite_id) if invite_id else None
-    if enforcement_email and invite_organization is not None:
-        blocked_organization = OrganizationDomain.objects.find_enforced_org_without_verified_email_domain(
-            enforcement_email, [invite_organization]
+    if (
+        enforcement_email
+        and invite_organization is not None
+        and OrganizationDomain.objects.is_email_blocked_by_sso_enforcement(enforcement_email, invite_organization)
+    ):
+        logger.warning(
+            "social_create_user_blocked_sso_enforced_domain",
+            organization=str(invite_organization.id),
         )
-        if blocked_organization is not None:
-            logger.warning(
-                "social_create_user_blocked_sso_enforced_domain",
-                organization=str(blocked_organization.id),
-            )
-            return redirect("/login?error_code=sso_domain_not_allowed")
+        return redirect("/login?error_code=sso_domain_not_allowed")
 
     if user:
         # If the user is already authenticated, we're looking for outstanding invites for them

--- a/posthog/api/signup.py
+++ b/posthog/api/signup.py
@@ -552,6 +552,17 @@ class InviteSignupSerializer(serializers.Serializer):
                 code="sso_enforced",
             )
 
+        # An org that enforces SSO only admits members on its verified domains. Refuse an invite whose
+        # target email is outside them, even if that email's own domain isn't itself SSO-enforced —
+        # otherwise a pre-existing outside-domain invite could still be accepted with a password.
+        if invite.target_email and OrganizationDomain.objects.find_enforced_org_without_verified_email_domain(
+            invite.target_email, [invite.organization]
+        ):
+            raise serializers.ValidationError(
+                "This organization enforces SSO, so invites can only be accepted from an email address on a verified domain.",
+                code="sso_enforced_domain",
+            )
+
         with transaction.atomic():
             if not user:
                 is_new_user = True
@@ -922,6 +933,16 @@ def process_social_domain_jit_provisioning_signup(
     return user
 
 
+def _resolve_invite_organization(invite_id: str) -> Optional[Organization]:
+    """Organization an invite grants access to, or None for legacy team-invite surrogates / missing invites."""
+    try:
+        # nosemgrep: idor-lookup-without-org (invite UUID from server session serves as auth token)
+        invite = OrganizationInvite.objects.select_related("organization").get(id=invite_id)
+    except (OrganizationInvite.DoesNotExist, ValidationError):
+        return None
+    return invite.organization
+
+
 @partial
 def social_create_user(
     strategy: DjangoStrategy,
@@ -947,6 +968,25 @@ def social_create_user(
     if not invite_id and organization_domain_id:
         invite = lookup_invite_for_saml(email, organization_domain_id)
         invite_id = invite.id if invite else None
+
+    # Keep SSO-enforced organizations to their verified domains, enforced at the join boundary: if this
+    # login would add the user to an org via an invite, and that org enforces SSO but the email's domain
+    # is not one of its verified domains, refuse the join. Only the invite target is checked — existing
+    # memberships are left alone, so nobody already in an org is locked out. JIT is already safe (it only
+    # joins an org whose verified domain matches the email). This lives here, not in the SSO gate
+    # (`social_auth_allowed`), because that gate only sees the email's own domain, not the org being joined.
+    enforcement_email = user.email if user else email
+    invite_organization = _resolve_invite_organization(invite_id) if invite_id else None
+    if enforcement_email and invite_organization is not None:
+        blocked_organization = OrganizationDomain.objects.find_enforced_org_without_verified_email_domain(
+            enforcement_email, [invite_organization]
+        )
+        if blocked_organization is not None:
+            logger.warning(
+                "social_create_user_blocked_sso_enforced_domain",
+                organization=str(blocked_organization.id),
+            )
+            return redirect("/login?error_code=sso_domain_not_allowed")
 
     if user:
         # If the user is already authenticated, we're looking for outstanding invites for them

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -30,6 +30,21 @@ from ee.models.rbac.access_control import AccessControl
 NAME_SEEDS = ["John", "Jane", "Alice", "Bob", ""]
 
 
+def _enforce_sso_on_domain(organization: Organization, domain: str) -> None:
+    organization.available_product_features = [
+        *(organization.available_product_features or []),
+        {"key": AvailableFeature.SSO_ENFORCEMENT},
+        {"key": AvailableFeature.SAML},
+    ]
+    organization.save()
+    OrganizationDomain.objects.create(
+        domain=domain,
+        organization=organization,
+        sso_enforcement="saml",
+        verified_at=timezone.now(),
+    )
+
+
 class TestOrganizationInvitesAPI(APIBaseTest):
     def setUp(self):
         super().setUp()
@@ -532,20 +547,6 @@ class TestOrganizationInvitesAPI(APIBaseTest):
 
         self.assertEqual(OrganizationInvite.objects.count(), count)
 
-    def _enforce_sso_on_domain(self, domain: str) -> None:
-        self.organization.available_product_features = [
-            *(self.organization.available_product_features or []),
-            {"key": AvailableFeature.SSO_ENFORCEMENT},
-            {"key": AvailableFeature.SAML},
-        ]
-        self.organization.save()
-        OrganizationDomain.objects.create(
-            domain=domain,
-            organization=self.organization,
-            sso_enforcement="saml",
-            verified_at=timezone.now(),
-        )
-
     @parameterized.expand(
         [
             ("blocks_unverified_domain", True, "newperson@gmail.com", status.HTTP_400_BAD_REQUEST),
@@ -555,7 +556,7 @@ class TestOrganizationInvitesAPI(APIBaseTest):
     )
     def test_invite_restricted_to_verified_domain_when_sso_enforced(self, _name, enforce, email, expected_status):
         if enforce:
-            self._enforce_sso_on_domain("hogflix.com")
+            _enforce_sso_on_domain(self.organization, "hogflix.com")
 
         response = self.client.post("/api/organizations/@current/invites/", {"target_email": email})
 
@@ -1595,18 +1596,7 @@ class TestOnboardingDelegationInviteAPI(APIBaseTest):
 
     def test_delegate_rejects_email_outside_enforced_verified_domain(self):
         # Delegation grants admin, so it must respect the same verified-domain rule as a normal invite.
-        self.organization.available_product_features = [
-            *(self.organization.available_product_features or []),
-            {"key": AvailableFeature.SSO_ENFORCEMENT},
-            {"key": AvailableFeature.SAML},
-        ]
-        self.organization.save()
-        OrganizationDomain.objects.create(
-            domain="hogflix.com",
-            organization=self.organization,
-            sso_enforcement="saml",
-            verified_at=timezone.now(),
-        )
+        _enforce_sso_on_domain(self.organization, "hogflix.com")
         response = self.client.post(self._delegate_url(), {"target_email": "engineer@gmail.com"})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.json()["code"], "sso_enforced_domain")

--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -18,6 +18,7 @@ from posthog.constants import AvailableFeature
 from posthog.models import User
 from posthog.models.instance_setting import set_instance_setting
 from posthog.models.organization import Organization, OrganizationMembership
+from posthog.models.organization_domain import OrganizationDomain
 from posthog.models.organization_invite import OrganizationInvite
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team.team import Team
@@ -530,6 +531,40 @@ class TestOrganizationInvitesAPI(APIBaseTest):
         self.assertEqual(response.json(), self.permission_denied_response())
 
         self.assertEqual(OrganizationInvite.objects.count(), count)
+
+    def _enforce_sso_on_domain(self, domain: str) -> None:
+        self.organization.available_product_features = [
+            *(self.organization.available_product_features or []),
+            {"key": AvailableFeature.SSO_ENFORCEMENT},
+            {"key": AvailableFeature.SAML},
+        ]
+        self.organization.save()
+        OrganizationDomain.objects.create(
+            domain=domain,
+            organization=self.organization,
+            sso_enforcement="saml",
+            verified_at=timezone.now(),
+        )
+
+    @parameterized.expand(
+        [
+            ("blocks_unverified_domain", True, "newperson@gmail.com", status.HTTP_400_BAD_REQUEST),
+            ("allows_verified_domain", True, "newperson@hogflix.com", status.HTTP_201_CREATED),
+            ("allows_when_not_enforced", False, "newperson@gmail.com", status.HTTP_201_CREATED),
+        ]
+    )
+    def test_invite_restricted_to_verified_domain_when_sso_enforced(self, _name, enforce, email, expected_status):
+        if enforce:
+            self._enforce_sso_on_domain("hogflix.com")
+
+        response = self.client.post("/api/organizations/@current/invites/", {"target_email": email})
+
+        self.assertEqual(response.status_code, expected_status, response.json())
+        if expected_status == status.HTTP_400_BAD_REQUEST:
+            self.assertEqual(response.json()["code"], "sso_enforced_domain")
+            self.assertFalse(OrganizationInvite.objects.filter(target_email=email).exists())
+        else:
+            self.assertTrue(OrganizationInvite.objects.filter(target_email=email).exists())
 
     # Bulk create invites
 
@@ -1557,6 +1592,25 @@ class TestOnboardingDelegationInviteAPI(APIBaseTest):
         self.assertEqual(self.user.onboarding_delegated_to_invite_id, invite.id)
         self.assertIsNotNone(self.user.onboarding_skipped_at)
         self.assertEqual(self.user.onboarding_skipped_reason, "delegated")
+
+    def test_delegate_rejects_email_outside_enforced_verified_domain(self):
+        # Delegation grants admin, so it must respect the same verified-domain rule as a normal invite.
+        self.organization.available_product_features = [
+            *(self.organization.available_product_features or []),
+            {"key": AvailableFeature.SSO_ENFORCEMENT},
+            {"key": AvailableFeature.SAML},
+        ]
+        self.organization.save()
+        OrganizationDomain.objects.create(
+            domain="hogflix.com",
+            organization=self.organization,
+            sso_enforcement="saml",
+            verified_at=timezone.now(),
+        )
+        response = self.client.post(self._delegate_url(), {"target_email": "engineer@gmail.com"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["code"], "sso_enforced_domain")
+        self.assertFalse(OrganizationInvite.objects.filter(target_email="engineer@gmail.com").exists())
 
     def test_delegate_requires_target_email(self):
         response = self.client.post(self._delegate_url(), {})

--- a/posthog/api/test/test_signup.py
+++ b/posthog/api/test/test_signup.py
@@ -1207,6 +1207,79 @@ class TestSignupAPI(APIBaseTest):
         self.assertEqual(User.objects.count(), user_count)
         self.assertEqual(Organization.objects.count(), org_count)
 
+    def _org_enforcing_google_sso(self) -> Organization:
+        org = Organization.objects.create(name="Enforced org")
+        org.available_product_features = [
+            {"key": AvailableFeature.SSO_ENFORCEMENT, "name": AvailableFeature.SSO_ENFORCEMENT}
+        ]
+        org.save()
+        OrganizationDomain.objects.create(
+            domain="hogflix.posthog.com",
+            verified_at=timezone.now(),
+            sso_enforcement="google-oauth2",
+            organization=org,
+        )
+        Team.objects.create(organization=org, name="Enforced project")
+        return org
+
+    @mock.patch("posthog.models.organization_domain.get_instance_available_sso_providers")
+    @mock.patch("social_core.backends.base.BaseAuth.request")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
+    @pytest.mark.ee
+    def test_sso_login_not_blocked_for_existing_outside_domain_member(
+        self, mock_sso_providers, mock_request, mock_domain_sso_providers
+    ):
+        # The block is join-only: an existing member on a non-verified domain (invited before
+        # enforcement was turned on) must still be able to log in. This is the guarantee that stops
+        # enabling enforcement from locking out the members already in the org.
+        mock_domain_sso_providers.return_value = {"google-oauth2": True}
+        with self.is_cloud(True):
+            org = self._org_enforcing_google_sso()
+            User.objects.create_and_join(
+                organization=org, email="outsider@gmail.com", password=None, first_name="Outsider"
+            )
+
+            response = self._complete_sso_for_email(mock_request, mock_sso_providers, "outsider@gmail.com")
+
+        self.assertRedirects(response, "/")
+        self.assertIn("_auth_user_id", self.client.session)
+
+    @mock.patch("posthog.models.organization_domain.get_instance_available_sso_providers")
+    @mock.patch("social_core.backends.base.BaseAuth.request")
+    @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
+    @pytest.mark.ee
+    def test_sso_invite_acceptance_blocked_for_unverified_domain(
+        self, mock_sso_providers, mock_request, mock_domain_sso_providers
+    ):
+        # Accepting an invite is a new join, so an outside-domain invitee into an SSO-enforced org is
+        # refused — this catches invites created before the restriction shipped.
+        mock_domain_sso_providers.return_value = {"google-oauth2": True}
+        mock_sso_providers.return_value = {"google-oauth2": True}
+        with self.is_cloud(True):
+            org = self._org_enforcing_google_sso()
+            invite = OrganizationInvite.objects.create(organization=org, target_email="outsider@gmail.com")
+
+            begin = self.client.get(reverse("social:begin", kwargs={"backend": "google-oauth2"}))
+            self.assertEqual(begin.status_code, status.HTTP_302_FOUND)
+            state = self.client.session["google-oauth2_state"]
+            session = self.client.session
+            session["invite_id"] = str(invite.id)
+            session.save()
+
+            url = reverse("social:complete", kwargs={"backend": "google-oauth2"})
+            url += f"?code=2&state={state}"
+            mock_request.return_value.json.return_value = {
+                "access_token": "123",
+                "email": "outsider@gmail.com",
+                "sub": "123",
+            }
+            response = self.client.get(url, follow=True)
+
+        self.assertRedirects(response, "/login?error_code=sso_domain_not_allowed")
+        # The invite is left unconsumed and no account is created.
+        self.assertTrue(OrganizationInvite.objects.filter(id=invite.id).exists())
+        self.assertFalse(User.objects.filter(email="outsider@gmail.com").exists())
+
     @mock.patch("social_core.backends.base.BaseAuth.request")
     @mock.patch("posthog.api.authentication.get_instance_available_sso_providers")
     @pytest.mark.ee
@@ -2628,6 +2701,28 @@ class TestInviteSignupAPI(APIBaseTest):
         # Verify no user was created and invite was not used
         self.assertFalse(User.objects.filter(email="test+sso@posthog.com").exists())
         self.assertFalse(OrganizationInvite.objects.filter(target_email="test+sso@posthog.com").exists())
+
+    def test_api_signup_with_sso_enforced_blocks_unverified_domain_invite(self):
+        # A pre-existing invite to an outside domain (whose own domain isn't SSO-enforced) must not be
+        # acceptable with a password once the org enforces SSO — otherwise it's a bypass of the boundary.
+        organization = Organization.objects.create(name="Test Org")
+        organization.available_product_features = [
+            {"key": AvailableFeature.SSO_ENFORCEMENT, "name": AvailableFeature.SSO_ENFORCEMENT},
+            {"key": AvailableFeature.SAML, "name": AvailableFeature.SAML},
+        ]
+        organization.save()
+        OrganizationDomain.objects.create(
+            domain="hogflix.com", organization=organization, sso_enforcement="saml", verified_at=timezone.now()
+        )
+        invite = OrganizationInvite.objects.create(target_email="outsider@gmail.com", organization=organization)
+
+        response = self.client.post(
+            f"/api/signup/{invite.id}/", {"first_name": "Alice", "password": VALID_TEST_PASSWORD}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["code"], "sso_enforced_domain")
+        self.assertFalse(User.objects.filter(email="outsider@gmail.com").exists())
 
     # Social signup (use invite)
 

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -1,5 +1,4 @@
 import secrets
-from collections.abc import Iterable
 from typing import Any, Optional
 
 from django.contrib.postgres.fields import ArrayField
@@ -146,13 +145,11 @@ class OrganizationDomainManager(models.Manager):
         available_product_features: list[dict[str, Any]],
         *,
         organization_id: Any,
-        domain: str | None,
+        domain: str,
     ) -> Optional[str]:
         """
-        Given a domain's configured `sso_enforcement` and its organization's product features, return
-        the provider only if the enforcement is actually active: the org holds an SSO enforcement license
-        and the provider itself is licensed (SAML) or configured on the instance (Google/GitHub/GitLab).
-        Returns None when the setting is present but inert, so callers never enforce a dead configuration.
+        Return the enforced provider only if enforcement is actually active: the org is licensed for
+        SSO enforcement and the provider is licensed (SAML) or configured on the instance. None otherwise.
         """
         available_product_feature_keys = [feature["key"] for feature in available_product_features]
         # Check organization has a license to enforce SSO
@@ -188,16 +185,14 @@ class OrganizationDomainManager(models.Manager):
 
     def get_active_sso_enforcement_for_organization(self, organization: Organization) -> Optional[str]:
         """
-        Returns the enforced SSO provider for an organization if any of its verified domains enforce SSO
-        and that enforcement is active (licensed and configured). Unlike `get_sso_enforcement_for_email_address`,
-        this is keyed on the organization rather than an email's domain — it answers "does this org require
-        SSO for its own domains?" so callers can gate who may join or remain a member.
+        The org's active (licensed and configured) SSO enforcement, if any of its verified domains
+        enforce SSO. Keyed on the org, unlike `get_sso_enforcement_for_email_address`.
         """
         query = (
             self.verified_domains()
             .filter(organization=organization)
             .exclude(sso_enforcement="")
-            .values("sso_enforcement", "organization_id", "organization__available_product_features")
+            .values("domain", "sso_enforcement", "organization_id", "organization__available_product_features")
             .first()
         )
         if not query:
@@ -206,7 +201,7 @@ class OrganizationDomainManager(models.Manager):
             query["sso_enforcement"],
             query["organization__available_product_features"],
             organization_id=query["organization_id"],
-            domain=None,
+            domain=query["domain"],
         )
 
     def is_domain_verified_for_organization(self, email: str, organization: Organization) -> bool:
@@ -216,20 +211,14 @@ class OrganizationDomainManager(models.Manager):
         domain = email[email.index("@") + 1 :]
         return self.verified_domains().filter(organization=organization, domain__iexact=domain).exists()
 
-    def find_enforced_org_without_verified_email_domain(
-        self, email: str, organizations: "Iterable[Organization]"
-    ) -> Optional[Organization]:
+    def is_email_blocked_by_sso_enforcement(self, email: str, organization: Organization) -> bool:
         """
-        Return the first organization that enforces SSO but for which `email`'s domain is not one of its
-        verified domains, meaning a login or join for this email into that org should be blocked. Returns
-        None when no organization blocks the email. Used to keep SSO-enforced orgs to their verified domains.
+        Whether a join for `email` into `organization` should be blocked: the org enforces SSO on a
+        verified domain, and `email`'s domain is not one of the org's verified domains.
         """
-        for organization in organizations:
-            if self.get_active_sso_enforcement_for_organization(organization) is None:
-                continue
-            if not self.is_domain_verified_for_organization(email, organization):
-                return organization
-        return None
+        if self.get_active_sso_enforcement_for_organization(organization) is None:
+            return False
+        return not self.is_domain_verified_for_organization(email, organization)
 
 
 class OrganizationDomain(ModelActivityMixin, UUIDTModel):

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -188,21 +188,24 @@ class OrganizationDomainManager(models.Manager):
         The org's active (licensed and configured) SSO enforcement, if any of its verified domains
         enforce SSO. Keyed on the org, unlike `get_sso_enforcement_for_email_address`.
         """
-        query = (
+        queryset = (
             self.verified_domains()
             .filter(organization=organization)
             .exclude(sso_enforcement="")
             .values("domain", "sso_enforcement", "organization_id", "organization__available_product_features")
-            .first()
         )
-        if not query:
-            return None
-        return self._active_sso_enforcement(
-            query["sso_enforcement"],
-            query["organization__available_product_features"],
-            organization_id=query["organization_id"],
-            domain=query["domain"],
-        )
+        # Check every enforcing domain: rows can be individually inert (e.g. an unconfigured
+        # provider), and one inert row must not mask another domain's active enforcement.
+        for query in queryset:
+            enforcement = self._active_sso_enforcement(
+                query["sso_enforcement"],
+                query["organization__available_product_features"],
+                organization_id=query["organization_id"],
+                domain=query["domain"],
+            )
+            if enforcement is not None:
+                return enforcement
+        return None
 
     def is_domain_verified_for_organization(self, email: str, organization: Organization) -> bool:
         """Whether the domain of `email` is a verified domain owned by `organization`."""

--- a/posthog/models/organization_domain.py
+++ b/posthog/models/organization_domain.py
@@ -1,4 +1,5 @@
 import secrets
+from collections.abc import Iterable
 from typing import Any, Optional
 
 from django.contrib.postgres.fields import ArrayField
@@ -132,16 +133,34 @@ class OrganizationDomainManager(models.Manager):
         if not query:
             return None
 
-        candidate_sso_enforcement = query["sso_enforcement"]
+        return self._active_sso_enforcement(
+            query["sso_enforcement"],
+            query["organization__available_product_features"],
+            organization_id=query["organization_id"],
+            domain=domain,
+        )
 
-        available_product_features = query["organization__available_product_features"]
+    def _active_sso_enforcement(
+        self,
+        candidate_sso_enforcement: str,
+        available_product_features: list[dict[str, Any]],
+        *,
+        organization_id: Any,
+        domain: str | None,
+    ) -> Optional[str]:
+        """
+        Given a domain's configured `sso_enforcement` and its organization's product features, return
+        the provider only if the enforcement is actually active: the org holds an SSO enforcement license
+        and the provider itself is licensed (SAML) or configured on the instance (Google/GitHub/GitLab).
+        Returns None when the setting is present but inert, so callers never enforce a dead configuration.
+        """
         available_product_feature_keys = [feature["key"] for feature in available_product_features]
         # Check organization has a license to enforce SSO
         if AvailableFeature.SSO_ENFORCEMENT not in available_product_feature_keys:
             logger.warning(
                 f"🤑🚪 SSO is enforced for domain {domain} but the organization does not have the proper license.",
                 domain=domain,
-                organization=str(query["organization_id"]),
+                organization=str(organization_id),
             )
             return None
 
@@ -152,7 +171,7 @@ class OrganizationDomainManager(models.Manager):
                 logger.warning(
                     f"🤑🚪 SAML SSO is enforced for domain {domain} but the organization does not have a SAML license.",
                     domain=domain,
-                    organization=str(query["organization_id"]),
+                    organization=str(organization_id),
                 )
                 return None
         else:
@@ -166,6 +185,51 @@ class OrganizationDomainManager(models.Manager):
                 return None
 
         return candidate_sso_enforcement
+
+    def get_active_sso_enforcement_for_organization(self, organization: Organization) -> Optional[str]:
+        """
+        Returns the enforced SSO provider for an organization if any of its verified domains enforce SSO
+        and that enforcement is active (licensed and configured). Unlike `get_sso_enforcement_for_email_address`,
+        this is keyed on the organization rather than an email's domain — it answers "does this org require
+        SSO for its own domains?" so callers can gate who may join or remain a member.
+        """
+        query = (
+            self.verified_domains()
+            .filter(organization=organization)
+            .exclude(sso_enforcement="")
+            .values("sso_enforcement", "organization_id", "organization__available_product_features")
+            .first()
+        )
+        if not query:
+            return None
+        return self._active_sso_enforcement(
+            query["sso_enforcement"],
+            query["organization__available_product_features"],
+            organization_id=query["organization_id"],
+            domain=None,
+        )
+
+    def is_domain_verified_for_organization(self, email: str, organization: Organization) -> bool:
+        """Whether the domain of `email` is a verified domain owned by `organization`."""
+        if "@" not in email:
+            return False
+        domain = email[email.index("@") + 1 :]
+        return self.verified_domains().filter(organization=organization, domain__iexact=domain).exists()
+
+    def find_enforced_org_without_verified_email_domain(
+        self, email: str, organizations: "Iterable[Organization]"
+    ) -> Optional[Organization]:
+        """
+        Return the first organization that enforces SSO but for which `email`'s domain is not one of its
+        verified domains, meaning a login or join for this email into that org should be blocked. Returns
+        None when no organization blocks the email. Used to keep SSO-enforced orgs to their verified domains.
+        """
+        for organization in organizations:
+            if self.get_active_sso_enforcement_for_organization(organization) is None:
+                continue
+            if not self.is_domain_verified_for_organization(email, organization):
+                return organization
+        return None
 
 
 class OrganizationDomain(ModelActivityMixin, UUIDTModel):

--- a/posthog/models/test/test_organization_domain.py
+++ b/posthog/models/test/test_organization_domain.py
@@ -43,6 +43,14 @@ class TestOrganizationDomainSSOEnforcement(BaseTest):
         org = self._org_with_domain(sso_enforcement=sso_enforcement, licensed=licensed)
         self.assertEqual(OrganizationDomain.objects.is_email_blocked_by_sso_enforcement(email, org), expect_blocked)
 
+    def test_email_on_any_verified_domain_is_allowed(self, _mock_providers):
+        # Enforcement gates on the org, but the allow-list is all of the org's verified domains —
+        # not just the enforcing one. Multi-domain orgs must accept invitees from every verified domain.
+        org = self._org_with_domain()
+        OrganizationDomain.objects.create(domain="hogflix.dev", organization=org, verified_at=timezone.now())
+        self.assertFalse(OrganizationDomain.objects.is_email_blocked_by_sso_enforcement("x@hogflix.dev", org))
+        self.assertTrue(OrganizationDomain.objects.is_email_blocked_by_sso_enforcement("x@gmail.com", org))
+
     def test_get_active_sso_enforcement_for_organization_returns_provider(self, _mock_providers):
         org = self._org_with_domain(sso_enforcement="github")
         self.assertEqual(OrganizationDomain.objects.get_active_sso_enforcement_for_organization(org), "github")

--- a/posthog/models/test/test_organization_domain.py
+++ b/posthog/models/test/test_organization_domain.py
@@ -1,0 +1,62 @@
+from posthog.test.base import BaseTest
+from unittest import mock
+
+from django.utils import timezone
+
+from parameterized import parameterized
+
+from posthog.constants import AvailableFeature
+from posthog.models import Organization, OrganizationDomain
+
+SSO_PROVIDERS = {"google-oauth2": True, "github": True, "gitlab": True}
+
+
+@mock.patch("posthog.models.organization_domain.get_instance_available_sso_providers", return_value=SSO_PROVIDERS)
+class TestOrganizationDomainSSOEnforcement(BaseTest):
+    def _org_with_domain(self, *, sso_enforcement: str = "google-oauth2", licensed: bool = True) -> Organization:
+        org = Organization.objects.create(name="Enforced org")
+        if licensed:
+            org.available_product_features = [
+                {"key": AvailableFeature.SSO_ENFORCEMENT, "name": AvailableFeature.SSO_ENFORCEMENT}
+            ]
+            org.save()
+        OrganizationDomain.objects.create(
+            domain="hogflix.posthog.com",
+            organization=org,
+            sso_enforcement=sso_enforcement,
+            verified_at=timezone.now(),
+        )
+        return org
+
+    @parameterized.expand(
+        [
+            # (name, sso_enforcement, licensed, email, expect_blocked)
+            ("blocks_domain_not_verified_for_org", "google-oauth2", True, "outsider@gmail.com", True),
+            ("allows_verified_domain", "google-oauth2", True, "insider@hogflix.posthog.com", False),
+            ("allows_when_enforcement_unlicensed", "google-oauth2", False, "outsider@gmail.com", False),
+            ("allows_when_org_does_not_enforce", "", True, "outsider@gmail.com", False),
+        ]
+    )
+    def test_find_enforced_org_without_verified_email_domain(
+        self, _mock_providers, _name, sso_enforcement, licensed, email, expect_blocked
+    ):
+        org = self._org_with_domain(sso_enforcement=sso_enforcement, licensed=licensed)
+        result = OrganizationDomain.objects.find_enforced_org_without_verified_email_domain(email, [org])
+        self.assertEqual(result, org if expect_blocked else None)
+
+    def test_find_enforced_org_scans_all_memberships(self, _mock_providers):
+        unenforced = Organization.objects.create(name="Open org")
+        enforced = self._org_with_domain()
+        # A member of both orgs whose gmail domain is only unverified in the enforcing one is still blocked.
+        result = OrganizationDomain.objects.find_enforced_org_without_verified_email_domain(
+            "outsider@gmail.com", [unenforced, enforced]
+        )
+        self.assertEqual(result, enforced)
+
+    def test_get_active_sso_enforcement_for_organization_returns_provider(self, _mock_providers):
+        org = self._org_with_domain(sso_enforcement="github")
+        self.assertEqual(OrganizationDomain.objects.get_active_sso_enforcement_for_organization(org), "github")
+
+    def test_get_active_sso_enforcement_ignores_unlicensed_org(self, _mock_providers):
+        org = self._org_with_domain(licensed=False)
+        self.assertIsNone(OrganizationDomain.objects.get_active_sso_enforcement_for_organization(org))

--- a/posthog/models/test/test_organization_domain.py
+++ b/posthog/models/test/test_organization_domain.py
@@ -37,21 +37,11 @@ class TestOrganizationDomainSSOEnforcement(BaseTest):
             ("allows_when_org_does_not_enforce", "", True, "outsider@gmail.com", False),
         ]
     )
-    def test_find_enforced_org_without_verified_email_domain(
+    def test_is_email_blocked_by_sso_enforcement(
         self, _mock_providers, _name, sso_enforcement, licensed, email, expect_blocked
     ):
         org = self._org_with_domain(sso_enforcement=sso_enforcement, licensed=licensed)
-        result = OrganizationDomain.objects.find_enforced_org_without_verified_email_domain(email, [org])
-        self.assertEqual(result, org if expect_blocked else None)
-
-    def test_find_enforced_org_scans_all_memberships(self, _mock_providers):
-        unenforced = Organization.objects.create(name="Open org")
-        enforced = self._org_with_domain()
-        # A member of both orgs whose gmail domain is only unverified in the enforcing one is still blocked.
-        result = OrganizationDomain.objects.find_enforced_org_without_verified_email_domain(
-            "outsider@gmail.com", [unenforced, enforced]
-        )
-        self.assertEqual(result, enforced)
+        self.assertEqual(OrganizationDomain.objects.is_email_blocked_by_sso_enforcement(email, org), expect_blocked)
 
     def test_get_active_sso_enforcement_for_organization_returns_provider(self, _mock_providers):
         org = self._org_with_domain(sso_enforcement="github")

--- a/posthog/models/test/test_organization_domain.py
+++ b/posthog/models/test/test_organization_domain.py
@@ -43,6 +43,24 @@ class TestOrganizationDomainSSOEnforcement(BaseTest):
         org = self._org_with_domain(sso_enforcement=sso_enforcement, licensed=licensed)
         self.assertEqual(OrganizationDomain.objects.is_email_blocked_by_sso_enforcement(email, org), expect_blocked)
 
+    def test_inert_enforcing_domain_does_not_mask_an_active_one(self, mock_providers):
+        # First row's provider is unconfigured on the instance; the org's other enforcing domain is
+        # fully active. Enforcement must still apply — one inert row can't disable the restriction.
+        mock_providers.return_value = {"google-oauth2": True, "github": False, "gitlab": True}
+        org = Organization.objects.create(name="Enforced org")
+        org.available_product_features = [
+            {"key": AvailableFeature.SSO_ENFORCEMENT, "name": AvailableFeature.SSO_ENFORCEMENT}
+        ]
+        org.save()
+        OrganizationDomain.objects.create(
+            domain="inert.hogflix.com", organization=org, sso_enforcement="github", verified_at=timezone.now()
+        )
+        OrganizationDomain.objects.create(
+            domain="active.hogflix.com", organization=org, sso_enforcement="google-oauth2", verified_at=timezone.now()
+        )
+        self.assertEqual(OrganizationDomain.objects.get_active_sso_enforcement_for_organization(org), "google-oauth2")
+        self.assertTrue(OrganizationDomain.objects.is_email_blocked_by_sso_enforcement("x@gmail.com", org))
+
     def test_email_on_any_verified_domain_is_allowed(self, _mock_providers):
         # Enforcement gates on the org, but the allow-list is all of the org's verified domains —
         # not just the enforcing one. Multi-domain orgs must accept invitees from every verified domain.


### PR DESCRIPTION
## Problem

An org that enforces **SSO** on a verified domain can still end up with members on unrelated domains. Two gaps combine:

- **Invites do no domain check.** `OrganizationInviteSerializer.validate_target_email` only normalizes the address, so you can invite `random@gmail.com` into an org that enforces Google SSO.
- **Enforcement is keyed on the login email's own domain, not the org.** `social_auth_allowed` looks up the verified-domain row matching the *email's* domain. `gmail.com` has no such row, so enforcement returns nothing and the login is allowed.

Net effect: enforce-SSO today means "emails on the verified domain must use SSO", not "everyone must be on the verified domain". 

## Changes

Close both sides at the **membership boundary** — where someone joins — and keep existing members (there are orgs with SSO enforcement where admins/owners have email with a different domain). 

- **Invite creation**  - if the org enforces SSO (licensed and configured) and the email's domain isn't one of its verified domains, reject with `sso_enforced_domain`. Wired into single, **bulk**, and **delegation** invites.
- **Invite acceptance / join** - refuse the join when an outside-domain invite is accepted into an SSO-enforced org — both the SSO pipeline (`social_create_user`) and password signup (`OrganizationInviteSignupSerializer`). This catches invites that already exist from before. 

> [!IMPORTANT]
> **This is join-only by design — it does not re-check existing members.** An earlier version blocked on *every* SSO login, but existing enforced orgs can already contain members (and owners) on non-verified domains, and a login-time block would lock them out. So the block only fires when a *new* membership would be created. 

## How did you test this code?

Tests. 

- `test_organization_domain.py` (new) — the decision at the manager level: blocks an unverified domain, allows a verified one, stays inert when unlicensed or not enforcing.
- Invite endpoint (`test_organization_invites.py`) — outside-domain invite rejected, verified-domain invite accepted, non-enforcing org unaffected; plus a delegation guard.
- Join paths (`test_signup.py`) — an existing outside-domain member still logs in (the join-only guarantee), an outside-domain **invite acceptance** via SSO is blocked, and the same is blocked on password signup.

<img width="1220" height="815" alt="image" src="https://github.com/user-attachments/assets/48738765-eb33-4859-9e28-810b96aaf311" />

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

It started as two stacked PRs — a login-side block and an invite-side block — with the login block re-checking on every SSO login. Before committing to that, we checked prod: a meaningful number of already-enforced orgs contain members and owners on non-verified domains, so an every-login block would have locked real users out. We changed course to **join-only + invite restriction**, combined into this one PR, which closes the hole for all new members without affecting anyone already in an org.

Decision worth flagging: I applied the rule to **delegation** invites too (they grant admin), and to the **password** acceptance path, so there's no bypass around the SSO path. 
