### PR TITLE
fix(data-warehouse): keep schema more-menu open during auto-refresh

### DIFF
--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -644,8 +644,16 @@ function SchemaBulkActions({
     schemas: readonly ExternalDataSourceSchema[]
     clearSelection: () => void
 }): JSX.Element {
-    const { bulkEnable, bulkDisable, bulkSetFrequency, bulkSyncNow, bulkResync, bulkDeleteData } =
-        useActions(sourceSettingsLogic)
+    const {
+        bulkEnable,
+        bulkDisable,
+        bulkSetFrequency,
+        bulkSyncNow,
+        bulkResync,
+        bulkDeleteData,
+        pausePolling,
+        resumePolling,
+    } = useActions(sourceSettingsLogic)
     const { bulkEnableLoading } = useValues(sourceSettingsLogic)
 
     // Wrap every action so the selection clears once it's been kicked off.
@@ -726,6 +734,11 @@ function SchemaBulkActions({
             </LemonButton>
             <More
                 size="small"
+                // Pause the 5s source refresh while the menu is open — a poll re-renders the table
+                // and dismisses the menu out from under the user.
+                dropdown={{
+                    onVisibilityChange: (visible) => (visible ? pausePolling() : resumePolling()),
+                }}
                 overlay={
                     <>
                         <LemonButton
@@ -792,11 +805,18 @@ function SchemaRowMore({
     cancelSchema: (schema: ExternalDataSourceSchema) => void
     deleteTable: (schema: ExternalDataSourceSchema) => void
 }): JSX.Element {
+    const { pausePolling, resumePolling } = useActions(sourceSettingsLogic)
+
     return (
         <SourceEditorAction source={source}>
             {({ disabledReason }) => (
                 <More
                     disabledReason={disabledReason}
+                    // Pause the 5s source refresh while the menu is open — a poll re-renders the
+                    // table and dismisses the menu out from under the user.
+                    dropdown={{
+                        onVisibilityChange: (visible) => (visible ? pausePolling() : resumePolling()),
+                    }}
                     overlay={
                         <>
                             <Tooltip

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
@@ -1297,6 +1297,13 @@ export const sourceSettingsLogic = kea<sourceSettingsLogicType>([
                     }, 'sourceRefreshTimeout')
                 }
             },
+            pausePolling: () => {
+                // Cancel the refresh already scheduled by the last load. Skipping the *reschedule*
+                // isn't enough on its own — without this, one more poll would still fire within
+                // REFRESH_INTERVAL and re-render the table, dismissing anything open over it (e.g. a
+                // row's "more" menu).
+                cache.disposables.dispose('sourceRefreshTimeout')
+            },
             resumePolling: () => {
                 // After the reducer runs we may have dropped to 0 — but no fresh load has been
                 // scheduled (the prior loadSourceSuccess fired while paused and skipped its


### PR DESCRIPTION
## Problem

On a managed source's schemas page, opening a row's "more" (⋯) menu, or the bulk-actions "more" menu, would work for a second or two and then close on its own, even while the pointer was still over the menu.

The schemas page polls the source every 5 seconds to keep sync statuses live. Each poll replaces the `source` in state, which re-renders the schemas table and dismisses any menu open over it. So the menu closes on the next poll tick, which lines up with the "opens for a couple of secs then closes" behavior.

The logic already had `pausePolling` / `resumePolling` actions (a nesting-safe counter) but nothing was wired to them.

## Changes

- Wire the row "more" menu and the bulk-actions "more" menu to `pausePolling` when they open and `resumePolling` when they close, via `onVisibilityChange`. While a menu is open the source stops refreshing, so the table stays put and the menu stays open. Closing it resumes the live refresh (and kicks an immediate load so status is fresh again).
- `pausePolling` now also cancels the refresh already scheduled by the previous load (`disposables.dispose('sourceRefreshTimeout')`). Skipping the reschedule alone wasn't enough — one already-queued poll would still fire within the 5s window and close the menu once.

Only the source poll is paused. The jobs poll doesn't replace the schemas list, so it doesn't remount the row and doesn't need pausing.

> [!NOTE]
> The pause is scoped to while a menu is open and self-limiting: opening a menu stops the churn that would otherwise unmount it, so the counter can't get stuck across the normal open → close flow, and navigating away unmounts the logic and resets it.

## How did you test this code?

This is a UI-timing fix. I traced the close to the 5s `loadSource` poll replacing `source` and re-rendering the table (the `More` dropdown is uncontrolled, so it only resets on remount). The fix stops that churn while a menu is open.

I couldn't run jest or tsc in my local checkout (Node 18 base, no workspace install), so I did not run the frontend test suite or typecheck locally — CI will cover both. `oxfmt --check` passes on both files. The change only uses pre-existing actions (`pausePolling`/`resumePolling`) and established props (`dropdown` / `onVisibilityChange`), so no kea typegen change is needed.

Manual repro for a reviewer: open a managed source's Schemas tab with at least one syncing schema, open a row's ⋯ menu, and wait ~5s. Before: it closes on the next poll. After: it stays open until you dismiss it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude (Claude Code, Opus 4.8) traced the root cause and made the change. It considered fixing the remount directly (stable `rowKey`, deep-equal guard on the poll) but landed on pausing the poll while a menu is open, since the `pausePolling`/`resumePolling` infra was already present and clearly built for this. No backend or serializer changes, so no OpenAPI regen.
