### PR TITLE
fix(data-warehouse): pass unpacked args to handle_non_retryable_error

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -351,7 +351,9 @@ async def _handle_import_error(
     # on every retry regardless of source — classify it non-retryable by type here rather than
     # relying on each source listing the message in get_non_retryable_errors.
     if isinstance(error, SchemaColumnTypeChangedException):
-        await handle_non_retryable_error(job_inputs, error_msg, logger, error)
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
 
     non_retryable_errors = source_cls.get_non_retryable_errors()
     if any(match in error_msg for match in non_retryable_errors):

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -218,7 +218,7 @@ async def test_schema_column_type_changed_routes_through_handler_without_source_
 
     handle_mock.assert_awaited_once()
     assert handle_mock.await_args is not None
-    assert handle_mock.await_args.args[3] is error
+    assert handle_mock.await_args.args[5] is error
     logger.aexception.assert_not_awaited()
 
 


### PR DESCRIPTION
## Problem

`master` is currently red on the Python code quality workflow: the `SchemaColumnTypeChangedException` branch added in #73135 calls `handle_non_retryable_error(job_inputs, error_msg, logger, error)`, but the function signature is `(team_id, source_id, run_id, error_msg, logger, error)`. mypy fails with four errors on `import_data_sync.py:354`, which blocks CI for every open PR.

## Changes

Unpack the arguments the same way the sibling call sites in the same function do.

## How did you test this code?

`uv run mypy --cache-fine-grained` no longer reports the four errors on the file; ruff check and format are clean. No behavior change beyond making the call actually match the signature (the previous form would have raised `TypeError` at runtime when the branch fired).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

One-line mechanical fix authored with Claude Code while babysitting an unrelated PR that inherited the red master. No design decisions involved; the argument shape mirrors the two adjacent call sites.
