### PR TITLE
fix(replay-vision): clarify spend tile period-end date

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/VisionMetrics.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionMetrics.tsx
@@ -108,7 +108,9 @@ export function VisionMetrics(): JSX.Element {
                         {hasCap && (
                             <span className={`text-xs tabular-nums ${styles.text}`}>
                                 {percentLabel}%{' '}
-                                <span className="text-muted font-normal">by {resetsOn ?? 'period end'}</span>
+                                <span className="text-muted font-normal">
+                                    by period end{resetsOn ? ` (${resetsOn})` : ''}
+                                </span>
                             </span>
                         )}
                     </div>


### PR DESCRIPTION
## Problem

On the Replay vision product page, the "Spend this month" tile shows a projection like "111% by August 17". It never says what that date is, so it's not clear the date is the billing period end. This came up as a UX confusion in a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1784905966021939).

## Changes

Label the projection date as the period end. The tile now reads "111% by period end (August 17)" when a period end is available, and falls back to "by period end" when it isn't.

## How did you test this code?

Manual reasoning only — I (the agent) didn't run the frontend locally. The change is a small JSX copy tweak in `VisionMetrics.tsx` reusing the existing `resetsOn` value (already formatted from `period_end`). No automated tests were added or run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app agent at Cory Slater's request. Traced the tile copy to `products/replay_vision/frontend/replay_scanners/components/VisionMetrics.tsx`, confirmed `resetsOn` derives from the billing `period_end` in `quotaProjection.ts`, and made the date's meaning explicit. No skills were required for this copy-only change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1784905966021939)*
