### PR TITLE
fix(data-imports): avoid per-file S3 LIST calls when copying query files

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+
+from unittest.mock import AsyncMock, patch
+
+from products.warehouse_sources.backend.temporal.data_imports import util as util_module
+from products.warehouse_sources.backend.temporal.data_imports.util import prepare_s3_files_for_querying
+
+
+def _fake_s3(**kwargs):
+    defaults = {
+        "invalidate_cache": lambda: None,
+        "_ls": AsyncMock(return_value=[]),
+        "_exists": AsyncMock(return_value=False),
+        "_cp_file": AsyncMock(),
+        "_copy": AsyncMock(),
+        "_rm": AsyncMock(),
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class _FakeS3CM:
+    def __init__(self, s3):
+        self._s3 = s3
+
+    async def __aenter__(self):
+        return self._s3
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class TestPrepareS3FilesForQuerying:
+    async def test_copies_files_with_cp_file_not_copy(self):
+        # `_copy()` globs the source and probes whether the destination is a directory,
+        # each requiring its own S3 ListObjectsV2 call. Copying many files concurrently
+        # through `_copy()` multiplies into enough LIST traffic to trigger S3's SlowDown
+        # rate limiting (see the OSError/ClientError SlowDown pair this regresses).
+        s3 = _fake_s3()
+
+        with patch.object(util_module, "aget_s3_client", return_value=_FakeS3CM(s3)):
+            await prepare_s3_files_for_querying(
+                folder_path="job",
+                table_name="my_table",
+                file_uris=["s3://bucket/job/my_table/part-0.parquet", "s3://bucket/job/my_table/part-1.parquet"],
+                delete_existing=False,
+            )
+
+        assert s3._cp_file.await_count == 2
+        s3._copy.assert_not_awaited()

--- a/products/warehouse_sources/backend/temporal/data_imports/util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/util.py
@@ -148,7 +148,12 @@ async def prepare_s3_files_for_querying(
         async def copy_file(file: str) -> None:
             async with semaphore:
                 file_name = file.replace(f"{s3_folder_for_schema}/", "")
-                await s3._copy(file, f"{s3_path_for_querying}/{file_name}")
+                # _cp_file() copies a single known source to a known destination key directly.
+                # The generic _copy() also globs the source and probes whether the destination
+                # is a directory, each requiring its own S3 ListObjectsV2 call — with hundreds of
+                # files copied concurrently, that multiplies into enough LIST traffic to trigger
+                # S3's SlowDown rate limiting on the destination prefix.
+                await s3._cp_file(file, f"{s3_path_for_querying}/{file_name}")
 
         await asyncio.gather(*[copy_file(file) for file in file_uris])
 


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OSError: [Errno 16] Please reduce your request rate.` (chained from a `botocore.exceptions.ClientError` `SlowDown` on `ListObjectsV2`, after 4 internal retries) from `copy_file` in `products/warehouse_sources/backend/temporal/data_imports/util.py`, during `prepare_s3_files_for_querying`'s post-load copy of synced files into their queryable S3 folder ([issue](https://us.posthog.com/project/2/error_tracking/019f9358-6aca-7432-ac52-6b701bab3da4)).

`copy_file` copies each file with `s3._copy(file, dest)`. fsspec's generic `_copy()` isn't a direct single-file copy: for a string source it expands/globs the path and, separately, probes whether the destination is a directory (`_isdir`) - each of those probes is its own S3 `ListObjectsV2` call. `copy_file` already knows the source is a single file and computes the exact destination key itself, so none of that probing is needed. With up to 50 files copied concurrently (`asyncio.Semaphore(50)`), the extra LIST calls multiply into enough request volume to trip S3's `SlowDown` rate limiting on the destination prefix.

## Changes

- Swap `s3._copy(file, dest)` for `s3._cp_file(file, dest)` in `copy_file` - `_cp_file` copies a known source to a known destination key directly (a `HEAD` + the copy itself), with no directory globbing or `_isdir` probing.

This is a shared-pipeline fix, not source-specific: any sync going through `prepare_s3_files_for_querying` with enough output files benefits.

## How did you test this code?

Added `products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py`:
- `test_copies_files_with_cp_file_not_copy` - drives `prepare_s3_files_for_querying` with a mocked S3 client and asserts `copy_file` calls `_cp_file` and never `_copy`. No existing test exercised this copy path at all (the only prior coverage patches `prepare_s3_files_for_querying` out entirely in `pipelines/common/test/test_load.py`). I confirmed the test fails against the pre-fix code (asserts `_cp_file.await_count == 0`) before locking in the fix.

Ran locally: `pytest products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py` (1 passed), `ruff check`/`ruff format` clean, and `mypy --cache-fine-grained` on the changed module (clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable - internal S3 client call change, no user-facing or documented workflow change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from the linked error-tracking issue (stack trace, sample events, impact) via PostHog Code. The event's `warehouse_sources_*` sync-context properties weren't populated on this particular capture (it fired from a management-command run rather than a tagged sync activity), so the fix targets the shared pipeline code the stack trace pointed at rather than a specific source.

Checked the batch consumer's retry handling first: this error is already retried at the batch level (`NON_RETRYABLE_ERROR_PATTERNS` in `pipeline_v3/postgres_queue/consumer.py` doesn't match it, so it goes through the existing exponential backoff/retry-attempt state machine) rather than crashing unretried - so the real bug isn't a missing retry, it's the wasted S3 API calls that make throttling likelier in the first place.

Checked open PRs for overlap: [#73395](https://github.com/PostHog/posthog/pull/73395) touches the same file (`util.py`) but a different, non-overlapping code path (`delete_folder`'s `ConnectTimeoutError` handling). [#73407](https://github.com/PostHog/posthog/pull/73407) and [#71756](https://github.com/PostHog/posthog/pull/71756) address the same `OSError`/SlowDown message but in unrelated call paths (`delta_table_helper.py`'s `_purge_s3_prefix`, and ClickHouse query-time S3 reads respectively). None fix this copy path.

Invoked `/writing-tests` before adding the regression test.