### PR TITLE
chore(mcp): regenerate UI app entry points to match generator output

### DIFF
--- a/services/mcp/src/ui-apps/apps/generated/action.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/action.tsx
@@ -8,11 +8,7 @@ import { type ActionData, ActionView } from 'products/actions/mcp/apps'
 import { AppWrapper } from '../../components/AppWrapper'
 
 function ActionApp(): JSX.Element {
-    return (
-        <AppWrapper<ActionData> appName="PostHog Action">
-            {({ data }) => <ActionView action={data!} />}
-        </AppWrapper>
-    )
+    return <AppWrapper<ActionData> appName="PostHog Action">{({ data }) => <ActionView action={data!} />}</AppWrapper>
 }
 
 const container = document.getElementById('root')

--- a/services/mcp/src/ui-apps/apps/generated/cohort.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/cohort.tsx
@@ -8,11 +8,7 @@ import { type CohortData, CohortView } from 'products/cohorts/mcp/apps'
 import { AppWrapper } from '../../components/AppWrapper'
 
 function CohortApp(): JSX.Element {
-    return (
-        <AppWrapper<CohortData> appName="PostHog Cohort">
-            {({ data }) => <CohortView cohort={data!} />}
-        </AppWrapper>
-    )
+    return <AppWrapper<CohortData> appName="PostHog Cohort">{({ data }) => <CohortView cohort={data!} />}</AppWrapper>
 }
 
 const container = document.getElementById('root')

--- a/services/mcp/src/ui-apps/apps/generated/llm-costs.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/llm-costs.tsx
@@ -9,9 +9,7 @@ import { AppWrapper } from '../../components/AppWrapper'
 
 function LlmCostsApp(): JSX.Element {
     return (
-        <AppWrapper<LLMCostsData> appName="PostHog Llm Costs">
-            {({ data }) => <LLMCostsView data={data!} />}
-        </AppWrapper>
+        <AppWrapper<LLMCostsData> appName="PostHog Llm Costs">{({ data }) => <LLMCostsView data={data!} />}</AppWrapper>
     )
 }
 

--- a/services/mcp/src/ui-apps/apps/generated/survey.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/survey.tsx
@@ -8,11 +8,7 @@ import { type SurveyData, SurveyView } from 'products/surveys/mcp/apps'
 import { AppWrapper } from '../../components/AppWrapper'
 
 function SurveyApp(): JSX.Element {
-    return (
-        <AppWrapper<SurveyData> appName="PostHog Survey">
-            {({ data }) => <SurveyView survey={data!} />}
-        </AppWrapper>
-    )
+    return <AppWrapper<SurveyData> appName="PostHog Survey">{({ data }) => <SurveyView survey={data!} />}</AppWrapper>
 }
 
 const container = document.getElementById('root')


### PR DESCRIPTION
## Problem

The "Check generated UI apps are up to date" step has been failing on every master push since ~18:20 UTC today, taking `MCP UI Apps CI`, `Build Package`, `Build and validate UI Apps`, and `MCP Tests Pass` red on master and on every open PR.

The committed generated files under `services/mcp/src/ui-apps/apps/generated/` don't match what `pnpm --filter=@posthog/mcp run generate:ui-apps` currently produces. The formatter output for four entry points flipped between single-line and multi-line JSX today, and the multi-line variants that landed on master via #73203 no longer match the generator's current output.

## Changes

Ran `pnpm --filter=@posthog/mcp run generate:ui-apps` on latest master and committed the result. Four generated entry points (`action.tsx`, `cohort.tsx`, `llm-costs.tsx`, `survey.tsx`) go back to the single-line form the generator emits. No hand edits.

## How did you test this code?

The committed blob for each file is byte-identical to the output the CI check itself printed in the latest master failure (e.g. `survey.tsx` → blob `310c2838`, exactly the hash CI's regenerated copy has). The `MCP UI Apps CI` run on this PR is the real verification.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (well, Claude via PostHog Code) hit this master breakage while shepherding an unrelated PR's CI, confirmed the same check fails on every recent master push in both directions of the formatting flip, and regenerated on latest master to realign the committed files with the generator. Pure codegen output, no logic changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*