### PR TITLE
fix(mysql): retry broken-pipe errors during connect as transient

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -450,6 +450,26 @@ def _is_transient_connect_reset(e: BaseException) -> bool:
     return _CONNECTION_RESET_TOKEN in " ".join(str(arg) for arg in e.args)
 
 
+# EPIPE at connect time: pymysql wraps a write to an already-closed socket — e.g. sending the
+# auth packet or the TLS handshake — as the 2003 "Can't connect to MySQL server on '<host>'
+# ([Errno 32] Broken pipe)" failure. It is the write-side sibling of the `Connection reset by
+# peer` case above (which fires on the read side): the peer, often a TCP proxy or load balancer
+# in front of the DB, accepted the connection then closed it while pymysql was still writing —
+# an overloaded server, a proxy idle cull, or a backend cycling. A fresh attempt usually reaches
+# a healthy backend. Match the stable strerror phrase, not the volatile host.
+_BROKEN_PIPE_TOKEN = "Broken pipe"
+
+
+def _is_transient_connect_broken_pipe(e: BaseException) -> bool:
+    """Return True if writing to the peer failed with a broken pipe during connect — a transient blip."""
+    if not isinstance(e, pymysql.err.OperationalError):
+        return False
+    code = e.args[0] if e.args else None
+    if code != _CANT_CONNECT_CODE:
+        return False
+    return _BROKEN_PIPE_TOKEN in " ".join(str(arg) for arg in e.args)
+
+
 # pymysql raises this `InternalError` from `_read_packet` when an incoming packet's
 # sequence number doesn't match the expected one (it `_force_close()`s the socket first).
 _PACKET_SEQUENCE_ERROR_PHRASE = "Packet sequence number wrong"
@@ -511,6 +531,7 @@ def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:
                 or _is_transient_connect_timeout(e)
                 or _is_transient_connect_dns_failure(e)
                 or _is_transient_connect_reset(e)
+                or _is_transient_connect_broken_pipe(e)
                 or _is_transient_packet_sequence_error(e)
                 or _is_transient_vitess_dial_timeout(e)
             ):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -25,6 +25,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysq
     MySQLImplementation,
     _build_query,
     _is_bad_plan_error,
+    _is_transient_connect_broken_pipe,
     _is_transient_connect_dns_failure,
     _is_transient_connect_drop,
     _is_transient_connect_gone_away,
@@ -1087,6 +1088,43 @@ class TestIsTransientConnectReset:
 
     def test_does_not_match_error_without_args(self):
         assert not _is_transient_connect_reset(pymysql.err.OperationalError())
+
+
+class TestIsTransientConnectBrokenPipe:
+    def test_matches_broken_pipe_on_connect(self):
+        # EPIPE at connect time — a write to an already-closed socket (e.g. sending the auth
+        # packet through a proxy that cycled its backend). A transient blip that must be retried
+        # in-process rather than surfacing as the non-retryable "Can't connect" config error.
+        assert _is_transient_connect_broken_pipe(
+            pymysql.err.OperationalError(
+                2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 32] Broken pipe)"
+            )
+        )
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            # Refused connection and failed DNS lookup are also 2003 but deterministic host/port
+            # misconfig — they must stay non-retryable, not be absorbed here.
+            "Can't connect to MySQL server on 'db.example.com' ([Errno 111] Connection refused)",
+            "Can't connect to MySQL server on 'nope.example.com' ([Errno -2] Name or service not known)",
+        ],
+    )
+    def test_does_not_match_permanent_connect_errors(self, message):
+        assert not _is_transient_connect_broken_pipe(pymysql.err.OperationalError(2003, message))
+
+    @pytest.mark.parametrize(
+        "code,message",
+        [
+            (2013, "Lost connection to MySQL server during query"),
+            (1045, "Access denied for user"),
+        ],
+    )
+    def test_does_not_match_other_error_codes(self, code, message):
+        assert not _is_transient_connect_broken_pipe(pymysql.err.OperationalError(code, message))
+
+    def test_does_not_match_error_without_args(self):
+        assert not _is_transient_connect_broken_pipe(pymysql.err.OperationalError())
 
 
 class TestIsTransientPacketSequenceError:


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError(2003, "Can't connect to MySQL server ... ([Errno 32] Broken pipe)")` from `_connect_with_transient_retry` in the MySQL data warehouse source ([issue](https://us.posthog.com/project/2/error_tracking/019f9134-142b-72b1-b075-be7bf490c9e4)).

`_connect_with_transient_retry` already retries several connect-time blips that pymysql wraps as the generic 2003 "Can't connect" error — connection resets, SSL EOF, DNS resolver hiccups, timeouts — but a broken pipe (EPIPE) wasn't one of them, so this class of blip surfaced as an unhandled failure and error-tracking noise instead of being retried in-process.

A broken pipe here means pymysql tried to write to the socket (e.g. the auth packet) after the peer had already closed it — the write-side sibling of the "Connection reset by peer" case this function already retries. It typically comes from a proxy or load balancer in front of the database cycling its backend mid-handshake, which is transient: a fresh attempt usually reaches a healthy backend.

## Changes

Added `_is_transient_connect_broken_pipe`, matching the same pattern as the existing `_is_transient_connect_reset` predicate (2003 code + a stable strerror phrase, ignoring the volatile host), and wired it into `_connect_with_transient_retry`'s retry classification.

## How did you test this code?

Added `TestIsTransientConnectBrokenPipe`, mirroring the existing `TestIsTransientConnectReset` test class: asserts the new predicate matches the broken-pipe 2003 shape, and does not match other permanent 2003 causes (refused connection, failed DNS) or unrelated error codes — this guards the classification so a future edit can't silently stop retrying this blip. Ran the full transient-connect test suite in `test_mysql.py` (57 tests) plus ruff and mypy against the changed files — all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal retry classification, no user-facing behavior or docs to update.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a real error surfaced by PostHog error tracking for this source.
- Skills invoked: `/investigating-error-issue` (pulled the issue baseline and stack trace), `/writing-tests` (gate before adding the new test class).
- Decision: classified as a fixable bug rather than a `NonRetryableErrors` addition, since the existing predicates already retry several sibling connect-time blips (reset, SSL EOF, DNS, timeout) for the same 2003 code — broken pipe was simply a gap in that coverage, not a user/upstream config error.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*