### PR TITLE
feat(cymbal): set posthog-python wire-order cutoff at 7.31.0

### DIFF
--- a/rust/cymbal/src/modes/processing/normalization.rs
+++ b/rust/cymbal/src/modes/processing/normalization.rs
@@ -124,7 +124,8 @@ fn lib_rules() -> &'static [LibRule] {
         rules.push(LibRule {
             lib: "posthog-python",
             fix: WireOrderFix::EXCEPTION_LIST,
-            canonical_since: None,
+            // posthog-python ships the flip in 7.30.0 (PostHog/posthog-python#728).
+            canonical_since: Some(Version::new(7, 30, 0)),
         });
 
         rules
@@ -329,6 +330,45 @@ mod test {
         // Natively-canonical SDKs have no legacy order.
         assert!(legacy_wire_order(Some("posthog-node"), &canonical).is_none());
         assert!(legacy_wire_order(None, &canonical).is_none());
+    }
+
+    #[test]
+    fn python_cutoff_gates_exception_list_normalization_by_version() {
+        // Python's fix reverses the exception list (root-cause-first ->
+        // outermost-first), not frames — the gate must key on the same fix.
+        let make_list = || -> ExceptionList {
+            vec![
+                exception_with_frames("RootCause", &["main", "boom"]),
+                exception_with_frames("Wrapper", &["main", "wrap"]),
+            ]
+            .into()
+        };
+
+        for version in [Some("7.29.0"), Some("6.0.0"), Some("garbage"), None] {
+            let mut list = make_list();
+            let legacy = normalize_wire_order(&mut list, Some("posthog-python"), version);
+            assert!(legacy.is_some(), "{version:?} should normalize");
+            assert_eq!(list[0].exception_type, "Wrapper", "list reversed");
+            assert_eq!(
+                frame_names(&list[0]),
+                vec!["main", "wrap"],
+                "frames untouched"
+            );
+        }
+
+        for version in ["7.30.0", "7.30.1", "7.31.0", "8.0.0"] {
+            let mut list = make_list();
+            let legacy = normalize_wire_order(&mut list, Some("posthog-python"), Some(version));
+            assert!(legacy.is_none(), "{version} should pass through");
+            assert_eq!(list[0].exception_type, "RootCause", "list untouched");
+        }
+
+        // Legacy hashing still reconstructs pre-flip list order post-cutoff.
+        let canonical = make_list();
+        let legacy = legacy_wire_order(Some("posthog-python"), &canonical)
+            .expect("reconstruction must ignore the cutoff");
+        assert_eq!(legacy[0].exception_type, "Wrapper");
+        assert_eq!(frame_names(&legacy[0]), vec!["main", "wrap"]);
     }
 
     #[test]

--- a/rust/cymbal/src/modes/processing/normalization.rs
+++ b/rust/cymbal/src/modes/processing/normalization.rs
@@ -124,8 +124,8 @@ fn lib_rules() -> &'static [LibRule] {
         rules.push(LibRule {
             lib: "posthog-python",
             fix: WireOrderFix::EXCEPTION_LIST,
-            // posthog-python ships the flip in 7.30.0 (PostHog/posthog-python#728).
-            canonical_since: Some(Version::new(7, 30, 0)),
+            // posthog-python ships the flip in 7.31.0 (PostHog/posthog-python#728).
+            canonical_since: Some(Version::new(7, 31, 0)),
         });
 
         rules
@@ -344,7 +344,7 @@ mod test {
             .into()
         };
 
-        for version in [Some("7.29.0"), Some("6.0.0"), Some("garbage"), None] {
+        for version in [Some("7.30.1"), Some("7.30.0"), Some("garbage"), None] {
             let mut list = make_list();
             let legacy = normalize_wire_order(&mut list, Some("posthog-python"), version);
             assert!(legacy.is_some(), "{version:?} should normalize");
@@ -356,7 +356,7 @@ mod test {
             );
         }
 
-        for version in ["7.30.0", "7.30.1", "7.31.0", "8.0.0"] {
+        for version in ["7.31.0", "7.31.1", "7.32.0", "8.0.0"] {
             let mut list = make_list();
             let legacy = normalize_wire_order(&mut list, Some("posthog-python"), Some(version));
             assert!(legacy.is_none(), "{version} should pass through");

--- a/rust/cymbal/src/modes/processing/normalization.rs
+++ b/rust/cymbal/src/modes/processing/normalization.rs
@@ -356,19 +356,32 @@ mod test {
             );
         }
 
+        // Post-flip senders emit canonical order: outermost wrapper first.
+        let make_canonical_list = || -> ExceptionList {
+            vec![
+                exception_with_frames("Wrapper", &["main", "wrap"]),
+                exception_with_frames("RootCause", &["main", "boom"]),
+            ]
+            .into()
+        };
+
         for version in ["7.31.0", "7.31.1", "7.32.0", "8.0.0"] {
-            let mut list = make_list();
+            let mut list = make_canonical_list();
             let legacy = normalize_wire_order(&mut list, Some("posthog-python"), Some(version));
             assert!(legacy.is_none(), "{version} should pass through");
-            assert_eq!(list[0].exception_type, "RootCause", "list untouched");
+            assert_eq!(
+                list[0].exception_type, "Wrapper",
+                "canonical list untouched"
+            );
         }
 
-        // Legacy hashing still reconstructs pre-flip list order post-cutoff.
-        let canonical = make_list();
+        // Legacy hashing still reconstructs the pre-flip (root-cause-first)
+        // list order from the canonical stored order post-cutoff.
+        let canonical = make_canonical_list();
         let legacy = legacy_wire_order(Some("posthog-python"), &canonical)
             .expect("reconstruction must ignore the cutoff");
-        assert_eq!(legacy[0].exception_type, "Wrapper");
-        assert_eq!(frame_names(&legacy[0]), vec!["main", "wrap"]);
+        assert_eq!(legacy[0].exception_type, "RootCause");
+        assert_eq!(frame_names(&legacy[0]), vec!["main", "boom"]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The eighth and final SDK flip of the wire-order standardization (PostHog/sdk-specs#11): posthog-python ships `$exception_list` in canonical order — caught/outermost exception first, root cause last — in **7.31.0** (PostHog/posthog-python#728, latest release posthog-v7.30.1 + that PR's lone minor changeset; no other changesets pending on main).

Python is unique in the table: its fix reverses the exception *list*, not frames (python frames were always bottom-up). It's also the mildest flip by construction — single-exception events (the vast majority) are unchanged by the reversal and hash identically either way; only chained-exception events change on the wire.

## Changes

- `posthog-python` gets `canonical_since: Some(7.31.0)`; everything below (or unparseable) keeps having its exception list flipped.
- New gate test asserting the *list-order* semantics specifically: below-cutoff versions get the list reversed with frames untouched, at/above passes through, and legacy reconstruction (re-flipping the list) ignores the cutoff.

## Merge sequencing

1. Re-verify posthog-python's latest `posthog-v*` release is still 7.30.x immediately before merging (other packages in the repo — e.g. the openfeature provider — release independently and don't claim this version stream).
2. Merge this, wait for cymbal autodeploy.
3. Merge PostHog/posthog-python#728 and release as 7.31.0; no other `posthog` package minor in between.

Watch `et-wire-order-launch` as with the previous seven. Highest event volume of the train (~2.9M/day) but the smallest behavioral delta: chained exceptions only, no frame changes, no resolution reshaping — reconstruction is byte-exact.

## How did you test this code?

Automated only: new `python_cutoff_gates_exception_list_normalization_by_version` unit test (16 normalization tests green); clippy `-D warnings` and fmt clean. Eighth instance of the reviewed cutoff pattern. The companion flip branch was rebased onto posthog-python main (58 commits of drift), verified the reversal-removal is intact, with 156 tests + ruff green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Rollout process documented in the sdk-specs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code authored this under my direction as the final step of the flip rollout, following the sequencing contract established across #69837/#70879/#71365/#72350/#72962/#73319. Target version derived from the latest `posthog-v` release plus #728's pending changeset.

