### PR TITLE
feat(sql): add "New SQL query" command to open a blank query in a new tab

### DIFF
--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -366,11 +366,16 @@ export interface searchLogicMeta {
             user: UserType | null,
             sceneLogViewsByRef: Record<string, string>
         ) => SearchItem[]
-        newItems: (featureFlags: FeatureFlagsSet, isDev: boolean | undefined, user: UserType | null) => SearchItem[]
+        newItems: (
+            featureFlags: FeatureFlagsSet,
+            isDev: boolean | undefined,
+            user: UserType | null,
+            arg: string
+        ) => SearchItem[]
         peopleItems: (treeGroupItems: FileSystemImport[], sceneLogViewsByRef: Record<string, string>) => SearchItem[]
         groupItems: (
             groupSearchResults: Partial<Record<GroupTypeIndex, GroupQueryResult[]>>,
-            aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun
+            aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun // groupsModel
         ) => SearchItem[]
         personItems: (personSearchResults: PersonType[]) => SearchItem[]
         playlistItems: (playlistSearchResults: FileSystemEntry[]) => SearchItem[]

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -785,11 +785,12 @@ export const searchLogic = kea<searchLogicType>([
             },
         ],
         newItems: [
-            (s) => [s.featureFlags, s.isDev, s.user],
+            (s) => [s.featureFlags, s.isDev, s.user, (_, props: SearchLogicProps) => props.logicKey],
             (
                 featureFlags: import('lib/logic/featureFlagLogic').FeatureFlagsSet,
                 isDev: boolean | undefined,
-                user: null | import('~/types').UserType
+                user: null | import('~/types').UserType,
+                logicKey: string
             ): SearchItem[] => {
                 const allNewItems = getTreeItemsNew()
                 const filteredItems = allNewItems.filter((item) => {
@@ -836,25 +837,28 @@ export const searchLogic = kea<searchLogicType>([
                     }
                 })
 
-                // Blank SQL query in a new browser tab. Can't use the href pipeline above, which
-                // always navigates in-place — a new tab needs onSelect + newInternalTab. Inherits
-                // the active warehouse connection when triggered from within the SQL editor.
-                items.push({
-                    id: 'new-sql-query-tab',
-                    name: 'New SQL query',
-                    displayName: 'New SQL query',
-                    category: 'create',
-                    productCategory: null,
-                    itemType: 'insight/hog',
-                    searchKeywords: ['sql', 'hogql', 'query', 'blank sql', 'new tab'],
-                    record: { type: 'insight', iconType: 'insight/hog' },
-                    onSelect: () => {
-                        const onSqlEditor =
-                            removeProjectIdIfPresent(router.values.location.pathname) === urls.sqlEditor()
-                        const connectionId = onSqlEditor ? router.values.hashParams?.c : undefined
-                        newInternalTab(urls.sqlEditor(connectionId ? { connectionId } : {}))
-                    },
-                })
+                // Blank SQL query in a new browser tab (inheriting the active warehouse connection when
+                // triggered from within the SQL editor). Scoped to the command palette: it relies on
+                // onSelect + newInternalTab, and only the 'command' Search surface honors onSelect —
+                // the new-tab scene and AI-first homepage are href-only and would render a dead item.
+                if (logicKey === 'command') {
+                    items.push({
+                        id: 'new-sql-query-tab',
+                        name: 'New SQL query',
+                        displayName: 'New SQL query',
+                        category: 'create',
+                        productCategory: null,
+                        itemType: 'insight/hog',
+                        searchKeywords: ['sql', 'hogql', 'query', 'blank sql', 'new tab'],
+                        record: { type: 'insight', iconType: 'insight/hog' },
+                        onSelect: () => {
+                            const onSqlEditor =
+                                removeProjectIdIfPresent(router.values.location.pathname) === urls.sqlEditor()
+                            const connectionId = onSqlEditor ? router.values.hashParams?.c : undefined
+                            newInternalTab(urls.sqlEditor(connectionId ? { connectionId } : {}))
+                        },
+                    })
+                }
 
                 return items
             },

--- a/frontend/src/lib/components/Search/searchLogic.tsx
+++ b/frontend/src/lib/components/Search/searchLogic.tsx
@@ -1,5 +1,6 @@
 import { MakeLogicType, actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { router } from 'kea-router'
 
 import { IconBell, IconClock, IconDownload, IconLeave, IconNotification } from '@posthog/icons'
 
@@ -9,6 +10,8 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { preflightLogic } from 'lib/logic/preflightLogic'
 import { getEntryAccessDisabledReason, getProductAccessDisabledReason } from 'lib/utils/accessControlUtils'
 import { GroupQueryResult, mapGroupQueryResponse } from 'lib/utils/groups'
+import { removeProjectIdIfPresent } from 'lib/utils/kea-router'
+import { newInternalTab } from 'lib/utils/newInternalTab'
 import { toSentenceCase } from 'lib/utils/strings'
 import { organizationIntegrationsLogic } from 'scenes/settings/organization/organizationIntegrationsLogic'
 import { urls } from 'scenes/urls'
@@ -799,7 +802,7 @@ export const searchLogic = kea<searchLogicType>([
                     return true
                 })
 
-                return filteredItems.map((item) => {
+                const items: SearchItem[] = filteredItems.map((item) => {
                     // Format display name:
                     // "Insight/Lifecycle" -> "New Lifecycle insight"
                     // "Data/Destination" -> "New Destination" (no suffix for Data)
@@ -832,6 +835,28 @@ export const searchLogic = kea<searchLogicType>([
                         },
                     }
                 })
+
+                // Blank SQL query in a new browser tab. Can't use the href pipeline above, which
+                // always navigates in-place — a new tab needs onSelect + newInternalTab. Inherits
+                // the active warehouse connection when triggered from within the SQL editor.
+                items.push({
+                    id: 'new-sql-query-tab',
+                    name: 'New SQL query',
+                    displayName: 'New SQL query',
+                    category: 'create',
+                    productCategory: null,
+                    itemType: 'insight/hog',
+                    searchKeywords: ['sql', 'hogql', 'query', 'blank sql', 'new tab'],
+                    record: { type: 'insight', iconType: 'insight/hog' },
+                    onSelect: () => {
+                        const onSqlEditor =
+                            removeProjectIdIfPresent(router.values.location.pathname) === urls.sqlEditor()
+                        const connectionId = onSqlEditor ? router.values.hashParams?.c : undefined
+                        newInternalTab(urls.sqlEditor(connectionId ? { connectionId } : {}))
+                    },
+                })
+
+                return items
             },
         ],
         peopleItems: [


### PR DESCRIPTION
## Problem

Getting a clean, blank SQL editor meant either wiping your current query or fishing through the sidebar's right-click "Open in new tab". There was no fast, always-available way to just say "give me a fresh SQL query in a new tab" from anywhere in the app.

Note the palette already had a "New SQL insight" entry, but it navigates in the *same* tab and pre-fills an example HogQL query, so it doesn't cover this.

## Changes

Adds a global command-palette (Cmd+K) entry, **New SQL query**, that opens a fresh, fully blank SQL editor in a new browser tab via `newInternalTab`. When you trigger it from within the SQL editor it carries over the active warehouse connection (read from the URL hash); everywhere else it opens with the default connection.

It lives in the palette's `create` group next to "New SQL insight". Because a new browser tab needs an `onSelect` callback (the manifest `href` pipeline always navigates in-place), it's a hardcoded `SearchItem` in `searchLogic.tsx` rather than a manifest tree item.

## How did you test this code?

I (the agent) didn't do manual browser testing in this environment. Automated checks I ran:

- `pnpm --filter=@posthog/frontend typescript:check` — no errors in `searchLogic.tsx` (unrelated pre-existing module-resolution errors in `products/workflows` remain, from an incomplete typegen setup in this sandbox).
- `pnpm --filter=@posthog/frontend fix` — lint + format clean.

Worth a human sanity-check: open Cmd+K, search "sql", confirm "New SQL query" opens a blank `/sql` tab, and that triggering it while on `/sql` with a warehouse connection selected carries that connection into the new tab.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Jovan (jovan@posthog.com) directed this from a Slack thread; built by the PostHog Slack app (Claude). We bounced ideas first and landed on browser tabs (not reviving in-app tabs) with a fully blank query. Along the way we found the existing "New SQL insight" palette entry — it surfaces under a recomputed label and navigates in-place with a sample query, which is why it didn't fit — so this is a deliberately distinct entry. Chose `newInternalTab` over raw `window.open` to match the sidebar's existing "Open in new tab" behavior, and placed the item in `searchLogic.tsx` as an `onSelect` command since the manifest `href` path can't open a new tab. No skills were needed for this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GNDPDNEN/p1784891546862649)*
