### PR TITLE
fix(data-warehouse): clarify error when source URL points at internal bucket

### DIFF
--- a/products/data_warehouse/backend/presentation/views/table.py
+++ b/products/data_warehouse/backend/presentation/views/table.py
@@ -209,7 +209,10 @@ class TableSerializer(UserAccessControlSerializerMixin, serializers.ModelSeriali
     def validate_url_pattern(self, url_pattern):
         s3_domain = settings.DATAWAREHOUSE_BUCKET_DOMAIN
         if s3_domain in url_pattern:
-            raise serializers.ValidationError("Cant use this bucket")
+            raise serializers.ValidationError(
+                "This URL points to PostHog's internal storage and can't be used as a source. "
+                "Enter the location of your own bucket instead."
+            )
 
         is_valid, error_message = validate_warehouse_table_url_pattern(url_pattern)
         if not is_valid:


### PR DESCRIPTION
## Problem

When someone links a self-managed data warehouse source and enters a URL that
points at PostHog's own internal storage, the create/update request was rejected
with the message `Cant use this bucket` — a typo, with no explanation of what was
wrong or what to do next. This surfaced in real onboarding sessions as an
unexplained save failure that led users to abandon and delete the source.

## Changes

Replace the terse, typo'd validation error with an actionable message:

> This URL points to PostHog's internal storage and can't be used as a source.
> Enter the location of your own bucket instead.

This matches the sentence style of the other URL-pattern validation messages in
the same flow (`validate_warehouse_table_url_pattern`). No behavior change — the
same URLs are accepted/rejected as before, only the message text changed.

## How did you test this code?

Automated: ran `ruff check` and `ruff format --check` over the changed file (both
pass). No existing test asserted the old string. The change is a pure copy edit to
an existing `ValidationError` message; the validation logic is unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found while synthesizing friction themes from data-warehouse new-source onboarding
sessions: a user uploaded a CSV, then hit `Cant use this bucket` when saving the
resulting self-managed source's settings and gave up. This PR only fixes the
user-facing copy; the separate question of why editing a CSV-backed self-managed
source can re-trigger this validation is left as a follow-up, not addressed here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
