### PR TITLE
chore(persons): remove dead legacy persons lifecycle endpoint

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -26,14 +26,7 @@ from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework_csv import renderers as csvrenderers
 
-from posthog.schema import (
-    ActorsQuery,
-    HogQLQueryModifiers,
-    InlineCohortCalculation,
-    InsightActorsQuery,
-    LifecycleQuery,
-    ProductKey,
-)
+from posthog.schema import ActorsQuery, ProductKey
 
 from posthog.hogql.constants import CSV_EXPORT_LIMIT
 
@@ -41,19 +34,17 @@ from posthog.api.capture import CaptureInternalError, capture_internal
 from posthog.api.documentation import PersonPropertiesSerializer
 from posthog.api.property_value_metrics import PROPERTY_VALUES_DURATION
 from posthog.api.routing import TeamAndOrgViewSetMixin
-from posthog.api.utils import action, format_paginated_url
+from posthog.api.utils import action
 from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.constants import LIMIT, OFFSET
 from posthog.event_usage import get_request_analytics_properties
 from posthog.helpers.impersonation import is_impersonated
-from posthog.hogql_queries.legacy_compatibility.filter_to_query import filter_to_query
 from posthog.metrics import LABEL_TEAM_ID
 from posthog.models import Filter, Person, Team, User
 from posthog.models.activity_logging.activity_log import Change, Detail, load_activity, log_activity
 from posthog.models.activity_logging.activity_page import activity_page_response
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
-from posthog.models.filters.lifecycle_filter import LifecycleFilter
 from posthog.models.filters.properties_timeline_filter import PropertiesTimelineFilter
 from posthog.models.person.bulk_delete import (
     delete_persons_profile,
@@ -70,7 +61,7 @@ from posthog.models.person.util import (
     get_persons_mapped_by_distinct_id,
 )
 from posthog.personhog_client.caller_tag import personhog_caller_tag
-from posthog.queries.actor_base_query import get_groups, get_serialized_people
+from posthog.queries.actor_base_query import get_serialized_people
 from posthog.queries.properties_timeline import PropertiesTimeline
 from posthog.rate_limit import ClickHouseBurstRateThrottle, PersonalApiKeyRateThrottle, UserOrEmailRateThrottle
 from posthog.renderers import SafeJSONRenderer
@@ -1247,67 +1238,6 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         enriched = [dataclasses.replace(row, function_name=name_by_id.get(row.function_id, "")) for row in data]
         return response.Response(MessageAssetSerializer(enriched, many=True).data)
 
-    @action(methods=["GET"], detail=False)
-    def lifecycle(self, request: request.Request) -> response.Response:
-        team = cast(User, request.user).team
-        if not team:
-            return response.Response(
-                {
-                    "message": "Could not retrieve team",
-                    "detail": "Could not validate team associated with user",
-                },
-                status=400,
-            )
-
-        target_date = request.GET.get("target_date", None)
-        if target_date is None:
-            return response.Response(
-                {
-                    "message": "Missing parameter",
-                    "detail": "Must include specified date",
-                },
-                status=400,
-            )
-        lifecycle_type = request.GET.get("lifecycle_type", None)
-        if lifecycle_type is None:
-            return response.Response(
-                {
-                    "message": "Missing parameter",
-                    "detail": "Must include lifecycle type",
-                },
-                status=400,
-            )
-
-        from posthog.hogql_queries.actors_query_runner import (  # noqa: PLC0415 — breaks import cycle (actors_query_runner imports from this module)
-            ActorsQueryRunner,
-        )
-
-        filter = LifecycleFilter(request=request, data=request.GET.dict(), team=self.team)
-        filter = prepare_actor_query_filter(filter)
-
-        lifecycle_query = cast(LifecycleQuery, filter_to_query({**filter.to_dict(), "insight": "LIFECYCLE"}))
-        source = InsightActorsQuery(source=lifecycle_query, day=target_date, status=lifecycle_type)
-
-        # Select actor ids only and hydrate them ourselves to keep the legacy response shape.
-        actors_query = ActorsQuery(source=source, select=["actor_id"], limit=filter.limit, offset=filter.offset)
-        # Expand cohorts inline so cohort filters work without a precomputed cohort. The modifier
-        # goes on the inner query because ActorsQueryRunner inherits modifiers from its source.
-        source.source.modifiers = (source.source.modifiers or HogQLQueryModifiers()).model_copy(
-            update={"inlineCohortCalculation": InlineCohortCalculation.ALWAYS}
-        )
-        with personhog_caller_tag("persons/lifecycle"):
-            results = list(ActorsQueryRunner(team=self.team, query=actors_query).calculate().results)
-            actor_ids = [str(row[0]) for row in results]
-
-            people: list[Any]
-            if lifecycle_query.aggregation_group_type_index is not None:
-                _, people = get_groups(self.team.pk, lifecycle_query.aggregation_group_type_index, actor_ids, None)
-            else:
-                people = get_serialized_people(self.team, actor_ids, None)
-
-        next_url = format_paginated_url(request, filter.offset, filter.limit) if len(results) >= filter.limit else None
-        return response.Response({"results": [{"people": people, "count": len(people)}], "next": next_url})
-
     @extend_schema(
         exclude=True,  # NOTE: We exclude as we want to push people to use the more powerful bulk_delete endpoint
         description="Queue deletion of all recordings associated with this person.",
@@ -1576,51 +1506,6 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 {"error": f"Failed to retrieve person properties for {identifier_type} '{identifier}'"},
                 status=500,
             )
-
-
-def prepare_actor_query_filter(filter: LifecycleFilter) -> LifecycleFilter:
-    if not filter.limit:
-        filter = filter.shallow_clone({LIMIT: DEFAULT_PAGE_LIMIT})
-
-    search = getattr(filter, "search", None)
-    if not search:
-        return filter
-
-    group_properties_filter_group: list[dict[str, object]] = []
-    if hasattr(filter, "aggregation_group_type_index"):
-        group_properties_filter_group += [
-            {
-                "key": "name",
-                "value": search,
-                "type": "group",
-                "group_type_index": filter.aggregation_group_type_index,
-                "operator": "icontains",
-            },
-            {
-                "key": "slug",
-                "value": search,
-                "type": "group",
-                "group_type_index": filter.aggregation_group_type_index,
-                "operator": "icontains",
-            },
-        ]
-
-    new_group = {
-        "type": "OR",
-        "values": [
-            {"key": "email", "type": "person", "value": search, "operator": "icontains"},
-            {"key": "name", "type": "person", "value": search, "operator": "icontains"},
-            {"key": "distinct_id", "type": "event", "value": search, "operator": "icontains"},
-            *group_properties_filter_group,
-        ],
-    }
-    prop_group = (
-        {"type": "AND", "values": [new_group, filter.property_groups.to_dict()]}
-        if filter.property_groups.to_dict()
-        else new_group
-    )
-
-    return filter.shallow_clone({"properties": prop_group, "search": None})
 
 
 class LegacyPersonViewSet(PersonViewSet):

--- a/products/persons/frontend/generated/api.schemas.ts
+++ b/products/persons/frontend/generated/api.schemas.ts
@@ -657,18 +657,6 @@ export const PersonsDeletionStatusListStatus = {
     Pending: 'pending',
 } as const
 
-export type PersonsLifecycleRetrieveParams = {
-    format?: PersonsLifecycleRetrieveFormat
-}
-
-export type PersonsLifecycleRetrieveFormat =
-    (typeof PersonsLifecycleRetrieveFormat)[keyof typeof PersonsLifecycleRetrieveFormat]
-
-export const PersonsLifecycleRetrieveFormat = {
-    Csv: 'csv',
-    Json: 'json',
-} as const
-
 export type PersonsPropertiesAtTimeRetrieveParams = {
     /**
      * The distinct_id of the person (mutually exclusive with person_id)

--- a/products/persons/frontend/generated/api.ts
+++ b/products/persons/frontend/generated/api.ts
@@ -30,7 +30,6 @@ import type {
     PersonsDeletePropertyCreateParams,
     PersonsDeletionStatusListParams,
     PersonsEmailsListParams,
-    PersonsLifecycleRetrieveParams,
     PersonsListParams,
     PersonsPartialUpdateParams,
     PersonsPropertiesAtTimeRetrieveParams,
@@ -596,36 +595,6 @@ export const personsDeletionStatusList = async (
     options?: RequestInit
 ): Promise<PaginatedAsyncDeletionStatusListApi> => {
     return apiMutator<PaginatedAsyncDeletionStatusListApi>(getPersonsDeletionStatusListUrl(projectId, params), {
-        ...options,
-        method: 'GET',
-    })
-}
-
-export const getPersonsLifecycleRetrieveUrl = (projectId: string, params?: PersonsLifecycleRetrieveParams) => {
-    const normalizedParams = new URLSearchParams()
-
-    Object.entries(params || {}).forEach(([key, value]) => {
-        if (value !== undefined) {
-            normalizedParams.append(key, value === null ? 'null' : String(value))
-        }
-    })
-
-    const stringifiedParams = normalizedParams.toString()
-
-    return stringifiedParams.length > 0
-        ? `/api/projects/${projectId}/persons/lifecycle/?${stringifiedParams}`
-        : `/api/projects/${projectId}/persons/lifecycle/`
-}
-
-/**
- * This endpoint is meant for reading and deleting persons. To create or update persons, we recommend using the [capture API](https://posthog.com/docs/api/capture), the `$set` and `$unset` [properties](https://posthog.com/docs/product-analytics/user-properties), or one of our SDKs.
- */
-export const personsLifecycleRetrieve = async (
-    projectId: string,
-    params?: PersonsLifecycleRetrieveParams,
-    options?: RequestInit
-): Promise<void> => {
-    return apiMutator<void>(getPersonsLifecycleRetrieveUrl(projectId, params), {
         ...options,
         method: 'GET',
     })

--- a/products/persons/mcp/tools.yaml
+++ b/products/persons/mcp/tools.yaml
@@ -58,9 +58,6 @@ tools:
     persons-emails-list:
         operation: persons_emails_list
         enabled: false
-    persons-lifecycle-retrieve:
-        operation: persons_lifecycle_retrieve
-        enabled: false
     persons-list:
         operation: persons_list
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -78550,18 +78550,6 @@ export namespace Schemas {
       Pending: 'pending',
     } as const;
 
-    export type PersonsLifecycleRetrieveParams = {
-    format?: PersonsLifecycleRetrieveFormat;
-    };
-
-    export type PersonsLifecycleRetrieveFormat = typeof PersonsLifecycleRetrieveFormat[keyof typeof PersonsLifecycleRetrieveFormat];
-
-
-    export const PersonsLifecycleRetrieveFormat = {
-      Csv: 'csv',
-      Json: 'json',
-    } as const;
-
     export type PersonsPropertiesAtTimeRetrieveParams = {
     /**
      * The distinct_id of the person (mutually exclusive with person_id)


### PR DESCRIPTION
## Problem

`/api/person/lifecycle` (and its `/api/projects/:id/persons/lifecycle/` route) is the last legacy person actor endpoint, and it is dead by the same standard used for funnel/trends in #73064:

- Prometheus per-view metrics show zero 2xx responses in 180 days in both regions. The only traffic is 401 probes and 403-rejected callers who never received data (US last 90d: 401×6, 403×157; EU: a single 401). See Grafana Explore ([US](https://grafana.prod-us.posthog.dev/explore/?schemaVersion=1&panes=%7B%22abc%22%3A%7B%22datasource%22%3A%22victoriametrics%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22sum+by+%28view%2C+status%29+%28increase%28django_http_responses_total_by_status_view_method_total%7Bview%3D~%5C%22persons-lifecycle%7Cperson-lifecycle%7Cproject_persons-lifecycle%5C%22%7D%5B1d%5D%29%29%22%2C%22legendFormat%22%3A%22%7B%7Bview%7D%7D+%5Cu2192+HTTP+%7B%7Bstatus%7D%7D%22%2C%22datasource%22%3A%7B%22type%22%3A%22prometheus%22%2C%22uid%22%3A%22victoriametrics%22%7D%2C%22editorMode%22%3A%22code%22%2C%22range%22%3Atrue%2C%22instant%22%3Afalse%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-90d%22%2C%22to%22%3A%22now%22%7D%2C%22compact%22%3Afalse%7D%7D&orgId=1) / [EU](https://grafana.prod-eu.posthog.dev/explore/?schemaVersion=1&panes=%7B%22abc%22%3A%7B%22datasource%22%3A%22victoriametrics%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22sum+by+%28view%2C+status%29+%28increase%28django_http_responses_total_by_status_view_method_total%7Bview%3D~%5C%22persons-lifecycle%7Cperson-lifecycle%7Cproject_persons-lifecycle%5C%22%7D%5B1d%5D%29%29%22%2C%22legendFormat%22%3A%22%7B%7Bview%7D%7D+%5Cu2192+HTTP+%7B%7Bstatus%7D%7D%22%2C%22datasource%22%3A%7B%22type%22%3A%22prometheus%22%2C%22uid%22%3A%22victoriametrics%22%7D%2C%22editorMode%22%3A%22code%22%2C%22range%22%3Atrue%2C%22instant%22%3Afalse%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-90d%22%2C%22to%22%3A%22now%22%7D%2C%22compact%22%3Afalse%7D%7D&orgId=1)).
- The frontend has no live references (only stale msw mock fixtures), the generated client function is imported nowhere, and the `persons-lifecycle-retrieve` MCP tool entry was `enabled: false`.

Follow-up to #73064, which removed the sibling funnel/trends endpoints and inlined the shared legacy actor helpers into lifecycle. This deletes that last block, ending the legacy actor machinery in `person.py`.

## Changes

- Remove the `lifecycle` action from `PersonViewSet` and `prepare_actor_query_filter` (its last helper), plus the imports only they used.
- Drop the `persons-lifecycle-retrieve` MCP tool entry and regenerate OpenAPI and generated types.

## How did you test this code?

- `posthog/api/test/test_person.py` (152 passed); the endpoint itself had no tests
- Repo-wide mypy clean; `hogli build:openapi` and `hogli ci:preflight --fix` green

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The API reference is generated from the OpenAPI spec, which this PR regenerates. No handwritten docs reference this endpoint.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked whether `persons/lifecycle` was still used after #73064 flagged it as the next removal candidate; I (Claude, via PostHog Code) verified it dead via the same Prometheus status-code recipe and removed it on his direction. `/improving-drf-endpoints` was loaded for the viewset change. The endpoint had no app-side deprecation telemetry, which is why #73064 initially deferred it — the django-prometheus per-view metrics turned out to be sufficient without new instrumentation. Originally opened as a stacked PR; #73064 merged mid-flight, so this was rebased onto master (one commit, clean replay).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
