### PR TITLE
fix(data-imports): retry transient redis blips before failing closed on v3 pipeline lock

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/sync_lock.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/sync_lock.py
@@ -8,6 +8,7 @@ from django.conf import settings
 
 import redis
 import structlog
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from posthog.exceptions_capture import capture_exception
 from posthog.redis import get_client
@@ -42,8 +43,22 @@ def _lock_meta_key(team_id: int, schema_id: str) -> str:
     return f"{LOCK_META_KEY_PREFIX}:{team_id}:{schema_id}"
 
 
+@retry(
+    retry=retry_if_exception_type((redis.exceptions.ConnectionError, redis.exceptions.TimeoutError)),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential_jitter(initial=0.1, max=1),
+    reraise=True,
+)
+def _connect_and_ping(redis_client: redis.Redis) -> None:
+    redis_client.ping()
+
+
 @contextmanager
 def _get_redis_client() -> Generator[redis.Redis | None]:
+    # The acquire/release activities run with a single Temporal attempt (see
+    # external_data_job.py), so a bare DNS/connection blip here has no outer retry
+    # and would skip the whole scheduled sync run. Absorb a few quick retries before
+    # falling back to the fail-closed/fail-silent behavior callers rely on.
     redis_client = None
     try:
         if not settings.DATA_WAREHOUSE_REDIS_HOST or not settings.DATA_WAREHOUSE_REDIS_PORT:
@@ -52,7 +67,7 @@ def _get_redis_client() -> Generator[redis.Redis | None]:
             )
 
         redis_client = get_client(f"redis://{settings.DATA_WAREHOUSE_REDIS_HOST}:{settings.DATA_WAREHOUSE_REDIS_PORT}/")
-        redis_client.ping()
+        _connect_and_ping(redis_client)
     except Exception as e:
         logger.exception("redis_unavailable_for_v3_pipeline_lock", error=str(e))
         capture_exception(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/test_sync_lock.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/test_sync_lock.py
@@ -1,8 +1,11 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
+import redis
+
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.sync_lock import (
     LOCK_TTL_SECONDS,
+    _get_redis_client,
     _lock_key,
     acquire_v3_pipeline_lock,
     get_v3_pipeline_lock_holder,
@@ -122,3 +125,28 @@ class TestReleaseV3PipelineLock:
         mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
 
         assert release_v3_pipeline_lock(1, "s-1", "tok-1") is False
+
+
+class TestGetRedisClient:
+    """The acquire/release activities run with a single Temporal attempt, so a bare
+    DNS/connection blip previously skipped the whole scheduled sync run with no retry."""
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.sync_lock.get_client")
+    def test_recovers_from_transient_connection_error(self, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_redis.ping.side_effect = [redis.exceptions.ConnectionError("Temporary failure in name resolution"), None]
+        mock_get_client.return_value = mock_redis
+
+        with _get_redis_client() as client:
+            assert client is mock_redis
+        assert mock_redis.ping.call_count == 2
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.sync_lock.get_client")
+    def test_fails_closed_after_exhausting_retries(self, mock_get_client: MagicMock) -> None:
+        mock_redis = MagicMock()
+        mock_redis.ping.side_effect = redis.exceptions.ConnectionError("Temporary failure in name resolution")
+        mock_get_client.return_value = mock_redis
+
+        with _get_redis_client() as client:
+            assert client is None
+        assert mock_redis.ping.call_count == 3


### PR DESCRIPTION
## Problem

Error tracking caught a `ConnectionError` (`gaierror`: temporary DNS name resolution failure) connecting to the dedicated data-warehouse Redis instance, raised from `_get_redis_client` in `sync_lock.py`. This helper backs the v3 pipeline's distributed sync lock (acquire/release/holder lookups).

The acquire/release Temporal activities that call into this run with `RetryPolicy(maximum_attempts=1)` (see `external_data_job.py`), and `_get_redis_client` itself never raises: on any connection failure it swallows the exception, logs, reports to error tracking, and returns `None`. Callers then fail closed — `acquire_v3_pipeline_lock_activity` treats a `None` client as "lock not acquired" and the whole scheduled sync is skipped for that run. So a single transient DNS/connection blip (which resolves in the next moment) had no retry anywhere in the path and caused an entire sync to be skipped rather than just that one connection attempt.

This event was a single occurrence with no `warehouse_sources_*` source/schema context — it fired from the shared lock helper, not from a specific connector, and the same error class (`ConnectionError`/`OSError`) is already classified as transient elsewhere in this pipeline (`retry_tracker.py`'s `TRANSIENT_ERRORS`, used for the data-loading retry budget). Treating it as non-retryable here would be inconsistent with that precedent, and it isn't a permanent/user-facing failure, so it doesn't belong in `NonRetryableErrors`.

## Changes

- Wrap the Redis connect+ping step in `_get_redis_client` with a small `tenacity` retry (3 attempts, short exponential backoff with jitter) scoped to `redis.exceptions.ConnectionError` / `redis.exceptions.TimeoutError`.
- Behavior is unchanged once retries are exhausted: still logs, still reports to error tracking, still returns `None`, and callers still fail closed/silently exactly as before. This only absorbs a transient blip that would otherwise resolve on its own before the whole activity gives up.

## How did you test this code?

Added `TestGetRedisClient` in `test_sync_lock.py`:
- `test_recovers_from_transient_connection_error` — `ping()` raises `ConnectionError` once then succeeds; asserts the context manager yields a usable client instead of `None`. This is the regression: previously any single blip meant `None` and a skipped sync.
- `test_fails_closed_after_exhausting_retries` — `ping()` always raises; asserts the context manager still yields `None` after 3 attempts, preserving the existing fail-closed guarantee.

Ran the full `test_sync_lock.py` suite (16 tests) plus `ruff check`/`ruff format` on both changed files — all green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or API changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code from a production error-tracking alert on this exact `ConnectionError`/DNS-resolution issue. Investigated via the PostHog error-tracking MCP tools to pull the stack trace, event properties, and occurrence count, then traced the call path from the Temporal activity's retry policy down into `_get_redis_client` to confirm the activity itself never sees a raised exception (so bumping the activity's retry policy alone would not have helped) — the fix had to sit inside the helper that swallows the error. Invoked `/writing-tests` before adding the regression test to apply the value gate. Checked open PRs and the maintainer's own queue for a prior fix to this exact path before opening this one; found related-but-distinct work on customer-source DNS failures (`sources/common/mixins.py`) and on a separate `row_tracking.py` Redis helper, neither of which touches `sync_lock.py`.