### PR TITLE
fix(hubspot): classify exhausted transient retries as retryable noise

### DIFF
--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -1757,6 +1757,15 @@ export interface ActivityLogEntryApi {
     readonly item_id: string
     detail?: DetailApi
     readonly created_at: string
+    /** Whether the activity was performed by the system rather than a user. */
+    readonly is_system: boolean
+    /** Whether the acting user was being impersonated by PostHog staff. */
+    readonly was_impersonated: boolean
+    /**
+     * API client that triggered the activity, from the x-posthog-client request header (e.g. 'mcp'). Null for requests that did not send the header.
+     * @nullable
+     */
+    readonly client: string | null
 }
 
 /**

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
@@ -133,6 +133,13 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
             "Integration not found": "The linked HubSpot integration no longer exists. Please reconnect your HubSpot account.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `fetch_page`/`fetch_search`/`_post_chunk`/`fetch_data` all tag transient statuses
+        # (429, 5xx, unrecognised non-standard 4xx) and truncated JSON bodies with this marker
+        # once their own tenacity retries (5 attempts, exponential backoff) are exhausted.
+        # Temporal retrying the whole activity is self-recovering, so don't track it as a bug.
+        return {"(retryable)"}
+
     # TODO: clean up hubspot job inputs to not have two auth config options
     def parse_config(self, job_inputs: dict) -> HubspotSourceConfig | HubspotSourceOldConfig:
         if "hubspot_integration_id" in job_inputs.keys():

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
@@ -256,6 +256,29 @@ def test_missing_token_error_is_non_retryable(error_msg: str) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "error_msg",
+    [
+        # fetch_search (status=522 is Cloudflare's "connection timed out" from api.hubapi.com's edge)
+        "Hubspot search error (retryable): status=522, url=https://api.hubapi.com/crm/v3/objects/meetings/search",
+        "Hubspot search error (retryable): status=429, url=https://api.hubapi.com/crm/v3/objects/deals/search",
+        # fetch_page / helpers.fetch_data (GET path)
+        "Hubspot API error (retryable): status=503, url=https://api.hubapi.com/crm/v3/objects/contacts",
+        # _post_chunk (v4 associations batch-read)
+        "Hubspot v4 associations error (retryable): status=500, url=https://api.hubapi.com/crm/v4/associations/deals/contacts/batch/read",
+        # truncated/malformed JSON body
+        "Hubspot search malformed JSON response (retryable): url=https://api.hubapi.com/crm/v3/objects/meetings/search",
+    ],
+)
+def test_exhausted_transient_error_is_retryable(error_msg: str) -> None:
+    # These are only raised after tenacity's in-process retries are exhausted, so Temporal
+    # retrying the whole activity is self-recovering — must not be tracked as a bug.
+    patterns = HubspotSource().get_retryable_errors()
+    assert any(pattern in error_msg for pattern in patterns), (
+        f"HubSpot error {error_msg!r} did not match any retryable pattern"
+    )
+
+
 class TestApiVersion:
     def test_defaults_to_v3_until_date_version_is_verified(self) -> None:
         src = HubspotSource()


### PR DESCRIPTION
## Problem

Error tracking surfaced a `HubspotRetryableError` ([issue](https://us.posthog.com/project/2/error_tracking/019f93c9-40ed-7e02-b2b3-5829b82c64a5)) for the HubSpot data-warehouse import source: `Hubspot search error (retryable): status=522, url=https://api.hubapi.com/crm/v3/objects/meetings/search`.

Status 522 is a Cloudflare edge status ("connection timed out" reaching the origin) — a transient infrastructure blip, not a customer credential/config problem. HubSpot's fetch loops (`fetch_page`, `fetch_search`, `_post_chunk`, `fetch_data`) already classify 429/5xx statuses and truncated JSON bodies as retryable and back off internally via `tenacity` (5 attempts, exponential backoff) before re-raising.

The bug: `HubspotSource` never overrode `get_retryable_errors()`, so once those internal retries were exhausted, the re-raised exception fell through to the generic "log as exception" path in `_handle_import_error` and got tracked as a bug, even though Temporal retrying the whole activity is expected to self-recover. Sibling sources (Salesforce, Intercom, Meta Ads, Mixpanel, MySQL, ClickHouse, Vercel, Matomo, TwelveData, MongoDB) already follow this pattern for their own transient errors.

## Changes

Added `HubspotSource.get_retryable_errors()`, matching the `(retryable)` marker that HubSpot's own request helpers already tag these messages with. Matching errors are now logged at `warning` instead of `exception`, keeping this benign, self-recovering failure out of error tracking.

## How did you test this code?

Added 5 parameterized cases to `test_source_routing.py` asserting representative exhausted-retry messages (status 429/5xx across the search, GET, and v4-associations paths, plus a malformed-JSON variant) match `get_retryable_errors()` — locks in that this exact class of transient failure stops being tracked as a bug. Ran the full `test_source_routing.py` suite (54 tests) locally, plus `ruff check`/`ruff format --check` on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking (issue linked above): pulled the full stack trace and confirmed the top in-app frame was `fetch_search` in this source's own `hubspot.py`, then read the source's retry/classification code and compared it against sibling sources that already implement `get_retryable_errors()`.

Ruled out a duplicate fix: searched open PRs by exception type, message phrase, and module path, and scanned the maintainer's other open PRs — none touch the HubSpot source files.

Skills invoked: `/writing-tests` before adding the regression test.