### PR TITLE
fix(mcp): fold metric discovery into the execute-sql prompt body

### DIFF
--- a/services/mcp/src/hono/instructions.ts
+++ b/services/mcp/src/hono/instructions.ts
@@ -140,13 +140,14 @@ export class InstructionsBuilder {
 
     formatExecuteSqlDescription(toolFeatureFlags?: EvaluatedFlags): string {
         const dataCatalogEnabled = toolFeatureFlags?.[PRODUCT_DATA_CATALOG_FLAG] === true
+        // Metric discovery leads the splice so catalog-first routing still precedes
+        // raw schema discovery, without displacing the tool's own intro line.
         const schemaDiscovery = dataCatalogEnabled
-            ? `${SCHEMA_DISCOVERY.trim()}\n\n${CATALOG_TRUST_DISCOVERY.trim()}`
+            ? `${METRIC_DISCOVERY.trim()}\n\n${SCHEMA_DISCOVERY.trim()}\n\n${CATALOG_TRUST_DISCOVERY.trim()}`
             : SCHEMA_DISCOVERY.trim()
-        const description = formatPrompt(EXECUTE_SQL_PROMPT, {
+        return formatPrompt(EXECUTE_SQL_PROMPT, {
             guidelines: this.guidelines.trim(),
             schema_discovery: schemaDiscovery,
         })
-        return dataCatalogEnabled ? `${METRIC_DISCOVERY.trim()}\n\n${description}` : description
     }
 }

--- a/services/mcp/tests/unit/execute-sql-description.test.ts
+++ b/services/mcp/tests/unit/execute-sql-description.test.ts
@@ -15,9 +15,12 @@ describe('formatExecuteSqlDescription', () => {
         expect(flagged).toContain('#### Metric discovery (semantic layer)')
         expect(flagged).toContain('system.information_schema.metrics')
         expect(flagged).toContain('data-catalog-metric-run')
+        // The tool's own intro must stay first; metric discovery sits after the
+        // query-* routing section but keeps catalog-first precedence over raw
+        // schema discovery.
+        expect(flagged.startsWith('Executes HogQL')).toBe(true)
         const metricRoutingPosition = flagged.indexOf('#### Metric discovery (semantic layer)')
-        expect(metricRoutingPosition).toBeLessThan(flagged.indexOf('some guidelines'))
-        expect(metricRoutingPosition).toBeLessThan(flagged.indexOf('### When to use `execute-sql`'))
+        expect(metricRoutingPosition).toBeGreaterThan(flagged.indexOf('### When to use `execute-sql`'))
         expect(metricRoutingPosition).toBeLessThan(flagged.indexOf('#### Regular schema discovery'))
 
         const baseline = builder.formatExecuteSqlDescription()


### PR DESCRIPTION
## Problem

#72754 made the data-catalog metric-discovery section a prefix prepended before the entire `execute-sql` tool description. With the flag on, the description now opens with `#### Metric discovery (semantic layer)` instead of the tool's own intro line ("Executes HogQL — PostHog's variant of SQL…"), which breaks the prompt's structure: intro → guidelines → routing → discovery workflow → pitfalls → examples.

## Changes

`formatExecuteSqlDescription()` now folds `METRIC_DISCOVERY` into the `{schema_discovery}` splice instead of prefixing the whole description. It renders right after the "When to use `execute-sql`" routing section and ahead of "Regular schema discovery", so catalog-first routing still precedes raw schema exploration – the intent of #72754 is preserved, just without displacing the intro.

- Flag-off output is byte-identical to before.
- `metric-discovery.md` itself and the sibling exec/tools instruction bundles in `instructions-formatter.ts` are untouched, matching how those surfaces already position the section (before the schema/retrieval sections, not before the entire bundle).

## How did you test this code?

- `pnpm vitest run tests/unit/execute-sql-description.test.ts tests/unit/instructions-formatter.test.ts tests/unit/instructions-formatter-snapshot.test.ts` – 34 tests pass.
- Updated the position assertions in `execute-sql-description.test.ts` to pin the new invariants: the flagged description must start with the intro line, and metric discovery must sit after the routing section but before regular schema discovery. This catches the regression where the section is reintroduced as a prefix, or demoted below schema discovery and loses its catalog-first precedence – the old assertions only pinned the prefix placement.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. I asked Claude to relocate the recently added prompt prefix deeper into the prompt so it stops displacing the tool intro. Claude traced the prefix to #72754, considered restoring the pre-#72754 position (after the trust signals) but rejected it since that buried the catalog-first precedence the original change was after, and instead placed the section at the top of the schema-discovery splice. Skills invoked: /writing-tests.
