### PR TITLE
fix(postgres): stop retrying fdw enum-mismatch reads

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -700,6 +700,21 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "connecting role on that foreign server (CREATE USER MAPPING ...), or remove the "
                 "foreign table from the sync, then re-enable the sync."
             ),
+            # A selected relation is a postgres_fdw foreign table whose locally-declared enum column
+            # doesn't match the data actually stored on the remote server — the remote row holds a
+            # label the local enum type doesn't define (SQLSTATE 22P02, "invalid input value for enum
+            # <type>: <value>"). Postgres enforces enum labels at write time on ordinary tables, so
+            # this can only surface when reading through a foreign table's separately-declared type.
+            # The schema drift lives on the customer's side and is deterministic, so retrying re-reads
+            # into the same row every time. Match the stable message and exclude the volatile enum
+            # type name and offending value.
+            "invalid input value for enum": (
+                "One of the tables you selected to sync is a foreign table (postgres_fdw) whose "
+                "locally-declared enum column doesn't match the data on the remote server "
+                '(PostgreSQL reported "invalid input value for enum"). Update the local enum type to '
+                "include the value used on the remote server, or remove the foreign table from the "
+                "sync, then re-enable the sync."
+            ),
         }
 
     def reconcile_schema_metadata(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1014,6 +1014,27 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw psycopg message (what the activity-level check sees via str(e)).
+            'invalid input value for enum "InvitationType": "workshop"\nCONTEXT:  column "invitation_type" of foreign table "invitations"',
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            'InvalidTextRepresentation: invalid input value for enum "InvitationType": "workshop"',
+        ],
+    )
+    def test_fdw_enum_mismatch_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"FDW enum mismatch error should be non-retryable: {error_msg}"
+
+    def test_fdw_enum_mismatch_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = 'invalid input value for enum "InvitationType": "workshop"'
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "FDW enum mismatch error should surface an actionable message"
+        assert "enum type" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A single recovery conflict is retried in-process; on its own it must stay retryable.
             "canceling statement due to conflict with recovery",
             "could not serialize access due to conflict with recovery",


### PR DESCRIPTION
## Problem

Error tracking surfaced a Postgres source failure: reading a table fails with `InvalidTextRepresentation: invalid input value for enum "..."`, with the error context pointing at a column on a `postgres_fdw` foreign table. This happens when a foreign table's locally-declared enum type doesn't include a label that the remote server actually stores for that column — Postgres enforces enum labels at write time on ordinary tables, so this can only surface when reading through a foreign table's separately-declared type. The mismatch lives entirely in the customer's schema and is deterministic: every retry re-reads into the same row and fails identically, so the sync just burns its retry budget before failing anyway.

## Changes

Added `"invalid input value for enum"` to `PostgresSource.get_non_retryable_errors()` with an actionable message pointing at the fix (update the local enum type or remove the foreign table from the sync), following the same pattern as the existing `user mapping not found for` and `invalid input syntax for type integer` entries for foreign-table/type-mismatch errors.

## How did you test this code?

Added `test_fdw_enum_mismatch_is_non_retryable` (parameterized over the raw psycopg message and the Temporal-wrapped form) and `test_fdw_enum_mismatch_returns_friendly_message`, following the existing test pattern for this file (e.g. `test_missing_fdw_user_mapping_is_non_retryable`). These catch a regression where the new key stops matching the raw or wrapped error string, or the friendly message doesn't mention the enum type.

Ran the full non-DB test suite for this file locally:
```
uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py -q
```
544 passed (53 pre-existing `RealDb`/DB-backed tests error in this sandbox because no live Postgres is available — unrelated to this change). Also ran `ruff check` and `ruff format --check` on both changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) triaged a live error-tracking issue for the Postgres warehouse source, confirmed the failure originates in `get_rows` in `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py`, and classified it as a customer-schema issue (foreign-table enum type drift) rather than a bug in our code. I searched open PRs for duplicates before proceeding and found none addressing this specific error. No skills were invoked for the fix itself; `/writing-tests` was consulted before adding the test cases, which extend the existing parameterized pattern in this file rather than introducing a new one.