### PR TITLE
fix(quickstart): show loading spinner beside tools live count

### DIFF
--- a/frontend/src/scenes/quickstart/Quickstart.tsx
+++ b/frontend/src/scenes/quickstart/Quickstart.tsx
@@ -24,7 +24,7 @@ import {
     IconSparkles,
     IconTerminal,
 } from '@posthog/icons'
-import { LemonButton, LemonDropdown, LemonSkeleton, LemonTag, SpinnerOverlay } from '@posthog/lemon-ui'
+import { LemonButton, LemonDropdown, LemonSkeleton, LemonTag, Spinner, SpinnerOverlay } from '@posthog/lemon-ui'
 
 import { CodeSnippet } from 'lib/components/CodeSnippet'
 import { commandLogic } from 'lib/components/Command/commandLogic'
@@ -1418,7 +1418,13 @@ function PublicationsSection(): JSX.Element | null {
 }
 
 export function Quickstart(): JSX.Element {
-    const { featuredProducts, additionalProducts, activeProductCount, totalProductCount } = useValues(quickstartLogic)
+    const {
+        featuredProducts,
+        additionalProducts,
+        activeProductCount,
+        totalProductCount,
+        activationDataLoading,
+    } = useValues(quickstartLogic)
     const { showInviteModal } = useActions(inviteLogic)
     const { openCompanionSetup } = useActions(quickstartLogic)
     const { openSidePanel } = useActions(sidePanelStateLogic)
@@ -1497,6 +1503,7 @@ export function Quickstart(): JSX.Element {
                     />
                     <HeaderStat icon={<IconApps />}>
                         {activeProductCount} of {totalProductCount} live
+                        {activationDataLoading && <Spinner textColored />}
                     </HeaderStat>
                 </div>
                 {featuredProducts.length > 0 ? (

--- a/frontend/src/scenes/quickstart/Quickstart.tsx
+++ b/frontend/src/scenes/quickstart/Quickstart.tsx
@@ -1418,13 +1418,8 @@ function PublicationsSection(): JSX.Element | null {
 }
 
 export function Quickstart(): JSX.Element {
-    const {
-        featuredProducts,
-        additionalProducts,
-        activeProductCount,
-        totalProductCount,
-        activationDataLoading,
-    } = useValues(quickstartLogic)
+    const { featuredProducts, additionalProducts, activeProductCount, totalProductCount, activationDataLoading } =
+        useValues(quickstartLogic)
     const { showInviteModal } = useActions(inviteLogic)
     const { openCompanionSetup } = useActions(quickstartLogic)
     const { openSidePanel } = useActions(sidePanelStateLogic)


### PR DESCRIPTION
## Problem

The Quickstart homepage header shows "X of Y live" next to the "Your tools" row, reflecting how many products are live. That count is driven by an activation HogQL query that scans 30 days of events, which can take a while to return. While it loaded there was no signal at all, so the count looked stale or finished when it was still pending.

## Changes

- Render a small indeterminate `Spinner` to the right of the "X of Y live" count while `activationDataLoading` is true, using the existing selector from `quickstartLogic`.

![quickstart loading spinner](https://raw.githubusercontent.com/PostHog/pr-assets/75cffcc36cc73a9e6dc678b02d34f66cbba649f7/2026/07/7dde301b-6cc3-401b-a907-da71cc4f69a4.png)

*The spinner (inherited `text-secondary` tone) sits to the right of "3 of 8 live" while the activation query loads. Rendered from the real `Spinner`/`IconApps` markup and PostHog light-theme tokens.*

## How did you test this code

- Verified the change against existing types: `activationDataLoading` is already declared on `quickstartLogicValues`, `Spinner` is already exported from `@posthog/lemon-ui`, and the surrounding `HeaderStat` already lays out its children with `flex items-center gap-1.5`.
- Rendered the actual `Spinner` and `IconApps` SVG markup with the real PostHog light-theme tokens (`--color-text-secondary` = neutral-750) in a headless Chromium page and captured the screenshot above. Diagnostics confirmed the spinner renders at the expected small size (14px) in the secondary tone (`rgb(64,64,64)` = `hsl(0 0% 25%)`), positioned to the right of the count, with the writhe animation active.
- I was not able to run the full dev server in this environment (no `node_modules`/flox available), so this was not verified against the live in-app page — only the isolated component markup. Flagging that explicitly rather than claiming end-to-end in-app verification.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs touched; this is a small UI loading-state affordance with no documented workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Code (Claude). Explored the Quickstart scene to locate the activation HogQL query and the header rendering the live count.
- Skills invoked: none. No DRF, migration, or test-skill areas applied; this is a one-line presentational wiring of an existing loading selector to an existing spinner component.
- Decision: chose the existing indeterminate `Spinner` (default `small` size) over `LemonProgressCircle`, since there is no determinate progress value for the aggregate query, only a loading/not-loading state. Colored it with `textColored` to match the secondary-tone header stat.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
