### PR TITLE
fix(data-warehouse): make Google Search Console findable by "seo" in source search

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/source.py
@@ -241,7 +241,7 @@ class GoogleSearchConsoleSource(
         return SourceConfig(
             name=SchemaExternalDataSourceType.GOOGLE_SEARCH_CONSOLE,
             category=DataWarehouseSourceCategory.ANALYTICS,
-            keywords=["gsc"],
+            keywords=["gsc", "seo", "search analytics", "organic search"],
             label="Google Search Console",
             caption=(
                 "Connect a verified Google Search Console property to sync daily Search Analytics performance data "


### PR DESCRIPTION
## Problem

Session summaries from the data-warehouse new-source onboarding flow show users looking for a search/SEO data source and searching for terms like "seo". The source catalog search matches on each connector's `keywords`, and Google Search Console — the canonical search-analytics source — only carried the single keyword `"gsc"`. So a user typing "seo" saw other SEO-adjacent connectors but never Google Search Console itself, even though it's exactly what they were after.

## Changes

Add SEO-related search aliases to the Google Search Console `SourceConfig`:

```
keywords=["gsc", "seo", "search analytics", "organic search"]
```

These are purely additive to the Fuse.js search index used by the new-source catalog — no change to connection, validation, or sync behavior. The keywords flow to the frontend through the existing `SourceConfig` schema, so no codegen or migration is needed.

## How did you test this code?

Ran `ruff check` and `ruff format --check` on the changed file (both pass). Change is a static config value; no existing test pins the keyword list, and the new terms describe what the connector does.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — no user-facing docs describe the catalog search keywords.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code while synthesizing friction themes from onboarding session summaries. The recurring theme here: users can't always find a connector by the name/term they search. Google Search Console was the most-attempted connector in the reviewed sessions and had the thinnest keyword coverage, so this is the highest-confidence, self-contained slice of that theme. Other connector-discovery gaps in the sessions were for sources that don't yet exist (so aliases wouldn't help) and were left as recommendations rather than changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
