### PR TITLE
fix(data-imports): retry delta table reset on transient S3 rate limits

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -494,6 +494,16 @@ async def handle_corrupted_delta_log(
     try:
         await delta_table_helper.reset_table()
     except Exception as e:
+        if is_transient_object_store_error(e):
+            # A rate-limited or connectivity blip purging the old table's S3 prefix isn't a bug —
+            # the revive markers stay set, so the next sync attempt retries the same reset from
+            # scratch. Escalating this through the non-retryable-error policy below would burn
+            # through its attempt budget on pure S3 throttling and give up on a revivable schema.
+            await logger.awarning(
+                f"handle_corrupted_delta_log: reset_table transient object-store error, retrying next sync, "
+                f"schema_id={schema.id}: {e}"
+            )
+            return False
         # A reset that can't even complete (e.g. the storage backend rejects the delete) leaves the
         # revive markers in place, so an unguarded re-raise here would repeat this exact same failing
         # reset on every subsequent sync attempt forever. Give up after a few identical failures

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -334,6 +334,32 @@ class TestHandleCorruptedDeltaLog:
         job.refresh_from_db()
         assert job.billable is True
 
+    def test_reset_transient_object_store_error_retries_next_sync(self, team):
+        # An S3 rate-limit blip purging the old table's prefix (see `_purge_s3_prefix`) is not a bug:
+        # it must skip the non-retryable-error escalation above (which would burn through its attempt
+        # budget on pure throttling) and leave the revive markers set so the next sync retries the
+        # reset from scratch, instead of minting an error-tracking issue for a self-healing blip.
+        schema, job = self._schema_and_job(team)
+        reset_error = OSError("[Errno 16] Please reduce your request rate.")
+        helper = MagicMock(
+            is_table_corrupted=AsyncMock(return_value=True), reset_table=AsyncMock(side_effect=reset_error)
+        )
+        logger = self._logger()
+
+        with (
+            patch(f"{_EXTRACT_MODULE}.posthoganalytics"),
+            patch(f"{_EXTRACT_MODULE}.capture_exception") as mock_capture,
+            patch(f"{_EXTRACT_MODULE}.handle_non_retryable_error") as handle_mock,
+        ):
+            result = async_to_sync(handle_corrupted_delta_log)(schema, job, helper, logger)
+
+        assert result is False
+        mock_capture.assert_not_called()
+        handle_mock.assert_not_called()
+        logger.awarning.assert_awaited()
+        job.refresh_from_db()
+        assert job.billable is True
+
     def test_revive_marker_resets_readable_table(self, team):
         # A hollow table — log opens fine but references data files gone from S3 — is invisible to
         # is_table_corrupted; the repartition scan marks it instead. The marker alone must trigger the

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -51,15 +51,19 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 DEFAULT_COMPACT_FILES_PER_PARTITION_THRESHOLD = 200
 DEFAULT_COMPACT_TOTAL_FILES_THRESHOLD = 5000
 
-# Substrings of the `OSError`s delta-rs's Rust `object_store` crate raises from
-# `DeltaTable.is_deltatable()` when it can't reach or authenticate against our own S3-backed
-# data-warehouse bucket (IMDS/STS blips, dispatch timeouts) — not a customer credential problem.
-# Transient and self-recovering: the next maintenance pass re-lists from scratch, so these
-# shouldn't be treated the same as a bug in our maintenance logic.
+# Substrings of the `OSError`s raised talking to our own S3-backed data-warehouse bucket that are
+# transient and self-recovering, not a bug in our code or a customer credential problem:
+# - the first three come from delta-rs's Rust `object_store` crate inside `DeltaTable.is_deltatable()`
+#   (IMDS/STS blips, dispatch timeouts)
+# - "Please reduce your request rate" is S3's SlowDown throttling response, surfaced by s3fs/aiobotocore
+#   when a bulk delete (e.g. `_purge_s3_prefix`) outruns the bucket's request-rate limit
+# A retry (next maintenance pass, or next sync attempt) redoes the same idempotent operation from
+# scratch, so these shouldn't be treated the same as a bug in our logic.
 TRANSIENT_OBJECT_STORE_ERRORS = (
     "an error occurred while loading credentials",
     "the credential provider was not enabled",
     "Generic S3 error",
+    "Please reduce your request rate",
 )
 
 


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OSError: [Errno 16] Please reduce your request rate.` from `_purge_s3_prefix` in `products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py`, during a Postgres sync's Delta-table corruption revive ([issue](https://us.posthog.com/project/2/error_tracking/019f9187-257f-7133-93b9-a6bc0b571bda)).

The call path: `handle_corrupted_delta_log` -> `reset_table` -> `_purge_s3_prefix`, which bulk-deletes every object under the table's old S3 prefix before rebuilding it. Under enough delete volume, S3 responds with its `SlowDown` throttling error, surfaced by `s3fs`/`aiobotocore` as this `OSError`.

`handle_corrupted_delta_log` routes any `reset_table` failure through the non-retryable-error policy (`handle_non_retryable_error`), which gives the schema a limited number of attempts within 24h before permanently marking it non-retryable. That's the right behavior for a genuine reset failure (e.g. the storage backend rejecting the delete outright), but a pure S3 throttling blip is transient and self-healing — the next sync attempt would redo the same idempotent purge from scratch. Escalating it toward permanent give-up burns through that attempt budget for something that isn't a bug.

This module already has a precedent for this exact distinction: `is_transient_object_store_error` classifies known-transient object-store `OSError`s and skips `capture_exception` for them elsewhere in the same file (`run_pre_write_defensive_compact`). `reset_table`'s failure path just wasn't using it.

## Changes

- Added the S3 `SlowDown` throttling message ("Please reduce your request rate") to `TRANSIENT_OBJECT_STORE_ERRORS` in `delta_table_helper.py`.
- `handle_corrupted_delta_log`'s `reset_table` failure handler now checks `is_transient_object_store_error` first: logs a warning and returns, leaving the revive markers in place so the next sync retries the reset, instead of routing through `handle_non_retryable_error`.

## How did you test this code?

Added `test_reset_transient_object_store_error_retries_next_sync` to `TestHandleCorruptedDeltaLog` in `test_extract.py`, mirroring the existing `test_reset_failure_routes_through_non_retryable_handler` case but with the S3 throttling `OSError` — asserts `capture_exception` and `handle_non_retryable_error` are never called and the job stays billable, which the existing non-retryable test doesn't cover (it only exercises a non-transient reset failure).

I wasn't able to run the test suite in this sandbox (no Python venv or `hogli`/`flox` available here). I did verify with `ruff check`/`ruff format` (clean) and `python -m py_compile` on the changed files, and the new test follows the exact same fixture/mocking pattern as the adjacent passing test in the same class.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable — internal error-handling behavior, no user-facing or documented workflow change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from the linked error-tracking issue (stack trace, sample events, and impact) via Claude Code. Confirmed the failure wasn't already fixed or covered by an open PR — checked PR #73395 (a different transient-S3-error fix in this same pipeline, but for `delete_folder` in `util.py`'s query-folder cleanup, not this `reset_table`/`_purge_s3_prefix` path) and the rest of the open PR queue.

Invoked `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*