### PR TITLE
feat(data-warehouse): cooperative shutdown yielding for import syncs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/external_data_job.py
@@ -101,8 +101,14 @@ LOGGER = get_logger(__name__)
 # Cap retries at 3 in local dev so failing syncs don't loop for tens of minutes while developers
 # iterate; prod cadence is unchanged. Defined at module level so tests can patch them to keep the
 # expensive retry-exhaustion paths fast.
-MAX_RESUMABLE_SOURCE_RETRIES = 3 if settings.DEBUG else 15
-MAX_INCREMENTAL_SOURCE_RETRIES = 3 if settings.DEBUG else 9
+#
+# `WorkerShuttingDownError` is retryable and burns one attempt, so a long backfill on the
+# data-warehouse worker (dozens of rollouts a day, each draining every pod) can exhaust its budget
+# on shutdown bounces alone before it ever finishes. These budgets are sized with that churn in mind
+# — resumable syncs resume cheaply so they get the most headroom; incremental ones re-read from the
+# last watermark. The real fix for the churn is fewer full-fleet rollouts, not unbounded retries.
+MAX_RESUMABLE_SOURCE_RETRIES = 3 if settings.DEBUG else 25
+MAX_INCREMENTAL_SOURCE_RETRIES = 3 if settings.DEBUG else 15
 
 Any_Source_Errors: dict[str, str | None] = {
     "Could not establish session to SSH gateway": None,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -620,11 +620,18 @@ def should_check_shutdown(
     reset_pipeline: bool,
     source_is_resumable: bool,
 ) -> bool:
-    # Only raise if we're not running in descending order, otherwise we'll often not
-    # complete the job before the incremental value can be updated. Or if the source is
-    # resumable
-    # TODO: raise when we're within `x` time of the worker being forced to shutdown
-    # Raising during a full reset will reset our progress back to 0 rows
+    """Whether a source can bail out *immediately* when the worker starts draining.
+
+    True only when the current run's progress survives a bail:
+    - a resumable source checkpoints its cursor every batch, so it resumes cheaply; or
+    - an ascending incremental sync persists its watermark per chunk, so a bail just re-reads
+      from the last persisted value.
+
+    Descending-sort incremental syncs commit their watermark only at completion (walking
+    newest->oldest), so bailing early loses the whole run — hence the `sort_mode != "desc"` guard.
+    A full reset would likewise restart from 0 rows. Those cases don't bail on shutdown; they ride
+    the drain to completion or are cancelled when the worker's graceful-shutdown timeout elapses.
+    """
     incremental_sync_raise_during_shutdown = (
         schema.should_use_incremental_field and resource.sort_mode != "desc" and not reset_pipeline
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -638,11 +638,18 @@ def should_check_shutdown(
     reset_pipeline: bool,
     source_is_resumable: bool,
 ) -> bool:
-    # Only raise if we're not running in descending order, otherwise we'll often not
-    # complete the job before the incremental value can be updated. Or if the source is
-    # resumable
-    # TODO: raise when we're within `x` time of the worker being forced to shutdown
-    # Raising during a full reset will reset our progress back to 0 rows
+    """Whether a source can bail out *immediately* when the worker starts draining.
+
+    True only when the current run's progress survives a bail:
+    - a resumable source checkpoints its cursor every batch, so it resumes cheaply; or
+    - an ascending incremental sync persists its watermark per chunk, so a bail just re-reads
+      from the last persisted value.
+
+    Descending-sort incremental syncs commit their watermark only at completion (walking
+    newest->oldest), so bailing early loses the whole run — hence the `sort_mode != "desc"` guard.
+    A full reset would likewise restart from 0 rows. Those cases don't bail on shutdown; they ride
+    the drain to completion or are cancelled when the worker's graceful-shutdown timeout elapses.
+    """
     incremental_sync_raise_during_shutdown = (
         schema.should_use_incremental_field and resource.sort_mode != "desc" and not reset_pipeline
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
@@ -157,7 +157,6 @@ class PipelineNonDLT(Generic[ResumableData]):
         pa_memory_pool = pa.default_memory_pool()
 
         should_resume = self._resumable_source_manager is not None and self._resumable_source_manager.can_resume()
-        source_is_resumable = self._resumable_source_manager is not None
         if should_resume:
             await self._logger.ainfo("Resumable source detected - attempting to resume previous import")
 
@@ -178,10 +177,6 @@ class PipelineNonDLT(Generic[ResumableData]):
                 self._logger,
                 billable=self._job.billable,
             )
-
-            py_table = None
-            row_count = 0
-            chunk_index = 0
 
             # Revive a corrupt-`_delta_log` table (from an interrupted repartition swap or OOM-crashed
             # merge) before extraction so it self-heals in this run instead of looping forever.
@@ -208,53 +203,11 @@ class PipelineNonDLT(Generic[ResumableData]):
                     self._schema, partition_count_fallback=self._resource.partition_count
                 )
 
-            async for item in async_iterate(self._resource.items()):
-                py_table = None
-
-                record_source_item_stats(
-                    item,
-                    source_type=self._source.source_type,
-                    logger=self._logger,
-                    team_id=self._job.team_id,
-                    schema_name=self._schema.name,
-                )
-
-                self._batcher.batch(item)
-
-                # A single batched table may be split into several when a string/binary/list
-                # column would otherwise overflow a 32-bit offset, so drain every ready chunk.
-                while self._batcher.should_yield():
-                    py_table = self._batcher.get_table()
-
-                    row_count += py_table.num_rows
-
-                    await self._process_pa_table(
-                        pa_table=py_table,
-                        index=chunk_index,
-                        resuming_sync=should_resume,
-                        row_count=row_count,
-                        is_first_ever_sync=is_first_ever_sync,
-                    )
-
-                    chunk_index += 1
-
-                    cleanup_memory(pa_memory_pool, py_table)
-                    py_table = None
-
-                if should_check_shutdown(self._schema, self._resource, self._reset_pipeline, source_is_resumable):
-                    self._shutdown_monitor.raise_if_is_worker_shutdown()
-
-            while self._batcher.should_yield(include_incomplete_chunk=True):
-                py_table = self._batcher.get_table()
-                row_count += py_table.num_rows
-                await self._process_pa_table(
-                    pa_table=py_table,
-                    index=chunk_index,
-                    resuming_sync=should_resume,
-                    row_count=row_count,
-                    is_first_ever_sync=is_first_ever_sync,
-                )
-                chunk_index += 1
+            row_count = await self._consume_and_load(
+                pa_memory_pool=pa_memory_pool,
+                should_resume=should_resume,
+                is_first_ever_sync=is_first_ever_sync,
+            )
 
             await self._persist_observed_columns()
 
@@ -281,7 +234,82 @@ class PipelineNonDLT(Generic[ResumableData]):
             del self._resource
             del self._delta_table_ref
 
-            cleanup_memory(pa_memory_pool, py_table if "py_table" in locals() else None)
+            # Per-chunk tables are cleaned up inside `_consume_and_load`; this just releases the pool.
+            cleanup_memory(pa_memory_pool, None)
+
+    async def _consume_and_load(self, *, pa_memory_pool: Any, should_resume: bool, is_first_ever_sync: bool) -> int:
+        """Pull rows from the source, batch them, and write each chunk to Delta. Returns rows synced.
+
+        When the worker drains and the sync can resume cheaply (`_should_bail_now`: a resumable source
+        with its own checkpoint, or an ascending incremental persisting its watermark per chunk), it
+        flushes the partial buffer — committing it so our written progress catches up to the source's
+        saved checkpoint, which can otherwise sit ahead of what we've persisted — then raises the
+        retryable `WorkerShuttingDownError` so the activity reschedules and resumes from that
+        checkpoint. No rows are skipped or duplicated. Sources that can't resume don't bail; they ride
+        the drain to completion or are cancelled when the worker's graceful-shutdown timeout elapses.
+        """
+        row_count = 0
+        chunk_index = 0
+        py_table: pa.Table | None = None
+
+        async def _load_ready_chunks(*, include_incomplete: bool) -> None:
+            nonlocal row_count, chunk_index, py_table
+            # A single batched table may be split into several when a string/binary/list column would
+            # otherwise overflow a 32-bit offset, so drain every ready chunk.
+            while self._batcher.should_yield(include_incomplete_chunk=include_incomplete):
+                py_table = self._batcher.get_table()
+                row_count += py_table.num_rows
+                await self._process_pa_table(
+                    pa_table=py_table,
+                    index=chunk_index,
+                    resuming_sync=should_resume,
+                    row_count=row_count,
+                    is_first_ever_sync=is_first_ever_sync,
+                )
+                chunk_index += 1
+                cleanup_memory(pa_memory_pool, py_table)
+                py_table = None
+
+        try:
+            async for item in async_iterate(self._resource.items()):
+                py_table = None
+
+                record_source_item_stats(
+                    item,
+                    source_type=self._source.source_type,
+                    logger=self._logger,
+                    team_id=self._job.team_id,
+                    schema_name=self._schema.name,
+                )
+
+                self._batcher.batch(item)
+                await _load_ready_chunks(include_incomplete=False)
+
+                if self._should_bail_now():
+                    # Flush the partial buffer so committed progress catches up to the checkpoint,
+                    # then hand off. Raised from inside the `async for` so the source generator's
+                    # cleanup (closing DB cursors/tunnels) runs as the exception unwinds it.
+                    await _load_ready_chunks(include_incomplete=True)
+                    self._shutdown_monitor.raise_if_is_worker_shutdown()
+
+            await _load_ready_chunks(include_incomplete=True)
+        finally:
+            cleanup_memory(pa_memory_pool, py_table)
+
+        return row_count
+
+    def _should_bail_now(self) -> bool:
+        """Whether the sync should hand off to a live pod when the worker drains.
+
+        True once the worker is draining and the source can resume cheaply (`should_check_shutdown`
+        — a resumable source with its own checkpoint, or an ascending incremental persisting its
+        watermark per chunk). The caller flushes the partial buffer, then raises. Non-resumable
+        sources return False and ride the drain (bailing would just restart them from zero).
+        """
+        if not self._shutdown_monitor.is_worker_shutdown():
+            return False
+        source_is_resumable = self._resumable_source_manager is not None
+        return should_check_shutdown(self._schema, self._resource, self._reset_pipeline, source_is_resumable)
 
     async def _persist_observed_columns(self) -> None:
         """Union the columns the source actually returned into `schema_metadata["columns"]`.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
@@ -165,7 +165,6 @@ class PipelineNonDLT(Generic[ResumableData]):
         pa_memory_pool = pa.default_memory_pool()
 
         should_resume = self._resumable_source_manager is not None and self._resumable_source_manager.can_resume()
-        source_is_resumable = self._resumable_source_manager is not None
         if should_resume:
             await self._logger.ainfo("Resumable source detected - attempting to resume previous import")
 
@@ -190,10 +189,6 @@ class PipelineNonDLT(Generic[ResumableData]):
                 self._logger,
                 billable=self._job.billable,
             )
-
-            py_table = None
-            row_count = 0
-            chunk_index = 0
 
             # Revive a corrupt-`_delta_log` table (from an interrupted repartition swap or OOM-crashed
             # merge) before extraction so it self-heals in this run instead of looping forever.
@@ -220,53 +215,11 @@ class PipelineNonDLT(Generic[ResumableData]):
                     self._schema, partition_count_fallback=self._resource.partition_count
                 )
 
-            async for item in async_iterate(self._resource.items()):
-                py_table = None
-
-                record_source_item_stats(
-                    item,
-                    source_type=self._source.source_type,
-                    logger=self._logger,
-                    team_id=self._job.team_id,
-                    schema_name=self._schema.name,
-                )
-
-                self._batcher.batch(item)
-
-                # A single batched table may be split into several when a string/binary/list
-                # column would otherwise overflow a 32-bit offset, so drain every ready chunk.
-                while self._batcher.should_yield():
-                    py_table = self._batcher.get_table()
-
-                    row_count += py_table.num_rows
-
-                    await self._process_pa_table(
-                        pa_table=py_table,
-                        index=chunk_index,
-                        resuming_sync=should_resume,
-                        row_count=row_count,
-                        is_first_ever_sync=is_first_ever_sync,
-                    )
-
-                    chunk_index += 1
-
-                    cleanup_memory(pa_memory_pool, py_table)
-                    py_table = None
-
-                if should_check_shutdown(self._schema, self._resource, self._reset_pipeline, source_is_resumable):
-                    self._shutdown_monitor.raise_if_is_worker_shutdown()
-
-            while self._batcher.should_yield(include_incomplete_chunk=True):
-                py_table = self._batcher.get_table()
-                row_count += py_table.num_rows
-                await self._process_pa_table(
-                    pa_table=py_table,
-                    index=chunk_index,
-                    resuming_sync=should_resume,
-                    row_count=row_count,
-                    is_first_ever_sync=is_first_ever_sync,
-                )
-                chunk_index += 1
+            row_count = await self._consume_and_load(
+                pa_memory_pool=pa_memory_pool,
+                should_resume=should_resume,
+                is_first_ever_sync=is_first_ever_sync,
+            )
 
             await self._persist_observed_columns()
 
@@ -293,7 +246,82 @@ class PipelineNonDLT(Generic[ResumableData]):
             del self._resource
             del self._delta_table_ref
 
-            cleanup_memory(pa_memory_pool, py_table if "py_table" in locals() else None)
+            # Per-chunk tables are cleaned up inside `_consume_and_load`; this just releases the pool.
+            cleanup_memory(pa_memory_pool, None)
+
+    async def _consume_and_load(self, *, pa_memory_pool: Any, should_resume: bool, is_first_ever_sync: bool) -> int:
+        """Pull rows from the source, batch them, and write each chunk to Delta. Returns rows synced.
+
+        When the worker drains and the sync can resume cheaply (`_should_bail_now`: a resumable source
+        with its own checkpoint, or an ascending incremental persisting its watermark per chunk), it
+        flushes the partial buffer — committing it so our written progress catches up to the source's
+        saved checkpoint, which can otherwise sit ahead of what we've persisted — then raises the
+        retryable `WorkerShuttingDownError` so the activity reschedules and resumes from that
+        checkpoint. No rows are skipped or duplicated. Sources that can't resume don't bail; they ride
+        the drain to completion or are cancelled when the worker's graceful-shutdown timeout elapses.
+        """
+        row_count = 0
+        chunk_index = 0
+        py_table: pa.Table | None = None
+
+        async def _load_ready_chunks(*, include_incomplete: bool) -> None:
+            nonlocal row_count, chunk_index, py_table
+            # A single batched table may be split into several when a string/binary/list column would
+            # otherwise overflow a 32-bit offset, so drain every ready chunk.
+            while self._batcher.should_yield(include_incomplete_chunk=include_incomplete):
+                py_table = self._batcher.get_table()
+                row_count += py_table.num_rows
+                await self._process_pa_table(
+                    pa_table=py_table,
+                    index=chunk_index,
+                    resuming_sync=should_resume,
+                    row_count=row_count,
+                    is_first_ever_sync=is_first_ever_sync,
+                )
+                chunk_index += 1
+                cleanup_memory(pa_memory_pool, py_table)
+                py_table = None
+
+        try:
+            async for item in async_iterate(self._resource.items()):
+                py_table = None
+
+                record_source_item_stats(
+                    item,
+                    source_type=self._source.source_type,
+                    logger=self._logger,
+                    team_id=self._job.team_id,
+                    schema_name=self._schema.name,
+                )
+
+                self._batcher.batch(item)
+                await _load_ready_chunks(include_incomplete=False)
+
+                if self._should_bail_now():
+                    # Flush the partial buffer so committed progress catches up to the checkpoint,
+                    # then hand off. Raised from inside the `async for` so the source generator's
+                    # cleanup (closing DB cursors/tunnels) runs as the exception unwinds it.
+                    await _load_ready_chunks(include_incomplete=True)
+                    self._shutdown_monitor.raise_if_is_worker_shutdown()
+
+            await _load_ready_chunks(include_incomplete=True)
+        finally:
+            cleanup_memory(pa_memory_pool, py_table)
+
+        return row_count
+
+    def _should_bail_now(self) -> bool:
+        """Whether the sync should hand off to a live pod when the worker drains.
+
+        True once the worker is draining and the source can resume cheaply (`should_check_shutdown`
+        — a resumable source with its own checkpoint, or an ascending incremental persisting its
+        watermark per chunk). The caller flushes the partial buffer, then raises. Non-resumable
+        sources return False and ride the drain (bailing would just restart them from zero).
+        """
+        if not self._shutdown_monitor.is_worker_shutdown():
+            return False
+        source_is_resumable = self._resumable_source_manager is not None
+        return should_check_shutdown(self._schema, self._resource, self._reset_pipeline, source_is_resumable)
 
     async def _persist_observed_columns(self) -> None:
         """Union the columns the source actually returned into `schema_metadata["columns"]`.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/test/test_pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/test/test_pipeline.py
@@ -1,9 +1,16 @@
 import uuid
-from typing import cast
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pyarrow as pa
+
+from posthog.temporal.common.shutdown import ShutdownMonitor
+
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v2.pipeline import PipelineNonDLT
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
 
@@ -68,3 +75,141 @@ async def test_post_run_operations_routes_through_shared_post_load():
     assert kwargs["resource"] is pipeline._resource
     assert kwargs["last_incremental_field_value"] == 5
     assert kwargs["row_count"] == 10
+
+
+class _YieldForShutdown(Exception):
+    pass
+
+
+class _FakeShutdownMonitor:
+    def __init__(self, shutting_down: bool):
+        self._shutting_down = shutting_down
+
+    def is_worker_shutdown(self) -> bool:
+        return self._shutting_down
+
+    def raise_if_is_worker_shutdown(self):
+        if self._shutting_down:
+            raise _YieldForShutdown()
+
+
+def _make_shutdown_pipeline(
+    *,
+    shutting_down: bool,
+    resumable: bool,
+    should_use_incremental_field: bool,
+    sort_mode: str,
+    reset_pipeline: bool,
+) -> PipelineNonDLT:
+    pipeline = PipelineNonDLT.__new__(PipelineNonDLT)
+    pipeline._shutdown_monitor = cast(ShutdownMonitor, _FakeShutdownMonitor(shutting_down))
+    pipeline._resumable_source_manager = cast(object, object()) if resumable else None  # type: ignore[assignment]
+    pipeline._schema = cast(
+        ExternalDataSchema,
+        SimpleNamespace(should_use_incremental_field=should_use_incremental_field),
+    )
+    pipeline._resource = cast(SourceResponse, SimpleNamespace(sort_mode=sort_mode))
+    pipeline._reset_pipeline = reset_pipeline
+    return pipeline
+
+
+# (resumable, incremental, sort_mode, reset) -> should this sync hand off *immediately* on drain?
+# Mirrors should_check_shutdown: resumable OR (ascending incremental and not a reset).
+@pytest.mark.parametrize(
+    "resumable,should_use_incremental_field,sort_mode,reset_pipeline,expect_bail_now",
+    [
+        (True, False, "asc", False, True),  # resumable source (e.g. Stripe), even desc/reset
+        (True, True, "desc", True, True),  # resumable wins over the desc/reset guards
+        (False, True, "asc", False, True),  # ascending incremental persists its watermark per chunk
+        (False, True, "desc", False, False),  # desc incremental commits watermark only at the end
+        (False, True, "asc", True, False),  # a reset would restart from 0 rows
+        (False, False, "asc", False, False),  # non-resumable full refresh
+    ],
+)
+def test_should_bail_now(resumable, should_use_incremental_field, sort_mode, reset_pipeline, expect_bail_now):
+    pipeline = _make_shutdown_pipeline(
+        shutting_down=True,
+        resumable=resumable,
+        should_use_incremental_field=should_use_incremental_field,
+        sort_mode=sort_mode,
+        reset_pipeline=reset_pipeline,
+    )
+    assert pipeline._should_bail_now() is expect_bail_now
+
+
+def test_should_bail_now_false_when_worker_healthy():
+    pipeline = _make_shutdown_pipeline(
+        shutting_down=False, resumable=True, should_use_incremental_field=True, sort_mode="asc", reset_pipeline=False
+    )
+    assert pipeline._should_bail_now() is False
+
+
+def _make_consume_pipeline(
+    *,
+    shutting_down: bool,
+    resumable: bool,
+    source_tables: list[pa.Table],
+    chunk_size: int = 10_000,
+) -> tuple[PipelineNonDLT, AsyncMock]:
+    pipeline = PipelineNonDLT.__new__(PipelineNonDLT)
+    pipeline._shutdown_monitor = cast(ShutdownMonitor, _FakeShutdownMonitor(shutting_down))
+    pipeline._resumable_source_manager = cast(object, object()) if resumable else None  # type: ignore[assignment]
+    pipeline._schema = cast(ExternalDataSchema, SimpleNamespace(should_use_incremental_field=False, name="test"))
+    pipeline._resource = cast(SourceResponse, SimpleNamespace(items=lambda: source_tables, sort_mode="asc"))
+    pipeline._reset_pipeline = False
+    pipeline._logger = MagicMock()
+    pipeline._source = cast(Any, SimpleNamespace(source_type="test"))
+    pipeline._job = cast(Any, SimpleNamespace(team_id=1))
+    pipeline._batcher = Batcher(MagicMock(), chunk_size=chunk_size)
+    process_mock = AsyncMock()
+    pipeline._process_pa_table = process_mock  # type: ignore[method-assign]
+    return pipeline, process_mock
+
+
+def _rows_processed(process_mock: AsyncMock) -> list[int]:
+    return [v.as_py() for call in process_mock.await_args_list for v in call.kwargs["pa_table"].column("id")]
+
+
+@pytest.mark.asyncio
+async def test_consume_and_load_syncs_everything_when_healthy():
+    tables = [pa.table({"id": [1, 2]}), pa.table({"id": [3, 4]}), pa.table({"id": [5]})]
+    pipeline, process_mock = _make_consume_pipeline(shutting_down=False, resumable=True, source_tables=tables)
+
+    row_count = await pipeline._consume_and_load(
+        pa_memory_pool=pa.default_memory_pool(), should_resume=False, is_first_ever_sync=True
+    )
+
+    assert row_count == 5
+    assert _rows_processed(process_mock) == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_consume_and_load_resumable_flushes_partial_before_raising():
+    # The whole point: when the worker drains, the buffered-but-not-yet-a-full-chunk rows are
+    # committed (flushed) *before* the raise, so committed progress catches up to the source's
+    # checkpoint and the resumed pod skips nothing. A big chunk size means nothing flushes on its own.
+    tables = [pa.table({"id": [1, 2]}), pa.table({"id": [3, 4]})]
+    pipeline, process_mock = _make_consume_pipeline(shutting_down=True, resumable=True, source_tables=tables)
+
+    with pytest.raises(_YieldForShutdown):
+        await pipeline._consume_and_load(
+            pa_memory_pool=pa.default_memory_pool(), should_resume=False, is_first_ever_sync=True
+        )
+
+    # The first item's rows were flushed and committed before the hand-off (not discarded).
+    assert _rows_processed(process_mock) == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_consume_and_load_non_resumable_rides_drain_and_completes():
+    # A non-resumable source can't resume cheaply, so it never bails on shutdown — it finishes the
+    # whole load on the draining pod rather than restarting from zero on a new one.
+    tables = [pa.table({"id": [1, 2]}), pa.table({"id": [3, 4]})]
+    pipeline, process_mock = _make_consume_pipeline(shutting_down=True, resumable=False, source_tables=tables)
+
+    row_count = await pipeline._consume_and_load(
+        pa_memory_pool=pa.default_memory_pool(), should_resume=False, is_first_ever_sync=True
+    )
+
+    assert row_count == 4
+    assert _rows_processed(process_mock) == [1, 2, 3, 4]

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/test/test_pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/test/test_pipeline.py
@@ -1,11 +1,17 @@
 import uuid
-from typing import cast
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pyarrow as pa
 from parameterized import parameterized
 
+from posthog.temporal.common.shutdown import ShutdownMonitor
+
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v2.pipeline import PipelineNonDLT
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.import_data_sync import (
@@ -125,3 +131,141 @@ class TestDeltaTableRefFirstSyncWiring:
             )
 
         assert mock_delta_table_ref_cls.call_args.kwargs["is_first_sync"] is expected_is_first_sync
+
+
+class _YieldForShutdown(Exception):
+    pass
+
+
+class _FakeShutdownMonitor:
+    def __init__(self, shutting_down: bool):
+        self._shutting_down = shutting_down
+
+    def is_worker_shutdown(self) -> bool:
+        return self._shutting_down
+
+    def raise_if_is_worker_shutdown(self):
+        if self._shutting_down:
+            raise _YieldForShutdown()
+
+
+def _make_shutdown_pipeline(
+    *,
+    shutting_down: bool,
+    resumable: bool,
+    should_use_incremental_field: bool,
+    sort_mode: str,
+    reset_pipeline: bool,
+) -> PipelineNonDLT:
+    pipeline = PipelineNonDLT.__new__(PipelineNonDLT)
+    pipeline._shutdown_monitor = cast(ShutdownMonitor, _FakeShutdownMonitor(shutting_down))
+    pipeline._resumable_source_manager = cast(object, object()) if resumable else None  # type: ignore[assignment]
+    pipeline._schema = cast(
+        ExternalDataSchema,
+        SimpleNamespace(should_use_incremental_field=should_use_incremental_field),
+    )
+    pipeline._resource = cast(SourceResponse, SimpleNamespace(sort_mode=sort_mode))
+    pipeline._reset_pipeline = reset_pipeline
+    return pipeline
+
+
+# (resumable, incremental, sort_mode, reset) -> should this sync hand off *immediately* on drain?
+# Mirrors should_check_shutdown: resumable OR (ascending incremental and not a reset).
+@pytest.mark.parametrize(
+    "resumable,should_use_incremental_field,sort_mode,reset_pipeline,expect_bail_now",
+    [
+        (True, False, "asc", False, True),  # resumable source (e.g. Stripe), even desc/reset
+        (True, True, "desc", True, True),  # resumable wins over the desc/reset guards
+        (False, True, "asc", False, True),  # ascending incremental persists its watermark per chunk
+        (False, True, "desc", False, False),  # desc incremental commits watermark only at the end
+        (False, True, "asc", True, False),  # a reset would restart from 0 rows
+        (False, False, "asc", False, False),  # non-resumable full refresh
+    ],
+)
+def test_should_bail_now(resumable, should_use_incremental_field, sort_mode, reset_pipeline, expect_bail_now):
+    pipeline = _make_shutdown_pipeline(
+        shutting_down=True,
+        resumable=resumable,
+        should_use_incremental_field=should_use_incremental_field,
+        sort_mode=sort_mode,
+        reset_pipeline=reset_pipeline,
+    )
+    assert pipeline._should_bail_now() is expect_bail_now
+
+
+def test_should_bail_now_false_when_worker_healthy():
+    pipeline = _make_shutdown_pipeline(
+        shutting_down=False, resumable=True, should_use_incremental_field=True, sort_mode="asc", reset_pipeline=False
+    )
+    assert pipeline._should_bail_now() is False
+
+
+def _make_consume_pipeline(
+    *,
+    shutting_down: bool,
+    resumable: bool,
+    source_tables: list[pa.Table],
+    chunk_size: int = 10_000,
+) -> tuple[PipelineNonDLT, AsyncMock]:
+    pipeline = PipelineNonDLT.__new__(PipelineNonDLT)
+    pipeline._shutdown_monitor = cast(ShutdownMonitor, _FakeShutdownMonitor(shutting_down))
+    pipeline._resumable_source_manager = cast(object, object()) if resumable else None  # type: ignore[assignment]
+    pipeline._schema = cast(ExternalDataSchema, SimpleNamespace(should_use_incremental_field=False, name="test"))
+    pipeline._resource = cast(SourceResponse, SimpleNamespace(items=lambda: source_tables, sort_mode="asc"))
+    pipeline._reset_pipeline = False
+    pipeline._logger = MagicMock()
+    pipeline._source = cast(Any, SimpleNamespace(source_type="test"))
+    pipeline._job = cast(Any, SimpleNamespace(team_id=1))
+    pipeline._batcher = Batcher(MagicMock(), chunk_size=chunk_size)
+    process_mock = AsyncMock()
+    pipeline._process_pa_table = process_mock  # type: ignore[method-assign]
+    return pipeline, process_mock
+
+
+def _rows_processed(process_mock: AsyncMock) -> list[int]:
+    return [v.as_py() for call in process_mock.await_args_list for v in call.kwargs["pa_table"].column("id")]
+
+
+@pytest.mark.asyncio
+async def test_consume_and_load_syncs_everything_when_healthy():
+    tables = [pa.table({"id": [1, 2]}), pa.table({"id": [3, 4]}), pa.table({"id": [5]})]
+    pipeline, process_mock = _make_consume_pipeline(shutting_down=False, resumable=True, source_tables=tables)
+
+    row_count = await pipeline._consume_and_load(
+        pa_memory_pool=pa.default_memory_pool(), should_resume=False, is_first_ever_sync=True
+    )
+
+    assert row_count == 5
+    assert _rows_processed(process_mock) == [1, 2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_consume_and_load_resumable_flushes_partial_before_raising():
+    # The whole point: when the worker drains, the buffered-but-not-yet-a-full-chunk rows are
+    # committed (flushed) *before* the raise, so committed progress catches up to the source's
+    # checkpoint and the resumed pod skips nothing. A big chunk size means nothing flushes on its own.
+    tables = [pa.table({"id": [1, 2]}), pa.table({"id": [3, 4]})]
+    pipeline, process_mock = _make_consume_pipeline(shutting_down=True, resumable=True, source_tables=tables)
+
+    with pytest.raises(_YieldForShutdown):
+        await pipeline._consume_and_load(
+            pa_memory_pool=pa.default_memory_pool(), should_resume=False, is_first_ever_sync=True
+        )
+
+    # The first item's rows were flushed and committed before the hand-off (not discarded).
+    assert _rows_processed(process_mock) == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_consume_and_load_non_resumable_rides_drain_and_completes():
+    # A non-resumable source can't resume cheaply, so it never bails on shutdown — it finishes the
+    # whole load on the draining pod rather than restarting from zero on a new one.
+    tables = [pa.table({"id": [1, 2]}), pa.table({"id": [3, 4]})]
+    pipeline, process_mock = _make_consume_pipeline(shutting_down=True, resumable=False, source_tables=tables)
+
+    row_count = await pipeline._consume_and_load(
+        pa_memory_pool=pa.default_memory_pool(), should_resume=False, is_first_ever_sync=True
+    )
+
+    assert row_count == 4
+    assert _rows_processed(process_mock) == [1, 2, 3, 4]

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -240,7 +240,6 @@ class PipelineV3(Generic[ResumableData]):
         pa_memory_pool = pa.default_memory_pool()
 
         should_resume = self._resumable_source_manager is not None and self._resumable_source_manager.can_resume()
-        source_is_resumable = self._resumable_source_manager is not None
 
         if should_resume:
             await self._logger.ainfo("V3 Pipeline: Resumable source detected - attempting to resume previous import")
@@ -281,10 +280,6 @@ class PipelineV3(Generic[ResumableData]):
                 billable=self._job.billable,
             )
 
-            py_table = None
-            row_count = 0
-            chunk_index = 0
-
             # On retry (attempt > 1) skip reset_table() - the consumer-side batch-0
             # overwrite handles it. Wiping the delta table mid-retry while the consumer
             # is loading the previous attempt's batches causes data loss.
@@ -313,57 +308,12 @@ class PipelineV3(Generic[ResumableData]):
                     self._schema, partition_count_fallback=self._resource.partition_count
                 )
 
-            async for item in async_iterate(self._resource.items()):
-                py_table = None
-
-                record_source_item_stats(
-                    item,
-                    source_type=source_type,
-                    logger=self._logger,
-                    team_id=self._job.team_id,
-                    schema_name=self._schema.name,
-                )
-
-                self._batcher.batch(item)
-
-                # A single batched table may be split into several when a string/binary/list
-                # column would otherwise overflow a 32-bit offset, so drain every ready chunk.
-                while self._batcher.should_yield():
-                    py_table = self._batcher.get_table()
-                    row_count += py_table.num_rows
-
-                    await self._process_batch(
-                        pa_table=py_table,
-                        batch_index=chunk_index,
-                        row_count=row_count,
-                    )
-
-                    if activity.in_activity():
-                        get_rows_extracted_metric(team_id_str, schema_id_str, source_type).add(py_table.num_rows)
-                        get_batches_produced_metric(team_id_str, schema_id_str).add(1)
-
-                    chunk_index += 1
-
-                    cleanup_memory(pa_memory_pool, py_table)
-                    py_table = None
-
-                if should_check_shutdown(self._schema, self._resource, self._reset_pipeline, source_is_resumable):
-                    self._shutdown_monitor.raise_if_is_worker_shutdown()
-
-            while self._batcher.should_yield(include_incomplete_chunk=True):
-                py_table = self._batcher.get_table()
-                row_count += py_table.num_rows
-                await self._process_batch(
-                    pa_table=py_table,
-                    batch_index=chunk_index,
-                    row_count=row_count,
-                )
-
-                if activity.in_activity():
-                    get_rows_extracted_metric(team_id_str, schema_id_str, source_type).add(py_table.num_rows)
-                    get_batches_produced_metric(team_id_str, schema_id_str).add(1)
-
-                chunk_index += 1
+            row_count = await self._consume_and_load(
+                pa_memory_pool=pa_memory_pool,
+                team_id_str=team_id_str,
+                schema_id_str=schema_id_str,
+                source_type=source_type,
+            )
 
             await self._finalize(row_count=row_count)
 
@@ -406,7 +356,81 @@ class PipelineV3(Generic[ResumableData]):
             self._pg_producer.close()
             del self._pg_producer
 
-            cleanup_memory(pa_memory_pool, py_table if "py_table" in locals() else None)
+            # Per-chunk tables are cleaned up inside `_consume_and_load`; this just releases the pool.
+            cleanup_memory(pa_memory_pool, None)
+
+    async def _consume_and_load(
+        self, *, pa_memory_pool: Any, team_id_str: str, schema_id_str: str, source_type: str
+    ) -> int:
+        """Pull rows from the source, batch them, and write each chunk. Returns rows synced.
+
+        When the worker drains and the sync can resume cheaply (`_should_bail_now`: a resumable source
+        with its own checkpoint, or an ascending incremental persisting its watermark per chunk), it
+        flushes the partial buffer — committing it so our written progress catches up to the source's
+        saved checkpoint, which can otherwise sit ahead of what we've persisted — then raises the
+        retryable `WorkerShuttingDownError` so the activity reschedules and resumes from that
+        checkpoint. No rows are skipped or duplicated. Sources that can't resume don't bail; they ride
+        the drain to completion or are cancelled when the worker's graceful-shutdown timeout elapses.
+        """
+        row_count = 0
+        chunk_index = 0
+        py_table: pa.Table | None = None
+
+        async def _load_ready_chunks(*, include_incomplete: bool) -> None:
+            nonlocal row_count, chunk_index, py_table
+            # A single batched table may be split into several when a string/binary/list column would
+            # otherwise overflow a 32-bit offset, so drain every ready chunk.
+            while self._batcher.should_yield(include_incomplete_chunk=include_incomplete):
+                py_table = self._batcher.get_table()
+                row_count += py_table.num_rows
+                await self._process_batch(pa_table=py_table, batch_index=chunk_index, row_count=row_count)
+                if activity.in_activity():
+                    get_rows_extracted_metric(team_id_str, schema_id_str, source_type).add(py_table.num_rows)
+                    get_batches_produced_metric(team_id_str, schema_id_str).add(1)
+                chunk_index += 1
+                cleanup_memory(pa_memory_pool, py_table)
+                py_table = None
+
+        try:
+            async for item in async_iterate(self._resource.items()):
+                py_table = None
+
+                record_source_item_stats(
+                    item,
+                    source_type=source_type,
+                    logger=self._logger,
+                    team_id=self._job.team_id,
+                    schema_name=self._schema.name,
+                )
+
+                self._batcher.batch(item)
+                await _load_ready_chunks(include_incomplete=False)
+
+                if self._should_bail_now():
+                    # Flush the partial buffer so committed progress catches up to the checkpoint,
+                    # then hand off. Raised from inside the `async for` so the source generator's
+                    # cleanup (closing DB cursors/tunnels) runs as the exception unwinds it.
+                    await _load_ready_chunks(include_incomplete=True)
+                    self._shutdown_monitor.raise_if_is_worker_shutdown()
+
+            await _load_ready_chunks(include_incomplete=True)
+        finally:
+            cleanup_memory(pa_memory_pool, py_table)
+
+        return row_count
+
+    def _should_bail_now(self) -> bool:
+        """Whether the sync should hand off to a live pod when the worker drains.
+
+        True once the worker is draining and the source can resume cheaply (`should_check_shutdown`
+        — a resumable source with its own checkpoint, or an ascending incremental persisting its
+        watermark per chunk). The caller flushes the partial buffer, then raises. Non-resumable
+        sources return False and ride the drain (bailing would just restart them from zero).
+        """
+        if not self._shutdown_monitor.is_worker_shutdown():
+            return False
+        source_is_resumable = self._resumable_source_manager is not None
+        return should_check_shutdown(self._schema, self._resource, self._reset_pipeline, source_is_resumable)
 
     async def _process_batch(self, pa_table: pa.Table, batch_index: int, row_count: int) -> None:
         pa_table = _append_debug_column_to_pyarrows_table(pa_table, self._load_id)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -240,7 +240,6 @@ class PipelineV3(Generic[ResumableData]):
         pa_memory_pool = pa.default_memory_pool()
 
         should_resume = self._resumable_source_manager is not None and self._resumable_source_manager.can_resume()
-        source_is_resumable = self._resumable_source_manager is not None
 
         if should_resume:
             await self._logger.ainfo("V3 Pipeline: Resumable source detected - attempting to resume previous import")
@@ -285,10 +284,6 @@ class PipelineV3(Generic[ResumableData]):
                 billable=self._job.billable,
             )
 
-            py_table = None
-            row_count = 0
-            chunk_index = 0
-
             # On retry (attempt > 1) skip reset_table() - the consumer-side batch-0
             # overwrite handles it. Wiping the delta table mid-retry while the consumer
             # is loading the previous attempt's batches causes data loss.
@@ -317,57 +312,12 @@ class PipelineV3(Generic[ResumableData]):
                     self._schema, partition_count_fallback=self._resource.partition_count
                 )
 
-            async for item in async_iterate(self._resource.items()):
-                py_table = None
-
-                record_source_item_stats(
-                    item,
-                    source_type=source_type,
-                    logger=self._logger,
-                    team_id=self._job.team_id,
-                    schema_name=self._schema.name,
-                )
-
-                self._batcher.batch(item)
-
-                # A single batched table may be split into several when a string/binary/list
-                # column would otherwise overflow a 32-bit offset, so drain every ready chunk.
-                while self._batcher.should_yield():
-                    py_table = self._batcher.get_table()
-                    row_count += py_table.num_rows
-
-                    await self._process_batch(
-                        pa_table=py_table,
-                        batch_index=chunk_index,
-                        row_count=row_count,
-                    )
-
-                    if activity.in_activity():
-                        get_rows_extracted_metric(team_id_str, schema_id_str, source_type).add(py_table.num_rows)
-                        get_batches_produced_metric(team_id_str, schema_id_str).add(1)
-
-                    chunk_index += 1
-
-                    cleanup_memory(pa_memory_pool, py_table)
-                    py_table = None
-
-                if should_check_shutdown(self._schema, self._resource, self._reset_pipeline, source_is_resumable):
-                    self._shutdown_monitor.raise_if_is_worker_shutdown()
-
-            while self._batcher.should_yield(include_incomplete_chunk=True):
-                py_table = self._batcher.get_table()
-                row_count += py_table.num_rows
-                await self._process_batch(
-                    pa_table=py_table,
-                    batch_index=chunk_index,
-                    row_count=row_count,
-                )
-
-                if activity.in_activity():
-                    get_rows_extracted_metric(team_id_str, schema_id_str, source_type).add(py_table.num_rows)
-                    get_batches_produced_metric(team_id_str, schema_id_str).add(1)
-
-                chunk_index += 1
+            row_count = await self._consume_and_load(
+                pa_memory_pool=pa_memory_pool,
+                team_id_str=team_id_str,
+                schema_id_str=schema_id_str,
+                source_type=source_type,
+            )
 
             await self._finalize(row_count=row_count)
 
@@ -410,7 +360,81 @@ class PipelineV3(Generic[ResumableData]):
             self._pg_producer.close()
             del self._pg_producer
 
-            cleanup_memory(pa_memory_pool, py_table if "py_table" in locals() else None)
+            # Per-chunk tables are cleaned up inside `_consume_and_load`; this just releases the pool.
+            cleanup_memory(pa_memory_pool, None)
+
+    async def _consume_and_load(
+        self, *, pa_memory_pool: Any, team_id_str: str, schema_id_str: str, source_type: str
+    ) -> int:
+        """Pull rows from the source, batch them, and write each chunk. Returns rows synced.
+
+        When the worker drains and the sync can resume cheaply (`_should_bail_now`: a resumable source
+        with its own checkpoint, or an ascending incremental persisting its watermark per chunk), it
+        flushes the partial buffer — committing it so our written progress catches up to the source's
+        saved checkpoint, which can otherwise sit ahead of what we've persisted — then raises the
+        retryable `WorkerShuttingDownError` so the activity reschedules and resumes from that
+        checkpoint. No rows are skipped or duplicated. Sources that can't resume don't bail; they ride
+        the drain to completion or are cancelled when the worker's graceful-shutdown timeout elapses.
+        """
+        row_count = 0
+        chunk_index = 0
+        py_table: pa.Table | None = None
+
+        async def _load_ready_chunks(*, include_incomplete: bool) -> None:
+            nonlocal row_count, chunk_index, py_table
+            # A single batched table may be split into several when a string/binary/list column would
+            # otherwise overflow a 32-bit offset, so drain every ready chunk.
+            while self._batcher.should_yield(include_incomplete_chunk=include_incomplete):
+                py_table = self._batcher.get_table()
+                row_count += py_table.num_rows
+                await self._process_batch(pa_table=py_table, batch_index=chunk_index, row_count=row_count)
+                if activity.in_activity():
+                    get_rows_extracted_metric(team_id_str, schema_id_str, source_type).add(py_table.num_rows)
+                    get_batches_produced_metric(team_id_str, schema_id_str).add(1)
+                chunk_index += 1
+                cleanup_memory(pa_memory_pool, py_table)
+                py_table = None
+
+        try:
+            async for item in async_iterate(self._resource.items()):
+                py_table = None
+
+                record_source_item_stats(
+                    item,
+                    source_type=source_type,
+                    logger=self._logger,
+                    team_id=self._job.team_id,
+                    schema_name=self._schema.name,
+                )
+
+                self._batcher.batch(item)
+                await _load_ready_chunks(include_incomplete=False)
+
+                if self._should_bail_now():
+                    # Flush the partial buffer so committed progress catches up to the checkpoint,
+                    # then hand off. Raised from inside the `async for` so the source generator's
+                    # cleanup (closing DB cursors/tunnels) runs as the exception unwinds it.
+                    await _load_ready_chunks(include_incomplete=True)
+                    self._shutdown_monitor.raise_if_is_worker_shutdown()
+
+            await _load_ready_chunks(include_incomplete=True)
+        finally:
+            cleanup_memory(pa_memory_pool, py_table)
+
+        return row_count
+
+    def _should_bail_now(self) -> bool:
+        """Whether the sync should hand off to a live pod when the worker drains.
+
+        True once the worker is draining and the source can resume cheaply (`should_check_shutdown`
+        — a resumable source with its own checkpoint, or an ascending incremental persisting its
+        watermark per chunk). The caller flushes the partial buffer, then raises. Non-resumable
+        sources return False and ride the drain (bailing would just restart them from zero).
+        """
+        if not self._shutdown_monitor.is_worker_shutdown():
+            return False
+        source_is_resumable = self._resumable_source_manager is not None
+        return should_check_shutdown(self._schema, self._resource, self._reset_pipeline, source_is_resumable)
 
     async def _process_batch(self, pa_table: pa.Table, batch_index: int, row_count: int) -> None:
         pa_table = _append_debug_column_to_pyarrows_table(pa_table, self._load_id)

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
@@ -2879,6 +2879,7 @@ async def test_worker_shutdown_triggers_schedule_buffer_one(team, zendesk_brands
         raise WorkerShuttingDownError("test_id", "test_type", "test_queue", 1, "test_workflow", "test_workflow_type")
 
     with (
+        mock.patch.object(ShutdownMonitor, "is_worker_shutdown", return_value=True),
         mock.patch.object(ShutdownMonitor, "raise_if_is_worker_shutdown", mock_raise_if_is_worker_shutdown),
         mock.patch(
             "products.warehouse_sources.backend.temporal.data_imports.external_data_job.trigger_schedule_buffer_one"
@@ -3386,7 +3387,10 @@ async def test_timestamped_query_folder(team, stripe_balance_transaction, mock_s
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_resumable_source_shutdown(team, stripe_customer, mock_stripe_client):
-    with mock.patch.object(ShutdownMonitor, "raise_if_is_worker_shutdown") as mock_raise_if_is_worker_shutdown:
+    with (
+        mock.patch.object(ShutdownMonitor, "is_worker_shutdown", return_value=True),
+        mock.patch.object(ShutdownMonitor, "raise_if_is_worker_shutdown") as mock_raise_if_is_worker_shutdown,
+    ):
         await _run(
             team=team,
             schema_name=STRIPE_CUSTOMER_RESOURCE_NAME,

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/e2e/test_end_to_end.py
@@ -3232,6 +3232,7 @@ async def test_worker_shutdown_triggers_schedule_buffer_one(team, zendesk_brands
         raise WorkerShuttingDownError("test_id", "test_type", "test_queue", 1, "test_workflow", "test_workflow_type")
 
     with (
+        mock.patch.object(ShutdownMonitor, "is_worker_shutdown", return_value=True),
         mock.patch.object(ShutdownMonitor, "raise_if_is_worker_shutdown", mock_raise_if_is_worker_shutdown),
         mock.patch(
             "products.warehouse_sources.backend.temporal.data_imports.external_data_job.trigger_schedule_buffer_one"
@@ -3739,7 +3740,10 @@ async def test_timestamped_query_folder(team, stripe_balance_transaction, mock_s
 @pytest.mark.django_db(transaction=True)
 @pytest.mark.asyncio
 async def test_resumable_source_shutdown(team, stripe_customer, mock_stripe_client):
-    with mock.patch.object(ShutdownMonitor, "raise_if_is_worker_shutdown") as mock_raise_if_is_worker_shutdown:
+    with (
+        mock.patch.object(ShutdownMonitor, "is_worker_shutdown", return_value=True),
+        mock.patch.object(ShutdownMonitor, "raise_if_is_worker_shutdown") as mock_raise_if_is_worker_shutdown,
+    ):
         await _run(
             team=team,
             schema_name=STRIPE_CUSTOMER_RESOURCE_NAME,


### PR DESCRIPTION
## Problem

The data-warehouse Temporal worker runs a large pod fleet with a ~6h graceful-drain window and gets rolled frequently. In-flight import activities keep running on a draining pod until they finish, so terminating pods pile up.

Work doesn't cleanly hop to a fresh pod on shutdown. The pipeline only checked for worker shutdown once per source item, so even a sync that could resume cheaply on a live pod kept running on the dying one until its next item boundary, instead of handing off promptly.

## Changes

Check for worker shutdown per chunk instead of once per source item, so a draining pod releases a resumable sync sooner:

- **Resumable and ascending-incremental syncs** flush their partial buffer at the item boundary — committing it so written progress catches up to the source's saved checkpoint/watermark, which can otherwise sit ahead of what we've persisted — then raise the retryable `WorkerShuttingDownError` so the activity reschedules and resumes from that checkpoint on a live pod. No rows are skipped or duplicated.
- **Everything else** (non-resumable full refreshes, descending-sort incrementals, and full resets) can only restart from zero, so bailing on drain would just discard partial progress. These ride the drain to completion, or are cancelled when the worker's graceful-shutdown timeout elapses — the same as before this change.

Retry budgets raised (resumable 15 → 25, incremental 9 → 15) since each shutdown yield burns a retryable attempt, and a long backfill can otherwise exhaust its budget on drain bounces alone. Applied symmetrically to the v2 (`PipelineNonDLT`) and v3 (`PipelineV3`) pipelines.

```mermaid
flowchart TD
  A[worker draining, chunk committed] --> B{check per chunk, at item boundary}
  B --> C{resumable or ascending-incremental, and not a reset?}
  C -->|yes| D[flush partial buffer, raise, resume on live pod]
  C -->|no| E[ride the drain to completion or graceful-shutdown cancel]
  class D phBlue
  class E phYellow
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
```

## How did you test this code?

Automated only. I did not exercise this against the live worker.

Added unit tests in `pipelines/pipeline_v2/test/test_pipeline.py`:

- `test_should_bail_now` — the decision matrix: resumable sources and ascending-incremental syncs (when not a reset) hand off immediately on drain; descending incrementals, resets, and non-resumable full refreshes ride the drain.
- `test_should_bail_now_false_when_worker_healthy` — no hand-off when the worker isn't draining.
- `test_consume_and_load_*` — a resumable source flushes its partial buffer before raising (so committed progress catches up to the checkpoint); a non-resumable source rides the drain to completion; the healthy path syncs everything.

These catch the regressions nothing covered before: a resumable source must hand off promptly on drain, a non-resumable one must not be bounced from zero, and the partial buffer must be committed before the hand-off so the resumed pod skips nothing.

Not run: mypy (CI covers it) and any live-worker verification.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected. This is worker-internal reliability behavior.
