### PR TITLE
feat(logs): add investigating-logs skill

### DIFF
--- a/products/logs/skills/investigating-logs/SKILL.md
+++ b/products/logs/skills/investigating-logs/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: investigating-logs
+description: >
+  Investigate logs in a PostHog project: verify a service or deployment is healthy, explain an error spike,
+  triage an incident, or understand what a log stream is saying. Use when the user asks to "check the logs",
+  asks whether a service, deploy, release, or change is working or broke anything, asks why errors are up or
+  what changed, or wants the root cause of failures visible in logs. Routes the logs MCP tools
+  (services overview, pattern mining, before/after pattern diffing, bucketed counts, facets, raw rows) so
+  investigations start from summaries instead of raw rows or hand-written SQL over the logs table.
+---
+
+# Investigating logs
+
+Investigation is a narrowing problem: **summarize before you read**.
+One `posthog:logs-patterns` call compresses millions of lines into at most 200 templates,
+and one `posthog:logs-patterns-diff` call answers "what is different about now vs. before" directly.
+Raw rows (`posthog:query-logs`) are the last step of an investigation, never the first.
+
+## When to use this skill
+
+- "Check the logs" / "is service X healthy?" / "did my deploy (or model bump, config change, migration) break anything?"
+- "Why are errors up?" / "explain this spike" / incident triage — "what changed?"
+- "What is this service logging?" — orienting in an unfamiliar or noisy stream.
+- Finding the log evidence for a failure reported elsewhere (an alert, an error-tracking issue, a user complaint).
+
+## When _not_ to use this skill
+
+- Creating or tuning log alerts — that's `authoring-log-alerts`.
+- Analytics over product events, persons, or insights — that's `querying-posthog-data`.
+- HogQL exposes a `logs` table via `posthog:execute-sql`, but do not investigate through it:
+  hand-written SQL over logs routinely hits read-byte caps and re-derives what the tools below do in one cheap call.
+  Reserve SQL for the rare case of joining log-derived facts with non-log data.
+
+## Tools
+
+| Tool                                                                  | Job                                                                                           |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `posthog:logs-services-create`                                        | Top-25 services with log_count, error_count, error_rate, sparkline. Orientation.              |
+| `posthog:logs-patterns`                                               | Mine one window's message templates, ordered by frequency. "What is this stream saying?"      |
+| `posthog:logs-patterns-diff`                                          | Diff templates between two windows: new / rate-shifted / gone. "What changed?"                |
+| `posthog:logs-count` / `posthog:logs-count-ranges`                    | Scalar and time-bucketed counts for a filter. Localize volume before pulling rows.            |
+| `posthog:logs-sparkline-query`                                        | Volume over time broken down by severity or service (the one bucketed view with a breakdown). |
+| `posthog:logs-facet-values-create`                                    | Distribution of severity/service (or a resource attribute) under a filter.                    |
+| `posthog:logs-attributes-list` / `posthog:logs-attribute-values-list` | Discover attribute keys and values before building filters.                                   |
+| `posthog:query-logs`                                                  | Raw rows. Endpoint of every drill-down, entry point of none.                                  |
+
+Each tool's own description documents its parameters and response shape — read it before calling.
+
+## Pick the workflow by question shape
+
+### "Is it healthy?" — post-deploy / post-change verification
+
+The user changed something (deploy, model bump, config, migration) and wants to know the logs still look right.
+
+1. Pin down the change time and the affected service(s). Ask if the user hasn't said; the diff is meaningless without a boundary.
+2. Orient with `posthog:logs-services-create`: is the service still logging at all, and what is its error_rate now?
+   A service that went silent fails verification just as hard as one that started erroring.
+3. `posthog:logs-patterns-diff` with `query.dateRange` from the change time to now and `baselineDateRange`
+   set to a comparable window just before the change, scoped to `serviceNames`.
+   New error/fatal templates right after a change are the classic regression signature;
+   large `rate_ratio` shifts on existing error templates are the second thing to check.
+4. Check volume continuity with `posthog:logs-count-ranges` spanning before and after the boundary:
+   a rate discontinuity (crash loop, restart storm, silence) shows up here even when message content looks unchanged.
+5. Drill only the suspects: pivot each suspicious pattern to raw lines via its `match_regex` with `posthog:query-logs`.
+
+A pass verdict needs all three: no new error templates, no large error rate_ratio shifts, and continuous volume.
+Say which windows you compared — "healthy" is only as strong as the baseline.
+
+### "Explain this spike"
+
+1. Localize it: `posthog:logs-count-ranges` over the user's window, then recurse into the dense bucket(s) — each bucket's
+   `date_from`/`date_to` feeds the next call. Stop after 3–4 levels.
+2. Explain it: `posthog:logs-patterns-diff` with the spike as `query.dateRange` and the window just before as
+   `baselineDateRange`. The top `new` and `rate_shift` entries are the explanation. Do not mine both windows
+   separately and diff by hand — the diff is one call.
+
+### Incident triage — "what broke?"
+
+`posthog:logs-patterns-diff` first: incident window vs. a known-good window just before (or omit the baseline for
+same-window-last-week). Suspects are `new` entries and the biggest `rate_ratio` shifts; pivot each to raw lines.
+If the failing service is unknown, find it first with `posthog:logs-facet-values-create` faceting `service_name`
+under `severityLevels: ["error", "fatal"]`.
+
+### "What is this stream saying?" — unfamiliar service
+
+`posthog:logs-patterns` over the last hour, scoped to the service. Scan templates by `estimated_count` and
+non-zero error share in `severity_counts`. Widen the window or add `searchTerm` only if the answer isn't there.
+
+### Known needle — a specific message, attribute, or person
+
+When the target is already precise (an error string, a request id, a distinct_id), skip pattern mining:
+discover the right keys with `posthog:logs-attributes-list` / `posthog:logs-attribute-values-list`,
+size the result with `posthog:logs-count`, then pull rows with `posthog:query-logs`.
+
+## Rules that keep investigations honest and cheap
+
+- Scope `serviceNames` (or a resource-attribute filter) on every call once the target service is known.
+  Unscoped calls scan the whole team's stream and starve the pattern sample budget.
+- `posthog:query-logs` requires an explicit `query.dateRange` — omitting it is a 400, not a default window.
+- Pattern counts are sampled estimates (`sampled: true`); templates rarer than ~1 in 10,000 rows can be invisible.
+  Absence of a rare template is not evidence it stopped.
+- Before trusting a wall of `new` entries in a diff, check `baseline.total_count` —
+  a tiny or empty baseline (logging only just started) makes everything look new.
+- `severityLevels` matches the six canonical lowercase buckets against `severity_text` exactly.
+  Zero rows on a severity filter → check the stored values with `posthog:logs-attribute-values-list { key: "severity_text" }`.
+- Budget: one services call, at most one patterns-diff per window pair, 3–4 count-ranges levels,
+  and `query-logs` only for confirmed suspects with `limit` ≤ 100.
+
+## Output
+
+Lead with the verdict, then the evidence:
+
+- **Verdict**: healthy / regressed / inconclusive, with the windows compared.
+- **Suspects** (if any): template, classification (`new` / `rate_shift`), estimated counts or `rate_ratio`, services, and 1–2 sample raw lines.
+- **What was checked and what wasn't**: services covered, windows, and any sampling or baseline caveats that limit confidence.
+
+The user should be able to act on the verdict without re-running the investigation.


### PR DESCRIPTION
## Problem

Agents asked to investigate logs ("is my service healthy after this deploy?", "why are errors up?", "what changed?") don't discover the pattern-mining tools. The MCP instructions' query-tool routing only surfaces `query-*`-prefixed tools, so `logs-patterns` and `logs-patterns-diff` never appear there, and the logs skillset only covered alert authoring (`authoring-log-alerts`). In practice agents fall back to raw `query-logs` row pulls or hand-written SQL over the HogQL `logs` table, which routinely hits read-byte caps and re-derives what the purpose-built tools do in one call.

`logs-patterns-diff` is purpose-built for exactly these questions (its own prompt calls the post-deploy check out as a primary use), but nothing above the tool layer routes an agent to it.

## Changes

Adds `products/logs/skills/investigating-logs/SKILL.md`, a routing skill that sits above the existing logs MCP tools:

- Core discipline: summarize before you read. Patterns and diffs first, raw rows last.
- Five workflows keyed by question shape: post-deploy/post-change verification, explaining a spike, incident triage, orienting in an unfamiliar stream, and hunting a known needle.
- Rules for honest results: sampled-count caveats, `baseline.total_count` sanity check before trusting "new" entries, canonical severity buckets, service scoping, and a per-investigation call budget.
- Explicitly routes away from `execute-sql` over the `logs` table for investigation work.
- A verdict-first output contract (healthy / regressed / inconclusive, with the windows compared).

The skill deliberately does not duplicate tool parameter docs. Those live in each tool's own description under `products/logs/mcp/prompts/`, and the skill defers to them.

## How did you test this code?

- `hogli lint:skills` passes (121 skills OK, no new warnings).
- `hogli build:skills -- --list` discovers `investigating-logs` under `product=logs`.

Static skill content, no automated tests beyond the build pipeline's frontmatter and structure validation. I have not yet re-run a live agent session against the published skill; that only becomes possible after merge, when CI distributes it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed. Agent-facing skill content, distributed automatically via the skills pipeline; no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude Code, directed by me. Skills invoked: the repo's `/writing-skills` guide before authoring.

Decisions along the way:

- Started from the observation that an agent asked to verify a deployment from logs never found the pattern tools. Root cause is discoverability, not availability: the tools are enabled and ungated in practice, but the MCP instructions layer only advertises `query-*`-named tools and no skill covered log investigation.
- Two candidate fixes were considered: widening the MCP instructions' query-tool routing (a `services/mcp` change that would also benefit other products whose `system_prompt_hint`s are silently dropped by the name filter) and adding a skill. This PR does the skill; the routing fix is separable follow-up work.
- Single `SKILL.md` with no `references/`, per the skill-count budget guidance in the writing-skills handbook page. Depth can move to references later if the entry point grows.
