### PR TITLE
fix(data-imports): fix non-retryable call for schema column type change

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -203,6 +203,7 @@ async def test_schema_column_type_changed_routes_through_handler_without_source_
     source.get_non_retryable_errors.return_value = {}
     source.get_retryable_errors.return_value = set()
 
+    job_inputs = mock.MagicMock()
     logger = mock.MagicMock()
     logger.awarning = mock.AsyncMock()
     logger.aexception = mock.AsyncMock()
@@ -216,11 +217,15 @@ async def test_schema_column_type_changed_routes_through_handler_without_source_
     ):
         handle_mock.side_effect = NonRetryableException()
         with pytest.raises(NonRetryableException):
-            await module._handle_import_error(mock.MagicMock(), logger, error)
+            await module._handle_import_error(job_inputs, logger, error)
 
     handle_mock.assert_awaited_once()
     assert handle_mock.await_args is not None
-    assert handle_mock.await_args.args[5] is error
+    args = handle_mock.await_args.args
+    assert args[0] is job_inputs.team_id
+    assert args[2] is job_inputs.run_id
+    assert args[4] is logger
+    assert args[5] is error
     logger.aexception.assert_not_awaited()
 
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a `NonRetryableException` in the data-warehouse import pipeline ([issue](https://us.posthog.com/project/2/error_tracking/019f8f25-f74c-74e0-bebc-d0f0727f75b6)). The underlying `SchemaColumnTypeChangedException` fires when an incoming decimal column no longer fits the stored Delta column type. delta-rs can't widen a column in place, so this is deterministic: the only fix is to reset and fully re-sync the table.

Shared pipeline code already recognizes this and tries to classify it as non-retryable in `_handle_import_error`. But that branch calls `handle_non_retryable_error` with the wrong argument list:

```python
await handle_non_retryable_error(job_inputs, error_msg, logger, error)
```

The handler's signature is `(team_id, source_id, run_id, error_msg, logger, error)`. Every other call site passes those six args; this newly-added branch was missed when the signature was refactored, so it still passes the old four-arg shape.

The effect is worse than a no-op. When the conflict fires, the branch raises `TypeError: missing a required argument: 'logger'` instead of classifying the error. That generic error escapes as a normal failure, so Temporal retries the sync forever rather than stopping after the retry limit with the actionable "reset and re-sync" guidance.

> [!NOTE]
> This is the intended non-retryable path being repaired, not a widening of what counts as non-retryable. A stored decimal column that can't hold the incoming integer digits can never be fixed by retrying, so stopping is correct.

## Changes

- Pass the correct six arguments to `handle_non_retryable_error` in the `SchemaColumnTypeChangedException` branch, matching the sibling call sites.
- Strengthen the existing regression test: patch the handler with `autospec=True` so a wrong-signature call surfaces as a `TypeError` in the test instead of being swallowed by a permissive `AsyncMock`, and assert the exact call shape (`team_id`, `run_id`, `logger`, `error` in their real positions).

```diff
-        await handle_non_retryable_error(job_inputs, error_msg, logger, error)
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
```

## How did you test this code?

Ran the affected test file with `uv run pytest` (11 passed). Confirmed the updated test catches the regression: reverting the fix makes `test_schema_column_type_changed_routes_through_handler_without_source_opt_in` fail with the same `TypeError` the production path hits, and restoring it passes. The prior test masked the bug by mocking the handler with a permissive `AsyncMock` and asserting the wrong argument index; the `autospec` change closes that gap. Ran `ruff check` and `ruff format --check` on both files (clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated by Claude (Claude Code) from an error-tracking webhook. Traced the stack from `align_incoming_decimals_to_delta` / `write_to_deltalake` up into `_handle_import_error`, then diffed the three `handle_non_retryable_error` call sites against the handler's actual signature to find the single stale one. Confirmed against open PRs (#70384, #70526) that the handler was recently refactored from a `job_inputs`-first signature, which is why this branch was left behind on master; those are stale drafts about message threading, not this crash. Invoked the `/writing-tests` skill before changing the test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
