### PR TITLE
chore(owners): remove team-growth ownership for organization, project, and settings routes

### DIFF
--- a/frontend/src/scenes/owners.yaml
+++ b/frontend/src/scenes/owners.yaml
@@ -71,12 +71,8 @@ rules:
       owners: team-ai-observability
     - match: '/onboarding/legacy/sdks/surveys/'
       owners: team-surveys
-    - match: '/organization/'
-      owners: team-growth
     - match: ['/paths-v2/', '/paths/', '/persons-management/', '/persons/']
       owners: team-product-analytics
-    - match: ['/project-homepage/', '/project/']
-      owners: team-growth
     - match: '/resource-transfer/'
       owners: team-platform-features
     - match: ['/retention/', '/saved-insights/']
@@ -85,7 +81,7 @@ rules:
       owners: team-replay
     - match: '/sessions/'
       owners: team-analytics-platform
-    - match: ['/settings/', '/startups/']
+    - match: '/startups/'
       owners: team-growth
     - match: '/surveys/'
       owners: team-surveys


### PR DESCRIPTION
Transfers ownership of `/organization/`, `/project-homepage/`, `/project/`, and `/settings/` scenes away from `team-growth`, leaving `team-growth` responsible only for `/startups/`.