### PR TITLE
fix(loops): record disabled_reason on auto-pause

### DIFF
--- a/products/tasks/backend/logic/services/loop_runs.py
+++ b/products/tasks/backend/logic/services/loop_runs.py
@@ -38,6 +38,13 @@ LOOP_TEAM_RATE_CAP_PER_DAY = 500
 LOOP_AUTO_PAUSE_THRESHOLD = 5
 TRIGGER_CONTEXT_MAX_BYTES = 64 * 1024
 
+# Stored on Loop.disabled_reason when the kill-switch pauses a loop, so clients can render the
+# cause (and a billing CTA for usage_limited) instead of a bare "Paused". Lifecycle pause codes
+# (owner deactivated/removed, GitHub disconnected) live in loop_lifecycle.py; re-enabling clears
+# the field in facade/loops.py::update_loop either way.
+DISABLED_REASON_USAGE_LIMITED = "usage_limited"
+DISABLED_REASON_REPEATED_FAILURES = "repeated_failures"
+
 _NON_TERMINAL_TASK_RUN_STATUSES = (TaskRun.Status.NOT_STARTED, TaskRun.Status.QUEUED, TaskRun.Status.IN_PROGRESS)
 _TERMINAL_TASK_RUN_STATUSES = (TaskRun.Status.COMPLETED, TaskRun.Status.FAILED, TaskRun.Status.CANCELLED)
 
@@ -279,7 +286,9 @@ def fire_loop(
     # advisory lock across it would stall every other fire for the team.
     gate_owner_id = loop.created_by_id
     if _usage_gate_blocked(loop):
-        _increment_consecutive_failures_and_maybe_pause(loop, error="cloud usage limit exceeded")
+        _increment_consecutive_failures_and_maybe_pause(
+            loop, error="cloud usage limit exceeded", disabled_reason=DISABLED_REASON_USAGE_LIMITED
+        )
         observe_loop_fire(reason="gate_blocked")
         dispatch_loop_event(loop, "needs_attention", {"reason": "gate_blocked"})
         return LoopFireResult(created=False, reason="gate_blocked", task_id=None, task_run_id=None)
@@ -614,7 +623,7 @@ def _execute_task_processing_workflow_for_loop(
     )
 
 
-def _increment_consecutive_failures_and_maybe_pause(loop: Loop, *, error: str) -> None:
+def _increment_consecutive_failures_and_maybe_pause(loop: Loop, *, error: str, disabled_reason: str) -> None:
     should_pause = False
     with transaction.atomic():
         locked_loop = Loop.objects.for_team(loop.team_id, canonical=True).select_for_update().get(id=loop.id)
@@ -623,7 +632,8 @@ def _increment_consecutive_failures_and_maybe_pause(loop: Loop, *, error: str) -
         update_fields = ["consecutive_failures", "last_error", "updated_at"]
         if locked_loop.consecutive_failures >= LOOP_AUTO_PAUSE_THRESHOLD and locked_loop.enabled:
             locked_loop.enabled = False
-            update_fields.append("enabled")
+            locked_loop.disabled_reason = disabled_reason
+            update_fields.extend(["enabled", "disabled_reason"])
             should_pause = True
         locked_loop.save(update_fields=update_fields)
 
@@ -672,7 +682,8 @@ def handle_loop_run_terminal(task_run: TaskRun) -> None:
         update_fields = ["last_run_at", "last_run_status", "last_error", "consecutive_failures", "updated_at"]
         if not is_success and loop.consecutive_failures >= LOOP_AUTO_PAUSE_THRESHOLD and loop.enabled:
             loop.enabled = False
-            update_fields.append("enabled")
+            loop.disabled_reason = DISABLED_REASON_REPEATED_FAILURES
+            update_fields.extend(["enabled", "disabled_reason"])
             should_pause = True
         loop.save(update_fields=update_fields)
 

--- a/products/tasks/backend/tests/test_loop_runs.py
+++ b/products/tasks/backend/tests/test_loop_runs.py
@@ -13,6 +13,8 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 
 from products.tasks.backend.logic.services.loop_runs import (
+    DISABLED_REASON_REPEATED_FAILURES,
+    DISABLED_REASON_USAGE_LIMITED,
     LOOP_AUTO_PAUSE_THRESHOLD,
     LOOP_RATE_CAP_PER_DAY,
     LOOP_TEAM_RATE_CAP_PER_DAY,
@@ -217,6 +219,7 @@ class TestFireLoopGuardrails(LoopRunsTestCase):
         loop.refresh_from_db()
         self.assertEqual(loop.consecutive_failures, 1)
         self.assertEqual(loop.last_error, "cloud usage limit exceeded")
+        self.assertIsNone(loop.disabled_reason)
         self.assertEqual(Task.objects.filter(team=self.team).count(), 0)
         mock_dispatch.assert_called_once_with(loop, "needs_attention", {"reason": "gate_blocked"})
 
@@ -233,6 +236,7 @@ class TestFireLoopGuardrails(LoopRunsTestCase):
 
         loop.refresh_from_db()
         self.assertFalse(loop.enabled)
+        self.assertEqual(loop.disabled_reason, DISABLED_REASON_USAGE_LIMITED)
         self.assertEqual(loop.consecutive_failures, LOOP_AUTO_PAUSE_THRESHOLD)
         mock_pause.assert_called_once()
         mock_dispatch.assert_any_call(
@@ -767,6 +771,7 @@ class TestHandleLoopRunTerminal(LoopRunsTestCase):
         self.assertEqual(loop.consecutive_failures, 1)
         self.assertEqual(loop.last_error, "boom")
         self.assertTrue(loop.enabled)
+        self.assertIsNone(loop.disabled_reason)
         mock_dispatch.assert_called_once_with(
             loop,
             "run_failed",
@@ -783,6 +788,7 @@ class TestHandleLoopRunTerminal(LoopRunsTestCase):
 
         loop.refresh_from_db()
         self.assertFalse(loop.enabled)
+        self.assertEqual(loop.disabled_reason, DISABLED_REASON_REPEATED_FAILURES)
         self.assertEqual(loop.consecutive_failures, LOOP_AUTO_PAUSE_THRESHOLD)
         mock_pause.assert_called_once()
         mock_dispatch.assert_any_call(


### PR DESCRIPTION
## Problem

Loops auto-pause after 5 consecutive failed fires (including usage-gate blocks), but unlike the lifecycle pauses (owner deactivated, GitHub disconnected) the kill-switch leaves `disabled_reason` null. A tripped loop reads as `enabled=false` with no recorded cause, so clients can't tell an auto-paused loop from one its owner paused, or say why it stopped.

## Changes

The kill-switch now records why it paused the loop:

- `disabled_reason="usage_limited"` when the pause was tripped by the cloud usage gate in `fire_loop`.
- `disabled_reason="repeated_failures"` when tripped by a failed run reaching the threshold in `handle_loop_run_terminal`.

Re-enabling already clears the field and resumes schedules via `facade/loops.py::update_loop`, so recovery needs no changes. The field is already exposed by `LoopSerializer`; a companion desktop PR (PostHog/code#3779) renders the new values.

## How did you test this code?

Extended the existing auto-pause tests in `test_loop_runs.py` to assert the recorded reason on both pause paths, and the below-threshold tests to assert the field stays null (the regression caught: a pause that flips `enabled` without recording a cause, or a reason written before the threshold). Ran `test_loop_runs.py` + `test_loop_lifecycle.py` locally: 50 passed. Ruff lint and format clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5). The session mapped the loops firing/kill-switch path and the existing lifecycle pause conventions, confirmed the usage gate and auto-pause already existed, and made the smallest change that lets clients render the pause cause: reuse the existing `disabled_reason` mechanism rather than adding a new status field or notification type. No repo skills were invoked.