### PR TITLE
fix(workflows): guard conditional branch render against missing config array

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5053,7 +5053,7 @@ snapshots:
     replay-scenes-group--group-events-tab-with-modal-not-found--dark:
         hash: v1.k794b7964.1326c64c54c2a719ef5e25d56ccd0a81aae74fdaaafb2aabe6994e9d34160406.MiSJPVzJoZFlKF5pViwuZUD-BTkuqq_m83d96uJy7bY
     replay-scenes-group--group-events-tab-with-modal-not-found--light:
-        hash: v1.k794b7964.1f70b90562d7d6f31e687dd47360c5c9e3ec9111b39443da3b56fa2532f534d5.IXrpXBGBprUBLitWrw_qN9Ee7JLn76tyJ-QeOniJKtY
+        hash: v1.k794b7964.a6ae7283986232e26123783358c3991b853b37e393bc0f846a648364249cdf6c.tzQYw0ED7oQFd1x7CLAuYcFrQoOirZMRh3X_5E5a5b4
     replay-scenes-group--group-recording-tab-empty--dark:
         hash: v1.k794b7964.0660887202ba71055373168f4b9df5cdc8251c89f0f96b77c4b3196845362f70.VFxGeaTyLzGuovqDxnkS9wWUmq2J0edku92QEPb1mJI
     replay-scenes-group--group-recording-tab-empty--light:
@@ -5587,7 +5587,7 @@ snapshots:
     scenes-app-dashboards--show-without-post-hog-ai-button-label--wide--light:
         hash: v1.k794b7964.bdf731e7da5ee6a208a690c18c0d5e38bd06011b383c57f526196da0f91f829c.1hMJmP7uN1mi3H6iqZFeDmGORCs42h4JJm5-VWxN9Rs
     scenes-app-dashboards--view-only-dashboard--dark:
-        hash: v1.k794b7964.a65acee97de57aeef30368365580e0e2c962193d6215acf55dac639823cb0ca8.zkO7nnEw6JoWOSq1KJ1DQrXzCI1FSmD0yzRsrMwcfA0
+        hash: v1.k794b7964.e15bc2243afd7e6692e7a30f3b077d727ba9ffa64c3c978c2dfe119564bf06da.M0ASGjGeENcp9BtMk92sx0r3HSFt4NsPJkjSzJCfd4k
     scenes-app-dashboards--view-only-dashboard--light:
         hash: v1.k794b7964.7ebc4aa50c00cbfa580fd96d32ef6565a6bd399e1ae6289278d36309c89e87f1.9xwqldb2HI9IewJABGeU3kmuyGXS-hwbloJgjznVypQ
     scenes-app-dashboards-add-insight-to-dashboard-modal--default--dark:

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -21,7 +21,7 @@ export function StepConditionalBranchConfiguration({
     node: Node<Extract<HogFlowAction, { type: 'conditional_branch' }>>
 }): JSX.Element {
     const action = node.data
-    const { conditions } = action.config
+    const conditions = action.config.conditions ?? []
 
     const { edgesByActionId } = useValues(hogFlowEditorLogic)
     const { setWorkflowAction, setWorkflowActionEdges } = useActions(hogFlowEditorLogic)

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
@@ -19,7 +19,7 @@ export function StepRandomCohortBranchConfiguration({
     node: Node<Extract<HogFlowAction, { type: 'random_cohort_branch' }>>
 }): JSX.Element {
     const action = node.data
-    const { cohorts } = action.config
+    const cohorts = action.config.cohorts ?? []
 
     const { edgesByActionId } = useValues(hogFlowEditorLogic)
     const { setWorkflowAction, setWorkflowActionEdges } = useActions(hogFlowEditorLogic)

--- a/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
@@ -61,12 +61,12 @@ export function useDebouncedNameInputs<T extends { name?: string }>(
     localNames: (string | undefined)[]
     handleNameChange: (index: number, value: string | undefined) => void
 } {
-    const [localNames, setLocalNames] = useState<(string | undefined)[]>(items.map((item) => item.name))
+    const [localNames, setLocalNames] = useState<(string | undefined)[]>((items ?? []).map((item) => item.name))
 
     // Update local state when items change from external sources
     useEffect(() => {
-        setLocalNames(items.map((item) => item.name))
-    }, [items.length, items]) // Only update when number of items changes
+        setLocalNames((items ?? []).map((item) => item.name))
+    }, [items?.length, items]) // Only update when number of items changes
 
     // Debounced function to update items
     const debouncedUpdate = useDebouncedCallback((index: number, value: string | undefined) => {


### PR DESCRIPTION
## Problem

The workflow editor's conditional-branch node detail panel crashes on render for some workflows. When a user opens a `split` (conditional branch) node, the panel throws `Cannot read properties of undefined (reading 'map')` and the content fails to render.

Root cause: `StepConditionalBranchConfiguration` and `StepRandomCohortBranchConfiguration` destructure `config.conditions` / `config.cohorts` and immediately `.map` over them — both directly in the JSX and inside the shared `useDebouncedNameInputs` hook, which runs first on mount. The zod schema types these arrays as required, so the components carry no fallback. If an action's `config` is missing the array (a partially-migrated or malformed node), the value is `undefined` at runtime and the first `.map` throws, taking down the whole panel.

Surfaced from a Slack thread: a user hit this repeatedly opening `?node=split-1` on a workflow, with the same client-side exception firing every time.

## Changes

- `StepConditionalBranch.tsx`: default `conditions` to `[]` where it enters the component.
- `StepRandomCohortBranch.tsx`: default `cohorts` to `[]` where it enters the component.
- `utils.ts` (`useDebouncedNameInputs`): guard the internal `.map` so an undefined list can't throw for any caller.

With the arrays defaulting to `[]`, a node with no conditions/cohorts now renders the empty panel with its "Add condition" / "Add cohort" button instead of crashing.

## How did you test this code?

I (an agent) made the edits and reasoned through the render paths; I did not run the app or add automated tests in this pass. A focused regression test — rendering each step config with `config.conditions` / `config.cohorts` undefined — would be a good follow-up. The change is a narrow, type-safe defensive default.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread reporting the conditional-branch UI failing to render. Traced the reported client-side `$exception` to the `split` node config panels, confirmed the deterministic crash on first render, and applied defensive `?? []` defaults at the value's entry points plus a guard in the shared hook. No repo skills were required for this frontend change. Assignee left unset because the driver's GitHub handle wasn't verified this session — the owning team should route it.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1784901016853839?thread_ts=1784901016.853839&cid=C0ACRAMJUAG)*
