### PR TITLE
feat(visual-review): add repository picker search

### DIFF
--- a/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
@@ -1,19 +1,7 @@
 import { useActions, useValues } from 'kea'
-import { useRef, useState } from 'react'
 
 import { IconArrowRight, IconCopy, IconGear, IconGithub, IconPencil, IconPlus, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonSkeleton, LemonSwitch, Spinner } from '@posthog/lemon-ui'
-import {
-    Button,
-    Combobox,
-    ComboboxContent,
-    ComboboxEmpty,
-    ComboboxInput,
-    ComboboxItem,
-    ComboboxList,
-    ComboboxListFooter,
-    ComboboxTrigger,
-} from '@posthog/quill'
+import { LemonButton, LemonInput, LemonSearchableSelect, LemonSkeleton, LemonSwitch, Spinner } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
@@ -258,18 +246,8 @@ function AddRepoDropdown(): JSX.Element {
         useValues(visualReviewSettingsSceneLogic)
     const { addRepo } = useActions(visualReviewSettingsSceneLogic)
     const { githubRepositoriesLoading } = useValues(integrationsLogic)
-    const triggerRef = useRef<HTMLButtonElement>(null)
-    const [searchQuery, setSearchQuery] = useState('')
 
     const unaddedRepos = availableRepos.filter((r: GitHubRepoApi) => !existingRepoNames.has(r.full_name))
-    const normalizedSearchQuery = searchQuery.trim().toLowerCase()
-    const filteredRepoNames = unaddedRepos
-        .filter(
-            (repo: GitHubRepoApi) =>
-                repo.full_name.toLowerCase().includes(normalizedSearchQuery) ||
-                repo.name.toLowerCase().includes(normalizedSearchQuery)
-        )
-        .map((repo: GitHubRepoApi) => repo.full_name)
 
     if (githubRepositoriesLoading && availableRepos.length === 0) {
         return (
@@ -282,58 +260,49 @@ function AddRepoDropdown(): JSX.Element {
     const manageAccessUrl = githubManageAccessUrl ?? urls.settings('environment-integrations')
 
     return (
-        <Combobox
-            items={filteredRepoNames}
-            filter={null}
-            value={null}
-            inputValue={searchQuery}
-            onInputValueChange={setSearchQuery}
-            onValueChange={(fullName: string | null) => {
+        <LemonSearchableSelect
+            placeholder="Add a repository..."
+            searchPlaceholder="Search repositories"
+            noResultsMessage="No repositories found"
+            loading={saving}
+            options={[
+                {
+                    options:
+                        unaddedRepos.length > 0
+                            ? unaddedRepos.map((repo: GitHubRepoApi) => ({
+                                  value: repo.full_name,
+                                  label: repo.full_name,
+                              }))
+                            : [
+                                  {
+                                      value: '__empty__' as any,
+                                      label: 'No more repositories',
+                                      disabledReason: 'All repositories have been added',
+                                  },
+                              ],
+                    footer: (
+                        <LemonButton
+                            type="tertiary"
+                            size="xsmall"
+                            fullWidth
+                            to={manageAccessUrl}
+                            targetBlank={!!githubManageAccessUrl}
+                            className="text-muted"
+                        >
+                            Manage access
+                        </LemonButton>
+                    ),
+                },
+            ]}
+            onChange={(fullName) => {
                 const repo = availableRepos.find((r: GitHubRepoApi) => r.full_name === fullName)
                 if (repo) {
                     addRepo(repo)
                 }
             }}
-            disabled={saving}
-        >
-            <ComboboxTrigger
-                render={
-                    <Button ref={triggerRef} variant="outline" size="sm" loading={saving}>
-                        Add a repository...
-                    </Button>
-                }
-            />
-            <ComboboxContent anchor={triggerRef} className="min-w-[280px]">
-                <ComboboxInput placeholder="Search repositories..." />
-                <ComboboxEmpty>
-                    {unaddedRepos.length === 0 ? 'No more repositories' : 'No repositories found'}
-                </ComboboxEmpty>
-                <ComboboxList>
-                    {(fullName: string) => (
-                        <ComboboxItem key={fullName} value={fullName}>
-                            {fullName}
-                        </ComboboxItem>
-                    )}
-                </ComboboxList>
-                <ComboboxListFooter>
-                    <Button
-                        variant="link-muted"
-                        size="sm"
-                        className="w-full justify-center"
-                        render={
-                            // eslint-disable-next-line react/forbid-elements
-                            <a
-                                href={manageAccessUrl}
-                                target={githubManageAccessUrl ? '_blank' : undefined}
-                                rel={githubManageAccessUrl ? 'noopener noreferrer' : undefined}
-                            />
-                        }
-                    >
-                        Manage access
-                    </Button>
-                </ComboboxListFooter>
-            </ComboboxContent>
-        </Combobox>
+            value={null}
+            size="small"
+        />
     )
 }
 

--- a/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
@@ -1,7 +1,19 @@
 import { useActions, useValues } from 'kea'
+import { useRef, useState } from 'react'
 
 import { IconArrowRight, IconCopy, IconGear, IconGithub, IconPencil, IconPlus, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonSearchableSelect, LemonSkeleton, LemonSwitch, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonSkeleton, LemonSwitch, Spinner } from '@posthog/lemon-ui'
+import {
+    Button,
+    Combobox,
+    ComboboxContent,
+    ComboboxEmpty,
+    ComboboxInput,
+    ComboboxItem,
+    ComboboxList,
+    ComboboxListFooter,
+    ComboboxTrigger,
+} from '@posthog/quill'
 
 import api from 'lib/api'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
@@ -246,8 +258,18 @@ function AddRepoDropdown(): JSX.Element {
         useValues(visualReviewSettingsSceneLogic)
     const { addRepo } = useActions(visualReviewSettingsSceneLogic)
     const { githubRepositoriesLoading } = useValues(integrationsLogic)
+    const triggerRef = useRef<HTMLButtonElement>(null)
+    const [searchQuery, setSearchQuery] = useState('')
 
     const unaddedRepos = availableRepos.filter((r: GitHubRepoApi) => !existingRepoNames.has(r.full_name))
+    const normalizedSearchQuery = searchQuery.trim().toLowerCase()
+    const filteredRepoNames = unaddedRepos
+        .filter(
+            (repo: GitHubRepoApi) =>
+                repo.full_name.toLowerCase().includes(normalizedSearchQuery) ||
+                repo.name.toLowerCase().includes(normalizedSearchQuery)
+        )
+        .map((repo: GitHubRepoApi) => repo.full_name)
 
     if (githubRepositoriesLoading && availableRepos.length === 0) {
         return (
@@ -260,49 +282,58 @@ function AddRepoDropdown(): JSX.Element {
     const manageAccessUrl = githubManageAccessUrl ?? urls.settings('environment-integrations')
 
     return (
-        <LemonSearchableSelect
-            placeholder="Add a repository..."
-            searchPlaceholder="Search repositories"
-            noResultsMessage="No repositories found"
-            loading={saving}
-            options={[
-                {
-                    options:
-                        unaddedRepos.length > 0
-                            ? unaddedRepos.map((repo: GitHubRepoApi) => ({
-                                  value: repo.full_name,
-                                  label: repo.full_name,
-                              }))
-                            : [
-                                  {
-                                      value: '__empty__' as any,
-                                      label: 'No more repositories',
-                                      disabledReason: 'All repositories have been added',
-                                  },
-                              ],
-                    footer: (
-                        <LemonButton
-                            type="tertiary"
-                            size="xsmall"
-                            fullWidth
-                            to={manageAccessUrl}
-                            targetBlank={!!githubManageAccessUrl}
-                            className="text-muted"
-                        >
-                            Manage access
-                        </LemonButton>
-                    ),
-                },
-            ]}
-            onChange={(fullName) => {
+        <Combobox
+            items={filteredRepoNames}
+            filter={null}
+            value={null}
+            inputValue={searchQuery}
+            onInputValueChange={setSearchQuery}
+            onValueChange={(fullName: string | null) => {
                 const repo = availableRepos.find((r: GitHubRepoApi) => r.full_name === fullName)
                 if (repo) {
                     addRepo(repo)
                 }
             }}
-            value={null}
-            size="small"
-        />
+            disabled={saving}
+        >
+            <ComboboxTrigger
+                render={
+                    <Button ref={triggerRef} variant="outline" size="sm" loading={saving}>
+                        Add a repository...
+                    </Button>
+                }
+            />
+            <ComboboxContent anchor={triggerRef} className="min-w-[280px]">
+                <ComboboxInput placeholder="Search repositories..." />
+                <ComboboxEmpty>
+                    {unaddedRepos.length === 0 ? 'No more repositories' : 'No repositories found'}
+                </ComboboxEmpty>
+                <ComboboxList>
+                    {(fullName: string) => (
+                        <ComboboxItem key={fullName} value={fullName}>
+                            {fullName}
+                        </ComboboxItem>
+                    )}
+                </ComboboxList>
+                <ComboboxListFooter>
+                    <Button
+                        variant="link-muted"
+                        size="sm"
+                        className="w-full justify-center"
+                        render={
+                            // eslint-disable-next-line react/forbid-elements
+                            <a
+                                href={manageAccessUrl}
+                                target={githubManageAccessUrl ? '_blank' : undefined}
+                                rel={githubManageAccessUrl ? 'noopener noreferrer' : undefined}
+                            />
+                        }
+                    >
+                        Manage access
+                    </Button>
+                </ComboboxListFooter>
+            </ComboboxContent>
+        </Combobox>
     )
 }
 

--- a/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
+++ b/products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconArrowRight, IconCopy, IconGear, IconGithub, IconPencil, IconPlus, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonInput, LemonSelect, LemonSkeleton, LemonSwitch, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonSearchableSelect, LemonSkeleton, LemonSwitch, Spinner } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
@@ -260,8 +260,10 @@ function AddRepoDropdown(): JSX.Element {
     const manageAccessUrl = githubManageAccessUrl ?? urls.settings('environment-integrations')
 
     return (
-        <LemonSelect
+        <LemonSearchableSelect
             placeholder="Add a repository..."
+            searchPlaceholder="Search repositories"
+            noResultsMessage="No repositories found"
             loading={saving}
             options={[
                 {


### PR DESCRIPTION
## Problem

The visual review settings repository picker can contain many GitHub repositories, but the current dropdown requires scanning the full list.

## Changes

- Replace the repository selector with the existing searchable select component.
- Filter available repositories by name and show a clear empty-search result.
- Preserve repository creation, loading, and GitHub access management behavior.

No screenshot is included because this environment did not run the frontend.

## How did you test this code?

- `pnpm exec oxfmt products/visual_review/frontend/scenes/VisualReviewSettingsScene.tsx`
- `git diff --check`
- `./bin/hogli ci:preflight --fix`

The repository-wide TypeScript check could not complete because the worktree dependency state reports unrelated missing modules and test types across existing packages.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update is needed for this small picker usability improvement.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code implemented the requested frontend change using the existing LemonSearchableSelect component. The `pr-shepherd` skill is being used to review and shepherd this PR. No API or business-logic changes were needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*