### PR TITLE
fix(hogql): suggest posthog. prefix for unknown data-plane tables

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -605,21 +605,46 @@ class Database(BaseModel):
         """
         import difflib
 
+        suggestions: list[str] = []
+
+        # Deterministic first: the data-plane tables (`ai_events`, `trace_spans`, `metrics`, …)
+        # live *only* under the `posthog.` namespace, so a bare `FROM ai_events` is the single
+        # most common unknown-table mistake. Fuzzy matching scores several of these just below
+        # any sane cutoff (`ai_events`/`posthog.ai_events` ≈ 0.69), so suggest the qualified
+        # name explicitly rather than leaving it to difflib.
+        qualified = self._suggest_posthog_qualified_name(name)
+        if qualified:
+            suggestions.append(qualified)
+
         try:
             candidates = set(self.get_posthog_table_names())
             candidates.update(self._warehouse_table_names)
             candidates.update(self._warehouse_self_managed_table_names)
             candidates.update(self._view_table_names)
         except Exception:
-            return []
+            return suggestions
         # Drop any candidate that matches the input — suggesting `persons` for `persons`
         # is noise, and on a direct connection the same name can exist in the broader
         # catalog without being available on the source we actually queried.
         lowered = name.casefold()
-        candidates = {c for c in candidates if c.casefold() != lowered}
-        if not candidates:
-            return []
-        return difflib.get_close_matches(name, sorted(candidates), n=limit, cutoff=0.7)
+        candidates = {c for c in candidates if c.casefold() != lowered and c not in suggestions}
+        for match in difflib.get_close_matches(name, sorted(candidates), n=limit, cutoff=0.7):
+            if match not in suggestions:
+                suggestions.append(match)
+        return suggestions[:limit]
+
+    def _suggest_posthog_qualified_name(self, name: str) -> str | None:
+        """If `name` is a bare table that only exists under the `posthog.` namespace,
+        return its fully-qualified name (e.g. `ai_events` -> `posthog.ai_events`)."""
+        if "." in name:
+            return None
+        try:
+            qualified = f"posthog.{name}"
+            if qualified in self.get_posthog_table_names(include_hidden=True):
+                return qualified
+        except Exception:
+            return None
+        return None
 
     def get_all_table_names(self) -> list[str]:
         warehouse_table_names: list[str] = []

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -224,6 +224,15 @@ class TestDatabase(BaseTest, QueryMatchingTest):
             Database.create_for(team_id=missing_team_id)
         self.assertIn(str(missing_team_id), str(cm.exception))
 
+    @parameterized.expand(["ai_events", "trace_spans", "metrics"])
+    def test_unknown_bare_data_plane_table_suggests_posthog_prefix(self, bare_name: str):
+        # These tables live only under the `posthog.` namespace; a bare `FROM ai_events`
+        # is the most common unknown-table mistake and fuzzy matching alone misses it.
+        database = Database.create_for(team=self.team)
+        with self.assertRaises(QueryError) as cm:
+            database.get_table(bare_name)
+        self.assertIn(f"Did you mean: posthog.{bare_name}", str(cm.exception))
+
     @pytest.mark.usefixtures("unittest_snapshot")
     def test_serialize_database_no_person_on_events(self):
         with override_settings(PERSON_ON_EVENTS_V2_OVERRIDE=False):


### PR DESCRIPTION
## Problem

Agents (and humans) writing HogQL repeatedly trip over the observability data-plane tables — `ai_events`, `trace_spans`, `metrics` — which are registered **only** under the `posthog.` namespace. A bare `FROM ai_events` errors with `Unknown table \`ai_events\`.` and, critically, no hint about the correct name, so agents conclude the table "isn't queryable" and give up. This came up from a Slack thread where an investigation agent hit exactly this dead-end.

The `Unknown table` error already runs a fuzzy "Did you mean" suggester, but it never helped here: the `posthog.`-qualified names weren't in its candidate pool at all, and even scored directly `ai_events` → `posthog.ai_events` (~0.69) falls just below the 0.7 difflib cutoff (`metrics` too; only `trace_spans` squeaked over). The error message is the highest-leverage place to steer, since it lands in-context exactly when the agent is stuck — prompt/skill guidance already documents the prefix but clearly isn't surviving.

## Changes

Add a deterministic check to `_suggest_table_names`: if a bare name exists only under the `posthog.` namespace, suggest the fully-qualified name first (e.g. `Did you mean: posthog.ai_events?`). Fuzzy matching stays as a fallback for genuine typos.

## How did you test this code?

Added a parameterized test in `TestDatabase` covering `ai_events`, `trace_spans`, and `metrics` — asserts `get_table("ai_events")` raises `QueryError` whose message includes `Did you mean: posthog.ai_events`. This catches the regression where the qualified suggestion is dropped and the three data-plane tables again error with no usable hint; no existing test covered it. Ran `ruff format`/`ruff check` on both files (pass). I was not able to run the ClickHouse/Django-backed test suite in this environment (toolchain unavailable), so the new test has not been executed here — I verified the suggestion logic in isolation against a stub of the catalog methods.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Investigated where the `posthog.` prefix guidance lives across the MCP `execute-sql` prompt, the `querying-posthog-data` skill, and the AI-observability skills, then chose the error-message path as the most robust fix (it fires regardless of whether the agent read the prompt). Invoked the `/writing-tests` skill before adding the test. A companion nudge for the silent `information_schema` 0-rows discovery path (which raises no error to enrich) is noted as a follow-up for the AI-eng team.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784894600983909?thread_ts=1784894600.983909&cid=C087XQ7K9K7)*
