### PR TITLE
fix(conversations): keep customer attribution on imported private notes

### DIFF
--- a/products/conversations/backend/temporal/zendesk_import/mappers.py
+++ b/products/conversations/backend/temporal/zendesk_import/mappers.py
@@ -36,21 +36,25 @@ def map_zendesk_priority(priority: str | None) -> str | None:
 def map_zendesk_author_type(*, role: str | None, is_public: bool, is_customer_side: bool) -> tuple[str, bool]:
     """Return (author_type, is_private) for Comment.item_context.
 
-    Role is the primary signal (`agent`/`admin` → staff, `end-user` → customer). Every
-    active participant resolves to a role, so a multi-party thread (requester + another
-    end-user + agent) classifies each correctly. `is_customer_side` — author is the
-    requester or a CC/collaborator — is only the fallback when `role` can't be resolved
-    (hard-deleted users): a deleted end-user stays a customer, while a deleted agent (staff
-    who was let go) is not customer-side and so is treated as staff. Prevents a staff reply
-    from being attributed to the customer.
+    `author_type` and `is_private` are independent: the author is who wrote the comment,
+    privacy is whether Zendesk kept it public. A customer's own internal (non-public)
+    comment stays attributed to the customer instead of being relabeled as staff.
+
+    Role is the primary signal for the author (`agent`/`admin` → staff, `end-user` →
+    customer). Every active participant resolves to a role, so a multi-party thread
+    (requester + another end-user + agent) classifies each correctly. `is_customer_side` —
+    author is the requester or a CC/collaborator — is only the fallback when `role` can't be
+    resolved (hard-deleted users): a deleted end-user stays a customer, while a deleted agent
+    (staff who was let go) is not customer-side and so is treated as staff. Prevents a staff
+    reply from being attributed to the customer.
     """
-    if not is_public:
-        return "support", True
     if role in ("agent", "admin"):
-        return "support", False
-    if role == "end-user":
-        return "customer", False
-    return ("customer", False) if is_customer_side else ("support", False)
+        author_type = "support"
+    elif role == "end-user":
+        author_type = "customer"
+    else:
+        author_type = "customer" if is_customer_side else "support"
+    return author_type, not is_public
 
 
 def default_channel_source() -> str:

--- a/products/conversations/backend/temporal/zendesk_import/tests/test_mappers.py
+++ b/products/conversations/backend/temporal/zendesk_import/tests/test_mappers.py
@@ -38,7 +38,7 @@ class TestZendeskMappers:
 
     @parameterized.expand(
         [
-            # role, is_public, is_customer_side, expected_author_type, expected_is_private
+            # name, role, is_public, is_customer_side, expected_author_type, expected_is_private
             # Role is authoritative when resolved, regardless of customer-side membership.
             ("end_user", "end-user", True, True, "customer", False),
             ("end_user_non_customer_side", "end-user", True, False, "customer", False),
@@ -47,6 +47,9 @@ class TestZendeskMappers:
             # A second end-user (person2) in a thread resolves by role → customer, not staff.
             ("second_end_user", "end-user", True, False, "customer", False),
             ("agent_private_note", "agent", False, False, "support", True),
+            # A non-public comment stays attributed to its author: privacy is independent of
+            # author_type, so a customer's internal note is (customer, private), not (support, private).
+            ("end_user_private_note", "end-user", False, True, "customer", True),
             # Role unresolved (hard-deleted): customer-side → customer, otherwise staff.
             ("deleted_customer_side", None, True, True, "customer", False),
             ("deleted_agent_not_customer_side", None, True, False, "support", False),


### PR DESCRIPTION
## Problem

When a support ticket is imported from Zendesk, every non-public (internal) comment was mapped to `author_type="support"` with `is_private=True` — regardless of who actually wrote it. So a customer's own internal note came across attributed to staff, losing the fact that the customer wrote it. This surfaced on a real imported ticket where a customer's internal comments showed up as "support" private notes.

## Changes

`map_zendesk_author_type` now treats author and privacy as independent:

- `author_type` is derived from the author's Zendesk role (`agent`/`admin` → support, `end-user` → customer), keeping the customer-side fallback for hard-deleted users.
- `is_private` is derived from the comment's `public` flag.

Result: a customer's non-public comment imports as `(customer, private)` instead of `(support, private)`. Public comments and staff internal notes are unchanged. Private notes are still dropped from the denormalized widget counts, so no count behavior changes.

## How did you test this code?

Added a parameterized case to `test_map_zendesk_author_type` (`end_user_private_note` → `(customer, private)`) that fails if the mapper reintroduces the short-circuit relabeling all private comments as support. Ran the mapper unit tests locally — 22 passed. The DB-backed activity tests could not run in this environment (no Postgres reachable); the mapping logic they wire up is covered by the pure-function tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation started from a question about where a ticket's private notes came from; traced them to the Zendesk import path and identified the author/privacy coupling in the mapper as the cause. Invoked `/writing-tests` before adjusting the test cases. Change is confined to the pure mapper function plus its unit test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
