### PR TITLE
fix(vercel): stop tracking self-recovering connection timeouts as bugs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/source.py
@@ -105,10 +105,16 @@ To sync resources owned by a team, also enter the team's ID (found under **Team 
         }
 
     def get_retryable_errors(self) -> set[str]:
-        # A 429 or 5xx is retried internally by `_fetch_page`/`_open_billing_stream`; if those
-        # retries still exhaust, the failure is transient and self-recovering, so let Temporal
-        # retry the activity without surfacing it as tracked exception noise.
-        return {"Vercel API error (retryable)"}
+        # `_fetch_page`/`_open_billing_stream` already retry these in-process (a 429/5xx surfaces as
+        # the "Vercel API error (retryable)" sentinel; connection failures and read timeouts surface
+        # as the urllib3 pool error). Once those retries exhaust, Temporal retries the whole activity
+        # and the failure is transient and self-recovering, so don't surface it as tracked exception
+        # noise. The host is a constant, not user input, so matching on it doesn't risk swallowing an
+        # unrelated failure.
+        return {
+            "Vercel API error (retryable)",
+            "HTTPSConnectionPool(host='api.vercel.com', port=443)",
+        }
 
     def get_schemas(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel_source.py
@@ -138,6 +138,26 @@ class TestVercelSource:
         retryable_errors = self.source.get_retryable_errors()
         assert any(key in observed_error for key in retryable_errors)
 
+    @parameterized.expand(
+        [
+            (
+                "connection_error",
+                "HTTPSConnectionPool(host='api.vercel.com', port=443): Max retries exceeded with url: "
+                '/v1/billing/charges?teamId=team_abc (Caused by ReadTimeoutError("HTTPSConnectionPool'
+                "(host='api.vercel.com', port=443): Read timed out. (read timeout=120)\"))",
+            ),
+            (
+                "read_timeout",
+                "HTTPSConnectionPool(host='api.vercel.com', port=443): Read timed out. (read timeout=120)",
+            ),
+        ]
+    )
+    def test_retryable_errors_match_transient_network_failures(self, _name: str, observed_error: str) -> None:
+        # `_fetch_page`/`_open_billing_stream` already retry these in-process; once exhausted, this
+        # keeps the benign, self-recovering failure out of error tracking.
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(key in observed_error for key in retryable_errors)
+
     def test_get_resumable_source_manager_binds_data_class(self) -> None:
         manager = self.source.get_resumable_source_manager(_source_inputs("deployments"))
         assert isinstance(manager, ResumableSourceManager)

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -351,7 +351,9 @@ async def _handle_import_error(
     # on every retry regardless of source — classify it non-retryable by type here rather than
     # relying on each source listing the message in get_non_retryable_errors.
     if isinstance(error, SchemaColumnTypeChangedException):
-        await handle_non_retryable_error(job_inputs, error_msg, logger, error)
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
 
     non_retryable_errors = source_cls.get_non_retryable_errors()
     if any(match in error_msg for match in non_retryable_errors):

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -218,7 +218,7 @@ async def test_schema_column_type_changed_routes_through_handler_without_source_
 
     handle_mock.assert_awaited_once()
     assert handle_mock.await_args is not None
-    assert handle_mock.await_args.args[3] is error
+    assert handle_mock.await_args.args[5] is error
     logger.aexception.assert_not_awaited()
 
 


### PR DESCRIPTION
## Problem

Error tracking flagged a `ConnectionError`/`ReadTimeoutError` from the Vercel data-warehouse source ([issue](https://us.posthog.com/project/2/error_tracking/019f8f10-c36f-77b3-a1a9-c70348441dfc)) hitting Vercel's FOCUS billing endpoint. The stack trace confirms this originates in `_open_billing_stream` in `products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py`.

Both `_fetch_page` and `_open_billing_stream` already retry `requests.ConnectionError`/`requests.ReadTimeout` in-process via `tenacity` (5 attempts, exponential backoff). Once those retries exhaust, the error re-raises and Temporal retries the whole activity — the failure is transient and self-recovering, not a code bug. But `VercelSource` had no `get_retryable_errors()` override, so this benign, self-recovering failure was logged as a full exception and surfaced as error-tracking noise.

This follows the same pattern already used by several other sources (ClickHouse, MySQL, Salesforce, Matomo, Mixpanel) for connection-level failures that are already retried internally.

Note: #73156 separately adds `get_retryable_errors()` to this same source for the `"Vercel API error (retryable)"` (429/5xx) marker, but that doesn't cover this connection/timeout error since the message never contains that marker — so this is a complementary fix, not a duplicate.

## Changes

- Added `VercelSource.get_retryable_errors()` matching the stable `HTTPSConnectionPool(host='api.vercel.com', port=443)` prefix that appears in both the wrapped `ConnectionError` and the underlying `ReadTimeoutError` messages. The host is a fixed constant (not user input), so matching on it is safe and precise.
- Left `NonRetryableErrors` untouched — this is a transient infrastructure error, not a user/credential problem, so the sync should keep retrying rather than stop.

## How did you test this code?

Added `test_retryable_errors_match_transient_network_failures`, parameterized over the two message shapes seen (`ConnectionError` wrapping `ReadTimeoutError`, and a bare `ReadTimeoutError`) — guards that `get_retryable_errors()` actually recognizes the error this issue reported. Ran the full `test_vercel_source.py` suite (20 tests, all passing) plus `mypy` and `ruff` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification change, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a webhook-delivered error-tracking alert. I (Claude) investigated the issue via PostHog's error-tracking MCP tools, confirmed the stack trace originates in the Vercel source's `_open_billing_stream`, and traced the retry/error-classification path through `_handle_import_error` and `SourceRegistry`. Checked for duplicate work first via `gh pr list` — found #73156 covers a related but distinct marker string, so this fix is scoped to the connection/timeout case specifically. No skills invoked beyond `/writing-tests` for the new test case.

---
Created with [PostHog Code](https://posthog.com/code?ref=pr)