### PR TITLE
fix(storybook): patch test-runner user agent before page scripts run

### DIFF
--- a/common/storybook/.storybook/test-runner.ts
+++ b/common/storybook/.storybook/test-runner.ts
@@ -150,6 +150,40 @@ const EMBED_STUB_HTML =
     '<!doctype html><meta charset="utf-8"><title>mock iframe</title><body style="color-scheme:light;background:#ffeb3b;margin:0">mock iframe</body>'
 
 export default {
+    // Overrides the runner's default prepare: identical navigation, plus a UA patch that must
+    // run BEFORE any page script. The runner itself only appends "StorybookTestRunner" to the
+    // user agent via addScriptTag AFTER the iframe's load event — app modules that evaluate
+    // during preview boot (chunk-graph dependent) read the unpatched UA, so a module-scope
+    // `inStorybookTestRunner()` caches `false` for the whole session. That intermittently
+    // disabled storybook-only rendering paths (e.g. InsightCard viz below the fold) and flipped
+    // visual regression snapshots. An init script re-runs before every document's first script,
+    // making the marker visible from the very first module evaluation.
+    async prepare({ page, browserContext, testRunnerConfig }) {
+        await page.addInitScript(() => {
+            const patchedUserAgent = `${navigator.userAgent} StorybookTestRunner`
+            Object.defineProperty(navigator, 'userAgent', {
+                get: () => patchedUserAgent,
+                configurable: true,
+            })
+        })
+
+        // The rest replicates @storybook/test-runner's defaultPrepare (not exported).
+        const targetURL = process.env.TARGET_URL
+        const iframeURL = new URL('iframe.html', targetURL).toString()
+        if (testRunnerConfig?.getHttpHeaders) {
+            const headers = await testRunnerConfig.getHttpHeaders(iframeURL)
+            await browserContext.setExtraHTTPHeaders(headers)
+        }
+        await page.goto(iframeURL, { waitUntil: 'load' }).catch((err) => {
+            if (err.message?.includes('ERR_CONNECTION_REFUSED')) {
+                throw new Error(
+                    `Could not access the Storybook instance at ${targetURL}. Are you sure it's running?\n\n${err.message}`
+                )
+            }
+            throw err
+        })
+    },
+
     setup() {
         expect.extend({ toMatchImageSnapshot })
         jest.retryTimes(RETRY_TIMES, { logErrorsBeforeRetry: true })

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -48,6 +48,8 @@ import { DashboardResizeHandles } from '../handles'
 import { EditModeEdge, EditModeEdgeOverlay } from './EditModeEdgeOverlay'
 import { InsightMeta } from './InsightMeta'
 
+const IS_STORYBOOK = inStorybook() || inStorybookTestRunner()
+
 export function shouldRenderInsightCardViz({
     isStorybook,
     placement,
@@ -271,11 +273,7 @@ function InsightCardInternal(
      * See https://wiki.whatwg.org/wiki/Canvas_Context_Loss_and_Restoration.
      */
     const shouldRenderViz = shouldRenderInsightCardViz({
-        // Evaluated per render, not at module scope: this module can be evaluated during Storybook's
-        // preview boot (chunk-graph dependent), before the test runner patches the user agent and
-        // before `__STORYBOOK_PREVIEW__` exists — a frozen `false` here made below-the-fold cards
-        // render without their viz in visual regression snapshots.
-        isStorybook: inStorybook() || inStorybookTestRunner(),
+        isStorybook: IS_STORYBOOK,
         placement,
         inView,
         isPageVisible,

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -48,8 +48,6 @@ import { DashboardResizeHandles } from '../handles'
 import { EditModeEdge, EditModeEdgeOverlay } from './EditModeEdgeOverlay'
 import { InsightMeta } from './InsightMeta'
 
-const IS_STORYBOOK = inStorybook() || inStorybookTestRunner()
-
 export function shouldRenderInsightCardViz({
     isStorybook,
     placement,
@@ -273,7 +271,11 @@ function InsightCardInternal(
      * See https://wiki.whatwg.org/wiki/Canvas_Context_Loss_and_Restoration.
      */
     const shouldRenderViz = shouldRenderInsightCardViz({
-        isStorybook: IS_STORYBOOK,
+        // Evaluated per render, not at module scope: this module can be evaluated during Storybook's
+        // preview boot (chunk-graph dependent), before the test runner patches the user agent and
+        // before `__STORYBOOK_PREVIEW__` exists — a frozen `false` here made below-the-fold cards
+        // render without their viz in visual regression snapshots.
+        isStorybook: inStorybook() || inStorybookTestRunner(),
         placement,
         inView,
         isPageVisible,


### PR DESCRIPTION
## TL;DR

The insight card story's visual snapshot flipped between "all cards show charts" and "cards below the fold are empty". Cause: app code asks "am I in the Storybook test runner?" by reading the user agent, but the runner only adds its UA marker after the page has loaded, so code that runs early gets the wrong answer and caches it. The runner now injects the marker before any page script runs, so the answer is always right.

## Problem

The Visual Review snapshot `components cards insight card @ insight-card` (dark and light, 1248×4448) was flaky: captures sometimes rendered every card's chart, sometimes rendered no viz below ~1490px. The identifier collected 16 auto-tolerated variants and ended up quarantined.

Root cause: `InsightCard` captures `inStorybook() || inStorybookTestRunner()` in a module-scope const. Depending on the build's chunk graph, that module can evaluate during Storybook preview boot. `@storybook/test-runner` appends `StorybookTestRunner` to `navigator.userAgent` via `addScriptTag` only after the iframe's `load` event, and `inStorybook()` was broken from the Storybook 8 upgrade until 063e0c5b1 (July 3), so early evaluation froze `IS_STORYBOOK` to `false`. That re-enabled the `useInView` gate (`rootMargin: '500px'`), and only cards within ~1220px of the top rendered their viz. Whether a capture had charts below the fold depended on module evaluation order.

The captures confirm the boundary: pre-July-3 CI artifacts have chart pixels only in the first three card rows (tops at 0/496/992px, inside viewport 720px + 500px margin); everything below, including plain DOM tables, is missing. Current builds render all 18 cards.

## Changes

Give the test runner a `prepare` hook (the documented override point) that installs the `StorybookTestRunner` UA marker as a Playwright init script, then performs the same navigation as the runner's default prepare. Init scripts run before every document's first script, so `inStorybookTestRunner()` is correct at any evaluation time, for every component, module-scope or not. No app code changes: an earlier commit on this branch moved InsightCard's check to render time, but that spreads environment sniffing through component code; the runner-level fix is the better practice and InsightCard is back to its original form.

## How did you test this code?

- Ordering proof: a Playwright probe with the same init script shows the first script on the page already sees `StorybookTestRunner` in the UA, and the story renders all 18 cards' viz (24 canvases, 4 tables).
- Built storybook and ran the story through `test-storybook` with the new prepare hook: 8 runs, byte-identical captures with every chart rendered, identical to the 14 runs before the change.
- Worst-case probe (direct iframe URL, no UA marker at all): all viz still renders via the `__STORYBOOK_PREVIEW__` check in `inStorybook()`.
- `jest src/lib/components/Cards/InsightCard/InsightCard.test.ts` (6 passing) and oxlint on the changed file.
- `typescript:check` (tsgo) was OOM-killed in the 15GB sandbox; relying on CI. The `prepare` signature matches the exported `PrepareContext` type.

Not done here (needs a VR-side decision): the identifier is still quarantined and its baseline predates the July 3 fix. After this lands, unquarantine and rebaseline `components-cards-insight-card--insight-card--{dark,light}`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Skills invoked: `fixing-flaky-tests`, `triaging-visual-review-runs`. Investigation used the Visual Review MCP tools to pull capture history and artifacts, compared captures by per-card chart-pixel counts (cross-platform font rendering makes raw pixel diffs useless), and bisected history to the Storybook 8 `inStorybook()` breakage and its July 3 fix. First attempt evaluated the check per render inside InsightCard; reviewer feedback rightly called that weak practice, so it was replaced by this runner-level fix and the component reverted. Also considered and rejected here: adding the lazy-chunk Suspense skeleton to `LOADER_SELECTORS` (stories that pin loading states would time out). Two VR API observations for the owners: `include_quarantined=true` on run snapshots raises `count` but still omits the rows from `results`, and snapshot history excludes quarantined identifiers entirely, which reads as "story stopped being captured".

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
