### PR TITLE
fix(ci): check out the dispatched PR head in hogbox preview frontend build

### DIFF
--- a/.github/workflows/hogbox-preview-env.yml
+++ b/.github/workflows/hogbox-preview-env.yml
@@ -322,6 +322,14 @@ jobs:
                       }
 
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  # A dispatched run would otherwise check out master (the dispatch ref)
+                  # and ship master's SPA as the "PR frontend" — dispatch is the only
+                  # preview path for draft/bot-authored PRs. The PR head is safe here:
+                  # the fork guard above has already hard-failed non-same-repo numbers,
+                  # and this job runs without credentials. pull_request events keep the
+                  # default merge-ref behavior (empty ref).
+                  ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/head', env.PR) || '' }}
 
             # --- Frontend: only build it when the PR actually touches it --------
             # The golden serves the :master SPA; mounting the backend doesn't


### PR DESCRIPTION
## Problem

Hogbox previews triggered via `workflow_dispatch` ship the wrong frontend. The `build-frontend` job's `actions/checkout` has no `ref:`, and on a dispatch event that defaults to **master** — so the job builds master's SPA and swaps it in as the "PR frontend". The box then runs the PR's backend with master's frontend, and any new frontend route in the PR 404s.

Dispatch is the only preview path for draft or bot-authored PRs (the `decide` gate skips them on `pull_request` events), so previews for those PRs were always built wrong. Hit in practice on [#73487](https://github.com/PostHog/posthog/pull/73487): the run log shows `git checkout -B master refs/remotes/origin/master` in "build PR frontend" ([run 30089142821](https://github.com/PostHog/posthog/actions/runs/30089142821)), and the new scene 404'd on the box.

Refs #73487

## Changes

One step changed in `.github/workflows/hogbox-preview-env.yml`: the `build-frontend` checkout gets

```yaml
ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/head', env.PR) || '' }}
```

- `workflow_dispatch` → checks out the dispatched PR's head, so the built dist matches the PR.
- `pull_request` events → expression yields `''`, checkout keeps its default merge-ref behavior, so the automatic preview path is completely unchanged (backward compatible with all in-flight PRs).

Security posture is unchanged: the fork guard step runs *before* this checkout and hard-fails any dispatched PR number whose head isn't in this repo, and `build-frontend` deliberately holds no credentials (`id-token` lives only on deploy/teardown, which still check out the default branch — untouched).

## How did you test this code?

- `bin/hogli lint:workflows` passes (all 6 checks across 104 workflows).
- Will validate end-to-end by dispatching this workflow from this branch for PR #73487 (a dispatched run executes the workflow file at the dispatched ref) and confirming the build-frontend checkout log references `refs/pull/73487/head` and the previously-404ing route renders on the box. Result will be posted here.
- No automated test: workflow trigger/ref resolution isn't exercisable outside GitHub Actions.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed — internal CI behavior; the workflow's own header comments document the trigger paths.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) while debugging why the hogbox preview for #73487 served a 404 for the PR's new route; the assignee asked for the fix as its own PR. Skills invoked: `/authoring-ci-workflows`. Root cause was confirmed from the failing run's checkout log before changing anything; the same finding was also reported via `hogli devex:feedback`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
