### PR TITLE
chore(cohorts): quarantine flaky test_cohort_filter_with_extra

### DIFF
--- a/.test_quarantine.json
+++ b/.test_quarantine.json
@@ -1,4 +1,15 @@
 {
     "version": 1,
-    "entries": []
+    "entries": [
+        {
+            "id": "ee/clickhouse/queries/test/test_cohort_query.py::TestCohortQuery::test_cohort_filter_with_extra",
+            "runner": "pytest",
+            "reason": "ClickHouse 26.3.x drops UNION DISTINCT dedup when every branch has ORDER BY; fails until prod US upgrades to CH 26.6",
+            "owner": "@team-feature-flags",
+            "issue": "https://github.com/PostHog/posthog/pull/72896",
+            "added": "2026-07-24",
+            "expires": "2026-08-07",
+            "mode": "run"
+        }
+    ]
 }


### PR DESCRIPTION
## Problem

- `TestCohortQuery::test_cohort_filter_with_extra` intermittently reds master. ClickHouse 26.3.x drops UNION DISTINCT dedup when every branch carries an `ORDER BY`, which is exactly the shape OR-cohorts print. It reddened master ~2h43m on 2026-07-22.
- Same `AssertionError: assert equals failed` on the `clickhouse-server:26.3.10` shard across that incident:
  - [2026-07-22 02:45 — Core POE-on 2/3](https://github.com/PostHog/posthog/actions/runs/29886642430/job/88818792962)
  - [2026-07-22 02:10 — Core POE-on 2/3](https://github.com/PostHog/posthog/actions/runs/29885079105/job/88814262960)
  - [2026-07-22 01:51 — Core POE-off 2/19](https://github.com/PostHog/posthog/actions/runs/29884226598/job/88811710017)

## Changes

- Quarantine that single test (`mode: run`) via `.test_quarantine.json`, expiring 2026-08-07, owner `@team-feature-flags`.
- Stopgap only. The real fix lives in [work around CH 26.3 union distinct dedup loss](https://github.com/PostHog/posthog/pull/72896), a parked draft waiting on the CH 26.6 US rollout. Once 26.6 lands in prod US, both this quarantine and that fix become unnecessary.

> [!NOTE]
> Scoped to the one canary test, not the whole file, so unrelated cohort-query regressions still fail normally.

## How did you test this code?

- No production code changed. `hogli test:quarantine check` passes; the nodeid selector was verified against the file (class `TestCohortQuery`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code. I first quarantined the whole file, then narrowed to the single canary after validating scope against [PR 72896](https://github.com/PostHog/posthog/pull/72896) over the GitHub API, which confirmed only `test_cohort_filter_with_extra` is affected.
- Evidence links above were confirmed by grepping the failed-step logs of each run for the exact `FAILED ... test_cohort_filter_with_extra` line; Trunk independently flags the test as flaky.
- No repo skills invoked beyond the `hogli test:quarantine` tooling.
