### PR TITLE
feat(managed-migrations): add IAM role auth for S3 batch imports

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -370,6 +370,7 @@ export const FEATURE_FLAGS = {
     LOGS_SPARKLINE_SERVICE_BREAKDOWN: 'logs-sparkline-service-breakdown', // owner: #team-logs
     LOGS_SQL_VIEW: 'logs-sql-view', // owner: #team-logs
     LOGS_TABBED_VIEW: 'logs-tabbed-view', // owner: #team-logs
+    MANAGED_MIGRATIONS_IAM_ROLE_AUTH: 'managed-migrations-iam-role-auth', // owner: #team-ingestion, gates IAM role auth for S3 batch imports
     MANAGED_MIGRATIONS_TRIAL_RUNS: 'managed-migrations-trial-runs', // owner: #team-ingestion, gates trial runs for managed migrations
     MANAGED_VIEWSETS: 'managed-viewsets', // owner: @rafaeelaudibert #team-revenue-analytics
     MARKETING_ANALYTICS_AI: 'marketing-analytics-ai', // owner: @jabahamondes #team-web-analytics

--- a/posthog/settings/managed_migrations.py
+++ b/posthog/settings/managed_migrations.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from posthog.settings.base_variables import DEBUG, TEST
 from posthog.settings.object_storage import OBJECT_STORAGE_REGION
+from posthog.settings.utils import get_from_env
+from posthog.utils import str_to_bool
 
 # S3-compatible store holding managed-migration trial run output (browsable
 # JSONL pages + summary), written by the batch-import worker (its TRIAL_BUCKET_*
@@ -30,3 +32,13 @@ MANAGED_MIGRATIONS_TRIAL_S3_REGION = os.getenv("MANAGED_MIGRATIONS_TRIAL_S3_REGI
 # responds accordingly); set it wherever the worker fleet has a trial bucket.
 MANAGED_MIGRATIONS_TRIAL_S3_BUCKET = os.getenv("MANAGED_MIGRATIONS_TRIAL_S3_BUCKET", "posthog" if TEST or DEBUG else "")
 MANAGED_MIGRATIONS_TRIAL_S3_PREFIX = os.getenv("MANAGED_MIGRATIONS_TRIAL_S3_PREFIX", "trial_runs")
+
+# ARN of the PostHog-owned IAM role the batch import worker runs as. Customers grant this
+# role access to their S3 buckets via a cross-account trust policy, so it must stay stable.
+MANAGED_MIGRATIONS_IMPORT_ROLE_ARN: str = os.getenv("MANAGED_MIGRATIONS_IMPORT_ROLE_ARN", "")
+
+# Requires the Django pods to be allowed to assume MANAGED_MIGRATIONS_IMPORT_ROLE_ARN,
+# so it stays off until that grant exists in the deployment.
+MANAGED_MIGRATIONS_VALIDATE_ROLE_ON_CREATE: bool = get_from_env(
+    "MANAGED_MIGRATIONS_VALIDATE_ROLE_ON_CREATE", False, type_cast=str_to_bool
+)

--- a/products/managed_migrations/backend/api/batch_imports.py
+++ b/products/managed_migrations/backend/api/batch_imports.py
@@ -766,7 +766,7 @@ class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     def _is_iam_role_enabled_for_team(self) -> bool:
-        user = self.request.user
+        user = cast(User, self.request.user)
         team = self.team
         return bool(
             posthoganalytics.feature_enabled(

--- a/products/managed_migrations/backend/api/batch_imports.py
+++ b/products/managed_migrations/backend/api/batch_imports.py
@@ -1,11 +1,17 @@
+import json
 import uuid
 from copy import deepcopy
 from datetime import timedelta
 from typing import cast
 
+from django.conf import settings
 from django.db import transaction
 
+import boto3
+import structlog
 import posthoganalytics
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import BotoCoreError, ClientError
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_field
 from rest_framework import filters, serializers, status, viewsets
@@ -24,7 +30,12 @@ from products.managed_migrations.backend.models.batch_imports import (
     BatchImportConfigBuilder,
     ContentType,
     DateRangeExportSource,
+    get_aws_external_id,
 )
+
+logger = structlog.get_logger(__name__)
+
+S3_ROLE_ARN_REGEX = r"^arn:aws:iam::\d{12}:role\/[\w+=,.@\/-]+$"
 
 TRIAL_RECORD_LIMIT_DEFAULT = 1_000
 TRIAL_RECORD_LIMIT_MAX = 50_000
@@ -121,23 +132,56 @@ class BatchImportSerializer(serializers.ModelSerializer):
 
 
 class BatchImportS3SourceCreateSerializer(BatchImportTrialOptionsMixin, BatchImportSerializer):
-    """Serializer for creating BatchImports with config builder methods"""
+    """Serializer for creating BatchImports reading JSONL files from S3."""
+
+    _builder_method = "from_s3"
 
     content_type = serializers.ChoiceField(
         choices=["mixpanel", "captured", "amplitude"],
         write_only=True,
         required=True,
+        help_text="Format of the events in the source files.",
     )
     source_type = serializers.ChoiceField(
         choices=["s3"],
         write_only=True,
         required=True,
+        help_text="Source storage type.",
     )
-    s3_bucket = serializers.CharField(write_only=True, required=False)
-    s3_prefix = serializers.CharField(write_only=True, required=False, allow_blank=True)
-    s3_region = serializers.CharField(write_only=True, required=False)
-    access_key = serializers.CharField(write_only=True, required=False)
-    secret_key = serializers.CharField(write_only=True, required=False)
+    s3_bucket = serializers.CharField(write_only=True, required=True, help_text="Name of the S3 bucket to import from.")
+    s3_prefix = serializers.CharField(
+        write_only=True,
+        required=False,
+        allow_blank=True,
+        default="",
+        help_text="Key prefix limiting which objects in the bucket are imported.",
+    )
+    s3_region = serializers.CharField(
+        write_only=True, required=True, help_text="AWS region the bucket lives in, e.g. us-east-1."
+    )
+    access_key = serializers.CharField(
+        write_only=True,
+        required=False,
+        allow_blank=True,
+        help_text="AWS access key ID. Use together with secret_key; mutually exclusive with role_arn.",
+    )
+    secret_key = serializers.CharField(
+        write_only=True,
+        required=False,
+        allow_blank=True,
+        help_text="AWS secret access key. Use together with access_key; mutually exclusive with role_arn.",
+    )
+    role_arn = serializers.RegexField(
+        regex=S3_ROLE_ARN_REGEX,
+        write_only=True,
+        required=False,
+        allow_blank=True,
+        help_text=(
+            "ARN of an IAM role in your AWS account that trusts PostHog's import role. "
+            "Recommended alternative to access keys; only works with AWS S3 (no custom endpoint_url). "
+            "Fetch the trust policy to configure from the aws_iam_setup endpoint."
+        ),
+    )
     endpoint_url = serializers.CharField(
         write_only=True,
         required=False,
@@ -145,9 +189,15 @@ class BatchImportS3SourceCreateSerializer(BatchImportTrialOptionsMixin, BatchImp
         default=None,
         help_text="Custom endpoint URL for S3-compatible storage (e.g. Cloudflare R2, MinIO).",
     )
-    import_events = serializers.BooleanField(write_only=True, required=False, default=True)
-    generate_identify_events = serializers.BooleanField(write_only=True, required=False, default=True)
-    generate_group_identify_events = serializers.BooleanField(write_only=True, required=False, default=False)
+    import_events = serializers.BooleanField(
+        write_only=True, required=False, default=True, help_text="Whether to import regular events."
+    )
+    generate_identify_events = serializers.BooleanField(
+        write_only=True, required=False, default=True, help_text="Whether to generate $identify events."
+    )
+    generate_group_identify_events = serializers.BooleanField(
+        write_only=True, required=False, default=False, help_text="Whether to generate $groupidentify events."
+    )
 
     class Meta:
         model = BatchImport
@@ -167,6 +217,7 @@ class BatchImportS3SourceCreateSerializer(BatchImportTrialOptionsMixin, BatchImp
             "s3_region",
             "access_key",
             "secret_key",
+            "role_arn",
             "endpoint_url",
             "import_events",
             "generate_identify_events",
@@ -185,27 +236,120 @@ class BatchImportS3SourceCreateSerializer(BatchImportTrialOptionsMixin, BatchImp
             "import_config",
         ]
 
+    def _is_iam_role_enabled(self) -> bool:
+        team = self.context["get_team"]()
+        user = self.context["request"].user
+        return bool(
+            posthoganalytics.feature_enabled(
+                "managed-migrations-iam-role-auth",
+                str(user.distinct_id),
+                groups={"organization": str(team.organization_id), "project": str(team.id)},
+                group_properties={"organization": {"id": str(team.organization_id)}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+
+    def validate(self, data: dict) -> dict:
+        data = super().validate(data)
+
+        has_access_key = bool(data.get("access_key"))
+        has_secret_key = bool(data.get("secret_key"))
+        has_role = bool(data.get("role_arn"))
+
+        if has_role and not self._is_iam_role_enabled():
+            raise serializers.ValidationError("IAM role authentication is not available for this project")
+
+        if has_role and (has_access_key or has_secret_key):
+            raise serializers.ValidationError("Provide either role_arn or access keys, not both")
+        if has_access_key != has_secret_key:
+            raise serializers.ValidationError(
+                "Both access_key and secret_key are required for access key authentication"
+            )
+        if not has_role and not has_access_key:
+            raise serializers.ValidationError(
+                "Authentication is required: provide role_arn (recommended) or access_key and secret_key"
+            )
+        if has_role and data.get("endpoint_url"):
+            raise serializers.ValidationError(
+                "IAM role authentication only works with AWS S3; S3-compatible storage must use access keys"
+            )
+        if (
+            has_role
+            and settings.MANAGED_MIGRATIONS_VALIDATE_ROLE_ON_CREATE
+            and settings.MANAGED_MIGRATIONS_IMPORT_ROLE_ARN
+        ):
+            self._validate_role_access(data)
+
+        return data
+
+    def _validate_role_access(self, data: dict) -> None:
+        external_id = get_aws_external_id(self.context["get_team"]())
+        boto_timeout = BotoConfig(connect_timeout=5, read_timeout=10)
+        try:
+            sts = boto3.client("sts", config=boto_timeout)
+            import_role = sts.assume_role(
+                RoleArn=settings.MANAGED_MIGRATIONS_IMPORT_ROLE_ARN,
+                RoleSessionName="posthog-managed-migration-validation",
+                DurationSeconds=900,
+            )["Credentials"]
+        except (ClientError, BotoCoreError):
+            logger.exception("managed_migrations_import_role_assume_failed")
+            return
+
+        customer_sts = boto3.client(
+            "sts",
+            aws_access_key_id=import_role["AccessKeyId"],
+            aws_secret_access_key=import_role["SecretAccessKey"],
+            aws_session_token=import_role["SessionToken"],
+            config=boto_timeout,
+        )
+        try:
+            credentials = customer_sts.assume_role(
+                RoleArn=data["role_arn"],
+                RoleSessionName="posthog-managed-migration-validation",
+                ExternalId=external_id,
+                DurationSeconds=900,
+            )["Credentials"]
+        except (ClientError, BotoCoreError):
+            raise serializers.ValidationError(
+                "PostHog could not assume this IAM role. Verify the role exists, its trust policy "
+                "allows PostHog's import role, and the External ID matches the one shown in setup."
+            )
+
+        s3 = boto3.client(
+            "s3",
+            region_name=data["s3_region"],
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+            config=boto_timeout,
+        )
+        try:
+            s3.list_objects_v2(Bucket=data["s3_bucket"], Prefix=data.get("s3_prefix", ""), MaxKeys=1)
+        except (ClientError, BotoCoreError):
+            raise serializers.ValidationError(
+                "The IAM role was assumed successfully, but listing the bucket failed. "
+                "Check the role's s3:ListBucket and s3:GetObject permissions for this bucket and prefix."
+            )
+
     def create(self, validated_data: dict, **kwargs) -> BatchImport:
-        """Create BatchImport using config builder pattern."""
         batch_import = BatchImport(
             team_id=self.context["team_id"],
             created_by_id=self.context["request"].user.id,
         )
 
-        content_type_map = {
-            "mixpanel": ContentType.MIXPANEL,
-            "amplitude": ContentType.AMPLITUDE,
-            "captured": ContentType.CAPTURED,
-        }
+        content_type = ContentType(validated_data["content_type"])
+        role_arn = validated_data.get("role_arn") or None
 
-        content_type = content_type_map[validated_data["content_type"]]
-
-        config_builder = batch_import.config.json_lines(content_type).from_s3(
+        config_builder = getattr(batch_import.config.json_lines(content_type), self._builder_method)(
             bucket=validated_data["s3_bucket"],
             prefix=validated_data.get("s3_prefix", ""),
             region=validated_data["s3_region"],
-            access_key_id=validated_data["access_key"],
-            secret_access_key=validated_data["secret_key"],
+            access_key_id=validated_data.get("access_key") or None,
+            secret_access_key=validated_data.get("secret_key") or None,
+            role_arn=role_arn,
+            external_id=get_aws_external_id(self.context["get_team"]()) if role_arn else None,
             endpoint_url=validated_data.get("endpoint_url"),
         )
 
@@ -222,106 +366,17 @@ class BatchImportS3SourceCreateSerializer(BatchImportTrialOptionsMixin, BatchImp
         return batch_import
 
 
-class BatchImportS3GzipSourceCreateSerializer(BatchImportTrialOptionsMixin, BatchImportSerializer):
-    """Serializer for creating BatchImports with S3 gzipped JSONL source"""
+class BatchImportS3GzipSourceCreateSerializer(BatchImportS3SourceCreateSerializer):
+    """Serializer for creating BatchImports with S3 gzipped JSONL source."""
 
-    content_type = serializers.ChoiceField(
-        choices=["mixpanel", "captured", "amplitude"],
-        write_only=True,
-        required=True,
-    )
+    _builder_method = "from_s3_gzip"
+
     source_type = serializers.ChoiceField(
         choices=["s3_gzip"],
         write_only=True,
         required=True,
+        help_text="Source storage type.",
     )
-    s3_bucket = serializers.CharField(write_only=True, required=False)
-    s3_prefix = serializers.CharField(write_only=True, required=False, allow_blank=True)
-    s3_region = serializers.CharField(write_only=True, required=False)
-    access_key = serializers.CharField(write_only=True, required=False)
-    secret_key = serializers.CharField(write_only=True, required=False)
-    endpoint_url = serializers.CharField(
-        write_only=True,
-        required=False,
-        allow_blank=True,
-        default=None,
-        help_text="Custom endpoint URL for S3-compatible storage (e.g. Cloudflare R2, MinIO).",
-    )
-    import_events = serializers.BooleanField(write_only=True, required=False, default=True)
-    generate_identify_events = serializers.BooleanField(write_only=True, required=False, default=True)
-    generate_group_identify_events = serializers.BooleanField(write_only=True, required=False, default=False)
-
-    class Meta:
-        model = BatchImport
-        fields = [
-            "id",
-            "team_id",
-            "created_at",
-            "updated_at",
-            "state",
-            "status",
-            "display_status_message",
-            "import_config",
-            "content_type",
-            "source_type",
-            "s3_bucket",
-            "s3_prefix",
-            "s3_region",
-            "access_key",
-            "secret_key",
-            "endpoint_url",
-            "import_events",
-            "generate_identify_events",
-            "generate_group_identify_events",
-            "is_trial",
-            "trial_record_limit",
-        ]
-        read_only_fields = [
-            "id",
-            "team_id",
-            "created_at",
-            "updated_at",
-            "state",
-            "status",
-            "display_status_message",
-            "import_config",
-        ]
-
-    def create(self, validated_data: dict, **kwargs) -> BatchImport:
-        """Create BatchImport using config builder pattern."""
-        batch_import = BatchImport(
-            team_id=self.context["team_id"],
-            created_by_id=self.context["request"].user.id,
-        )
-
-        content_type_map = {
-            "mixpanel": ContentType.MIXPANEL,
-            "amplitude": ContentType.AMPLITUDE,
-            "captured": ContentType.CAPTURED,
-        }
-
-        content_type = content_type_map[validated_data["content_type"]]
-
-        config_builder = batch_import.config.json_lines(content_type).from_s3_gzip(
-            bucket=validated_data["s3_bucket"],
-            prefix=validated_data.get("s3_prefix", ""),
-            region=validated_data["s3_region"],
-            access_key_id=validated_data["access_key"],
-            secret_access_key=validated_data["secret_key"],
-            endpoint_url=validated_data.get("endpoint_url"),
-        )
-
-        if content_type == ContentType.AMPLITUDE:
-            config_builder = (
-                config_builder.with_import_events(validated_data.get("import_events", True))
-                .with_generate_identify_events(validated_data.get("generate_identify_events", True))
-                .with_generate_group_identify_events(validated_data.get("generate_group_identify_events", False))
-            )
-
-        _apply_output_sink(config_builder, validated_data)
-
-        batch_import.save()
-        return batch_import
 
 
 class BatchImportDateRangeSourceCreateSerializer(BatchImportTrialOptionsMixin, BatchImportSerializer):
@@ -571,6 +626,27 @@ class TrialRecordsResponseSerializer(serializers.Serializer):
     )
 
 
+class BatchImportAWSIAMSetupSerializer(serializers.Serializer):
+    """Values a customer needs to configure cross-account IAM role access for S3 imports."""
+
+    available = serializers.BooleanField(
+        help_text="Whether IAM role authentication is available on this PostHog deployment."
+    )
+    external_id = serializers.CharField(
+        help_text="External ID to pin in the role trust policy's sts:ExternalId condition. Stable per project."
+    )
+    posthog_role_arn = serializers.CharField(
+        allow_blank=True, help_text="ARN of PostHog's import role -- the principal your role must trust."
+    )
+    trust_policy = serializers.CharField(
+        allow_blank=True, help_text="Ready-to-paste IAM trust policy JSON for the role in your AWS account."
+    )
+    permission_policy_template = serializers.CharField(
+        allow_blank=True,
+        help_text="IAM permission policy JSON template; replace YOUR_BUCKET and YOUR_PREFIX with your values.",
+    )
+
+
 class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     """Viewset for BatchImport model"""
 
@@ -688,6 +764,88 @@ class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         response_serializer = BatchImportResponseSerializer(migration)
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+    def _is_iam_role_enabled_for_team(self) -> bool:
+        user = self.request.user
+        team = self.team
+        return bool(
+            posthoganalytics.feature_enabled(
+                "managed-migrations-iam-role-auth",
+                str(user.distinct_id),
+                groups={"organization": str(team.organization_id), "project": str(team.id)},
+                group_properties={"organization": {"id": str(team.organization_id)}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+
+    @extend_schema(
+        responses={200: BatchImportAWSIAMSetupSerializer},
+        description=(
+            "Values needed to set up cross-account IAM role access for S3 imports: the external ID, "
+            "PostHog's import role ARN, and ready-to-paste trust/permission policy JSON."
+        ),
+    )
+    @action(methods=["GET"], detail=False)
+    def aws_iam_setup(self, request: Request, **kwargs) -> Response:
+        external_id = get_aws_external_id(self.team)
+        posthog_role_arn = settings.MANAGED_MIGRATIONS_IMPORT_ROLE_ARN
+
+        if not posthog_role_arn or not self._is_iam_role_enabled_for_team():
+            serializer = BatchImportAWSIAMSetupSerializer(
+                {
+                    "available": False,
+                    "external_id": external_id,
+                    "posthog_role_arn": "",
+                    "trust_policy": "",
+                    "permission_policy_template": "",
+                }
+            )
+            return Response(serializer.data)
+
+        trust_policy = json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"AWS": posthog_role_arn},
+                        "Action": "sts:AssumeRole",
+                        "Condition": {"StringEquals": {"sts:ExternalId": external_id}},
+                    }
+                ],
+            },
+            indent=2,
+        )
+        permission_policy_template = json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["s3:ListBucket"],
+                        "Resource": "arn:aws:s3:::YOUR_BUCKET",
+                        "Condition": {"StringLike": {"s3:prefix": ["YOUR_PREFIX*"]}},
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": ["s3:GetObject"],
+                        "Resource": "arn:aws:s3:::YOUR_BUCKET/YOUR_PREFIX*",
+                    },
+                ],
+            },
+            indent=2,
+        )
+        serializer = BatchImportAWSIAMSetupSerializer(
+            {
+                "available": True,
+                "external_id": external_id,
+                "posthog_role_arn": posthog_role_arn,
+                "trust_policy": trust_policy,
+                "permission_policy_template": permission_policy_template,
+            }
+        )
+        return Response(serializer.data)
 
     @action(methods=["POST"], detail=True)
     def pause(self, request: Request, **kwargs) -> Response:

--- a/products/managed_migrations/backend/api/batch_imports.py
+++ b/products/managed_migrations/backend/api/batch_imports.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from copy import deepcopy
 from datetime import timedelta
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from django.conf import settings
 from django.db import transaction
@@ -34,9 +34,26 @@ from products.managed_migrations.backend.models.batch_imports import (
     get_aws_external_id,
 )
 
+if TYPE_CHECKING:
+    from posthog.models.team import Team
+
 logger = structlog.get_logger(__name__)
 
 S3_ROLE_ARN_REGEX = r"^arn:aws:iam::\d{12}:role\/[\w+=,.@\/-]+$"
+
+
+def _is_iam_role_auth_enabled(user: User, team: "Team") -> bool:
+    return bool(
+        posthoganalytics.feature_enabled(
+            "managed-migrations-iam-role-auth",
+            str(user.distinct_id),
+            groups={"organization": str(team.organization_id), "project": str(team.id)},
+            group_properties={"organization": {"id": str(team.organization_id)}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
+    )
+
 
 TRIAL_RECORD_LIMIT_DEFAULT = 1_000
 TRIAL_RECORD_LIMIT_MAX = 50_000
@@ -238,18 +255,7 @@ class BatchImportS3SourceCreateSerializer(BatchImportTrialOptionsMixin, BatchImp
         ]
 
     def _is_iam_role_enabled(self) -> bool:
-        team = self.context["get_team"]()
-        user = self.context["request"].user
-        return bool(
-            posthoganalytics.feature_enabled(
-                "managed-migrations-iam-role-auth",
-                str(user.distinct_id),
-                groups={"organization": str(team.organization_id), "project": str(team.id)},
-                group_properties={"organization": {"id": str(team.organization_id)}},
-                only_evaluate_locally=False,
-                send_feature_flag_events=False,
-            )
-        )
+        return _is_iam_role_auth_enabled(self.context["request"].user, self.context["get_team"]())
 
     def validate(self, data: dict) -> dict:
         data = super().validate(data)
@@ -771,18 +777,7 @@ class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     def _is_iam_role_enabled_for_team(self) -> bool:
-        user = cast(User, self.request.user)
-        team = self.team
-        return bool(
-            posthoganalytics.feature_enabled(
-                "managed-migrations-iam-role-auth",
-                str(user.distinct_id),
-                groups={"organization": str(team.organization_id), "project": str(team.id)},
-                group_properties={"organization": {"id": str(team.organization_id)}},
-                only_evaluate_locally=False,
-                send_feature_flag_events=False,
-            )
-        )
+        return _is_iam_role_auth_enabled(cast(User, self.request.user), self.team)
 
     @extend_schema(
         responses={200: BatchImportAWSIAMSetupSerializer},

--- a/products/managed_migrations/backend/api/batch_imports.py
+++ b/products/managed_migrations/backend/api/batch_imports.py
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 from posthog.api.documentation import _FallbackSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
+from posthog.exceptions_capture import capture_exception
 from posthog.models.user import User
 
 from products.managed_migrations.backend import trial_storage
@@ -257,7 +258,7 @@ class BatchImportS3SourceCreateSerializer(BatchImportTrialOptionsMixin, BatchImp
         has_secret_key = bool(data.get("secret_key"))
         has_role = bool(data.get("role_arn"))
 
-        if has_role and not self._is_iam_role_enabled():
+        if has_role and not (settings.MANAGED_MIGRATIONS_IMPORT_ROLE_ARN and self._is_iam_role_enabled()):
             raise serializers.ValidationError("IAM role authentication is not available for this project")
 
         if has_role and (has_access_key or has_secret_key):
@@ -293,8 +294,12 @@ class BatchImportS3SourceCreateSerializer(BatchImportTrialOptionsMixin, BatchImp
                 RoleSessionName="posthog-managed-migration-validation",
                 DurationSeconds=900,
             )["Credentials"]
-        except (ClientError, BotoCoreError):
+        except (ClientError, BotoCoreError) as err:
+            # PostHog-side failure (our role grant or STS), not the customer's setup: skip
+            # validation rather than block the create. The worker re-validates the full
+            # chain and pauses the job with an actionable message if the role is broken.
             logger.exception("managed_migrations_import_role_assume_failed")
+            capture_exception(err)
             return
 
         customer_sts = boto3.client(

--- a/products/managed_migrations/backend/api/test/test_batch_imports.py
+++ b/products/managed_migrations/backend/api/test/test_batch_imports.py
@@ -8,13 +8,19 @@ from django.contrib.messages import get_messages
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
-from django.test import RequestFactory
+from django.test import RequestFactory, SimpleTestCase
 
 from parameterized import parameterized
 
 from products.managed_migrations.backend import trial_storage
 from products.managed_migrations.backend.admin.batch_imports import BatchImportAdmin
-from products.managed_migrations.backend.models.batch_imports import BatchImport, BatchImportConfigBuilder, ContentType
+from products.managed_migrations.backend.api.batch_imports import BatchImportS3SourceCreateSerializer
+from products.managed_migrations.backend.models.batch_imports import (
+    BatchImport,
+    BatchImportConfigBuilder,
+    ContentType,
+    get_aws_external_id,
+)
 
 
 class TestBatchImportModel(BaseTest):
@@ -400,6 +406,140 @@ class TestBatchImportConfigBuilder(BaseTest):
             "generate_group_identify_events": True,
         }
         self.assertEqual(self.batch_import.import_config, expected_config)
+
+    @parameterized.expand([("s3", "from_s3"), ("s3_gzip", "from_s3_gzip")])
+    def test_from_s3_with_iam_role(self, _name, method):
+        getattr(self.batch_import.config, method)(
+            bucket="customer-bucket",
+            prefix="events/",
+            region="eu-west-1",
+            role_arn="arn:aws:iam::123456789012:role/PostHogImport",
+            external_id="posthog-us-test-uuid",
+        )
+
+        source = self.batch_import.import_config["source"]
+        self.assertEqual(source["type"], _name)
+        self.assertEqual(source["bucket"], "customer-bucket")
+        self.assertEqual(source["role_arn"], "arn:aws:iam::123456789012:role/PostHogImport")
+        self.assertEqual(source["external_id"], "posthog-us-test-uuid")
+        self.assertNotIn("access_key_id_key", source)
+        self.assertNotIn("secret_access_key_key", source)
+        self.assertIsNone(self.batch_import.secrets)
+
+    @parameterized.expand(
+        [
+            (
+                "role_and_keys",
+                {
+                    "role_arn": "arn:aws:iam::123456789012:role/R",
+                    "external_id": "ext",
+                    "access_key_id": "AK",
+                    "secret_access_key": "SK",
+                },
+                "Exactly one of access keys or role_arn",
+            ),
+            (
+                "role_and_endpoint",
+                {
+                    "role_arn": "arn:aws:iam::123456789012:role/R",
+                    "external_id": "ext",
+                    "endpoint_url": "http://minio:9000",
+                },
+                "only works with AWS S3",
+            ),
+            (
+                "role_without_external_id",
+                {"role_arn": "arn:aws:iam::123456789012:role/R"},
+                "external_id is required",
+            ),
+            (
+                "no_auth",
+                {},
+                "Exactly one of access keys or role_arn",
+            ),
+        ]
+    )
+    def test_from_s3_invalid_auth_combinations(self, _name, kwargs, expected_message):
+        with self.assertRaises(ValueError, msg=expected_message):
+            self.batch_import.config.from_s3(
+                bucket="b",
+                prefix="",
+                region="us-east-1",
+                **kwargs,
+            )
+
+
+class TestBatchImportS3AuthValidation(SimpleTestCase):
+    @parameterized.expand(
+        [
+            (
+                "role_only_valid",
+                {"role_arn": "arn:aws:iam::123456789012:role/PostHogImport"},
+                True,
+            ),
+            (
+                "keys_only_valid",
+                {"access_key": "AKIATEST", "secret_key": "secret123"},
+                True,
+            ),
+            (
+                "role_and_keys_rejected",
+                {"role_arn": "arn:aws:iam::123456789012:role/R", "access_key": "AK", "secret_key": "SK"},
+                False,
+            ),
+            (
+                "role_and_endpoint_rejected",
+                {"role_arn": "arn:aws:iam::123456789012:role/R", "endpoint_url": "http://minio:9000"},
+                False,
+            ),
+            (
+                "partial_keys_rejected",
+                {"access_key": "AK"},
+                False,
+            ),
+            (
+                "no_auth_rejected",
+                {},
+                False,
+            ),
+        ]
+    )
+    @patch.object(BatchImportS3SourceCreateSerializer, "_is_iam_role_enabled", return_value=True)
+    def test_auth_combination_validation(self, _name, auth_fields, should_be_valid, _mock_flag):
+        data = {
+            "source_type": "s3",
+            "content_type": "captured",
+            "s3_bucket": "test-bucket",
+            "s3_region": "us-east-1",
+            **auth_fields,
+        }
+        serializer = BatchImportS3SourceCreateSerializer(data=data)
+        self.assertEqual(serializer.is_valid(), should_be_valid, serializer.errors)
+
+    def test_invalid_role_arn_format_rejected(self):
+        data = {
+            "source_type": "s3",
+            "content_type": "captured",
+            "s3_bucket": "test-bucket",
+            "s3_region": "us-east-1",
+            "role_arn": "not-a-valid-arn",
+        }
+        serializer = BatchImportS3SourceCreateSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("role_arn", serializer.errors)
+
+    @patch.object(BatchImportS3SourceCreateSerializer, "_is_iam_role_enabled", return_value=False)
+    def test_role_arn_rejected_when_flag_off(self, _mock_flag):
+        data = {
+            "source_type": "s3",
+            "content_type": "captured",
+            "s3_bucket": "test-bucket",
+            "s3_region": "us-east-1",
+            "role_arn": "arn:aws:iam::123456789012:role/PostHogImport",
+        }
+        serializer = BatchImportS3SourceCreateSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("IAM role authentication is not available", str(serializer.errors))
 
 
 class TestBatchImportAdminActions(BaseTest):
@@ -968,6 +1108,73 @@ class TestBatchImportAPI(APIBaseTest):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()["attr"], "endpoint_url")
+
+    @patch("products.managed_migrations.backend.api.batch_imports.posthoganalytics.feature_enabled", return_value=True)
+    def test_s3_import_with_iam_role_creates_config_without_secrets(self, _mock_flag):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/managed_migrations",
+            {
+                "source_type": "s3",
+                "content_type": "captured",
+                "s3_bucket": "customer-bucket",
+                "s3_region": "eu-west-1",
+                "s3_prefix": "events/",
+                "role_arn": "arn:aws:iam::123456789012:role/PostHogImport",
+            },
+        )
+
+        self.assertEqual(response.status_code, 201, response.json())
+        batch_import = BatchImport.objects.get(id=response.json()["id"])
+        source = batch_import.import_config["source"]
+        self.assertEqual(source["role_arn"], "arn:aws:iam::123456789012:role/PostHogImport")
+        self.assertIn("external_id", source)
+        self.assertNotIn("access_key_id_key", source)
+        self.assertIsNone(batch_import.secrets)
+
+    @patch("products.managed_migrations.backend.api.batch_imports.posthoganalytics.feature_enabled", return_value=False)
+    def test_s3_import_with_role_rejected_when_flag_off(self, _mock_flag):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/managed_migrations",
+            {
+                "source_type": "s3",
+                "content_type": "captured",
+                "s3_bucket": "test-bucket",
+                "s3_region": "us-east-1",
+                "role_arn": "arn:aws:iam::123456789012:role/PostHogImport",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("not available", str(response.json()))
+
+    @patch("products.managed_migrations.backend.api.batch_imports.posthoganalytics.feature_enabled", return_value=True)
+    def test_aws_iam_setup_returns_policy_material(self, _mock_flag):
+        with self.settings(MANAGED_MIGRATIONS_IMPORT_ROLE_ARN="arn:aws:iam::999999999999:role/PostHogBatchImport"):
+            response = self.client.get(f"/api/projects/{self.team.id}/managed_migrations/aws_iam_setup")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data["available"])
+        self.assertEqual(data["external_id"], get_aws_external_id(self.team))
+        self.assertEqual(data["posthog_role_arn"], "arn:aws:iam::999999999999:role/PostHogBatchImport")
+        self.assertIn("sts:AssumeRole", data["trust_policy"])
+        self.assertIn("s3:GetObject", data["permission_policy_template"])
+
+    @patch("products.managed_migrations.backend.api.batch_imports.posthoganalytics.feature_enabled", return_value=True)
+    def test_aws_iam_setup_unavailable_without_role_arn_setting(self, _mock_flag):
+        with self.settings(MANAGED_MIGRATIONS_IMPORT_ROLE_ARN=""):
+            response = self.client.get(f"/api/projects/{self.team.id}/managed_migrations/aws_iam_setup")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["available"])
+
+    @patch("products.managed_migrations.backend.api.batch_imports.posthoganalytics.feature_enabled", return_value=False)
+    def test_aws_iam_setup_unavailable_when_flag_off(self, _mock_flag):
+        with self.settings(MANAGED_MIGRATIONS_IMPORT_ROLE_ARN="arn:aws:iam::999999999999:role/PostHogBatchImport"):
+            response = self.client.get(f"/api/projects/{self.team.id}/managed_migrations/aws_iam_setup")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.json()["available"])
 
 
 class TestBatchImportTrialAPI(APIBaseTest):

--- a/products/managed_migrations/backend/api/test/test_batch_imports.py
+++ b/products/managed_migrations/backend/api/test/test_batch_imports.py
@@ -460,7 +460,7 @@ class TestBatchImportConfigBuilder(BaseTest):
         ]
     )
     def test_from_s3_invalid_auth_combinations(self, _name, kwargs, expected_message):
-        with self.assertRaises(ValueError, msg=expected_message):
+        with self.assertRaisesRegex(ValueError, expected_message):
             self.batch_import.config.from_s3(
                 bucket="b",
                 prefix="",

--- a/products/managed_migrations/backend/api/test/test_batch_imports.py
+++ b/products/managed_migrations/backend/api/test/test_batch_imports.py
@@ -8,7 +8,7 @@ from django.contrib.messages import get_messages
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
-from django.test import RequestFactory, SimpleTestCase
+from django.test import RequestFactory, SimpleTestCase, override_settings
 
 from parameterized import parameterized
 
@@ -469,6 +469,7 @@ class TestBatchImportConfigBuilder(BaseTest):
             )
 
 
+@override_settings(MANAGED_MIGRATIONS_IMPORT_ROLE_ARN="arn:aws:iam::999999999999:role/PostHogBatchImport")
 class TestBatchImportS3AuthValidation(SimpleTestCase):
     @parameterized.expand(
         [
@@ -539,6 +540,20 @@ class TestBatchImportS3AuthValidation(SimpleTestCase):
         }
         serializer = BatchImportS3SourceCreateSerializer(data=data)
         self.assertFalse(serializer.is_valid())
+        self.assertIn("IAM role authentication is not available", str(serializer.errors))
+
+    @patch.object(BatchImportS3SourceCreateSerializer, "_is_iam_role_enabled", return_value=True)
+    def test_role_arn_rejected_when_import_role_unconfigured(self, _mock_flag):
+        data = {
+            "source_type": "s3",
+            "content_type": "captured",
+            "s3_bucket": "test-bucket",
+            "s3_region": "us-east-1",
+            "role_arn": "arn:aws:iam::123456789012:role/PostHogImport",
+        }
+        with override_settings(MANAGED_MIGRATIONS_IMPORT_ROLE_ARN=""):
+            serializer = BatchImportS3SourceCreateSerializer(data=data)
+            self.assertFalse(serializer.is_valid())
         self.assertIn("IAM role authentication is not available", str(serializer.errors))
 
 
@@ -1109,6 +1124,7 @@ class TestBatchImportAPI(APIBaseTest):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()["attr"], "endpoint_url")
 
+    @override_settings(MANAGED_MIGRATIONS_IMPORT_ROLE_ARN="arn:aws:iam::999999999999:role/PostHogBatchImport")
     @patch("products.managed_migrations.backend.api.batch_imports.posthoganalytics.feature_enabled", return_value=True)
     def test_s3_import_with_iam_role_creates_config_without_secrets(self, _mock_flag):
         response = self.client.post(

--- a/products/managed_migrations/backend/models/batch_imports.py
+++ b/products/managed_migrations/backend/models/batch_imports.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Self
+from typing import TYPE_CHECKING, Self
 
 from django.conf import settings
 from django.db import models
@@ -9,6 +9,14 @@ from posthog.models.activity_logging.model_activity import ModelActivityMixin
 from posthog.models.utils import UUIDTModel
 
 from products.managed_migrations.backend.models.batch_import_utils import redact_part_key
+
+if TYPE_CHECKING:
+    from posthog.models.team import Team
+
+
+def get_aws_external_id(team: "Team") -> str:
+    region = (settings.CLOUD_DEPLOYMENT or "dev").lower()
+    return f"posthog-{region}-{team.uuid}"
 
 
 class DateRangeExportSource(str, Enum):
@@ -171,7 +179,12 @@ class BatchImportConfigBuilder:
         self.batch_import = batch_import
         if initialize_empty:
             self.batch_import.import_config = {}
+            self.batch_import.secrets = None
+
+    def _store_secret(self, key: str, value: str | list[str]) -> None:
+        if self.batch_import.secrets is None:
             self.batch_import.secrets = {}
+        self.batch_import.secrets[key] = value
 
     def json_lines(self, content_type: ContentType, skip_blanks: bool = True) -> Self:
         self.batch_import.import_config["data_format"] = {
@@ -194,7 +207,50 @@ class BatchImportConfigBuilder:
             "allow_internal_ips": allow_internal_ips,
             "timeout_seconds": timeout_seconds,
         }
-        self.batch_import.secrets[urls_key] = urls
+        self._store_secret(urls_key, urls)
+        return self
+
+    def _s3_source(
+        self,
+        source_type: str,
+        bucket: str,
+        prefix: str,
+        region: str,
+        access_key_id: str | None,
+        secret_access_key: str | None,
+        role_arn: str | None,
+        external_id: str | None,
+        endpoint_url: str | None,
+        access_key_id_key: str,
+        secret_access_key_key: str,
+    ) -> Self:
+        source: dict = {
+            "type": source_type,
+            "bucket": bucket,
+            "prefix": prefix,
+            "region": region,
+        }
+        if role_arn:
+            if access_key_id is not None or secret_access_key is not None:
+                raise ValueError("Exactly one of access keys or role_arn must be provided for S3 sources")
+            if endpoint_url:
+                raise ValueError("IAM role authentication only works with AWS S3 endpoints")
+            if not external_id:
+                raise ValueError("external_id is required for IAM role authentication")
+            source["role_arn"] = role_arn
+            source["external_id"] = external_id
+        else:
+            if access_key_id is None or secret_access_key is None:
+                raise ValueError("Exactly one of access keys or role_arn must be provided for S3 sources")
+            source["access_key_id_key"] = access_key_id_key
+            source["secret_access_key_key"] = secret_access_key_key
+            self._store_secret(access_key_id_key, access_key_id)
+            self._store_secret(secret_access_key_key, secret_access_key)
+        if endpoint_url:
+            source["endpoint_url"] = endpoint_url
+            if settings.DEBUG:
+                source["allow_internal_ips"] = True
+        self.batch_import.import_config["source"] = source
         return self
 
     def from_s3(
@@ -202,62 +258,54 @@ class BatchImportConfigBuilder:
         bucket: str,
         prefix: str,
         region: str,
-        access_key_id: str,
-        secret_access_key: str,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+        role_arn: str | None = None,
+        external_id: str | None = None,
         endpoint_url: str | None = None,
         access_key_id_key: str = "aws_access_key_id",
         secret_access_key_key: str = "aws_secret_access_key",
     ) -> Self:
-        source: dict = {
-            "type": "s3",
-            "bucket": bucket,
-            "prefix": prefix,
-            "region": region,
-            "access_key_id_key": access_key_id_key,
-            "secret_access_key_key": secret_access_key_key,
-        }
-        if endpoint_url:
-            source["endpoint_url"] = endpoint_url
-            if settings.DEBUG:
-                # Local dev: let custom endpoints point at the dev stack
-                # (SeaweedFS on localhost) — the worker's SSRF guard blocks
-                # non-public IPs otherwise. Never set outside DEBUG.
-                source["allow_internal_ips"] = True
-        self.batch_import.import_config["source"] = source
-        self.batch_import.secrets[access_key_id_key] = access_key_id
-        self.batch_import.secrets[secret_access_key_key] = secret_access_key
-        return self
+        return self._s3_source(
+            "s3",
+            bucket,
+            prefix,
+            region,
+            access_key_id,
+            secret_access_key,
+            role_arn,
+            external_id,
+            endpoint_url,
+            access_key_id_key,
+            secret_access_key_key,
+        )
 
     def from_s3_gzip(
         self,
         bucket: str,
         prefix: str,
         region: str,
-        access_key_id: str,
-        secret_access_key: str,
+        access_key_id: str | None = None,
+        secret_access_key: str | None = None,
+        role_arn: str | None = None,
+        external_id: str | None = None,
         endpoint_url: str | None = None,
         access_key_id_key: str = "aws_access_key_id",
         secret_access_key_key: str = "aws_secret_access_key",
     ) -> Self:
-        source: dict = {
-            "type": "s3_gzip",
-            "bucket": bucket,
-            "prefix": prefix,
-            "region": region,
-            "access_key_id_key": access_key_id_key,
-            "secret_access_key_key": secret_access_key_key,
-        }
-        if endpoint_url:
-            source["endpoint_url"] = endpoint_url
-            if settings.DEBUG:
-                # Local dev: let custom endpoints point at the dev stack
-                # (SeaweedFS on localhost) — the worker's SSRF guard blocks
-                # non-public IPs otherwise. Never set outside DEBUG.
-                source["allow_internal_ips"] = True
-        self.batch_import.import_config["source"] = source
-        self.batch_import.secrets[access_key_id_key] = access_key_id
-        self.batch_import.secrets[secret_access_key_key] = secret_access_key
-        return self
+        return self._s3_source(
+            "s3_gzip",
+            bucket,
+            prefix,
+            region,
+            access_key_id,
+            secret_access_key,
+            role_arn,
+            external_id,
+            endpoint_url,
+            access_key_id_key,
+            secret_access_key_key,
+        )
 
     def from_date_range(
         self,
@@ -329,8 +377,8 @@ class BatchImportConfigBuilder:
             "base_url": base_url,
             **additional_config,
         }
-        self.batch_import.secrets[access_key_key] = access_key
-        self.batch_import.secrets[secret_key_key] = secret_key
+        self._store_secret(access_key_key, access_key)
+        self._store_secret(secret_key_key, secret_key)
         return self
 
     def to_stdout(self, as_json: bool = True) -> Self:

--- a/products/managed_migrations/backend/models/batch_imports.py
+++ b/products/managed_migrations/backend/models/batch_imports.py
@@ -249,6 +249,9 @@ class BatchImportConfigBuilder:
         if endpoint_url:
             source["endpoint_url"] = endpoint_url
             if settings.DEBUG:
+                # Local dev: let custom endpoints point at the dev stack
+                # (SeaweedFS on localhost) — the worker's SSRF guard blocks
+                # non-public IPs otherwise. Never set outside DEBUG.
                 source["allow_internal_ips"] = True
         self.batch_import.import_config["source"] = source
         return self

--- a/products/managed_migrations/frontend/generated/api.schemas.ts
+++ b/products/managed_migrations/frontend/generated/api.schemas.ts
@@ -379,6 +379,22 @@ export interface TrialRecordsResponseApi {
     summary: unknown
 }
 
+/**
+ * Values a customer needs to configure cross-account IAM role access for S3 imports.
+ */
+export interface BatchImportAWSIAMSetupApi {
+    /** Whether IAM role authentication is available on this PostHog deployment. */
+    available: boolean
+    /** External ID to pin in the role trust policy's sts:ExternalId condition. Stable per project. */
+    external_id: string
+    /** ARN of PostHog's import role -- the principal your role must trust. */
+    posthog_role_arn: string
+    /** Ready-to-paste IAM trust policy JSON for the role in your AWS account. */
+    trust_policy: string
+    /** IAM permission policy JSON template; replace YOUR_BUCKET and YOUR_PREFIX with your values. */
+    permission_policy_template: string
+}
+
 export type ManagedMigrationsSupportListParams = {
     /**
      * Number of results to return per page.

--- a/products/managed_migrations/frontend/generated/api.ts
+++ b/products/managed_migrations/frontend/generated/api.ts
@@ -9,6 +9,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    BatchImportAWSIAMSetupApi,
     BatchImportApi,
     BatchImportResponseApi,
     BatchImportSupportDetailApi,
@@ -298,6 +299,23 @@ export const managedMigrationsTrialRecordsRetrieve = async (
     options?: RequestInit
 ): Promise<TrialRecordsResponseApi> => {
     return apiMutator<TrialRecordsResponseApi>(getManagedMigrationsTrialRecordsRetrieveUrl(projectId, id, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getManagedMigrationsAwsIamSetupRetrieveUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/managed_migrations/aws_iam_setup/`
+}
+
+/**
+ * Values needed to set up cross-account IAM role access for S3 imports: the external ID, PostHog's import role ARN, and ready-to-paste trust/permission policy JSON.
+ */
+export const managedMigrationsAwsIamSetupRetrieve = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<BatchImportAWSIAMSetupApi> => {
+    return apiMutator<BatchImportAWSIAMSetupApi>(getManagedMigrationsAwsIamSetupRetrieveUrl(projectId), {
         ...options,
         method: 'GET',
     })

--- a/products/managed_migrations/mcp/tools.yaml
+++ b/products/managed_migrations/mcp/tools.yaml
@@ -9,6 +9,9 @@ feature: managed_migrations
 url_prefix: /managed_migrations
 ui_apps: {}
 tools:
+    managed-migrations-aws-iam-setup-retrieve:
+        operation: managed_migrations_aws_iam_setup_retrieve
+        enabled: false
     managed-migrations-create:
         operation: managed_migrations_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -12252,6 +12252,22 @@ export namespace Schemas {
       readonly import_config: unknown;
     }
 
+    /**
+     * Values a customer needs to configure cross-account IAM role access for S3 imports.
+     */
+    export interface BatchImportAWSIAMSetup {
+      /** Whether IAM role authentication is available on this PostHog deployment. */
+      available: boolean;
+      /** External ID to pin in the role trust policy's sts:ExternalId condition. Stable per project. */
+      external_id: string;
+      /** ARN of PostHog's import role -- the principal your role must trust. */
+      posthog_role_arn: string;
+      /** Ready-to-paste IAM trust policy JSON for the role in your AWS account. */
+      trust_policy: string;
+      /** IAM permission policy JSON template; replace YOUR_BUCKET and YOUR_PREFIX with your values. */
+      permission_policy_template: string;
+    }
+
     export interface BatchImportPartsProgress {
       /** Number of finished parts (a part is done when its committed byte offset has reached its known total size). */
       done: number;


### PR DESCRIPTION
## Problem

To import events from S3, customers currently have to paste long-lived AWS access keys into PostHog. Keys like that don't expire, people forget to rotate them, and if they leak, whoever has them can read the customer's bucket.

The standard way to give a vendor access to an S3 bucket is an IAM role instead. The customer creates a role in their own AWS account that says "PostHog's importer may read this one bucket". No keys change hands, AWS issues short-lived credentials each time, and the customer can cut off access at any moment by deleting the role.

## Changes

Backend support for IAM role auth on S3 batch imports. It is off for everyone until the `managed-migrations-iam-role-auth` feature flag is turned on, and the flag is enforced by the API itself, not just hidden in the UI. With the flag off (or not defined at all), role requests get a 400 and nothing new is visible.

How it works:

- When creating an S3 import you can now pass a role ARN instead of access keys. One or the other, never both.
- A new `aws_iam_setup` endpoint returns everything the customer needs to set up the role on their side: a trust policy to copy and paste, a permission policy template scoped to their bucket and prefix, and an external ID.
- The external ID is generated by us and unique per project. It's what stops one customer from pointing an import at another customer's role, because the customer pins it in their trust policy and we always send the one belonging to the project that created the import.
- Imports that use a role store no secrets at all. There are simply no keys to save, which is the point of the feature.
- Optionally the API can check at creation time that the role actually works, by assuming it and listing one object in the bucket. That way a broken setup fails immediately with a helpful message instead of when the import starts. This is behind the `MANAGED_MIGRATIONS_VALIDATE_ROLE_ON_CREATE` setting since our API pods need AWS permissions for it first.

Two new settings: `MANAGED_MIGRATIONS_IMPORT_ROLE_ARN` (the PostHog-owned role that customers trust) and the validation toggle above.

The worker side of this (actually assuming the role and reading the bucket) is already on master. The frontend form is stacked on top in #69077.

## How did you test this code?

The full batch imports test file passes locally (105 tests). New coverage:

- Config builder: a role-based import writes the role ARN and external ID into the config and leaves secrets empty, and invalid combinations (role plus keys, role plus custom endpoint, role without external ID, no auth at all) raise with the right message.
- Serializer validation: a parameterized matrix of role only, keys only, both, neither, and partial keys, checked without a database.
- Flag gating: creating with a role ARN is rejected when the flag is off, and `aws_iam_setup` reports unavailable when either the flag or the role ARN setting is missing.
- One end-to-end API test that a role-based create produces the right config and no secrets row.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A for now. The feature is behind a flag, docs will follow with the frontend rollout.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Ported from an earlier branch and put behind a feature flag so it can be tested before customer rollout. Used the /improving-drf-endpoints, /django-migrations, and /writing-tests skills. Validation matrix uses SimpleTestCase since DRF field validation needs no database, with one DB-backed test as the wiring guard. A later review session tightened the invalid-combination tests to assert the actual error messages, restored the MCP tools.yaml registration lost in a rebase, and regenerated the OpenAPI types on a current master base so the PR no longer carries a bulk regen.
