### PR TITLE
chore(metrics): add CD workflow for the metrics agent image and chart

### DIFF
--- a/.github/actions/docker-meta/action.yml
+++ b/.github/actions/docker-meta/action.yml
@@ -17,7 +17,7 @@ inputs:
         description: 'DockerHub username'
     dockerhub-password:
         required: true
-        description: 'DockerHub password/token'
+        description: 'DockerHub password/token. Pass an empty string to skip the DockerHub login, e.g. on PR validation builds that must not see the credential.'
     ecr-image-name:
         required: false
         default: ''
@@ -74,6 +74,9 @@ runs:
               logout: false
 
         - name: Login to DockerHub
+          # Skipped when no credential is passed (fork PRs, credential-free
+          # validation builds) instead of failing the login.
+          if: inputs.dockerhub-password != ''
           uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
           with:
               username: ${{ inputs.dockerhub-username }}

--- a/.github/actions/docker-meta/action.yml
+++ b/.github/actions/docker-meta/action.yml
@@ -17,7 +17,7 @@ inputs:
         description: 'DockerHub username'
     dockerhub-password:
         required: true
-        description: 'DockerHub password/token. Pass an empty string to skip the DockerHub login, e.g. on PR validation builds that must not see the credential.'
+        description: 'DockerHub password/token'
     ecr-image-name:
         required: false
         default: ''
@@ -74,9 +74,6 @@ runs:
               logout: false
 
         - name: Login to DockerHub
-          # Skipped when no credential is passed (fork PRs, credential-free
-          # validation builds) instead of failing the login.
-          if: inputs.dockerhub-password != ''
           uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
           with:
               username: ${{ inputs.dockerhub-username }}

--- a/.github/workflows/cd-metrics-agent-image.yml
+++ b/.github/workflows/cd-metrics-agent-image.yml
@@ -1,0 +1,130 @@
+#
+# Build, test and publish the PostHog metrics agent image and Helm chart
+# (products/metrics/agent) - a customer-deployable Prometheus scrape agent.
+#
+# Unlike most CD workflows this image is pulled by customers, not deployed to
+# PostHog's clusters: it pushes to Docker Hub + GHCR and publishes the chart
+# as an OCI artifact, with no charts-repo deploy dispatch.
+#
+name: Metrics Agent Image CD
+
+on:
+    push:
+        branches:
+            - master
+        paths:
+            - 'products/metrics/agent/**'
+            - '.github/workflows/cd-metrics-agent-image.yml'
+    # paths mirror the push trigger; the build-metrics-agent-image label only
+    # forces a build on PRs touching these paths, use workflow_dispatch otherwise.
+    pull_request:
+        types: [opened, synchronize, reopened, labeled]
+        paths:
+            - 'products/metrics/agent/**'
+            - '.github/workflows/cd-metrics-agent-image.yml'
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event_name == 'push' && github.sha || github.head_ref || github.ref }}
+    cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+    test:
+        name: Agent render, helm and integration tests
+        # No secrets needed, so this also runs on fork PRs.
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 20
+        permissions:
+            contents: read
+
+        steps:
+            - name: Check out
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Config render golden tests
+              run: products/metrics/agent/tests/render/run.sh
+
+            - name: Helm chart tests
+              run: products/metrics/agent/tests/helm/run.sh
+
+            - name: Integration smoke test (exemplars survive scrape -> OTLP)
+              run: products/metrics/agent/tests/integration/run.sh
+
+    build:
+        name: Build and push container image
+        needs: test
+        if: |
+            github.repository_owner == 'PostHog' &&
+            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+            (
+                github.event_name == 'push' ||
+                github.event_name == 'workflow_dispatch' ||
+                contains(github.event.pull_request.labels.*.name, 'build-metrics-agent-image')
+            )
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 30
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - name: Check out
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Docker meta and registry login
+              id: docker-meta
+              uses: ./.github/actions/docker-meta
+              with:
+                  image-name: metrics-agent
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
+                  dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+                  # Docker Hub is the primary customer-facing registry for this image.
+                  push-to-dockerhub: 'true'
+                  push-to-ghcr: ${{ vars.PUBLIC_IMAGE_PUSH_PAUSED != 'true' }}
+                  # Nothing internal deploys this image, so no ECR.
+                  push-to-ecr: 'false'
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+            - name: Build and push container image
+              uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+              with:
+                  context: products/metrics/agent
+                  push: ${{ github.ref == 'refs/heads/master' && vars.CD_DEPLOY_ENABLED == 'true' }}
+                  tags: ${{ steps.docker-meta.outputs.tags }}
+                  labels: ${{ steps.docker-meta.outputs.labels }}
+                  platforms: linux/arm64,linux/amd64
+
+    publish-chart:
+        name: Publish Helm chart to GHCR
+        needs: build
+        if: github.repository_owner == 'PostHog' && github.ref == 'refs/heads/master' && vars.CD_DEPLOY_ENABLED == 'true'
+        runs-on: ubuntu-24.04
+        timeout-minutes: 10
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - name: Check out
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Package and push chart
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  CHART=products/metrics/agent/chart/posthog-metrics-agent
+                  VERSION=$(awk '/^version:/{print $2}' "$CHART/Chart.yaml")
+                  echo "$GH_TOKEN" | helm registry login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+                  # Chart versions are immutable: re-runs of the same version are a no-op.
+                  if helm show chart "oci://ghcr.io/posthog/charts/posthog-metrics-agent" --version "$VERSION" >/dev/null 2>&1; then
+                      echo "chart version $VERSION already published, skipping"
+                      exit 0
+                  fi
+                  helm package "$CHART"
+                  helm push "posthog-metrics-agent-$VERSION.tgz" oci://ghcr.io/posthog/charts

--- a/.github/workflows/cd-metrics-agent-image.yml
+++ b/.github/workflows/cd-metrics-agent-image.yml
@@ -15,13 +15,15 @@ on:
         paths:
             - 'products/metrics/agent/**'
             - '.github/workflows/cd-metrics-agent-image.yml'
-    # paths mirror the push trigger; the build-metrics-agent-image label only
-    # forces a build on PRs touching these paths, use workflow_dispatch otherwise.
+    # paths mirror the push trigger; the build-metrics-agent-image label
+    # forces a build on PRs touching these paths.
     pull_request:
         types: [opened, synchronize, reopened, labeled]
         paths:
             - 'products/metrics/agent/**'
             - '.github/workflows/cd-metrics-agent-image.yml'
+    # Manual rebuilds of master only: the build job hands the Docker Hub token
+    # to the checked-out docker-meta action, so it must never run branch code.
     workflow_dispatch:
 
 concurrency:
@@ -58,7 +60,7 @@ jobs:
             (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
             (
                 github.event_name == 'push' ||
-                github.event_name == 'workflow_dispatch' ||
+                (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
                 contains(github.event.pull_request.labels.*.name, 'build-metrics-agent-image')
             )
         runs-on: depot-ubuntu-24.04
@@ -77,13 +79,34 @@ jobs:
               with:
                   image-name: metrics-agent
                   github-token: ${{ secrets.GITHUB_TOKEN }}
+                  # PR validation builds never push to Docker Hub, so they never
+                  # see the token: it reaches the checked-out action only for
+                  # master code (push, or dispatch restricted to master above).
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
-                  dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+                  dockerhub-password: ${{ github.event_name != 'pull_request' && secrets.DOCKERHUB_TOKEN || '' }}
                   # Docker Hub is the primary customer-facing registry for this image.
                   push-to-dockerhub: 'true'
                   push-to-ghcr: ${{ vars.PUBLIC_IMAGE_PUSH_PAUSED != 'true' }}
                   # Nothing internal deploys this image, so no ECR.
                   push-to-ecr: 'false'
+
+            - name: Read release tag from the chart appVersion
+              id: release-tag
+              # The chart's default image tag is its appVersion, so every
+              # master build also publishes under that tag; bumping appVersion
+              # is how a new agent version is released to chart users.
+              env:
+                  PUSH_GHCR: ${{ vars.PUBLIC_IMAGE_PUSH_PAUSED != 'true' }}
+              run: |
+                  APP_VERSION=$(awk '/^appVersion:/{print $2}' products/metrics/agent/chart/posthog-metrics-agent/Chart.yaml)
+                  {
+                    echo "tags<<EOF"
+                    echo "posthog/metrics-agent:$APP_VERSION"
+                    if [ "$PUSH_GHCR" = "true" ]; then
+                      echo "ghcr.io/posthog/metrics-agent:$APP_VERSION"
+                    fi
+                    echo "EOF"
+                  } >> "$GITHUB_OUTPUT"
 
             - name: Set up QEMU
               uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
@@ -96,7 +119,9 @@ jobs:
               with:
                   context: products/metrics/agent
                   push: ${{ github.ref == 'refs/heads/master' && vars.CD_DEPLOY_ENABLED == 'true' }}
-                  tags: ${{ steps.docker-meta.outputs.tags }}
+                  tags: |
+                      ${{ steps.docker-meta.outputs.tags }}
+                      ${{ steps.release-tag.outputs.tags }}
                   labels: ${{ steps.docker-meta.outputs.labels }}
                   platforms: linux/arm64,linux/amd64
 

--- a/.github/workflows/cd-metrics-agent-image.yml
+++ b/.github/workflows/cd-metrics-agent-image.yml
@@ -52,16 +52,48 @@ jobs:
             - name: Integration smoke test (exemplars survive scrape -> OTLP)
               run: products/metrics/agent/tests/integration/run.sh
 
+    # PR validation only: proves the multi-arch image builds, with no registry
+    # logins, no push destinations, and a read-only token, so PR-controlled
+    # code (workflow, Dockerfile, local actions) never sees a credential.
+    validate-build:
+        name: Validate container image build
+        needs: test
+        if: |
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            contains(github.event.pull_request.labels.*.name, 'build-metrics-agent-image')
+        runs-on: depot-ubuntu-24.04
+        timeout-minutes: 30
+        permissions:
+            contents: read
+
+        steps:
+            - name: Check out
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+            - name: Build container image (no push)
+              uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+              with:
+                  context: products/metrics/agent
+                  push: false
+                  platforms: linux/arm64,linux/amd64
+
     build:
         name: Build and push container image
         needs: test
+        # Only master code reaches this job: push events, or workflow_dispatch
+        # restricted to master. It is the only job holding registry credentials.
         if: |
             github.repository_owner == 'PostHog' &&
-            (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
             (
                 github.event_name == 'push' ||
-                (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
-                contains(github.event.pull_request.labels.*.name, 'build-metrics-agent-image')
+                (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
             )
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 30
@@ -79,11 +111,8 @@ jobs:
               with:
                   image-name: metrics-agent
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  # PR validation builds never push to Docker Hub, so they never
-                  # see the token: it reaches the checked-out action only for
-                  # master code (push, or dispatch restricted to master above).
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
-                  dockerhub-password: ${{ github.event_name != 'pull_request' && secrets.DOCKERHUB_TOKEN || '' }}
+                  dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
                   # Docker Hub is the primary customer-facing registry for this image.
                   push-to-dockerhub: 'true'
                   push-to-ghcr: ${{ vars.PUBLIC_IMAGE_PUSH_PAUSED != 'true' }}


### PR DESCRIPTION
## Problem

Stacked on #73377. The agent image and chart from the previous PRs need automated tests on PRs and a publish path customers can pull from.

## Changes

Adds `.github/workflows/cd-metrics-agent-image.yml`:

```mermaid
flowchart LR
    PR{{PR / master push}} --> T[test: render goldens + helm assertions + exemplar integration smoke]
    T --> B[build: buildx amd64+arm64]
    B --> H[publish-chart: OCI push]
    B --> D[(Docker Hub posthog/metrics-agent + GHCR)]
    H --> C[(ghcr.io/posthog/charts)]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class T,B,H phBlue;
    class PR phYellow;
    class D,C phGray;
```

- The test job runs on every PR touching `products/metrics/agent/**` (no secrets, fork-safe): render goldens, helm assertions, and the integration smoke test that gates exemplar preservation.
- Build pushes only on master with `CD_DEPLOY_ENABLED`, to Docker Hub (`push-to-dockerhub: true`, the customer-facing registry) and GHCR (behind the `PUBLIC_IMAGE_PUSH_PAUSED` embargo var), with `push-to-ecr: false` since nothing internal deploys this image. PR builds require the `build-metrics-agent-image` label and are blocked on fork PRs.
- The chart is published as an OCI artifact to `ghcr.io/posthog/charts` with an immutable-version check, so re-runs of the same chart version are a no-op. No charts-repo deploy dispatch: customers pull, PostHog doesn't deploy this.
- Uses `docker/build-push-action` with QEMU rather than Depot because no Depot project exists for this image; happy to swap once one is provisioned.

> [!NOTE]
> This workflow is paths-scoped and not a required check, so it never dispatches on unrelated PRs and is safe for unrebased branches.

## How did you test this code?

- `bin/hogli lint:workflows` (all 6 checks pass) and `actionlint` pass locally.
- All three test scripts the workflow calls were run locally and pass (see #73376/#73377 for what they observe).
- The publish jobs can only be proven on a master merge; the version-exists guard was exercised locally against a nonexistent OCI ref.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a (CI only).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) with the /authoring-ci-workflows skill loaded. Followed cd-mcp-image.yml for trigger shape and docker-meta usage, livestream-docker-image.yml for the Docker Hub arm. Action SHAs were resolved from the GitHub API, not memory. Concurrency uses the per-SHA push arm since this publishes on push.

## 🎬 Demo context

The image this workflow publishes was built from source and exercised end to end locally: it scraped the unmodified prometheus-example-app and the metrics landed in ClickHouse `posthog.metrics` with values matching the app's own counters per label.

![agent install and startup](https://raw.githubusercontent.com/PostHog/pr-assets/b58c8f9784a3450357bb269ed94122f65ba0e405/2026/07/eaba32b5-91f1-4eae-9a5c-abae5e30c6e8.png)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

