### PR TITLE
fix(data-warehouse): deprovision managed warehouse on organization deletion

### DIFF
--- a/posthog/temporal/delete_teams/__init__.py
+++ b/posthog/temporal/delete_teams/__init__.py
@@ -10,6 +10,7 @@ from posthog.temporal.delete_teams.activities import (
     delete_project_record_activity,
     delete_team_persons_activity,
     delete_team_records_activity,
+    deprovision_managed_warehouse_activity,
     enqueue_clickhouse_deletion_activity,
     queue_recording_deletions_activity,
     send_organization_deleted_email_activity,
@@ -28,6 +29,7 @@ WORKFLOWS = [
 ]
 
 ACTIVITIES = [
+    deprovision_managed_warehouse_activity,
     queue_recording_deletions_activity,
     delete_misc_small_tables_activity,
     delete_personless_distinct_ids_activity,

--- a/posthog/temporal/delete_teams/activities.py
+++ b/posthog/temporal/delete_teams/activities.py
@@ -153,6 +153,24 @@ async def delete_project_record_activity(inputs: ProjectRecordInputs) -> None:
         await database_sync_to_async_pool(delete_project_record)(inputs.project_id)
 
 
+def _deprovision_managed_warehouse(organization_id: str) -> None:
+    from products.data_warehouse.backend.presentation.views.managed_warehouse import deprovision_for_org_deletion
+
+    deprovision_for_org_deletion(organization_id)
+
+
+@temporalio.activity.defn
+async def deprovision_managed_warehouse_activity(inputs: OrganizationRecordInputs) -> None:
+    """Deprovision the org's managed duckgres warehouse (no-op for orgs without one).
+
+    Must run before ``delete_organization_record_activity``: the org-record cascade
+    destroys the ``DuckgresServer`` row, after which the warehouse would be orphaned
+    alive (ingestion, metering, and credentials all still working) with no pointer left.
+    """
+    async with Heartbeater():
+        await database_sync_to_async_pool(_deprovision_managed_warehouse)(inputs.organization_id)
+
+
 def _delete_organization_record(organization_id: str, user_id: int) -> None:
     from posthog.event_usage import report_organization_deletion_completed
     from posthog.models.team.util import delete_organization_record

--- a/posthog/temporal/delete_teams/workflows.py
+++ b/posthog/temporal/delete_teams/workflows.py
@@ -217,25 +217,22 @@ class DeleteOrganizationWorkflow(PostHogWorkflow):
         # below destroys the DuckgresServer pointer, and without this the warehouse would
         # survive the org fully alive — external writers keep ingesting, storage keeps being
         # metered, and its credentials stay valid. Gated with `patched` so in-flight deletions
-        # from before this deploy don't fail replay on a new command. Best-effort after
-        # retries: a duckgres outage must not wedge the org deletion — a warehouse the
-        # retries could not deprovision is logged as an error for manual cleanup.
+        # from before this deploy don't fail replay on a new command. The rest of the deletion
+        # is CONDITIONAL on duckgres accepting the deprovision: proceeding past a failure
+        # would drop the only pointer to a live warehouse and foreclose any later automatic
+        # cleanup, so the activity retries indefinitely with capped backoff (like the bulky
+        # delete phases) — a persistent control-plane outage stalls this workflow visibly
+        # (ops-alertable) and the deletion completes once duckgres is reachable again.
+        # Orgs without a warehouse and already-torn-down warehouses succeed immediately
+        # inside the activity.
         if temporalio.workflow.patched("deprovision-managed-warehouse"):
-            try:
-                await temporalio.workflow.execute_activity(
-                    deprovision_managed_warehouse_activity,
-                    OrganizationRecordInputs(organization_id=inputs.organization_id, user_id=inputs.user_id),
-                    start_to_close_timeout=LIGHT_ACTIVITY_TIMEOUT,
-                    heartbeat_timeout=LIGHT_HEARTBEAT_TIMEOUT,
-                    retry_policy=SIDE_EFFECT_RETRY_POLICY,
-                )
-            except temporalio.exceptions.ActivityError:
-                temporalio.workflow.logger.error(
-                    "deprovision_managed_warehouse_activity failed; continuing organization deletion "
-                    f"— the managed warehouse for organization {inputs.organization_id} must be "
-                    "deprovisioned manually",
-                    exc_info=True,
-                )
+            await temporalio.workflow.execute_activity(
+                deprovision_managed_warehouse_activity,
+                OrganizationRecordInputs(organization_id=inputs.organization_id, user_id=inputs.user_id),
+                start_to_close_timeout=LIGHT_ACTIVITY_TIMEOUT,
+                heartbeat_timeout=LIGHT_HEARTBEAT_TIMEOUT,
+                retry_policy=DELETE_RETRY_POLICY,
+            )
 
         if inputs.team_ids:
             await _delete_teams_data_child(

--- a/posthog/temporal/delete_teams/workflows.py
+++ b/posthog/temporal/delete_teams/workflows.py
@@ -17,6 +17,7 @@ from posthog.temporal.delete_teams.activities import (
     delete_project_record_activity,
     delete_team_persons_activity,
     delete_team_records_activity,
+    deprovision_managed_warehouse_activity,
     enqueue_clickhouse_deletion_activity,
     queue_recording_deletions_activity,
     send_organization_deleted_email_activity,
@@ -212,6 +213,30 @@ class DeleteOrganizationWorkflow(PostHogWorkflow):
 
     @temporalio.workflow.run
     async def run(self, inputs: DeleteOrganizationWorkflowInputs) -> None:
+        # Deprovision the org's managed warehouse (duckgres) first: the org-record cascade
+        # below destroys the DuckgresServer pointer, and without this the warehouse would
+        # survive the org fully alive — external writers keep ingesting, storage keeps being
+        # metered, and its credentials stay valid. Gated with `patched` so in-flight deletions
+        # from before this deploy don't fail replay on a new command. Best-effort after
+        # retries: a duckgres outage must not wedge the org deletion — a warehouse the
+        # retries could not deprovision is logged as an error for manual cleanup.
+        if temporalio.workflow.patched("deprovision-managed-warehouse"):
+            try:
+                await temporalio.workflow.execute_activity(
+                    deprovision_managed_warehouse_activity,
+                    OrganizationRecordInputs(organization_id=inputs.organization_id, user_id=inputs.user_id),
+                    start_to_close_timeout=LIGHT_ACTIVITY_TIMEOUT,
+                    heartbeat_timeout=LIGHT_HEARTBEAT_TIMEOUT,
+                    retry_policy=SIDE_EFFECT_RETRY_POLICY,
+                )
+            except temporalio.exceptions.ActivityError:
+                temporalio.workflow.logger.error(
+                    "deprovision_managed_warehouse_activity failed; continuing organization deletion "
+                    f"— the managed warehouse for organization {inputs.organization_id} must be "
+                    "deprovisioned manually",
+                    exc_info=True,
+                )
+
         if inputs.team_ids:
             await _delete_teams_data_child(
                 DeleteTeamsDataWorkflowInputs(team_ids=inputs.team_ids, user_id=inputs.user_id),

--- a/posthog/temporal/tests/delete_teams/test_workflows.py
+++ b/posthog/temporal/tests/delete_teams/test_workflows.py
@@ -1,4 +1,5 @@
 import uuid
+import datetime as dt
 
 import pytest
 from unittest.mock import patch
@@ -221,10 +222,12 @@ async def test_transient_error_is_retried():
     assert len(attempts) == 2  # retried once, then succeeded
 
 
-async def test_warehouse_deprovision_failure_does_not_block_org_deletion():
-    # Deprovisioning the managed warehouse is best-effort: a duckgres outage must not wedge the
-    # organization deletion — the workflow logs the orphaned warehouse and proceeds once the
-    # activity has exhausted its retries.
+async def test_warehouse_deprovision_failure_blocks_org_record_deletion():
+    # The rest of the org deletion is conditional on duckgres accepting the deprovision: the
+    # org-record cascade destroys the DuckgresServer pointer, so a persistent control-plane
+    # outage must stall the workflow (the activity keeps retrying) rather than orphan a live
+    # warehouse with no pointer left. The execution timeout is test-only, to bound the
+    # otherwise-indefinite retries.
     attempts: list[str] = []
     calls: list[str] = []
 
@@ -246,21 +249,23 @@ async def test_warehouse_deprovision_failure_does_not_block_org_deletion():
             activities=activities,
             workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
         ):
-            await env.client.execute_workflow(
-                DeleteOrganizationWorkflow.run,
-                DeleteOrganizationWorkflowInputs(
-                    team_ids=[1],
-                    organization_id="11111111-1111-1111-1111-111111111111",
-                    user_id=7,
-                    organization_name="org",
-                    project_names=["a"],
-                ),
-                id=str(uuid.uuid4()),
-                task_queue=task_queue,
-            )
+            with pytest.raises(WorkflowFailureError):
+                await env.client.execute_workflow(
+                    DeleteOrganizationWorkflow.run,
+                    DeleteOrganizationWorkflowInputs(
+                        team_ids=[1],
+                        organization_id="11111111-1111-1111-1111-111111111111",
+                        user_id=7,
+                        organization_name="org",
+                        project_names=["a"],
+                    ),
+                    id=str(uuid.uuid4()),
+                    task_queue=task_queue,
+                    execution_timeout=dt.timedelta(hours=1),
+                )
 
-    assert len(attempts) == 5  # exhausted SIDE_EFFECT_RETRY_POLICY, then swallowed
-    assert "delete_organization_record_activity" in calls  # deletion still ran to completion
+    assert len(attempts) > 1  # durably retried until the test-only execution timeout
+    assert calls == []  # nothing else ran — the pointer-destroying cascade never started
 
 
 async def test_recording_deletion_failure_does_not_block_workflow():

--- a/posthog/temporal/tests/delete_teams/test_workflows.py
+++ b/posthog/temporal/tests/delete_teams/test_workflows.py
@@ -45,7 +45,7 @@ CORE_ACTIVITY_ORDER = [
 ]
 
 
-def _recording_activities(calls: list[str]) -> list:
+def _recording_activities(calls: list[str], exclude: frozenset[str] = frozenset()) -> list:
     """Mock every delete_teams activity by name; each records its invocation order."""
 
     def _team_activity(name: str):
@@ -54,6 +54,10 @@ def _recording_activities(calls: list[str]) -> list:
             calls.append(name)
 
         return _fn
+
+    @activity.defn(name="deprovision_managed_warehouse_activity")
+    async def deprovision_managed_warehouse_activity(inputs: OrganizationRecordInputs) -> None:
+        calls.append("deprovision_managed_warehouse_activity")
 
     @activity.defn(name="delete_project_record_activity")
     async def delete_project_record_activity(inputs: ProjectRecordInputs) -> None:
@@ -71,13 +75,15 @@ def _recording_activities(calls: list[str]) -> list:
     async def send_organization_deleted_email_activity(inputs: OrganizationEmailInputs) -> None:
         calls.append("send_organization_deleted_email_activity")
 
-    return [
+    mocks = [
         *[_team_activity(name) for name in CORE_ACTIVITY_ORDER],
+        deprovision_managed_warehouse_activity,
         delete_project_record_activity,
         delete_organization_record_activity,
         send_project_deleted_email_activity,
         send_organization_deleted_email_activity,
     ]
+    return [fn for fn in mocks if fn.__name__ not in exclude]
 
 
 async def _run(workflow, inputs, calls: list[str]) -> None:
@@ -145,6 +151,7 @@ async def test_organization_workflow_deletes_record_then_emails():
         calls,
     )
     assert calls == [
+        "deprovision_managed_warehouse_activity",
         *CORE_ACTIVITY_ORDER,
         "delete_organization_record_activity",
         "send_organization_deleted_email_activity",
@@ -212,6 +219,48 @@ async def test_transient_error_is_retried():
     await _run_core_with(activities)  # completes despite the first failure
 
     assert len(attempts) == 2  # retried once, then succeeded
+
+
+async def test_warehouse_deprovision_failure_does_not_block_org_deletion():
+    # Deprovisioning the managed warehouse is best-effort: a duckgres outage must not wedge the
+    # organization deletion — the workflow logs the orphaned warehouse and proceeds once the
+    # activity has exhausted its retries.
+    attempts: list[str] = []
+    calls: list[str] = []
+
+    @activity.defn(name="deprovision_managed_warehouse_activity")
+    async def failing_deprovision(inputs: OrganizationRecordInputs) -> None:
+        attempts.append("attempt")
+        raise RuntimeError("duckgres control plane unavailable")
+
+    activities = [
+        *_recording_activities(calls, exclude=frozenset({"deprovision_managed_warehouse_activity"})),
+        failing_deprovision,
+    ]
+    task_queue = str(uuid.uuid4())
+    async with await WorkflowEnvironment.start_time_skipping() as env:
+        async with Worker(
+            env.client,
+            task_queue=task_queue,
+            workflows=WORKFLOWS,
+            activities=activities,
+            workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+        ):
+            await env.client.execute_workflow(
+                DeleteOrganizationWorkflow.run,
+                DeleteOrganizationWorkflowInputs(
+                    team_ids=[1],
+                    organization_id="11111111-1111-1111-1111-111111111111",
+                    user_id=7,
+                    organization_name="org",
+                    project_names=["a"],
+                ),
+                id=str(uuid.uuid4()),
+                task_queue=task_queue,
+            )
+
+    assert len(attempts) == 5  # exhausted SIDE_EFFECT_RETRY_POLICY, then swallowed
+    assert "delete_organization_record_activity" in calls  # deletion still ran to completion
 
 
 async def test_recording_deletion_failure_does_not_block_workflow():

--- a/products/data_warehouse/backend/presentation/views/managed_warehouse.py
+++ b/products/data_warehouse/backend/presentation/views/managed_warehouse.py
@@ -285,6 +285,30 @@ def project_reader_namespaces(
     return schemas, relations
 
 
+def _block_if_pending_deletion(organization_id: UUID | str) -> Response | None:
+    """Refuse warehouse-creating calls for an organization whose deletion is underway.
+
+    Organization deletion is asynchronous: ``perform_destroy`` marks the org
+    ``is_pending_deletion`` and hands off to the Temporal workflow, whose first step
+    deprovisions the org's managed warehouse. API-key routes bypass the UI's
+    pending-deletion lockout, so without this guard a caller could provision a NEW
+    warehouse (or add a team row) after that deprovision step and before the org cascade —
+    recreating exactly the orphaned-warehouse hole the workflow closes (the fresh
+    ``DuckgresServer`` row is cascade-deleted without ever being deprovisioned). Every
+    entrypoint that can create duckgres state calls this first; read-only endpoints stay
+    accessible.
+    """
+    # Keep posthog.models off this adapter's import path.
+    from posthog.models.organization import Organization  # noqa: PLC0415
+
+    if Organization.objects.filter(id=organization_id, is_pending_deletion=True).exists():
+        return Response(
+            {"error": "This organization is pending deletion; its managed warehouse can no longer be modified."},
+            status=status.HTTP_409_CONFLICT,
+        )
+    return None
+
+
 def provision(
     organization_id: UUID | str,
     database_name: str | None,
@@ -292,6 +316,9 @@ def provision(
     schema_name: str | None,
     require_enabled: bool = True,
 ) -> Response:
+    pending_deletion = _block_if_pending_deletion(organization_id)
+    if pending_deletion is not None:
+        return pending_deletion
     name_error = validate_warehouse_name(database_name)
     if name_error:
         return Response({"error": name_error}, status=status.HTTP_400_BAD_REQUEST)
@@ -587,6 +614,9 @@ def onboard_team(
     Backend/ops callers (the Django admin) pass `require_enabled=False` to bypass the
     org feature-flag gate.
     """
+    pending_deletion = _block_if_pending_deletion(organization_id)
+    if pending_deletion is not None:
+        return pending_deletion
     if require_enabled and not is_enabled(organization_id):
         return Response({"error": "This feature is not enabled"}, status=status.HTTP_403_FORBIDDEN)
     schema_error = _validate_schema_name(schema_name)

--- a/products/data_warehouse/backend/presentation/views/managed_warehouse.py
+++ b/products/data_warehouse/backend/presentation/views/managed_warehouse.py
@@ -900,9 +900,11 @@ def deprovision_for_org_deletion(organization_id: UUID | str) -> None:
     so unrelated org deletions never touch the control plane). Idempotent against
     duckgres: 404 (warehouse unknown to the control plane) and 409 (teardown already
     started or finished — deprovision is not re-POSTable) are treated as converged. Any
-    other failure raises so the Temporal activity retries; once retries are exhausted the
-    workflow logs loudly and proceeds rather than wedging the org deletion on a duckgres
-    outage.
+    other failure raises so the Temporal activity retries: the org-record deletion (whose
+    cascade drops the ``DuckgresServer`` pointer) is conditional on this call being
+    accepted, so a persistent duckgres outage stalls the deletion workflow — visibly, and
+    resumable once the control plane is reachable — instead of orphaning a live warehouse
+    with no pointer left for any later cleanup.
     """
     # Keep ducklake.models off the core import path.
     from posthog.ducklake.models import DuckgresServer  # noqa: PLC0415

--- a/products/data_warehouse/backend/presentation/views/managed_warehouse.py
+++ b/products/data_warehouse/backend/presentation/views/managed_warehouse.py
@@ -887,6 +887,60 @@ def deprovision(organization_id: UUID | str, require_enabled: bool = True) -> Re
     return resp
 
 
+def deprovision_for_org_deletion(organization_id: UUID | str) -> None:
+    """Deprovision the org's managed warehouse ahead of an organization deletion.
+
+    Called from the organization-deletion Temporal workflow while the ``DuckgresServer``
+    row still exists (the Django cascade destroys it with the org). Without this call the
+    duckgres warehouse outlives the organization fully alive: external writers keep
+    ingesting into it, storage keeps being metered, and its credentials stay valid — while
+    the Django pointer to it is gone.
+
+    No-op for orgs without a managed warehouse (mirrors ``block_team_deletion``'s gating,
+    so unrelated org deletions never touch the control plane). Idempotent against
+    duckgres: 404 (warehouse unknown to the control plane) and 409 (teardown already
+    started or finished — deprovision is not re-POSTable) are treated as converged. Any
+    other failure raises so the Temporal activity retries; once retries are exhausted the
+    workflow logs loudly and proceeds rather than wedging the org deletion on a duckgres
+    outage.
+    """
+    # Keep ducklake.models off the core import path.
+    from posthog.ducklake.models import DuckgresServer  # noqa: PLC0415
+
+    org_id = str(organization_id)
+    if not DuckgresServer.objects.filter(organization_id=organization_id).exists():
+        return
+
+    # Backend caller: bypass the user-facing feature flag so the deletion never depends on
+    # flag evaluation on the Temporal worker.
+    resp = deprovision(organization_id, require_enabled=False)
+    if status.is_success(resp.status_code):
+        logger.info(
+            "Managed warehouse deprovisioning started for organization deletion",
+            organization_id=org_id,
+        )
+        return
+    if resp.status_code in (status.HTTP_404_NOT_FOUND, status.HTTP_409_CONFLICT):
+        logger.info(
+            "Managed warehouse already deprovisioned or unknown to duckgres; continuing organization deletion",
+            organization_id=org_id,
+            status_code=resp.status_code,
+        )
+        return
+    if resp.status_code == status.HTTP_501_NOT_IMPLEMENTED:
+        # DUCKGRES_API_URL is not configured (e.g. a dev/env-var-backed DuckgresServer
+        # row): there is no control plane to deprovision against.
+        logger.warning(
+            "Managed warehouse deprovisioning skipped: provisioning API not configured",
+            organization_id=org_id,
+        )
+        return
+    raise RuntimeError(
+        f"duckgres deprovision failed with status {resp.status_code} for organization {org_id}; "
+        "the org's managed warehouse must be deprovisioned before the Django cascade drops its pointer"
+    )
+
+
 def _remove_direct_connection_sources(organization_id: UUID | str) -> None:
     """Soft-delete the org's auto-created Postgres query connections after deprovisioning."""
     # Keep the data_warehouse/warehouse_sources stack off this adapter's import path.

--- a/products/data_warehouse/backend/tests/api/test_managed_warehouse.py
+++ b/products/data_warehouse/backend/tests/api/test_managed_warehouse.py
@@ -1166,6 +1166,35 @@ def test_deprovision_for_org_deletion_treats_converged_states_as_done(
 
 
 @pytest.mark.django_db
+@patch("products.data_warehouse.backend.presentation.views.managed_warehouse._request")
+def test_provision_rejected_for_org_pending_deletion(mock_request: MagicMock) -> None:
+    # The deletion workflow's deprovision step runs once, early: a warehouse provisioned for a
+    # pending-deletion org afterwards would be cascade-deleted without ever being deprovisioned,
+    # so the control plane must never be reached.
+    org = Organization.objects.create(name="Org", is_pending_deletion=True)
+    team = Team.objects.create(organization=org, name="Env")
+
+    resp = managed_warehouse.provision(org.id, "my-warehouse", team.id, "myschema", require_enabled=False)
+
+    assert resp.status_code == 409
+    assert "pending deletion" in resp.data["error"]
+    mock_request.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.presentation.views.managed_warehouse.create_team")
+def test_onboard_team_rejected_for_org_pending_deletion(mock_create_team: MagicMock) -> None:
+    org = Organization.objects.create(name="Org", is_pending_deletion=True)
+    team = Team.objects.create(organization=org, name="Env")
+
+    resp = managed_warehouse.onboard_team(org.id, team.id, "myschema", require_enabled=False)
+
+    assert resp.status_code == 409
+    assert "pending deletion" in resp.data["error"]
+    mock_create_team.assert_not_called()
+
+
+@pytest.mark.django_db
 @patch("products.data_warehouse.backend.presentation.views.managed_warehouse.deprovision")
 def test_deprovision_for_org_deletion_raises_on_control_plane_error(mock_deprovision: MagicMock) -> None:
     # A transient failure must raise so the Temporal activity retries instead of silently

--- a/products/data_warehouse/backend/tests/api/test_managed_warehouse.py
+++ b/products/data_warehouse/backend/tests/api/test_managed_warehouse.py
@@ -1120,6 +1120,63 @@ def test_block_team_deletion_lets_unonboarded_team_through_on_control_plane_erro
     assert managed_warehouse.block_team_deletion(team.id, org.id) is None
 
 
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.presentation.views.managed_warehouse.deprovision")
+def test_deprovision_for_org_deletion_skips_orgs_without_warehouse(mock_deprovision: MagicMock) -> None:
+    # Orgs with no managed warehouse must never trigger a control-plane call.
+    org = Organization.objects.create(name="Org")
+
+    managed_warehouse.deprovision_for_org_deletion(org.id)
+
+    mock_deprovision.assert_not_called()
+
+
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.presentation.views.managed_warehouse.deprovision")
+def test_deprovision_for_org_deletion_deprovisions_the_orgs_warehouse(mock_deprovision: MagicMock) -> None:
+    # The flag is bypassed: org deletion must not depend on flag evaluation on the Temporal worker.
+    org, _team, _server = _provisioned_org()
+    mock_deprovision.return_value = Response({"status": "deprovisioning started", "org": str(org.id)}, status=202)
+
+    managed_warehouse.deprovision_for_org_deletion(org.id)
+
+    mock_deprovision.assert_called_once_with(org.id, require_enabled=False)
+
+
+@parameterized.expand(
+    [
+        ("unknown_to_duckgres", 404),
+        ("teardown_already_started", 409),
+        ("provisioning_api_not_configured", 501),
+    ]
+)
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.presentation.views.managed_warehouse.deprovision")
+def test_deprovision_for_org_deletion_treats_converged_states_as_done(
+    _name: str, cp_status: int, mock_deprovision: MagicMock
+) -> None:
+    # 404 (no warehouse in duckgres), 409 (teardown already started/finished — deprovision is not
+    # re-POSTable), and 501 (no provisioning API configured) all mean there is nothing to start.
+    org, _team, _server = _provisioned_org()
+    mock_deprovision.return_value = Response({"error": "nope"}, status=cp_status)
+
+    managed_warehouse.deprovision_for_org_deletion(org.id)  # must not raise
+
+    mock_deprovision.assert_called_once_with(org.id, require_enabled=False)
+
+
+@pytest.mark.django_db
+@patch("products.data_warehouse.backend.presentation.views.managed_warehouse.deprovision")
+def test_deprovision_for_org_deletion_raises_on_control_plane_error(mock_deprovision: MagicMock) -> None:
+    # A transient failure must raise so the Temporal activity retries instead of silently
+    # orphaning the warehouse.
+    org, _team, _server = _provisioned_org()
+    mock_deprovision.return_value = Response({"error": "unreachable"}, status=502)
+
+    with pytest.raises(RuntimeError, match="deprovision failed"):
+        managed_warehouse.deprovision_for_org_deletion(org.id)
+
+
 @patch("products.data_warehouse.backend.presentation.views.managed_warehouse.internal_requests")
 @override_settings(DUCKGRES_API_URL="http://duckgres.invalid", DUCKGRES_INTERNAL_SECRET="s")
 def test_update_team_puts_only_passed_fields_to_org_team_route(mock_internal: MagicMock) -> None:


### PR DESCRIPTION
## Why

Deleting an organization never called the managed-warehouse deprovision. The Django cascade dropped the `DuckgresServer` row (`on_delete=CASCADE` — the only pointer to the warehouse) while the duckgres warehouse survived fully alive:

- external-writer discovery kept listing the tenant, so ingestion kept writing into it,
- the storage sampler kept metering it,
- its credentials stayed valid.

The team-deletion guard (`block_team_deletion`) even directs users to *delete the organization* as the sanctioned route for removing a warehouse's last project — which orphaned the warehouse.

## What

- **`managed_warehouse.deprovision_for_org_deletion(organization_id)`**: no-op for orgs without a `DuckgresServer` row (mirrors `block_team_deletion`'s gating, so unrelated org deletions never touch the control plane); otherwise calls the existing `deprovision` adapter with `require_enabled=False` (backend caller — org deletion must not depend on flag evaluation on the Temporal worker). Idempotent against duckgres: 404 (unknown warehouse), 409 (teardown already started/finished — deprovision is not re-POSTable), and 501 (provisioning API not configured) are treated as converged; anything else raises so the activity retries.
- **`deprovision_managed_warehouse_activity`** as the *first* step of `DeleteOrganizationWorkflow` (gated with `workflow.patched("deprovision-managed-warehouse")` so in-flight deletions don't fail replay). Running it in the workflow covers both org-deletion entrypoints (API `perform_destroy` and the Django admin action) with one choke point, and it runs before `delete_organization_record_activity` destroys the `DuckgresServer` row.
- Only the warehouse **deprovision** is issued. The duckgres org record itself is left for the existing manual `delete-org` flow / operators: duckgres refuses to delete the org row while the warehouse still exists (teardown is async, deleting → deleted, with no terminal failed state), so issuing it here would always 409 — same sequencing as the manual UI flow.
- **Pending-deletion guard (TOCTOU)**: `provision` and `onboard_team` — the entrypoints that can create a `DuckgresServer` row or a duckgres team row — now refuse orgs marked `is_pending_deletion` with a clear 409 (shared `_block_if_pending_deletion` helper). API routes bypass the UI's pending-deletion lockout, so without this a caller could provision a *new* warehouse after the workflow's deprovision step and before the org cascade, recreating the orphan. Read-only endpoints stay accessible. The deprovision activity also re-reads the `DuckgresServer` row at execution time, so rows created before it runs are still deprovisioned.

## Failure semantics

**The rest of the org deletion is conditional on duckgres accepting the deprovision.** The activity uses the same unlimited-retries-with-capped-backoff policy as the workflow's other critical delete phases (`DELETE_RETRY_POLICY`), and its failure propagates instead of being swallowed: a persistent control-plane outage visibly stalls the deletion workflow (ops-alertable), and the deletion simply completes later once duckgres is reachable — the `DuckgresServer` pointer survives until then. Rationale: proceeding past a failed deprovision would drop the only pointer to a live warehouse, foreclosing any automatic retry or reconciliation — exactly the orphaned-warehouse bug this PR fixes, reintroduced for the persistent-outage case. Nobody is waiting synchronously (the org is already `is_pending_deletion` and the workflow is async), so blocking is the safe direction. Orgs without a warehouse and already-torn-down warehouses (404/409/501) succeed immediately inside the activity, so unrelated org deletions are unaffected by a duckgres outage.

## Tests

- `test_managed_warehouse.py`: no `DuckgresServer` row → no control-plane call; row present → deprovision called with the org id and `require_enabled=False`; 404/409/501 tolerated as converged; other errors raise for retry. Provision and onboard-team against a pending-deletion org are rejected 409 without touching the control plane.
- `test_workflows.py`: org workflow runs the deprovision activity first, before all other phases; a persistently failing deprovision keeps retrying and the org record is **not** deleted (the workflow stalls until a test-only execution timeout fails it; nothing else runs).
- Ran locally: `posthog/temporal/tests/delete_teams/test_workflows.py` (11 passed) and the non-DB portion of `test_managed_warehouse.py` (17 passed); the new `django_db`-marked tests need a Postgres test DB and are covered by CI. `ruff check`/`ruff format` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
