### PR TITLE
fix(web-analytics): skip precompute for teams with property access controls

### DIFF
--- a/products/access_control/backend/facade/api.py
+++ b/products/access_control/backend/facade/api.py
@@ -27,6 +27,7 @@ from posthog.models import OrganizationMembership, PropertyDefinition, Team
 from ee.models.rbac.role import Role
 
 from ..models.property_access_control import PropertyAccessControl
+from ..property_access_control import is_property_access_control_enabled
 from . import contracts
 from .contracts import PropertyAccessLevel
 
@@ -100,6 +101,19 @@ def get_property_access_state(
         available_access_levels=list(PropertyAccessLevel),
         default_access_level=default_level,
     )
+
+
+def team_has_property_access_rules(*, team_id: int) -> bool:
+    """Whether the team has any property-level access-control rules in effect.
+
+    True only when the feature is available for the org AND at least one rule
+    targeting a property definition exists. Callers that share results across
+    users (e.g. userless precompute) use this to opt out entirely, since a
+    result computed without a user cannot honor per-user property restrictions.
+    """
+    if not is_property_access_control_enabled(team_id=team_id):
+        return False
+    return PropertyAccessControl.objects.filter(team_id=team_id, property_definition__isnull=False).exists()
 
 
 # --- Write API ---

--- a/products/access_control/backend/tests/test_property_access_control_api.py
+++ b/products/access_control/backend/tests/test_property_access_control_api.py
@@ -5,6 +5,7 @@ from posthog.models import PropertyDefinition
 from posthog.models.event.util import ClickhouseEventSerializer
 from posthog.test.persons import create_person
 
+from products.access_control.backend.facade.api import team_has_property_access_rules
 from products.access_control.backend.models.property_access_control import PropertyAccessControl
 from products.access_control.backend.property_access_control import PropertyAccessLevel
 
@@ -251,3 +252,29 @@ class TestPropertyAccessControlHelpers(BaseTest):
         props = {"a": 1, "b": 2}
         result = strip_restricted_properties(props, set())
         assert result == {"a": 1, "b": 2}
+
+
+class TestTeamHasPropertyAccessRules(BaseTest):
+    def _prop(self) -> PropertyDefinition:
+        return PropertyDefinition.objects.create(
+            team=self.team, name="secret", property_type="String", type=PropertyDefinition.Type.EVENT
+        )
+
+    def test_false_when_feature_unavailable_even_with_rules(self):
+        # No feature entitlement short-circuits before any rule query, so a stray rule
+        # (e.g. left over after a downgrade) never re-enables the restriction path.
+        PropertyAccessControl.objects.create(
+            team=self.team, property_definition=self._prop(), access_level=PropertyAccessLevel.NONE.value
+        )
+        assert team_has_property_access_rules(team_id=self.team.id) is False
+
+    def test_false_when_enabled_but_no_rules(self):
+        _enable_property_access_control(self.organization)
+        assert team_has_property_access_rules(team_id=self.team.id) is False
+
+    def test_true_when_enabled_and_a_rule_targets_a_property(self):
+        _enable_property_access_control(self.organization)
+        PropertyAccessControl.objects.create(
+            team=self.team, property_definition=self._prop(), access_level=PropertyAccessLevel.NONE.value
+        )
+        assert team_has_property_access_rules(team_id=self.team.id) is True

--- a/products/web_analytics/PRECOMPUTATION.md
+++ b/products/web_analytics/PRECOMPUTATION.md
@@ -80,6 +80,7 @@ The 24 h pad matches the JS SDK's hard `SESSION_LENGTH_LIMIT` and covers effecti
 - `query.conversionGoal` is set
 - `query.sampling.enabled` is True
 - `query.modifiers.sessionsV2JoinMode == "uuid"` (column type mismatch — temporary; should be re-enabled by re-typing `uniq_sessions_state` to `(uniq, UUID)`)
+- The team has any property-level access controls (`team_has_property_access_rules`) — precompute results are built userless and shared by a user-independent cache key, so they can't honor per-user property restrictions; the query falls through to the live path, which enforces them per requesting user
 - Date range exceeds `MAX_PRECOMPUTE_DAYS` (90)
 - Either date_from or date_to is None
 

--- a/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_lazy_precompute_common.py
@@ -40,6 +40,7 @@ from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common imp
     STALE_WHILE_REVALIDATE_SECONDS,
     TEAM_SHAPE_SET_TTL_SECONDS,
     PerQueryOptedOut,
+    PropertyAccessControlled,
     UnsupportedFilterType,
     _oom_pin_key,
     _team_shape_set_key,
@@ -149,6 +150,14 @@ class TestCheckCommonEligibility(BaseTest):
         prop = PersonPropertyFilter(key="email", value="a@b.com", operator=PropertyOperator.EXACT)
         with override_settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=[self.team.pk]):
             self._check(use_precompute=None, properties=[prop])
+
+    @mock.patch(f"{_COMMON}.team_has_property_access_rules", return_value=True)
+    def test_team_with_property_access_controls_falls_through_to_live(self, _mock) -> None:
+        # Userless shared precompute can't honor per-user property restrictions, so a team
+        # with property access controls must not precompute — the live path enforces them.
+        with override_settings(WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS=[self.team.pk]):
+            with self.assertRaises(PropertyAccessControlled):
+                self._check(use_precompute=None)
 
 
 class TestCacheKeyVariesWithRolloutState(BaseTest):

--- a/products/web_analytics/backend/hogql_queries/web_analytics_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_analytics_lazy_precompute.py
@@ -26,6 +26,7 @@ from posthog.hogql.visitor import CloningVisitor, TraversingVisitor, clone_expr
 
 from posthog.models.team import Team
 
+from products.access_control.backend.facade.api import team_has_property_access_rules
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
     LAZY_TTL_SECONDS,  # noqa: F401 — re-exported; several runners import it from this module
     is_precompute_enabled_for_team,
@@ -176,6 +177,11 @@ class UnsupportedFilterType(LazyPrecomputeIneligible):
         super().__init__(f"type={filter_type!r}")
 
 
+class PropertyAccessControlled(LazyPrecomputeIneligible):
+    """The team has property-level access controls — userless shared precompute
+    can't honor per-user property restrictions, so the query stays on the live path."""
+
+
 class MissingDateRange(LazyPrecomputeIneligible):
     pass
 
@@ -282,6 +288,13 @@ def check_common_eligible(runner: LazyPrecomputeRunner, *, require_integer_timez
     for prop in query.properties or []:
         if get_property_type(prop) not in ("event", "person"):
             raise UnsupportedFilterType(get_property_type(prop))
+
+    # Precompute results are built userless and shared by a user-independent cache
+    # key, so they cannot honor per-user property restrictions. If the team has any
+    # property-level access controls, skip precompute and let the live path enforce
+    # them per requesting user.
+    if team_has_property_access_rules(team_id=runner.team.id):
+        raise PropertyAccessControlled()
 
     date_from = runner.query_date_range.date_from()  # type: ignore[attr-defined]
     date_to = runner.query_date_range.date_to()  # type: ignore[attr-defined]

--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -32,6 +32,7 @@ from posthog import redis
 from posthog.clickhouse.query_tagging import tag_queries
 from posthog.models import Team
 
+from products.access_control.backend.facade.api import team_has_property_access_rules
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
     LazyComputationResult,
     TtlSchedule,
@@ -526,6 +527,11 @@ class UnsupportedFilterType(LazyPrecomputeIneligible):
         super().__init__(f"type={filter_type!r}")
 
 
+class PropertyAccessControlled(LazyPrecomputeIneligible):
+    """The team has property-level access controls — userless shared precompute
+    can't honor per-user property restrictions, so the query stays on the live path."""
+
+
 class MissingDateRange(LazyPrecomputeIneligible):
     pass
 
@@ -630,6 +636,13 @@ def check_common_eligibility(
     for prop in properties:
         if get_property_type(prop) not in ("event", "person"):
             raise UnsupportedFilterType(get_property_type(prop))
+
+    # Precompute results are built userless and shared across users by a
+    # user-independent cache key, so they cannot honor per-user property
+    # restrictions. If the team has any property-level access controls, skip
+    # precompute entirely and let the live path enforce them per requesting user.
+    if team_has_property_access_rules(team_id=team.id):
+        raise PropertyAccessControlled()
 
     date_from, date_to = resolve_date_range()
     if date_from is None or date_to is None:

--- a/tach.toml
+++ b/tach.toml
@@ -763,6 +763,7 @@ layer = "modules"
 [[modules]]
 path = "products.web_analytics"
 depends_on = [
+    "products.access_control",
     "products.cohorts",
     "ee",
     "posthog",


### PR DESCRIPTION
## Problem

Follow-up to #73303. That PR loosened web analytics lazy precompute to admit event/person property filters. hex-security flagged (and we deferred) a real issue it widens: precompute results are built **userless** and shared across users by a **user-independent cache key**, while property-level access control is only enforced on the **userful live path**. So a query filtering or breaking down on an access-controlled property would build a shared bucket that ignores the restriction, and a restricted user could read it and infer values they shouldn't see.

## Changes

- **New facade helper** `team_has_property_access_rules(team_id)` on `products/access_control` — true only when the org has the `PROPERTY_ACCESS_CONTROL` feature **and** at least one rule targeting a property definition exists (feature-gate short-circuits the query).
- **Gate wiring**: `check_common_eligibility` and the parallel `web_analytics_lazy_precompute` gate now reject precompute (new `PropertyAccessControlled` reason) when the team has any property access controls — the query falls through to the live path, which enforces the restrictions per requesting user.
- Coarse and safe: if the team has *any* property-AC rule, it opts out of precompute entirely (property access control is a rarely-used beta feature). A precise per-property version — only opting out when the specific filtered/breakdown property is restricted — is a possible later refinement.
- `tach.toml`: declare the `products.web_analytics → products.access_control` dependency (used via the facade; `posthog`/`experiments`/`marketing_analytics` already depend on it).

## How did you test this code?

- `TestTeamHasPropertyAccessRules` (access_control): feature-off short-circuits to false even with a stray rule; enabled + no rules → false; enabled + a rule → true.
- `test_team_with_property_access_controls_falls_through_to_live` (web analytics): the gate raises `PropertyAccessControlled` when the team has controls.
- Full web-analytics common suite (61) passes locally; `tach check`, `ruff`, `mypy` (changed modules), `markdownlint`, `ci:preflight` clean. ClickHouse-backed suites validate in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — @lricoy asked to ship the deferred access-control fix as a follow-up rather than defer indefinitely. Stacked on #73303 (base branch `lricoy/web-analytics-precompute-shape-cap`); rebase onto master once that merges. Closes the hex-security finding on #73303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
