### PR TITLE
fix(data-imports): decode arrow field metadata before writing schema.json

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/test_writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/test_writer.py
@@ -1,0 +1,21 @@
+import json
+
+import pyarrow as pa
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.s3.writer import build_schema_dict
+
+
+class TestBuildSchemaDict:
+    def test_field_metadata_is_json_serializable(self) -> None:
+        schema = pa.schema([pa.field("id", pa.int64(), metadata={"comment": "primary key"})])
+
+        schema_dict = build_schema_dict(schema)
+
+        # Would raise "keys must be str ... not bytes" if the bytes metadata wasn't decoded.
+        json.dumps(schema_dict)
+        assert schema_dict["fields"][0]["metadata"] == {"comment": "primary key"}
+
+    def test_field_without_metadata_stays_none(self) -> None:
+        schema = pa.schema([pa.field("id", pa.int64())])
+
+        assert build_schema_dict(schema)["fields"][0]["metadata"] is None

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/writer.py
@@ -28,6 +28,31 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 ParquetCompression = Literal["gzip", "bz2", "brotli", "lz4", "zstd", "snappy", "none"]
 
 
+def _decode_field_metadata(metadata: dict | None) -> dict[str, str] | None:
+    # PyArrow stores field metadata as bytes keys/values; JSON keys can't be bytes.
+    if not metadata:
+        return None
+    return {
+        (key.decode() if isinstance(key, bytes) else key): (value.decode() if isinstance(value, bytes) else value)
+        for key, value in metadata.items()
+    }
+
+
+def build_schema_dict(schema: pa.Schema) -> dict:
+    return {
+        "fields": [
+            {
+                "name": field.name,
+                "type": str(field.type),
+                "nullable": field.nullable,
+                "metadata": _decode_field_metadata(field.metadata),
+            }
+            for field in schema
+        ],
+        "pandas_metadata": schema.pandas_metadata,
+    }
+
+
 class S3BatchWriter:
     _job: ExternalDataJob
     _schema_id: str
@@ -120,18 +145,7 @@ class S3BatchWriter:
         schema_path = f"{self._base_folder}/schema.json"
         s3_path_without_protocol = strip_s3_protocol(schema_path)
 
-        schema_dict = {
-            "fields": [
-                {
-                    "name": field.name,
-                    "type": str(field.type),
-                    "nullable": field.nullable,
-                    "metadata": dict(field.metadata) if field.metadata else None,
-                }
-                for field in self._schema
-            ],
-            "pandas_metadata": self._schema.pandas_metadata,
-        }
+        schema_dict = build_schema_dict(self._schema)
 
         self._logger.debug(f"Writing schema to {schema_path}")
 


### PR DESCRIPTION
## Problem

A `TypeError: keys must be str, int, float, bool or None, not bytes` was firing during data-warehouse import syncs, surfaced by [error tracking](https://us.posthog.com/project/2/error_tracking/019f8f60-a7ef-73d2-9469-50f40a6b5ff4).

The failing frame is `write_schema` in the shared pipeline code (`pipeline_v3/s3/writer.py`), reached from `_finalize` at the end of a sync. It builds a `schema.json` describing the written Parquet schema and serializes it with `json.dump`. Each field's metadata was passed through as `dict(field.metadata)`.

PyArrow stores field-level metadata as **bytes** keys and values (`{b'comment': b'...'}`). `json.dump` refuses bytes keys, so finalization blew up for any source whose Arrow schema carries field metadata. It showed up on a Databricks sync, but the bug is source-agnostic - it lives entirely in shared pipeline code.

## Changes

- Decode the field metadata to `str` keys/values before serializing (`_decode_field_metadata`), leaving `None` metadata as-is.
- Extract the schema-dict construction into a pure `build_schema_dict(schema)` helper so it is testable without S3.

## How did you test this code?

Added `test_writer.py` with two pure-function cases against `build_schema_dict`:

- A field with metadata round-trips through `json.dumps` and comes back with string keys. This is the regression - reverting the decode makes it fail with the exact `TypeError` from the issue. No existing test exercised schema-dict serialization.
- A field with no metadata still serializes to `None`.

Ran the new tests locally (`pytest`, 2 passed) plus ruff check/format. I (Claude) did not run the full import pipeline end to end.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue. I (Claude) pulled the stack trace, traced it from the `import_data` activity through `pipeline_v3` `_finalize` into `write_schema`, and confirmed with a scratch repro that `dict(pa.field(...).metadata)` yields bytes keys that `json.dump` rejects. Concluded this is our bug in shared code (not a user/upstream error to make non-retryable), so fixed it there and added a regression test at the same layer. Invoked `/writing-tests` to size the test - kept it as a cheap pure-function test rather than standing up S3.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
