### PR TITLE
fix(experiments): respect decrease goal in significance notifications

### DIFF
--- a/posthog/temporal/experiments/test_significance_transition.py
+++ b/posthog/temporal/experiments/test_significance_transition.py
@@ -16,7 +16,7 @@ METRIC_DICT = {
     "uuid": "metric-123",
     "metric_type": "mean",
     "source": {"kind": "EventsNode", "event": "$pageview"},
-    "goal_direction": "increase",
+    "goal": "increase",
 }
 
 
@@ -147,6 +147,44 @@ class TestCheckSignificanceTransition(BaseTest):
         )
         assert event.properties["variant_key"] == "control"
 
+    @parameterized.expand(
+        [
+            ("increase_goal", "increase", "increase", "99%"),
+            ("decrease_goal", "decrease", "decrease", "1%"),
+        ]
+    )
+    @patch("posthog.temporal.experiments.utils.produce_internal_event")
+    def test_goal_direction_and_chance_to_win(
+        self,
+        _name: str,
+        goal: str,
+        expected_goal_direction: str,
+        expected_chance_to_win: str,
+        mock_produce: MagicMock,
+    ) -> None:
+        flag = FeatureFlag.objects.create(team=self.team, key=f"test-flag-{goal}", created_by=self.user)
+        experiment = Experiment.objects.create(
+            team=self.team,
+            name="Goal Experiment",
+            feature_flag=flag,
+            start_date=datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+            metrics=[{**METRIC_DICT, "goal": goal}],
+        )
+
+        result_dict = _make_result(["test"])
+        check_significance_transition(
+            experiment, "metric-123", "fp", result_dict, datetime(2024, 1, 10, tzinfo=ZoneInfo("UTC"))
+        )
+
+        mock_produce.assert_called_once()
+        event = (
+            mock_produce.call_args.kwargs.get("event")
+            or mock_produce.call_args[1].get("event")
+            or mock_produce.call_args[0][1]
+        )
+        assert event.properties["goal_direction"] == expected_goal_direction
+        assert event.properties["chance_to_win"] == expected_chance_to_win
+
     @patch("posthog.temporal.experiments.utils.produce_internal_event")
     def test_metric_name_fallback_to_event_name(self, mock_produce: MagicMock) -> None:
         flag = FeatureFlag.objects.create(
@@ -164,7 +202,7 @@ class TestCheckSignificanceTransition(BaseTest):
                     "uuid": "metric-456",
                     "metric_type": "mean",
                     "source": {"kind": "EventsNode", "event": "purchase_completed"},
-                    "goal_direction": "increase",
+                    "goal": "increase",
                 }
             ],
         )

--- a/posthog/temporal/experiments/test_significance_transition.py
+++ b/posthog/temporal/experiments/test_significance_transition.py
@@ -185,6 +185,35 @@ class TestCheckSignificanceTransition(BaseTest):
         assert event.properties["goal_direction"] == expected_goal_direction
         assert event.properties["chance_to_win"] == expected_chance_to_win
 
+    @parameterized.expand([("increase",), ("decrease",)])
+    @patch("posthog.temporal.experiments.utils.produce_internal_event")
+    def test_missing_chance_to_win_reports_na(self, goal: str, mock_produce: MagicMock) -> None:
+        # Frequentist results have no chance_to_win; it must not be inverted into a fabricated 100%
+        flag = FeatureFlag.objects.create(team=self.team, key=f"test-flag-na-{goal}", created_by=self.user)
+        experiment = Experiment.objects.create(
+            team=self.team,
+            name="No Probability Experiment",
+            feature_flag=flag,
+            start_date=datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+            metrics=[{**METRIC_DICT, "goal": goal}],
+        )
+
+        result_dict = _make_result(["test"])
+        for variant in result_dict["variant_results"]:
+            variant.pop("chance_to_win")
+
+        check_significance_transition(
+            experiment, "metric-123", "fp", result_dict, datetime(2024, 1, 10, tzinfo=ZoneInfo("UTC"))
+        )
+
+        mock_produce.assert_called_once()
+        event = (
+            mock_produce.call_args.kwargs.get("event")
+            or mock_produce.call_args[1].get("event")
+            or mock_produce.call_args[0][1]
+        )
+        assert event.properties["chance_to_win"] == "N/A"
+
     @patch("posthog.temporal.experiments.utils.produce_internal_event")
     def test_metric_name_fallback_to_event_name(self, mock_produce: MagicMock) -> None:
         flag = FeatureFlag.objects.create(

--- a/posthog/temporal/experiments/utils.py
+++ b/posthog/temporal/experiments/utils.py
@@ -141,11 +141,14 @@ def check_significance_transition(
 
         metric_dict = _find_metric_dict(experiment, metric_uuid)
         metric_name = _get_metric_name(metric_dict) if metric_dict else "Untitled metric"
-        goal_direction = metric_dict.get("goal_direction", "increase") if metric_dict else "increase"
+        goal_direction = metric_dict.get("goal", "increase") if metric_dict else "increase"
 
         for variant_key in newly_significant:
             variant_result = _get_variant_result(result_dict, variant_key)
             chance_to_win_raw = variant_result.get("chance_to_win", 0) if variant_result else 0
+            # chance_to_win is P(variant > control); invert it for decrease goals so lower is better
+            if goal_direction == "decrease":
+                chance_to_win_raw = 1 - chance_to_win_raw
             chance_to_win = f"{round(chance_to_win_raw * 100)}%"
             raw_change = _get_relative_change(result_dict, variant_key)
             relative_change = f"({raw_change})" if raw_change else ""

--- a/posthog/temporal/experiments/utils.py
+++ b/posthog/temporal/experiments/utils.py
@@ -145,11 +145,15 @@ def check_significance_transition(
 
         for variant_key in newly_significant:
             variant_result = _get_variant_result(result_dict, variant_key)
-            chance_to_win_raw = variant_result.get("chance_to_win", 0) if variant_result else 0
-            # chance_to_win is P(variant > control); invert it for decrease goals so lower is better
-            if goal_direction == "decrease":
-                chance_to_win_raw = 1 - chance_to_win_raw
-            chance_to_win = f"{round(chance_to_win_raw * 100)}%"
+            chance_to_win_raw = variant_result.get("chance_to_win") if variant_result else None
+            if chance_to_win_raw is None:
+                # No probability computed (e.g. frequentist results) — don't fabricate one
+                chance_to_win = "N/A"
+            else:
+                # chance_to_win is P(variant > control); invert it for decrease goals so lower is better
+                if goal_direction == "decrease":
+                    chance_to_win_raw = 1 - chance_to_win_raw
+                chance_to_win = f"{round(chance_to_win_raw * 100)}%"
             raw_change = _get_relative_change(result_dict, variant_key)
             relative_change = f"({raw_change})" if raw_change else ""
 


### PR DESCRIPTION
Context: https://posthog.slack.com/archives/C0368RPHLQH/p1784817776372499

## Problem

The experiment **"reached significance"** Slack notification renders the wrong goal direction and chance to win for **decrease-goal** metrics.

For a decrease-goal guardrail metric (e.g. errors shown per user), a variant that reduced the metric was reported as `Goal: increase` with a low `Chance to win` (the raw `P(variant > control)`), directly contradicting the notification's own "variant is winning" headline. The in-app experiment UI shows these correctly, so the discrepancy only appeared in the notification.

Raised in a Slack thread — the alert claimed a ~4% chance to win on a metric that had actually reached ~96%.

## Changes

Two causes in the significance-transition event builder (`posthog/temporal/experiments/utils.py`):

- It read a non-existent `goal_direction` key from the metric dict — the field is `goal` — so the goal always defaulted to `"increase"`.
- It emitted the raw `chance_to_win` (which is `P(variant > control)`) without inverting it for decrease goals.

The fix reads `goal` and inverts `chance_to_win` for decrease goals (`1 - chance_to_win`), matching the frontend's canonical `getChanceToWin` in `frontend/src/scenes/experiments/MetricsView/shared/utils.ts`. Significance detection itself was already correct (credible-interval based), so only the displayed goal and chance to win change.

## How did you test this code?

Added a parameterized case to `test_significance_transition.py` asserting the emitted `goal_direction` and (inverted) `chance_to_win` for both increase and decrease goals — this catches a revert of either fix. The existing fixtures used the same wrong `goal_direction` key (which is why they passed against the bug), so they were corrected to use `goal`.

The agent could not run the DB-backed tests in its sandbox (no Postgres available); the suite collected and parameterized correctly, and `ruff check` / `ruff format` pass on both files. Please rely on CI for the test run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread where an experiment significance alert showed a contradictory goal/chance-to-win. Traced it to the notification event builder, cross-checked ground truth via the experiment results (the decrease-goal metric's stored `chance_to_win` is un-inverted `P(variant>control)`), and confirmed the frontend already inverts. Invoked the repo `writing-tests` skill before touching the test file. No migrations, DRF, or ClickHouse changes.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1784817776372499?thread_ts=1784817776.372499&cid=C0368RPHLQH)*
