### PR TITLE
feat(error-tracking): add analytics events for recommendations center

### DIFF
--- a/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
+++ b/products/error_tracking/frontend/components/IssueActions/issueActionsLogic.tsx
@@ -251,7 +251,11 @@ export const issueActionsLogic = kea<issueActionsLogicType>([
                 await runMutation(
                     'updateIssueStatus',
                     async () => {
-                        posthog.capture('error_tracking_issue_update_status')
+                        posthog.capture('error_tracking_issue_update_status', {
+                            status,
+                            issue_id: id,
+                            source: 'issue_actions',
+                        })
                         await api.errorTracking.updateIssue(id, { status })
                     },
                     async () => pendingUpdateActions()?.capturePendingUpdatesForIssues([id], { status })

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
@@ -237,8 +237,10 @@ export const recommendationsTabLogic = kea<recommendationsTabLogicType>([
         },
         suppressIssue: async ({ issueId }) => {
             await api.errorTracking.updateIssue(issueId, { status: 'suppressed' })
-            posthog.capture('error_tracking_long_running_issue_suppressed', {
+            posthog.capture('error_tracking_issue_update_status', {
+                status: 'suppressed',
                 issue_id: issueId,
+                source: 'recommendations',
             })
             const longRunning = values.recommendations.find(isLongRunningIssuesRecommendation)
             if (!longRunning) {
@@ -250,6 +252,11 @@ export const recommendationsTabLogic = kea<recommendationsTabLogicType>([
         },
         activateIssue: async ({ issueId }) => {
             await api.errorTracking.updateIssue(issueId, { status: 'active' })
+            posthog.capture('error_tracking_issue_update_status', {
+                status: 'active',
+                issue_id: issueId,
+                source: 'recommendations',
+            })
             const longRunning = values.recommendations.find(isLongRunningIssuesRecommendation)
             if (!longRunning) {
                 return

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
@@ -194,7 +194,7 @@ export const recommendationsTabLogic = kea<recommendationsTabLogicType>([
             try {
                 const response = await api.errorTracking.listRecommendations()
                 actions.setRecommendations(response.results)
-                posthog.capture('error_tracking_recommendations_viewed', {
+                posthog.capture('error_tracking_recommendations_loaded', {
                     open_count: response.results.filter((r) => !r.dismissed_at && !r.completed).length,
                     completed_count: response.results.filter((r) => !r.dismissed_at && r.completed).length,
                     dismissed_count: response.results.filter((r) => !!r.dismissed_at).length,

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/recommendationsTabLogic.ts
@@ -1,4 +1,5 @@
 import { MakeLogicType, actions, afterMount, beforeUnmount, kea, listeners, path, reducers, selectors } from 'kea'
+import posthog from 'posthog-js'
 
 import { lemonToast } from '@posthog/lemon-ui'
 
@@ -193,6 +194,12 @@ export const recommendationsTabLogic = kea<recommendationsTabLogicType>([
             try {
                 const response = await api.errorTracking.listRecommendations()
                 actions.setRecommendations(response.results)
+                posthog.capture('error_tracking_recommendations_viewed', {
+                    open_count: response.results.filter((r) => !r.dismissed_at && !r.completed).length,
+                    completed_count: response.results.filter((r) => !r.dismissed_at && r.completed).length,
+                    dismissed_count: response.results.filter((r) => !!r.dismissed_at).length,
+                    total_count: response.results.length,
+                })
             } finally {
                 actions.setRecommendationsLoading(false)
             }
@@ -220,6 +227,9 @@ export const recommendationsTabLogic = kea<recommendationsTabLogicType>([
         dismissRecommendation: async ({ id }) => {
             const updated = await api.errorTracking.dismissRecommendation(id)
             actions.upsertRecommendation(updated)
+            posthog.capture('error_tracking_recommendation_dismissed', {
+                recommendation_type: updated.type,
+            })
         },
         restoreRecommendation: async ({ id }) => {
             const updated = await api.errorTracking.restoreRecommendation(id)
@@ -227,6 +237,9 @@ export const recommendationsTabLogic = kea<recommendationsTabLogicType>([
         },
         suppressIssue: async ({ issueId }) => {
             await api.errorTracking.updateIssue(issueId, { status: 'suppressed' })
+            posthog.capture('error_tracking_long_running_issue_suppressed', {
+                issue_id: issueId,
+            })
             const longRunning = values.recommendations.find(isLongRunningIssuesRecommendation)
             if (!longRunning) {
                 return


### PR DESCRIPTION
## Problem

The error tracking recommendations center has no instrumentation for key user interactions, so we can't see how users engage with recommendations — how many they have, which ones they dismiss, or whether they act on long-running issues.

## Changes

Adds analytics capture in `recommendationsTabLogic`:

- `error_tracking_recommendations_loaded` — fired when the recommendations tab loads, with `open_count`, `completed_count`, `dismissed_count`, and `total_count` properties
- `error_tracking_recommendation_dismissed` — fired when a recommendation card is dismissed, with `recommendation_type`
- `error_tracking_issue_update_status` — the existing status-change event, reused for suppress and activate from the long-running issues card with `source: 'recommendations'`, instead of introducing a separate event

To make the reused event segmentable, the existing capture in `issueActionsLogic` gains `status`, `issue_id`, and `source: 'issue_actions'` properties (it previously had no properties).

No behavior changes — analytics only.

## How did you test this code?

Ran `prettier --check` and `oxlint` on the changed files — both pass. No automated tests added: the change only adds fire-and-forget analytics capture calls to existing listeners, with no behavior to regress. Not manually tested in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5). The developer specified the interactions to instrument and chose to reuse the existing `error_tracking_issue_update_status` event with a `source` property rather than adding a narrow suppress-only event; the agent located the call sites, followed the existing `error_tracking_*` naming conventions, and placed captures in the kea listeners after their API calls succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
