### PR TITLE
refactor(ingestion): replace merge-fold prescan with group-level pipeChunk

### DIFF
--- a/nodejs/src/ingestion/common/common-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/common/common-ingestion-pipeline.ts
@@ -385,7 +385,7 @@ export class CommonTeamStage<
         groupingFn: GroupingFunction<TCurrent, TKey>,
         callback: (
             group: GroupProcessingBuilder<TPost, TCurrent, TeamAwareContext<TContext>, TeamAwareContext<TContext>, ROut>
-        ) => ChunkPipelineBuilder<TPost, U, TeamAwareContext<TContext>, TeamAwareContext<TContext>, ROut>,
+        ) => GroupProcessingBuilder<TPost, U, TeamAwareContext<TContext>, TeamAwareContext<TContext>, ROut>,
         options?: { maxConcurrency?: number }
     ): CommonTeamStage<TInput, TContext, ROut, CBatch, TPost, U> {
         const committed = this.chain.build()

--- a/nodejs/src/ingestion/common/persons/person-merge-fold.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-fold.test.ts
@@ -1,9 +1,10 @@
+import { isOkResult } from '~/ingestion/framework/results'
 import { PluginEvent } from '~/plugin-scaffold'
 import { EventHeaders, Team } from '~/types'
 
-import { MergeFoldScanItem, createMergeFoldPrescan } from './person-merge-fold'
+import { MergeFoldScanItem, createMergeFoldPlanningStep } from './person-merge-fold'
 
-describe('createMergeFoldPrescan', () => {
+describe('createMergeFoldPlanningStep', () => {
     const team = { id: 7 } as Team
 
     let uuidCounter: number
@@ -34,26 +35,34 @@ describe('createMergeFoldPrescan', () => {
         }
     }
 
-    function scan(
-        items: MergeFoldScanItem[],
+    async function scan(
+        values: MergeFoldScanItem[],
         options: { enabled?: boolean; allowlist?: string } = {}
-    ): MergeFoldScanItem[] {
-        const prescan = createMergeFoldPrescan({
+    ): Promise<MergeFoldScanItem[]> {
+        const step = createMergeFoldPlanningStep({
             PERSON_MERGE_FOLD_ENABLED: options.enabled ?? true,
             PERSON_MERGE_FOLD_TEAM_ALLOWLIST: options.allowlist ?? '*',
         })
-        prescan?.(items.map((value) => ({ value, context: { sideEffects: [], warnings: [] } })))
-        return items
+        const results = await step(values)
+        expect(results).toHaveLength(values.length)
+        return results.map((result) => {
+            if (!isOkResult(result)) {
+                throw new Error('planning step must not fail values')
+            }
+            return result.value
+        })
     }
 
-    it('returns null when folding is disabled', () => {
-        expect(
-            createMergeFoldPrescan({ PERSON_MERGE_FOLD_ENABLED: false, PERSON_MERGE_FOLD_TEAM_ALLOWLIST: '*' })
-        ).toBeNull()
+    it('passes values through unplanned when folding is disabled', async () => {
+        const inputs = [identify('anon-1'), identify('anon-2')]
+        const items = await scan(inputs, { enabled: false })
+
+        expect(items).toEqual(inputs)
+        expect(items.every((item) => item.mergeFoldPlan === undefined)).toBe(true)
     })
 
-    it('plans one shared fold for a run of identifies with distinct anon ids', () => {
-        const items = scan([identify('anon-1'), identify('anon-2'), identify('anon-3')])
+    it('plans one shared fold for a run of identifies with distinct anon ids', async () => {
+        const items = await scan([identify('anon-1'), identify('anon-2'), identify('anon-3')])
 
         const plan = items[0].mergeFoldPlan
         expect(plan).toBeDefined()
@@ -69,8 +78,18 @@ describe('createMergeFoldPrescan', () => {
         })
     })
 
-    it('dedupes repeated pairs, keeping the first event uuid', () => {
-        const items = scan([identify('anon-1'), identify('anon-1'), identify('anon-2')])
+    it('annotates planned values without mutating the inputs', async () => {
+        const inputs = [identify('anon-1'), identify('anon-2'), event('$pageview')]
+        const items = await scan(inputs)
+
+        expect(inputs.every((input) => input.mergeFoldPlan === undefined)).toBe(true)
+        expect(items[0].mergeFoldPlan).toBeDefined()
+        // Values outside the planned run pass through as the same object.
+        expect(items[2]).toBe(inputs[2])
+    })
+
+    it('dedupes repeated pairs, keeping the first event uuid', async () => {
+        const items = await scan([identify('anon-1'), identify('anon-1'), identify('anon-2')])
 
         expect(items[0].mergeFoldPlan?.pairs).toEqual([
             { anonDistinctId: 'anon-1', eventUuid: 'uuid-0' },
@@ -79,14 +98,14 @@ describe('createMergeFoldPrescan', () => {
         expect(items[1].mergeFoldPlan).toBe(items[0].mergeFoldPlan)
     })
 
-    it('does not plan a single merge event', () => {
-        const items = scan([identify('anon-1'), event('$pageview')])
+    it('does not plan a single merge event', async () => {
+        const items = await scan([identify('anon-1'), event('$pageview')])
 
         expect(items.every((item) => item.mergeFoldPlan === undefined)).toBe(true)
     })
 
-    it('splits runs on interleaved non-merge events', () => {
-        const items = scan([
+    it('splits runs on interleaved non-merge events', async () => {
+        const items = await scan([
             identify('anon-1'),
             identify('anon-2'),
             event('$pageview'),
@@ -106,8 +125,8 @@ describe('createMergeFoldPrescan', () => {
         ['$create_alias', { alias: 'anon-1' }],
         ['$merge_dangerously', { alias: 'anon-1' }],
         ['$identify', {}],
-    ])('does not treat %s as foldable', (name, properties) => {
-        const items = scan([event(name, 'user-1', properties), identify('anon-2'), identify('anon-3')])
+    ])('does not treat %s as foldable', async (name, properties) => {
+        const items = await scan([event(name, 'user-1', properties), identify('anon-2'), identify('anon-3')])
 
         expect(items[0].mergeFoldPlan).toBeUndefined()
         expect(items[1].mergeFoldPlan?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-2', 'anon-3'])
@@ -129,8 +148,13 @@ describe('createMergeFoldPrescan', () => {
                     { force_disable_person_processing: true }
                 ),
         ],
-    ])('does not fold an $identify with %s and splits the run on it', (_name, disabledIdentify) => {
-        const items = scan([identify('anon-1'), identify('anon-2'), disabledIdentify('anon-3'), identify('anon-4')])
+    ])('does not fold an $identify with %s and splits the run on it', async (_name, disabledIdentify) => {
+        const items = await scan([
+            identify('anon-1'),
+            identify('anon-2'),
+            disabledIdentify('anon-3'),
+            identify('anon-4'),
+        ])
 
         const plan = items[0].mergeFoldPlan
         expect(plan?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-1', 'anon-2'])
@@ -139,8 +163,8 @@ describe('createMergeFoldPrescan', () => {
         expect(items[3].mergeFoldPlan).toBeUndefined()
     })
 
-    it('excludes illegal anon distinct ids from the plan without splitting the run', () => {
-        const items = scan([identify('anon-1'), identify('anonymous'), identify('anon-2')])
+    it('excludes illegal anon distinct ids from the plan without splitting the run', async () => {
+        const items = await scan([identify('anon-1'), identify('anonymous'), identify('anon-2')])
 
         const plan = items[0].mergeFoldPlan
         expect(plan?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-1', 'anon-2'])
@@ -148,30 +172,30 @@ describe('createMergeFoldPrescan', () => {
         expect(items[2].mergeFoldPlan).toBe(plan)
     })
 
-    it('skips planning when only illegal anon distinct ids are in the run', () => {
-        const items = scan([identify('anonymous'), identify('null')])
+    it('skips planning when only illegal anon distinct ids are in the run', async () => {
+        const items = await scan([identify('anonymous'), identify('null')])
 
         expect(items.every((item) => item.mergeFoldPlan === undefined)).toBe(true)
     })
 
-    it('excludes self-merges from the plan', () => {
-        const items = scan([identify('user-1'), identify('anon-1'), identify('anon-2')])
+    it('excludes self-merges from the plan', async () => {
+        const items = await scan([identify('user-1'), identify('anon-1'), identify('anon-2')])
 
         expect(items[0].mergeFoldPlan).toBeUndefined()
         expect(items[1].mergeFoldPlan?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-1', 'anon-2'])
     })
 
-    it('skips planning when only self-merges are in the run', () => {
-        const items = scan([identify('user-1'), identify('user-1')])
+    it('skips planning when only self-merges are in the run', async () => {
+        const items = await scan([identify('user-1'), identify('user-1')])
 
         expect(items.every((item) => item.mergeFoldPlan === undefined)).toBe(true)
     })
 
-    it('respects the team allowlist', () => {
-        const planned = scan([identify('anon-1'), identify('anon-2')], { allowlist: '7' })
+    it('respects the team allowlist', async () => {
+        const planned = await scan([identify('anon-1'), identify('anon-2')], { allowlist: '7' })
         expect(planned[0].mergeFoldPlan).toBeDefined()
 
-        const skipped = scan([identify('anon-1'), identify('anon-2')], { allowlist: '8,9' })
+        const skipped = await scan([identify('anon-1'), identify('anon-2')], { allowlist: '8,9' })
         expect(skipped.every((item) => item.mergeFoldPlan === undefined)).toBe(true)
     })
 })

--- a/nodejs/src/ingestion/common/persons/person-merge-fold.test.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-fold.test.ts
@@ -2,7 +2,12 @@ import { isOkResult } from '~/ingestion/framework/results'
 import { PluginEvent } from '~/plugin-scaffold'
 import { EventHeaders, Team } from '~/types'
 
-import { MergeFoldScanItem, createMergeFoldPlanningStep } from './person-merge-fold'
+import {
+    MergeFoldPlan,
+    MergeFoldScanItem,
+    WithMergeFoldDecision,
+    createMergeFoldPlanningStep,
+} from './person-merge-fold'
 
 describe('createMergeFoldPlanningStep', () => {
     const team = { id: 7 } as Team
@@ -35,10 +40,14 @@ describe('createMergeFoldPlanningStep', () => {
         }
     }
 
+    function planOf(item: WithMergeFoldDecision): MergeFoldPlan | undefined {
+        return item.mergeFold.type === 'planned' ? item.mergeFold.plan : undefined
+    }
+
     async function scan(
         values: MergeFoldScanItem[],
         options: { enabled?: boolean; allowlist?: string } = {}
-    ): Promise<MergeFoldScanItem[]> {
+    ): Promise<(MergeFoldScanItem & WithMergeFoldDecision)[]> {
         const step = createMergeFoldPlanningStep({
             PERSON_MERGE_FOLD_ENABLED: options.enabled ?? true,
             PERSON_MERGE_FOLD_TEAM_ALLOWLIST: options.allowlist ?? '*',
@@ -53,20 +62,19 @@ describe('createMergeFoldPlanningStep', () => {
         })
     }
 
-    it('passes values through unplanned when folding is disabled', async () => {
+    it('emits every value as immediate when folding is disabled', async () => {
         const inputs = [identify('anon-1'), identify('anon-2')]
         const items = await scan(inputs, { enabled: false })
 
-        expect(items).toEqual(inputs)
-        expect(items.every((item) => item.mergeFoldPlan === undefined)).toBe(true)
+        expect(items).toEqual(inputs.map((input) => ({ ...input, mergeFold: { type: 'immediate' } })))
     })
 
     it('plans one shared fold for a run of identifies with distinct anon ids', async () => {
         const items = await scan([identify('anon-1'), identify('anon-2'), identify('anon-3')])
 
-        const plan = items[0].mergeFoldPlan
+        const plan = planOf(items[0])
         expect(plan).toBeDefined()
-        expect(items.every((item) => item.mergeFoldPlan === plan)).toBe(true)
+        expect(items.every((item) => planOf(item) === plan)).toBe(true)
         expect(plan).toMatchObject({
             targetDistinctId: 'user-1',
             status: 'planned',
@@ -78,30 +86,29 @@ describe('createMergeFoldPlanningStep', () => {
         })
     })
 
-    it('annotates planned values without mutating the inputs', async () => {
+    it('decides via returned values without mutating the inputs', async () => {
         const inputs = [identify('anon-1'), identify('anon-2'), event('$pageview')]
         const items = await scan(inputs)
 
-        expect(inputs.every((input) => input.mergeFoldPlan === undefined)).toBe(true)
-        expect(items[0].mergeFoldPlan).toBeDefined()
-        // Values outside the planned run pass through as the same object.
-        expect(items[2]).toBe(inputs[2])
+        expect(inputs.every((input) => !('mergeFold' in input))).toBe(true)
+        expect(items[0].mergeFold.type).toBe('planned')
+        expect(items[2].mergeFold.type).toBe('immediate')
     })
 
     it('dedupes repeated pairs, keeping the first event uuid', async () => {
         const items = await scan([identify('anon-1'), identify('anon-1'), identify('anon-2')])
 
-        expect(items[0].mergeFoldPlan?.pairs).toEqual([
+        expect(planOf(items[0])?.pairs).toEqual([
             { anonDistinctId: 'anon-1', eventUuid: 'uuid-0' },
             { anonDistinctId: 'anon-2', eventUuid: 'uuid-2' },
         ])
-        expect(items[1].mergeFoldPlan).toBe(items[0].mergeFoldPlan)
+        expect(planOf(items[1])).toBe(planOf(items[0]))
     })
 
     it('does not plan a single merge event', async () => {
         const items = await scan([identify('anon-1'), event('$pageview')])
 
-        expect(items.every((item) => item.mergeFoldPlan === undefined)).toBe(true)
+        expect(items.every((item) => item.mergeFold.type === 'immediate')).toBe(true)
     })
 
     it('splits runs on interleaved non-merge events', async () => {
@@ -113,12 +120,12 @@ describe('createMergeFoldPlanningStep', () => {
             identify('anon-4'),
         ])
 
-        const firstPlan = items[0].mergeFoldPlan
-        const secondPlan = items[3].mergeFoldPlan
+        const firstPlan = planOf(items[0])
+        const secondPlan = planOf(items[3])
         expect(firstPlan?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-1', 'anon-2'])
         expect(secondPlan?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-3', 'anon-4'])
         expect(firstPlan).not.toBe(secondPlan)
-        expect(items[2].mergeFoldPlan).toBeUndefined()
+        expect(items[2].mergeFold.type).toBe('immediate')
     })
 
     it.each([
@@ -128,8 +135,8 @@ describe('createMergeFoldPlanningStep', () => {
     ])('does not treat %s as foldable', async (name, properties) => {
         const items = await scan([event(name, 'user-1', properties), identify('anon-2'), identify('anon-3')])
 
-        expect(items[0].mergeFoldPlan).toBeUndefined()
-        expect(items[1].mergeFoldPlan?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-2', 'anon-3'])
+        expect(items[0].mergeFold.type).toBe('immediate')
+        expect(planOf(items[1])?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-2', 'anon-3'])
     })
 
     it.each([
@@ -156,46 +163,45 @@ describe('createMergeFoldPlanningStep', () => {
             identify('anon-4'),
         ])
 
-        const plan = items[0].mergeFoldPlan
-        expect(plan?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-1', 'anon-2'])
-        expect(items[2].mergeFoldPlan).toBeUndefined()
+        expect(planOf(items[0])?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-1', 'anon-2'])
+        expect(items[2].mergeFold.type).toBe('immediate')
         // anon-4 is a lone identify after the split, so nothing to fold.
-        expect(items[3].mergeFoldPlan).toBeUndefined()
+        expect(items[3].mergeFold.type).toBe('immediate')
     })
 
     it('excludes illegal anon distinct ids from the plan without splitting the run', async () => {
         const items = await scan([identify('anon-1'), identify('anonymous'), identify('anon-2')])
 
-        const plan = items[0].mergeFoldPlan
+        const plan = planOf(items[0])
         expect(plan?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-1', 'anon-2'])
-        expect(items[1].mergeFoldPlan).toBeUndefined()
-        expect(items[2].mergeFoldPlan).toBe(plan)
+        expect(items[1].mergeFold.type).toBe('immediate')
+        expect(planOf(items[2])).toBe(plan)
     })
 
     it('skips planning when only illegal anon distinct ids are in the run', async () => {
         const items = await scan([identify('anonymous'), identify('null')])
 
-        expect(items.every((item) => item.mergeFoldPlan === undefined)).toBe(true)
+        expect(items.every((item) => item.mergeFold.type === 'immediate')).toBe(true)
     })
 
     it('excludes self-merges from the plan', async () => {
         const items = await scan([identify('user-1'), identify('anon-1'), identify('anon-2')])
 
-        expect(items[0].mergeFoldPlan).toBeUndefined()
-        expect(items[1].mergeFoldPlan?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-1', 'anon-2'])
+        expect(items[0].mergeFold.type).toBe('immediate')
+        expect(planOf(items[1])?.pairs.map((p) => p.anonDistinctId)).toEqual(['anon-1', 'anon-2'])
     })
 
     it('skips planning when only self-merges are in the run', async () => {
         const items = await scan([identify('user-1'), identify('user-1')])
 
-        expect(items.every((item) => item.mergeFoldPlan === undefined)).toBe(true)
+        expect(items.every((item) => item.mergeFold.type === 'immediate')).toBe(true)
     })
 
     it('respects the team allowlist', async () => {
         const planned = await scan([identify('anon-1'), identify('anon-2')], { allowlist: '7' })
-        expect(planned[0].mergeFoldPlan).toBeDefined()
+        expect(planned[0].mergeFold.type).toBe('planned')
 
         const skipped = await scan([identify('anon-1'), identify('anon-2')], { allowlist: '8,9' })
-        expect(skipped.every((item) => item.mergeFoldPlan === undefined)).toBe(true)
+        expect(skipped.every((item) => item.mergeFold.type === 'immediate')).toBe(true)
     })
 })

--- a/nodejs/src/ingestion/common/persons/person-merge-fold.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-fold.ts
@@ -2,6 +2,7 @@ import { buildIntegerMatcher } from '~/common/config/config'
 import { decideProcessPerson, isDistinctIdIllegal } from '~/common/persons/person-utils'
 import type { ChunkProcessingStep } from '~/ingestion/framework/base-chunk-pipeline'
 import { PipelineResult, ok } from '~/ingestion/framework/results'
+import type { ProcessingStep } from '~/ingestion/framework/steps'
 import { PluginEvent } from '~/plugin-scaffold'
 import { EventHeaders, InternalPerson, Team } from '~/types'
 
@@ -38,12 +39,39 @@ export interface MergeFoldOptions {
     PERSON_MERGE_FOLD_TEAM_ALLOWLIST: string
 }
 
-/** The fields of the pipeline item value the fold planning step reads and annotates. */
+/** The fields of the pipeline item value the fold planning step reads. */
 export interface MergeFoldScanItem {
     event: PluginEvent
     team: Team
     headers: EventHeaders
-    mergeFoldPlan?: MergeFoldPlan
+}
+
+/**
+ * The planning step's decision for one value:
+ * - `planned`: the event is part of a fold run; the run's shared plan executes
+ *   on its first event and the others short-circuit against it.
+ * - `immediate`: no fold applies; the event processes individually right away,
+ *   exactly as it would without folding.
+ */
+export type MergeFoldDecision = { type: 'planned'; plan: MergeFoldPlan } | { type: 'immediate' }
+
+/** Attached to every value the planning step emits. */
+export interface WithMergeFoldDecision {
+    mergeFold: MergeFoldDecision
+}
+
+// Decisions carry no per-event state, so every immediate value shares one instance.
+const IMMEDIATE: MergeFoldDecision = { type: 'immediate' }
+
+/**
+ * Per-item step for lanes where no merges can occur, and so nothing can fold:
+ * decide `immediate` for every event so the person step's input is satisfied
+ * without the lane's callers having to supply a decision.
+ */
+export function createImmediateMergeFoldStep<T>(): ProcessingStep<T, T & WithMergeFoldDecision> {
+    return function immediateMergeFoldStep(value: T): Promise<PipelineResult<T & WithMergeFoldDecision>> {
+        return Promise.resolve(ok({ ...value, mergeFold: IMMEDIATE }))
+    }
 }
 
 // Only $identify runs are folded. $create_alias/$merge_dangerously have
@@ -68,29 +96,29 @@ function getFoldableAnonDistinctId(item: MergeFoldScanItem): string | null {
 }
 
 /**
- * Build the group chunk step that plans merge folds. The step is always wired;
- * whether it plans anything is its own decision, gated on the enabled flag and
- * the team allowlist, so disabled configurations pass every value through
- * unplanned.
+ * Build the group chunk step that decides, per value, whether the event folds
+ * or processes immediately. The step is always wired; whether it plans
+ * anything is its own decision, gated on the enabled flag and the team
+ * allowlist, so disabled configurations emit every value as `immediate`.
  *
  * Scans a group's queued chunk for consecutive runs of two or more foldable
  * $identify events (a single merge has nothing to fold). Each run gets one
- * shared MergeFoldPlan, attached to the run's values in the step's results,
+ * shared MergeFoldPlan, carried by the run's values as a `planned` decision,
  * with the distinct anon ids as pairs (first event wins the pair's eventUuid;
- * self-merges are excluded). Values outside a planned run pass through
- * unchanged. Fold size is naturally bounded by the batch size; pathological
- * per-source distinct_id counts are handled by the merge-mode limit pre-check
- * at execution time.
+ * self-merges are excluded). Every other value gets the `immediate` decision.
+ * Fold size is naturally bounded by the batch size; pathological per-source
+ * distinct_id counts are handled by the merge-mode limit pre-check at
+ * execution time.
  */
 export function createMergeFoldPlanningStep<T extends MergeFoldScanItem>(
     options: MergeFoldOptions
-): ChunkProcessingStep<T, T> {
+): ChunkProcessingStep<T, T & WithMergeFoldDecision> {
     const isTeamEnabled = buildIntegerMatcher(options.PERSON_MERGE_FOLD_TEAM_ALLOWLIST, true)
 
     // Deliberately await-free: the single wrapping promise is the only
     // microtask this step adds to a group chunk.
-    return function planMergeFolds(values: T[]): Promise<PipelineResult<T>[]> {
-        const results = values.map((value) => ok(value))
+    return function planMergeFolds(values: T[]): Promise<PipelineResult<T & WithMergeFoldDecision>[]> {
+        const results = values.map((value) => ok({ ...value, mergeFold: IMMEDIATE }))
         if (!options.PERSON_MERGE_FOLD_ENABLED || values.length < 2 || !isTeamEnabled(values[0].team.id)) {
             return Promise.resolve(results)
         }
@@ -116,7 +144,7 @@ export function createMergeFoldPlanningStep<T extends MergeFoldScanItem>(
 
 function planRun<T extends MergeFoldScanItem>(
     values: T[],
-    results: PipelineResult<T>[],
+    results: PipelineResult<T & WithMergeFoldDecision>[],
     runStart: number,
     runEnd: number
 ): void {
@@ -128,9 +156,9 @@ function planRun<T extends MergeFoldScanItem>(
         if (anonDistinctId === null || anonDistinctId === targetDistinctId || pairByAnonId.has(anonDistinctId)) {
             continue
         }
-        // An illegal anon id never merges; leaving its event off the plan
-        // sends it down the sequential path, which emits the per-event
-        // warning and keeps is_identified untouched, exactly as today.
+        // An illegal anon id never merges; keeping its event on the immediate
+        // path emits the per-event warning and keeps is_identified untouched,
+        // exactly as today.
         if (isDistinctIdIllegal(anonDistinctId)) {
             continue
         }
@@ -149,7 +177,7 @@ function planRun<T extends MergeFoldScanItem>(
     for (let index = runStart; index < runEnd; index++) {
         const anonDistinctId = getFoldableAnonDistinctId(values[index])
         if (anonDistinctId !== null && pairByAnonId.has(anonDistinctId)) {
-            results[index] = ok({ ...values[index], mergeFoldPlan: plan })
+            results[index] = ok({ ...values[index], mergeFold: { type: 'planned', plan } })
         }
     }
 }

--- a/nodejs/src/ingestion/common/persons/person-merge-fold.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-fold.ts
@@ -1,6 +1,7 @@
 import { buildIntegerMatcher } from '~/common/config/config'
 import { decideProcessPerson, isDistinctIdIllegal } from '~/common/persons/person-utils'
-import type { GroupPrescanFunction } from '~/ingestion/framework/concurrently-grouping-chunk-pipeline'
+import type { ChunkProcessingStep } from '~/ingestion/framework/base-chunk-pipeline'
+import { PipelineResult, ok } from '~/ingestion/framework/results'
 import { PluginEvent } from '~/plugin-scaffold'
 import { EventHeaders, InternalPerson, Team } from '~/types'
 
@@ -37,7 +38,7 @@ export interface MergeFoldOptions {
     PERSON_MERGE_FOLD_TEAM_ALLOWLIST: string
 }
 
-/** The fields of the pipeline item value the fold prescan reads and writes. */
+/** The fields of the pipeline item value the fold planning step reads and annotates. */
 export interface MergeFoldScanItem {
     event: PluginEvent
     team: Team
@@ -67,54 +68,63 @@ function getFoldableAnonDistinctId(item: MergeFoldScanItem): string | null {
 }
 
 /**
- * Build the group prescan that plans merge folds. Returns null when folding
- * is disabled so the pipeline is constructed without any prescan at all.
+ * Build the group chunk step that plans merge folds. The step is always wired;
+ * whether it plans anything is its own decision, gated on the enabled flag and
+ * the team allowlist, so disabled configurations pass every value through
+ * unplanned.
  *
  * Scans a group's queued chunk for consecutive runs of two or more foldable
  * $identify events (a single merge has nothing to fold). Each run gets one
- * shared MergeFoldPlan attached to the run's item values, with the distinct
- * anon ids as pairs (first event wins the pair's eventUuid; self-merges are
- * excluded). Fold size is naturally bounded by the batch size; pathological
+ * shared MergeFoldPlan, attached to the run's values in the step's results,
+ * with the distinct anon ids as pairs (first event wins the pair's eventUuid;
+ * self-merges are excluded). Values outside a planned run pass through
+ * unchanged. Fold size is naturally bounded by the batch size; pathological
  * per-source distinct_id counts are handled by the merge-mode limit pre-check
  * at execution time.
  */
-export function createMergeFoldPrescan<T extends MergeFoldScanItem, C>(
+export function createMergeFoldPlanningStep<T extends MergeFoldScanItem>(
     options: MergeFoldOptions
-): GroupPrescanFunction<T, C> | null {
-    if (!options.PERSON_MERGE_FOLD_ENABLED) {
-        return null
-    }
+): ChunkProcessingStep<T, T> {
     const isTeamEnabled = buildIntegerMatcher(options.PERSON_MERGE_FOLD_TEAM_ALLOWLIST, true)
 
-    return (items) => {
-        if (items.length < 2 || !isTeamEnabled(items[0].value.team.id)) {
-            return
+    // Deliberately await-free: the single wrapping promise is the only
+    // microtask this step adds to a group chunk.
+    return function planMergeFolds(values: T[]): Promise<PipelineResult<T>[]> {
+        const results = values.map((value) => ok(value))
+        if (!options.PERSON_MERGE_FOLD_ENABLED || values.length < 2 || !isTeamEnabled(values[0].team.id)) {
+            return Promise.resolve(results)
         }
 
         let runStart = 0
-        while (runStart < items.length) {
-            if (getFoldableAnonDistinctId(items[runStart].value) === null) {
+        while (runStart < values.length) {
+            if (getFoldableAnonDistinctId(values[runStart]) === null) {
                 runStart++
                 continue
             }
             let runEnd = runStart + 1
-            while (runEnd < items.length && getFoldableAnonDistinctId(items[runEnd].value) !== null) {
+            while (runEnd < values.length && getFoldableAnonDistinctId(values[runEnd]) !== null) {
                 runEnd++
             }
             if (runEnd - runStart >= 2) {
-                planRun(items.slice(runStart, runEnd))
+                planRun(values, results, runStart, runEnd)
             }
             runStart = runEnd
         }
+        return Promise.resolve(results)
     }
 }
 
-function planRun<T extends MergeFoldScanItem>(run: { value: T }[]): void {
-    const targetDistinctId = run[0].value.event.distinct_id
+function planRun<T extends MergeFoldScanItem>(
+    values: T[],
+    results: PipelineResult<T>[],
+    runStart: number,
+    runEnd: number
+): void {
+    const targetDistinctId = values[runStart].event.distinct_id
     const pairByAnonId = new Map<string, MergeFoldPair>()
 
-    for (const item of run) {
-        const anonDistinctId = getFoldableAnonDistinctId(item.value)
+    for (let index = runStart; index < runEnd; index++) {
+        const anonDistinctId = getFoldableAnonDistinctId(values[index])
         if (anonDistinctId === null || anonDistinctId === targetDistinctId || pairByAnonId.has(anonDistinctId)) {
             continue
         }
@@ -124,7 +134,7 @@ function planRun<T extends MergeFoldScanItem>(run: { value: T }[]): void {
         if (isDistinctIdIllegal(anonDistinctId)) {
             continue
         }
-        pairByAnonId.set(anonDistinctId, { anonDistinctId, eventUuid: item.value.event.uuid })
+        pairByAnonId.set(anonDistinctId, { anonDistinctId, eventUuid: values[index].event.uuid })
     }
 
     if (pairByAnonId.size === 0) {
@@ -136,10 +146,10 @@ function planRun<T extends MergeFoldScanItem>(run: { value: T }[]): void {
         pairs: [...pairByAnonId.values()],
         status: 'planned',
     }
-    for (const item of run) {
-        const anonDistinctId = getFoldableAnonDistinctId(item.value)
+    for (let index = runStart; index < runEnd; index++) {
+        const anonDistinctId = getFoldableAnonDistinctId(values[index])
         if (anonDistinctId !== null && pairByAnonId.has(anonDistinctId)) {
-            item.value.mergeFoldPlan = plan
+            results[index] = ok({ ...values[index], mergeFoldPlan: plan })
         }
     }
 }

--- a/nodejs/src/ingestion/common/steps/event-processing/process-persons-step.ts
+++ b/nodejs/src/ingestion/common/steps/event-processing/process-persons-step.ts
@@ -4,7 +4,7 @@ import { buildIntegerMatcher } from '~/common/config/config'
 import { AsyncOutput } from '~/common/outputs'
 import { MergeEventsConfig, PersonContext, PersonOutputs } from '~/ingestion/common/persons/person-context'
 import { PersonEventProcessor } from '~/ingestion/common/persons/person-event-processor'
-import type { MergeFoldPlan } from '~/ingestion/common/persons/person-merge-fold'
+import type { MergeFoldDecision } from '~/ingestion/common/persons/person-merge-fold'
 import { PersonMergeService } from '~/ingestion/common/persons/person-merge-service'
 import { determineMergeMode } from '~/ingestion/common/persons/person-merge-types'
 import { PersonPropertyService } from '~/ingestion/common/persons/person-property-service'
@@ -22,7 +22,8 @@ export type ProcessPersonsInput = {
     timestamp: DateTime
     personlessPerson?: Person
     personsStoreForBatch: PersonsStoreForBatch
-    mergeFoldPlan?: MergeFoldPlan
+    /** The merge-fold planning decision for this event; `immediate` everywhere except planned $identify runs in the grouped analytics lane. */
+    mergeFold: MergeFoldDecision
 }
 
 export type ProcessPersonsOutput = {
@@ -69,7 +70,7 @@ export function createProcessPersonsStep<TInput extends ProcessPersonsInput>(
             options.PERSON_PROPERTIES_UPDATE_ALL,
             shouldUpdateLastSeenAt,
             mergeEventsConfig,
-            input.mergeFoldPlan
+            input.mergeFold.type === 'planned' ? input.mergeFold.plan : undefined
         )
 
         const processor = new PersonEventProcessor(

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -163,8 +163,8 @@ export type IngestionConsumerConfig = {
     // means "no teams", not "all teams"; use '*' to open the gate.
     PERSON_MERGE_EVENTS_TEAM_ALLOWLIST: string
     // Fold consecutive runs of $identify merges for the same distinct_id in a batch into a single
-    // merge operation (merge-storm mitigation). Master switch; when off, no prescan is wired and
-    // behavior is identical to sequential merges.
+    // merge operation (merge-storm mitigation). Master switch; when off, the planning step passes
+    // every event through unplanned and merges stay sequential.
     PERSON_MERGE_FOLD_ENABLED: boolean
     // Teams eligible for merge folding: comma-separated team IDs, or '*' for all teams.
     PERSON_MERGE_FOLD_TEAM_ALLOWLIST: string

--- a/nodejs/src/ingestion/framework/base-chunk-pipeline.ts
+++ b/nodejs/src/ingestion/framework/base-chunk-pipeline.ts
@@ -22,6 +22,67 @@ function isSuccessResultWithContext<T, C, R extends string>(
  */
 export type ChunkProcessingStep<T, U, R extends string = never> = (values: T[]) => Promise<PipelineResult<U, R>[]>
 
+/**
+ * Apply a chunk step to a chunk of results: run the step over the OK values,
+ * enforce the one-result-per-value contract, and zip the step results back onto
+ * their contexts (recording lastStep and accumulating side effects and
+ * warnings). Non-OK results pass through unchanged. This is the single
+ * implementation of chunk-step semantics, shared by {@link BaseChunkPipeline}
+ * and the group-level pipeChunk in ConcurrentlyGroupingChunkPipeline.
+ */
+export async function applyChunkStepToResults<TIn, TOut, C, RPrev extends string, RStep extends string>(
+    step: ChunkProcessingStep<TIn, TOut, RStep>,
+    stepName: string,
+    items: PipelineResultWithContext<TIn, C, RPrev>[]
+): Promise<PipelineResultWithContext<TOut, C, RPrev | RStep>[]> {
+    const successfulValues = items
+        .filter(isSuccessResultWithContext)
+        .map((resultWithContext) => resultWithContext.result.value)
+
+    let stepResults: PipelineResult<TOut, RStep>[] = []
+    if (successfulValues.length > 0) {
+        const end = pipelineStepDurationHistogram.startTimer({ step_name: stepName, step_type: 'chunk' })
+        try {
+            stepResults = await instrumentFn({ key: stepName, sendException: false, measureTime: false }, () =>
+                step(successfulValues)
+            )
+            end({ result: 'chunk' })
+        } catch (e) {
+            end({ result: 'exception' })
+            throw e
+        }
+        if (stepResults.length !== successfulValues.length) {
+            throw new Error(
+                `Chunk pipeline step ${stepName} returned different number of results than input values: ${stepResults.length} !== ${successfulValues.length}`
+            )
+        }
+    }
+    let stepIndex = 0
+
+    // Map results back, preserving context and non-successful results
+    const output: PipelineResultWithContext<TOut, C, RPrev | RStep>[] = []
+    for (const resultWithContext of items) {
+        if (isOkResult(resultWithContext.result)) {
+            const stepResult = stepResults[stepIndex++]
+            output.push({
+                result: stepResult,
+                context: {
+                    ...resultWithContext.context,
+                    lastStep: stepName,
+                    sideEffects: [...resultWithContext.context.sideEffects, ...stepResult.sideEffects],
+                    warnings: [...resultWithContext.context.warnings, ...stepResult.warnings],
+                },
+            })
+        } else {
+            output.push({
+                result: resultWithContext.result,
+                context: resultWithContext.context,
+            })
+        }
+    }
+    return output
+}
+
 export class BaseChunkPipeline<
     TInput,
     TIntermediate,
@@ -51,53 +112,6 @@ export class BaseChunkPipeline<
             return null
         }
 
-        // Filter successful values for processing
-        const successfulValues = previousResults
-            .filter(isSuccessResultWithContext)
-            .map((resultWithContext) => resultWithContext.result.value)
-
-        // Apply current step to successful values
-        let stepResults: PipelineResult<TOutput, RStep>[] = []
-        if (successfulValues.length > 0) {
-            const end = pipelineStepDurationHistogram.startTimer({ step_name: this.stepName, step_type: 'chunk' })
-            try {
-                stepResults = await instrumentFn({ key: this.stepName, sendException: false, measureTime: false }, () =>
-                    this.currentStep(successfulValues)
-                )
-                end({ result: 'chunk' })
-            } catch (e) {
-                end({ result: 'exception' })
-                throw e
-            }
-            if (stepResults.length !== successfulValues.length) {
-                throw new Error(
-                    `Chunk pipeline step ${this.stepName} returned different number of results than input values: ${stepResults.length} !== ${successfulValues.length}`
-                )
-            }
-        }
-        let stepIndex = 0
-
-        // Map results back, preserving context and non-successful results
-        const output: ChunkPipelineResultWithContext<TOutput, COutput, RPrev | RStep> = []
-        for (const resultWithContext of previousResults) {
-            if (isOkResult(resultWithContext.result)) {
-                const stepResult = stepResults[stepIndex++]
-                output.push({
-                    result: stepResult,
-                    context: {
-                        ...resultWithContext.context,
-                        lastStep: this.stepName,
-                        sideEffects: [...resultWithContext.context.sideEffects, ...stepResult.sideEffects],
-                        warnings: [...resultWithContext.context.warnings, ...stepResult.warnings],
-                    },
-                })
-            } else {
-                output.push({
-                    result: resultWithContext.result,
-                    context: resultWithContext.context,
-                })
-            }
-        }
-        return output
+        return await applyChunkStepToResults(this.currentStep, this.stepName, previousResults)
     }
 }

--- a/nodejs/src/ingestion/framework/builders/chunk-pipeline-builders.ts
+++ b/nodejs/src/ingestion/framework/builders/chunk-pipeline-builders.ts
@@ -3,14 +3,19 @@ import { Message } from 'node-rdkafka'
 import { IngestionWarningsOutput } from '~/common/outputs'
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { PromiseScheduler } from '~/common/utils/promise-scheduler'
-import { BaseChunkPipeline, ChunkProcessingStep } from '~/ingestion/framework/base-chunk-pipeline'
+import {
+    BaseChunkPipeline,
+    ChunkProcessingStep,
+    applyChunkStepToResults,
+} from '~/ingestion/framework/base-chunk-pipeline'
 import { BufferingChunkPipeline } from '~/ingestion/framework/buffering-chunk-pipeline'
 import { ChunkPipeline } from '~/ingestion/framework/chunk-pipeline.interface'
 import { ConcurrentChunkProcessingPipeline } from '~/ingestion/framework/concurrent-chunk-pipeline'
 import {
     ConcurrentlyGroupingChunkPipeline,
-    GroupPrescanFunction,
+    GroupChunkPreparation,
     GroupingFunction,
+    passThroughGroupChunk,
 } from '~/ingestion/framework/concurrently-grouping-chunk-pipeline'
 import { FilterMapChunkPipeline, FilterMapMappingFunction } from '~/ingestion/framework/filter-map-chunk-pipeline'
 import { GatheringChunkPipeline } from '~/ingestion/framework/gathering-chunk-pipeline'
@@ -34,7 +39,8 @@ export interface TeamIdContext {
 /**
  * Configures how items within a group are processed. Groups produced by
  * `concurrentlyPerGroup` run concurrently; this builder's `sequentially` method
- * defines how the items within a single group are processed.
+ * defines how the items within a single group are processed, and `pipeChunk`
+ * lets chunk steps run over a group's queued chunk before that.
  */
 export class GroupProcessingBuilder<
     TInput,
@@ -49,21 +55,34 @@ export class GroupProcessingBuilder<
     // subpipeline callbacks (e.g. in newBatchingPipeline). In this closure's
     // signature TOutput only appears in variance-neutral positions.
     constructor(
-        private readonly buildGroupedPipeline: <U, R2 extends string>(
-            processor: Pipeline<TOutput, U, COutput, R2>,
-            prescan?: GroupPrescanFunction<TOutput, COutput>
-        ) => ChunkPipeline<TInput, U, CInput, COutput, R | R2>,
-        private readonly prescanFn?: GroupPrescanFunction<TOutput, COutput>
+        private readonly buildGroupedPipeline: <TMid, U, R2 extends string>(
+            prepare: GroupChunkPreparation<TOutput, TMid, COutput, R2>,
+            processor: Pipeline<TMid, U, COutput, R2>
+        ) => ChunkPipeline<TInput, U, CInput, COutput, R | R2>
     ) {}
 
     /**
-     * Run a synchronous scan over each group's queued chunk before its items
-     * are processed. The scan sees the OK items in processing order and may
-     * attach group-scoped state by mutating item values (see
-     * {@link GroupPrescanFunction} for the exact contract).
+     * Apply a chunk step to each group's queued chunk before its items are
+     * processed sequentially. Same contract as the outer `pipeChunk`: the step
+     * sees the chunk's OK values in processing order and returns one result
+     * per value; non-OK results pass through. Runs once per started group
+     * chunk. Chained calls compose in order.
      */
-    prescan(fn: GroupPrescanFunction<TOutput, COutput>): GroupProcessingBuilder<TInput, TOutput, CInput, COutput, R> {
-        return new GroupProcessingBuilder(this.buildGroupedPipeline, fn)
+    pipeChunk<U, R2 extends string = never>(
+        step: ChunkProcessingStep<TOutput, U, R2>
+    ): GroupProcessingBuilder<TInput, U, CInput, COutput, R | R2> {
+        const stepName = step.name || 'anonymousChunkStep'
+        const buildWithEarlierSteps = this.buildGroupedPipeline
+        return new GroupProcessingBuilder<TInput, U, CInput, COutput, R | R2>(
+            <TMid, V, R3 extends string>(
+                prepare: GroupChunkPreparation<U, TMid, COutput, R3>,
+                processor: Pipeline<TMid, V, COutput, R3>
+            ) =>
+                buildWithEarlierSteps<TMid, V, R2 | R3>(
+                    async (items) => await prepare(await applyChunkStepToResults(step, stepName, items)),
+                    processor
+                )
+        )
     }
 
     /**
@@ -75,7 +94,7 @@ export class GroupProcessingBuilder<
         callback: (builder: StartPipelineBuilder<TOutput, COutput>) => PipelineBuilder<TOutput, U, COutput, R2>
     ): ChunkPipelineBuilder<TInput, U, CInput, COutput, R | R2> {
         const processor = callback(new StartPipelineBuilder<TOutput, COutput>()).build()
-        return new ChunkPipelineBuilder(this.buildGroupedPipeline(processor, this.prescanFn))
+        return new ChunkPipelineBuilder(this.buildGroupedPipeline(passThroughGroupChunk, processor))
     }
 }
 
@@ -170,16 +189,16 @@ export class ChunkPipelineBuilder<TInput, TOutput, CInput, COutput = CInput, R e
     ): ChunkPipelineBuilder<TInput, U, CInput, COutput, R | ROut> {
         return callback(
             new GroupProcessingBuilder(
-                <U2, R2 extends string>(
-                    processor: Pipeline<TOutput, U2, COutput, R2>,
-                    prescan?: GroupPrescanFunction<TOutput, COutput>
+                <TMid, U2, R2 extends string>(
+                    prepare: GroupChunkPreparation<TOutput, TMid, COutput, R2>,
+                    processor: Pipeline<TMid, U2, COutput, R2>
                 ) =>
                     new ConcurrentlyGroupingChunkPipeline(
                         groupingFn,
                         processor,
+                        prepare,
                         this.pipeline,
-                        options?.maxConcurrency,
-                        prescan
+                        options?.maxConcurrency
                     )
             )
         )

--- a/nodejs/src/ingestion/framework/builders/chunk-pipeline-builders.ts
+++ b/nodejs/src/ingestion/framework/builders/chunk-pipeline-builders.ts
@@ -13,14 +13,13 @@ import { ChunkPipeline } from '~/ingestion/framework/chunk-pipeline.interface'
 import { ConcurrentChunkProcessingPipeline } from '~/ingestion/framework/concurrent-chunk-pipeline'
 import {
     ConcurrentlyGroupingChunkPipeline,
-    GroupChunkPreparation,
+    GroupChunkProcessor,
     GroupingFunction,
-    passThroughGroupChunk,
+    processGroupChunkSequentially,
 } from '~/ingestion/framework/concurrently-grouping-chunk-pipeline'
 import { FilterMapChunkPipeline, FilterMapMappingFunction } from '~/ingestion/framework/filter-map-chunk-pipeline'
 import { GatheringChunkPipeline } from '~/ingestion/framework/gathering-chunk-pipeline'
 import { IngestionWarningHandlingChunkPipeline } from '~/ingestion/framework/ingestion-warning-handling-chunk-pipeline'
-import { Pipeline } from '~/ingestion/framework/pipeline.interface'
 import { PipelineConfig, ResultHandlingPipeline } from '~/ingestion/framework/result-handling-pipeline'
 import { RetryOptions, withChunkRetry } from '~/ingestion/framework/retry'
 import { SequentialChunkPipeline } from '~/ingestion/framework/sequential-chunk-pipeline'
@@ -37,10 +36,11 @@ export interface TeamIdContext {
 }
 
 /**
- * Configures how items within a group are processed. Groups produced by
- * `concurrentlyPerGroup` run concurrently; this builder's `sequentially` method
- * defines how the items within a single group are processed, and `pipeChunk`
- * lets chunk steps run over a group's queued chunk before that.
+ * Composes how a group's queued chunk is processed, as a chain of group chunk
+ * stages: `pipeChunk` applies a chunk step to the whole chunk, `sequentially`
+ * runs each item through a per-item pipeline one at a time. Stages run in
+ * declaration order; `concurrentlyPerGroup` finalizes the chain into the
+ * single {@link GroupChunkProcessor} the grouping pipeline executes per chunk.
  */
 export class GroupProcessingBuilder<
     TInput,
@@ -55,34 +55,33 @@ export class GroupProcessingBuilder<
     // subpipeline callbacks (e.g. in newBatchingPipeline). In this closure's
     // signature TOutput only appears in variance-neutral positions.
     constructor(
-        private readonly buildGroupedPipeline: <TMid, U, R2 extends string>(
-            prepare: GroupChunkPreparation<TOutput, TMid, COutput, R2>,
-            processor: Pipeline<TMid, U, COutput, R2>
+        /** @internal Completes the group definition; called by concurrentlyPerGroup with the terminal stage. */
+        readonly buildGroupedPipeline: <U, R2 extends string>(
+            downstream: GroupChunkProcessor<TOutput, U, COutput, R2>
         ) => ChunkPipeline<TInput, U, CInput, COutput, R | R2>
     ) {}
 
+    private stage<U, R2 extends string>(
+        stageProcessor: GroupChunkProcessor<TOutput, U, COutput, R2>
+    ): GroupProcessingBuilder<TInput, U, CInput, COutput, R | R2> {
+        const buildWithEarlierStages = this.buildGroupedPipeline
+        return new GroupProcessingBuilder<TInput, U, CInput, COutput, R | R2>(
+            <V, R3 extends string>(downstream: GroupChunkProcessor<U, V, COutput, R3>) =>
+                buildWithEarlierStages<V, R2 | R3>(async (items) => await downstream(await stageProcessor(items)))
+        )
+    }
+
     /**
-     * Apply a chunk step to each group's queued chunk before its items are
-     * processed sequentially. Same contract as the outer `pipeChunk`: the step
-     * sees the chunk's OK values in processing order and returns one result
-     * per value; non-OK results pass through. Runs once per started group
-     * chunk. Chained calls compose in order.
+     * Apply a chunk step to each group's queued chunk. Same contract as the
+     * outer `pipeChunk`: the step sees the chunk's OK values in processing
+     * order and returns one result per value; non-OK results pass through.
+     * Runs once per started group chunk.
      */
     pipeChunk<U, R2 extends string = never>(
         step: ChunkProcessingStep<TOutput, U, R2>
     ): GroupProcessingBuilder<TInput, U, CInput, COutput, R | R2> {
         const stepName = step.name || 'anonymousChunkStep'
-        const buildWithEarlierSteps = this.buildGroupedPipeline
-        return new GroupProcessingBuilder<TInput, U, CInput, COutput, R | R2>(
-            <TMid, V, R3 extends string>(
-                prepare: GroupChunkPreparation<U, TMid, COutput, R3>,
-                processor: Pipeline<TMid, V, COutput, R3>
-            ) =>
-                buildWithEarlierSteps<TMid, V, R2 | R3>(
-                    async (items) => await prepare(await applyChunkStepToResults(step, stepName, items)),
-                    processor
-                )
-        )
+        return this.stage((items) => applyChunkStepToResults(step, stepName, items))
     }
 
     /**
@@ -92,9 +91,9 @@ export class GroupProcessingBuilder<
      */
     sequentially<U, R2 extends string = never>(
         callback: (builder: StartPipelineBuilder<TOutput, COutput>) => PipelineBuilder<TOutput, U, COutput, R2>
-    ): ChunkPipelineBuilder<TInput, U, CInput, COutput, R | R2> {
+    ): GroupProcessingBuilder<TInput, U, CInput, COutput, R | R2> {
         const processor = callback(new StartPipelineBuilder<TOutput, COutput>()).build()
-        return new ChunkPipelineBuilder(this.buildGroupedPipeline(passThroughGroupChunk, processor))
+        return this.stage(processGroupChunkSequentially(processor))
     }
 }
 
@@ -174,9 +173,9 @@ export class ChunkPipelineBuilder<TInput, TOutput, CInput, COutput = CInput, R e
      * Group items by key and process the groups concurrently, optionally capped
      * by `maxConcurrency`. Results are returned unordered as each group completes.
      *
-     * The callback receives a group builder whose only method, `sequentially`,
-     * configures how items WITHIN a group are processed. Making that step explicit
-     * keeps within-group ordering visible at the call site.
+     * The callback composes how a group's queued chunk is processed from group
+     * chunk stages (`pipeChunk`, `sequentially`), keeping within-group ordering
+     * visible at the call site.
      *
      * @param options.maxConcurrency - Cap on how many groups process at once. Omitted means unbounded.
      */
@@ -184,24 +183,21 @@ export class ChunkPipelineBuilder<TInput, TOutput, CInput, COutput = CInput, R e
         groupingFn: GroupingFunction<TOutput, TKey>,
         callback: (
             group: GroupProcessingBuilder<TInput, TOutput, CInput, COutput, R>
-        ) => ChunkPipelineBuilder<TInput, U, CInput, COutput, ROut>,
+        ) => GroupProcessingBuilder<TInput, U, CInput, COutput, ROut>,
         options?: { maxConcurrency?: number }
     ): ChunkPipelineBuilder<TInput, U, CInput, COutput, R | ROut> {
-        return callback(
+        const group = callback(
             new GroupProcessingBuilder(
-                <TMid, U2, R2 extends string>(
-                    prepare: GroupChunkPreparation<TOutput, TMid, COutput, R2>,
-                    processor: Pipeline<TMid, U2, COutput, R2>
-                ) =>
+                <U2, R2 extends string>(processGroupChunk: GroupChunkProcessor<TOutput, U2, COutput, R2>) =>
                     new ConcurrentlyGroupingChunkPipeline(
                         groupingFn,
-                        processor,
-                        prepare,
+                        processGroupChunk,
                         this.pipeline,
                         options?.maxConcurrency
                     )
             )
         )
+        return new ChunkPipelineBuilder(group.buildGroupedPipeline((items) => Promise.resolve(items)))
     }
 
     handleSideEffects(

--- a/nodejs/src/ingestion/framework/builders/index.ts
+++ b/nodejs/src/ingestion/framework/builders/index.ts
@@ -5,6 +5,6 @@ export {
     TeamAwareChunkPipelineBuilder,
 } from './chunk-pipeline-builders'
 export type { RetryOptions } from '~/ingestion/framework/retry'
-export type { GroupPrescanFunction } from '~/ingestion/framework/concurrently-grouping-chunk-pipeline'
+export type { ChunkProcessingStep } from '~/ingestion/framework/base-chunk-pipeline'
 export { BranchingPipelineBuilder, PipelineBuilder, StartPipelineBuilder } from './pipeline-builders'
 export { newChunkPipelineBuilder, newBatchingPipeline, newPipelineBuilder } from './helpers'

--- a/nodejs/src/ingestion/framework/concurrently-grouping-chunk-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/concurrently-grouping-chunk-pipeline.test.ts
@@ -3,7 +3,10 @@ import { Message } from 'node-rdkafka'
 import { createTestMessage } from '~/tests/helpers/kafka-message'
 import { createMockPipeline } from '~/tests/helpers/mock-pipeline'
 
-import { ConcurrentlyGroupingChunkPipeline, passThroughGroupChunk } from './concurrently-grouping-chunk-pipeline'
+import {
+    ConcurrentlyGroupingChunkPipeline,
+    processGroupChunkSequentially,
+} from './concurrently-grouping-chunk-pipeline'
 import { createContext, createNewChunkPipeline, createNewPipeline, createOkContext } from './helpers'
 import { PipelineResultWithContext } from './pipeline.interface'
 import { dlq, drop, ok } from './results'
@@ -61,8 +64,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -80,8 +82,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
             const testBatch = [createOkContext({ value: 'test', group: 'A' }, context1)]
@@ -101,8 +102,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -121,8 +121,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -146,8 +145,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -180,8 +178,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -226,8 +223,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -290,8 +286,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -332,8 +327,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -405,8 +399,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline,
                 maxConcurrency
             )
@@ -448,8 +441,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline,
                 2
             )
@@ -515,8 +507,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -549,8 +540,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
 
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -680,8 +670,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -751,8 +740,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -966,8 +954,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -994,8 +981,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -1039,8 +1025,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -1077,8 +1062,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -1118,8 +1102,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             previousPipeline.feed([createOkContext({ value: 'a1', group: 'A' }, context1)])
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 
@@ -1137,8 +1120,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             }
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input: { value: string; group: string }) => input.group,
-                processor,
-                passThroughGroupChunk,
+                processGroupChunkSequentially(processor),
                 previousPipeline
             )
 

--- a/nodejs/src/ingestion/framework/concurrently-grouping-chunk-pipeline.test.ts
+++ b/nodejs/src/ingestion/framework/concurrently-grouping-chunk-pipeline.test.ts
@@ -3,7 +3,7 @@ import { Message } from 'node-rdkafka'
 import { createTestMessage } from '~/tests/helpers/kafka-message'
 import { createMockPipeline } from '~/tests/helpers/mock-pipeline'
 
-import { ConcurrentlyGroupingChunkPipeline } from './concurrently-grouping-chunk-pipeline'
+import { ConcurrentlyGroupingChunkPipeline, passThroughGroupChunk } from './concurrently-grouping-chunk-pipeline'
 import { createContext, createNewChunkPipeline, createNewPipeline, createOkContext } from './helpers'
 import { PipelineResultWithContext } from './pipeline.interface'
 import { dlq, drop, ok } from './results'
@@ -59,7 +59,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             )
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             expect(pipeline).toBeInstanceOf(ConcurrentlyGroupingChunkPipeline)
         })
@@ -73,7 +78,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
             const spy = jest.spyOn(previousPipeline, 'feed')
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
             const testBatch = [createOkContext({ value: 'test', group: 'A' }, context1)]
 
             pipeline.feed(testBatch)
@@ -89,7 +99,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             )
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             const result = await pipeline.next()
             expect(result).toBeNull()
@@ -104,7 +119,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const testBatch = [createOkContext({ value: 'test', group: 'A' }, context1)]
             previousPipeline.feed(testBatch)
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             await expect(pipeline.next()).rejects.toThrow('Processor error')
         })
@@ -124,7 +144,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             ]
             previousPipeline.feed(testBatch)
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             const results: PipelineResultWithContext<any, any>[] = []
             let result = await pipeline.next()
@@ -153,7 +178,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             ]
             previousPipeline.feed(testBatch)
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             const resultsPromise = (async () => {
                 let result = await pipeline.next()
@@ -194,7 +224,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const testBatch = events.map((e) => createOkContext(e, context1))
             previousPipeline.feed(testBatch)
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             // Collect results and track per-group ordering
             const groupResults = new Map<string, number[]>()
@@ -253,7 +288,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             }
             previousPipeline.feed(testBatch)
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             const results: PipelineResultWithContext<any, any>[] = []
             let result = await pipeline.next()
@@ -290,7 +330,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             testBatch.push(createOkContext({ index: index++, group: 'slow' }, context1))
             previousPipeline.feed(testBatch)
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             // Consume results until we have all normal groups
             const results: PipelineResultWithContext<any, any>[] = []
@@ -361,6 +406,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
                 processor,
+                passThroughGroupChunk,
                 previousPipeline,
                 maxConcurrency
             )
@@ -403,6 +449,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const pipeline = new ConcurrentlyGroupingChunkPipeline(
                 (input) => input.group,
                 processor,
+                passThroughGroupChunk,
                 previousPipeline,
                 2
             )
@@ -466,7 +513,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             const testBatch = [createContext(dropResult, context1), createContext(dlqResult, context2)]
             const previousPipeline = createMockPipeline<{ value: string; group: string }>(testBatch)
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             const results: PipelineResultWithContext<any, any>[] = []
             let result = await pipeline.next()
@@ -495,7 +547,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             ]
             const previousPipeline = createMockPipeline<{ value: string; group: string }>(testBatch)
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             const results: PipelineResultWithContext<any, any>[] = []
             let result = await pipeline.next()
@@ -542,14 +599,26 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             expect(results.every((r) => r.result.type === 0 && (r.result as any).value.processed)).toBe(true)
         })
 
-        it('should thread the prescan through the builder', async () => {
-            const scans: string[][] = []
+        it('should compose chained group chunk steps in order', async () => {
             const pipeline = createNewChunkPipeline<{ value: string; group: string }>()
                 .concurrentlyPerGroup(
                     (input) => input.group,
                     (group) =>
                         group
-                            .prescan((items) => scans.push(items.map((item) => item.value.value)))
+                            .pipeChunk((values: { value: string; group: string }[]) =>
+                                Promise.resolve(
+                                    values.map((value) =>
+                                        value.value === 'a1'
+                                            ? drop<{ value: string; group: string; first: boolean }>(
+                                                  'dropped by first step'
+                                              )
+                                            : ok({ ...value, first: true })
+                                    )
+                                )
+                            )
+                            .pipeChunk((values: { value: string; group: string; first: boolean }[]) =>
+                                Promise.resolve(values.map((value) => ok({ ...value, second: true })))
+                            )
                             .sequentially((builder) => builder.pipe((input) => Promise.resolve(ok(input))))
                 )
                 .build()
@@ -557,16 +626,20 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             pipeline.feed([
                 createOkContext({ value: 'a1', group: 'A' }, context1),
                 createOkContext({ value: 'a2', group: 'A' }, context2),
-                createOkContext({ value: 'b1', group: 'B' }, context3),
             ])
 
+            const results: PipelineResultWithContext<any, any>[] = []
             let result = await pipeline.next()
             while (result !== null) {
+                results.push(...result)
                 result = await pipeline.next()
             }
 
-            expect(scans).toContainEqual(['a1', 'a2'])
-            expect(scans).toContainEqual(['b1'])
+            expect(results).toHaveLength(2)
+            const dropped = results.find((r) => r.context.message === message1)!
+            const processed = results.find((r) => r.context.message === message2)!
+            expect(dropped.result.type).toBe(2) // DROP
+            expect(processed.result).toMatchObject({ value: { value: 'a2', first: true, second: true } })
         })
 
         it('should chain with gather to collect all results', async () => {
@@ -605,7 +678,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
                 return ok({ ...input, processed: true })
             })
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             // Feed first batch with items for group A
             previousPipeline.feed([
@@ -671,7 +749,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
                 return ok({ ...input, processed: true })
             })
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             // Feed one element each for groups A and B (B is slow)
             previousPipeline.feed([
@@ -881,7 +964,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
                 return ok({ ...input, processed: true })
             })
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             previousPipeline.feed([createOkContext({ value: 'a1', group: 'A' }, context1)])
             const nextPromise = pipeline.next()
@@ -904,7 +992,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
                 return ok({ ...input, processed: true })
             })
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             previousPipeline.feed([createOkContext({ value: 'a1', group: 'A' }, context1)])
 
@@ -944,7 +1037,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
                 return ok({ ...input, processed: true })
             })
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             previousPipeline.feed([
                 createOkContext({ value: 'a1', group: 'A' }, context1),
@@ -977,7 +1075,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
                 return ok({ ...input, processed: true })
             })
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             previousPipeline.feed([
                 createOkContext({ value: 'a1', group: 'A' }, context1),
@@ -1013,7 +1116,12 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             )
             const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
             previousPipeline.feed([createOkContext({ value: 'a1', group: 'A' }, context1)])
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             await expect(pipeline.next()).rejects.toThrow('processor boom')
             await expect(pipeline.next()).rejects.toThrow('processor boom')
@@ -1027,33 +1135,39 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
                 feed: jest.fn(),
                 next: jest.fn().mockRejectedValueOnce(new Error('source boom')).mockResolvedValue(null),
             }
-            const pipeline = new ConcurrentlyGroupingChunkPipeline((input) => input.group, processor, previousPipeline)
+            const pipeline = new ConcurrentlyGroupingChunkPipeline(
+                (input: { value: string; group: string }) => input.group,
+                processor,
+                passThroughGroupChunk,
+                previousPipeline
+            )
 
             await expect(pipeline.next()).rejects.toThrow('source boom')
             await expect(pipeline.next()).rejects.toThrow('source boom')
         })
     })
 
-    describe('prescan', () => {
-        it("runs once per group chunk with that group's items in order", async () => {
+    describe('group chunk step', () => {
+        it("runs once per group chunk with that group's values in order", async () => {
             const scans: string[][] = []
-            const processor = createNewPipeline<{ value: string; group: string }>().pipe((input) =>
-                Promise.resolve(ok(input))
-            )
-            const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
-            previousPipeline.feed([
+            const pipeline = createNewChunkPipeline<{ value: string; group: string }>()
+                .concurrentlyPerGroup(
+                    (input) => input.group,
+                    (group) =>
+                        group
+                            .pipeChunk((values: { value: string; group: string }[]) => {
+                                scans.push(values.map((value) => value.value))
+                                return Promise.resolve(values.map((value) => ok(value)))
+                            })
+                            .sequentially((builder) => builder.pipe((input) => Promise.resolve(ok(input))))
+                )
+                .build()
+
+            pipeline.feed([
                 createOkContext({ value: 'a1', group: 'A' }, context1),
                 createOkContext({ value: 'b1', group: 'B' }, context2),
                 createOkContext({ value: 'a2', group: 'A' }, context3),
             ])
-
-            const pipeline = new ConcurrentlyGroupingChunkPipeline(
-                (input) => input.group,
-                processor,
-                previousPipeline,
-                undefined,
-                (items) => scans.push(items.map((item) => item.value.value))
-            )
 
             let result = await pipeline.next()
             while (result !== null) {
@@ -1065,33 +1179,29 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             expect(scans).toContainEqual(['b1'])
         })
 
-        it('makes value mutations visible to the processor', async () => {
+        it('makes returned values visible to the processor', async () => {
             const seenTags: (string | undefined)[] = []
-            const processor = createNewPipeline<{ value: string; group: string; groupTag?: string }>().pipe((input) => {
-                seenTags.push(input.groupTag)
-                return Promise.resolve(ok(input))
-            })
-            const previousPipeline = createNewChunkPipeline<{
-                value: string
-                group: string
-                groupTag?: string
-            }>().build()
-            previousPipeline.feed([
+            const pipeline = createNewChunkPipeline<{ value: string; group: string; groupTag?: string }>()
+                .concurrentlyPerGroup(
+                    (input) => input.group,
+                    (group) =>
+                        group
+                            .pipeChunk((values: { value: string; group: string; groupTag?: string }[]) =>
+                                Promise.resolve(values.map((value) => ok({ ...value, groupTag: `A:${values.length}` })))
+                            )
+                            .sequentially((builder) =>
+                                builder.pipe((input) => {
+                                    seenTags.push(input.groupTag)
+                                    return Promise.resolve(ok(input))
+                                })
+                            )
+                )
+                .build()
+
+            pipeline.feed([
                 createOkContext({ value: 'a1', group: 'A' }, context1),
                 createOkContext({ value: 'a2', group: 'A' }, context2),
             ])
-
-            const pipeline = new ConcurrentlyGroupingChunkPipeline(
-                (input) => input.group,
-                processor,
-                previousPipeline,
-                undefined,
-                (items) => {
-                    for (const item of items) {
-                        item.value.groupTag = `A:${items.length}`
-                    }
-                }
-            )
 
             let result = await pipeline.next()
             while (result !== null) {
@@ -1101,22 +1211,70 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             expect(seenTags).toEqual(['A:2', 'A:2'])
         })
 
-        it('scans chunks queued while the group was active separately', async () => {
-            const scans: string[][] = []
-            const processor = createNewPipeline<{ value: string; group: string }>().pipe(async (input) => {
-                await new Promise((resolve) => setTimeout(resolve, 50))
-                return ok(input)
-            })
-            const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
-            const pipeline = new ConcurrentlyGroupingChunkPipeline(
-                (input) => input.group,
-                processor,
-                previousPipeline,
-                undefined,
-                (items) => scans.push(items.map((item) => item.value.value))
-            )
+        it('passes step-failed values through without invoking the processor', async () => {
+            const processed: string[] = []
+            const pipeline = createNewChunkPipeline<{ value: string; group: string }>()
+                .concurrentlyPerGroup(
+                    (input) => input.group,
+                    (group) =>
+                        group
+                            .pipeChunk((values: { value: string; group: string }[]) =>
+                                Promise.resolve(
+                                    values.map((value) =>
+                                        value.value === 'a1'
+                                            ? dlq<{ value: string; group: string }>('rejected by group step')
+                                            : ok(value)
+                                    )
+                                )
+                            )
+                            .sequentially((builder) =>
+                                builder.pipe((input) => {
+                                    processed.push(input.value)
+                                    return Promise.resolve(ok(input))
+                                })
+                            )
+                )
+                .build()
 
-            previousPipeline.feed([
+            pipeline.feed([
+                createOkContext({ value: 'a1', group: 'A' }, context1),
+                createOkContext({ value: 'a2', group: 'A' }, context2),
+            ])
+
+            const results: PipelineResultWithContext<any, any>[] = []
+            let result = await pipeline.next()
+            while (result !== null) {
+                results.push(...result)
+                result = await pipeline.next()
+            }
+
+            expect(processed).toEqual(['a2'])
+            expect(results).toHaveLength(2)
+            const dlqd = results.find((r) => r.context.message === message1)!
+            expect(dlqd.result.type).toBe(1) // DLQ
+        })
+
+        it('applies the step to chunks queued while the group was active separately', async () => {
+            const scans: string[][] = []
+            const pipeline = createNewChunkPipeline<{ value: string; group: string }>()
+                .concurrentlyPerGroup(
+                    (input) => input.group,
+                    (group) =>
+                        group
+                            .pipeChunk((values: { value: string; group: string }[]) => {
+                                scans.push(values.map((value) => value.value))
+                                return Promise.resolve(values.map((value) => ok(value)))
+                            })
+                            .sequentially((builder) =>
+                                builder.pipe(async (input) => {
+                                    await new Promise((resolve) => setTimeout(resolve, 50))
+                                    return ok(input)
+                                })
+                            )
+                )
+                .build()
+
+            pipeline.feed([
                 createOkContext({ value: 'a1', group: 'A' }, context1),
                 createOkContext({ value: 'a2', group: 'A' }, context2),
             ])
@@ -1126,7 +1284,7 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             expect(scans).toEqual([['a1', 'a2']])
 
             // a3 arrives while the group is mid-chunk: it must not join the
-            // in-flight scan, and gets its own when its chunk starts.
+            // in-flight step application, and gets its own when its chunk starts.
             pipeline.feed([createOkContext({ value: 'a3', group: 'A' }, context3)])
             await jest.advanceTimersByTimeAsync(100)
             await nextPromise
@@ -1138,25 +1296,23 @@ describe('ConcurrentlyGroupingChunkPipeline', () => {
             expect(scans).toEqual([['a1', 'a2'], ['a3']])
         })
 
-        it('poisons the pipeline when the prescan throws', async () => {
-            const processor = createNewPipeline<{ value: string; group: string }>().pipe((input) =>
-                Promise.resolve(ok(input))
-            )
-            const previousPipeline = createNewChunkPipeline<{ value: string; group: string }>().build()
-            previousPipeline.feed([createOkContext({ value: 'a1', group: 'A' }, context1)])
+        it('poisons the pipeline when the step throws', async () => {
+            const pipeline = createNewChunkPipeline<{ value: string; group: string }>()
+                .concurrentlyPerGroup(
+                    (input) => input.group,
+                    (group) =>
+                        group
+                            .pipeChunk((): Promise<never> => {
+                                throw new Error('group step boom')
+                            })
+                            .sequentially((builder) => builder.pipe((input) => Promise.resolve(ok(input))))
+                )
+                .build()
 
-            const pipeline = new ConcurrentlyGroupingChunkPipeline(
-                (input) => input.group,
-                processor,
-                previousPipeline,
-                undefined,
-                () => {
-                    throw new Error('prescan boom')
-                }
-            )
+            pipeline.feed([createOkContext({ value: 'a1', group: 'A' }, context1)])
 
-            await expect(pipeline.next()).rejects.toThrow('prescan boom')
-            await expect(pipeline.next()).rejects.toThrow('prescan boom')
+            await expect(pipeline.next()).rejects.toThrow('group step boom')
+            await expect(pipeline.next()).rejects.toThrow('group step boom')
         })
     })
 })

--- a/nodejs/src/ingestion/framework/concurrently-grouping-chunk-pipeline.ts
+++ b/nodejs/src/ingestion/framework/concurrently-grouping-chunk-pipeline.ts
@@ -9,25 +9,39 @@ import { isOkResult } from './results'
 export type GroupingFunction<TInput, TKey> = (input: TInput) => TKey
 
 /**
- * Transforms a group's queued chunk before its items are processed
- * sequentially. Built by GroupProcessingBuilder from the chained pipeChunk
- * steps; {@link passThroughGroupChunk} when none are configured. A synchronous
- * return is honored without awaiting, so the pass-through adds no microtask.
+ * Processes one group's queued chunk: receives the chunk's results in
+ * processing order and returns one result per item. Composed by
+ * GroupProcessingBuilder from pipeChunk steps and sequential per-item stages,
+ * in declaration order.
  */
-export type GroupChunkPreparation<TIn, TOut, C, RStep extends string> = <RPrev extends string>(
+export type GroupChunkProcessor<TIn, TOut, C, RStep extends string> = <RPrev extends string>(
     items: PipelineResultWithContext<TIn, C, RPrev>[]
-) => PipelineResultWithContext<TOut, C, RPrev | RStep>[] | Promise<PipelineResultWithContext<TOut, C, RPrev | RStep>[]>
+) => Promise<PipelineResultWithContext<TOut, C, RPrev | RStep>[]>
 
-/** The no-op group chunk preparation: hand the queued chunk straight to sequential processing. */
-export function passThroughGroupChunk<T, C, RPrev extends string>(
-    items: PipelineResultWithContext<T, C, RPrev>[]
-): PipelineResultWithContext<T, C, RPrev>[] {
-    return items
+/**
+ * The group chunk stage behind `sequentially`: each OK item runs through the
+ * per-item pipeline one at a time, in input order; non-OK items pass through.
+ */
+export function processGroupChunkSequentially<T, U, C, RStep extends string>(
+    processor: Pipeline<T, U, C, RStep>
+): GroupChunkProcessor<T, U, C, RStep> {
+    return async <RPrev extends string>(items: PipelineResultWithContext<T, C, RPrev>[]) => {
+        const results: PipelineResultWithContext<U, C, RPrev | RStep>[] = []
+        for (const item of items) {
+            if (isOkResult(item.result)) {
+                results.push(await processor.process({ result: item.result, context: item.context }))
+            } else {
+                results.push({ result: item.result, context: item.context })
+            }
+        }
+        return results
+    }
 }
 
 /**
  * A chunk pipeline that groups inputs by a key and processes each group concurrently.
- * Within each group, items are processed sequentially through the provided pipeline.
+ * Each group's queued chunk runs through a single {@link GroupChunkProcessor},
+ * composed by the builder from chunk steps and sequential per-item stages.
  *
  * Ordering guarantees:
  * - Items within the same group are always processed in order, even across multiple next() calls
@@ -50,7 +64,6 @@ export function passThroughGroupChunk<T, C, RPrev extends string>(
 export class ConcurrentlyGroupingChunkPipeline<
     TInput,
     TIntermediate,
-    TMid,
     TOutput,
     TKey,
     CInput,
@@ -86,13 +99,11 @@ export class ConcurrentlyGroupingChunkPipeline<
 
     constructor(
         private groupingFn: GroupingFunction<TIntermediate, TKey>,
-        private processor: Pipeline<TMid, TOutput, COutput, RStep>,
-        // Applied to each group's queued chunk before its items are processed
-        // sequentially, with the same semantics as an outer pipeChunk (one
-        // result per OK value, non-OK results pass through). Runs once per
-        // started group chunk: items queued while a group is active form a new
-        // chunk with its own preparation.
-        private prepareGroupChunk: GroupChunkPreparation<TIntermediate, TMid, COutput, RStep>,
+        // One processor for a group's whole queued chunk, composed by the
+        // builder from chunk steps and sequential per-item stages. Runs once
+        // per started group chunk: items queued while a group is active form a
+        // new chunk with its own invocation.
+        private processGroupChunk: GroupChunkProcessor<TIntermediate, TOutput, COutput, RStep>,
         private previousPipeline: ChunkPipeline<TInput, TIntermediate, CInput, COutput, RPrev>,
         maxConcurrency?: number
     ) {
@@ -183,9 +194,7 @@ export class ConcurrentlyGroupingChunkPipeline<
 
         // The key is claimed in activeProcessing synchronously below, so per-key ordering holds even
         // when a group parks waiting for a concurrency permit.
-        const run = this.limit
-            ? this.limit(() => this.processGroupSequentially(queue))
-            : this.processGroupSequentially(queue)
+        const run = this.limit ? this.limit(() => this.processGroupChunk(queue)) : this.processGroupChunk(queue)
         const processingPromise = run.then(
             (results) => {
                 this.completedResults.push(results)
@@ -210,33 +219,5 @@ export class ConcurrentlyGroupingChunkPipeline<
         )
 
         this.activeProcessing.set(key, processingPromise)
-    }
-
-    private async processGroupSequentially(
-        items: PipelineResultWithContext<TIntermediate, COutput, RPrev | RStep>[]
-    ): Promise<PipelineResultWithContext<TOutput, COutput, RPrev | RStep>[]> {
-        // Honor a synchronous preparation without awaiting: the pass-through
-        // must not add a microtask between the queue snapshot and the loop.
-        const prepared = this.prepareGroupChunk(items)
-        const steppedItems = Array.isArray(prepared) ? prepared : await prepared
-
-        const results: PipelineResultWithContext<TOutput, COutput, RPrev | RStep>[] = []
-
-        for (const item of steppedItems) {
-            if (isOkResult(item.result)) {
-                const result = await this.processor.process({
-                    result: item.result,
-                    context: item.context,
-                })
-                results.push(result)
-            } else {
-                results.push({
-                    result: item.result,
-                    context: item.context,
-                })
-            }
-        }
-
-        return results
     }
 }

--- a/nodejs/src/ingestion/framework/concurrently-grouping-chunk-pipeline.ts
+++ b/nodejs/src/ingestion/framework/concurrently-grouping-chunk-pipeline.ts
@@ -2,22 +2,28 @@ import pLimit from 'p-limit'
 
 import { ChunkPipeline, ChunkPipelineResultWithContext, OkResultWithContext } from './chunk-pipeline.interface'
 import { InterleavingChunkPipeline, PullOutcome } from './interleaving-chunk-pipeline'
-import { Pipeline, PipelineContext, PipelineResultWithContext } from './pipeline.interface'
+import { Pipeline, PipelineResultWithContext } from './pipeline.interface'
 import { ResettableSignal } from './resettable-signal'
 import { isOkResult } from './results'
 
 export type GroupingFunction<TInput, TKey> = (input: TInput) => TKey
 
 /**
- * Synchronous scan over a group's queued chunk, run before the items are
- * processed sequentially. Receives the OK items in processing order and may
- * attach group-scoped state by mutating item values (the same convention
- * beforeBatch steps use to attach batch-scoped stores). Runs once per started
- * group chunk (items queued while a group is active get their own scan when
- * their chunk starts). A thrown error poisons the pipeline, same as a
- * processor error.
+ * Transforms a group's queued chunk before its items are processed
+ * sequentially. Built by GroupProcessingBuilder from the chained pipeChunk
+ * steps; {@link passThroughGroupChunk} when none are configured. A synchronous
+ * return is honored without awaiting, so the pass-through adds no microtask.
  */
-export type GroupPrescanFunction<T, C> = (items: { value: T; context: PipelineContext<C> }[]) => void
+export type GroupChunkPreparation<TIn, TOut, C, RStep extends string> = <RPrev extends string>(
+    items: PipelineResultWithContext<TIn, C, RPrev>[]
+) => PipelineResultWithContext<TOut, C, RPrev | RStep>[] | Promise<PipelineResultWithContext<TOut, C, RPrev | RStep>[]>
+
+/** The no-op group chunk preparation: hand the queued chunk straight to sequential processing. */
+export function passThroughGroupChunk<T, C, RPrev extends string>(
+    items: PipelineResultWithContext<T, C, RPrev>[]
+): PipelineResultWithContext<T, C, RPrev>[] {
+    return items
+}
 
 /**
  * A chunk pipeline that groups inputs by a key and processes each group concurrently.
@@ -44,6 +50,7 @@ export type GroupPrescanFunction<T, C> = (items: { value: T; context: PipelineCo
 export class ConcurrentlyGroupingChunkPipeline<
     TInput,
     TIntermediate,
+    TMid,
     TOutput,
     TKey,
     CInput,
@@ -79,10 +86,15 @@ export class ConcurrentlyGroupingChunkPipeline<
 
     constructor(
         private groupingFn: GroupingFunction<TIntermediate, TKey>,
-        private processor: Pipeline<TIntermediate, TOutput, COutput, RStep>,
+        private processor: Pipeline<TMid, TOutput, COutput, RStep>,
+        // Applied to each group's queued chunk before its items are processed
+        // sequentially, with the same semantics as an outer pipeChunk (one
+        // result per OK value, non-OK results pass through). Runs once per
+        // started group chunk: items queued while a group is active form a new
+        // chunk with its own preparation.
+        private prepareGroupChunk: GroupChunkPreparation<TIntermediate, TMid, COutput, RStep>,
         private previousPipeline: ChunkPipeline<TInput, TIntermediate, CInput, COutput, RPrev>,
-        maxConcurrency?: number,
-        private prescan?: GroupPrescanFunction<TIntermediate, COutput>
+        maxConcurrency?: number
     ) {
         this.limit = maxConcurrency !== undefined ? pLimit(maxConcurrency) : null
         this.inner = new InterleavingChunkPipeline<TInput, TOutput, CInput, COutput, RPrev | RStep>({
@@ -203,18 +215,14 @@ export class ConcurrentlyGroupingChunkPipeline<
     private async processGroupSequentially(
         items: PipelineResultWithContext<TIntermediate, COutput, RPrev | RStep>[]
     ): Promise<PipelineResultWithContext<TOutput, COutput, RPrev | RStep>[]> {
-        if (this.prescan) {
-            const okItems = items.flatMap((item) =>
-                isOkResult(item.result) ? [{ value: item.result.value, context: item.context }] : []
-            )
-            if (okItems.length > 0) {
-                this.prescan(okItems)
-            }
-        }
+        // Honor a synchronous preparation without awaiting: the pass-through
+        // must not add a microtask between the queue snapshot and the loop.
+        const prepared = this.prepareGroupChunk(items)
+        const steppedItems = Array.isArray(prepared) ? prepared : await prepared
 
         const results: PipelineResultWithContext<TOutput, COutput, RPrev | RStep>[] = []
 
-        for (const item of items) {
+        for (const item of steppedItems) {
             if (isOkResult(item.result)) {
                 const result = await this.processor.process({
                     result: item.result,

--- a/nodejs/src/ingestion/pipelines/ai/pipelines/ai-event-subpipeline.ts
+++ b/nodejs/src/ingestion/pipelines/ai/pipelines/ai-event-subpipeline.ts
@@ -1,4 +1,5 @@
 import { AsyncOutput, EVENTS_OUTPUT } from '~/common/outputs'
+import { createImmediateMergeFoldStep } from '~/ingestion/common/persons/person-merge-fold'
 import { createCreateEventStep } from '~/ingestion/common/steps/event-processing/create-event-step'
 import { EmitEventStepOutput, createEmitEventStep } from '~/ingestion/common/steps/event-processing/emit-event-step'
 import { createHogTransformEventStep } from '~/ingestion/common/steps/event-processing/hog-transform-event-step'
@@ -31,90 +32,97 @@ export function createAiEventSubpipeline<TInput extends AiEventSubpipelineInput,
 ): PipelineBuilder<TInput, EmitEventStepOutput, TContext, AsyncOutput> {
     const { options, outputs, teamManager, groupTypeManager, hogTransformer, topHog } = config
 
-    return builder
-        .pipe(createNormalizeProcessPersonFlagStep())
-        .pipe(
-            topHog(createHogTransformEventStep(hogTransformer), [
-                sumOk(
-                    'transformations_run',
-                    (output) => ({ team_id: String(output.team.id) }),
-                    (output) => output.transformationsRun
-                ),
-                sumOk(
-                    'transformations_run_per_partition',
-                    (output, input) => ({
-                        team_id: String(output.team.id),
-                        partition: String(input.message.partition),
-                    }),
-                    (output) => output.transformationsRun
-                ),
-                sumResult(
-                    'events_dropped_by_transformation',
-                    (_result, input) => ({ team_id: String(input.team.id) }),
-                    (result) => (isDropResult(result) ? 1 : 0)
-                ),
-                sumResult(
-                    'events_dropped_by_transformation_per_partition',
-                    (_result, input) => ({
+    return (
+        builder
+            .pipe(createNormalizeProcessPersonFlagStep())
+            .pipe(
+                topHog(createHogTransformEventStep(hogTransformer), [
+                    sumOk(
+                        'transformations_run',
+                        (output) => ({ team_id: String(output.team.id) }),
+                        (output) => output.transformationsRun
+                    ),
+                    sumOk(
+                        'transformations_run_per_partition',
+                        (output, input) => ({
+                            team_id: String(output.team.id),
+                            partition: String(input.message.partition),
+                        }),
+                        (output) => output.transformationsRun
+                    ),
+                    sumResult(
+                        'events_dropped_by_transformation',
+                        (_result, input) => ({ team_id: String(input.team.id) }),
+                        (result) => (isDropResult(result) ? 1 : 0)
+                    ),
+                    sumResult(
+                        'events_dropped_by_transformation_per_partition',
+                        (_result, input) => ({
+                            team_id: String(input.team.id),
+                            partition: String(input.message.partition),
+                        }),
+                        (result) => (isDropResult(result) ? 1 : 0)
+                    ),
+                ]),
+                { retry: { tries: 5, sleepMs: 100, name: 'hog_transform_event' } }
+            )
+            .pipe(createNormalizeEventStep())
+            .pipe(createProcessAiEventStep())
+            .pipe(createProcessPersonlessStep(options.FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS), {
+                retry: { tries: 5, sleepMs: 100, name: 'process_personless' },
+            })
+            // AI events are never merge events, so there are no merges to fold in
+            // this branch: every event processes immediately. The branch itself is
+            // temporary and goes away once ingestion fully switches over to the
+            // dedicated AI pipeline.
+            .pipe(createImmediateMergeFoldStep())
+            .pipe(
+                topHog(createProcessPersonsStep(options, outputs), [
+                    timer('process_persons_time', (input) => ({
                         team_id: String(input.team.id),
-                        partition: String(input.message.partition),
+                        distinct_id: input.normalizedEvent.distinct_id,
+                    })),
+                ]),
+                { retry: { tries: 5, sleepMs: 100, name: 'process_persons' } }
+            )
+            .pipe(createPrepareEventStep())
+            .pipe(createProcessGroupsStep(teamManager, groupTypeManager, options), {
+                retry: { tries: 5, sleepMs: 100, name: 'process_groups' },
+            })
+            .pipe(createCreateEventStep(EVENTS_OUTPUT))
+            .pipe(createSplitAiEventsStep())
+            .pipe(
+                topHog(
+                    createEmitEventStep({
+                        outputs,
                     }),
-                    (result) => (isDropResult(result) ? 1 : 0)
+                    [
+                        sum(
+                            'emitted_events',
+                            (input) => ({ team_id: String(input.teamId) }),
+                            (input) => input.eventsToEmit.length
+                        ),
+                        sum(
+                            'emitted_events_per_distinct_id',
+                            (input) => ({
+                                team_id: String(input.teamId),
+                                distinct_id: input.eventsToEmit[0]?.event.distinct_id ?? '',
+                                partition: String(input.message.partition),
+                            }),
+                            (input) => input.eventsToEmit.length
+                        ),
+                        sum(
+                            'emitted_events_per_partition',
+                            (input) => ({
+                                team_id: String(input.teamId),
+                                partition: String(input.message.partition),
+                            }),
+                            (input) => input.eventsToEmit.length
+                        ),
+                    ]
                 ),
-            ]),
-            { retry: { tries: 5, sleepMs: 100, name: 'hog_transform_event' } }
-        )
-        .pipe(createNormalizeEventStep())
-        .pipe(createProcessAiEventStep())
-        .pipe(createProcessPersonlessStep(options.FLAG_CALLED_PERSONLESS_DEFAULT_TEAMS), {
-            retry: { tries: 5, sleepMs: 100, name: 'process_personless' },
-        })
-        .pipe(
-            topHog(createProcessPersonsStep(options, outputs), [
-                timer('process_persons_time', (input) => ({
-                    team_id: String(input.team.id),
-                    distinct_id: input.normalizedEvent.distinct_id,
-                })),
-            ]),
-            { retry: { tries: 5, sleepMs: 100, name: 'process_persons' } }
-        )
-        .pipe(createPrepareEventStep())
-        .pipe(createProcessGroupsStep(teamManager, groupTypeManager, options), {
-            retry: { tries: 5, sleepMs: 100, name: 'process_groups' },
-        })
-        .pipe(createCreateEventStep(EVENTS_OUTPUT))
-        .pipe(createSplitAiEventsStep())
-        .pipe(
-            topHog(
-                createEmitEventStep({
-                    outputs,
-                }),
-                [
-                    sum(
-                        'emitted_events',
-                        (input) => ({ team_id: String(input.teamId) }),
-                        (input) => input.eventsToEmit.length
-                    ),
-                    sum(
-                        'emitted_events_per_distinct_id',
-                        (input) => ({
-                            team_id: String(input.teamId),
-                            distinct_id: input.eventsToEmit[0]?.event.distinct_id ?? '',
-                            partition: String(input.message.partition),
-                        }),
-                        (input) => input.eventsToEmit.length
-                    ),
-                    sum(
-                        'emitted_events_per_partition',
-                        (input) => ({
-                            team_id: String(input.teamId),
-                            partition: String(input.message.partition),
-                        }),
-                        (input) => input.eventsToEmit.length
-                    ),
-                ]
-            ),
-            { retry: { tries: 5, sleepMs: 100, name: 'emit_event' } }
-        )
-        .pipe(createRecordIngestionLagStep())
+                { retry: { tries: 5, sleepMs: 100, name: 'emit_event' } }
+            )
+            .pipe(createRecordIngestionLagStep())
+    )
 }

--- a/nodejs/src/ingestion/pipelines/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/event-subpipeline.ts
@@ -6,7 +6,7 @@ import { IngestionWarningsOutput } from '~/common/outputs'
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { TeamManager } from '~/common/utils/team-manager'
 import { GroupStoreForBatch } from '~/ingestion/common/groups/group-store-for-batch'
-import { MergeFoldPlan } from '~/ingestion/common/persons/person-merge-fold'
+import { WithMergeFoldDecision } from '~/ingestion/common/persons/person-merge-fold'
 import { PersonsStoreForBatch } from '~/ingestion/common/persons/persons-store-for-batch'
 import { createCreateEventStep } from '~/ingestion/common/steps/event-processing/create-event-step'
 import { EmitEventStepOutput, createEmitEventStep } from '~/ingestion/common/steps/event-processing/emit-event-step'
@@ -52,8 +52,6 @@ export interface EventSubpipelineInput {
     headers: EventHeaders
     personsStoreForBatch: PersonsStoreForBatch
     groupStoreForBatch: GroupStoreForBatch
-    /** Fold plan attached by the merge-fold group chunk step; absent when folding is off or the event is not part of a planned run. */
-    mergeFoldPlan?: MergeFoldPlan
 }
 
 export interface EventSubpipelineConfig {
@@ -67,7 +65,10 @@ export interface EventSubpipelineConfig {
     topHog: TopHogWrapper
 }
 
-export function createEventSubpipeline<TInput extends EventSubpipelineInput, TContext>(
+// The WithMergeFoldDecision constraint (not a field on EventSubpipelineInput) is deliberate: the
+// decision is produced by the merge-fold planning step, so only compositions wired after it — or
+// ones that decide `immediate` themselves — can build this subpipeline.
+export function createEventSubpipeline<TInput extends EventSubpipelineInput & WithMergeFoldDecision, TContext>(
     builder: StartPipelineBuilder<TInput, TContext>,
     config: EventSubpipelineConfig
 ): PipelineBuilder<TInput, EmitEventStepOutput, TContext, AsyncOutput> {

--- a/nodejs/src/ingestion/pipelines/analytics/event-subpipeline.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/event-subpipeline.ts
@@ -52,7 +52,7 @@ export interface EventSubpipelineInput {
     headers: EventHeaders
     personsStoreForBatch: PersonsStoreForBatch
     groupStoreForBatch: GroupStoreForBatch
-    /** Fold plan attached by the merge-fold group prescan; absent when folding is off or the event is not part of a planned run. */
+    /** Fold plan attached by the merge-fold group chunk step; absent when folding is off or the event is not part of a planned run. */
     mergeFoldPlan?: MergeFoldPlan
 }
 

--- a/nodejs/src/ingestion/pipelines/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/joined-ingestion-pipeline.ts
@@ -14,7 +14,7 @@ import { EventFilterManager } from '~/ingestion/common/event-filters'
 import { FeatureFlagCalledDedupService } from '~/ingestion/common/feature-flag-called-dedup/feature-flag-called-dedup-service'
 import { BatchWritingGroupStore } from '~/ingestion/common/groups/batch-writing-group-store'
 import { OverflowRedirectService } from '~/ingestion/common/overflow-redirect/overflow-redirect-service'
-import { createMergeFoldPrescan } from '~/ingestion/common/persons/person-merge-fold'
+import { createMergeFoldPlanningStep } from '~/ingestion/common/persons/person-merge-fold'
 import { PersonsStore } from '~/ingestion/common/persons/persons-store'
 import { createDenyEventsStep } from '~/ingestion/common/steps/deny-events'
 import {
@@ -182,9 +182,7 @@ export function createJoinedIngestionPipeline<
         topHog: topHogWrapper,
     }
 
-    const mergeFoldPrescan = createMergeFoldPrescan<PerDistinctIdPipelineInput, JoinedIngestionPipelineContext>(
-        perDistinctIdOptions
-    )
+    const mergeFoldPlanningStep = createMergeFoldPlanningStep<PerDistinctIdPipelineInput>(perDistinctIdOptions)
 
     return (
         newCommonIngestionPipeline<TInput, TContext, OverflowOutput | AsyncOutput>({
@@ -227,14 +225,14 @@ export function createJoinedIngestionPipeline<
             .pipe(createEnrichSurveyPersonPropertiesStep())
             .compose((b) => createPostTeamPreprocessingSubpipeline(b, postTeamConfig))
             // Group by token:distinctId and process each group concurrently.
-            // Events within each group are processed sequentially. When merge
-            // folding is enabled, a prescan plans folds over each group's
-            // chunk before its events run; when disabled, no prescan is wired
-            // and the pipeline is identical to the sequential-only shape.
+            // Events within each group are processed sequentially, after the
+            // merge-fold planning step has scanned the group's chunk. Whether
+            // the step plans anything is its own config-driven decision; when
+            // folding is disabled it passes every event through unplanned.
             .concurrentlyPerGroup(getTokenAndDistinctId, (group) =>
-                (mergeFoldPrescan ? group.prescan(mergeFoldPrescan) : group).sequentially((event) =>
-                    createPerDistinctIdPipeline(event, perEventConfig)
-                )
+                group
+                    .pipeChunk(mergeFoldPlanningStep)
+                    .sequentially((event) => createPerDistinctIdPipeline(event, perEventConfig))
             )
             .afterBatch((afterBatch) =>
                 afterBatch

--- a/nodejs/src/ingestion/pipelines/analytics/per-distinct-id-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/per-distinct-id-pipeline.ts
@@ -5,6 +5,7 @@ import { HogTransformer } from '~/common/hog-transformations/hog-transformer.int
 import { IngestionWarningsOutput } from '~/common/outputs'
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { TeamManager } from '~/common/utils/team-manager'
+import { WithMergeFoldDecision } from '~/ingestion/common/persons/person-merge-fold'
 import { EmitEventStepOutput } from '~/ingestion/common/steps/event-processing/emit-event-step'
 import { EventPipelineRunnerOptions } from '~/ingestion/common/steps/event-processing/event-pipeline-options'
 import { AI_EVENT_TYPES } from '~/ingestion/common/subpipelines/ai-event-types'
@@ -60,7 +61,12 @@ function classifyEvent(input: PerDistinctIdPipelineInput): EventBranch {
     return EVENT_BRANCH_MAP.get(input.event.event) ?? 'event'
 }
 
-export function createPerDistinctIdPipeline<TInput extends PerDistinctIdPipelineInput, TContext>(
+// The event branch's person step consumes the merge-fold decision, so this pipeline requires it on
+// its inputs (the joined pipeline's planning step attaches it); the AI branch ignores it.
+export function createPerDistinctIdPipeline<
+    TInput extends PerDistinctIdPipelineInput & WithMergeFoldDecision,
+    TContext,
+>(
     builder: StartPipelineBuilder<TInput, TContext>,
     config: PerDistinctIdPipelineConfig
 ): PipelineBuilder<TInput, EmitEventStepOutput, TContext, AsyncOutput> {

--- a/nodejs/tests/ingestion/common/steps/event-processing/process-persons-step.integration.test.ts
+++ b/nodejs/tests/ingestion/common/steps/event-processing/process-persons-step.integration.test.ts
@@ -116,6 +116,7 @@ describe('createProcessPersonsStep', () => {
         team,
         timestamp,
         personsStoreForBatch: new BatchBoundPersonsStore(personsStore, 0),
+        mergeFold: { type: 'immediate' },
         ...overrides,
     })
 
@@ -481,7 +482,7 @@ describe('createProcessPersonsStep', () => {
                     createInput({
                         normalizedEvent: event,
                         timestamp: DateTime.fromISO(event.timestamp!),
-                        mergeFoldPlan: plan,
+                        mergeFold: plan ? { type: 'planned', plan } : { type: 'immediate' },
                     })
                 )
                 expect(isOkResult(result)).toBe(true)


### PR DESCRIPTION
## Problem

#72823 introduces merge folding via a new `prescan` hook on `ConcurrentlyGroupingChunkPipeline`.
The hook is a bespoke one-off contract: it returns `void` and communicates by silently mutating item values (`mergeFoldPlan?`), so nothing in the type flow reveals where the plan comes from, when it exists, or who consumes it — and the framework gains a second, weaker way to express "run something over a group's chunk" alongside the established `ChunkProcessingStep`.

## Changes

Builds on #72823 (stacked on that branch). Three moves, each replacing implicit state with explicit contracts.

**1. Group processing is one composable chunk processor.** `ConcurrentlyGroupingChunkPipeline` now holds a single `GroupChunkProcessor` function per group chunk and keeps only the grouping policy (queues, scheduling, poisoning). `GroupProcessingBuilder` composes that processor from stages: `pipeChunk(step)` applies a chunk step to the whole chunk, `sequentially(cb)` runs items one at a time through a per-item pipeline. Stages chain in declaration order and in any order (`pipeChunk` after `sequentially` works); `concurrentlyPerGroup` finalizes. The chunk-step application (filter OK values, instrumented call, one-result-per-value check, zip back with side effects and warnings) is extracted from `BaseChunkPipeline.next()` into a shared `applyChunkStepToResults`, so outer and group-level `pipeChunk` are identical by construction. Existing `(group) => group.sequentially(...)` call sites are source compatible. No casts anywhere in the changeset.

**Before**

```mermaid
flowchart LR
    Q[group chunk] --> P{{prescan: void, mutates values}} --> S[sequential per-item pipeline]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class P phBlue;
    class Q phYellow;
    class S phGray;
```

**After**

```mermaid
flowchart LR
    Q[group chunk] --> GP{{"group chunk processor = pipeChunk stage(s) + sequential stage(s)"}} --> R[group results]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class GP phBlue;
    class Q phYellow;
    class R phGray;
```

**2. The fold plan becomes a typed per-event decision.** `createMergeFoldPlanningStep` is a `ChunkProcessingStep<T, T & WithMergeFoldDecision>`: every value leaves the step carrying a discriminated union, `{ type: 'planned', plan }` (part of a fold run) or `{ type: 'immediate' }` (no plan — process the event as-is right away). No optional plan field, no mutation of inputs; the step's output type is where the decision provably originates. The step is wired unconditionally; the enabled flag and team allowlist are its own decision, so disabled configurations emit everything as `immediate`.

**3. The decision threads only through lanes that can merge.** It is not a field on any broad input contract. `ProcessPersonsInput` requires it (the person step consumes it); `createEventSubpipeline` and `createPerDistinctIdPipeline` require it via `& WithMergeFoldDecision` constraints, satisfied by the planning step in the joined pipeline. The AI branch — whose events are never merge events — keeps its contract untouched and pipes an explicit `createImmediateMergeFoldStep()` before its person step, with a note that nothing can fold there and that the branch is temporary until ingestion fully switches to the dedicated AI pipeline. `GroupPrescanFunction` and the prescan hook are removed.

> [!NOTE]
> Two behavior deltas versus the prescan design, both deliberate. Disabled configurations now run the planning step per group chunk (values get a shallow copy with the `immediate` decision and a rebuilt context carrying `lastStep: planMergeFolds`) where the prescan wired nothing. Group results are still emitted whole-chunk-at-a-time as each group chunk completes, exactly as before.

## How did you test this code?

Automated only (no manual testing):

- Framework prescan tests rewritten against the group `pipeChunk` API through the builder, plus two regressions no prior test caught: a step-failed (DLQ) value must skip the per-item pipeline but still come out as a result, and chained group chunk steps must compose in order.
- Fold planner tests migrated to the decision-union contract, plus new cases: inputs are not mutated (decisions arrive via returned values), and a disabled step emits every value as `immediate`.
- Full framework suite, fold planner, person-step integration (including the folded-vs-sequential differential tests), and AI subpipeline integration tests pass locally; the whole ingestion e2e suite under the fold on/off matrix (152 tests) passes. One unrelated local failure (`ingestion-warnings.test.ts` read-own-writes) fails identically on untouched master in this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal framework refactor behind the same default-off env flag; no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code during review of #72823, at the reviewer's direction, as a concrete counter-proposal to the prescan hook.
The design iterated under explicit reviewer constraints: no casts in the framework (an internal pass-through cast was rejected, leading to the single-composed-processor shape); the planning step always wired with config gating inside it; the plan typed as the step's output rather than an input-side optional; and the decision modeled as a discriminated union instead of `MergeFoldPlan | undefined`.
A first attempt put the required decision on the broad input contracts, which wrongly forced it into the AI lane's public contract — replaced by factory-level `& WithMergeFoldDecision` constraints plus an explicit immediate-decision step in the AI branch, since that lane can never merge.
One process note: a mid-session working-directory mixup caused a round of typecheck/test runs to execute against a master worktree; all validation was re-run against this branch afterwards.
Skills invoked: /writing-tests.
