### PR TITLE
feat(navigation): drop starred sidebar item, instrument files tree

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -7095,37 +7095,37 @@ snapshots:
     scenes-app-settings-user--settings-user-reminders-modal--light:
         hash: v1.k794b7964.fbcf3f0f69a5b43c28ea7537ce6f1aab3c21e70f9c2cbb6fdfef4546dadba86c.yYIPurSofuNP1kZXYzNBOa3YU5Zy7VLaSegvGrNZ8Mw
     scenes-app-sidepanels--side-panel-access-control--dark:
-        hash: v1.k794b7964.ab76b9589b4b7e1e1ca84725b693b53629f9309f9472966d360b87377f7a7f2c.zbWOHBcSUM1lyU4uwh85J9XpPlcKOJSDMvLJ33AQUAc
+        hash: v1.k794b7964.f17439abc9b2f4bda8f86d2549ea2f2f315d57df346e0e32f04f251377828b62.ZrvqHM9LEHcN6tSqfybToBxgFC4pLc6Tm1ZCjWj2D4A
     scenes-app-sidepanels--side-panel-access-control--light:
-        hash: v1.k794b7964.2e00dbb1d898d398ff8f576ba65d9a2f8a6c828bde46df7ce8d82415dbecd4e4.TlXXdgdFnMaqSL3tyrjLvNGm8D4KDazrs0qyy7XuDHc
+        hash: v1.k794b7964.df9522e07333e83daf56ade57a3f49f93b22336aa35b4446b42def56984ee682.Nqhj4Nmor1i3-j1wsLqJ2PwcHwGj_LeRNcm-A39jphs
     scenes-app-sidepanels--side-panel-activity--dark:
-        hash: v1.k794b7964.7e0a972f5f871f3d297961496d987279afb7492a590651b1c58e9c4b1970d467.kxzi1d-b51DcdDr2BOXtjMvGbfMrz-x5gSbIfA3fHgY
+        hash: v1.k794b7964.f0d28c71ea60e37ca2ba69297689e3d37c4296119999d829196073c5a8e869de.QXT5jt5M1GDwiOPkk66KNUd2iRLWtEbWv9Of6GczHec
     scenes-app-sidepanels--side-panel-activity--light:
-        hash: v1.k794b7964.8926af56d8ff83ce86572e5855559ae0430729e1d5e076affa2485ccf3b8a731.vo7CrYreqcAuSOgoDo8VUYQW8gwyDLlB7JZTzDGWfiY
+        hash: v1.k794b7964.9a7a85ff60769daaeaa660ec6de1883aaed3aa986a4813eb5a870eb472d74ff2.SNW2Fq1YE1AGvfl7M8Zumrij9hFaLxvimTRkajRSoRY
     scenes-app-sidepanels--side-panel-discussion--dark:
-        hash: v1.k794b7964.91d8b06e77607161adbe5f388d2c2bf5349804805a025ef5e034808400da2659.L8ypfATQfuq6LLlmubjBMl2431q7vVCKcF-PbNRAJ5E
+        hash: v1.k794b7964.0fd39b510066088b538009beccfec961f59c794f84d30632df6ede5ba52601f6.sH1JnKc2SKRgefMkPpkifYRvOPdc9ZPrsC0QqPkWVZc
     scenes-app-sidepanels--side-panel-discussion--light:
-        hash: v1.k794b7964.4a35e6ab52e3e1f72b67caaf1069a75529c2a4fe0838c96099f9aac630c315e1.qqhLUdQ13n6oITHLeGeWq7FAemOi46tMEQXLkINsQ6g
+        hash: v1.k794b7964.6ede12e293703215d72de47c08ad7d8431e2d9a0e445f8b0b9a18abb7d27600f._5hsKK_wHKi3AH-HHDNzlRx2gprYL6QzKryj8_n0SmI
     scenes-app-sidepanels--side-panel-exports--dark:
-        hash: v1.k794b7964.fe7a8cd4b30ca44e34d86877cd2acf1e02ecf4ab8fe7e24f4cfc28d18e5d9a7e.mUc1KgNkww7ZJJ6gC5y1fQf95x0TiG-c4_ogL1LavxU
+        hash: v1.k794b7964.d8134e73af2dfa823b83b51dc942fb848304dd4cec0888439eaaad0e9dd8d5f9.zxy_idfLzYTj-HEbyUcXStyHsAVR8HfPUBx5Y6P7QgY
     scenes-app-sidepanels--side-panel-exports--light:
-        hash: v1.k794b7964.ff380b03df8cb6ee5daca928d7b9a4222261924bc3dfbdb27ac0fb5269f9ed6a.-vbFJskzjgLHYMTL9V0EHxay4NFZFkkdgyt5Y1_9dfQ
+        hash: v1.k794b7964.7df2f87888b4546a00efe016a6a4e8b0d44b4b78fcfe0e9ccf0f8be1705922c6.f01kqsTsCFl1uO8DPcXdk--LzZd3tWQuwg_oFwcDsWg
     scenes-app-sidepanels--side-panel-info--dark:
-        hash: v1.k794b7964.ab76b9589b4b7e1e1ca84725b693b53629f9309f9472966d360b87377f7a7f2c.GcaTLH1M9CtK59oIIJF-yE_WOqjJcZZ5eRUpa01zdjI
+        hash: v1.k794b7964.f17439abc9b2f4bda8f86d2549ea2f2f315d57df346e0e32f04f251377828b62.ggqS_aXxe8myZbwo71ICZkm712fHjE1ENAMDmW1imx8
     scenes-app-sidepanels--side-panel-info--light:
-        hash: v1.k794b7964.2e00dbb1d898d398ff8f576ba65d9a2f8a6c828bde46df7ce8d82415dbecd4e4.3X8XboxhJHndd-i_hEb1SjJiNNOrx_a6x5xV5xXm5Pc
+        hash: v1.k794b7964.df9522e07333e83daf56ade57a3f49f93b22336aa35b4446b42def56984ee682.UWJbR-5MPUWR0Ebzw0aDwFIrM9iFR6I7ha7v2O1PTYQ
     scenes-app-sidepanels--side-panel-max--dark:
-        hash: v1.k794b7964.ab76b9589b4b7e1e1ca84725b693b53629f9309f9472966d360b87377f7a7f2c.Fnya1jw63b86cgldD5P0qADIjXNHxMU3H4jVbVbDap8
+        hash: v1.k794b7964.f17439abc9b2f4bda8f86d2549ea2f2f315d57df346e0e32f04f251377828b62.MJvCiu8-npFjoN7gEIJ-Y7ntOc5_cpuHJcTzCLyyxqo
     scenes-app-sidepanels--side-panel-max--light:
-        hash: v1.k794b7964.2f761d3053776fe71e4ded98da3c1298ed674559d620947afe4c5dd862dec04e.6D44uOYc298ot2_QgwUouvdBZUK__ejTwzE9InYoI3M
+        hash: v1.k794b7964.3b1e33fb8a090386379cff87db2f7a5babd0424c348b6a01a14295ede2cb987c.sRwv3JoMNNst7wgD0L08ryPsRfCV8S9bWCek2Z_GDCI
     scenes-app-sidepanels--side-panel-notebooks--dark:
-        hash: v1.k794b7964.7a06ad37e572b3198c73710450cc4e28e7c3099fd30858fab60ca5a40ff0a37c.iosKS3MwgnJ6vjBNTWB8jSFlU1_pgnb50eAO5do3zMc
+        hash: v1.k794b7964.4c018ef7eef641cdaa1e1a0e88d2dcbd5522a39733529249cc89a1f50abbbab6.-jbX3dDHLjM-RwRl1DtW1j7r8XxyCD2dV0poXZwhgJA
     scenes-app-sidepanels--side-panel-notebooks--light:
-        hash: v1.k794b7964.7b25c66c82c3fc40b49a6d31a38da5a8c7629b409d3002f1b0a216a2221e66bb.xsMWO3z7bs3NKggn4rMDNmigeA2iVmLXFuehWuD3Afo
+        hash: v1.k794b7964.4f95fa2d149ef833573fa240bfe88177115c5e7bef6543b1931238c3c0cff7ce.uemaKg-Vg2drs8cMztGDt3Dv1slswbO_YNyqI7cU_ro
     scenes-app-sidepanels--side-panel-support--dark:
-        hash: v1.k794b7964.28a02f4270bc87964944d614522f6512c530906de7c72ac635f8154e802943d0.GQNNBUsCcwGYXzNSgZXeGTXZ2RZLL_Q4y2VUodztSfI
+        hash: v1.k794b7964.0fd64e1c397852c809ef69724691610ab9ad359e2d08d6c733b5f9ead6aa8291.dwo2_aCUYE-BT1n22S0mcFO-v5T-UqzbJ31LnUL50KA
     scenes-app-sidepanels--side-panel-support--light:
-        hash: v1.k794b7964.6f4d33da3ded2438fd7c5bd5b618cc1caf2e355b004b421e78120d33d2c15f8b.6tfLPSZ6q3T8jCH-J6mWbTwIolu2uJ3zyRDL7A3Lpto
+        hash: v1.k794b7964.87cae042d1f0a60a2c843a358cbb0c3ef2acd60284df8de0e84b9b7eb8d5084f.VMPQg6ury8nhCzIjULK0WgJTTN5h0vnVM4OZTx3A8ig
     scenes-app-surveys--new-multi-question-survey-section--dark:
         hash: v1.k794b7964.e4c838e9c192c01eab518de2435a2fef6d3ed65b727fe4c05af61eee010bf03d.yIm_bRCN_65TxDwWd9qVeapTEfZ5QAYSmpJbKKle8Hw
     scenes-app-surveys--new-multi-question-survey-section--light:
@@ -7303,17 +7303,17 @@ snapshots:
     scenes-app-visual-review-run--tracking-only-master-run--light:
         hash: v1.k794b7964.82f2750059b1ef9ab2adb777da603d4d0985b7213235780f24377be11e601a5e.BdVEZ3jDXINsbZgssAvaGfjq_qmGcGOqm2AhdvSYmXg
     scenes-app-web-analytics--web-analytics-dashboard--dark:
-        hash: v1.k794b7964.b8f3c46ceb7184a09413f1690b14e2aa7a2ab69e0c7d5e4a88831b0ab2c0bc1e.AmbpQANFdxUBMXYgPcyjAdkJx0PgbWYWgUlPMhLe5AM
+        hash: v1.k794b7964.d770c1d9b147b468d56e5410243cc97c8c65b946c2e6611c368a17ae75835dd8.cghWPtll7EXT-YRjlGCUuOVgReEsw6JeH3beM9eEO7o
     scenes-app-web-analytics--web-analytics-dashboard--light:
-        hash: v1.k794b7964.125ddde8a36a86a1afca4e0f0087f66233fe71290705cdfc0bdd01f3032e212a.fINztkH45Ovv9xKzbsOvdKe5BnXaJAUdDpf-P3ifyXc
+        hash: v1.k794b7964.0e87c0e8661f6d7f8fc6355921c9d8d8126a23351ac35c7a3eaadfd02596b2c2.96JBTFeICtmoji3VNI057LAKCJ-ALRtNqliqKPX5Lc4
     scenes-app-web-analytics--web-analytics-dashboard-loading--dark:
-        hash: v1.k794b7964.0c540b30c4131b7a443a9176ea31b1d148958071fbedec368b688db607e3292d.gXEHVDOq7woSy4fAiUiZVbRUaiPoJYxX3W3nkM49Cw4
+        hash: v1.k794b7964.2fce58d75a6328600aa6ad670ce4a8430dd4edbc29bf9fe97a0e77fa7582233f.Ot9sYCxJpRY1eubdEIyLW7oF2SWz39XovhQRxkPxppc
     scenes-app-web-analytics--web-analytics-dashboard-loading--light:
-        hash: v1.k794b7964.5c60f267b548fd160974349d81416aff28a67d7ffa5dccb8d089aacb1e508d09.xfEvFiIWkpFanGkg5rZKbB-fMpAXRWy6617NeawKp2Q
+        hash: v1.k794b7964.21e2d9d306d25f7ae9ff7c1633ae495012b4e17988a9b63092b0227408dc24bb.0G_rDxlMNqORis7vhkeF-uLwmCdzU_hkF7sCw5YUMS8
     scenes-app-web-analytics--web-analytics-dashboard-metric-cards--dark:
-        hash: v1.k794b7964.badf3caf9ac303168d6991dc3d1f35e1443e1347e8ee3bd208e2302da2f92c00._ZnyJ86nJYoE0_prJTMniCmZUVu1yu0m7VEFA5-hXdk
+        hash: v1.k794b7964.ecf21b9df25121f536965b32dcf1033fd3b29931df06ce4255f43234b3154c2f.z_B4O2teWs83rPA7XkLpFdKUsNujsI0vE5oCw2nfdbg
     scenes-app-web-analytics--web-analytics-dashboard-metric-cards--light:
-        hash: v1.k794b7964.37b843b19edad6a8cb55c1214386d5910708fda7eadbac15830696a1d3f89742.bfR4KAm2FINsp4lSF840psU3qzPdeuXwqBZOjZ1W_ig
+        hash: v1.k794b7964.ac90ca427590f23d635d7bffff3718decfa20c38212140f5d8d245e841ee5a5a.DZ_hjWjeO651apsTLorzn3bTo9iyLWNp4SdD28GHsP0
     scenes-app-web-analytics-achievements--daily-only-arm--dark:
         hash: v1.k794b7964.8f024a521e113d8101749768f8d4f49d8dcac1365f43d9b2038c6df0021bac6a.BYx467NAatau4dzb13PnZCTODi-yUho-Vhm_JdtCY9w
     scenes-app-web-analytics-achievements--daily-only-arm--light:

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -268,7 +268,7 @@ export function ProjectTree({
                 }
 
                 posthog.capture('project tree item clicked', {
-                    root: root ?? null,
+                    root: root ?? 'project://',
                     item_type: item?.type ?? null,
                     record_type: item?.record?.type ?? null,
                     has_href: !!item?.record?.href,
@@ -298,7 +298,7 @@ export function ProjectTree({
             onFolderClick={(folder, isExpanded) => {
                 if (folder) {
                     posthog.capture('project tree folder toggled', {
-                        root: root ?? null,
+                        root: root ?? 'project://',
                         is_expanded: isExpanded,
                         name: folder.name ?? null,
                     })
@@ -360,7 +360,7 @@ export function ProjectTree({
                     const { newPath, isValidMove } = calculateMovePath(oldItem, folder)
                     if (isValidMove) {
                         posthog.capture('project tree item moved', {
-                            root: root ?? null,
+                            root: root ?? 'project://',
                             item_type: oldItem.type ?? null,
                             method: 'drag',
                         })
@@ -698,7 +698,7 @@ export function ProjectTree({
                             'data-attr': 'tree-panel-enable-multi-select-button',
                             onClick: () => {
                                 posthog.capture('project tree multi-select toggled', {
-                                    root: root ?? null,
+                                    root: root ?? 'project://',
                                     enabled: selectMode === 'default',
                                 })
                                 setSelectMode(selectMode === 'default' ? 'multi' : 'default')

--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -359,6 +359,11 @@ export function ProjectTree({
                 } else {
                     const { newPath, isValidMove } = calculateMovePath(oldItem, folder)
                     if (isValidMove) {
+                        posthog.capture('project tree item moved', {
+                            root: root ?? null,
+                            item_type: oldItem.type ?? null,
+                            method: 'drag',
+                        })
                         moveItem(oldItem, newPath, false, logicKey ?? uniqueKey)
                     }
                 }
@@ -691,7 +696,13 @@ export function ProjectTree({
                         sortMethod !== 'recent' && {
                             tooltip: selectMode === 'default' ? 'Enable multi-select' : 'Disable multi-select',
                             'data-attr': 'tree-panel-enable-multi-select-button',
-                            onClick: () => setSelectMode(selectMode === 'default' ? 'multi' : 'default'),
+                            onClick: () => {
+                                posthog.capture('project tree multi-select toggled', {
+                                    root: root ?? null,
+                                    enabled: selectMode === 'default',
+                                })
+                                setSelectMode(selectMode === 'default' ? 'multi' : 'default')
+                            },
                             active: selectMode === 'multi',
                             'aria-pressed': selectMode === 'multi',
                             children: (

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -14,6 +14,7 @@ import {
 } from 'kea'
 import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
+import posthog from 'posthog-js'
 
 import { IconPlus } from '@posthog/icons'
 import { Spinner } from '@posthog/lemon-ui'
@@ -1192,7 +1193,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             },
         ],
     }),
-    listeners(({ actions, values, key }) => ({
+    listeners(({ actions, values, key, props }) => ({
         setActivePanelIdentifier: () => {
             if (values.searchTerm !== '') {
                 actions.clearSearch()
@@ -1213,7 +1214,15 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         createSavedItem: () => {
             actions.checkSelectedFolders()
         },
-        loadSearchResultsSuccess: () => {
+        loadSearchResultsSuccess: ({ searchResults, payload }) => {
+            // Fire once per settled search term (the 250ms breakpoint cancels intermediate keystrokes),
+            // and only for the first page so pagination doesn't double-count.
+            if (searchResults.searchTerm && (!payload || !payload.offset)) {
+                posthog.capture('project tree searched', {
+                    root: props.root ?? null,
+                    has_results: searchResults.results.length > 0,
+                })
+            }
             actions.checkSelectedFolders()
         },
         deleteSavedItem: () => {
@@ -1356,6 +1365,11 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             }
         },
         moveCheckedItems: ({ path }) => {
+            posthog.capture('project tree items moved', {
+                root: props.root ?? null,
+                count: values.checkedItemCountNumeric,
+                is_bulk: true,
+            })
             const { checkedItems } = values
             let skipInFolder: string | null = null
             for (const item of values.sortedItems) {
@@ -1493,12 +1507,26 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             const splits = splitPath(item.path)
             if (splits.length > 0) {
                 if (value) {
+                    posthog.capture('project tree item renamed', {
+                        root: props.root ?? null,
+                        item_type: item.type ?? null,
+                    })
                     actions.moveItem(item, joinPath([...splits.slice(0, -1), value]), false, key)
                     actions.setEditingItemId('')
                 }
             }
         },
+        deleteItem: ({ item }) => {
+            posthog.capture('project tree item deleted', {
+                root: props.root ?? null,
+                item_type: item.type ?? null,
+            })
+        },
         createFolder: ({ parentPath, editAfter, callback }) => {
+            posthog.capture('project tree folder created', {
+                root: props.root ?? null,
+                is_root_folder: !parentPath,
+            })
             const parentSplits = parentPath ? splitPath(parentPath) : []
             const newPath = joinPath([...parentSplits, 'Untitled folder'])
             actions.addFolder(newPath, editAfter, callback)
@@ -1507,6 +1535,10 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             actions.loadSearchResults(searchTerm)
         },
         setSortMethod: ({ sortMethod }) => {
+            posthog.capture('project tree sort changed', {
+                root: props.root ?? null,
+                sort_method: sortMethod,
+            })
             if (values.searchTerm) {
                 actions.loadSearchResults(values.searchTerm, 0)
             }

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeLogic.tsx
@@ -1219,7 +1219,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             // and only for the first page so pagination doesn't double-count.
             if (searchResults.searchTerm && (!payload || !payload.offset)) {
                 posthog.capture('project tree searched', {
-                    root: props.root ?? null,
+                    root: props.root ?? 'project://',
                     has_results: searchResults.results.length > 0,
                 })
             }
@@ -1365,13 +1365,11 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             }
         },
         moveCheckedItems: ({ path }) => {
-            posthog.capture('project tree items moved', {
-                root: props.root ?? null,
-                count: values.checkedItemCountNumeric,
-                is_bulk: true,
-            })
             const { checkedItems } = values
             let skipInFolder: string | null = null
+            // Count only the moves actually issued — descendants of a moved folder are skipped,
+            // so the checked count would overstate how many items moved.
+            let movedCount = 0
             for (const item of values.sortedItems) {
                 if (skipInFolder !== null) {
                     if (item.path.startsWith(skipInFolder + '/')) {
@@ -1383,11 +1381,17 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
                 const itemId = item.type === 'folder' ? `project://${item.path}` : `project/${item.id}`
                 if (checkedItems[itemId]) {
                     actions.moveItem(item, joinPath([...splitPath(path), ...splitPath(item.path).slice(-1)]), true, key)
+                    movedCount++
                     if (item.type === 'folder') {
                         skipInFolder = item.path
                     }
                 }
             }
+            posthog.capture('project tree items moved', {
+                root: props.root ?? 'project://',
+                count: movedCount,
+                is_bulk: true,
+            })
         },
         linkCheckedItems: ({ path }) => {
             const { checkedItems } = values
@@ -1508,7 +1512,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
             if (splits.length > 0) {
                 if (value) {
                     posthog.capture('project tree item renamed', {
-                        root: props.root ?? null,
+                        root: props.root ?? 'project://',
                         item_type: item.type ?? null,
                     })
                     actions.moveItem(item, joinPath([...splits.slice(0, -1), value]), false, key)
@@ -1518,13 +1522,13 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         },
         deleteItem: ({ item }) => {
             posthog.capture('project tree item deleted', {
-                root: props.root ?? null,
+                root: props.root ?? 'project://',
                 item_type: item.type ?? null,
             })
         },
         createFolder: ({ parentPath, editAfter, callback }) => {
             posthog.capture('project tree folder created', {
-                root: props.root ?? null,
+                root: props.root ?? 'project://',
                 is_root_folder: !parentPath,
             })
             const parentSplits = parentPath ? splitPath(parentPath) : []
@@ -1536,7 +1540,7 @@ export const projectTreeLogic = kea<projectTreeLogicType>([
         },
         setSortMethod: ({ sortMethod }) => {
             posthog.capture('project tree sort changed', {
-                root: props.root ?? null,
+                root: props.root ?? 'project://',
                 sort_method: sortMethod,
             })
             if (values.searchTerm) {

--- a/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/tabs/NavTabBrowse.tsx
@@ -72,11 +72,6 @@ const panelTriggerItems: {
         label: 'Tools',
         icon: <IconApps />,
     },
-    {
-        identifier: 'Shortcuts',
-        label: 'Starred',
-        icon: <IconStar />,
-    },
 ]
 
 function getItemName(item: FileSystemEntry): string {


### PR DESCRIPTION
## Problem

Closes GROW-217

Two asks came out of a Slack thread (linked below):

1. The "Starred" item in the left navigation is being retired, so it should no longer show up in the sidebar.
2. The Files feature (the project tree) had almost no product analytics, so we couldn't tell how people actually use it.

## Changes

- Removed the `Shortcuts` / "Starred" entry from `panelTriggerItems` in `NavTabBrowse`, so it no longer renders in the browse tab. The underlying shortcuts logic and the "Add to starred" action on recent items are untouched.
- Added usage instrumentation to the Files tree, mostly in `projectTreeLogic` so it fires regardless of which UI path triggers the action, plus a couple of interaction-only events in `ProjectTree`. Every event carries the tree `root` so the Files tree (`project://`) can be isolated from the other trees that reuse the same component.

New events: `project tree folder created`, `project tree item renamed`, `project tree item deleted`, `project tree items moved` (bulk), `project tree item moved` (drag), `project tree searched`, `project tree sort changed`, `project tree multi-select toggled`. These sit alongside the existing `project tree item clicked` and `project tree folder toggled`.

Context: https://posthog.slack.com/archives/C0113360FFV/p1784832773192549

## How did you test this code?

I (Claude) could not run the frontend toolchain in this environment (`node_modules` not installed, so typecheck / lint / typegen did not run). Changes are limited to adding `posthog.capture` calls and removing one array entry, following the existing capture patterns already in these files. No automated tests were added or run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code). I located the Files feature (the ProjectTree / file-system panel) and the "Starred" nav trigger, then added the instrumentation in the kea logic rather than the component so events fire from any entry point. Care was taken to merge captures into existing `loadSearchResultsSuccess` and `moveCheckedItems` listeners instead of declaring duplicate listener keys, which would have silently shadowed the real handlers. I was unable to read the linked Slack thread (auth-gated, no Slack tool available) and worked from the task description.
---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
