### PR TITLE
feat(metrics): offer the scrape agent in metrics onboarding

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5573,7 +5573,7 @@ snapshots:
     scenes-app-dashboards--show-across-viewports--narrow--dark:
         hash: v1.k794b7964.e919c4955d7113170ab00269c5f628c318afe14f26dc8aafb046b172e17f362e.YDXD84rrb2KR1I36pHMxEsGZ0sN0os_cBBdNIf89Pu8
     scenes-app-dashboards--show-across-viewports--narrow--light:
-        hash: v1.k794b7964.2a88f06991ca4c13ad27ee62db8eaa037c542301e28c24934eedc1bbb78cb338.3Ne0cm6_2xQiGE1wGcRzmw0QBd3QrEYkELz3PCg9J48
+        hash: v1.k794b7964.8b1d5f4429205bae6f3c4e64504ccd9b955562bec56305007e6c1fb51e6ffe5b.6C7YLoVSuBpeYoz0R7duqujHCorEqBKyJTXeuFAM9EA
     scenes-app-dashboards--show-across-viewports--superwide--dark:
         hash: v1.k794b7964.9948b52cf842206c1584057a6a16b8caed7a32d95f103dbea07089a02df75a53.AuXGqOvw-P-XuzOL2Zl-BkBPb1-Q3R1949f5-IkTjZA
     scenes-app-dashboards--show-across-viewports--superwide--light:

--- a/products/metrics/frontend/components/MetricsSetupPrompt.tsx
+++ b/products/metrics/frontend/components/MetricsSetupPrompt.tsx
@@ -1,13 +1,15 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import * as greekPng from '@posthog/brand/hoggies/png/greek'
-import { LemonButton, Link, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonTabs, Link, Spinner } from '@posthog/lemon-ui'
 
 import { pngHoggie } from 'lib/brand/hoggies'
+import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { useInterval } from 'lib/hooks/useInterval'
+import { apiHostOrigin } from 'lib/utils/apiHost'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
@@ -49,8 +51,10 @@ export const MetricsSetupPrompt = ({
 
 const NoMetricsPrompt = ({ className }: { className?: string }): JSX.Element | null => {
     const { addProductIntent } = useActions(teamLogic)
+    const { currentTeam } = useValues(teamLogic)
     const { hasMetrics } = useValues(metricsIngestionLogic)
     const { loadTeamHasMetrics } = useActions(metricsIngestionLogic)
+    const [agentTab, setAgentTab] = useState<'docker' | 'kubernetes'>('docker')
 
     useEffect(() => {
         posthog.capture('metrics setup prompt viewed')
@@ -69,6 +73,25 @@ const NoMetricsPrompt = ({ className }: { className?: string }): JSX.Element | n
             intent_context: ProductIntentContext.METRICS_DOCS_VIEWED,
         })
     }
+
+    const apiKey = currentTeam?.api_token ?? '<your project API key>'
+    const dockerSnippet = [
+        'docker run -d --name posthog-metrics-agent \\',
+        `  -e POSTHOG_API_KEY=${apiKey} \\`,
+        `  -e POSTHOG_HOST=${apiHostOrigin()} \\`,
+        '  -e SCRAPE_TARGETS=your-app:9090 \\',
+        '  posthog/metrics-agent:latest',
+    ].join('\n')
+    const helmSnippet = [
+        'helm install posthog-metrics-agent \\',
+        '  oci://ghcr.io/posthog/charts/posthog-metrics-agent \\',
+        `  --set posthog.apiKey=${apiKey} \\`,
+        `  --set posthog.host=${apiHostOrigin()}`,
+        '',
+        '# then annotate the pods you want scraped:',
+        '#   prometheus.io/scrape: "true"',
+        '#   prometheus.io/port: "9090"',
+    ].join('\n')
 
     return (
         <ProductIntroduction
@@ -98,6 +121,33 @@ const NoMetricsPrompt = ({ className }: { className?: string }): JSX.Element | n
                         </Link>
                         .
                     </p>
+                    <div className="flex flex-col gap-1 w-full max-w-160">
+                        <h5 className="m-0">Or scrape your existing Prometheus metrics</h5>
+                        <p className="text-sm text-secondary m-0">
+                            Already exposing Prometheus metrics? Deploy the PostHog metrics agent in your infra and it
+                            forwards them for you, no code changes needed. Counters and histograms with OpenMetrics
+                            exemplars get clickable trace links automatically.
+                        </p>
+                        <LemonTabs
+                            activeKey={agentTab}
+                            onChange={(key) => {
+                                setAgentTab(key)
+                                onDocsLinkClick(key === 'docker' ? 'agent-docker' : 'agent-helm')
+                            }}
+                            tabs={[
+                                {
+                                    key: 'docker' as const,
+                                    label: 'Docker',
+                                    content: <CodeSnippet language={Language.Bash}>{dockerSnippet}</CodeSnippet>,
+                                },
+                                {
+                                    key: 'kubernetes' as const,
+                                    label: 'Kubernetes',
+                                    content: <CodeSnippet language={Language.Bash}>{helmSnippet}</CodeSnippet>,
+                                },
+                            ]}
+                        />
+                    </div>
                     <div className="flex items-center gap-4">
                         <div className="flex items-center gap-2 px-3 py-1.5 border border-accent rounded">
                             <div className="relative flex items-center justify-center">


### PR DESCRIPTION
## Problem

Stacked on #73378. The metrics empty state only mentions OpenTelemetry SDKs, so users with existing Prometheus endpoints don't learn there's a no-code-changes path.

## Changes

Adds a "scrape your existing Prometheus metrics" section to `MetricsSetupPrompt`, with Docker and Kubernetes tabs whose copy-paste commands come pre-filled with the project's API key and the regional ingest host (`apiHostOrigin()`). Tab switches reuse the existing `metrics onboarding docs clicked` event with `docs_type: agent-docker | agent-helm` and the METRICS_DOCS_VIEWED product intent. The "Watching for metrics" live poller stays below, so the first scrape flips the page over automatically.

Merge last in the stack, once `posthog/metrics-agent:latest` actually exists on Docker Hub.

## How did you test this code?

- `tsgo --noEmit` reports the same 195 pre-existing errors with and without this change, none in metrics (the baseline was compared by stashing the change).
- oxfmt/oxlint pass. I (Claude) did not screenshot the rendered state in a browser; the change is a straightforward composition of existing CodeSnippet/LemonTabs components.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The in-app copy links to https://posthog.com/docs/metrics, which needs an agent section as a follow-up in the posthog.com repo.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). No new kea logic: the polling and intent wiring already lived in metricsIngestionLogic/teamLogic, so this is view-only composition with a local tab state.

## 🎬 Demo context (screen recorded)

The flow this onboarding section points users at was run end to end on a local stack: an unmodified Prometheus-instrumented app, the agent installed with `docker run` + project API key, and the scraped metrics arriving in the Metrics viewer.

Current empty state (setup banner this PR extends):

![metrics empty state](https://raw.githubusercontent.com/PostHog/pr-assets/ec9cc70c3eec7dc6de0fb0217c88b5971a94c22c/2026/07/9116b289-4147-4fd7-8624-6d0c36d43528.png)

After the agent runs, the scraped counter in the viewer, grouped by the `code` label:

![metrics viewer with scraped data](https://raw.githubusercontent.com/PostHog/pr-assets/8fc1ca85978c77f93c1923fa2b2389c837eae5f7/2026/07/b1143b47-13fb-42e8-b21a-4d5a7b8b91b3.png)

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

