### PR TITLE
chore(cli): trigger v0.9.1 release

### DIFF
--- a/cli/.sampo/changesets/windows-release-checkout.md
+++ b/cli/.sampo/changesets/windows-release-checkout.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Publish fresh CLI artifacts after fixing repository paths that prevented the Windows release build from checking out the source.


### PR DESCRIPTION
## Problem

The `posthog-cli` 0.9.0 release updated the source version, but publishing failed before producing release artifacts because the Windows runner could not check out the repository. Current `master` contains the Windows-compatible path fixes, but the CLI release workflow only runs when a new Sampo changeset lands.

## Changes

- add a patch changeset for `posthog-cli`
- let the release workflow generate version 0.9.1, Cargo updates, and the changelog after merge and release approval

## Tests

- validated the patch changeset maps the current 0.9.0 source version to 0.9.1
- `cargo metadata --manifest-path cli/Cargo.toml --format-version 1 --no-deps`
- `git diff --check origin/master...HEAD`
- pre-commit Markdown formatting
- autoreview: no accepted or actionable findings
