### PR TITLE
chore(ci): cache rust dependency builds in the nodejs and crate-publish jobs

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -129,7 +129,7 @@ jobs:
         name: Node.js Code quality (depot-ubuntu-24.04)
         needs: changes
         runs-on: depot-ubuntu-24.04
-        timeout-minutes: 15
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -185,7 +185,7 @@ jobs:
         name: Node.js Build (depot-ubuntu-24.04)
         needs: changes
         runs-on: depot-ubuntu-24.04
-        timeout-minutes: 15
+        timeout-minutes: 10
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -145,8 +145,7 @@ jobs:
               with:
                   toolchain: 1.91.1
 
-            # Fork PRs run untrusted build scripts: keep them off the shared WebDAV compiler
-            # cache (no RUSTC_WRAPPER means no cache writes an internal build would later read).
+            # for security reasons, external builds (forks) don't use the shared WebDAV cache
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
               if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
@@ -202,8 +201,7 @@ jobs:
               with:
                   toolchain: 1.91.1
 
-            # Fork PRs run untrusted build scripts: keep them off the shared WebDAV compiler
-            # cache (no RUSTC_WRAPPER means no cache writes an internal build would later read).
+            # for security reasons, external builds (forks) don't use the shared WebDAV cache
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
               if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
@@ -310,8 +308,7 @@ jobs:
               with:
                   toolchain: 1.91.1
 
-            # Fork PRs run untrusted build scripts: keep them off the shared WebDAV compiler
-            # cache (no RUSTC_WRAPPER means no cache writes an internal build would later read).
+            # for security reasons, external builds (forks) don't use the shared WebDAV cache
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
               if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
@@ -568,8 +565,7 @@ jobs:
               with:
                   toolchain: 1.91.1
 
-            # Fork PRs run untrusted build scripts: keep them off the shared WebDAV compiler
-            # cache (no RUSTC_WRAPPER means no cache writes an internal build would later read).
+            # for security reasons, external builds (forks) don't use the shared WebDAV cache
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
               if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -413,13 +413,7 @@ jobs:
                   # Create dedicated persons database for postgres-parity tests
                   cd nodejs && pnpm run setup:test:persons-parity
 
-            # Build the workspace deps (the Rust addons + TS) up front so the Jest step below times
-            # only the tests. Otherwise turbo's `test` task pulls `^build`, folding the addon compile
-            # into the test step and making a slow shard ambiguous (cold cargo vs slow tests).
-            # SHARD_INDEX/SHARD_COUNT are in the `build` task's turbo cache key, so they must match the
-            # Jest step's values here — otherwise `^build` hashes differently in the two steps and the
-            # addon rebuilds inside Jest anyway. (The build output doesn't actually vary by shard; the
-            # real fix is dropping them from the build task's env in turbo.json.)
+            # Build workspace deps (Rust addons + TS) up front so the Jest step times only tests; the shard env must match Jest's, or turbo's build cache key differs between the steps and the addon rebuilds inside Jest anyway.
             - name: Prepare Node.js workspace
               env:
                   SHARD_INDEX: ${{ matrix.shard }}

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -145,10 +145,14 @@ jobs:
               with:
                   toolchain: 1.91.1
 
+            # Fork PRs run untrusted build scripts: keep them off the shared WebDAV compiler
+            # cache (no RUSTC_WRAPPER means no cache writes an internal build would later read).
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
+              if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
+              if: env.RUNS_ON_INTERNAL_PR == 'true'
               uses: ./.github/actions/setup-sccache
 
             - name: Cache Rust dependencies
@@ -198,10 +202,14 @@ jobs:
               with:
                   toolchain: 1.91.1
 
+            # Fork PRs run untrusted build scripts: keep them off the shared WebDAV compiler
+            # cache (no RUSTC_WRAPPER means no cache writes an internal build would later read).
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
+              if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
+              if: env.RUNS_ON_INTERNAL_PR == 'true'
               uses: ./.github/actions/setup-sccache
 
             - name: Cache Rust dependencies
@@ -302,10 +310,14 @@ jobs:
               with:
                   toolchain: 1.91.1
 
+            # Fork PRs run untrusted build scripts: keep them off the shared WebDAV compiler
+            # cache (no RUSTC_WRAPPER means no cache writes an internal build would later read).
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
+              if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
+              if: env.RUNS_ON_INTERNAL_PR == 'true'
               uses: ./.github/actions/setup-sccache
 
             - name: Cache Rust dependencies
@@ -556,10 +568,14 @@ jobs:
               with:
                   toolchain: 1.91.1
 
+            # Fork PRs run untrusted build scripts: keep them off the shared WebDAV compiler
+            # cache (no RUSTC_WRAPPER means no cache writes an internal build would later read).
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
+              if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
+              if: env.RUNS_ON_INTERNAL_PR == 'true'
               uses: ./.github/actions/setup-sccache
 
             - name: Cache Rust dependencies

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -416,7 +416,14 @@ jobs:
             # Build the workspace deps (the Rust addons + TS) up front so the Jest step below times
             # only the tests. Otherwise turbo's `test` task pulls `^build`, folding the addon compile
             # into the test step and making a slow shard ambiguous (cold cargo vs slow tests).
+            # SHARD_INDEX/SHARD_COUNT are in the `build` task's turbo cache key, so they must match the
+            # Jest step's values here — otherwise `^build` hashes differently in the two steps and the
+            # addon rebuilds inside Jest anyway. (The build output doesn't actually vary by shard; the
+            # real fix is dropping them from the build task's env in turbo.json.)
             - name: Prepare Node.js workspace
+              env:
+                  SHARD_INDEX: ${{ matrix.shard }}
+                  SHARD_COUNT: 3
               run: bin/turbo --filter=@posthog/nodejs prepare
 
             - name: Test with Jest

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -413,7 +413,7 @@ jobs:
                   # Create dedicated persons database for postgres-parity tests
                   cd nodejs && pnpm run setup:test:persons-parity
 
-            # Build workspace deps (Rust addons + TS) up front so the Jest step times only tests; the shard env must match Jest's, or turbo's build cache key differs between the steps and the addon rebuilds inside Jest anyway.
+            # Build workspace deps (Rust addons + TS) up front so the Jest step times only tests, not the addon compile.
             - name: Prepare Node.js workspace
               env:
                   SHARD_INDEX: ${{ matrix.shard }}

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -413,6 +413,12 @@ jobs:
                   # Create dedicated persons database for postgres-parity tests
                   cd nodejs && pnpm run setup:test:persons-parity
 
+            # Build the workspace deps (the Rust addons + TS) up front so the Jest step below times
+            # only the tests. Otherwise turbo's `test` task pulls `^build`, folding the addon compile
+            # into the test step and making a slow shard ambiguous (cold cargo vs slow tests).
+            - name: Prepare Node.js workspace
+              run: bin/turbo --filter=@posthog/nodejs prepare
+
             - name: Test with Jest
               id: run-jest
               # continue-on-error so the quarantine gate below is the verdict — it passes when

--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -129,7 +129,7 @@ jobs:
         name: Node.js Code quality (depot-ubuntu-24.04)
         needs: changes
         runs-on: depot-ubuntu-24.04
-        timeout-minutes: 10
+        timeout-minutes: 15
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -139,6 +139,24 @@ jobs:
               uses: ./.github/actions/pnpm-install
               with:
                   install-command: pnpm --filter=@posthog/nodejs... install --frozen-lockfile
+
+            - name: Install rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+
+            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
+              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
+
+            - name: Install sccache
+              uses: ./.github/actions/setup-sccache
+
+            - name: Cache Rust dependencies
+              uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+              with:
+                  shared-key: 'v2-rust-nodejs'
+                  workspaces: rust
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Prepare Node.js workspace
               run: bin/turbo --filter=@posthog/nodejs prepare
@@ -164,7 +182,7 @@ jobs:
         name: Node.js Build (depot-ubuntu-24.04)
         needs: changes
         runs-on: depot-ubuntu-24.04
-        timeout-minutes: 10
+        timeout-minutes: 15
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -174,6 +192,24 @@ jobs:
               uses: ./.github/actions/pnpm-install
               with:
                   install-command: pnpm --filter=@posthog/nodejs... install --frozen-lockfile
+
+            - name: Install rust
+              uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+              with:
+                  toolchain: 1.91.1
+
+            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
+              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
+
+            - name: Install sccache
+              uses: ./.github/actions/setup-sccache
+
+            - name: Cache Rust dependencies
+              uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+              with:
+                  shared-key: 'v2-rust-nodejs'
+                  workspaces: rust
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Prepare Node.js workspace
               run: bin/turbo --filter=@posthog/nodejs prepare
@@ -265,6 +301,19 @@ jobs:
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
                   toolchain: 1.91.1
+
+            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
+              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
+
+            - name: Install sccache
+              uses: ./.github/actions/setup-sccache
+
+            - name: Cache Rust dependencies
+              uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+              with:
+                  shared-key: 'v2-rust-nodejs'
+                  workspaces: rust
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli
@@ -506,6 +555,19 @@ jobs:
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
                   toolchain: 1.91.1
+
+            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
+              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
+
+            - name: Install sccache
+              uses: ./.github/actions/setup-sccache
+
+            - name: Cache Rust dependencies
+              uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+              with:
+                  shared-key: 'v2-rust-nodejs'
+                  workspaces: rust
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Install sqlx-cli
               uses: ./.github/actions/setup-sqlx-cli

--- a/.github/workflows/publish-replay-anonymizer-crate.yml
+++ b/.github/workflows/publish-replay-anonymizer-crate.yml
@@ -80,10 +80,8 @@ jobs:
 
     publish:
         name: Publish to crates.io
-        # Depot: ambient sccache WebDAV credentials, so the verify build's dependency
-        # compiles hit the shared cache instead of building cold under the timeout.
         runs-on: depot-ubuntu-24.04
-        timeout-minutes: 15
+        timeout-minutes: 10
         if: github.event_name == 'push' && github.repository == 'PostHog/posthog'
         permissions:
             contents: read

--- a/.github/workflows/publish-replay-anonymizer-crate.yml
+++ b/.github/workflows/publish-replay-anonymizer-crate.yml
@@ -80,8 +80,10 @@ jobs:
 
     publish:
         name: Publish to crates.io
-        runs-on: ubuntu-24.04
-        timeout-minutes: 10
+        # Depot: ambient sccache WebDAV credentials, so the verify build's dependency
+        # compiles hit the shared cache instead of building cold under the timeout.
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 15
         if: github.event_name == 'push' && github.repository == 'PostHog/posthog'
         permissions:
             contents: read
@@ -139,6 +141,22 @@ jobs:
               uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
               with:
                   toolchain: 1.91.1
+
+            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
+              if: steps.version.outputs.publish-needed == 'true'
+              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
+
+            - name: Install sccache
+              if: steps.version.outputs.publish-needed == 'true'
+              uses: ./.github/actions/setup-sccache
+
+            - name: Cache Rust dependencies
+              if: steps.version.outputs.publish-needed == 'true'
+              uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+              with:
+                  shared-key: 'v2-rust-nodejs'
+                  workspaces: rust
+                  save-if: ${{ github.ref == 'refs/heads/master' }}
 
             - name: Authenticate with crates.io
               if: steps.version.outputs.publish-needed == 'true'

--- a/.github/workflows/publish-replay-anonymizer-crate.yml
+++ b/.github/workflows/publish-replay-anonymizer-crate.yml
@@ -80,7 +80,9 @@ jobs:
 
     publish:
         name: Publish to crates.io
-        runs-on: depot-ubuntu-24.04
+        # Not on a Depot runner: this job holds CARGO_REGISTRY_TOKEN and Depot injects the shared
+        # sccache WebDAV credentials ambiently, which a malicious dependency build script could read.
+        runs-on: ubuntu-24.04
         timeout-minutes: 10
         if: github.event_name == 'push' && github.repository == 'PostHog/posthog'
         permissions:
@@ -140,14 +142,9 @@ jobs:
               with:
                   toolchain: 1.91.1
 
-            - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              if: steps.version.outputs.publish-needed == 'true'
-              run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
-
-            - name: Install sccache
-              if: steps.version.outputs.publish-needed == 'true'
-              uses: ./.github/actions/setup-sccache
-
+            # No sccache here: cargo publish runs dependency build scripts with CARGO_REGISTRY_TOKEN
+            # present, so it must not read the fork-writable shared compiler cache. rust-cache is
+            # GitHub's own cache (fork-isolated, master-write-only below), so it stays.
             - name: Cache Rust dependencies
               if: steps.version.outputs.publish-needed == 'true'
               uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2


### PR DESCRIPTION
## Problem

We've had a rust build as part of the node CI for a long time (due to cyclotron), but we are missing some important devex things in node CI:

* toolchain pinning (partially existed already)
* dependency caching

This PR adds them, based on the Rust CI

Claude code continues:

The nodejs CI jobs build the `@posthog/replay-anonymizer` native addon through turbo's `^build` dependency. Turbo's remote cache serves the built addon while the rust sources are untouched, but any PR that changes `rust/replay-anonymizer{,-node}` misses that cache and cold-builds the crate plus its whole dependency tree (`image`, `simd-json`, `zstd-sys`, ...) in release mode, with no rust caching at all in those jobs:

- Node.js Code quality and Node.js Build: 10 minute timeouts on 2-vCPU runners
- Node.js Tests x3 and the rust ingestion e2e job: the cold build eats a large slice of their 30 minutes (a test shard on #70308 hit its timeout)
- `cargo publish` verify build: 10 minutes on an uncached GitHub-hosted runner

`ci-rust.yml` already solved this with sccache over Depot's WebDAV cache plus `Swatinem/rust-cache`; the nodejs workflow just never got the same treatment.

## Changes

Wire the same pattern (same pinned action SHAs) into every nodejs job that can end up running cargo, and the crate-publish workflow:

- sccache with the WebDAV key prefixed by the `Cargo.lock` hash, so dependency compiles hit the shared cache even when turbo misses
- `Swatinem/rust-cache` under a dedicated `v2-rust-nodejs` shared key (saved from master, restored by PRs). Kept separate from ci-rust's `v2-rust-ci` because those jobs run ubuntu 22.04 and these run 24.04
- a pinned `dtolnay/rust-toolchain` install in the code-quality and build jobs, which previously relied on the runner image's preinstalled toolchain
- the publish job gets rust-cache but **not** sccache, and stays on GitHub-hosted `ubuntu-24.04`: it runs `cargo publish` with `CARGO_REGISTRY_TOKEN` present, so it must not read a fork-writable compiler cache (poisoned artifact -> code exec with the token) nor sit on a runner where the WebDAV credentials are ambient

> [!NOTE]
> **Why does a node job need a rust toolchain at all?** It always has, just implicitly. `bin/turbo --filter=@posthog/nodejs prepare` runs `^build`, and two workspace deps of `@posthog/nodejs` are Neon native addons whose turbo `build` task is `cargo build --release`: `@posthog/cyclotron` (rust/cyclotron-node, predates this by a long way) and `@posthog/replay-anonymizer` (rust/replay-anonymizer-node). Whenever turbo's remote cache misses for either, these jobs compile rust today, on whatever unpinned toolchain the runner image happens to preinstall. The explicit `dtolnay/rust-toolchain` step pins 1.91.1 like every other rust-building job, and gives rust-cache and sccache a stable rustc for their cache keys, which the image's rotating toolchain would silently churn on every image update.

> [!WARNING]
> **Fork PRs are kept off the shared compiler cache.** The sccache steps are gated on `RUNS_ON_INTERNAL_PR`: fork PRs execute untrusted build scripts (cargo `build.rs`, npm lifecycle hooks), and with a `RUSTC_WRAPPER` pointed at the shared WebDAV cache they could write poisoned entries that internal builds later read. Gated off, fork builds just run cold. To be precise about what the gate does and does not do: the Depot runner injects the WebDAV credentials into the job environment ambiently on these runner types regardless of this workflow's steps (that pre-existing posture is why `_rust-build-images.yml` has its own fork guard, and it applies to `ci-rust.yml`'s fork runs today too), so the gate's job is to keep this PR from turning those credentials into a useful write path into trusted builds, not to hide them.

The first run after a `Cargo.lock` change still pays the cold build and warms the caches; every run after that reads them. Unrebased branches are unaffected: every referenced action and file predates this change, and `hashFiles` on a missing file just degrades the cache key.

## How did you test this code?

`bin/hogli lint:workflows` passes (all 6 checks across 103 workflows). The caching steps are copied verbatim from `ci-rust.yml`, which exercises them on every rust PR. No new tests: workflow-only change, verified by this PR's own CI runs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: internal CI wiring only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Fable 5) in the session working on #70308, where a rust-touching push exposed the cold-build problem (a Node.js Tests shard hit its 30 minute timeout). The `/authoring-ci-workflows` skill was invoked before editing. Originally committed onto #70308, then split out here to keep that PR's scope down; #70308 carries only a minimal tests-shard timeout bump (30 to 45) until this lands. One deliberate choice: a dedicated `v2-rust-nodejs` rust-cache key rather than reusing `v2-rust-ci`, trading some cache duplication for not mixing artifacts built on different ubuntu versions.


