### PR TITLE
fix(data-warehouse): stop repartition re-flag loop on terminal skips

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/repartition_controller.py
@@ -277,6 +277,12 @@ async def maybe_flag_for_repartition(
                 partition_count=len(partition_bytes),
             )
             capture_exception(Exception(f"Repartition needed but skipped for schema {schema.id}: {reason}"))
+            # Engage the cooldown even though no rewrite happened: the trigger (over budget or repeated
+            # OOMs) is still true next sync and the table's scheme can't go finer, so without this we
+            # re-measure, re-emit the skip event, and re-alert on every 5-minute sync forever. The
+            # cooldown re-evaluates at most daily; a real change to the table clears it via a later
+            # successful repartition.
+            await asyncio.to_thread(schema.stamp_last_repartition_at)
             return
 
         pending = {**target.to_dict(), "trigger_reason": trigger_reason, "attempts": 0}

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test_repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test_repartition_controller.py
@@ -184,6 +184,30 @@ class TestRepartitionDetection:
         assert schema.repartition_pending is None
         assert capture.call_args.args[0] == "warehouse_repartition_skipped"
         assert capture.call_args.args[1]["reason"] == "unpartitionable_no_keys"
+        # A table with no usable partition target must engage the cooldown, otherwise detection
+        # re-measures and re-emits the skip on every 5-minute sync forever (the loop we're fixing).
+        assert schema.last_repartition_at is not None
+
+    def test_unpartitionable_skip_does_not_reflag_next_sync(self, team):
+        # Regression: the terminal skip stamps the cooldown so the immediately-following sync is a
+        # no-op instead of re-emitting flagged/skipped — this is the every-5-minute loop guard.
+        schema = _make_schema(team, {})
+        with tempfile.TemporaryDirectory() as d:
+            delta = _write_unpartitioned_delta(f"{d}/u")
+            with (
+                patch.object(ctrl, "target_partition_bytes", return_value=1),
+                patch.object(ctrl, "is_auto_repartition_enabled", return_value=True),
+                patch.object(ctrl, "capture_repartition_event") as capture,
+            ):
+                self._detect(team, schema, delta)
+                first_pass_events = [c.args[0] for c in capture.call_args_list]
+                capture.reset_mock()
+                schema.refresh_from_db()
+                self._detect(team, schema, delta)
+                second_pass_events = [c.args[0] for c in capture.call_args_list]
+
+        assert "warehouse_repartition_skipped" in first_pass_events
+        assert second_pass_events == []
 
     def test_unpartitioned_over_budget_with_keys_enables_partitioning(self, team):
         # An unpartitioned table that's over budget but HAS a usable key must be flagged to become
@@ -408,6 +432,9 @@ class TestRepartitionActivity:
         schema.refresh_from_db()
         assert schema.repartition_pending is None
         assert "warehouse_repartition_skipped" in [c.args[0] for c in capture.call_args_list]
+        # Clearing pending alone re-arms the loop — detection re-flags the unchanged table next sync.
+        # The cooldown stamp is what actually stops the flag → start → skip churn every 5 minutes.
+        assert schema.last_repartition_at is not None
 
     def test_failure_increments_attempts_without_clearing(self, team):
         schema = _make_schema(team, {})

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -290,9 +290,14 @@ def _maybe_repartition_table(inputs: RepartitionActivityInputs, logger: Filterin
         DELTA_REPARTITION_TOTAL.labels(team_id=str(inputs.team_id), outcome="superseded").inc()
         return
     except RepartitionUnpartitionableError as e:
-        # Terminal: the table can't be partitioned. Clear the flag so we don't retry every run.
+        # Terminal: the table can't be partitioned on its keys. Clear the flag AND engage the cooldown —
+        # clearing `repartition_pending` alone re-arms the loop, because detection re-flags on the very
+        # next sync (the OOM/size trigger is still true and the table's scheme is unchanged), so the
+        # table churns flag → start → skip every 5 minutes forever. The cooldown re-evaluates at most
+        # daily instead.
         schema.refresh_from_db(fields=["sync_type_config"])
         schema.clear_repartition_pending()
+        schema.stamp_last_repartition_at()
         props = base_event_props(schema, schema.source, inputs.job_id)
         props.update({"trigger_reason": trigger_reason, "reason": str(e)})
         capture_repartition_event("warehouse_repartition_skipped", props)


### PR DESCRIPTION
## Problem

The automated repartition controller was stuck re-flagging the same tables every 5 minutes, forever. A table gets flagged by the OOM-history trigger (it OOM'd repeatedly in the last 7 days, so the trigger stays true for the whole window). The repartition then hits a terminal skip because there's nothing valid to do:

- `datetime_at_finest_tier` — already partitioned as fine as it goes
- `unpartitionable_no_keys` / `No supported partition mode for keys=['id']` — the key can't be partitioned

Both terminal-skip paths only cleared `repartition_pending` and returned. They never engaged the 24h cooldown. So on the very next sync, detection saw the flag cleared and the trigger still true, and re-flagged the unchanged table. The result is an endless `flag -> start -> skip` loop.

From prod telemetry (the repartition dashboard) this is fleet-wide, not one table: dozens of schemas across Stripe, Postgres, Hubspot, BigQuery, Shopify, Chargebee and others, each churning ~2,000 cycles over 7 days. Every cycle emits three PostHog events and, on the detection path, a `capture_exception` to error tracking. The Chargebee `Subscriptions` table that surfaced this had fired the loop 1,578 times since 2026-07-18.

The `MAX_REPARTITION_ATTEMPTS` circuit breaker didn't catch it because a skip isn't a failure, so the attempt counter never incremented.

## Changes

Stamp `last_repartition_at` on both terminal-skip paths so the existing 24h cooldown (`REPARTITION_COOLDOWN_SECONDS`) throttles re-evaluation to at most once a day instead of every sync:

- `repartition_controller.py` — the detection-time skip when `select_repartition_target` returns no target.
- `repartition_table.py` — the `RepartitionUnpartitionableError` path in the activity (the Chargebee case). Its comment already claimed to stop the retry loop. It now actually does.

A table that genuinely changes still gets re-evaluated (daily, or immediately after a real repartition clears the cooldown), so this only kills the futile churn.

> [!NOTE]
> This stops future re-arming once deployed. The tables looping right now each have a stale trigger and will fire one more daily cycle until their 7-day OOM window rolls off. To stop them sooner the lever is the `data-warehouse-auto-repartition` flag.

There's a separate, narrower `no_delta_table` case (one internal team-1 table) that loops on the activity side because it leaves `repartition_pending` set rather than re-flagging. It's a different mechanism and may be intentional, so I left it out of this PR.

## How did you test this code?

Added three regression cases to `test_repartition_controller.py`:

- the detection-time terminal skip now stamps the cooldown
- the `RepartitionUnpartitionableError` skip now stamps the cooldown
- `test_unpartitionable_skip_does_not_reflag_next_sync` — a second detection pass immediately after a skip is a no-op instead of re-emitting, which is the loop guard itself

I (Claude) could not run these locally: this checkout's venv is Python 3.12 while the pipeline modules the tests import use 3.13-only typing syntax, so collection errors out. CI runs on 3.13 and will exercise them. I did verify ruff is clean and all three files compile under 3.13, and the cooldown gate these tests rely on is already covered by the existing `test_cooldown_blocks_flagging`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom pointed at the repartition dashboard and asked why the Chargebee Subscriptions table was repeatedly repartitioning. I (Claude) traced it through prod telemetry (`warehouse_repartition_flagged` / `started` / `skipped` events via the PostHog MCP), found the fleet-wide `flag -> start -> skip` loop, and root-caused it to terminal skips not engaging the cooldown.

I considered a few fixes and rejected them: a dedicated "unpartitionable" marker on the schema (more state, more migration surface, when the existing 24h cooldown already models exactly the right throttle), and routing skips through the attempt/circuit-breaker counter (semantically wrong, a skip isn't a failed rewrite). Reusing `stamp_last_repartition_at` is the smallest change that reuses tested machinery. No skills were invoked; `/writing-tests` conventions were followed for the added cases.
