### PR TITLE
feat(replay-vision): rename the group-summary action to "digest"

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ActionEditorScene.tsx
@@ -571,8 +571,8 @@ function DeliverySection(): JSX.Element {
             )}
             {!actionForm.channel && (
                 <span className="text-xs text-muted">
-                    No channel selected — this summary will appear on the scanner page and in its run history, without a
-                    Slack notification.
+                    No channel selected — this {actionForm.mode === VisionActionModeEnumApi.Alert ? 'alert' : 'digest'}{' '}
+                    will appear on the scanner page and in its run history, without a Slack notification.
                 </span>
             )}
         </div>
@@ -609,7 +609,7 @@ export function ActionEditorSceneComponent(): JSX.Element {
     if (!isNew && !loadedAction) {
         return (
             <SceneContent>
-                <SceneTitleSection name="Summary not found" resourceType={{ type: 'replay_vision' }} />
+                <SceneTitleSection name="Action not found" resourceType={{ type: 'replay_vision' }} />
                 <div className="flex justify-center pt-4">
                     <LemonButton type="secondary" to={urls.replayVision()}>
                         Back to Replay vision
@@ -620,7 +620,7 @@ export function ActionEditorSceneComponent(): JSX.Element {
     }
 
     const isAlert = actionForm.mode === VisionActionModeEnumApi.Alert
-    const noun = isAlert ? 'alert' : 'summary'
+    const noun = isAlert ? 'alert' : 'digest'
     const title = isNew
         ? scannerName
             ? `New ${noun} for ${scannerName}`
@@ -640,7 +640,7 @@ export function ActionEditorSceneComponent(): JSX.Element {
                         description={
                             isAlert
                                 ? 'Watch this scanner on a schedule and get notified only when the condition is met.'
-                                : "Schedule an AI summary of this scanner's observations and deliver it to Slack."
+                                : "Schedule an AI digest of this scanner's observations and deliver it to Slack."
                         }
                         resourceType={{ type: 'replay_vision' }}
                         actions={<ReplayVisionFeedbackButton />}
@@ -655,7 +655,7 @@ export function ActionEditorSceneComponent(): JSX.Element {
                         <div className="bg-bg-light border rounded-lg shadow-sm p-6 flex flex-col gap-4">
                             <LemonField name="name" label="Name">
                                 <LemonInput
-                                    placeholder={isAlert ? 'Rage click alert' : 'Daily checkout summary'}
+                                    placeholder={isAlert ? 'Rage click alert' : 'Daily checkout digest'}
                                     autoFocus
                                 />
                             </LemonField>
@@ -682,7 +682,7 @@ export function ActionEditorSceneComponent(): JSX.Element {
                                 <LemonField
                                     name="prompt_guide"
                                     label="Additional guidance (optional)"
-                                    info="Steers how the AI writes the summary."
+                                    info="Steers how the AI writes the digest."
                                 >
                                     <LemonTextArea
                                         placeholder="e.g. focus on issues, bugs, and friction users face — or focus on general user behavior and flows."
@@ -698,7 +698,7 @@ export function ActionEditorSceneComponent(): JSX.Element {
 
                             {!isAlert && (
                                 <div className="text-xs text-muted">
-                                    Each scheduled run generates an AI summary using your PostHog AI credits. Runs are
+                                    Each scheduled run generates an AI digest using your PostHog AI credits. Runs are
                                     skipped while you're over your AI-credit budget.
                                 </div>
                             )}
@@ -718,7 +718,7 @@ export function ActionEditorSceneComponent(): JSX.Element {
                                     }
                                     data-attr="vision-action-editor-save"
                                 >
-                                    {isNew ? (isAlert ? 'Create alert' : 'Create summary') : 'Save'}
+                                    {isNew ? (isAlert ? 'Create alert' : 'Create digest') : 'Save'}
                                 </LemonButton>
                             </div>
                         </div>

--- a/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
+++ b/products/replay_vision/frontend/replay_scanners/ReplayScanner.tsx
@@ -143,7 +143,7 @@ export function ReplayScannerSceneComponent(): JSX.Element {
                     },
                     actionsTabEnabled && {
                         key: ReplayScannerTab.Actions,
-                        label: 'Summaries and alerts',
+                        label: 'Digests and alerts',
                         content: (
                             <VisionActionsTab
                                 scannerId={scannerId}

--- a/products/replay_vision/frontend/replay_scanners/VisionActionScene.tsx
+++ b/products/replay_vision/frontend/replay_scanners/VisionActionScene.tsx
@@ -94,7 +94,7 @@ function ActionOverview({
             />
             {!isAlert && (
                 <LemonCard hoverEffect={false} className="p-4">
-                    <div className="text-xs font-semibold uppercase text-secondary mb-1">Summary guidance</div>
+                    <div className="text-xs font-semibold uppercase text-secondary mb-1">Digest guidance</div>
                     {guidance ? (
                         <p className="m-0 whitespace-pre-wrap">{guidance}</p>
                     ) : (

--- a/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/actionEditorSceneLogic.ts
@@ -183,7 +183,7 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
                 setActionId: (_, { actionId }) => actionId,
             },
         ],
-        // Whether the summary covers everything or only matching observations. Explicit state (not
+        // Whether the digest covers everything or only matching observations. Explicit state (not
         // derived from the filter values) so picking "only matching" shows the controls before any
         // value is chosen.
         targetingMode: [
@@ -248,7 +248,9 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
                 crumbs.push(
                     {
                         key: `action-${actionId}`,
-                        name: loadedAction?.name || 'Summary',
+                        name:
+                            loadedAction?.name ||
+                            (loadedAction?.mode === VisionActionModeEnumApi.Alert ? 'Alert' : 'Digest'),
                         path: urls.replayVisionAction(actionId),
                     },
                     { key: `action-${actionId}-edit`, name: 'Edit' }
@@ -270,7 +272,11 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
                 alert_frequency,
                 alert_threshold,
             }: VisionActionForm) => ({
-                name: !name?.trim() ? 'Give this summary a name' : undefined,
+                name: !name?.trim()
+                    ? mode === VisionActionModeEnumApi.Alert
+                        ? 'Give this alert a name'
+                        : 'Give this digest a name'
+                    : undefined,
                 // kea-forms can't carry a string error on the weekdays array, so hang it on `hour` to
                 // mark the form invalid and block Enter-to-submit; the visible copy is the inline text.
                 // Alerts have no schedule UI (checked continuously on every sweep), so weekdays don't apply.
@@ -301,15 +307,13 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
                 const body = buildActionBody(form, scannerId)
                 if (values.isNew) {
                     const created = await visionActionsCreate(String(teamId), body)
-                    lemonToast.success(
-                        form.mode === VisionActionModeEnumApi.Alert ? 'Alert created' : 'Summary created'
-                    )
+                    lemonToast.success(form.mode === VisionActionModeEnumApi.Alert ? 'Alert created' : 'Digest created')
                     visionActionsLogic.findMounted({ scannerId })?.actions.loadActions()
                     router.actions.push(urls.replayVisionAction(created.id))
                     return
                 }
                 const updated = await visionActionsPartialUpdate(String(teamId), values.actionId, body)
-                lemonToast.success(form.mode === VisionActionModeEnumApi.Alert ? 'Alert updated' : 'Summary updated')
+                lemonToast.success(form.mode === VisionActionModeEnumApi.Alert ? 'Alert updated' : 'Digest updated')
                 visionActionsLogic.findMounted({ scannerId })?.actions.loadActions()
                 const runsLogic = visionActionRunsLogic.findMounted({ actionId: updated.id })
                 runsLogic?.actions.loadAction()
@@ -322,7 +326,7 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
     listeners(({ actions, values }) => ({
         setTargetingMode: ({ mode }) => {
             if (mode === 'all') {
-                // Clear the filter values so a hidden filter can't silently narrow the summary.
+                // Clear the filter values so a hidden filter can't silently narrow the digest.
                 actions.setActionFormValues({ verdict: [], tags: [], min_score: null, max_score: null })
             }
         },
@@ -340,7 +344,7 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
                 actions.setScannerName(scanner.name)
                 actions.setScannerType(scanner.scanner_type)
             } catch {
-                // Display-only — the title falls back to "New summary".
+                // Display-only — the title falls back to "New digest".
             }
         },
 
@@ -372,7 +376,7 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
                 if (isBreakpoint(error)) {
                     throw error
                 }
-                lemonToast.error(`Failed to load summary${error.detail ? `: ${error.detail}` : ''}`)
+                lemonToast.error(`Failed to load this action${error.detail ? `: ${error.detail}` : ''}`)
                 actions.loadActionFailure()
             }
         },
@@ -388,7 +392,7 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
             )
             actions.setTargetingMode(hasFilter ? 'filtered' : 'all')
             // Stored alerts without a frequency predate the field and behaved as on_breach; anything
-            // else gets the fresh-form default so flipping a summary to an alert starts at every_match.
+            // else gets the fresh-form default so flipping a digest to an alert starts at every_match.
             const alertFrequency =
                 action.alert_config?.frequency ??
                 (action.mode === VisionActionModeEnumApi.Alert
@@ -417,7 +421,8 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
         },
 
         submitActionFormFailure: ({ error }: { error?: Error & { detail?: string } }) => {
-            lemonToast.error(`Failed to save summary${error?.detail ? `: ${error.detail}` : ''}`)
+            const noun = values.actionForm.mode === VisionActionModeEnumApi.Alert ? 'alert' : 'digest'
+            lemonToast.error(`Failed to save ${noun}${error?.detail ? `: ${error.detail}` : ''}`)
         },
     })),
 
@@ -425,7 +430,7 @@ export const actionEditorSceneLogic = kea<actionEditorSceneLogicType>([
         [urls.replayVisionActionNew(':scannerId')]: ({ scannerId }, { mode }) => {
             actions.setActionId('new')
             actions.setScannerId(scannerId || '')
-            // Mode is picked before opening the editor (the "New summary" / "New alert" buttons), so the
+            // Mode is picked before opening the editor (the "New digest" / "New alert" buttons), so the
             // form opens committed to one shape rather than showing a type toggle.
             const startMode =
                 mode === VisionActionModeEnumApi.Alert

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionRuns.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionRuns.tsx
@@ -102,11 +102,11 @@ function EmptyRuns(): JSX.Element {
     return (
         <div className="flex flex-col items-center text-center gap-3 py-10">
             <SleepingHog className="w-40 h-40" />
-            <h3 className="m-0">{isAlert ? 'Your alert is live' : 'Your action is live'}</h3>
+            <h3 className="m-0">{isAlert ? 'Your alert is live' : 'Your digest is live'}</h3>
             <p className="text-muted max-w-md">
                 {isAlert
                     ? `Checks run ${everyMatch ? 'every few minutes' : 'about every hour'}. When the condition is met, the alert and its matching observations show up here.`
-                    : "Results will show up after its next scheduled run. Once it runs, you'll see the summaries here — check back soon."}
+                    : "Results will show up after its next scheduled run. Once it runs, you'll see the digests here — check back soon."}
             </p>
         </div>
     )

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -106,7 +106,7 @@ function VisionActionsTable({
     const { visionActions, visionActionsLoading, togglingIds } = useValues(visionActionsLogic)
     const { toggleActionEnabled, deleteAction } = useActions(visionActionsLogic)
 
-    // The scanner's built-in daily digest is listed here alongside user-created summaries and alerts
+    // The scanner's built-in daily digest is listed here alongside user-created digests and alerts
     // (marked with a "Daily digest" chip), so this page is the one place to see and manage every
     // automation on the scanner. It also has its own hero surface on the Observations tab.
     const rows = visionActions
@@ -114,11 +114,11 @@ function VisionActionsTable({
     if (!visionActionsLoading && rows.length === 0) {
         return (
             <ProductIntroduction
-                productName="Summaries and alerts"
-                thingName="summary or alert"
+                productName="Digests and alerts"
+                thingName="digest or alert"
                 isEmpty
                 customHog={HedgehogXRay}
-                description="Get scheduled summaries of this scanner's observations, synthesized by AI on the cadence you choose. Or set alerts that notify you when new matches appear or a threshold is reached. Both can deliver to Slack."
+                description="Get scheduled digests of this scanner's observations, synthesized by AI on the cadence you choose. Or set alerts that notify you when new matches appear or a threshold is reached. Both can deliver to Slack."
                 actionElementOverride={
                     <div className="flex gap-2">
                         <EditorGate userAccessLevel={scannerUserAccessLevel ?? undefined}>
@@ -128,7 +128,7 @@ function VisionActionsTable({
                                 to={urls.replayVisionActionNew(scannerId, 'group_summary')}
                                 data-attr="vision-action-new-empty"
                             >
-                                New summary
+                                New digest
                             </LemonButton>
                         </EditorGate>
                         <EditorGate userAccessLevel={scannerUserAccessLevel ?? undefined}>
@@ -241,7 +241,7 @@ function VisionActionsTable({
                                 LemonDialog.open({
                                     title: `Delete "${action.name}"?`,
                                     description:
-                                        'This stops its scheduled summaries and removes its delivery destinations. This cannot be undone.',
+                                        'This stops its scheduled runs and removes its delivery destinations. This cannot be undone.',
                                     primaryButton: {
                                         children: 'Delete',
                                         status: 'danger',
@@ -267,7 +267,7 @@ function VisionActionsTable({
                         to={urls.replayVisionActionNew(scannerId, 'group_summary')}
                         data-attr="vision-action-new"
                     >
-                        New summary
+                        New digest
                     </LemonButton>
                 </EditorGate>
                 <EditorGate userAccessLevel={scannerUserAccessLevel ?? undefined}>
@@ -287,7 +287,7 @@ function VisionActionsTable({
                 loading={visionActionsLoading}
                 rowKey="id"
                 data-attr="vision-actions-table"
-                emptyState="No summaries or alerts set up for this scanner yet."
+                emptyState="No digests or alerts set up for this scanner yet."
             />
         </div>
     )

--- a/products/replay_vision/frontend/replay_scanners/visionActionRunSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionRunSceneLogic.ts
@@ -160,7 +160,7 @@ export const visionActionRunSceneLogic = kea<visionActionRunSceneLogicType>([
                 }
                 breadcrumbs.push({
                     key: actionId ? `action-${actionId}` : 'action',
-                    name: action?.name || 'Summary',
+                    name: action?.name || 'Digest',
                     path: urls.replayVisionAction(actionId),
                 })
                 breadcrumbs.push({

--- a/products/replay_vision/frontend/replay_scanners/visionActionRunsLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionRunsLogic.ts
@@ -146,7 +146,7 @@ export const visionActionRunsLogic = kea<visionActionRunsLogicType>([
     }),
 
     selectors({
-        // A summary/alert run is actively processing — used to keep "Run now" disabled (a second run
+        // A digest/alert run is actively processing — used to keep "Run now" disabled (a second run
         // coalesces server-side anyway, but disabling makes that obvious) and to drive polling.
         runInProgress: [
             (s) => [s.runs],
@@ -211,7 +211,7 @@ export const visionActionRunsLogic = kea<visionActionRunsLogicType>([
                     // (the workflow creates the row asynchronously) and then until it finishes.
                     actions.loadRuns()
                 } catch (error: any) {
-                    lemonToast.error(`Couldn't run this summary${error?.detail ? `: ${error.detail}` : ''}`)
+                    lemonToast.error(`Couldn't run this digest${error?.detail ? `: ${error.detail}` : ''}`)
                 } finally {
                     actions.runNowDone()
                 }

--- a/products/replay_vision/frontend/replay_scanners/visionActionSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionSceneLogic.ts
@@ -96,7 +96,7 @@ export const visionActionSceneLogic = kea<visionActionSceneLogicType>([
                 }
                 breadcrumbs.push({
                     key: actionId ? `action-${actionId}` : 'action',
-                    name: context.name || 'Summary',
+                    name: context.name || 'Digest',
                     path: urls.replayVisionAction(actionId),
                 })
                 return breadcrumbs

--- a/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionsLogic.ts
@@ -92,7 +92,7 @@ export function buildActionBody(form: VisionActionForm, scannerId: string): Para
         scanner: scannerId,
         mode: form.mode,
         // Alerts have no user-facing schedule: the engine checks them on every scanner sweep and
-        // ignores this rrule (kept so the trigger stays well-formed); summaries run on the picked days/time.
+        // ignores this rrule (kept so the trigger stays well-formed); digests run on the picked days/time.
         trigger_config: isAlert
             ? { rrule: 'FREQ=HOURLY', timezone: form.timezone }
             : { rrule: cadenceToRrule(form.cadence), timezone: form.timezone },
@@ -242,12 +242,12 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
             try {
                 const response = await visionActionsList(String(teamId), { scanner: props.scannerId, limit: 100 })
                 // Keep the digest in the shared list — scannerDigestLogic (the Observations-tab card)
-                // reads it from here via is_scanner_digest. The Summaries-and-alerts table filters it
+                // reads it from here via is_scanner_digest. The Digests-and-alerts table filters it
                 // out at render time instead, so the card and the table can disagree without this
                 // source hiding the digest from both.
                 actions.loadActionsSuccess(response.results ?? [])
             } catch (error: any) {
-                lemonToast.error(`Failed to load summaries${error.detail ? `: ${error.detail}` : ''}`)
+                lemonToast.error(`Failed to load digests and alerts${error.detail ? `: ${error.detail}` : ''}`)
                 actions.loadActionsFailure()
             }
         },
@@ -265,7 +265,8 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
                 actions.toggleActionEnabledDone(id)
             } catch (error: any) {
                 const verb = action.enabled ? 'enable' : 'disable'
-                lemonToast.error(`Failed to ${verb} summary${error.detail ? `: ${error.detail}` : ''}`)
+                const noun = action.mode === VisionActionModeEnumApi.Alert ? 'alert' : 'digest'
+                lemonToast.error(`Failed to ${verb} ${noun}${error.detail ? `: ${error.detail}` : ''}`)
                 actions.revertActionEnabled(id)
             }
         },
@@ -275,12 +276,16 @@ export const visionActionsLogic = kea<visionActionsLogicType>([
             if (!teamId) {
                 return
             }
+            const noun =
+                values.visionActions.find((a) => a.id === id)?.mode === VisionActionModeEnumApi.Alert
+                    ? 'alert'
+                    : 'digest'
             try {
                 await visionActionsDestroy(String(teamId), id)
                 actions.deleteActionSuccess(id)
-                lemonToast.success('Summary deleted')
+                lemonToast.success(`${noun === 'alert' ? 'Alert' : 'Digest'} deleted`)
             } catch (error: any) {
-                lemonToast.error(`Failed to delete summary${error.detail ? `: ${error.detail}` : ''}`)
+                lemonToast.error(`Failed to delete ${noun}${error.detail ? `: ${error.detail}` : ''}`)
             }
         },
     })),


### PR DESCRIPTION
## Problem

The scheduled group-summary Vision Action (the "and then…" layer that summarizes a scanner's observations on a cadence and delivers to Slack) was labeled "summary" throughout the UI. That collides with the **summarizer scanner type**, which produces per-observation summaries — two different things wearing the same word. "Digest" is the clearer noun for the scheduled roll-up.

## Changes

Rename the user-facing group-summary action from "summary" to "digest" across the Summaries-and-alerts surface:

- Tab: **Digests and alerts**
- Buttons: **New digest**, **Create digest** (empty-state + toolbar)
- Editor: "New/Edit digest", "Schedule an AI digest of this scanner's observations…", guidance info + card ("Digest guidance"), credits note, placeholder ("Daily checkout digest")
- Toasts: "Digest created/updated/deleted", "Couldn't run this digest"; toasts and breadcrumbs shared with alerts are branded per-mode (alert vs digest) or made neutral ("Failed to load digests and alerts", "Action not found")
- Empty states, delete-confirmation copy, breadcrumb fallbacks

Deliberately **not** renamed:
- The **summarizer scanner type** and per-observation summaries ("Summarizer", "Summary length", "every new summary this scanner produces", the `session_summary` template) — a distinct concept.
- Behavior-describing verbs — the digest still "summarizes up to 100 observations" in helper text.
- Code identifiers, the `group_summary` mode value, URLs, and `data-attr`s — no functional change.

## How did you test this code?

Copy-only change (no kea structure change, so no typegen). Automated, all run locally by the agent:
- `tsgo` typecheck clean for the touched files; oxlint + oxfmt clean; `hogli ci:preflight --strict` clean.
- Full `products/replay_vision/frontend/replay_scanners` jest suite: 214 passed. No test asserted on the renamed strings, so none needed updating; the remaining "summary" occurrences in tests belong to the summarizer scanner type.

The agent did not exercise the UI in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover this surface yet; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: @ksvat

Built with PostHog Code (Claude Opus 4.8). Stacked on top of the Overview-tab PR (#73337).

The main judgment call: several toasts and breadcrumbs are shared code paths that fire for both alert and group-summary actions. A blind find-replace would have mislabeled alerts, so those were either branded per-mode (matching the existing `mode === Alert ? … : …` pattern) or reworded neutrally. Verb forms ("summarize") and the summarizer scanner type were left alone per the rename's scope.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*