### PR TITLE
feat(error-tracking): migrate spike notifications to Temporal

### DIFF
--- a/products/error_tracking/backend/temporal/__init__.py
+++ b/products/error_tracking/backend/temporal/__init__.py
@@ -9,6 +9,7 @@ from products.error_tracking.backend.temporal.lifecycle import (
     WORKFLOWS as LIFECYCLE_WORKFLOWS,
     ErrorTrackingIssueCreatedWorkflow,
     ErrorTrackingIssueReopenedWorkflow,
+    ErrorTrackingIssueSpikingWorkflow,
 )
 from products.error_tracking.backend.temporal.recommendations_refresh import (
     ACTIVITIES as RECOMMENDATIONS_REFRESH_ACTIVITIES,
@@ -51,6 +52,7 @@ __all__ = [
     "ErrorTrackingFingerprintEmbeddingResultWorkflow",
     "ErrorTrackingIssueCreatedWorkflow",
     "ErrorTrackingIssueReopenedWorkflow",
+    "ErrorTrackingIssueSpikingWorkflow",
     "ErrorTrackingRecommendationsRefreshWorkflow",
     "ErrorTrackingSpikeEventCleanupWorkflow",
     "ErrorTrackingSymbolSetCleanupWorkflow",

--- a/products/error_tracking/backend/temporal/lifecycle/__init__.py
+++ b/products/error_tracking/backend/temporal/lifecycle/__init__.py
@@ -8,13 +8,19 @@ from products.error_tracking.backend.temporal.lifecycle.issue_reopened import (
     WORKFLOWS as ISSUE_REOPENED_WORKFLOWS,
     ErrorTrackingIssueReopenedWorkflow,
 )
+from products.error_tracking.backend.temporal.lifecycle.issue_spiking import (
+    ACTIVITIES as ISSUE_SPIKING_ACTIVITIES,
+    WORKFLOWS as ISSUE_SPIKING_WORKFLOWS,
+    ErrorTrackingIssueSpikingWorkflow,
+)
 
-WORKFLOWS = ISSUE_CREATED_WORKFLOWS + ISSUE_REOPENED_WORKFLOWS
-ACTIVITIES = ISSUE_CREATED_ACTIVITIES + ISSUE_REOPENED_ACTIVITIES
+WORKFLOWS = ISSUE_CREATED_WORKFLOWS + ISSUE_REOPENED_WORKFLOWS + ISSUE_SPIKING_WORKFLOWS
+ACTIVITIES = ISSUE_CREATED_ACTIVITIES + ISSUE_REOPENED_ACTIVITIES + ISSUE_SPIKING_ACTIVITIES
 
 __all__ = [
     "ACTIVITIES",
     "WORKFLOWS",
     "ErrorTrackingIssueCreatedWorkflow",
     "ErrorTrackingIssueReopenedWorkflow",
+    "ErrorTrackingIssueSpikingWorkflow",
 ]

--- a/products/error_tracking/backend/temporal/lifecycle/issue_spiking/__init__.py
+++ b/products/error_tracking/backend/temporal/lifecycle/issue_spiking/__init__.py
@@ -1,0 +1,19 @@
+from products.error_tracking.backend.temporal.lifecycle.issue_spiking.activities import (
+    ACTIVITIES as ISSUE_SPIKING_ACTIVITIES,
+    emit_issue_spiking_internal_event_activity,
+    emit_issue_spiking_signal_activity,
+    persist_issue_spiking_event_activity,
+)
+from products.error_tracking.backend.temporal.lifecycle.issue_spiking.workflow import ErrorTrackingIssueSpikingWorkflow
+
+WORKFLOWS = [ErrorTrackingIssueSpikingWorkflow]
+ACTIVITIES = ISSUE_SPIKING_ACTIVITIES
+
+__all__ = [
+    "ACTIVITIES",
+    "WORKFLOWS",
+    "ErrorTrackingIssueSpikingWorkflow",
+    "emit_issue_spiking_internal_event_activity",
+    "emit_issue_spiking_signal_activity",
+    "persist_issue_spiking_event_activity",
+]

--- a/products/error_tracking/backend/temporal/lifecycle/issue_spiking/activities.py
+++ b/products/error_tracking/backend/temporal/lifecycle/issue_spiking/activities.py
@@ -1,0 +1,91 @@
+from django.db import transaction
+from django.utils.dateparse import parse_datetime
+
+import posthoganalytics
+from temporalio import activity
+
+from posthog.temporal.common.scoped import scoped_temporal
+from posthog.temporal.common.utils import close_db_connections
+
+from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrackingSpikeEvent
+from products.error_tracking.backend.temporal.lifecycle.issue_spiking.types import (
+    IssueSpikingWorkflowInputs,
+    SpikeEventPersistenceResult,
+)
+from products.error_tracking.backend.temporal.lifecycle.side_effects import (
+    emit_issue_lifecycle_signal,
+    produce_issue_lifecycle_internal_event,
+)
+from products.error_tracking.backend.temporal.lifecycle.types import SpikeEventPersistenceStatus
+
+
+@activity.defn
+@posthoganalytics.scoped()
+@close_db_connections
+def persist_issue_spiking_event_activity(inputs: IssueSpikingWorkflowInputs) -> SpikeEventPersistenceResult:
+    detected_at = parse_datetime(inputs.detected_at)
+    if detected_at is None:
+        raise ValueError(f"Invalid spike detection timestamp: {inputs.detected_at}")
+
+    with transaction.atomic():
+        issue = (
+            ErrorTrackingIssue.objects.select_for_update()
+            .filter(team_id=inputs.team_id, id=inputs.issue_id)
+            .only("id")
+            .first()
+        )
+        if issue is None:
+            return SpikeEventPersistenceResult(status=SpikeEventPersistenceStatus.MISSING_ISSUE)
+
+        _, created = ErrorTrackingSpikeEvent.objects.get_or_create(
+            id=inputs.notification_id,
+            team_id=inputs.team_id,
+            defaults={
+                "issue": issue,
+                "detected_at": detected_at,
+                "computed_baseline": inputs.computed_baseline,
+                "current_bucket_value": int(inputs.current_bucket_value),
+            },
+        )
+    return SpikeEventPersistenceResult(
+        status=SpikeEventPersistenceStatus.INSERTED if created else SpikeEventPersistenceStatus.ALREADY_PERSISTED
+    )
+
+
+@activity.defn
+@posthoganalytics.scoped()
+@close_db_connections
+def emit_issue_spiking_internal_event_activity(inputs: IssueSpikingWorkflowInputs) -> None:
+    produce_issue_lifecycle_internal_event(
+        inputs,
+        event="$error_tracking_issue_spiking",
+        exception_timestamp=inputs.detected_at,
+        extra_properties={
+            "computed_baseline": inputs.computed_baseline,
+            "current_bucket_value": inputs.current_bucket_value,
+        },
+        include_status=False,
+    )
+
+
+@activity.defn
+@scoped_temporal()
+@close_db_connections
+async def emit_issue_spiking_signal_activity(inputs: IssueSpikingWorkflowInputs) -> None:
+    multiplier = inputs.current_bucket_value / inputs.computed_baseline if inputs.computed_baseline else float("inf")
+    await emit_issue_lifecycle_signal(
+        inputs,
+        source_type="issue_spiking",
+        preamble=(
+            "This error tracking issue is experiencing a spike in occurrences\n"
+            f"(baseline: {inputs.computed_baseline:.1f}, current: {inputs.current_bucket_value:.1f}) "
+            f"({multiplier:.1f} over baseline)"
+        ),
+    )
+
+
+ACTIVITIES = [
+    persist_issue_spiking_event_activity,
+    emit_issue_spiking_internal_event_activity,
+    emit_issue_spiking_signal_activity,
+]

--- a/products/error_tracking/backend/temporal/lifecycle/issue_spiking/test/test_issue_spiking_workflow.py
+++ b/products/error_tracking/backend/temporal/lifecycle/issue_spiking/test/test_issue_spiking_workflow.py
@@ -1,0 +1,124 @@
+import json
+import uuid
+import dataclasses
+
+import pytest
+from posthog.test.base import BaseTest
+
+from temporalio import activity
+from temporalio.testing import WorkflowEnvironment
+from temporalio.worker import UnsandboxedWorkflowRunner, Worker
+
+from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrackingSpikeEvent
+from products.error_tracking.backend.temporal.lifecycle.issue_spiking.activities import (
+    persist_issue_spiking_event_activity,
+)
+from products.error_tracking.backend.temporal.lifecycle.issue_spiking.types import (
+    IssueSpikingSnapshot,
+    IssueSpikingWorkflowInputs,
+    IssueSpikingWorkflowResult,
+    SpikeEventPersistenceResult,
+)
+from products.error_tracking.backend.temporal.lifecycle.issue_spiking.workflow import ErrorTrackingIssueSpikingWorkflow
+from products.error_tracking.backend.temporal.lifecycle.types import SpikeEventPersistenceStatus
+
+
+def _inputs(
+    fingerprint: str = "inserted", *, team_id: int = 1, issue_id: str | None = None
+) -> IssueSpikingWorkflowInputs:
+    return IssueSpikingWorkflowInputs(
+        notification_id=str(uuid.uuid4()),
+        team_id=team_id,
+        issue_id=issue_id or str(uuid.uuid4()),
+        issue=IssueSpikingSnapshot(
+            name="TypeError",
+            description="Something failed",
+            status="active",
+            created_at="2026-07-21T12:00:00Z",
+        ),
+        fingerprint=fingerprint,
+        event_uuid=str(uuid.uuid4()),
+        event_timestamp="2026-07-21T12:00:00Z",
+        detected_at="2026-07-21T12:05:00Z",
+        computed_baseline=2.0,
+        current_bucket_value=20.0,
+    )
+
+
+def test_parse_inputs_accepts_cymbal_issue_spiking_notification() -> None:
+    inputs = _inputs()
+    payload = {
+        **dataclasses.asdict(inputs),
+        "type": "issue_spiking",
+        "event_properties": {"$exception_list": [{"type": "TypeError", "value": "boom"}]},
+    }
+
+    assert ErrorTrackingIssueSpikingWorkflow.parse_inputs([json.dumps(payload)]) == inputs
+
+
+class TestPersistIssueSpikingEventActivity(BaseTest):
+    def test_is_idempotent_and_ignores_missing_issues(self) -> None:
+        issue = ErrorTrackingIssue.objects.create(team=self.team)
+        inputs = _inputs(team_id=self.team.id, issue_id=str(issue.id))
+
+        inserted = persist_issue_spiking_event_activity(inputs)
+        existing = persist_issue_spiking_event_activity(inputs)
+        missing = persist_issue_spiking_event_activity(
+            dataclasses.replace(inputs, notification_id=str(uuid.uuid4()), issue_id=str(uuid.uuid4()))
+        )
+
+        assert inserted == SpikeEventPersistenceResult(status=SpikeEventPersistenceStatus.INSERTED)
+        assert existing == SpikeEventPersistenceResult(status=SpikeEventPersistenceStatus.ALREADY_PERSISTED)
+        assert missing == SpikeEventPersistenceResult(status=SpikeEventPersistenceStatus.MISSING_ISSUE)
+        assert ErrorTrackingSpikeEvent.objects.filter(id=inputs.notification_id, team=self.team).exists()
+
+
+@pytest.mark.asyncio
+async def test_notifies_after_idempotent_persistence_and_ignores_missing_issues() -> None:
+    emitted_events: list[str] = []
+    emitted_signals: list[str] = []
+
+    @activity.defn(name="persist_issue_spiking_event_activity")
+    async def persist(inputs: IssueSpikingWorkflowInputs) -> SpikeEventPersistenceResult:
+        status = {
+            "inserted": SpikeEventPersistenceStatus.INSERTED,
+            "existing": SpikeEventPersistenceStatus.ALREADY_PERSISTED,
+            "missing": SpikeEventPersistenceStatus.MISSING_ISSUE,
+        }[inputs.fingerprint]
+        return SpikeEventPersistenceResult(status=status)
+
+    @activity.defn(name="emit_issue_spiking_internal_event_activity")
+    async def emit_event(inputs: IssueSpikingWorkflowInputs) -> None:
+        emitted_events.append(inputs.issue_id)
+
+    @activity.defn(name="emit_issue_spiking_signal_activity")
+    async def emit_signal(inputs: IssueSpikingWorkflowInputs) -> None:
+        emitted_signals.append(inputs.issue_id)
+
+    task_queue = str(uuid.uuid4())
+    inputs_by_status = {status: _inputs(status) for status in ("inserted", "existing", "missing")}
+    async with await WorkflowEnvironment.start_time_skipping() as environment:
+        async with Worker(
+            environment.client,
+            task_queue=task_queue,
+            workflows=[ErrorTrackingIssueSpikingWorkflow],
+            activities=[persist, emit_event, emit_signal],
+            workflow_runner=UnsandboxedWorkflowRunner(),
+        ):
+            results = {
+                status: await environment.client.execute_workflow(
+                    ErrorTrackingIssueSpikingWorkflow.run,
+                    inputs,
+                    id=str(uuid.uuid4()),
+                    task_queue=task_queue,
+                )
+                for status, inputs in inputs_by_status.items()
+            }
+
+    assert results == {
+        "inserted": IssueSpikingWorkflowResult(persisted=True, notified=True),
+        "existing": IssueSpikingWorkflowResult(persisted=True, notified=True),
+        "missing": IssueSpikingWorkflowResult(),
+    }
+    assert emitted_events == [inputs_by_status["inserted"].issue_id, inputs_by_status["existing"].issue_id]
+    assert emitted_signals == [inputs_by_status["inserted"].issue_id, inputs_by_status["existing"].issue_id]

--- a/products/error_tracking/backend/temporal/lifecycle/issue_spiking/types.py
+++ b/products/error_tracking/backend/temporal/lifecycle/issue_spiking/types.py
@@ -1,0 +1,31 @@
+import dataclasses
+
+from products.error_tracking.backend.temporal.lifecycle.types import LifecycleIssueSnapshot, SpikeEventPersistenceStatus
+
+IssueSpikingSnapshot = LifecycleIssueSnapshot
+
+
+@dataclasses.dataclass(frozen=True)
+class IssueSpikingWorkflowInputs:
+    notification_id: str
+    team_id: int
+    issue_id: str
+    issue: LifecycleIssueSnapshot
+    fingerprint: str
+    event_uuid: str
+    event_timestamp: str
+    detected_at: str
+    computed_baseline: float
+    current_bucket_value: float
+    assignee: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class SpikeEventPersistenceResult:
+    status: SpikeEventPersistenceStatus
+
+
+@dataclasses.dataclass(frozen=True)
+class IssueSpikingWorkflowResult:
+    persisted: bool = False
+    notified: bool = False

--- a/products/error_tracking/backend/temporal/lifecycle/issue_spiking/workflow.py
+++ b/products/error_tracking/backend/temporal/lifecycle/issue_spiking/workflow.py
@@ -1,0 +1,87 @@
+import json
+from datetime import timedelta
+
+from temporalio import common, workflow
+
+from posthog.temporal.common.base import PostHogWorkflow
+
+from products.error_tracking.backend.temporal.lifecycle.issue_spiking.types import (
+    IssueSpikingSnapshot,
+    IssueSpikingWorkflowInputs,
+    IssueSpikingWorkflowResult,
+    SpikeEventPersistenceResult,
+)
+from products.error_tracking.backend.temporal.lifecycle.types import SpikeEventPersistenceStatus
+
+WORKFLOW_NAME = "error-tracking-issue-spiking"
+
+ACTIVITY_RETRY_POLICY = common.RetryPolicy(
+    initial_interval=timedelta(seconds=1),
+    maximum_interval=timedelta(seconds=15),
+    maximum_attempts=10,
+)
+ACTIVITY_START_TO_CLOSE_TIMEOUT = timedelta(minutes=5)
+
+
+@workflow.defn(name=WORKFLOW_NAME)
+class ErrorTrackingIssueSpikingWorkflow(PostHogWorkflow):
+    @staticmethod
+    def workflow_id_for(notification_id: str) -> str:
+        return f"{WORKFLOW_NAME}-{notification_id}"
+
+    @staticmethod
+    def parse_inputs(inputs: list[str]) -> IssueSpikingWorkflowInputs:
+        if len(inputs) != 1:
+            raise ValueError("Issue spiking workflow requires exactly one input")
+        data = json.loads(inputs[0])
+        data.pop("type", None)
+        data.pop("event_properties", None)
+        data["issue"] = IssueSpikingSnapshot(**data["issue"])
+        return IssueSpikingWorkflowInputs(**data)
+
+    @workflow.run
+    async def run(self, inputs: IssueSpikingWorkflowInputs) -> IssueSpikingWorkflowResult:
+        persistence = await workflow.execute_activity(
+            "persist_issue_spiking_event_activity",
+            inputs,
+            result_type=SpikeEventPersistenceResult,
+            start_to_close_timeout=ACTIVITY_START_TO_CLOSE_TIMEOUT,
+            retry_policy=ACTIVITY_RETRY_POLICY,
+        )
+        if persistence.status == SpikeEventPersistenceStatus.MISSING_ISSUE:
+            workflow.logger.warning(
+                "Dropping spike notification for missing issue",
+                extra={
+                    "notification_id": inputs.notification_id,
+                    "team_id": inputs.team_id,
+                    "issue_id": inputs.issue_id,
+                },
+            )
+            (
+                workflow.metric_meter()
+                .create_counter(
+                    "error_tracking_issue_spiking_missing_issue",
+                    "Issue-spiking workflows dropped because their issue no longer exists",
+                )
+                .add(1)
+            )
+            return IssueSpikingWorkflowResult()
+        if persistence.status not in {
+            SpikeEventPersistenceStatus.INSERTED,
+            SpikeEventPersistenceStatus.ALREADY_PERSISTED,
+        }:
+            raise ValueError(f"Unknown spike persistence status: {persistence.status}")
+
+        await workflow.execute_activity(
+            "emit_issue_spiking_internal_event_activity",
+            inputs,
+            start_to_close_timeout=ACTIVITY_START_TO_CLOSE_TIMEOUT,
+            retry_policy=ACTIVITY_RETRY_POLICY,
+        )
+        await workflow.execute_activity(
+            "emit_issue_spiking_signal_activity",
+            inputs,
+            start_to_close_timeout=ACTIVITY_START_TO_CLOSE_TIMEOUT,
+            retry_policy=ACTIVITY_RETRY_POLICY,
+        )
+        return IssueSpikingWorkflowResult(persisted=True, notified=True)

--- a/products/error_tracking/backend/temporal/lifecycle/side_effects.py
+++ b/products/error_tracking/backend/temporal/lifecycle/side_effects.py
@@ -70,6 +70,8 @@ def produce_issue_lifecycle_internal_event(
     *,
     event: str,
     exception_timestamp: str,
+    extra_properties: dict[str, object] | None = None,
+    include_status: bool = True,
     humanize_status: bool = True,
 ) -> None:
     try:
@@ -93,20 +95,23 @@ def produce_issue_lifecycle_internal_event(
         "exception_timestamp": timestamp.isoformat(),
         "exception_props": event_properties,
     }
-    status = inputs.issue.status
-    properties["status"] = (
-        {
-            "archived": "Archived",
-            "active": "Active",
-            "resolved": "Resolved",
-            "pending_release": "Pending Release",
-            "suppressed": "Suppressed",
-        }.get(status, status)
-        if humanize_status
-        else status
-    )
+    if include_status:
+        status = inputs.issue.status
+        properties["status"] = (
+            {
+                "archived": "Archived",
+                "active": "Active",
+                "resolved": "Resolved",
+                "pending_release": "Pending Release",
+                "suppressed": "Suppressed",
+            }.get(status, status)
+            if humanize_status
+            else status
+        )
     if inputs.assignee is not None:
         properties["assignee"] = inputs.assignee
+    if extra_properties is not None:
+        properties.update(extra_properties)
 
     def produce(properties_to_send: dict[str, object]) -> None:
         result = produce_internal_event(

--- a/products/error_tracking/backend/temporal/lifecycle/test/test_side_effects.py
+++ b/products/error_tracking/backend/temporal/lifecycle/test/test_side_effects.py
@@ -123,6 +123,7 @@ def test_oversized_internal_event_retries_without_exception_properties() -> None
             inputs,
             event="$error_tracking_issue_reopened",
             exception_timestamp="2026-07-21T12:05:00",
+            extra_properties={"attempt": 2},
         )
 
     assert produce_internal_event.call_count == 2
@@ -140,6 +141,7 @@ def test_oversized_internal_event_retries_without_exception_properties() -> None
         "exception_props": event_properties,
         "status": "Pending Release",
         "assignee": inputs.assignee,
+        "attempt": 2,
     }
     assert sent_events[1].properties == {
         key: value for key, value in sent_events[0].properties.items() if key != "exception_props"
@@ -176,11 +178,13 @@ def test_internal_event_reraises_non_size_kafka_errors() -> None:
     ):
         produce_issue_lifecycle_internal_event(
             _inputs(),
-            event="$error_tracking_issue_reopened",
+            event="$error_tracking_issue_spiking",
             exception_timestamp="invalid",
+            include_status=False,
         )
 
     assert len(sent_events) == 1
+    assert "status" not in sent_events[0].properties
 
 
 @pytest.mark.asyncio

--- a/products/error_tracking/backend/temporal/lifecycle/types.py
+++ b/products/error_tracking/backend/temporal/lifecycle/types.py
@@ -1,4 +1,5 @@
 import dataclasses
+from enum import StrEnum
 
 
 @dataclasses.dataclass(frozen=True)
@@ -7,3 +8,9 @@ class LifecycleIssueSnapshot:
     description: str | None
     status: str
     created_at: str
+
+
+class SpikeEventPersistenceStatus(StrEnum):
+    INSERTED = "inserted"
+    ALREADY_PERSISTED = "already_persisted"
+    MISSING_ISSUE = "missing_issue"

--- a/rust/cymbal/src/core/types/notification.rs
+++ b/rust/cymbal/src/core/types/notification.rs
@@ -81,10 +81,18 @@ impl<'de> Deserialize<'de> for IngestionNotification {
                         value.meta.team_id, value.issue.issue_id, event_reference
                     )
                 }
-                Self::IssueSpiking(value) => format!(
+                Self::IssueSpiking(value) if value.event_uuid.is_nil() => format!(
                     "issue_spiking:{}:{}:{}:{}",
                     value.meta.team_id,
                     value.issue.issue_id,
+                    value.computed_baseline.to_bits(),
+                    value.current_bucket_value.to_bits()
+                ),
+                Self::IssueSpiking(value) => format!(
+                    "issue_spiking:{}:{}:{}:{}:{}",
+                    value.meta.team_id,
+                    value.issue.issue_id,
+                    value.event_uuid,
                     value.computed_baseline.to_bits(),
                     value.current_bucket_value.to_bits()
                 ),
@@ -225,6 +233,10 @@ pub struct IssueSpiking {
     pub meta: NotificationMeta,
     #[serde(flatten)]
     pub issue: IssueNotificationContext,
+    #[serde(default)]
+    pub event_uuid: Uuid,
+    #[serde(default)]
+    pub event_timestamp: String,
     pub computed_baseline: f64,
     pub current_bucket_value: f64,
     #[serde(default)]
@@ -318,5 +330,59 @@ mod tests {
             decoded.validate(),
             Err(NotificationValidationError::FingerprintMismatch { .. })
         ));
+    }
+
+    #[test]
+    fn legacy_issue_spiking_notification_keeps_its_original_fallback_id() {
+        let issue_id = Uuid::now_v7();
+        let notification = IngestionNotification::IssueSpiking(IssueSpiking {
+            meta: NotificationMeta {
+                notification_id: Uuid::now_v7(),
+                team_id: 42,
+            },
+            issue: IssueNotificationContext {
+                issue_id,
+                issue: IssueSnapshot {
+                    name: Some("Example".to_string()),
+                    description: Some("Example issue".to_string()),
+                    status: "active".to_string(),
+                    created_at: DateTime::from_timestamp(0, 0).unwrap(),
+                },
+                event_properties: serde_json::from_value(serde_json::json!({
+                    "$exception_list": [{"type": "Error", "value": "boom"}],
+                    "$exception_fingerprint": "abc",
+                    "$exception_fingerprint_record": [{"type": "manual"}],
+                    "$exception_issue_id": issue_id,
+                    "$exception_handled": false,
+                    "$exception_types": ["Error"],
+                    "$exception_values": ["boom"],
+                    "$exception_sources": [],
+                    "$exception_functions": [],
+                }))
+                .unwrap(),
+            },
+            event_uuid: Uuid::now_v7(),
+            event_timestamp: "1970-01-01T00:00:00Z".to_string(),
+            computed_baseline: 2.5,
+            current_bucket_value: 20.0,
+            assignee: None,
+        });
+        let mut legacy_json = serde_json::to_value(notification).unwrap();
+        let object = legacy_json.as_object_mut().unwrap();
+        object.remove("notification_id");
+        object.remove("event_uuid");
+        object.remove("event_timestamp");
+
+        let decoded: IngestionNotification = serde_json::from_value(legacy_json).unwrap();
+        let fallback_key = format!(
+            "issue_spiking:42:{issue_id}:{}:{}",
+            2.5_f64.to_bits(),
+            20.0_f64.to_bits()
+        );
+
+        assert_eq!(
+            decoded.notification_id(),
+            Uuid::new_v5(&Uuid::NAMESPACE_OID, fallback_key.as_bytes())
+        );
     }
 }

--- a/rust/cymbal/src/modes/notifications/config.rs
+++ b/rust/cymbal/src/modes/notifications/config.rs
@@ -82,6 +82,15 @@ pub struct NotificationsConfig {
     #[envconfig(from = "ERROR_TRACKING_ISSUE_REOPENED_WORKFLOW_TEAM_IDS", default = "")]
     pub issue_reopened_workflow_team_ids: String,
 
+    #[envconfig(
+        from = "ERROR_TRACKING_ISSUE_SPIKING_WORKFLOW_ENABLED",
+        default = "false"
+    )]
+    pub issue_spiking_workflow_enabled: bool,
+
+    #[envconfig(from = "ERROR_TRACKING_ISSUE_SPIKING_WORKFLOW_TEAM_IDS", default = "")]
+    pub issue_spiking_workflow_team_ids: String,
+
     #[envconfig(from = "TEMPORAL_HOST", default = "")]
     pub temporal_host: String,
 

--- a/rust/cymbal/src/modes/notifications/issue_handler.rs
+++ b/rust/cymbal/src/modes/notifications/issue_handler.rs
@@ -134,12 +134,21 @@ pub async fn handle_issue_spiking(
     context: &NotificationsContext,
     notification: IssueSpiking,
 ) -> Result<(), UnhandledError> {
+    if context
+        .issue_lifecycle_workflow_starters
+        .start_spiking_if_enabled(&notification)
+        .await?
+    {
+        return Ok(());
+    }
+
     let IssueSpiking {
         meta,
         issue,
         computed_baseline,
         current_bucket_value,
         assignee,
+        ..
     } = notification;
     let IssueNotificationContext {
         issue_id,

--- a/rust/cymbal/src/modes/notifications/temporal.rs
+++ b/rust/cymbal/src/modes/notifications/temporal.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use chrono::{DateTime, Utc};
 use common_temporal::{
     StartWorkflowOptions, StartWorkflowOutcome, TemporalClientConfig, TemporalWorkflowClient,
 };
@@ -7,7 +8,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use crate::core::error::UnhandledError;
-use crate::core::types::notification::{IssueCreated, IssueReopened, IssueSnapshot};
+use crate::core::types::notification::{IssueCreated, IssueReopened, IssueSnapshot, IssueSpiking};
 use crate::modes::notifications::config::NotificationsConfig;
 
 #[derive(Clone, Copy)]
@@ -21,6 +22,7 @@ struct WorkflowDefinition {
 enum IssueLifecycleKind {
     Created,
     Reopened,
+    Spiking,
 }
 
 impl IssueLifecycleKind {
@@ -36,12 +38,18 @@ impl IssueLifecycleKind {
                 starts_metric: "cymbal_issue_reopened_workflow_starts_total",
                 routes_metric: "cymbal_issue_reopened_workflow_routes_total",
             },
+            Self::Spiking => WorkflowDefinition {
+                name: "error-tracking-issue-spiking",
+                starts_metric: "cymbal_issue_spiking_workflow_starts_total",
+                routes_metric: "cymbal_issue_spiking_workflow_routes_total",
+            },
         }
     }
 }
 
 const ISSUE_CREATED_WORKFLOW: WorkflowDefinition = IssueLifecycleKind::Created.workflow();
 const ISSUE_REOPENED_WORKFLOW: WorkflowDefinition = IssueLifecycleKind::Reopened.workflow();
+const ISSUE_SPIKING_WORKFLOW: WorkflowDefinition = IssueLifecycleKind::Spiking.workflow();
 
 #[derive(Clone)]
 struct LifecycleWorkflowRoute {
@@ -62,6 +70,7 @@ pub struct IssueLifecycleWorkflowStarters {
     task_queue: String,
     created: Option<LifecycleWorkflowRoute>,
     reopened: Option<LifecycleWorkflowRoute>,
+    spiking: Option<LifecycleWorkflowRoute>,
 }
 
 impl IssueLifecycleWorkflowStarters {
@@ -79,7 +88,12 @@ impl IssueLifecycleWorkflowStarters {
             &config.issue_reopened_workflow_team_ids,
             "ERROR_TRACKING_ISSUE_REOPENED_WORKFLOW_TEAM_IDS",
         )?;
-        if (created.is_some() || reopened.is_some()) && client.is_none() {
+        let spiking = build_route(
+            config.issue_spiking_workflow_enabled,
+            &config.issue_spiking_workflow_team_ids,
+            "ERROR_TRACKING_ISSUE_SPIKING_WORKFLOW_TEAM_IDS",
+        )?;
+        if (created.is_some() || reopened.is_some() || spiking.is_some()) && client.is_none() {
             return Err(UnhandledError::Other(
                 "Temporal client missing for enabled lifecycle workflow".to_string(),
             ));
@@ -90,6 +104,7 @@ impl IssueLifecycleWorkflowStarters {
             task_queue: config.error_tracking_lifecycle_task_queue.clone(),
             created,
             reopened,
+            spiking,
         })
     }
 
@@ -141,6 +156,32 @@ impl IssueLifecycleWorkflowStarters {
         Ok(true)
     }
 
+    pub async fn start_spiking_if_enabled(
+        &self,
+        notification: &IssueSpiking,
+    ) -> Result<bool, UnhandledError> {
+        if !has_event_reference(notification.event_uuid, &notification.event_timestamp) {
+            record_route(ISSUE_SPIKING_WORKFLOW, "legacy_missing_event_reference");
+            return Ok(false);
+        }
+        if !route_is_enabled(
+            &self.spiking,
+            notification.meta.team_id,
+            ISSUE_SPIKING_WORKFLOW,
+        ) {
+            return Ok(false);
+        }
+
+        self.start(
+            notification.meta.notification_id,
+            &IssueSpikingWorkflowInput::from(notification),
+            ISSUE_SPIKING_WORKFLOW,
+        )
+        .await?;
+        record_route(ISSUE_SPIKING_WORKFLOW, "temporal");
+        Ok(true)
+    }
+
     async fn start<T: Serialize>(
         &self,
         notification_id: Uuid,
@@ -177,7 +218,10 @@ impl IssueLifecycleWorkflowStarters {
 pub async fn build_issue_lifecycle_temporal_client(
     config: &NotificationsConfig,
 ) -> Result<Option<TemporalWorkflowClient>, UnhandledError> {
-    if !config.issue_created_workflow_enabled && !config.issue_reopened_workflow_enabled {
+    if !config.issue_created_workflow_enabled
+        && !config.issue_reopened_workflow_enabled
+        && !config.issue_spiking_workflow_enabled
+    {
         return Ok(None);
     }
 
@@ -303,6 +347,49 @@ impl<'a> From<&'a IssueReopened> for IssueReopenedWorkflowInput<'a> {
     }
 }
 
+#[derive(Serialize)]
+struct IssueSpikingWorkflowInput<'a> {
+    notification_id: Uuid,
+    team_id: i32,
+    issue_id: Uuid,
+    issue: &'a IssueSnapshot,
+    fingerprint: &'a str,
+    event_uuid: Uuid,
+    event_timestamp: &'a str,
+    detected_at: DateTime<Utc>,
+    computed_baseline: f64,
+    current_bucket_value: f64,
+    assignee: Option<&'a str>,
+}
+
+impl<'a> From<&'a IssueSpiking> for IssueSpikingWorkflowInput<'a> {
+    fn from(notification: &'a IssueSpiking) -> Self {
+        Self {
+            notification_id: notification.meta.notification_id,
+            team_id: notification.meta.team_id,
+            issue_id: notification.issue.issue_id,
+            issue: &notification.issue.issue,
+            fingerprint: notification.issue.event_properties.fingerprint(),
+            event_uuid: notification.event_uuid,
+            event_timestamp: &notification.event_timestamp,
+            detected_at: notification_time(notification.meta.notification_id),
+            computed_baseline: notification.computed_baseline,
+            current_bucket_value: notification.current_bucket_value,
+            assignee: notification.assignee.as_deref(),
+        }
+    }
+}
+
+fn notification_time(notification_id: Uuid) -> DateTime<Utc> {
+    notification_id
+        .get_timestamp()
+        .and_then(|timestamp| {
+            let (seconds, nanos) = timestamp.to_unix();
+            DateTime::from_timestamp(seconds as i64, nanos)
+        })
+        .unwrap_or_else(Utc::now)
+}
+
 fn parse_team_ids(
     raw: &str,
     env_var: &'static str,
@@ -386,11 +473,27 @@ mod tests {
         }
     }
 
+    fn issue_spiking() -> IssueSpiking {
+        IssueSpiking {
+            meta: NotificationMeta {
+                notification_id: notification_id(),
+                team_id: 42,
+            },
+            issue: issue_context(),
+            event_uuid: Uuid::now_v7(),
+            event_timestamp: "2026-07-21T12:00:00Z".to_string(),
+            computed_baseline: 2.0,
+            current_bucket_value: 20.0,
+            assignee: None,
+        }
+    }
+
     #[test]
     fn workflow_inputs_exclude_event_properties() {
         let values = [
             serde_json::to_value(IssueCreatedWorkflowInput::from(&issue_created())).unwrap(),
             serde_json::to_value(IssueReopenedWorkflowInput::from(&issue_reopened())).unwrap(),
+            serde_json::to_value(IssueSpikingWorkflowInput::from(&issue_spiking())).unwrap(),
         ];
 
         for value in values {
@@ -402,7 +505,11 @@ mod tests {
 
     #[test]
     fn start_options_are_idempotent_and_target_the_lifecycle_queue() {
-        for workflow in [ISSUE_CREATED_WORKFLOW, ISSUE_REOPENED_WORKFLOW] {
+        for workflow in [
+            ISSUE_CREATED_WORKFLOW,
+            ISSUE_REOPENED_WORKFLOW,
+            ISSUE_SPIKING_WORKFLOW,
+        ] {
             let options = start_options(
                 notification_id(),
                 "error-tracking-lifecycle-task-queue",
@@ -442,7 +549,7 @@ mod tests {
     }
 
     #[test]
-    fn reopened_requires_event_references() {
+    fn reopened_and_spiking_require_event_references() {
         assert!(has_event_reference(Uuid::now_v7(), "2026-07-21T12:00:00Z"));
         assert!(!has_event_reference(Uuid::nil(), "2026-07-21T12:00:00Z"));
         assert!(!has_event_reference(Uuid::now_v7(), ""));

--- a/rust/cymbal/src/modes/processing/issue_resolution.rs
+++ b/rust/cymbal/src/modes/processing/issue_resolution.rs
@@ -486,9 +486,21 @@ pub async fn send_issue_spiking_notification(
     context: &AppContext,
     issue: &Issue,
     processed_properties: ProcessedExceptionProperties,
+    event_uuid: Uuid,
+    event_timestamp: &str,
     computed_baseline: f64,
     current_bucket_value: f64,
 ) -> Result<(), UnhandledError> {
+    store_error_tracking_event_properties(
+        &*context.issue_buckets_redis_client,
+        context.config.event_properties_ttl_seconds,
+        context.config.event_properties_max_bytes,
+        issue.team_id,
+        event_uuid,
+        "issue_spiking",
+        &processed_properties,
+    )
+    .await;
     let assignment = issue
         .get_assignments(&context.posthog_pool)
         .await?
@@ -500,6 +512,8 @@ pub async fn send_issue_spiking_notification(
         IngestionNotification::IssueSpiking(IssueSpiking {
             meta: notification_meta(issue),
             issue: issue_notification_context(issue, processed_properties),
+            event_uuid,
+            event_timestamp: event_timestamp.to_string(),
             computed_baseline,
             current_bucket_value,
             assignee: assignment_to_string(assignment)?,

--- a/rust/cymbal/src/modes/processing/stages/alerting/spike_alert.rs
+++ b/rust/cymbal/src/modes/processing/stages/alerting/spike_alert.rs
@@ -10,14 +10,13 @@ use crate::{
     issue_resolution::Issue,
     metric_consts::SPIKE_ALERT_STAGE,
     stages::{
-        alerting::spike_detection::do_spike_detection,
+        alerting::spike_detection::{do_spike_detection, SpikeSample},
         pipeline::{FinalizedPipelineItem, RateCheckedPipelineItem},
     },
     types::{
         batch::Batch,
         exception_event::ExceptionEvent,
         stage::{Stage, StageResult},
-        ProcessedExceptionProperties,
     },
 };
 
@@ -42,14 +41,18 @@ impl Stage for SpikeAlertStage {
 
     async fn process(self, batch: Batch<RateCheckedPipelineItem>) -> StageResult<Self> {
         let mut issues: Vec<Issue> = Vec::new();
-        let mut issue_props_by_id: HashMap<Uuid, ProcessedExceptionProperties> = HashMap::new();
+        let mut issue_samples_by_id: HashMap<Uuid, SpikeSample> = HashMap::new();
 
         for res in batch.inner_ref() {
             let Ok(evt) = res else { continue };
             let issue = evt.issue();
             // Keep one ProcessedExceptionProperties per issue (they share the same stack shape)
-            if let Entry::Vacant(e) = issue_props_by_id.entry(issue.id) {
-                e.insert(evt.processed_properties());
+            if let Entry::Vacant(e) = issue_samples_by_id.entry(issue.id) {
+                e.insert(SpikeSample {
+                    props: evt.processed_properties(),
+                    event_uuid: evt.uuid(),
+                    event_timestamp: evt.timestamp().to_string(),
+                });
             }
             issues.push(issue.clone());
         }
@@ -68,7 +71,7 @@ impl Stage for SpikeAlertStage {
         do_spike_detection(
             self.context,
             issues_by_id,
-            issue_props_by_id,
+            issue_samples_by_id,
             issues_count_by_id,
         )
         .await?;

--- a/rust/cymbal/src/modes/processing/stages/alerting/spike_detection.rs
+++ b/rust/cymbal/src/modes/processing/stages/alerting/spike_detection.rs
@@ -43,8 +43,17 @@ fn cooldown_key(issue_id: &Uuid) -> String {
 pub struct SpikingIssue {
     pub issue: Issue,
     pub props: ProcessedExceptionProperties,
+    pub event_uuid: Uuid,
+    pub event_timestamp: String,
     pub computed_baseline: f64,
     pub current_bucket_value: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct SpikeSample {
+    pub props: ProcessedExceptionProperties,
+    pub event_uuid: Uuid,
+    pub event_timestamp: String,
 }
 
 /// Bucket data for a single issue
@@ -168,7 +177,7 @@ async fn try_increment_team_buckets(
 pub async fn do_spike_detection(
     context: Arc<AppContext>,
     issues_by_id: HashMap<Uuid, Issue>,
-    issue_props_by_id: HashMap<Uuid, ProcessedExceptionProperties>,
+    issue_samples_by_id: HashMap<Uuid, SpikeSample>,
     issue_counts: HashMap<Uuid, u32>,
 ) -> Result<(), UnhandledError> {
     if issue_counts.is_empty() {
@@ -218,7 +227,7 @@ pub async fn do_spike_detection(
     let spiking = get_spiking_issues(
         &*context.issue_buckets_redis_client,
         &issues_by_id,
-        &issue_props_by_id,
+        &issue_samples_by_id,
         &team_configs,
     )
     .await;
@@ -306,6 +315,8 @@ async fn emit_spiking_events(
             context,
             &spike.issue,
             spike.props.clone(),
+            spike.event_uuid,
+            &spike.event_timestamp,
             spike.computed_baseline,
             spike.current_bucket_value as f64,
         )
@@ -379,7 +390,7 @@ fn is_spiking(current_value: i64, baseline: f64, config: &SpikeDetectionConfig) 
 async fn get_spiking_issues(
     redis: &(dyn Client + Send + Sync),
     issues_by_id: &HashMap<Uuid, Issue>,
-    issue_props_by_id: &HashMap<Uuid, ProcessedExceptionProperties>,
+    issue_samples_by_id: &HashMap<Uuid, SpikeSample>,
     team_configs: &HashMap<i32, SpikeDetectionConfig>,
 ) -> Result<Vec<SpikingIssue>, UnhandledError> {
     if issues_by_id.is_empty() {
@@ -419,7 +430,7 @@ async fn get_spiking_issues(
         })?;
 
         if is_spiking(current_value, baseline, config) {
-            let props = issue_props_by_id
+            let sample = issue_samples_by_id
                 .get(&bucket.issue_id)
                 .cloned()
                 .ok_or_else(|| {
@@ -430,7 +441,9 @@ async fn get_spiking_issues(
                 })?;
             spiking.push(SpikingIssue {
                 issue: issue.clone(),
-                props,
+                props: sample.props,
+                event_uuid: sample.event_uuid,
+                event_timestamp: sample.event_timestamp,
                 computed_baseline: baseline,
                 current_bucket_value: current_value,
             });
@@ -550,6 +563,14 @@ mod tests {
         .unwrap()
     }
 
+    fn spike_sample(issue_id: Uuid) -> SpikeSample {
+        SpikeSample {
+            props: processed_properties(issue_id),
+            event_uuid: Uuid::now_v7(),
+            event_timestamp: Utc::now().to_rfc3339(),
+        }
+    }
+
     struct TestContext {
         redis: MockRedisClient,
         issue_id: Uuid,
@@ -625,8 +646,8 @@ mod tests {
 
         async fn get_spiking(&self) -> Vec<SpikingIssue> {
             let configs = HashMap::from([(self.team_id, SpikeDetectionConfig::default())]);
-            let properties = HashMap::from([(self.issue_id, processed_properties(self.issue_id))]);
-            get_spiking_issues(&self.redis, &self.issues_by_id(), &properties, &configs)
+            let samples = HashMap::from([(self.issue_id, spike_sample(self.issue_id))]);
+            get_spiking_issues(&self.redis, &self.issues_by_id(), &samples, &configs)
                 .await
                 .unwrap()
         }
@@ -1054,11 +1075,11 @@ mod tests {
             (team_1, SpikeDetectionConfig::default()),
             (team_2, SpikeDetectionConfig::default()),
         ]);
-        let properties = issues_by_id
+        let samples = issues_by_id
             .keys()
-            .map(|issue_id| (*issue_id, processed_properties(*issue_id)))
+            .map(|issue_id| (*issue_id, spike_sample(*issue_id)))
             .collect();
-        let result = get_spiking_issues(&redis, &issues_by_id, &properties, &configs)
+        let result = get_spiking_issues(&redis, &issues_by_id, &samples, &configs)
             .await
             .unwrap();
 


### PR DESCRIPTION
## Problem

Spike notifications still persist records and execute side effects directly in Cymbal. They need the same durable, independently rolled-out Temporal path as created and reopened notifications, with explicit handling for persistence retries and missing issues.

This PR is stacked on #73229.

## Changes

I migrated issue-spiking notifications onto the shared lifecycle infrastructure introduced by the base PR.

- Added the spike workflow, activities, typed persistence outcomes, and worker registration.
- Stored spike rows idempotently before emitting the internal event and signal.
- Continued notification after an activity retry finds the row already persisted, while stopping when the issue no longer exists.
- Added event references to Cymbal's spike payload and preserved the deterministic fallback ID for legacy payloads.
- Added independent spike rollout configuration and retained the legacy Cymbal path when disabled.

> [!NOTE]
> Internal-event publication retains its existing at-least-once delivery semantics. Exactly-once dispatch across Temporal, Kafka, and CDP requires downstream idempotency or a transactional outbox and is outside this migration.

**Before**

```mermaid
flowchart LR
    A[Spike detected] --> B[Cymbal persists spike]
    B --> C[Cymbal side effects]
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,C phGray;
```

**After**

```mermaid
flowchart LR
    A[Spike detected] --> B{Workflow enabled for team?}
    B -->|Yes| C[Temporal spike workflow]
    B -->|No| D[Legacy Cymbal handling]
    C --> E[Idempotent spike persistence]
    E --> F[Internal event and signal]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class A phYellow;
    class B,D phGray;
    class C,E,F phBlue;
```

## How did you test this code?

- `./bin/hogli test products/error_tracking/backend/temporal/lifecycle` with 17 tests passing, including the PostgreSQL-backed spike persistence test.
- `cargo test -p cymbal modes::notifications` with 12 tests passing.
- `cargo test -p cymbal modes::processing::stages::alerting::spike_detection` with 13 tests passing.
- `cargo clippy -p cymbal --all-targets --all-features -- -D warnings`.
- `cargo fmt -- --check` and `cargo shear` using CI's pinned cargo-shear 1.1.12.
- `uv run mypy --cache-fine-grained .` with no issues across 16,796 source files.
- `./bin/hogli ci:preflight --fix` with no failures.

The spike tests guard persistence retries continuing to notification, missing issues stopping side effects, legacy fallback IDs remaining stable, and event properties staying outside Temporal payloads.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update. This is an internal lifecycle processing migration with rollout flags disabled by default.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent using repository file, shell, and editing tools. Session link is unavailable. Invoked `/error-tracking`, `/writing-tests`, `/running-ci-preflight`, and `/pr`.

I separated spike handling from the reopened migration because spike persistence and activity retry behavior carry different correctness risks. This PR remains stacked until #73229 merges.
