### PR TITLE
fix(data-modeling): reduce models table page size to 25

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/modeling/constants.ts
+++ b/frontend/src/scenes/data-warehouse/scene/modeling/constants.ts
@@ -1,4 +1,4 @@
-export const PAGE_SIZE = 40
+export const PAGE_SIZE = 25
 export const NODE_WIDTH = 180
 export const NODE_HEIGHT = 120
 


### PR DESCRIPTION
## Problem

Follow-up to #73408. That PR made the models table paginate natively, but auto-merged at 40 rows/page before the page size was finalized. 40 is still a tall scroll before the pagination footer; 25 keeps the footer within easy reach.

## Changes

`PAGE_SIZE` 40 → 25 in the data modeling modeling-tab constants. Used by both the table's `pagination.pageSize` and the client-side slice in `dataModelingLogic`, so they stay in sync.

## How did you test this code?

One-line constant change. Verified locally against a seeded ~180-node DAG that the table paginates at 25/page with the footer reachable with a short scroll.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Jovan asked to drop the page size to 25 after #73408 had already auto-merged at 40. I (Claude) branched off master and made the one-line change.
