### PR TITLE
fix(dev): cheap wait-for-docker polling with daemon-down backoff

### DIFF
--- a/bin/wait-for-docker
+++ b/bin/wait-for-docker
@@ -97,6 +97,8 @@ compose() {
 # shadow the real service in the last-write-wins scan below). `-a` keeps
 # exited containers visible so timeout diagnostics can show their logs.
 # Fails when the daemon is unreachable, which the main loop uses to back off.
+# stderr is captured by the caller: a failure isn't necessarily a stopped
+# daemon (bad context, socket permissions), so the real error is reported.
 poll_containers() {
     docker ps -a \
         --filter "label=com.docker.compose.project=${PROJECT}" \
@@ -149,9 +151,13 @@ print_service_diagnostics() {
     echo "=========================================="
 }
 
+POLL_ERR_FILE="$(mktemp "${TMPDIR:-/tmp}/wait-for-docker-err.XXXXXX")"
+trap 'rm -f "$POLL_ERR_FILE"' EXIT
+
 SECONDS=0
 last_progress_log=-5
 daemon_down=0
+poll_error=""
 pending=("${SERVICES[@]}")
 # Services that time out, captured at the moment of timeout as
 # "svc|status|container_id" (this iteration's status is the last observed).
@@ -159,19 +165,21 @@ timed_out=()
 
 while [ ${#pending[@]} -gt 0 ]; do
     ps_output=""
-    if ! ps_output=$(poll_containers 2>/dev/null); then
-        # Nothing can converge until the daemon is back, so poll slowly.
+    if ! ps_output=$(poll_containers 2>"$POLL_ERR_FILE"); then
+        poll_error="$(head -n 1 "$POLL_ERR_FILE" 2>/dev/null || true)"
+        # Nothing can converge until docker is back, so poll slowly.
         if [ "$SECONDS" -ge "$TIMEOUT" ]; then
             echo ""
             echo "=========================================="
             echo "TIMEOUT: ${TIMEOUT}s waiting for the Docker daemon"
             echo "=========================================="
-            echo "The Docker daemon was unreachable the whole time."
-            echo "Start Docker (OrbStack, Docker Desktop, colima, ...) and retry."
+            echo "docker ps kept failing with: ${poll_error:-no error output}"
+            echo "If the daemon isn't running, start Docker (OrbStack, Docker Desktop, colima, ...) and retry."
             exit 1
         fi
         if [ "$daemon_down" -eq 0 ] || [ $(( SECONDS - last_progress_log )) -ge 10 ]; then
-            echo "Docker daemon is not running. Start it (OrbStack, Docker Desktop, colima, ...); retrying... (${SECONDS}s)"
+            echo "Docker is not reachable: ${poll_error:-no error output}"
+            echo "If the daemon isn't running, start it (OrbStack, Docker Desktop, colima, ...); retrying... (${SECONDS}s)"
             last_progress_log=$SECONDS
             daemon_down=1
         fi

--- a/bin/wait-for-docker
+++ b/bin/wait-for-docker
@@ -5,6 +5,12 @@ set -euo pipefail
 # Read-only: does not start, stop, or recreate any containers.
 # Used by phrocs processes to block until infrastructure is ready.
 #
+# Dozens of phrocs panes run this loop concurrently, so each poll must be
+# cheap: readiness is read via plain `docker ps` (label-filtered), not
+# `docker compose ps`, which re-parses and re-interpolates every compose file
+# on each invocation (~0.5 CPU-seconds per call). While the docker daemon is
+# unreachable the loop backs off to a slow poll instead of spinning.
+#
 # Usage:
 #   bin/wait-for-docker                     # wait for core (db redis7 kafka clickhouse)
 #   bin/wait-for-docker temporal            # wait for core + temporal
@@ -26,6 +32,12 @@ SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 DEFAULT_COMPOSE_FILE="${REPO_ROOT}/docker-compose.dev.yml"
 TIMEOUT="${WAIT_FOR_DOCKER_TIMEOUT:-300}"
+DAEMON_DOWN_POLL_SECONDS=2
+
+# Pin the project so polls target the same stack the up command created under
+# (see generator.py). Without -p, compose derives it from COMPOSE_PROJECT_NAME
+# or the worktree folder name, which drifts from "posthog" when direnv is off.
+PROJECT="${COMPOSE_PROJECT_NAME:-posthog}"
 
 only_listed=0
 if [ "${1:-}" = "--only" ]; then
@@ -66,11 +78,6 @@ compose() {
     local compose_file
     local separator
 
-    # Pin the project so `ps` targets the same stack the up command created under
-    # (see generator.py). Without -p, compose derives it from COMPOSE_PROJECT_NAME
-    # or the worktree folder name, which drifts from "posthog" when direnv is off.
-    local project="${COMPOSE_PROJECT_NAME:-posthog}"
-
     if [ -n "${COMPOSE_FILE:-}" ]; then
         separator="${COMPOSE_PATH_SEPARATOR:-:}"
         IFS="$separator" read -r -a compose_files <<< "$COMPOSE_FILE"
@@ -79,10 +86,22 @@ compose() {
                 compose_args+=(-f "$compose_file")
             fi
         done
-        env -u COMPOSE_FILE docker compose -p "$project" ${compose_args[@]+"${compose_args[@]}"} "$@"
+        env -u COMPOSE_FILE docker compose -p "$PROJECT" ${compose_args[@]+"${compose_args[@]}"} "$@"
     else
-        docker compose -p "$project" -f "$DEFAULT_COMPOSE_FILE" "$@"
+        docker compose -p "$PROJECT" -f "$DEFAULT_COMPOSE_FILE" "$@"
     fi
+}
+
+# One readiness poll. The label filters reproduce compose's view of the
+# project (oneoff=False excludes `compose run` containers, whose rows would
+# shadow the real service in the last-write-wins scan below). `-a` keeps
+# exited containers visible so timeout diagnostics can show their logs.
+# Fails when the daemon is unreachable, which the main loop uses to back off.
+poll_containers() {
+    docker ps -a \
+        --filter "label=com.docker.compose.project=${PROJECT}" \
+        --filter "label=com.docker.compose.oneoff=False" \
+        --format '{{.Label "com.docker.compose.service"}}|{{.Status}}|{{.State}}|{{.ID}}'
 }
 
 readiness_status() {
@@ -132,24 +151,58 @@ print_service_diagnostics() {
 
 SECONDS=0
 last_progress_log=-5
+daemon_down=0
 pending=("${SERVICES[@]}")
 # Services that time out, captured at the moment of timeout as
 # "svc|status|container_id" (this iteration's status is the last observed).
 timed_out=()
 
 while [ ${#pending[@]} -gt 0 ]; do
-    # Parse this poll's `compose ps` into parallel arrays keyed by ps_keys.
+    ps_output=""
+    if ! ps_output=$(poll_containers 2>/dev/null); then
+        # Nothing can converge until the daemon is back, so poll slowly.
+        if [ "$SECONDS" -ge "$TIMEOUT" ]; then
+            echo ""
+            echo "=========================================="
+            echo "TIMEOUT: ${TIMEOUT}s waiting for the Docker daemon"
+            echo "=========================================="
+            echo "The Docker daemon was unreachable the whole time."
+            echo "Start Docker (OrbStack, Docker Desktop, colima, ...) and retry."
+            exit 1
+        fi
+        if [ "$daemon_down" -eq 0 ] || [ $(( SECONDS - last_progress_log )) -ge 10 ]; then
+            echo "Docker daemon is not running. Start it (OrbStack, Docker Desktop, colima, ...); retrying... (${SECONDS}s)"
+            last_progress_log=$SECONDS
+            daemon_down=1
+        fi
+        sleep "$DAEMON_DOWN_POLL_SECONDS"
+        continue
+    fi
+    if [ "$daemon_down" -eq 1 ]; then
+        echo "Docker daemon is reachable after ${SECONDS}s."
+        daemon_down=0
+    fi
+
+    # Parse this poll into parallel arrays keyed by ps_keys.
     ps_keys=()
     ps_health=()
     ps_state=()
     ps_id=()
-    while IFS='|' read -r svc health state container_id; do
+    while IFS='|' read -r svc status_text state container_id; do
         [ -z "$svc" ] && continue
+        # docker ps has no Health column; health is embedded in the status
+        # text, e.g. "Up 3 minutes (healthy)" / "Up 2 seconds (health: starting)".
+        case "$status_text" in
+            *"(healthy)"*) health="healthy" ;;
+            *"(health: starting)"*) health="starting" ;;
+            *"(unhealthy)"*) health="unhealthy" ;;
+            *) health="" ;;
+        esac
         ps_keys+=("$svc")
         ps_health+=("$health")
         ps_state+=("$state")
         ps_id+=("$container_id")
-    done < <(compose ps --format '{{.Service}}|{{.Health}}|{{.State}}|{{.ID}}' "${pending[@]}" 2>/dev/null || true)
+    done <<< "$ps_output"
 
     still_pending=()
     pending_summary=()
@@ -200,9 +253,8 @@ while [ ${#pending[@]} -gt 0 ]; do
         last_progress_log=$SECONDS
     fi
 
-    # Poll faster than 1 Hz so the convergence cost summed across the
-    # ~10 phrocs procs that all block on this script is bounded by docker
-    # daemon health-check cadence, not the polling cadence.
+    # Fast polling keeps convergence latency low for every pane gated on this
+    # script, and is affordable because `docker ps` is a thin API call.
     sleep 0.2
 done
 

--- a/services/mcp/src/tools/generated/actions.ts
+++ b/services/mcp/src/tools/generated/actions.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/actions/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     ActionsCreateBody,
     ActionsDestroyParams,
@@ -16,6 +10,10 @@ import {
     ActionsPartialUpdateParams,
     ActionsRetrieveParams,
 } from '@/generated/actions/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ActionCreateSchema = ActionsCreateBody.omit({ _create_in_folder: true }).extend({
     name: ActionsCreateBody.shape['name'].describe('Name of the action (must be unique within the project)'),

--- a/services/mcp/src/tools/generated/agent_platform.ts
+++ b/services/mcp/src/tools/generated/agent_platform.ts
@@ -1,10 +1,7 @@
 // AUTO-GENERATED from services/mcp/definitions/agent_platform.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     AgentApplicationsCreateBody,
     AgentApplicationsDestroyParams,
@@ -66,6 +63,7 @@ import {
     AgentRevisionsEnvKeysGetParams,
     AgentRevisionsEnvKeysListParams,
 } from '@/generated/agent_platform/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AgentApplicationsCreateSchema = AgentApplicationsCreateBody
 

--- a/services/mcp/src/tools/generated/ai_observability.ts
+++ b/services/mcp/src/tools/generated/ai_observability.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/ai_observability/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { PromptListInputSchema, ScoreDefinitionConfigSchema } from '@/schema/tool-inputs'
-
 import {
     EvaluationRunsCreateBody,
     EvaluationsCreateBody,
@@ -77,6 +72,9 @@ import {
     TaggersListQueryParams,
     TaggersTestHogCreateBody,
 } from '@/generated/ai_observability/api'
+import { PromptListInputSchema, ScoreDefinitionConfigSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const LlmaClusteringConfigGetSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/alerts.ts
+++ b/services/mcp/src/tools/generated/alerts.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/alerts/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     AlertsCreateBody,
     AlertsDestroyParams,
@@ -16,6 +12,8 @@ import {
     AlertsRetrieveQueryParams,
     AlertsSimulateCreateBody,
 } from '@/generated/alerts/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AlertCreateSchema = AlertsCreateBody
 

--- a/services/mcp/src/tools/generated/annotations.ts
+++ b/services/mcp/src/tools/generated/annotations.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/annotations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     AnnotationsCreateBody,
     AnnotationsDestroyParams,
@@ -15,6 +10,9 @@ import {
     AnnotationsPartialUpdateParams,
     AnnotationsRetrieveParams,
 } from '@/generated/annotations/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AnnotationCreateSchema = AnnotationsCreateBody.omit({
     creation_type: true,

--- a/services/mcp/src/tools/generated/batch_exports.ts
+++ b/services/mcp/src/tools/generated/batch_exports.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/batch_exports/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     BatchExportsCreateBody,
     BatchExportsDestroyParams,
@@ -18,6 +14,8 @@ import {
     FileDownloadBatchExportsCreateBody,
     FileDownloadBatchExportsRetrieveParams,
 } from '@/generated/batch_exports/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const BatchExportCreateSchema = BatchExportsCreateBody
 

--- a/services/mcp/src/tools/generated/business_knowledge.ts
+++ b/services/mcp/src/tools/generated/business_knowledge.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/business_knowledge/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { BusinessKnowledgeUrlSourceCreateSchema } from '@/schema/tool-inputs'
-
 import {
     BusinessKnowledgeDocumentsSearchListQueryParams,
     BusinessKnowledgeDocumentsWindowListParams,
@@ -17,6 +12,9 @@ import {
     BusinessKnowledgeSourcesPartialUpdateParams,
     BusinessKnowledgeSourcesRetrieveParams,
 } from '@/generated/business_knowledge/api'
+import { BusinessKnowledgeUrlSourceCreateSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const BusinessKnowledgeDocumentWindowRetrieveSchema = BusinessKnowledgeDocumentsWindowListParams.omit({
     project_id: true,

--- a/services/mcp/src/tools/generated/cdp_function_templates.ts
+++ b/services/mcp/src/tools/generated/cdp_function_templates.ts
@@ -1,15 +1,13 @@
 // AUTO-GENERATED from products/cdp/mcp/cdp_function_templates.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HogFunctionTemplatesListQueryParams,
     HogFunctionTemplatesRetrieveParams,
 } from '@/generated/cdp_function_templates/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CdpFunctionTemplatesListSchema = HogFunctionTemplatesListQueryParams
 

--- a/services/mcp/src/tools/generated/cdp_functions.ts
+++ b/services/mcp/src/tools/generated/cdp_functions.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/cdp/mcp/cdp_functions.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HogFunctionsCreateBody,
     HogFunctionsDestroyParams,
@@ -21,6 +17,8 @@ import {
     HogFunctionsRearrangePartialUpdateBody,
     HogFunctionsRetrieveParams,
 } from '@/generated/cdp_functions/api'
+import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CdpFunctionsCreateSchema = HogFunctionsCreateBody.extend({
     type: HogFunctionsCreateBody.shape['type'].describe(

--- a/services/mcp/src/tools/generated/cohorts.ts
+++ b/services/mcp/src/tools/generated/cohorts.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/cohorts/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     CohortsAddPersonsToStaticCohortPartialUpdateBody,
     CohortsAddPersonsToStaticCohortPartialUpdateParams,
@@ -19,6 +13,10 @@ import {
     CohortsRemovePersonFromStaticCohortPartialUpdateParams,
     CohortsRetrieveParams,
 } from '@/generated/cohorts/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CohortsAddPersonsToStaticCohortPartialUpdateSchema = CohortsAddPersonsToStaticCohortPartialUpdateParams.omit({
     project_id: true,

--- a/services/mcp/src/tools/generated/conversations.ts
+++ b/services/mcp/src/tools/generated/conversations.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/conversations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     ConversationsTicketsListQueryParams,
     ConversationsTicketsMessagesListParams,
@@ -17,6 +13,8 @@ import {
     ConversationsTicketsRetrieveParams,
     ConversationsViewsListQueryParams,
 } from '@/generated/conversations/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ConversationsTicketsListSchema = ConversationsTicketsListQueryParams
 

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from services/mcp/definitions/core.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { omitResponseFields, pickResponseFields } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     DesktopFileSystemCanvasPartialUpdateBody,
     DesktopFileSystemCanvasPartialUpdateParams,
@@ -23,6 +18,9 @@ import {
     UsersPartialUpdateParams,
     UsersRetrieveParams,
 } from '@/generated/core/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { omitResponseFields, pickResponseFields } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DesktopFileSystemCanvasPartialUpdateSchema = DesktopFileSystemCanvasPartialUpdateParams.omit({ project_id: true })
     .extend(DesktopFileSystemCanvasPartialUpdateBody.shape)

--- a/services/mcp/src/tools/generated/customer_analytics.ts
+++ b/services/mcp/src/tools/generated/customer_analytics.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/customer_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { UsageMetricFiltersSchema } from '@/schema/tool-inputs'
-
 import {
     AccountRelationshipDefinitionsCreateBody,
     AccountRelationshipDefinitionsDestroyParams,
@@ -59,6 +54,9 @@ import {
     GroupsTypesMetricsPartialUpdateParams,
     GroupsTypesMetricsRetrieveParams,
 } from '@/generated/customer_analytics/api'
+import { UsageMetricFiltersSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AccountRelationshipDefinitionsCreateSchema = AccountRelationshipDefinitionsCreateBody
 

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -1,18 +1,7 @@
 // AUTO-GENERATED from products/dashboards/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import {
-    withPostHogUrl,
-    omitResponseFields,
-    withInformationalResponse,
-    type WithPostHogUrl,
-    type WithInformationalResponse,
-} from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     DashboardTemplatesListQueryParams,
     DashboardTemplatesRetrieveParams,
@@ -46,6 +35,15 @@ import {
     DashboardsWidgetsBatchCreateBody,
     DashboardsWidgetsBatchCreateParams,
 } from '@/generated/dashboards/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import {
+    withPostHogUrl,
+    omitResponseFields,
+    withInformationalResponse,
+    type WithPostHogUrl,
+    type WithInformationalResponse,
+} from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DashboardCreateSchema = DashboardsCreateQueryParams.omit({ format: true }).extend(DashboardsCreateBody.shape)
 

--- a/services/mcp/src/tools/generated/data_catalog.ts
+++ b/services/mcp/src/tools/generated/data_catalog.ts
@@ -1,16 +1,7 @@
 // AUTO-GENERATED from products/data_catalog/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
-import {
-    executeConfirmedAction,
-    prepareConfirmedAction,
-    type PrepareConfirmedActionResult,
-} from '@/tools/confirmed-action-runtime'
-
 import {
     DataCatalogCertificationsCertifyCreateParams,
     DataCatalogCertificationsCreateBody,
@@ -27,6 +18,13 @@ import {
     DataCatalogRelationshipProposalsRejectCreateBody,
     DataCatalogRelationshipProposalsRejectCreateParams,
 } from '@/generated/data_catalog/api'
+import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
+import {
+    executeConfirmedAction,
+    prepareConfirmedAction,
+    type PrepareConfirmedActionResult,
+} from '@/tools/confirmed-action-runtime'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DataCatalogCertificationCertifySchema = DataCatalogCertificationsCertifyCreateParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/data_management.ts
+++ b/services/mcp/src/tools/generated/data_management.ts
@@ -1,12 +1,10 @@
 // AUTO-GENERATED from services/mcp/definitions/data_management.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import { IngestionWarningsV2ListQueryParams } from '@/generated/data_management/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const IngestionWarningsListSchema = IngestionWarningsV2ListQueryParams
 

--- a/services/mcp/src/tools/generated/data_warehouse.ts
+++ b/services/mcp/src/tools/generated/data_warehouse.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/data_warehouse/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     InsightVariablesCreateBody,
     InsightVariablesDestroyParams,
@@ -32,6 +28,8 @@ import {
     WarehouseSavedQueriesRunHistoryRetrieveParams,
     WarehouseTablesRefreshSchemaCreateParams,
 } from '@/generated/data_warehouse/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SavedQueryColumnAnnotationsCreateSchema = SavedQueryColumnAnnotationsCreateBody.extend({
     column_name: SavedQueryColumnAnnotationsCreateBody.shape['column_name'].describe(

--- a/services/mcp/src/tools/generated/docs.ts
+++ b/services/mcp/src/tools/generated/docs.ts
@@ -1,11 +1,9 @@
 // AUTO-GENERATED from services/mcp/definitions/docs.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import { DocsSearchBody } from '@/generated/docs/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DocsSearchSchema = DocsSearchBody
 

--- a/services/mcp/src/tools/generated/early_access_features.ts
+++ b/services/mcp/src/tools/generated/early_access_features.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/early_access_features/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     EarlyAccessFeatureCreateBody,
     EarlyAccessFeatureDestroyParams,
@@ -14,6 +10,8 @@ import {
     EarlyAccessFeaturePartialUpdateParams,
     EarlyAccessFeatureRetrieveParams,
 } from '@/generated/early_access_features/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const EarlyAccessFeatureCreateSchema = EarlyAccessFeatureCreateBody.omit({ _create_in_folder: true })
 

--- a/services/mcp/src/tools/generated/email_templates.ts
+++ b/services/mcp/src/tools/generated/email_templates.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/workflows/mcp/email_templates.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { EmailTemplateDesignPatchSchema } from '@/schema/tool-inputs'
-
 import {
     MessagingTemplatesCreateBody,
     MessagingTemplatesListQueryParams,
@@ -15,6 +9,10 @@ import {
     MessagingTemplatesPartialUpdateParams,
     MessagingTemplatesRetrieveParams,
 } from '@/generated/email_templates/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { EmailTemplateDesignPatchSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const WorkflowsCreateEmailTemplateSchema = MessagingTemplatesCreateBody
 

--- a/services/mcp/src/tools/generated/endpoints.ts
+++ b/services/mcp/src/tools/generated/endpoints.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/endpoints/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     EndpointsCreateBody,
     EndpointsDestroyParams,
@@ -28,6 +24,8 @@ import {
     EndpointsVersionsListParams,
     EndpointsVersionsListQueryParams,
 } from '@/generated/endpoints/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const EndpointCreateSchema = EndpointsCreateBody.omit({
     is_active: true,

--- a/services/mcp/src/tools/generated/engineering_analytics.ts
+++ b/services/mcp/src/tools/generated/engineering_analytics.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/engineering_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     EngineeringAnalyticsBrokenTestsQueryParams,
     EngineeringAnalyticsCiFailureLogsQueryParams,
@@ -19,6 +15,8 @@ import {
     EngineeringAnalyticsWorkflowJobsQueryParams,
     EngineeringAnalyticsWorkflowRunnerCostsQueryParams,
 } from '@/generated/engineering_analytics/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const EngineeringAnalyticsBrokenTestsSchema = EngineeringAnalyticsBrokenTestsQueryParams
 

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/error_tracking/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     ErrorTrackingAssignmentRulesCreateBody,
     ErrorTrackingAssignmentRulesListQueryParams,
@@ -37,6 +32,9 @@ import {
     ErrorTrackingSymbolSetsListQueryParams,
     ErrorTrackingSymbolSetsRetrieveParams,
 } from '@/generated/error_tracking/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ErrorTrackingAssignmentRulesCreateSchema = ErrorTrackingAssignmentRulesCreateBody
 

--- a/services/mcp/src/tools/generated/error_tracking_alerts.ts
+++ b/services/mcp/src/tools/generated/error_tracking_alerts.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/error_tracking/mcp/error_tracking_alerts.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HogFunctionsCreateBody,
     HogFunctionsDestroyParams,
@@ -13,6 +9,8 @@ import {
     HogFunctionsPartialUpdateBody,
     HogFunctionsPartialUpdateParams,
 } from '@/generated/error_tracking_alerts/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ErrorTrackingAlertsCreateSchema = HogFunctionsCreateBody.extend({
     type: HogFunctionsCreateBody.shape['type'].describe(

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -1,14 +1,7 @@
 // AUTO-GENERATED from products/experiments/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { SavedMetricsAttachSchema } from '@/schema/tool-inputs'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     ExperimentHoldoutsCreateBody,
     ExperimentHoldoutsDestroyParams,
@@ -49,6 +42,11 @@ import {
     ExperimentsUnarchiveCreateParams,
     ExperimentsUnfreezeExposureCreateParams,
 } from '@/generated/experiments/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { SavedMetricsAttachSchema } from '@/schema/tool-inputs'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ExperimentArchiveSchema = ExperimentsArchiveCreateParams.omit({ project_id: true })
     .extend(ExperimentsArchiveCreateBody.shape)

--- a/services/mcp/src/tools/generated/feature_flags.ts
+++ b/services/mcp/src/tools/generated/feature_flags.ts
@@ -1,14 +1,7 @@
 // AUTO-GENERATED from products/feature_flags/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { validateDistinctIdPersonIdExclusive } from '@/schema/tool-inputs'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     FeatureFlagsActivityRetrieveParams,
     FeatureFlagsActivityRetrieveQueryParams,
@@ -36,6 +29,11 @@ import {
     ScheduledChangesPartialUpdateParams,
     ScheduledChangesRetrieveParams,
 } from '@/generated/feature_flags/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { validateDistinctIdPersonIdExclusive } from '@/schema/tool-inputs'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CreateFeatureFlagSchema = FeatureFlagsCreateBody.omit({ archived: true }).extend({
     is_remote_configuration: FeatureFlagsCreateBody.shape['is_remote_configuration'].describe(

--- a/services/mcp/src/tools/generated/field_notes.ts
+++ b/services/mcp/src/tools/generated/field_notes.ts
@@ -1,17 +1,15 @@
 // AUTO-GENERATED from products/field_notes/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     FieldNotesListQueryParams,
     FieldNotesPartialUpdateBody,
     FieldNotesPartialUpdateParams,
     FieldNotesRetrieveParams,
 } from '@/generated/field_notes/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const FieldNotesGetSchema = FieldNotesRetrieveParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/health_issues.ts
+++ b/services/mcp/src/tools/generated/health_issues.ts
@@ -1,12 +1,10 @@
 // AUTO-GENERATED from services/mcp/definitions/health_issues.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import { HealthIssuesListQueryParams, HealthIssuesRetrieveParams } from '@/generated/health_issues/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const HealthIssuesGetSchema = HealthIssuesRetrieveParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/integrations.ts
+++ b/services/mcp/src/tools/generated/integrations.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/integrations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     IntegrationsChannelsRetrieveParams,
     IntegrationsChannelsRetrieveQueryParams,
@@ -17,6 +13,8 @@ import {
     IntegrationsListQueryParams,
     IntegrationsRetrieveParams,
 } from '@/generated/integrations/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const IntegrationDeleteSchema = IntegrationsDestroyParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/logs.ts
+++ b/services/mcp/src/tools/generated/logs.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/logs/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     LogsAlertsCreateBody,
     LogsAlertsDestinationsCreateBody,
@@ -31,6 +27,8 @@ import {
     LogsSparklineCreateBody,
     LogsValuesRetrieveQueryParams,
 } from '@/generated/logs/api'
+import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const LogsAlertsCreateSchema = LogsAlertsCreateBody
 

--- a/services/mcp/src/tools/generated/managed_migrations.ts
+++ b/services/mcp/src/tools/generated/managed_migrations.ts
@@ -1,15 +1,13 @@
 // AUTO-GENERATED from products/managed_migrations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     ManagedMigrationsSupportListQueryParams,
     ManagedMigrationsSupportRetrieveParams,
 } from '@/generated/managed_migrations/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ManagedMigrationsSupportGetSchema = ManagedMigrationsSupportRetrieveParams
 

--- a/services/mcp/src/tools/generated/marketing_analytics.ts
+++ b/services/mcp/src/tools/generated/marketing_analytics.ts
@@ -1,10 +1,7 @@
 // AUTO-GENERATED from products/marketing_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     MarketingAnalyticsDataSourcesRetrieveQueryParams,
     MarketingAnalyticsDiagnoseRetrieveQueryParams,
@@ -13,6 +10,7 @@ import {
     MarketingAnalyticsSuggestUtmMappingsRetrieveQueryParams,
     MarketingAnalyticsUtmAuditRetrieveQueryParams,
 } from '@/generated/marketing_analytics/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const MarketingAnalyticsConversionGoalsSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/mcp_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { createQueryWrapper } from '@/tools/query-wrapper-factory'
-
 import {
     McpAnalyticsFeedbackCreateBody,
     McpAnalyticsMissingCapabilitiesCreateBody,
@@ -16,6 +11,9 @@ import {
     McpAnalyticsSessionsToolCallsParams,
     McpAnalyticsSessionsToolCallsQueryParams,
 } from '@/generated/mcp_analytics/api'
+import { createQueryWrapper } from '@/tools/query-wrapper-factory'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const McpAnalyticsIntentClustersRecomputeSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/mcp_store.ts
+++ b/services/mcp/src/tools/generated/mcp_store.ts
@@ -1,15 +1,13 @@
 // AUTO-GENERATED from products/mcp_store/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     McpServerInstallationsListQueryParams,
     McpServerInstallationsToolsRetrieveParams,
 } from '@/generated/mcp_store/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const McpConnectionToolsListSchema = McpServerInstallationsToolsRetrieveParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/metrics.ts
+++ b/services/mcp/src/tools/generated/metrics.ts
@@ -1,16 +1,14 @@
 // AUTO-GENERATED from products/metrics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { pickResponseFields } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     MetricsCharacterizeCreateBody,
     MetricsQueryCreateBody,
     MetricsValuesRetrieveQueryParams,
 } from '@/generated/metrics/api'
+import { pickResponseFields } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CharacterizeMetricAnomalySchema = MetricsCharacterizeCreateBody
 

--- a/services/mcp/src/tools/generated/notebooks.ts
+++ b/services/mcp/src/tools/generated/notebooks.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/notebooks/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     NotebooksCreateBody,
     NotebooksDestroyParams,
@@ -14,6 +10,8 @@ import {
     NotebooksPartialUpdateParams,
     NotebooksRetrieveParams,
 } from '@/generated/notebooks/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const NotebooksCreateSchema = NotebooksCreateBody
 

--- a/services/mcp/src/tools/generated/persons.ts
+++ b/services/mcp/src/tools/generated/persons.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/persons/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     PersonsBulkDeleteCreateBody,
     PersonsCohortsRetrieveQueryParams,
@@ -18,6 +13,9 @@ import {
     PersonsUpdatePropertyCreateParams,
     PersonsValuesRetrieveQueryParams,
 } from '@/generated/persons/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const PersonsBulkDeleteSchema = PersonsBulkDeleteCreateBody
 

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -1,23 +1,7 @@
 // AUTO-GENERATED from products/platform_features/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import {
-    withPostHogUrl,
-    pickResponseFields,
-    withInformationalResponse,
-    type WithPostHogUrl,
-    type WithInformationalResponse,
-} from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
-import {
-    executeConfirmedAction,
-    prepareConfirmedAction,
-    type PrepareConfirmedActionResult,
-} from '@/tools/confirmed-action-runtime'
-
 import {
     AdvancedActivityLogsListQueryParams,
     ApprovalPoliciesListQueryParams,
@@ -45,6 +29,20 @@ import {
     UserHomeSettingsPartialUpdateParams,
     UserHomeSettingsRetrieveParams,
 } from '@/generated/platform_features/api'
+import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
+import {
+    executeConfirmedAction,
+    prepareConfirmedAction,
+    type PrepareConfirmedActionResult,
+} from '@/tools/confirmed-action-runtime'
+import {
+    withPostHogUrl,
+    pickResponseFields,
+    withInformationalResponse,
+    type WithPostHogUrl,
+    type WithInformationalResponse,
+} from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AdvancedActivityLogsFiltersSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/product_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt, normalizeParamAliases } from '@/tools/cast-helpers'
-
 import {
     ElementsStatsRetrieveQueryParams,
     InsightsActivityRetrieveParams,
@@ -21,6 +16,9 @@ import {
     InsightsRetrieveQueryParams,
     InsightsTrendingRetrieveQueryParams,
 } from '@/generated/product_analytics/api'
+import { castStringToInt, normalizeParamAliases } from '@/tools/cast-helpers'
+import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AssistantInsightVizNode = z.object({
     kind: z.literal('InsightVizNode').default('InsightVizNode'),

--- a/services/mcp/src/tools/generated/proxy-records.ts
+++ b/services/mcp/src/tools/generated/proxy-records.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from services/mcp/definitions/proxy-records.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     ProxyRecordsCreateBody,
     ProxyRecordsDestroyParams,
@@ -13,6 +9,8 @@ import {
     ProxyRecordsRetrieveParams,
     ProxyRecordsRetryCreateParams,
 } from '@/generated/proxy-records/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ProxyCreateSchema = ProxyRecordsCreateBody
 

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -1,8 +1,8 @@
 // AUTO-GENERATED from services/mcp/definitions/query-wrappers.yaml + schema.json — do not edit
 import { z } from 'zod'
 
-import type { ZodObjectAny } from '@/tools/types'
 import { createQueryWrapper } from '@/tools/query-wrapper-factory'
+import type { ZodObjectAny } from '@/tools/types'
 
 // --- Shared Zod schemas generated from schema.json ---
 

--- a/services/mcp/src/tools/generated/reminders.ts
+++ b/services/mcp/src/tools/generated/reminders.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/reminders/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     RemindersCreateBody,
     RemindersDestroyParams,
@@ -14,6 +10,8 @@ import {
     RemindersPartialUpdateParams,
     RemindersRetrieveParams,
 } from '@/generated/reminders/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ReminderCreateSchema = RemindersCreateBody
 

--- a/services/mcp/src/tools/generated/replay.ts
+++ b/services/mcp/src/tools/generated/replay.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/replay/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { createQueryWrapper } from '@/tools/query-wrapper-factory'
-
 import {
     SessionRecordingPlaylistsCreateBody,
     SessionRecordingPlaylistsListQueryParams,
@@ -20,6 +14,10 @@ import {
     SingleSessionSummariesListQueryParams,
     SingleSessionSummariesRetrieveParams,
 } from '@/generated/replay/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { createQueryWrapper } from '@/tools/query-wrapper-factory'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SessionRecordingBulkDeleteSchema = SessionRecordingsBulkDeleteCreateBody
 

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/replay_vision/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     VisionActionsListQueryParams,
     VisionActionsRetrieveParams,
@@ -43,6 +39,8 @@ import {
     VisionScannersPromptSuggestionsGenerateCreateParams,
     VisionScannersRetrieveParams,
 } from '@/generated/replay_vision/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const VisionActionsListSchema = VisionActionsListQueryParams
 

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -1,19 +1,7 @@
 // AUTO-GENERATED from products/signals/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import {
-    withPostHogUrl,
-    withAgentNote,
-    pickResponseFields,
-    withInformationalResponse,
-    type WithPostHogUrl,
-    type WithAgentNote,
-    type WithInformationalResponse,
-} from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     SignalsReportArtefactsCreateBody,
     SignalsReportArtefactsCreateParams,
@@ -62,6 +50,16 @@ import {
     SignalsSourceConfigsUpdateBody,
     SignalsSourceConfigsUpdateParams,
 } from '@/generated/signals/api'
+import {
+    withPostHogUrl,
+    withAgentNote,
+    pickResponseFields,
+    withInformationalResponse,
+    type WithPostHogUrl,
+    type WithAgentNote,
+    type WithInformationalResponse,
+} from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const InboxReportArtefactsCreateSchema = SignalsReportArtefactsCreateParams.omit({ project_id: true }).extend(
     SignalsReportArtefactsCreateBody.shape

--- a/services/mcp/src/tools/generated/skills.ts
+++ b/services/mcp/src/tools/generated/skills.ts
@@ -1,10 +1,7 @@
 // AUTO-GENERATED from products/skills/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     LlmSkillsCreateBody,
     LlmSkillsListQueryParams,
@@ -25,6 +22,7 @@ import {
     LlmSkillsNameRetrieveParams,
     LlmSkillsNameRetrieveQueryParams,
 } from '@/generated/skills/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SkillArchiveSchema = LlmSkillsNameArchiveCreateParams.omit({ project_id: true }).extend({
     skill_name: LlmSkillsNameArchiveCreateParams.shape['skill_name'].describe(

--- a/services/mcp/src/tools/generated/stamphog.ts
+++ b/services/mcp/src/tools/generated/stamphog.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/stamphog/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     StamphogDigestChannelsCreateBody,
     StamphogDigestChannelsDestroyParams,
@@ -19,6 +15,8 @@ import {
     StamphogReviewRunsListQueryParams,
     StamphogReviewRunsRetrieveParams,
 } from '@/generated/stamphog/api'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const StamphogDigestChannelsCreateSchema = StamphogDigestChannelsCreateBody
 

--- a/services/mcp/src/tools/generated/subscriptions.ts
+++ b/services/mcp/src/tools/generated/subscriptions.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/subscriptions/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     SubscriptionsCreateBody,
     SubscriptionsDeliveriesListParams,
@@ -19,6 +14,9 @@ import {
     SubscriptionsRetrieveParams,
     SubscriptionsTestDeliveryCreateParams,
 } from '@/generated/subscriptions/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SubscriptionsCreateSchema = SubscriptionsCreateBody
 

--- a/services/mcp/src/tools/generated/surveys.ts
+++ b/services/mcp/src/tools/generated/surveys.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/surveys/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     SurveysCreateBody,
     SurveysDestroyParams,
@@ -25,6 +20,9 @@ import {
     SurveysSummarizeResponsesCreateParams,
     SurveysSummarizeResponsesCreateQueryParams,
 } from '@/generated/surveys/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SurveyCreateSchema = SurveysCreateBody.omit({
     linked_insight_id: true,

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -1,17 +1,7 @@
 // AUTO-GENERATED from products/tasks/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
-import {
-    executeConfirmedAction,
-    prepareConfirmedAction,
-    type PrepareConfirmedActionResult,
-} from '@/tools/confirmed-action-runtime'
-
 import {
     LoopsCreateBody,
     LoopsDestroyParams,
@@ -33,6 +23,14 @@ import {
     TasksRunsSessionLogsRetrieveParams,
     TasksRunsSessionLogsRetrieveQueryParams,
 } from '@/generated/tasks/api'
+import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
+import {
+    executeConfirmedAction,
+    prepareConfirmedAction,
+    type PrepareConfirmedActionResult,
+} from '@/tools/confirmed-action-runtime'
+import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const LoopsCreateSchema = LoopsCreateBody
 

--- a/services/mcp/src/tools/generated/tracing.ts
+++ b/services/mcp/src/tools/generated/tracing.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/tracing/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     TracingSpansAggregateCreateBody,
     TracingSpansAttributeBreakdownCreateBody,
@@ -22,6 +17,9 @@ import {
     TracingSpansTreeCreateBody,
     TracingSpansValuesRetrieveQueryParams,
 } from '@/generated/tracing/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, pickResponseFields } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ApmAttributeBreakdownSchema = TracingSpansAttributeBreakdownCreateBody
 

--- a/services/mcp/src/tools/generated/user_interviews.ts
+++ b/services/mcp/src/tools/generated/user_interviews.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/user_interviews/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     UserInterviewTopicsAddIntervieweeCreateBody,
     UserInterviewTopicsAddIntervieweeCreateParams,
@@ -38,6 +33,9 @@ import {
     UserInterviewsRetrieveParams,
     UserInterviewsSearchCreateBody,
 } from '@/generated/user_interviews/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const UserInterviewTopicsAddIntervieweeSchema = UserInterviewTopicsAddIntervieweeCreateParams.omit({
     project_id: true,

--- a/services/mcp/src/tools/generated/visual_review.ts
+++ b/services/mcp/src/tools/generated/visual_review.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/visual_review/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     VisualReviewReposListQueryParams,
     VisualReviewReposRetrieveParams,
@@ -25,6 +20,9 @@ import {
     VisualReviewRunsToleratedHashesListParams,
     VisualReviewRunsToleratedHashesListQueryParams,
 } from '@/generated/visual_review/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const VisualReviewReposListSchema = VisualReviewReposListQueryParams
 

--- a/services/mcp/src/tools/generated/warehouse_sources.ts
+++ b/services/mcp/src/tools/generated/warehouse_sources.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/warehouse_sources/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { ExternalDataSourcePayloadSchema, ExternalDataSourceTypeSchema } from '@/schema/tool-inputs'
-
 import {
     ExternalDataSchemasCancelCreateParams,
     ExternalDataSchemasDeleteDataDestroyParams,
@@ -43,6 +38,9 @@ import {
     ExternalDataSourcesWebhookInfoRetrieveParams,
     ExternalDataSourcesWizardRetrieveQueryParams,
 } from '@/generated/warehouse_sources/api'
+import { ExternalDataSourcePayloadSchema, ExternalDataSourceTypeSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DataWarehouseSourceConnectLinkSchema = ExternalDataSourcesConnectLinkRetrieveQueryParams.extend({
     source_type: ExternalDataSourceTypeSchema,

--- a/services/mcp/src/tools/generated/web_analytics.ts
+++ b/services/mcp/src/tools/generated/web_analytics.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/web_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HeatmapsEventsRetrieveQueryParams,
     HeatmapsListQueryParams,
@@ -17,6 +13,8 @@ import {
     SavedRetrieveParams,
     WebAnalyticsWeeklyDigestQueryParams,
 } from '@/generated/web_analytics/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const HeatmapsEventsSchema = HeatmapsEventsRetrieveQueryParams
 

--- a/services/mcp/src/tools/generated/workflows.ts
+++ b/services/mcp/src/tools/generated/workflows.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/workflows/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { WorkflowGraphPatchSchema } from '@/schema/tool-inputs'
-
 import {
     HogFlowsBatchJobsListParams,
     HogFlowsCreateBody,
@@ -36,6 +30,10 @@ import {
     HogFlowsSchedulesPartialUpdateBody,
     HogFlowsSchedulesPartialUpdateParams,
 } from '@/generated/workflows/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { WorkflowGraphPatchSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const WorkflowsCreateSchema = HogFlowsCreateBody
 


### PR DESCRIPTION
## TL;DR

If you run `hogli start` while Docker (OrbStack) isn't running, your laptop melts. ~27 phrocs panes each wait for docker by spawning a heavyweight `docker compose ps` five times per second, and each of those calls burns ~0.5 CPU-seconds re-parsing the compose files before it even notices the daemon is down. This PR makes each poll a millisecond-cheap `docker ps` call, and when the daemon is down the loop now says so and checks every 2 seconds instead of spinning.

## Problem

Every phrocs pane gates on `bin/wait-for-docker` (27 panes in a current dev setup, most with `autorestart: true`). The readiness poll used `docker compose ps`, which re-parses and re-interpolates every compose file on each invocation, costing ~0.5 CPU-seconds per call.

Two consequences:

- With the docker daemon down (OrbStack not started), every pane spins at 5 Hz for the full 300s timeout, autorestart relaunches it, and the churn is permanent. Observed on a 15-core laptop: several hundred percent CPU of nothing but short-lived docker-compose processes, with no message telling the user the actual problem.
- Even on healthy startups, all panes polling with compose burns a couple of cores while services converge.

## Changes

- Poll with plain `docker ps -a`, filtered by the `com.docker.compose.project` and `com.docker.compose.oneoff=False` labels, instead of `docker compose ps`. This reproduces compose's view of the project without parsing any compose files. Health is derived from the status text ("(healthy)", "(health: starting)", "(unhealthy)"), falling back to container state as before.
- When the daemon is unreachable (the poll fails), print one actionable line ("Docker daemon is not running. Start it (OrbStack, Docker Desktop, colima, ...)"), back off to a 2s poll, and on timeout fail with a daemon-specific message instead of per-service noise. Recovery mid-wait resumes fast polling.
- Timeout diagnostics for a specific stuck service are unchanged (still use compose once for the detailed view).

Readiness semantics are unchanged: a service is ready when healthy, or running without a healthcheck. `bin/ci-wait-for-docker` only consumes the exit code, which still signals failure with 1.

## How did you test this code?

On a machine where the daemon state could be controlled, plus a fake `docker` CLI shim to force each path:

- Live daemon, all services healthy: exits 0 immediately. Whole run costs ~0.06 CPU-s vs ~0.34 CPU-s for a single poll of the old script.
- Daemon down then recovering: prints the actionable message, polls slowly, resumes and reports ready.
- Daemon down past timeout: prints the daemon timeout block, exits 1.
- `(health: starting)` transitioning to `(healthy)`: waits, then ready.
- Service that never gets a container: unchanged per-service timeout diagnostics, exits 1.
- `--only db redis7`: unchanged.

No automated test added: the script has none today and testing it would need a docker daemon fixture; the shim-based manual matrix above covers the behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference this script's behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code) investigated a laptop-wide CPU spike, traced it to 35 concurrent `wait-for-docker` loops spawning docker-compose against a stopped OrbStack daemon, and wrote this fix. Considered alternatives: a one-shot `docker info` gate per iteration (rejected: adds a spawn on the healthy path), and a single shared waiter across panes (rejected for now: needs phrocs/generator changes; the cheap poll makes it unnecessary). Verified output-format compatibility with `bin/ci-wait-for-docker` (exit-code driven) and the generator's command-string peeling. No repo skills applied to this area.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*