### PR TITLE
fix(data-warehouse): retry UNAVAILABLE rpc status in temporalio source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
@@ -59,13 +59,16 @@ T = TypeVar("T")
 
 # Temporal Cloud surfaces transient server-side conditions as gRPC errors that a short backoff
 # usually clears: per-namespace throttling (RESOURCE_EXHAUSTED — e.g. "namespace rate limit
-# exceeded") and request deadlines on the visibility/history services (DEADLINE_EXCEEDED — e.g.
-# "downstream duration timeout"). Riding these out in-process keeps a brief blip from failing the
-# whole import activity (which would rebuild the client and restart pagination) and avoids
-# error-tracking noise. Persistent failures re-raise so Temporal's activity retry still applies.
+# exceeded"), request deadlines on the visibility/history services (DEADLINE_EXCEEDED — e.g.
+# "downstream duration timeout"), and connection-level failures (UNAVAILABLE — e.g. a DNS lookup
+# blip resolving the cluster's frontend host). Riding these out in-process keeps a brief blip from
+# failing the whole import activity (which would rebuild the client and restart pagination) and
+# avoids error-tracking noise. Persistent failures re-raise so Temporal's activity retry still applies.
 _MAX_TRANSIENT_RPC_ATTEMPTS = 6
 
-_RETRYABLE_RPC_STATUSES = frozenset({RPCStatusCode.RESOURCE_EXHAUSTED, RPCStatusCode.DEADLINE_EXCEEDED})
+_RETRYABLE_RPC_STATUSES = frozenset(
+    {RPCStatusCode.RESOURCE_EXHAUSTED, RPCStatusCode.DEADLINE_EXCEEDED, RPCStatusCode.UNAVAILABLE}
+)
 
 # tonic/hyper surface a mid-stream HTTP/2 transport interruption (a reset stream or a response
 # body read cut short) as an RPCError with status UNKNOWN and an "h2 protocol error" message,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -119,6 +119,9 @@ class TestTransientRPCRetry:
             # tonic cancels a call that outruns the client's RPC deadline with status CANCELLED and
             # message "Timeout expired" — a client-side timeout that must be ridden out, not raised.
             ("Timeout expired", RPCStatusCode.CANCELLED),
+            # A DNS resolution blip surfaces as UNAVAILABLE — a connection-level failure that must
+            # be ridden out rather than failing the whole import activity.
+            ("dns error", RPCStatusCode.UNAVAILABLE),
         ],
     )
     @patch(
@@ -146,6 +149,7 @@ class TestTransientRPCRetry:
         [
             ("namespace rate limit exceeded", RPCStatusCode.RESOURCE_EXHAUSTED),
             ("downstream duration timeout", RPCStatusCode.DEADLINE_EXCEEDED),
+            ("dns error", RPCStatusCode.UNAVAILABLE),
         ],
     )
     @patch(


### PR DESCRIPTION
## Problem

The Temporal.io warehouse import wraps its `list_workflows`/`fetch_next_page`/`fetch_history` calls in `_with_transient_rpc_retry` to ride out transient server blips. The retryable set covers `RESOURCE_EXHAUSTED`, `DEADLINE_EXCEEDED`, and a couple of message-matched cases (`h2 protocol error`, `Timeout expired`), but not gRPC status `UNAVAILABLE`.

An error-tracking issue surfaced an `RPCError` with message `dns error` (gRPC status code 14, i.e. `UNAVAILABLE`) — a transient connection-level failure resolving the cluster's frontend host. Since `UNAVAILABLE` wasn't in the retryable set, the helper re-raised on the first attempt instead of backing off, failing the whole import activity (which rebuilds the client and restarts pagination) for what should have been a one-off blip.

I checked for an existing fix first: [#71792](https://github.com/PostHog/posthog/pull/71792) attempted something similar (adding `UNAVAILABLE` plus a message-fragment match), but it now conflicts with master (`mergeable: false`) since a separate change independently landed the `h2 protocol error`/`Timeout expired` message-matching this PR's base already has. So it doesn't cleanly cover this case as-is; this PR adds `UNAVAILABLE` fresh against current master.

## Changes

Add `RPCStatusCode.UNAVAILABLE` to `_RETRYABLE_RPC_STATUSES` — an unambiguously transient connection-level gRPC status, so it gets the same in-process backoff as the existing rate-limit and deadline cases. Persistent failures still re-raise so Temporal's activity-level retry applies.

## How did you test this code?

Extended the existing parametrized `TestTransientRPCRetry` tests in `test_temporalio.py`:

- Added a `dns error` / `UNAVAILABLE` row to `test_rides_out_transient_error` — locks in that this connection-level status now backs off and retries rather than failing immediately (the regression this PR fixes).
- Added the same row to `test_persistent_transient_error_is_reraised` — confirms a persistent `UNAVAILABLE` failure still re-raises after exhausting attempts, same as the other retryable statuses.

Ran `pytest products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py::TestTransientRPCRetry` (11 passed), plus `ruff check`/`ruff format --check`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude) triaging an error-tracking issue where a single `dns error` RPCError failed a Temporal.io warehouse import activity. Root cause: `_RETRYABLE_RPC_STATUSES` didn't include `UNAVAILABLE` (gRPC status 14), which is what a DNS resolution blip surfaces as.

Before implementing, checked for a duplicate fix among open PRs (search on "temporalio", "RPCError", "dns error", plus the maintainer's own open PRs). Found [#71792](https://github.com/PostHog/posthog/pull/71792), which targets the same helper and a similar connection-level retry gap, but its base has since diverged (another change independently added message-based matching for `h2 protocol error`/`Timeout expired`), leaving it in a conflicting state that doesn't apply cleanly. This PR makes the narrower, still-missing addition (`UNAVAILABLE` by status) against current master.

Invoked `/writing-tests` before extending test coverage — the added cases are parametrize rows on the existing retry tests, not new test functions.