### PR TITLE
chore(hogai): read conversation stream events as JSON or pickle

### DIFF
--- a/ee/hogai/stream/redis_stream.py
+++ b/ee/hogai/stream/redis_stream.py
@@ -201,8 +201,14 @@ class ConversationStreamSerializer:
         )
 
     def deserialize(self, data: dict[bytes, bytes]) -> StreamEvent:
-        # nosemgrep: python.lang.security.deserialization.pickle.avoid-pickle (internal Redis stream, data is self-generated)
-        return pickle.loads(data[bytes(self.serialization_key, "utf-8")])
+        raw = data[bytes(self.serialization_key, "utf-8")]
+        # Migration Phase 1: read both formats. JSON (the new format) starts with '{';
+        # legacy pickle starts with 0x80. Once every writer emits JSON, the pickle
+        # branch is removed (Phase 3).
+        if raw[:1] == b"{":
+            return StreamEvent.model_validate_json(raw)
+        # nosemgrep: python.lang.security.deserialization.pickle.avoid-pickle (transitional legacy read, removed in migration Phase 3 once all writers emit JSON)
+        return pickle.loads(raw)
 
 
 class StreamError(Exception):

--- a/ee/hogai/stream/test/test_redis_stream.py
+++ b/ee/hogai/stream/test/test_redis_stream.py
@@ -1,3 +1,4 @@
+import pickle
 import asyncio
 from typing import cast
 from uuid import uuid4
@@ -6,13 +7,20 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import AsyncMock, patch
 
+from django.test import SimpleTestCase
+
 import redis.exceptions as redis_exceptions
+from parameterized import parameterized
 
 from posthog.schema import (
     AssistantEventType,
     AssistantGenerationStatusEvent,
     AssistantGenerationStatusType,
     AssistantMessage,
+    AssistantToolCallMessage,
+    FailureMessage,
+    HumanMessage,
+    ReasoningMessage,
 )
 
 from products.posthog_ai.backend.models.assistant import Conversation
@@ -600,3 +608,40 @@ class TestGetSubagentStreamKey(BaseTest):
         key1 = get_subagent_stream_key(conv_id_1, tool_call_id)
         key2 = get_subagent_stream_key(conv_id_2, tool_call_id)
         self.assertNotEqual(key1, key2)
+
+
+class TestConversationStreamSerializerJson(SimpleTestCase):
+    # Phase 1 of the pickle->JSON migration: the reader must parse JSON entries (and still read
+    # legacy pickle) before any writer emits JSON. The inner payload union is resolved by pydantic
+    # smart mode, so each member — especially the three that share only `content: str` — is a
+    # distinct resolution case that could misresolve or drop fields on the validate-back leg.
+    @parameterized.expand(
+        [
+            ("assistant", AssistantMessage(content="hi")),
+            ("human", HumanMessage(content="hi")),
+            ("reasoning", ReasoningMessage(content="thinking")),
+            ("failure", FailureMessage()),
+            ("tool_call", AssistantToolCallMessage(content="done", tool_call_id="tc_1")),
+        ]
+    )
+    def test_deserialize_json_message_preserves_payload(self, _name, payload):
+        serializer = ConversationStreamSerializer()
+        event = StreamEvent(event=MessageEvent(type=AssistantEventType.MESSAGE, payload=payload))
+        json_bytes = event.model_dump_json().encode("utf-8")
+        assert json_bytes[:1] == b"{"  # the byte the reader branches on to pick JSON over pickle
+
+        result = serializer.deserialize({b"data": json_bytes})
+
+        self.assertEqual(result.event.type, AssistantEventType.MESSAGE)
+        self.assertIs(type(result.event.payload), type(payload))  # smart-union resolved to same member
+        self.assertEqual(result.event.payload, payload)  # no data lost on round-trip
+
+    def test_deserialize_still_reads_legacy_pickle(self):
+        serializer = ConversationStreamSerializer()
+        event = StreamEvent(event=StreamStatusEvent(payload=StatusPayload(status="complete")))
+
+        result = serializer.deserialize({b"data": pickle.dumps(event)})
+
+        self.assertEqual(result.event.type, "STREAM_STATUS")
+        payload = cast(StatusPayload, result.event.payload)
+        self.assertEqual(payload.status, "complete")

--- a/ee/hogai/stream/test/test_redis_stream.py
+++ b/ee/hogai/stream/test/test_redis_stream.py
@@ -17,10 +17,13 @@ from posthog.schema import (
     AssistantGenerationStatusEvent,
     AssistantGenerationStatusType,
     AssistantMessage,
+    AssistantToolCall,
     AssistantToolCallMessage,
+    AssistantUpdateEvent,
     FailureMessage,
     HumanMessage,
     ReasoningMessage,
+    SubagentUpdateEvent,
 )
 
 from products.posthog_ai.backend.models.assistant import Conversation
@@ -28,16 +31,20 @@ from products.posthog_ai.backend.models.assistant import Conversation
 from ee.hogai.stream.redis_stream import (
     CONVERSATION_STREAM_PREFIX,
     CONVERSATION_STREAM_TIMEOUT,
+    ApprovalEvent,
+    ConversationEvent,
     ConversationRedisStream,
     ConversationStreamSerializer,
+    GenerationStatusEvent,
     MessageEvent,
     StatusPayload,
     StreamError,
     StreamEvent,
     StreamStatusEvent,
+    UpdateEvent,
     get_subagent_stream_key,
 )
-from ee.hogai.utils.types.base import AssistantOutput
+from ee.hogai.utils.types.base import ApprovalPayload, AssistantOutput
 
 
 class TestRedisStream(BaseTest):
@@ -635,6 +642,62 @@ class TestConversationStreamSerializerJson(SimpleTestCase):
         self.assertEqual(result.event.type, AssistantEventType.MESSAGE)
         self.assertIs(type(result.event.payload), type(payload))  # smart-union resolved to same member
         self.assertEqual(result.event.payload, payload)  # no data lost on round-trip
+
+    @parameterized.expand(
+        [
+            ("conversation", ConversationEvent(type="conversation", payload=uuid4())),
+            (
+                "generation_status",
+                GenerationStatusEvent(
+                    type=AssistantEventType.STATUS,
+                    payload=AssistantGenerationStatusEvent(type=AssistantGenerationStatusType.GENERATION_ERROR),
+                ),
+            ),
+            (
+                "update_assistant",
+                UpdateEvent(
+                    type=AssistantEventType.UPDATE,
+                    payload=AssistantUpdateEvent(content="progress", id="u1", tool_call_id="tc1"),
+                ),
+            ),
+            (
+                "update_subagent",
+                UpdateEvent(
+                    type=AssistantEventType.UPDATE,
+                    payload=SubagentUpdateEvent(
+                        content=AssistantToolCall(id="tc2", name="run", args={"x": 1}), id="u2", tool_call_id="tc2"
+                    ),
+                ),
+            ),
+            ("stream_status", StreamStatusEvent(payload=StatusPayload(status="complete"))),
+            (
+                "approval",
+                ApprovalEvent(
+                    type=AssistantEventType.APPROVAL,
+                    payload=ApprovalPayload(
+                        proposal_id="p1",
+                        decision_status="pending",
+                        tool_name="run",
+                        preview="preview",
+                        payload={},
+                        original_tool_call_id=None,
+                        message_id=None,
+                    ),
+                ),
+            ),
+        ]
+    )
+    def test_deserialize_json_event_branch_round_trips(self, _name, event):
+        # Every StreamEventUnion branch must survive the JSON round trip before the writer cutover.
+        # UpdateEvent.payload is a second smart-mode union (AssistantUpdateEvent | SubagentUpdateEvent),
+        # the same resolution risk as MessageEvent's payload.
+        serializer = ConversationStreamSerializer()
+        stream_event = StreamEvent(event=event)
+
+        result = serializer.deserialize({b"data": stream_event.model_dump_json().encode("utf-8")})
+
+        self.assertIs(type(result.event), type(event))
+        self.assertEqual(result.event, event)
 
     def test_deserialize_still_reads_legacy_pickle(self):
         serializer = ConversationStreamSerializer()


### PR DESCRIPTION
## Problem

The AI conversation stream (Max) serializes its events to a Redis stream with `pickle`. Pickle deserialization is a code-execution risk on any bytes an attacker could plant, and it pins the format to Python. I want to move this stream to JSON.

A naive cutover would error conversations that are mid-stream during the deploy, because a reader still running old code would choke on a new JSON entry (and vice versa). So I'm doing it in three deploy-safe phases.

## Changes

This is **phase 1 of 3**. The reader now understands **both** formats: JSON entries start with `{`, legacy pickle with `0x80`. The writer still emits pickle, so nothing changes on the wire yet. This just teaches every reader to accept JSON before any writer starts producing it.

> [!WARNING]
> Deploy ordering matters. Phase 2 (writer emits JSON) must ship only after this phase is fully rolled out. Phase 3 (drop the pickle read path) ships only after phase 2. This is a stacked PR: phase 2 is based on this branch, phase 3 on phase 2.

## How did you test this code?

I (Claude) added `TestConversationStreamSerializerJson`, a `SimpleTestCase` that round-trips five real streamed-message union members through the actual serializer's JSON path and asserts each resolves back to the same type with no data lost. The payload union is a pydantic smart-mode union, so the three members that share only `content: str` are the ones that could misresolve on the validate-back leg — they're covered explicitly. I ran that class locally: 6 passed. The existing DB-backed stream tests need Postgres/Redis and run in CI, which I couldn't run locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Opus 4.8), directed by the assignee. Skills invoked: `superpowers:brainstorming`, `superpowers:test-driven-development`, `writing-tests`.

I explored the repo's pickle usage first, then we chose the three-phase zero-disruption rollout over a single-PR read-both cutover specifically to avoid erroring in-flight conversations during the deploy window (the streams have a 30 minute TTL, so old entries drain on their own between phases). The auth-token cache pickle hardening and the repo pickle policy that came out of the same exploration are on a separate branch, not in this stack.
