### PR TITLE
fix(mongodb): classify DNS SRV lifetime timeout as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
@@ -151,6 +151,16 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             "Topology Description:": _MONGO_UNREACHABLE_MESSAGE,
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # For a `mongodb+srv://` URI, pymongo resolves the SRV record via dnspython inside the
+        # MongoClient constructor, before any of our own connectivity handling runs. dnspython
+        # already retries across nameservers for the whole resolution lifetime before giving up
+        # with a ConfigurationError wrapping its LifetimeTimeout — a momentary DNS blip on the
+        # resolver PostHog's worker queries, unrelated to the user's cluster hostname — so Temporal
+        # retrying the whole activity is self-recovering. Match dnspython's fixed message prefix,
+        # not the variable timeout duration or nameserver address it's followed by.
+        return {"The resolution lifetime expired"}
+
     def get_schemas(
         self,
         config: MongoDBSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -463,6 +463,27 @@ class TestMongoDBNonRetryableErrors(SimpleTestCase):
         assert expected_substring in message.lower()
 
 
+class TestGetRetryableErrors(SimpleTestCase):
+    """DNS SRV resolution for `mongodb+srv://` happens inside the MongoClient constructor, before
+    any of our own connectivity handling runs. dnspython already retries across nameservers for
+    the whole resolution lifetime before giving up, so once Temporal retries the whole activity
+    the failure is self-recovering and must not flood error tracking as an exception."""
+
+    def setUp(self):
+        from products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source import MongoDBSource
+
+        self.retryable = MongoDBSource().get_retryable_errors()
+
+    def test_dns_lifetime_timeout_is_classified_retryable(self):
+        error_msg = (
+            "The resolution lifetime expired after 20.763 seconds: Server Do53:10.0.0.53@53 "
+            "answered The DNS operation timed out."
+        )
+        assert any(pattern in error_msg for pattern in self.retryable), (
+            f"MongoDB DNS SRV resolution timeout should be classified retryable: {error_msg}"
+        )
+
+
 class TestGetRowsToSync(SimpleTestCase):
     """rows_to_sync is a best-effort progress estimate; a failed count must degrade to
     0 without failing the sync, and expected pymongo errors must not be reported to


### PR DESCRIPTION
## Problem

Error tracking flagged a `ConfigurationError` raised by pymongo's SRV resolution inside the `MongoClient` constructor: dnspython's resolution lifetime expired while querying the resolver our worker uses. This happens before any of our own connectivity handling runs (see `mongo_client` in `products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/mongo.py`).

The failing DNS lookup was against the resolver our own worker queries, not a problem with the customer's cluster hostname or credentials — a momentary DNS blip, not a permanent misconfiguration. It doesn't match any pattern in `get_non_retryable_errors`, so Temporal already retries the sync as normal. But because it isn't classified as a known-transient error, every occurrence is logged at `exception` level and shows up as error-tracking noise for a self-recovering failure.

## Changes

Adds `get_retryable_errors()` to `MongoDBSource`, following the existing pattern used by other sources (MySQL, Meta Ads, etc.) for conditions that are already retried by the driver/Temporal and shouldn't be tracked as bugs. Matches dnspython's stable `"The resolution lifetime expired"` message prefix — not the variable timeout duration or nameserver address that follows it.

## How did you test this code?

Added `TestGetRetryableErrors.test_dns_lifetime_timeout_is_classified_retryable`, asserting the DNS SRV lifetime-timeout message is matched by `get_retryable_errors()`. This guards the noise-reduction behavior: without it, `_handle_import_error` logs this transient failure at `exception` level on every occurrence.

Ran the full `mongodb` test suite (68 passed), `ruff check`/`ruff format --check` on both changed files, and `uv run mypy --cache-fine-grained .` repo-wide (no issues).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged a live error-tracking issue for the MongoDB data-warehouse source (`ConfigurationError` / DNS resolution lifetime timeout), read the full stack trace and code path, and confirmed the failure originates in `mongo_client` at `MongoClient()` construction during SRV resolution.
- Determined this is a transient infrastructure DNS blip against PostHog's own resolver (not a customer credential/config issue), so it should stay retryable rather than being added to `get_non_retryable_errors`.
- Followed the existing `get_retryable_errors()` convention (documented in `products/warehouse_sources/backend/temporal/data_imports/sources/README.md`) to keep this self-recovering condition out of error-tracking noise, mirroring how MySQL/Meta Ads/etc. classify similar transient blips.
- Searched open PRs for a duplicate fix before opening this one — none found.