### PR TITLE
feat(ai): surface property definition descriptions to Max taxonomy

### DIFF
--- a/ee/hogai/chat_agent/taxonomy/format.py
+++ b/ee/hogai/chat_agent/taxonomy/format.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from typing import Optional
 
 # nosemgrep: python.lang.security.use-defused-xml.use-defused-xml (XML generation only, no parsing - no XXE risk)
@@ -83,7 +83,18 @@ def format_properties_yaml(children: list[tuple[str, str | None, str | None]]):
     return yaml.dump(result, default_flow_style=False, sort_keys=False)
 
 
-def enrich_props_with_descriptions(entity: str, props: Iterable[tuple[str, str | None]]):
+def enrich_props_with_descriptions(
+    entity: str,
+    props: Iterable[tuple[str, str | None]],
+    stored_descriptions: Mapping[str, str] | None = None,
+):
+    """Attach a description to each property.
+
+    The built-in core taxonomy wins. For custom properties it has never heard of, fall back to the
+    user-authored description stored on the property definition (passed in already sanitized). This
+    only enriches properties the caller already discovered via ClickHouse — it never sources the
+    property list itself from Postgres.
+    """
     enriched_props = []
     mapping = {
         "session": CORE_FILTER_DEFINITIONS_BY_GROUP["session_properties"],
@@ -92,11 +103,14 @@ def enrich_props_with_descriptions(entity: str, props: Iterable[tuple[str, str |
     }
     # Entities other than the well-known ones are group types.
     entity_definitions = mapping.get(entity, CORE_FILTER_DEFINITIONS_BY_GROUP["groups"])
+    stored_descriptions = stored_descriptions or {}
     for prop_name, prop_type in props:
         description = None
         if entity_definition := entity_definitions.get(prop_name):
             if entity_definition.get("system") or entity_definition.get("ignored_in_assistant"):
                 continue
             description = entity_definition.get("description_llm") or entity_definition.get("description")
+        else:
+            description = stored_descriptions.get(prop_name)
         enriched_props.append((prop_name, prop_type, description))
     return enriched_props

--- a/ee/hogai/chat_agent/taxonomy/test/test_toolkit.py
+++ b/ee/hogai/chat_agent/taxonomy/test/test_toolkit.py
@@ -48,6 +48,17 @@ class TestTaxonomyAgentToolkit(BaseTest):
         self.assertEqual(browser_prop[1], "String")
         self.assertIsNotNone(browser_prop[2])
 
+    def test_enrich_props_uses_stored_description_only_for_custom_props(self):
+        # Custom properties fall back to the user-authored description; core taxonomy still wins so a
+        # stored description can never override (or spoof) a built-in one.
+        props = [("$browser", "String"), ("custom_prop", "Numeric")]
+        stored = {"custom_prop": "Revenue in cents", "$browser": "should be ignored"}
+        enriched = self.toolkit._enrich_props_with_descriptions("event", props, stored)
+        by_name = {name: description for name, _, description in enriched}
+
+        self.assertEqual(by_name["custom_prop"], "Revenue in cents")
+        self.assertNotEqual(by_name["$browser"], "should be ignored")
+
     @parameterized.expand(
         [
             ([], 0, False, "The property does not have any values"),
@@ -292,6 +303,25 @@ class TestTaxonomyAgentToolkit(BaseTest):
         result = await self.toolkit._handle_entity_properties_task({"task": task})
         self.assertIn("<name>visible</name>", result.result)
         self.assertNotIn("<name>secret</name>", result.result)
+
+    async def test_person_properties_surface_stored_descriptions_sanitized(self):
+        from ee.models.property_definition import EnterprisePropertyDefinition
+
+        # An EnterprisePropertyDefinition also creates the base PropertyDefinition row the person path
+        # discovers, so its user-authored description should ride along on the surfaced property.
+        await EnterprisePropertyDefinition.objects.acreate(
+            team=self.team,
+            type=PropertyDefinition.Type.PERSON,
+            name="plan_tier",
+            property_type="String",
+            description="Subscription tier\nof the account",
+        )
+        task = AssistantToolCall(id="1", name="retrieve_entity_properties", args={"entity": "person"})
+        result = await self.toolkit._handle_entity_properties_task({"task": task})
+
+        self.assertIn("<name>plan_tier</name>", result.result)
+        # Sanitization collapses the newline so a description can't break out of its line.
+        self.assertIn("<description>Subscription tier of the account</description>", result.result)
 
     @patch("ee.hogai.chat_agent.taxonomy.toolkit.restricted_property_names")
     async def test_retrieve_multiple_entity_property_values_hides_restricted(self, mock_restricted):

--- a/ee/hogai/chat_agent/taxonomy/toolkit.py
+++ b/ee/hogai/chat_agent/taxonomy/toolkit.py
@@ -29,6 +29,7 @@ from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import Actor
 from posthog.hogql_queries.ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Team, User
+from posthog.settings import EE_AVAILABLE
 from posthog.sync import database_sync_to_async
 from posthog.taxonomy.property_access import restricted_property_names
 from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP, CoreFilterDefinition
@@ -53,6 +54,7 @@ from ee.hogai.chat_agent.taxonomy.virtual_properties import (
     virtual_group_for_entity,
     virtual_property_no_values_message,
 )
+from ee.hogai.utils.helpers import sanitize_event_description
 from ee.hogai.utils.types.base import AssistantState, BaseStateWithTasks, TaskArtifact, TaskResult
 
 from ..parallel_task_execution.nodes import BaseTaskExecutorNode, TaskExecutionInputTuple
@@ -200,8 +202,45 @@ class TaxonomyAgentToolkit:
     def _get_team_group_types(self) -> list[str]:
         return self._team_group_types
 
-    def _enrich_props_with_descriptions(self, entity: str, props: Iterable[tuple[str, str | None]]):
-        return enrich_props_with_descriptions(entity, props)
+    def _enrich_props_with_descriptions(
+        self,
+        entity: str,
+        props: Iterable[tuple[str, str | None]],
+        stored_descriptions: dict[str, str] | None = None,
+    ):
+        return enrich_props_with_descriptions(entity, props, stored_descriptions)
+
+    async def _get_stored_property_descriptions(
+        self,
+        property_type: PropertyDefinition.Type,
+        names: list[str],
+        group_type_index: int | None = None,
+    ) -> dict[str, str]:
+        """Map property name -> sanitized user-authored description from the team's property definitions.
+
+        Only the enterprise `PropertyDefinition` model carries a `description` field, so this is a
+        no-op on non-EE builds. Descriptions live only in Postgres and never influence which
+        properties are surfaced — the list still comes from ClickHouse. Runs a single batched query.
+        """
+        if not EE_AVAILABLE or not names:
+            return {}
+
+        from ee.models.property_definition import (
+            EnterprisePropertyDefinition,  # noqa: PLC0415 — EE-only model, keep off the OSS import path
+        )
+
+        qs = (
+            EnterprisePropertyDefinition.objects.filter(team=self._team, type=property_type, name__in=names)
+            .exclude(description__isnull=True)
+            .exclude(description="")
+        )
+        if group_type_index is not None:
+            qs = qs.filter(group_type_index=group_type_index)
+        return {
+            name: sanitize_event_description(description)
+            async for name, description in qs.values_list("name", "description")
+            if description
+        }
 
     def _format_property_values(
         self,
@@ -529,7 +568,12 @@ class TaxonomyAgentToolkit:
                 status=TaskExecutionStatus.FAILED,
             )
 
-        formatted_properties = self._format_properties(self._enrich_props_with_descriptions("event", props))
+        stored_descriptions = await self._get_stored_property_descriptions(
+            PropertyDefinition.Type.EVENT, [name for name, _ in props]
+        )
+        formatted_properties = self._format_properties(
+            self._enrich_props_with_descriptions("event", props, stored_descriptions)
+        )
         return TaskResult(
             id=task.id,
             result=formatted_properties,
@@ -580,8 +624,15 @@ class TaxonomyAgentToolkit:
                     properties += list_virtual_properties(
                         "groups", exclude={name for name, _ in properties} | restricted
                     )
+                    stored_descriptions = await self._get_stored_property_descriptions(
+                        PropertyDefinition.Type.GROUP,
+                        [name for name, _ in properties],
+                        group_type_index=group_index,
+                    )
                     result = (
-                        self._format_properties(self._enrich_props_with_descriptions(entity, properties))
+                        self._format_properties(
+                            self._enrich_props_with_descriptions(entity, properties, stored_descriptions)
+                        )
                         if properties
                         else TaxonomyErrorMessages.properties_not_found(entity)
                     )
@@ -613,7 +664,12 @@ class TaxonomyAgentToolkit:
                 "person_properties", exclude={name for name, _ in person_definitions} | restricted
             )
             if person_definitions:
-                result = self._format_properties(self._enrich_props_with_descriptions("person", person_definitions))
+                stored_descriptions = await self._get_stored_property_descriptions(
+                    PropertyDefinition.Type.PERSON, [name for name, _ in person_definitions]
+                )
+                result = self._format_properties(
+                    self._enrich_props_with_descriptions("person", person_definitions, stored_descriptions)
+                )
                 status = TaskExecutionStatus.COMPLETED
             else:
                 result = TaxonomyErrorMessages.properties_not_found(entity)


### PR DESCRIPTION
## Problem

PostHog AI (Max) could read *event* descriptions but not *property* descriptions. When the taxonomy agent listed properties, the user-authored description a customer wrote in Data Management — including via the `property-definition-update` MCP tool — was silently dropped, so Max only ever saw the property name and type.

This is the property-side completion of the same work done for events, and the remaining half of #62925.

Refs #62925

## Changes

`enrich_props_with_descriptions` only sourced descriptions from the built-in core taxonomy, never from the enterprise `PropertyDefinition.description` column. Now, for custom properties the core taxonomy has never heard of, we fall back to the stored user-authored description across the event, person, and group property paths.

- Fetch the description from the enterprise `PropertyDefinition` alongside the property type, in one batched query per path (no N+1).
- EE-gated — a no-op on OSS builds, where the `description` field doesn't exist.
- Descriptions are run through the same `sanitize_event_description` guard used for events, so untrusted project metadata can't inject framing into another user's session.
- Core taxonomy still wins, so a stored description can never override (or spoof) a built-in one.

The functional change is 3 files under `ee/hogai/chat_agent/taxonomy/`. Any additional `services/mcp/src/tools/generated/*.ts` files in the diff are **not** part of this change — they're an automated codegen sync auto-committed by the `check-openapi-types` CI job (`tests-posthog[bot]`, "chore: update OpenAPI generated types"), which regenerates OpenAPI/MCP types on any backend-touching PR and commits the delta where the committed copies drift from current codegen output. This PR touches no serializer or tool YAML, so those files are unrelated to it and should be reviewed as a repo-wide codegen sync, not part of the feature.

**On the "no read tool for property definitions is intentional" concern:** that principle is preserved. The property *list* is still sourced from ClickHouse to fight recency, actuality, and data volume — nothing here enumerates property definitions from Postgres. A description is different in kind: it's human-authored metadata that lives *only* in Postgres and never influences which properties are surfaced or how they're ranked. We only attach a description to a property Max has *already* discovered via ClickHouse. This mirrors the distinction the event-description PRs (#72088, #72685) already settled: keep enumeration ClickHouse-backed, enrich each surfaced item with its Postgres-stored description.

## How did you test this code?

Added two backend tests in `test_toolkit.py`:
- `test_enrich_props_uses_stored_description_only_for_custom_props` — locks the precedence: a custom property picks up its stored description, while a core-taxonomy property (`$browser`) ignores a stored value so it can't be overridden/spoofed. Catches the fallback being dropped (the exact bug fixed here).
- `test_person_properties_surface_stored_descriptions_sanitized` — end-to-end person path: a custom property's stored description surfaces on the formatted output, with a newline collapsed to prove sanitization is applied. Catches the wiring being broken and sanitization being skipped.

The agent could not run the Django-backed suite in this environment (no provisioned dev stack). Verified: the changed files byte-compile, ruff `check`/`format` pass, and the enrichment precedence logic was checked in isolation. The person-path DB test mirrors the existing `test_handle_entity_properties_excludes_restricted` pattern.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The task was to evaluate what it would take for Max to read property descriptions and weigh it against the intentional "no read tool for property definitions" decision, then implement.

Skills invoked: `/writing-tests` (test value gate). Decisions: reused the existing event-description pattern (`sanitize_event_description`, EE-gating, batched lookup) rather than introducing a new read path; used a stored-description *fallback* in `enrich_props_with_descriptions` so the core taxonomy keeps precedence; scoped the group lookup by `group_type_index` to match how group properties are queried.

Note on diff size: the functional change is the 3 files under `ee/hogai/chat_agent/taxonomy/`. The `services/mcp/src/tools/generated/*.ts` files were auto-committed by the `check-openapi-types` CI job (`tests-posthog[bot]`) because master's committed generated files are stale relative to current codegen output; this PR does not intentionally modify them. The durable fix is a separate chore PR that regenerates those files on master.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BALLBBKAB/p1784830865575919)*
