### PR TITLE
fix(playwright): log in via page.request instead of in-page fetch

### DIFF
--- a/playwright/e2e/sql-editor-dual-mode-postgres.spec.ts
+++ b/playwright/e2e/sql-editor-dual-mode-postgres.spec.ts
@@ -63,19 +63,9 @@ test.describe('SQL Editor dual-mode synced Postgres source', () => {
                     INSERT INTO ${tableName} (id, label) VALUES (1, 'alpha'), (2, 'beta');
                 `,
             ])
-            await page.goto('/login')
-            await page.evaluate(
-                async ({ email, password }) => {
-                    await fetch('/api/login/', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({ email, password }),
-                    })
-                },
-                { email: LOGIN_USERNAME, password: LOGIN_PASSWORD }
-            )
+            await page.request.post('/api/login/', {
+                data: { email: LOGIN_USERNAME, password: LOGIN_PASSWORD },
+            })
             await page.goto('/')
             await expect(page).toHaveURL(/\/project\/\d+/)
 

--- a/playwright/e2e/workflows-property-filter-category-dropdown.spec.ts
+++ b/playwright/e2e/workflows-property-filter-category-dropdown.spec.ts
@@ -93,36 +93,18 @@ test.describe('Workflows conditional branch property filter category dropdown', 
         const teamId: number = meData.team.id
 
         const workflowPayload = buildConditionalBranchWorkflow()
-        const workflowId = await page.evaluate(
-            async ({ teamId, payload }) => {
-                const csrfToken =
-                    document.cookie
-                        .split(';')
-                        .map((c) => c.trim())
-                        .find((c) => c.startsWith('posthog_csrftoken='))
-                        ?.split('=')
-                        .slice(1)
-                        .join('=') || ''
-                if (!csrfToken) {
-                    throw new Error('CSRF cookie missing')
-                }
-                const response = await fetch(`/api/environments/${teamId}/hog_flows/`, {
-                    method: 'POST',
-                    credentials: 'include',
-                    headers: {
-                        'Content-Type': 'application/json',
-                        'X-CSRFToken': decodeURIComponent(csrfToken),
-                    },
-                    body: JSON.stringify(payload),
-                })
-                if (!response.ok) {
-                    throw new Error(`hog_flows POST failed: ${response.status} ${await response.text()}`)
-                }
-                const data = await response.json()
-                return data.id as string
-            },
-            { teamId, payload: workflowPayload }
-        )
+        const csrfToken = (await page.context().cookies()).find((c) => c.name === 'posthog_csrftoken')?.value
+        if (!csrfToken) {
+            throw new Error('CSRF cookie missing')
+        }
+        const response = await page.request.post(`/api/environments/${teamId}/hog_flows/`, {
+            data: workflowPayload,
+            headers: { 'X-CSRFToken': decodeURIComponent(csrfToken) },
+        })
+        if (!response.ok()) {
+            throw new Error(`hog_flows POST failed: ${response.status()} ${await response.text()}`)
+        }
+        const workflowId: string = (await response.json()).id
 
         await test.step('open the workflow editor and select the conditional branch', async () => {
             await page.goto(`/workflows/${workflowId}/workflow`)

--- a/playwright/utils/playwright-setup.ts
+++ b/playwright/utils/playwright-setup.ts
@@ -10,7 +10,7 @@
  * - Team: Environment within project where data lives (e.g., "Production", "Staging")
  * - User: Configurable via LOGIN_USERNAME/LOGIN_PASSWORD env vars (defaults: test@posthog.com/12345678)
  */
-import { APIRequestContext, Page, request as playwrightRequest } from '@playwright/test'
+import { APIRequestContext, APIResponse, Page, request as playwrightRequest } from '@playwright/test'
 
 import { LOGIN_PASSWORD } from './playwright-test-core'
 
@@ -274,39 +274,28 @@ export class PlaywrightSetup {
     }
 
     async login(page: Page, workspace: PlaywrightWorkspaceSetupResult): Promise<void> {
-        await page.goto(`${this.baseURL}/login`)
-        await page.waitForLoadState('networkidle')
-        await page.evaluate(
-            async ({ email, password }) => {
-                const maxAttempts = 3
-                for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-                    try {
-                        const res = await fetch('/api/login/', {
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json',
-                            },
-                            body: JSON.stringify({ email, password }),
-                        })
-                        if (res.ok) {
-                            return
-                        }
-                        if (attempt === maxAttempts || res.status < 500) {
-                            throw new Error(`Login failed with status ${res.status}`)
-                        }
-                    } catch (e) {
-                        if (attempt === maxAttempts) {
-                            throw e
-                        }
-                    }
-                    await new Promise((r) => setTimeout(r, 500 * attempt))
+        const maxAttempts = 3
+        for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+            let response: APIResponse
+            try {
+                response = await page.request.post(`${this.baseURL}/api/login/`, {
+                    data: { email: workspace.user_email, password: LOGIN_PASSWORD },
+                })
+            } catch (e) {
+                if (attempt === maxAttempts) {
+                    throw e
                 }
-            },
-            {
-                email: workspace.user_email,
-                password: LOGIN_PASSWORD,
+                await new Promise((r) => setTimeout(r, 500 * attempt))
+                continue
             }
-        )
+            if (response.ok()) {
+                return
+            }
+            if (attempt === maxAttempts || response.status() < 500) {
+                throw new Error(`Login failed with status ${response.status()}`)
+            }
+            await new Promise((r) => setTimeout(r, 500 * attempt))
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

The shared Playwright login helper runs the login POST inside the page's JS execution context via `page.evaluate(fetch('/api/login/'))`, after a `page.goto('/login')` and a bare `waitForLoadState('networkidle')`.
The mounted login SPA can issue an async client-side redirect at any moment, and when that navigation lands mid-evaluate the execution context is destroyed, failing the test in `beforeEach` with `page.evaluate: Execution context was destroyed, most likely because of a navigation`.
This hit the e2e suite on PR #72752 (`dashboards.spec.ts` via `PlaywrightSetup.login`), and the design guarantees intermittent recurrence: the in-page fetch is racing a navigation the test doesn't control.
A previous retry-based attempt (#64763) targeted transient fetch failures and didn't address the race, and `networkidle` is already known to be unreliable on this SPA (see the workaround in `playwright/utils/navigation.ts`).

## Changes

- `PlaywrightSetup.login` now posts to `/api/login/` with `page.request.post`, which runs from Playwright's Node context while sharing the browser context's cookie jar. The session cookie still lands for subsequent `page.goto` calls, but no page navigation can destroy the request mid-flight.
- Dropped the `goto('/login')` and bare `networkidle` wait, both now unnecessary.
- Kept the 3-attempt retry with backoff for network errors and 5xx, now wrapped around the Node-side request. Non-5xx failures fail fast.
- Applied the same replacement to the duplicated in-page fetch pattern in `sql-editor-dual-mode-postgres.spec.ts`.

`page.request` for API-based setup is already the established pattern in this suite (for example `shared-dashboard-unauthenticated.spec.ts` and `workflows-property-filter-category-dropdown.spec.ts`).
CSRF isn't a concern: `/api/login/` is `AllowAny` and DRF only enforces CSRF once a session user is resolved, which is why the current header-less in-page fetch works today.

## How did you test this code?

- Frontend typecheck (`tsgo --noEmit` over the root tsconfig, which includes `playwright/**/*`) reports no errors in the touched files.
- No new tests: this is a deflake of shared test setup, validated by the e2e suite itself in CI.
- I did not run the e2e suite locally (needs the full dev stack), and the race only manifests under CI runner contention, so CI on this PR is the meaningful validation.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, test infrastructure only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code during a CI triage of PR #72752.
An investigation subagent traced the flake to the login helper's in-page fetch racing SPA redirects, checked prior art (#64763 added the retry loop but widened the race window), and confirmed the `page.request` pattern and the CSRF non-blocker before any code was written.
Skills invoked: `debugging-ci-failures`, `writing-tests`.
Considered retrying the `page.evaluate` on context destruction instead, rejected in favor of eliminating the error class entirely.
