### PR TITLE
fix(data-imports): stop resurrecting deleted schema rows on bookkeeping save

### DIFF
--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -119,6 +119,13 @@ class ExternalDataSchema(ModelActivityMixin, CreatedMetaFields, UpdatedMetaField
             # an audit trail. Bypass ModelActivityMixin.save() so we skip its extra _get_before_update
             # SELECT — that read needs a fresh pooler connection and raises OperationalError when the
             # transaction pooler has dropped the connection mid-sync, failing the import activity.
+            #
+            # These calls always target an already-persisted row. Without force_update, Django's
+            # UUID-pk-with-default fallback would silently retry a no-op UPDATE as an INSERT if the
+            # row was deleted concurrently (e.g. the source/schema deleted mid-sync) — either
+            # resurrecting deleted data, or failing with a misleading FK IntegrityError on source_id
+            # instead of a clear "no such row" error.
+            kwargs.setdefault("force_update", True)
             super(ModelActivityMixin, self).save(*args, **kwargs)
         else:
             super().save(*args, **kwargs)

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -5,6 +5,7 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.db import DatabaseError
 from django.db.models import Model
 from django.test import SimpleTestCase
 from django.utils import timezone
@@ -198,6 +199,22 @@ class TestExternalDataSchemaActivityLogging(BaseTest):
             model_activity_signal.disconnect(self._signal_handler, sender=ExternalDataSchema)
         schema.refresh_from_db()
         assert schema.incremental_field_last_value == 42
+
+    def test_bookkeeping_save_raises_instead_of_resurrecting_deleted_row(self) -> None:
+        # Source (and its schema, via CASCADE) deleted concurrently with a sync still holding a
+        # stale in-memory schema reference. Without force_update, Django's UUID-pk insert fallback
+        # would silently recreate the row here and hit an FK violation on source_id instead.
+        schema = self._create(
+            sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+            sync_type_config={"incremental_field_type": IncrementalFieldType.Integer},
+        )
+        schema_id = schema.pk
+        self.source.delete()
+
+        with self.assertRaises(DatabaseError):
+            schema.update_incremental_field_value(42)
+
+        assert not ExternalDataSchema.objects.filter(pk=schema_id).exists()
 
 
 class TestExternalDataSchemaOOMEvent(BaseTest):

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -209,7 +209,9 @@ class TestExternalDataSchemaActivityLogging(BaseTest):
             sync_type_config={"incremental_field_type": IncrementalFieldType.Integer},
         )
         schema_id = schema.pk
-        self.source.delete()
+        # A queryset delete (unlike self.source.delete()) doesn't null out this process's cached
+        # `schema.source`, matching production where the delete happens on another connection.
+        ExternalDataSource.objects.filter(pk=self.source.pk).delete()
 
         with self.assertRaises(DatabaseError):
             schema.update_incremental_field_value(42)

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -5,7 +5,7 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
-from django.db import DatabaseError
+from django.db import DatabaseError, transaction
 from django.db.models import Model
 from django.test import SimpleTestCase
 from django.utils import timezone
@@ -213,7 +213,9 @@ class TestExternalDataSchemaActivityLogging(BaseTest):
         # `schema.source`, matching production where the delete happens on another connection.
         ExternalDataSource.objects.filter(pk=self.source.pk).delete()
 
-        with self.assertRaises(DatabaseError):
+        # Postgres aborts the whole transaction on an unhandled DatabaseError; a savepoint keeps
+        # the failure scoped so the existence check below can still run.
+        with self.assertRaises(DatabaseError), transaction.atomic():
             schema.update_incremental_field_value(42)
 
         assert not ExternalDataSchema.objects.filter(pk=schema_id).exists()


### PR DESCRIPTION
## Problem

Error tracking surfaced an `IntegrityError` during a GoogleAds sync: an INSERT into `posthog_externaldataschema` violated the foreign key to `posthog_externaldatasource` because the referenced source no longer existed. That was surprising — the failing call site (`update_incremental_field_value`, invoked from the shared pipeline's `update_incremental_field_values` in `pipelines/common/extract.py`) only ever calls `.save()` on a schema row it already fetched from the database, to persist incremental-sync bookkeeping (cursor position). It should never be doing an INSERT.

Root cause: `ExternalDataSchema`'s primary key is a `UUIDField` with a callable default (via the deprecated `UUIDTModel` base). Django has a documented ORM behavior for models like this — if an UPDATE affects zero rows, it silently falls back to an INSERT instead of raising, since it can't otherwise tell a "new object with a pre-assigned pk" from "existing object whose row is gone." Here, the row was gone: the source (and its schema, via cascade) had been deleted concurrently with an in-flight sync that was still holding a stale in-memory reference to the schema. The resulting INSERT then hit the FK constraint on `source_id`.

The top-most frame in the stack trace (`posthog/temporal/common/posthog_client.py`) is just the generic Temporal activity-exception interceptor that reports every unhandled activity error to error tracking — the real failure originates in `ExternalDataSchema.save()`.

## Changes

`ExternalDataSchema.save(skip_activity_log=True, ...)` — the path used exclusively by internal pipeline bookkeeping saves (incremental cursor, xmin state, sync_type_config) — now passes `force_update=True` by default. This stops Django from ever falling back to an INSERT here: if the row is gone, `.save()` now raises a clear `django.db.DatabaseError` ("Forced update did not affect any rows") instead of a misleading FK `IntegrityError`, and it can no longer silently resurrect a deleted row.

## How did you test this code?

Added `test_bookkeeping_save_raises_instead_of_resurrecting_deleted_row` to `TestExternalDataSchemaActivityLogging` in `products/warehouse_sources/backend/tests/test_models.py`: deletes a schema's source (cascading to the schema row) while a stale in-memory `schema` reference is held, calls `update_incremental_field_value()` on it, and asserts a `DatabaseError` is raised with no row recreated. No existing test in the suite exercised a bookkeeping save racing a concurrent deletion.

Ran `ruff check`/`ruff format --check` (pass) and a repo-wide `mypy --cache-fine-grained .` (pass, no issues) on the changed files.

> [!NOTE]
> I could not run the new Django `TestCase` itself in this sandbox — no Postgres/Docker service is available here. CI (or a reviewer) should confirm it passes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (PostHog Code), triaging a PostHog error-tracking issue for an `IntegrityError` in the data-imports pipeline.
- Skill invoked: `/writing-tests` before adding the regression test.
- Traced the stack trace end-to-end to rule out the source connector and shared pipeline code (Arrow/Delta conversion) as the cause, and instead found the bug in `ExternalDataSchema.save()`'s interaction with Django's UUID-pk insert-fallback behavior.
- Considered classifying this via `NonRetryableErrors` instead of fixing the model, but concluded the misleading `IntegrityError` (and the latent risk of silently resurrecting a deleted row on a lucky FK match) is a genuine shared-code defect worth fixing directly rather than papering over with a retry-policy change.