### PR TITLE
feat(workflows): notify on email reputation state transitions

### DIFF
--- a/frontend/src/lib/components/NotificationsMenu/NotificationRow.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationRow.tsx
@@ -69,6 +69,10 @@ export const REALTIME_NOTIFICATION_TYPE_META: Record<string, { label: string; de
         label: 'Subscription suggestions',
         description: 'When PostHog suggests subscribing to a dashboard you keep coming back to',
     },
+    email_reputation: {
+        label: 'Email reputation',
+        description: 'When workflow email bounce or spam complaint rates put your email sending at risk',
+    },
 }
 
 export function NotificationTitle({

--- a/frontend/src/lib/components/NotificationsMenu/notificationToasts.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/notificationToasts.tsx
@@ -35,6 +35,7 @@ const NOTIFICATION_TYPE_ICONS: Record<string, { Icon: ComponentType<{ className?
     web_analytics_digest: { Icon: IconPieChart, color: 'text-primary' },
     achievement_unlocked: { Icon: IconStar, color: 'text-warning' },
     subscription_nudge: { Icon: IconBell, color: 'text-primary' },
+    email_reputation: { Icon: IconWarning, color: 'text-danger' },
 }
 
 export function getNotificationIcon(notificationType: string, className: string = 'size-5'): JSX.Element {

--- a/frontend/src/scenes/settings/user/UpdateEmailPreferences.tsx
+++ b/frontend/src/scenes/settings/user/UpdateEmailPreferences.tsx
@@ -23,6 +23,7 @@ enum NotificationBlock {
     CommentMentions = 'comment-mentions',
     ApiKeyExposure = 'api-key-exposure',
     MaterializedViewSync = 'materialized-view-sync',
+    EmailReputation = 'email-reputation',
 }
 
 const NOTIFICATION_BLOCK_ORDER = Object.values(NotificationBlock)
@@ -44,6 +45,7 @@ const NOTIFICATION_DEFAULTS: BooleanNotificationSettings = {
     project_api_key_exposed: true,
     materialized_view_sync_failed: false,
     web_analytics_weekly_digest: true,
+    email_reputation_degraded: true,
 }
 
 function ProjectDigestSelector({
@@ -515,6 +517,16 @@ export function UpdateEmailPreferences(): JSX.Element {
                     label="Materialized view sync failures"
                     description="Get notified when a materialized view fails to sync"
                     dataAttr="materialized_view_sync_failed_enabled"
+                />
+            </div>
+        ),
+        [NotificationBlock.EmailReputation]: (
+            <div className="border rounded p-4">
+                <SimpleSwitch
+                    setting="email_reputation_degraded"
+                    label="Email reputation warnings"
+                    description="Get notified when workflow email bounce or spam complaint rates put your email sending at risk"
+                    dataAttr="email_reputation_degraded_enabled"
                 />
             </div>
         ),

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -445,6 +445,7 @@ export interface NotificationSettings {
     data_pipeline_error_threshold?: number
     project_api_key_exposed?: boolean
     materialized_view_sync_failed?: boolean
+    email_reputation_degraded?: boolean
     web_analytics_weekly_digest: boolean
     web_analytics_weekly_digest_project_enabled?: Record<string, boolean>
     organization_member_join_email_disabled?: Record<string, boolean>

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -1853,6 +1853,7 @@ class TestUserAPI(APIBaseTest):
                 "project_api_key_exposed": True,
                 "materialized_view_sync_failed": True,
                 "web_analytics_weekly_digest": True,
+                "email_reputation_degraded": True,
                 "organization_member_join_email_disabled": {},
                 "realtime_notifications_disabled": {},
                 "pipeline_notifications_disabled": {},
@@ -1873,6 +1874,7 @@ class TestUserAPI(APIBaseTest):
                 "project_api_key_exposed": True,
                 "materialized_view_sync_failed": True,
                 "web_analytics_weekly_digest": True,
+                "email_reputation_degraded": True,
                 "organization_member_join_email_disabled": {},
                 "realtime_notifications_disabled": {},
                 "pipeline_notifications_disabled": {},
@@ -2141,6 +2143,7 @@ class TestUserAPI(APIBaseTest):
                 "project_api_key_exposed": True,  # Default value
                 "materialized_view_sync_failed": False,  # Default value
                 "web_analytics_weekly_digest": True,  # Default value
+                "email_reputation_degraded": True,  # Default value
                 "organization_member_join_email_disabled": {},  # Default value
                 "realtime_notifications_disabled": {},  # Default value
                 "pipeline_notifications_disabled": {},  # Default value

--- a/posthog/models/user.py
+++ b/posthog/models/user.py
@@ -46,6 +46,7 @@ class Notifications(TypedDict, total=False):
     project_api_key_exposed: bool
     materialized_view_sync_failed: bool
     web_analytics_weekly_digest: bool
+    email_reputation_degraded: bool
     web_analytics_weekly_digest_project_enabled: dict[str, bool]
     organization_member_join_email_disabled: dict[
         str, bool
@@ -69,6 +70,7 @@ NOTIFICATION_DEFAULTS: Notifications = {
     "project_api_key_exposed": True,  # Private project API key (secure API key) exposure alerts enabled by default
     "materialized_view_sync_failed": False,  # Materialized view failure disabled by default
     "web_analytics_weekly_digest": True,  # Web analytics weekly digest enabled by default
+    "email_reputation_degraded": True,  # Workflow email reputation warnings enabled by default
     "organization_member_join_email_disabled": {},  # No per-org opt-out until user configures
     "realtime_notifications_disabled": {},  # No opt-outs by default
     "pipeline_notifications_disabled": {},  # No per-pipeline opt-out until user configures

--- a/posthog/settings/ses.py
+++ b/posthog/settings/ses.py
@@ -13,3 +13,7 @@ else:
     SES_SECRET_ACCESS_KEY = os.getenv("SES_SECRET_ACCESS_KEY", "") or None
 
 SES_REGION = os.getenv("SES_REGION", "us-east-1")
+
+# Incoming webhook for internal alerts when a team's email reputation goes critical.
+# Unset: Slack alerting is skipped.
+EMAIL_REPUTATION_SLACK_WEBHOOK_URL: str = os.getenv("EMAIL_REPUTATION_SLACK_WEBHOOK_URL", "")

--- a/posthog/settings/ses.py
+++ b/posthog/settings/ses.py
@@ -13,7 +13,3 @@ else:
     SES_SECRET_ACCESS_KEY = os.getenv("SES_SECRET_ACCESS_KEY", "") or None
 
 SES_REGION = os.getenv("SES_REGION", "us-east-1")
-
-# Incoming webhook for internal alerts when a team's email reputation goes critical.
-# Unset: Slack alerting is skipped.
-EMAIL_REPUTATION_SLACK_WEBHOOK_URL: str = os.getenv("EMAIL_REPUTATION_SLACK_WEBHOOK_URL", "")

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -61,6 +61,7 @@ class NotificationSetting(Enum):
     PROJECT_API_KEY_EXPOSED = "project_api_key_exposed"
     MATERIALIZED_VIEW_SYNC_FAILED = "materialized_view_sync_failed"
     WEB_ANALYTICS_WEEKLY_DIGEST = "web_analytics_weekly_digest"
+    EMAIL_REPUTATION_DEGRADED = "email_reputation_degraded"
 
 
 NotificationSettingType = Literal[
@@ -72,6 +73,7 @@ NotificationSettingType = Literal[
     "project_api_key_exposed",
     "materialized_view_sync_failed",
     "web_analytics_weekly_digest",
+    "email_reputation_degraded",
 ]
 
 
@@ -199,6 +201,10 @@ def should_send_notification(
 
     elif notification_type == NotificationSetting.MATERIALIZED_VIEW_SYNC_FAILED.value:
         return settings.get(notification_type, False)
+
+    # Default to True (enabled) if not set
+    elif notification_type == NotificationSetting.EMAIL_REPUTATION_DEGRADED.value:
+        return settings.get(notification_type, True)
 
     # The below typeerror is ignored because we're currently handling the notification
     # types above, so technically it's unreachable. However if another is added but
@@ -646,6 +652,44 @@ def send_email_sending_unsuspended(team_id: int, unsuspended_at: str) -> None:
         template_name="email_sending_unsuspended",
         template_context={
             "team": team,
+            "reputation_path": f"/project/{team.id}/workflows/reputation",
+        },
+    )
+    for membership in memberships_to_email:
+        message.add_user_recipient(membership.user)
+    message.send()
+
+
+@shared_task(**EMAIL_TASK_KWARGS)
+def send_email_reputation_degraded(
+    team_id: int, state: str, bounce_rate: float, complaint_rate: float, evaluated_at: str
+) -> None:
+    """
+    Warn a team's members that their workflow email reputation entered ``warning`` or
+    ``critical``. The campaign key embeds the snapshot's ``evaluated_at``, so the hourly
+    transition scan can re-enqueue safely — MessagingRecord makes repeats a no-op.
+    """
+    if not is_email_available(with_absolute_urls=True):
+        return
+    team = Team.objects.get(id=team_id)
+    memberships_to_email = get_members_to_notify(team, "email_reputation_degraded")
+    if not memberships_to_email:
+        return
+
+    is_critical = state == "critical"
+    campaign_key = f"email_reputation_{team_id}_{state}_{evaluated_at}"
+    message = EmailMessage(
+        campaign_key=campaign_key,
+        subject=(
+            f"[Action required] Email sending for project '{team}' is at risk of suspension"
+            if is_critical
+            else f"[Alert] Email reputation for project '{team}' needs attention"
+        ),
+        template_name="email_reputation_critical" if is_critical else "email_reputation_warning",
+        template_context={
+            "team": team,
+            "bounce_rate": f"{bounce_rate:.2%}",
+            "complaint_rate": f"{complaint_rate:.2%}",
             "reputation_path": f"/project/{team.id}/workflows/reputation",
         },
     )

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -116,6 +116,7 @@ from products.web_analytics.backend.tasks.heatmap_screenshot import (
     reap_stale_prewarm_heatmaps,
     report_stuck_heatmap_screenshots,
 )
+from products.workflows.backend.tasks.email_reputation import check_email_reputation_transitions
 
 TWENTY_FOUR_HOURS = 24 * 60 * 60
 
@@ -263,6 +264,15 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(minute="0"),
         kill_stale_queued_task_runs.s(),
         name="kill stale queued task runs",
+    )
+
+    # Email reputation transition notifications - hourly at :20. The evaluator snapshots daily
+    # (06:00 UTC); scanning hourly keeps notification lag small when a run lands late.
+    add_periodic_task_with_expiry(
+        sender,
+        crontab(minute="20"),
+        check_email_reputation_transitions.s(),
+        name="check email reputation transitions",
     )
 
     # Re-dispatch orphaned QUEUED task runs whose on_commit dispatch was lost - every 2 minutes

--- a/posthog/templates/email/email_reputation_critical.html
+++ b/posthog/templates/email/email_reputation_critical.html
@@ -1,0 +1,36 @@
+{% extends "email/base.html" %} {% load posthog_assets %}
+{% block heading %}Email sending is at risk of suspension{% endblock %}
+{% block section %}
+<!-- prettier-ignore -->
+<p>
+    Workflow emails sent from project <b>{{ team }}</b> have crossed critical reputation thresholds.
+    Over your recent sending, the hard bounce rate is <b>{{ bounce_rate }}</b> and the spam complaint rate is <b>{{ complaint_rate }}</b>.
+</p>
+<p>
+    Sending at these rates damages deliverability for your emails. <b>Email sending for this project may be suspended</b> to protect deliverability unless the rates come back down.
+</p>
+<p>
+    Act now: open the Reputation tab to find the workflow responsible, remove old or purchased addresses from your lists, and stop sending to recipients who never engage. Rates are recalculated daily, so improvements show up quickly.
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{% absolute_uri reputation_path %}">View reputation</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{% absolute_uri reputation_path %}">{% absolute_uri reputation_path %}</a>
+    </p>
+</div>
+{% endblock %}
+
+{% block footer %}
+Need help?
+<a href="https://posthog.com/questions?{{ utm_tags }}"
+    target="_blank"><b>Visit support</b></a>
+or
+<a href="https://posthog.com/docs?{{ utm_tags }}"
+    target="_blank"><b>read our documentation</b></a>.<br /><br />
+
+<a href="{% absolute_uri '/settings/user-notifications' %}">Manage these notifications in PostHog</a>
+
+{% endblock %}

--- a/posthog/templates/email/email_reputation_warning.html
+++ b/posthog/templates/email/email_reputation_warning.html
@@ -1,0 +1,36 @@
+{% extends "email/base.html" %} {% load posthog_assets %}
+{% block heading %}Your email reputation needs attention{% endblock %}
+{% block section %}
+<!-- prettier-ignore -->
+<p>
+    Workflow emails sent from project <b>{{ team }}</b> are bouncing or being marked as spam more often than they should.
+    Over your recent sending, the hard bounce rate is <b>{{ bounce_rate }}</b> and the spam complaint rate is <b>{{ complaint_rate }}</b>.
+</p>
+<p>
+    High rates hurt deliverability for your emails. If they keep climbing past the critical thresholds, email sending for this project may be suspended to protect deliverability.
+</p>
+<p>
+    The Reputation tab shows the rates for each workflow, so you can find the one responsible. Common fixes: remove old or purchased addresses from your lists, and stop sending to recipients who never engage.
+</p>
+<div class="mb mt text-center">
+    <a class="button" href="{% absolute_uri reputation_path %}">View reputation</a>
+</div>
+<div class="mt">
+    <p>
+        If the button above doesn't work, paste this link into your browser:<br />
+        <a href="{% absolute_uri reputation_path %}">{% absolute_uri reputation_path %}</a>
+    </p>
+</div>
+{% endblock %}
+
+{% block footer %}
+Need help?
+<a href="https://posthog.com/questions?{{ utm_tags }}"
+    target="_blank"><b>Visit support</b></a>
+or
+<a href="https://posthog.com/docs?{{ utm_tags }}"
+    target="_blank"><b>read our documentation</b></a>.<br /><br />
+
+<a href="{% absolute_uri '/settings/user-notifications' %}">Manage these notifications in PostHog</a>
+
+{% endblock %}

--- a/products/workflows/backend/tasks/email_reputation.py
+++ b/products/workflows/backend/tasks/email_reputation.py
@@ -1,0 +1,175 @@
+from collections.abc import Mapping
+from datetime import datetime, timedelta
+from typing import Any, Optional
+
+from django.conf import settings
+from django.core.cache import cache
+from django.utils import timezone
+
+import requests
+from celery import shared_task
+from structlog import get_logger
+
+from posthog.models import Team
+from posthog.tasks.email import send_email_reputation_degraded
+from posthog.tasks.utils import CeleryQueue
+
+from products.notifications.backend.facade.api import (
+    NotificationData,
+    NotificationType,
+    Priority,
+    TargetType,
+    create_notification,
+)
+from products.workflows.backend.models.email_reputation import EmailReputationSnapshot
+from products.workflows.backend.models.team_workflows_config import TeamWorkflowsConfig
+
+logger = get_logger(__name__)
+
+# The evaluator snapshots daily; two days of lookback pairs each latest snapshot with its
+# predecessor even when a run lands late, and a longer gap means the previous state is stale
+# enough that re-entering a degraded state deserves a fresh notification anyway.
+SNAPSHOT_LOOKBACK = timedelta(days=2)
+
+# The scan runs hourly but each snapshot must produce side effects exactly once; the marker
+# outlives any realistic evaluator gap. Emails are additionally deduped via MessagingRecord,
+# so a cache eviction can at worst duplicate an in-app notification or Slack message.
+PROCESSED_MARKER_TTL_SECONDS = int(timedelta(days=7).total_seconds())
+
+REPUTATION_TAB_PATH = "/workflows/reputation"
+
+
+def _processed_marker_key(team_id: int, evaluated_at: datetime) -> str:
+    return f"email_reputation_transitions:{team_id}:{evaluated_at.isoformat()}"
+
+
+@shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
+def check_email_reputation_transitions() -> None:
+    """
+    Notify on team email reputation state transitions.
+
+    Compares each team's two most recent team-scope snapshots (written daily by the Node
+    Temporal evaluator): entering ``warning`` notifies the customer (email + in-app);
+    entering ``critical`` additionally alerts us on Slack, and Slack keeps firing on every
+    new critical snapshot until the team is suspended or recovers — that nag is the manual
+    enforcement queue.
+    """
+    now = timezone.now()
+    # Cross-team by design: this scan covers every sending team, hence unscoped().
+    rows = (
+        EmailReputationSnapshot.objects.unscoped()
+        .filter(scope=EmailReputationSnapshot.Scope.TEAM, evaluated_at__gte=now - SNAPSHOT_LOOKBACK)
+        .order_by("team_id", "-evaluated_at")
+        .values("team_id", "state", "bounce_rate", "complaint_rate", "emails_sent", "evaluated_at")
+    )
+
+    snapshots_by_team: dict[int, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        team_rows = snapshots_by_team.setdefault(row["team_id"], [])
+        if len(team_rows) < 2:
+            team_rows.append(row)
+
+    degraded_team_ids = [
+        team_id
+        for team_id, team_rows in snapshots_by_team.items()
+        if team_rows[0]["state"] in (EmailReputationSnapshot.State.WARNING, EmailReputationSnapshot.State.CRITICAL)
+    ]
+    if not degraded_team_ids:
+        return
+
+    teams_by_id = {team.id: team for team in Team.objects.filter(id__in=degraded_team_ids)}
+    suspended_team_ids = set(
+        TeamWorkflowsConfig.objects.filter(
+            team_id__in=degraded_team_ids, email_sending_suspended_at__isnull=False
+        ).values_list("team_id", flat=True)
+    )
+
+    for team_id in degraded_team_ids:
+        team = teams_by_id.get(team_id)
+        if not team:
+            continue
+        latest = snapshots_by_team[team_id][0]
+        previous = snapshots_by_team[team_id][1] if len(snapshots_by_team[team_id]) > 1 else None
+        marker_key = _processed_marker_key(team_id, latest["evaluated_at"])
+        if cache.get(marker_key):
+            continue
+        try:
+            _process_team_transition(team, latest, previous, suspended=team_id in suspended_team_ids)
+        except Exception:
+            # Per-team isolation: one team failing must not starve the rest of the scan.
+            logger.exception("Failed to process email reputation transition", team_id=team_id)
+            continue
+        cache.set(marker_key, True, PROCESSED_MARKER_TTL_SECONDS)
+
+
+def _process_team_transition(
+    team: Team, latest: Mapping[str, Any], previous: Optional[Mapping[str, Any]], suspended: bool
+) -> None:
+    latest_state = latest["state"]
+    previous_state = previous["state"] if previous else None
+
+    if latest_state == EmailReputationSnapshot.State.CRITICAL:
+        if previous_state != EmailReputationSnapshot.State.CRITICAL:
+            _notify_customer(team, latest)
+        if not suspended:
+            _send_slack_critical_alert(team, latest)
+    elif latest_state == EmailReputationSnapshot.State.WARNING and previous_state not in (
+        EmailReputationSnapshot.State.WARNING,
+        EmailReputationSnapshot.State.CRITICAL,
+    ):
+        _notify_customer(team, latest)
+
+
+def _notify_customer(team: Team, snapshot: Mapping[str, Any]) -> None:
+    is_critical = snapshot["state"] == EmailReputationSnapshot.State.CRITICAL
+    send_email_reputation_degraded.delay(
+        team_id=team.id,
+        state=snapshot["state"],
+        bounce_rate=snapshot["bounce_rate"],
+        complaint_rate=snapshot["complaint_rate"],
+        evaluated_at=snapshot["evaluated_at"].isoformat(),
+    )
+    create_notification(
+        NotificationData(
+            team_id=team.id,
+            notification_type=NotificationType.EMAIL_REPUTATION,
+            priority=Priority.CRITICAL if is_critical else Priority.NORMAL,
+            title=(
+                "Email sending is at risk of suspension" if is_critical else "Your email reputation needs attention"
+            ),
+            body=(
+                f"Your recent hard bounce rate is {snapshot['bounce_rate']:.2%} and spam complaint rate is "
+                f"{snapshot['complaint_rate']:.2%}. Check the Reputation tab to find the workflow responsible."
+            ),
+            target_type=TargetType.TEAM,
+            target_id=str(team.id),
+            source_url=REPUTATION_TAB_PATH,
+        )
+    )
+
+
+def _send_slack_critical_alert(team: Team, snapshot: Mapping[str, Any]) -> None:
+    webhook_url = settings.EMAIL_REPUTATION_SLACK_WEBHOOK_URL
+    if not webhook_url:
+        logger.warning("No Slack webhook configured for email reputation alerts", team_id=team.id)
+        return
+
+    admin_url = f"{settings.SITE_URL}/admin/posthog/team/{team.id}/change/"
+    blocks = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    f":rotating_light: *Email reputation critical* for team `{team.id}` ({team.name})\n"
+                    f"Hard bounce rate: *{snapshot['bounce_rate']:.2%}* · "
+                    f"Complaint rate: *{snapshot['complaint_rate']:.2%}* · "
+                    f"Emails evaluated: *{snapshot['emails_sent']}*\n"
+                    f"Evaluated at {snapshot['evaluated_at'].isoformat()} — sending is NOT suspended yet.\n"
+                    f"<{admin_url}|Review and suspend in Django admin>"
+                ),
+            },
+        }
+    ]
+    response = requests.post(webhook_url, json={"blocks": blocks}, timeout=10)
+    response.raise_for_status()

--- a/products/workflows/backend/tasks/email_reputation.py
+++ b/products/workflows/backend/tasks/email_reputation.py
@@ -2,11 +2,9 @@ from collections.abc import Mapping
 from datetime import datetime, timedelta
 from typing import Any, Optional
 
-from django.conf import settings
 from django.core.cache import cache
 from django.utils import timezone
 
-import requests
 from celery import shared_task
 from structlog import get_logger
 
@@ -22,7 +20,6 @@ from products.notifications.backend.facade.api import (
     create_notification,
 )
 from products.workflows.backend.models.email_reputation import EmailReputationSnapshot
-from products.workflows.backend.models.team_workflows_config import TeamWorkflowsConfig
 
 logger = get_logger(__name__)
 
@@ -33,7 +30,7 @@ SNAPSHOT_LOOKBACK = timedelta(days=2)
 
 # The scan runs hourly but each snapshot must produce side effects exactly once; the marker
 # outlives any realistic evaluator gap. Emails are additionally deduped via MessagingRecord,
-# so a cache eviction can at worst duplicate an in-app notification or Slack message.
+# so a cache eviction can at worst duplicate an in-app notification.
 PROCESSED_MARKER_TTL_SECONDS = int(timedelta(days=7).total_seconds())
 
 REPUTATION_TAB_PATH = "/workflows/reputation"
@@ -46,13 +43,13 @@ def _processed_marker_key(team_id: int, evaluated_at: datetime) -> str:
 @shared_task(ignore_result=True, queue=CeleryQueue.DEFAULT.value)
 def check_email_reputation_transitions() -> None:
     """
-    Notify on team email reputation state transitions.
+    Notify customers when their team's email reputation state degrades.
 
     Compares each team's two most recent team-scope snapshots (written daily by the Node
-    Temporal evaluator): entering ``warning`` notifies the customer (email + in-app);
-    entering ``critical`` additionally alerts us on Slack, and Slack keeps firing on every
-    new critical snapshot until the team is suspended or recovers — that nag is the manual
-    enforcement queue.
+    Temporal evaluator): entering ``warning`` or ``critical`` notifies the customer by
+    email and in-app notification. Internal alerting is not handled here — the evaluator
+    emits ``workflow_email_reputation_state_changed`` into PostHog's own project, and a
+    workflow with a Slack destination consumes it.
     """
     now = timezone.now()
     # Cross-team by design: this scan covers every sending team, hence unscoped().
@@ -78,11 +75,6 @@ def check_email_reputation_transitions() -> None:
         return
 
     teams_by_id = {team.id: team for team in Team.objects.filter(id__in=degraded_team_ids)}
-    suspended_team_ids = set(
-        TeamWorkflowsConfig.objects.filter(
-            team_id__in=degraded_team_ids, email_sending_suspended_at__isnull=False
-        ).values_list("team_id", flat=True)
-    )
 
     for team_id in degraded_team_ids:
         team = teams_by_id.get(team_id)
@@ -94,7 +86,7 @@ def check_email_reputation_transitions() -> None:
         if cache.get(marker_key):
             continue
         try:
-            _process_team_transition(team, latest, previous, suspended=team_id in suspended_team_ids)
+            _process_team_transition(team, latest, previous)
         except Exception:
             # Per-team isolation: one team failing must not starve the rest of the scan.
             logger.exception("Failed to process email reputation transition", team_id=team_id)
@@ -102,17 +94,13 @@ def check_email_reputation_transitions() -> None:
         cache.set(marker_key, True, PROCESSED_MARKER_TTL_SECONDS)
 
 
-def _process_team_transition(
-    team: Team, latest: Mapping[str, Any], previous: Optional[Mapping[str, Any]], suspended: bool
-) -> None:
+def _process_team_transition(team: Team, latest: Mapping[str, Any], previous: Optional[Mapping[str, Any]]) -> None:
     latest_state = latest["state"]
     previous_state = previous["state"] if previous else None
 
     if latest_state == EmailReputationSnapshot.State.CRITICAL:
         if previous_state != EmailReputationSnapshot.State.CRITICAL:
             _notify_customer(team, latest)
-        if not suspended:
-            _send_slack_critical_alert(team, latest)
     elif latest_state == EmailReputationSnapshot.State.WARNING and previous_state not in (
         EmailReputationSnapshot.State.WARNING,
         EmailReputationSnapshot.State.CRITICAL,
@@ -146,30 +134,3 @@ def _notify_customer(team: Team, snapshot: Mapping[str, Any]) -> None:
             source_url=REPUTATION_TAB_PATH,
         )
     )
-
-
-def _send_slack_critical_alert(team: Team, snapshot: Mapping[str, Any]) -> None:
-    webhook_url = settings.EMAIL_REPUTATION_SLACK_WEBHOOK_URL
-    if not webhook_url:
-        logger.warning("No Slack webhook configured for email reputation alerts", team_id=team.id)
-        return
-
-    admin_url = f"{settings.SITE_URL}/admin/posthog/team/{team.id}/change/"
-    blocks = [
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": (
-                    f":rotating_light: *Email reputation critical* for team `{team.id}` ({team.name})\n"
-                    f"Hard bounce rate: *{snapshot['bounce_rate']:.2%}* · "
-                    f"Complaint rate: *{snapshot['complaint_rate']:.2%}* · "
-                    f"Emails evaluated: *{snapshot['emails_sent']}*\n"
-                    f"Evaluated at {snapshot['evaluated_at'].isoformat()} — sending is NOT suspended yet.\n"
-                    f"<{admin_url}|Review and suspend in Django admin>"
-                ),
-            },
-        }
-    ]
-    response = requests.post(webhook_url, json={"blocks": blocks}, timeout=10)
-    response.raise_for_status()

--- a/products/workflows/backend/test/test_email_reputation_transitions.py
+++ b/products/workflows/backend/test/test_email_reputation_transitions.py
@@ -1,0 +1,118 @@
+from datetime import datetime, timedelta
+
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import cache
+from django.test import override_settings
+from django.utils import timezone
+
+from parameterized import parameterized
+
+from products.workflows.backend.models import EmailReputationSnapshot
+from products.workflows.backend.models.team_workflows_config import TeamWorkflowsConfig
+from products.workflows.backend.tasks.email_reputation import check_email_reputation_transitions
+
+WEBHOOK_URL = "https://hooks.slack.example/services/T000/B000/XXX"
+
+
+@override_settings(EMAIL_REPUTATION_SLACK_WEBHOOK_URL=WEBHOOK_URL)
+class TestCheckEmailReputationTransitions(BaseTest):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def _snapshot(self, state: str, evaluated_at: datetime) -> None:
+        EmailReputationSnapshot(
+            team=self.team,
+            hog_flow=None,
+            scope=EmailReputationSnapshot.Scope.TEAM,
+            state=state,
+            bounce_rate=0.06,
+            complaint_rate=0.002,
+            emails_sent=5000,
+            evaluated_at=evaluated_at,
+        ).save()
+
+    def _run(self) -> tuple[MagicMock, MagicMock, MagicMock]:
+        with (
+            patch("products.workflows.backend.tasks.email_reputation.send_email_reputation_degraded") as email_task,
+            patch("products.workflows.backend.tasks.email_reputation.create_notification") as notification,
+            patch("products.workflows.backend.tasks.email_reputation.requests.post") as slack_post,
+        ):
+            slack_post.return_value.raise_for_status = MagicMock()
+            check_email_reputation_transitions()
+        return email_task, notification, slack_post
+
+    @parameterized.expand(
+        [
+            ("healthy_to_warning", "healthy", "warning", False, True, False),
+            ("no_previous_to_warning", None, "warning", False, True, False),
+            ("insufficient_data_to_warning", "insufficient_data", "warning", False, True, False),
+            ("warning_to_critical", "warning", "critical", False, True, True),
+            ("no_previous_to_critical", None, "critical", False, True, True),
+            ("critical_persists_unsuspended", "critical", "critical", False, False, True),
+            ("critical_persists_suspended", "critical", "critical", True, False, False),
+            ("warning_persists", "warning", "warning", False, False, False),
+            ("recovered_to_healthy", "critical", "healthy", False, False, False),
+        ]
+    )
+    def test_transition_side_effects(
+        self,
+        _name: str,
+        previous_state: str | None,
+        latest_state: str,
+        suspended: bool,
+        expect_customer_notice: bool,
+        expect_slack: bool,
+    ) -> None:
+        now = timezone.now()
+        if previous_state is not None:
+            self._snapshot(previous_state, now - timedelta(days=1))
+        self._snapshot(latest_state, now - timedelta(hours=1))
+        if suspended:
+            TeamWorkflowsConfig.objects.update_or_create(team=self.team, defaults={"email_sending_suspended_at": now})
+
+        email_task, notification, slack_post = self._run()
+
+        assert email_task.delay.called == expect_customer_notice
+        assert notification.called == expect_customer_notice
+        assert slack_post.called == expect_slack
+        if expect_customer_notice:
+            assert email_task.delay.call_args.kwargs["team_id"] == self.team.id
+            assert email_task.delay.call_args.kwargs["state"] == latest_state
+        if expect_slack:
+            assert slack_post.call_args.args[0] == WEBHOOK_URL
+
+    def test_rerun_is_idempotent_per_snapshot(self):
+        now = timezone.now()
+        self._snapshot("healthy", now - timedelta(days=1))
+        self._snapshot("warning", now - timedelta(hours=1))
+
+        first_email_task, _, _ = self._run()
+        second_email_task, second_notification, _ = self._run()
+
+        assert first_email_task.delay.call_count == 1
+        assert second_email_task.delay.call_count == 0
+        assert second_notification.call_count == 0
+
+    def test_new_snapshot_is_processed_after_earlier_one_was_marked(self):
+        now = timezone.now()
+        self._snapshot("warning", now - timedelta(days=1))
+        self._run()
+
+        self._snapshot("critical", now - timedelta(hours=1))
+        email_task, _, slack_post = self._run()
+
+        assert email_task.delay.call_count == 1
+        assert slack_post.call_count == 1
+
+    @override_settings(EMAIL_REPUTATION_SLACK_WEBHOOK_URL="")
+    def test_missing_webhook_skips_slack_without_failing(self):
+        self._snapshot("critical", timezone.now() - timedelta(hours=1))
+
+        email_task, _, slack_post = self._run()
+
+        assert slack_post.called is False
+        # Customer notice still goes out; only the internal alert is skipped
+        assert email_task.delay.call_count == 1

--- a/products/workflows/backend/test/test_email_reputation_transitions.py
+++ b/products/workflows/backend/test/test_email_reputation_transitions.py
@@ -4,19 +4,14 @@ from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
-from django.test import override_settings
 from django.utils import timezone
 
 from parameterized import parameterized
 
 from products.workflows.backend.models import EmailReputationSnapshot
-from products.workflows.backend.models.team_workflows_config import TeamWorkflowsConfig
 from products.workflows.backend.tasks.email_reputation import check_email_reputation_transitions
 
-WEBHOOK_URL = "https://hooks.slack.example/services/T000/B000/XXX"
 
-
-@override_settings(EMAIL_REPUTATION_SLACK_WEBHOOK_URL=WEBHOOK_URL)
 class TestCheckEmailReputationTransitions(BaseTest):
     def setUp(self):
         super().setUp()
@@ -34,27 +29,24 @@ class TestCheckEmailReputationTransitions(BaseTest):
             evaluated_at=evaluated_at,
         ).save()
 
-    def _run(self) -> tuple[MagicMock, MagicMock, MagicMock]:
+    def _run(self) -> tuple[MagicMock, MagicMock]:
         with (
             patch("products.workflows.backend.tasks.email_reputation.send_email_reputation_degraded") as email_task,
             patch("products.workflows.backend.tasks.email_reputation.create_notification") as notification,
-            patch("products.workflows.backend.tasks.email_reputation.requests.post") as slack_post,
         ):
-            slack_post.return_value.raise_for_status = MagicMock()
             check_email_reputation_transitions()
-        return email_task, notification, slack_post
+        return email_task, notification
 
     @parameterized.expand(
         [
-            ("healthy_to_warning", "healthy", "warning", False, True, False),
-            ("no_previous_to_warning", None, "warning", False, True, False),
-            ("insufficient_data_to_warning", "insufficient_data", "warning", False, True, False),
-            ("warning_to_critical", "warning", "critical", False, True, True),
-            ("no_previous_to_critical", None, "critical", False, True, True),
-            ("critical_persists_unsuspended", "critical", "critical", False, False, True),
-            ("critical_persists_suspended", "critical", "critical", True, False, False),
-            ("warning_persists", "warning", "warning", False, False, False),
-            ("recovered_to_healthy", "critical", "healthy", False, False, False),
+            ("healthy_to_warning", "healthy", "warning", True),
+            ("no_previous_to_warning", None, "warning", True),
+            ("insufficient_data_to_warning", "insufficient_data", "warning", True),
+            ("warning_to_critical", "warning", "critical", True),
+            ("no_previous_to_critical", None, "critical", True),
+            ("critical_persists", "critical", "critical", False),
+            ("warning_persists", "warning", "warning", False),
+            ("recovered_to_healthy", "critical", "healthy", False),
         ]
     )
     def test_transition_side_effects(
@@ -62,35 +54,28 @@ class TestCheckEmailReputationTransitions(BaseTest):
         _name: str,
         previous_state: str | None,
         latest_state: str,
-        suspended: bool,
         expect_customer_notice: bool,
-        expect_slack: bool,
     ) -> None:
         now = timezone.now()
         if previous_state is not None:
             self._snapshot(previous_state, now - timedelta(days=1))
         self._snapshot(latest_state, now - timedelta(hours=1))
-        if suspended:
-            TeamWorkflowsConfig.objects.update_or_create(team=self.team, defaults={"email_sending_suspended_at": now})
 
-        email_task, notification, slack_post = self._run()
+        email_task, notification = self._run()
 
         assert email_task.delay.called == expect_customer_notice
         assert notification.called == expect_customer_notice
-        assert slack_post.called == expect_slack
         if expect_customer_notice:
             assert email_task.delay.call_args.kwargs["team_id"] == self.team.id
             assert email_task.delay.call_args.kwargs["state"] == latest_state
-        if expect_slack:
-            assert slack_post.call_args.args[0] == WEBHOOK_URL
 
     def test_rerun_is_idempotent_per_snapshot(self):
         now = timezone.now()
         self._snapshot("healthy", now - timedelta(days=1))
         self._snapshot("warning", now - timedelta(hours=1))
 
-        first_email_task, _, _ = self._run()
-        second_email_task, second_notification, _ = self._run()
+        first_email_task, _ = self._run()
+        second_email_task, second_notification = self._run()
 
         assert first_email_task.delay.call_count == 1
         assert second_email_task.delay.call_count == 0
@@ -102,17 +87,7 @@ class TestCheckEmailReputationTransitions(BaseTest):
         self._run()
 
         self._snapshot("critical", now - timedelta(hours=1))
-        email_task, _, slack_post = self._run()
+        email_task, notification = self._run()
 
         assert email_task.delay.call_count == 1
-        assert slack_post.call_count == 1
-
-    @override_settings(EMAIL_REPUTATION_SLACK_WEBHOOK_URL="")
-    def test_missing_webhook_skips_slack_without_failing(self):
-        self._snapshot("critical", timezone.now() - timedelta(hours=1))
-
-        email_task, _, slack_post = self._run()
-
-        assert slack_post.called is False
-        # Customer notice still goes out; only the internal alert is skipped
-        assert email_task.delay.call_count == 1
+        assert notification.call_count == 1


### PR DESCRIPTION
## Problem

Email reputation is calculated daily and visible in the Reputation tab, but customers aren't told when it degrades – they discover problems only if they check the tab. For phase A of enforcement (manual suspension via the merged #72891 kill switch), the signal has to reach the customer early enough to fix their lists before a human decides whether to suspend.

## Changes

**Transition detection** – hourly Celery task `check_email_reputation_transitions` compares each team's two most recent team-scope snapshots (the evaluator writes them daily at 06:00 UTC; hourly scanning just keeps notification lag small when a run lands late):

- entered `warning` → customer email + in-app notification
- entered `critical` → customer email ("sending may be suspended") + critical in-app notification
- persisting states and recoveries → nothing

Idempotency is layered: a per-snapshot cache marker stops hourly rescans, and the email campaign key embeds the snapshot's `evaluated_at` so `MessagingRecord` dedupes even if the marker is evicted. Per-team failures are isolated so one bad team can't starve the scan.

**Customer emails** – `send_email_reputation_degraded` follows the `send_hog_function_disabled` pattern: recipients via `get_members_to_notify` (org members with project access), gated by a new `email_reputation_degraded` notification setting (default on, toggle added to user notification preferences). Two templates (warning/critical) state the rates, what they mean, and the next action, linking to the Reputation tab.

**In-app** – uses the `email_reputation` notification type (merged in #72891): normal priority for warning, critical (persistent toast) for critical, targeted at the team, linking to the Reputation tab.

> [!NOTE]
> Internal alerting is deliberately **not** in this PR. An earlier revision posted to Slack via a hardcoded webhook; that was replaced by #74558, where the Temporal evaluator emits `workflow_email_reputation_state_changed` into PostHog's own project – the internal Slack alert becomes a workflow/destination on that event, so routing and filters are UI config instead of code.

## How did you test this code?

- Parameterized transition matrix covers all eight state combinations (entering warning from each prior state, entering critical, persisting critical/warning, recovery) asserting exactly which side effects fire.
- Rerun idempotency: second scan of the same snapshot sends nothing; a new snapshot after a processed one is processed.
- Notification-settings tests updated for the new default key (full-dict assertions).
- Repo-wide `mypy --cache-fine-grained .` clean; 10/10 tests pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Skills invoked: /sending-notifications, /writing-tests. Key design decisions: detection runs Django-side against the snapshot table because the customer comms need Django machinery (templates, MessagingRecord dedupe, notification settings) – no new service-to-service auth surface. The warning→critical gap is deliberately the customer's redemption window; there is no countdown timer. The Slack webhook that used to live here was removed after review discussion in favor of dogfooding our own CDP (#74558).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
