### PR TITLE
fix(ci): exclude new semgrep add-mask audit rule

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -306,6 +306,7 @@ jobs:
                       --exclude-rule dockerfile.security.no-sudo-in-dockerfile.no-sudo-in-dockerfile \
                       --exclude-rule trailofbits.generic.redis-unencrypted-transport.redis-unencrypted-transport \
                       --exclude-rule trailofbits.yaml.docker-compose.port-all-interfaces.port-all-interfaces \
+                      --exclude-rule yaml.github-actions.security.audit.unsafe-add-mask-workflow-command.unsafe-add-mask-workflow-command \
                       --error \
                       --metrics=off \
                       --verbose \


### PR DESCRIPTION
## Problem

- `semgrep-general` went red on every PR and on master around 20:21 UTC.
- Registry packs are fetched live (only the image is pinned), and `p/github-actions` gained `unsafe-add-mask-workflow-command`.
- It fires on all 7 pre-existing `echo "::add-mask::$VAR"` lines. Rollout is gradual, so jobs load 807 rules (green) or 809 (red), which looked like flake.

## Changes

- One more `--exclude-rule`, alongside the three already there.
- No code fix exists: the rule flags masking itself, since `::stop-commands::` can defeat `add-mask`.

## How did you test this code?

Pinned CI image against `.github/workflows/`: `p/github-actions` alone gives 7 blocking findings, exit 1. With the exclusion, 0 and exit 0. No automated tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code diagnosed and wrote this. I pointed it at "semgrep is failing across CI".
- Comparing rule counts between passing and failing jobs (807 vs 809) pinned it to a registry change rather than the diff.
- Follow-up worth filing: pin or vendor the packs so upstream additions can't red the repo.
