### PR TITLE
feat(cdp): compress invocation_globals with zstd instead of gzip

### DIFF
--- a/nodejs/src/cdp/rerun/rerun-e2e.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-e2e.test.ts
@@ -308,7 +308,7 @@ describe('CDP hog invocation rerun e2e', () => {
         const originalInvocationId = originalRows[0].invocation_id
         expect(originalRows[0].is_retry).toBe(0)
         expect(originalRows[0].function_kind).toBe('hog_function')
-        // invocation_globals is stored gzip+base64'd, not raw JSON — base64
+        // invocation_globals is stored compressed+base64'd, not raw JSON — base64
         // never starts with `{`. The rerun below proves the round-trip: it can
         // only rehydrate and re-run if `decodeInvocationGlobals` decompresses
         // this value correctly.

--- a/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.ts
@@ -1,6 +1,6 @@
-import { decompress as zstdDecompress } from '@mongodb-js/zstd'
+import { compress as zstdCompress, decompress as zstdDecompress } from '@mongodb-js/zstd'
 import { promisify } from 'node:util'
-import { gunzip, gzip } from 'node:zlib'
+import { gunzip } from 'node:zlib'
 import { Counter, Gauge } from 'prom-client'
 
 import { HOG_INVOCATION_RESULTS_OUTPUT, HogInvocationResultsOutput } from '~/common/outputs'
@@ -72,7 +72,7 @@ export interface HogInvocationResultRow {
     event_uuid: string
     distinct_id: string
     person_id: string
-    invocation_globals: string // globals JSON (inputs/groups/person stripped) — gzip+base64'd on produce
+    invocation_globals: string // globals JSON (inputs/groups/person stripped) — zstd+base64'd on produce (older rows: gzip+base64 or raw JSON)
     version: string // microsecond-precision UInt64; serialized as string to dodge JS's 53-bit precision
     is_deleted: 0 | 1
 }
@@ -241,16 +241,18 @@ const serializeInvocationGlobals = (invocation: CyclotronJobInvocation): string 
     return '{}'
 }
 
-const gzipAsync = promisify(gzip)
 const gunzipAsync = promisify(gunzip)
 
 // `invocation_globals` is the bulk of every lifecycle row. Warpstream meters
-// the uncompressed message bytes, so gzipping this one field before produce
+// the uncompressed message bytes, so compressing this one field before produce
 // directly cuts cyclotron throughput. The row envelope stays plain JSON — only
 // this field is opaque — so the ClickHouse Kafka engine still parses the
-// message as JSONEachRow. `decodeInvocationGlobals` is the inverse.
+// message as JSONEachRow. Zstd level 3 compresses our payloads ~4x faster than
+// the gzip codec it replaced at a near-identical ratio (within ~4%, measured
+// on production samples), so the metered-bytes savings hold while the CPU cost
+// per row drops. `decodeInvocationGlobals` is the inverse.
 const compressInvocationGlobals = async (globalsJson: string): Promise<string> => {
-    return (await gzipAsync(globalsJson)).toString('base64')
+    return (await zstdCompress(Buffer.from(globalsJson), 3)).toString('base64')
 }
 
 const ZSTD_MAGIC = Buffer.from([0x28, 0xb5, 0x2f, 0xfd])

--- a/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.ts
+++ b/nodejs/src/cdp/services/monitoring/hog-invocation-results.service.ts
@@ -243,16 +243,19 @@ const serializeInvocationGlobals = (invocation: CyclotronJobInvocation): string 
 
 const gunzipAsync = promisify(gunzip)
 
+// Level 3 (the library default) compresses our payloads ~4x faster than the
+// gzip codec it replaced at a near-identical ratio (within ~4%, measured on
+// production samples), so the metered-bytes savings hold while the CPU cost
+// per row drops.
+const ZSTD_COMPRESSION_LEVEL = 3
+
 // `invocation_globals` is the bulk of every lifecycle row. Warpstream meters
 // the uncompressed message bytes, so compressing this one field before produce
 // directly cuts cyclotron throughput. The row envelope stays plain JSON — only
 // this field is opaque — so the ClickHouse Kafka engine still parses the
-// message as JSONEachRow. Zstd level 3 compresses our payloads ~4x faster than
-// the gzip codec it replaced at a near-identical ratio (within ~4%, measured
-// on production samples), so the metered-bytes savings hold while the CPU cost
-// per row drops. `decodeInvocationGlobals` is the inverse.
+// message as JSONEachRow. `decodeInvocationGlobals` is the inverse.
 const compressInvocationGlobals = async (globalsJson: string): Promise<string> => {
-    return (await zstdCompress(Buffer.from(globalsJson), 3)).toString('base64')
+    return (await zstdCompress(Buffer.from(globalsJson), ZSTD_COMPRESSION_LEVEL)).toString('base64')
 }
 
 const ZSTD_MAGIC = Buffer.from([0x28, 0xb5, 0x2f, 0xfd])


### PR DESCRIPTION
## Problem

Second half of the `invocation_globals` codec swap; stacked on #73432 (readers-first).

Every hog invocation lifecycle row gzip-compresses its `invocation_globals` field before Kafka produce. Profiling shows that gzip pipeline dominating the workers' wall-clock time — several times the cost of the hog VM execution itself — throttling consume throughput on saturated workers:

| Where wall-clock time goes (busy worker, Pyroscope, 45 min) | Share |
| --- | --- |
| zlib gzip pipeline (compress callback → emit → write) | 43.7% |
| Serializing + stripping `invocation_globals` | 11.9% |
| GC | 10.9% |
| OTel span overhead | 10.6% |
| Hog VM execution (the actual work) | 7.3% |
| Kafka produce of the lifecycle row | 4.7% |

Fleet-wide, the gzip machinery alone is roughly 22% of aggregate worker CPU (~30% including its async scheduling) versus ~5-7% for hog VM execution. Zstd compresses the same payloads roughly 4x faster at a near-identical ratio, so the WarpStream metered-bytes savings that motivated field-level compression are preserved.

## Changes

`compressInvocationGlobals` now uses `@mongodb-js/zstd` at level 3 instead of `node:zlib` gzip. The `gzip`/`gzipAsync` write path is removed; `gunzip` stays for decoding the gzip rows written before this change, until they age out under the table's 30-day TTL. Comment-only updates elsewhere.

Level choice, measured offline on 90 recent production `invocation_globals` payloads (aggregate ratios only):

| Codec | Compressed size vs gzip |
| --- | --- |
| zstd level 1 | +4.6% |
| **zstd level 3** | **+3.6%** |
| zstd level 5 | +0.4% |
| zstd level 7 | ±0% |

Level 7 reaches byte parity but gives up most of the compression-speed win, and CPU relief is the goal here; level 3 keeps ~4x gzip's compress speed at a ~3.6% byte penalty on this one field. Level 3 is also the library default.

> [!WARNING]
> Merge only after #73432 is deployed to **both Django and the Node workers in both regions**. From the moment this deploys, new rows are zstd-encoded; a reader without the magic-byte dispatch would fail on them (Node rerun paginator skips such rows; the Python detail API degrades them to `{}`).

## How did you test this code?

Automated tests only (no manual testing): `jest src/cdp/services/monitoring/hog-invocation-results.service.test.ts src/cdp/rerun/rerun-paginator.replay-fidelity.test.ts` — 24 passed. No new tests: the existing round-trip test is codec-agnostic and now exercises the zstd writer end-to-end, and #73432 already added the decode coverage for both codecs (including the cross-language fixture the Python API decodes).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover this internal field encoding.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) as the follow-up to #73432 (see its agent context for the overall investigation). For the level choice the agent pulled recent production `invocation_globals` blobs via internal ClickHouse tooling, decompressed them locally, and recompressed at several zstd levels to produce the table above; raw payloads never left the local analysis. A cleanup PR can drop the gzip decode branches once the gzip cohort has fully expired from the table TTL (~30 days after this deploys).

Skills invoked: `/writing-tests` (concluded no new tests were warranted here).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
