### PR TITLE
fix(data-imports): fix handle_non_retryable_error call for schema type changes

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -351,7 +351,9 @@ async def _handle_import_error(
     # on every retry regardless of source — classify it non-retryable by type here rather than
     # relying on each source listing the message in get_non_retryable_errors.
     if isinstance(error, SchemaColumnTypeChangedException):
-        await handle_non_retryable_error(job_inputs, error_msg, logger, error)
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
 
     non_retryable_errors = source_cls.get_non_retryable_errors()
     if any(match in error_msg for match in non_retryable_errors):

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -208,9 +208,11 @@ async def test_schema_column_type_changed_routes_through_handler_without_source_
     logger.aexception = mock.AsyncMock()
     logger.adebug = mock.AsyncMock()
 
+    # autospec enforces handle_non_retryable_error's real signature, so a call with the wrong
+    # positional args (as this branch once had) fails here instead of only at runtime.
     with (
         mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
-        mock.patch.object(module, "handle_non_retryable_error", new=mock.AsyncMock()) as handle_mock,
+        mock.patch.object(module, "handle_non_retryable_error", autospec=True) as handle_mock,
     ):
         handle_mock.side_effect = NonRetryableException()
         with pytest.raises(NonRetryableException):
@@ -218,7 +220,7 @@ async def test_schema_column_type_changed_routes_through_handler_without_source_
 
     handle_mock.assert_awaited_once()
     assert handle_mock.await_args is not None
-    assert handle_mock.await_args.args[3] is error
+    assert handle_mock.await_args.args[5] is error
     logger.aexception.assert_not_awaited()
 
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a `SchemaColumnTypeChangedException` raised from shared data-import pipeline code (`align_incoming_decimals_to_delta` in `pipelines/pipeline/utils.py`) when an incoming decimal column no longer fits its stored Delta column type. delta-rs can't widen a decimal column in place, so this fails identically on every retry — the pipeline deliberately raises this exception so the job can stop cleanly and tell the user to reset and re-sync the table.

That handling is broken. In `_handle_import_error`, the branch that classifies this exception as non-retryable called `handle_non_retryable_error` with a **stale 4-argument signature**:

```python
await handle_non_retryable_error(job_inputs, error_msg, logger, error)
```

`handle_non_retryable_error` was refactored to take `(team_id, source_id, run_id, error_msg, logger, error)`, and every other call site was updated — this one was missed. So when the exception fires, the handler itself raises `TypeError: missing a required argument: 'logger'` instead of routing the error. The `TypeError` is a generic exception, so it isn't classified as non-retryable: the activity retries to its maximum, crash-looping and spamming error tracking, and the original actionable "reset and re-sync this table" message is masked — the exact anti-pattern this branch exists to prevent.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019f8f20-c27a-7930-b7da-11a2927ae660

## Changes

- Pass the correct arguments to `handle_non_retryable_error` in the `SchemaColumnTypeChangedException` branch, matching the two other call sites in the same function.
- Tighten the existing unit test to `autospec=True` the mocked handler so a wrong call signature fails the test at call time rather than only at runtime. The previous plain `AsyncMock` accepted any arguments and its assertion had been written against the buggy positional layout.

The `align_incoming_decimals_to_delta` behavior and the decision to treat this as non-retryable are unchanged — only the malformed handler call is fixed. The v3 pipeline path already handles this correctly via substring matching, so no change was needed there.

## How did you test this code?

Automated unit tests in `tests/test_import_data_sync.py` (run locally with `uv run pytest`, all 11 pass):

- Verified the updated `test_schema_column_type_changed_routes_through_handler_without_source_opt_in` **fails** against the pre-fix code (`TypeError: missing a required argument: 'logger'`) and **passes** with the fix — it now catches a wrong-signature regression that the previous mock silently accepted, which no other test covered.
- The sibling `RESTClientNonRetryableError` and general non-retryable-error tests continue to pass, confirming the other call sites are unaffected.

No manual end-to-end sync was run.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live error-tracking issue in the data-warehouse import pipeline. Investigated the exception origin and call path via the PostHog error-tracking MCP tools, traced the raise site in shared pipeline code, and found the classification handler was calling `handle_non_retryable_error` with an outdated signature (a refactor casualty — the function's other two call sites were migrated to the new signature but this branch was not). Checked open PRs (including the maintainer's) for a duplicate fix; the related open PRs touch different files or predate this branch and none correct this call site.

Skills invoked: `/writing-tests` (to decide the test approach — extended the existing test with `autospec` rather than adding a redundant new one).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
