### PR TITLE
chore(surveys): add test coverage for widget position reset

### DIFF
--- a/frontend/src/scenes/surveys/SurveyWidgetCustomization.tsx
+++ b/frontend/src/scenes/surveys/SurveyWidgetCustomization.tsx
@@ -5,15 +5,9 @@ import { LemonCheckbox, LemonInput, LemonSelect } from '@posthog/lemon-ui'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 
-import {
-    AvailableFeature,
-    SurveyAppearance,
-    SurveyPosition,
-    SurveySchedule,
-    SurveyTabPosition,
-    SurveyWidgetType,
-} from '~/types'
+import { AvailableFeature, SurveyAppearance, SurveySchedule, SurveyTabPosition, SurveyWidgetType } from '~/types'
 
+import { resolveWidgetPosition } from './constants'
 import { SurveyTabPositionSelector } from './survey-appearance/SurveyTabPositionSelector'
 import { surveysLogic } from './surveysLogic'
 
@@ -53,13 +47,7 @@ export function SurveyWidgetCustomization(): JSX.Element {
                             <LemonSelect
                                 value={appearance.widgetType}
                                 onChange={(widgetType) => {
-                                    // NextToTrigger is only available for Selector widget type
-                                    const newPosition =
-                                        widgetType !== SurveyWidgetType.Selector &&
-                                        appearance?.position === SurveyPosition.NextToTrigger
-                                            ? SurveyPosition.Right
-                                            : appearance?.position
-
+                                    const newPosition = resolveWidgetPosition(widgetType, appearance?.position)
                                     onAppearanceChange({ ...appearance, widgetType, position: newPosition })
                                 }}
                                 options={[

--- a/frontend/src/scenes/surveys/constants.test.ts
+++ b/frontend/src/scenes/surveys/constants.test.ts
@@ -1,0 +1,15 @@
+import { SurveyPosition, SurveyWidgetType } from '~/types'
+
+import { resolveWidgetPosition } from './constants'
+
+describe('resolveWidgetPosition', () => {
+    test.each([
+        [SurveyWidgetType.Tab, SurveyPosition.NextToTrigger, SurveyPosition.Right],
+        [SurveyWidgetType.Button, SurveyPosition.NextToTrigger, SurveyPosition.Right],
+        [SurveyWidgetType.Selector, SurveyPosition.NextToTrigger, SurveyPosition.NextToTrigger],
+        [SurveyWidgetType.Tab, SurveyPosition.Left, SurveyPosition.Left],
+        [SurveyWidgetType.Selector, undefined, undefined],
+    ])('widgetType=%s currentPosition=%s -> %s', (widgetType, currentPosition, expected) => {
+        expect(resolveWidgetPosition(widgetType, currentPosition)).toBe(expected)
+    })
+})

--- a/frontend/src/scenes/surveys/constants.tsx
+++ b/frontend/src/scenes/surveys/constants.tsx
@@ -916,6 +916,19 @@ export const surveyThemes: SurveyTheme[] = [
     },
 ]
 
+// NextToTrigger only makes sense for the Selector widget (position relative to its CSS
+// selector); switching to another widget type leaves a position posthog-js can't resolve,
+// so fall back to Right.
+export function resolveWidgetPosition(
+    widgetType: SurveyWidgetType,
+    currentPosition: SurveyPosition | undefined
+): SurveyPosition | undefined {
+    if (widgetType !== SurveyWidgetType.Selector && currentPosition === SurveyPosition.NextToTrigger) {
+        return SurveyPosition.Right
+    }
+    return currentPosition
+}
+
 export function getMatchingSurveyThemeId(appearance?: Partial<SurveyAppearance> | null): string | null {
     if (!appearance) {
         return 'clean'


### PR DESCRIPTION
## Problem

`SurveyWidgetCustomization.tsx` and `constants.tsx` had zero test coverage for the
widget-position logic, despite that exact area causing two real bugs (a survey
ending up with a position value posthog-js can't resolve for its widget type).
Specifically, `NextToTrigger` is only valid for the `Selector` widget type — switching
to `Tab`/`Button` while it's set needs to reset the position, and that reset logic
lived inline in a JSX `onChange` handler with nothing exercising it.

## Changes

- Extracted the reset logic out of `SurveyWidgetCustomization`'s inline `onChange`
  handler into a plain exported function, `resolveWidgetPosition`, in `constants.tsx`.
  No behavior change — same condition, just testable in isolation instead of requiring
  a component render.
- Added `constants.test.ts` with parameterized cases covering: reset from
  `NextToTrigger` on `Tab`/`Button`, no reset when already on `Selector`, and
  non-`NextToTrigger` positions passing through unchanged.

## How did you test this code?

- `pnpm --filter=@posthog/frontend exec jest frontend/src/scenes/surveys/constants.test.ts` — 5/5 passing.
- `pnpm exec oxlint` and `oxfmt --check` on the changed files — clean, no issues.
- Ran the whole-app `typescript:check`; it reports pre-existing errors unrelated to
  this change (missing `@posthog/quill-primitives` type declarations in unrelated
  `products/*` files, likely from a partial workspace install in my sandbox rather
  than a real regression) — confirmed none reference `SurveyWidgetCustomization.tsx`
  or `constants.tsx`/`constants.test.ts`.
- No behavior changed (pure extraction + new test file), so the risk surface is
  limited to the extracted function, which the tests cover directly.

## Docs update

Not applicable — no user-facing behavior, API, or config changed.
