### PR TITLE
feat(replay-vision): expose vision action group-summary MCP tools

### DIFF
--- a/frontend/src/lib/agentScopes.generated.ts
+++ b/frontend/src/lib/agentScopes.generated.ts
@@ -127,6 +127,7 @@ export const AGENT_USE_CASE_SCOPES = [
     'user:write',
     'user_interview:read',
     'user_interview:write',
+    'vision_action:read',
     'visual_review:read',
     'visual_review:write',
     'warehouse_table:read',

--- a/products/replay_vision/mcp/tools.yaml
+++ b/products/replay_vision/mcp/tools.yaml
@@ -17,19 +17,81 @@ tools:
         enabled: false
     vision-actions-list:
         operation: vision_actions_list
-        enabled: false
+        enabled: true
+        scopes:
+            - vision_action:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List vision actions
+        description: >
+            List the vision actions (the "and then…" automations that run over a scanner's observations) for the current
+            project. A vision action in `mode: group_summary` produces the group summary shown on the "Summaries and
+            alerts" tab — one report synthesized from up to `max_observations` observations of its bound scanner; `mode:
+            alert` delivers only when its alert condition holds. Each row carries the bound `scanner`, `mode`,
+            `trigger_type`, cadence, and `is_scanner_digest` (the built-in daily digest). Pass `?scanner=<id>` to filter
+            to one scanner. To read a specific action's produced reports, list its runs with `vision-actions-runs-list`.
+        feature_flag: replay-vision
     vision-actions-partial-update:
         operation: vision_actions_partial_update
         enabled: false
     vision-actions-retrieve:
         operation: vision_actions_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - vision_action:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get a vision action
+        description: >
+            Get a single vision action by ID. Returns its configuration: the bound `scanner`, `mode`
+            (group_summary/alert), `selection` (the observation-targeting predicate — verdict/tags/score bounds/window),
+            `synthesis_config`, `alert_config`, cadence, and delivery targets. Use `vision-actions-runs-list` +
+            `vision-actions-runs-retrieve` to read the reports it has actually produced.
+        feature_flag: replay-vision
     vision-actions-runs-list:
         operation: vision_actions_runs_list
-        enabled: false
+        enabled: true
+        scopes:
+            - vision_action:read
+            - session_recording:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        list: true
+        title: List a vision action's runs
+        description: >
+            List the run history for one vision action (nested under the action). Each run is one execution that
+            produced a group summary or evaluated an alert. Rows are lightweight — `status`
+            (running/completed/failed/skipped), `scheduled_at`, `observation_count` (how many observations fed the
+            summary), `error_reason`, and `is_recovery` — without the report body. Fetch a completed run with
+            `vision-actions-runs-retrieve` to get the synthesized report and the observations it cited.
+        feature_flag: replay-vision
     vision-actions-runs-retrieve:
         operation: vision_actions_runs_retrieve
-        enabled: false
+        enabled: true
+        scopes:
+            - vision_action:read
+            - session_recording:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get a vision action run's full group summary
+        description: >
+            Get one vision action run in full: `synthesized_markdown` (the group-summary report, which cites its source
+            observations inline with `[obs N]` markers) and `observations` — the recordings the run included, in summary
+            order, each carrying the 1-based `index` that the report's `[obs N]` markers reference plus that
+            observation's title and outcome. This is the tool for auditing a group summary: for each `[obs N]` in the
+            markdown, `observations[N-1]` is the observation it cites, so you can check whether the cited observation
+            actually supports the claim. Empty `synthesized_markdown`/`observations` means the run skipped, failed, or
+            predates observation tracking.
+        feature_flag: replay-vision
     vision-observations-create-task-create:
         operation: vision_observations_create_task_create
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -9742,6 +9742,66 @@
             "readOnlyHint": false
         }
     },
+    "vision-actions-list": {
+        "description": "List the vision actions (the \"and then…\" automations that run over a scanner's observations) for the current project. A vision action in `mode: group_summary` produces the group summary shown on the \"Summaries and alerts\" tab — one report synthesized from up to `max_observations` observations of its bound scanner; `mode: alert` delivers only when its alert condition holds. Each row carries the bound `scanner`, `mode`, `trigger_type`, cadence, and `is_scanner_digest` (the built-in daily digest). Pass `?scanner=<id>` to filter to one scanner. To read a specific action's produced reports, list its runs with `vision-actions-runs-list`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "List vision actions",
+        "title": "List vision actions",
+        "required_scopes": ["vision_action:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-actions-retrieve": {
+        "description": "Get a single vision action by ID. Returns its configuration: the bound `scanner`, `mode` (group_summary/alert), `selection` (the observation-targeting predicate — verdict/tags/score bounds/window), `synthesis_config`, `alert_config`, cadence, and delivery targets. Use `vision-actions-runs-list` + `vision-actions-runs-retrieve` to read the reports it has actually produced.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get a vision action",
+        "title": "Get a vision action",
+        "required_scopes": ["vision_action:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-actions-runs-list": {
+        "description": "List the run history for one vision action (nested under the action). Each run is one execution that produced a group summary or evaluated an alert. Rows are lightweight — `status` (running/completed/failed/skipped), `scheduled_at`, `observation_count` (how many observations fed the summary), `error_reason`, and `is_recovery` — without the report body. Fetch a completed run with `vision-actions-runs-retrieve` to get the synthesized report and the observations it cited.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "List a vision action's runs",
+        "title": "List a vision action's runs",
+        "required_scopes": ["vision_action:read", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-actions-runs-retrieve": {
+        "description": "Get one vision action run in full: `synthesized_markdown` (the group-summary report, which cites its source observations inline with `[obs N]` markers) and `observations` — the recordings the run included, in summary order, each carrying the 1-based `index` that the report's `[obs N]` markers reference plus that observation's title and outcome. This is the tool for auditing a group summary: for each `[obs N]` in the markdown, `observations[N-1]` is the observation it cites, so you can check whether the cited observation actually supports the claim. Empty `synthesized_markdown`/`observations` means the run skipped, failed, or predates observation tracking.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get a vision action run's full group summary",
+        "title": "Get a vision action run's full group summary",
+        "required_scopes": ["vision_action:read", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
     "vision-observations-label-create": {
         "description": "Set or update the shared thumbs up/down rating on a replay scanner observation: `is_correct` true means the scanner got the session right (thumbs up), false means it got it wrong (thumbs down), plus optional written `feedback` explaining why (applies to both directions). One shared rating per observation, team-wide, last write wins; re-posting updates it in place. These ratings power the scanner's Quality tab: the quality-over-time chart and the AI prompt recommendations (see `vision-scanners-prompt-suggestions-generate`). Find observation IDs via `vision-scanners-observations-list` (filter `labeled=false` for unrated ones) or `vision-observations-list` for a session.",
         "category": "Replay vision",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -10335,6 +10335,66 @@
             "readOnlyHint": false
         }
     },
+    "vision-actions-list": {
+        "description": "List the vision actions (the \"and then…\" automations that run over a scanner's observations) for the current project. A vision action in `mode: group_summary` produces the group summary shown on the \"Summaries and alerts\" tab — one report synthesized from up to `max_observations` observations of its bound scanner; `mode: alert` delivers only when its alert condition holds. Each row carries the bound `scanner`, `mode`, `trigger_type`, cadence, and `is_scanner_digest` (the built-in daily digest). Pass `?scanner=<id>` to filter to one scanner. To read a specific action's produced reports, list its runs with `vision-actions-runs-list`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "List vision actions",
+        "title": "List vision actions",
+        "required_scopes": ["vision_action:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-actions-retrieve": {
+        "description": "Get a single vision action by ID. Returns its configuration: the bound `scanner`, `mode` (group_summary/alert), `selection` (the observation-targeting predicate — verdict/tags/score bounds/window), `synthesis_config`, `alert_config`, cadence, and delivery targets. Use `vision-actions-runs-list` + `vision-actions-runs-retrieve` to read the reports it has actually produced.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get a vision action",
+        "title": "Get a vision action",
+        "required_scopes": ["vision_action:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-actions-runs-list": {
+        "description": "List the run history for one vision action (nested under the action). Each run is one execution that produced a group summary or evaluated an alert. Rows are lightweight — `status` (running/completed/failed/skipped), `scheduled_at`, `observation_count` (how many observations fed the summary), `error_reason`, and `is_recovery` — without the report body. Fetch a completed run with `vision-actions-runs-retrieve` to get the synthesized report and the observations it cited.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "List a vision action's runs",
+        "title": "List a vision action's runs",
+        "required_scopes": ["vision_action:read", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
+    "vision-actions-runs-retrieve": {
+        "description": "Get one vision action run in full: `synthesized_markdown` (the group-summary report, which cites its source observations inline with `[obs N]` markers) and `observations` — the recordings the run included, in summary order, each carrying the 1-based `index` that the report's `[obs N]` markers reference plus that observation's title and outcome. This is the tool for auditing a group summary: for each `[obs N]` in the markdown, `observations[N-1]` is the observation it cites, so you can check whether the cited observation actually supports the claim. Empty `synthesized_markdown`/`observations` means the run skipped, failed, or predates observation tracking.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Get a vision action run's full group summary",
+        "title": "Get a vision action run's full group summary",
+        "required_scopes": ["vision_action:read", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "replay-vision"
+    },
     "vision-observations-label-create": {
         "description": "Set or update the shared thumbs up/down rating on a replay scanner observation: `is_correct` true means the scanner got the session right (thumbs up), false means it got it wrong (thumbs down), plus optional written `feedback` explaining why (applies to both directions). One shared rating per observation, team-wide, last write wins; re-posting updates it in place. These ratings power the scanner's Quality tab: the quality-over-time chart and the AI prompt recommendations (see `vision-scanners-prompt-suggestions-generate`). Find observation IDs via `vision-scanners-observations-list` (filter `labeled=false` for unrated ones) or `vision-observations-list` for a session.",
         "category": "Replay vision",

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -3,10 +3,69 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 21 enabled ops
+ * PostHog API - MCP 25 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
+
+/**
+ * CRUD for Replay Vision actions — scheduled "and then…" automations over a scanner's observations.
+ */
+export const VisionActionsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+export const VisionActionsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    scanner: zod.string().optional().describe('Filter to the actions belonging to one scanner.'),
+})
+
+/**
+ * CRUD for Replay Vision actions — scheduled "and then…" automations over a scanner's observations.
+ */
+export const VisionActionsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this vision action.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+})
+
+/**
+ * Read-only run history for a single vision action (nested under /vision/actions/{action_id}/runs/).
+ */
+export const VisionActionsRunsListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    vision_action_id: zod.string(),
+})
+
+export const VisionActionsRunsListQueryParams = /* @__PURE__ */ zod.object({
+    limit: zod.number().optional().describe('Number of results to return per page.'),
+    offset: zod.number().optional().describe('The initial index from which to return the results.'),
+})
+
+/**
+ * Read-only run history for a single vision action (nested under /vision/actions/{action_id}/runs/).
+ */
+export const VisionActionsRunsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this vision action run.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    vision_action_id: zod.string(),
+})
 
 /**
  * Read-only access to a session's observations across every scanner the caller can read, for the replay-page dock.

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -3,6 +3,11 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
+    VisionActionsListQueryParams,
+    VisionActionsRetrieveParams,
+    VisionActionsRunsListParams,
+    VisionActionsRunsListQueryParams,
+    VisionActionsRunsRetrieveParams,
     VisionObservationsLabelCreateBody,
     VisionObservationsLabelCreateParams,
     VisionObservationsLabelDestroyParams,
@@ -36,6 +41,83 @@ import {
 } from '@/generated/replay_vision/api'
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const VisionActionsListSchema = VisionActionsListQueryParams
+
+const visionActionsList = (): ToolBase<
+    typeof VisionActionsListSchema,
+    WithPostHogUrl<Schemas.PaginatedVisionActionList>
+> => ({
+    name: 'vision-actions-list',
+    schema: VisionActionsListSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionActionsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedVisionActionList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/actions/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+                scanner: params.scanner,
+            },
+        })
+        return await withPostHogUrl(context, result, '/replay-vision')
+    },
+})
+
+const VisionActionsRetrieveSchema = VisionActionsRetrieveParams.omit({ project_id: true })
+
+const visionActionsRetrieve = (): ToolBase<typeof VisionActionsRetrieveSchema, Schemas.VisionAction> => ({
+    name: 'vision-actions-retrieve',
+    schema: VisionActionsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionActionsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.VisionAction>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/actions/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const VisionActionsRunsListSchema = VisionActionsRunsListParams.omit({ project_id: true }).extend(
+    VisionActionsRunsListQueryParams.shape
+)
+
+const visionActionsRunsList = (): ToolBase<
+    typeof VisionActionsRunsListSchema,
+    WithPostHogUrl<Schemas.PaginatedVisionActionRunListList>
+> => ({
+    name: 'vision-actions-runs-list',
+    schema: VisionActionsRunsListSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionActionsRunsListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.PaginatedVisionActionRunListList>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/actions/${encodeURIComponent(String(params.vision_action_id))}/runs/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+            },
+        })
+        return await withPostHogUrl(context, result, '/replay-vision')
+    },
+})
+
+const VisionActionsRunsRetrieveSchema = VisionActionsRunsRetrieveParams.omit({ project_id: true })
+
+const visionActionsRunsRetrieve = (): ToolBase<typeof VisionActionsRunsRetrieveSchema, Schemas.VisionActionRun> => ({
+    name: 'vision-actions-runs-retrieve',
+    schema: VisionActionsRunsRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionActionsRunsRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.VisionActionRun>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/actions/${encodeURIComponent(String(params.vision_action_id))}/runs/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
 
 const VisionObservationsLabelCreateSchema = VisionObservationsLabelCreateParams.omit({ project_id: true }).extend(
     VisionObservationsLabelCreateBody.shape
@@ -613,6 +695,10 @@ const visionScannersUpdate = (): ToolBase<typeof VisionScannersUpdateSchema, Sch
 })
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'vision-actions-list': visionActionsList,
+    'vision-actions-retrieve': visionActionsRetrieve,
+    'vision-actions-runs-list': visionActionsRunsList,
+    'vision-actions-runs-retrieve': visionActionsRunsRetrieve,
     'vision-observations-label-create': visionObservationsLabelCreate,
     'vision-observations-label-destroy': visionObservationsLabelDestroy,
     'vision-observations-list': visionObservationsList,


### PR DESCRIPTION
## Problem

Replay Vision scanners produce group summaries and alerts (the "Summaries and alerts" tab) by synthesizing up to 100 observations into one report. Those reports cite their source observations inline with `[obs N]` markers. There was no way for an agent to read those reports over the MCP, so there was no way to audit whether a report's citations actually hold up, whether `[obs N]` points at an observation that supports the claim or a bogus one.

The underlying REST API (`VisionActionViewSet`, `VisionActionRunViewSet`) already exists and already resolves each `[obs N]` to its observation. It just wasn't exposed as MCP tools.

## Changes

Enables four read-only MCP tools that were already scaffolded (disabled) in `products/replay_vision/mcp/tools.yaml`, adds their scopes, annotations, and descriptions, and regenerates the MCP and type artifacts:

- `vision-actions-list` / `vision-actions-retrieve`, the "and then…" automations over a scanner's observations (`mode: group_summary` or `alert`).
- `vision-actions-runs-list`, a single action's run history (lightweight rows).
- `vision-actions-runs-retrieve`, one run in full: `synthesized_markdown` (the report, with its `[obs N]` markers) plus `observations`, the recordings it included in summary order, each carrying the 1-based `index` that `[obs N]` references. So `observations[N-1]` is the observation cited by `[obs N]`, which is exactly what a citation audit needs.

No backend changes. The endpoints, serializers, and RBAC already existed on master. Scopes match the viewsets: `vision_action:read` throughout, plus `session_recording:read` on the run tools since runs surface recording-derived summaries. All four are read-only and gated behind the existing `replay-vision` feature flag.

## How did you test this code?

I (Claude) ran `hogli build:openapi` to regenerate, `pnpm --filter=@posthog/mcp lint-tool-names` (passes), and `hogli ci:preflight` (0 failures). I verified codegen is idempotent: regenerating on clean master with no change produces zero diff, so the only generated churn here is the four new tools. I did not exercise the tools against a live MCP connection, the deployed MCP doesn't serve them until this ships, and the local MCP wasn't wired up for prod data in this session.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Kim directed this. The goal was to audit whether the citations in Replay Vision group summaries actually support their claims. Investigating that surfaced the gap: the per-session summarizer observations were readable over MCP, but the group summaries (VisionActionRun) were not. I confirmed the REST API already existed and resolved `[obs N]` to observations, so the fix was to enable the already-scaffolded tools rather than build anything.

Tools/agent: Claude Code (Opus 4.8). Skills invoked: `/exploring-replay-vision-observations`, `/implementing-mcp-tools`, `/querying-local-postgres`, `/improving-drf-endpoints` (read-only, no serializer changes were needed).

One snag worth noting for the reviewer: an earlier version of this change got picked up and committed by a parallel session into #73062. This PR rebuilds it cleanly off master so it stands alone, so expect a `tools.yaml` conflict between the two. Whichever lands second reconciles the generated files by re-running `hogli build:openapi`.