### PR TITLE
chore(kafka-assigner): drive handoffs in k3s initial-assignment wait

### DIFF
--- a/rust/kafka-assigner/tests/k3s_integration.rs
+++ b/rust/kafka-assigner/tests/k3s_integration.rs
@@ -550,13 +550,35 @@ async fn deployment_rollout_reassigns_partitions() {
         .expect("register old-1 failed")
         .into_inner();
 
-    // Wait for initial assignment across both consumers
+    // Wait for initial assignment to settle across both consumers.
+    //
+    // The two Register RPCs write to etcd sequentially, and each runs a k3s
+    // controller-discovery lookup first. If the second write lands outside the
+    // assigner's rebalance debounce window (e.g. when the k3s API server is
+    // slow under CI load), the assigner first assigns all partitions to
+    // consumer A, then rebalances half to B via handoffs rather than in one
+    // direct assignment. Drive any such in-flight handoffs here, exactly as a
+    // real consumer would, so we converge on steady state regardless of which
+    // path the assigner took, instead of hanging on a transient handoff.
     let check_store = Arc::clone(&store);
     let check_names = old_names.clone();
     wait_for_condition(E2E_TIMEOUT, POLL_INTERVAL, || {
         let store = Arc::clone(&check_store);
         let names = check_names.clone();
         async move {
+            let handoffs = store.list_handoffs().await.unwrap_or_default();
+            for h in &handoffs {
+                match h.phase {
+                    kafka_assigner::types::HandoffPhase::Warming => {
+                        signal_ready(&store, &h.topic_partition()).await;
+                    }
+                    kafka_assigner::types::HandoffPhase::Complete => {
+                        signal_released(&store, &h.topic_partition()).await;
+                    }
+                    kafka_assigner::types::HandoffPhase::Ready => {}
+                }
+            }
+
             let a = store.list_assignments().await.unwrap_or_default();
             let h = store.list_handoffs().await.unwrap_or_default();
             a.len() == NUM_PARTITIONS as usize


### PR DESCRIPTION
> **Weekly top-10 flaky-test sweep.** `deployment_rollout_reassigns_partitions` (kafka-assigner k3s integration) flaked in 4 of 19 Rust master reds, burning the full 180s timeout.
> Evidence (same master SHA `be0dad2`): [PASS 33.6s](https://github.com/PostHog/posthog/actions/runs/30006917381) → [FAIL 209.9s — the failing Rust shard, panic + 180s hang](https://github.com/PostHog/posthog/actions/runs/30008939688/job/89212179998) → [PASS 34.9s](https://github.com/PostHog/posthog/actions/runs/30009885482). The 34s-vs-210s split is the fingerprint.

|  |  |
|---|---|
| **Root cause** | The assigner batches consumer registrations in a 1s debounce window. When the k3s API is slow under CI load, the 2nd consumer registers after that window, so partitions rebalance to consumer B via Warming handoffs instead of one direct assignment. The test's first wait only checked `is_empty()`, never drove those handoffs → hang. |
| **Fix** | Drive in-flight handoffs (Warming → ready, Complete → released) in the first wait, mirroring the already-proven second wait. Test-only, no product change, no timeout bump. |
| **Validation** | Automated (Claude): analytical (repro needs etcd + k3s and only fires under CI latency). `cargo check --test k3s_integration` clean; `cargo test --lib` passes. |

## 🤖 Agent context

Human-driven (agent-assisted). Skill: `/fixing-flaky-tests`. A similarly-named panic in the feature-flags harness is a different root cause (coincidental filename), not addressed here.
