### PR TITLE
fix(ci): restore one Playwright retry

### DIFF
--- a/.github/scripts/report_test_timings.py
+++ b/.github/scripts/report_test_timings.py
@@ -185,6 +185,10 @@ def collect_artifact_infos(artifacts_root: Path) -> list[ArtifactInfo]:
 # ---------- junit parsing ----------
 
 
+def is_retry_attempt(tag: str) -> bool:
+    return tag.startswith("rerun") or tag in ("flakyFailure", "flakyError")
+
+
 def classify_testcase(testcase: Any) -> tuple[str, int]:
     """Return (outcome, attempts) from a single `<testcase>` element.
 
@@ -205,7 +209,7 @@ def classify_testcase(testcase: Any) -> tuple[str, int]:
                         rerun_count += max(0, int(prop.get("value", "0")))
                     except ValueError:
                         pass
-        elif tag.startswith("rerun") or tag in ("flakyFailure", "flakyError"):
+        elif is_retry_attempt(tag):
             rerun_count += 1
         elif tag in ("failure", "error", "skipped") and final_outcome is None:
             if tag == "skipped" and child.get("type") == "pytest.xfail":
@@ -315,6 +319,12 @@ def parse_shard(xml_path: Path, info: ArtifactInfo) -> Shard | None:
             duration = float(tc.get("time", "0"))
         except ValueError:
             duration = 0.0
+        for child in tc:
+            if is_retry_attempt(child.tag):
+                try:
+                    duration += max(0.0, float(child.get("time", "0")))
+                except ValueError:
+                    pass
         test_start = cursor
         test_end = cursor + timedelta(seconds=duration)
         cursor = test_end

--- a/.github/scripts/report_test_timings.py
+++ b/.github/scripts/report_test_timings.py
@@ -205,7 +205,7 @@ def classify_testcase(testcase: Any) -> tuple[str, int]:
                         rerun_count += max(0, int(prop.get("value", "0")))
                     except ValueError:
                         pass
-        elif tag.startswith("rerun"):
+        elif tag.startswith("rerun") or tag in ("flakyFailure", "flakyError"):
             rerun_count += 1
         elif tag in ("failure", "error", "skipped") and final_outcome is None:
             if tag == "skipped" and child.get("type") == "pytest.xfail":

--- a/.github/scripts/test_report_test_timings.py
+++ b/.github/scripts/test_report_test_timings.py
@@ -144,7 +144,7 @@ def test_collect_shards_builds_test_windows_and_overhead(tmp_path: Path) -> None
             <testcase classname="pkg.test_a.TestA" name="test_fast" time="0.1"/>
             <testcase classname="pkg.test_a.TestA" name="test_slow" time="2.0"/>
             <testcase classname="pkg.test_a.TestA" name="test_rerun" time="0.2">
-              <rerunFailure message="x"/>
+              <flakyFailure message="x" time="0.3"/>
             </testcase>
             <testcase classname="pkg.test_a.TestA" name="test_fail" time="0.1"><failure message="x"/></testcase>
         """,
@@ -160,8 +160,8 @@ def test_collect_shards_builds_test_windows_and_overhead(tmp_path: Path) -> None
     assert shard.info.total == 7
     assert shard.start == datetime(2026, 5, 4, 10, 0, 0, tzinfo=UTC)
     assert (shard.end - shard.start).total_seconds() == pytest.approx(10.0)
-    assert shard.testcase_seconds == pytest.approx(2.4)
-    assert shard.overhead_seconds == pytest.approx(7.6)
+    assert shard.testcase_seconds == pytest.approx(2.7)
+    assert shard.overhead_seconds == pytest.approx(7.3)
     assert shard.junit_filename == "junit-core.xml"
     assert [t.name for t in shard.tests] == ["test_fast", "test_slow", "test_rerun", "test_fail"]
     assert shard.tests[0].nodeid == "pkg/test_a/TestA::test_fast"
@@ -169,6 +169,7 @@ def test_collect_shards_builds_test_windows_and_overhead(tmp_path: Path) -> None
     assert shard.tests[0].end == datetime(2026, 5, 4, 10, 0, 0, 100000, tzinfo=UTC)
     assert shard.tests[1].start == shard.tests[0].end
     assert shard.tests[2].start == datetime(2026, 5, 4, 10, 0, 2, 100000, tzinfo=UTC)
+    assert shard.tests[2].duration_seconds == pytest.approx(0.5)
     assert shard.tests[2].outcome == "rerun_passed"
     assert shard.tests[2].attempts == 2
     assert shard.tests[3].outcome == "failed"

--- a/.github/scripts/test_report_test_timings.py
+++ b/.github/scripts/test_report_test_timings.py
@@ -197,9 +197,13 @@ def test_collect_shards_builds_test_windows_and_overhead(tmp_path: Path) -> None
             '<testcase name="t"><properties><property name="posthog.reruns" value="garbage"/></properties></testcase>',
             ("passed", 1),
         ),
+        # Playwright's JUnit reporter uses flakyFailure/flakyError for attempts
+        # that failed before the final successful retry.
+        ('<testcase name="t"><flakyFailure message="x"/></testcase>', ("rerun_passed", 2)),
+        ('<testcase name="t"><flakyError message="x"/></testcase>', ("rerun_passed", 2)),
     ],
 )
-def test_classify_testcase_reads_rerun_property(testcase_xml: str, expected: tuple[str, int]) -> None:
+def test_classify_testcase_reads_retry_attempts(testcase_xml: str, expected: tuple[str, int]) -> None:
     assert report_test_timings.classify_testcase(ElementTree.fromstring(testcase_xml)) == expected
 
 

--- a/.github/workflows/ci-e2e-playwright-audit.yml
+++ b/.github/workflows/ci-e2e-playwright-audit.yml
@@ -1,8 +1,7 @@
 # Nightly flake-rate audit for the Playwright suite.
 #
-# The main E2E Playwright workflow retries each test 3 times, which masks per-test
-# flake rate (a test failing 50% of the time still shows green 93.75% of the time
-# across 4 attempts). This workflow re-runs the same suite with PLAYWRIGHT_RETRIES=0
+# The main E2E Playwright workflow retries each test once as a flake safety net.
+# This workflow re-runs the same suite with PLAYWRIGHT_RETRIES=0
 # on a nightly cron, so we can rank tests by raw failure rate and feed that signal
 # back into prioritization.
 #

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -14,7 +14,7 @@ on:
     workflow_dispatch:
         inputs:
             playwright_retries:
-                description: 'Override Playwright retries (leave empty for default of 0 on CI so raw per-test signal reaches Trunk). Set to 1+ to add a retry net for a one-off run.'
+                description: 'Override Playwright retries (leave empty for the normal CI default of 1; use 0 to expose raw failures).'
                 required: false
                 type: string
                 default: ''
@@ -839,10 +839,9 @@ jobs:
               continue-on-error: true
               shell: bash
               env:
-                  # Retries default to 0 so raw per-test signal reaches Trunk — retries mask
-                  # the flake signal quarantining relies on; the quarantine gate below is the
-                  # flake net instead. workflow_dispatch can override for a one-off run.
-                  PLAYWRIGHT_RETRIES: ${{ inputs.playwright_retries || '0' }}
+                  # Normal CI gets one retry as a temporary flake safety net. The nightly
+                  # audit overrides this to 0 so raw first-attempt failures remain visible.
+                  PLAYWRIGHT_RETRIES: ${{ inputs.playwright_retries || '1' }}
                   # Empty when select-specs was skipped (full-run events) or chose a full run.
                   SELECT_MODE: ${{ needs.select-specs.outputs.mode }}
                   SELECT_SPECS: ${{ needs.select-specs.outputs.spec_files }}

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -37,11 +37,9 @@ export default defineConfig({
     /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
     /*
-        Retries are 3 on CI by default (when PLAYWRIGHT_RETRIES is unset). The CI
-        Playwright workflow and the nightly flake-audit both set PLAYWRIGHT_RETRIES=0
-        to surface the true per-test failure rate for Trunk quarantining, which a
-        retry budget otherwise hides (50%-flaky tests pass 93.75% of the time with
-        4 attempts).
+        Retries are 3 on CI when PLAYWRIGHT_RETRIES is unset. Normal CI explicitly
+        sets one retry as a flake safety net, while the nightly audit sets zero to
+        preserve raw per-test failure signal.
      */
     retries: process.env.PLAYWRIGHT_RETRIES ? Number(process.env.PLAYWRIGHT_RETRIES) : process.env.CI ? 3 : 2,
     /*

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -54,7 +54,7 @@ export default defineConfig({
         // flaky tests can't block CI (schema: .test_quarantine.json). No-op when empty.
         ['./playwright.quarantine.reporter.ts'],
         ['html', { open: 'never' }],
-        ...(process.env.CI ? [['junit', { outputFile: 'junit-results.xml' }] as const] : []),
+        ...(process.env.CI ? [['junit', { outputFile: 'junit-results.xml', includeRetries: true }] as const] : []),
         ...(process.env.CI ? [['json', { outputFile: 'results.json' }] as const] : []),
     ],
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
## Problem

Playwright CI currently runs with zero retries after its quarantine safety net was disabled. A single intermittent failure therefore makes the job red, increasing disruption while raw flake measurement already has a dedicated nightly audit.

## Changes

- Restore one retry for normal PR and master Playwright runs.
- Keep the nightly flake audit at zero retries.
- Include failed retry attempts in JUnit so recovered flakes remain visible to Trunk telemetry.
- Classify Playwright's `flakyFailure` and `flakyError` JUnit records as retry attempts in engineering analytics.
- Update the workflow input and configuration comments to document the split.

```diff
- Normal CI: 0 retries
+ Normal CI: 1 retry with all attempts preserved in telemetry
  Nightly audit: 0 retries
```

## How did you test this code?

- `hogli lint:workflows`
- `actionlint` 1.7.12 against both edited workflows
- `pnpm --filter=@posthog/playwright exec playwright test --list`
- `uv run pytest .github/scripts/test_report_test_timings.py` (47 passed)
- `ruff check .github/scripts/report_test_timings.py .github/scripts/test_report_test_timings.py`
- `hogli ci:preflight --fix`
- `git diff --check`

Extended the existing parameterized retry-classification test with Playwright's two recovered-attempt JUnit tags. This catches the regression where engineering analytics reports a recovered flake as one ordinary passing attempt.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed. The workflow input descriptions and adjacent configuration comments are the source of truth for this setting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the retry and telemetry split using the repository-provided `/authoring-ci-workflows` and `/writing-tests` skills plus the public `/pr-shepherd` skill. We chose one retry for normal CI while preserving the zero-retry nightly audit, failed attempts in JUnit, and their retry classification in engineering analytics.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
