### PR TITLE
fix(data-imports): coerce numeric-string cells in numeric columns

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -89,6 +89,24 @@ def test_table_from_py_list_numeric_column_with_non_numeric_value_raises_named_e
     assert "<blank>" in message
 
 
+def test_table_from_py_list_numeric_column_coerces_numeric_string_values():
+    # Numeric columns whose cells arrive as numeric strings (common with JSON-based sources
+    # such as Mixpanel, where a property flips between 570 and "570") must coerce, not fail
+    # the whole sync. Blank cells become null; genuinely non-numeric text still raises.
+    table = table_from_py_list(
+        [{"column": 1.5}, {"column": "570"}, {"column": "  42  "}, {"column": ""}, {"column": None}]
+    )
+
+    assert pa.types.is_decimal(table.schema.field("column").type)
+    assert table.column("column").to_pylist() == [
+        decimal.Decimal("1.5"),
+        decimal.Decimal("570"),
+        decimal.Decimal("42"),
+        None,
+        None,
+    ]
+
+
 @pytest.mark.parametrize(
     "values,expected,type_check",
     [

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
@@ -1180,8 +1180,14 @@ def _process_batch(table_data: list[dict], schema: Optional[pa.Schema] = None) -
                     return None
 
                 if isinstance(x, str):
-                    # Non-numeric value in a column imported as a number; the caller adds column context.
-                    raise TypeError("must be real number, not str")
+                    stripped = x.strip()
+                    if stripped == "":
+                        return None
+                    try:
+                        x = decimal.Decimal(stripped)
+                    except decimal.InvalidOperation:
+                        # A genuinely non-numeric value in a column imported as a number; the caller adds column context.
+                        raise TypeError("must be real number, not str")
 
                 if (
                     math.isnan(x)
@@ -1200,7 +1206,13 @@ def _process_batch(table_data: list[dict], schema: Optional[pa.Schema] = None) -
                     return None
 
                 if isinstance(x, str):
-                    raise TypeError("must be real number, not str")
+                    stripped = x.strip()
+                    if stripped == "":
+                        return None
+                    try:
+                        x = float(stripped)
+                    except ValueError:
+                        raise TypeError("must be real number, not str")
 
                 if math.isnan(x) or np.isinf(x):
                     return None


### PR DESCRIPTION
## Problem

A data-warehouse sync failed with a `TypeError` raised from shared import-pipeline code:

```
must be real number, not str: column '<redacted>' is imported as a number
but contains N non-numeric value(s) such as ['570', '570', ...].
```

The offending values (`'570'`) are perfectly valid numbers that merely arrived as
strings. This is common with JSON-based sources, where a single property flips
between a number (`570`) and its string form (`"570"`) across events. In
`table_from_py_list`, once a numeric column was seen with a mixed set of types, the
conversion path rejected **any** string outright, failing the entire batch — and the
whole sync — on data we can trivially handle.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f8fb2-9e7f-7cc2-ab20-ff7a4ef8f14f

## Changes

`_convert_to_decimal_or_none` / `_convert_to_float_or_none` in the shared pipeline
`utils.py` now parse numeric strings into numbers and treat blank/whitespace-only
cells as null (matching the "or empty" promise already in the error message).
Strings that are genuinely non-numeric still raise the same named, non-retryable
`must be real number, not str` error, so real bad data is still surfaced clearly
and the source non-retryable matching keeps firing.

This is a general fix in shared code, not a per-source patch — it resolves the whole
class of "numeric column with occasional stringified numbers" failures across every
source that flows through `table_from_py_list`.

## How did you test this code?

Added `test_table_from_py_list_numeric_column_coerces_numeric_string_values` to
`test_pipeline_utils.py`, which locks in that a numeric column containing `"570"`,
`"  42  "`, `""` and `None` alongside a float coerces to decimals with blanks as
null. No existing test covered coercion — the existing
`..._non_numeric_value_raises_named_error` only asserts that genuinely non-numeric
text (`"N/A"`) still raises, which continues to pass.

Ran the full `test_pipeline_utils.py` suite (127 passed) plus `ruff check` /
`ruff format --check` on both files. No manual sync was run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for a failing warehouse import. Traced the
stack from the import activity into `table_from_py_list`'s numeric-conversion path,
confirmed the offending values were numeric strings rather than genuinely bad data,
and chose to coerce them in the shared layer rather than widen `NonRetryableErrors`
(which would have permanently failed syncs on data we can handle). Invoked the
`/writing-tests` skill before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
