### PR TITLE
fix(tests): deflake rerun paginator seeding after topic recreation

### DIFF
--- a/nodejs/src/cdp/rerun/rerun-paginator.service.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-paginator.service.test.ts
@@ -10,7 +10,7 @@ import { UUIDT } from '~/common/utils/utils'
 import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { Clickhouse } from '~/tests/helpers/clickhouse'
 import { waitForExpect } from '~/tests/helpers/expectations'
-import { ensureKafkaTopics, resetKafka } from '~/tests/helpers/kafka'
+import { TEST_KAFKA_TOPICS, ensureKafkaTopics } from '~/tests/helpers/kafka'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 
 import { Hub, Team } from '../../types'
@@ -126,10 +126,10 @@ describe('RerunPaginatorService integration', () => {
         seededCount += rows.length
         const expected = seededCount
 
-        // Seed visibility rides the shared Kafka -> ClickHouse pipe, whose consumer may still be
-        // chewing a backlog from whichever suite the shard ran just before this one (run order
-        // shifts whenever sibling files change size). The deadline is sized for that worst case;
-        // waitForExpect polls, so a healthy pipe still completes in seconds.
+        // The suite-level warmup proved the pipe flowing and caught up, so delivery is
+        // guaranteed and this wait is bounded by consumer throughput of our own rows.
+        // The deadline is generous headroom for contended CI runners; waitForExpect
+        // polls, so a healthy pipe still completes in seconds.
         await waitForExpect(async () => {
             const got = await clickhouse.query<{ c: number }>(
                 `SELECT count() AS c FROM hog_invocation_results
@@ -186,11 +186,92 @@ describe('RerunPaginatorService integration', () => {
         }, 90_000)
     }
 
+    /**
+     * Prove the Kafka → ClickHouse MV pipe is flowing and caught up before any test
+     * seeds real rows.
+     *
+     * A sibling suite calling resetKafka() deletes and recreates this topic, which
+     * resets message offsets to zero while the ClickHouse Kafka engine's consumer
+     * group keeps the offset it committed against the old topic incarnation. The
+     * consumer then resumes at that stale offset and silently skips the first
+     * messages produced to the recreated topic — a permanent loss no seed-side wait
+     * can recover from (the cause of this suite's long-running "2 of 3 rows" flake).
+     *
+     * Producing sentinels one at a time until one becomes visible drains that skew:
+     * each retry lands at a higher offset, so eventually a sentinel lands at or past
+     * the stale committed offset (or triggers an out-of-range reset), the consumer
+     * catches up to the topic end, and every message produced afterwards is
+     * guaranteed to be consumed.
+     */
+    const warmUpKafkaToClickhousePipe = async (): Promise<void> => {
+        const warmupProducer: KafkaProducerWrapper = await ActualKafkaProducerWrapper.create(undefined)
+        const warmupFunctionId = `warmup-${new UUIDT().toString()}`
+        const deadline = Date.now() + 120_000
+        try {
+            for (let attempt = 1; ; attempt++) {
+                await warmupProducer.queueMessages({
+                    topic: KAFKA_HOG_INVOCATION_RESULTS,
+                    messages: [
+                        {
+                            key: warmupFunctionId,
+                            value: JSON.stringify({
+                                team_id: 0,
+                                function_kind: 'hog_function',
+                                function_id: warmupFunctionId,
+                                invocation_id: `${warmupFunctionId}-${attempt}`,
+                                parent_run_id: '',
+                                status: 'succeeded',
+                                attempts: 0,
+                                is_retry: 0,
+                                scheduled_at: DateTime.utc().toFormat("yyyy-MM-dd HH:mm:ss.SSS'000'"),
+                                started_at: null,
+                                finished_at: null,
+                                duration_ms: null,
+                                error_kind: '',
+                                error_message: '',
+                                event_uuid: '',
+                                distinct_id: '',
+                                person_id: '',
+                                invocation_globals: '',
+                                version: String(BigInt(Date.now()) * 1000n),
+                                is_deleted: 0,
+                            }),
+                        },
+                    ],
+                })
+                await warmupProducer.flush()
+                try {
+                    // 10s per attempt: the Kafka engine flushes batches every ~7.5s (stream_flush_interval_ms), so a shorter wait expires even on a healthy pipe.
+                    await waitForExpect(async () => {
+                        const got = await clickhouse.query<{ c: number }>(
+                            `SELECT count() AS c FROM hog_invocation_results
+                             WHERE function_id = '${warmupFunctionId}'`
+                        )
+                        expect(Number(got[0]?.c ?? 0)).toBeGreaterThanOrEqual(1)
+                    }, 10_000)
+                    return
+                } catch (error) {
+                    if (Date.now() > deadline) {
+                        throw new Error(
+                            `Kafka -> ClickHouse pipe warmup failed: none of ${attempt} sentinel rows became visible in hog_invocation_results within 120s`,
+                            { cause: error }
+                        )
+                    }
+                }
+            }
+        } finally {
+            await warmupProducer.disconnect().catch(() => undefined)
+        }
+    }
+
     beforeAll(async () => {
         MockKafkaProducerWrapper.create = jest.fn((...args: any[]) => ActualKafkaProducerWrapper.create(...args))
-        await resetKafka()
-        await ensureKafkaTopics([KAFKA_HOG_INVOCATION_RESULTS])
+        // Never resetKafka() here: deleting this topic while the ClickHouse consumer
+        // group retains committed offsets is exactly the incarnation skew the warmup
+        // exists to recover from — see warmUpKafkaToClickhousePipe.
+        await ensureKafkaTopics([...TEST_KAFKA_TOPICS, KAFKA_HOG_INVOCATION_RESULTS])
         await clickhouse.truncate('hog_invocation_results_data')
+        await warmUpKafkaToClickhousePipe()
     })
 
     beforeEach(async () => {


### PR DESCRIPTION
## Problem

`RerunPaginatorService integration › by-ids mode › rehydrates and re-enqueues only the requested invocations, ignoring others` is flaky in CI: the `seedRows` wait intermittently sees only 2 of the 3 seeded rows in ClickHouse and times out after 90s (e.g. runs [29830823494](https://github.com/PostHog/posthog/actions/runs/29830823494) and [29912396213](https://github.com/PostHog/posthog/actions/runs/29912396213), Node.js Tests shard 3/3, three failures in one day on #70308).

Two earlier patches treated it as a slow pipe (#71566 raised the timeout, #72889 added a producer flush) and the flake survived both, because the missing row is not late, it is permanently lost:

- The suite's `beforeAll` called `resetKafka()`, which deletes every Kafka topic (including `clickhouse_hog_invocation_results`, which is not in `TEST_KAFKA_TOPICS`) and recreates them empty, resetting message offsets to zero.
- The ClickHouse Kafka engine's consumer group (`clickhouse_hog_invocation_results`) survives the recreation and keeps the offset it committed against the old topic incarnation. In the failing shard, `workflows-e2e.test.ts` runs first and produces real lifecycle rows to this topic, so a committed offset exists.
- When the first test then seeds 3 messages at offsets 0-2 of the fresh topic, the consumer resumes from its stale committed offset and silently skips the messages below it. Hence `Received: 2` with a stable count for the full 90s, while every later test in the file passes (the consumer is aligned again once past the skew).

No seed-side wait can recover from that, which is why bumping the timeout was never going to stick.

## Changes

Two changes in [rerun-paginator.service.test.ts](https://github.com/PostHog/posthog/blob/master/nodejs/src/cdp/rerun/rerun-paginator.service.test.ts), both in test setup only:

- Stop deleting topics: replace `resetKafka()` with idempotent `ensureKafkaTopics([...TEST_KAFKA_TOPICS, KAFKA_HOG_INVOCATION_RESULTS])`. This is the pattern `rerun-e2e.test.ts` already uses, with a comment documenting the same hazard.
- Add a suite-level pipe warmup: `beforeAll` now produces sentinel rows (one at a time, under a throwaway `function_id`) until one becomes visible in ClickHouse. If a sibling suite's `resetKafka()` left the consumer group with a stale offset, the first sentinel(s) get skipped, but each retry lands at a higher offset, so the loop provably converges with the consumer caught up to the topic end. After that, every message the tests produce is guaranteed to be consumed, so the existing per-test waits are bounded by consumer throughput of the suite's own rows rather than racing an unrecoverable skip.

The seeding still exercises the real path (producer → Kafka → ClickHouse Kafka engine → MV → table), which is the point of this integration test.

## How did you test this code?

- Verified root cause against the CI evidence: both failing runs show `Received: 2` / `Expected: >= 3` on the first test only, with all later tests in the file passing, which fits permanent prefix loss and rules out a slow pipe. `ClickHouse KafkaConfigLoader` defaults `auto.offset.reset=earliest`, so only a retained committed offset produces this skip pattern.
- I (Claude) could not run the integration suite locally because the dev stack (ClickHouse, Redpanda, Postgres) was not running in this session, so validation is analytical rather than an N-run repro loop. The suite runs in CI on this PR (Node.js Tests shard containing `src/cdp/rerun`).
- `tsc` and eslint pass on the changed file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Claude Fable 5) in a local session driven by Robbie, using the `/fixing-flaky-tests` skill. Investigation: measured the failure from the GitHub runs, read the seeding pipeline (`HogInvocationResultsService` → Kafka → CH Kafka engine table → MV), and traced the loss to `resetKafka()` topic deletion under a live consumer group with committed offsets. Considered and rejected: raising the timeout again (already tried in #71566, cannot fix permanent loss), seeding ClickHouse directly (would gut the end-to-end purpose of the test), and re-producing rows on wait timeout (a retry crutch that would mask the root cause and can double-count rows). The warmup-probe design was chosen because it is robust to every topic-incarnation scenario regardless of which sibling suites run first in the shard.
