### PR TITLE
chore(mcp): regenerate UI app entry points

### DIFF
--- a/services/mcp/src/ui-apps/apps/generated/action.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/action.tsx
@@ -8,7 +8,11 @@ import { type ActionData, ActionView } from 'products/actions/mcp/apps'
 import { AppWrapper } from '../../components/AppWrapper'
 
 function ActionApp(): JSX.Element {
-    return <AppWrapper<ActionData> appName="PostHog Action">{({ data }) => <ActionView action={data!} />}</AppWrapper>
+    return (
+        <AppWrapper<ActionData> appName="PostHog Action">
+            {({ data }) => <ActionView action={data!} />}
+        </AppWrapper>
+    )
 }
 
 const container = document.getElementById('root')

--- a/services/mcp/src/ui-apps/apps/generated/cohort.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/cohort.tsx
@@ -8,7 +8,11 @@ import { type CohortData, CohortView } from 'products/cohorts/mcp/apps'
 import { AppWrapper } from '../../components/AppWrapper'
 
 function CohortApp(): JSX.Element {
-    return <AppWrapper<CohortData> appName="PostHog Cohort">{({ data }) => <CohortView cohort={data!} />}</AppWrapper>
+    return (
+        <AppWrapper<CohortData> appName="PostHog Cohort">
+            {({ data }) => <CohortView cohort={data!} />}
+        </AppWrapper>
+    )
 }
 
 const container = document.getElementById('root')

--- a/services/mcp/src/ui-apps/apps/generated/llm-costs.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/llm-costs.tsx
@@ -9,7 +9,9 @@ import { AppWrapper } from '../../components/AppWrapper'
 
 function LlmCostsApp(): JSX.Element {
     return (
-        <AppWrapper<LLMCostsData> appName="PostHog Llm Costs">{({ data }) => <LLMCostsView data={data!} />}</AppWrapper>
+        <AppWrapper<LLMCostsData> appName="PostHog Llm Costs">
+            {({ data }) => <LLMCostsView data={data!} />}
+        </AppWrapper>
     )
 }
 

--- a/services/mcp/src/ui-apps/apps/generated/survey.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/survey.tsx
@@ -8,7 +8,11 @@ import { type SurveyData, SurveyView } from 'products/surveys/mcp/apps'
 import { AppWrapper } from '../../components/AppWrapper'
 
 function SurveyApp(): JSX.Element {
-    return <AppWrapper<SurveyData> appName="PostHog Survey">{({ data }) => <SurveyView survey={data!} />}</AppWrapper>
+    return (
+        <AppWrapper<SurveyData> appName="PostHog Survey">
+            {({ data }) => <SurveyView survey={data!} />}
+        </AppWrapper>
+    )
 }
 
 const container = document.getElementById('root')


### PR DESCRIPTION
## Problem

The committed generated MCP UI app entry points are stale relative to what `pnpm --filter=@posthog/mcp run generate:ui-apps` now emits: a formatter update changed how the generator wraps JSX, and four files on master still carry the old single-line form.

The drift is latent on master because MCP CI is path-filtered to `services/mcp` changes, but it fails the "Check generated UI apps are up to date" freshness gate on any PR whose merge ref touches `services/mcp` — currently blocking [#72990](https://github.com/PostHog/posthog/pull/72990), which only hit MCP CI because a bot pushed an OpenAPI-types commit to its branch.

## Changes

Reran the generator and committed the result. Four files, formatting only:

- `services/mcp/src/ui-apps/apps/generated/action.tsx`
- `services/mcp/src/ui-apps/apps/generated/cohort.tsx`
- `services/mcp/src/ui-apps/apps/generated/llm-costs.tsx`
- `services/mcp/src/ui-apps/apps/generated/survey.tsx`

## How did you test this code?

- Ran `pnpm run generate:ui-apps` in `services/mcp` on a clean master checkout and committed the diff; the same freshness check CI runs (`git diff --exit-code` on the generated paths) now passes locally.
- No behavior change: the diff is JSX wrapping only, which is why it doesn't need a manual test pass. MCP CI on this PR runs the full check suite since it touches `services/mcp`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: generated-file refresh, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed with PostHog Code (Claude) while investigating the MCP CI failure on #72990: reproduced by merging master and rerunning the generator, confirmed the drift is formatting-only and predates that PR, then split this fix out so the ClickHouse migration PR stays migration-only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
