### PR TITLE
ci: reject Windows-incompatible repository paths

### DIFF
--- a/.github/scripts/check-windows-paths.sh
+++ b/.github/scripts/check-windows-paths.sh
@@ -70,18 +70,35 @@ def windows_fold(value: str) -> str:
     return "".join(result)
 
 bad = False
-seen: dict[str, str] = {}
+files: dict[str, str] = {}
+directories: dict[str, tuple[str, str]] = {}
 for raw_path in sys.stdin.buffer.read().split(b"\0"):
     if not raw_path:
         continue
     path = os.fsdecode(raw_path)
     folded = windows_fold(path)
-    other = seen.get(folded)
+    other = files.get(folded)
     if other is not None and other != path:
         print(f"::error file={path}::\047{path}\047 collides with \047{other}\047 on case-insensitive Windows filesystems")
         bad = True
     else:
-        seen[folded] = path
+        files[folded] = path
+
+    directory = directories.get(folded)
+    if directory is not None:
+        name, owner = directory
+        print(f"::error file={path}::\047{path}\047 is a file, but \047{owner}\047 requires \047{name}\047 to be a directory on case-insensitive Windows filesystems")
+        bad = True
+
+    parts = path.split("/")
+    for index in range(1, len(parts)):
+        name = "/".join(parts[:index])
+        folded_name = windows_fold(name)
+        other = files.get(folded_name)
+        if other is not None:
+            print(f"::error file={path}::\047{path}\047 requires \047{name}\047 to be a directory, but it collides with tracked file \047{other}\047 on case-insensitive Windows filesystems")
+            bad = True
+        directories.setdefault(folded_name, (name, path))
 
 raise SystemExit(bad)
 '; then

--- a/.github/scripts/check-windows-paths.sh
+++ b/.github/scripts/check-windows-paths.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Reject tracked paths that cannot be checked out on Windows.
+#
+# Run on Linux CI: Windows runners cannot execute this after checkout because Git
+# rejects reserved device names such as aux.hcl while materializing the worktree.
+set -euo pipefail
+export LC_ALL=C
+
+# core.quotePath=false keeps valid non-ASCII filenames readable. Git still quotes
+# control characters, which also makes this check reject them through `\\` or `"`.
+status=0
+if ! git -c core.quotePath=false ls-files | awk -F/ '
+function fail(path, component, reason) {
+    printf "::error file=%s::\047%s\047 %s\n", path, component, reason
+    bad = 1
+}
+
+function is_reserved(component, lower) {
+    lower = tolower(component)
+    # Git for Windows uses isdigit() after LPT, so its checkout rejects LPT0 too.
+    return lower ~ /^(con|prn|aux|nul|conin\$|conout\$|com[1-9]|lpt[0-9]|com¹|com²|com³|lpt¹|lpt²|lpt³) *([.:].*)?$/
+}
+
+function is_ntfs_dotgit(component, lower) {
+    lower = tolower(component)
+    return lower ~ /^git~1[ .]*$/
+}
+
+{
+    for (i = 1; i <= NF; i++) {
+        component = $i
+
+        if (is_reserved(component)) {
+            fail($0, component, "uses a Windows-reserved device name")
+        }
+        if (is_ntfs_dotgit(component)) {
+            fail($0, component, "uses the protected NTFS alias for .git")
+        }
+        if (component ~ /[<>:"\\|?*]/ || component ~ /[[:cntrl:]]/) {
+            fail($0, component, "contains characters that Windows filenames do not support")
+        }
+        if (component ~ /[. ]$/) {
+            fail($0, component, "ends with a dot or space, which Windows does not support")
+        }
+    }
+
+}
+
+END {
+    exit bad
+}
+'; then
+    status=1
+fi
+
+# NTFS is case-insensitive for non-ASCII names too. Read NUL-delimited paths so
+# whitespace and quoting cannot hide a collision from Windows-style casing.
+if ! git ls-files -z | PYTHONUTF8=1 python3 -c '
+import os
+import sys
+
+def windows_fold(value: str) -> str:
+    result: list[str] = []
+    for character in value:
+        upper = character.upper()
+        if ord(character) <= 0xFFFF and len(upper) == 1 and ord(upper) <= 0xFFFF:
+            result.append(upper)
+        else:
+            result.append(character)
+    return "".join(result)
+
+bad = False
+seen: dict[str, str] = {}
+for raw_path in sys.stdin.buffer.read().split(b"\0"):
+    if not raw_path:
+        continue
+    path = os.fsdecode(raw_path)
+    folded = windows_fold(path)
+    other = seen.get(folded)
+    if other is not None and other != path:
+        print(f"::error file={path}::\047{path}\047 collides with \047{other}\047 on case-insensitive Windows filesystems")
+        bad = True
+    else:
+        seen[folded] = path
+
+raise SystemExit(bad)
+'; then
+    status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "All tracked paths are Windows-compatible."
+fi
+
+exit "$status"

--- a/.github/scripts/check-windows-paths.test.sh
+++ b/.github/scripts/check-windows-paths.test.sh
@@ -20,6 +20,8 @@ add_path safe/Strasse.ts
 add_path safe/mydocu~1.txt
 add_path safe/𐐨.ts
 add_path safe/𐐀.ts
+add_path safe/Shared/one.ts
+add_path safe/shared/two.ts
 add_path 'bad/AUX .txt'
 add_path 'bad/CONIN$.log'
 add_path 'bad/CONOUT$'
@@ -33,6 +35,10 @@ add_path case/Foo.ts
 add_path case/foo.ts
 add_path case/Ä.ts
 add_path case/ä.ts
+add_path case/Foo
+add_path case/foo/bar.txt
+add_path reverse/Dir/child.txt
+add_path reverse/dir
 
 set +e
 output="$(GIT_INDEX_FILE="$index" "$checker")"
@@ -44,7 +50,7 @@ if [ "$status" -ne 1 ]; then
     exit 1
 fi
 
-for path in 'bad/AUX .txt' 'bad/CONIN$.log' 'bad/CONOUT$' bad/LPT0.txt bad/COM¹.txt bad/GIT~1 bad/git~1... 'bad/name?.txt' bad/trailing. case/foo.ts case/ä.ts; do
+for path in 'bad/AUX .txt' 'bad/CONIN$.log' 'bad/CONOUT$' bad/LPT0.txt bad/COM¹.txt bad/GIT~1 bad/git~1... 'bad/name?.txt' bad/trailing. case/foo.ts case/ä.ts case/foo/bar.txt reverse/dir; do
     if ! grep -Fq "file=$path::" <<<"$output"; then
         echo "expected checker error for $path"
         exit 1

--- a/.github/scripts/check-windows-paths.test.sh
+++ b/.github/scripts/check-windows-paths.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+checker=.github/scripts/check-windows-paths.sh
+index="$(mktemp)"
+trap 'rm -f "$index"' EXIT
+rm -f "$index"
+
+blob="$(git rev-parse HEAD:.gitignore)"
+add_path() {
+    GIT_INDEX_FILE="$index" git -c core.protectNTFS=false update-index --add --cacheinfo "100644,$blob,$1"
+}
+
+add_path safe/local-aux.hcl
+add_path safe/auxiliary.sql
+add_path safe/com0.txt
+add_path safe/naïve.txt
+add_path safe/Straße.ts
+add_path safe/Strasse.ts
+add_path safe/mydocu~1.txt
+add_path safe/𐐨.ts
+add_path safe/𐐀.ts
+add_path 'bad/AUX .txt'
+add_path 'bad/CONIN$.log'
+add_path 'bad/CONOUT$'
+add_path bad/LPT0.txt
+add_path bad/COM¹.txt
+add_path bad/GIT~1
+add_path bad/git~1...
+add_path 'bad/name?.txt'
+add_path bad/trailing.
+add_path case/Foo.ts
+add_path case/foo.ts
+add_path case/Ä.ts
+add_path case/ä.ts
+
+set +e
+output="$(GIT_INDEX_FILE="$index" "$checker")"
+status=$?
+set -e
+
+if [ "$status" -ne 1 ]; then
+    echo "expected checker to reject invalid paths, got exit $status"
+    exit 1
+fi
+
+for path in 'bad/AUX .txt' 'bad/CONIN$.log' 'bad/CONOUT$' bad/LPT0.txt bad/COM¹.txt bad/GIT~1 bad/git~1... 'bad/name?.txt' bad/trailing. case/foo.ts case/ä.ts; do
+    if ! grep -Fq "file=$path::" <<<"$output"; then
+        echo "expected checker error for $path"
+        exit 1
+    fi
+done
+
+if ! grep -Fq "file=bad/git~1...::'git~1...' uses the protected NTFS alias for .git" <<<"$output"; then
+    echo "expected checker to recognize the padded git~1 alias"
+    exit 1
+fi
+
+if grep -Fq 'file=safe/' <<<"$output"; then
+    echo "checker rejected a valid path"
+    exit 1
+fi
+
+echo "Windows path checker regression cases passed."

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -18,6 +18,12 @@ jobs:
             - name: Check secrets scripts
               run: cd bin && shellcheck deploy-hobby
 
+            - name: Check Windows-compatible repository paths
+              run: |
+                  shellcheck .github/scripts/check-windows-paths.sh .github/scripts/check-windows-paths.test.sh
+                  .github/scripts/check-windows-paths.test.sh
+                  .github/scripts/check-windows-paths.sh
+
             # Runs here, not in a path-gated ci-* job, so AGENTS/CLAUDE changes
             # anywhere in the repo are validated on every PR.
             - name: Check AGENTS.md / CLAUDE.md symlinks


### PR DESCRIPTION
## Problem

A Windows CLI release checkout failed after a tracked `aux.hcl` path landed. Windows rejects reserved device names before any build step can run. The HCL-specific fix in #73002 does not protect arbitrary repository paths.

## Changes

- add repository-wide validation for tracked paths that Windows cannot check out
- detect reserved device names, invalid characters, protected NTFS aliases, trailing dots or spaces, and case-insensitive collisions
- run the check in the existing every-PR shellcheck job on Linux
- add alternate-index regression cases for unsafe and intentionally safe paths

## Tests

- `shellcheck .github/scripts/check-windows-paths.sh .github/scripts/check-windows-paths.test.sh`
- `.github/scripts/check-windows-paths.test.sh`
- `.github/scripts/check-windows-paths.sh`
- `actionlint .github/workflows/shellcheck.yml`
- `./bin/hogli lint:workflows`
- `git diff --check origin/master...HEAD`
