### PR TITLE
feat(experiments): loading placeholder for replay experiments box

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4978,6 +4978,10 @@ snapshots:
         hash: v1.k794b7964.13e51a486b40a1455fde0075af333e3dff21f25491d06cc59ab10c24200eb1d2.Fn0OHVeRm39HLB3-xcZUZavR375CxuNraJZdmfxTS-U
     replay-overview-tab-experiments--empty--light:
         hash: v1.k794b7964.34d2a031b8e3cea8e905aacec4f7d70ae9f625f56bb1649d8e95f73b1eba71a8._AeRzz6TNgrSmnERRCH2YbGUFjFBA4HPfW4wFM4uySU
+    replay-overview-tab-experiments--loading--dark:
+        hash: v1.k794b7964.55ed027ece39592bf5eee139b78d0147e93849476016cd690928a1416cce057a.FCepXFnoPBB-F5-GGDsNJtwO_uHeAKixmqN28WPHZkQ
+    replay-overview-tab-experiments--loading--light:
+        hash: v1.k794b7964.3f7009b98adc6ca7dcba54e597f03f59f12ddb26d91f07b738fa3a9b56eea9e6.SWwJIdNaiXQVVznfLVN8jx9ch0dlALIz39YRWPZcgHk
     replay-overview-tab-other-watchers--default--dark:
         hash: v1.k794b7964.6ce320055ae4f9e4d3b3d7cfdb104907c7ae6fe30b7f3fb87cff5ea420ae7213.dz7F6LW1kHlCjl_p5iTLTlqoxYrXMrXqBZ3KfwswVcw
     replay-overview-tab-other-watchers--default--light:

--- a/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/inspector/playerInspectorLogic.test.ts
@@ -118,6 +118,10 @@ describe('playerInspectorLogic', () => {
             },
         })
         featureFlagLogic.mount()
+        // featureFlags persist to localStorage across tests, so pin the experiment-context flag
+        // off before the first mount — otherwise a prior test leaves it on and the context load
+        // kicks off with stale state. The experiment-variant tests below opt in explicitly.
+        featureFlagLogic.actions.setFeatureFlags([], {})
 
         dataLogic = sessionRecordingDataCoordinatorLogic(playerLogicProps)
         dataLogic.mount()
@@ -321,9 +325,11 @@ describe('playerInspectorLogic', () => {
         it('synthesizes no markers when the feature flag is off', async () => {
             remountWithFlagState(false)
 
-            await expectLogic(sessionRecordingExperimentContextLogic({ sessionRecordingId: '1' })).toDispatchActions([
-                'loadExperimentContextSuccess',
-            ])
+            // With the flag off the context load never starts (afterMount is gated on the flag),
+            // so there is no exposure data and no markers are synthesized.
+            await expectLogic(
+                sessionRecordingExperimentContextLogic({ sessionRecordingId: '1' })
+            ).toNotHaveDispatchedActions(['loadExperimentContext'])
 
             expect(logic.values.allItems.items.filter((item) => item.type === 'experiment-variant')).toHaveLength(0)
             expect(logic.values.seekbarItems.filter((item) => item.type === 'experiment-variant')).toHaveLength(0)

--- a/frontend/src/scenes/session-recordings/player/player-meta/sessionRecordingExperimentContextLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/player/player-meta/sessionRecordingExperimentContextLogic.test.ts
@@ -75,13 +75,16 @@ describe('sessionRecordingExperimentContextLogic', () => {
         })
     })
 
-    it('does not fetch when the feature flag is off', async () => {
+    it('does not start a load when the feature flag is off', async () => {
         setFlagEnabled(false)
         logic = sessionRecordingExperimentContextLogic({ sessionRecordingId: 'session-3' })
         logic.mount()
 
-        await expectLogic(logic).toDispatchActions(['loadExperimentContextSuccess']).toMatchValues({
+        // No load may even start: a vacuous load would flip `experimentContextLoading` true
+        // for a beat, flashing the sidebar's loading placeholder for flag-disabled viewers.
+        await expectLogic(logic).toNotHaveDispatchedActions(['loadExperimentContext']).toMatchValues({
             experimentContext: null,
+            experimentContextLoading: false,
             hasExperimentContext: false,
         })
     })
@@ -150,7 +153,7 @@ describe('sessionRecordingExperimentContextLogic', () => {
         logic = sessionRecordingExperimentContextLogic({ sessionRecordingId: 'session-1' })
         logic.mount()
 
-        await expectLogic(logic).toDispatchActions(['loadExperimentContextSuccess']).toMatchValues({
+        await expectLogic(logic).toNotHaveDispatchedActions(['loadExperimentContext']).toMatchValues({
             experimentContext: null,
         })
 

--- a/frontend/src/scenes/session-recordings/player/player-meta/sessionRecordingExperimentContextLogic.ts
+++ b/frontend/src/scenes/session-recordings/player/player-meta/sessionRecordingExperimentContextLogic.ts
@@ -219,8 +219,11 @@ export const sessionRecordingExperimentContextLogic = kea<sessionRecordingExperi
             }
         },
     })),
+    // Gated on the flag so `experimentContextLoading` never goes true for flag-disabled
+    // viewers — an ungated load here resolves to null but flashes the sidebar's loading
+    // placeholder on the way. The subscription above starts the load if the flag arrives late.
     afterMount(({ actions, values }) => {
-        if (!values.experimentContextLoading) {
+        if (values.experimentContextEnabled && !values.experimentContextLoading) {
             actions.loadExperimentContext()
         }
     }),

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.stories.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.stories.tsx
@@ -1,7 +1,10 @@
 import { Meta } from '@storybook/react'
 import { BindLogic } from 'kea'
+import { router } from 'kea-router'
+import { delay } from 'msw'
 
 import { FEATURE_FLAGS } from 'lib/constants'
+import { urls } from 'scenes/urls'
 
 import { mswDecorator } from '~/mocks/browser'
 
@@ -64,6 +67,31 @@ Default.decorators = [
         get: {
             '/api/environments/:team_id/session_recordings/:id': recordingMetaJson,
             '/api/projects/:team_id/experiments/session_context/': experimentSessionContextResponse,
+        },
+    }),
+]
+
+// While the context request is in flight the box shows a skeleton placeholder — but only when the
+// viewer arrived from an experiment's recordings tab, so the route is put on /experiments/<id>
+// first. The mocked request never resolves, holding the section in its loading state.
+export function Loading(): JSX.Element {
+    router.actions.push(urls.experiment(123))
+    return <MockedPlayerSidebarExperimentsSection sessionRecordingId="experiment-context-loading" />
+}
+Loading.parameters = {
+    testOptions: {
+        waitForLoadersToDisappear: false,
+        waitForSelector: '[data-attr=replay-experiment-context-overview-loading]',
+    },
+}
+Loading.decorators = [
+    mswDecorator({
+        get: {
+            '/api/environments/:team_id/session_recordings/:id': recordingMetaJson,
+            '/api/projects/:team_id/experiments/session_context/': async () => {
+                await delay('infinite')
+                return [200, { session_id: 'experiment-context-loading', results: [] }]
+            },
         },
     }),
 ]

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
@@ -7,6 +7,7 @@ import { IconCollapse, IconExpand, IconExternal, IconMinus, IconWarning } from '
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { LemonTag, LemonTagType } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
@@ -218,7 +219,8 @@ export function PlayerSidebarExperimentsSection(): JSX.Element | null {
     const experimentContextLogic = sessionRecordingExperimentContextLogic({
         sessionRecordingId: logicProps.sessionRecordingId,
     })
-    const { seenItems, enrolledItems, hasExperimentContext, expandedExperimentIds } = useValues(experimentContextLogic)
+    const { seenItems, enrolledItems, hasExperimentContext, expandedExperimentIds, experimentContextLoading } =
+        useValues(experimentContextLogic)
     const { setExperimentExpanded } = useActions(experimentContextLogic)
     const { location } = useValues(router)
 
@@ -247,6 +249,27 @@ export function PlayerSidebarExperimentsSection(): JSX.Element | null {
             setExperimentExpanded(currentExpandableId, true)
         }
     }, [currentExpandableId, currentMetricCount, setExperimentExpanded])
+
+    // The context takes a few seconds to resolve (several ClickHouse scans server-side). Show a
+    // loading placeholder only when we already know this session belongs to an experiment — i.e. the
+    // viewer opened it from an experiment's recordings tab (currentExperimentId set). On the generic
+    // replay page most sessions have no experiment context, so a placeholder there would flash in and
+    // vanish; gate it out and let the section appear once the context confirms there's something to show.
+    if (experimentContextLoading && !hasExperimentContext) {
+        if (currentExperimentId == null) {
+            return null
+        }
+        return (
+            <div
+                className="rounded border bg-surface-primary px-2 py-1 flex flex-col gap-y-1"
+                data-attr="replay-experiment-context-overview-loading"
+            >
+                <h4 className="font-semibold text-xs mb-0">Experiments</h4>
+                <LemonSkeleton className="h-4 w-2/3" />
+                <LemonSkeleton className="h-4 w-1/2" />
+            </div>
+        )
+    }
 
     if (!hasExperimentContext) {
         return null

--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarExperimentsSection.tsx
@@ -250,11 +250,6 @@ export function PlayerSidebarExperimentsSection(): JSX.Element | null {
         }
     }, [currentExpandableId, currentMetricCount, setExperimentExpanded])
 
-    // The context takes a few seconds to resolve (several ClickHouse scans server-side). Show a
-    // loading placeholder only when we already know this session belongs to an experiment — i.e. the
-    // viewer opened it from an experiment's recordings tab (currentExperimentId set). On the generic
-    // replay page most sessions have no experiment context, so a placeholder there would flash in and
-    // vanish; gate it out and let the section appear once the context confirms there's something to show.
     if (experimentContextLoading && !hasExperimentContext) {
         if (currentExperimentId == null) {
             return null


### PR DESCRIPTION
## Problem

The session replay sidebar's experiments box resolves its context server-side over a few seconds. Without a placeholder the whole section pops in late, which reads as a layout jump.

## Changes

Show a `LemonSkeleton` placeholder for the experiments box while its context loads.


<img width="626" height="489" alt="loading state" src="https://github.com/user-attachments/assets/0ba351f8-360e-4388-a996-fdcfdc939961" />


Two gates keep the placeholder from flashing where no content is coming:

- **Session gate:** the placeholder only renders when the session is already known to belong to an experiment — i.e. the viewer opened the recording from an experiment's recordings tab (`currentExperimentId` set from the `/experiments/<id>` route). On the generic replay page most sessions have no experiment context, so an ungated placeholder would flash in and then vanish the moment the context confirms there's nothing to show.
- **Flag gate:** `afterMount` no longer fires the loader when the feature flag is off (the flag check used to live only inside the loader), so `experimentContextLoading` never flips true for flag-disabled viewers and the placeholder can't flash for them. The existing subscription still starts the load when the flag arrives after mount.

## How did you test this code?

- `sessionRecordingExperimentContextLogic.test.ts` (all 5 tests pass): the flag-off test now pins that no load starts at all — a vacuous load would flip the loading state and flash the placeholder — and the late-flag test covers the subscription still loading once the flag arrives.
- Added a `Loading` Storybook story that holds the section in its loading state (route on `/experiments/<id>` so the session gate passes, context request never resolves). The screenshot above was captured from that story running in Storybook, which also confirms the session gate: the placeholder only appears because the route puts us on an experiment.
- Full `typescript:check` isn't runnable in this sandbox (partial dependency install); CI covers it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Marcel asked to pull the frontend loading state out of #73103 into its own PR, and to fix the flicker: the original early-return showed the placeholder for every recording, including the majority with no experiment context. The placeholder is gated on `currentExperimentId` (the viewer arrived from an experiment's recordings tab) — the strongest cheap signal that real content is coming — and, per a follow-up review pass, the mount-time load is gated on the feature flag so flag-disabled viewers never enter a loading state. The screenshot was produced by running the new `Loading` story in Storybook and capturing the rendered component. Authored with Claude Code. Skills invoked: /writing-tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
