### PR TITLE
feat(slack_app): disclose auto-created #posthog-inbox channel on install

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -225,6 +225,7 @@ export const FEATURE_FLAGS = {
     SETTINGS_SESSIONS_V2_JOIN: 'settings-sessions-v2-join', // owner: @robbie-c #team-web-analytics
     SETTINGS_WEB_ANALYTICS_PRE_AGGREGATED_TABLES: 'web-analytics-pre-aggregated-tables', // owner: @lricoy #team-web-analytics
     SIGNALS_PR_REFUNDS: 'signals-pr-refunds', // owner: #team-self-driving, gates the inbox PR refund flow (also checked server-side)
+    SLACK_APP_ASSISTANT: 'slack-app-assistant', // owner: @VojtechBartos #team-platform-features
     SLACK_APP_OAUTH: 'slack-app-oauth', // owner: @VojtechBartos #team-platform-features
     SLOPE_GRAPH_INSIGHT: 'slope-graph-insight', // owner: @pauldambra #team-product-analytics
     STARTUP_PROGRAM_INTENT: 'startup-program-intent', // owner: @pawel-cebula #team-billing

--- a/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
+++ b/frontend/src/lib/integrations/SlackIntegrationHelpers.tsx
@@ -11,8 +11,10 @@ import {
 } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { usePeriodicRerender } from 'lib/hooks/usePeriodicRerender'
 import { IconSlackExternal } from 'lib/lemon-ui/icons'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { IntegrationType, SlackChannelType } from '~/types'
 
@@ -20,27 +22,36 @@ import { slackChannelId } from './slackChannel'
 import { slackIntegrationLogic } from './slackIntegrationLogic'
 
 export function SlackNotConfiguredBanner(): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
     return (
         <LemonBanner type="info">
-            <div className="flex justify-between gap-2 items-center">
-                <span>
-                    Slack is not yet configured for this project. Add PostHog to your Slack workspace to continue.
-                </span>
-                <Link
-                    to={api.integrations.authorizeUrl({
-                        kind: 'slack',
-                        next: window.location.pathname + '?target_type=slack',
-                    })}
-                    disableClientSideRouting
-                >
-                    <img
-                        alt="Add to Slack"
-                        height="40"
-                        width="139"
-                        src="https://platform.slack-edge.com/img/add_to_slack.png"
-                        srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"
-                    />
-                </Link>
+            <div className="flex flex-col gap-2">
+                <div className="flex justify-between gap-2 items-center">
+                    <span>
+                        Slack is not yet configured for this project. Add PostHog to your Slack workspace to continue.
+                    </span>
+                    <Link
+                        to={api.integrations.authorizeUrl({
+                            kind: 'slack',
+                            next: window.location.pathname + '?target_type=slack',
+                        })}
+                        disableClientSideRouting
+                    >
+                        <img
+                            alt="Add to Slack"
+                            height="40"
+                            width="139"
+                            src="https://platform.slack-edge.com/img/add_to_slack.png"
+                            srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"
+                        />
+                    </Link>
+                </div>
+                {featureFlags[FEATURE_FLAGS.SLACK_APP_ASSISTANT] && (
+                    <span className="text-sm text-secondary">
+                        Adding PostHog creates a public #posthog-inbox channel in your Slack workspace, where PostHog
+                        posts what it finds.
+                    </span>
+                )}
             </div>
         </LemonBanner>
     )

--- a/frontend/src/scenes/integrations/IntegrationFullPage.tsx
+++ b/frontend/src/scenes/integrations/IntegrationFullPage.tsx
@@ -93,7 +93,7 @@ function ConnectView({
             ) : (
                 // onClickCapture fires before the connect button triggers its OAuth redirect
                 <div onClickCapture={onConnectClick}>
-                    <SettingsSection next={urls.integration(definition.slug)} />
+                    <SettingsSection next={urls.integration(definition.slug)} centered />
                 </div>
             )}
 

--- a/frontend/src/scenes/integrations/components/SlackIntegration.tsx
+++ b/frontend/src/scenes/integrations/components/SlackIntegration.tsx
@@ -52,7 +52,7 @@ const getSlackAppManifest = (): any => ({
     },
 })
 
-export function SlackIntegration({ next }: { next?: string } = {}): JSX.Element {
+export function SlackIntegration({ next, centered }: { next?: string; centered?: boolean } = {}): JSX.Element {
     const { slackIntegrations, slackAvailable } = useValues(integrationsLogic)
     const [showSlackInstructions, setShowSlackInstructions] = useState(false)
     const { user } = useValues(userLogic)
@@ -70,7 +70,7 @@ export function SlackIntegration({ next }: { next?: string } = {}): JSX.Element 
 
                 <div>
                     {slackAvailable ? (
-                        <>
+                        <div className={centered ? 'flex flex-col items-center gap-2 text-center' : undefined}>
                             <Link to={api.integrations.authorizeUrl({ kind: 'slack', next })} disableClientSideRouting>
                                 <img
                                     alt="Connect to Slack workspace"
@@ -81,12 +81,18 @@ export function SlackIntegration({ next }: { next?: string } = {}): JSX.Element 
                                 />
                             </Link>
                             {featureFlags[FEATURE_FLAGS.SLACK_APP_ASSISTANT] && (
-                                <p className="text-sm text-secondary mt-2 mb-0">
+                                <p
+                                    className={
+                                        centered
+                                            ? 'text-sm text-secondary max-w-sm m-0'
+                                            : 'text-sm text-secondary mt-2 mb-0'
+                                    }
+                                >
                                     Adding PostHog creates a public #posthog-inbox channel in your Slack workspace,
                                     where PostHog posts what it finds.
                                 </p>
                             )}
-                        </>
+                        </div>
                     ) : user?.is_staff ? (
                         !showSlackInstructions ? (
                             <>

--- a/frontend/src/scenes/integrations/components/SlackIntegration.tsx
+++ b/frontend/src/scenes/integrations/components/SlackIntegration.tsx
@@ -5,8 +5,10 @@ import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { IntegrationView } from 'lib/integrations/IntegrationView'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
@@ -54,6 +56,7 @@ export function SlackIntegration({ next }: { next?: string } = {}): JSX.Element 
     const { slackIntegrations, slackAvailable } = useValues(integrationsLogic)
     const [showSlackInstructions, setShowSlackInstructions] = useState(false)
     const { user } = useValues(userLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
 
     const requiredScopesArr = useSlackRequiredScopes()
     const requiredScopes = useMemo(() => requiredScopesArr.join(' '), [requiredScopesArr])
@@ -67,15 +70,23 @@ export function SlackIntegration({ next }: { next?: string } = {}): JSX.Element 
 
                 <div>
                     {slackAvailable ? (
-                        <Link to={api.integrations.authorizeUrl({ kind: 'slack', next })} disableClientSideRouting>
-                            <img
-                                alt="Connect to Slack workspace"
-                                height="40"
-                                width="139"
-                                src="https://platform.slack-edge.com/img/add_to_slack.png"
-                                srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"
-                            />
-                        </Link>
+                        <>
+                            <Link to={api.integrations.authorizeUrl({ kind: 'slack', next })} disableClientSideRouting>
+                                <img
+                                    alt="Connect to Slack workspace"
+                                    height="40"
+                                    width="139"
+                                    src="https://platform.slack-edge.com/img/add_to_slack.png"
+                                    srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x"
+                                />
+                            </Link>
+                            {featureFlags[FEATURE_FLAGS.SLACK_APP_ASSISTANT] && (
+                                <p className="text-sm text-secondary mt-2 mb-0">
+                                    Adding PostHog creates a public #posthog-inbox channel in your Slack workspace,
+                                    where PostHog posts what it finds.
+                                </p>
+                            )}
+                        </>
                     ) : user?.is_staff ? (
                         !showSlackInstructions ? (
                             <>

--- a/frontend/src/scenes/integrations/integrationTypes.ts
+++ b/frontend/src/scenes/integrations/integrationTypes.ts
@@ -1,7 +1,8 @@
 import { IntegrationKind, IntegrationType } from '~/types'
 
-/** The actionable connect section, reused in both settings and the full page. */
-export type SettingsSectionComponent = (props: { next?: string }) => JSX.Element
+/** The actionable connect section, reused in both settings and the full page.
+ * The full page passes ``centered`` so the section can match its centered layout. */
+export type SettingsSectionComponent = (props: { next?: string; centered?: boolean }) => JSX.Element
 
 /**
  * Optional slot rendered on the OAuth landing page directly below the success card,


### PR DESCRIPTION
## Problem

Came up during the Slack Marketplace submission review — one of the reviewer's feedback items. Installing PostHog to a Slack workspace auto-creates a public `#posthog-inbox` channel, but nothing tells the user this before they install. The reviewer asked us to disclose it in the web app.

## Changes

Adds a short disclaimer next to the "Add to Slack" button (Settings → Integrations, and the shared `SlackNotConfiguredBanner`), gated on the `slack-app-assistant` feature flag.

<img width="882" height="239" alt="Screenshot 2026-07-24 at 13 31 18" src="https://github.com/user-attachments/assets/e1a0f559-c22b-43f2-9a2c-635294dddf0c" />
<img width="698" height="727" alt="Screenshot 2026-07-24 at 13 31 14" src="https://github.com/user-attachments/assets/d4a2b453-326c-4e62-bb82-2121b5ad432b" />


## How did you test this code?

Manually tested

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Copy and flag-gating placement directed by the author. No skills required beyond frontend conventions.