### PR TITLE
fix(data-imports): stop reporting duckgres sink maintenance timeouts as errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
@@ -43,6 +43,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.jobs_db import (
     DuckgresBatchQueue,
+    is_eligibility_query_timeout,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.jobs_db import (
     LEASE_TTL_SECONDS,
@@ -219,8 +220,14 @@ class DuckgresBatchConsumerAdapter:
             )
             SINK_ORGS_AT_BUDGET.set(orgs_at_budget)
         except Exception as e:
-            logger.exception("duckgres_sink_maintenance_query_failed")
-            capture_exception(e)
+            if is_eligibility_query_timeout(e):
+                # Expected under a slow/loaded queue DB — the eligibility-CTE
+                # queries are timeout-bounded specifically so this fails fast
+                # and the next tick just retries; not worth an error-tracking report.
+                logger.warning("duckgres_sink_maintenance_query_timed_out")
+            else:
+                logger.exception("duckgres_sink_maintenance_query_failed")
+                capture_exception(e)
             return
 
         block_list_was_unset = self._blocked_schema_ids is None

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/jobs_db.py
@@ -62,6 +62,13 @@ def _latest_status_lateral(status_table: str, batch_alias: str) -> str:
 ELIGIBILITY_QUERY_STATEMENT_TIMEOUT_MS = 30_000
 
 
+def is_eligibility_query_timeout(error: BaseException) -> bool:
+    """True when ``error`` is a query cancellation, the expected shape of
+    ELIGIBILITY_QUERY_STATEMENT_TIMEOUT_MS tripping under a slow/loaded queue DB.
+    Callers should skip the tick and retry rather than report it as a defect."""
+    return isinstance(error, psycopg.errors.QueryCanceled)
+
+
 @asynccontextmanager
 async def _statement_timeout(conn: psycopg.AsyncConnection[Any], timeout_ms: int) -> AsyncIterator[None]:
     """Bound the wrapped query with a server-side ``statement_timeout``.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_consumer.py
@@ -426,7 +426,9 @@ class TestDuckgresEnablementGating:
         # The eligibility-CTE maintenance queries are statement-timeout bounded;
         # a timeout (or any transient queue-DB error) must be swallowed so the
         # poll loop is neither wedged nor crashed — the planner is skipped and
-        # nothing is claimed this tick, and the next poll just retries.
+        # nothing is claimed this tick, and the next poll just retries. It's
+        # also the expected shape of that bound tripping under load, so it
+        # must not be reported to error tracking as a defect.
         adapter = DuckgresBatchConsumerAdapter()
         adapter._team_ids = [1, 2]
         adapter._team_ids_fetched_at = time.monotonic()
@@ -445,6 +447,9 @@ class TestDuckgresEnablementGating:
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer.run_backfill_planner",
             ) as mock_planner,
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer.capture_exception",
+            ) as mock_capture,
         ):
             batches = await adapter.fetch_and_lock(
                 conn, limit=50, retry_backoff_base_seconds=0, owner_token="test-owner", lease_ttl_seconds=300
@@ -453,6 +458,43 @@ class TestDuckgresEnablementGating:
         assert batches == []
         mock_planner.assert_not_called()
         mock_fetch.assert_not_called()
+        mock_capture.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fetch_reports_unexpected_maintenance_query_error(self):
+        # A genuine, unexpected maintenance-query failure (not the queue DB's
+        # own statement timeout) must still be swallowed to protect the poll
+        # loop, but is worth surfacing to error tracking as a real defect.
+        adapter = DuckgresBatchConsumerAdapter()
+        adapter._team_ids = [1, 2]
+        adapter._team_ids_fetched_at = time.monotonic()
+        conn = _make_healthy_conn()
+
+        with (
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer.DuckgresBatchQueue.get_delta_succeeded_and_lock",
+                new_callable=AsyncMock,
+            ) as mock_fetch,
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer.DuckgresBatchQueue.supersede_replaced_runs",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("unexpected queue db failure"),
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer.run_backfill_planner",
+            ) as mock_planner,
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer.capture_exception",
+            ) as mock_capture,
+        ):
+            batches = await adapter.fetch_and_lock(
+                conn, limit=50, retry_backoff_base_seconds=0, owner_token="test-owner", lease_ttl_seconds=300
+            )
+
+        assert batches == []
+        mock_planner.assert_not_called()
+        mock_fetch.assert_not_called()
+        mock_capture.assert_called_once()
 
 
 class TestMidClaimRetire:


### PR DESCRIPTION
## Problem

Error tracking surfaced a `QueryCanceled: canceling statement due to statement timeout` from `products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py`, raised inside `_run_maintenance`'s call to `DuckgresBatchQueue.supersede_replaced_runs` in `jobs_db.py`.

`_run_maintenance` runs every ~30s to sweep obsolete runs and refresh backlog gauges. Its three queries (`supersede_replaced_runs`, `get_backlog_stats`, `count_orgs_at_budget`) are already wrapped in a 30s `statement_timeout` (`ELIGIBILITY_QUERY_STATEMENT_TIMEOUT_MS`) specifically so a slow/loaded queue DB fails fast instead of stacking up long-running scans — the code comment right above the call already says a timeout here "must not wedge or crash the poll loop — skip this tick and retry on the next one."

The poll loop does correctly skip and retry: the `except Exception` around the whole maintenance block swallows the error so nothing crashes. But it also unconditionally calls `capture_exception(e)` for every exception in that block, including this expected, self-healing timeout. So the very safeguard designed to make timeouts benign was reporting each one to error tracking as if it were a defect.

## Changes

- Added `is_eligibility_query_timeout` next to `ELIGIBILITY_QUERY_STATEMENT_TIMEOUT_MS` in `jobs_db.py` — a small classifier for `psycopg.errors.QueryCanceled`, the expected shape of that bound tripping.
- `consumer.py`'s `_run_maintenance` now branches on it: a `QueryCanceled` logs a warning and skips the tick as before, without `capture_exception`. Any other, genuinely unexpected error in that block still gets captured, same as today.

This only changes what gets reported to error tracking — the swallow-and-retry behavior for the whole block is unchanged.

## How did you test this code?

Extended the existing `test_fetch_swallows_maintenance_query_timeout_and_skips_planner` (which already asserted the timeout is swallowed and the planner/fetch are skipped) to also assert `capture_exception` is **not** called. Added a sibling `test_fetch_reports_unexpected_maintenance_query_error` asserting a genuinely unexpected error (e.g. a `RuntimeError`) still gets captured — locking in that the fix is scoped to the specific timeout case, not a blanket suppression.

Ran:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_consumer.py -k "test_fetch_swallows_maintenance_query_timeout_and_skips_planner or test_fetch_reports_unexpected_maintenance_query_error"` — 2 passed
- `uv run mypy --cache-fine-grained` on the two changed source files — clean
- `ruff check` / `ruff format` — clean
- `hogli ci:preflight --fix` — 0 failures

The rest of the duckgres test suite (DB-backed integration tests) requires a running Postgres instance not available in this sandbox; those were not run, but this change doesn't touch any DB-facing query logic.

## Docs update

N/A — internal error-classification change, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered PostHog error tracking issue using the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace and sync context, then read `consumer.py` and `jobs_db.py` directly to confirm the timeout is already an expected, bounded condition per the existing code comments and a pre-existing test (`test_fetch_swallows_maintenance_query_timeout_and_skips_planner`) that only asserted the swallow, not the error-tracking report. Used an Explore-style subagent to check for a shared "transient DB error" classifier elsewhere in the pipeline (`repartition_table.py`'s `_is_transient_infra_error`, `delta_table_helper.py`'s object-store classifier, `sources/postgres/postgres.py`'s `QueryCanceled` handling) — none covered this specific queue-DB maintenance path, so I added a small local classifier next to the timeout constant it's paired with. Invoked `/writing-tests` before extending the test. Checked for duplicate open PRs (exception type, message phrase, module path, and the maintainer's own open PRs) — found related-but-non-overlapping prior work (e.g. #73386, which classifies a different error type in a different file) rather than a duplicate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*