### PR TITLE
fix(data-imports): classify DB connection blips as transient in pre-write maintenance

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -21,7 +21,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arr
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.cdp_producer import CDPProducer
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper import (
     DeltaTableHelper,
-    is_transient_delta_maintenance_error,
+    is_transient_maintenance_error,
     is_transient_object_store_error,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.person_property_row_sink import (
@@ -705,10 +705,10 @@ async def run_pre_write_defensive_compact(
     the CDC post-load path in `common/load.py` writes the same watermark, and both merge
     via `update_sync_type_config_keys` under a row lock. Wrapped in try/except so a
     maintenance failure never blocks the actual sync; the original error path is unaffected.
-    A transient object-store error (see `is_transient_object_store_error`) or a racy
-    concurrent-maintenance DeltaError (see `is_transient_delta_maintenance_error`) is
-    logged at warning instead of captured — the next sync's maintenance pass retries it
-    from scratch, so neither is a bug in this function.
+    A transient infra error (see `is_transient_maintenance_error`) — an object-store hiccup, a racy
+    concurrent-maintenance DeltaError, or an app-DB connection blip — is logged at warning instead of
+    captured. The next sync's maintenance pass retries it from scratch, so it isn't a bug in this
+    function, just a temporary blip talking to our own S3 bucket, delta table, or app DB.
 
     Used by both `PipelineNonDLT.run` (v2) and `PipelineV3.run` to keep the behaviour
     identical across pipelines without each having to know how to look up `partition_count`
@@ -732,8 +732,8 @@ async def run_pre_write_defensive_compact(
                 schema.id, schema.team_id, updates={"last_vacuum_version": new_version}
             )
     except Exception as e:
-        if is_transient_object_store_error(e) or is_transient_delta_maintenance_error(e):
-            await logger.awarning(f"Pre-write maintenance skipped: transient error: {e}")
+        if is_transient_maintenance_error(e):
+            await logger.awarning(f"Pre-write maintenance skipped: transient infra error: {e}")
             return
         capture_exception(e)
         await logger.aexception(f"Pre-write maintenance failed: {e}", exc_info=e)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -5,6 +5,8 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from django.db import InterfaceError, OperationalError
+
 import deltalake.exceptions
 from asgiref.sync import async_to_sync
 from parameterized import parameterized
@@ -225,6 +227,30 @@ class TestRunPreWriteDefensiveCompact:
             "Object at location .../part-0.parquet not found: 404 Not Found"
         )
         helper = MagicMock(run_maintenance=AsyncMock(side_effect=error))
+        logger = MagicMock(aexception=AsyncMock(), awarning=AsyncMock())
+
+        schema = MagicMock(partition_count=5, sync_type_config={})
+        with patch(f"{_EXTRACT_MODULE}.capture_exception") as mock_capture:
+            await run_pre_write_defensive_compact(helper, schema, MagicMock(partition_count=None), logger)
+
+        mock_capture.assert_not_called()
+        logger.awarning.assert_awaited_once()
+        logger.aexception.assert_not_awaited()
+
+    @parameterized.expand(
+        [
+            ("dns_resolution_failure", OperationalError, "[Errno -2] Name or service not known"),
+            ("pooler_dropped_connection", InterfaceError, "connection already closed"),
+        ]
+    )
+    @pytest.mark.asyncio
+    async def test_logs_transient_db_connection_error_without_capturing(
+        self, _name: str, error_cls: type[Exception], error_message: str
+    ):
+        # A DNS/pooler blip hit while resolving `job.folder_path()` on a pooled app-DB connection
+        # (e.g. inside `_get_delta_table_uri`) isn't a maintenance bug either — same treatment as
+        # the object-store blips above, so a self-healing retry doesn't flood error tracking.
+        helper = MagicMock(run_maintenance=AsyncMock(side_effect=error_cls(error_message)))
         logger = MagicMock(aexception=AsyncMock(), awarning=AsyncMock())
 
         schema = MagicMock(partition_count=5, sync_type_config={})

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Sequence
 from typing import Any, Literal
 
 from django.conf import settings
+from django.db import InterfaceError, OperationalError
 
 import numpy as np
 import pyarrow as pa
@@ -107,6 +108,20 @@ def is_transient_delta_maintenance_error(error: BaseException) -> bool:
 # _purge_s3_prefix is idempotent (every step is existence-gated), so retrying it whole after a brief
 # backoff is as safe as retrying a single failed call, and simpler.
 _PURGE_S3_PREFIX_MAX_ATTEMPTS = 4
+
+
+def is_transient_maintenance_error(error: BaseException) -> bool:
+    """Infra blips seen during pre-write maintenance that aren't a maintenance bug.
+
+    Covers S3/object-store hiccups reaching our own data-warehouse bucket (see
+    `is_transient_object_store_error` above), racy concurrent-maintenance DeltaErrors (see
+    `is_transient_delta_maintenance_error` above), and app-DB connection blips (DNS, pooler drops) hit
+    while resolving `job.folder_path()` on a pooled connection — the same `OperationalError`/`InterfaceError`
+    classification used for this failure class in `repartition_table.py`'s `_is_transient_infra_error`.
+    """
+    if isinstance(error, OperationalError | InterfaceError):
+        return True
+    return is_transient_object_store_error(error) or is_transient_delta_maintenance_error(error)
 
 
 def _delta_merge_spill_kwargs() -> dict[str, int]:


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError: [Errno -2] Name or service not known` from `products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py`, with the top in-app frame in `ExternalDataSchema.folder_path`.

The call chain: `run_pre_write_defensive_compact` -> `DeltaTableHelper.run_maintenance` -> `compact_if_fragmented` -> `get_delta_table` -> `_get_delta_table_uri`, which resolves the Delta table's S3 URI via `job.folder_path()` — a Django ORM lookup that traverses `job.schema` and `schema.source` FKs on a pooled app-DB connection. A DNS/pooler blip while opening that connection raised the `OperationalError`.

This is a transient, self-healing infra blip, not a maintenance bug: `run_pre_write_defensive_compact` already catches every exception and skips a matching *transient* one with a quiet warning (the next sync's maintenance pass just retries from scratch). But the existing classifier (`is_transient_object_store_error`) only recognized S3/object-store `OSError`s from delta-rs, so this DB-connection error fell through to `capture_exception` instead — noise in error tracking for something that isn't a code defect.

The same failure class (Postgres `OperationalError`/`InterfaceError` from a transient connection blip) is already classified as transient infra elsewhere in this tree, in `repartition_table.py`'s `_is_transient_infra_error`.

## Changes

- Added `is_transient_maintenance_error` in `delta_table_helper.py`, which treats `django.db.OperationalError`/`InterfaceError` as transient on top of the existing S3/object-store substring matches. It delegates to `is_transient_object_store_error`, which stays unchanged so its other object-store-specific callers (`get_delta_table`, `reset_table`, CDC load) keep their narrower classification.
- Updated `extract.py`'s `run_pre_write_defensive_compact` to use the broadened `is_transient_maintenance_error` classifier.

I found an open PR ([#71934](https://github.com/PostHog/posthog/pull/71934)) that reduces how often this call path issues the underlying lazy DB query in the first place (via `select_related` + memoization). That's a complementary root-cause fix for the redundant query; it doesn't touch this classifier, so this change still closes the gap for connection blips on the remaining DB round-trip. I also found two open PRs ([#69787](https://github.com/PostHog/posthog/pull/69787), [#69309](https://github.com/PostHog/posthog/pull/69309)) that suppress transient DNS/DB errors at the Temporal activity-interceptor level — those cover *uncaught* activity failures. This error never reaches that interceptor: it's caught and manually reported inside `run_pre_write_defensive_compact` itself, so those PRs don't cover this code path.

## How did you test this code?

Extended `TestRunPreWriteDefensiveCompact` in `test_extract.py` with `test_logs_transient_db_connection_error_without_capturing`, parameterized over `OperationalError` (DNS failure) and `InterfaceError` (dropped pooler connection) — asserts `capture_exception` is skipped and a warning is logged instead, mirroring the existing S3/object-store transient-error test right above it. This locks in the exact regression this PR fixes: without the classifier change, both cases would fall through to `capture_exception` again.

Ran:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py -k TestRunPreWriteDefensiveCompact` — 9 passed
- `uv run mypy --cache-fine-grained` on the three changed files — clean
- `ruff check --fix` / `ruff format` — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification change, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaging a webhook-delivered error tracking issue. Used the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace, then an Explore subagent to read `posthog/sync.py`, the `folder_path` property chain, `delta_table_helper.py`, and existing `NonRetryableErrors`/transient-error precedent across the pipeline. Confirmed the DB round-trip and precedent (`repartition_table.py`'s `_is_transient_infra_error`) directly before writing the fix. Invoked `/writing-tests` before adding the regression test. Checked for duplicate open PRs by exception type, message phrase, module path, and the maintainer's own open PRs — found related-but-non-overlapping work (see Changes section) rather than a duplicate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
