### PR TITLE
fix(signals): Suggest only commit authors, never invent nearby reviewers

### DIFF
--- a/products/signals/backend/custom_agent/base.py
+++ b/products/signals/backend/custom_agent/base.py
@@ -386,9 +386,9 @@ involvement — the ranking handles that.
         """Re-rank agent-proposed assignees through the recency-aware activity system.
 
         Same scoring as the deterministic reviewer path: the agent's order supplies the
-        evidence weights, cached area activity supplies recency, and active-in-area
-        contributors enter as capped fallbacks. The agent's own list is the fallback when
-        there is no repository or the ranking yields nothing (e.g. no activity map yet).
+        evidence weights and cached area activity supplies recency. No one outside the
+        agent's own list is added. The agent's own list is the fallback when there is no
+        repository or the ranking yields nothing (e.g. no activity map yet).
         """
         if self.repository is None or not (result.assignees or result.relevant_paths):
             return result.assignees

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -47,6 +47,11 @@ STALE_BLAME_MULTIPLIER = 0.15
 # Caps activity-only fallbacks below blame candidates: they only win when every blame author is stale.
 ACTIVITY_ONLY_SCORE_CAP = 0.25
 ACTIVITY_BONUS_SATURATION_COMMITS = 10
+# An area only implies ownership when a small set of people account for it. A source root like
+# `frontend/src` has dozens of unrelated committers, so being active there says nothing about
+# owning a given change. Above this many recent contributors we treat the area as a catch-all and
+# don't draw activity-only reviewers from it. Repo-agnostic: it's just a contributor count.
+MAX_AREA_CONTRIBUTORS_FOR_OWNERSHIP = 15
 GitHubLoginFieldLookup = Literal[
     "extra_data__login",
     "config__github_user__login",
@@ -280,6 +285,18 @@ class _AreaContributor:
     area: str  # the area of the evidence (freshest) commit, for evidence wording
 
 
+def _is_ownership_area(area: str, activity_by_area: dict[str, list[ContributorActivity]]) -> bool:
+    """Whether an active area is narrow enough that being active in it implies ownership.
+
+    Skips the repo-wide bucket and catch-all source roots — an area with too many distinct
+    recent committers is a scaffolding directory, not something a person can be said to own.
+    """
+    contributors = activity_by_area.get(area)
+    if not contributors or area == REPO_WIDE_AREA:
+        return False
+    return len(contributors) <= MAX_AREA_CONTRIBUTORS_FOR_OWNERSHIP
+
+
 def _relevant_area_activity(
     team_id: int,
     repository: str,
@@ -289,9 +306,11 @@ def _relevant_area_activity(
 
     Cache-only; a missing or stale map schedules an async rebuild and this report falls
     back to whatever is cached (possibly nothing). An area with no active contributors
-    falls back up its chain (parent directory, then repo-wide) — someone active nearby
-    beats nobody. Returns an empty dict when nothing is known — callers must treat that
-    as "no signal", not "nobody is active".
+    falls back up its chain to its parent directory. Catch-all levels are skipped: the
+    repo-wide bucket, and any area with more than ``MAX_AREA_CONTRIBUTORS_FOR_OWNERSHIP``
+    recent contributors (a source root, not an ownership signal). When no narrow-enough
+    area is active, returns an empty dict — callers must treat that as "no signal", which
+    leaves reviewer resolution on blame alone.
     """
     areas = areas_for_paths(touched_paths)
     if not areas:
@@ -306,7 +325,7 @@ def _relevant_area_activity(
     merged: dict[str, _AreaContributor] = {}
     used_levels: set[str] = set()
     for chain in chains:
-        level = next((area for area in chain if activity_by_area.get(area)), None)
+        level = next((area for area in chain if _is_ownership_area(area, activity_by_area)), None)
         if level is None or level in used_levels:
             continue
         used_levels.add(level)

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -44,13 +44,10 @@ MAX_COMMIT_LOOKUPS = 15
 RECENCY_FULL_WEIGHT_DAYS = 30
 RECENCY_DECAY_FLOOR = 0.3
 STALE_BLAME_MULTIPLIER = 0.15
-# Caps activity-only fallbacks below blame candidates: they only win when every blame author is stale.
-ACTIVITY_ONLY_SCORE_CAP = 0.25
-ACTIVITY_BONUS_SATURATION_COMMITS = 10
 # An area only implies ownership when a small set of people account for it. A source root like
 # `frontend/src` has dozens of unrelated committers, so being active there says nothing about
 # owning a given change. Above this many recent contributors we treat the area as a catch-all and
-# don't draw activity-only reviewers from it. Repo-agnostic: it's just a contributor count.
+# ignore it for recency. Repo-agnostic: it's just a contributor count.
 MAX_AREA_CONTRIBUTORS_FOR_OWNERSHIP = 15
 GitHubLoginFieldLookup = Literal[
     "extra_data__login",
@@ -209,23 +206,22 @@ def rank_assignee_candidates(
     candidate_logins: list[str],
     touched_paths: list[str],
 ) -> list[_ResolvedReviewer]:
-    """Rank agent-proposed assignees through the area-activity system.
+    """Re-rank agent-proposed assignees through the area-activity system.
 
-    The ordered candidate list is position-weighted like blame commits, blended with
-    cached recent activity for the touched paths, and topped up with active-in-area
-    fallbacks — the same scoring the deterministic reviewer path uses. Returns an empty
-    list when nothing is known (no candidates and no activity data), so callers keep
-    their own ordering as the fallback.
+    The ordered candidate list is position-weighted like blame commits, then decayed by
+    how recently each is active in the touched areas — the same scoring the deterministic
+    reviewer path uses. No one is added who the agent did not propose. Returns an empty
+    list when there are no candidates, so callers keep their own ordering as the fallback.
     """
     deduped = list(dict.fromkeys(login.strip().lower() for login in candidate_logins if login.strip()))
+    if not deduped:
+        return []
     login_weights: Counter[str] = Counter()
     total = len(deduped)
     for i, login in enumerate(deduped):
         login_weights[login] = total - i
 
     activity_by_login = _relevant_area_activity(team_id, repository, touched_paths)
-    if not activity_by_login and not login_weights:
-        return []
     return _rank_scored_candidates(login_weights, activity_by_login, login_commits={}, login_names={})
 
 
@@ -391,32 +387,22 @@ def _score_candidates(
     login_weights: Counter[str],
     activity_by_login: dict[str, _AreaContributor],
 ) -> dict[str, float]:
-    """Blend blame weights with area recency; add capped activity-only fallbacks.
+    """Score blame authors by their weight, decayed by how recently they worked the area.
 
-    Invariants: a freshly-active area contributor always outranks a blame author who is
-    gone from the area (their base starts above the stale floor), and never outranks the
-    *top-weighted* blame author while that author is active in the window (the cap sits
-    below the decay floor). Lower-weighted active blame authors can still be outranked by
-    a very active area owner — deliberate: weight-1 blame is one marginal commit, not a
-    stronger claim than sustained area ownership. With no activity data at all, blame
-    weights pass through unchanged (legacy behavior).
+    Only the people who authored the relevant commits are ever candidates: nobody is
+    invented from area activity. The area signal is used subtractively — an author who is
+    not recently active in a genuinely ownable touched area decays toward the stale floor,
+    so when there are more candidates than seats the irrelevant ones fall off. With no
+    activity data at all, blame weights pass through unchanged.
     """
     if not activity_by_login:
         return {login: float(weight) for login, weight in login_weights.items()}
 
-    max_blame_weight = float(max(login_weights.values(), default=0)) or 1.0
     scores: dict[str, float] = {}
     for login, weight in login_weights.items():
         activity = activity_by_login.get(login)
         multiplier = _recency_multiplier(activity.days_since_last_commit if activity else None)
         scores[login] = float(weight) * multiplier
-
-    for login, activity in activity_by_login.items():
-        if login in scores:
-            continue
-        saturation = min(activity.commit_count, ACTIVITY_BONUS_SATURATION_COMMITS) / ACTIVITY_BONUS_SATURATION_COMMITS
-        base = STALE_BLAME_MULTIPLIER + (ACTIVITY_ONLY_SCORE_CAP - STALE_BLAME_MULTIPLIER) * saturation
-        scores[login] = max_blame_weight * base * _recency_multiplier(activity.days_since_last_commit)
     return scores
 
 

--- a/products/signals/backend/test/test_resolve_reviewers.py
+++ b/products/signals/backend/test/test_resolve_reviewers.py
@@ -18,6 +18,7 @@ from posthog.models.user_integration import UserIntegration
 from products.signals.backend.models import SignalRepositoryAreaActivity
 from products.signals.backend.report_generation.repo_activity import ACTIVITY_WINDOW_DAYS, ContributorActivity
 from products.signals.backend.report_generation.resolve_reviewers import (
+    MAX_AREA_CONTRIBUTORS_FOR_OWNERSHIP,
     RECENCY_DECAY_FLOOR,
     RECENCY_FULL_WEIGHT_DAYS,
     STALE_BLAME_MULTIPLIER,
@@ -225,46 +226,61 @@ class TestRecencyScoring:
         assert scores["long-gone"] >= scores["half-stale"]
 
 
+def _seed_area_row(team: Team, area: str, logins: list[str]) -> None:
+    SignalRepositoryAreaActivity.objects.create(
+        team=team,
+        repository="acme/app",
+        area=area,
+        contributors=[
+            {
+                "login": login,
+                "name": login.title(),
+                "commit_count": 3,
+                "last_commit_at": timezone.now().isoformat(),
+                "last_commit_sha": "a" * 7,
+                "last_commit_url": "https://github.com/acme/app/commit/aaaaaaa",
+            }
+            for login in logins
+        ],
+        refreshed_at=timezone.now(),
+    )
+
+
 @pytest.mark.django_db
 class TestAreaWalkUp:
-    def test_empty_area_falls_back_to_parent_then_repo_wide(self, team):
-        def _row(area: str, logins: list[str]) -> None:
-            SignalRepositoryAreaActivity.objects.create(
-                team=team,
-                repository="acme/app",
-                area=area,
-                contributors=[
-                    {
-                        "login": login,
-                        "name": login.title(),
-                        "commit_count": 3,
-                        "last_commit_at": timezone.now().isoformat(),
-                        "last_commit_sha": "a" * 7,
-                        "last_commit_url": "https://github.com/acme/app/commit/aaaaaaa",
-                    }
-                    for login in logins
-                ],
-                refreshed_at=timezone.now(),
-            )
-
+    def test_empty_area_falls_back_to_parent_not_repo_wide(self, team):
         with team_scope(team.id, canonical=True):
-            _row("products/dead", [])  # refreshed, nobody active
-            _row("products", ["parent-owner"])
-            _row("*", ["repo-regular"])
+            _seed_area_row(team, "products/dead", [])  # refreshed, nobody active
+            _seed_area_row(team, "products", ["parent-owner"])
+            _seed_area_row(team, "*", ["repo-regular"])
 
         with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
             merged = _relevant_area_activity(team.id, "acme/app", ["products/dead/models.py"])
 
-        # the dead area walks up to its parent; repo-wide stays in reserve
+        # the dead area walks up to its parent
         assert set(merged) == {"parent-owner"}
         assert merged["parent-owner"].area == "products"
 
+        # with the parent empty too, the repo-wide bucket is not a fallback: no ownership signal
         with team_scope(team.id, canonical=True):
             SignalRepositoryAreaActivity.objects.filter(area="products").update(contributors=[])
         with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
             merged = _relevant_area_activity(team.id, "acme/app", ["products/dead/models.py"])
 
-        assert set(merged) == {"repo-regular"}
+        assert merged == {}
+
+    def test_broad_area_is_skipped_as_a_catch_all(self, team):
+        # A source root with more committers than an area can meaningfully be owned by.
+        busy = [f"gen{i}" for i in range(MAX_AREA_CONTRIBUTORS_FOR_OWNERSHIP + 1)]
+        with team_scope(team.id, canonical=True):
+            _seed_area_row(team, "frontend/src", busy)
+            _seed_area_row(team, "frontend", ["frontend-owner"])
+
+        with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
+            merged = _relevant_area_activity(team.id, "acme/app", ["frontend/src/lib/api.ts"])
+
+        # none of the catch-all committers are ownership candidates; it walks up to the parent
+        assert set(merged) == {"frontend-owner"}
 
 
 @pytest.mark.django_db

--- a/products/signals/backend/test/test_resolve_reviewers.py
+++ b/products/signals/backend/test/test_resolve_reviewers.py
@@ -150,80 +150,51 @@ class TestRecencyScoring:
 
         assert scores == {"old-timer": 10.0, "runner-up": 4.0}
 
-    def test_stale_blame_author_loses_to_active_area_contributor(self):
-        weights = Counter({"old-timer": 10})
+    def test_recency_decays_blame_author_absent_from_the_area(self):
+        # Both authored the relevant commits; only "active" has recent commits in the area.
+        weights = Counter({"active": 10, "gone": 10})
         activity = {
-            "active-owner": _AreaContributor(
-                name="Active Owner",
-                commit_count=12,
+            "active": _AreaContributor(
+                name=None,
+                commit_count=5,
                 days_since_last_commit=2,
                 last_commit_sha="a" * 7,
-                last_commit_url="https://github.com/acme/app/commit/aaaaaaa",
+                last_commit_url="",
                 area="products/signals",
             ),
         }
 
         scores = _score_candidates(weights, activity)
 
-        # old-timer authored the blame commits but has no recent commits in the area.
-        assert scores["active-owner"] > scores["old-timer"]
+        assert scores["active"] == pytest.approx(10.0)
+        assert scores["gone"] == pytest.approx(10.0 * STALE_BLAME_MULTIPLIER)
 
-    def test_recently_active_blame_author_beats_activity_only_contributor(self):
-        def contributor(days_since: float) -> _AreaContributor:
-            return _AreaContributor(
-                name=None,
-                commit_count=12,
-                days_since_last_commit=days_since,
-                last_commit_sha="b" * 7,
-                last_commit_url="https://github.com/acme/app/commit/bbbbbbb",
-                area="products/signals",
-            )
-
-        weights = Counter({"active-author": 10})
+    def test_non_authors_are_never_scored(self):
+        # The area is active, but only people who authored a relevant commit are candidates:
+        # a nearby-active bystander is not invented into the reviewer set.
+        weights = Counter({"author": 4})
         activity = {
-            "active-author": contributor(days_since=5),
-            "bystander": contributor(days_since=1),
-        }
-
-        scores = _score_candidates(weights, activity)
-
-        assert scores["active-author"] > scores["bystander"]
-
-    def test_lightly_active_contributor_beats_stale_blame_even_with_tiny_blame_weight(self):
-        # Regression: a single old blame commit (weight 1) used to crush activity-only
-        # candidates via the cap, so the long-gone author still won the assign.
-        weights = Counter({"long-gone": 1})
-        activity = {
-            "light-owner": _AreaContributor(
+            "author": _AreaContributor(
                 name=None,
                 commit_count=3,
                 days_since_last_commit=1,
-                last_commit_sha="c" * 7,
+                last_commit_sha="a" * 7,
                 last_commit_url="",
-                area="posthog/migrations",
+                area="products/signals",
             ),
-        }
-
-        scores = _score_candidates(weights, activity)
-
-        assert scores["light-owner"] > scores["long-gone"]
-
-    def test_half_stale_bystander_does_not_beat_stale_blame(self):
-        weights = Counter({"long-gone": 1})
-        activity = {
-            "half-stale": _AreaContributor(
+            "busy-bystander": _AreaContributor(
                 name=None,
-                commit_count=3,
-                days_since_last_commit=70,
-                last_commit_sha="c" * 7,
+                commit_count=50,
+                days_since_last_commit=0,
+                last_commit_sha="b" * 7,
                 last_commit_url="",
-                area="posthog/migrations",
+                area="products/signals",
             ),
         }
 
         scores = _score_candidates(weights, activity)
 
-        assert scores["long-gone"] >= scores["half-stale"]
+        assert set(scores) == {"author"}
 
 
 def _seed_area_row(team: Team, area: str, logins: list[str]) -> None:
@@ -305,20 +276,9 @@ class TestRankAssigneeCandidates:
                 refreshed_at=timezone.now(),
             )
 
-    def test_stale_agent_candidate_demoted_below_active_area_owner(self, team):
-        self._seed_area(team, "products/signals", [("active-owner", 12, 2)])
-
-        with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
-            ranked = rank_assignee_candidates(
-                team.id, "acme/app", ["old-timer"], ["products/signals/backend/models.py"]
-            )
-
-        assert [candidate.login for candidate in ranked] == ["active-owner", "old-timer"]
-        # activity-only candidate carries generated evidence; the agent candidate keeps none
-        assert "Recently active in `products/signals`" in ranked[0].commits[0].reason
-        assert ranked[1].commits == []
-
-    def test_active_agent_candidate_keeps_top_spot(self, team):
+    def test_only_agent_proposed_candidates_are_ranked(self, team):
+        # "bystander" is the busiest person in the area but the agent did not propose them,
+        # so they are not added to the ranking.
         self._seed_area(team, "products/signals", [("agent-pick", 5, 3), ("bystander", 12, 1)])
 
         with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
@@ -326,15 +286,16 @@ class TestRankAssigneeCandidates:
                 team.id, "acme/app", ["agent-pick"], ["products/signals/backend/models.py"]
             )
 
-        assert ranked[0].login == "agent-pick"
+        assert [candidate.login for candidate in ranked] == ["agent-pick"]
 
-    def test_paths_alone_yield_activity_candidates(self, team):
+    def test_paths_alone_yield_nothing(self, team):
+        # No agent-proposed candidates: area activity alone never invents an assignee.
         self._seed_area(team, "products/signals", [("area-owner", 8, 1)])
 
         with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
             ranked = rank_assignee_candidates(team.id, "acme/app", [], ["products/signals/backend/models.py"])
 
-        assert [candidate.login for candidate in ranked] == ["area-owner"]
+        assert ranked == []
 
     def test_no_activity_data_returns_agent_order(self, team):
         with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
@@ -347,7 +308,7 @@ class TestRankAssigneeCandidates:
 
 @pytest.mark.django_db
 class TestResolveSuggestedReviewersEndToEnd:
-    def test_stale_blame_author_demoted_and_active_owner_suggested(self, team):
+    def test_only_commit_authors_are_suggested(self, team):
         class FakeGitHub:
             def get_commit_author_info(self, repository, sha):
                 return GitHubCommitAuthor(
@@ -386,9 +347,6 @@ class TestResolveSuggestedReviewersEndToEnd:
         ):
             reviewers = resolve_suggested_reviewers(team.id, "acme/app", {"d" * 7: "introduced the bug"})
 
-        assert [r.login for r in reviewers] == ["active-owner", "old-timer"]
-        # The activity-only candidate carries their latest area commit as evidence.
-        assert reviewers[0].commits[0].sha == "c" * 7
-        assert "Recently active in `products/signals`" in reviewers[0].commits[0].reason
-        # The blame author keeps their blame commit evidence, just demoted.
-        assert reviewers[1].commits[0].sha == "d" * 7
+        # Only the commit author is suggested; the nearby-active non-author is never invented in.
+        assert [r.login for r in reviewers] == ["old-timer"]
+        assert reviewers[0].commits[0].sha == "d" * 7

--- a/products/signals/backend/test/test_reviewer_scenarios.py
+++ b/products/signals/backend/test/test_reviewer_scenarios.py
@@ -156,15 +156,14 @@ class TestReviewerScenarios:
         lowered = [r.login.lower() for r in reviewers]
         assert len(lowered) == len(set(lowered))
 
-    def test_new_joiner_surfaces_when_all_blame_is_stale(self, seeded_team):
+    def test_stale_blame_still_returns_the_author_not_a_bystander(self, seeded_team):
         reviewers = _resolve(seeded_team, ["f" * 40, "e" * 40])
 
         logins = [r.login for r in reviewers]
-        # Everyone in blame is gone; the area's actual current contributors fill in.
-        assert "mariusandra" in logins
-        assert "new-joiner" in logins
-        if "departedfounder" in logins:
-            assert logins.index("mariusandra") < logins.index("departedfounder")
+        # The blame author is long gone from the area, but they caused the change: we still
+        # return them and never invent an active-nearby bystander in their place.
+        assert logins == ["departedfounder"]
+        assert "mariusandra" not in logins and "new-joiner" not in logins
 
     def test_bots_never_suggested(self, seeded_team):
         # The bot is both the busiest area committer and a blame author.

--- a/services/mcp/src/tools/generated/actions.ts
+++ b/services/mcp/src/tools/generated/actions.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/actions/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     ActionsCreateBody,
     ActionsDestroyParams,
@@ -16,6 +10,10 @@ import {
     ActionsPartialUpdateParams,
     ActionsRetrieveParams,
 } from '@/generated/actions/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ActionCreateSchema = ActionsCreateBody.omit({ _create_in_folder: true }).extend({
     name: ActionsCreateBody.shape['name'].describe('Name of the action (must be unique within the project)'),

--- a/services/mcp/src/tools/generated/agent_platform.ts
+++ b/services/mcp/src/tools/generated/agent_platform.ts
@@ -1,10 +1,7 @@
 // AUTO-GENERATED from services/mcp/definitions/agent_platform.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     AgentApplicationsCreateBody,
     AgentApplicationsDestroyParams,
@@ -66,6 +63,7 @@ import {
     AgentRevisionsEnvKeysGetParams,
     AgentRevisionsEnvKeysListParams,
 } from '@/generated/agent_platform/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AgentApplicationsCreateSchema = AgentApplicationsCreateBody
 

--- a/services/mcp/src/tools/generated/ai_observability.ts
+++ b/services/mcp/src/tools/generated/ai_observability.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/ai_observability/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { PromptListInputSchema, ScoreDefinitionConfigSchema } from '@/schema/tool-inputs'
-
 import {
     EvaluationRunsCreateBody,
     EvaluationsCreateBody,
@@ -77,6 +72,9 @@ import {
     TaggersListQueryParams,
     TaggersTestHogCreateBody,
 } from '@/generated/ai_observability/api'
+import { PromptListInputSchema, ScoreDefinitionConfigSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const LlmaClusteringConfigGetSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/alerts.ts
+++ b/services/mcp/src/tools/generated/alerts.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/alerts/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     AlertsCreateBody,
     AlertsDestroyParams,
@@ -16,6 +12,8 @@ import {
     AlertsRetrieveQueryParams,
     AlertsSimulateCreateBody,
 } from '@/generated/alerts/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AlertCreateSchema = AlertsCreateBody
 

--- a/services/mcp/src/tools/generated/annotations.ts
+++ b/services/mcp/src/tools/generated/annotations.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/annotations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     AnnotationsCreateBody,
     AnnotationsDestroyParams,
@@ -15,6 +10,9 @@ import {
     AnnotationsPartialUpdateParams,
     AnnotationsRetrieveParams,
 } from '@/generated/annotations/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AnnotationCreateSchema = AnnotationsCreateBody.omit({
     creation_type: true,

--- a/services/mcp/src/tools/generated/batch_exports.ts
+++ b/services/mcp/src/tools/generated/batch_exports.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/batch_exports/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     BatchExportsCreateBody,
     BatchExportsDestroyParams,
@@ -18,6 +14,8 @@ import {
     FileDownloadBatchExportsCreateBody,
     FileDownloadBatchExportsRetrieveParams,
 } from '@/generated/batch_exports/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const BatchExportCreateSchema = BatchExportsCreateBody
 

--- a/services/mcp/src/tools/generated/business_knowledge.ts
+++ b/services/mcp/src/tools/generated/business_knowledge.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/business_knowledge/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { BusinessKnowledgeUrlSourceCreateSchema } from '@/schema/tool-inputs'
-
 import {
     BusinessKnowledgeDocumentsSearchListQueryParams,
     BusinessKnowledgeDocumentsWindowListParams,
@@ -17,6 +12,9 @@ import {
     BusinessKnowledgeSourcesPartialUpdateParams,
     BusinessKnowledgeSourcesRetrieveParams,
 } from '@/generated/business_knowledge/api'
+import { BusinessKnowledgeUrlSourceCreateSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const BusinessKnowledgeDocumentWindowRetrieveSchema = BusinessKnowledgeDocumentsWindowListParams.omit({
     project_id: true,

--- a/services/mcp/src/tools/generated/cdp_function_templates.ts
+++ b/services/mcp/src/tools/generated/cdp_function_templates.ts
@@ -1,15 +1,13 @@
 // AUTO-GENERATED from products/cdp/mcp/cdp_function_templates.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HogFunctionTemplatesListQueryParams,
     HogFunctionTemplatesRetrieveParams,
 } from '@/generated/cdp_function_templates/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CdpFunctionTemplatesListSchema = HogFunctionTemplatesListQueryParams
 

--- a/services/mcp/src/tools/generated/cdp_functions.ts
+++ b/services/mcp/src/tools/generated/cdp_functions.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/cdp/mcp/cdp_functions.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HogFunctionsCreateBody,
     HogFunctionsDestroyParams,
@@ -21,6 +17,8 @@ import {
     HogFunctionsRearrangePartialUpdateBody,
     HogFunctionsRetrieveParams,
 } from '@/generated/cdp_functions/api'
+import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CdpFunctionsCreateSchema = HogFunctionsCreateBody.extend({
     type: HogFunctionsCreateBody.shape['type'].describe(

--- a/services/mcp/src/tools/generated/cohorts.ts
+++ b/services/mcp/src/tools/generated/cohorts.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/cohorts/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     CohortsAddPersonsToStaticCohortPartialUpdateBody,
     CohortsAddPersonsToStaticCohortPartialUpdateParams,
@@ -19,6 +13,10 @@ import {
     CohortsRemovePersonFromStaticCohortPartialUpdateParams,
     CohortsRetrieveParams,
 } from '@/generated/cohorts/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CohortsAddPersonsToStaticCohortPartialUpdateSchema = CohortsAddPersonsToStaticCohortPartialUpdateParams.omit({
     project_id: true,

--- a/services/mcp/src/tools/generated/conversations.ts
+++ b/services/mcp/src/tools/generated/conversations.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/conversations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     ConversationsTicketsListQueryParams,
     ConversationsTicketsMessagesListParams,
@@ -17,6 +13,8 @@ import {
     ConversationsTicketsRetrieveParams,
     ConversationsViewsListQueryParams,
 } from '@/generated/conversations/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ConversationsTicketsListSchema = ConversationsTicketsListQueryParams
 

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from services/mcp/definitions/core.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { omitResponseFields, pickResponseFields } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     DesktopFileSystemCanvasPartialUpdateBody,
     DesktopFileSystemCanvasPartialUpdateParams,
@@ -23,6 +18,9 @@ import {
     UsersPartialUpdateParams,
     UsersRetrieveParams,
 } from '@/generated/core/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { omitResponseFields, pickResponseFields } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DesktopFileSystemCanvasPartialUpdateSchema = DesktopFileSystemCanvasPartialUpdateParams.omit({ project_id: true })
     .extend(DesktopFileSystemCanvasPartialUpdateBody.shape)

--- a/services/mcp/src/tools/generated/customer_analytics.ts
+++ b/services/mcp/src/tools/generated/customer_analytics.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/customer_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { UsageMetricFiltersSchema } from '@/schema/tool-inputs'
-
 import {
     AccountRelationshipDefinitionsCreateBody,
     AccountRelationshipDefinitionsDestroyParams,
@@ -59,6 +54,9 @@ import {
     GroupsTypesMetricsPartialUpdateParams,
     GroupsTypesMetricsRetrieveParams,
 } from '@/generated/customer_analytics/api'
+import { UsageMetricFiltersSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AccountRelationshipDefinitionsCreateSchema = AccountRelationshipDefinitionsCreateBody
 

--- a/services/mcp/src/tools/generated/dashboards.ts
+++ b/services/mcp/src/tools/generated/dashboards.ts
@@ -1,18 +1,7 @@
 // AUTO-GENERATED from products/dashboards/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import {
-    withPostHogUrl,
-    omitResponseFields,
-    withInformationalResponse,
-    type WithPostHogUrl,
-    type WithInformationalResponse,
-} from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     DashboardTemplatesListQueryParams,
     DashboardTemplatesRetrieveParams,
@@ -46,6 +35,15 @@ import {
     DashboardsWidgetsBatchCreateBody,
     DashboardsWidgetsBatchCreateParams,
 } from '@/generated/dashboards/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import {
+    withPostHogUrl,
+    omitResponseFields,
+    withInformationalResponse,
+    type WithPostHogUrl,
+    type WithInformationalResponse,
+} from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DashboardCreateSchema = DashboardsCreateQueryParams.omit({ format: true }).extend(DashboardsCreateBody.shape)
 

--- a/services/mcp/src/tools/generated/data_catalog.ts
+++ b/services/mcp/src/tools/generated/data_catalog.ts
@@ -1,16 +1,7 @@
 // AUTO-GENERATED from products/data_catalog/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
-import {
-    executeConfirmedAction,
-    prepareConfirmedAction,
-    type PrepareConfirmedActionResult,
-} from '@/tools/confirmed-action-runtime'
-
 import {
     DataCatalogCertificationsCertifyCreateParams,
     DataCatalogCertificationsCreateBody,
@@ -27,6 +18,13 @@ import {
     DataCatalogRelationshipProposalsRejectCreateBody,
     DataCatalogRelationshipProposalsRejectCreateParams,
 } from '@/generated/data_catalog/api'
+import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
+import {
+    executeConfirmedAction,
+    prepareConfirmedAction,
+    type PrepareConfirmedActionResult,
+} from '@/tools/confirmed-action-runtime'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DataCatalogCertificationCertifySchema = DataCatalogCertificationsCertifyCreateParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/data_management.ts
+++ b/services/mcp/src/tools/generated/data_management.ts
@@ -1,12 +1,10 @@
 // AUTO-GENERATED from services/mcp/definitions/data_management.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import { IngestionWarningsV2ListQueryParams } from '@/generated/data_management/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const IngestionWarningsListSchema = IngestionWarningsV2ListQueryParams
 

--- a/services/mcp/src/tools/generated/data_warehouse.ts
+++ b/services/mcp/src/tools/generated/data_warehouse.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/data_warehouse/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     InsightVariablesCreateBody,
     InsightVariablesDestroyParams,
@@ -32,6 +28,8 @@ import {
     WarehouseSavedQueriesRunHistoryRetrieveParams,
     WarehouseTablesRefreshSchemaCreateParams,
 } from '@/generated/data_warehouse/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SavedQueryColumnAnnotationsCreateSchema = SavedQueryColumnAnnotationsCreateBody.extend({
     column_name: SavedQueryColumnAnnotationsCreateBody.shape['column_name'].describe(

--- a/services/mcp/src/tools/generated/docs.ts
+++ b/services/mcp/src/tools/generated/docs.ts
@@ -1,11 +1,9 @@
 // AUTO-GENERATED from services/mcp/definitions/docs.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import { DocsSearchBody } from '@/generated/docs/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DocsSearchSchema = DocsSearchBody
 

--- a/services/mcp/src/tools/generated/early_access_features.ts
+++ b/services/mcp/src/tools/generated/early_access_features.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/early_access_features/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     EarlyAccessFeatureCreateBody,
     EarlyAccessFeatureDestroyParams,
@@ -14,6 +10,8 @@ import {
     EarlyAccessFeaturePartialUpdateParams,
     EarlyAccessFeatureRetrieveParams,
 } from '@/generated/early_access_features/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const EarlyAccessFeatureCreateSchema = EarlyAccessFeatureCreateBody.omit({ _create_in_folder: true })
 

--- a/services/mcp/src/tools/generated/email_templates.ts
+++ b/services/mcp/src/tools/generated/email_templates.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/workflows/mcp/email_templates.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { EmailTemplateDesignPatchSchema } from '@/schema/tool-inputs'
-
 import {
     MessagingTemplatesCreateBody,
     MessagingTemplatesListQueryParams,
@@ -15,6 +9,10 @@ import {
     MessagingTemplatesPartialUpdateParams,
     MessagingTemplatesRetrieveParams,
 } from '@/generated/email_templates/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { EmailTemplateDesignPatchSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const WorkflowsCreateEmailTemplateSchema = MessagingTemplatesCreateBody
 

--- a/services/mcp/src/tools/generated/endpoints.ts
+++ b/services/mcp/src/tools/generated/endpoints.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/endpoints/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     EndpointsCreateBody,
     EndpointsDestroyParams,
@@ -28,6 +24,8 @@ import {
     EndpointsVersionsListParams,
     EndpointsVersionsListQueryParams,
 } from '@/generated/endpoints/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const EndpointCreateSchema = EndpointsCreateBody.omit({
     is_active: true,

--- a/services/mcp/src/tools/generated/engineering_analytics.ts
+++ b/services/mcp/src/tools/generated/engineering_analytics.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/engineering_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     EngineeringAnalyticsBrokenTestsQueryParams,
     EngineeringAnalyticsCiFailureLogsQueryParams,
@@ -19,6 +15,8 @@ import {
     EngineeringAnalyticsWorkflowJobsQueryParams,
     EngineeringAnalyticsWorkflowRunnerCostsQueryParams,
 } from '@/generated/engineering_analytics/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const EngineeringAnalyticsBrokenTestsSchema = EngineeringAnalyticsBrokenTestsQueryParams
 

--- a/services/mcp/src/tools/generated/error_tracking.ts
+++ b/services/mcp/src/tools/generated/error_tracking.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/error_tracking/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     ErrorTrackingAssignmentRulesCreateBody,
     ErrorTrackingAssignmentRulesListQueryParams,
@@ -37,6 +32,9 @@ import {
     ErrorTrackingSymbolSetsListQueryParams,
     ErrorTrackingSymbolSetsRetrieveParams,
 } from '@/generated/error_tracking/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ErrorTrackingAssignmentRulesCreateSchema = ErrorTrackingAssignmentRulesCreateBody
 

--- a/services/mcp/src/tools/generated/error_tracking_alerts.ts
+++ b/services/mcp/src/tools/generated/error_tracking_alerts.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/error_tracking/mcp/error_tracking_alerts.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HogFunctionsCreateBody,
     HogFunctionsDestroyParams,
@@ -13,6 +9,8 @@ import {
     HogFunctionsPartialUpdateBody,
     HogFunctionsPartialUpdateParams,
 } from '@/generated/error_tracking_alerts/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ErrorTrackingAlertsCreateSchema = HogFunctionsCreateBody.extend({
     type: HogFunctionsCreateBody.shape['type'].describe(

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -1,14 +1,7 @@
 // AUTO-GENERATED from products/experiments/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { SavedMetricsAttachSchema } from '@/schema/tool-inputs'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     ExperimentHoldoutsCreateBody,
     ExperimentHoldoutsDestroyParams,
@@ -49,6 +42,11 @@ import {
     ExperimentsUnarchiveCreateParams,
     ExperimentsUnfreezeExposureCreateParams,
 } from '@/generated/experiments/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { SavedMetricsAttachSchema } from '@/schema/tool-inputs'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ExperimentArchiveSchema = ExperimentsArchiveCreateParams.omit({ project_id: true })
     .extend(ExperimentsArchiveCreateBody.shape)

--- a/services/mcp/src/tools/generated/feature_flags.ts
+++ b/services/mcp/src/tools/generated/feature_flags.ts
@@ -1,14 +1,7 @@
 // AUTO-GENERATED from products/feature_flags/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { validateDistinctIdPersonIdExclusive } from '@/schema/tool-inputs'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     FeatureFlagsActivityRetrieveParams,
     FeatureFlagsActivityRetrieveQueryParams,
@@ -36,6 +29,11 @@ import {
     ScheduledChangesPartialUpdateParams,
     ScheduledChangesRetrieveParams,
 } from '@/generated/feature_flags/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { validateDistinctIdPersonIdExclusive } from '@/schema/tool-inputs'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CreateFeatureFlagSchema = FeatureFlagsCreateBody.omit({ archived: true }).extend({
     is_remote_configuration: FeatureFlagsCreateBody.shape['is_remote_configuration'].describe(

--- a/services/mcp/src/tools/generated/field_notes.ts
+++ b/services/mcp/src/tools/generated/field_notes.ts
@@ -1,17 +1,15 @@
 // AUTO-GENERATED from products/field_notes/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     FieldNotesListQueryParams,
     FieldNotesPartialUpdateBody,
     FieldNotesPartialUpdateParams,
     FieldNotesRetrieveParams,
 } from '@/generated/field_notes/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const FieldNotesGetSchema = FieldNotesRetrieveParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/health_issues.ts
+++ b/services/mcp/src/tools/generated/health_issues.ts
@@ -1,12 +1,10 @@
 // AUTO-GENERATED from services/mcp/definitions/health_issues.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import { HealthIssuesListQueryParams, HealthIssuesRetrieveParams } from '@/generated/health_issues/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const HealthIssuesGetSchema = HealthIssuesRetrieveParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/integrations.ts
+++ b/services/mcp/src/tools/generated/integrations.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/integrations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     IntegrationsChannelsRetrieveParams,
     IntegrationsChannelsRetrieveQueryParams,
@@ -17,6 +13,8 @@ import {
     IntegrationsListQueryParams,
     IntegrationsRetrieveParams,
 } from '@/generated/integrations/api'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const IntegrationDeleteSchema = IntegrationsDestroyParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/logs.ts
+++ b/services/mcp/src/tools/generated/logs.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/logs/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     LogsAlertsCreateBody,
     LogsAlertsDestinationsCreateBody,
@@ -31,6 +27,8 @@ import {
     LogsSparklineCreateBody,
     LogsValuesRetrieveQueryParams,
 } from '@/generated/logs/api'
+import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const LogsAlertsCreateSchema = LogsAlertsCreateBody
 

--- a/services/mcp/src/tools/generated/managed_migrations.ts
+++ b/services/mcp/src/tools/generated/managed_migrations.ts
@@ -1,15 +1,13 @@
 // AUTO-GENERATED from products/managed_migrations/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     ManagedMigrationsSupportListQueryParams,
     ManagedMigrationsSupportRetrieveParams,
 } from '@/generated/managed_migrations/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ManagedMigrationsSupportGetSchema = ManagedMigrationsSupportRetrieveParams
 

--- a/services/mcp/src/tools/generated/marketing_analytics.ts
+++ b/services/mcp/src/tools/generated/marketing_analytics.ts
@@ -1,10 +1,7 @@
 // AUTO-GENERATED from products/marketing_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     MarketingAnalyticsDataSourcesRetrieveQueryParams,
     MarketingAnalyticsDiagnoseRetrieveQueryParams,
@@ -13,6 +10,7 @@ import {
     MarketingAnalyticsSuggestUtmMappingsRetrieveQueryParams,
     MarketingAnalyticsUtmAuditRetrieveQueryParams,
 } from '@/generated/marketing_analytics/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const MarketingAnalyticsConversionGoalsSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/mcp_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { createQueryWrapper } from '@/tools/query-wrapper-factory'
-
 import {
     McpAnalyticsFeedbackCreateBody,
     McpAnalyticsMissingCapabilitiesCreateBody,
@@ -16,6 +11,9 @@ import {
     McpAnalyticsSessionsToolCallsParams,
     McpAnalyticsSessionsToolCallsQueryParams,
 } from '@/generated/mcp_analytics/api'
+import { createQueryWrapper } from '@/tools/query-wrapper-factory'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const McpAnalyticsIntentClustersRecomputeSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/mcp_store.ts
+++ b/services/mcp/src/tools/generated/mcp_store.ts
@@ -1,15 +1,13 @@
 // AUTO-GENERATED from products/mcp_store/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     McpServerInstallationsListQueryParams,
     McpServerInstallationsToolsRetrieveParams,
 } from '@/generated/mcp_store/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const McpConnectionToolsListSchema = McpServerInstallationsToolsRetrieveParams.omit({ project_id: true })
 

--- a/services/mcp/src/tools/generated/metrics.ts
+++ b/services/mcp/src/tools/generated/metrics.ts
@@ -1,16 +1,14 @@
 // AUTO-GENERATED from products/metrics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { pickResponseFields } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     MetricsCharacterizeCreateBody,
     MetricsQueryCreateBody,
     MetricsValuesRetrieveQueryParams,
 } from '@/generated/metrics/api'
+import { pickResponseFields } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const CharacterizeMetricAnomalySchema = MetricsCharacterizeCreateBody
 

--- a/services/mcp/src/tools/generated/notebooks.ts
+++ b/services/mcp/src/tools/generated/notebooks.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/notebooks/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     NotebooksCreateBody,
     NotebooksDestroyParams,
@@ -14,6 +10,8 @@ import {
     NotebooksPartialUpdateParams,
     NotebooksRetrieveParams,
 } from '@/generated/notebooks/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const NotebooksCreateSchema = NotebooksCreateBody
 

--- a/services/mcp/src/tools/generated/persons.ts
+++ b/services/mcp/src/tools/generated/persons.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/persons/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     PersonsBulkDeleteCreateBody,
     PersonsCohortsRetrieveQueryParams,
@@ -18,6 +13,9 @@ import {
     PersonsUpdatePropertyCreateParams,
     PersonsValuesRetrieveQueryParams,
 } from '@/generated/persons/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const PersonsBulkDeleteSchema = PersonsBulkDeleteCreateBody
 

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -1,23 +1,7 @@
 // AUTO-GENERATED from products/platform_features/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import {
-    withPostHogUrl,
-    pickResponseFields,
-    withInformationalResponse,
-    type WithPostHogUrl,
-    type WithInformationalResponse,
-} from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
-import {
-    executeConfirmedAction,
-    prepareConfirmedAction,
-    type PrepareConfirmedActionResult,
-} from '@/tools/confirmed-action-runtime'
-
 import {
     AdvancedActivityLogsListQueryParams,
     ApprovalPoliciesListQueryParams,
@@ -45,6 +29,20 @@ import {
     UserHomeSettingsPartialUpdateParams,
     UserHomeSettingsRetrieveParams,
 } from '@/generated/platform_features/api'
+import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
+import {
+    executeConfirmedAction,
+    prepareConfirmedAction,
+    type PrepareConfirmedActionResult,
+} from '@/tools/confirmed-action-runtime'
+import {
+    withPostHogUrl,
+    pickResponseFields,
+    withInformationalResponse,
+    type WithPostHogUrl,
+    type WithInformationalResponse,
+} from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AdvancedActivityLogsFiltersSchema = z.object({})
 

--- a/services/mcp/src/tools/generated/product_analytics.ts
+++ b/services/mcp/src/tools/generated/product_analytics.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/product_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt, normalizeParamAliases } from '@/tools/cast-helpers'
-
 import {
     ElementsStatsRetrieveQueryParams,
     InsightsActivityRetrieveParams,
@@ -21,6 +16,9 @@ import {
     InsightsRetrieveQueryParams,
     InsightsTrendingRetrieveQueryParams,
 } from '@/generated/product_analytics/api'
+import { castStringToInt, normalizeParamAliases } from '@/tools/cast-helpers'
+import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const AssistantInsightVizNode = z.object({
     kind: z.literal('InsightVizNode').default('InsightVizNode'),

--- a/services/mcp/src/tools/generated/proxy-records.ts
+++ b/services/mcp/src/tools/generated/proxy-records.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from services/mcp/definitions/proxy-records.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     ProxyRecordsCreateBody,
     ProxyRecordsDestroyParams,
@@ -13,6 +9,8 @@ import {
     ProxyRecordsRetrieveParams,
     ProxyRecordsRetryCreateParams,
 } from '@/generated/proxy-records/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ProxyCreateSchema = ProxyRecordsCreateBody
 

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -1,8 +1,8 @@
 // AUTO-GENERATED from services/mcp/definitions/query-wrappers.yaml + schema.json — do not edit
 import { z } from 'zod'
 
-import type { ZodObjectAny } from '@/tools/types'
 import { createQueryWrapper } from '@/tools/query-wrapper-factory'
+import type { ZodObjectAny } from '@/tools/types'
 
 // --- Shared Zod schemas generated from schema.json ---
 

--- a/services/mcp/src/tools/generated/reminders.ts
+++ b/services/mcp/src/tools/generated/reminders.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/reminders/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     RemindersCreateBody,
     RemindersDestroyParams,
@@ -14,6 +10,8 @@ import {
     RemindersPartialUpdateParams,
     RemindersRetrieveParams,
 } from '@/generated/reminders/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ReminderCreateSchema = RemindersCreateBody
 

--- a/services/mcp/src/tools/generated/replay.ts
+++ b/services/mcp/src/tools/generated/replay.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/replay/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { createQueryWrapper } from '@/tools/query-wrapper-factory'
-
 import {
     SessionRecordingPlaylistsCreateBody,
     SessionRecordingPlaylistsListQueryParams,
@@ -20,6 +14,10 @@ import {
     SingleSessionSummariesListQueryParams,
     SingleSessionSummariesRetrieveParams,
 } from '@/generated/replay/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { createQueryWrapper } from '@/tools/query-wrapper-factory'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SessionRecordingBulkDeleteSchema = SessionRecordingsBulkDeleteCreateBody
 

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/replay_vision/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     VisionActionsListQueryParams,
     VisionActionsRetrieveParams,
@@ -43,6 +39,8 @@ import {
     VisionScannersPromptSuggestionsGenerateCreateParams,
     VisionScannersRetrieveParams,
 } from '@/generated/replay_vision/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const VisionActionsListSchema = VisionActionsListQueryParams
 

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -1,19 +1,7 @@
 // AUTO-GENERATED from products/signals/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import {
-    withPostHogUrl,
-    withAgentNote,
-    pickResponseFields,
-    withInformationalResponse,
-    type WithPostHogUrl,
-    type WithAgentNote,
-    type WithInformationalResponse,
-} from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     SignalsReportArtefactsCreateBody,
     SignalsReportArtefactsCreateParams,
@@ -62,6 +50,16 @@ import {
     SignalsSourceConfigsUpdateBody,
     SignalsSourceConfigsUpdateParams,
 } from '@/generated/signals/api'
+import {
+    withPostHogUrl,
+    withAgentNote,
+    pickResponseFields,
+    withInformationalResponse,
+    type WithPostHogUrl,
+    type WithAgentNote,
+    type WithInformationalResponse,
+} from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const InboxReportArtefactsCreateSchema = SignalsReportArtefactsCreateParams.omit({ project_id: true }).extend(
     SignalsReportArtefactsCreateBody.shape

--- a/services/mcp/src/tools/generated/skills.ts
+++ b/services/mcp/src/tools/generated/skills.ts
@@ -1,10 +1,7 @@
 // AUTO-GENERATED from products/skills/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     LlmSkillsCreateBody,
     LlmSkillsListQueryParams,
@@ -25,6 +22,7 @@ import {
     LlmSkillsNameRetrieveParams,
     LlmSkillsNameRetrieveQueryParams,
 } from '@/generated/skills/api'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SkillArchiveSchema = LlmSkillsNameArchiveCreateParams.omit({ project_id: true }).extend({
     skill_name: LlmSkillsNameArchiveCreateParams.shape['skill_name'].describe(

--- a/services/mcp/src/tools/generated/stamphog.ts
+++ b/services/mcp/src/tools/generated/stamphog.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/stamphog/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     StamphogDigestChannelsCreateBody,
     StamphogDigestChannelsDestroyParams,
@@ -19,6 +15,8 @@ import {
     StamphogReviewRunsListQueryParams,
     StamphogReviewRunsRetrieveParams,
 } from '@/generated/stamphog/api'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const StamphogDigestChannelsCreateSchema = StamphogDigestChannelsCreateBody
 

--- a/services/mcp/src/tools/generated/subscriptions.ts
+++ b/services/mcp/src/tools/generated/subscriptions.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/subscriptions/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { castStringToInt } from '@/tools/cast-helpers'
-
 import {
     SubscriptionsCreateBody,
     SubscriptionsDeliveriesListParams,
@@ -19,6 +14,9 @@ import {
     SubscriptionsRetrieveParams,
     SubscriptionsTestDeliveryCreateParams,
 } from '@/generated/subscriptions/api'
+import { castStringToInt } from '@/tools/cast-helpers'
+import { withPostHogUrl, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SubscriptionsCreateSchema = SubscriptionsCreateBody
 

--- a/services/mcp/src/tools/generated/surveys.ts
+++ b/services/mcp/src/tools/generated/surveys.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/surveys/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     SurveysCreateBody,
     SurveysDestroyParams,
@@ -25,6 +20,9 @@ import {
     SurveysSummarizeResponsesCreateParams,
     SurveysSummarizeResponsesCreateQueryParams,
 } from '@/generated/surveys/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const SurveyCreateSchema = SurveysCreateBody.omit({
     linked_insight_id: true,

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -1,17 +1,7 @@
 // AUTO-GENERATED from products/tasks/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
-import {
-    executeConfirmedAction,
-    prepareConfirmedAction,
-    type PrepareConfirmedActionResult,
-} from '@/tools/confirmed-action-runtime'
-
 import {
     LoopsCreateBody,
     LoopsDestroyParams,
@@ -33,6 +23,14 @@ import {
     TasksRunsSessionLogsRetrieveParams,
     TasksRunsSessionLogsRetrieveQueryParams,
 } from '@/generated/tasks/api'
+import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
+import {
+    executeConfirmedAction,
+    prepareConfirmedAction,
+    type PrepareConfirmedActionResult,
+} from '@/tools/confirmed-action-runtime'
+import { withPostHogUrl, pickResponseFields, omitResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const LoopsCreateSchema = LoopsCreateBody
 

--- a/services/mcp/src/tools/generated/tracing.ts
+++ b/services/mcp/src/tools/generated/tracing.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/tracing/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, pickResponseFields } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     TracingSpansAggregateCreateBody,
     TracingSpansAttributeBreakdownCreateBody,
@@ -22,6 +17,9 @@ import {
     TracingSpansTreeCreateBody,
     TracingSpansValuesRetrieveQueryParams,
 } from '@/generated/tracing/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, pickResponseFields } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const ApmAttributeBreakdownSchema = TracingSpansAttributeBreakdownCreateBody
 

--- a/services/mcp/src/tools/generated/user_interviews.ts
+++ b/services/mcp/src/tools/generated/user_interviews.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/user_interviews/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     UserInterviewTopicsAddIntervieweeCreateBody,
     UserInterviewTopicsAddIntervieweeCreateParams,
@@ -38,6 +33,9 @@ import {
     UserInterviewsRetrieveParams,
     UserInterviewsSearchCreateBody,
 } from '@/generated/user_interviews/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const UserInterviewTopicsAddIntervieweeSchema = UserInterviewTopicsAddIntervieweeCreateParams.omit({
     project_id: true,

--- a/services/mcp/src/tools/generated/visual_review.ts
+++ b/services/mcp/src/tools/generated/visual_review.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/visual_review/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-
 import {
     VisualReviewReposListQueryParams,
     VisualReviewReposRetrieveParams,
@@ -25,6 +20,9 @@ import {
     VisualReviewRunsToleratedHashesListParams,
     VisualReviewRunsToleratedHashesListQueryParams,
 } from '@/generated/visual_review/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const VisualReviewReposListSchema = VisualReviewReposListQueryParams
 

--- a/services/mcp/src/tools/generated/warehouse_sources.ts
+++ b/services/mcp/src/tools/generated/warehouse_sources.ts
@@ -1,12 +1,7 @@
 // AUTO-GENERATED from products/warehouse_sources/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { ExternalDataSourcePayloadSchema, ExternalDataSourceTypeSchema } from '@/schema/tool-inputs'
-
 import {
     ExternalDataSchemasCancelCreateParams,
     ExternalDataSchemasDeleteDataDestroyParams,
@@ -43,6 +38,9 @@ import {
     ExternalDataSourcesWebhookInfoRetrieveParams,
     ExternalDataSourcesWizardRetrieveQueryParams,
 } from '@/generated/warehouse_sources/api'
+import { ExternalDataSourcePayloadSchema, ExternalDataSourceTypeSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, omitResponseFields, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const DataWarehouseSourceConnectLinkSchema = ExternalDataSourcesConnectLinkRetrieveQueryParams.extend({
     source_type: ExternalDataSourceTypeSchema,

--- a/services/mcp/src/tools/generated/web_analytics.ts
+++ b/services/mcp/src/tools/generated/web_analytics.ts
@@ -1,11 +1,7 @@
 // AUTO-GENERATED from products/web_analytics/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-
 import {
     HeatmapsEventsRetrieveQueryParams,
     HeatmapsListQueryParams,
@@ -17,6 +13,8 @@ import {
     SavedRetrieveParams,
     WebAnalyticsWeeklyDigestQueryParams,
 } from '@/generated/web_analytics/api'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const HeatmapsEventsSchema = HeatmapsEventsRetrieveQueryParams
 

--- a/services/mcp/src/tools/generated/workflows.ts
+++ b/services/mcp/src/tools/generated/workflows.ts
@@ -1,13 +1,7 @@
 // AUTO-GENERATED from products/workflows/mcp/tools.yaml + OpenAPI — do not edit
 import { z } from 'zod'
 
-import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
-import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
-
 import type { Schemas } from '@/api/generated'
-import { withUiApp } from '@/resources/ui-apps'
-import { WorkflowGraphPatchSchema } from '@/schema/tool-inputs'
-
 import {
     HogFlowsBatchJobsListParams,
     HogFlowsCreateBody,
@@ -36,6 +30,10 @@ import {
     HogFlowsSchedulesPartialUpdateBody,
     HogFlowsSchedulesPartialUpdateParams,
 } from '@/generated/workflows/api'
+import { withUiApp } from '@/resources/ui-apps'
+import { WorkflowGraphPatchSchema } from '@/schema/tool-inputs'
+import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
+import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
 
 const WorkflowsCreateSchema = HogFlowsCreateBody
 


### PR DESCRIPTION
## Problem

Reviewer routing suggested up to three people by starting from the authors of the issue's relevant commits (blame) and topping them up with people merely active in the touched areas (activity-only "fill-ins", capped at 25% of the top author). On real reports that surfaced high-volume generalists (the busiest committer in all of `frontend/src`, say) over the people who actually wrote the code. We only want the people who caused the problem and their genuine owners, not invented nearby-active names.

## Changes

1. **Drop fill-ins entirely.** Reviewers are only the authors of the relevant commits. Nobody is invented from area activity. If that yields one or two names, that is fine.
2. **The area signal is now used only to rank and drop, never to add.** An author's blame weight decays by how recently they are active in a genuinely ownable area, so when there are more authors than seats the stale/irrelevant ones fall off.
3. **"Ownable area" is breadth-gated.** An area only counts when a small set of people account for it (at most `MAX_AREA_CONTRIBUTORS_FOR_OWNERSHIP`), and the repo-wide bucket is never used. A source root like `frontend/src` (dozens of unrelated committers) is not an ownership signal. Repo-agnostic (just a contributor count), which matters because this runs on customers' repos too.

The same scoring backs the agent-assignee re-ranking in `custom_agent`, which now only re-orders the agent's own proposed list.

Backtested against a real report (subscriptions network errors, 8 relevant commits, run on the live prod area map):

- Before: top 3 = `[vdekrijger, benjackwhite, pauldambra]` — `pauldambra` a `frontend/src` generalist who wrote none of it.
- After: `[vdekrijger, benjackwhite, twixes]` — the three people who wrote the relevant commits, ranked with the active owner on top. Nobody invented.

## How did you test this code?

I'm an agent (Claude Code). Ran:
- `hogli test` on `test_resolve_reviewers.py` (15 passed) and `test_reviewer_scenarios.py` (6 passed).
- Replaced the fill-in tests with ones that guard the new behavior: non-authors are never scored; a stale blame author is still returned rather than replaced by a nearby bystander; area recency still ranks authors; a catch-all area contributes nothing.
- `hogli ci:preflight --strict` on push: ruff lint + format clean; type-check clean.

## Rollback

Revert this PR. Pure scoring / candidate-selection change, no schema or data migration.

## 🤖 Agent context

- **Agent/tool:** Claude Code (Opus 4.8).
- **Scope note:** this supersedes the PR's initial "breadth gate only" scope. Backtesting showed the gate alone still let *other-area* fills displace a genuine author, so per product direction the fill-in mechanism is removed entirely and the area signal is used only to rank and drop authors.
- **Reshapes #71029:** that PR intentionally let recently-active area owners outrank stale/marginal blame authors (the fill-in). This removes that. Worth a look from its author before merge.
