### PR TITLE
fix(data-imports): map DeltaLake object-store access errors to an actionable message

### DIFF
--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -71,6 +71,9 @@ SERIALIZED_FIELD_TO_CLICKHOUSE_MAPPING: dict[DatabaseSerializedFieldType, str] =
 ExtractErrors = {
     "The AWS Access Key Id you provided does not exist": "The Access Key you provided does not exist",
     "Access Denied: while reading key:": "Access was denied when reading the provided file",
+    # DeltaLake-kernel object_store errors (Delta-format tables, e.g. all warehouse_sources synced
+    # tables) use a different vocabulary than ClickHouse's native S3 errors above.
+    "The operation lacked the necessary privileges to complete": "Access was denied when reading the provided file",
     "Could not list objects in bucket": "Access was denied to the provided bucket",
     "file is empty": "The provided file contains no data",
     "The specified key does not exist": "The provided file doesn't exist in the bucket",

--- a/products/warehouse_sources/backend/tests/test_table.py
+++ b/products/warehouse_sources/backend/tests/test_table.py
@@ -111,6 +111,23 @@ class TestSafeExposeChError:
             DataWarehouseTable()._safe_expose_ch_error(err)
         assert exc_info.value is err
 
+    def test_delta_kernel_permission_error_gets_actionable_message(self) -> None:
+        # Delta-format tables (the default for every warehouse_sources synced table) read via
+        # ClickHouse's DeltaLake kernel, whose object_store errors use different wording than
+        # the native ClickHouse S3 errors above. Without a matching ExtractErrors entry this
+        # fell through to the generic fallback message regardless of the actual cause.
+        delta_kernel_error = ServerException(
+            "DB::Exception: Received DeltaLake kernel error ObjectStoreError: Error interacting with "
+            "object store: The operation lacked the necessary privileges to complete for path "
+            "team_2_mysql_x/dw_table/_delta_log/_last_checkpoint: Error performing GET "
+            "http://objectstorage:19000/data-warehouse/team_2_mysql_x/dw_table/_delta_log/_last_checkpoint "
+            "- Server returned non-2xx status code: 403 Forbidden: AccessDenied",
+            code=742,  # DELTA_KERNEL_ERROR
+        )
+
+        with pytest.raises(Exception, match="Access was denied when reading the provided file"):
+            DataWarehouseTable()._safe_expose_ch_error(delta_kernel_error)
+
 
 class TestRunChdbQuery:
     def test_hung_query_is_killed_and_raises_instead_of_blocking(self) -> None:


### PR DESCRIPTION
## Problem

Error tracking surfaced a generic exception during a MySQL sync's schema-validation step: [issue](https://us.posthog.com/project/2/error_tracking/019f93d3-6303-7833-93d0-7e1070d4438a).

```
Exception: Could not read the files from your storage bucket. Check that the files URL pattern, file format, and credentials are correct, then try again.
```

The call path: `import_data_activity_sync` -> `pipeline.run` -> `validate_schema_and_update_table` -> `DataWarehouseTable.get_columns()` (`products/warehouse_sources/backend/models/table.py`), which issues a ClickHouse `DESCRIBE TABLE` against the synced Delta table. That query failed with a genuine object-store access error from ClickHouse's DeltaLake kernel:

```
DB::Exception: Received DeltaLake kernel error ObjectStoreError: Error interacting with object store:
The operation lacked the necessary privileges to complete for path .../dw_sku_dim/_delta_log/_last_checkpoint:
... Server returned non-2xx status code: 403 Forbidden: AccessDenied
```

`get_columns()`'s fallback error handler (`_safe_expose_ch_error`) matches known ClickHouse error substrings in `ExtractErrors` to surface a specific, actionable message, falling back to a generic one otherwise. `ExtractErrors` already has an entry for this exact situation from ClickHouse's *native* S3 client (`"Access Denied: while reading key:"`), but every warehouse_sources synced table reads its schema through ClickHouse's DeltaLake kernel instead (`format="DeltaS3Wrapper"`), which uses different wording from the underlying Rust `object_store` crate. That vocabulary wasn't represented in `ExtractErrors` at all, so this whole error class — not just this one occurrence — fell through to the generic fallback regardless of the actual cause.

This occurred 3 times in a ~36 second window during a single sync attempt and never recurred, consistent with a transient storage blip rather than a persistent credential problem — retries (5 attempts with backoff) are already correct behavior here and I didn't change the retry policy. The gap is purely in the message a user sees when this class of error does surface.

## Changes

- Added an `ExtractErrors` entry matching the DeltaLake-kernel `object_store` crate's permission-error wording (`"The operation lacked the necessary privileges to complete"`), mapping it to the same actionable message already used for the equivalent native-ClickHouse-S3 case.

## How did you test this code?

Added `test_delta_kernel_permission_error_gets_actionable_message` to the existing `TestSafeExposeChError` class in `test_table.py`, using the real captured error text (with identifiers redacted) — this is exactly the shape of the bug this PR fixes: without the `ExtractErrors` entry, this case falls through to the generic message like every other unmatched error.

Ran:
- `uv run pytest products/warehouse_sources/backend/tests/test_table.py -k SafeExposeChError` — 3 passed
- `uv run mypy --cache-fine-grained products/warehouse_sources/backend/models/table.py products/warehouse_sources/backend/tests/test_table.py` — clean
- `./bin/hogli ci:preflight --fix` — 0 failures

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-message mapping, no user-facing API/config change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from the linked error-tracking issue via PostHog's error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`), which surfaced the full stack/exception-chain and confirmed the failure originates in shared schema-introspection code (`table.py`), not the MySQL source connector. Traced the ClickHouse error-wrapping path (`posthog/errors.py`'s `wrap_clickhouse_query_error`, dynamically-built `CHQueryErrorDeltaKernelError` for ClickHouse error code 742) to confirm the DeltaLake-kernel error vocabulary is structurally different from the native-S3 vocabulary `ExtractErrors` already covers.

Checked for duplicate open PRs by exception type, message phrase, and module path, and scanned the maintainer's own open PR queue. Found #73454 ("recognize DeltaError as a transient object-store error"), which fixes a related-but-distinct gap in `delta_table_helper.py`'s best-effort pre-write maintenance classifier (a different code path, using the Python `deltalake` package rather than ClickHouse's SQL-level DeltaLake kernel) — it doesn't touch the `ExtractErrors`/`get_columns` gap this PR closes.

Invoked `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*