### PR TITLE
fix(data-warehouse): index externaldatajob latest-run + incremental scans

### DIFF
--- a/products/warehouse_sources/backend/migrations/0093_externaldatajob_latest_run_idx.py
+++ b/products/warehouse_sources/backend/migrations/0093_externaldatajob_latest_run_idx.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # Concurrent index builds cannot run inside a transaction. Lives in its own
+    # migration per PostHog policy (don't mix CONCURRENTLY operations with regular DDL).
+    atomic = False
+    dependencies = [("warehouse_sources", "0092_repin_lightspeed_retail_api_version")]
+
+    operations = [
+        SafeAddIndexConcurrently(
+            model_name="externaldatajob",
+            index=models.Index(
+                fields=["team", "pipeline", "status", "-created_at"],
+                name="idx_extdatajob_latest_run",
+            ),
+        ),
+    ]

--- a/products/warehouse_sources/backend/migrations/0094_externaldatajob_updated_at_idx.py
+++ b/products/warehouse_sources/backend/migrations/0094_externaldatajob_updated_at_idx.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+from posthog.migration_helpers import SafeAddIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    # Concurrent index builds cannot run inside a transaction. Lives in its own
+    # migration per PostHog policy (don't mix CONCURRENTLY operations with regular DDL).
+    atomic = False
+    dependencies = [("warehouse_sources", "0093_externaldatajob_latest_run_idx")]
+
+    operations = [
+        SafeAddIndexConcurrently(
+            model_name="externaldatajob",
+            index=models.Index(
+                fields=["updated_at"],
+                name="idx_extdatajob_updated_at",
+            ),
+        ),
+    ]

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0093_externaldatajob_latest_run_idx
+0094_externaldatajob_updated_at_idx

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0092_repin_lightspeed_retail_api_version
+0093_externaldatajob_latest_run_idx

--- a/products/warehouse_sources/backend/models/external_data_job.py
+++ b/products/warehouse_sources/backend/models/external_data_job.py
@@ -54,6 +54,13 @@ class ExternalDataJob(CreatedMetaFields, UpdatedMetaFields, UUIDTModel):
                 fields=["team", "pipeline", "status", "-created_at"],
                 name="idx_extdatajob_latest_run",
             ),
+            # Serves the incremental-sync watermark scan when the warehouse imports this
+            # table (WHERE updated_at > <cursor> ORDER BY updated_at): without it the read
+            # is a full seq scan + sort of the whole table on every run.
+            models.Index(
+                fields=["updated_at"],
+                name="idx_extdatajob_updated_at",
+            ),
         ]
 
     def folder_path(self) -> str:

--- a/products/warehouse_sources/backend/models/external_data_job.py
+++ b/products/warehouse_sources/backend/models/external_data_job.py
@@ -47,6 +47,14 @@ class ExternalDataJob(CreatedMetaFields, UpdatedMetaFields, UUIDTModel):
 
     class Meta:
         db_table = "posthog_externaldatajob"
+        indexes = [
+            # Serves the hot "latest run for a pipeline" lookup (get_latest_run_if_exists):
+            # equality on team/pipeline/status, ordered by created_at DESC with LIMIT.
+            models.Index(
+                fields=["team", "pipeline", "status", "-created_at"],
+                name="idx_extdatajob_latest_run",
+            ),
+        ]
 
     def folder_path(self) -> str:
         if self.schema:

--- a/products/warehouse_sources/backend/tests/test_migration_0052.py
+++ b/products/warehouse_sources/backend/tests/test_migration_0052.py
@@ -1,9 +1,9 @@
 from typing import Any
 
-from posthog.test.base import TestMigrations
+from posthog.test.base import NonAtomicTestMigrations
 
 
-class BackfillGoogleAdsIncrementalLookbackMigrationTest(TestMigrations):
+class BackfillGoogleAdsIncrementalLookbackMigrationTest(NonAtomicTestMigrations):
     """0051 backfills a default incremental lookback onto existing Google Ads incremental stats
     schemas, which were created before the source set one and so re-fetch only the newest day,
     freezing every prior day at its first-imported, not-yet-final value. It must touch only Google
@@ -11,6 +11,9 @@ class BackfillGoogleAdsIncrementalLookbackMigrationTest(TestMigrations):
     soft-deleted row, and never an explicit user value (including 0, which means "no overlap").
     """
 
+    # NonAtomic: setUp rewinds from the current schema down to migrate_from, which crosses the
+    # concurrent (atomic = False) index migrations later in the app — reversing a CREATE INDEX
+    # CONCURRENTLY can't run inside TestMigrations' wrapping transaction.
     migrate_from = "0051_warehousecolumnstatistics"
     migrate_to = "0052_backfill_google_ads_incremental_lookback"
 


### PR DESCRIPTION
## Problem

`ExternalDataJob.get_latest_run_if_exists` runs constantly from the data-imports Temporal workers to find the most recent completed run for a pipeline. On prod it averages ~425ms per call at ~670 calls/min (~970k calls/day) and reads ~8KB from disk each call.

The query filters on three equality columns and sorts by a fourth:

```sql
SELECT ... FROM posthog_externaldatajob
WHERE pipeline_id = $1 AND status = $2 AND team_id = $3
ORDER BY created_at DESC
LIMIT $4
```

`posthog_externaldatajob` only had the default single-column btree indexes on the FK columns. So Postgres scanned every job for the pipeline via the `pipeline_id` index, filtered by status, then sorted the whole set by `created_at` just to return one row. On active sources that's a lot of rows sorted per call.

## Changes

Added a composite index matching the query shape exactly — the three equality columns first, the sort column last with its direction:

```sql
CREATE INDEX CONCURRENTLY "idx_extdatajob_latest_run"
ON "posthog_externaldatajob" ("team_id", "pipeline_id", "status", "created_at" DESC);
```

Now the lookup is a single index seek: jump to `(team_id, pipeline_id, 'Completed', ...)` and read the first entry in descending `created_at` order, which is the `LIMIT` answer. No heap scan of every run, no sort. Leading with `team_id` also lets it serve other team-scoped prefix lookups on the table.

> [!NOTE]
> This is safe to deploy on a very active, large table without freezing it. The index is built via `SafeAddIndexConcurrently`, so `CREATE INDEX CONCURRENTLY` takes only a `SHARE UPDATE EXCLUSIVE` lock. Reads and writes (`SELECT`/`INSERT`/`UPDATE`/`DELETE`) keep flowing throughout the build. It only conflicts with other DDL on the table, not normal traffic. The helper also disables `lock_timeout`/`statement_timeout` so a long build can't be cancelled mid-deploy, skips if a valid index already exists, and drops-and-rebuilds an invalid leftover from an interrupted build. The build itself will run for a while on this table when deployed. That is expected and non-blocking, not a hang.

## How did you test this code?

No new automated tests. This is a pure index addition with no behavior change, and the existing `get_latest_run_if_exists` behavior is unchanged.

Validated the migration locally against `master` state:
- `manage.py makemigrations warehouse_sources --dry-run` reports no state drift (model `Meta.indexes` matches the migration).
- `manage.py sqlmigrate warehouse_sources 0093` emits the `CREATE INDEX CONCURRENTLY ... DESC` shown above, confirming the field names resolve to the right columns and the sort direction is preserved.
- `ruff check` / `ruff format --check` clean.

I (Claude) was not able to run this migration against a production-sized table, so the runtime plan improvement is reasoned from the index shape rather than measured on prod data.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom spotted this in pganalyze as a hot ~425ms query and asked me (Claude) to make it faster in a deploy-safe way. I traced the fingerprint to `get_latest_run_if_exists`, confirmed no composite index existed on `posthog_externaldatajob`, and added one matching the exact WHERE + ORDER BY.

Invoked the repo `/django-migrations` skill. Per its guidance I used the `SafeAddIndexConcurrently` helper (CI blocks Django's raw `AddIndexConcurrently`) in its own `atomic = False` migration. Considered a partial index scoped to `status = 'Completed'` but kept `status` as a full equality column in the index so it also serves other status values with the same `team`/`pipeline` prefix. Column order puts the equality columns first and `created_at DESC` last so the seek returns the `LIMIT` row directly.


---

## Second index: `updated_at` for incremental scans

The data warehouse dogfoods this table by importing it as a Postgres source (team 2). Incremental syncs read it with:

```sql
SELECT * FROM posthog_externaldatajob
WHERE updated_at > $cursor
ORDER BY updated_at ASC
```

With no index on `updated_at`, every run was a full parallel seq scan of the whole table plus an explicit sort — confirmed on prod, where the planner picks a `Parallel Seq Scan` (cost ≈ 13.9M) for the watermark filter. When a sync falls behind, the cursor stops advancing and each retry re-reads an ever-larger window, so the read cost compounds on top of the merge cost.

Added a single-column btree so the watermark scan becomes an ordered index range scan — only the qualifying rows, in `updated_at` order, no sort:

```sql
CREATE INDEX CONCURRENTLY "idx_extdatajob_updated_at"
ON "posthog_externaldatajob" ("updated_at");
```

Same deploy-safety as the first index: `SafeAddIndexConcurrently`, `atomic = False`, `SHARE UPDATE EXCLUSIVE` only.

> [!NOTE]
> **Tradeoff worth a look on review.** `updated_at` is `auto_now=True` on a very high-churn table, so this index is written on every row update — real write-amplification and index bloat, unlike the mostly-append `created_at` used by the latest-run index. It's justified because the incremental import currently full-scans the table every run, but if source-side write throughput is the bigger concern we could instead bound the import's merge/read batch and skip this index. BRIN isn't a clean substitute here — `auto_now` re-updates rows in place, so `updated_at` isn't heap-correlated.
