### PR TITLE
chore(cdp): deflake rerun-paginator clickhouse seed race

### DIFF
--- a/nodejs/src/cdp/rerun/rerun-e2e.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-e2e.test.ts
@@ -13,6 +13,7 @@ import { closeHub, createHub } from '~/common/utils/db/hub'
 import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { Clickhouse } from '~/tests/helpers/clickhouse'
 import { waitForExpect } from '~/tests/helpers/expectations'
+import { waitForHogInvocationResultsMvReady } from '~/tests/helpers/hog-invocation-results'
 import { TEST_KAFKA_TOPICS, ensureKafkaTopics } from '~/tests/helpers/kafka'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 
@@ -49,59 +50,6 @@ interface PersistedRow {
     error_kind: string
     function_kind: string
     invocation_globals: string
-}
-
-/**
- * Probe the ClickHouse Kafka MV for our topic in particular. With
- * auto.offset.reset=latest, anything produced before the MV's internal consumer
- * has attached is silently dropped. Send probe rows until one lands in CH so we
- * know the MV is live before the test produces real rows.
- */
-const waitForHogInvocationResultsMvReady = async (clickhouse: Clickhouse): Promise<void> => {
-    const producer = await ActualKafkaProducerWrapper.create(undefined)
-    const probeTeamId = -999_999
-    try {
-        await waitForExpect(async () => {
-            await producer.queueMessages({
-                topic: KAFKA_HOG_INVOCATION_RESULTS,
-                messages: [
-                    {
-                        key: 'probe',
-                        value: JSON.stringify({
-                            team_id: probeTeamId,
-                            function_kind: 'hog_function',
-                            function_id: 'probe',
-                            invocation_id: 'probe',
-                            parent_run_id: '',
-                            status: 'running',
-                            attempts: 0,
-                            is_retry: 0,
-                            scheduled_at: DateTime.utc().toFormat("yyyy-MM-dd HH:mm:ss.SSS'000'"),
-                            started_at: null,
-                            finished_at: null,
-                            duration_ms: null,
-                            error_kind: '',
-                            error_message: '',
-                            event_uuid: '',
-                            distinct_id: '',
-                            person_id: '',
-                            invocation_globals: '{}',
-                            version: String(BigInt(Date.now()) * 1000n),
-                            is_deleted: 0,
-                        }),
-                    },
-                ],
-            })
-            await producer.flush()
-
-            const result = await clickhouse.query<{ c: number }>(
-                `SELECT count() AS c FROM hog_invocation_results WHERE team_id = ${probeTeamId}`
-            )
-            expect(Number(result[0]?.c ?? 0)).toBeGreaterThan(0)
-        }, 30_000)
-    } finally {
-        await producer.disconnect()
-    }
 }
 
 /**

--- a/nodejs/src/cdp/rerun/rerun-paginator.service.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-paginator.service.test.ts
@@ -10,7 +10,8 @@ import { UUIDT } from '~/common/utils/utils'
 import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
 import { Clickhouse } from '~/tests/helpers/clickhouse'
 import { waitForExpect } from '~/tests/helpers/expectations'
-import { ensureKafkaTopics, resetKafka } from '~/tests/helpers/kafka'
+import { waitForHogInvocationResultsMvReady } from '~/tests/helpers/hog-invocation-results'
+import { TEST_KAFKA_TOPICS, ensureKafkaTopics } from '~/tests/helpers/kafka'
 import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
 
 import { Hub, Team } from '../../types'
@@ -188,9 +189,17 @@ describe('RerunPaginatorService integration', () => {
 
     beforeAll(async () => {
         MockKafkaProducerWrapper.create = jest.fn((...args: any[]) => ActualKafkaProducerWrapper.create(...args))
-        await resetKafka()
-        await ensureKafkaTopics([KAFKA_HOG_INVOCATION_RESULTS])
+        // Ensure every topic the ClickHouse Kafka engines subscribe to exists, idempotently and
+        // WITHOUT deleting anything. resetKafka() drops+recreates all topics, which forces the
+        // hog_invocation_results engine's consumer to reattach at auto.offset.reset=latest — rows
+        // produced during that reattach window are silently dropped, so the first seed loses a row
+        // and its count poll times out. Keeping the topics in place preserves the consumer's offset.
+        await ensureKafkaTopics([...TEST_KAFKA_TOPICS, KAFKA_HOG_INVOCATION_RESULTS])
         await clickhouse.truncate('hog_invocation_results_data')
+        // Prime the MV before any seeding: probe until a row lands so the engine's consumer is
+        // provably attached and reading. Without this, a cold consumer (e.g. after a sibling suite
+        // called resetKafka) drops the first seed's rows at offset=latest. Mirrors rerun-e2e.test.ts.
+        await waitForHogInvocationResultsMvReady(clickhouse)
     })
 
     beforeEach(async () => {

--- a/nodejs/src/cdp/rerun/rerun-paginator.service.test.ts
+++ b/nodejs/src/cdp/rerun/rerun-paginator.service.test.ts
@@ -189,16 +189,11 @@ describe('RerunPaginatorService integration', () => {
 
     beforeAll(async () => {
         MockKafkaProducerWrapper.create = jest.fn((...args: any[]) => ActualKafkaProducerWrapper.create(...args))
-        // Ensure every topic the ClickHouse Kafka engines subscribe to exists, idempotently and
-        // WITHOUT deleting anything. resetKafka() drops+recreates all topics, which forces the
-        // hog_invocation_results engine's consumer to reattach at auto.offset.reset=latest — rows
-        // produced during that reattach window are silently dropped, so the first seed loses a row
-        // and its count poll times out. Keeping the topics in place preserves the consumer's offset.
+        // Ensure all topics exist (idempotently, without deleting) so the ClickHouse Kafka engine
+        // consumers keep their connections. Includes KAFKA_HOG_INVOCATION_RESULTS, which this test's
+        // MV needs but the shared set does not cover.
         await ensureKafkaTopics([...TEST_KAFKA_TOPICS, KAFKA_HOG_INVOCATION_RESULTS])
         await clickhouse.truncate('hog_invocation_results_data')
-        // Prime the MV before any seeding: probe until a row lands so the engine's consumer is
-        // provably attached and reading. Without this, a cold consumer (e.g. after a sibling suite
-        // called resetKafka) drops the first seed's rows at offset=latest. Mirrors rerun-e2e.test.ts.
         await waitForHogInvocationResultsMvReady(clickhouse)
     })
 

--- a/nodejs/tests/helpers/hog-invocation-results.ts
+++ b/nodejs/tests/helpers/hog-invocation-results.ts
@@ -5,17 +5,14 @@ import { KafkaProducerWrapper } from '~/common/kafka/producer'
 import { Clickhouse } from '~/tests/helpers/clickhouse'
 import { waitForExpect } from '~/tests/helpers/expectations'
 
-// The `~/common/kafka/producer` module is auto-mocked in these integration tests, so grab the
-// real wrapper to actually push probe rows through Kafka.
+// `~/common/kafka/producer` is auto-mocked in these tests; use the real wrapper to push probe rows.
 const ActualKafkaProducerWrapper: typeof KafkaProducerWrapper =
     jest.requireActual('~/common/kafka/producer').KafkaProducerWrapper
 
 /**
- * Probe the ClickHouse Kafka MV for the hog_invocation_results topic in particular. With
- * `auto.offset.reset=latest` on the engine's consumer, anything produced before the MV's
- * internal consumer has attached is silently dropped — so a seed run right after topic
- * (re)creation can lose rows and never satisfy a row-count poll. Send probe rows until one
- * lands in ClickHouse so we know the MV is live before the test produces real rows.
+ * Probe hog_invocation_results until a row lands, proving the ClickHouse Kafka engine's consumer has
+ * attached. Its `auto.offset.reset=latest` drops rows produced before attach, so a seed right after
+ * topic (re)creation can lose rows and never satisfy a count poll. Mirrors waitForClickHouseKafkaConsumer.
  */
 export const waitForHogInvocationResultsMvReady = async (clickhouse: Clickhouse): Promise<void> => {
     const producer = await ActualKafkaProducerWrapper.create(undefined)

--- a/nodejs/tests/helpers/hog-invocation-results.ts
+++ b/nodejs/tests/helpers/hog-invocation-results.ts
@@ -1,0 +1,65 @@
+import { DateTime } from 'luxon'
+
+import { KAFKA_HOG_INVOCATION_RESULTS } from '~/common/config/kafka-topics'
+import { KafkaProducerWrapper } from '~/common/kafka/producer'
+import { Clickhouse } from '~/tests/helpers/clickhouse'
+import { waitForExpect } from '~/tests/helpers/expectations'
+
+// The `~/common/kafka/producer` module is auto-mocked in these integration tests, so grab the
+// real wrapper to actually push probe rows through Kafka.
+const ActualKafkaProducerWrapper: typeof KafkaProducerWrapper =
+    jest.requireActual('~/common/kafka/producer').KafkaProducerWrapper
+
+/**
+ * Probe the ClickHouse Kafka MV for the hog_invocation_results topic in particular. With
+ * `auto.offset.reset=latest` on the engine's consumer, anything produced before the MV's
+ * internal consumer has attached is silently dropped — so a seed run right after topic
+ * (re)creation can lose rows and never satisfy a row-count poll. Send probe rows until one
+ * lands in ClickHouse so we know the MV is live before the test produces real rows.
+ */
+export const waitForHogInvocationResultsMvReady = async (clickhouse: Clickhouse): Promise<void> => {
+    const producer = await ActualKafkaProducerWrapper.create(undefined)
+    const probeTeamId = -999_999
+    try {
+        await waitForExpect(async () => {
+            await producer.queueMessages({
+                topic: KAFKA_HOG_INVOCATION_RESULTS,
+                messages: [
+                    {
+                        key: 'probe',
+                        value: JSON.stringify({
+                            team_id: probeTeamId,
+                            function_kind: 'hog_function',
+                            function_id: 'probe',
+                            invocation_id: 'probe',
+                            parent_run_id: '',
+                            status: 'running',
+                            attempts: 0,
+                            is_retry: 0,
+                            scheduled_at: DateTime.utc().toFormat("yyyy-MM-dd HH:mm:ss.SSS'000'"),
+                            started_at: null,
+                            finished_at: null,
+                            duration_ms: null,
+                            error_kind: '',
+                            error_message: '',
+                            event_uuid: '',
+                            distinct_id: '',
+                            person_id: '',
+                            invocation_globals: '{}',
+                            version: String(BigInt(Date.now()) * 1000n),
+                            is_deleted: 0,
+                        }),
+                    },
+                ],
+            })
+            await producer.flush()
+
+            const result = await clickhouse.query<{ c: number }>(
+                `SELECT count() AS c FROM hog_invocation_results WHERE team_id = ${probeTeamId}`
+            )
+            expect(Number(result[0]?.c ?? 0)).toBeGreaterThan(0)
+        }, 30_000)
+    } finally {
+        await producer.disconnect()
+    }
+}


### PR DESCRIPTION
> **Weekly top-10 flaky-test sweep.** `RerunPaginatorService › by-ids › rehydrates and re-enqueues only the requested invocations` flaked in ~8 of 9 sampled Node.js master reds (permanently lost 1 of 3 seeded rows).
> Evidence: FAIL [Node.js Tests 3/3](https://github.com/PostHog/posthog/actions/runs/30008398714/job/89210257283) (the failing shard, which names the test), between green [30007566336](https://github.com/PostHog/posthog/actions/runs/30007566336/job/89208388618) and [30009885519](https://github.com/PostHog/posthog/actions/runs/30009885519/job/89215561883) on adjacent commits.

|  |  |
|---|---|
| **Root cause** | `beforeAll`'s destructive `resetKafka()` forces the ClickHouse Kafka-engine consumer (`auto.offset.reset=latest`) to reattach; rows seeded during that window land past `latest` and are silently dropped. The earlier producer-flush fix ([#72889](https://github.com/PostHog/posthog/pull/72889)) couldn't help, because the loss is consumer-side. |
| **Fix** | Non-destructive `ensureKafkaTopics(...)` (keeps the consumer's offset) + prime the MV before seeding. Shared probe helper extracted from `rerun-e2e.test.ts`. |
| **Validation** | Not reproducible on a warm local stack, since it needs a cold or reattaching consumer, so the evidence is structural. Confirmed against the live schema that the engine has no `auto_offset_reset` override (ClickHouse defaults to `latest`), and that only the first test after `beforeAll` flakes, which rules out a short `waitForExpect`, a service bug, or dedup. eslint + prettier clean. |
| **Cross-suite safety** | Other suites still call `resetKafka()`, but CI runs `jest --runInBand` with each shard on its own runner and compose stack, so they can never overlap this one. If one runs first, the readiness probe re-establishes the guarantee, so the probe rather than the `resetKafka` removal is what makes this robust. Probe rows use `team_id = -999999` and every query binds `team_id`, so they cannot leak into assertions. |

## 🤖 Agent context

Human-driven (agent-assisted). Skill: `/fixing-flaky-tests`. `tests/helpers/kafka.ts` already warns `resetKafka` causes flaky tests; this removes the one caller seeding through this MV.
