### PR TITLE
chore(lint): lint generated MCP clients again with a targeted rule override

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -115,7 +115,6 @@
         "frontend/src/layout.html",
         "**/fixtures/**",
         "services/mcp/**/generated.ts",
-        "services/mcp/**/generated/**",
         "services/mcp/src/**/*.md",
         "services/mcp/worker-configuration.d.ts",
         "frontend/src/taxonomy/core-filter-definitions-by-group.json",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -22,7 +22,6 @@
         "frontend/src/queries/validators.js",
         "frontend/src/generated/**",
         "services/mcp/**/generated.ts",
-        "services/mcp/**/generated/**",
         "services/mcp/schema/tool-inputs.json",
         "products/**/frontend/generated/**"
     ],
@@ -200,6 +199,12 @@
             "files": ["*.stories.tsx"],
             "rules": {
                 "react-hooks/rules-of-hooks": "off"
+            }
+        },
+        {
+            "files": ["services/mcp/src/generated/**/*.ts"],
+            "rules": {
+                "no-useless-escape": "off"
             }
         },
         {


### PR DESCRIPTION
## Problem

#73291 stopped oxlint/oxfmt churning the generated MCP client by adding a blanket `services/mcp/**/generated/**` ignore to both `.oxlintrc.json` and `.oxfmtrc.json`. That pattern was too broad, and it excluded all of `services/mcp/src/generated/` (the Orval API clients, e.g. `src/generated/workflows/api.ts`) from linting and formatting entirely. It also silently broke the codegen pipeline's own format step, since `generate-orval-schemas.mjs` runs `hogli format:js` on its output, and the formatter was now skipping those files.

We do want these files linted, we just don't want `lint:fix` rewriting them only for the next codegen run to revert the change.

## Changes

- Remove `services/mcp/**/generated/**` from the ignore lists in `.oxlintrc.json` and `.oxfmtrc.json` (the pre-existing `services/mcp/**/generated.ts` entry stays).
- Add an oxlint override disabling only `no-useless-escape` for `services/mcp/src/generated/**/*.ts`. That rule was the actual source of the churn: Orval emits `\"` inside single-quoted `.describe()` strings (53 hits, e.g. in `experiments/api.ts`), so `lint:fix` would rewrite them and regeneration would put them right back. Every other lint rule now applies to the generated clients.

The minified bundles in `services/mcp/public/ui-apps/generated/` need no config entry, since that path is gitignored and oxlint/oxfmt skip gitignored files.

## How did you test this code?

Ran locally in `services/mcp`:

- `pnpm lint` (the same `oxlint --quiet` invocation CI runs): clean.
- `oxlint src/generated/` with warnings visible: 0 findings after the override, and the other generated TS dirs (`src/tools/generated`, `src/ui-apps/generated`, `src/ui-apps/apps/generated`) were already clean.
- `pnpm format:check`: all 1211 files pass, now including the generated clients.
- `pnpm fix` (lint:fix + format): leaves the working tree unmodified, so the churn loop is gone.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5). I asked it to restore linting for the generated MCP clients after #73291. It traced the regression to the blanket ignore, confirmed the churn came solely from `no-useless-escape` on Orval's escaped quotes, and chose a scoped rule override over keeping the ignore (files stay linted) or fixing the escapes post-generation (would fight the generator on every run). No skills were invoked.
