### PR TITLE
chore(ci): raise the multinode migration smoke timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -30,7 +30,10 @@ jobs:
     multinode-migration-smoke:
         name: Run ClickHouse migrations against per-cluster topology
         runs-on: ubuntu-24.04
-        timeout-minutes: 25
+        # The job applies every Postgres and ClickHouse migration from scratch, so its
+        # runtime grows with the migration count: ~20 minutes in June 2026, past 25 by
+        # July. Sized with headroom so it fails on hangs, not on ordinary growth.
+        timeout-minutes: 40
         env:
             DEBUG: '1'
             MULTINODE_CLICKHOUSE: '1'

--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -32,8 +32,8 @@ jobs:
         runs-on: ubuntu-24.04
         # The job applies every Postgres and ClickHouse migration from scratch, so its
         # runtime grows with the migration count: ~20 minutes in June 2026, past 25 by
-        # July. Sized with headroom so it fails on hangs, not on ordinary growth.
-        timeout-minutes: 40
+        # July, ~27 minutes as of this bump. Raise further if it keeps creeping up.
+        timeout-minutes: 30
         env:
             DEBUG: '1'
             MULTINODE_CLICKHOUSE: '1'


### PR DESCRIPTION
## Problem

The ClickHouse multinode migration smoke job (`ci-clickhouse-multinode-migrations.yml`) applies every Postgres and ClickHouse migration from scratch against the per-cluster topology, so its runtime grows with the migration count. It ran about 20 minutes in late June and now exceeds its 25-minute `timeout-minutes` cap: the runner kills healthy runs mid-migration, and every PR touching ClickHouse migrations fails the check. [#72990](https://github.com/PostHog/posthog/pull/72990) hit this twice in a row, with the job still making steady DDL progress at both kills.

## Changes

Raises `timeout-minutes` from 25 to 30 and documents why the number needs headroom, so the next person doesn't shave it back down. A hung run still fails well before burning serious runner minutes.

Started at 30 rather than jumping straight to 40, per review feedback: a verification run finished in 26m55s, so 30 gives real headroom without over-provisioning. Will raise further if the job's runtime keeps creeping up.

Per the CI backwards-compatibility rule: a pure timeout increase requires nothing from unrebased branches, so open PRs are unaffected except that their smoke runs can now finish.

## How did you test this code?

- `bin/hogli lint:workflows` passes (all 6 checks across 104 workflows).
- Evidence for the sizing: the June 27 master run completed in 19m36s; both July 23 runs on #72990 were killed at exactly 25:00 while still executing migrations normally; a subsequent verification run completed in 26m55s.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: CI-internal timeout, no documented workflow behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed with PostHog Code (Claude) while investigating repeated smoke-test failures on #72990: pulled both failing job logs, confirmed the kills happened at exactly the 25-minute cap during healthy DDL execution (never an error), and compared against the June baseline run duration. Skills invoked: `/authoring-ci-workflows`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
