### PR TITLE
chore(lint): stop oxlint/oxfmt churning generated MCP client

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -115,6 +115,7 @@
         "frontend/src/layout.html",
         "**/fixtures/**",
         "services/mcp/**/generated.ts",
+        "services/mcp/**/generated/**",
         "services/mcp/src/**/*.md",
         "services/mcp/worker-configuration.d.ts",
         "frontend/src/taxonomy/core-filter-definitions-by-group.json",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -22,6 +22,7 @@
         "frontend/src/queries/validators.js",
         "frontend/src/generated/**",
         "services/mcp/**/generated.ts",
+        "services/mcp/**/generated/**",
         "services/mcp/schema/tool-inputs.json",
         "products/**/frontend/generated/**"
     ],

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilter.tsx
@@ -129,7 +129,7 @@ export function TaxonomicFilter({
         if (taxonomicFilterRef.current) {
             setRefReady(true)
         }
-    }, [taxonomicFilterRef.current])
+    }, [])
 
     const style = {
         ...(width ? { width } : {}),

--- a/frontend/src/lib/lemon-ui/LemonInput/RawInputAutosize.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/RawInputAutosize.tsx
@@ -21,7 +21,7 @@ export const RawInputAutosize = React.forwardRef<HTMLInputElement, RawInputAutos
         if (inputRef.current) {
             setInputStyles(getComputedStyle(inputRef.current))
         }
-    }, [inputRef.current])
+    }, [])
 
     useLayoutEffect(() => {
         if (inputStyles) {
@@ -47,7 +47,7 @@ export const RawInputAutosize = React.forwardRef<HTMLInputElement, RawInputAutos
         if (newInputWidth !== inputWidth) {
             setInputWidth(newInputWidth)
         }
-    }, [sizerRef.current, placeHolderSizerRef.current, inputProps.placeholder, inputProps.value, inputWidth])
+    }, [inputProps.placeholder, inputProps.value, inputWidth])
 
     return (
         <div className={clsx('relative min-w-0', wrapperClassName)}>

--- a/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
+++ b/frontend/src/queries/nodes/HogQLQuery/HogQLQueryEditor.tsx
@@ -44,6 +44,7 @@ export function HogQLQueryEditor(props: HogQLQueryEditorProps): JSX.Element {
         if (router.values.location.pathname.includes(urls.sqlEditor())) {
             setKey(router.values.location.pathname)
         }
+        // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally re-run to reset the editor key when the SQL editor route changes
     }, [router.values.location.pathname])
 
     const [monacoAndEditor, setMonacoAndEditor] = useState(

--- a/frontend/src/scenes/settings/user/scopes/ScopeAccessSelector/RequiredOrganizationAccessSelector.tsx
+++ b/frontend/src/scenes/settings/user/scopes/ScopeAccessSelector/RequiredOrganizationAccessSelector.tsx
@@ -29,6 +29,7 @@ export const RequiredOrganizationAccessSelector = ({
                         if (autoSelectFirst && arrayValue.length === 0 && organizations.length > 0) {
                             onChange([organizations[0].id])
                         }
+                        // eslint-disable-next-line react-hooks/exhaustive-deps -- autoSelectFirst is a reactive prop; keep it so the effect re-runs if it changes
                     }, [autoSelectFirst, arrayValue.length, onChange])
 
                     return (

--- a/frontend/src/scenes/settings/user/scopes/ScopeAccessSelector/RequiredTeamAccessSelector.tsx
+++ b/frontend/src/scenes/settings/user/scopes/ScopeAccessSelector/RequiredTeamAccessSelector.tsx
@@ -31,6 +31,7 @@ export const RequiredTeamAccessSelector = ({
                         if (autoSelectFirst && arrayValue.length === 0 && teams && teams.length > 0) {
                             onChange([teams[0].id])
                         }
+                        // eslint-disable-next-line react-hooks/exhaustive-deps -- autoSelectFirst is a reactive prop; keep it so the effect re-runs if it changes
                     }, [autoSelectFirst, arrayValue.length, onChange])
 
                     return (


### PR DESCRIPTION
## Problem

Running `pnpm --filter=@posthog/frontend fix` (the standard lint + format pass) rewrites files that have nothing to do with your change. In my case a one-file frontend edit came back with 15 unrelated files modified: the entire `services/mcp/src/generated/**` client plus five hand-written components. That's noisy, easy to commit by accident, and makes every `fix` run look scary.

## Changes

Two root causes, fixed separately.

**1. The generated MCP client wasn't excluded from lint/format.**

The ignore lists only had `services/mcp/**/generated.ts`. That glob matches the one hand-written `services/mcp/src/api/generated.ts`, but not the codegen output under `services/mcp/src/generated/<product>/*.ts`. So `oxlint --fix` kept rewriting generated files (escape and `**` cleanups) that get blown away by `hogli build:openapi` anyway.

Added `services/mcp/**/generated/**` to both `.oxlintrc.json` and `.oxfmtrc.json`, alongside the existing pattern. This mirrors how `frontend/src/generated/**` and `products/**/frontend/generated/**` are already excluded.

**2. Five components carried latent `react-hooks/exhaustive-deps` warnings that `--fix` rewrote every run.**

I judged each one instead of blanket-applying the autofix, because the fixer's "unnecessary dependency" call is only right for some of them:

| File | Flagged dep | Verdict | Action |
| --- | --- | --- | --- |
| `RawInputAutosize` | `inputRef`, `sizerRef`, `placeHolderSizerRef` | Correct — refs never re-render | Dropped from deps |
| `TaxonomicFilter` | `taxonomicFilterRef` | Correct — ref | Dropped from deps |
| `RequiredOrganizationAccessSelector` | `autoSelectFirst` | False positive — it's a reactive prop | Kept dep, scoped disable |
| `RequiredTeamAccessSelector` | `autoSelectFirst` | False positive — reactive prop | Kept dep, scoped disable |
| `HogQLQueryEditor` | `router` (`.values.location.pathname`) | Intentional — resets the editor key on SQL-editor route change | Kept dep, scoped disable |

The rule treats values captured from an outer closure (a component prop read inside a `LemonField` render prop, a `kea-router` read) as non-reactive. For `autoSelectFirst` that's wrong: it's a prop, so a parent changing it should re-run the effect. For `HogQLQueryEditor` the effect deliberately re-runs on navigation to reset the keyed editor. Dropping either dep would be a real behavior change, so those keep the dependency with a `// eslint-disable-next-line react-hooks/exhaustive-deps` and a one-line reason.

Re-running the full `fix` now produces no diff beyond these seven files.

> [!NOTE]
> A pre-existing `no-unused-expressions` warning in `TaxonomicFilter.tsx:285` is left alone — it isn't auto-fixed, so it doesn't cause churn, and it's out of scope here.

## How did you test this code?

- Re-ran `pnpm --filter=@posthog/frontend fix` from a clean tree; the only diff is these 7 files (no generated churn, nothing else resurfaces).
- `oxlint` on the 5 components reports no `exhaustive-deps` warnings.
- `oxlint services/mcp/src/generated/...` now reports "No files found to lint".
- `pnpm --filter=@posthog/frontend typescript:check` clean.

No behavior change intended; no tests added.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Opus 4.8) did this on Rafael's direction, spun off from an unrelated instrumentation PR where the broad `fix` command had churned these files. Rafael asked me to understand why they were being reformatted and decide, per file, between excluding them or merging the change.

The key decision was not trusting the `exhaustive-deps` autofix wholesale. I reverted all five components to master, ran `oxlint` in report mode to read the exact rule and rationale, then checked each effect body: refs are safe to drop, but a reactive prop and an intentional route-reset dependency are not. Those three keep their dependency behind a scoped disable rather than silently changing behavior.

No repo skills were invoked.
