### PR TITLE
fix(phai): stop completed progress labels sticking as thinking status

### DIFF
--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -2308,6 +2308,36 @@ describe('runStreamLogic', () => {
             ])
         })
 
+        it('clears currentProgress when a step finishes so the milestone label never sticks as live status', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/progress', {
+                        sessionId: 's',
+                        step: 'agent',
+                        status: 'in_progress',
+                        label: 'Starting agent',
+                        group: 'setup:run-1',
+                    })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentProgress).toEqual('Starting agent')
+
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/progress', {
+                        sessionId: 's',
+                        step: 'agent',
+                        status: 'completed',
+                        label: 'Started agent',
+                        group: 'setup:run-1',
+                    })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentProgress).toBeNull()
+        })
+
         it('falls back to detail when label is absent', async () => {
             await expectLogic(logic, () => {
                 logic.actions.ingestAcpFrame(

--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -2412,6 +2412,36 @@ describe('runStreamLogic', () => {
             ])
         })
 
+        it('clears currentProgress when a step finishes so the milestone label never sticks as live status', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/progress', {
+                        sessionId: 's',
+                        step: 'agent',
+                        status: 'in_progress',
+                        label: 'Starting agent',
+                        group: 'setup:run-1',
+                    })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentProgress).toEqual('Starting agent')
+
+            await expectLogic(logic, () => {
+                logic.actions.ingestAcpFrame(
+                    notification('_posthog/progress', {
+                        sessionId: 's',
+                        step: 'agent',
+                        status: 'completed',
+                        label: 'Started agent',
+                        group: 'setup:run-1',
+                    })
+                )
+            }).toFinishAllListeners()
+
+            expect(logic.values.currentProgress).toBeNull()
+        })
+
         it('falls back to detail when label is absent', async () => {
             await expectLogic(logic, () => {
                 logic.actions.ingestAcpFrame(

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -1533,8 +1533,8 @@ export interface runStreamLogicActions {
     setCurrentMode: (mode: string) => {
         mode: string
     }
-    setCurrentProgress: (progress: string) => {
-        progress: string
+    setCurrentProgress: (progress: string | null) => {
+        progress: string | null
     }
     setCurrentStage: (stage: string | null) => {
         stage: string | null
@@ -1763,7 +1763,7 @@ export const runStreamLogic = kea<runStreamLogicType>([
         handleStreamError: (envelope: StreamErrorEnvelope) => envelope,
         // Value-fold side effects emitted by ingestAcpFrame (thread items are derived in the projection).
         setCurrentMode: (mode: string) => ({ mode }),
-        setCurrentProgress: (progress: string) => ({ progress }),
+        setCurrentProgress: (progress: string | null) => ({ progress }),
         /** Optional `task_run_state.stage` — wired for a future richer status surface (G6). */
         setCurrentStage: (stage: string | null) => ({ stage }),
         markRunStarted: true,
@@ -3104,9 +3104,17 @@ export const runStreamLogic = kea<runStreamLogicType>([
             }
             if (method === '_posthog/progress') {
                 const progress = (notification.params ?? {}) as PosthogProgressParams
-                actions.setCurrentProgress(
-                    stringifyOptional(progress.label) ?? stringifyOptional(progress.detail) ?? ''
-                )
+                const status = normalizeProgressStatus(progress.status)
+                // A finished step is a milestone (the thread's progress card keeps it), not the current
+                // activity — clear it so the thinking line falls back to the rotating message instead of
+                // sticking on e.g. "Started agent" for the rest of the turn.
+                if (status === 'completed' || status === 'failed') {
+                    actions.setCurrentProgress(null)
+                } else {
+                    actions.setCurrentProgress(
+                        stringifyOptional(progress.label) ?? stringifyOptional(progress.detail) ?? ''
+                    )
+                }
                 return
             }
             // The agent-server persists the permission lifecycle to the run log — pending approvals

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -1587,8 +1587,8 @@ export interface runStreamLogicActions {
     setCurrentMode: (mode: string) => {
         mode: string
     }
-    setCurrentProgress: (progress: string) => {
-        progress: string
+    setCurrentProgress: (progress: string | null) => {
+        progress: string | null
     }
     setCurrentStage: (stage: string | null) => {
         stage: string | null
@@ -1817,7 +1817,7 @@ export const runStreamLogic = kea<runStreamLogicType>([
         handleStreamError: (envelope: StreamErrorEnvelope) => envelope,
         // Value-fold side effects emitted by ingestAcpFrame (thread items are derived in the projection).
         setCurrentMode: (mode: string) => ({ mode }),
-        setCurrentProgress: (progress: string) => ({ progress }),
+        setCurrentProgress: (progress: string | null) => ({ progress }),
         /** Optional `task_run_state.stage` — wired for a future richer status surface (G6). */
         setCurrentStage: (stage: string | null) => ({ stage }),
         markRunStarted: true,
@@ -3226,9 +3226,17 @@ export const runStreamLogic = kea<runStreamLogicType>([
             }
             if (method === '_posthog/progress') {
                 const progress = (notification.params ?? {}) as PosthogProgressParams
-                actions.setCurrentProgress(
-                    stringifyOptional(progress.label) ?? stringifyOptional(progress.detail) ?? ''
-                )
+                const status = normalizeProgressStatus(progress.status)
+                // A finished step is a milestone (the thread's progress card keeps it), not the current
+                // activity — clear it so the thinking line falls back to the rotating message instead of
+                // sticking on e.g. "Started agent" for the rest of the turn.
+                if (status === 'completed' || status === 'failed') {
+                    actions.setCurrentProgress(null)
+                } else {
+                    actions.setCurrentProgress(
+                        stringifyOptional(progress.label) ?? stringifyOptional(progress.detail) ?? ''
+                    )
+                }
                 return
             }
             // The agent-server persists the permission lifecycle to the run log — pending approvals


### PR DESCRIPTION
## Problem

In the PostHog AI run surface, the sticky bottom-of-thread thinking indicator stays on "Started agent" for the entire active turn (including the very first one).
"Started agent" is a completed setup milestone emitted by the task workflow as a `_posthog/progress` frame, not the agent's current activity, so the footer reads as if the run is stuck starting while the agent is already deep into tool calls.

## Changes

`runStreamLogic` set `currentProgress` from every `_posthog/progress` frame regardless of the frame's `status`, and only cleared it on turn complete.
The `ThinkingIndicator` footer prefers `currentProgress` over its rotating thinking message, so the last setup frame (`agent` / `completed` / "Started agent") pinned itself there for the whole turn.

Now the handler normalizes the frame status first. A `completed` or `failed` step clears `currentProgress`, so the footer falls back to the rotating thinking message and the milestone stays visible only in the thread's setup progress card, where it belongs.
Frames with `in_progress` status, or without a status (ambient labels like "Querying events"), keep setting the label exactly as before.
`setCurrentProgress` is widened to accept `null`.

## How did you test this code?

Added one Jest case to the existing `_posthog/progress handling` block in `runStreamLogic.test.ts`. It catches the exact regression: an `in_progress` "Starting agent" frame sets `currentProgress`, and the subsequent `completed` "Started agent" frame must clear it to `null`. No existing test exercised a completed-status frame's effect on `currentProgress`.

All 177 tests in `runStreamLogic.test.ts` pass locally. Oxlint and oxfmt are clean on the touched files, and the frontend typecheck reports no errors in `products/posthog_ai`. I did not manually test in a running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5), directed by the assignee. Skills invoked: `/writing-tests`.
Explored gating the fix at the render layer (`ThinkingIndicator` / `ThreadRow`) but chose the logic layer per the surface's "logic in the logic" convention, and kept the statusless-frame path untouched since ambient progress labels legitimately arrive without a status.
The in-thread setup progress card is intentionally unchanged, since it correctly renders "Started agent" as a checkmarked milestone.
