### PR TITLE
fix(funnels): validate unsupported AND operator for event groups

### DIFF
--- a/posthog/hogql_queries/insights/funnels/funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/funnel_event_query.py
@@ -369,6 +369,10 @@ class FunnelEventQuery(DataWarehouseSchemaMixin):
                 child_exprs.append(self._build_step_query(child, table_entity))
             if step_entity.operator == FilterLogicalOperator.OR_:
                 event_expr = ast.Or(exprs=child_exprs)
+            else:
+                raise ValidationError(
+                    f"Funnel step event groups only support the OR operator, got {step_entity.operator}"
+                )
         elif step_entity.event is None:
             # all events
             if isinstance(table_entity, FunnelsDataWarehouseNode):

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_event_query.py
@@ -1,13 +1,12 @@
 from textwrap import dedent
 
 from freezegun import freeze_time
-from rest_framework.exceptions import ValidationError
-
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 import regex
 import sqlparse
 from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
     ActionsNode,

--- a/posthog/hogql_queries/insights/funnels/test/test_funnel_event_query.py
+++ b/posthog/hogql_queries/insights/funnels/test/test_funnel_event_query.py
@@ -1,6 +1,8 @@
 from textwrap import dedent
 
 from freezegun import freeze_time
+from rest_framework.exceptions import ValidationError
+
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 import regex
@@ -590,6 +592,19 @@ class TestFunnelEventQuery(ClickhouseTestMixin, APIBaseTest):
 
         select = format_query(funnel_event_query)
         self.assertIn("IN(event, tuple('$pageleave', '$pageview'))", select)
+
+    @freeze_time("2025-11-12")
+    def test_group_node_and_operator_is_rejected(self):
+        # AND groups aren't supported yet — must fail validation, not raise UnboundLocalError (500).
+        group = GroupNode(
+            operator=FilterLogicalOperator.AND_,
+            nodes=[EventsNode(event="$pageview"), EventsNode(event="$pageleave")],
+        )
+        query = FunnelsQuery(series=[group, EventsNode(event="$checkout")])
+        context = FunnelQueryContext(query=query, team=self.team)
+
+        with self.assertRaises(ValidationError):
+            FunnelEventQuery(context=context).to_query()
 
     @parameterized.expand(
         [

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -7512,16 +7512,18 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         # Label should show combined events
         self.assertEqual("$pageview, $pageleave", response.results[0]["label"])
 
-    def test_group_node_and_operator_is_rejected(self):
+    @parameterized.expand(
+        [
+            # Zero / one effective filters previously bypassed the operator check via early returns.
+            ("zero_nodes", []),
+            ("one_node", [EventsNode(event="$pageview")]),
+            ("two_nodes", [EventsNode(event="$pageview"), EventsNode(event="$pageleave")]),
+        ]
+    )
+    def test_group_node_and_operator_is_rejected(self, _name, nodes):
         # AND groups aren't supported yet. Must fail validation rather than silently drop the
         # event filter (which would match every event and return wrong counts).
-        group_node = GroupNode(
-            operator=FilterLogicalOperator.AND_,
-            nodes=[
-                EventsNode(event="$pageview"),
-                EventsNode(event="$pageleave"),
-            ],
-        )
+        group_node = GroupNode(operator=FilterLogicalOperator.AND_, nodes=nodes)
 
         with self.assertRaises(DRFValidationError):
             TrendsQueryRunner(

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -7512,6 +7512,30 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         # Label should show combined events
         self.assertEqual("$pageview, $pageleave", response.results[0]["label"])
 
+    def test_group_node_and_operator_is_rejected(self):
+        # AND groups aren't supported yet. Must fail validation rather than silently drop the
+        # event filter (which would match every event and return wrong counts).
+        group_node = GroupNode(
+            operator=FilterLogicalOperator.AND_,
+            nodes=[
+                EventsNode(event="$pageview"),
+                EventsNode(event="$pageleave"),
+            ],
+        )
+
+        with self.assertRaises(DRFValidationError):
+            TrendsQueryRunner(
+                query=TrendsQuery(
+                    dateRange=DateRange(
+                        date_from=self.default_date_from,
+                        date_to=self.default_date_to,
+                    ),
+                    interval=IntervalType.DAY,
+                    series=[group_node],
+                ),
+                team=self.team,
+            ).calculate()
+
     def test_group_node_with_actions(self):
         """Test that GroupNode works with ActionsNode"""
         self._create_test_events()

--- a/posthog/hogql_queries/insights/trends/utils.py
+++ b/posthog/hogql_queries/insights/trends/utils.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Union
 
+from rest_framework.exceptions import ValidationError
+
 from posthog.schema import (
     ActionsNode,
     BaseMathType,
     BreakdownType,
     DataWarehouseNode,
     EventsNode,
+    FilterLogicalOperator,
     GroupNode,
     MultipleBreakdownType,
 )
@@ -97,7 +100,9 @@ def group_node_to_expr(group: GroupNode, team: Team) -> ast.Expr | None:
     if len(group_filters) == 1:
         return group_filters[0]
 
-    if group.operator == "OR":
+    if group.operator == FilterLogicalOperator.OR_:
         return ast.Or(exprs=group_filters)
 
-    return None
+    # AND grouping isn't supported yet. Fail loudly instead of silently dropping the
+    # event filter, which would match every event and return wrong results.
+    raise ValidationError(f"Event groups only support the OR operator, got {group.operator}")

--- a/posthog/hogql_queries/insights/trends/utils.py
+++ b/posthog/hogql_queries/insights/trends/utils.py
@@ -68,6 +68,11 @@ def is_groups_math(series: Union[EventsNode, ActionsNode, DataWarehouseNode | Gr
 def group_node_to_expr(group: GroupNode, team: Team) -> ast.Expr | None:
     from products.actions.backend.models.action import Action
 
+    # AND grouping isn't supported yet. Validate up front so it fails loudly regardless of how
+    # many nodes resolve, rather than silently dropping the event filter and matching every event.
+    if group.operator != FilterLogicalOperator.OR_:
+        raise ValidationError(f"Event groups only support the OR operator, got {group.operator}")
+
     group_filters: list[ast.Expr] = []
     for node in group.nodes:
         if isinstance(node, EventsNode):
@@ -100,9 +105,4 @@ def group_node_to_expr(group: GroupNode, team: Team) -> ast.Expr | None:
     if len(group_filters) == 1:
         return group_filters[0]
 
-    if group.operator == FilterLogicalOperator.OR_:
-        return ast.Or(exprs=group_filters)
-
-    # AND grouping isn't supported yet. Fail loudly instead of silently dropping the
-    # event filter, which would match every event and return wrong results.
-    raise ValidationError(f"Event groups only support the OR operator, got {group.operator}")
+    return ast.Or(exprs=group_filters)


### PR DESCRIPTION
## Problem

Running a funnel with an inline-events group step whose events are joined by **AND** returns a 500 and no results. Funnel step event groups (`GroupNode`) only ever implemented the `OR` operator when building the step condition — an `AND`-tagged group left `event_expr` unbound and raised `UnboundLocalError`, which surfaces as an uncaught 500 rather than a clean validation error.

The same OR-only gap exists in **trends**, where `GroupNode` is also a valid series member. There it's worse: `group_node_to_expr` returned `None` for an `AND` operator, which silently dropped the series event filter — the series matched *every* event in the range and returned a 200 with silently-wrong numbers. This affected both the main trends chart query and the actors drill-down.

**Why:** raised in the error-tracking inbox. `GroupNode.operator` is a required `AND`/`OR` enum in both the funnels and trends series schemas, so a client can send `AND` today.

## Changes

`AND` grouping isn't supported yet, so both query builders now raise a `ValidationError` for any non-`OR` group operator instead of crashing (funnels) or silently returning wrong results (trends). Requests fail cleanly with a message explaining only `OR` is supported.

- `funnels/funnel_event_query.py` — `_build_step_query` group branch.
- `trends/utils.py` — `group_node_to_expr`.

## How did you test this code?

Added two regression tests:
- `test_group_node_and_operator_is_rejected` in `test_funnel_event_query.py` — asserts an `AND` group step raises `ValidationError` (previously `UnboundLocalError`/500).
- `test_group_node_and_operator_is_rejected` in `test_trends_query_runner.py` — asserts an `AND` group series raises `ValidationError` (previously a 200 with the event filter dropped).

No existing `GroupNode` test in either suite used `AND` — they all hardcode `OR`. Both tests are DB-backed and I could not run them in this environment (no Postgres/ClickHouse available); all changed files were syntax-checked and linted.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The reporter confirmed we don't intend to support `AND` for now, so the chosen fix is validation rather than implementing an `ast.And` branch. The trends counterpart was found by checking whether the same group-operator handling existed elsewhere. Skill invoked: `/writing-tests`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1784831869728779?thread_ts=1784831869.728779&cid=C0B3E1Y576X)*
