### PR TITLE
fix(resend): surface a clear error when the OAuth account isn't connected

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/resend/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/resend/source.py
@@ -183,7 +183,16 @@ Either way, the connection needs **full access** so the following resources can 
         try:
             token = self._probe_token(config, team_id)
         except ValueError as e:
-            return False, str(e)
+            # _probe_token and the OAuth mixin raise deterministic config/credential errors
+            # (missing integration ID, integration deleted) whose developer wording is unhelpful in
+            # the wizard and can carry a volatile integration ID. Reuse the curated messages from
+            # get_non_retryable_errors so this path doesn't leak the internal string; fall back to
+            # the raw message if unmapped.
+            raw = str(e)
+            for pattern, friendly in self.get_non_retryable_errors().items():
+                if friendly and pattern in raw:
+                    return False, friendly
+            return False, raw
 
         if validate_resend_credentials(token):
             return True, None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/resend/tests/test_resend_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/resend/tests/test_resend_source.py
@@ -187,11 +187,22 @@ class TestResendSource:
         assert error_message is not None and "reconnect" in error_message.lower()
 
     @mock.patch.object(ResendSource, "get_oauth_integration", side_effect=ValueError("Integration not found: 42"))
-    def test_validate_credentials_oauth_missing_integration(self, _mock_get_integration):
+    def test_validate_credentials_oauth_deleted_integration(self, _mock_get_integration):
         is_valid, error_message = self.source.validate_credentials(_oauth_config(), self.team_id)
 
         assert is_valid is False
-        assert error_message == "Integration not found: 42"
+        # The raw "Integration not found: <id>" must be mapped to curated wording so the wizard
+        # never leaks the internal string or the volatile integration ID.
+        assert error_message == "The linked Resend integration no longer exists. Please reconnect your Resend account."
+        assert "42" not in (error_message or "")
+
+    def test_validate_credentials_oauth_missing_integration_id(self):
+        config = ResendSourceConfig(auth_method=ResendAuthMethodConfig(selection="oauth", resend_integration_id=None))
+
+        is_valid, error_message = self.source.validate_credentials(config, self.team_id)
+
+        assert is_valid is False
+        assert error_message == "Resend integration is not configured. Please reconnect your Resend account."
 
     def test_get_resumable_source_manager(self):
         inputs = mock.MagicMock()


### PR DESCRIPTION
## Problem

When someone sets up a Resend source with OAuth in the new-source wizard but hasn't finished connecting an account (or the linked account was removed), the wizard showed a raw internal string like `Missing Resend integration ID` or `Integration not found: <id>`. That gives the user nothing to act on and can echo back a volatile integration ID.

The root cause: `ResendSource.validate_credentials` caught the `ValueError` from the OAuth token resolver and returned `str(e)` verbatim. The source already has curated, user-facing wording for exactly these cases in `get_non_retryable_errors` (used on the sync path), but the create-time validation path never applied it.

## Changes

Map the `ValueError` through the source's existing `get_non_retryable_errors` messages before falling back to the raw string. This mirrors how the GitHub source handles the identical OAuth config errors in its own `validate_credentials`.

Now the wizard shows:

- `Resend integration is not configured. Please reconnect your Resend account.` (no account connected)
- `The linked Resend integration no longer exists. Please reconnect your Resend account.` (account removed, no ID leaked)

The API-key path is unchanged.

## How did you test this code?

Automated only (I'm an agent and did not manually test):

- Updated `test_validate_credentials_oauth_deleted_integration` — it previously asserted the leaked raw `Integration not found: 42`; it now asserts the curated message and that the integration ID is not present in the output.
- Added `test_validate_credentials_oauth_missing_integration_id` for the observed case (OAuth selected, no account connected) → curated message. No existing test covered this path.
- Ran the `validate_credentials` suite in `resend/tests/test_resend_source.py` (7 passed).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Produced by Claude while triaging data-warehouse source-creation failures. I compared the Resend validate path against the GitHub source, which already maps the same OAuth `ValueError`s through curated wording, and applied the same pattern to Resend. Invoked the `/writing-tests` skill before touching the tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
