### PR TITLE
feat(data-warehouse): surface group properties in custom-property MCP tools

### DIFF
--- a/products/customer_analytics/backend/presentation/views/serializers.py
+++ b/products/customer_analytics/backend/presentation/views/serializers.py
@@ -308,7 +308,7 @@ class CustomPropertyReferenceSerializer(DataclassSerializer):
 
 
 class CustomPropertySyncTriggerResponseSerializer(serializers.Serializer):
-    """Response of the person-property sync/backfill trigger actions."""
+    """Response of the person/group-property sync/backfill trigger actions."""
 
     status = serializers.ChoiceField(
         choices=[("triggered", "triggered"), ("started", "started"), ("already_running", "already_running")],
@@ -324,8 +324,8 @@ class CustomPropertySyncTriggerResponseSerializer(serializers.Serializer):
 
 
 class CustomPropertySyncRunSerializer(DataclassSerializer):
-    """One person-property sync or backfill run. Read-only: runs are created by the sync/backfill
-    pipeline, never through the API."""
+    """One person- or group-property sync or backfill run. Read-only: runs are created by the
+    sync/backfill pipeline, never through the API."""
 
     id = serializers.UUIDField(read_only=True)
     trigger = serializers.CharField(
@@ -340,13 +340,15 @@ class CustomPropertySyncRunSerializer(DataclassSerializer):
     rows_read = serializers.IntegerField(read_only=True, help_text="Warehouse rows scanned this run.")
     changed = serializers.IntegerField(read_only=True, help_text="Rows whose mapped values changed since the last run.")
     existing = serializers.IntegerField(
-        read_only=True, help_text="Person profiles updated (changed rows that matched an existing person)."
+        read_only=True,
+        help_text="Person or group profiles updated (changed rows that matched an existing person/group).",
     )
     produced = serializers.IntegerField(
         read_only=True, help_text="Property-update intents produced to the ingestion pipeline."
     )
     skipped_missing_person = serializers.IntegerField(
-        read_only=True, help_text="Changed rows dropped because no existing person matched the distinct id."
+        read_only=True,
+        help_text="Changed rows dropped because no existing person/group matched the key column value.",
     )
     error = serializers.CharField(
         read_only=True, allow_null=True, help_text="Error summary if the run failed, else null."
@@ -373,8 +375,9 @@ class CustomPropertySyncRunSerializer(DataclassSerializer):
 
 
 class CustomPropertySourceSerializer(DataclassSerializer):
-    """Binds a materialized data-warehouse view column to a custom property definition; the view's
-    values are synced onto matching accounts on each materialization."""
+    """Binds a data-warehouse source to a custom property definition. Account sources read a
+    materialized view column and sync onto matching accounts; person and group sources read a
+    warehouse schema and sync onto matching persons or groups on each warehouse sync."""
 
     id = serializers.UUIDField(read_only=True)
     definition = serializers.UUIDField(
@@ -392,8 +395,8 @@ class CustomPropertySourceSerializer(DataclassSerializer):
         required=False,
         allow_null=True,
         help_text=(
-            "Person sources only: UUID of the warehouse schema (raw incremental table) to read from. "
-            "Mutually exclusive with saved_query."
+            "Person and group sources only: UUID of the warehouse schema (raw incremental table) to "
+            "read from. Mutually exclusive with saved_query."
         ),
     )
     source_column = serializers.CharField(
@@ -406,15 +409,15 @@ class CustomPropertySourceSerializer(DataclassSerializer):
         required=False,
         allow_null=True,
         help_text=(
-            "Person sources only: {warehouse_column: person_property_name} mapping the columns this "
-            "source writes onto the person."
+            "Person and group sources only: {warehouse_column: property_name} mapping the columns this "
+            "source writes onto the person or group."
         ),
     )
     key_column = serializers.CharField(
         max_length=400,
         help_text=(
             "Column whose value identifies the target: an account's external_id for account sources, "
-            "or the person's distinct_id for person sources."
+            "the person's distinct_id for person sources, or the group key for group sources."
         ),
     )
     is_enabled = serializers.BooleanField(
@@ -441,22 +444,23 @@ class CustomPropertySourceSerializer(DataclassSerializer):
         read_only=True,
         allow_null=True,
         help_text=(
-            "Person sources only: how often the underlying warehouse schema syncs, in seconds. Null "
-            "for account sources or when unavailable."
+            "Person and group sources only: how often the underlying warehouse schema syncs, in "
+            "seconds. Null for account sources or when unavailable."
         ),
     )
     next_sync_at = serializers.DateTimeField(
         read_only=True,
         allow_null=True,
         help_text=(
-            "Person sources only: approximate time of the next scheduled sync (last synced + interval). "
-            "Approximate — drifts if the schedule was paused. Null for account sources or if never synced."
+            "Person and group sources only: approximate time of the next scheduled sync (last synced + "
+            "interval). Approximate — drifts if the schedule was paused. Null for account sources or if "
+            "never synced."
         ),
     )
     latest_run = CustomPropertySyncRunSerializer(
         read_only=True,
         allow_null=True,
-        help_text="Person sources only: the most recent sync/backfill run, or null if none yet.",
+        help_text="Person and group sources only: the most recent sync/backfill run, or null if none yet.",
     )
 
     class Meta:

--- a/products/customer_analytics/backend/presentation/views/views.py
+++ b/products/customer_analytics/backend/presentation/views/views.py
@@ -642,8 +642,9 @@ class CustomPropertySourceViewSet(
     )
     @action(methods=["POST"], detail=True)
     def sync(self, request: Request, *args, **kwargs) -> Response:
-        """Person sources only: trigger the underlying warehouse schema's sync now. This re-runs a
-        real (billable) warehouse sync; the incremental person-property update runs off it."""
+        """Person and group sources only: trigger the underlying warehouse schema's sync now. This
+        re-runs a real (billable) warehouse sync; the incremental person/group-property update runs
+        off it."""
         self._guard_group_source(request, self.kwargs["pk"])
         try:
             triggered = api.trigger_person_property_sync(
@@ -654,7 +655,7 @@ class CustomPropertySourceViewSet(
         except api.WarehouseSyncPausedError as e:
             return Response({"message": str(e)}, status=status.HTTP_400_BAD_REQUEST)
         if not triggered:
-            raise ValidationError("This action is only available for enabled person-property sources.")
+            raise ValidationError("This action is only available for enabled person- or group-property sources.")
         return Response({"status": "triggered"}, status=status.HTTP_202_ACCEPTED)
 
     @extend_schema(
@@ -664,8 +665,9 @@ class CustomPropertySourceViewSet(
     )
     @action(methods=["POST"], detail=True)
     def backfill(self, request: Request, *args, **kwargs) -> Response:
-        """Person sources only: start a backfill that reads the whole warehouse table and populates
-        person properties for historical rows. Coalesces if one is already running for the table."""
+        """Person and group sources only: start a backfill that reads the whole warehouse table and
+        populates person or group properties for historical rows. Coalesces if one is already running
+        for the table."""
         self._guard_group_source(request, self.kwargs["pk"])
         try:
             started = api.trigger_person_property_backfill(
@@ -677,7 +679,7 @@ class CustomPropertySourceViewSet(
         except api.ResourceForbiddenError:
             raise PermissionDenied()
         if started is None:
-            raise ValidationError("This action is only available for enabled person-property sources.")
+            raise ValidationError("This action is only available for enabled person- or group-property sources.")
         return Response(
             {"status": "started" if started else "already_running", "already_running": not started},
             status=status.HTTP_202_ACCEPTED,
@@ -689,8 +691,9 @@ class CustomPropertySourceViewSet(
     )
     @action(methods=["GET"], detail=True)
     def runs(self, request: Request, *args, **kwargs) -> Response:
-        """Person sources only: the source's sync/backfill run history, newest first. Gated on the
-        caller's warehouse-source viewer access, since the runs expose its row counts and sync errors."""
+        """Person and group sources only: the source's sync/backfill run history, newest first. Gated
+        on the caller's warehouse-source viewer access, since the runs expose its row counts and sync
+        errors."""
         # Hide the run history of a group-target source from callers without group read authorization.
         source = api.get_custom_property_source(self.team_id, self.kwargs["pk"])
         if (

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -644,8 +644,8 @@ export interface CustomPropertyOptionApi {
 }
 
 /**
- * One person-property sync or backfill run. Read-only: runs are created by the sync/backfill
- * pipeline, never through the API.
+ * One person- or group-property sync or backfill run. Read-only: runs are created by the
+ * sync/backfill pipeline, never through the API.
  */
 export interface CustomPropertySyncRunApi {
     readonly id: string
@@ -667,11 +667,11 @@ export interface CustomPropertySyncRunApi {
     readonly rows_read: number
     /** Rows whose mapped values changed since the last run. */
     readonly changed: number
-    /** Person profiles updated (changed rows that matched an existing person). */
+    /** Person or group profiles updated (changed rows that matched an existing person/group). */
     readonly existing: number
     /** Property-update intents produced to the ingestion pipeline. */
     readonly produced: number
-    /** Changed rows dropped because no existing person matched the distinct id. */
+    /** Changed rows dropped because no existing person/group matched the key column value. */
     readonly skipped_missing_person: number
     /**
      * Error summary if the run failed, else null.
@@ -683,8 +683,9 @@ export interface CustomPropertySyncRunApi {
 }
 
 /**
- * Binds a materialized data-warehouse view column to a custom property definition; the view's
- * values are synced onto matching accounts on each materialization.
+ * Binds a data-warehouse source to a custom property definition. Account sources read a
+ * materialized view column and sync onto matching accounts; person and group sources read a
+ * warehouse schema and sync onto matching persons or groups on each warehouse sync.
  */
 export interface CustomPropertySourceApi {
     readonly id: string
@@ -696,7 +697,7 @@ export interface CustomPropertySourceApi {
      */
     saved_query?: string | null
     /**
-     * Person sources only: UUID of the warehouse schema (raw incremental table) to read from. Mutually exclusive with saved_query.
+     * Person and group sources only: UUID of the warehouse schema (raw incremental table) to read from. Mutually exclusive with saved_query.
      * @nullable
      */
     external_data_schema?: string | null
@@ -706,10 +707,10 @@ export interface CustomPropertySourceApi {
      * @nullable
      */
     source_column?: string | null
-    /** Person sources only: {warehouse_column: person_property_name} mapping the columns this source writes onto the person. */
+    /** Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group. */
     column_property_map?: unknown
     /**
-     * Column whose value identifies the target: an account's external_id for account sources, or the person's distinct_id for person sources.
+     * Column whose value identifies the target: an account's external_id for account sources, the person's distinct_id for person sources, or the group key for group sources.
      * @maxLength 400
      */
     key_column: string
@@ -733,16 +734,16 @@ export interface CustomPropertySourceApi {
     /** @nullable */
     readonly updated_at: string | null
     /**
-     * Person sources only: how often the underlying warehouse schema syncs, in seconds. Null for account sources or when unavailable.
+     * Person and group sources only: how often the underlying warehouse schema syncs, in seconds. Null for account sources or when unavailable.
      * @nullable
      */
     readonly sync_frequency_interval_seconds: number | null
     /**
-     * Person sources only: approximate time of the next scheduled sync (last synced + interval). Approximate — drifts if the schedule was paused. Null for account sources or if never synced.
+     * Person and group sources only: approximate time of the next scheduled sync (last synced + interval). Approximate — drifts if the schedule was paused. Null for account sources or if never synced.
      * @nullable
      */
     readonly next_sync_at: string | null
-    /** Person sources only: the most recent sync/backfill run, or null if none yet. */
+    /** Person and group sources only: the most recent sync/backfill run, or null if none yet. */
     readonly latest_run: CustomPropertySyncRunApi | null
 }
 
@@ -972,7 +973,7 @@ export const CustomPropertySyncTriggerResponseStatusEnumApi = {
 } as const
 
 /**
- * Response of the person-property sync/backfill trigger actions.
+ * Response of the person/group-property sync/backfill trigger actions.
  */
 export interface CustomPropertySyncTriggerResponseApi {
     /** 'triggered' (sync now started the warehouse sync), 'started' (a new backfill began), or 'already_running' (a backfill for this table was already in flight, so this was a no-op).

--- a/products/customer_analytics/frontend/generated/api.ts
+++ b/products/customer_analytics/frontend/generated/api.ts
@@ -879,8 +879,9 @@ export const getCustomPropertySourcesBackfillUrl = (projectId: string, id: strin
 }
 
 /**
- * Person sources only: start a backfill that reads the whole warehouse table and populates
- * person properties for historical rows. Coalesces if one is already running for the table.
+ * Person and group sources only: start a backfill that reads the whole warehouse table and
+ * populates person or group properties for historical rows. Coalesces if one is already running
+ * for the table.
  */
 export const customPropertySourcesBackfill = async (
     projectId: string,
@@ -914,8 +915,9 @@ export const getCustomPropertySourcesRunsListUrl = (
 }
 
 /**
- * Person sources only: the source's sync/backfill run history, newest first. Gated on the
- * caller's warehouse-source viewer access, since the runs expose its row counts and sync errors.
+ * Person and group sources only: the source's sync/backfill run history, newest first. Gated
+ * on the caller's warehouse-source viewer access, since the runs expose its row counts and sync
+ * errors.
  */
 export const customPropertySourcesRunsList = async (
     projectId: string,
@@ -937,8 +939,9 @@ export const getCustomPropertySourcesSyncUrl = (projectId: string, id: string) =
 }
 
 /**
- * Person sources only: trigger the underlying warehouse schema's sync now. This re-runs a
- * real (billable) warehouse sync; the incremental person-property update runs off it.
+ * Person and group sources only: trigger the underlying warehouse schema's sync now. This
+ * re-runs a real (billable) warehouse sync; the incremental person/group-property update runs
+ * off it.
  */
 export const customPropertySourcesSync = async (
     projectId: string,

--- a/products/customer_analytics/frontend/generated/api.zod.ts
+++ b/products/customer_analytics/frontend/generated/api.zod.ts
@@ -572,7 +572,7 @@ export const CustomPropertySourcesCreateBody = /* @__PURE__ */ zod
             .uuid()
             .nullish()
             .describe(
-                'Person sources only: UUID of the warehouse schema (raw incremental table) to read from. Mutually exclusive with saved_query.'
+                'Person and group sources only: UUID of the warehouse schema (raw incremental table) to read from. Mutually exclusive with saved_query.'
             ),
         source_column: zod
             .string()
@@ -583,13 +583,13 @@ export const CustomPropertySourcesCreateBody = /* @__PURE__ */ zod
             .unknown()
             .optional()
             .describe(
-                'Person sources only: {warehouse_column: person_property_name} mapping the columns this source writes onto the person.'
+                'Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group.'
             ),
         key_column: zod
             .string()
             .max(customPropertySourcesCreateBodyKeyColumnMax)
             .describe(
-                "Column whose value identifies the target: an account's external_id for account sources, or the person's distinct_id for person sources."
+                "Column whose value identifies the target: an account's external_id for account sources, the person's distinct_id for person sources, or the group key for group sources."
             ),
         is_enabled: zod
             .boolean()
@@ -599,7 +599,7 @@ export const CustomPropertySourcesCreateBody = /* @__PURE__ */ zod
             ),
     })
     .describe(
-        "Binds a materialized data-warehouse view column to a custom property definition; the view's\nvalues are synced onto matching accounts on each materialization."
+        'Binds a data-warehouse source to a custom property definition. Account sources read a\nmaterialized view column and sync onto matching accounts; person and group sources read a\nwarehouse schema and sync onto matching persons or groups on each warehouse sync.'
     )
 
 export const customPropertySourcesUpdateBodySourceColumnMax = 400

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -385,12 +385,17 @@ tools:
             idempotent: false
         title: Create custom property definition
         description: >
-            Create a Customer Analytics custom property definition — the shape of a custom account attribute. Provide
-            `name` (required, unique within the team), optional `description`, `display_type` (required; one of text,
-            number, currency, percent, date, datetime, boolean), and optional `is_big_number` to abbreviate large
-            numeric values (e.g. 10,000 → 10K; only valid for numeric display types). Definitions are team-scoped and
-            shared across all accounts; set the value a specific account holds via the account custom property value
-            tools.
+            Create a Customer Analytics custom property definition — the shape of a custom attribute. Provide `name`
+            (required, unique within the team), optional `description`, `display_type` (required; one of text, number,
+            currency, percent, date, datetime, boolean), and optional `is_big_number` to abbreviate large numeric values
+            (e.g. 10,000 → 10K; only valid for numeric display types). `target_type` picks what the property attaches
+            to: `account` (default; value set manually or from a materialized view), `person`, or `group` (person/group
+            properties are populated from a warehouse table via a custom property source and become usable like any
+            other person/group property in feature flags, cohorts, and insights). For `group` targets, also pass
+            `group_type_index` (0-4) selecting the group type. Person and group targets require the
+            `warehouse-person-properties` feature; creating a `group` target additionally requires the `group:write`
+            scope. Definitions are team-scoped; for account targets, set the value a specific account holds via the
+            account custom property value tools.
         feature_flag: customer-analytics-csp
     custom-property-definitions-destroy:
         operation: custom_property_definitions_destroy
@@ -403,9 +408,11 @@ tools:
             idempotent: true
         title: Delete custom property definition
         description: >
-            Permanently delete a Customer Analytics custom property definition by id. Because values reference the
-            definition, deleting it also removes the value every account holds for that property. The definition is
-            team-scoped, so this affects all accounts.
+            Permanently delete a Customer Analytics custom property definition by id. For account targets, because
+            values reference the definition, deleting it also removes the value every account holds for that property;
+            for person/group targets it removes the source binding and stops future syncs (already-written person/group
+            properties stay). The definition is team-scoped, so this affects all accounts. Deleting a group-target
+            definition additionally requires the `group:write` scope.
         feature_flag: customer-analytics-csp
     custom-property-definitions-list:
         operation: custom_property_definitions_list
@@ -420,14 +427,16 @@ tools:
         title: List custom property definitions
         description: >
             List Customer Analytics custom property definitions for the project. A definition is the shape of a custom
-            account attribute — its `name`, optional `description`, `display_type` (one of text, number, currency,
-            percent, date, datetime, boolean), and `is_big_number` flag. Definitions are team-scoped and shared across
-            all accounts; the value a specific account holds for a definition is managed separately via the account
-            custom property value tools. Use `custom-property-definitions-retrieve` to fetch a single definition by id.
-            To list or filter accounts by a custom property value in bulk, take a definition `id` from this tool and
-            query it via HogQL against `system.accounts`, selecting ``custom_properties.values.`<definition_id>` ``
-            (backtick-quote the id) and filtering it `IS NOT NULL`. The per-account value tools return one account at a
-            time; this HogQL path scales to all accounts.
+            attribute — its `name`, optional `description`, `display_type` (one of text, number, currency, percent,
+            date, datetime, boolean), `is_big_number` flag, and `target_type` (`account`, `person`, or `group`, with
+            `group_type_index` set for group targets). Definitions are team-scoped; for account targets, the value a
+            specific account holds is managed separately via the account custom property value tools. Group-target
+            definitions are only listed for callers holding the `group:read` scope. Use
+            `custom-property-definitions-retrieve` to fetch a single definition by id. To list or filter accounts by a
+            custom property value in bulk, take a definition `id` from this tool and query it via HogQL against
+            `system.accounts`, selecting ``custom_properties.values.`<definition_id>` `` (backtick-quote the id) and
+            filtering it `IS NOT NULL`. The per-account value tools return one account at a time; this HogQL path scales
+            to all accounts.
         feature_flag: customer-analytics-csp
     custom-property-definitions-partial-update:
         operation: custom_property_definitions_partial_update
@@ -443,7 +452,9 @@ tools:
             Update fields on an existing Customer Analytics custom property definition. Accepts a subset of fields;
             unspecified fields are left unchanged. Updatable fields: `name` (must remain unique within the team),
             `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), and
-            `is_big_number` (only valid for numeric display types).
+            `is_big_number` (only valid for numeric display types). `target_type` and `group_type_index` are create-only
+            and cannot be changed here. Updating a group-target definition additionally requires the `group:write`
+            scope.
         feature_flag: customer-analytics-csp
     custom-property-definitions-retrieve:
         operation: custom_property_definitions_retrieve
@@ -457,9 +468,11 @@ tools:
         title: Get custom property definition
         description: >
             Fetch a single Customer Analytics custom property definition by id. Returns its `name`, optional
-            `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), and
-            `is_big_number` flag. A definition is the shape of a custom account attribute; the value a specific account
-            holds for it is managed separately via the account custom property value tools.
+            `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean),
+            `is_big_number` flag, and `target_type` (`account`, `person`, or `group`, with `group_type_index` for group
+            targets). A definition is the shape of a custom attribute; for account targets, the value a specific account
+            holds is managed separately via the account custom property value tools. A group-target definition is only
+            returned to callers holding the `group:read` scope.
         feature_flag: customer-analytics-csp
     custom-property-definitions-update:
         operation: custom_property_definitions_update
@@ -476,12 +489,13 @@ tools:
             readOnly: false
             destructive: false
             idempotent: false
-        title: Backfill a warehouse person-property source
+        title: Backfill a warehouse person- or group-property source
         description: >
-            Person-property sources only: start a backfill that reads the whole warehouse table and populates person
-            properties for its historical rows. Backfill is per table — one call refreshes every enabled person property
-            mapped from that table — and it coalesces if one is already running for the table (the response's
-            `already_running` is then true). Returns 400 for a source that is not an enabled person-property source.
+            Person- and group-property sources only: start a backfill that reads the whole warehouse table and populates
+            person or group properties for its historical rows. Backfill is per table — one call refreshes every enabled
+            property mapped from that table — and it coalesces if one is already running for the table (the response's
+            `already_running` is then true). Returns 400 for a source that is not an enabled person- or group-property
+            source. Backfilling a group-target source additionally requires the `group:write` scope.
         feature_flag: warehouse-person-properties
     custom-property-sources-create:
         operation: custom_property_sources_create
@@ -495,9 +509,11 @@ tools:
         title: Create custom property source
         description: >
             Bind a custom property definition to a data source. Account sources read a materialized view (`saved_query`
-            + `source_column`); person sources read a synced warehouse table (`external_data_schema` +
-            `column_property_map` mapping warehouse columns to person properties, plus `key_column` = the person's
-            distinct_id column). One source per definition.
+            + `source_column`); person and group sources read a synced warehouse table (`external_data_schema` +
+            `column_property_map` mapping warehouse columns to person/group properties, plus `key_column` = the
+            distinct_id column for person sources or the group-key column for group sources). One source per definition.
+            The target (account, person, or group) follows the bound definition's `target_type`; creating a source for a
+            group-target definition additionally requires the `group:write` scope.
         feature_flag: customer-analytics-csp
     custom-property-sources-destroy:
         operation: custom_property_sources_destroy
@@ -510,8 +526,9 @@ tools:
             idempotent: true
         title: Delete custom property source
         description: >
-            Delete a custom property source by id, stopping its sync. Values already written stay on the accounts/people
-            but stop updating. The definition itself is not deleted.
+            Delete a custom property source by id, stopping its sync. Values already written stay on the
+            accounts/people/groups but stop updating. The definition itself is not deleted. Deleting a group-target
+            source additionally requires the `group:write` scope.
         feature_flag: customer-analytics-csp
     custom-property-sources-list:
         operation: custom_property_sources_list
@@ -526,8 +543,9 @@ tools:
         title: List custom property sources
         description: >
             List custom property sources for the project, newest first. Each source binds a definition to a data source
-            and reports its sync status (`last_synced_at`, `last_sync_error`) and, for person sources, the schedule
-            (`next_sync_at`, `sync_frequency_interval_seconds`) and the most recent run (`latest_run`).
+            and reports its sync status (`last_synced_at`, `last_sync_error`) and, for person and group sources, the
+            schedule (`next_sync_at`, `sync_frequency_interval_seconds`) and the most recent run (`latest_run`). Sources
+            feeding group-target definitions are only listed for callers holding the `group:read` scope.
         feature_flag: customer-analytics-csp
     custom-property-sources-partial-update:
         operation: custom_property_sources_partial_update
@@ -542,7 +560,7 @@ tools:
         description: >
             Update the editable fields of a custom property source (`key_column`, `is_enabled`). Re-enabling a disabled
             source resets its failure count. The definition binding, warehouse schema, and column map are create-only
-            and cannot be changed here.
+            and cannot be changed here. Updating a group-target source additionally requires the `group:write` scope.
         feature_flag: customer-analytics-csp
     custom-property-sources-retrieve:
         operation: custom_property_sources_retrieve
@@ -555,8 +573,9 @@ tools:
             idempotent: true
         title: Get custom property source
         description: >
-            Fetch a single custom property source by id, including its binding, sync status, and (for person sources)
-            schedule and latest run.
+            Fetch a single custom property source by id, including its binding, sync status, and (for person and group
+            sources) schedule and latest run. Fetching a source that feeds a group-target definition additionally
+            requires the `group:read` scope.
         feature_flag: customer-analytics-csp
     custom-property-sources-runs-list:
         operation: custom_property_sources_runs_list
@@ -568,12 +587,13 @@ tools:
             destructive: false
             idempotent: true
         list: true
-        title: List person-property source runs
+        title: List person- or group-property source runs
         description: >
-            Person-property sources only: the source's sync/backfill run history, newest first. Each run reports
-            `trigger` (scheduled/manual/backfill), `status` (running/completed/failed), the funnel counts (`rows_read`,
-            `changed`, `existing` = person profiles affected, `produced`, `skipped_missing_person`), `error`, and
-            timestamps.
+            Person- and group-property sources only: the source's sync/backfill run history, newest first. Each run
+            reports `trigger` (scheduled/manual/backfill), `status` (running/completed/failed), the funnel counts
+            (`rows_read`, `changed`, `existing` = person/group profiles affected, `produced`, `skipped_missing_person`),
+            `error`, and timestamps. Listing runs for a group-target source additionally requires the `group:read`
+            scope.
         feature_flag: warehouse-person-properties
     custom-property-sources-sync:
         operation: custom_property_sources_sync
@@ -584,11 +604,12 @@ tools:
             readOnly: false
             destructive: false
             idempotent: false
-        title: Sync a warehouse person-property source now
+        title: Sync a warehouse person- or group-property source now
         description: >
-            Person-property sources only: trigger the underlying warehouse schema's sync now. This re-runs a real
-            (billable) warehouse sync, and the incremental person-property update rides off it. It does not reset the
-            schema's recurring sync schedule. Returns 400 for a source that is not an enabled person-property source.
+            Person- and group-property sources only: trigger the underlying warehouse schema's sync now. This re-runs a
+            real (billable) warehouse sync, and the incremental person/group-property update rides off it. It does not
+            reset the schema's recurring sync schedule. Returns 400 for a source that is not an enabled person- or
+            group-property source. Syncing a group-target source additionally requires the `group:write` scope.
         feature_flag: warehouse-person-properties
     custom-property-sources-update:
         operation: custom_property_sources_update

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2005,7 +2005,7 @@
         }
     },
     "custom-property-definitions-create": {
-        "description": "Create a Customer Analytics custom property definition — the shape of a custom account attribute. Provide `name` (required, unique within the team), optional `description`, `display_type` (required; one of text, number, currency, percent, date, datetime, boolean), and optional `is_big_number` to abbreviate large numeric values (e.g. 10,000 → 10K; only valid for numeric display types). Definitions are team-scoped and shared across all accounts; set the value a specific account holds via the account custom property value tools.",
+        "description": "Create a Customer Analytics custom property definition — the shape of a custom attribute. Provide `name` (required, unique within the team), optional `description`, `display_type` (required; one of text, number, currency, percent, date, datetime, boolean), and optional `is_big_number` to abbreviate large numeric values (e.g. 10,000 → 10K; only valid for numeric display types). `target_type` picks what the property attaches to: `account` (default; value set manually or from a materialized view), `person`, or `group` (person/group properties are populated from a warehouse table via a custom property source and become usable like any other person/group property in feature flags, cohorts, and insights). For `group` targets, also pass `group_type_index` (0-4) selecting the group type. Person and group targets require the `warehouse-person-properties` feature; creating a `group` target additionally requires the `group:write` scope. Definitions are team-scoped; for account targets, set the value a specific account holds via the account custom property value tools.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Create custom property definition",
@@ -2020,7 +2020,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-definitions-destroy": {
-        "description": "Permanently delete a Customer Analytics custom property definition by id. Because values reference the definition, deleting it also removes the value every account holds for that property. The definition is team-scoped, so this affects all accounts.",
+        "description": "Permanently delete a Customer Analytics custom property definition by id. For account targets, because values reference the definition, deleting it also removes the value every account holds for that property; for person/group targets it removes the source binding and stops future syncs (already-written person/group properties stay). The definition is team-scoped, so this affects all accounts. Deleting a group-target definition additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Delete custom property definition",
@@ -2035,7 +2035,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-definitions-list": {
-        "description": "List Customer Analytics custom property definitions for the project. A definition is the shape of a custom account attribute — its `name`, optional `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), and `is_big_number` flag. Definitions are team-scoped and shared across all accounts; the value a specific account holds for a definition is managed separately via the account custom property value tools. Use `custom-property-definitions-retrieve` to fetch a single definition by id. To list or filter accounts by a custom property value in bulk, take a definition `id` from this tool and query it via HogQL against `system.accounts`, selecting ``custom_properties.values.`<definition_id>` `` (backtick-quote the id) and filtering it `IS NOT NULL`. The per-account value tools return one account at a time; this HogQL path scales to all accounts.",
+        "description": "List Customer Analytics custom property definitions for the project. A definition is the shape of a custom attribute — its `name`, optional `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), `is_big_number` flag, and `target_type` (`account`, `person`, or `group`, with `group_type_index` set for group targets). Definitions are team-scoped; for account targets, the value a specific account holds is managed separately via the account custom property value tools. Group-target definitions are only listed for callers holding the `group:read` scope. Use `custom-property-definitions-retrieve` to fetch a single definition by id. To list or filter accounts by a custom property value in bulk, take a definition `id` from this tool and query it via HogQL against `system.accounts`, selecting ``custom_properties.values.`<definition_id>` `` (backtick-quote the id) and filtering it `IS NOT NULL`. The per-account value tools return one account at a time; this HogQL path scales to all accounts.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "List custom property definitions",
@@ -2050,7 +2050,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-definitions-partial-update": {
-        "description": "Update fields on an existing Customer Analytics custom property definition. Accepts a subset of fields; unspecified fields are left unchanged. Updatable fields: `name` (must remain unique within the team), `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), and `is_big_number` (only valid for numeric display types).",
+        "description": "Update fields on an existing Customer Analytics custom property definition. Accepts a subset of fields; unspecified fields are left unchanged. Updatable fields: `name` (must remain unique within the team), `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), and `is_big_number` (only valid for numeric display types). `target_type` and `group_type_index` are create-only and cannot be changed here. Updating a group-target definition additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Update custom property definition",
@@ -2065,7 +2065,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-definitions-retrieve": {
-        "description": "Fetch a single Customer Analytics custom property definition by id. Returns its `name`, optional `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), and `is_big_number` flag. A definition is the shape of a custom account attribute; the value a specific account holds for it is managed separately via the account custom property value tools.",
+        "description": "Fetch a single Customer Analytics custom property definition by id. Returns its `name`, optional `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), `is_big_number` flag, and `target_type` (`account`, `person`, or `group`, with `group_type_index` for group targets). A definition is the shape of a custom attribute; for account targets, the value a specific account holds is managed separately via the account custom property value tools. A group-target definition is only returned to callers holding the `group:read` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Get custom property definition",
@@ -2080,11 +2080,11 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-backfill": {
-        "description": "Person-property sources only: start a backfill that reads the whole warehouse table and populates person properties for its historical rows. Backfill is per table — one call refreshes every enabled person property mapped from that table — and it coalesces if one is already running for the table (the response's `already_running` is then true). Returns 400 for a source that is not an enabled person-property source.",
+        "description": "Person- and group-property sources only: start a backfill that reads the whole warehouse table and populates person or group properties for its historical rows. Backfill is per table — one call refreshes every enabled property mapped from that table — and it coalesces if one is already running for the table (the response's `already_running` is then true). Returns 400 for a source that is not an enabled person- or group-property source. Backfilling a group-target source additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
-        "summary": "Backfill a warehouse person-property source",
-        "title": "Backfill a warehouse person-property source",
+        "summary": "Backfill a warehouse person- or group-property source",
+        "title": "Backfill a warehouse person- or group-property source",
         "required_scopes": ["account:write"],
         "annotations": {
             "destructiveHint": false,
@@ -2095,7 +2095,7 @@
         "feature_flag": "warehouse-person-properties"
     },
     "custom-property-sources-create": {
-        "description": "Bind a custom property definition to a data source. Account sources read a materialized view (`saved_query` + `source_column`); person sources read a synced warehouse table (`external_data_schema` + `column_property_map` mapping warehouse columns to person properties, plus `key_column` = the person's distinct_id column). One source per definition.",
+        "description": "Bind a custom property definition to a data source. Account sources read a materialized view (`saved_query` + `source_column`); person and group sources read a synced warehouse table (`external_data_schema` + `column_property_map` mapping warehouse columns to person/group properties, plus `key_column` = the distinct_id column for person sources or the group-key column for group sources). One source per definition. The target (account, person, or group) follows the bound definition's `target_type`; creating a source for a group-target definition additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Create custom property source",
@@ -2110,7 +2110,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-destroy": {
-        "description": "Delete a custom property source by id, stopping its sync. Values already written stay on the accounts/people but stop updating. The definition itself is not deleted.",
+        "description": "Delete a custom property source by id, stopping its sync. Values already written stay on the accounts/people/groups but stop updating. The definition itself is not deleted. Deleting a group-target source additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Delete custom property source",
@@ -2125,7 +2125,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-list": {
-        "description": "List custom property sources for the project, newest first. Each source binds a definition to a data source and reports its sync status (`last_synced_at`, `last_sync_error`) and, for person sources, the schedule (`next_sync_at`, `sync_frequency_interval_seconds`) and the most recent run (`latest_run`).",
+        "description": "List custom property sources for the project, newest first. Each source binds a definition to a data source and reports its sync status (`last_synced_at`, `last_sync_error`) and, for person and group sources, the schedule (`next_sync_at`, `sync_frequency_interval_seconds`) and the most recent run (`latest_run`). Sources feeding group-target definitions are only listed for callers holding the `group:read` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "List custom property sources",
@@ -2140,7 +2140,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-partial-update": {
-        "description": "Update the editable fields of a custom property source (`key_column`, `is_enabled`). Re-enabling a disabled source resets its failure count. The definition binding, warehouse schema, and column map are create-only and cannot be changed here.",
+        "description": "Update the editable fields of a custom property source (`key_column`, `is_enabled`). Re-enabling a disabled source resets its failure count. The definition binding, warehouse schema, and column map are create-only and cannot be changed here. Updating a group-target source additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Update custom property source",
@@ -2155,7 +2155,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-retrieve": {
-        "description": "Fetch a single custom property source by id, including its binding, sync status, and (for person sources) schedule and latest run.",
+        "description": "Fetch a single custom property source by id, including its binding, sync status, and (for person and group sources) schedule and latest run. Fetching a source that feeds a group-target definition additionally requires the `group:read` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Get custom property source",
@@ -2170,11 +2170,11 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-runs-list": {
-        "description": "Person-property sources only: the source's sync/backfill run history, newest first. Each run reports `trigger` (scheduled/manual/backfill), `status` (running/completed/failed), the funnel counts (`rows_read`, `changed`, `existing` = person profiles affected, `produced`, `skipped_missing_person`), `error`, and timestamps.",
+        "description": "Person- and group-property sources only: the source's sync/backfill run history, newest first. Each run reports `trigger` (scheduled/manual/backfill), `status` (running/completed/failed), the funnel counts (`rows_read`, `changed`, `existing` = person/group profiles affected, `produced`, `skipped_missing_person`), `error`, and timestamps. Listing runs for a group-target source additionally requires the `group:read` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
-        "summary": "List person-property source runs",
-        "title": "List person-property source runs",
+        "summary": "List person- or group-property source runs",
+        "title": "List person- or group-property source runs",
         "required_scopes": ["account:read"],
         "annotations": {
             "destructiveHint": false,
@@ -2185,11 +2185,11 @@
         "feature_flag": "warehouse-person-properties"
     },
     "custom-property-sources-sync": {
-        "description": "Person-property sources only: trigger the underlying warehouse schema's sync now. This re-runs a real (billable) warehouse sync, and the incremental person-property update rides off it. It does not reset the schema's recurring sync schedule. Returns 400 for a source that is not an enabled person-property source.",
+        "description": "Person- and group-property sources only: trigger the underlying warehouse schema's sync now. This re-runs a real (billable) warehouse sync, and the incremental person/group-property update rides off it. It does not reset the schema's recurring sync schedule. Returns 400 for a source that is not an enabled person- or group-property source. Syncing a group-target source additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
-        "summary": "Sync a warehouse person-property source now",
-        "title": "Sync a warehouse person-property source now",
+        "summary": "Sync a warehouse person- or group-property source now",
+        "title": "Sync a warehouse person- or group-property source now",
         "required_scopes": ["account:write"],
         "annotations": {
             "destructiveHint": false,

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2034,7 +2034,7 @@
         }
     },
     "custom-property-definitions-create": {
-        "description": "Create a Customer Analytics custom property definition — the shape of a custom account attribute. Provide `name` (required, unique within the team), optional `description`, `display_type` (required; one of text, number, currency, percent, date, datetime, boolean), and optional `is_big_number` to abbreviate large numeric values (e.g. 10,000 → 10K; only valid for numeric display types). Definitions are team-scoped and shared across all accounts; set the value a specific account holds via the account custom property value tools.",
+        "description": "Create a Customer Analytics custom property definition — the shape of a custom attribute. Provide `name` (required, unique within the team), optional `description`, `display_type` (required; one of text, number, currency, percent, date, datetime, boolean), and optional `is_big_number` to abbreviate large numeric values (e.g. 10,000 → 10K; only valid for numeric display types). `target_type` picks what the property attaches to: `account` (default; value set manually or from a materialized view), `person`, or `group` (person/group properties are populated from a warehouse table via a custom property source and become usable like any other person/group property in feature flags, cohorts, and insights). For `group` targets, also pass `group_type_index` (0-4) selecting the group type. Person and group targets require the `warehouse-person-properties` feature; creating a `group` target additionally requires the `group:write` scope. Definitions are team-scoped; for account targets, set the value a specific account holds via the account custom property value tools.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Create custom property definition",
@@ -2049,7 +2049,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-definitions-destroy": {
-        "description": "Permanently delete a Customer Analytics custom property definition by id. Because values reference the definition, deleting it also removes the value every account holds for that property. The definition is team-scoped, so this affects all accounts.",
+        "description": "Permanently delete a Customer Analytics custom property definition by id. For account targets, because values reference the definition, deleting it also removes the value every account holds for that property; for person/group targets it removes the source binding and stops future syncs (already-written person/group properties stay). The definition is team-scoped, so this affects all accounts. Deleting a group-target definition additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Delete custom property definition",
@@ -2064,7 +2064,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-definitions-list": {
-        "description": "List Customer Analytics custom property definitions for the project. A definition is the shape of a custom account attribute — its `name`, optional `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), and `is_big_number` flag. Definitions are team-scoped and shared across all accounts; the value a specific account holds for a definition is managed separately via the account custom property value tools. Use `custom-property-definitions-retrieve` to fetch a single definition by id. To list or filter accounts by a custom property value in bulk, take a definition `id` from this tool and query it via HogQL against `system.accounts`, selecting ``custom_properties.values.`<definition_id>` `` (backtick-quote the id) and filtering it `IS NOT NULL`. The per-account value tools return one account at a time; this HogQL path scales to all accounts.",
+        "description": "List Customer Analytics custom property definitions for the project. A definition is the shape of a custom attribute — its `name`, optional `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), `is_big_number` flag, and `target_type` (`account`, `person`, or `group`, with `group_type_index` set for group targets). Definitions are team-scoped; for account targets, the value a specific account holds is managed separately via the account custom property value tools. Group-target definitions are only listed for callers holding the `group:read` scope. Use `custom-property-definitions-retrieve` to fetch a single definition by id. To list or filter accounts by a custom property value in bulk, take a definition `id` from this tool and query it via HogQL against `system.accounts`, selecting ``custom_properties.values.`<definition_id>` `` (backtick-quote the id) and filtering it `IS NOT NULL`. The per-account value tools return one account at a time; this HogQL path scales to all accounts.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "List custom property definitions",
@@ -2079,7 +2079,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-definitions-partial-update": {
-        "description": "Update fields on an existing Customer Analytics custom property definition. Accepts a subset of fields; unspecified fields are left unchanged. Updatable fields: `name` (must remain unique within the team), `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), and `is_big_number` (only valid for numeric display types).",
+        "description": "Update fields on an existing Customer Analytics custom property definition. Accepts a subset of fields; unspecified fields are left unchanged. Updatable fields: `name` (must remain unique within the team), `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), and `is_big_number` (only valid for numeric display types). `target_type` and `group_type_index` are create-only and cannot be changed here. Updating a group-target definition additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Update custom property definition",
@@ -2094,7 +2094,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-definitions-retrieve": {
-        "description": "Fetch a single Customer Analytics custom property definition by id. Returns its `name`, optional `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), and `is_big_number` flag. A definition is the shape of a custom account attribute; the value a specific account holds for it is managed separately via the account custom property value tools.",
+        "description": "Fetch a single Customer Analytics custom property definition by id. Returns its `name`, optional `description`, `display_type` (one of text, number, currency, percent, date, datetime, boolean), `is_big_number` flag, and `target_type` (`account`, `person`, or `group`, with `group_type_index` for group targets). A definition is the shape of a custom attribute; for account targets, the value a specific account holds is managed separately via the account custom property value tools. A group-target definition is only returned to callers holding the `group:read` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Get custom property definition",
@@ -2109,11 +2109,11 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-backfill": {
-        "description": "Person-property sources only: start a backfill that reads the whole warehouse table and populates person properties for its historical rows. Backfill is per table — one call refreshes every enabled person property mapped from that table — and it coalesces if one is already running for the table (the response's `already_running` is then true). Returns 400 for a source that is not an enabled person-property source.",
+        "description": "Person- and group-property sources only: start a backfill that reads the whole warehouse table and populates person or group properties for its historical rows. Backfill is per table — one call refreshes every enabled property mapped from that table — and it coalesces if one is already running for the table (the response's `already_running` is then true). Returns 400 for a source that is not an enabled person- or group-property source. Backfilling a group-target source additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
-        "summary": "Backfill a warehouse person-property source",
-        "title": "Backfill a warehouse person-property source",
+        "summary": "Backfill a warehouse person- or group-property source",
+        "title": "Backfill a warehouse person- or group-property source",
         "required_scopes": ["account:write"],
         "annotations": {
             "destructiveHint": false,
@@ -2124,7 +2124,7 @@
         "feature_flag": "warehouse-person-properties"
     },
     "custom-property-sources-create": {
-        "description": "Bind a custom property definition to a data source. Account sources read a materialized view (`saved_query` + `source_column`); person sources read a synced warehouse table (`external_data_schema` + `column_property_map` mapping warehouse columns to person properties, plus `key_column` = the person's distinct_id column). One source per definition.",
+        "description": "Bind a custom property definition to a data source. Account sources read a materialized view (`saved_query` + `source_column`); person and group sources read a synced warehouse table (`external_data_schema` + `column_property_map` mapping warehouse columns to person/group properties, plus `key_column` = the distinct_id column for person sources or the group-key column for group sources). One source per definition. The target (account, person, or group) follows the bound definition's `target_type`; creating a source for a group-target definition additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Create custom property source",
@@ -2139,7 +2139,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-destroy": {
-        "description": "Delete a custom property source by id, stopping its sync. Values already written stay on the accounts/people but stop updating. The definition itself is not deleted.",
+        "description": "Delete a custom property source by id, stopping its sync. Values already written stay on the accounts/people/groups but stop updating. The definition itself is not deleted. Deleting a group-target source additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Delete custom property source",
@@ -2154,7 +2154,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-list": {
-        "description": "List custom property sources for the project, newest first. Each source binds a definition to a data source and reports its sync status (`last_synced_at`, `last_sync_error`) and, for person sources, the schedule (`next_sync_at`, `sync_frequency_interval_seconds`) and the most recent run (`latest_run`).",
+        "description": "List custom property sources for the project, newest first. Each source binds a definition to a data source and reports its sync status (`last_synced_at`, `last_sync_error`) and, for person and group sources, the schedule (`next_sync_at`, `sync_frequency_interval_seconds`) and the most recent run (`latest_run`). Sources feeding group-target definitions are only listed for callers holding the `group:read` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "List custom property sources",
@@ -2169,7 +2169,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-partial-update": {
-        "description": "Update the editable fields of a custom property source (`key_column`, `is_enabled`). Re-enabling a disabled source resets its failure count. The definition binding, warehouse schema, and column map are create-only and cannot be changed here.",
+        "description": "Update the editable fields of a custom property source (`key_column`, `is_enabled`). Re-enabling a disabled source resets its failure count. The definition binding, warehouse schema, and column map are create-only and cannot be changed here. Updating a group-target source additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Update custom property source",
@@ -2184,7 +2184,7 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-retrieve": {
-        "description": "Fetch a single custom property source by id, including its binding, sync status, and (for person sources) schedule and latest run.",
+        "description": "Fetch a single custom property source by id, including its binding, sync status, and (for person and group sources) schedule and latest run. Fetching a source that feeds a group-target definition additionally requires the `group:read` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
         "summary": "Get custom property source",
@@ -2199,11 +2199,11 @@
         "feature_flag": "customer-analytics-csp"
     },
     "custom-property-sources-runs-list": {
-        "description": "Person-property sources only: the source's sync/backfill run history, newest first. Each run reports `trigger` (scheduled/manual/backfill), `status` (running/completed/failed), the funnel counts (`rows_read`, `changed`, `existing` = person profiles affected, `produced`, `skipped_missing_person`), `error`, and timestamps.",
+        "description": "Person- and group-property sources only: the source's sync/backfill run history, newest first. Each run reports `trigger` (scheduled/manual/backfill), `status` (running/completed/failed), the funnel counts (`rows_read`, `changed`, `existing` = person/group profiles affected, `produced`, `skipped_missing_person`), `error`, and timestamps. Listing runs for a group-target source additionally requires the `group:read` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
-        "summary": "List person-property source runs",
-        "title": "List person-property source runs",
+        "summary": "List person- or group-property source runs",
+        "title": "List person- or group-property source runs",
         "required_scopes": ["account:read"],
         "annotations": {
             "destructiveHint": false,
@@ -2214,11 +2214,11 @@
         "feature_flag": "warehouse-person-properties"
     },
     "custom-property-sources-sync": {
-        "description": "Person-property sources only: trigger the underlying warehouse schema's sync now. This re-runs a real (billable) warehouse sync, and the incremental person-property update rides off it. It does not reset the schema's recurring sync schedule. Returns 400 for a source that is not an enabled person-property source.",
+        "description": "Person- and group-property sources only: trigger the underlying warehouse schema's sync now. This re-runs a real (billable) warehouse sync, and the incremental person/group-property update rides off it. It does not reset the schema's recurring sync schedule. Returns 400 for a source that is not an enabled person- or group-property source. Syncing a group-target source additionally requires the `group:write` scope.",
         "category": "Customer analytics",
         "feature": "customer_analytics",
-        "summary": "Sync a warehouse person-property source now",
-        "title": "Sync a warehouse person-property source now",
+        "summary": "Sync a warehouse person- or group-property source now",
+        "title": "Sync a warehouse person- or group-property source now",
         "required_scopes": ["account:write"],
         "annotations": {
             "destructiveHint": false,

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16502,8 +16502,8 @@ export namespace Schemas {
     }
 
     /**
-     * One person-property sync or backfill run. Read-only: runs are created by the sync/backfill
-     * pipeline, never through the API.
+     * One person- or group-property sync or backfill run. Read-only: runs are created by the
+     * sync/backfill pipeline, never through the API.
      */
     export interface CustomPropertySyncRun {
       readonly id: string;
@@ -16525,11 +16525,11 @@ export namespace Schemas {
       readonly rows_read: number;
       /** Rows whose mapped values changed since the last run. */
       readonly changed: number;
-      /** Person profiles updated (changed rows that matched an existing person). */
+      /** Person or group profiles updated (changed rows that matched an existing person/group). */
       readonly existing: number;
       /** Property-update intents produced to the ingestion pipeline. */
       readonly produced: number;
-      /** Changed rows dropped because no existing person matched the distinct id. */
+      /** Changed rows dropped because no existing person/group matched the key column value. */
       readonly skipped_missing_person: number;
       /**
          * Error summary if the run failed, else null.
@@ -16541,8 +16541,9 @@ export namespace Schemas {
     }
 
     /**
-     * Binds a materialized data-warehouse view column to a custom property definition; the view's
-     * values are synced onto matching accounts on each materialization.
+     * Binds a data-warehouse source to a custom property definition. Account sources read a
+     * materialized view column and sync onto matching accounts; person and group sources read a
+     * warehouse schema and sync onto matching persons or groups on each warehouse sync.
      */
     export interface CustomPropertySource {
       readonly id: string;
@@ -16554,7 +16555,7 @@ export namespace Schemas {
          */
       saved_query?: string | null;
       /**
-         * Person sources only: UUID of the warehouse schema (raw incremental table) to read from. Mutually exclusive with saved_query.
+         * Person and group sources only: UUID of the warehouse schema (raw incremental table) to read from. Mutually exclusive with saved_query.
          * @nullable
          */
       external_data_schema?: string | null;
@@ -16564,10 +16565,10 @@ export namespace Schemas {
          * @nullable
          */
       source_column?: string | null;
-      /** Person sources only: {warehouse_column: person_property_name} mapping the columns this source writes onto the person. */
+      /** Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group. */
       column_property_map?: unknown;
       /**
-         * Column whose value identifies the target: an account's external_id for account sources, or the person's distinct_id for person sources.
+         * Column whose value identifies the target: an account's external_id for account sources, the person's distinct_id for person sources, or the group key for group sources.
          * @maxLength 400
          */
       key_column: string;
@@ -16591,16 +16592,16 @@ export namespace Schemas {
       /** @nullable */
       readonly updated_at: string | null;
       /**
-         * Person sources only: how often the underlying warehouse schema syncs, in seconds. Null for account sources or when unavailable.
+         * Person and group sources only: how often the underlying warehouse schema syncs, in seconds. Null for account sources or when unavailable.
          * @nullable
          */
       readonly sync_frequency_interval_seconds: number | null;
       /**
-         * Person sources only: approximate time of the next scheduled sync (last synced + interval). Approximate — drifts if the schedule was paused. Null for account sources or if never synced.
+         * Person and group sources only: approximate time of the next scheduled sync (last synced + interval). Approximate — drifts if the schedule was paused. Null for account sources or if never synced.
          * @nullable
          */
       readonly next_sync_at: string | null;
-      /** Person sources only: the most recent sync/backfill run, or null if none yet. */
+      /** Person and group sources only: the most recent sync/backfill run, or null if none yet. */
       readonly latest_run: CustomPropertySyncRun | null;
     }
 
@@ -16712,7 +16713,7 @@ export namespace Schemas {
     } as const;
 
     /**
-     * Response of the person-property sync/backfill trigger actions.
+     * Response of the person/group-property sync/backfill trigger actions.
      */
     export interface CustomPropertySyncTriggerResponse {
       /** 'triggered' (sync now started the warehouse sync), 'started' (a new backfill began), or 'already_running' (a backfill for this table was already in flight, so this was a no-op).

--- a/services/mcp/src/generated/customer_analytics/api.ts
+++ b/services/mcp/src/generated/customer_analytics/api.ts
@@ -676,7 +676,7 @@ export const CustomPropertySourcesCreateBody = /* @__PURE__ */ zod
             .string()
             .nullish()
             .describe(
-                'Person sources only: UUID of the warehouse schema (raw incremental table) to read from. Mutually exclusive with saved_query.'
+                'Person and group sources only: UUID of the warehouse schema (raw incremental table) to read from. Mutually exclusive with saved_query.'
             ),
         source_column: zod
             .string()
@@ -687,13 +687,13 @@ export const CustomPropertySourcesCreateBody = /* @__PURE__ */ zod
             .unknown()
             .optional()
             .describe(
-                'Person sources only: {warehouse_column: person_property_name} mapping the columns this source writes onto the person.'
+                'Person and group sources only: {warehouse_column: property_name} mapping the columns this source writes onto the person or group.'
             ),
         key_column: zod
             .string()
             .max(customPropertySourcesCreateBodyKeyColumnMax)
             .describe(
-                "Column whose value identifies the target: an account's external_id for account sources, or the person's distinct_id for person sources."
+                "Column whose value identifies the target: an account's external_id for account sources, the person's distinct_id for person sources, or the group key for group sources."
             ),
         is_enabled: zod
             .boolean()
@@ -703,7 +703,7 @@ export const CustomPropertySourcesCreateBody = /* @__PURE__ */ zod
             ),
     })
     .describe(
-        "Binds a materialized data-warehouse view column to a custom property definition; the view's\nvalues are synced onto matching accounts on each materialization."
+        'Binds a data-warehouse source to a custom property definition. Account sources read a\nmaterialized view column and sync onto matching accounts; person and group sources read a\nwarehouse schema and sync onto matching persons or groups on each warehouse sync.'
     )
 
 export const CustomPropertySourcesRetrieveParams = /* @__PURE__ */ zod.object({
@@ -759,8 +759,9 @@ export const CustomPropertySourcesDestroyParams = /* @__PURE__ */ zod.object({
 })
 
 /**
- * Person sources only: start a backfill that reads the whole warehouse table and populates
- * person properties for historical rows. Coalesces if one is already running for the table.
+ * Person and group sources only: start a backfill that reads the whole warehouse table and
+ * populates person or group properties for historical rows. Coalesces if one is already running
+ * for the table.
  */
 export const CustomPropertySourcesBackfillParams = /* @__PURE__ */ zod.object({
     id: zod.string(),
@@ -772,8 +773,9 @@ export const CustomPropertySourcesBackfillParams = /* @__PURE__ */ zod.object({
 })
 
 /**
- * Person sources only: the source's sync/backfill run history, newest first. Gated on the
- * caller's warehouse-source viewer access, since the runs expose its row counts and sync errors.
+ * Person and group sources only: the source's sync/backfill run history, newest first. Gated
+ * on the caller's warehouse-source viewer access, since the runs expose its row counts and sync
+ * errors.
  */
 export const CustomPropertySourcesRunsListParams = /* @__PURE__ */ zod.object({
     id: zod.string(),
@@ -790,8 +792,9 @@ export const CustomPropertySourcesRunsListQueryParams = /* @__PURE__ */ zod.obje
 })
 
 /**
- * Person sources only: trigger the underlying warehouse schema's sync now. This re-runs a
- * real (billable) warehouse sync; the incremental person-property update runs off it.
+ * Person and group sources only: trigger the underlying warehouse schema's sync now. This
+ * re-runs a real (billable) warehouse sync; the incremental person/group-property update runs
+ * off it.
  */
 export const CustomPropertySourcesSyncParams = /* @__PURE__ */ zod.object({
     id: zod.string(),


### PR DESCRIPTION
## Problem

Warehouse **group** properties are wired end to end in #72876, but the Customer Analytics custom-property MCP tools — and the serializer/view descriptions they generate from — still describe everything as person- or account-only. An agent reading the tool schemas has no way to discover that it can create a group-target property definition, bind a warehouse source to it, or sync/backfill/inspect group-property runs, nor that group operations need the `group:read`/`group:write` scope.

## Changes

Pure description/metadata layer on top of the group-properties backend (no behavior change):

- **Definition tools** (`custom-property-definitions-*`) now document `target_type` (`account`/`person`/`group`) and `group_type_index`, and note that group targets are gated behind the `warehouse-person-properties` feature and require the `group:write` scope to mutate / `group:read` to view.
- **Source tools** (`custom-property-sources-*`) — create/list/retrieve/update/destroy and the sync/backfill/runs actions — now cover person **and** group sources, describe the group-key `key_column`, and call out the group scope requirements.
- **Serializer `help_text` and view docstrings** generalize the person-only wording to person and group; the person-only `ValidationError` messages on sync/backfill now read "person- or group-property sources".
- Regenerated the OpenAPI-derived frontend types (`products/customer_analytics/frontend/generated/*`) and the MCP tool definitions (`services/mcp/*`).

Scopes are intentionally left as `account:*` on the shared tools: MCP scope filtering is `AND` (`hasScopes(...).every`), so adding `group:*` to a shared CRUD tool would hide it from account/person-only callers. The backend already enforces the additional group scope per-target at the view level, so group operations return a clear `PermissionDenied` when the caller lacks group scope — the descriptions now say so.

## How did you test this code?

- `hogli build:openapi` regenerates cleanly (OpenAPI → frontend types → MCP tool definitions), and the group descriptions propagate into `services/mcp/schema/generated-tool-definitions.json`.
- `pnpm --filter=@posthog/mcp lint-tool-names` passes.
- `ruff check` / `ruff format --check` clean on the changed Python.
- Backend: `warehouse_scope_gate_test.py` + `custom_property_source_person_test.py` — 27 passed. `test_views.py` — 218 passed, **1 pre-existing failure unrelated to this PR** (`test_group_definition_value_suggestions_require_group_read_scope`): the `values` action rejects all personal-API-key access (`403 "This action does not support personal API key access"`), so the test's premise that an account-only PAK gets `404` can't hold. This path is untouched here and fails identically on the base branch (#72876) — flagged for a fix there.

No new tests: this change adds no behavior; the existing group-scope gating tests already cover the sources/definitions endpoints.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Invoked the `/implementing-mcp-tools` skill for the regen workflow (`hogli build:openapi`) and scope model. Verified the MCP scope semantics (`hasScopes` = `.every()`) before deciding to keep the shared tools on `account:*` rather than over-requiring `group:*`. Stacked on `tom/dwh-group-props` (#72876).
