### PR TITLE
fix(mysql): retry TLS-handshake-drop connect errors as transient

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -328,6 +328,13 @@ _SSL_UNEXPECTED_EOF_TOKEN = "[SSL: UNEXPECTED_EOF_WHILE_READING]"
 # phrase, not the volatile `_ssl.c:<line>` suffix that shifts across Python builds.
 _SSL_CONNECTION_CLOSED_EOF_TOKEN = "TLS/SSL connection has been closed (EOF)"
 
+# CPython's ssl module raises this when the peer closes the raw socket (a TCP RST or FIN) after
+# sending some bytes that never got consumed by the still-in-progress TLS handshake — a third
+# rendering of the same peer-closed-mid-handshake condition as the two tokens above (an overloaded
+# server, a proxy/load-balancer idle cull, a failover, or a momentary network blip). pymysql wraps
+# it as the same 2003 connect failure, so it's equally transient and must be retried too.
+_SSL_CLOSED_WITH_BUFFERED_DATA_TOKEN = "Closed before TLS handshake with data in recv buffer"
+
 # paramiko raises a bare, message-less EOFError from `start_client` when the SSH gateway accepts
 # the TCP connection but closes it during the SSH handshake — a non-SSH service on the port, a
 # bastion refusing PostHog's IPs, or a proxy that resets the stream. sshtunnel doesn't wrap it
@@ -351,9 +358,10 @@ def _is_transient_connect_drop(e: BaseException) -> bool:
       A fresh attempt recovers. The one 2013 that is *not* transient is the SSL-version
       mismatch (a deterministic config error, already non-retryable): it arrives with an
       `[SSL: ...` suffix, so exclude that and let it surface.
-    - `2003` (can't connect) carrying an SSL peer-close cause — either
-      `[SSL: UNEXPECTED_EOF_WHILE_READING]` (an abrupt read EOF) or "TLS/SSL connection
-      has been closed (EOF)" (`SSLZeroReturnError`, a clean close): the peer dropped the
+    - `2003` (can't connect) carrying an SSL peer-close cause — `[SSL:
+      UNEXPECTED_EOF_WHILE_READING]` (an abrupt read EOF), "TLS/SSL connection has been
+      closed (EOF)" (`SSLZeroReturnError`, a clean close), or "Closed before TLS handshake
+      with data in recv buffer" (a raw socket close mid-handshake): the peer dropped the
       TLS connection mid-handshake — the SSL-flavoured sibling of the 2013 drop, equally
       transient. The generic 2003 (wrong host/port, firewall) stays non-retryable, so
       match only the SSL peer-close tokens.
@@ -365,7 +373,11 @@ def _is_transient_connect_drop(e: BaseException) -> bool:
     if code == _LOST_CONNECTION_DURING_QUERY_CODE:
         return "[SSL:" not in args_text
     if code == _CANT_CONNECT_TO_SERVER_CODE:
-        return _SSL_UNEXPECTED_EOF_TOKEN in args_text or _SSL_CONNECTION_CLOSED_EOF_TOKEN in args_text
+        return (
+            _SSL_UNEXPECTED_EOF_TOKEN in args_text
+            or _SSL_CONNECTION_CLOSED_EOF_TOKEN in args_text
+            or _SSL_CLOSED_WITH_BUFFERED_DATA_TOKEN in args_text
+        )
     return False
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -926,6 +926,9 @@ class TestIsTransientConnectDrop:
             "([SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1032))",
             # The `SSLZeroReturnError` rendering of the same peer-closed-the-TLS-connection drop.
             "Can't connect to MySQL server on 'db.example.com' (TLS/SSL connection has been closed (EOF) (_ssl.c:1032))",
+            # A raw socket close (TCP RST/FIN) mid-handshake, with unread bytes still buffered.
+            "Can't connect to MySQL server on 'db.example.com' "
+            "(Closed before TLS handshake with data in recv buffer. (_ssl.c:1032))",
         ],
     )
     def test_matches_ssl_peer_close_on_connect(self, message):


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError(2003, "Can't connect to MySQL server on '<host>' (Closed before TLS handshake with data in recv buffer.)")` from `_connect_with_transient_retry` in the MySQL data warehouse source ([issue](https://us.posthog.com/project/2/error_tracking/019f9156-eda1-7462-9528-307fb8f3e763)).

`_connect_with_transient_retry` already retries two renderings of the same "peer closed the TLS connection mid-handshake" condition for the generic 2003 connect failure — `[SSL: UNEXPECTED_EOF_WHILE_READING]` (an abrupt read EOF) and `SSLZeroReturnError`'s "TLS/SSL connection has been closed (EOF)" (a clean close). This is a third rendering of that same condition: CPython's ssl module raises it when the peer closes the raw socket (a TCP RST or FIN) with some bytes still buffered before the handshake finishes. It wasn't in the retry classification, so this blip surfaced as an unhandled connect failure instead of being retried in-process — the same overloaded-server / proxy-idle-cull / momentary-network-blip class the other two tokens already cover.

## Changes

Added `_SSL_CLOSED_WITH_BUFFERED_DATA_TOKEN` and matched it alongside the existing two SSL peer-close tokens inside `_is_transient_connect_drop`, following the same pattern.

## How did you test this code?

Added a parameterized case to the existing `TestIsTransientConnectDrop.test_matches_ssl_peer_close_on_connect` covering the new token shape — guards that a future edit can't silently stop retrying this blip. Ran the full `test_mysql.py` suite (235 tests), `ruff check`/`ruff format --check` on the changed files, and repo-wide `mypy` — all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal retry classification, no user-facing behavior or docs to update.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a real error surfaced by PostHog error tracking for this source.
- Skills invoked: `/writing-tests` (gate before extending the existing test case).
- Decision: classified as a fixable bug rather than a `NonRetryableErrors` addition, since the existing predicate already retries two sibling SSL-peer-close renderings for the same 2003 code — this was simply a third rendering of the same transient condition, not a user/upstream config error.
- Checked for duplicate work: reviewed open PR #73392 (`fix(mysql): retry broken-pipe errors during connect as transient`) which addresses a different 2003 sub-cause (EPIPE on write) — not a duplicate of this fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*