### PR TITLE
chore(mcp): regenerate UI app entry points under the restored oxfmt config

### DIFF
--- a/services/mcp/src/ui-apps/apps/generated/action.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/action.tsx
@@ -8,11 +8,7 @@ import { type ActionData, ActionView } from 'products/actions/mcp/apps'
 import { AppWrapper } from '../../components/AppWrapper'
 
 function ActionApp(): JSX.Element {
-    return (
-        <AppWrapper<ActionData> appName="PostHog Action">
-            {({ data }) => <ActionView action={data!} />}
-        </AppWrapper>
-    )
+    return <AppWrapper<ActionData> appName="PostHog Action">{({ data }) => <ActionView action={data!} />}</AppWrapper>
 }
 
 const container = document.getElementById('root')

--- a/services/mcp/src/ui-apps/apps/generated/cohort.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/cohort.tsx
@@ -8,11 +8,7 @@ import { type CohortData, CohortView } from 'products/cohorts/mcp/apps'
 import { AppWrapper } from '../../components/AppWrapper'
 
 function CohortApp(): JSX.Element {
-    return (
-        <AppWrapper<CohortData> appName="PostHog Cohort">
-            {({ data }) => <CohortView cohort={data!} />}
-        </AppWrapper>
-    )
+    return <AppWrapper<CohortData> appName="PostHog Cohort">{({ data }) => <CohortView cohort={data!} />}</AppWrapper>
 }
 
 const container = document.getElementById('root')

--- a/services/mcp/src/ui-apps/apps/generated/llm-costs.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/llm-costs.tsx
@@ -9,9 +9,7 @@ import { AppWrapper } from '../../components/AppWrapper'
 
 function LlmCostsApp(): JSX.Element {
     return (
-        <AppWrapper<LLMCostsData> appName="PostHog Llm Costs">
-            {({ data }) => <LLMCostsView data={data!} />}
-        </AppWrapper>
+        <AppWrapper<LLMCostsData> appName="PostHog Llm Costs">{({ data }) => <LLMCostsView data={data!} />}</AppWrapper>
     )
 }
 

--- a/services/mcp/src/ui-apps/apps/generated/survey.tsx
+++ b/services/mcp/src/ui-apps/apps/generated/survey.tsx
@@ -8,11 +8,7 @@ import { type SurveyData, SurveyView } from 'products/surveys/mcp/apps'
 import { AppWrapper } from '../../components/AppWrapper'
 
 function SurveyApp(): JSX.Element {
-    return (
-        <AppWrapper<SurveyData> appName="PostHog Survey">
-            {({ data }) => <SurveyView survey={data!} />}
-        </AppWrapper>
-    )
+    return <AppWrapper<SurveyData> appName="PostHog Survey">{({ data }) => <SurveyView survey={data!} />}</AppWrapper>
 }
 
 const container = document.getElementById('root')


### PR DESCRIPTION
## Problem

[#73338](https://github.com/PostHog/posthog/pull/73338) removed `services/mcp/**/generated/**` from the oxfmt ignore list, so `generate:ui-apps` formats its output again. The four UI app entry points regenerated eight minutes earlier under the ignore-era config ([#73203](https://github.com/PostHog/posthog/pull/73203)) no longer match what the generator emits.

MCP CI is path-filtered, so master doesn't notice, but the "Check generated UI apps are up to date" freshness gate fails every PR whose merge ref touches `services/mcp` — currently blocking [#72990](https://github.com/PostHog/posthog/pull/72990).

## Changes

Reran `pnpm --filter=@posthog/mcp run generate:ui-apps` on current master and committed the result. Four files, JSX line-wrapping only:

- `services/mcp/src/ui-apps/apps/generated/action.tsx`
- `services/mcp/src/ui-apps/apps/generated/cohort.tsx`
- `services/mcp/src/ui-apps/apps/generated/llm-costs.tsx`
- `services/mcp/src/ui-apps/apps/generated/survey.tsx`

## How did you test this code?

- Ran the generator locally on current master (post-#73338 config) and confirmed it reproduces exactly this content; a second run produces no further diff. The same `git diff --exit-code` freshness check CI runs now passes locally.
- No behavior change: formatting only. MCP CI on this PR runs the full check suite since it touches `services/mcp`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: generated-file refresh, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed with PostHog Code (Claude) while investigating recurring MCP CI failures on #72990. Timeline: #73291 added the oxfmt ignore for generated MCP files, #73203 regenerated under that config (wrapped JSX), #73338 restored formatting without regenerating — leaving master internally inconsistent. An earlier fix attempt (#73343) regenerated under the ignore-era config and was closed as superseded; this one regenerates under the current config.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
