### PR TITLE
feat(support): offer email fallback when support ticket submission fails

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -7,7 +7,7 @@ import { LemonSelectOptions } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { EMAIL_SUPPORT_BUTTON, lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { preflightLogic } from 'lib/logic/preflightLogic'
 import { uuid } from 'lib/utils/dom'
@@ -854,7 +854,7 @@ export const supportLogic = kea<supportLogicType>([
                         current_url_length: window.location.href.length,
                     })
                     lemonToast.error("Oops, the message couldn't be sent. Please try again in a moment.", {
-                        hideButton: true,
+                        button: EMAIL_SUPPORT_BUTTON,
                     })
                     return
                 }
@@ -1077,7 +1077,7 @@ export const supportLogic = kea<supportLogicType>([
                     })
                     lemonToast.error(
                         `Oops, the message couldn't be sent. Please change your browser's privacy level to the standard or default level, then try again. (E.g. In Firefox: Settings > Privacy & Security > Standard)`,
-                        { hideButton: true }
+                        { button: EMAIL_SUPPORT_BUTTON }
                     )
                     // Don't close the form or reset the data so user can try again
                     return
@@ -1119,7 +1119,7 @@ export const supportLogic = kea<supportLogicType>([
                 // Use the same error message regardless of browser
                 lemonToast.error(
                     `Oops, the message couldn't be sent. Please change your browser's privacy level to the standard or default level, then try again. (E.g. In Firefox: Settings > Privacy & Security > Standard)`,
-                    { hideButton: true }
+                    { button: EMAIL_SUPPORT_BUTTON }
                 )
                 // Don't close the form or reset the data so user can try again
             }

--- a/frontend/src/lib/lemon-ui/LemonToast/LemonToast.tsx
+++ b/frontend/src/lib/lemon-ui/LemonToast/LemonToast.tsx
@@ -43,6 +43,15 @@ export const GET_HELP_BUTTON: ToastButton = {
     },
 }
 
+// Fallback for when submitting a support ticket in-app fails: let the user reach us
+// directly by email instead of being sent back to the form that just failed.
+export const EMAIL_SUPPORT_BUTTON: ToastButton = {
+    label: 'Email us directly',
+    action: () => {
+        window.location.href = 'mailto:supportreply@posthog.com?subject=PostHog support request'
+    },
+}
+
 export interface ToastContentProps {
     type: 'info' | 'success' | 'warning' | 'error'
     message: string | JSX.Element

--- a/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
+++ b/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
@@ -17,7 +17,7 @@ import posthog from 'posthog-js'
 
 import { appendExceptionToMessage, supportLogic, warnIfMessageTooLong } from 'lib/components/Support/supportLogic'
 import { FEATURE_FLAGS } from 'lib/constants'
-import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { EMAIL_SUPPORT_BUTTON, lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
@@ -476,7 +476,7 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                     current_url_length: window.location.href.length,
                     is_new_ticket: values.view === 'new',
                 })
-                lemonToast.error('Failed to send message. Please try again.')
+                lemonToast.error('Failed to send message. Please try again.', { button: EMAIL_SUPPORT_BUTTON })
             } finally {
                 actions.setMessageSending(false)
             }


### PR DESCRIPTION
## Problem

When an in-app support ticket submission fails, the user hits a dead end. The error toast either shows the generic "Get help" button (which opens `posthog.com/support` in a new tab) or, on the Zendesk paths, hides the button entirely. When the support form is what just failed, "Get help" loops the user straight back to the thing that's broken, and there's no direct way to reach us.

This came out of a Slack thread investigating a customer whose ticket never arrived: they clicked "Submit ticket" four times, got "Failed to send message. Please try again." each time, and gave up. The failing path was the conversations side-panel composer, which had no escape hatch.

## Changes

Add a shared `EMAIL_SUPPORT_BUTTON` (next to the existing `GET_HELP_BUTTON` in `LemonToast`) that opens a `mailto:supportreply@posthog.com`, and wire it into the customer-facing support-submission failure toasts:

- Conversations side-panel composer (`sidepanelTicketsLogic` `sendMessage` catch) — previously fell through to the default "Get help".
- The three `supportLogic` `submitSupportTicket` failure paths (conversations catch, Zendesk fetch+beacon failure, outer Zendesk catch) — previously `hideButton: true`.

Now every failed submission gives the user a one-click "Email us directly" fallback. Using `supportreply@` rather than `support@` since that's the monitored inbox.

The staff-facing ticket reply scene (`supportTicketSceneLogic`) is intentionally left alone — a customer-email CTA doesn't belong there.

> [!NOTE]
> This is a client-side CTA fallback, not a fix for the underlying submission failure. It's a companion to the failure-visibility instrumentation in #73101; together they let us both see failures and give the user a way through when one happens.

## How did you test this code?

No automated tests added — this is a small additive change (one shared button constant plus swapping the toast options at four call sites). I (the PostHog Slack app, Claude) did **not** run the frontend typecheck or lint in this environment, since the monorepo dependencies weren't installed. Suggested check before merge: `pnpm --filter=@posthog/frontend typescript:check` and `pnpm --filter=@posthog/frontend fix`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Luke from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1784819568812759?thread_ts=1784819568.812759&cid=C075D3C5HST) that started from a session-replay investigation into a lost support ticket. We traced the failure to the side-panel composer's `sendMessage` catch, found that `lemonToast.error` appends a default "Get help" button unless overridden, and picked the "custom mailto CTA" option (over hiding the button or keeping "Get help") as the best fit while the support product is still young. I mapped all customer-facing support-submission failure toasts before editing and deliberately excluded the staff-facing reply scene.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1784819568812759?thread_ts=1784819568.812759&cid=C075D3C5HST)*
