### PR TITLE
fix(conversations): preserve support ticket filters on back navigation

### DIFF
--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import { combineUrl, router } from 'kea-router'
 import { useRef } from 'react'
 
 import { IconChevronDown } from '@posthog/icons'
@@ -103,7 +104,11 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
 
     const { user } = useValues(userLogic)
     const { currentTeam } = useValues(teamLogic)
+    const { searchParams } = useValues(router)
     const aiSuggestionsEnabled = !!currentTeam?.conversations_settings?.ai_suggestions_enabled
+
+    // Preserve the filters/saved view carried over from the list so going back restores them.
+    const backToTicketsUrl = combineUrl(urls.supportTickets(), searchParams).url
 
     const conversationsSettingsUrl = urls.settings('environment-conversations', 'conversations-general')
     const replyDisabledReason: JSX.Element | undefined = emailReplyBlockedReason
@@ -158,7 +163,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                 <div className="flex items-center justify-center h-96">
                     <div className="text-center">
                         <h2 className="text-xl font-semibold mb-2">Ticket not found</h2>
-                        <LemonButton type="primary" to={urls.supportTickets()}>
+                        <LemonButton type="primary" to={backToTicketsUrl}>
                             Back to tickets
                         </LemonButton>
                     </div>
@@ -180,7 +185,7 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                 resourceType={{ type: 'conversation' }}
                 forceBackTo={{
                     name: 'Ticket list',
-                    path: urls.supportTickets(),
+                    path: backToTicketsUrl,
                     key: 'supportTickets',
                 }}
             />

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { useActions, useMountedLogic, useValues } from 'kea'
-import { router } from 'kea-router'
+import { combineUrl, router } from 'kea-router'
 import { useEffect, useMemo, useRef } from 'react'
 
 import { IconChevronDown, IconRefresh } from '@posthog/icons'
@@ -214,7 +214,11 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
                         : undefined,
             }}
             onRow={(ticket) => {
-                const ticketUrl = urls.supportTicketDetail(ticket.ticket_number)
+                // Carry the current filters/saved view along so "back to tickets" can restore them.
+                const ticketUrl = combineUrl(
+                    urls.supportTicketDetail(ticket.ticket_number),
+                    router.values.searchParams
+                ).url
                 return {
                     onClick: (e: React.MouseEvent) => {
                         if (e.metaKey || e.ctrlKey) {


### PR DESCRIPTION
## Problem

In the support product you can filter tickets with a saved view, e.g. `/support/tickets?view=rC1RTu9s`. Open a ticket, hit the "back to tickets" arrow, and you land on a bare `/support/tickets` with every filter forgotten and the list reset to a plain state. Raised from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1784834358120209).

## Changes

Two symmetric fixes so filters survive the round trip:

- Clicking into a ticket now carries the current list query params (the `view` short id, or the ad-hoc filter params) onto the ticket detail URL.
- The "back to tickets" arrow (and the "Ticket not found" fallback button) rebuild the list URL from those carried params instead of the hard-coded bare path.

Both use `combineUrl` from `kea-router`. Because the params ride on the ticket detail URL, they also survive a reload of the ticket page.

Root cause was `urls.supportTickets()` returning a zero-arg bare `/support/tickets`, with the list's `view`/filter params dropped both on the way into a ticket and on the way back out.

## How did you test this code?

I (Claude, the PostHog Slack app) ran the frontend TypeScript check on the two changed scenes with no errors. I did not run the app manually. No automated tests were added — the change is a URL-construction fix in two React scenes, and there's no existing Jest harness for these scenes to extend without standing one up.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover this navigation behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) from a Slack request. I used the Explore agent to trace the support tickets scenes (they live under `products/conversations/`, not `products/support/`), found the back link came from a `forceBackTo` breadcrumb pointing at the zero-arg `urls.supportTickets()`, and confirmed the `view` param was dropped on entry as well as exit. Chose to carry all current search params through the ticket URL rather than special-casing `view`, so ad-hoc filters are preserved too. No repo skills were required for this frontend-only change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1784834358120209)*
