### PR TITLE
feat(replay-vision): make scanner analysis chart drillable

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/ScannerInsightsChart.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerInsightsChart.tsx
@@ -16,6 +16,7 @@ import {
     PropertyOperator,
 } from '~/types'
 
+import { getReplayVisionRecordingViewDisabledReason } from '../../utils/accessControl'
 import { replayScannerLogic } from '../replayScannerLogic'
 import { ScannerType } from '../types'
 import { VisionInsightChart } from './VisionInsightChart'
@@ -178,6 +179,9 @@ export function ScannerInsightsChart({
         }),
         [scannerId]
     )
+    // Drill-down opens the actors modal, which surfaces the recordings behind a data point. Only enable it for
+    // users who can view recordings, so a scanner-only viewer denied session_recording access can't enumerate them.
+    const canDrillIntoRecordings = !getReplayVisionRecordingViewDisabledReason()
     return (
         <div className="border rounded p-4 bg-surface-primary space-y-3">
             <div className="flex items-baseline justify-between gap-2">
@@ -207,7 +211,7 @@ export function ScannerInsightsChart({
                 query={chartQuery}
                 insightProps={chartInsightProps}
                 className="InsightCard h-80"
-                drillable
+                drillable={canDrillIntoRecordings}
             />
         </div>
     )

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerInsightsChart.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerInsightsChart.tsx
@@ -203,7 +203,12 @@ export function ScannerInsightsChart({
                     onChange={(from, to) => setChartDateRange(from ?? null, to ?? null)}
                 />
             </div>
-            <VisionInsightChart query={chartQuery} insightProps={chartInsightProps} className="InsightCard h-80" />
+            <VisionInsightChart
+                query={chartQuery}
+                insightProps={chartInsightProps}
+                className="InsightCard h-80"
+                drillable
+            />
         </div>
     )
 }

--- a/products/replay_vision/frontend/replay_scanners/components/VisionInsightChart.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionInsightChart.tsx
@@ -15,6 +15,8 @@ interface VisionInsightChartProps {
     insightProps: InsightLogicProps
     /** Sizing classes for the chart container — pass the same layout the chart sat in before, the chart sizes against it. */
     className?: string
+    /** When true, clicking a data point opens the persons/recordings modal. Off by default so summary charts stay static. */
+    drillable?: boolean
 }
 
 export type ChartOverlayState = 'none' | 'loading' | 'error'
@@ -39,7 +41,12 @@ export function chartOverlayState(
  * blank box when a query is cancelled or hasn't resolved (its empty/refresh fallbacks are dashboard-only), so we
  * overlay our own spinner/retry whenever there's no response to render.
  */
-export function VisionInsightChart({ query, insightProps, className }: VisionInsightChartProps): JSX.Element {
+export function VisionInsightChart({
+    query,
+    insightProps,
+    className,
+    drillable = false,
+}: VisionInsightChartProps): JSX.Element {
     const logic = insightVizDataLogic(insightProps)
     const { insightData, insightDataLoading } = useValues(logic)
     const { loadData } = useActions(logic)
@@ -48,7 +55,7 @@ export function VisionInsightChart({ query, insightProps, className }: VisionIns
 
     return (
         <div className={clsx('relative', className)}>
-            <Query query={query} readOnly embedded inSharedMode context={{ insightProps }} />
+            <Query query={query} readOnly embedded inSharedMode={!drillable} context={{ insightProps }} />
             {overlay !== 'none' && (
                 <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-bg-light">
                     {overlay === 'loading' ? (

--- a/products/replay_vision/frontend/utils/accessControl.ts
+++ b/products/replay_vision/frontend/utils/accessControl.ts
@@ -22,6 +22,15 @@ export function getReplayVisionEditDisabledReason(scannerUserAccessLevel?: Acces
 }
 
 /**
+ * Reading recording-derived content (e.g. drilling from a scanner chart into the sessions behind a data
+ * point) requires session_recording viewer access, independent of scanner access. A scanner-only viewer
+ * denied recordings must not be able to enumerate them, so gate any recording-surfacing affordance on this.
+ */
+export function getReplayVisionRecordingViewDisabledReason(): string | null {
+    return getAccessControlDisabledReason(AccessControlResourceType.SessionRecording, AccessControlLevel.Viewer) ?? null
+}
+
+/**
  * Deleting a scanner or vision action is the one write that skips the session_recording check —
  * destroy doesn't expose or process recording content (see `_CONFIG_ACTIONS`, which omits "destroy",
  * in ReplayScannerViewSet/VisionActionViewSet). Kept as its own export so delete call sites are


### PR DESCRIPTION
## Problem

From the Replay Vision closed-beta feedback: the analysis chart on a scanner's detail page is read-only. You can see a metric move but can't click into the sessions behind a data point, so following up on a spike or dip means leaving the chart and filtering recordings by hand.

## Changes

The chart is already a real trends insight (not a static image); its drill-down was suppressed only by the `inSharedMode` prop.

- Add a `drillable` prop to `VisionInsightChart` (default `false`). When set, `inSharedMode` is dropped so clicking a data point opens the standard persons/recordings modal.
- Turn it on for the scanner-detail chart (`ScannerInsightsChart`), but only for users with `session_recording` viewer access. The drill-down opens the actors modal, which surfaces the recordings behind a data point, so a scanner-only viewer who is denied recordings must not get the affordance. This reuses the same access check the product already applies to other recording-derived surfaces (`getReplayVisionEditDisabledReason`). The cross-scanner summary chart on the list scene stays static.

Frontend only. No API or generated-type changes.

> [!NOTE]
> The frontend gate closes the incremental exposure this PR adds. A separate, pre-existing concern is that the shared `InsightActorsQuery` `includeRecordings` path does not itself enforce recording access server-side, so a direct API caller could still enumerate recordings regardless of this PR. That is a cross-cutting platform issue, not introduced here, and out of scope for this UI change.

### Screenshots

I could not capture a before/after of the drill-down modal opening. The Hedgebox demo project seeds scanner observations in Postgres but never emits the `$recording_observed` analytics events the chart queries, so the scanner chart renders empty even with all 81 observations in range (0 chart events), leaving no data point to click. The change is a one-prop enable (`inSharedMode={!drillable}`) of the exact persons/recordings modal already used across product-analytics insights, so it behaves identically once the chart has data.

## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check` passes (workspace packages built), including after the access-gate change.
- `oxlint` clean on the changed files.
- Verified in the local dev app that the swapped build renders the scanner chart; the drill-down modal itself couldn't be exercised because the demo chart has no `$recording_observed` events (see Screenshots).

No automated tests added: this is a one-prop wiring change into the shared trends persons modal. A unit test would assert the prop pass-through (implementation detail) and rendering the full `Query` + modal in jsdom is brittle, so it wouldn't earn its place.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Arnaud triaged the closed-beta feedback and asked me (Claude) to ship the "on-demand quick wins"; this is one of them. I brainstormed scope (superpowers:brainstorming), wrote an implementation plan (superpowers:writing-plans), and implemented in an isolated worktree off master. Chosen deliberately small: this enables the generic persons/recordings modal via one prop. A bespoke "jump straight to the exact observations behind this point" panel is a larger follow-up I did not build here.
