### PR TITLE
feat(review-hog): add detailed view of the review pipeline

### DIFF
--- a/products/review_hog/frontend/CodeReviewScene.tsx
+++ b/products/review_hog/frontend/CodeReviewScene.tsx
@@ -52,6 +52,7 @@ import type {
 } from 'products/review_hog/frontend/generated/api.schemas'
 import { ReviewHogReviewsListScope } from 'products/review_hog/frontend/generated/api.schemas'
 
+import { PipelineDetailModal } from './PipelineDetailModal'
 import { REVIEWS_PAGE_SIZE, ReviewDrawerTab, ReviewSkillKind, reviewHogSettingsLogic } from './reviewHogSettingsLogic'
 
 /** "review-hog-perspective-logic-correctness" → "Logic correctness" */
@@ -63,18 +64,22 @@ function prettifySkillName(skillName: string): string {
     return cleaned ? cleaned.charAt(0).toUpperCase() + cleaned.slice(1) : skillName
 }
 
+// Step numbering and names match the detailed-view modal (PipelineDetailModal) — keep them in sync.
 const PIPELINE_PHASES: { name: string; hint: string; steps: { number: string; title: string; caption: string }[] }[] = [
     {
         name: 'Prepare',
         hint: 'get the diff ready to read',
         steps: [
-            { number: '01', title: 'Changed code', caption: "we fetch the PR's diff" },
+            {
+                number: '01',
+                title: 'Meaningful diff',
+                caption: "we fetch the PR's diff; generated files, lock files, and snapshots are skipped",
+            },
             {
                 number: '02',
-                title: 'Meaningful files',
-                caption: 'generated files, lock files, and snapshots are skipped',
+                title: 'Split into chunks',
+                caption: 'larger PRs are split into logically reviewable chunks',
             },
-            { number: '03', title: 'Chunks', caption: 'larger PRs are split into logically reviewable chunks' },
         ],
     },
     {
@@ -82,21 +87,21 @@ const PIPELINE_PHASES: { name: string; hint: string; steps: { number: string; ti
         hint: 'pick the lenses, read in parallel',
         steps: [
             {
-                number: '04',
+                number: '03',
                 title: 'Pick perspectives',
                 caption: 'each chunk gets only the perspectives it actually needs',
             },
-            { number: '05', title: 'Perspectives', caption: 'specialist reviewers read each chunk in parallel' },
-            { number: '06', title: 'Blind spots', caption: 'one more sweep for what every perspective missed' },
+            { number: '04', title: 'Perspectives', caption: 'specialist reviewers read each chunk in parallel' },
+            { number: '05', title: 'Blind spots', caption: 'one more sweep for what every perspective missed' },
         ],
     },
     {
         name: 'Refine & publish',
         hint: 'clean up and ship the review',
         steps: [
-            { number: '07', title: 'Dedupe', caption: 'overlapping findings are merged' },
-            { number: '08', title: 'Validate', caption: 'each finding is checked against your quality bar' },
-            { number: '09', title: 'Publish', caption: 'a cleaned-up review lands on the pull request' },
+            { number: '06', title: 'Dedupe', caption: 'overlapping findings are merged' },
+            { number: '07', title: 'Validate', caption: 'each finding is checked against your quality bar' },
+            { number: '08', title: 'Publish', caption: 'a cleaned-up review lands on the pull request' },
         ],
     },
 ]
@@ -124,11 +129,13 @@ function SectionHeader({
     icon,
     title,
     pill,
+    action,
     children,
 }: {
     icon: JSX.Element
     title: string
     pill?: JSX.Element
+    action?: JSX.Element
     children: string
 }): JSX.Element {
     return (
@@ -139,6 +146,7 @@ function SectionHeader({
                 </span>
                 <h3 className="m-0 text-base font-semibold">{title}</h3>
                 {pill}
+                {action && <div className="ml-auto">{action}</div>}
             </div>
             {/* Indented so the copy aligns under the title, not the icon tile */}
             <p className="m-0 ml-9 max-w-160 text-xs text-secondary">{children}</p>
@@ -224,9 +232,23 @@ function ProofCard(): JSX.Element | null {
 }
 
 function PipelineSection(): JSX.Element {
+    const { openPipelineDetail } = useActions(reviewHogSettingsLogic)
     return (
         <section className="flex flex-col gap-4 border-t border-primary pt-8">
-            <SectionHeader icon={<IconDirectedGraph />} title="How we review your PRs">
+            <SectionHeader
+                icon={<IconDirectedGraph />}
+                title="How we review your PRs"
+                action={
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        onClick={() => openPipelineDetail()}
+                        data-attr="review-pipeline-detailed-view"
+                    >
+                        Detailed view
+                    </LemonButton>
+                }
+            >
                 Every review runs through the same steps before it's published.
             </SectionHeader>
             <div className="flex flex-wrap items-stretch gap-2.5">
@@ -253,6 +275,7 @@ function PipelineSection(): JSX.Element {
                     </div>
                 ))}
             </div>
+            <PipelineDetailModal />
         </section>
     )
 }

--- a/products/review_hog/frontend/PipelineDetailModal.tsx
+++ b/products/review_hog/frontend/PipelineDetailModal.tsx
@@ -1,0 +1,295 @@
+import { useActions, useValues } from 'kea'
+
+import { LemonModal } from '@posthog/lemon-ui'
+
+import { useWindowSize } from 'lib/hooks/useWindowSize'
+
+import { reviewHogSettingsLogic } from './reviewHogSettingsLogic'
+
+/**
+ * "Detailed view" of the review pipeline, opened from the "How we review your PRs" section.
+ * The diagram is a fixed 1280×720 canvas recreated from the design handoff with a hardcoded dark
+ * palette — it renders identically in light and dark theme (treat it as artwork; its contrast was
+ * tuned against this exact background) and scales down uniformly instead of reflowing.
+ */
+
+const CANVAS_W = 1280
+const CANVAS_H = 720
+
+/** Shared lane centers: chunk cards, validate cards, and every connector line up on these. */
+const LANES = ['16.667%', '50%', '83.333%'] as const
+
+/** Perspectives stay abstract (A/B/C) on purpose: rosters differ per user, the modal teaches the logic. */
+const PERSPECTIVE_NAMES = ['Perspective A', 'Perspective B', 'Perspective C']
+const CHUNK_PICKS: boolean[][] = [
+    [true, true, false],
+    [true, false, true],
+    [true, true, true],
+]
+
+function DashedDrop({ left, top, height }: { left: string; top: number; height: number }): JSX.Element {
+    return (
+        <div
+            className="absolute w-0 -translate-x-1/2 border-l-2 border-dashed border-[#3a3f46]"
+            style={{ left, top, height }}
+        />
+    )
+}
+
+function ArrowHead({ left }: { left: string }): JSX.Element {
+    return (
+        <div
+            className="absolute h-0 w-0 -translate-x-1/2"
+            style={{
+                left,
+                top: 21,
+                borderLeft: '5px solid transparent',
+                borderRight: '5px solid transparent',
+                borderTop: '7px solid #3a3f46',
+            }}
+        />
+    )
+}
+
+function DashedRail({ left, right }: { left: string; right: string }): JSX.Element {
+    return (
+        <div
+            className="absolute h-0.5"
+            style={{
+                left,
+                right,
+                top: 13,
+                backgroundImage: 'repeating-linear-gradient(90deg, rgba(93,100,109,0.5) 0 6px, transparent 6px 15px)',
+            }}
+        />
+    )
+}
+
+/** 03 → chunk cards: a stub from under the "Pick perspectives" box feeds the distribution rail. */
+function FanOutConnector(): JSX.Element {
+    return (
+        <div className="relative my-1.5 h-8" aria-hidden="true">
+            <DashedDrop left="85.5%" top={4} height={9} />
+            <DashedRail left={LANES[0]} right="14.5%" />
+            {LANES.map((lane) => (
+                <DashedDrop key={lane} left={lane} top={13} height={8} />
+            ))}
+            {LANES.map((lane) => (
+                <ArrowHead key={lane} left={lane} />
+            ))}
+        </div>
+    )
+}
+
+/** Straight per-lane drops (chunks → dedupe, dedupe → validate). */
+function LaneConnector(): JSX.Element {
+    return (
+        <div className="relative my-1.5 h-8" aria-hidden="true">
+            {LANES.map((lane) => (
+                <DashedDrop key={lane} left={lane} top={4} height={17} />
+            ))}
+            {LANES.map((lane) => (
+                <ArrowHead key={lane} left={lane} />
+            ))}
+        </div>
+    )
+}
+
+/** Validate lanes → the single published review. */
+function MergeConnector(): JSX.Element {
+    return (
+        <div className="relative my-1.5 h-8" aria-hidden="true">
+            <DashedDrop left={LANES[0]} top={4} height={9} />
+            <DashedDrop left={LANES[2]} top={4} height={9} />
+            <DashedDrop left={LANES[1]} top={4} height={17} />
+            <DashedRail left={LANES[0]} right={LANES[0]} />
+            <ArrowHead left={LANES[1]} />
+        </div>
+    )
+}
+
+function SequenceArrow(): JSX.Element {
+    return <div className="text-center text-[15px] text-[#5f656c]">→</div>
+}
+
+function StepBox({ number, title, caption }: { number: string; title: string; caption?: string }): JSX.Element {
+    return (
+        <div className="rounded-lg border border-[#34383f] bg-[#212429] px-3 py-2.5">
+            <span className="mr-2 font-mono text-[11px] tracking-[0.1em] text-[#f0a009]">{number}</span>
+            <span className="text-[12.5px] font-semibold">{title}</span>
+            {caption && <span className="text-xs text-[#b3b9c0]"> · {caption}</span>}
+        </div>
+    )
+}
+
+function ChunkCard({ index }: { index: number }): JSX.Element {
+    return (
+        <div className="rounded-[9px] border border-[#2a2d32] bg-[#1c1f23] px-3 py-2.5">
+            <div className="mb-[7px] font-mono text-xs text-[#b3b9c0]">CHUNK {index + 1}</div>
+            <div className="flex flex-nowrap gap-[5px]">
+                {PERSPECTIVE_NAMES.map((name, i) =>
+                    CHUNK_PICKS[index][i] ? (
+                        <span
+                            key={name}
+                            className="whitespace-nowrap rounded-md border border-[rgba(240,160,9,0.4)] bg-[rgba(240,160,9,0.08)] px-2 py-[3px] text-xs font-medium text-white"
+                        >
+                            {name}
+                        </span>
+                    ) : (
+                        <span
+                            key={name}
+                            className="whitespace-nowrap rounded-md border border-dashed border-[#3c4148] px-2 py-[3px] text-xs text-[#7d848c]"
+                        >
+                            {name} · not needed
+                        </span>
+                    )
+                )}
+            </div>
+            <div className="mb-[5px] mt-1.5 text-center text-xs leading-none text-[#7d848c]">↓</div>
+            <div className="flex items-baseline justify-center gap-[7px] rounded-md border border-[#383d44] bg-[#262a30] px-2 py-[5px]">
+                <span className="text-xs font-semibold">Blind spot</span>
+                <span className="text-[11px] text-[#b3b9c0]">sweeps what the perspectives missed</span>
+            </div>
+        </div>
+    )
+}
+
+function ValidateCard({ index }: { index: number }): JSX.Element {
+    return (
+        <div className="rounded-lg border border-[#2a2d32] bg-[#212429] px-3 py-2.5">
+            <div className="flex items-baseline gap-2">
+                <span className="font-mono text-[11px] text-[#b3b9c0]">CHUNK {index + 1}</span>
+                <span className="text-xs font-semibold">Validate</span>
+            </div>
+            <div className="mt-0.5 text-[11.5px] text-[#b3b9c0]">warm session · one verdict per finding</div>
+        </div>
+    )
+}
+
+function GoldBandNumber({ children }: { children: string }): JSX.Element {
+    return <span className="font-mono text-[#f0a009]">{children}</span>
+}
+
+export function PipelineDetailModal(): JSX.Element {
+    const { pipelineDetailOpen } = useValues(reviewHogSettingsLogic)
+    const { closePipelineDetail } = useActions(reviewHogSettingsLogic)
+    const { windowSize } = useWindowSize()
+
+    // LemonModal caps itself at 90% of the viewport width and just under the viewport height; fit
+    // the fixed-ratio canvas inside those bounds, never upscaling past the designed size.
+    const scale = Math.min(
+        1,
+        ((windowSize.width ?? CANVAS_W) * 0.9) / CANVAS_W,
+        ((windowSize.height ?? CANVAS_H + 124) - 124) / CANVAS_H
+    )
+
+    return (
+        <LemonModal
+            isOpen={pipelineDetailOpen}
+            onClose={closePipelineDetail}
+            simple
+            hideCloseButton
+            className="overflow-hidden rounded-xl border-[#2c2f35] bg-[#17191d] shadow-[0_32px_90px_rgba(0,0,0,0.65)]"
+            data-attr="review-pipeline-detail-modal"
+        >
+            <div style={{ width: CANVAS_W * scale, height: CANVAS_H * scale }}>
+                <div
+                    className="flex flex-col text-[#f2f3f5]"
+                    style={{
+                        width: CANVAS_W,
+                        height: CANVAS_H,
+                        transform: `scale(${scale})`,
+                        transformOrigin: 'top left',
+                    }}
+                >
+                    <div className="flex flex-none items-center justify-between border-b border-[#25282d] px-[22px] py-4">
+                        <div>
+                            <div className="text-[15px] font-bold">How we review your PRs</div>
+                            <div className="mt-0.5 text-xs text-[#b3b9c0]">
+                                Every review runs through the same steps before it's published.
+                            </div>
+                        </div>
+                        <button
+                            type="button"
+                            aria-label="Close"
+                            onClick={closePipelineDetail}
+                            className="flex size-[26px] cursor-pointer items-center justify-center rounded-md border border-[#34383f] text-sm text-[#b3b9c0] transition-colors hover:border-[#4a4f57] hover:text-[#f2f3f5]"
+                        >
+                            ×
+                        </button>
+                    </div>
+
+                    <div className="flex flex-1 flex-col justify-center px-11 py-4">
+                        <div
+                            className="grid items-center"
+                            style={{ gridTemplateColumns: '90px 24px 1fr 24px 1fr 24px 1.2fr' }}
+                        >
+                            <div className="justify-self-start rounded-full bg-[#f2f3f5] px-3 py-[7px] text-xs font-bold text-[#141518]">
+                                Your PR
+                            </div>
+                            <SequenceArrow />
+                            <StepBox number="01" title="Meaningful diff" caption="noise files skipped" />
+                            <SequenceArrow />
+                            <StepBox number="02" title="Split into chunks" />
+                            <SequenceArrow />
+                            <StepBox number="03" title="Pick perspectives" caption="only what each chunk needs" />
+                        </div>
+
+                        <FanOutConnector />
+
+                        <div className="mb-2.5 text-center">
+                            <div className="text-[11px] font-semibold tracking-[0.14em] text-[#9aa1a9]">
+                                <GoldBandNumber>04</GoldBandNumber> PERSPECTIVES → <GoldBandNumber>05</GoldBandNumber>{' '}
+                                BLIND SPOT · EVERY CHUNK, IN PARALLEL
+                            </div>
+                            <div className="mt-[3px] text-[11.5px] text-[#7d848c]">
+                                e.g. contracts & security, logic & correctness, performance & reliability, or your own
+                            </div>
+                        </div>
+
+                        <div className="grid grid-cols-3 gap-3">
+                            {CHUNK_PICKS.map((_, i) => (
+                                <ChunkCard key={i} index={i} />
+                            ))}
+                        </div>
+
+                        <LaneConnector />
+
+                        <div className="flex items-baseline justify-center gap-2.5 rounded-lg border border-[rgba(240,160,9,0.45)] bg-[#201d15] px-3 py-2.5">
+                            <span className="font-mono text-[11px] tracking-[0.1em] text-[#d59220]">06</span>
+                            <span className="text-[13px] font-bold">Dedupe</span>
+                            <span className="text-xs text-[#cbb27e]">
+                                the one pass that crosses all chunks: overlaps merged, already-raised dropped
+                            </span>
+                        </div>
+
+                        <LaneConnector />
+
+                        <div className="mb-2.5 text-center text-[11px] font-semibold tracking-[0.14em] text-[#9aa1a9]">
+                            <GoldBandNumber>07</GoldBandNumber> VALIDATE · BACK IN EACH CHUNK’S LANE, IN PARALLEL
+                        </div>
+
+                        <div className="grid grid-cols-3 gap-3">
+                            {CHUNK_PICKS.map((_, i) => (
+                                <ValidateCard key={i} index={i} />
+                            ))}
+                        </div>
+
+                        <MergeConnector />
+
+                        <div className="flex items-center justify-center gap-2.5">
+                            <div className="rounded-lg bg-[#f0a009] px-[13px] py-[9px] text-xs font-bold text-[#17130a]">
+                                <span className="mr-2 font-mono text-[11px] tracking-[0.1em]">08</span>Review on your PR
+                            </div>
+                            <span className="text-xs text-[#9aa1a9]">one review per PR, only validated findings</span>
+                        </div>
+
+                        <div className="mt-2.5 text-center text-xs text-[#9aa1a9]">
+                            Every reviewer and validator investigates your codebase, not just the diff.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </LemonModal>
+    )
+}

--- a/products/review_hog/frontend/PipelineDetailModal.tsx
+++ b/products/review_hog/frontend/PipelineDetailModal.tsx
@@ -16,6 +16,11 @@ import { reviewHogSettingsLogic } from './reviewHogSettingsLogic'
 const CANVAS_W = 1280
 const CANVAS_H = 720
 
+/** LemonModal's vertical chrome: its max-height offset (60px + 2rem) plus its 1rem top/bottom margins. */
+const MODAL_VERTICAL_CHROME_PX = 124
+/** Scale floor: in a viewport shorter than the modal chrome the canvas overflows, not collapses. */
+const MIN_SCALE = 0.1
+
 /** Shared lane centers: chunk cards, validate cards, and every connector line up on these. */
 const LANES = ['16.667%', '50%', '83.333%'] as const
 
@@ -177,10 +182,13 @@ export function PipelineDetailModal(): JSX.Element {
 
     // LemonModal caps itself at 90% of the viewport width and just under the viewport height; fit
     // the fixed-ratio canvas inside those bounds, never upscaling past the designed size.
-    const scale = Math.min(
-        1,
-        ((windowSize.width ?? CANVAS_W) * 0.9) / CANVAS_W,
-        ((windowSize.height ?? CANVAS_H + 124) - 124) / CANVAS_H
+    const scale = Math.max(
+        MIN_SCALE,
+        Math.min(
+            1,
+            ((windowSize.width ?? CANVAS_W) * 0.9) / CANVAS_W,
+            ((windowSize.height ?? CANVAS_H + MODAL_VERTICAL_CHROME_PX) - MODAL_VERTICAL_CHROME_PX) / CANVAS_H
+        )
     )
 
     return (

--- a/products/review_hog/frontend/reviewHogSettingsLogic.ts
+++ b/products/review_hog/frontend/reviewHogSettingsLogic.ts
@@ -139,6 +139,7 @@ export interface reviewHogSettingsLogicValues {
     perspectiveStatsLoading: boolean
     perspectives: ReviewPerspectiveConfigApi[] | null
     perspectivesLoading: boolean
+    pipelineDetailOpen: boolean
     recentReviews: ReviewRecentReviewApi[] | null
     recentReviewsPage: ReviewRecentReviewsPageApi | null
     recentReviewsPageLoading: boolean
@@ -168,6 +169,9 @@ export interface reviewHogSettingsLogicActions {
     }
     blockSingleActiveDeactivation: (kindLabel: string) => {
         kindLabel: string
+    }
+    closePipelineDetail: () => {
+        value: true
     }
     closeReviewDrawer: () => {
         value: true
@@ -282,6 +286,9 @@ export interface reviewHogSettingsLogicActions {
     ) => {
         validators: ReviewValidatorConfigApi[]
         payload?: any
+    }
+    openPipelineDetail: () => {
+        value: true
     }
     openReviewDetail: (review: ReviewRecentReviewApi) => {
         review: ReviewRecentReviewApi
@@ -417,6 +424,8 @@ export const reviewHogSettingsLogic = kea<reviewHogSettingsLogicType>([
         closeSkillDrawer: true,
         openReviewDetail: (review: ReviewRecentReviewApi) => ({ review }),
         closeReviewDrawer: true,
+        openPipelineDetail: true,
+        closePipelineDetail: true,
         setReviewDrawerTab: (tab: ReviewDrawerTab) => ({ tab }),
         toggleReviewRowExpanded: (reviewId: string) => ({ reviewId }),
         setReviewsScope: (scope: ReviewHogReviewsListScope) => ({ scope }),
@@ -562,6 +571,13 @@ export const reviewHogSettingsLogic = kea<reviewHogSettingsLogicType>([
             {
                 openReviewDetail: () => true,
                 closeReviewDrawer: () => false,
+            },
+        ],
+        pipelineDetailOpen: [
+            false,
+            {
+                openPipelineDetail: () => true,
+                closePipelineDetail: () => false,
             },
         ],
         reviewDrawerTab: [

--- a/services/mcp/src/ui-apps/generated/render-dispatch.generated.tsx
+++ b/services/mcp/src/ui-apps/generated/render-dispatch.generated.tsx
@@ -2,21 +2,61 @@
 import type { App } from '@modelcontextprotocol/ext-apps'
 import { useCallback } from 'react'
 
-import { Component } from '../components/Component'
 import { ActionListView, ActionView, type ActionData, type ActionListData } from 'products/actions/mcp/apps'
 import { LLMCostsView, type LLMCostsData } from 'products/ai_observability/mcp/apps'
 import { CohortListView, CohortView, type CohortData, type CohortListData } from 'products/cohorts/mcp/apps'
-import { ErrorDetailsView, ErrorIssueListView, ErrorIssueView, type ErrorDetailsData, type ErrorIssueData, type ErrorIssueListData } from 'products/error_tracking/mcp/apps'
-import { ExperimentListView, ExperimentResultsView, ExperimentView, type ExperimentData, type ExperimentListData, type ExperimentResultsData } from 'products/experiments/mcp/apps'
-import { FeatureFlagListView, FeatureFlagTestingView, FeatureFlagView, type FeatureFlagData, type FeatureFlagListData, type FeatureFlagTestingData } from 'products/feature_flags/mcp/apps'
+import {
+    ErrorDetailsView,
+    ErrorIssueListView,
+    ErrorIssueView,
+    type ErrorDetailsData,
+    type ErrorIssueData,
+    type ErrorIssueListData,
+} from 'products/error_tracking/mcp/apps'
+import {
+    ExperimentListView,
+    ExperimentResultsView,
+    ExperimentView,
+    type ExperimentData,
+    type ExperimentListData,
+    type ExperimentResultsData,
+} from 'products/experiments/mcp/apps'
+import {
+    FeatureFlagListView,
+    FeatureFlagTestingView,
+    FeatureFlagView,
+    type FeatureFlagData,
+    type FeatureFlagListData,
+    type FeatureFlagTestingData,
+} from 'products/feature_flags/mcp/apps'
 import { InsightActorsView, type InsightActorsData } from 'products/product_analytics/mcp/apps'
-import { SessionRecordingView, SessionSummaryView, type SessionRecordingData, type SessionSummaryData } from 'products/replay/mcp/apps'
-import { SurveyListView, SurveyStatsView, SurveyView, type SurveyData, type SurveyListData, type SurveyStatsData } from 'products/surveys/mcp/apps'
+import {
+    SessionRecordingView,
+    SessionSummaryView,
+    type SessionRecordingData,
+    type SessionSummaryData,
+} from 'products/replay/mcp/apps'
+import {
+    SurveyListView,
+    SurveyStatsView,
+    SurveyView,
+    type SurveyData,
+    type SurveyListData,
+    type SurveyStatsData,
+} from 'products/surveys/mcp/apps'
 import { TraceSpanListView, TraceSpanView, type TraceSpanData, type TraceSpanListData } from 'products/tracing/mcp/apps'
 import { InviteEmailPreviewView, type InviteEmailPreviewData } from 'products/user_interviews/mcp/apps'
-import { EmailTemplateView, WorkflowListView, WorkflowView, type EmailTemplateData, type WorkflowData, type WorkflowListData } from 'products/workflows/mcp/apps'
+import {
+    EmailTemplateView,
+    WorkflowListView,
+    WorkflowView,
+    type EmailTemplateData,
+    type WorkflowData,
+    type WorkflowListData,
+} from 'products/workflows/mcp/apps'
 
 import type { UiAppKey } from '../../resources/ui-apps.generated'
+import { Component } from '../components/Component'
 
 export interface RenderDispatchProps {
     data: unknown
@@ -329,32 +369,34 @@ function WorkflowListContent({ data, app }: { data: WorkflowListData; app: App |
 }
 
 export const RENDER_DISPATCH: Partial<Record<UiAppKey, (props: RenderDispatchProps) => JSX.Element>> = {
-    'action': ({ data }) => <ActionView action={data as ActionData} />,
+    action: ({ data }) => <ActionView action={data as ActionData} />,
     'action-list': ({ data, app }) => <ActionListContent data={data as ActionListData} app={app} />,
-    'cohort': ({ data }) => <CohortView cohort={data as CohortData} />,
+    cohort: ({ data }) => <CohortView cohort={data as CohortData} />,
     'cohort-list': ({ data, app }) => <CohortListContent data={data as CohortListData} app={app} />,
     'email-template': ({ data }) => <EmailTemplateView template={data as EmailTemplateData} />,
     'error-details': ({ data }) => <ErrorDetailsView data={data as ErrorDetailsData} />,
     'error-issue': ({ data }) => <ErrorIssueView issue={data as ErrorIssueData} />,
     'error-issue-list': ({ data, app }) => <ErrorIssueListContent data={data as ErrorIssueListData} app={app} />,
-    'experiment': ({ data }) => <ExperimentView experiment={data as ExperimentData} />,
+    experiment: ({ data }) => <ExperimentView experiment={data as ExperimentData} />,
     'experiment-list': ({ data, app }) => <ExperimentListContent data={data as ExperimentListData} app={app} />,
     'experiment-results': ({ data }) => <ExperimentResultsView data={data as ExperimentResultsData} />,
     'feature-flag': ({ data }) => <FeatureFlagView flag={data as FeatureFlagData} />,
     'feature-flag-list': ({ data, app }) => <FeatureFlagListContent data={data as FeatureFlagListData} app={app} />,
     'feature-flag-testing': ({ data }) => <FeatureFlagTestingView flag={data as FeatureFlagTestingData} />,
-    'insight-actors': ({ data, openLink }) => <InsightActorsView data={data as InsightActorsData} openLink={openLink} />,
+    'insight-actors': ({ data, openLink }) => (
+        <InsightActorsView data={data as InsightActorsData} openLink={openLink} />
+    ),
     'invite-email-preview': ({ data }) => <InviteEmailPreviewView data={data as InviteEmailPreviewData} />,
     'llm-costs': ({ data }) => <LLMCostsView data={data as LLMCostsData} />,
     'query-results': ({ data }) => <Component data={data} />,
     'session-recording': ({ data }) => <SessionRecordingView recording={data as SessionRecordingData} />,
     'session-summary': ({ data }) => <SessionSummaryView data={data as SessionSummaryData} />,
-    'survey': ({ data }) => <SurveyView survey={data as SurveyData} />,
+    survey: ({ data }) => <SurveyView survey={data as SurveyData} />,
     'survey-global-stats': ({ data }) => <SurveyStatsView data={data as SurveyStatsData} />,
     'survey-list': ({ data, app }) => <SurveyListContent data={data as SurveyListData} app={app} />,
     'survey-stats': ({ data }) => <SurveyStatsView data={data as SurveyStatsData} />,
     'trace-span': ({ data }) => <TraceSpanView data={data as TraceSpanData} />,
     'trace-span-list': ({ data, app }) => <TraceSpanListContent data={data as TraceSpanListData} app={app} />,
-    'workflow': ({ data }) => <WorkflowView workflow={data as WorkflowData} />,
+    workflow: ({ data }) => <WorkflowView workflow={data as WorkflowData} />,
     'workflow-list': ({ data, app }) => <WorkflowListContent data={data as WorkflowListData} app={app} />,
 }


### PR DESCRIPTION
## Problem

The "How we review your PRs" section on the Code review scene compresses ReviewHog's pipeline into four short steps. That's not enough to understand (or trust) how a review actually runs: how the diff is chunked, which perspectives look at each chunk, where the blind-spot sweep and dedupe happen, and why only validated findings end up on the PR.

## Changes

- Adds a "Detailed view" modal to the pipeline section: a fixed 1280×720 diagram of the full review flow (meaningful diff → chunks → per-chunk perspectives + blind-spot sweep → cross-chunk dedupe → per-chunk validation → one published review) that scales down uniformly to fit the viewport.
- `reviewHogSettingsLogic` gains `pipelineDetailOpen` state with open/close actions to drive the modal.
- Review feedback addressed: the fit-to-viewport scale is clamped to a positive floor (`MIN_SCALE`) and the modal chrome offset is a named constant (`MODAL_VERTICAL_CHROME_PX`), so viewports shorter than the modal chrome overflow instead of collapsing or mirroring the canvas.

## How did you test this code?

- `oxfmt --check` and `oxlint` (repo-pinned versions) pass on the changed files.
- The clamp fix: previously `window.innerHeight <= 124` produced a scale ≤ 0 (zero-size wrapper, inverted transform); it is now floored at 0.1.
- The agent session that produced the follow-up commit had no runnable frontend stack, so no manual visual check was done there; typechecking and Jest run in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed: the modal is self-describing UI explaining existing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- The detailed-view modal and kea wiring were built in a PostHog Code (Claude Code) session; a follow-up PostHog Code session addressed the Greptile/Copilot review comments (scale clamp + named chrome constant) and filled in this description.
- No repo skills were invoked; validation was pinned-version oxfmt/oxlint on the touched files (no node_modules available in the session, so Jest/typecheck are left to CI).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
