### PR TITLE
feat(metrics): add helm chart for the prometheus scrape agent

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -119,6 +119,7 @@
         "services/mcp/worker-configuration.d.ts",
         "frontend/src/taxonomy/core-filter-definitions-by-group.json",
         "products/review_hog/backend/reviewer/prompts/**/schema.json",
+        "**/chart/*/templates/**",
         "products/metrics/agent/tests/**/golden/**",
         "frontend/dist/",
         "frontend/**/*LogicType.ts",

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5395,13 +5395,13 @@ snapshots:
     scenes-app-customer-analytics-dashboard--b-2-c-mode--light:
         hash: v1.k794b7964.ff25e11868464e00df352180254dbe0a1017cd1d8c7c4f4c7d6995068e80e2dc.m0XFOZVPCdSaCLaPQ6XTePvkZJ1I11QI2KARZi9QpWs
     scenes-app-customer-analytics-dashboard--gated-with-feature-toggle--dark:
-        hash: v1.k794b7964.f07be6c5a9a602a1b2de2e07ff8329cf79022a86359c8592ec0ffa997e06815e.4p0ObyV8dflPFp4eV8-iGtIyPw-H4rNRImtZ98MUaq0
+        hash: v1.k794b7964.731394bccab76141d6dc494f99dd56cc85e18b3f787977f8edd5c1a50c5564c8.9z2bNOo-dAM0tEyxcqStccQSV7X6iHbKnJdqAgvNapU
     scenes-app-customer-analytics-dashboard--gated-with-feature-toggle--light:
-        hash: v1.k794b7964.c08ac439ce99c1885784bb01585643983c42e334ee9b66dc4fdca3a200f49aa8.1nfQJfx8u9E46SodXwq0FKkEXnMgRERGpZ3LrS7lsgk
+        hash: v1.k794b7964.d4a3f7e666d9788b86e4e35e6e976dc048f50189129b316352f60e389916e740.XNraHFrJz2oo-ioKjtSG3b53aSd7SUozc4GkGnRUVPw
     scenes-app-customer-analytics-dashboard--gated-without-matching-early-access-feature--dark:
-        hash: v1.k794b7964.df78ad055d2df40bd8f7291c6be67f5186e055f66f8d642e54f4493bfea8dee4.ZN0UYUnaFqZlJQb_8eCa8a74QdPPt4v9VBEQNfMT5Dw
+        hash: v1.k794b7964.212105add8f003ebda9493c4f1324aa86a9ea9d4f078a9202f746125bc188ee0.mcCJ4cjTJAjHr9-eqJV3Vki9l2-kPcGcbCkwbnXGGNI
     scenes-app-customer-analytics-dashboard--gated-without-matching-early-access-feature--light:
-        hash: v1.k794b7964.261496c85d5d04af3eb5e766063ec3e1783ea9ba2d54f82bb9c7d4b0f1cc28a0.5Gacg7ZDoAp-d35eiCG9-Jp2vYDw-4uvGAJsL5U4uiI
+        hash: v1.k794b7964.c17e8855ba266d7d7732b79d59cbe6996e34469b95aaf820146a2ec098d4c1cd.xHHIXeNzT7uaxywPDDglLPD96SXg9n66LgqmXi677J0
     scenes-app-customer-analytics-journey-builder--new-journey--dark:
         hash: v1.k794b7964.5e2f6c51e7e4db5d5d8bed07edeb90f8e71b6dbe9e4aa7042ce9337e407ff3bb.qbiM7NeFkMfNbY374tsbc_nZloshk9lmHLFgIPx5-ow
     scenes-app-customer-analytics-journey-builder--new-journey--light:

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
             "bin/hogli format:js",
             "sh -c 'pnpm build:products && git add frontend/src/products.tsx frontend/src/productScenes.tsx frontend/src/products.json'"
         ],
-        "!(**/.sqlx/**|products/review_hog/backend/reviewer/prompts/*/schema.json)*.{json,yaml,yml}": "bin/hogli format:yaml",
+        "!(**/.sqlx/**|products/review_hog/backend/reviewer/prompts/*/schema.json|**/chart/*/templates/**|products/metrics/agent/tests/**/golden/**)*.{json,yaml,yml}": "bin/hogli format:yaml",
         "*.{css,scss}": "bin/hogli format:css",
         "frontend/src/lib/constants.tsx": [
             "bin/hogli lint:feature-flags:fix",

--- a/products/metrics/agent/chart/posthog-metrics-agent/Chart.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: posthog-metrics-agent
+description: Scrapes Prometheus /metrics endpoints in your cluster and forwards them to PostHog
+type: application
+version: 0.1.0
+appVersion: latest
+home: https://posthog.com/docs/metrics
+sources:
+    - https://github.com/PostHog/posthog/tree/master/products/metrics/agent

--- a/products/metrics/agent/chart/posthog-metrics-agent/Chart.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/Chart.yaml
@@ -3,7 +3,9 @@ name: posthog-metrics-agent
 description: Scrapes Prometheus /metrics endpoints in your cluster and forwards them to PostHog
 type: application
 version: 0.1.0
-appVersion: latest
+# The image tag installs pin to by default. CD publishes the image under this
+# tag, so bump it together with `version` to release a new agent.
+appVersion: 0.1.0
 home: https://posthog.com/docs/metrics
 sources:
     - https://github.com/PostHog/posthog/tree/master/products/metrics/agent

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/_helpers.tpl
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/_helpers.tpl
@@ -23,7 +23,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.serviceAccount.create }}
 {{- default (include "posthog-metrics-agent.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- /* Never fall back to the namespace's shared `default` account: the chart's
+      ClusterRole would leak to every workload already using it. */}}
+{{- required "serviceAccount.name is required when serviceAccount.create is false" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/_helpers.tpl
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/_helpers.tpl
@@ -1,0 +1,121 @@
+{{- define "posthog-metrics-agent.fullname" -}}
+{{- if contains .Chart.Name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{- define "posthog-metrics-agent.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "posthog-metrics-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "posthog-metrics-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "posthog-metrics-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "posthog-metrics-agent.secretName" -}}
+{{- if .Values.posthog.existingSecret }}
+{{- .Values.posthog.existingSecret }}
+{{- else }}
+{{- include "posthog-metrics-agent.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+The full collector config mounted at /etc/posthog/config.yaml (the image
+entrypoint's full-override escape hatch). The API key is referenced as
+${env:POSTHOG_API_KEY} and resolved by the collector from the pod env,
+so it never appears in the ConfigMap.
+*/}}
+{{- define "posthog-metrics-agent.collectorConfig" -}}
+{{- if and (not .Values.scrape.annotationDiscovery) (not .Values.scrape.staticTargets) (not .Values.scrape.extraScrapeConfigs) }}
+{{- fail "at least one of scrape.annotationDiscovery, scrape.staticTargets or scrape.extraScrapeConfigs must be set" }}
+{{- end }}
+receivers:
+    prometheus:
+        config:
+            scrape_configs:
+{{- if .Values.scrape.annotationDiscovery }}
+                - job_name: kubernetes-pods
+                  scrape_interval: {{ .Values.scrape.interval }}
+                  # OpenMetrics first so exemplars (trace links) survive the scrape.
+                  scrape_protocols: [OpenMetricsText1.0.0, OpenMetricsText0.0.1, PrometheusText0.0.4]
+                  kubernetes_sd_configs:
+                      - role: pod
+                  relabel_configs:
+                      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                        action: keep
+                        regex: 'true'
+                      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                        action: replace
+                        regex: (.+)
+                        target_label: __metrics_path__
+                      - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+                        action: replace
+                        regex: ([^:]+)(?::\d+)?;(\d+)
+                        replacement: $$1:$$2
+                        target_label: __address__
+                      - source_labels: [__meta_kubernetes_namespace]
+                        action: replace
+                        target_label: namespace
+                      - source_labels: [__meta_kubernetes_pod_name]
+                        action: replace
+                        target_label: pod
+{{- end }}
+{{- if .Values.scrape.staticTargets }}
+                - job_name: static-targets
+                  scrape_interval: {{ .Values.scrape.interval }}
+                  # OpenMetrics first so exemplars (trace links) survive the scrape.
+                  scrape_protocols: [OpenMetricsText1.0.0, OpenMetricsText0.0.1, PrometheusText0.0.4]
+                  static_configs:
+                      - targets: [{{ range $i, $t := .Values.scrape.staticTargets }}{{ if $i }}, {{ end }}'{{ $t }}'{{ end }}]
+{{- end }}
+{{- with .Values.scrape.extraScrapeConfigs }}
+{{ tpl . $ | indent 16 }}
+{{- end }}
+
+processors:
+    # Shed load instead of buffering unbounded memory when PostHog is unreachable.
+    memory_limiter:
+        check_interval: 1s
+        limit_mib: 512
+        spike_limit_mib: 128
+    batch:
+
+exporters:
+    otlphttp:
+        # The otlphttp exporter appends /v1/metrics to `endpoint`, but PostHog's
+        # public ingest route is /i/v1/metrics, so pin the per-signal path.
+        metrics_endpoint: '{{ .Values.posthog.host }}/i/v1/metrics'
+        compression: gzip
+        headers:
+            authorization: 'Bearer ${env:POSTHOG_API_KEY}'
+        retry_on_failure:
+            enabled: true
+
+extensions:
+    health_check:
+        endpoint: 0.0.0.0:13133
+
+service:
+    extensions: [health_check]
+    pipelines:
+        metrics:
+            receivers: [prometheus]
+            processors: [memory_limiter, batch]
+            exporters: [otlphttp]
+{{- end }}

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/clusterrole.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/clusterrole.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: {{ include "posthog-metrics-agent.fullname" . }}
+    labels:
+        {{- include "posthog-metrics-agent.labels" . | nindent 8 }}
+rules:
+    # Prometheus kubernetes_sd needs to watch scrape targets across the cluster.
+    - apiGroups: ['']
+      resources: [pods, services, endpoints, nodes]
+      verbs: [get, list, watch]
+    - apiGroups: [discovery.k8s.io]
+      resources: [endpointslices]
+      verbs: [get, list, watch]
+{{- end }}

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/clusterrolebinding.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: {{ include "posthog-metrics-agent.fullname" . }}
+    labels:
+        {{- include "posthog-metrics-agent.labels" . | nindent 8 }}
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: {{ include "posthog-metrics-agent.fullname" . }}
+subjects:
+    - kind: ServiceAccount
+      name: {{ include "posthog-metrics-agent.serviceAccountName" . }}
+      namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/configmap.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: {{ include "posthog-metrics-agent.fullname" . }}
+    labels:
+        {{- include "posthog-metrics-agent.labels" . | nindent 8 }}
+data:
+    config.yaml: |
+        {{- include "posthog-metrics-agent.collectorConfig" . | nindent 8 }}

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/deployment.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: {{ include "posthog-metrics-agent.fullname" . }}
+    labels:
+        {{- include "posthog-metrics-agent.labels" . | nindent 8 }}
+spec:
+    # A single replica by design: multiple replicas would scrape every target
+    # multiple times and double-count all metrics.
+    replicas: 1
+    selector:
+        matchLabels:
+            {{- include "posthog-metrics-agent.selectorLabels" . | nindent 12 }}
+    template:
+        metadata:
+            labels:
+                {{- include "posthog-metrics-agent.selectorLabels" . | nindent 16 }}
+            annotations:
+                checksum/config: {{ include "posthog-metrics-agent.collectorConfig" . | sha256sum }}
+        spec:
+            serviceAccountName: {{ include "posthog-metrics-agent.serviceAccountName" . }}
+            containers:
+                - name: agent
+                  image: '{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
+                  imagePullPolicy: {{ .Values.image.pullPolicy }}
+                  env:
+                      - name: POSTHOG_API_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: {{ include "posthog-metrics-agent.secretName" . }}
+                                key: posthog-api-key
+                  volumeMounts:
+                      - name: config
+                        mountPath: /etc/posthog/config.yaml
+                        subPath: config.yaml
+                        readOnly: true
+                  ports:
+                      - name: health
+                        containerPort: 13133
+                  livenessProbe:
+                      httpGet:
+                          path: /
+                          port: health
+                  readinessProbe:
+                      httpGet:
+                          path: /
+                          port: health
+                  resources:
+                      {{- toYaml .Values.resources | nindent 22 }}
+            volumes:
+                - name: config
+                  configMap:
+                      name: {{ include "posthog-metrics-agent.fullname" . }}
+            {{- with .Values.nodeSelector }}
+            nodeSelector:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.tolerations }}
+            tolerations:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}
+            {{- with .Values.affinity }}
+            affinity:
+                {{- toYaml . | nindent 16 }}
+            {{- end }}

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/deployment.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/deployment.yaml
@@ -17,12 +17,23 @@ spec:
                 {{- include "posthog-metrics-agent.selectorLabels" . | nindent 16 }}
             annotations:
                 checksum/config: {{ include "posthog-metrics-agent.collectorConfig" . | sha256sum }}
+                # Covers the chart-managed Secret so an API key rotation rolls the pod.
+                checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         spec:
             serviceAccountName: {{ include "posthog-metrics-agent.serviceAccountName" . }}
+            securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                    type: RuntimeDefault
             containers:
                 - name: agent
                   image: '{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}'
                   imagePullPolicy: {{ .Values.image.pullPolicy }}
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
                   env:
                       - name: POSTHOG_API_KEY
                         valueFrom:

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/secret.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.posthog.existingSecret }}
+{{- if not .Values.posthog.apiKey }}
+{{- fail "posthog.apiKey is required (or set posthog.existingSecret)" }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+    name: {{ include "posthog-metrics-agent.fullname" . }}
+    labels:
+        {{- include "posthog-metrics-agent.labels" . | nindent 8 }}
+type: Opaque
+data:
+    posthog-api-key: {{ .Values.posthog.apiKey | b64enc }}
+{{- end }}

--- a/products/metrics/agent/chart/posthog-metrics-agent/templates/serviceaccount.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: {{ include "posthog-metrics-agent.serviceAccountName" . }}
+    labels:
+        {{- include "posthog-metrics-agent.labels" . | nindent 8 }}
+{{- end }}

--- a/products/metrics/agent/chart/posthog-metrics-agent/values.yaml
+++ b/products/metrics/agent/chart/posthog-metrics-agent/values.yaml
@@ -1,0 +1,42 @@
+image:
+    repository: posthog/metrics-agent
+    # Defaults to the chart's appVersion.
+    tag: ''
+    pullPolicy: IfNotPresent
+
+posthog:
+    # PostHog ingestion origin. EU cloud: https://eu.i.posthog.com
+    host: https://us.i.posthog.com
+    # Project API key. Stored in a chart-managed Secret.
+    apiKey: ''
+    # Alternatively, the name of an existing Secret with the key `posthog-api-key`.
+    # Takes precedence over apiKey.
+    existingSecret: ''
+
+scrape:
+    interval: 15s
+    # Scrape pods annotated with prometheus.io/scrape: "true"
+    # (path and port via prometheus.io/path and prometheus.io/port).
+    annotationDiscovery: true
+    # Extra fixed host:port targets, e.g. ['my-svc:9090'].
+    staticTargets: []
+    # Raw Prometheus scrape_configs YAML (a list) appended verbatim.
+    extraScrapeConfigs: ''
+
+resources:
+    requests:
+        cpu: 100m
+        memory: 256Mi
+    limits:
+        memory: 512Mi
+
+rbac:
+    create: true
+
+serviceAccount:
+    create: true
+    name: ''
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/products/metrics/agent/tests/helm/golden/default.yaml
+++ b/products/metrics/agent/tests/helm/golden/default.yaml
@@ -10,7 +10,6 @@ metadata:
         app.kubernetes.io/instance: test-release
         app.kubernetes.io/version: "latest"
         app.kubernetes.io/managed-by: Helm
-
 ---
 # Source: posthog-metrics-agent/templates/secret.yaml
 apiVersion: v1
@@ -26,7 +25,6 @@ metadata:
 type: Opaque
 data:
     posthog-api-key: cGhjX3Rlc3Q=
-
 ---
 # Source: posthog-metrics-agent/templates/configmap.yaml
 apiVersion: v1
@@ -41,7 +39,6 @@ metadata:
         app.kubernetes.io/managed-by: Helm
 data:
     config.yaml: |
-        
         receivers:
             prometheus:
                 config:
@@ -71,7 +68,6 @@ data:
                               - source_labels: [__meta_kubernetes_pod_name]
                                 action: replace
                                 target_label: pod
-        
         processors:
             # Shed load instead of buffering unbounded memory when PostHog is unreachable.
             memory_limiter:
@@ -79,7 +75,6 @@ data:
                 limit_mib: 512
                 spike_limit_mib: 128
             batch:
-        
         exporters:
             otlphttp:
                 # The otlphttp exporter appends /v1/metrics to `endpoint`, but PostHog's
@@ -90,11 +85,9 @@ data:
                     authorization: 'Bearer ${env:POSTHOG_API_KEY}'
                 retry_on_failure:
                     enabled: true
-        
         extensions:
             health_check:
                 endpoint: 0.0.0.0:13133
-        
         service:
             extensions: [health_check]
             pipelines:
@@ -102,7 +95,6 @@ data:
                     receivers: [prometheus]
                     processors: [memory_limiter, batch]
                     exporters: [otlphttp]
-
 ---
 # Source: posthog-metrics-agent/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -123,7 +115,6 @@ rules:
     - apiGroups: [discovery.k8s.io]
       resources: [endpointslices]
       verbs: [get, list, watch]
-
 ---
 # Source: posthog-metrics-agent/templates/clusterrolebinding.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -144,7 +135,6 @@ subjects:
     - kind: ServiceAccount
       name: test-release-posthog-metrics-agent
       namespace: default
-
 ---
 # Source: posthog-metrics-agent/templates/deployment.yaml
 apiVersion: apps/v1

--- a/products/metrics/agent/tests/helm/golden/default.yaml
+++ b/products/metrics/agent/tests/helm/golden/default.yaml
@@ -8,7 +8,7 @@ metadata:
         helm.sh/chart: posthog-metrics-agent-0.1.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/version: "0.1.0"
         app.kubernetes.io/managed-by: Helm
 ---
 # Source: posthog-metrics-agent/templates/secret.yaml
@@ -20,7 +20,7 @@ metadata:
         helm.sh/chart: posthog-metrics-agent-0.1.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/version: "0.1.0"
         app.kubernetes.io/managed-by: Helm
 type: Opaque
 data:
@@ -35,7 +35,7 @@ metadata:
         helm.sh/chart: posthog-metrics-agent-0.1.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/version: "0.1.0"
         app.kubernetes.io/managed-by: Helm
 data:
     config.yaml: |
@@ -105,7 +105,7 @@ metadata:
         helm.sh/chart: posthog-metrics-agent-0.1.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/version: "0.1.0"
         app.kubernetes.io/managed-by: Helm
 rules:
     # Prometheus kubernetes_sd needs to watch scrape targets across the cluster.
@@ -125,7 +125,7 @@ metadata:
         helm.sh/chart: posthog-metrics-agent-0.1.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/version: "0.1.0"
         app.kubernetes.io/managed-by: Helm
 roleRef:
     apiGroup: rbac.authorization.k8s.io
@@ -145,7 +145,7 @@ metadata:
         helm.sh/chart: posthog-metrics-agent-0.1.0
         app.kubernetes.io/name: posthog-metrics-agent
         app.kubernetes.io/instance: test-release
-        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/version: "0.1.0"
         app.kubernetes.io/managed-by: Helm
 spec:
     # A single replica by design: multiple replicas would scrape every target
@@ -162,12 +162,23 @@ spec:
                 app.kubernetes.io/instance: test-release
             annotations:
                 checksum/config: 1411c19dbd295f3baa0b938200623d437042a8fbba649ea037b24def467025bb
+                # Covers the chart-managed Secret so an API key rotation rolls the pod.
+                checksum/secret: e89605c80663cb97ad49cb086ea1470e13424ba9ac0f44429337d2f4e2eff7fe
         spec:
             serviceAccountName: test-release-posthog-metrics-agent
+            securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                    type: RuntimeDefault
             containers:
                 - name: agent
-                  image: 'posthog/metrics-agent:latest'
+                  image: 'posthog/metrics-agent:0.1.0'
                   imagePullPolicy: IfNotPresent
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
                   env:
                       - name: POSTHOG_API_KEY
                         valueFrom:

--- a/products/metrics/agent/tests/helm/golden/default.yaml
+++ b/products/metrics/agent/tests/helm/golden/default.yaml
@@ -1,0 +1,212 @@
+---
+# Source: posthog-metrics-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: test-release-posthog-metrics-agent
+    labels:
+        helm.sh/chart: posthog-metrics-agent-0.1.0
+        app.kubernetes.io/name: posthog-metrics-agent
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+
+---
+# Source: posthog-metrics-agent/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+    name: test-release-posthog-metrics-agent
+    labels:
+        helm.sh/chart: posthog-metrics-agent-0.1.0
+        app.kubernetes.io/name: posthog-metrics-agent
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+type: Opaque
+data:
+    posthog-api-key: cGhjX3Rlc3Q=
+
+---
+# Source: posthog-metrics-agent/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: test-release-posthog-metrics-agent
+    labels:
+        helm.sh/chart: posthog-metrics-agent-0.1.0
+        app.kubernetes.io/name: posthog-metrics-agent
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+data:
+    config.yaml: |
+        
+        receivers:
+            prometheus:
+                config:
+                    scrape_configs:
+                        - job_name: kubernetes-pods
+                          scrape_interval: 15s
+                          # OpenMetrics first so exemplars (trace links) survive the scrape.
+                          scrape_protocols: [OpenMetricsText1.0.0, OpenMetricsText0.0.1, PrometheusText0.0.4]
+                          kubernetes_sd_configs:
+                              - role: pod
+                          relabel_configs:
+                              - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                                action: keep
+                                regex: 'true'
+                              - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                                action: replace
+                                regex: (.+)
+                                target_label: __metrics_path__
+                              - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+                                action: replace
+                                regex: ([^:]+)(?::\d+)?;(\d+)
+                                replacement: $$1:$$2
+                                target_label: __address__
+                              - source_labels: [__meta_kubernetes_namespace]
+                                action: replace
+                                target_label: namespace
+                              - source_labels: [__meta_kubernetes_pod_name]
+                                action: replace
+                                target_label: pod
+        
+        processors:
+            # Shed load instead of buffering unbounded memory when PostHog is unreachable.
+            memory_limiter:
+                check_interval: 1s
+                limit_mib: 512
+                spike_limit_mib: 128
+            batch:
+        
+        exporters:
+            otlphttp:
+                # The otlphttp exporter appends /v1/metrics to `endpoint`, but PostHog's
+                # public ingest route is /i/v1/metrics, so pin the per-signal path.
+                metrics_endpoint: 'https://us.i.posthog.com/i/v1/metrics'
+                compression: gzip
+                headers:
+                    authorization: 'Bearer ${env:POSTHOG_API_KEY}'
+                retry_on_failure:
+                    enabled: true
+        
+        extensions:
+            health_check:
+                endpoint: 0.0.0.0:13133
+        
+        service:
+            extensions: [health_check]
+            pipelines:
+                metrics:
+                    receivers: [prometheus]
+                    processors: [memory_limiter, batch]
+                    exporters: [otlphttp]
+
+---
+# Source: posthog-metrics-agent/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: test-release-posthog-metrics-agent
+    labels:
+        helm.sh/chart: posthog-metrics-agent-0.1.0
+        app.kubernetes.io/name: posthog-metrics-agent
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+rules:
+    # Prometheus kubernetes_sd needs to watch scrape targets across the cluster.
+    - apiGroups: ['']
+      resources: [pods, services, endpoints, nodes]
+      verbs: [get, list, watch]
+    - apiGroups: [discovery.k8s.io]
+      resources: [endpointslices]
+      verbs: [get, list, watch]
+
+---
+# Source: posthog-metrics-agent/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: test-release-posthog-metrics-agent
+    labels:
+        helm.sh/chart: posthog-metrics-agent-0.1.0
+        app.kubernetes.io/name: posthog-metrics-agent
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: test-release-posthog-metrics-agent
+subjects:
+    - kind: ServiceAccount
+      name: test-release-posthog-metrics-agent
+      namespace: default
+
+---
+# Source: posthog-metrics-agent/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: test-release-posthog-metrics-agent
+    labels:
+        helm.sh/chart: posthog-metrics-agent-0.1.0
+        app.kubernetes.io/name: posthog-metrics-agent
+        app.kubernetes.io/instance: test-release
+        app.kubernetes.io/version: "latest"
+        app.kubernetes.io/managed-by: Helm
+spec:
+    # A single replica by design: multiple replicas would scrape every target
+    # multiple times and double-count all metrics.
+    replicas: 1
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: posthog-metrics-agent
+            app.kubernetes.io/instance: test-release
+    template:
+        metadata:
+            labels:
+                app.kubernetes.io/name: posthog-metrics-agent
+                app.kubernetes.io/instance: test-release
+            annotations:
+                checksum/config: 1411c19dbd295f3baa0b938200623d437042a8fbba649ea037b24def467025bb
+        spec:
+            serviceAccountName: test-release-posthog-metrics-agent
+            containers:
+                - name: agent
+                  image: 'posthog/metrics-agent:latest'
+                  imagePullPolicy: IfNotPresent
+                  env:
+                      - name: POSTHOG_API_KEY
+                        valueFrom:
+                            secretKeyRef:
+                                name: test-release-posthog-metrics-agent
+                                key: posthog-api-key
+                  volumeMounts:
+                      - name: config
+                        mountPath: /etc/posthog/config.yaml
+                        subPath: config.yaml
+                        readOnly: true
+                  ports:
+                      - name: health
+                        containerPort: 13133
+                  livenessProbe:
+                      httpGet:
+                          path: /
+                          port: health
+                  readinessProbe:
+                      httpGet:
+                          path: /
+                          port: health
+                  resources:
+                      limits:
+                        memory: 512Mi
+                      requests:
+                        cpu: 100m
+                        memory: 256Mi
+            volumes:
+                - name: config
+                  configMap:
+                      name: test-release-posthog-metrics-agent

--- a/products/metrics/agent/tests/helm/run.sh
+++ b/products/metrics/agent/tests/helm/run.sh
@@ -80,7 +80,9 @@ out=$(render --set posthog.apiKey=phc_test --set posthog.host=https://eu.i.posth
 assert_contains eu-host 'https://eu.i.posthog.com/i/v1/metrics' "$out"
 
 # --- golden drift guard for the fully default render ---
-default=$(render --set posthog.apiKey=phc_test)
+# Blank lines are stripped before comparing: helm 3 and 4 disagree on
+# blank-line placement between documents, and that isn't drift we care about.
+default=$(render --set posthog.apiKey=phc_test | grep -v '^[[:space:]]*$')
 if [ "${1:-}" = "--update-golden" ]; then
     printf '%s\n' "$default" >golden/default.yaml
     echo "updated golden/default.yaml"

--- a/products/metrics/agent/tests/helm/run.sh
+++ b/products/metrics/agent/tests/helm/run.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Behavior tests + golden diff for the posthog-metrics-agent Helm chart.
+# Usage: products/metrics/agent/tests/helm/run.sh [--update-golden]
+set -u
+cd "$(dirname "$0")"
+CHART=../../chart/posthog-metrics-agent
+PASS=0
+FAIL=0
+
+render() {
+    helm template test-release "$CHART" "$@" 2>&1
+}
+
+assert_contains() {
+    name=$1
+    needle=$2
+    haystack=$3
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        echo "PASS $name"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL $name: output does not contain '$needle'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    name=$1
+    needle=$2
+    haystack=$3
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        echo "FAIL $name: output unexpectedly contains '$needle'"
+        FAIL=$((FAIL + 1))
+    else
+        echo "PASS $name"
+        PASS=$((PASS + 1))
+    fi
+}
+
+# --- defaults: annotation discovery on, chart-managed secret ---
+out=$(render --set posthog.apiKey=phc_test)
+assert_contains default-deployment 'kind: Deployment' "$out"
+assert_contains default-configmap 'kind: ConfigMap' "$out"
+assert_contains default-secret 'kind: Secret' "$out"
+assert_contains default-clusterrole 'kind: ClusterRole' "$out"
+assert_contains default-clusterrolebinding 'kind: ClusterRoleBinding' "$out"
+assert_contains default-serviceaccount 'kind: ServiceAccount' "$out"
+assert_contains default-single-replica 'replicas: 1' "$out"
+assert_contains default-pod-discovery 'kubernetes_sd_configs' "$out"
+assert_contains default-annotation-relabel '__meta_kubernetes_pod_annotation_prometheus_io_scrape' "$out"
+assert_contains default-openmetrics-pinned 'scrape_protocols: [OpenMetricsText1.0.0, OpenMetricsText0.0.1, PrometheusText0.0.4]' "$out"
+assert_contains default-key-via-env-reference '${env:POSTHOG_API_KEY}' "$out"
+assert_contains default-key-in-secret 'posthog-api-key:' "$out"
+assert_contains default-secret-env-ref 'secretKeyRef' "$out"
+assert_contains default-config-checksum 'checksum/config:' "$out"
+assert_contains default-health-probe '13133' "$out"
+assert_contains default-ingest-route '/i/v1/metrics' "$out"
+# The raw API key must appear only in the Secret (base64), never in the ConfigMap.
+configmap_only=$(printf '%s' "$out" | awk '/^kind: Secret$/{skip=1} /^---$/{skip=0} !skip')
+assert_not_contains default-key-not-in-configmap 'phc_test' "$configmap_only"
+
+# --- existingSecret: chart must not create its own Secret ---
+out=$(render --set posthog.existingSecret=my-secret)
+assert_not_contains existing-secret-no-secret 'kind: Secret' "$out"
+assert_contains existing-secret-referenced 'name: my-secret' "$out"
+
+# --- static targets + extra scrape configs, discovery off ---
+out=$(render --set posthog.apiKey=phc_test -f values/static-targets.yaml)
+assert_not_contains static-no-discovery 'kubernetes_sd_configs' "$out"
+assert_contains static-target-present "'static-svc:9090'" "$out"
+assert_contains static-extra-job 'job_name: extra-job' "$out"
+
+# --- rbac disabled ---
+out=$(render --set posthog.apiKey=phc_test --set rbac.create=false --set serviceAccount.create=false)
+assert_not_contains no-rbac-clusterrole 'kind: ClusterRole' "$out"
+assert_not_contains no-rbac-serviceaccount 'kind: ServiceAccount' "$out"
+
+# --- eu host flows into the rendered collector config ---
+out=$(render --set posthog.apiKey=phc_test --set posthog.host=https://eu.i.posthog.com)
+assert_contains eu-host 'https://eu.i.posthog.com/i/v1/metrics' "$out"
+
+# --- golden drift guard for the fully default render ---
+default=$(render --set posthog.apiKey=phc_test)
+if [ "${1:-}" = "--update-golden" ]; then
+    printf '%s\n' "$default" >golden/default.yaml
+    echo "updated golden/default.yaml"
+elif printf '%s\n' "$default" | diff -u golden/default.yaml -; then
+    echo "PASS golden-default"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL golden-default: rendered output drifted (rerun with --update-golden if intentional)"
+    FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "helm tests: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/products/metrics/agent/tests/helm/run.sh
+++ b/products/metrics/agent/tests/helm/run.sh
@@ -53,8 +53,17 @@ assert_contains default-key-via-env-reference '${env:POSTHOG_API_KEY}' "$out"
 assert_contains default-key-in-secret 'posthog-api-key:' "$out"
 assert_contains default-secret-env-ref 'secretKeyRef' "$out"
 assert_contains default-config-checksum 'checksum/config:' "$out"
+assert_contains default-secret-checksum 'checksum/secret:' "$out"
 assert_contains default-health-probe '13133' "$out"
 assert_contains default-ingest-route '/i/v1/metrics' "$out"
+# The default image tag is the pinned appVersion, never a floating tag.
+assert_contains default-pinned-image "image: 'posthog/metrics-agent:0.1.0'" "$out"
+assert_not_contains default-no-latest-tag ':latest' "$out"
+# Restricted Pod Security Standard: these fields are required for admission.
+assert_contains default-run-as-nonroot 'runAsNonRoot: true' "$out"
+assert_contains default-no-priv-escalation 'allowPrivilegeEscalation: false' "$out"
+assert_contains default-seccomp 'type: RuntimeDefault' "$out"
+assert_contains default-drop-all-caps '- ALL' "$out"
 # The raw API key must appear only in the Secret (base64), never in the ConfigMap.
 configmap_only=$(printf '%s' "$out" | awk '/^kind: Secret$/{skip=1} /^---$/{skip=0} !skip')
 assert_not_contains default-key-not-in-configmap 'phc_test' "$configmap_only"
@@ -64,6 +73,17 @@ out=$(render --set posthog.existingSecret=my-secret)
 assert_not_contains existing-secret-no-secret 'kind: Secret' "$out"
 assert_contains existing-secret-referenced 'name: my-secret' "$out"
 
+# --- rotating the API key must change the pod spec so the pod restarts ---
+sum_a=$(render --set posthog.apiKey=phc_a | grep 'checksum/secret:')
+sum_b=$(render --set posthog.apiKey=phc_b | grep 'checksum/secret:')
+if [ -n "$sum_a" ] && [ "$sum_a" != "$sum_b" ]; then
+    echo "PASS secret-checksum-tracks-key"
+    PASS=$((PASS + 1))
+else
+    echo "FAIL secret-checksum-tracks-key: checksum/secret did not change with the API key"
+    FAIL=$((FAIL + 1))
+fi
+
 # --- static targets + extra scrape configs, discovery off ---
 out=$(render --set posthog.apiKey=phc_test -f values/static-targets.yaml)
 assert_not_contains static-no-discovery 'kubernetes_sd_configs' "$out"
@@ -71,9 +91,14 @@ assert_contains static-target-present "'static-svc:9090'" "$out"
 assert_contains static-extra-job 'job_name: extra-job' "$out"
 
 # --- rbac disabled ---
-out=$(render --set posthog.apiKey=phc_test --set rbac.create=false --set serviceAccount.create=false)
+out=$(render --set posthog.apiKey=phc_test --set rbac.create=false --set serviceAccount.create=false --set serviceAccount.name=external-sa)
 assert_not_contains no-rbac-clusterrole 'kind: ClusterRole' "$out"
 assert_not_contains no-rbac-serviceaccount 'kind: ServiceAccount' "$out"
+assert_contains no-rbac-sa-referenced 'serviceAccountName: external-sa' "$out"
+
+# --- an unmanaged service account must be named explicitly, never 'default' ---
+out=$(render --set posthog.apiKey=phc_test --set serviceAccount.create=false)
+assert_contains sa-name-required 'serviceAccount.name is required' "$out"
 
 # --- eu host flows into the rendered collector config ---
 out=$(render --set posthog.apiKey=phc_test --set posthog.host=https://eu.i.posthog.com)

--- a/products/metrics/agent/tests/helm/values/static-targets.yaml
+++ b/products/metrics/agent/tests/helm/values/static-targets.yaml
@@ -1,0 +1,9 @@
+scrape:
+    annotationDiscovery: false
+    staticTargets:
+        - static-svc:9090
+        - static-worker:9091
+    extraScrapeConfigs: |
+        - job_name: extra-job
+          static_configs:
+              - targets: ['extra:8080']


### PR DESCRIPTION
## Problem

Stacked on #73376. Kubernetes users shouldn't have to hand-write scrape configs to try PostHog Metrics: the easy path should be one `helm install` plus the `prometheus.io/scrape` annotations most workloads already carry.

## Changes

Adds `products/metrics/agent/chart/posthog-metrics-agent`:

```sh
helm install posthog-metrics-agent oci://ghcr.io/posthog/charts/posthog-metrics-agent \
  --set posthog.apiKey=<project api key>
```

- Single-replica Deployment by design (two replicas would double-scrape every target), with a `checksum/config` rollout annotation and health probes on the collector's health_check extension.
- The chart renders the full collector config into a ConfigMap mounted at `/etc/posthog/config.yaml`, driving the image through its full-override escape hatch rather than a parallel config path.
- Default scrape job discovers pods annotated `prometheus.io/scrape: "true"` (path/port via `prometheus.io/path` / `prometheus.io/port`) through `kubernetes_sd_configs` plus the matching ClusterRole. Optional `scrape.staticTargets` and raw `scrape.extraScrapeConfigs` for everything else.
- The API key lives in a chart-managed Secret (or `posthog.existingSecret`) and reaches the collector only via env substitution, never the ConfigMap.
- Helm templates are Go templates, not YAML, so they're excluded from oxfmt and the lint-staged yaml formatter, along with the byte-exact test goldens.

## How did you test this code?

- `tests/helm/run.sh`: 26 assertions written red-first (existingSecret suppresses the Secret manifest, rbac/serviceAccount toggles, discovery off with static targets, EU host propagation, OpenMetrics protocols pinned, API key absent from the ConfigMap) plus a golden render drift guard. These catch chart regressions nothing else covers since no other chart exists in this repo.
- Rendered the chart's collector config and validated it with the real `otelcol-contrib validate` binary in docker, which catches receiver config mistakes (relabel regexes, `$$` escaping) that helm tests can't.
- `helm lint` passes. I (Claude) did not run a live `helm install` against a cluster; that's the one manual step left for review (kind/minikube with an annotated pod pointed at a dev stack).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Covered by the agent README in this directory; posthog.com docs follow with the stack.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). The ConfigMap-as-full-override design was chosen over env-var rendering because k8s discovery config is structural, and it exercises the same escape hatch customers use. Formatter exclusions were added after lint-staged rejected the Go-template files as invalid YAML on commit.

## 🎬 Demo context

The agent image this chart deploys was exercised end to end locally (docker run against a local PostHog stack; scrape -> capture-logs -> Kafka -> ClickHouse verified, values matching the app's own counters per label). The chart itself is covered by the golden-render and helm tests in this PR; it was not installed on a live cluster in that demo.

![validation queries: app counters vs posthog.metrics](https://raw.githubusercontent.com/PostHog/pr-assets/919835139b2d9027786f953cb1bef673a2132939/2026/07/898b5f15-3612-4f63-8a0c-f7ee8862a74a.png)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

