### PR TITLE
fix(marketing-analytics): stop match_key from splitting the costs dedup grain

### DIFF
--- a/posthog/hogql/database/schema/marketing_costs_precomputed.py
+++ b/posthog/hogql/database/schema/marketing_costs_precomputed.py
@@ -15,8 +15,13 @@ _RAW_FIELDS = MarketingCostsPreaggregatedTable().fields  # reuse the raw column 
 _INTERNAL = {"job_id", "computed_at"}  # folded away by the dedup, not exposed
 # argMax(…, computed_at) columns; expires_at rides along so `expires_at > today()` sees the freshest row.
 _LATEST = {"cost", "clicks", "impressions", "reported_conversions", "reported_conversion_value", "expires_at"}
+# match_key is a join key re-derived per job from the team's campaign_field_preferences (campaign_name or
+# campaign_id), not cell identity — keeping it in the GROUP BY duplicates every cell when the preference
+# flips, so the latest job's value wins instead.
+_LATEST_LABELS = {"match_key"}
+_ARGMAX = _LATEST | _LATEST_LABELS
 # Full cell identity — always GROUP BY all of it so each cell collapses independently.
-_DIMENSIONS = [c for c in _RAW_FIELDS if c not in _INTERNAL | _LATEST | {"timestamp"}]
+_DIMENSIONS = [c for c in _RAW_FIELDS if c not in _INTERNAL | _ARGMAX | {"timestamp"}]
 
 
 class MarketingCostsPrecomputedTable(LazyTable):
@@ -42,7 +47,7 @@ class MarketingCostsPrecomputedTable(LazyTable):
 
         select_fields: list[ast.Expr] = []
         for name in requested:
-            if name in _LATEST:
+            if name in _ARGMAX:
                 expr: ast.Expr = ast.Call(name="argMax", args=[raw(name), raw("computed_at")])
             elif name == "timestamp":
                 expr = ast.Call(name="toDateTime", args=[raw("cost_date")])

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_costs_precompute.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_costs_precompute.py
@@ -7,6 +7,8 @@ from unittest.mock import Mock, patch
 
 from django.test import override_settings
 
+from parameterized import parameterized
+
 from posthog.schema import DateRange, MarketingAnalyticsDrillDownLevel, MarketingAnalyticsTableQuery
 
 from posthog.hogql import ast
@@ -148,7 +150,15 @@ class TestMarketingCostsPrecompute(ClickhouseTestMixin, BaseTest):
         # cost_date is a real per-day date (not the sentinel empty), enabling daily-window caching.
         assert all(r[self._col(cols, "cost_date")] is not None for r in rows)
 
-    def test_native_read_takes_latest_job_per_cell_not_sum(self):
+    @parameterized.expand(
+        [
+            ("stale_and_matured_job", "c1", "c1"),
+            # match_key is re-derived per job from the team's campaign_field_preferences, so a preference
+            # flip writes the same real cell under two match_key values; the view must still collapse them.
+            ("campaign_field_preference_flip", "Camp 1", "c1"),
+        ]
+    )
+    def test_native_read_takes_latest_job_per_cell_not_sum(self, _name, match_key_old, match_key_new):
         # The same (campaign, day) cell materialized under two job_ids — a stale value and a matured one.
         # job_id is in the raw ReplacingMergeTree sort key, so both rows survive. The read filters by
         # source (not job_id) and goes through the `marketing_costs_precomputed` view, which must collapse the cell to
@@ -157,7 +167,6 @@ class TestMarketingCostsPrecompute(ClickhouseTestMixin, BaseTest):
             "source_id": "google_test",
             "source_name": "google",
             "grain": "campaign",
-            "match_key": "c1",
             "campaign_id": "c1",
             "campaign_name": "Camp 1",
             "cost_date": date(2023, 1, 15),
@@ -170,7 +179,7 @@ class TestMarketingCostsPrecompute(ClickhouseTestMixin, BaseTest):
                 cell["source_id"],
                 cell["source_name"],
                 cell["grain"],
-                cell["match_key"],
+                match_key,
                 cell["campaign_id"],
                 cell["campaign_name"],
                 "",
@@ -186,9 +195,9 @@ class TestMarketingCostsPrecompute(ClickhouseTestMixin, BaseTest):
                 computed_at,
                 date(2099, 1, 1),
             )
-            for job, cost, computed_at in (
-                (job_old, 100.0, datetime(2023, 1, 15, 10, 0)),
-                (job_new, 150.0, datetime(2023, 1, 16, 10, 0)),
+            for job, match_key, cost, computed_at in (
+                (job_old, match_key_old, 100.0, datetime(2023, 1, 15, 10, 0)),
+                (job_new, match_key_new, 150.0, datetime(2023, 1, 16, 10, 0)),
             )
         ]
         sync_execute(


### PR DESCRIPTION
## Problem

The Marketing analytics cost tile and cost table can report ~2× the real ad spend for teams on the costs precompute path.

The dedup view `marketing_costs_precomputed` collapses the raw `marketing_costs_preaggregated` ReplacingMergeTree by grouping on all dimension columns and taking `argMax(metric, computed_at)` per cell. `match_key` was part of that dimension set, but it isn't cell identity. It's a join key re-derived on every materialization job from the team's `campaign_field_preferences.match_field`, equal to either `campaign_name` or `campaign_id`.

When a team flips that preference, jobs before the flip stored `match_key = campaign_name` and jobs after store `match_key = campaign_id`. Both generations of the same real (campaign, day) cell stay live within the 7-day TTL, the view keeps both because they differ in `match_key`, and `sum(cost)` doubles. The doubling is systematic across all of the team's sources and only self-heals when the stale generation ages out via TTL, then re-breaks on the next flip.

## Changes

`match_key` moves out of the dedup GROUP BY grain into the `argMax(…, computed_at)` set, so the latest job's value wins. That value always reflects the team's current preference, which is also what the read-side conversion-goal join expects. Downstream reads already treat it this way: the campaign-level re-aggregation selects `any(match_key)` on the assumption that all rows in a group share one value, which is exactly the invariant this restores.

Every reader goes through this view (the dashboard tile via a `DataWarehouseNode`, and the table/aggregated path via `_costs_native_read_query`, which delegates dedup to the view), so the single view change fixes all surfaces and self-corrects existing duplicated rows at read time. No re-materialization or backfill needed.

## How did you test this code?

Parameterized the existing dedup test (`test_native_read_takes_latest_job_per_cell_not_sum`) with a `campaign_field_preference_flip` case: two job rows for the same cell with different `match_key` values (one `campaign_name`-shaped, one `campaign_id`-shaped). It asserts the read returns the latest job's cost once (150) instead of summing both generations (250). The existing case uses the same `match_key` for both jobs, so it did not cover this regression.

Verified locally that the new case fails without the view change and passes with it, and that the full `test_marketing_costs_precompute.py` file passes (5/5).

Also replayed the fix against production data: applying the corrected grain to the affected team's live rows halves the summed cost (google ÷1.96, meta ÷1.62) with no other dimension collapsing, so no legitimate rows are lost.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I root-caused this on prod data and handed Claude Code the analysis; Claude implemented the view change and the parameterized test in an isolated worktree, verified the test fails without the fix, and opened this PR. Skills invoked: /writing-tests. One judgment call worth a reviewer's eye: taking `argMax(match_key, computed_at)` assumes no consumer relies on `match_key` being stable across jobs. I believe none do (it's re-aggregated with `any()` at read time), but flagging it explicitly.
