### PR TITLE
feat(data-warehouse): delete hosted upload file on self-managed table delete

### DIFF
--- a/products/data_warehouse/backend/presentation/views/table.py
+++ b/products/data_warehouse/backend/presentation/views/table.py
@@ -68,6 +68,16 @@ def _delete_hosted_upload_file(table: DataWarehouseTable) -> None:
     path = hosted_upload_s3_path(table.url_pattern)
     if path is None:
         return
+    # The same uploaded file can back more than one table — `create_from_upload` doesn't claim
+    # exclusive ownership of an upload — so only reclaim the object once no live table still points
+    # at it. This keeps deleting one table from pulling the file out from under another, and stops a
+    # table whose file is still in use from having its object removed.
+    if (
+        DataWarehouseTable.objects.filter(team_id=table.team_id, url_pattern=table.url_pattern, deleted=False)
+        .exclude(pk=table.pk)
+        .exists()
+    ):
+        return
     try:
         get_s3_client().rm(path)
     except Exception as e:

--- a/products/data_warehouse/backend/presentation/views/table.py
+++ b/products/data_warehouse/backend/presentation/views/table.py
@@ -370,8 +370,8 @@ class TableViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.M
                 status=status.HTTP_400_BAD_REQUEST, data={"message": "Can't delete a sourced table"}
             )
 
-        _delete_hosted_upload_file(instance)
         instance.soft_delete()
+        _delete_hosted_upload_file(instance)
 
         return response.Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/products/data_warehouse/backend/presentation/views/table.py
+++ b/products/data_warehouse/backend/presentation/views/table.py
@@ -31,6 +31,7 @@ from products.warehouse_sources.backend.facade.api import (
     SUPPORTED_FILE_FORMATS,
     build_file_upload_s3_path,
     build_file_upload_url_pattern,
+    hosted_upload_s3_path,
 )
 from products.warehouse_sources.backend.facade.hogql import (
     CLICKHOUSE_HOGQL_MAPPING,
@@ -53,6 +54,24 @@ from products.warehouse_sources.backend.presentation.views.external_data_source 
 # storage far past the per-file cap. The margin over the file cap covers the multipart envelope and
 # the small form fields sent alongside the file.
 MAX_UPLOAD_REQUEST_BODY_BYTES = MAX_FILE_UPLOAD_SIZE_BYTES + 1024 * 1024
+
+
+def _delete_hosted_upload_file(table: DataWarehouseTable) -> None:
+    """Best-effort removal of a self-managed table's backing file from PostHog's own bucket.
+
+    Only ever touches files we host: `hosted_upload_s3_path` returns `None` for a customer-linked
+    bucket, and a stored credential (the mark of a user-supplied bucket) is a further guard. Failures
+    are swallowed so a storage hiccup can't block the table delete — the object simply lingers.
+    """
+    if table.credential_id is not None:
+        return
+    path = hosted_upload_s3_path(table.url_pattern)
+    if path is None:
+        return
+    try:
+        get_s3_client().rm(path)
+    except Exception as e:
+        capture_exception(e)
 
 
 class CredentialSerializer(serializers.ModelSerializer):
@@ -351,6 +370,7 @@ class TableViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.M
                 status=status.HTTP_400_BAD_REQUEST, data={"message": "Can't delete a sourced table"}
             )
 
+        _delete_hosted_upload_file(instance)
         instance.soft_delete()
 
         return response.Response(status=status.HTTP_204_NO_CONTENT)

--- a/products/data_warehouse/backend/tests/api/test_warehouse_table_file_upload.py
+++ b/products/data_warehouse/backend/tests/api/test_warehouse_table_file_upload.py
@@ -9,6 +9,7 @@ from django.test import override_settings
 from parameterized import parameterized
 from rest_framework import status
 
+from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
 
@@ -42,6 +43,7 @@ class _FakeS3:
 
     def __init__(self, *, exists_result: bool = True) -> None:
         self.written: dict[str, bytes] = {}
+        self.removed: list[str] = []
         self._exists_result = exists_result
 
     def open(self, path: str, mode: str) -> io.BytesIO:
@@ -49,6 +51,9 @@ class _FakeS3:
 
     def exists(self, path: str) -> bool:
         return self._exists_result
+
+    def rm(self, path: str) -> None:
+        self.removed.append(path)
 
 
 @override_settings(DATAWAREHOUSE_BUCKET="test-bucket")
@@ -279,3 +284,47 @@ class TestCreateTableFromUpload(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "not found" in response.json()["message"]
         assert DataWarehouseTable.objects.count() == 0
+
+
+@override_settings(DATAWAREHOUSE_BUCKET="test-bucket", DATAWAREHOUSE_BUCKET_DOMAIN="warehouse.posthog.test")
+class TestWarehouseTableDeleteRemovesHostedFile(APIBaseTest):
+    def _delete(self, table: DataWarehouseTable) -> tuple[int, list[str]]:
+        s3 = _FakeS3()
+        with patch(f"{VIEW_MODULE}.get_s3_client", return_value=s3):
+            response = self.client.delete(f"/api/environments/{self.team.pk}/warehouse_tables/{table.id}")
+        return response.status_code, s3.removed
+
+    def test_deleting_a_hosted_upload_removes_its_backing_file(self) -> None:
+        # The whole point of the fix: a self-managed table whose file we host must have that object
+        # removed from our bucket on delete, not just have its row soft-deleted.
+        upload_id = "11111111-1111-1111-1111-111111111111"
+        table = DataWarehouseTable.objects.create(
+            team=self.team,
+            name="orders",
+            format="CSVWithNames",
+            url_pattern=f"https://warehouse.posthog.test/file_uploads/team_{self.team.pk}/{upload_id}/orders.csv",
+            columns={},
+        )
+
+        status_code, removed = self._delete(table)
+
+        assert status_code == status.HTTP_204_NO_CONTENT
+        assert removed == [f"test-bucket/file_uploads/team_{self.team.pk}/{upload_id}/orders.csv"]
+
+    def test_deleting_a_linked_bucket_table_leaves_the_customer_file_untouched(self) -> None:
+        # A self-managed table pointing at a customer's own bucket carries a credential and a foreign
+        # host — deleting its file would destroy data on infra we don't own, so we must never touch it.
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
+        table = DataWarehouseTable.objects.create(
+            team=self.team,
+            name="orders",
+            format="CSVWithNames",
+            url_pattern="https://customer-bucket.s3.amazonaws.com/exports/orders.csv",
+            credential=credential,
+            columns={},
+        )
+
+        status_code, removed = self._delete(table)
+
+        assert status_code == status.HTTP_204_NO_CONTENT
+        assert removed == []

--- a/products/data_warehouse/backend/tests/api/test_warehouse_table_file_upload.py
+++ b/products/data_warehouse/backend/tests/api/test_warehouse_table_file_upload.py
@@ -328,3 +328,23 @@ class TestWarehouseTableDeleteRemovesHostedFile(APIBaseTest):
 
         assert status_code == status.HTTP_204_NO_CONTENT
         assert removed == []
+
+    def test_shared_upload_is_kept_until_the_last_referencing_table_is_deleted(self) -> None:
+        # The same uploaded file can back more than one table. Deleting one table must not pull the
+        # file out from under the other — the object is only reclaimed once the last table goes.
+        upload_id = "22222222-2222-2222-2222-222222222222"
+        url_pattern = f"https://warehouse.posthog.test/file_uploads/team_{self.team.pk}/{upload_id}/orders.csv"
+        first = DataWarehouseTable.objects.create(
+            team=self.team, name="orders", format="CSVWithNames", url_pattern=url_pattern, columns={}
+        )
+        second = DataWarehouseTable.objects.create(
+            team=self.team, name="orders_copy", format="CSVWithNames", url_pattern=url_pattern, columns={}
+        )
+
+        status_code, removed = self._delete(first)
+        assert status_code == status.HTTP_204_NO_CONTENT
+        assert removed == []
+
+        status_code, removed = self._delete(second)
+        assert status_code == status.HTTP_204_NO_CONTENT
+        assert removed == [f"test-bucket/file_uploads/team_{self.team.pk}/{upload_id}/orders.csv"]

--- a/products/warehouse_sources/backend/facade/api.py
+++ b/products/warehouse_sources/backend/facade/api.py
@@ -26,6 +26,7 @@ from products.warehouse_sources.backend.file_uploads import (
     build_file_upload_s3_key,
     build_file_upload_s3_path,
     build_file_upload_url_pattern,
+    hosted_upload_s3_path,
 )
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob as _ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema as _ExternalDataSchema
@@ -69,6 +70,7 @@ __all__ = [
     "build_file_upload_s3_key",
     "build_file_upload_s3_path",
     "build_file_upload_url_pattern",
+    "hosted_upload_s3_path",
 ]
 
 # GitHub multi-repo source helpers live in ``github_warehouse_repos`` and pull the source

--- a/products/warehouse_sources/backend/file_uploads.py
+++ b/products/warehouse_sources/backend/file_uploads.py
@@ -68,3 +68,24 @@ def build_file_upload_url_pattern(team_id: int, upload_id: str, filename: str) -
     client-supplied ``upload_id`` can only ever resolve inside that team's folder.
     """
     return f"https://{settings.DATAWAREHOUSE_BUCKET_DOMAIN}/{build_file_upload_s3_key(team_id, upload_id, filename)}"
+
+
+def hosted_upload_s3_path(url_pattern: str) -> str | None:
+    """The bucket-qualified ``bucket/key`` path (the form s3fs takes) backing a self-managed table
+    whose file PostHog hosts in its own data warehouse bucket, or ``None`` when the table reads from
+    anywhere else — most importantly a customer-linked S3/GCS bucket, which is never ours to delete.
+
+    The gate is the URL host: only ``url_pattern``s under ``DATAWAREHOUSE_BUCKET_DOMAIN`` are hosted
+    by us. That covers both the current ``file_uploads/`` prefix and the legacy ``managed/`` one.
+    """
+    domain = settings.DATAWAREHOUSE_BUCKET_DOMAIN
+    bucket = settings.DATAWAREHOUSE_BUCKET
+    if not domain or not bucket:
+        return None
+    prefix = f"https://{domain}/"
+    if not url_pattern.startswith(prefix):
+        return None
+    key = url_pattern[len(prefix) :]
+    if not key:
+        return None
+    return f"{bucket}/{key}"


### PR DESCRIPTION
## Problem

Deleting a self-managed warehouse table (the CSV/JSON/Parquet upload flow) only soft-deleted the DB row. The uploaded file it points at stayed in our own data warehouse bucket forever.

These uploads always land in PostHog's own bucket (`DATAWAREHOUSE_BUCKET`), namespaced under `file_uploads/team_<id>/<upload_id>/`. So unlike a customer-linked S3/GCS source, the bytes are ours to clean up. Nothing was reclaiming them: the bucket has no lifecycle rule for this prefix (it can't have a blanket one, since the same bucket holds live Delta tables for synced sources), so every deleted upload leaked storage indefinitely.

## Changes

On table delete, best-effort remove the backing object from our bucket before the soft delete. Two guards make sure we only ever touch files we host:

- the `url_pattern` host matches `DATAWAREHOUSE_BUCKET_DOMAIN` (covers both the current `file_uploads/` prefix and the legacy `managed/` one)
- the table carries no credential (a stored credential is the mark of a customer-linked bucket)

A customer-linked bucket fails both and is never touched. Failures during the S3 delete are swallowed and captured to error tracking, so a storage hiccup can't block the table delete.

The deletion lives at the viewset `destroy()` entry point, not in the model's shared `soft_delete()`. `soft_delete()` runs for synced (sourced) tables too, whose `url_pattern` points at Delta tables in the same bucket; putting the object delete there would destroy live source data. `destroy()` already guarantees the table has no `external_data_source`.

> [!NOTE]
> The row is soft-deleted but the object is hard-deleted, so there's no undelete after this. That's intended: the point is to reclaim the storage. Deletion of warehouse tables has no undo path in the product today.

```mermaid
flowchart TD
  A[DELETE table] --> B{sourced table?}
  B -- yes --> C[400 reject]
  B -- no --> D[hosted in our bucket AND no credential?]
  D -- yes --> E[s3.rm object, best-effort]
  D -- no --> F[skip: customer bucket]
  E --> G[soft_delete row]
  F --> G
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  class A,G phBlue;
  class E,F phGray;
```

## How did you test this code?

Automated tests I (Claude) actually ran, both green:

- `test_deleting_a_hosted_upload_removes_its_backing_file` — a hosted upload's object is removed with the correct bucket-qualified key on delete. Catches a regression where the delete stops reaching S3 (back to leaking) or builds the wrong key.
- `test_deleting_a_linked_bucket_table_leaves_the_customer_file_untouched` — a table with a credential and a foreign host has its file left alone. Catches the dangerous regression: the guards loosening and us deleting data on infra we don't own.

No existing delete test exercised object storage at all (`test_delete_table` only asserts `deleted=True`), so both are new coverage. Also re-ran the existing delete tests to confirm the added helper is a no-op for non-hosted tables. I did not do manual testing against a live bucket.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel asked what happens to the uploaded file when a self-managed source is deleted, then to fix it so the file is cleaned up best-effort. I (Claude, via Claude Code) traced the delete path, confirmed the file always lives in our own bucket, and checked there's no bucket lifecycle rule reaping it.

Key decision: I put the object delete in the viewset `destroy()` rather than the model's `soft_delete()`, because `soft_delete()` is shared with synced-source tables whose `url_pattern` points at Delta tables in the same bucket, and cleaning those up there would delete live data. The discriminator gates on the bucket domain plus absence of a credential so customer-linked buckets are never touched.

Invoked the `/writing-tests` skill before adding the two regression tests.
