### PR TITLE
fix(data-warehouse): fix handle_non_retryable_error call for schema type change

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -351,7 +351,9 @@ async def _handle_import_error(
     # on every retry regardless of source — classify it non-retryable by type here rather than
     # relying on each source listing the message in get_non_retryable_errors.
     if isinstance(error, SchemaColumnTypeChangedException):
-        await handle_non_retryable_error(job_inputs, error_msg, logger, error)
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
 
     non_retryable_errors = source_cls.get_non_retryable_errors()
     if any(match in error_msg for match in non_retryable_errors):

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -218,7 +218,7 @@ async def test_schema_column_type_changed_routes_through_handler_without_source_
 
     handle_mock.assert_awaited_once()
     assert handle_mock.await_args is not None
-    assert handle_mock.await_args.args[3] is error
+    assert handle_mock.await_args.args[5] is error
     logger.aexception.assert_not_awaited()
 
 


### PR DESCRIPTION
## Problem

`Python code quality` (mypy) is failing on master, which red-lines the typecheck job on every open PR (e.g. #73191, which is unrelated to this code). The `SchemaColumnTypeChangedException` branch in `_handle_import_error` calls `handle_non_retryable_error` with the old single-`job_inputs` signature:

```python
await handle_non_retryable_error(job_inputs, error_msg, logger, error)
```

but `handle_non_retryable_error` now takes `(team_id, source_id, run_id, error_msg, logger, error)`. The signature was widened and the other three call sites in this file were updated, but this one was missed (it was added around the same time in #72233).

It's not just a type error. If a real `SchemaColumnTypeChangedException` were raised, this call would `TypeError` at runtime instead of stopping the job non-retryably, so a deterministic schema-type failure would retry to the activity max instead of failing fast.

```
import_data_sync.py:354: error: Missing positional arguments "logger", "error" in call to "handle_non_retryable_error"  [call-arg]
import_data_sync.py:354: error: Argument 1 ... has incompatible type "PipelineInputs"; expected "int"  [arg-type]
import_data_sync.py:354: error: Argument 3 ... "FilteringBoundLogger"; expected "str"  [arg-type]
import_data_sync.py:354: error: Argument 4 ... "SchemaColumnTypeChangedException"; expected "str"  [arg-type]
```

## Changes

- Update the `SchemaColumnTypeChangedException` call site to the current signature, matching the three sibling calls in the same file:

```python
await handle_non_retryable_error(
    job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
)
```

- Tighten `test_schema_column_type_changed_routes_through_handler_without_source_opt_in`. It mocked `handle_non_retryable_error` and asserted `await_args.args[3] is error` — the index for the old 4-arg call, so it passed against the buggy code and never guarded the signature. It now asserts `args[5] is error`, matching the 6-arg signature and its sibling `RESTClientNonRetryableError` test. That makes the test actually catch this regression rather than encode it.

## How did you test this code?

- `mypy` on `import_data_sync.py`: the 4 errors are gone, file is clean.
- `pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py`: 11 passed. The tightened assertion fails against the old call and passes against the fix, confirming it now guards the signature.
