### PR TITLE
perf(warehouse_sources): speed up the new-source catalog page

### DIFF
--- a/products/data_warehouse/frontend/shared/components/SourceIcon.tsx
+++ b/products/data_warehouse/frontend/shared/components/SourceIcon.tsx
@@ -70,6 +70,11 @@ function SourceIconImage({ src, alt, sizePx }: { src: string; alt: string; sizeP
             alt={alt}
             height={sizePx}
             width={sizePx}
+            // The catalog renders every source's icon at once (1000+ tiles). Without lazy loading the
+            // browser eagerly requests all of them on mount, flooding the network and delaying paint —
+            // only the icons scrolled into view need to load.
+            loading="lazy"
+            decoding="async"
             className="object-contain max-w-none rounded"
             onError={(e) => {
                 const img = e.currentTarget

--- a/products/warehouse_sources/backend/presentation/views/external_data_source.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_source.py
@@ -13,6 +13,7 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import connection, transaction
 from django.db.models import Prefetch, Q
 from django.utils import timezone
+from django.utils.cache import patch_cache_control
 
 import structlog
 import temporalio
@@ -4356,7 +4357,13 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 )
             configs = {st: config for st, config in configs.items() if st in requested_types}
 
-        return Response(status=status.HTTP_200_OK, data=configs)
+        response = Response(status=status.HTTP_200_OK, data=configs)
+        # The catalog is deploy-static and identical for every user (no team/user input), so let the
+        # browser reuse it across navigations instead of re-downloading and re-parsing several hundred
+        # KB on each visit to the new-source page. `private` because the route is auth-gated; a new
+        # source ships at most once per deploy, so a short freshness window is safe.
+        patch_cache_control(response, private=True, max_age=600)
+        return response
 
     @extend_schema(
         parameters=[

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source.py
@@ -7833,9 +7833,9 @@ class TestExternalDataSource(APIBaseTest):
         assert response.status_code == 200
         assert payload is not None
         # The deploy-static catalog is browser-cacheable so repeat visits skip re-downloading it.
-        cache_control = response.headers["Cache-Control"]
-        assert "private" in cache_control
-        assert "max-age=600" in cache_control
+        directives = response.headers["Cache-Control"].split(", ")
+        assert "private" in directives
+        assert "max-age=600" in directives
 
     @parameterized.expand(
         [

--- a/products/warehouse_sources/backend/tests/api/test_external_data_source.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_source.py
@@ -7832,6 +7832,10 @@ class TestExternalDataSource(APIBaseTest):
         payload = response.json()
         assert response.status_code == 200
         assert payload is not None
+        # The deploy-static catalog is browser-cacheable so repeat visits skip re-downloading it.
+        cache_control = response.headers["Cache-Control"]
+        assert "private" in cache_control
+        assert "max-age=600" in cache_control
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

The **New data pipeline source** page (`/project/:id/pipeline/new/source`) is slow to load.

The catalog now lists **1000+** connectors. Two things make the page heavy:

1. **~1000+ icon requests fire at once.** Each catalog tile renders an `<img>` for the source logo, and the grid renders every source (no virtualization). With default eager loading, the browser requests all ~1000 logos on mount — a network flood that delays first paint.
2. **The catalog payload is re-fetched and re-parsed on every visit.** The `external_data_sources/wizard` response (a few hundred KB) has no cache headers, so navigating to the page always re-downloads and re-parses the whole catalog — even though it's identical for every user and only changes on deploy.

The obvious server-side wins were already in place (gzip allow-list entry, `functools.cache`, dropping the docs-only `tables`), so these two target what's left.

## Changes

- **Lazy-load source icons** — add `loading="lazy"` + `decoding="async"` to the catalog icon `<img>`, so only icons scrolled into view are requested.
- **Browser-cache the wizard catalog** — set `Cache-Control: private, max-age=600` on the wizard response. The catalog is deploy-static and has no per-user/per-team content, so repeat visits within the window skip the download and re-parse entirely.

## How did you test this code?

- Added one assertion to the existing `test_get_wizard_sources` locking in the `Cache-Control` header (guards against silently dropping browser caching). No local Postgres/CI DB was available in this environment to execute the Django test suite; `ruff` passes on the changed backend files.
- The frontend change is two standard HTML image attributes.

### Follow-ups worth considering (not in this PR)
- **Slim the catalog payload**: the grid only needs metadata (name/label/icon/category/keywords), not the per-source `fields` form schemas. Those could be fetched on demand when a source is selected (the endpoint already supports `?source_type=`). Bigger win on transfer/parse, but touches the wizard form flow, so left for a separate change.
- **Virtualize or cap the browse grid** so it doesn't mount 1000+ tiles when browsing "All sources".

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated the slow-load report with PostHog Code (Claude). Traced the render path (`SourceCatalog` → `SourceTile` → `SourceIcon`) and the data path (`availableSourcesLogic` → `external_data_sources/wizard` → `build_source_configs`). Confirmed the catalog registers 1000+ sources, the grid renders all tiles unvirtualized, icons load eagerly, and the wizard response carries no cache headers (while gzip/`functools.cache`/`include_tables=False` were already done). Chose the two lowest-risk, highest-leverage fixes and left the payload-slimming and virtualization work as proposed follow-ups since they carry UX/flow risk.

Skills invoked: `/improving-drf-endpoints` (viewset change), `/writing-tests` (test assertion).


---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
