### PR TITLE
chore(ci): auto-rerun frontend CI jobs killed by runner shutdown

### DIFF
--- a/.github/scripts/ci-rerun-transient-failures.js
+++ b/.github/scripts/ci-rerun-transient-failures.js
@@ -19,22 +19,50 @@ const TRANSIENT_PATTERNS = [/operation was canceled/i, /runner has received a sh
 const GATE_JOB_PATTERN = /Tests Pass$/
 
 // Stop retrying once a run has reached this many attempts (so we auto-rerun at most twice).
-const MAX_ATTEMPTS = Number(process.env.MAX_ATTEMPTS || 3)
+const DEFAULT_MAX_ATTEMPTS = 3
+
+// A job failed transiently when it emitted failure annotations and every one of
+// them matches the runner-shutdown signature (no other failure reason present).
+function isTransientFailure(failureMessages) {
+    return failureMessages.length > 0 && failureMessages.every((m) => TRANSIENT_PATTERNS.some((p) => p.test(m)))
+}
+
+// Pure decision used by the orchestrator and the tests. `jobs` is the run's jobs
+// shaped as { name, conclusion, failureMessages: string[] }.
+function shouldRerun({ conclusion, runAttempt, maxAttempts = DEFAULT_MAX_ATTEMPTS, jobs }) {
+    if (conclusion !== 'failure') {
+        return false
+    }
+    if (runAttempt >= maxAttempts) {
+        return false
+    }
+
+    const failedLeafJobs = jobs.filter(
+        (j) => (j.conclusion === 'failure' || j.conclusion === 'cancelled') && !GATE_JOB_PATTERN.test(j.name)
+    )
+    if (failedLeafJobs.length === 0) {
+        return false
+    }
+
+    // Any non-transient leaf failure means a real problem — don't mask it.
+    return failedLeafJobs.every((j) => isTransientFailure(j.failureMessages))
+}
 
 module.exports = async ({ github, context, core }) => {
     const run = context.payload.workflow_run
     const { owner, repo } = context.repo
+    const maxAttempts = Number(process.env.MAX_ATTEMPTS || DEFAULT_MAX_ATTEMPTS)
 
     if (run.conclusion !== 'failure') {
         core.info(`Run ${run.id} concluded '${run.conclusion}', not 'failure' — nothing to do.`)
         return
     }
-    if (run.run_attempt >= MAX_ATTEMPTS) {
-        core.info(`Run ${run.id} is on attempt ${run.run_attempt} (cap ${MAX_ATTEMPTS}) — not retrying again.`)
+    if (run.run_attempt >= maxAttempts) {
+        core.info(`Run ${run.id} is on attempt ${run.run_attempt} (cap ${maxAttempts}) — not retrying again.`)
         return
     }
 
-    const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
+    const rawJobs = await github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
         owner,
         repo,
         run_id: run.id,
@@ -42,39 +70,32 @@ module.exports = async ({ github, context, core }) => {
         per_page: 100,
     })
 
-    const failedLeafJobs = jobs.filter(
-        (j) => (j.conclusion === 'failure' || j.conclusion === 'cancelled') && !GATE_JOB_PATTERN.test(j.name)
-    )
-    if (failedLeafJobs.length === 0) {
-        core.info('No failed non-aggregator jobs — leaving the run alone (gate failed without a leaf cause).')
-        return
-    }
-
-    let sawTransient = false
-    for (const job of failedLeafJobs) {
+    const jobs = []
+    for (const job of rawJobs) {
+        if (job.conclusion !== 'failure' && job.conclusion !== 'cancelled') {
+            continue
+        }
         const annotations = await github.paginate(github.rest.checks.listAnnotations, {
             owner,
             repo,
             check_run_id: job.id,
             per_page: 100,
         })
-        const failureMsgs = annotations.filter((a) => a.annotation_level === 'failure').map((a) => a.message)
-        const isTransient =
-            failureMsgs.length > 0 && failureMsgs.every((m) => TRANSIENT_PATTERNS.some((p) => p.test(m)))
-
-        if (isTransient) {
-            sawTransient = true
-            core.info(`Job "${job.name}" failed transiently (runner shutdown).`)
-        } else {
-            core.info(`Job "${job.name}" failed for a non-transient reason — will NOT auto-rerun.`)
-            return
-        }
+        jobs.push({
+            name: job.name,
+            conclusion: job.conclusion,
+            failureMessages: annotations.filter((a) => a.annotation_level === 'failure').map((a) => a.message),
+        })
     }
 
-    if (!sawTransient) {
+    if (!shouldRerun({ conclusion: run.conclusion, runAttempt: run.run_attempt, maxAttempts, jobs })) {
+        core.info(`Run ${run.id}: failure was not purely a transient runner shutdown — leaving it alone.`)
         return
     }
 
     core.info(`Re-running failed jobs of run ${run.id} (attempt ${run.run_attempt}) after transient runner shutdown.`)
     await github.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: run.id })
 }
+
+module.exports.shouldRerun = shouldRerun
+module.exports.isTransientFailure = isTransientFailure

--- a/.github/scripts/ci-rerun-transient-failures.js
+++ b/.github/scripts/ci-rerun-transient-failures.js
@@ -1,0 +1,80 @@
+// Auto-reruns a Frontend CI run's failed jobs when the ONLY thing that failed
+// was a runner shutdown — a spot-instance preemption or the runner service
+// being recycled mid-step. GitHub surfaces this as "The operation was canceled"
+// / "The runner has received a shutdown signal", not a real command failure.
+// A plain re-run passes on the same commit, so we absorb the flake automatically
+// instead of pinging a human to click "re-run".
+//
+// Safety: we only rerun when at least one leaf job failed with the transient
+// signature AND no leaf job failed for any other reason — so a genuine test or
+// type error is never masked. Aggregator gate jobs (e.g. "Frontend Tests Pass")
+// only mirror their dependencies, so they're excluded from the decision.
+// A per-run attempt cap stops an infinite rerun loop if the flake is persistent.
+
+// Failure-annotation text that marks an externally-killed runner (not a real failure).
+const TRANSIENT_PATTERNS = [/operation was canceled/i, /runner has received a shutdown signal/i]
+
+// Aggregator jobs whose failure only reflects a failed dependency — ignored when
+// deciding whether the underlying failure was transient.
+const GATE_JOB_PATTERN = /Tests Pass$/
+
+// Stop retrying once a run has reached this many attempts (so we auto-rerun at most twice).
+const MAX_ATTEMPTS = Number(process.env.MAX_ATTEMPTS || 3)
+
+module.exports = async ({ github, context, core }) => {
+    const run = context.payload.workflow_run
+    const { owner, repo } = context.repo
+
+    if (run.conclusion !== 'failure') {
+        core.info(`Run ${run.id} concluded '${run.conclusion}', not 'failure' — nothing to do.`)
+        return
+    }
+    if (run.run_attempt >= MAX_ATTEMPTS) {
+        core.info(`Run ${run.id} is on attempt ${run.run_attempt} (cap ${MAX_ATTEMPTS}) — not retrying again.`)
+        return
+    }
+
+    const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
+        owner,
+        repo,
+        run_id: run.id,
+        attempt_number: run.run_attempt,
+        per_page: 100,
+    })
+
+    const failedLeafJobs = jobs.filter(
+        (j) => (j.conclusion === 'failure' || j.conclusion === 'cancelled') && !GATE_JOB_PATTERN.test(j.name)
+    )
+    if (failedLeafJobs.length === 0) {
+        core.info('No failed non-aggregator jobs — leaving the run alone (gate failed without a leaf cause).')
+        return
+    }
+
+    let sawTransient = false
+    for (const job of failedLeafJobs) {
+        const annotations = await github.paginate(github.rest.checks.listAnnotations, {
+            owner,
+            repo,
+            check_run_id: job.id,
+            per_page: 100,
+        })
+        const failureMsgs = annotations.filter((a) => a.annotation_level === 'failure').map((a) => a.message)
+        const isTransient =
+            failureMsgs.length > 0 && failureMsgs.every((m) => TRANSIENT_PATTERNS.some((p) => p.test(m)))
+
+        if (isTransient) {
+            sawTransient = true
+            core.info(`Job "${job.name}" failed transiently (runner shutdown).`)
+        } else {
+            core.info(`Job "${job.name}" failed for a non-transient reason — will NOT auto-rerun.`)
+            return
+        }
+    }
+
+    if (!sawTransient) {
+        return
+    }
+
+    core.info(`Re-running failed jobs of run ${run.id} (attempt ${run.run_attempt}) after transient runner shutdown.`)
+    await github.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: run.id })
+}

--- a/.github/scripts/ci-rerun-transient-failures.test.js
+++ b/.github/scripts/ci-rerun-transient-failures.test.js
@@ -1,0 +1,94 @@
+// Run with: node --test .github/scripts/ci-rerun-transient-failures.test.js
+//
+// The workflow only runs post-merge (workflow_run triggers fire from the default
+// branch), so this unit test is the sole pre-merge signal that the classifier
+// reruns runner-shutdown flakes while never masking a genuine failure.
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const { shouldRerun, isTransientFailure } = require('./ci-rerun-transient-failures')
+
+const CANCELED = 'The operation was canceled.'
+const SHUTDOWN = 'The runner has received a shutdown signal. This can happen when the runner service is stopped.'
+const GATE_EXIT = 'Process completed with exit code 1.'
+const TYPE_ERROR = "Expected 2 arguments, but got 1."
+
+const typecheckShutdown = { name: 'Frontend typechecking', conclusion: 'failure', failureMessages: [CANCELED] }
+const gateFail = { name: 'Frontend Tests Pass', conclusion: 'failure', failureMessages: [GATE_EXIT] }
+const jestGenuine = { name: 'Jest test (EE - 1)', conclusion: 'failure', failureMessages: [TYPE_ERROR] }
+
+const SHOULD_RERUN_CASES = [
+    {
+        description: 'transient typecheck + consequential gate -> rerun',
+        input: { conclusion: 'failure', runAttempt: 1, jobs: [typecheckShutdown, gateFail] },
+        expected: true,
+    },
+    {
+        description: 'shutdown-signal wording is also transient',
+        input: {
+            conclusion: 'failure',
+            runAttempt: 1,
+            jobs: [{ name: 'Frontend typechecking', conclusion: 'failure', failureMessages: [SHUTDOWN] }, gateFail],
+        },
+        expected: true,
+    },
+    {
+        description: 'genuine leaf failure -> no rerun',
+        input: { conclusion: 'failure', runAttempt: 1, jobs: [jestGenuine, gateFail] },
+        expected: false,
+    },
+    {
+        description: 'mixed transient + genuine -> no rerun (never mask a real failure)',
+        input: { conclusion: 'failure', runAttempt: 1, jobs: [typecheckShutdown, jestGenuine, gateFail] },
+        expected: false,
+    },
+    {
+        description: 'only the gate failed, no leaf cause -> no rerun',
+        input: { conclusion: 'failure', runAttempt: 1, jobs: [gateFail] },
+        expected: false,
+    },
+    {
+        description: 'attempt cap reached -> no rerun',
+        input: { conclusion: 'failure', runAttempt: 3, jobs: [typecheckShutdown, gateFail] },
+        expected: false,
+    },
+    {
+        description: 'run did not fail -> no rerun',
+        input: { conclusion: 'success', runAttempt: 1, jobs: [typecheckShutdown] },
+        expected: false,
+    },
+    {
+        description: 'transient job with no failure annotations -> no rerun (empty is not transient)',
+        input: {
+            conclusion: 'failure',
+            runAttempt: 1,
+            jobs: [{ name: 'Frontend typechecking', conclusion: 'failure', failureMessages: [] }, gateFail],
+        },
+        expected: false,
+    },
+]
+
+test('shouldRerun', async (t) => {
+    for (const { description, input, expected } of SHOULD_RERUN_CASES) {
+        await t.test(description, () => {
+            assert.equal(shouldRerun(input), expected)
+        })
+    }
+})
+
+const IS_TRANSIENT_CASES = [
+    { description: 'canceled message', messages: [CANCELED], expected: true },
+    { description: 'shutdown-signal message', messages: [SHUTDOWN], expected: true },
+    { description: 'empty annotations are not transient', messages: [], expected: false },
+    { description: 'a real error alongside a cancel is not transient', messages: [CANCELED, TYPE_ERROR], expected: false },
+    { description: 'generic exit code is not transient', messages: [GATE_EXIT], expected: false },
+]
+
+test('isTransientFailure', async (t) => {
+    for (const { description, messages, expected } of IS_TRANSIENT_CASES) {
+        await t.test(description, () => {
+            assert.equal(isTransientFailure(messages), expected)
+        })
+    }
+})

--- a/.github/workflows/ci-rerun-transient-failures.yml
+++ b/.github/workflows/ci-rerun-transient-failures.yml
@@ -1,0 +1,41 @@
+name: Rerun transient CI failures
+
+# Frontend CI's typecheck job runs on spot capacity and is occasionally killed
+# mid-step by a runner shutdown (spot preemption / runner recycle), which shows
+# up as a "failure" even though the code is fine — a re-run passes on the same
+# commit. This listener detects that signature and re-runs only the failed jobs,
+# so the flake doesn't need a human to click "re-run". Genuine failures are left
+# untouched. See .github/scripts/ci-rerun-transient-failures.js.
+
+on:
+    workflow_run:
+        workflows: ['Frontend CI']
+        types: [completed]
+
+# Serialize per triggering run so a run is never re-dispatched twice at once.
+concurrency:
+    group: ci-rerun-transient-failures-${{ github.event.workflow_run.id }}
+    cancel-in-progress: false
+
+permissions:
+    contents: read
+    actions: write
+
+jobs:
+    rerun:
+        if: github.event.workflow_run.conclusion == 'failure'
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  sparse-checkout: |
+                      .github/scripts/ci-rerun-transient-failures.js
+                  sparse-checkout-cone-mode: false
+
+            - name: Re-run failed jobs if the failure was a transient runner shutdown
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              with:
+                  script: |
+                      const script = require('./.github/scripts/ci-rerun-transient-failures.js')
+                      await script({ github, context, core })

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -71,3 +71,6 @@ jobs:
 
             - name: Turbo-discover dependent-cascade tests (Node)
               run: node --test .github/scripts/turbo-discover-cascade.test.js
+
+            - name: Rerun transient CI failures tests (Node)
+              run: node --test .github/scripts/ci-rerun-transient-failures.test.js


### PR DESCRIPTION
## Problem

Frontend CI's typecheck job runs on spot capacity and is periodically killed mid-step by a runner shutdown (spot preemption or the runner being recycled). GitHub reports this as a run *failure* — "The operation was canceled" / "The runner has received a shutdown signal" — even though the code is fine; re-running the same commit passes. Over a recent ~10h window this signature accounted for a meaningful share of frontend CI failures and was essentially exclusive to the typecheck job, so it's a recurring tax that currently needs a human to click "re-run".

## Changes

Add a `workflow_run` listener that fires when a `Frontend CI` run concludes as failure. It inspects the failed jobs' annotations and re-runs only the failed jobs when the *sole* cause was the transient runner-shutdown signature.

Safety properties:
- Reruns only when at least one leaf job failed transiently **and** no leaf job failed for any other reason — a genuine test/type error is never masked.
- Aggregator gate jobs (matching `… Tests Pass`) are excluded from the decision, since they only mirror their dependencies (they carry a generic `exit code 1`).
- A per-run attempt cap (`MAX_ATTEMPTS`, default 3) stops an infinite rerun loop if the flake turns out to be persistent.
- Uses `rerun-failed-jobs`, so passing jobs aren't re-executed.

## How did you test this code?

Automated: added a local harness driving the classifier against the real annotation shapes (transient typecheck + gate → rerun; genuine Jest failure → no rerun; mixed transient+genuine → no rerun; attempt cap → no rerun; success conclusion → no rerun; gate-only failure → no rerun). All six cases behaved as expected. `node --check` passes on the script and the workflow YAML parses.

Not tested end-to-end in CI — `workflow_run` triggers only take effect once merged to the default branch, so the live behavior can only be observed after merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable — internal CI plumbing, no user-facing surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a reported frontend typechecking failure that turned out to be a spot-instance preemption (confirmed via the runner's "shutdown signal" log line), then quantified how often the signature recurs across recent CI runs. Chose an auto-rerun listener over the alternatives that were considered and rejected: a step-level retry (`nick-fields/retry`) can't help because the runner itself dies with the step, and runner-size bumps only address OOM, which the shutdown-signal evidence rules out. Scoped to `Frontend CI` since that's where the signature was concentrated. Invoked the `/authoring-ci-workflows` skill while writing the workflow.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1784816177005579?thread_ts=1784816177.005579&cid=C09ADEV3AJD)*
