### PR TITLE
fix(postgres): stop reporting admin-shutdown connection drops as defects

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -702,6 +702,17 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             ),
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `get_rows` already retries a mid-stream drop in-process (reconnect, or fall back to
+        # offset chunking) — see `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` in postgres.py. It only
+        # reaches here once that in-process handling gives up (e.g. a full-table scan can't safely
+        # resume once rows have been yielded, since OFFSET has no stable ORDER BY to resume from).
+        # Temporal then retries the whole activity and the failure is transient and
+        # self-recovering, so classify it here too — otherwise `_handle_import_error` logs it at
+        # `exception` on every occurrence, flooding error tracking with a self-recovering failure
+        # (e.g. a cloud provider terminating a backend for maintenance or failover).
+        return {"terminating connection due to"}
+
     def reconcile_schema_metadata(
         self,
         source: "ExternalDataSource",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1082,6 +1082,37 @@ class TestPostgresSourceNonRetryableErrors:
         assert is_non_retryable, f"SSH handshake EOF should be non-retryable: {_SSH_HANDSHAKE_EOF_ERROR}"
 
 
+class TestPostgresSourceRetryableErrors:
+    @pytest.fixture
+    def source(self):
+        return PostgresSource()
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # SQLSTATE 57P01: a DBA (or a cloud provider's maintenance/failover automation) killed
+            # our backend. `get_rows`'s in-process reconnect/offset-chunking already retries this
+            # mid-stream; it only reaches `_handle_import_error` once that resume is unsafe (a
+            # full-table scan with rows already yielded) or its retry budget is exhausted.
+            "terminating connection due to administrator command",
+            "OperationalError: terminating connection due to administrator command",
+        ],
+    )
+    def test_admin_shutdown_is_classified_retryable(self, source, error_msg):
+        retryable = source.get_retryable_errors()
+        is_retryable = any(pattern in error_msg for pattern in retryable)
+        assert is_retryable, f"Admin-shutdown error should be classified retryable: {error_msg}"
+
+    def test_admin_shutdown_is_not_also_non_retryable(self, source):
+        # Guards against the two classifications disagreeing — `_handle_import_error` checks
+        # non-retryable first, so if this ever matched both, it would stop the sync instead of
+        # retrying the activity.
+        error_msg = "terminating connection due to administrator command"
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert not is_non_retryable, f"Admin-shutdown error should not be non-retryable: {error_msg}"
+
+
 def _raise_eof() -> None:
     # Indirection so the `yield` below stays reachable under mypy's warn_unreachable — at runtime
     # this raises before the generator yields, standing in for paramiko's handshake EOFError.


### PR DESCRIPTION
## Problem

[This error tracking issue](https://us.posthog.com/project/2/error_tracking/019f92c9-4fc4-7810-bff0-4f9478e51ea6) fired for the Postgres data-warehouse import source:

```
AdminShutdown: terminating connection due to administrator command
```

This is SQLSTATE 57P01 — a DBA (or a cloud provider's maintenance/failover automation) terminated our backend connection mid-read. `get_rows` in `postgres.py` already retries this class of mid-stream connection drop in-process (reconnect, or fall back to offset chunking) — see `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`. It only escapes to the activity boundary once that in-process handling can't safely continue (a full-table scan can't resume via `OFFSET` once rows have already been yielded, since there's no stable `ORDER BY` to resume from) or the retry budget is exhausted.

Temporal then retries the whole activity and the sync recovers on its own — but `PostgresSource` had no `get_retryable_errors()` override, so `_handle_import_error` logged this at `exception` level on every occurrence, reporting a self-recovering transient as a new defect.

## Changes

- Added `PostgresSource.get_retryable_errors()`, matching the same `"terminating connection due to"` substring `postgres.py` already treats as a transient connection drop. This mirrors the existing pattern in the MySQL and Salesforce sources (`get_retryable_errors()` for a failure the source already retries in-process before re-raising for Temporal).

## How did you test this code?

- Added `TestPostgresSourceRetryableErrors` in `test_postgres.py`: parameterized cases assert the raw and Temporal-wrapped `AdminShutdown` message classify as retryable, plus a guard test that it isn't also matched by `get_non_retryable_errors` (the two classifications disagreeing would stop the sync instead of retrying it). No existing test covered this classification — the existing `TestIsConnectionDroppedError` tests only cover the in-process reconnect decision, not what happens once that reconnect gives up.
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py -k "RetryableErrors or NonRetryableErrors"` — 114 passed.
- `uv run mypy --cache-fine-grained .` — clean, no issues in 16776 source files.
- `ruff check` / `ruff format --check` on the changed files — clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by PostHog Code (Claude) from the error tracking issue linked above. Traced the stack trace to `get_rows` in `postgres.py`, confirmed `AdminShutdown` subclasses `psycopg.OperationalError` and that its message already matches the existing `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` transient-drop classification, and found the gap was that `PostgresSource` (unlike MySQL/Salesforce) had no `get_retryable_errors()` at all, so a drop that outlives the in-process retry/resume budget always logs as a captured exception. Searched open PRs and Gilbert09's own PRs first; PostHog/posthog#71932 handles `AdminShutdown` too but in the unrelated batch-exports destination-writer path, not this warehouse-sources import source, so this isn't a duplicate.