### PR TITLE
chore(aio): remove llm-analytics early adopter feature flags

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -345,8 +345,6 @@ export const FEATURE_FLAGS = {
     LIVE_EVENTS_RICH_FILTERS: 'live-events-rich-filters', // owner: @jordanm-posthog #team-web-analytics
     LLM_ANALYTICS_CLUSTERING_ADMIN: 'llm-analytics-clustering-admin', // owner: #team-ai-observability
     LLM_ANALYTICS_DATASETS: 'llm-analytics-datasets', // owner: #team-ai-observability #team-posthog-ai
-    LLM_ANALYTICS_EARLY_ADOPTERS: 'llm-analytics-early-adopters', // owner: #team-ai-observability
-    LLM_ANALYTICS_EVALUATIONS_REPORTS: 'llm-analytics-evaluations-reports', // owner: #team-ai-observability
     LLM_ANALYTICS_EVALUATIONS_START_WITH_AI: 'llm-analytics-evaluations-start-with-ai', // owner: #team-ai-observability
     LLM_ANALYTICS_OFFLINE_EVALS: 'llm-analytics-offline-evals', // owner: #team-ai-observability
     LLM_ANALYTICS_TAGS: 'llm-analytics-tags', // owner: #team-ai-observability

--- a/products/ai_observability/frontend/AIObservabilitySessionScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilitySessionScene.tsx
@@ -169,8 +169,6 @@ function SessionSceneWrapper({ showBreadcrumb = false }: { showBreadcrumb?: bool
         }
     }, [playing, revealedTurnCount])
 
-    const showSessionSummarization = featureFlags[FEATURE_FLAGS.LLM_ANALYTICS_EARLY_ADOPTERS]
-
     // Calculate session aggregates
     const sessionStats = traces.reduce(
         (acc, trace) => ({
@@ -252,7 +250,6 @@ function SessionSceneWrapper({ showBreadcrumb = false }: { showBreadcrumb?: bool
                         turn={turn}
                         phase={isScrubbing ? phaseOf(i) : 'complete'}
                         showSentiment
-                        showSessionSummarization={!!showSessionSummarization}
                         traceSearchParams={traceSearchParams}
                     />
                 ))}
@@ -386,14 +383,12 @@ function SessionTurnView({
     turn,
     phase = 'complete',
     showSentiment,
-    showSessionSummarization,
     traceSearchParams,
     rootRef,
 }: {
     turn: SessionTurn
     phase?: TurnPhase
     showSentiment: boolean
-    showSessionSummarization: boolean
     traceSearchParams: Record<string, unknown>
     rootRef?: Ref<HTMLDivElement>
 }): JSX.Element {
@@ -433,7 +428,7 @@ function SessionTurnView({
             </div>
             <div className="pb-4">
                 <div className="flex-1 min-w-0 flex flex-col gap-2">
-                    {isComplete && showSessionSummarization && summary && (
+                    {isComplete && summary && (
                         <TurnSummaryLine summary={summary} summaryUrl={summaryUrl} />
                     )}
 

--- a/products/ai_observability/frontend/AIObservabilitySessionScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilitySessionScene.tsx
@@ -428,9 +428,7 @@ function SessionTurnView({
             </div>
             <div className="pb-4">
                 <div className="flex-1 min-w-0 flex flex-col gap-2">
-                    {isComplete && summary && (
-                        <TurnSummaryLine summary={summary} summaryUrl={summaryUrl} />
-                    )}
+                    {isComplete && summary && <TurnSummaryLine summary={summary} summaryUrl={summaryUrl} />}
 
                     <TurnBody
                         turn={turn}


### PR DESCRIPTION
## Problem

The `llm-analytics-early-adopters` early access feature had become a vague, catch-all "meta" enrollment gating a handful of unrelated in-progress features. Following a discussion to clean it up, this removes two of its flags from the codebase.

## Changes

- Remove the `llm-analytics-early-adopters` and `llm-analytics-evaluations-reports` feature flag constants.
- `llm-analytics-evaluations-reports` had no code references — pure constant removal.
- `llm-analytics-early-adopters` gated session summarization in the AI observability session scene. That feature is fully implemented, so it's now graduated (always on) and the flag plumbing through `SessionTurnView` is removed.

## How did you test this code?

No automated tests were added or run by the agent (deletion-only change; no local frontend toolchain available in this environment). A reviewer should run the frontend typecheck (`pnpm --filter=@posthog/frontend typescript:check`) to confirm no dangling references. A repo-wide grep confirms no remaining references to either flag key/constant or to `showSessionSummarization`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack to remove these two flags from the repo. The one judgment call: `llm-analytics-early-adopters` gated session summarization, so removal meant either graduating the feature or deleting it — graduated it (made it unconditional), the conventional flag-cleanup path, since the feature is fully built. Flag it if you'd prefer session summarization removed instead. No skills were required (frontend-only constant + prop cleanup).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784824279501319?thread_ts=1784824279.501319&cid=C087XQ7K9K7)*
