### PR TITLE
fix(data-imports): stop reporting billing-check redis blips to error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/row_tracking.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/row_tracking.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.db.models import F, Q, Sum
 
 from dateutil import parser
+from redis import exceptions as redis_exceptions
 from structlog.types import FilteringBoundLogger
 
 from posthog.cloud_utils import get_cached_instance_license
@@ -233,6 +234,13 @@ async def will_hit_billing_limit(team_id: int, source: "ExternalDataSource", log
         )
 
         return result
+    except redis_exceptions.RedisError as e:
+        # The billing check already fails open, so a Redis connectivity blip (e.g. a
+        # DNS resolution failure reaching the quota-limiting cache) shouldn't be reported
+        # as an error-tracking issue.
+        await logger.awarning(f"BillingLimits: Redis error while checking billing limits, failing open: {e}")
+
+        return False
     except Exception as e:
         await logger.adebug(f"BillingLimits: Failed with exception {e}")
         capture_exception(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_row_tracking.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_row_tracking.py
@@ -12,6 +12,7 @@ from unittest import mock
 from django.test import override_settings
 
 from asgiref.sync import sync_to_async
+from redis import exceptions as redis_exceptions
 from structlog.types import FilteringBoundLogger
 
 from posthog.models import Team
@@ -195,3 +196,25 @@ class TestRowTracking(BaseTest):
 
         async with self._setup_redis_rows(20, team_id=another_team.pk):
             assert await self._run(source, 10) is True
+
+    @pytest.mark.asyncio
+    async def test_row_tracking_fails_open_on_redis_error_without_capturing_exception(self):
+        # A transient Redis connectivity blip while fetching billing data (e.g. a DNS
+        # resolution failure reaching the quota-limiting cache) must fail open like any
+        # other billing-check error, but shouldn't be reported to error tracking since
+        # the check already tolerates it.
+        source = await self._create_source()
+
+        with (
+            mock.patch("ee.billing.billing_manager.BillingManager.get_billing") as mock_get_billing,
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.row_tracking.capture_exception"
+            ) as mock_capture_exception,
+        ):
+            mock_get_billing.side_effect = redis_exceptions.ConnectionError(
+                "Error -3 connecting to redis:6379. Temporary failure in name resolution."
+            )
+
+            assert await self._run(source, 10) is False
+
+        mock_capture_exception.assert_not_called()


### PR DESCRIPTION
## Problem

PostHog error tracking caught a `ConnectionError` (`gaierror`: temporary DNS resolution failure) raised from `remove_limited_team_tokens` in `ee/billing/quota_limiting.py`, connecting to the billing-quota-limiting Redis instance.

The call path: the data-warehouse import pipeline's `will_hit_billing_limit` (`products/warehouse_sources/backend/temporal/data_imports/row_tracking.py`) checks whether a sync would exceed the org's billing limit. As part of fetching billing data, it calls into `BillingManager.get_billing()`, which as a side effect calls `update_org_details()` → `update_org_billing_quotas()` → `remove_limited_team_tokens()`, writing to a Redis sorted set. A transient DNS/connectivity blip reaching that Redis instance surfaced here.

`will_hit_billing_limit` already wraps this whole call in a broad `try/except Exception` that fails open (returns `False`, so the sync proceeds as if the org isn't over its limit) and reports every exception via `capture_exception`. So this specific blip never broke a sync — it just generated error-tracking noise for a connectivity hiccup the function was already designed to tolerate. This matches a pattern already fixed for other Redis call sites in this same pipeline (row tracking's own dedicated Redis client, and the v3 pipeline sync lock).

## Changes

- In `will_hit_billing_limit`, catch `redis.exceptions.RedisError` before the generic `Exception` handler and log a warning instead of calling `capture_exception`. Behavior is otherwise unchanged: the function still fails open and returns `False`.
- Genuinely unexpected exceptions (anything not a `RedisError`) still go to `capture_exception` as before.

## How did you test this code?

Added `test_row_tracking_fails_open_on_redis_error_without_capturing_exception` to `test_row_tracking.py`: mocks `BillingManager.get_billing` to raise `redis.exceptions.ConnectionError` and asserts `will_hit_billing_limit` still returns `False` while `capture_exception` is never called. No existing test exercised this exception path — every other test in the file runs against a working billing/Redis mock.

I (Claude) couldn't run the Django test suite in this sandbox (no reachable Postgres). I verified: `ruff check` and `ruff format --check` pass on both changed files, both files compile (`py_compile`), and `redis.exceptions.ConnectionError` is confirmed to subclass `redis.exceptions.RedisError` (so the new `except` clause actually catches it) via `python -c`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or API changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code from a production error-tracking alert on this exact `ConnectionError`/DNS-resolution issue. Investigated via the PostHog error-tracking MCP tools to pull the stack trace and occurrence count, then traced the call path from `will_hit_billing_limit` down through `ee.billing` into the Redis write that failed, confirming the exception was already fully swallowed before reaching the Temporal activity boundary (so this is error-tracking noise, not a broken sync). Invoked `/writing-tests` before adding the regression test to apply the value gate. Checked open PRs and the maintainer's own queue for a prior fix first — found related-but-distinct work on other Redis call sites in this pipeline (the dedicated row-tracking Redis client, and the v3 pipeline sync lock), neither of which touches this billing-quota code path.