### PR TITLE
fix(phai): make debug logs opt-in instead of on by default

### DIFF
--- a/products/posthog_ai/frontend/logics/debugLogsLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/debugLogsLogic.test.ts
@@ -34,10 +34,10 @@ describe('debugLogsLogic', () => {
         logic?.unmount()
     })
 
-    it('defaults to showing debug logs for staff with no stored preference', () => {
+    it('hides debug logs for staff with no stored preference until explicitly enabled', () => {
         setup({ user: { is_staff: true }, isDev: false })
-        expect(logic.values.debugLogsEnabled).toBe(true)
-        expect(logic.values.showDebugLogs).toBe(true)
+        expect(logic.values.debugLogsEnabled).toBe(false)
+        expect(logic.values.showDebugLogs).toBe(false)
     })
 
     it('offers no toggle to a staff user who is also impersonating, but still forces logs on', () => {

--- a/products/posthog_ai/frontend/logics/debugLogsLogic.ts
+++ b/products/posthog_ai/frontend/logics/debugLogsLogic.ts
@@ -38,9 +38,10 @@ export type debugLogsLogicType = MakeLogicType<
 
 /**
  * Staff-only preference for whether `_posthog/console` debug rows surface in the run thread. Persisted
- * to localStorage and shared across every run surface (singleton, unkeyed), enabled by default. An
- * impersonated session always forces debug logs on, independent of the persisted toggle, so an engineer
- * debugging a customer's session never has them silently hidden.
+ * to localStorage and shared across every run surface (singleton, unkeyed), off by default — debug rows
+ * render only after the user explicitly opts in. An impersonated session always forces debug logs on,
+ * independent of the persisted toggle, so an engineer debugging a customer's session never has them
+ * silently hidden.
  */
 export const debugLogsLogic = kea<debugLogsLogicType>([
     path(['products', 'posthog_ai', 'frontend', 'logics', 'debugLogsLogic']),
@@ -52,7 +53,7 @@ export const debugLogsLogic = kea<debugLogsLogicType>([
     }),
     reducers({
         debugLogsEnabled: [
-            true,
+            false,
             { persist: true, storageKey: 'posthog_ai.debugLogsEnabled' },
             {
                 setDebugLogsEnabled: (_, { enabled }) => enabled,
@@ -72,7 +73,7 @@ export const debugLogsLogic = kea<debugLogsLogicType>([
         ],
         /**
          * Whether debug rows should actually render. Impersonation always shows them; otherwise staff/dev
-         * see them subject to the persisted toggle (on by default); everyone else never does.
+         * see them only after opting in via the persisted toggle (off by default); everyone else never does.
          */
         showDebugLogs: [
             (s) => [s.user, s.canControlDebugLogs, s.debugLogsEnabled],

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDebugLogsMenu.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDebugLogsMenu.tsx
@@ -7,7 +7,7 @@ import { debugLogsLogic } from '../../../logics/debugLogsLogic'
 /**
  * Staff-only menu exposing the debug-logs toggle for the run thread. Renders nothing unless the current
  * user may control debug logs (staff or local dev) — impersonated sessions force debug logs on and have
- * no toggle. The checkmark reflects the persisted (localStorage) preference, on by default.
+ * no toggle. The checkmark reflects the persisted (localStorage) preference, off by default.
  */
 export function TaskDebugLogsMenu(): JSX.Element | null {
     const { canControlDebugLogs, debugLogsEnabled } = useValues(debugLogsLogic)


### PR DESCRIPTION
## Problem

The PostHog AI run surface shows `_posthog/console` debug rows to every staff user (and local dev) by default. The persisted "Show debug logs" toggle in the task menu bar defaulted to on, so staff saw noisy debug output in every run thread without ever opting in.

## Changes

- Flipped the `debugLogsEnabled` reducer default in `debugLogsLogic` from `true` to `false`, so debug rows render only after the user explicitly checks "Show debug logs". The choice persists to localStorage either way, so anyone who has already toggled it explicitly keeps their preference.
- Updated the doc comments in `debugLogsLogic` and `TaskDebugLogsMenu` that described the old on-by-default behavior.

> [!NOTE]
> Impersonated sessions still force debug logs on regardless of the toggle. That invariant is unchanged on purpose, since impersonation hides the toggle and an engineer debugging a customer session shouldn't have logs silently hidden. Non-staff users still never see debug rows.

## How did you test this code?

Updated the existing default-behavior test in `debugLogsLogic.test.ts` to pin the new opt-in default (staff with no stored preference sees no debug rows until they enable the toggle). All 8 tests in the file pass locally. No manual testing was done.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. The change is a one-line default flip plus comment and test sync, so no skills beyond the repo conventions were involved. Considered also making impersonated sessions opt-in, but kept the force-on override because those sessions have no toggle and would otherwise have no way to see logs at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
