### PR TITLE
fix(warehouse_sources): stop retrying metabase syncs on unresolvable host

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/source.py
@@ -133,6 +133,11 @@ The API key (or user) needs read access to the data you want to sync.""",
             "403 Client Error": "Your Metabase credentials lack the permissions needed to sync this data. Grant read access and reconnect.",
             HOST_NOT_ALLOWED_ERROR: "The Metabase host is not allowed. Please use your instance's public URL.",
             SESSION_RESPONSE_NOT_JSON_ERROR: "Metabase didn't return a valid session response. Check that the Instance URL points to your Metabase instance, then reconnect.",
+            # `_is_host_safe` raises this when the Instance URL doesn't resolve via DNS — a
+            # hostname the customer typed wrong or one that's no longer publicly reachable.
+            # Deterministic and permanent until the Instance URL is corrected, so stop
+            # retrying. Match the stable prefix, not the customer's hostname that follows it.
+            "Couldn't resolve the host": "The Metabase Instance URL could not be resolved via DNS. Check that it's spelled correctly and reachable from the public internet, then reconnect.",
         }
 
     def _build_auth(self, config: MetabaseSourceConfig) -> MetabaseAuth:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase_source.py
@@ -1,3 +1,4 @@
+import socket
 from typing import Literal
 
 import pytest
@@ -5,6 +6,7 @@ from unittest import mock
 
 from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldSelectConfig
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import _is_host_safe
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.metabase import (
     MetabaseAuthMethodConfig,
     MetabaseSourceConfig,
@@ -67,10 +69,42 @@ class TestMetabaseSource:
 
     @pytest.mark.parametrize(
         "expected_key",
-        ["401 Client Error", "403 Client Error", "Invalid Metabase credentials", SESSION_RESPONSE_NOT_JSON_ERROR],
+        [
+            "401 Client Error",
+            "403 Client Error",
+            "Invalid Metabase credentials",
+            SESSION_RESPONSE_NOT_JSON_ERROR,
+            "Couldn't resolve the host",
+        ],
     )
     def test_non_retryable_errors(self, expected_key):
         assert expected_key in self.source.get_non_retryable_errors()
+
+    def test_dns_resolution_failure_message_is_classified_non_retryable(self):
+        # `_is_host_safe` raises this exact message when the Instance URL doesn't resolve via
+        # DNS — a permanent, deterministic failure until it's corrected. Build the message via
+        # the real `_is_host_safe` code path (not a hand-typed copy) so this test breaks if
+        # either side's wording drifts from the classifier's key.
+        with (
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins.is_cloud",
+                return_value=True,
+            ),
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins.get_instance_region",
+                return_value="US",
+            ),
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins.socket.getaddrinfo",
+                side_effect=socket.gaierror,
+            ),
+        ):
+            ok, err = _is_host_safe("nonexistent.example", team_id=999)
+
+        assert not ok
+        assert err is not None
+        non_retryable = self.source.get_non_retryable_errors()
+        assert any(key in err for key in non_retryable)
 
     def test_get_schemas_returns_all_endpoints(self):
         schemas = self.source.get_schemas(self.config, self.team_id)


### PR DESCRIPTION
## Problem

Error tracking surfaced [`MetabaseHostNotAllowedError`](https://us.posthog.com/project/2/error_tracking/019f910e-d2d6-73d3-b337-8a2329e35633): `Couldn't resolve the host '<redacted>'. Check that it's spelled correctly and reachable from the public internet.`, raised from `get_rows` in `products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py:274`.

This fires when `_is_host_safe` (`products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py`) can't resolve the customer's configured Metabase Instance URL via DNS — a typo'd or no-longer-reachable hostname. That's a permanent, customer-side configuration problem: retrying re-runs the same DNS lookup and fails identically every time, so the sync just burns activity budget until it's marked as a stale error.

## Changes

Add the stable `_is_host_safe` DNS-failure message prefix (`"Couldn't resolve the host"`, excluding the variable hostname) to `MetabaseSource.get_non_retryable_errors()`, so the sync stops retrying and surfaces an actionable message pointing the user at the Instance URL field.

This mirrors the identical fix already shipped for the custom REST source in [#73363](https://github.com/PostHog/posthog/pull/73363), which hits the same `_is_host_safe` helper.

## How did you test this code?

Extended the existing parametrized `test_non_retryable_errors` case in `test_metabase_source.py` with the new key, and added `test_dns_resolution_failure_message_is_classified_non_retryable`, which drives the real `_is_host_safe` code path (mocking only `is_cloud`, `get_instance_region`, and `socket.getaddrinfo`) to build the actual DNS-failure message and assert it's classified as non-retryable — this guards against the classifier key and `_is_host_safe`'s wording drifting apart, which the plain dict-membership check wouldn't catch.

Ran:
```
uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/ -q
```
70 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal retry-classification change, no user-facing behavior or documented workflow changes beyond the error message shown for this specific failure.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triggered by an error-tracking webhook alert for a `MetabaseHostNotAllowedError` occurrence. Investigated via the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the stack trace originates in this source's code, then read the Metabase source and its shared `_is_host_safe` host-validation helper.
- Checked for duplicate work first: searched open PRs by exception type, message phrase, and module path, and scanned the maintainer's own open PRs. Found #73363 fixes the same underlying `_is_host_safe` DNS-failure message but only for the `custom` REST source — Metabase was untouched, so this PR extends the same fix there.
- Decision: classified as a user/upstream configuration error (unresolvable customer-typed host), not a transient infra issue, per the precedent already established for other sources (MySQL, and now the custom source) that treat this exact `_is_host_safe` message as non-retryable.
- No skills were invoked beyond `/writing-tests` before adding test coverage.