### PR TITLE
fix(workflows): use stable empty-array fallback for branch config

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepConditionalBranch.tsx
@@ -15,13 +15,16 @@ import { HogFlow, HogFlowAction } from '../types'
 import { StepSchemaErrors } from './components/StepSchemaErrors'
 import { getBranchRemovalDisabledReason, removeBranchEdge, useDebouncedNameInputs } from './utils'
 
+// Stable reference so a config missing `conditions` doesn't allocate a new array each render
+const EMPTY_CONDITIONS: Extract<HogFlowAction, { type: 'conditional_branch' }>['config']['conditions'] = []
+
 export function StepConditionalBranchConfiguration({
     node,
 }: {
     node: Node<Extract<HogFlowAction, { type: 'conditional_branch' }>>
 }): JSX.Element {
     const action = node.data
-    const conditions = action.config.conditions ?? []
+    const conditions = action.config.conditions ?? EMPTY_CONDITIONS
 
     const { edgesByActionId } = useValues(hogFlowEditorLogic)
     const { setWorkflowAction, setWorkflowActionEdges } = useActions(hogFlowEditorLogic)

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
@@ -13,13 +13,16 @@ import { HogFlow, HogFlowAction } from '../types'
 import { StepSchemaErrors } from './components/StepSchemaErrors'
 import { useDebouncedNameInputs } from './utils'
 
+// Stable reference so a config missing `cohorts` doesn't allocate a new array each render
+const EMPTY_COHORTS: Extract<HogFlowAction, { type: 'random_cohort_branch' }>['config']['cohorts'] = []
+
 export function StepRandomCohortBranchConfiguration({
     node,
 }: {
     node: Node<Extract<HogFlowAction, { type: 'random_cohort_branch' }>>
 }): JSX.Element {
     const action = node.data
-    const cohorts = action.config.cohorts ?? []
+    const cohorts = action.config.cohorts ?? EMPTY_COHORTS
 
     const { edgesByActionId } = useValues(hogFlowEditorLogic)
     const { setWorkflowAction, setWorkflowActionEdges } = useActions(hogFlowEditorLogic)


### PR DESCRIPTION
## Problem

Follow-up to #73531. That PR fixed the conditional-branch node panel crashing when an action's `config` omits `conditions` / `cohorts`, by defaulting to `?? []`. But a Greptile review caught that the inline `[]` allocates a **new array reference on every render**. `useDebouncedNameInputs` runs an effect keyed on that array's identity that unconditionally calls `setState`, so a fresh reference each render drives a render loop — "maximum update depth exceeded" — instead of the original crash. The fix commit landed after #73531 auto-merged, so master currently has the render-loop version.

## Changes

Point each fallback at a module-level constant (`EMPTY_CONDITIONS` / `EMPTY_COHORTS`) so the reference is stable across renders. A branch node with no conditions/cohorts now renders the empty panel with its "Add condition" / "Add cohort" button, no loop.

## How did you test this code?

I (an agent) made the edits and reasoned through the render/effect paths; I did not run the app or add automated tests in this pass. Couldn't run typecheck/lint locally (no `node_modules` in this environment). The change is a one-line-per-file swap to a stable reference and is type-safe by inspection — the constant's type is the same indexed-access type already used in each file's setter signature.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Greptile (trusted review bot) flagged the render-loop on #73531; the fix commit missed the auto-merge window, so this re-lands it against master as a fresh PR. Assignee left unset because the driver's GitHub handle wasn't verified this session.

> [!NOTE]
> Separately worth a look (out of scope here): branch nodes can reach a state where `conditions`/`cohorts` is missing at all. Draft auto-save doesn't hard-validate, so a node may persist without its array. This PR stops the client from crashing/looping on such a node but doesn't address how it gets saved that way.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1784901016853839?thread_ts=1784901016.853839&cid=C0ACRAMJUAG)*
