### PR TITLE
fix(data-modeling): speed up large DAG layout, fix table pagination

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/modeling/TableView.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/modeling/TableView.tsx
@@ -48,7 +48,6 @@ export function TableView(): JSX.Element {
     }
     return (
         <LemonTable
-            className="h-[calc(100vh-17rem)] overflow-y-auto"
             dataSource={visibleNodes}
             loading={nodesLoading}
             columns={[

--- a/frontend/src/scenes/data-warehouse/scene/modeling/autolayout.ts
+++ b/frontend/src/scenes/data-warehouse/scene/modeling/autolayout.ts
@@ -3,7 +3,7 @@ import type { ElkExtendedEdge, ElkNode } from 'elkjs/lib/elk.bundled.js'
 
 import { getElk } from 'lib/elk'
 
-import { NODE_HEIGHT, NODE_WIDTH } from './constants'
+import { LARGE_GRAPH_NODE_THRESHOLD, NODE_HEIGHT, NODE_WIDTH } from './constants'
 import type { ElkDirection, Node } from './types'
 
 const getElkPortSide = (position: Position): string => {
@@ -25,6 +25,10 @@ export const getFormattedNodes = async (nodes: Node[], edges: Edge[], direction?
     }
 
     direction ??= 'DOWN'
+    // NETWORK_SIMPLEX node placement gives the tightest layout but scales
+    // super-linearly; on large graphs it's the main reason the DAG takes
+    // seconds to appear. BRANDES_KOEPF is ~5x cheaper with a comparable result.
+    const nodePlacementStrategy = nodes.length > LARGE_GRAPH_NODE_THRESHOLD ? 'BRANDES_KOEPF' : 'NETWORK_SIMPLEX'
     const elkOptions = {
         'elk.algorithm': 'layered',
         'elk.direction': direction,
@@ -34,7 +38,7 @@ export const getFormattedNodes = async (nodes: Node[], edges: Edge[], direction?
         'elk.layered.layering.strategy': 'NETWORK_SIMPLEX',
         'elk.layered.mergeEdges': 'true',
         'elk.layered.nodePlacement.bk.fixedAlignment': 'BALANCED',
-        'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
+        'elk.layered.nodePlacement.strategy': nodePlacementStrategy,
         'elk.layered.spacing.nodeNodeBetweenLayers': '60',
         'elk.padding': '[left=0, top=0, right=0, bottom=0]',
         'elk.separateConnectedComponents': 'true',

--- a/frontend/src/scenes/data-warehouse/scene/modeling/constants.ts
+++ b/frontend/src/scenes/data-warehouse/scene/modeling/constants.ts
@@ -1,6 +1,12 @@
-export const PAGE_SIZE = 100
+export const PAGE_SIZE = 40
 export const NODE_WIDTH = 180
 export const NODE_HEIGHT = 120
+
+// Above this node count, ELK's NETWORK_SIMPLEX node placement (which scales
+// super-linearly and runs on the main thread) becomes the dominant cost of
+// showing the graph. We switch to the much cheaper BRANDES_KOEPF placement for
+// large graphs; smaller graphs keep NETWORK_SIMPLEX for its tighter layout.
+export const LARGE_GRAPH_NODE_THRESHOLD = 150
 
 export const TOP_HANDLE_POSITION = {
     x: NODE_WIDTH / 2,


### PR DESCRIPTION
## Problem

On the Data ops → Modeling tab, teams with large DAGs (hundreds of nodes) hit two problems:

1. **The graph takes a very long time to show up.** It blanks out behind a spinner for seconds before the DAG appears.
2. **The list view looks like it doesn't paginate** — you scroll a long list and never see page controls.

## Changes

**Graph layout speed.** The graph is laid out with ELK's `layered` algorithm on the main thread. The dominant cost is the node-placement pass, which was set to `NETWORK_SIMPLEX` — it produces the tightest layout but scales super-linearly, so on a large graph it's several seconds of frozen main thread. I benchmarked the alternatives on a synthetic 800-node / ~950-edge DAG (ELK 0.10.0, the version we ship):

| node placement | layout time |
| --- | --- |
| `NETWORK_SIMPLEX` (before) | ~3500 ms |
| `BRANDES_KOEPF` (after, large graphs) | ~670 ms |

That's ~5x faster, and it isolates to the placement strategy alone — the layering strategy stays `NETWORK_SIMPLEX`, so the tier structure (vertical layers) is identical. `BRANDES_KOEPF` just spreads nodes a bit wider within each tier, which is fine on a pan/zoom canvas. `elk.layered.nodePlacement.bk.fixedAlignment: BALANCED` was already configured for exactly this placement.

To avoid changing anything for the common small-DAG case, the switch is gated on node count (`LARGE_GRAPH_NODE_THRESHOLD = 150`). Below that, both strategies finish in well under ~120 ms, so small graphs keep the tighter `NETWORK_SIMPLEX` placement.

**Table pagination.** `TableView` wrapped the whole `LemonTable` in `h-[calc(100vh-17rem)] overflow-y-auto`. `LemonTable` renders its pagination footer after the rows, so inside that fixed-height scroll box the footer sat below the rows and out of view — which is why it looked like there was no pagination. The fix is to drop the scroll box and let the table paginate natively like every other list in the app, and drop the page size from 100 to 40 so the footer is reachable with a short scroll. Net diff here is one deleted line plus the page-size constant.

> [!NOTE]
> Large graphs (>150 nodes) now use `BRANDES_KOEPF` node placement instead of `NETWORK_SIMPLEX`. Same layer structure, slightly wider horizontal spread. Small graphs are unchanged.

## How did you test this code?

- **Benchmark**: ran ELK 0.10.0 directly against synthetic layered DAGs from 30 to 800 nodes, comparing placement strategies. Numbers above. Confirmed `NETWORK_SIMPLEX` is the super-linear term and `BRANDES_KOEPF` scales far better, while the two are indistinguishable in cost below the threshold.
- **Layout quality**: rendered the same 90-node graph both ways and compared — identical tiering, clean edge routing, no overlaps.
- **Local app**: seeded ~180 view/matview/endpoint nodes + edges into a local DAG and loaded the Modeling tab. Graph renders; table paginates natively at 40/page with the footer visible.
- **Lint/format**: `oxlint` and `oxfmt` clean on the changed files.
- **Not done**: I did not exercise this against the live large-DAG team, and there are no existing unit tests for `autolayout`/`TableView` to extend. The graph fix is a pure ELK option change, so I leaned on the benchmark + local render rather than a snapshot test that wouldn't catch a realistic regression.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Jovan pointed at the Modeling tab being slow on an ~800-node DAG and asked to make it work on huge DAGs. I (Claude) mapped the render path, traced the graph slowness to the ELK `nodePlacement.strategy` option (not the whole engine, and not the layering strategy — swapping layering actually made it worse), and benchmarked the fix before changing code. For the table, the "no pagination" report was a footer hidden inside a fixed-height scroll box; after trying an `allowContentScroll` variant (correctly flagged in review for keeping the footer inside the scroll area) I settled on the boring fix — remove the scroll box, paginate natively, shrink the page size. Rejected moving ELK to a web worker: it keeps the tab responsive but needs a new bundler entrypoint + `/static` asset (the fragile pattern that already bites Monaco in dev), and the option change already gives a 5x win with zero build changes.
