### PR TITLE
feat(command-menu): capture item selections in command menu

### DIFF
--- a/frontend/src/lib/components/Search/Search.tsx
+++ b/frontend/src/lib/components/Search/Search.tsx
@@ -24,6 +24,7 @@ import { filterSearchItems } from 'lib/components/Search/utils'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { TreeDataItem } from 'lib/lemon-ui/LemonTree/LemonTree'
 import { themeLogic } from 'lib/logic/themeLogic'
+import posthog from 'lib/posthog-typed'
 import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { ContextMenu, ContextMenuContent, ContextMenuGroup, ContextMenuTrigger } from 'lib/ui/ContextMenu/ContextMenu'
 import { Label } from 'lib/ui/Label/Label'
@@ -414,6 +415,9 @@ function SearchRoot({
     const inputRef = useRef<HTMLInputElement>(null!)
     const actionsRef = useRef<Autocomplete.Root.Actions>(null)
     const highlightedItemRef = useRef<SearchItem | null>(null)
+    // Kept current with the flat, DOM-order item list so a click handler can report
+    // the selected item's position without depending on it (it's computed further down).
+    const orderedItemsRef = useRef<SearchItem[]>([])
 
     const allItems = useMemo(() => {
         const items: SearchItem[] = []
@@ -501,6 +505,14 @@ function SearchRoot({
             if (item.disabledReason) {
                 return
             }
+            if (logicKey === 'command') {
+                const position = orderedItemsRef.current.findIndex((i) => i.id === item.id)
+                posthog.capture('command menu item selected', {
+                    category: item.category,
+                    item_type: item.itemType ?? null,
+                    result_position: position >= 0 ? position : null,
+                })
+            }
             if (item.id === SETTINGS_THEME_ITEM_ID) {
                 const record = item.record as { themeMode?: UserTheme; toggleTheme?: boolean } | undefined
                 if (record?.themeMode) {
@@ -522,7 +534,7 @@ function SearchRoot({
                 router.actions.push(item.href)
             }
         },
-        [onItemSelect, onAskAiClick, updateUser, toggleTheme]
+        [onItemSelect, onAskAiClick, updateUser, toggleTheme, logicKey]
     )
 
     const groupedItems = useMemo(() => {
@@ -589,6 +601,7 @@ function SearchRoot({
     // exactly matches the DOM render order. Without this, Base UI's keyboard navigation
     // breaks at group boundaries where the two orderings diverge.
     const orderedItems = useMemo(() => stableGroupedItems.flatMap((g) => g.items), [stableGroupedItems])
+    orderedItemsRef.current = orderedItems
 
     const contextValue: SearchContextValue = useMemo(
         () => ({


### PR DESCRIPTION
## Problem

The Cmd+K command menu only captured `command menu opened`. We could see the menu open, with a `source` for where it was triggered from, but nothing about what happened next. There was no way to tell whether opening the menu actually led to a selection, or which kinds of results people pick.

This blocks the [Cmd+K nav experiment](https://us.posthog.com/project/2/experiments/387170): we want a secondary metric for how often someone actually clicks something inside the menu, and there was no event to build it on.

## Changes

Fire a `command menu item selected` event when a result is chosen in the command menu. It carries:

| Property | Meaning |
| --- | --- |
| `category` | The result's group (`recents`, `tools`, `settings`, `persons`, `insight`, ...) |
| `item_type` | The finer-grained type where the item has one, else `null` |
| `result_position` | 0-based index in the flat, DOM-order results list, or `null` if not found |

The capture lives in `Search.tsx`'s `handleItemClick`, which is where the ordered result list is available. It's gated on the Search `logicKey` being `command`, so other Search surfaces (the new-tab page) don't emit it. Disabled items still no-op and don't capture.

I deliberately don't report the search query length: pulling `searchValue` into the click handler would rebuild the `useCallback` on every keystroke, and it isn't worth that for this metric. Position and category already tell us browse vs search well enough.

I didn't touch the generated `posthog-typed.ts`: `posthog.capture` already accepts new event-name string literals through its flexible overload, and that file is regenerated from real captured events.

The matching secondary metric ("Command menu item selections per user", a per-user count of the event) is already wired onto experiment 387170.

## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check` — clean.
- Lint + format clean.

I did not verify the event end-to-end in a running app. The event count reads zero on the experiment until this merges and deploys.

No automated test added: exercising this path means rendering the whole Search + Autocomplete + kea stack to assert an analytics call, which is brittle and low-value relative to the one-line gating it would cover.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Opus 4.8) wrote this on Rafael's direction. The ask started as a question: does the command menu already capture clicks so we can add a secondary metric to the nav experiment? It doesn't. An Explore subagent swept the command menu code and confirmed only `command menu opened` fires; the old `command bar search result executed` event is dead code from a previous generation and is never dispatched.

Decisions along the way:
- Put the capture in `Search.tsx` rather than `Command.tsx` because that's the only place with the final result ordering (after debounce and re-rank). Scoped it to `logicKey === 'command'` so it stays specific to the Cmd+K menu.
- Read the ordered list via a ref that's kept current after the memo, to avoid a temporal-dead-zone reference when computing `result_position` inside a handler defined earlier in the component, and to keep the handler off the per-render list identity.
- Dropped an earlier `search_query_length` property to avoid depending on `searchValue` in the click handler.
- Left the generated types file alone (see Changes).

No repo skills were invoked. The secondary metric was added to the experiment via the PostHog MCP with `allow_unknown_events=true`, since the event is intentional but not yet ingested.
