### PR TITLE
fix(data-imports): keep cdp producer db blips retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/cdp_producer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/cdp_producer.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 
 from django.conf import settings
+from django.db.utils import OperationalError as DjangoOperationalError
 
 import orjson
 import pyarrow as pa
@@ -23,6 +24,7 @@ from products.cdp.backend.models.hog_functions import HogFunction
 from products.data_warehouse.backend.facade.api import aget_s3_client, ensure_bucket_exists
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.helpers import build_table_name
+from products.warehouse_sources.backend.temporal.data_imports.util import PostHogInternalDatabaseError
 from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
 
 
@@ -119,28 +121,38 @@ class CDPProducer:
             self.logger.debug(f"Checking if table {dot_notated_table_name} is used in any hog functions or workflows")
             self.logger.debug(f"Using table_name = {dot_notated_table_name}, source = data-warehouse-table")
 
-            has_matching_hog_function = (
-                HogFunction.objects.filter(
-                    team_id=self.team_id,
-                    enabled=True,
-                    filters__source="data-warehouse-table",
-                    filters__data_warehouse__contains=[{"table_name": dot_notated_table_name}],
+            try:
+                has_matching_hog_function = (
+                    HogFunction.objects.filter(
+                        team_id=self.team_id,
+                        enabled=True,
+                        filters__source="data-warehouse-table",
+                        filters__data_warehouse__contains=[{"table_name": dot_notated_table_name}],
+                    )
+                    .exclude(deleted=True)
+                    .exists()
                 )
-                .exclude(deleted=True)
-                .exists()
-            )
 
-            if has_matching_hog_function:
-                return True
+                if has_matching_hog_function:
+                    return True
 
-            # Also gate on active workflows (HogFlows) triggered by this table - without this the
-            # producer never emits to Kafka for a team whose only consumer is a warehouse-triggered workflow.
-            return HogFlow.objects.filter(
-                team_id=self.team_id,
-                status=HogFlow.State.ACTIVE,
-                trigger__type="data-warehouse-table",
-                trigger__table_name=dot_notated_table_name,
-            ).exists()
+                # Also gate on active workflows (HogFlows) triggered by this table - without this the
+                # producer never emits to Kafka for a team whose only consumer is a warehouse-triggered workflow.
+                return HogFlow.objects.filter(
+                    team_id=self.team_id,
+                    status=HogFlow.State.ACTIVE,
+                    trigger__type="data-warehouse-table",
+                    trigger__table_name=dot_notated_table_name,
+                ).exists()
+            except DjangoOperationalError as e:
+                # This queries PostHog's own database, not the source being synced. A transient
+                # failure reaching it (e.g. a DNS blip resolving our host) stringifies with the
+                # same wording a customer's misconfigured source host would, which the source's
+                # `get_non_retryable_errors` would misclassify as non-retryable and permanently
+                # stop a healthy sync. Re-raise clear of those substrings so it stays retryable.
+                raise PostHogInternalDatabaseError(
+                    "Failed to check hog function/workflow triggers in PostHog's database"
+                ) from e
 
         self._should_produce_cache = await _check()
         return self._should_produce_cache

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_cdp_producer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_cdp_producer.py
@@ -7,6 +7,8 @@ import pytest
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+from django.db.utils import OperationalError as DjangoOperationalError
+
 import pyarrow as pa
 import pyarrow.parquet as pq
 from asgiref.sync import sync_to_async
@@ -16,6 +18,8 @@ from products.warehouse_sources.backend.models.external_data_schema import Exter
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.cdp_producer import CDPProducer
+from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.source import PostgresSource
+from products.warehouse_sources.backend.temporal.data_imports.util import PostHogInternalDatabaseError
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 from products.workflows.backend.models.hog_flow.hog_flow import HogFlow
 
@@ -284,6 +288,39 @@ async def test_should_produce_table_with_both_hog_function_and_flow(team):
 
     producer = CDPProducer(team_id=team.id, schema_id=str(schema.id), job_id="", logger=mock.AsyncMock())
     assert await producer.should_produce_table() is True
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_should_produce_table_posthog_database_connection_failure_stays_retryable(team):
+    # `should_produce_table` queries PostHog's own database (HogFunction/HogFlow), not the
+    # source being synced. A transient connection failure there (e.g. a DNS blip resolving our
+    # host) surfaces the same "Name or service not known" wording a customer's misconfigured
+    # source host would, so it must be re-raised as PostHogInternalDatabaseError to avoid being
+    # misclassified as non-retryable by the source's `get_non_retryable_errors`.
+    source = await sync_to_async(ExternalDataSource.objects.create)(
+        team=team, source_type=ExternalDataSourceType.POSTGRES
+    )
+    table = await sync_to_async(DataWarehouseTable.objects.create)(
+        team=team, name="postgres_table_1", external_data_source=source
+    )
+    schema = await sync_to_async(ExternalDataSchema.objects.create)(
+        team=team, name="table_1", source=source, table=table
+    )
+
+    producer = CDPProducer(team_id=team.id, schema_id=str(schema.id), job_id="", logger=mock.AsyncMock())
+
+    with patch(
+        "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.cdp_producer.HogFunction.objects"
+    ) as mock_hog_function_objects:
+        mock_hog_function_objects.filter.side_effect = DjangoOperationalError("[Errno -2] Name or service not known")
+        with pytest.raises(PostHogInternalDatabaseError) as exc_info:
+            await producer.should_produce_table()
+
+    non_retryable = PostgresSource().get_non_retryable_errors()
+    error_msg = str(exc_info.value)
+    is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+    assert not is_non_retryable, f"A PostHog-side DB connection failure must stay retryable: {error_msg}"
 
 
 @pytest.mark.django_db(transaction=True)

--- a/products/warehouse_sources/backend/temporal/data_imports/util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/util.py
@@ -26,6 +26,18 @@ class NonRetryableException(Exception):
         return self.__cause__
 
 
+class PostHogInternalDatabaseError(Exception):
+    """Raised when shared pipeline code fails to reach PostHog's own database.
+
+    A transient connectivity blip reaching our database (e.g. a DNS hiccup resolving our
+    host) stringifies with the same wording (e.g. "Name or service not known") a customer's
+    misconfigured source host would produce. Sources' `get_non_retryable_errors` match on
+    that wording to stop syncs against a permanently broken customer host, so this error's
+    message intentionally avoids those substrings to keep it retryable instead of being
+    misclassified as a permanent failure of the source being synced.
+    """
+
+
 # 10 mins buffer to avoid deleting files Clickhouse may be reading
 S3_DELETE_TIME_BUFFER = 600
 


### PR DESCRIPTION
## Problem

Error tracking caught a `TimeoutError: Timeout connecting to server` in the data-warehouse import pipeline ([issue](https://us.posthog.com/project/2/error_tracking/019f912b-17f3-7c21-878b-488a043c59f5)), during a Supabase sync. The reported exception was chained from an earlier `OperationalError: [Errno -2] Name or service not known`.

The call chain: `CDPProducer.should_produce_table` → `_check` runs Django ORM `.exists()` queries against `HogFunction`/`HogFlow` — a lookup against **PostHog's own database**, not the customer's Supabase database. A transient DNS/pooler blip reaching that connection raised the `OperationalError` uncaught.

That error then propagated up into `_handle_import_error`, whose classification is keyed on the source's `get_non_retryable_errors()`. Postgres-family sources (including Supabase) list `"Name or service not known"` as non-retryable — meant to catch a customer's misconfigured database host. Since our own internal DB failure stringifies identically, it was misclassified as non-retryable and routed to `handle_non_retryable_error`, which then tried to write a retry counter to Redis — and *that* Redis call also timed out, producing the confusing `TimeoutError` that actually reached error tracking, masking the real cause.

This is the same class of bug already fixed once for `PostgresSource.source_for_pipeline` (see `PostHogDatabaseConnectionError`/`ForeignServerUnreachableError` in `sources/postgres/exceptions.py`), but `should_produce_table` is shared pipeline code used by every source, and had no equivalent guard.

## Changes

- Added `PostHogInternalDatabaseError` to `data_imports/util.py`, following the same pattern as `PostHogDatabaseConnectionError`: a message that intentionally avoids connection-error substrings so it can't collide with any source's `get_non_retryable_errors`.
- `CDPProducer.should_produce_table`'s internal `_check()` now catches `django.db.utils.OperationalError` from the `HogFunction`/`HogFlow` lookups and re-raises as `PostHogInternalDatabaseError`, so a transient blip reaching our own database stays retryable regardless of which source is syncing.

## How did you test this code?

Added `test_should_produce_table_posthog_database_connection_failure_stays_retryable` to `test_cdp_producer.py`, mirroring the existing `test_posthog_database_connection_failure_stays_retryable` test in `test_postgres.py`: forces `HogFunction.objects.filter` to raise `django.db.utils.OperationalError("[Errno -2] Name or service not known")`, asserts `should_produce_table` raises `PostHogInternalDatabaseError`, and asserts the resulting message doesn't match any pattern in `PostgresSource.get_non_retryable_errors()`. This is the regression: without the fix, the raw `OperationalError` would propagate and its message would match `PostgresSource`'s non-retryable list.

Ran:
- `uv run ruff check --fix` / `ruff format` on all three changed files — clean
- `uv run mypy --cache-fine-grained .` (repo-wide) — clean, no issues in 16780 source files
- `tach check --dependencies --interfaces` — all modules validated, no boundary violations

Could not run the Django test suite itself in this sandbox (no reachable Postgres), so I couldn't execute the new test directly — its structure directly mirrors the existing, presumably-passing `test_postgres.py` precedent test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification change, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error tracking issue using the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the chained stack trace and confirm the call path. Traced the shared `cdp_producer.py`/`extract.py`/`import_data_sync.py` code path, and found the existing `PostHogDatabaseConnectionError` precedent in `sources/postgres/exceptions.py` that this fix generalizes to shared code. Invoked `/writing-tests` before adding the regression test. Checked for duplicate open PRs by exception type, message phrase, module path, and the maintainer's own open queue — found related-but-non-overlapping fixes for other Redis/DB blips in this pipeline (`#73386`, `#73388`, `#73384`), none of which touch `cdp_producer.py`'s `should_produce_table`.