### PR TITLE
feat(conversations): add dynamic "me" assignee filter

### DIFF
--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -1076,6 +1076,41 @@ class TestTicketAssignment(APIBaseTest):
         returned_ids = {result["id"] for result in response.json()["results"]}
         self.assertEqual(returned_ids, {str(tickets[key].id) for key in expected_keys})
 
+    def test_filter_by_me_resolves_to_requesting_user(self):
+        """The dynamic `me` token filters to whoever is making the request."""
+        TicketAssignment.objects.create(ticket=self.ticket, user=self.user)
+
+        other_user = User.objects.create_and_join(self.organization, "other-me@posthog.com", None)
+        other_ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.WIDGET,
+            widget_session_id="other-session",
+            distinct_id="other-user",
+        )
+        TicketAssignment.objects.create(ticket=other_ticket, user=other_user)
+
+        response = self.client.get(f"/api/projects/{self.team.id}/conversations/tickets/?assignee=me")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["results"][0]["id"], str(self.ticket.id))
+
+    def test_filter_by_me_combined_with_unassigned(self):
+        """`me` composes with other assignee entries in a match-any list."""
+        TicketAssignment.objects.create(ticket=self.ticket, user=self.user)
+        unassigned_ticket = Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.WIDGET,
+            widget_session_id="unassigned-session",
+            distinct_id="unassigned-user",
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/conversations/tickets/?assignee=me,unassigned")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        returned_ids = {result["id"] for result in response.json()["results"]}
+        self.assertEqual(returned_ids, {str(self.ticket.id), str(unassigned_ticket.id)})
+
     def test_assignment_logs_activity(self):
         """Test that assignment changes are logged in activity log."""
         response = self.client.patch(

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -408,6 +408,11 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
                 entry = raw_entry.strip()
                 if entry.lower() == "unassigned":
                     include_unassigned = True
+                elif entry.lower() == "me":
+                    # Dynamic per-viewer token: resolve to the requesting user so a
+                    # shared saved view scoped to "me" means each viewer's own tickets.
+                    if self.request.user and self.request.user.is_authenticated:
+                        user_ids.append(self.request.user.id)
                 elif entry.startswith("user:"):
                     try:
                         user_ids.append(int(entry[5:]))
@@ -708,7 +713,8 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
                 description=(
                     "Filter by assignee. Accepts a single value or a comma-separated list "
                     "(matches any, max 100 entries). Each entry is `unassigned` (no assignee), "
-                    "`user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`."
+                    "`me` (the requesting user), `user:<user_id>`, or `role:<role_uuid>`, "
+                    "e.g. `assignee=unassigned,user:123`."
                 ),
             ),
             OpenApiParameter(

--- a/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
+++ b/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
@@ -66,23 +66,6 @@ export function AssigneeMultiSelect({
                         fullWidth
                     />
                     <ul className="deprecated-space-y-2">
-                        <li>
-                            <LemonButton
-                                fullWidth
-                                role="menuitem"
-                                size="small"
-                                icon={
-                                    <LemonCheckbox checked={isSelected('unassigned')} className="pointer-events-none" />
-                                }
-                                disabledReason={isSelected('unassigned') ? undefined : selectionCapReason}
-                                onClick={() => toggleEntry('unassigned')}
-                            >
-                                <span className="flex items-center gap-1">
-                                    <AssigneeIconDisplay assignee={null} size="small" />
-                                    Unassigned
-                                </span>
-                            </LemonButton>
-                        </li>
                         {currentUserMember && (
                             <li>
                                 {/* Dynamic "me" entry — resolves to whoever is signed in, so a
@@ -108,6 +91,23 @@ export function AssigneeMultiSelect({
                                 </LemonButton>
                             </li>
                         )}
+                        <li>
+                            <LemonButton
+                                fullWidth
+                                role="menuitem"
+                                size="small"
+                                icon={
+                                    <LemonCheckbox checked={isSelected('unassigned')} className="pointer-events-none" />
+                                }
+                                disabledReason={isSelected('unassigned') ? undefined : selectionCapReason}
+                                onClick={() => toggleEntry('unassigned')}
+                            >
+                                <span className="flex items-center gap-1">
+                                    <AssigneeIconDisplay assignee={null} size="small" />
+                                    Unassigned
+                                </span>
+                            </LemonButton>
+                        </li>
                         <Section
                             title="Roles"
                             loading={rolesLoading}

--- a/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
+++ b/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
-import { IconPlusSmall } from '@posthog/icons'
+import { IconPerson, IconPlusSmall } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonDropdown, LemonInput } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
@@ -12,7 +12,8 @@ import { assigneeSelectLogic } from './assigneeSelectLogic'
 import { Assignee, AssigneeFilterEntry, MAX_ASSIGNEE_FILTER_ENTRIES } from './types'
 
 function isSameEntry(a: AssigneeFilterEntry, b: AssigneeFilterEntry): boolean {
-    if (a === 'unassigned' || b === 'unassigned') {
+    // String tokens ('unassigned', 'me') only match the identical token.
+    if (typeof a === 'string' || typeof b === 'string') {
         return a === b
     }
     return a.type === b.type && String(a.id) === String(b.id)
@@ -25,7 +26,7 @@ export function AssigneeMultiSelect({
     value: AssigneeFilterEntry[]
     onChange: (value: AssigneeFilterEntry[]) => void
 }): JSX.Element {
-    const { search, filteredRoles, otherFilteredMembers, currentUserMember, rolesLoading, membersLoading } =
+    const { search, filteredRoles, filteredMembers, currentUserMember, rolesLoading, membersLoading } =
         useValues(assigneeSelectLogic)
     const { setSearch, ensureAssigneeTypesLoaded } = useActions(assigneeSelectLogic)
     const [showPopover, setShowPopover] = useState(false)
@@ -84,17 +85,27 @@ export function AssigneeMultiSelect({
                         </li>
                         {currentUserMember && (
                             <li>
-                                <AssigneeFilterItem
-                                    item={{
-                                        id: currentUserMember.user.id,
-                                        type: 'user',
-                                        user: currentUserMember.user,
-                                    }}
-                                    isSelected={isSelected}
-                                    onToggle={toggleEntry}
-                                    selectionCapReason={selectionCapReason}
-                                    labelSuffix={<span className="text-secondary">(you)</span>}
-                                />
+                                {/* Dynamic "me" entry — resolves to whoever is signed in, so a
+                                    saved view scoped to it stays each viewer's own tickets. */}
+                                <LemonButton
+                                    fullWidth
+                                    role="menuitem"
+                                    size="small"
+                                    icon={
+                                        <LemonCheckbox
+                                            checked={isSelected('me')}
+                                            className="pointer-events-none"
+                                        />
+                                    }
+                                    disabledReason={isSelected('me') ? undefined : selectionCapReason}
+                                    onClick={() => toggleEntry('me')}
+                                >
+                                    <span className="flex items-center gap-1">
+                                        <MeIcon />
+                                        Me
+                                        <span className="text-secondary">(current user)</span>
+                                    </span>
+                                </LemonButton>
                             </li>
                         )}
                         <Section
@@ -116,12 +127,15 @@ export function AssigneeMultiSelect({
                                 </LemonButton>
                             }
                         />
-                        {(!!search || membersLoading || otherFilteredMembers.length > 0) && (
+                        {(!!search || membersLoading || filteredMembers.length > 0) && (
                             <Section
                                 title="Users"
                                 loading={membersLoading}
                                 search={!!search}
-                                items={otherFilteredMembers.map((member) => ({
+                                // Include the current user here too (as their concrete
+                                // user:<id>), so they can filter to their own UUID
+                                // specifically — distinct from the dynamic "Me" row above.
+                                items={filteredMembers.map((member) => ({
                                     id: member.user.id,
                                     type: 'user' as const,
                                     user: member.user,
@@ -163,6 +177,14 @@ function TriggerLabel({ value }: { value: AssigneeFilterEntry[] }): JSX.Element 
             </span>
         )
     }
+    if (entry === 'me') {
+        return (
+            <span className="flex items-center gap-1">
+                <MeIcon />
+                Me
+            </span>
+        )
+    }
     return (
         <AssigneeResolver assignee={entry}>
             {({ assignee }) => (
@@ -173,6 +195,12 @@ function TriggerLabel({ value }: { value: AssigneeFilterEntry[] }): JSX.Element 
             )}
         </AssigneeResolver>
     )
+}
+
+// Solid person glyph for the dynamic "me" entry — distinct from the dashed
+// "unassigned" icon and from any specific member's avatar.
+function MeIcon(): JSX.Element {
+    return <IconPerson className="rounded-full bg-accent-highlight text-accent p-0.5 h-4 w-4" />
 }
 
 const AssigneeFilterItem = ({

--- a/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
+++ b/products/conversations/frontend/components/Assignee/AssigneeMultiSelect.tsx
@@ -74,12 +74,7 @@ export function AssigneeMultiSelect({
                                     fullWidth
                                     role="menuitem"
                                     size="small"
-                                    icon={
-                                        <LemonCheckbox
-                                            checked={isSelected('me')}
-                                            className="pointer-events-none"
-                                        />
-                                    }
+                                    icon={<LemonCheckbox checked={isSelected('me')} className="pointer-events-none" />}
                                     disabledReason={isSelected('me') ? undefined : selectionCapReason}
                                     onClick={() => toggleEntry('me')}
                                 >

--- a/products/conversations/frontend/components/Assignee/types.ts
+++ b/products/conversations/frontend/components/Assignee/types.ts
@@ -5,7 +5,13 @@ export type TicketAssignee = {
     id: string | number
 } | null
 
-export type AssigneeFilterEntry = 'unassigned' | NonNullable<TicketAssignee>
+// `'me'` is a dynamic, per-viewer token: it filters to whoever is currently
+// signed in, resolved server-side against `request.user`. Unlike a concrete
+// `{ type: 'user', id }` entry it stays correct when a saved view is shared, so
+// a "My tickets" view means each teammate's own tickets rather than the
+// creator's. It's a filter-only concept — a ticket's actual assignee is always
+// a concrete user/role, never `'me'`.
+export type AssigneeFilterEntry = 'unassigned' | 'me' | NonNullable<TicketAssignee>
 
 /** Mirrors the entry cap the tickets list endpoint applies to the `assignee` param. */
 export const MAX_ASSIGNEE_FILTER_ENTRIES = 100

--- a/products/conversations/frontend/components/SavedViews/SavedViewsModal.tsx
+++ b/products/conversations/frontend/components/SavedViews/SavedViewsModal.tsx
@@ -42,10 +42,12 @@ function FiltersSummary({ filters }: { filters: TicketViewFilters }): JSX.Elemen
         lines.push({
             label: 'Assignee',
             value: assigneeEntries.map((entry, index) => (
-                <span key={entry === 'unassigned' ? 'unassigned' : `${entry.type}:${entry.id}`}>
+                <span key={typeof entry === 'string' ? entry : `${entry.type}:${entry.id}`}>
                     {index > 0 ? ', ' : ''}
                     {entry === 'unassigned' ? (
                         'Unassigned'
+                    ) : entry === 'me' ? (
+                        'Me (current user)'
                     ) : (
                         <AssigneeResolver assignee={entry}>
                             {({ assignee }) => (

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -1193,7 +1193,7 @@ export type ConversationsListParams = {
 
 export type ConversationsTicketsListParams = {
     /**
-     * Filter by assignee. Accepts a single value or a comma-separated list (matches any, max 100 entries). Each entry is `unassigned` (no assignee), `user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`.
+     * Filter by assignee. Accepts a single value or a comma-separated list (matches any, max 100 entries). Each entry is `unassigned` (no assignee), `me` (the requesting user), `user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`.
      */
     assignee?: string
     /**

--- a/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.test.ts
@@ -37,6 +37,7 @@ describe('supportTicketsSceneLogic', () => {
         it.each([
             ['legacy "all"', 'all', []],
             ['legacy "unassigned"', 'unassigned', ['unassigned']],
+            ['dynamic "me"', 'me', ['me']],
             ['legacy single user', { type: 'user', id: 1 }, [{ type: 'user', id: 1 }]],
             ['undefined', undefined, []],
             ['null', null, []],
@@ -93,6 +94,21 @@ describe('supportTicketsSceneLogic', () => {
             }).toFinishAllListeners()
             expect(logic.values.assigneeFilterEntries).toEqual(['unassigned'])
             expect(lastAssigneeParam).toBe('unassigned')
+        })
+
+        it('passes the dynamic "me" token through unchanged so the backend resolves the viewer', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setAssigneeFilter(['me', { type: 'user', id: 1 }])
+            }).toFinishAllListeners()
+            expect(lastAssigneeParam).toBe('me,user:1')
+
+            // A saved view scoped to "me" round-trips as the portable token, not a
+            // concrete user id — so it stays each viewer's own tickets.
+            await expectLogic(logic, () => {
+                logic.actions.applyViewFilters({ assignee: ['me'] })
+            }).toFinishAllListeners()
+            expect(logic.values.assigneeFilterEntries).toEqual(['me'])
+            expect(lastAssigneeParam).toBe('me')
         })
     })
 

--- a/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.ts
+++ b/products/conversations/frontend/scenes/tickets/supportTicketsSceneLogic.ts
@@ -74,7 +74,8 @@ function orderByToSorting(orderBy: string): Sorting {
 }
 
 function encodeAssigneeEntry(entry: AssigneeFilterEntry): string {
-    return entry === 'unassigned' ? 'unassigned' : `${entry.type}:${entry.id}`
+    // 'unassigned' and 'me' are string tokens; concrete entries encode as type:id.
+    return typeof entry === 'string' ? entry : `${entry.type}:${entry.id}`
 }
 
 // kea-router hands back arrays for multi-value params, but a hand-typed single
@@ -91,8 +92,8 @@ function toStringArray(value: unknown): string[] {
 
 function decodeAssignee(value: unknown): AssigneeFilterEntry[] {
     const entries = toStringArray(value).map((token): AssigneeFilterEntry | null => {
-        if (token === 'unassigned') {
-            return 'unassigned'
+        if (token === 'unassigned' || token === 'me') {
+            return token
         }
         const separator = token.indexOf(':')
         const type = token.slice(0, separator)
@@ -696,9 +697,7 @@ export const supportTicketsSceneLogic = kea<supportTicketsSceneLogicType>([
                 params.sla = values.slaFilter
             }
             if (values.assigneeFilterEntries.length > 0) {
-                params.assignee = values.assigneeFilterEntries
-                    .map((entry) => (entry === 'unassigned' ? 'unassigned' : `${entry.type}:${entry.id}`))
-                    .join(',')
+                params.assignee = values.assigneeFilterEntries.map(encodeAssigneeEntry).join(',')
             }
             if (values.tagsFilter.length > 0) {
                 params[values.tagsMatch === 'all' ? 'tags_all' : 'tags'] = JSON.stringify(values.tagsFilter)

--- a/products/conversations/frontend/types.ts
+++ b/products/conversations/frontend/types.ts
@@ -28,7 +28,7 @@ export type RestoreFlowState = 'idle' | 'sending' | 'sent' | 'error'
 export type AssigneeFilterValue = 'all' | 'unassigned' | TicketAssignee
 
 function isAssigneeFilterEntry(value: unknown): value is AssigneeFilterEntry {
-    if (value === 'unassigned') {
+    if (value === 'unassigned' || value === 'me') {
         return true
     }
     if (typeof value !== 'object' || value === null) {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -72822,7 +72822,7 @@ export namespace Schemas {
 
     export type ConversationsTicketsListParams = {
     /**
-     * Filter by assignee. Accepts a single value or a comma-separated list (matches any, max 100 entries). Each entry is `unassigned` (no assignee), `user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`.
+     * Filter by assignee. Accepts a single value or a comma-separated list (matches any, max 100 entries). Each entry is `unassigned` (no assignee), `me` (the requesting user), `user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`.
      */
     assignee?: string;
     /**

--- a/services/mcp/src/generated/conversations/api.ts
+++ b/services/mcp/src/generated/conversations/api.ts
@@ -24,7 +24,7 @@ export const ConversationsTicketsListQueryParams = /* @__PURE__ */ zod.object({
         .string()
         .optional()
         .describe(
-            'Filter by assignee. Accepts a single value or a comma-separated list (matches any, max 100 entries). Each entry is `unassigned` (no assignee), `user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`.'
+            'Filter by assignee. Accepts a single value or a comma-separated list (matches any, max 100 entries). Each entry is `unassigned` (no assignee), `me` (the requesting user), `user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`.'
         ),
     channel_detail: zod
         .enum([

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/conversations-tickets-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/conversations-tickets-list.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "assignee": {
-            "description": "Filter by assignee. Accepts a single value or a comma-separated list (matches any, max 100 entries). Each entry is `unassigned` (no assignee), `user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`.",
+            "description": "Filter by assignee. Accepts a single value or a comma-separated list (matches any, max 100 entries). Each entry is `unassigned` (no assignee), `me` (the requesting user), `user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`.",
             "type": "string"
         },
         "channel_detail": {


### PR DESCRIPTION
## Problem

"Assigned to me" in a saved ticket view resolves to a literal user id, so a view built by one person shows *their* tickets to everyone it's shared with — it can't be a shared "My tickets" view. Raised in the PostHog support Slack.

## Changes

Adds a dynamic **`me`** entry to the assignee filter — a per-viewer token that resolves to whoever is currently signed in (server-side, against `request.user`), rather than baking in a concrete user id. A saved view scoped to `me` therefore stays each viewer's own tickets.

- New `'me'` value in `AssigneeFilterEntry`, accepted by `normalizeAssigneeFilter` and threaded through the URL/param encode/decode and the saved-view filters summary.
- The assignee dropdown's "bump current user to the top" row is replaced by the dynamic **Me (current user)** entry. The current user still appears concretely in the Users list, so you can also filter to your own id specifically.
- Backend resolves a `me` token in the tickets `assignee` query param to the requesting user; it composes with other entries in the match-any list.

The shared `assigneeSelectLogic` (used by the single-assignee ticket picker) is left unchanged.

## How did you test this code?

Added automated tests; I did not run them (the monorepo toolchain isn't installed in this environment) or perform manual testing.

- Backend (`test_tickets.py`): `me` resolves to the requesting user, and `me,unassigned` composes as match-any — catches a regression where the token would be dropped or resolve to the wrong user.
- Frontend (`supportTicketsSceneLogic.test.ts`): `normalizeAssigneeFilter` accepts `me`, and the token round-trips through the API param / saved-view apply path unchanged (portable rather than resolved to a concrete id).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code). The approach — a dynamic `me` token resolved server-side, replacing the current-user-to-top row while keeping the concrete self entry — was chosen in the Slack thread over the alternatives of a hardcoded per-user id (rejected: not shareable) and a single fixed built-in view (rejected: not composable with other filters).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1784902498971919)*
