### PR TITLE
fix(data-imports): handle JS Date.toString() cursors in incremental sync

### DIFF
--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import uuid
 import fnmatch
@@ -706,6 +707,22 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
             self.update_sync_type_config_for_reset_pipeline()
 
 
+# JS `Date.prototype.toString()` output (e.g. "Sun Mar 15 2026 16:59:47 GMT+0000 (Coordinated
+# Universal Time)") appends a human-readable timezone name in parentheses that dateutil can't
+# parse, even though the preceding GMT offset already fully specifies the instant.
+JS_DATE_TOSTRING_TZ_NAME_RE = re.compile(r"\([^()]*\)\s*\Z")
+
+
+def _parse_datetime_string(value: str) -> datetime:
+    try:
+        return parser.parse(value)
+    except parser.ParserError:
+        stripped = JS_DATE_TOSTRING_TZ_NAME_RE.sub("", value)
+        if stripped == value:
+            raise
+        return parser.parse(stripped)
+
+
 def process_incremental_value(value: Any | None, field_type: IncrementalFieldType | None) -> Any:
     if value is None or value == "None" or field_type is None:
         return None
@@ -726,7 +743,7 @@ def process_incremental_value(value: Any | None, field_type: IncrementalFieldTyp
         if isinstance(value, int | float) and not isinstance(value, bool):
             return value
 
-        return parser.parse(value)
+        return _parse_datetime_string(value)
 
     if field_type == IncrementalFieldType.Date:
         if isinstance(value, datetime):
@@ -738,7 +755,7 @@ def process_incremental_value(value: Any | None, field_type: IncrementalFieldTyp
         if isinstance(value, int | float) and not isinstance(value, bool):
             return value
 
-        return parser.parse(value).date()
+        return _parse_datetime_string(value).date()
 
     if field_type == IncrementalFieldType.ObjectID:
         return str(value)

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -717,6 +717,18 @@ def test_process_incremental_value_xid_returns_value_as_is() -> None:
         (datetime(2024, 6, 14, 15, 33, 31), IncrementalFieldType.DateTime, datetime(2024, 6, 14, 15, 33, 31)),
         ("2024-06-14T15:33:31", IncrementalFieldType.DateTime, datetime(2024, 6, 14, 15, 33, 31)),
         ("2024-06-14", IncrementalFieldType.Date, date(2024, 6, 14)),
+        # JS `Date.prototype.toString()` cursors carry a parenthetical timezone name dateutil
+        # can't parse on its own, even though the GMT offset earlier in the string is sufficient.
+        (
+            "Sun Mar 15 2026 16:59:47 GMT+0000 (Coordinated Universal Time)",
+            IncrementalFieldType.DateTime,
+            datetime(2026, 3, 15, 16, 59, 47, tzinfo=timezone.get_fixed_timezone(0)),
+        ),
+        (
+            "Mon Jan 05 2026 09:15:00 GMT-0800 (Pacific Standard Time)",
+            IncrementalFieldType.Date,
+            date(2026, 1, 5),
+        ),
     ],
 )
 def test_process_incremental_value_datetime_handles_epoch_numbers(value, field_type, expected) -> None:


### PR DESCRIPTION
## Problem

Error tracking surfaced a live `ParserError` in the data warehouse import pipeline: `Unknown string format: Sun Mar 15 2026 16:59:47 GMT+0000 (Coordinated Universal Time)`.

The stack trace traces through `import_data_activity_sync` → `pipeline_v3` → `extract.update_incremental_field_values` → `load.get_incremental_field_value` → `external_data_schema.process_incremental_value`, which calls `dateutil.parser.parse()` on the raw incremental cursor value read back from a batch. All observed occurrences (retries of the same activity) carried the same cursor value, so this is one sync repeatedly failing, not sporadic bad data.

The cursor string is what JavaScript's `Date.prototype.toString()` produces (`Www Mmm dd yyyy hh:mm:ss GMT±hhmm (Timezone Name)`). `dateutil` can't parse the trailing multi-word timezone name in parentheses, even though the GMT offset earlier in the string already fully specifies the instant:

```python
>>> dateutil.parser.parse("Sun Mar 15 2026 16:59:47 GMT+0000 (Coordinated Universal Time)")
ParserError: Unknown string format: ...
>>> dateutil.parser.parse("Sun Mar 15 2026 16:59:47 GMT+0000")
datetime.datetime(2026, 3, 15, 16, 59, 47, tzinfo=tzutc())
```

Since this is an unhandled exception (not registered as non-retryable), the sync retries forever on the same unparseable cursor, generating a fresh error-tracking occurrence each attempt.

## Changes

Added a fallback in `process_incremental_value`: when `dateutil.parser.parse()` raises `ParserError`, strip a trailing parenthetical suffix and retry once before re-raising. This is a general parsing fix in shared pipeline code, not scoped to one source, since any incremental DateTime/Timestamp/Date cursor can carry this shape.

## How did you test this code?

Extended the existing parametrized test for `process_incremental_value` (`test_process_incremental_value_datetime_handles_epoch_numbers` in `products/warehouse_sources/backend/tests/test_models.py`) with two new cases covering the JS `Date.toString()` shape for both `DateTime` and `Date` field types. Ran the full parametrized test locally — all 9 cases pass. Also ran `ruff check --fix` / `ruff format` and a scoped `mypy` check on the changed file, both clean; `hogli ci:preflight --fix` reports no failures.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error-tracking issue (`ParserError` in the data-imports pipeline, ~8 occurrences from retries of a single incremental sync). Confirmed the issue via PostHog's error tracking MCP tools (stack trace, sample events, source/schema breakdown), then reproduced the `dateutil.parser` failure locally against the exact captured message before writing the fix. No open PR addresses this same root cause (checked by exception type, message substring, module path, and the maintainer's own open PRs).