### PR TITLE
feat(integrations): add mpim:history to in-review Slack scopes

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -45251,6 +45251,7 @@
                 "commands",
                 "files:write",
                 "im:history",
+                "mpim:history",
                 "mpim:read"
             ],
             "type": "string"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5505,6 +5505,7 @@ export enum SlackIntegrationScopeInReview {
     COMMANDS = 'commands',
     FILES_WRITE = 'files:write',
     IM_HISTORY = 'im:history',
+    MPIM_HISTORY = 'mpim:history',
     MPIM_READ = 'mpim:read',
 }
 

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3664,6 +3664,7 @@ class SlackIntegrationScopeInReview(StrEnum):
     COMMANDS = "commands"
     FILES_WRITE = "files:write"
     IM_HISTORY = "im:history"
+    MPIM_HISTORY = "mpim:history"
     MPIM_READ = "mpim:read"
 
 


### PR DESCRIPTION
## Problem

The PostHog Slack app can already request `mpim:read` but not `mpim:history`, so it can see multi-person DM channels without reading their message history. Reading history in group DMs needs `mpim:history`, mirroring how `im:history` covers 1:1 DMs.

## Changes

Add `mpim:history` to `SlackIntegrationScopeInReview` (the DEV-only, pending-Slack-review scope set). The enum in `frontend/src/types.ts` is the source of truth; the backend iterates it dynamically to build the OAuth scope request, so no backend list needed hand-editing. Regenerated schema (`schema.json`, `schema_enums.py`) via `bin/hogli build:schema`.

The scope only takes effect on the internal DEV instance where the app manifest lists it; requesting it on US/EU Cloud fails with `invalid_scope` until Slack approves the public app, at which point it moves into `SlackIntegrationScope`.

> [!NOTE]
> The new scope only reaches OAuth if the DEV Slack app manifest subscribes to `mpim:history`. Confirm the manifest lists it.

## How did you test this code?

No new automated tests — this is a single enum member addition that the backend already covers generically (it iterates `SlackIntegrationScopeInReview` to assemble the scope request), and adding a per-member test would assert the framework, not a real regression. Verified the generated schema diff is exactly the one-line addition across the three files. Ran `bin/hogli build:schema` (clean) and lint-staged on commit (ruff/ty/oxfmt, clean). The scope itself was validated against the DEV Slack app out-of-band.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Vojta directed this; I (Claude) made the change. The enum lives in `frontend/src/types.ts` and feeds generated `posthog/schema_enums.py` + `frontend/src/queries/schema.json` through `bin/hogli build:schema` — I edited the source and regenerated rather than hand-editing generated files. Placed the member alphabetically (between `im:history` and `mpim:read`). No `SlackIntegration.tsx` change was needed since the reconnect UI derives from the enum too.
