### PR TITLE
feat(cymbal): set posthog-elixir wire-order cutoff at 2.13.0

### DIFF
--- a/rust/cymbal/src/modes/processing/normalization.rs
+++ b/rust/cymbal/src/modes/processing/normalization.rs
@@ -107,6 +107,8 @@ fn lib_rules() -> &'static [LibRule] {
                     // but each module reports its own version stream.
                     "posthog-android" => Some(Version::new(3, 56, 0)),
                     "posthog-server" => Some(Version::new(2, 9, 0)),
+                    // posthog-elixir ships the flip in 2.13.0 (PostHog/posthog-elixir#160).
+                    "posthog-elixir" => Some(Version::new(2, 13, 0)),
                     // posthog-flutter ships its Dart flip in 5.33.0 and raises
                     // its Android SDK floor to the canonical 3.56.0 release.
                     "posthog-flutter" => Some(Version::new(5, 33, 0)),
@@ -327,6 +329,32 @@ mod test {
         // Natively-canonical SDKs have no legacy order.
         assert!(legacy_wire_order(Some("posthog-node"), &canonical).is_none());
         assert!(legacy_wire_order(None, &canonical).is_none());
+    }
+
+    #[test]
+    fn elixir_cutoff_gates_normalization_by_version() {
+        for version in [Some("2.12.1"), Some("2.1.0"), Some("garbage"), None] {
+            let mut list: ExceptionList =
+                vec![exception_with_frames("Boom", &["main", "boom"])].into();
+            let legacy = normalize_wire_order(&mut list, Some("posthog-elixir"), version);
+            assert!(legacy.is_some(), "{version:?} should normalize");
+            assert_eq!(frame_names(&list[0]), vec!["boom", "main"]);
+        }
+
+        for version in ["2.13.0", "2.13.1", "2.14.0", "3.0.0"] {
+            let mut list: ExceptionList =
+                vec![exception_with_frames("Boom", &["main", "boom"])].into();
+            let legacy = normalize_wire_order(&mut list, Some("posthog-elixir"), Some(version));
+            assert!(legacy.is_none(), "{version} should pass through");
+            assert_eq!(frame_names(&list[0]), vec!["main", "boom"]);
+        }
+
+        // Legacy hashing still reconstructs pre-flip order post-cutoff.
+        let canonical: ExceptionList =
+            vec![exception_with_frames("Boom", &["main", "boom"])].into();
+        let legacy = legacy_wire_order(Some("posthog-elixir"), &canonical)
+            .expect("reconstruction must ignore the cutoff");
+        assert_eq!(frame_names(&legacy[0]), vec!["boom", "main"]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Seventh SDK flip of the wire-order standardization (PostHog/sdk-specs#11): posthog-elixir ships canonical bottom-up frames in **2.13.0** (PostHog/posthog-elixir#160, latest release 2.12.1 + that PR's lone minor changeset; no other changesets pending).

This one was deliberately held until the elixir grouping fix (PostHog/posthog-elixir#164, released in 2.12.0) proved out: fleets on 2.12.x now fragment at ~2.4% unique fingerprints per event versus 40–99% on older versions, so the flip lands on a healthy grouping baseline.

## Changes

- `posthog-elixir` gets `canonical_since: Some(2.13.0)`; everything below (or unparseable) keeps normalizing.
- Mirror of the established cutoff gate test: 2.12.1 / 2.1.0 / garbage / missing normalize; 2.13.x, 2.14.0, 3.0.0 pass through; legacy-order reconstruction ignores the cutoff.

## Merge sequencing

1. Re-verify posthog-elixir's latest release is still 2.12.x immediately before merging (the standing version-claim rule).
2. Merge this, wait for cymbal autodeploy.
3. Merge PostHog/posthog-elixir#160 and release as 2.13.0; no other elixir minor in between.

Watch `et-wire-order-launch` as with the previous six. Elixir frames are `platform: "custom"` (no resolution reshaping), so post-cutoff legacy reconstruction is byte-exact — no inline-expansion caveat here.

## How did you test this code?

Automated only: new `elixir_cutoff_gates_normalization_by_version` unit test; normalization module green (15 tests); clippy `-D warnings` and fmt clean. Seventh instance of the reviewed cutoff pattern. The companion flip branch was rebased onto elixir main v2.12.1 (which includes #164's handler changes — verified it introduces no additional frame-building path) with the full elixir suite green (322 passed) on the pinned toolchain.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Rollout process documented in the sdk-specs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code authored this under my direction as step 7 of the flip rollout, after validating in production data that the #164 grouping fix works for upgraded fleets (2.4% unique fingerprints on 2.12.0 vs 91–99% on 2.4–2.5). Target version derived from the latest release plus #160's pending changeset.
