### PR TITLE
revert(ci): drop ineffective fork sccache gating in nodejs jobs

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -145,13 +145,10 @@ jobs:
               with:
                   toolchain: 1.91.1
 
-            # for security reasons, external builds (forks) don't use the shared WebDAV cache
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
-              if: env.RUNS_ON_INTERNAL_PR == 'true'
               uses: ./.github/actions/setup-sccache
 
             - name: Cache Rust dependencies
@@ -201,13 +198,10 @@ jobs:
               with:
                   toolchain: 1.91.1
 
-            # for security reasons, external builds (forks) don't use the shared WebDAV cache
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
-              if: env.RUNS_ON_INTERNAL_PR == 'true'
               uses: ./.github/actions/setup-sccache
 
             - name: Cache Rust dependencies
@@ -308,13 +302,10 @@ jobs:
               with:
                   toolchain: 1.91.1
 
-            # for security reasons, external builds (forks) don't use the shared WebDAV cache
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
-              if: env.RUNS_ON_INTERNAL_PR == 'true'
               uses: ./.github/actions/setup-sccache
 
             - name: Cache Rust dependencies
@@ -575,13 +566,10 @@ jobs:
               with:
                   toolchain: 1.91.1
 
-            # for security reasons, external builds (forks) don't use the shared WebDAV cache
             - name: Set sccache WebDAV key prefix (Cargo.lock hash)
-              if: env.RUNS_ON_INTERNAL_PR == 'true'
               run: echo "SCCACHE_WEBDAV_KEY_PREFIX=cargo-${{ hashFiles('rust/Cargo.lock') }}" >> "$GITHUB_ENV"
 
             - name: Install sccache
-              if: env.RUNS_ON_INTERNAL_PR == 'true'
               uses: ./.github/actions/setup-sccache
 
             - name: Cache Rust dependencies


### PR DESCRIPTION
## Problem

#73307 added `if: env.RUNS_ON_INTERNAL_PR == 'true'` to the sccache steps in the nodejs CI jobs, framed as keeping fork PRs off PostHog's shared WebDAV compiler cache. Investigating what actually happens on Depot shows that gate guards nothing real, so this reverts it.

I checked two things directly against real fork PR runs.

**1. Depot already withholds the shared cache from untrusted forks.** Identical Storybook build on a Depot runner, two fork PRs:

| Fork PR | Author | Depot remote cache |
| --- | --- | --- |
| External contributor (`Aidan945/posthog`, non-member) | untrusted | **disabled** — 0/7 cached, all tasks executed locally |
| Org member's fork (`head_repository` resolves to `PostHog/posthog`) | trusted | **enabled** — 7/7 cache hits |

The untrusted fork's only cache hit was GitHub's own `actions/cache` for pnpm, which GitHub scopes read-only for forks and can't be poisoned. Depot's ambient cache (turbo remote cache, and by the same delivery mechanism sccache WebDAV — there is no cache token in the repo, it's injected by the runner) is simply not present for an untrusted fork job. So a genuinely untrusted fork cannot read or poison the shared compiler cache. The fork PRs that do get cache access are from org members with write access, who can push to the base repo anyway, so that path is trusted by design.

**2. PostHog also requires approval for all outside collaborators.** Every recent external fork PR — including repeat `CONTRIBUTOR`s, not just first-timers — shows zero auto-executed CI runs. Under GitHub's default (approve first-timers only) a returning contributor would run automatically, so the repo is on the stricter "all outside collaborators" setting. External fork code doesn't touch Depot at all until a maintainer approves.

So the gate protected against a scenario Depot already prevents. It only ever changed behavior for trusted member forks (which are meant to have cache access), while reading like a security boundary. And because a `pull_request` run executes the fork's own copy of the workflow, no in-file gate or `runs-on` choice is enforceable against a real attacker regardless.

## Changes

Remove the `if: env.RUNS_ON_INTERNAL_PR == 'true'` gate (and its "for security reasons" comment) from the four sccache step pairs in `ci-nodejs.yml`, so the steps run unconditionally like everywhere else. The `RUNS_ON_INTERNAL_PR` env var stays for its unrelated trunk-analytics upload gate.

Net effect: nothing in the workflow pretends to be a fork boundary. On the rare untrusted fork run the sccache install is a harmless no-op (Depot gives it no WebDAV credentials to use).

## How did you test this code?

- `bin/hogli lint:workflows` passes (all 6 checks)
- `actionlint` v1.7.12 (the CI-pinned version) passes on `ci-nodejs.yml`
- Confirmed `RUNS_ON_INTERNAL_PR` still resolves for the remaining trunk-upload gate
- Findings above verified by reading real fork PR run logs (external contributor vs member) via the GitHub Actions API

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Claude Fable 5), driven by Robbie. Skills invoked: /authoring-ci-workflows. This PR started as an attempt to *add* fork protection (gate sccache in ci-rust, then route fork jobs to GitHub-hosted runners). Investigation reversed that: reading real fork PR run logs showed Depot already disables its shared cache for untrusted fork jobs (turbo "Remote caching disabled" on an external contributor's run vs "enabled" on a member's), and PostHog requires approval for all outside collaborators. The gate guarded a non-threat while implying a boundary, so the PR was rewritten to remove it. One residual: the disabled-cache behavior is directly confirmed for turbo; sccache WebDAV uses the same ambient-credential delivery so it's inferred to be withheld identically, not separately captured (no external fork PR happened to run a Depot rust/node build).
