### PR TITLE
refactor(s3): Update tests to cover both AWSS3 and S3Compatible

### DIFF
--- a/products/batch_exports/backend/api/destination_tests/__init__.py
+++ b/products/batch_exports/backend/api/destination_tests/__init__.py
@@ -1,5 +1,4 @@
 from products.batch_exports.backend.api.destination_tests.base import DestinationTest
-from products.batch_exports.backend.models.batch_export import S3_FAMILY_TYPES
 
 
 def get_destination_test(
@@ -11,10 +10,14 @@ def get_destination_test(
     (databricks, google-cloud-bigquery, snowflake, etc.). Importing them lazily keeps the
     SDKs off the API import path — only the requested destination's SDK loads.
     """
-    if destination in S3_FAMILY_TYPES:
-        from products.batch_exports.backend.api.destination_tests.s3 import S3DestinationTest  # noqa: PLC0415
+    if destination in ("S3", "S3Compatible"):
+        from products.batch_exports.backend.api.destination_tests.s3 import S3CompatibleDestinationTest  # noqa: PLC0415
 
-        return S3DestinationTest()
+        return S3CompatibleDestinationTest()
+    elif destination == "AwsS3":
+        from products.batch_exports.backend.api.destination_tests.s3 import AwsS3DestinationTest  # noqa: PLC0415
+
+        return AwsS3DestinationTest()
     elif destination == "BigQuery":
         from products.batch_exports.backend.api.destination_tests.bigquery import (  # noqa: PLC0415
             BigQueryDestinationTest,

--- a/products/batch_exports/backend/api/destination_tests/s3.py
+++ b/products/batch_exports/backend/api/destination_tests/s3.py
@@ -56,6 +56,9 @@ class S3AssumeRoleTestStep(DestinationTestStep):
                 policy_statements=[
                     PolicyStatement(Effect="Allow", Action=["s3:ListBucket"], Resource="arn:aws:s3:::*")
                 ],
+                # This test verifies user-provided config, where failures are expected, so
+                # report them promptly rather than retrying.
+                max_attempts=1,
             )
         except InvalidCredentialsError as err:
             return DestinationTestStepResult(
@@ -157,6 +160,9 @@ class S3EnsureBucketTestStep(DestinationTestStep):
                         Effect="Allow", Action=["s3:ListBucket"], Resource=f"arn:aws:s3:::{self.bucket_name}"
                     )
                 ],
+                # This test verifies user-provided config, where failures are expected, so
+                # report them promptly rather than retrying.
+                max_attempts=1,
             )
 
             aws_access_key_id, aws_secret_access_key, aws_session_token = (

--- a/products/batch_exports/backend/api/destination_tests/s3.py
+++ b/products/batch_exports/backend/api/destination_tests/s3.py
@@ -6,6 +6,84 @@ from products.batch_exports.backend.api.destination_tests.base import (
     DestinationTestStepResult,
     Status,
 )
+from products.batch_exports.backend.temporal.destinations.s3_batch_export import (
+    InvalidCredentialsError,
+    PolicyStatement,
+    get_credentials_using_user_aws_role,
+)
+
+
+class S3AssumeRoleTestStep(DestinationTestStep):
+    """Test whether we can assume a configured AWS role.
+
+
+    Attributes:
+        aws_role_arn: AWS role ARN we are testing.
+    """
+
+    name = "Ensure we can assume provided AWS role"
+    description = (
+        "Ensure the configured AWS role ARN exists and that we have the required trust relationship to assume it."
+    )
+
+    def __init__(
+        self,
+        aws_role_arn: str | None = None,
+        organization_id: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.aws_role_arn = aws_role_arn
+        self.organization_id = organization_id
+
+    def _is_configured(self) -> bool:
+        # Always considered configured: when there is no role ARN to assume (e.g.
+        # key-based auth) the step reports SKIPPED rather than failing.
+        return True
+
+    async def _run_step(self) -> DestinationTestStepResult:
+        """Run this test step."""
+        from botocore.exceptions import ClientError
+
+        if self.aws_role_arn is None:
+            return DestinationTestStepResult(status=Status.SKIPPED, message="No configured AWS role ARN, skipping test")
+
+        external_id = f"posthog-{self.organization_id}"
+        try:
+            _ = await get_credentials_using_user_aws_role(
+                self.aws_role_arn,
+                external_id,
+                session_name="PostHog-batch-exports-test",
+                policy_statements=[
+                    PolicyStatement(Effect="Allow", Action=["s3:ListBucket"], Resource="arn:aws:s3:::*")
+                ],
+            )
+        except InvalidCredentialsError as err:
+            return DestinationTestStepResult(
+                status=Status.FAILED,
+                # The error message here is already pretty clear.
+                message=str(err),
+            )
+
+        except ClientError as err:
+            error_code = err.response.get("Error", {}).get("Code")
+            if error_code == "AccessDenied":
+                # We can't really separate what went wrong here.
+                return DestinationTestStepResult(
+                    status=Status.FAILED,
+                    message=f"We couldn't assume '{self.aws_role_arn}' due to an 'AccessDenied' error. Ensure that the trust policy attached to the role allows 'sts:AssumeRole' for the PostHog role, that the 'ExternalId' condition is set, and that the role actually exists.",
+                )
+
+            return DestinationTestStepResult(
+                status=Status.FAILED,
+                message=f"An unknown error occurred when trying to assume '{self.aws_role_arn}': {err}",
+            )
+        except Exception as err:
+            return DestinationTestStepResult(
+                status=Status.FAILED,
+                message=f"An unknown error occurred when trying to assume '{self.aws_role_arn}': {err}",
+            )
+
+        return DestinationTestStepResult(status=Status.PASSED)
 
 
 class S3EnsureBucketTestStep(DestinationTestStep):
@@ -32,6 +110,8 @@ class S3EnsureBucketTestStep(DestinationTestStep):
         endpoint_url: str | None = None,
         aws_access_key_id: str | None = None,
         aws_secret_access_key: str | None = None,
+        aws_role_arn: str | None = None,
+        organization_id: str | None = None,
     ) -> None:
         super().__init__()
         self.bucket_name = bucket_name
@@ -39,11 +119,19 @@ class S3EnsureBucketTestStep(DestinationTestStep):
         self.endpoint_url = endpoint_url
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key
+        self.aws_role_arn = aws_role_arn
+        self.organization_id = organization_id
 
     def _is_configured(self) -> bool:
         """Ensure required configuration parameters are set."""
-        if self.bucket_name is None or self.aws_access_key_id is None or self.aws_secret_access_key is None:
+        if self.bucket_name is None:
             return False
+
+        if (self.aws_role_arn is None or self.organization_id is None) and (
+            self.aws_access_key_id is None or self.aws_secret_access_key is None
+        ):
+            return False
+
         return True
 
     async def _run_step(self) -> DestinationTestStepResult:
@@ -52,11 +140,37 @@ class S3EnsureBucketTestStep(DestinationTestStep):
         from botocore.exceptions import ClientError
 
         session = aioboto3.Session()
+
+        aws_access_key_id = self.aws_access_key_id
+        aws_secret_access_key = self.aws_secret_access_key
+        aws_session_token = None
+
+        if self.aws_role_arn is not None:
+            external_id = f"posthog-{self.organization_id}"
+
+            credentials = await get_credentials_using_user_aws_role(
+                self.aws_role_arn,
+                external_id,
+                session_name="PostHog-batch-exports-test",
+                policy_statements=[
+                    PolicyStatement(
+                        Effect="Allow", Action=["s3:ListBucket"], Resource=f"arn:aws:s3:::{self.bucket_name}"
+                    )
+                ],
+            )
+
+            aws_access_key_id, aws_secret_access_key, aws_session_token = (
+                credentials.aws_access_key_id,
+                credentials.aws_secret_access_key,
+                credentials.aws_session_token,
+            )
+
         async with session.client(
             "s3",
             region_name=self.region,
-            aws_access_key_id=self.aws_access_key_id,
-            aws_secret_access_key=self.aws_secret_access_key,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
             endpoint_url=self.endpoint_url,
         ) as client:
             assert self.bucket_name is not None
@@ -88,7 +202,7 @@ class S3EnsureBucketTestStep(DestinationTestStep):
         return DestinationTestStepResult(status=Status.PASSED)
 
 
-class S3DestinationTest(DestinationTest):
+class S3CompatibleDestinationTest(DestinationTest):
     """A concrete implementation of a `DestinationTest` for S3.
 
     Attributes:
@@ -125,4 +239,52 @@ class S3DestinationTest(DestinationTest):
                 aws_access_key_id=self.aws_access_key_id,
                 aws_secret_access_key=self.aws_secret_access_key,
             )
+        ]
+
+
+class AwsS3DestinationTest(DestinationTest):
+    """A concrete implementation of a `DestinationTest` for AWS S3.
+
+    Attributes:
+        bucket_name: The bucket we are batch exporting to.
+        region: Region where the bucket is supposed to be.
+        aws_access_key_id: Access key ID for the bucket.
+        aws_secret_access_key: Secret access key for the bucket.
+        aws_role_arn: Role to assume to access the bucket, if not using
+            long-lived credentials.
+    """
+
+    def __init__(self):
+        self.bucket_name = None
+        self.region = None
+        self.aws_access_key_id = None
+        self.aws_secret_access_key = None
+        self.aws_role_arn = None
+        self.organization_id: str | None = None
+
+    def configure(self, **kwargs):
+        """Configure this test with necessary attributes."""
+        self.bucket_name = kwargs.get("bucket_name", None)
+        self.region = kwargs.get("region", None)
+        self.aws_access_key_id = kwargs.get("aws_access_key_id", None)
+        self.aws_secret_access_key = kwargs.get("aws_secret_access_key", None)
+        self.aws_role_arn = kwargs.get("aws_role_arn", None)
+
+        integration = kwargs.get("integration", None)
+        if integration is not None:
+            self.organization_id = integration.team.organization_id
+
+    @property
+    def steps(self) -> collections.abc.Sequence[DestinationTestStep]:
+        """Sequence of test steps that make up this destination test."""
+        return [
+            S3AssumeRoleTestStep(aws_role_arn=self.aws_role_arn, organization_id=self.organization_id),
+            S3EnsureBucketTestStep(
+                bucket_name=self.bucket_name,
+                region=self.region,
+                aws_access_key_id=self.aws_access_key_id,
+                aws_secret_access_key=self.aws_secret_access_key,
+                aws_role_arn=self.aws_role_arn,
+                organization_id=self.organization_id,
+            ),
         ]

--- a/products/batch_exports/backend/api/destination_tests/s3.py
+++ b/products/batch_exports/backend/api/destination_tests/s3.py
@@ -30,10 +30,14 @@ class S3AssumeRoleTestStep(DestinationTestStep):
         self,
         aws_role_arn: str | None = None,
         organization_id: str | None = None,
+        max_attempts: int = 1,
     ) -> None:
         super().__init__()
         self.aws_role_arn = aws_role_arn
         self.organization_id = organization_id
+        # This test verifies user-provided config, where failures are expected, so
+        # default to a single attempt and report promptly rather than retrying.
+        self.max_attempts = max_attempts
 
     def _is_configured(self) -> bool:
         # Always considered configured: when there is no role ARN to assume (e.g.
@@ -56,9 +60,7 @@ class S3AssumeRoleTestStep(DestinationTestStep):
                 policy_statements=[
                     PolicyStatement(Effect="Allow", Action=["s3:ListBucket"], Resource="arn:aws:s3:::*")
                 ],
-                # This test verifies user-provided config, where failures are expected, so
-                # report them promptly rather than retrying.
-                max_attempts=1,
+                max_attempts=self.max_attempts,
             )
         except InvalidCredentialsError as err:
             return DestinationTestStepResult(
@@ -115,6 +117,7 @@ class S3EnsureBucketTestStep(DestinationTestStep):
         aws_secret_access_key: str | None = None,
         aws_role_arn: str | None = None,
         organization_id: str | None = None,
+        max_attempts: int = 1,
     ) -> None:
         super().__init__()
         self.bucket_name = bucket_name
@@ -124,6 +127,9 @@ class S3EnsureBucketTestStep(DestinationTestStep):
         self.aws_secret_access_key = aws_secret_access_key
         self.aws_role_arn = aws_role_arn
         self.organization_id = organization_id
+        # This test verifies user-provided config, where failures are expected, so
+        # default to a single attempt and report promptly rather than retrying.
+        self.max_attempts = max_attempts
 
     def _is_configured(self) -> bool:
         """Ensure required configuration parameters are set."""
@@ -160,9 +166,7 @@ class S3EnsureBucketTestStep(DestinationTestStep):
                         Effect="Allow", Action=["s3:ListBucket"], Resource=f"arn:aws:s3:::{self.bucket_name}"
                     )
                 ],
-                # This test verifies user-provided config, where failures are expected, so
-                # report them promptly rather than retrying.
-                max_attempts=1,
+                max_attempts=self.max_attempts,
             )
 
             aws_access_key_id, aws_secret_access_key, aws_session_token = (

--- a/products/batch_exports/backend/api/destination_tests/s3.py
+++ b/products/batch_exports/backend/api/destination_tests/s3.py
@@ -29,11 +29,13 @@ class S3AssumeRoleTestStep(DestinationTestStep):
     def __init__(
         self,
         aws_role_arn: str | None = None,
+        bucket_name: str | None = None,
         organization_id: str | None = None,
         max_attempts: int = 1,
     ) -> None:
         super().__init__()
         self.aws_role_arn = aws_role_arn
+        self.bucket_name = bucket_name
         self.organization_id = organization_id
         # This test verifies user-provided config, where failures are expected, so
         # default to a single attempt and report promptly rather than retrying.
@@ -48,7 +50,7 @@ class S3AssumeRoleTestStep(DestinationTestStep):
         """Run this test step."""
         from botocore.exceptions import ClientError
 
-        if self.aws_role_arn is None:
+        if self.aws_role_arn is None or self.bucket_name is None:
             return DestinationTestStepResult(status=Status.SKIPPED, message="No configured AWS role ARN, skipping test")
 
         external_id = f"posthog-{self.organization_id}"
@@ -58,7 +60,9 @@ class S3AssumeRoleTestStep(DestinationTestStep):
                 external_id,
                 session_name="PostHog-batch-exports-test",
                 policy_statements=[
-                    PolicyStatement(Effect="Allow", Action=["s3:ListBucket"], Resource="arn:aws:s3:::*")
+                    PolicyStatement(
+                        Effect="Allow", Action=["s3:ListBucket"], Resource=f"arn:aws:s3:::{self.bucket_name}"
+                    )
                 ],
                 max_attempts=self.max_attempts,
             )
@@ -288,7 +292,9 @@ class AwsS3DestinationTest(DestinationTest):
     def steps(self) -> collections.abc.Sequence[DestinationTestStep]:
         """Sequence of test steps that make up this destination test."""
         return [
-            S3AssumeRoleTestStep(aws_role_arn=self.aws_role_arn, organization_id=self.organization_id),
+            S3AssumeRoleTestStep(
+                aws_role_arn=self.aws_role_arn, bucket_name=self.bucket_name, organization_id=self.organization_id
+            ),
             S3EnsureBucketTestStep(
                 bucket_name=self.bucket_name,
                 region=self.region,

--- a/products/batch_exports/backend/tests/api/destination_tests/conftest.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/conftest.py
@@ -84,18 +84,23 @@ async def identity_role(session: aioboto3.Session) -> str:
     return identity_role_name
 
 
+# Named distinctly from the test module's function-scoped `bucket_name` fixture (used by
+# the MinIO tests) so this module-scoped fixture is not shadowed, which would cause a
+# ScopeMismatch when the module-scoped `aws_bucket` requests it.
 @pytest.fixture(scope="module")
-def bucket_name() -> str:
+def aws_bucket_name() -> str:
     """Name for a test S3 bucket."""
     return f"{TEST_ROOT_BUCKET}-{str(uuid.uuid4())}"
 
 
 @pytest_asyncio.fixture(scope="module")
-async def aws_bucket(session: aioboto3.Session, bucket_name: str, region: str) -> collections.abc.AsyncIterator[str]:
+async def aws_bucket(
+    session: aioboto3.Session, aws_bucket_name: str, region: str
+) -> collections.abc.AsyncIterator[str]:
     """A real S3 bucket the destination role is granted access to."""
     async with session.client("s3") as s3_client:
         try:
-            await s3_client.create_bucket(Bucket=bucket_name, ACL="private")
+            await s3_client.create_bucket(Bucket=aws_bucket_name, ACL="private")
         except (
             botocore.exceptions.NoCredentialsError,
             botocore.exceptions.PartialCredentialsError,
@@ -103,11 +108,11 @@ async def aws_bucket(session: aioboto3.Session, bucket_name: str, region: str) -
         ):
             raise pytest.skip("Could not setup S3 bucket")
 
-        yield bucket_name
+        yield aws_bucket_name
 
         try:
-            await delete_all_from_s3(s3_client, bucket_name, key_prefix="")
-            await s3_client.delete_bucket(Bucket=bucket_name)
+            await delete_all_from_s3(s3_client, aws_bucket_name, key_prefix="")
+            await s3_client.delete_bucket(Bucket=aws_bucket_name)
         except Exception:
             pass
 

--- a/products/batch_exports/backend/tests/api/destination_tests/conftest.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/conftest.py
@@ -1,0 +1,229 @@
+import os
+import uuid
+import secrets
+import collections.abc
+
+import pytest
+
+import aioboto3
+import pytest_asyncio
+import botocore.exceptions
+
+from products.batch_exports.backend.tests.temporal.utils.s3 import aws_role, delete_all_from_s3
+
+TEST_ROOT_BUCKET = "test-destination-tests"
+TEST_REGION = os.getenv("TEST_S3_BUCKET_REGION", "us-east-1")
+
+
+@pytest.fixture(scope="module")
+def region() -> str:
+    return TEST_REGION
+
+
+@pytest.fixture
+def token() -> str:
+    return secrets.token_hex(6)
+
+
+@pytest.fixture
+def external_aws_role_name(token: str) -> str:
+    return f"test-destination-external-role-{token}"
+
+
+@pytest.fixture
+def destination_aws_role_name(token: str) -> str:
+    return f"test-destination-role-{token}"
+
+
+@pytest_asyncio.fixture(scope="module")
+async def session() -> aioboto3.Session:
+    session = aioboto3.Session()
+
+    try:
+        async with session.client("sts") as sts:
+            await sts.get_caller_identity()
+    except (
+        botocore.exceptions.NoCredentialsError,
+        botocore.exceptions.PartialCredentialsError,
+        botocore.exceptions.ClientError,
+        botocore.exceptions.NoRegionError,
+    ):
+        raise pytest.skip("Missing AWS credentials")
+
+    return session
+
+
+@pytest_asyncio.fixture(scope="module")
+async def account_id(session: aioboto3.Session) -> str:
+    async with session.client("sts") as sts:
+        try:
+            identity = await sts.get_caller_identity()
+        except (
+            botocore.exceptions.NoCredentialsError,
+            botocore.exceptions.PartialCredentialsError,
+            botocore.exceptions.ClientError,
+        ):
+            raise pytest.skip("Could not obtain current identity")
+
+    return identity["Account"]
+
+
+@pytest_asyncio.fixture(scope="module")
+async def identity_role(session: aioboto3.Session) -> str:
+    async with session.client("sts") as sts:
+        try:
+            identity = await sts.get_caller_identity()
+            identity_role_name = identity["Arn"].split("/")[-2]
+        except (
+            botocore.exceptions.NoCredentialsError,
+            botocore.exceptions.PartialCredentialsError,
+            botocore.exceptions.ClientError,
+        ):
+            raise pytest.skip("Could not obtain current identity")
+
+    return identity_role_name
+
+
+@pytest.fixture(scope="module")
+def bucket_name() -> str:
+    """Name for a test S3 bucket."""
+    return f"{TEST_ROOT_BUCKET}-{str(uuid.uuid4())}"
+
+
+@pytest_asyncio.fixture(scope="module")
+async def aws_bucket(session: aioboto3.Session, bucket_name: str, region: str) -> collections.abc.AsyncIterator[str]:
+    """A real S3 bucket the destination role is granted access to."""
+    async with session.client("s3") as s3_client:
+        try:
+            await s3_client.create_bucket(Bucket=bucket_name, ACL="private")
+        except (
+            botocore.exceptions.NoCredentialsError,
+            botocore.exceptions.PartialCredentialsError,
+            botocore.exceptions.ClientError,
+        ):
+            raise pytest.skip("Could not setup S3 bucket")
+
+        yield bucket_name
+
+        try:
+            await delete_all_from_s3(s3_client, bucket_name, key_prefix="")
+            await s3_client.delete_bucket(Bucket=bucket_name)
+        except Exception:
+            pass
+
+
+@pytest_asyncio.fixture
+async def external_aws_role_arn(
+    session: aioboto3.Session,
+    account_id: str,
+    identity_role: str,
+    external_aws_role_name: str,
+    destination_aws_role_name: str,
+) -> collections.abc.AsyncIterator[str]:
+    """Role used to assume a destination AWS role.
+
+    This simulates the role shown to PostHog users so that they can grant it
+    permission to assume one of their roles.
+    """
+    current_role_trust_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": f"arn:aws:iam::{account_id}:role/aws-reserved/sso.amazonaws.com/{identity_role}",
+                },
+                "Action": "sts:AssumeRole",
+            }
+        ],
+    }
+
+    external_role_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowAssumeDestinationRole",
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Resource": f"arn:aws:iam::{account_id}:role/{destination_aws_role_name}",
+            }
+        ],
+    }
+
+    async with aws_role(
+        session,
+        external_aws_role_name,
+        description="External role used to assume a user's role",
+        trust_policy=current_role_trust_policy,
+        role_policy=external_role_policy,
+        policy_name="AssumeDestinationRole",
+    ) as arn:
+        yield arn
+
+
+@pytest.fixture
+def external_id(request, aorganization) -> str | None:
+    """External id used in the destination role's trust policy.
+
+    Parametrize indirectly to test wrong (or missing) external ids.
+    """
+    try:
+        return request.param
+    except AttributeError:
+        return f"posthog-{aorganization.id}"
+
+
+@pytest_asyncio.fixture
+async def destination_aws_role_arn(
+    session: aioboto3.Session,
+    external_aws_role_arn: str,
+    destination_aws_role_name: str,
+    aws_bucket: str,
+    external_id: str | None,
+) -> collections.abc.AsyncIterator[str]:
+    """Role with S3 permissions in a destination.
+
+    This simulates a role in a user's destination. It can be assumed by our
+    external role and grants access to S3. When `external_id` is `None`, the
+    trust policy omits the external id condition (used to test that path).
+    """
+    statement: dict[str, object] = {
+        "Effect": "Allow",
+        "Principal": {
+            "AWS": external_aws_role_arn,
+        },
+        "Action": "sts:AssumeRole",
+    }
+    if external_id is not None:
+        statement["Condition"] = {
+            "StringEquals": {
+                "sts:ExternalId": external_id,
+            },
+        }
+
+    external_trust_policy = {
+        "Version": "2012-10-17",
+        "Statement": [statement],
+    }
+
+    s3_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "BucketAccess",
+                "Effect": "Allow",
+                "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+                "Resource": f"arn:aws:s3:::{aws_bucket}",
+            },
+        ],
+    }
+
+    async with aws_role(
+        session,
+        destination_aws_role_name,
+        trust_policy=external_trust_policy,
+        description="A user's role with access to S3",
+        role_policy=s3_policy,
+        policy_name="S3BucketAccess",
+    ) as arn:
+        yield arn

--- a/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
@@ -162,6 +162,7 @@ async def test_assume_role_step_passes_with_assumable_role(
 async def test_assume_role_step_fails_with_wrong_external_id(
     external_aws_role_arn: str,
     destination_aws_role_arn: str,
+    external_id: str | None,
     aorganization,
 ):
     """A mismatched external id surfaces an AccessDenied failure."""
@@ -179,6 +180,7 @@ async def test_assume_role_step_fails_with_wrong_external_id(
 async def test_assume_role_step_fails_without_external_id_condition(
     external_aws_role_arn: str,
     destination_aws_role_arn: str,
+    external_id: str | None,
     aorganization,
 ):
     """A role whose trust policy omits the external id condition is rejected."""

--- a/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
@@ -3,11 +3,17 @@ import uuid
 import pytest
 
 from django.conf import settings
+from django.test import override_settings
 
-from products.batch_exports.backend.api.destination_tests.s3 import S3EnsureBucketTestStep, Status
+from products.batch_exports.backend.api.destination_tests import get_destination_test
+from products.batch_exports.backend.api.destination_tests.s3 import (
+    AwsS3DestinationTest,
+    S3AssumeRoleTestStep,
+    S3CompatibleDestinationTest,
+    S3EnsureBucketTestStep,
+    Status,
+)
 from products.batch_exports.backend.tests.temporal.utils.s3 import create_test_client, delete_all_from_s3
-
-pytestmark = [pytest.mark.asyncio]
 
 TEST_ROOT_BUCKET = "test-destination-tests"
 
@@ -73,3 +79,136 @@ async def test_test_steps_fail_if_not_configured(step):
     result = await step.run()
     assert result.status == Status.FAILED
     assert result.message == "The test step cannot run as it's not configured."
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        # Bucket plus long-lived credentials.
+        ({"bucket_name": "b", "aws_access_key_id": "a", "aws_secret_access_key": "s"}, True),
+        # Bucket plus role assumption.
+        ({"bucket_name": "b", "aws_role_arn": "arn:aws:iam::123:role/r", "organization_id": "1"}, True),
+        # Missing bucket.
+        ({"aws_access_key_id": "a", "aws_secret_access_key": "s"}, False),
+        # Bucket but no credentials at all.
+        ({"bucket_name": "b"}, False),
+        # Role without organization id can't build the external id, so it's not usable on its own.
+        ({"bucket_name": "b", "aws_role_arn": "arn:aws:iam::123:role/r"}, False),
+    ],
+)
+def test_ensure_bucket_step_is_configured(kwargs, expected):
+    assert S3EnsureBucketTestStep(**kwargs)._is_configured() is expected
+
+
+async def test_assume_role_step_skips_without_role():
+    """The assume role step is skipped (not failed) when no role is configured.
+
+    This lets key-based AwsS3 exports run the rest of their steps.
+    """
+    test_step = S3AssumeRoleTestStep(aws_role_arn=None)
+    result = await test_step.run()
+
+    assert result.status == Status.SKIPPED
+    assert result.message == "No configured AWS role ARN, skipping test"
+
+
+@pytest.mark.parametrize(
+    "destination,expected_test,expected_steps",
+    [
+        ("S3", S3CompatibleDestinationTest, [S3EnsureBucketTestStep]),
+        ("S3Compatible", S3CompatibleDestinationTest, [S3EnsureBucketTestStep]),
+        ("AwsS3", AwsS3DestinationTest, [S3AssumeRoleTestStep, S3EnsureBucketTestStep]),
+    ],
+)
+def test_get_destination_test_resolves_s3_family(destination, expected_test, expected_steps):
+    destination_test = get_destination_test(destination=destination)
+
+    assert isinstance(destination_test, expected_test)
+    assert [type(step) for step in destination_test.steps] == expected_steps
+
+
+def test_aws_s3_destination_test_serializes_without_integration():
+    """AwsS3 configured with inline credentials (no integration) must not raise.
+
+    Its steps reference `organization_id` and each step needs an initialized
+    `result`, so building the steps and serializing them exercises both.
+    """
+    destination_test = AwsS3DestinationTest()
+    destination_test.configure(bucket_name="b", region="us-east-1", aws_access_key_id="a", aws_secret_access_key="s")
+
+    assert destination_test.as_dict() == {
+        "steps": [
+            {"name": step.name, "description": step.description, "result": None} for step in destination_test.steps
+        ]
+    }
+
+
+async def test_assume_role_step_passes_with_assumable_role(
+    external_aws_role_arn: str,
+    destination_aws_role_arn: str,
+    aorganization,
+):
+    """The assume role step passes when the role is assumable with the right external id."""
+    test_step = S3AssumeRoleTestStep(aws_role_arn=destination_aws_role_arn, organization_id=aorganization.id)
+
+    with override_settings(BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN=external_aws_role_arn):
+        result = await test_step.run()
+
+    assert result.status == Status.PASSED
+    assert result.message is None
+
+
+@pytest.mark.parametrize("external_id", ["not-an-org-id"], indirect=True)
+async def test_assume_role_step_fails_with_wrong_external_id(
+    external_aws_role_arn: str,
+    destination_aws_role_arn: str,
+    aorganization,
+):
+    """A mismatched external id surfaces an AccessDenied failure."""
+    test_step = S3AssumeRoleTestStep(aws_role_arn=destination_aws_role_arn, organization_id=aorganization.id)
+
+    with override_settings(BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN=external_aws_role_arn):
+        result = await test_step.run()
+
+    assert result.status == Status.FAILED
+    assert result.message is not None
+    assert "AccessDenied" in result.message
+
+
+@pytest.mark.parametrize("external_id", [None], indirect=True)
+async def test_assume_role_step_fails_without_external_id_condition(
+    external_aws_role_arn: str,
+    destination_aws_role_arn: str,
+    aorganization,
+):
+    """A role whose trust policy omits the external id condition is rejected."""
+    test_step = S3AssumeRoleTestStep(aws_role_arn=destination_aws_role_arn, organization_id=aorganization.id)
+
+    with override_settings(BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN=external_aws_role_arn):
+        result = await test_step.run()
+
+    assert result.status == Status.FAILED
+    assert result.message is not None
+    assert "without a required external id condition" in result.message
+
+
+async def test_ensure_bucket_step_passes_with_role_assumption(
+    external_aws_role_arn: str,
+    destination_aws_role_arn: str,
+    aws_bucket: str,
+    region: str,
+    aorganization,
+):
+    """The bucket check resolves temporary credentials via role assumption and passes."""
+    test_step = S3EnsureBucketTestStep(
+        bucket_name=aws_bucket,
+        region=region,
+        aws_role_arn=destination_aws_role_arn,
+        organization_id=aorganization.id,
+    )
+
+    with override_settings(BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN=external_aws_role_arn):
+        result = await test_step.run()
+
+    assert result.status == Status.PASSED
+    assert result.message is None

--- a/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
@@ -17,6 +17,11 @@ from products.batch_exports.backend.tests.temporal.utils.s3 import create_test_c
 
 TEST_ROOT_BUCKET = "test-destination-tests"
 
+# Production destination tests use a single attempt (fast failure for users verifying
+# config). These tests create a role and immediately assume it, so they need extra
+# attempts to absorb IAM's eventual consistency.
+ROLE_PROPAGATION_ATTEMPTS = 5
+
 
 @pytest.fixture
 def bucket_name(request) -> str:
@@ -149,7 +154,11 @@ async def test_assume_role_step_passes_with_assumable_role(
     aorganization,
 ):
     """The assume role step passes when the role is assumable with the right external id."""
-    test_step = S3AssumeRoleTestStep(aws_role_arn=destination_aws_role_arn, organization_id=aorganization.id)
+    test_step = S3AssumeRoleTestStep(
+        aws_role_arn=destination_aws_role_arn,
+        organization_id=aorganization.id,
+        max_attempts=ROLE_PROPAGATION_ATTEMPTS,
+    )
 
     with override_settings(BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN=external_aws_role_arn):
         result = await test_step.run()
@@ -184,7 +193,11 @@ async def test_assume_role_step_fails_without_external_id_condition(
     aorganization,
 ):
     """A role whose trust policy omits the external id condition is rejected."""
-    test_step = S3AssumeRoleTestStep(aws_role_arn=destination_aws_role_arn, organization_id=aorganization.id)
+    test_step = S3AssumeRoleTestStep(
+        aws_role_arn=destination_aws_role_arn,
+        organization_id=aorganization.id,
+        max_attempts=ROLE_PROPAGATION_ATTEMPTS,
+    )
 
     with override_settings(BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN=external_aws_role_arn):
         result = await test_step.run()
@@ -207,6 +220,7 @@ async def test_ensure_bucket_step_passes_with_role_assumption(
         region=region,
         aws_role_arn=destination_aws_role_arn,
         organization_id=aorganization.id,
+        max_attempts=ROLE_PROPAGATION_ATTEMPTS,
     )
 
     with override_settings(BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN=external_aws_role_arn):

--- a/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
+++ b/products/batch_exports/backend/tests/api/destination_tests/test_s3_destination_tests.py
@@ -152,10 +152,12 @@ async def test_assume_role_step_passes_with_assumable_role(
     external_aws_role_arn: str,
     destination_aws_role_arn: str,
     aorganization,
+    bucket_name,
 ):
     """The assume role step passes when the role is assumable with the right external id."""
     test_step = S3AssumeRoleTestStep(
         aws_role_arn=destination_aws_role_arn,
+        bucket_name=bucket_name,
         organization_id=aorganization.id,
         max_attempts=ROLE_PROPAGATION_ATTEMPTS,
     )
@@ -163,7 +165,7 @@ async def test_assume_role_step_passes_with_assumable_role(
     with override_settings(BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN=external_aws_role_arn):
         result = await test_step.run()
 
-    assert result.status == Status.PASSED
+    assert result.status == Status.PASSED, result.message
     assert result.message is None
 
 
@@ -172,10 +174,13 @@ async def test_assume_role_step_fails_with_wrong_external_id(
     external_aws_role_arn: str,
     destination_aws_role_arn: str,
     external_id: str | None,
+    bucket_name: str,
     aorganization,
 ):
     """A mismatched external id surfaces an AccessDenied failure."""
-    test_step = S3AssumeRoleTestStep(aws_role_arn=destination_aws_role_arn, organization_id=aorganization.id)
+    test_step = S3AssumeRoleTestStep(
+        aws_role_arn=destination_aws_role_arn, bucket_name=bucket_name, organization_id=aorganization.id
+    )
 
     with override_settings(BATCH_EXPORT_S3_EXTERNAL_ROLE_ARN=external_aws_role_arn):
         result = await test_step.run()
@@ -187,14 +192,12 @@ async def test_assume_role_step_fails_with_wrong_external_id(
 
 @pytest.mark.parametrize("external_id", [None], indirect=True)
 async def test_assume_role_step_fails_without_external_id_condition(
-    external_aws_role_arn: str,
-    destination_aws_role_arn: str,
-    external_id: str | None,
-    aorganization,
+    external_aws_role_arn: str, destination_aws_role_arn: str, external_id: str | None, aorganization, bucket_name: str
 ):
     """A role whose trust policy omits the external id condition is rejected."""
     test_step = S3AssumeRoleTestStep(
         aws_role_arn=destination_aws_role_arn,
+        bucket_name=bucket_name,
         organization_id=aorganization.id,
         max_attempts=ROLE_PROPAGATION_ATTEMPTS,
     )

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/conftest.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/conftest.py
@@ -1,10 +1,7 @@
 import os
-import json
 import uuid
 import typing
-import asyncio
 import secrets
-import contextlib
 import collections.abc
 
 import pytest
@@ -18,7 +15,7 @@ import botocore.exceptions
 
 from posthog.temporal.tests.utils.models import acreate_batch_export, adelete_batch_export
 
-from products.batch_exports.backend.tests.temporal.utils.s3 import create_test_client, delete_all_from_s3
+from products.batch_exports.backend.tests.temporal.utils.s3 import aws_role, create_test_client, delete_all_from_s3
 
 if typing.TYPE_CHECKING:
     from types_aiobotocore_s3 import S3Client
@@ -27,7 +24,6 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
 LOGGER = structlog.get_logger()
 TEST_ROOT_BUCKET = "test-batch-exports"
-ARN = str
 TEST_REGION = os.getenv("TEST_S3_BUCKET_REGION", "us-east-1")
 
 
@@ -420,68 +416,3 @@ async def destination_aws_role_arn(
         policy_name="S3BucketAccess",
     ) as arn:
         yield arn
-
-
-@contextlib.asynccontextmanager
-async def aws_role(
-    session: aioboto3.Session,
-    role_name: str,
-    /,
-    *,
-    description: str,
-    trust_policy: dict,
-    role_policy: dict | None = None,
-    policy_name: str | None = None,
-    max_attempts: int = 5,
-    delay: int | float = 3.0,
-) -> collections.abc.AsyncIterator[ARN]:
-    async with session.client("iam") as iam:
-        attempt = 0
-
-        for attempt in range(max_attempts):
-            try:
-                resp = await iam.create_role(
-                    RoleName=role_name,
-                    MaxSessionDuration=3600,
-                    AssumeRolePolicyDocument=json.dumps(trust_policy),
-                    Description=description,
-                )
-
-            except botocore.exceptions.ClientError as exc:
-                if (
-                    exc.response["Error"]["Code"] != "MalformedPolicyDocument"
-                    or "Invalid principal" not in exc.response["Error"]["Message"]
-                ) and exc.response["Error"]["Code"] != "EntityAlreadyExists":
-                    raise pytest.skip(f"Failed with an unknown error when creating role: {type(exc)} {exc}")
-
-                if attempt >= max_attempts:
-                    raise pytest.skip("Failed multiple times to create role")
-
-                await asyncio.sleep(delay)
-
-            except (
-                botocore.exceptions.NoCredentialsError,
-                botocore.exceptions.PartialCredentialsError,
-            ):
-                raise pytest.skip("Credentials error when attempting to create role")
-
-            else:
-                break
-
-        if role_policy is not None and policy_name is not None:
-            await iam.put_role_policy(
-                RoleName=role_name,
-                PolicyName=policy_name,
-                PolicyDocument=json.dumps(role_policy),
-            )
-
-        yield resp["Role"]["Arn"]
-
-        try:
-            resp = await iam.list_role_policies(RoleName=role_name)
-            for policy_name in resp.get("PolicyNames", []):
-                await iam.delete_role_policy(RoleName=role_name, PolicyName=policy_name)
-            await iam.delete_role(RoleName=role_name)
-
-        except Exception:
-            LOGGER.warning("Test role clean-up failed", name=role_name, arn=resp["Role"]["Arn"], exc_info=True)

--- a/products/batch_exports/backend/tests/temporal/utils/s3.py
+++ b/products/batch_exports/backend/tests/temporal/utils/s3.py
@@ -1,13 +1,20 @@
 import gzip
 import json
+import asyncio
 import datetime as dt
 import functools
+import contextlib
+import collections.abc
+
+import pytest
 
 from django.conf import settings
 
 import brotli
 import aioboto3
+import structlog
 import pyarrow.parquet as pq
+import botocore.exceptions
 from pyarrow import fs
 from types_aiobotocore_s3.client import S3Client
 
@@ -16,8 +23,81 @@ from products.batch_exports.backend.temporal.destinations.s3_batch_export import
     FILE_FORMAT_EXTENSIONS,
 )
 
+LOGGER = structlog.get_logger()
+ARN = str
+
 SESSION = aioboto3.Session()
 create_test_client = functools.partial(SESSION.client, endpoint_url=settings.OBJECT_STORAGE_ENDPOINT)
+
+
+@contextlib.asynccontextmanager
+async def aws_role(
+    session: aioboto3.Session,
+    role_name: str,
+    /,
+    *,
+    description: str,
+    trust_policy: dict,
+    role_policy: dict | None = None,
+    policy_name: str | None = None,
+    max_attempts: int = 5,
+    delay: int | float = 3.0,
+) -> collections.abc.AsyncIterator[ARN]:
+    """Create a temporary AWS IAM role for the duration of a test.
+
+    The role is created with the provided trust and (optional) inline policy, and
+    cleaned up on exit. Skips the test if AWS credentials or permissions are missing.
+    """
+    async with session.client("iam") as iam:
+        attempt = 0
+
+        for attempt in range(max_attempts):
+            try:
+                resp = await iam.create_role(
+                    RoleName=role_name,
+                    MaxSessionDuration=3600,
+                    AssumeRolePolicyDocument=json.dumps(trust_policy),
+                    Description=description,
+                )
+
+            except botocore.exceptions.ClientError as exc:
+                if (
+                    exc.response["Error"]["Code"] != "MalformedPolicyDocument"
+                    or "Invalid principal" not in exc.response["Error"]["Message"]
+                ) and exc.response["Error"]["Code"] != "EntityAlreadyExists":
+                    raise pytest.skip(f"Failed with an unknown error when creating role: {type(exc)} {exc}")
+
+                if attempt >= max_attempts:
+                    raise pytest.skip("Failed multiple times to create role")
+
+                await asyncio.sleep(delay)
+
+            except (
+                botocore.exceptions.NoCredentialsError,
+                botocore.exceptions.PartialCredentialsError,
+            ):
+                raise pytest.skip("Credentials error when attempting to create role")
+
+            else:
+                break
+
+        if role_policy is not None and policy_name is not None:
+            await iam.put_role_policy(
+                RoleName=role_name,
+                PolicyName=policy_name,
+                PolicyDocument=json.dumps(role_policy),
+            )
+
+        yield resp["Role"]["Arn"]
+
+        try:
+            resp = await iam.list_role_policies(RoleName=role_name)
+            for policy_name in resp.get("PolicyNames", []):
+                await iam.delete_role_policy(RoleName=role_name, PolicyName=policy_name)
+            await iam.delete_role(RoleName=role_name)
+
+        except Exception:
+            LOGGER.warning("Test role clean-up failed", name=role_name, arn=resp["Role"]["Arn"], exc_info=True)
 
 
 async def read_parquet_from_s3(


### PR DESCRIPTION
## Problem

We need destination tests covering new AWS S3 functionality.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Split up destination tests into AWSS3 and S3Compatible. Add a new assume role test for AWSS3 destination test. Update bucket check test step to use role ARN if available.

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran all destination tests tests (new and old) all passing.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

While contemplating my life and how everything is so over, I had the robot generate some tests, I reviewed them and ran them. They are ok. The rest is all mine. 

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
