### PR TITLE
fix(aio): use secret_key instead of deprecated personal_api_key in prompt snippet

### DIFF
--- a/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
+++ b/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
@@ -448,7 +448,7 @@ from posthog.ai.prompts import Prompts
 posthog = Posthog(
     '${projectApiKey}',
     host='${host}',
-    personal_api_key='<personal_api_key>',  # scope: llm_prompt:read
+    secret_key='<personal_api_key>',  # scope: llm_prompt:read
 )
 prompts = Prompts(posthog)
 


### PR DESCRIPTION
## Problem

posthog-python 7.28 deprecated `personal_api_key=` on the `Posthog` constructor in favor of `secret_key=`. The prompt page's Python snippet still teaches the deprecated kwarg, so everyone copying it gets a deprecation warning.

## Changes

Swap `personal_api_key=` for `secret_key=` in `buildPythonSnippet`. The Node snippet is unchanged since `personalApiKey` is not deprecated in posthog-node (checked 5.46.1).

## How did you test this code?

String-only change inside a template literal, no tests reference the snippet text. Verified against posthog-python master that `personal_api_key=` emits a DeprecationWarning and `secret_key=` is the replacement.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Companion posthog.com PR updates the same snippet in the prompt management docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code made this change. It verified the deprecation in posthog-python master (constructor warns on `personal_api_key`, resolves it to `secret_key`) and confirmed posthog-node has no equivalent deprecation before leaving the JS snippet alone.
