### PR TITLE
fix(data-warehouse): unstick schema when cancelling a terminated sync

### DIFF
--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -1511,16 +1511,30 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
             )
 
         if latest_running_job.pipeline_version != ExternalDataJob.PipelineVersion.V3:
-            # v1/v2: the workflow itself owns the job's terminal status, so keep the legacy
-            # behavior where the cancel RPC is the whole operation and a missing workflow
-            # is an error.
+            # v1/v2: normally the workflow handles the cancellation and writes the job's
+            # terminal status itself, so the cancel RPC is the whole operation.
             try:
                 cancel_external_data_workflow(latest_running_job.workflow_id)
             except temporalio.service.RPCError as e:
-                logger.exception(f"Could not cancel external data workflow for schema {instance.id}", exc_info=e)
-                return Response(
-                    status=status.HTTP_400_BAD_REQUEST,
-                    data={"detail": "Could not find workflow to cancel. The sync may have already finished."},
+                if e.status != temporalio.service.RPCStatusCode.NOT_FOUND:
+                    # Transient RPC failure against a possibly-live workflow. The workflow still
+                    # owns the terminal status, so leave the job Running and surface the failure.
+                    logger.exception(f"Could not cancel external data workflow for schema {instance.id}", exc_info=e)
+                    return Response(
+                        status=status.HTTP_400_BAD_REQUEST,
+                        data={"detail": "Could not cancel the running sync. Please try again."},
+                    )
+                # The workflow is already gone (e.g. it was terminated rather than cancelled), so it
+                # will never run the cleanup that writes the terminal status - the job and schema
+                # would stay stuck on Running forever. Write the Failed status ourselves so the
+                # schema unsticks and can be synced again.
+                logger.info("cancel_sync_v2_workflow_already_gone", schema_id=str(instance.id))
+                update_external_job_status(
+                    job_id=str(latest_running_job.id),
+                    team_id=instance.team_id,
+                    status=ExternalDataJob.Status.FAILED,
+                    logger=logger,
+                    latest_error="Sync cancelled by user",
                 )
             return Response(status=status.HTTP_200_OK)
 

--- a/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
@@ -2954,16 +2954,45 @@ class TestCancelExternalDataSchema(APIBaseTest):
         assert job.status == ExternalDataJob.Status.RUNNING
         assert job.latest_error is None
 
+    @parameterized.expand([("v1", "v1-dlt-sync"), ("legacy_null_version", None)])
     @mock.patch(
         "products.warehouse_sources.backend.presentation.views.external_data_schema.cancel_external_data_workflow"
     )
-    def test_cancel_legacy_pipeline_returns_400_when_workflow_missing(self, mock_cancel):
+    def test_cancel_legacy_pipeline_recovers_when_workflow_already_gone(self, _case, pipeline_version, mock_cancel):
+        # A workflow that was terminated (not cancelled) never runs the cleanup that writes the
+        # terminal status, so the cancel RPC comes back NOT_FOUND. Without recovery the job and
+        # schema would stay stuck on Running forever and the schema could never be synced again.
+        from temporalio.service import RPCError, RPCStatusCode
+
+        from products.warehouse_sources.backend.facade.models import ExternalDataJob
+
+        schema, job = self._create_schema_with_running_job(pipeline_version=pipeline_version)
+        mock_cancel.side_effect = RPCError("workflow not found", RPCStatusCode.NOT_FOUND, b"")
+
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/cancel/",
+        )
+
+        assert response.status_code == 200
+
+        job.refresh_from_db()
+        schema.refresh_from_db()
+        assert job.status == ExternalDataJob.Status.FAILED
+        assert job.latest_error == "Sync cancelled by user"
+        assert schema.status == ExternalDataSchema.Status.FAILED
+
+    @mock.patch(
+        "products.warehouse_sources.backend.presentation.views.external_data_schema.cancel_external_data_workflow"
+    )
+    def test_cancel_legacy_pipeline_returns_400_on_transient_rpc_error(self, mock_cancel):
+        # A transient RPC failure against a possibly-live workflow must not mark the job Failed -
+        # the workflow still owns the terminal status, so leave it Running and surface the error.
         from temporalio.service import RPCError, RPCStatusCode
 
         from products.warehouse_sources.backend.facade.models import ExternalDataJob
 
         schema, job = self._create_schema_with_running_job(pipeline_version=ExternalDataJob.PipelineVersion.V1)
-        mock_cancel.side_effect = RPCError("workflow not found", RPCStatusCode.NOT_FOUND, b"")
+        mock_cancel.side_effect = RPCError("temporal unavailable", RPCStatusCode.UNAVAILABLE, b"")
 
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/cancel/",


### PR DESCRIPTION
## Problem

On a source's schemas page, hitting "Cancel sync" did nothing for a schema whose Temporal workflow had been **terminated** (killed abruptly) rather than gracefully cancelled. The schema stayed stuck on `Running`, which also disabled "Sync now" ("A sync is already running") with no way to recover.

The cause is in the v1/v2 cancel path. A terminated workflow never runs the cleanup that writes the job's terminal status, so both the `ExternalDataJob` and `ExternalDataSchema` stay on `Running`. The v1/v2 path relied entirely on the workflow to write that status, then called the cancel RPC. Since the workflow was already gone, the RPC came back `NOT_FOUND` and the endpoint returned a 400 while updating nothing. The frontend gates both the "Cancel sync" button and the "Sync now" disabled reason on `schema.status === 'Running'`, so the schema was stuck for good.

The v3 path already handles this correctly (it writes a durable `FAILED` marker first, then tolerates `NOT_FOUND`).

## Changes

In the v1/v2 cancel path, when the cancel RPC comes back `NOT_FOUND` (workflow already gone), write the `FAILED` status ourselves via `update_external_job_status`, which flips both the job and schema to `FAILED` and unsticks the schema so it can be synced again.

Transient RPC errors (anything other than `NOT_FOUND`) still return a 400 and leave the job on `Running`, since the workflow may still be live and owns the terminal status.

> [!NOTE]
> No frontend change needed. Once the schema flips to `FAILED`, the existing UI re-enables "Sync now" on its own.

## How did you test this code?

Automated tests in `products/warehouse_sources/backend/tests/api/test_external_data_schema.py` (`TestCancelExternalDataSchema`). I replaced the old `test_cancel_legacy_pipeline_returns_400_when_workflow_missing` (which locked in the buggy behavior) with two focused tests:

- `test_cancel_legacy_pipeline_recovers_when_workflow_already_gone` (parameterized over v1 and the null legacy version) — asserts `NOT_FOUND` now returns 200 and marks both job and schema `FAILED`. This is the regression the fix guards: revert the change and the schema stays stuck on `Running`.
- `test_cancel_legacy_pipeline_returns_400_on_transient_rpc_error` — asserts a transient (`UNAVAILABLE`) error still returns 400 and leaves the job `Running`, so we don't prematurely fail a possibly-live workflow.

Ran the full `TestCancelExternalDataSchema` class locally against Postgres: 9 passed. ruff clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude (Claude Code, Opus 4.8) traced the bug and wrote the fix and tests. It invoked the `/improving-drf-endpoints` and `/writing-tests` skills along the way. The change is a pure logic fix inside the existing `cancel` action, so no serializer/schema annotations changed. The fix mirrors the recovery logic the v3 path already uses.
