### PR TITLE
fix(data-imports): keep exhausted Notion 5xx retries out of error tracking

### DIFF
--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -1757,6 +1757,15 @@ export interface ActivityLogEntryApi {
     readonly item_id: string
     detail?: DetailApi
     readonly created_at: string
+    /** Whether the activity was performed by the system rather than a user. */
+    readonly is_system: boolean
+    /** Whether the acting user was being impersonated by PostHog staff. */
+    readonly was_impersonated: boolean
+    /**
+     * API client that triggered the activity, from the x-posthog-client request header (e.g. 'mcp'). Null for requests that did not send the header.
+     * @nullable
+     */
+    readonly client: string | null
 }
 
 /**

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/notion/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/notion/source.py
@@ -53,6 +53,12 @@ class NotionSource(ResumableSource[NotionSourceConfig, NotionResumeConfig]):
             "403 Client Error: Forbidden for url: https://api.notion.com": "Your Notion integration is missing the required capabilities, or the pages/databases you want to sync have not been shared with it.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # A 5xx is already retried internally with backoff (see notion.py's tenacity-wrapped
+        # _request); if those retries still exhaust, the failure is transient and self-recovering,
+        # so let Temporal retry the activity without surfacing it as tracked exception noise.
+        return {"Notion API error (retryable)"}
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion_source.py
@@ -150,6 +150,17 @@ class TestNotionSource:
             for pattern in non_retryable
         )
 
+    def test_retryable_marker_matches_raised_message(self) -> None:
+        # notion.py's _request raises this exact message on a 5xx after tenacity's internal
+        # retries exhaust; matching it here keeps that self-recovering failure out of error
+        # tracking as noise instead of being logged as an unclassified exception.
+        markers = self.source.get_retryable_errors()
+        assert markers
+        assert any(
+            marker in "Notion API error (retryable): status=522, url=https://api.notion.com/v1/comments"
+            for marker in markers
+        )
+
 
 @pytest.mark.parametrize("status_code", [500, 503])
 def test_http_error_message_format_matches_non_retryable(status_code: int) -> None:


### PR DESCRIPTION
## Problem

Error tracking caught a `NotionRetryableError` (`Notion API error (retryable): status=522, url=https://api.notion.com/v1/comments`) in the data-warehouse import pipeline ([issue](https://us.posthog.com/project/2/error_tracking/019f93c9-4513-7b23-8d12-4f0ae6e0f062)).

The stack trace confirms it originates in `notion.py`'s `_request` (line 188), reached via the comments fan-out stream (`_comments_stream` → `get_rows` → the shared import pipeline).

`_request` already retries a 5xx internally with exponential backoff via tenacity (5 attempts) before giving up and re-raising `NotionRetryableError`. When those internal retries are exhausted, the exception falls through to `_handle_import_error`'s default branch, which logs it with `logger.aexception(...)` — capturing it as a tracked exception — before re-raising so Temporal retries the whole activity.

A 522 (origin timed out, per Cloudflare's status code in front of Notion's API) is a transient infrastructure condition, not something PostHog's code or the customer's config can fix. Since Temporal already retries the activity and the failure is self-recovering, this doesn't need to reach error tracking as noise.

## Decision

Classified as a **fixable improvement**, not a user/upstream error: the source already has a mechanism for exactly this (`get_retryable_errors()` on `ResumableSource`, used to keep self-recovering, internally-retried failures out of error tracking), but `NotionSource` didn't implement it. Mixpanel, Intercom, and MongoDB sources already use this same mechanism for their own transient/self-recovering errors, so this follows established precedent rather than introducing a new pattern.

## Changes

- Added `get_retryable_errors()` to `NotionSource`, matching the stable `"Notion API error (retryable)"` prefix that `_request` raises on any 5xx.

## How did you test this code?

Added `test_retryable_marker_matches_raised_message` to `test_notion_source.py`, mirroring the equivalent Mixpanel test — asserts the marker returned by `get_retryable_errors()` matches the exact message `_request` raises on a 5xx. This is the regression: without the fix, an exhausted-retry 5xx would keep being logged as a tracked exception.

Ran:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/notion/tests/test_notion_source.py` — 22 passed
- `ruff check --fix` / `ruff format` on both changed files — clean
- `uv run mypy --cache-fine-grained .` (repo-wide) — clean, no issues in 16783 source files

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification change, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error tracking issue using the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the full stack trace and confirm the failure genuinely originates in the Notion source's `_request`. Read `notion.py` and `source.py` to understand the retry/classification flow, and found the `get_retryable_errors()` precedent already used by the Mixpanel, Intercom, and MongoDB sources for the same class of problem (self-recovering errors already retried internally). Invoked `/writing-tests` before adding the regression test. Checked for duplicate open PRs by exception type, message phrase, and module path, and reviewed the maintainer's own open PR queue — found one Notion-related draft (#71645) but it addresses 401/403 auth-expiry classification, an unrelated code path.