### PR TITLE
fix(hubspot): stop reporting transient HubSpot API errors as exceptions

### DIFF
--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -1757,6 +1757,15 @@ export interface ActivityLogEntryApi {
     readonly item_id: string
     detail?: DetailApi
     readonly created_at: string
+    /** Whether the activity was performed by the system rather than a user. */
+    readonly is_system: boolean
+    /** Whether the acting user was being impersonated by PostHog staff. */
+    readonly was_impersonated: boolean
+    /**
+     * API client that triggered the activity, from the x-posthog-client request header (e.g. 'mcp'). Null for requests that did not send the header.
+     * @nullable
+     */
+    readonly client: string | null
 }
 
 /**

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
@@ -133,6 +133,22 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
             "Integration not found": "The linked HubSpot integration no longer exists. Please reconnect your HubSpot account.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `hubspot.py`/`helpers.py` already retry these in-process via tenacity (5 attempts,
+        # exponential backoff) before re-raising `HubspotRetryableError`. A 429/5xx/malformed-body
+        # that survives all 5 attempts is a transient HubSpot/edge blip (e.g. Cloudflare 522), not
+        # a bug — Temporal's activity retry recovers once the upstream issue clears, so keep it out
+        # of error tracking as noise. Match the stable message prefix HubSpot's own status/url are
+        # appended to, not the volatile status code or URL.
+        return {
+            "Hubspot API error (retryable): status=",
+            "Hubspot API malformed JSON response (retryable)",
+            "Hubspot search error (retryable): status=",
+            "Hubspot search malformed JSON response (retryable)",
+            "Hubspot v4 associations error (retryable): status=",
+            "Hubspot v4 associations malformed JSON response (retryable)",
+        }
+
     # TODO: clean up hubspot job inputs to not have two auth config options
     def parse_config(self, job_inputs: dict) -> HubspotSourceConfig | HubspotSourceOldConfig:
         if "hubspot_integration_id" in job_inputs.keys():

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
@@ -256,6 +256,28 @@ def test_missing_token_error_is_non_retryable(error_msg: str) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "error_msg",
+    [
+        # fetch_page/_get, exhausted after tenacity's 5 in-process attempts (e.g. a Cloudflare 522)
+        "Hubspot API error (retryable): status=522, url=https://api.hubapi.com/crm/v3/properties/meetings",
+        "Hubspot API error (retryable): status=429, url=https://api.hubapi.com/crm/v3/objects/contacts",
+        "Hubspot API malformed JSON response (retryable): url=https://api.hubapi.com/crm/v3/objects/deals",
+        "Hubspot search error (retryable): status=503, url=https://api.hubapi.com/crm/v3/objects/contacts/search",
+        "Hubspot search malformed JSON response (retryable): url=https://api.hubapi.com/crm/v3/objects/deals/search",
+        "Hubspot v4 associations error (retryable): status=500, "
+        "url=https://api.hubapi.com/crm/v4/associations/contacts/deals/batch/read",
+        "Hubspot v4 associations malformed JSON response (retryable): "
+        "url=https://api.hubapi.com/crm/v4/associations/contacts/deals/batch/read",
+    ],
+)
+def test_transient_http_error_is_retryable(error_msg: str) -> None:
+    patterns = HubspotSource().get_retryable_errors()
+    assert any(pattern in error_msg for pattern in patterns), (
+        f"HubSpot error {error_msg!r} did not match any retryable pattern"
+    )
+
+
 class TestApiVersion:
     def test_defaults_to_v3_until_date_version_is_verified(self) -> None:
         src = HubspotSource()


### PR DESCRIPTION
## Problem

Error tracking surfaced a `HubspotRetryableError` for the HubSpot data-warehouse source ([issue](https://us.posthog.com/project/2/error_tracking/019f93ca-ed6f-7ee2-8277-15cd9fd6bc96)):

```
Hubspot API error (retryable): status=522, url=https://api.hubapi.com/crm/v3/properties/meetings
```

Status 522 is a Cloudflare "connection timed out" response from HubSpot's edge – a transient upstream blip, not a bug in our code and not a customer credential/config issue.

The HubSpot source already retries these transient statuses (429, 5xx, malformed JSON bodies) in-process via tenacity (5 attempts, exponential backoff) before re-raising `HubspotRetryableError`. Once those attempts are exhausted, the import activity re-raises the error and Temporal retries the whole activity — the sync recovers on its own once HubSpot's edge is healthy again. But because `HubspotSource` had no `get_retryable_errors()` override, this self-healing failure was logged at `exception` level and showed up in error tracking as noise, rather than at `warning` level like other sources already do for the same class of problem.

## Changes

Added `get_retryable_errors()` to `HubspotSource`, matching the stable message prefixes HubSpot's own request helpers use for transient failures (API/search/associations-batch requests, plus malformed-JSON responses). This mirrors the existing pattern in `SalesforceSource`, `IntercomSource`, and `MetaAdsSource` for errors a source already retries internally and that recover via Temporal's activity retry.

No retry behavior changes — the request-level backoff and Temporal-level activity retry are unchanged. Only the logging/error-tracking classification changes.

## How did you test this code?

Added a parameterized test (`test_transient_http_error_is_retryable`) asserting each of the new retryable message shapes — including the exact reported `status=522` message — matches a pattern in `get_retryable_errors()`. This guards the noise-suppression classification the way the existing `test_unauthorized_error_is_non_retryable` test guards the non-retryable classification.

Ran locally:
- `hogli test products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py` (56 passed)
- `ruff check` / `ruff format --check` on changed files
- `uv run mypy --cache-fine-grained` on the hubspot source directory

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) triaged this from a webhook-delivered error tracking issue. I confirmed the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/helpers.py`'s `_get`, traced the call path (`fetch_data` → `_get_property_names` → `_resolve_search_properties` → `get_rows_via_search`), and confirmed it's a Cloudflare 522 already retried via tenacity. I compared it against the Stripe/Salesforce/Intercom/Meta Ads sources' `get_retryable_errors()` precedent (documented in `products/warehouse_sources/backend/temporal/data_imports/sources/README.md`) and decided this was the right classification rather than `get_non_retryable_errors()` (not a customer config/credential problem) or a code fix (retry/backoff logic is already correct).

No repo skill directly covers this triage flow; I followed the existing source-classification pattern and its README documentation.