### PR TITLE
feat(posthog_ai): float composer and panel header over the run thread

### DIFF
--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -172,7 +172,13 @@ export const MaxInstance = React.memo(function MaxInstance({ sidePanel, tabId }:
         </BindLogic>
     )
     const header = (
-        <SidePanelPaneHeader className="transition-all duration-200" showCloseButton={false}>
+        <SidePanelPaneHeader
+            // New view: the header floats over the panel content (which reserves clearance for it — see
+            // `SidePanelRunnerImpl`), so the runner's internally-scrolled thread passes behind it, like the
+            // legacy view's thread does behind this same header when it's sticky in the outer scroller.
+            className={cn('transition-all duration-200', isNewView && 'absolute top-0 left-0 right-0')}
+            showCloseButton={false}
+        >
             <div className="flex flex-1 min-w-0 overflow-hidden">
                 <div className="flex items-center flex-1 min-w-0">
                     <AnimatedBackButton in={isNewView ? panelCanGoBack : !backButtonDisabled}>
@@ -240,8 +246,9 @@ export const MaxInstance = React.memo(function MaxInstance({ sidePanel, tabId }:
             {/* The new view scrolls internally (virtualized thread, history list), so the ScrollArea
             content must stay clamped to the panel height — without `min-h-0` its `min-height: auto`
             grows it to fit the whole thread and no scroller ever engages. The legacy view is the
-            opposite: it relies on this container growing so the outer viewport scrolls it. */}
-            <SidePanelContentContainer contentClassName={cn('flex flex-col flex-1', isNewView && 'min-h-0')}>
+            opposite: it relies on this container growing so the outer viewport scrolls it. `relative`
+            anchors the new view's floating header (absolute, above) over the panel content. */}
+            <SidePanelContentContainer contentClassName={cn('flex flex-col flex-1', isNewView && 'min-h-0 relative')}>
                 {header}
                 {content}
             </SidePanelContentContainer>

--- a/products/posthog_ai/frontend/components/ResourcesBar.tsx
+++ b/products/posthog_ai/frontend/components/ResourcesBar.tsx
@@ -2,6 +2,8 @@ import { useValues } from 'kea'
 
 import { Tooltip } from '@posthog/lemon-ui'
 
+import { cn } from 'lib/utils/css-classes'
+
 import { runStreamLogic } from '../logics/runStreamLogic'
 import { resolveProductMeta } from '../messages/posthogProducts'
 
@@ -11,7 +13,7 @@ import { resolveProductMeta } from '../messages/posthogProducts'
  * product the agent grounded an answer in. Hidden when empty. Each chip is a product icon plus a
  * Sentence-cased label; unknown ids degrade to the wire label and a generic icon.
  */
-export function ResourcesBar(): JSX.Element | null {
+export function ResourcesBar({ className }: { className?: string } = {}): JSX.Element | null {
     const { resourcesUsed } = useValues(runStreamLogic)
 
     if (resourcesUsed.length === 0) {
@@ -19,7 +21,10 @@ export function ResourcesBar(): JSX.Element | null {
     }
 
     return (
-        <div className="flex flex-wrap items-center gap-1.5 px-3" data-attr="max-sandbox-resources-bar">
+        <div
+            className={cn('flex flex-wrap items-center gap-1.5 px-3', className)}
+            data-attr="max-sandbox-resources-bar"
+        >
             <span className="text-xs text-muted mr-0.5">PostHog resources used:</span>
             {resourcesUsed.map((product) => {
                 const { label, Icon } = resolveProductMeta(product.id, product.label)

--- a/products/posthog_ai/frontend/components/RunSurfaceImpl.tsx
+++ b/products/posthog_ai/frontend/components/RunSurfaceImpl.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { createContext, type ReactNode, useContext, useEffect } from 'react'
 
-import { LemonBanner, LemonButton, LemonDivider } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
 import { isTerminalRunStatus, runStreamLogic } from '../logics/runStreamLogic'
 import { taskLogic } from '../logics/taskLogic'
@@ -190,7 +190,17 @@ function RunSurfaceThread({
     className,
     listClassName,
     rowClassName,
-}: { className?: string; listClassName?: string; rowClassName?: string } = {}): JSX.Element {
+    bottomOverlay,
+}: {
+    className?: string
+    listClassName?: string
+    rowClassName?: string
+    /**
+     * Input-region chrome floated over the thread's bottom edge (typically `<RunSurface.Composer>`); the
+     * thread scrolls behind it, with its measured height reserved so content can always scroll clear.
+     */
+    bottomOverlay?: ReactNode
+} = {}): JSX.Element {
     const { interaction, isScout } = useRunSurfaceContext()
     const { bootstrapLoading, threadItems } = useValues(runStreamLogic)
     const showSkeleton = bootstrapLoading && threadItems.length === 0
@@ -204,6 +214,7 @@ function RunSurfaceThread({
             className={className}
             listClassName={listClassName}
             rowClassName={rowClassName}
+            bottomOverlay={bottomOverlay}
             showContextUsage={interaction === 'live' && !isScout}
         />
     )
@@ -216,6 +227,10 @@ function RunSurfaceThread({
  * window, or when no composer children are supplied (e.g. `ReadonlyRunSurface`). The composer thus shows for
  * any settled run status (active runs take a follow-up, terminal runs start a fresh run from the typed
  * message), is hidden during bootstrap, and is replaced by the prompt while a request is pending.
+ *
+ * Styled as floating chrome, meant to be pinned over the thread's bottom edge via `RunSurface.Thread`'s
+ * `bottomOverlay` — the thread scrolls behind it, visible through the translucent blur. Pointer events are
+ * re-enabled on the visible cards only, so the transparent gutters stay click-through to the thread.
  */
 function RunSurfaceComposer({ children }: { children?: ReactNode }): JSX.Element | null {
     const { interaction, runId } = useRunSurfaceContext()
@@ -223,17 +238,20 @@ function RunSurfaceComposer({ children }: { children?: ReactNode }): JSX.Element
     if (interaction !== 'live') {
         return null
     }
-    // Pending approval/question takes precedence over the composer.
+    // Pending approval/question takes precedence over the composer. An opaque card in a blurred
+    // translucent gutter, matching the legacy sidebar's pending-approval treatment.
     if (pendingPermissionRequest && !isTerminalRunStatus(currentRunStatus)) {
         const isQuestion = !!pendingPermissionRequest.questions && pendingPermissionRequest.questions.length > 0
         return (
-            <div className="border-t px-4 py-3">
-                <div className="mx-auto w-full max-w-180">
-                    {isQuestion ? (
-                        <QuestionInput streamKey={runId} request={pendingPermissionRequest} />
-                    ) : (
-                        <PermissionInput streamKey={runId} request={pendingPermissionRequest} />
-                    )}
+            <div className="px-4 pb-3">
+                <div className="pointer-events-auto mx-auto w-full max-w-180 rounded-lg backdrop-blur-sm bg-glass-bg-3000">
+                    <div className="border border-primary rounded-lg bg-surface-primary">
+                        {isQuestion ? (
+                            <QuestionInput streamKey={runId} request={pendingPermissionRequest} />
+                        ) : (
+                            <PermissionInput streamKey={runId} request={pendingPermissionRequest} />
+                        )}
+                    </div>
                 </div>
             </div>
         )
@@ -241,10 +259,11 @@ function RunSurfaceComposer({ children }: { children?: ReactNode }): JSX.Element
     if (!children || currentRunStatus === null) {
         return null // no composer UI supplied (e.g. ReadonlyRunSurface) or pre-bootstrap
     }
+    // `flex flex-col` so the composer chrome (`Composer.Root` with `isSticky`) can center itself with
+    // `self-center`; the glass card itself re-enables pointer events.
     return (
-        <div data-attr="composer" className="px-4 pb-[calc(1rem_+_env(safe-area-inset-bottom))]">
-            <LemonDivider className="mt-0 mb-4" />
-            <div className="mx-auto w-full max-w-180">{children}</div>
+        <div data-attr="composer" className="flex flex-col px-4 pb-[calc(1rem_+_env(safe-area-inset-bottom))]">
+            {children}
         </div>
     )
 }

--- a/products/posthog_ai/frontend/components/ThreadView.tsx
+++ b/products/posthog_ai/frontend/components/ThreadView.tsx
@@ -1,5 +1,5 @@
 import { useValues } from 'kea'
-import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { memo, type ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 
 import { inStorybookTestRunner } from 'lib/utils/dom'
 
@@ -55,6 +55,12 @@ interface ThreadViewProps {
      * non-scout runs.
      */
     showContextUsage?: boolean
+    /**
+     * Chrome pinned over the thread's bottom edge — the composer/input region — floating above the scroll
+     * viewport so rows scroll behind it; forwarded to `VirtualizedThread`, which reserves its measured
+     * height as scroll padding. Virtualized mode only.
+     */
+    bottomOverlay?: ReactNode
     className?: string
     listClassName?: string
     rowClassName?: string
@@ -74,6 +80,7 @@ interface ThreadViewProps {
 export function ThreadView({
     virtualized = true,
     showContextUsage = false,
+    bottomOverlay,
     className,
     listClassName,
     rowClassName,
@@ -179,7 +186,11 @@ export function ThreadView({
             anchorItemKey={anchorItemKey}
             header={header}
             footer={footer}
+            bottomOverlay={bottomOverlay}
             stickToBottom
+            // Provisioning counts too: the optimistic "spinning up" window is part of the turn, so the
+            // thread is already pinned when the first streamed rows land.
+            turnActive={streamPhase !== 'idle'}
             virtualized={virtualized}
             className={className}
             listClassName={listClassName}

--- a/products/posthog_ai/frontend/components/VirtualizedThread.stories.tsx
+++ b/products/posthog_ai/frontend/components/VirtualizedThread.stories.tsx
@@ -100,9 +100,43 @@ export const BoundedEmbed: Story = {
 }
 
 /**
+ * Bottom overlay — floating input chrome pinned over the scroll viewport (the composer treatment ported from
+ * the legacy sidebar). The overlay's measured height is reserved as end padding, so opening at the bottom
+ * lands the last message above the chrome; scrolling moves rows visibly behind the translucent card.
+ */
+export const BottomOverlay: Story = {
+    render: () => {
+        const items = makeItems(30)
+        return (
+            <div className="h-[500px] w-180 border rounded overflow-hidden">
+                <VirtualizedThread.Root
+                    items={items}
+                    getItemKey={getKey}
+                    stickToBottom
+                    bottomOverlay={
+                        <div className="px-4 pb-4">
+                            <div className="pointer-events-auto mx-auto w-full max-w-180 rounded-lg border border-primary backdrop-blur-sm bg-glass-bg-3000 p-3 text-sm text-muted">
+                                Fake composer — the thread scrolls behind this card
+                            </div>
+                        </div>
+                    }
+                >
+                    {(item) => (
+                        <VirtualizedThread.Row>
+                            <FakeMessage role={item.role} text={item.text} />
+                        </VirtualizedThread.Row>
+                    )}
+                </VirtualizedThread.Root>
+            </div>
+        )
+    },
+}
+
+/**
  * Streaming — a timer appends items and grows the height of the last message; the viewport stays pinned to the
- * bottom. This exercises the height-only-growth stick path, the case `anchorTo: 'end'` does not cover. Timers
- * are non-deterministic, so this story is skipped in the visual-regression run.
+ * bottom (`turnActive` simulates the agent working, which is what gates append-following). This exercises the
+ * height-only-growth stick path, the case `anchorTo: 'end'` does not cover. Timers are non-deterministic, so
+ * this story is skipped in the visual-regression run.
  */
 export const Streaming: Story = {
     tags: ['test-skip'],
@@ -143,6 +177,7 @@ export const Streaming: Story = {
                         </VirtualizedThread.Row>
                     }
                     stickToBottom
+                    turnActive
                 >
                     {(item) => (
                         <VirtualizedThread.Row>

--- a/products/posthog_ai/frontend/components/VirtualizedThread.tsx
+++ b/products/posthog_ai/frontend/components/VirtualizedThread.tsx
@@ -73,6 +73,15 @@ export interface VirtualizedThreadRootProps<T> {
     header?: ReactNode
     /** Rendered as a measured trailing row (e.g. thinking indicator, PR card). */
     footer?: ReactNode
+    /**
+     * Chrome pinned over the thread's bottom edge — the input region, floating above the scroll viewport
+     * so rows scroll behind it (give it a translucent background for the see-through effect). Its
+     * measured height is reserved as end padding in the virtualizer, so content can always scroll clear
+     * of it. The overlay layer is `pointer-events-none`; re-enable pointer events on the visible chrome
+     * so the transparent gutters around it stay click/scroll-through. Virtualized mode only — in flow
+     * mode an ancestor owns scroll (and any pinned chrome), so this is not rendered.
+     */
+    bottomOverlay?: ReactNode
     /** Inter-row spacing in px (default 6, matching `gap-1.5`). */
     gap?: number
     /** Height used until a row is measured. */
@@ -88,14 +97,22 @@ export interface VirtualizedThreadRootProps<T> {
     /** Follow the bottom as rows grow/append; unpins when the user scrolls up. */
     stickToBottom?: boolean
     /**
+     * True while the agent is actively working a turn (streaming output into the thread). Gates
+     * bottom-pinning: while active, the thread opens pinned to the bottom and streamed rows keep pulling
+     * the view down — until the user scrolls up, which unpins; a scroll that lands back at the bottom
+     * re-pins (only while the turn is active). While inactive, streamed rows never move the view.
+     */
+    turnActive?: boolean
+    /**
      * Key of the row the reader's attention anchors to — the last human message, typically. Two behaviors
-     * hang off it. Open: the thread opens with this row at the top of the viewport (the last meaningful
-     * turn, its response below) instead of the absolute bottom; clamping degrades to the bottom when
-     * little content follows. Change to a new non-null value (a fresh send): the row is scrolled to the
-     * top with bottom padding reserved so it can anchor there — the "sent message pins to the top, the
-     * response streams into the space below" chat pattern. The reserve also moves the true end below the
-     * viewport, so stick-to-bottom stops following until the user deliberately returns to the bottom, and
-     * it persists until the next anchor.
+     * hang off it. Open (turn not active): the thread opens with this row at the top of the viewport (the
+     * last meaningful turn, its response below) instead of the absolute bottom; clamping degrades to the
+     * bottom when little content follows. Change to a new non-null value (a fresh send): the row is
+     * scrolled to the top with bottom padding reserved so it can anchor there — the "sent message pins to
+     * the top, the response streams into the space below" chat pattern. The reserve shrinks 1:1 as the
+     * response streams into it, so the view stays put while the space fills; once the response outgrows
+     * the viewport the reserve is gone and stick-to-bottom follows the newest output for the rest of the
+     * turn.
      */
     anchorItemKey?: string | null
     maxWidthClassName?: string
@@ -113,19 +130,22 @@ export interface VirtualizedThreadRootProps<T> {
 /**
  * Embeddable virtualized thread. Fills any height-bounded parent (`h-full`/`flex-1 min-h-0`/fixed),
  * virtualizes rows with TanStack Virtual, measures dynamic heights, owns its own scroll and an optional
- * stick-to-bottom that follows streaming growth. Render rows through the `children` render-prop, each
- * wrapped in `VirtualizedThread.Row`.
+ * stick-to-bottom that follows streaming growth. Chrome passed as `bottomOverlay` floats over the scroll
+ * viewport with its height reserved, so rows scroll behind it. Render rows through the `children`
+ * render-prop, each wrapped in `VirtualizedThread.Row`.
  */
 function Root<T>({
     items,
     getItemKey,
     header,
     footer,
+    bottomOverlay,
     gap = 6,
     defaultRowHeight = 56,
     estimateItemHeight,
     overscanCount = 10,
     stickToBottom = true,
+    turnActive = false,
     anchorItemKey,
     maxWidthClassName = 'max-w-180',
     className,
@@ -139,11 +159,36 @@ function Root<T>({
 
     const scrollRef = useRef<HTMLDivElement>(null)
     const didInitialScrollRef = useRef(false)
+    // Bottom-pinning state (see `turnActive`). Explicit rather than position-derived: during fast
+    // streaming the scroll position transiently lags the growing content past any at-bottom threshold,
+    // so "is the user at the bottom right now" cannot distinguish "scrolled away" from "content briefly
+    // outran the follow scroll". Starts pinned: a thread that opens onto an active turn follows from the
+    // first frame, and it stays inert while no turn is active.
+    const pinnedRef = useRef(true)
+    // Read by the scroll listener without re-subscribing it per render.
+    const turnActiveRef = useRef(turnActive)
+    turnActiveRef.current = turnActive
     // Bottom padding reserved by the anchor-on-send behavior (`anchorItemKey`), fed to the virtualizer as
     // `paddingEnd`. `undefined` in the prev-key ref means "thread not yet populated".
     const [anchorPadding, setAnchorPadding] = useState(0)
     const prevAnchorKeyRef = useRef<string | null | undefined>(undefined)
     const pendingAnchorScrollRef = useRef<{ index: number; padding: number } | null>(null)
+    // Measured height of `bottomOverlay`, reserved as extra virtualizer `paddingEnd` so scrolling to the
+    // end always leaves the newest content visible above the overlaid chrome — not hidden behind it.
+    const [overlayInset, setOverlayInset] = useState(0)
+    const overlayObserverRef = useRef<ResizeObserver | null>(null)
+    const overlayRef = useCallback((node: HTMLDivElement | null): void => {
+        overlayObserverRef.current?.disconnect()
+        overlayObserverRef.current = null
+        if (!node) {
+            setOverlayInset(0)
+            return
+        }
+        setOverlayInset(node.offsetHeight)
+        const observer = new ResizeObserver(() => setOverlayInset(node.offsetHeight))
+        observer.observe(node)
+        overlayObserverRef.current = observer
+    }, [])
 
     const renderRow = useCallback(
         (index: number): ReactNode => {
@@ -176,11 +221,11 @@ function Root<T>({
             if (i < items.length) {
                 return getItemKey(items[i], i)
             }
-            // The item count rides in the footer key: TanStack detects "append at the end" (the
-            // `followOnAppend` stick) by a last-key change, and a constant footer key would mask every item
-            // append behind it — count grows, last key stays the footer — silently breaking follow while the
-            // footer (the streaming case's thinking indicator) is visible. The cost is one estimate-sized
-            // frame per append while the always-mounted footer re-measures under its new key.
+            // The item count rides in the footer key: TanStack detects "append at the end" by a last-key
+            // change, and a constant footer key would mask every item append behind it — count grows, last
+            // key stays the footer — hiding appends from the core's end-anchoring while the footer (the
+            // streaming case's thinking indicator) is visible. The cost is one estimate-sized frame per
+            // append while the always-mounted footer re-measures under its new key.
             return `${FOOTER_KEY}${items.length}`
         },
         [items, getItemKey, hasHeader]
@@ -224,26 +269,30 @@ function Root<T>({
         estimateSize: estimateVirtualRow,
         overscan: overscanCount,
         getItemKey: getVirtualItemKey,
-        paddingEnd: anchorPadding,
+        paddingEnd: anchorPadding + overlayInset,
         // The virtualizer writes container height + row offsets to the DOM itself, in the same tick as each
         // measurement — no stale-offset overlap while rows measure, and React re-renders only on range change.
         directDomUpdates: true,
         // No `gap` — inter-row spacing is baked into the measured row height via `paddingBottom` (see `Row`).
         ...(stickToBottom
             ? {
-                  // The core owns stick-to-bottom entirely: `anchorTo: 'end'` re-anchors on count/edge-key
-                  // change (append/prepend/reorder), `followOnAppend` scrolls to new rows when at the end,
-                  // and the core's resize handling compensates height-only growth (token streaming) while
-                  // within `scrollEndThreshold` of the end — and stops the moment the user scrolls away.
-                  anchorTo: 'end' as const,
-                  followOnAppend: 'auto' as const,
+                  // `anchorTo: 'end'` re-anchors on count/edge-key change (append/prepend/reorder) and the
+                  // core's resize handling compensates height-only growth (token streaming) while within
+                  // `scrollEndThreshold` of the end. Bottom-pinning itself is owned by the explicit
+                  // pinned-state effects below, not the core (`followOnAppend` stays off). While the send
+                  // reserve is up (`anchorPadding > 0`) the core would pin to the *padded* end — scrolling
+                  // content up over a blank band — so end-anchoring switches off and the view stays put
+                  // while the response streams into the reserved space (see the shrink effect).
+                  anchorTo: anchorPadding > 0 ? ('start' as const) : ('end' as const),
                   scrollEndThreshold: BOTTOM_THRESHOLD,
                   // Seed the virtual offset so the very first render window already emits the right rows
                   // (not a blank top frame): the anchor row's estimated start when opening onto an anchor,
-                  // past the end for a plain bottom open. Summing the row estimates keeps this exact
-                  // whatever `estimateItemHeight` returns; the pre-paint `scrollToIndex` below lands it.
+                  // past the end for a plain bottom open (which an active turn always uses — see the
+                  // initial-open effect). Summing the row estimates keeps this exact whatever
+                  // `estimateItemHeight` returns; the pre-paint `scrollToIndex` below lands it.
                   initialOffset: () => {
-                      const anchorIndex = anchorItemKey != null ? findVirtualIndexForKey(anchorItemKey) : -1
+                      const anchorIndex =
+                          !turnActive && anchorItemKey != null ? findVirtualIndexForKey(anchorItemKey) : -1
                       const limit = anchorIndex >= 0 ? anchorIndex : rowCount
                       let total = 0
                       for (let i = 0; i < limit; i++) {
@@ -256,23 +305,24 @@ function Root<T>({
     })
 
     // Initial open (once): land before the browser paints, so a long thread never shows a top-frame
-    // flicker or a visible crawl. Reopen where the reader left off: with an anchor (the last human
-    // message) the thread opens on the last meaningful turn — anchor row at the top, its response below —
-    // not the absolute bottom; scroll clamping degrades this to the bottom when little content follows the
-    // anchor. No anchor ⇒ plain bottom open. TanStack's built-in RAF reconciliation holds the landing
-    // steady as rows measure — replacing the old settle loop.
+    // flicker or a visible crawl. An actively-streaming thread opens pinned to the bottom — the turn's
+    // newest output — so the reader lands where the action is. A settled thread reopens where the reader
+    // left off: with an anchor (the last human message) it opens on the last meaningful turn — anchor row
+    // at the top, its response below — not the absolute bottom; scroll clamping degrades this to the
+    // bottom when little content follows the anchor. No anchor ⇒ plain bottom open. TanStack's built-in
+    // RAF reconciliation holds the landing steady as rows measure — replacing the old settle loop.
     useLayoutEffect(() => {
         if (!virtualized || !stickToBottom || didInitialScrollRef.current || rowCount === 0) {
             return
         }
         didInitialScrollRef.current = true
-        const anchorIndex = anchorItemKey != null ? findVirtualIndexForKey(anchorItemKey) : -1
+        const anchorIndex = !turnActive && anchorItemKey != null ? findVirtualIndexForKey(anchorItemKey) : -1
         if (anchorIndex >= 0) {
             virtualizer.scrollToIndex(anchorIndex, { align: 'start' })
         } else {
             virtualizer.scrollToIndex(rowCount - 1, { align: 'end' })
         }
-    }, [virtualized, stickToBottom, rowCount, virtualizer, anchorItemKey, findVirtualIndexForKey])
+    }, [virtualized, stickToBottom, rowCount, virtualizer, turnActive, anchorItemKey, findVirtualIndexForKey])
 
     // Anchor-on-change (see `anchorItemKey`): a key change means a new anchor row landed. A *trailing*
     // anchor (nothing after it yet) is a fresh send — reserve enough bottom padding for the row to reach
@@ -303,20 +353,32 @@ function Root<T>({
             return
         }
         // `getTotalSize()` first: it recomputes the measurements, so the `measurementsCache` read below
-        // reflects this commit's rows (including the anchor row's just-taken first measurement).
+        // reflects this commit's rows (including the anchor row's just-taken first measurement). The
+        // viewport that content can actually occupy ends at the bottom overlay's top edge, and
+        // `getTotalSize()` already includes the overlay inset reserved as `paddingEnd` — both corrections
+        // below keep the reserve sized to the visible thread area, not the raw scroll box.
         const totalSize = virtualizer.getTotalSize()
         const anchorStart = virtualizer.measurementsCache[anchorIndex]?.start
-        const viewport = scrollRef.current?.clientHeight ?? 0
-        if (anchorStart === undefined || viewport === 0) {
+        const viewport = (scrollRef.current?.clientHeight ?? 0) - overlayInset
+        if (anchorStart === undefined || viewport <= 0) {
             return
         }
         // Content below the anchor's top edge, excluding the currently reserved padding — the new reserve
         // must top it up to a full viewport so the anchor row can sit flush at the top.
-        const contentBelow = totalSize - anchorPadding - anchorStart
+        const contentBelow = totalSize - anchorPadding - overlayInset - anchorStart
         const padding = Math.max(0, Math.ceil(viewport - contentBelow))
         pendingAnchorScrollRef.current = { index: anchorIndex, padding }
         setAnchorPadding(padding)
-    }, [virtualized, items.length, anchorItemKey, findVirtualIndexForKey, virtualizer, anchorPadding, hasHeader])
+    }, [
+        virtualized,
+        items.length,
+        anchorItemKey,
+        findVirtualIndexForKey,
+        virtualizer,
+        anchorPadding,
+        overlayInset,
+        hasHeader,
+    ])
 
     // Runs every commit: performs the pending anchor scroll only once the reserved padding is committed to
     // the DOM — scrolling earlier would clamp against the un-padded scroll range and land short of the top.
@@ -327,6 +389,96 @@ function Root<T>({
         }
         pendingAnchorScrollRef.current = null
         virtualizer.scrollToIndex(pending.index, { align: 'start' })
+    })
+
+    // Runs every commit while the send reserve is up: shrink it 1:1 as the response streams in. The
+    // reserved whitespace is consumed by new content, so the total size — and with it the reader's scroll
+    // position — stays put while the response fills the viewport below the anchor. Once content below the
+    // anchor exceeds the viewport the reserve is exhausted, the true end is the content end again, and
+    // stick-to-bottom takes over for the rest of the turn. Shrink-only on purpose: a row collapsing
+    // mid-turn must not re-open whitespace under the thread.
+    useLayoutEffect(() => {
+        if (!virtualized || anchorPadding <= 0 || pendingAnchorScrollRef.current) {
+            return
+        }
+        // Same overlay corrections as the reserve calculation above: the visible viewport ends at the
+        // bottom overlay's top edge, and `getTotalSize()` includes the overlay inset in `paddingEnd`.
+        const viewport = (scrollRef.current?.clientHeight ?? 0) - overlayInset
+        if (viewport <= 0) {
+            return
+        }
+        const anchorKey = prevAnchorKeyRef.current
+        const anchorIndex = anchorKey != null ? findVirtualIndexForKey(anchorKey) : -1
+        if (anchorIndex < 0) {
+            // The anchor row left the thread (reset/replay) — drop the reserve with it.
+            setAnchorPadding(0)
+            return
+        }
+        // `getTotalSize()` first: it recomputes the measurements, so the `measurementsCache` read below
+        // reflects this commit's rows.
+        const totalSize = virtualizer.getTotalSize()
+        const anchorStart = virtualizer.measurementsCache[anchorIndex]?.start
+        if (anchorStart === undefined) {
+            return
+        }
+        const contentBelow = totalSize - anchorPadding - overlayInset - anchorStart
+        const needed = Math.max(0, Math.min(anchorPadding, Math.ceil(viewport - contentBelow)))
+        if (needed !== anchorPadding) {
+            setAnchorPadding(needed)
+        }
+    })
+
+    // Pin/unpin from scroll intent, not position: an upward wheel gesture or an offset *decrease*
+    // (scrollbar drag, PageUp, touch fling) is the user moving away from the bottom — programmatic follow
+    // scrolls only ever move down — so it unpins; a scroll that lands within the bottom threshold re-pins,
+    // but only while a turn is active. The wheel listener matters because a scroll event alone can race
+    // the per-commit follow write and never surface the decrease. The 4px slack absorbs sub-pixel
+    // rounding in the virtualizer's own adjustments.
+    useEffect(() => {
+        const el = scrollRef.current
+        if (!virtualized || !stickToBottom || !el) {
+            return
+        }
+        let prevTop = el.scrollTop
+        const onWheel = (event: WheelEvent): void => {
+            if (event.deltaY < 0) {
+                pinnedRef.current = false
+            }
+        }
+        const onScroll = (): void => {
+            const top = el.scrollTop
+            if (top < prevTop - 4) {
+                pinnedRef.current = false
+            } else if (turnActiveRef.current && el.scrollHeight - top - el.clientHeight <= BOTTOM_THRESHOLD) {
+                pinnedRef.current = true
+            }
+            prevTop = top
+        }
+        el.addEventListener('wheel', onWheel, { passive: true })
+        el.addEventListener('scroll', onScroll, { passive: true })
+        return () => {
+            el.removeEventListener('wheel', onWheel)
+            el.removeEventListener('scroll', onScroll)
+        }
+    }, [virtualized, stickToBottom])
+
+    // Runs every commit: while a turn is active and the reader is pinned, keep the bottom in view. Each
+    // streamed frame is a commit, so this needs no other trigger; the core's at-end resize compensation
+    // smooths growth that lands between commits. During the send-reserve phase the bottom is the padded
+    // end, which the shrink effect holds constant — so this no-ops and the view stays put while the
+    // reserved space fills. Writes `scrollTop` directly instead of `scrollToEnd()`: the latter arms the
+    // core's multi-frame scroll reconciler, which re-targets the (growing) end every frame and overrides
+    // the user's attempt to scroll away — exactly the gesture that must win here.
+    useLayoutEffect(() => {
+        // A queued anchor scroll (fresh send) owns the next landing — following here would paint one
+        // frame at the unpadded end before the anchor scroll pulls the sent message to the top.
+        if (!virtualized || !stickToBottom || !turnActive || !pinnedRef.current || pendingAnchorScrollRef.current) {
+            return
+        }
+        const el = scrollRef.current
+        if (el && el.scrollHeight - el.scrollTop - el.clientHeight > 1) {
+            el.scrollTop = el.scrollHeight
+        }
     })
 
     // Mobile Safari: the soft keyboard shrinks the visual (not layout) viewport, so a pinned bottom can slip
@@ -381,7 +533,7 @@ function Root<T>({
 
     return (
         <RootContext.Provider value={rootValue}>
-            <div className={cn('flex flex-col h-full min-h-0 w-full', className)}>
+            <div className={cn('relative flex flex-col h-full min-h-0 w-full', className)}>
                 <div
                     ref={scrollRef}
                     className={cn('flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain', listClassName)}
@@ -403,6 +555,13 @@ function Root<T>({
                         })}
                     </div>
                 </div>
+                {bottomOverlay != null && (
+                    // `pointer-events-none` so the transparent spacing around the chrome stays
+                    // click/scroll-through to the thread; the chrome itself re-enables pointer events.
+                    <div ref={overlayRef} className="absolute bottom-0 left-0 right-0 z-10 pointer-events-none">
+                        {bottomOverlay}
+                    </div>
+                )}
             </div>
         </RootContext.Provider>
     )

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/SidePanelRunnerImpl.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/SidePanelRunnerImpl.tsx
@@ -1,7 +1,9 @@
 import { BindLogic, useActions, useValues } from 'kea'
 
 import { IconArrowLeft } from '@posthog/icons'
-import { LemonButton, LemonDivider } from '@posthog/lemon-ui'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { cn } from 'lib/utils/css-classes'
 
 import { RunSurface } from 'products/posthog_ai/frontend/api/runSurface'
 
@@ -19,11 +21,21 @@ export interface SidePanelRunnerImplProps {
 }
 
 /**
+ * Top clearance for the side panel's floating pane header: its 40px height plus the 20px gap it kept below
+ * itself when it still sat in flow (`SidePanelPaneHeader`'s `h-[40px]` + `mb-5`).
+ */
+const PANEL_HEADER_CLEARANCE = 'pt-15'
+
+/**
  * Compact task-run surface for narrow hosts (Max's side panel): the same optimistic
  * create -> pending thread -> live run flow as the `/tasks` scene, without its list/detail chrome or
  * `/tasks/:id` navigation. Binds an embedded `taskTrackerSceneLogic` instance (keyed by `panelId`, see
  * `TaskTrackerSceneLogicProps`) so `TaskComposer` — which reads the unbound `taskTrackerSceneLogic` — resolves
  * this instance instead of the scene's own singleton.
+ *
+ * The side panel's pane header floats over this surface (see `MaxInstance`), so every state below clears it
+ * with `PANEL_HEADER_CLEARANCE` at rest — as scroll-content padding where the state scrolls, so the thread
+ * (and the welcome column) scroll behind the header, matching the legacy sidebar.
  */
 export function SidePanelRunnerImpl({ panelId }: SidePanelRunnerImplProps): JSX.Element {
     return (
@@ -50,7 +62,7 @@ function SidePanelRunnerContent(): JSX.Element {
 
     if (!activeCreation && historyExpanded) {
         return (
-            <div className="flex flex-col h-full min-h-0">
+            <div className={cn('flex flex-col h-full min-h-0', PANEL_HEADER_CLEARANCE)}>
                 <div className="flex items-center shrink-0 border-b border-primary px-2 py-1">
                     <LemonButton size="small" icon={<IconArrowLeft />} onClick={() => toggleHistory()}>
                         Back
@@ -66,8 +78,15 @@ function SidePanelRunnerContent(): JSX.Element {
     if (!activeCreation) {
         // Mirrors the legacy Max welcome layout: a centered composer with the recent-tasks
         // history pinned as a sibling at the bottom of the panel, not inside the composer column.
+        // The clearance is scroll-content padding (this column is the scroller), so an overflowing
+        // welcome column scrolls behind the floating header.
         return (
-            <div className="relative flex flex-col gap-4 pb-7 h-full min-h-0 overflow-y-auto">
+            <div
+                className={cn(
+                    'relative flex flex-col gap-4 pb-7 h-full min-h-0 overflow-y-auto',
+                    PANEL_HEADER_CLEARANCE
+                )}
+            >
                 {/* No `items-center` (unlike the legacy welcome block): `TaskComposer` must stretch to full
                 width — it centers its own content, same as under the `/tasks` scene's wrapper. */}
                 <div className="grow min-h-0 flex flex-col">
@@ -78,9 +97,10 @@ function SidePanelRunnerContent(): JSX.Element {
         )
     }
 
+    // The thread clearance rides `listClassName` (scroll-content padding, not container padding) so rows
+    // start below the floating header at rest but scroll up behind it — the legacy sidebar behavior.
     return (
         <div className="flex flex-col h-full min-h-0">
-            <LemonDivider className="my-0" />
             {activeCreation.taskId && activeCreation.runId ? (
                 // `TaskRunChat`'s inner container compensates for the `/tasks` scene's own horizontal margin
                 // with `-mx-4`; a `px-4` wrapper here neutralizes that bleed instead of editing the shared
@@ -91,12 +111,17 @@ function SidePanelRunnerContent(): JSX.Element {
                         runId={activeCreation.runId}
                         streamKey={activeCreation.streamKey}
                         onRunStarted={updateActiveCreationRun}
+                        threadListClassName={cn('pb-4', PANEL_HEADER_CLEARANCE)}
                     />
                 </div>
             ) : (
                 <div className="@container/thread flex flex-col flex-1 min-h-0">
                     <RunSurface.Root taskId="" runId={null} streamKey={activeCreation.streamKey} interaction="live">
-                        <RunSurface.Thread className="flex-1 min-h-0" listClassName="py-4" rowClassName="px-4" />
+                        <RunSurface.Thread
+                            className="flex-1 min-h-0"
+                            listClassName={cn('pb-4', PANEL_HEADER_CLEARANCE)}
+                            rowClassName="px-4"
+                        />
                     </RunSurface.Root>
                 </div>
             )}

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunChat.tsx
@@ -30,6 +30,12 @@ export interface TaskRunChatProps {
     streamKey?: string
     /** Called after a fresh run starts, in addition to the `taskDetailSceneLogic` re-pointing below. */
     onRunStarted?: (runId: string) => void
+    /**
+     * Scroll-content padding for the thread list. Hosts that overlay chrome on the thread's top edge (the
+     * side panel's floating header) pass extra top padding here so content clears the chrome at rest while
+     * still scrolling behind it.
+     */
+    threadListClassName?: string
 }
 
 /**
@@ -40,7 +46,13 @@ export interface TaskRunChatProps {
  * re-points scene selection to it. `RunSurface.Root` owns bootstrap: it reads the run status from the tasks
  * API and never opens SSE for an already-terminal run.
  */
-export function TaskRunChat({ taskId, runId, streamKey, onRunStarted }: TaskRunChatProps): JSX.Element {
+export function TaskRunChat({
+    taskId,
+    runId,
+    streamKey,
+    onRunStarted,
+    threadListClassName = 'py-4',
+}: TaskRunChatProps): JSX.Element {
     const { setSelectedRunId, loadTaskRuns } = useActions(taskDetailSceneLogic({ taskId }))
     const { selectedRun, task } = useValues(taskDetailSceneLogic({ taskId }))
     const { user } = useValues(userLogic)
@@ -65,7 +77,7 @@ export function TaskRunChat({ taskId, runId, streamKey, onRunStarted }: TaskRunC
 
     return (
         <BindLogic logic={runInteractionLogic} props={logicProps}>
-            <TaskRunChatContent logicProps={logicProps} readOnly={readOnly} />
+            <TaskRunChatContent logicProps={logicProps} readOnly={readOnly} threadListClassName={threadListClassName} />
         </BindLogic>
     )
 }
@@ -73,9 +85,11 @@ export function TaskRunChat({ taskId, runId, streamKey, onRunStarted }: TaskRunC
 function TaskRunChatContent({
     logicProps,
     readOnly,
+    threadListClassName,
 }: {
     logicProps: RunInteractionLogicProps
     readOnly: boolean
+    threadListClassName: string
 }): JSX.Element {
     // This surface renders the approval card, so persist tools must prompt here — register as a
     // foreground stream (same key resolution as `RunSurface.Root`). A read-only staff view omits the
@@ -92,16 +106,23 @@ function TaskRunChatContent({
             interaction="live"
         >
             <div className="@container/thread flex flex-col h-full -mx-4">
-                <RunSurface.Thread className="flex-1 min-h-0" listClassName="py-4" rowClassName="px-4" />
-                {/* Stay live (stream keeps flowing) but omit the composer entirely for a read-only viewer. */}
-                {!readOnly && (
-                    <RunSurface.Composer>
-                        <RunSurface.Resources />
-                        {/* The composer owns the per-keystroke draft in an isolated child so typing never re-renders
-                        the thread/virtualizer rendered as its sibling above — that cascade is what made the input lag. */}
-                        <LiveComposer logicProps={logicProps} />
-                    </RunSurface.Composer>
-                )}
+                <RunSurface.Thread
+                    className="flex-1 min-h-0"
+                    listClassName={threadListClassName}
+                    rowClassName="px-4"
+                    // The composer floats over the thread's bottom edge (glass chrome, the thread scrolls
+                    // behind it) rather than sitting below it as a flex sibling — the legacy sidebar look.
+                    // Stay live (stream keeps flowing) but omit the composer entirely for a read-only viewer.
+                    bottomOverlay={
+                        !readOnly ? (
+                            <RunSurface.Composer>
+                                {/* The composer owns the per-keystroke draft in an isolated child so typing never
+                                re-renders the thread/virtualizer it overlays — that cascade is what made the input lag. */}
+                                <LiveComposer logicProps={logicProps} />
+                            </RunSurface.Composer>
+                        ) : undefined
+                    }
+                />
             </div>
         </RunSurface.Root>
     )
@@ -144,7 +165,17 @@ function LiveComposer({ logicProps }: { logicProps: RunInteractionLogicProps }):
                 loading={isSubmitting}
                 isTurnActive={isBusy}
                 onStop={() => cancelRun()}
+                // The legacy sidebar's floating chrome: bordered translucent glass around an inset frame.
+                // This composer overlays the thread (see `bottomOverlay` above), which scrolls behind it,
+                // blurred through the glass. `px-0`: the `RunSurface.Composer` wrapper already provides the
+                // horizontal inset, keeping the card aligned with the thread rows. Pointer events come back
+                // on at the glass card so the gutters around it stay click-through to the thread.
+                isSticky
+                isThreadVisible
+                containerClassName="px-0"
+                className="pointer-events-auto"
             >
+                <RunSurface.Resources className="pt-2" />
                 {queuedMessages.length > 0 && (
                     <Composer.Banner>
                         <QueuedMessageList


### PR DESCRIPTION
## Problem

The legacy PostHog AI sidebar has a signature look the new run surface lost: the thread scrolls behind the pane header and behind a floating glass composer, instead of being clipped by them.
The new surface renders header and composer as non-overlapping flex rows around the virtualized thread, so content hard-clips at a divider above the composer and at the header's bottom edge.

## Changes

Ports the scroll-behind-chrome styling to the new surface. Legacy achieved it with `position: sticky` chrome inside a single scroll container, which doesn't translate to the virtualized thread (the virtualizer owns its own scroll element), so it's implemented as an overlay with reserved scroll padding.

- `VirtualizedThread` gets a `bottomOverlay` slot. It renders as an absolutely-pinned layer over the scroll viewport, and its height (tracked with a `ResizeObserver`) feeds the virtualizer's `paddingEnd`, so end-scrolling, `isAtEnd` and the send-anchor reserve all stay correct while content can always scroll clear of the chrome. The overlay layer is `pointer-events-none` with events re-enabled on the visible cards, so gutters stay click-through.
- `RunSurface.Composer` swaps its divider-block styling for the legacy floating chrome. The composer renders `Composer.Root`'s existing glass card (`isSticky` + `isThreadVisible`, i.e. translucent blur around an inset frame), the approval prompt becomes an opaque card in a blurred gutter, and the resources bar moves inside the glass card. `TaskRunChat` passes the composer to the thread as `bottomOverlay` instead of rendering it as a flex sibling, which applies to the side panel, the `/tasks` scene and the `/ai` embed.
- In the side panel's new view, the pane header floats over the runner content (`absolute` over a `relative` container in `Max.tsx`), and `SidePanelRunnerImpl` gives each state 60px top clearance as scroll-content padding, so the thread starts below the header at rest but scrolls up behind it. The run state's `LemonDivider` goes away since the floating header replaces it. The legacy view is untouched, everything is gated on the new-view toggle.

This also ships the turn-gated bottom pinning the overlay math builds on: explicit pin/unpin from scroll intent (wheel up or an offset decrease unpins, returning to the bottom re-pins while a turn is active), and the send-anchor reserve now shrinks 1:1 as the response streams into it, so the view stays put while the reserved space fills.

Opened at the bottom, the last message clears the floating composer:

![overlay_bottom](https://raw.githubusercontent.com/PostHog/pr-assets/d1be89519a9347f0d285dbd33bd5a84a819c1158/2026/07/11bca00c-7ecd-48ea-8cb0-f55d448262ca.png)

Scrolled, rows pass visibly behind the translucent card:

![overlay_scrolled](https://raw.githubusercontent.com/PostHog/pr-assets/f50d75625dbe1a99cce2d8e32fe4fa2696d31b1b/2026/07/4441368b-fe35-4683-b30c-3d72933a9fda.png)

## How did you test this code?

- `pnpm --filter=@posthog/frontend typescript:check` passes.
- The existing `RunSurfaceImpl`, `ThreadView.connection` and `ReadonlyRunSurfaceImpl` jest suites pass (22 tests). They cover the composer slot's precedence and gating, which this PR restyles without changing behavior.
- Added a deterministic `BottomOverlay` story to `VirtualizedThread.stories.tsx` for the visual-regression run. It catches the regression no existing story covers: opening at the bottom must land the last row above the overlaid chrome (the reserved-padding path), which the screenshots above were taken from via Storybook + Playwright.
- Not manually tested in a running PostHog instance. The side panel header overlay in `Max.tsx`/`SidePanelRunnerImpl` was verified by typecheck and reasoning over the layout only, so it deserves a look in the dev stack before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5) directed by the assignee, who asked for the legacy sidebar's scroll-behind-header/footer behavior to be ported to the new surface and supplied the in-progress turn-pinning work this sits on. Claude explored both implementations, then chose an overlay + virtualizer `paddingEnd` reservation over two rejected alternatives: sticky chrome inside the scroll element (breaks `scrollToIndex(end)` landing, which special-cases to the DOM max offset while sticky flow height is invisible to the virtual math) and plain CSS scroll padding (invisible to the virtualizer's virtual-coordinate calculations). The glass styling reuses `Composer.Root`'s existing `isSticky` chrome, ported earlier from legacy `QuestionInput`, rather than introducing new card styles. Verified via Storybook + Playwright screenshots of the new story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bjVEWAUZLRciPe1gVNXdR
