### PR TITLE
feat(data-warehouse): lead the source catalog with featured sources

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
@@ -81,6 +81,8 @@ export interface CatalogItem {
     existingSource?: boolean
     /** Self-managed: the user keeps the data in their own bucket, PostHog only links to it. */
     selfManaged?: boolean
+    /** The sources most people connect (Stripe, Postgres, the ad platforms, ...). Led with when browsing. */
+    featured?: boolean
 }
 
 export interface CatalogCategory {
@@ -1512,6 +1514,7 @@ export const sourceCatalogLogic = kea<sourceCatalogLogicType>([
                                 name: connector.name,
                                 label: connector.label ?? connector.name,
                                 keywords: connector.keywords ?? [],
+                                featured: connector.featured,
                                 url: urls.dataWarehouseSourceNew(connector.name),
                             },
                         ]
@@ -1603,16 +1606,23 @@ export const sourceCatalogLogic = kea<sourceCatalogLogicType>([
                         ? base
                         : base.filter((item) => item.category === selectedCategory)
                 // Keep fuzzy-search relevance order when searching. When browsing, lead with the
-                // sources the user can connect right now (alphabetically), then "Coming soon" ones,
-                // so the catalog doesn't open on a wall of unavailable tiles.
+                // featured sources people connect most (Stripe, Postgres, the ad platforms, ...),
+                // then the rest of the connectable sources, then "Coming soon" ones — all
+                // alphabetical within a tier — so the catalog doesn't open on a wall of obscure or
+                // unavailable tiles.
                 if (trimmed) {
                     return filtered
                 }
+                const browseRank = (item: CatalogItem): number => {
+                    if (item.status === 'coming_soon') {
+                        return 2
+                    }
+                    return item.featured ? 0 : 1
+                }
                 return [...filtered].sort((a, b) => {
-                    const aComingSoon = a.status === 'coming_soon'
-                    const bComingSoon = b.status === 'coming_soon'
-                    if (aComingSoon !== bComingSoon) {
-                        return aComingSoon ? 1 : -1
+                    const rankDiff = browseRank(a) - browseRank(b)
+                    if (rankDiff !== 0) {
+                        return rankDiff
                     }
                     return a.label.localeCompare(b.label)
                 })

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceCatalogLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/tests/sourceCatalogLogic.test.ts
@@ -8,10 +8,12 @@ import { availableSourcesLogic } from '../availableSourcesLogic'
 import { sourceCatalogLogic } from '../sourceCatalogLogic'
 
 const AVAILABLE_SOURCES: Record<string, SourceConfig> = {
+    // Featured, so it must lead the browse list even though `Stripe` sorts after `Mango`.
     Stripe: {
         name: 'Stripe',
         iconPath: '',
         caption: '',
+        featured: true,
         fields: [],
     } as unknown as SourceConfig,
     // `Apple` sorts alphabetically first but is unreleased, so connectable-first ordering must
@@ -69,6 +71,16 @@ describe('sourceCatalogLogic', () => {
         const names = items.map((item) => item.name)
         expect(names.indexOf('Mango')).toBeLessThan(names.indexOf('Apple'))
         expect(names.indexOf('Zebra')).toBeLessThan(names.indexOf('Apple'))
+    })
+
+    it('leads the browse list with featured sources', () => {
+        const logic = sourceCatalogLogic()
+        const names = logic.values.filteredItems.map((item) => item.name)
+
+        // `Stripe` is featured, so it must come before the plain connectable sources even though
+        // it sorts after `Mango` alphabetically.
+        expect(names.indexOf('Stripe')).toBeLessThan(names.indexOf('Mango'))
+        expect(names.indexOf('Stripe')).toBeLessThan(names.indexOf('Zebra'))
     })
 
     it('surfaces self-managed file-storage connectors when searching for a file format', () => {


### PR DESCRIPTION
## Problem

The new-source catalog (the "+ New source" page in Data warehouse) opened on a flat alphabetical list of 1,200+ connectors. Browsing users landed on obscure sources first (1Password, Ably, ActiveCampaign, ...) and had to scroll or search to reach the handful most people actually connect. Session review of the new-source onboarding flow showed repeated browse-and-abandon behavior on this page, including users scrolling the full catalog without picking anything.

## Changes

Lead the browse list with the sources already flagged `featured` in each connector's `SourceConfig` (Stripe, Postgres, MySQL, MongoDB, Supabase, BigQuery, GitHub, HubSpot, and the ad platforms) - the same set the embedded `InlineSourceSetup` already surfaces first. Ordering is now three tiers, alphabetical within each:

1. Featured, connectable sources
2. The rest of the connectable sources
3. "Coming soon" sources

Fuzzy-search relevance order is untouched - this only changes the default browse (no search) ordering. No sync behavior, schemas, or connector definitions change.

## How did you test this code?

Added a unit test in `sourceCatalogLogic.test.ts` asserting a featured source leads the browse list even when it sorts alphabetically after non-featured ones, and kept the existing connectable-before-coming-soon test green. The frontend toolchain (jest, oxlint) isn't installed in my environment, so I couldn't run the suite or linter locally - CI will. I reasoned through the sort by hand against the test fixture.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (PostHog Code) from a review of new-source onboarding sessions. I confirmed `featured` already exists on `SourceConfig`, is set on exactly the popular sources, and flows to the frontend generated types - but the main catalog page ignored it while `InlineSourceSetup` already leads with it, so this closes that gap rather than introducing a new concept. Considered instead surfacing a separate "Popular" section, but reordering the existing grid is smaller and needs no new UI. No skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
