### PR TITLE
fix(llm-gateway): strip global inference prefix for bedrock count_tokens routing

### DIFF
--- a/services/llm-gateway/src/llm_gateway/bedrock.py
+++ b/services/llm-gateway/src/llm_gateway/bedrock.py
@@ -310,7 +310,7 @@ async def count_tokens_with_bedrock(
     def _sync() -> int:
         bedrock_runtime_client = get_bedrock_runtime_client(aws_region_name, timeout_seconds)
 
-        # CountTokens API does not support regional model prefixes ("us.anthropic.", "eu.anthropic.")
+        # CountTokens API does not support inference-profile prefixes ("us.anthropic.", "global.anthropic.")
         count_tokens_model = _strip_regional_inference_prefix(model)
 
         # Build the minimal invoke body Bedrock CountTokens accepts. Unlike invoke_model,
@@ -331,9 +331,13 @@ async def count_tokens_with_bedrock(
 
 
 def _strip_regional_inference_prefix(model: str) -> str:
-    """Drop the regional inference-profile prefix ("us.anthropic.", "eu.anthropic.") so the
-    bare foundation-model id ("anthropic.<model>") is used for token counting."""
-    return model.replace("us.anthropic.", "anthropic.").replace("eu.anthropic.", "anthropic.")
+    """Drop the inference-profile prefix ("us.anthropic.", "eu.anthropic.", "global.anthropic.")
+    so the bare foundation-model id ("anthropic.<model>") is used for token counting."""
+    return (
+        model.replace("us.anthropic.", "anthropic.")
+        .replace("eu.anthropic.", "anthropic.")
+        .replace("global.anthropic.", "anthropic.")
+    )
 
 
 # Models bedrock-runtime CountTokens rejects outright with "The provided model doesn't support

--- a/services/llm-gateway/tests/test_bedrock.py
+++ b/services/llm-gateway/tests/test_bedrock.py
@@ -569,10 +569,12 @@ class TestBedrockCountTokensViaProvider:
         )
 
     @pytest.mark.parametrize(
-        "model,expected_mantle_model",
+        "model,region,expected_mantle_model",
         [
-            pytest.param("claude-opus-4-8", "us.anthropic.claude-opus-4-8", id="opus_4_8"),
-            pytest.param("claude-fable-5", "us.anthropic.claude-fable-5", id="fable_5"),
+            pytest.param("claude-opus-4-8", "us-east-1", "us.anthropic.claude-opus-4-8", id="opus_4_8"),
+            pytest.param("claude-fable-5", "us-east-1", "us.anthropic.claude-fable-5", id="fable_5"),
+            # EU maps fable to the global profile; it must skip runtime CountTokens like the us. form.
+            pytest.param("claude-fable-5", "eu-central-1", "global.anthropic.claude-fable-5", id="fable_5_eu_global"),
         ],
     )
     @patch("llm_gateway.api.anthropic.get_settings")
@@ -586,10 +588,11 @@ class TestBedrockCountTokensViaProvider:
         authenticated_client: TestClient,
         valid_request_headers: dict[str, str],
         model: str,
+        region: str,
         expected_mantle_model: str,
     ) -> None:
         mock_settings = MagicMock()
-        mock_settings.bedrock_region_name = "us-east-1"
+        mock_settings.bedrock_region_name = region
         mock_settings.request_timeout = 300.0
         mock_get_settings.return_value = mock_settings
 
@@ -921,6 +924,9 @@ class TestSupportsBedrockRuntimeCountTokens:
             pytest.param("us.anthropic.claude-opus-4-8", False, id="unsupported_opus"),
             pytest.param("eu.anthropic.claude-opus-4-8", False, id="unsupported_opus_eu_prefix"),
             pytest.param("us.anthropic.claude-fable-5", False, id="unsupported_fable"),
+            # EU routes fable through the global profile (no eu. geo profile exists for it);
+            # runtime CountTokens rejects it the same as the us. form.
+            pytest.param("global.anthropic.claude-fable-5", False, id="unsupported_fable_global_prefix"),
         ],
     )
     def test_classifies_bedrock_model_ids(self, model: str, expected: bool) -> None:


### PR DESCRIPTION
## Problem

PR #72158 mapped EU `claude-fable-5` traffic to the `global.anthropic.claude-fable-5` inference profile (no `eu.` geo profile exists for it), but `_strip_regional_inference_prefix` only knows the `us.anthropic.` and `eu.anthropic.` prefixes. That breaks the count_tokens routing for the global form in two ways:

- `supports_bedrock_runtime_count_tokens` fails to reduce `global.anthropic.claude-fable-5` to `anthropic.claude-fable-5`, so the model misses the `BEDROCK_RUNTIME_COUNT_TOKENS_UNSUPPORTED` denylist and the gateway calls bedrock-runtime CountTokens - an API that rejects this model, and an action/resource combination the gateway's IAM role does not grant on global profiles. Result: 403 AccessDenied on the count_tokens path whenever the Bedrock path is taken in EU, instead of routing to the mantle fallback like the `us.` form does.
- `count_tokens_with_bedrock_mantle` would pass the unstripped `global.anthropic.` model id to the mantle endpoint.

## Changes

- `_strip_regional_inference_prefix` now also strips `global.anthropic.`, so global-profile model ids behave exactly like their `us.`/`eu.` forms in count_tokens routing.

## How did you test this code?

- `uv run pytest tests/test_bedrock.py` in `services/llm-gateway`: 49 passed.
- Extended two existing parameterized tests rather than adding new ones:
  - `test_classifies_bedrock_model_ids`: new `global.anthropic.claude-fable-5` case. Regression caught: the global form of a denylisted model being classified as runtime-countable.
  - `test_cris_only_models_skip_runtime_and_count_via_mantle`: parameterized the region, new `eu-central-1` case asserting fable maps to the global profile, skips runtime CountTokens, and counts via mantle. Regression caught: EU count_tokens requests for fable hitting bedrock-runtime instead of mantle.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed - internal routing fix, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) while investigating EU Bedrock fallback 403s with Chris Volzer. The invoke-path IAM gap was fixed separately in infra; the remaining 403s were traced to this count_tokens routing gap by reading the code, since the denial names `bedrock:CountTokens` rather than `bedrock:InvokeModel`. Invoked the /writing-tests skill before extending tests. Considered granting `bedrock:CountTokens` on global profiles in IAM instead and rejected it: runtime CountTokens rejects this model regardless, so the correct behavior is the existing mantle fallback path, which the role already permits.