### PR TITLE
fix(conversations): isolate ticket org attribution fallback failures

### DIFF
--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -1069,9 +1069,10 @@ class TestConversationEvents(BaseTest):
 
     @parameterized.expand(
         [
-            # Person lookups can come up empty (channel email differs from the profile email,
-            # person row not ingested yet) or fail transiently — either way, org groups the
-            # requester's own sessions stamped onto events must still attribute the ticket.
+            # Events keyed by the bare email distinct_id are public-token-captured, so anyone
+            # who knows the email can plant a $groups value on them. Whether person lookups
+            # miss or fail, and even for a verified sender, those events must never attribute
+            # the ticket without a resolved-person anchor.
             ("person_lookups_miss", False),
             ("person_lookups_fail", True),
         ]
@@ -1081,7 +1082,7 @@ class TestConversationEvents(BaseTest):
     @patch("products.conversations.backend.events.get_group_types_for_project")
     @patch("products.conversations.backend.person_lookup._get_persons_by_email")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
-    def test_capture_ticket_created_requester_events_resolve_groups_without_person(
+    def test_capture_ticket_created_no_person_means_no_event_keyed_attribution(
         self, _name, lookups_fail, mock_get_persons, mock_get_by_email, mock_group_types, mock_hogql, mock_capture
     ):
         if lookups_fail:
@@ -1091,90 +1092,15 @@ class TestConversationEvents(BaseTest):
             mock_get_persons.return_value = []
             mock_get_by_email.return_value = {}
         mock_group_types.return_value = [{"group_type": "organization", "group_type_index": 0}]
-        mock_hogql.return_value.results = [["org-eu-123", ""]]
-
-        ticket = Ticket.objects.create_with_number(
-            team=self.team,
-            widget_session_id="",
-            distinct_id="cust@acme.com",
-            channel_source="slack",
-            identity_verified=True,
-            anonymous_traits={"name": "Biz", "email": "cust@acme.com"},
-        )
-
-        capture_ticket_created(ticket)
-
-        call_kwargs = mock_capture.call_args.kwargs
-        assert call_kwargs["process_person_profile"] is False
-        assert call_kwargs["properties"]["$groups"]["organization"] == "org-eu-123"
-        ticket.refresh_from_db()
-        assert ticket.organization_id == "org-eu-123"
-        assert ticket.organization_id_source == OrganizationIdSource.PERSON
-
-    @parameterized.expand(
-        [
-            # A forged From that failed SPF is assessed as False; a caller-supplied
-            # distinct_id on an API-created ticket is never assessed (None). Neither is
-            # server-attested, so neither may resolve an org from event $groups.
-            ("unverified_identity", False),
-            ("unassessed_identity", None),
-        ]
-    )
-    @patch("products.conversations.backend.events.capture_internal")
-    @patch("posthog.hogql.query.execute_hogql_query")
-    @patch("products.conversations.backend.events.get_group_types_for_project")
-    @patch("products.conversations.backend.person_lookup._get_persons_by_email")
-    @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
-    def test_capture_ticket_created_requester_events_require_attested_identity(
-        self, _name, identity_verified, mock_get_persons, mock_get_by_email, mock_group_types, mock_hogql, mock_capture
-    ):
-        mock_get_persons.return_value = []
-        mock_get_by_email.return_value = {}
-        mock_group_types.return_value = [{"group_type": "organization", "group_type_index": 0}]
-        mock_hogql.return_value.results = [["victim-org", ""]]
+        mock_hogql.return_value.results = [["attacker-org", ""]]
 
         ticket = Ticket.objects.create_with_number(
             team=self.team,
             widget_session_id="",
             distinct_id="victim@bigcorp.com",
             channel_source="email",
-            identity_verified=identity_verified,
-            anonymous_traits={"name": "Attacker", "email": "victim@bigcorp.com"},
-        )
-
-        capture_ticket_created(ticket)
-
-        call_kwargs = mock_capture.call_args.kwargs
-        assert call_kwargs["process_person_profile"] is False
-        assert "$groups" not in call_kwargs["properties"]
-        ticket.refresh_from_db()
-        assert ticket.organization_id is None
-
-    @parameterized.expand(
-        [
-            ("widget", "widget"),
-            ("github", "github"),
-        ]
-    )
-    @patch("products.conversations.backend.events.capture_internal")
-    @patch("posthog.hogql.query.execute_hogql_query")
-    @patch("products.conversations.backend.events.get_group_types_for_project")
-    @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
-    def test_capture_ticket_created_requester_events_skip_non_verified_channels(
-        self, _name, channel, mock_get_persons, mock_group_types, mock_hogql, mock_capture
-    ):
-        # Without a provider-verified identity, an anonymous distinct_id must not resolve an
-        # org from event $groups — same trust posture as the email fallback's channel gate.
-        mock_get_persons.return_value = []
-        mock_group_types.return_value = [{"group_type": "organization", "group_type_index": 0}]
-        mock_hogql.return_value.results = [["org-eu-123", ""]]
-
-        ticket = Ticket.objects.create_with_number(
-            team=self.team,
-            widget_session_id="",
-            distinct_id="anon-attacker",
-            channel_source=channel,
-            anonymous_traits={"name": "Attacker"},
+            identity_verified=True,
+            anonymous_traits={"name": "Victim", "email": "victim@bigcorp.com"},
         )
 
         capture_ticket_created(ticket)
@@ -1367,6 +1293,9 @@ class TestConversationEvents(BaseTest):
             ("channel_derived", OrganizationIdSource.SLACK_CHANNEL_ACCOUNT.value, False),
             ("person_derived", OrganizationIdSource.PERSON.value, True),
             ("legacy_no_source", None, True),
+            # The gate is an allowlist: a source added later that doesn't attest the
+            # sender must not silently turn person-profile processing back on.
+            ("future_non_person_source", "requester_events", False),
         ]
     )
     @patch("products.conversations.backend.events.capture_internal")

--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -1098,6 +1098,7 @@ class TestConversationEvents(BaseTest):
             widget_session_id="",
             distinct_id="cust@acme.com",
             channel_source="slack",
+            identity_verified=True,
             anonymous_traits={"name": "Biz", "email": "cust@acme.com"},
         )
 
@@ -1109,6 +1110,45 @@ class TestConversationEvents(BaseTest):
         ticket.refresh_from_db()
         assert ticket.organization_id == "org-eu-123"
         assert ticket.organization_id_source == OrganizationIdSource.PERSON
+
+    @parameterized.expand(
+        [
+            # A forged From that failed SPF is assessed as False; a caller-supplied
+            # distinct_id on an API-created ticket is never assessed (None). Neither is
+            # server-attested, so neither may resolve an org from event $groups.
+            ("unverified_identity", False),
+            ("unassessed_identity", None),
+        ]
+    )
+    @patch("products.conversations.backend.events.capture_internal")
+    @patch("posthog.hogql.query.execute_hogql_query")
+    @patch("products.conversations.backend.events.get_group_types_for_project")
+    @patch("products.conversations.backend.person_lookup._get_persons_by_email")
+    @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
+    def test_capture_ticket_created_requester_events_require_attested_identity(
+        self, _name, identity_verified, mock_get_persons, mock_get_by_email, mock_group_types, mock_hogql, mock_capture
+    ):
+        mock_get_persons.return_value = []
+        mock_get_by_email.return_value = {}
+        mock_group_types.return_value = [{"group_type": "organization", "group_type_index": 0}]
+        mock_hogql.return_value.results = [["victim-org", ""]]
+
+        ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            widget_session_id="",
+            distinct_id="victim@bigcorp.com",
+            channel_source="email",
+            identity_verified=identity_verified,
+            anonymous_traits={"name": "Attacker", "email": "victim@bigcorp.com"},
+        )
+
+        capture_ticket_created(ticket)
+
+        call_kwargs = mock_capture.call_args.kwargs
+        assert call_kwargs["process_person_profile"] is False
+        assert "$groups" not in call_kwargs["properties"]
+        ticket.refresh_from_db()
+        assert ticket.organization_id is None
 
     @parameterized.expand(
         [

--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -518,6 +518,62 @@ class TestConversationEvents(BaseTest):
         assert call_kwargs["process_person_profile"] is False
         assert "$groups" not in call_kwargs["properties"]
 
+    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.person_lookup._get_persons_by_email")
+    @patch("products.conversations.backend.events.get_persons_by_distinct_ids", side_effect=Exception("personhog down"))
+    def test_capture_ticket_created_person_lookup_failure_falls_through_to_email_fallback(
+        self, mock_get_persons, mock_get_by_email, mock_capture
+    ):
+        # A transient personhog failure must degrade to the email fallback, not lose attribution.
+        from posthog.models.person.person import Person
+
+        person_org = Organization.objects.create(name="Acme")
+        person_user = User.objects.create(email="login@acme.com", distinct_id="real-did-1")
+        OrganizationMembership.objects.create(user=person_user, organization=person_org)
+        person = Person(team_id=self.team.id, is_identified=True)
+        person._distinct_ids = ["real-did-1"]
+        mock_get_by_email.return_value = {"biz@acme.com": person}
+
+        ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            widget_session_id="",
+            distinct_id="biz@acme.com",
+            channel_source="slack",
+            anonymous_traits={"name": "Biz", "email": "biz@acme.com"},
+        )
+
+        capture_ticket_created(ticket)
+
+        call_kwargs = mock_capture.call_args.kwargs
+        assert call_kwargs["process_person_profile"] is True
+        assert call_kwargs["properties"]["$groups"]["organization"] == str(person_org.id)
+
+    @patch("products.conversations.backend.events.capture_internal")
+    @patch("products.conversations.backend.events.get_groups_by_identifiers")
+    @patch("products.conversations.backend.events.get_group_types_for_project")
+    @patch(
+        "products.conversations.backend.events._resolve_groups_from_analytics",
+        side_effect=Exception("clickhouse unavailable"),
+    )
+    @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
+    def test_capture_ticket_created_analytics_failure_falls_through_to_person_property(
+        self, mock_get_persons, _mock_analytics, mock_group_types, mock_get_groups, mock_capture
+    ):
+        # A transient ClickHouse failure in the analytics fallback must degrade to the profile fallback.
+        from posthog.models.person.person import Person
+
+        mock_get_persons.return_value = [
+            Person(team_id=self.team.id, is_identified=True, properties={"organization_id": "org-uuid-1"})
+        ]
+        mock_group_types.return_value = [{"group_type": "organization", "group_type_index": 0}]
+        mock_get_groups.return_value = [Mock()]
+
+        capture_ticket_created(self.ticket)
+
+        call_kwargs = mock_capture.call_args.kwargs
+        assert call_kwargs["process_person_profile"] is True
+        assert call_kwargs["properties"]["$groups"]["organization"] == "org-uuid-1"
+
     @parameterized.expand(
         [
             # name, channel, traits_email, email_from -- exercises both the traits.email and the email_from source
@@ -1010,6 +1066,84 @@ class TestConversationEvents(BaseTest):
                 assert call.kwargs["properties"]["$groups"]["organization"] == "org-eu-123"
             else:
                 assert "$groups" not in call.kwargs["properties"]
+
+    @parameterized.expand(
+        [
+            # Person lookups can come up empty (channel email differs from the profile email,
+            # person row not ingested yet) or fail transiently — either way, org groups the
+            # requester's own sessions stamped onto events must still attribute the ticket.
+            ("person_lookups_miss", False),
+            ("person_lookups_fail", True),
+        ]
+    )
+    @patch("products.conversations.backend.events.capture_internal")
+    @patch("posthog.hogql.query.execute_hogql_query")
+    @patch("products.conversations.backend.events.get_group_types_for_project")
+    @patch("products.conversations.backend.person_lookup._get_persons_by_email")
+    @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
+    def test_capture_ticket_created_requester_events_resolve_groups_without_person(
+        self, _name, lookups_fail, mock_get_persons, mock_get_by_email, mock_group_types, mock_hogql, mock_capture
+    ):
+        if lookups_fail:
+            mock_get_persons.side_effect = Exception("personhog down")
+            mock_get_by_email.side_effect = Exception("person query failed")
+        else:
+            mock_get_persons.return_value = []
+            mock_get_by_email.return_value = {}
+        mock_group_types.return_value = [{"group_type": "organization", "group_type_index": 0}]
+        mock_hogql.return_value.results = [["org-eu-123", ""]]
+
+        ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            widget_session_id="",
+            distinct_id="cust@acme.com",
+            channel_source="slack",
+            anonymous_traits={"name": "Biz", "email": "cust@acme.com"},
+        )
+
+        capture_ticket_created(ticket)
+
+        call_kwargs = mock_capture.call_args.kwargs
+        assert call_kwargs["process_person_profile"] is False
+        assert call_kwargs["properties"]["$groups"]["organization"] == "org-eu-123"
+        ticket.refresh_from_db()
+        assert ticket.organization_id == "org-eu-123"
+        assert ticket.organization_id_source == OrganizationIdSource.PERSON
+
+    @parameterized.expand(
+        [
+            ("widget", "widget"),
+            ("github", "github"),
+        ]
+    )
+    @patch("products.conversations.backend.events.capture_internal")
+    @patch("posthog.hogql.query.execute_hogql_query")
+    @patch("products.conversations.backend.events.get_group_types_for_project")
+    @patch("products.conversations.backend.events.get_persons_by_distinct_ids")
+    def test_capture_ticket_created_requester_events_skip_non_verified_channels(
+        self, _name, channel, mock_get_persons, mock_group_types, mock_hogql, mock_capture
+    ):
+        # Without a provider-verified identity, an anonymous distinct_id must not resolve an
+        # org from event $groups — same trust posture as the email fallback's channel gate.
+        mock_get_persons.return_value = []
+        mock_group_types.return_value = [{"group_type": "organization", "group_type_index": 0}]
+        mock_hogql.return_value.results = [["org-eu-123", ""]]
+
+        ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            widget_session_id="",
+            distinct_id="anon-attacker",
+            channel_source=channel,
+            anonymous_traits={"name": "Attacker"},
+        )
+
+        capture_ticket_created(ticket)
+
+        call_kwargs = mock_capture.call_args.kwargs
+        assert call_kwargs["process_person_profile"] is False
+        assert "$groups" not in call_kwargs["properties"]
+        ticket.refresh_from_db()
+        assert ticket.organization_id is None
 
     @patch("products.conversations.backend.events.capture_internal")
     @patch("products.conversations.backend.events.get_persons_by_distinct_ids")

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -275,7 +275,7 @@ def _resolve_person_org_groups(ticket: Ticket, team: Team) -> tuple[bool, dict |
             person = _get_persons_by_email(team, [email]).get(email.lower())
         except Exception:
             # Same isolation as above: a failed email lookup still leaves the
-            # requester-events fallback in _resolve_org_groups a chance to attribute.
+            # Slack-channel fallback in _resolve_org_groups a chance to attribute.
             logger.exception("ticket_org_email_person_lookup_failed", team_id=team.id, ticket_id=str(ticket.id))
         if person is not None:
             groups = _org_groups_for_person(ticket, team, person, person.distinct_ids or [])
@@ -332,23 +332,12 @@ def _resolve_org_groups(ticket: Ticket, team: Team) -> tuple[bool, dict | None, 
     if groups is not None:
         return process_person, groups, OrganizationIdSource.PERSON
 
-    # Person lookups can miss (no person row yet, profile email differing from the
-    # channel email) or fail transiently even when the requester's own sessions stamped
-    # org groups onto this project's events. Those events are keyed by the ticket's own
-    # distinct_id — the exact evidence the person path's analytics fallback trusts — so
-    # read them directly before falling back to channel-level attribution. The channel
-    # gate alone is not enough: email tickets can carry an unverified identity (forged
-    # From that failed SPF, or an API-supplied distinct_id assessed as None), so require
-    # the server-attested identity_verified=True on top of it.
-    if ticket.distinct_id and ticket.channel_source in _EMAIL_FALLBACK_CHANNELS and ticket.identity_verified is True:
-        try:
-            groups = _resolve_groups_from_analytics(team, [ticket.distinct_id])
-        except Exception:
-            logger.exception("ticket_org_requester_events_lookup_failed", team_id=team.id, ticket_id=str(ticket.id))
-            groups = None
-        if groups is not None:
-            return process_person, groups, OrganizationIdSource.PERSON
-
+    # Deliberately no analytics fallback keyed on the bare ticket distinct_id here: for
+    # email/Slack/Teams that value is the raw customer email, and events under it are
+    # captured with the public project token, so anyone who knows the email can plant a
+    # $groups value. identity_verified only attests the ticket's sender, not who captured
+    # historical events under that key. Event-derived attribution is only trusted when
+    # anchored to a resolved person (see _org_groups_for_person).
     if ticket.channel_source == Channel.SLACK.value and ticket.slack_channel_id:
         groups = _resolve_groups_from_slack_channel(team, ticket.slack_channel_id)
         if groups is not None:
@@ -574,9 +563,11 @@ def capture_message_received(ticket: Ticket, message_id: str, message_content: s
     try:
         if ticket.organization_id:
             properties["$groups"] = _groups_from_org_id(team, ticket.organization_id)
-            # A channel-inferred org says nothing about the sender, so don't create a
-            # person profile for it (legacy rows without a source were person-resolved).
-            process_person = ticket.organization_id_source != OrganizationIdSource.SLACK_CHANNEL_ACCOUNT
+            # Only a person-resolved org attests the sender (legacy rows without a source
+            # were person-resolved); a channel-inferred org says nothing about them, so
+            # don't create a person profile for it. Allowlist rather than blocklist so a
+            # future non-person source defaults to no person processing.
+            process_person = ticket.organization_id_source in (OrganizationIdSource.PERSON, None, "")
         else:
             process_person, groups, groups_source = _resolve_org_groups(ticket, team)
             if groups is not None:

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -336,9 +336,11 @@ def _resolve_org_groups(ticket: Ticket, team: Team) -> tuple[bool, dict | None, 
     # channel email) or fail transiently even when the requester's own sessions stamped
     # org groups onto this project's events. Those events are keyed by the ticket's own
     # distinct_id — the exact evidence the person path's analytics fallback trusts — so
-    # read them directly before falling back to channel-level attribution. Restricted to
-    # channels with a provider-verified identity, like the email fallback.
-    if ticket.distinct_id and ticket.channel_source in _EMAIL_FALLBACK_CHANNELS:
+    # read them directly before falling back to channel-level attribution. The channel
+    # gate alone is not enough: email tickets can carry an unverified identity (forged
+    # From that failed SPF, or an API-supplied distinct_id assessed as None), so require
+    # the server-attested identity_verified=True on top of it.
+    if ticket.distinct_id and ticket.channel_source in _EMAIL_FALLBACK_CHANNELS and ticket.identity_verified is True:
         try:
             groups = _resolve_groups_from_analytics(team, [ticket.distinct_id])
         except Exception:

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -186,6 +186,44 @@ def _resolve_groups_from_person_properties(team: Team, person: Person) -> dict |
     return {"instance": SITE_URL, "project": str(team.uuid), "organization": org_id}
 
 
+def _org_groups_for_person(ticket: Ticket, team: Team, person: Person, distinct_ids: list[str]) -> dict | None:
+    """Resolve org ``$groups`` for an already-resolved person: membership, then analytics
+    events, then the person's own profile.
+
+    Each lookup hits a different subsystem (Postgres, ClickHouse, personhog), so failures
+    are isolated per step: the created event is emitted exactly once, and a transient error
+    in one source must degrade to the next fallback rather than permanently losing the
+    ticket's attribution (which downstream SLA/tagging workflows key off).
+    """
+    if distinct_ids:
+        try:
+            membership = (
+                OrganizationMembership.objects.select_related("organization")
+                .filter(user__distinct_id__in=distinct_ids)
+                .first()
+            )
+            if membership:
+                return build_groups(membership.organization, team)
+        except Exception:
+            logger.exception("ticket_org_membership_lookup_failed", team_id=team.id, ticket_id=str(ticket.id))
+        # Membership rows are region-local: accounts registered in another region
+        # never appear in this Postgres. Fall back to the $groups their sessions
+        # stamped onto this project's analytics events.
+        try:
+            groups = _resolve_groups_from_analytics(team, distinct_ids)
+            if groups:
+                return groups
+        except Exception:
+            logger.exception("ticket_org_analytics_lookup_failed", team_id=team.id, ticket_id=str(ticket.id))
+    # Their events may have aged out of the analytics window; the profile they
+    # identified with is still the same person's own claim about their org.
+    try:
+        return _resolve_groups_from_person_properties(team, person)
+    except Exception:
+        logger.exception("ticket_org_person_properties_lookup_failed", team_id=team.id, ticket_id=str(ticket.id))
+        return None
+
+
 def _resolve_person_org_groups(ticket: Ticket, team: Team) -> tuple[bool, dict | None]:
     """Resolve the customer organization's ``$groups`` from the requester's identity.
 
@@ -204,29 +242,19 @@ def _resolve_person_org_groups(ticket: Ticket, team: Team) -> tuple[bool, dict |
     # have no org membership, don't guess via email (a shared email could resolve to a
     # different person's org), so return early instead of falling through.
     if ticket.distinct_id:
-        # Only is_identified and properties are read, and the membership lookup below keys off
-        # the ticket's own distinct_id — so skip fetching the person's distinct_ids.
-        with personhog_caller_tag("conversations/ticket-event-person"):
-            persons = get_persons_by_distinct_ids(team.id, [ticket.distinct_id], distinct_id_limit=0)
+        persons: list[Person] = []
+        try:
+            # Only is_identified and properties are read, and the membership lookup keys off
+            # the ticket's own distinct_id — so skip fetching the person's distinct_ids.
+            with personhog_caller_tag("conversations/ticket-event-person"):
+                persons = get_persons_by_distinct_ids(team.id, [ticket.distinct_id], distinct_id_limit=0)
+        except Exception:
+            # A failed lookup is not "no identified person": fall through to the email
+            # path instead of losing attribution to a transient personhog error.
+            logger.exception("ticket_org_person_lookup_failed", team_id=team.id, ticket_id=str(ticket.id))
         identified_person = next((p for p in persons if p.is_identified), None)
         if identified_person is not None:
-            membership = (
-                OrganizationMembership.objects.select_related("organization")
-                .filter(user__distinct_id=ticket.distinct_id)
-                .first()
-            )
-            if membership:
-                return True, build_groups(membership.organization, team)
-            # Membership rows are region-local: accounts registered in another region
-            # never appear in this Postgres. Fall back to the $groups their sessions
-            # stamped onto this project's analytics events (same distinct_id, so the
-            # shared-email caveat above still holds).
-            groups = _resolve_groups_from_analytics(team, [ticket.distinct_id])
-            if groups:
-                return True, groups
-            # Their events may have aged out of the analytics window; the profile they
-            # identified with is still the same person's own claim about their org.
-            groups = _resolve_groups_from_person_properties(team, identified_person)
+            groups = _org_groups_for_person(ticket, team, identified_person, [ticket.distinct_id])
             if groups:
                 return True, groups
             return False, None
@@ -242,22 +270,15 @@ def _resolve_person_org_groups(ticket: Ticket, team: Team) -> tuple[bool, dict |
         # via the conversations signal wiring, so import it lazily.
         from products.conversations.backend.person_lookup import _get_persons_by_email  # noqa: PLC0415
 
-        person = _get_persons_by_email(team, [email]).get(email.lower())
+        person: Person | None = None
+        try:
+            person = _get_persons_by_email(team, [email]).get(email.lower())
+        except Exception:
+            # Same isolation as above: a failed email lookup still leaves the
+            # requester-events fallback in _resolve_org_groups a chance to attribute.
+            logger.exception("ticket_org_email_person_lookup_failed", team_id=team.id, ticket_id=str(ticket.id))
         if person is not None:
-            if person.distinct_ids:
-                membership = (
-                    OrganizationMembership.objects.select_related("organization")
-                    .filter(user__distinct_id__in=person.distinct_ids)
-                    .first()
-                )
-                if membership:
-                    return True, build_groups(membership.organization, team)
-                # Same cross-region fallback as above, keyed by the person's distinct_ids.
-                groups = _resolve_groups_from_analytics(team, person.distinct_ids)
-                if groups:
-                    return True, groups
-            # Same last resort as above: the org id the person's own profile carries.
-            groups = _resolve_groups_from_person_properties(team, person)
+            groups = _org_groups_for_person(ticket, team, person, person.distinct_ids or [])
             if groups:
                 return True, groups
 
@@ -310,6 +331,21 @@ def _resolve_org_groups(ticket: Ticket, team: Team) -> tuple[bool, dict | None, 
     process_person, groups = _resolve_person_org_groups(ticket, team)
     if groups is not None:
         return process_person, groups, OrganizationIdSource.PERSON
+
+    # Person lookups can miss (no person row yet, profile email differing from the
+    # channel email) or fail transiently even when the requester's own sessions stamped
+    # org groups onto this project's events. Those events are keyed by the ticket's own
+    # distinct_id — the exact evidence the person path's analytics fallback trusts — so
+    # read them directly before falling back to channel-level attribution. Restricted to
+    # channels with a provider-verified identity, like the email fallback.
+    if ticket.distinct_id and ticket.channel_source in _EMAIL_FALLBACK_CHANNELS:
+        try:
+            groups = _resolve_groups_from_analytics(team, [ticket.distinct_id])
+        except Exception:
+            logger.exception("ticket_org_requester_events_lookup_failed", team_id=team.id, ticket_id=str(ticket.id))
+            groups = None
+        if groups is not None:
+            return process_person, groups, OrganizationIdSource.PERSON
 
     if ticket.channel_source == Channel.SLACK.value and ticket.slack_channel_id:
         groups = _resolve_groups_from_slack_channel(team, ticket.slack_channel_id)


### PR DESCRIPTION
## Problem

Support tickets were getting the `unknown_slack_default_enterprise` tag (default Enterprise SLA) from the SLA workflow even though the customer's organization was fully known in PostHog — org group present, requester identified, profile carrying the org id, and org-stamped events in the analytics window.

Root cause: `$conversation_ticket_created` resolves the ticket's org `$groups` through a chain of lookups spanning four subsystems (personhog, Postgres membership, ClickHouse analytics events, person profile), but a single catch-all wrapped the whole chain. A transient failure in any one step aborted every remaining fallback, the event was emitted once without `$groups`, and downstream plan/segment workflow branches all missed — falling through to the default-to-Enterprise branch. The same resolution succeeded seconds later for the ticket's `$conversation_message_received` event, confirming the data was there all along.

Context: raised from [ticket #64626](https://us.posthog.com/project/2/support/tickets/64626) mis-tagged by the [SLA workflow](https://us.posthog.com/project/2/workflows/019f5ae1-273d-0000-0f78-6d4b55c8c042/workflow).

## Changes

- Isolate each attribution lookup: a failing step now logs and degrades to the next fallback instead of aborting the chain (`_org_groups_for_person` consolidates the shared membership → analytics → profile tail).
- A failed personhog or email person lookup now falls through instead of being treated as "no person".
- Harden the `process_person` gate in `capture_message_received` to an allowlist: only a person-resolved org (or a legacy row predating the source column) turns on person-profile processing, so future non-person attribution sources default to not creating person profiles.

An earlier revision also added a "requester-events" fallback that read org `$groups` from events captured under the ticket's own distinct_id when person lookups missed. Review (ReviewHog must-fix) correctly flagged that for email/Slack/Teams that distinct_id is the raw customer email, and events under it are captured with the public project token — so anyone who knows the email could plant a `$groups` value and have it adopted precisely when nothing else corroborates. That fallback is removed: event-derived attribution is only trusted when anchored to a resolved person, and the per-step isolation above already covers the incident class (a transient personhog failure degrades to the person-anchored email path instead of aborting).

Happy paths are unchanged: same lookup order, same sources, same authoritative-identified-person early return, same negative-result caching.

## How did you test this code?

- `pytest products/conversations/backend/api/tests/test_events.py` — full suite passing locally.
- `pytest products/conversations/backend/api/tests/test_signals.py` — 39 passed.
- Repo-wide `mypy --cache-fine-grained .` — no new errors.

Tests and the regression each catches:
- `test_capture_ticket_created_person_lookup_failure_falls_through_to_email_fallback` — reverting the per-step guard makes a personhog blip permanently lose attribution.
- `test_capture_ticket_created_analytics_failure_falls_through_to_person_property` — reverting the analytics guard loses attribution despite the profile carrying the org.
- `test_capture_ticket_created_no_person_means_no_event_keyed_attribution` (miss + fail cases) — re-adding unanchored event-keyed attribution would let a planted event under a bare email distinct_id resolve the org.
- `test_capture_message_received_stored_org_source_controls_person_processing` (new `future_non_person_source` case) — regressing the allowlist back to a blocklist would silently re-enable person-profile writes for non-person sources.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal resolution behavior only; no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated via PostHog MCP (workflow definition, event timeline for the affected ticket) with Claude Code. The event timeline showed the created event missing `$groups` while the message event 6 seconds later resolved them — narrowing the cause to a swallowed transient failure rather than missing data. Skills invoked: /writing-tests. Considered a retry-with-delay in `capture_ticket_created` but rejected it (blocking sleep in the webhook path, and per-step isolation already covers every single-subsystem outage since the fallbacks span independent stores). The requester-events fallback from an earlier revision was removed after review flagged its unanchored trust in public-token event data.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
