### PR TITLE
fix(data-modeling): scope DAG run preemption to the run's own nodes

### DIFF
--- a/posthog/temporal/data_modeling/activities/preempt_dag_run.py
+++ b/posthog/temporal/data_modeling/activities/preempt_dag_run.py
@@ -4,6 +4,7 @@ from structlog import get_logger
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 from temporalio.client import Client, WorkflowExecutionStatus
+from temporalio.service import RPCError, RPCStatusCode
 
 from posthog.exceptions_capture import capture_exception
 from posthog.sync import database_sync_to_async_pool
@@ -90,9 +91,15 @@ async def _abandoned_jobs(temporal: Client, candidates: list[DataModelingJob]) -
             continue
         try:
             description = await temporal.get_workflow_handle(job.workflow_id).describe()
+        except RPCError as e:
+            # NOT_FOUND is the only error that proves absence. Timeouts, unavailability and
+            # permission errors say nothing about the workflow, and marking a live job Failed is
+            # unrecoverable (succeed_materialization refuses to overwrite a terminal status), so
+            # anything else leaves the row alone for a later run to judge.
+            if e.status == RPCStatusCode.NOT_FOUND:
+                abandoned.append(job)
+            continue
         except Exception:
-            # Not found: Temporal has no record of it, so nothing is running.
-            abandoned.append(job)
             continue
         if description.status != WorkflowExecutionStatus.RUNNING:
             abandoned.append(job)
@@ -132,33 +139,46 @@ async def preempt_dag_run_activity(inputs: PreemptDAGRunInputs) -> None:
         await logger.adebug("No previous DAG run to preempt")
         return
 
+    try:
+        temporal = await async_connect()
+    except Exception as e:
+        # Nothing has been touched yet, and marking a row Failed without cancelling its workflow
+        # is the corruption this activity exists to avoid. Leave everything Running and let the
+        # activity's own retry (or the next run) handle it.
+        capture_exception(e)
+        await logger.aexception(f"Failed to connect to Temporal: {str(e)}")
+        raise
+
+    # Preempt first, and cancel before marking. Reaping below makes one RPC per candidate row and
+    # can outrun the activity timeout; if that happens after the owned rows are already marked, a
+    # retry no longer finds them as Running and their workflows would never be cancelled, leaving
+    # the new run free to materialize the same node concurrently. Cancelling first also means a
+    # crash between the two steps is recoverable: the rows are still Running, so the retry
+    # re-finds them and cancellation is idempotent.
     if ours:
         await logger.ainfo(
             f"Preempting previous DAG run: found {len(ours)} running jobs",
             dag_id=inputs.dag_id,
         )
+        for workflow_id in {job.workflow_id for job in ours if job.workflow_id}:
+            try:
+                await temporal.get_workflow_handle(workflow_id).cancel()
+                await logger.ainfo(f"Requested cancellation of materialize workflow {workflow_id}")
+            except Exception as e:
+                # workflow may have already completed — that's fine
+                await logger.awarning(f"Could not cancel materialize workflow {workflow_id}: {str(e)}")
         updated_count = await _mark_jobs_failed([str(job.id) for job in ours], PREEMPTED_ERROR)
         await logger.ainfo(f"Marked {updated_count} jobs as preempted", dag_id=inputs.dag_id)
 
-    try:
-        temporal = await async_connect()
-    except Exception as e:
-        # The preemption marks above already landed; without a client we can neither cancel
-        # nor prove anything is abandoned, so leave the rest for the next run.
-        capture_exception(e)
-        await logger.aexception(f"Failed to connect to Temporal: {str(e)}")
+    if not others:
         return
 
-    if others:
+    # Best-effort cleanup: it must never undo or block the preemption above.
+    try:
         abandoned = await _abandoned_jobs(temporal, others)
         if abandoned:
             reaped = await _mark_jobs_failed([str(job.id) for job in abandoned], ABANDONED_ERROR)
             await logger.ainfo(f"Reaped {reaped} abandoned jobs", dag_id=inputs.dag_id)
-
-    for workflow_id in {job.workflow_id for job in ours if job.workflow_id}:
-        try:
-            await temporal.get_workflow_handle(workflow_id).cancel()
-            await logger.ainfo(f"Requested cancellation of materialize workflow {workflow_id}")
-        except Exception as e:
-            # workflow may have already completed — that's fine
-            await logger.awarning(f"Could not cancel materialize workflow {workflow_id}: {str(e)}")
+    except Exception as e:
+        capture_exception(e)
+        await logger.aexception(f"Failed to reap abandoned jobs: {str(e)}")

--- a/posthog/temporal/data_modeling/activities/preempt_dag_run.py
+++ b/posthog/temporal/data_modeling/activities/preempt_dag_run.py
@@ -1,4 +1,7 @@
+import datetime as dt
 import dataclasses
+
+from django.utils import timezone
 
 from structlog import get_logger
 from structlog.contextvars import bind_contextvars
@@ -13,6 +16,12 @@ from products.data_modeling.backend.facade.models import DataModelingJob, DataMo
 LOGGER = get_logger(__name__)
 
 PREEMPTED_ERROR = "Preempted: a new DAG run started before this job completed"
+ABANDONED_ERROR = "Abandoned: the materialization workflow is no longer running"
+
+# A MaterializeViewWorkflow's activities cap out at 20 minutes with a 2-minute heartbeat, so a row
+# still marked Running well past that has lost its workflow and will never close itself. Kept
+# deliberately loose: over-waiting only delays cleanup, while under-waiting would fail a live job.
+STALE_RUNNING_JOB_AGE = dt.timedelta(hours=6)
 
 
 @dataclasses.dataclass
@@ -34,63 +43,96 @@ def _node_id_from_workflow_id(workflow_id: str, dag_id: str) -> str | None:
 
 
 @database_sync_to_async_pool
-def _get_running_jobs_for_dag(team_id: int, dag_id: str, node_ids: list[str] | None) -> list[DataModelingJob]:
-    """Find RUNNING DataModelingJob records belonging to a previous run of *these* nodes.
+def _get_running_jobs_for_dag(team_id: int, dag_id: str) -> list[DataModelingJob]:
+    """Every RUNNING job belonging to this DAG, whether or not this run owns its node.
 
     Child workflow IDs follow the pattern `materialize-view-{dag_id}-{node_id}-{timestamp}`,
     so we can match jobs by their workflow_id prefix.
-
-    Cadence tiers of one DAG hold disjoint node sets and run on their own schedules, so a tier
-    must only preempt its own nodes — matching on `dag_id` alone lets one tier cancel another
-    tier's unrelated in-flight work. An unset `node_ids` means a whole-DAG run (the legacy
-    single v2 schedule), which owns every node and preempts accordingly.
     """
-    jobs = DataModelingJob.objects.filter(
-        team_id=team_id,
-        status=DataModelingJobStatus.RUNNING,
-        workflow_id__startswith=f"materialize-view-{dag_id}-",
+    return list(
+        DataModelingJob.objects.filter(
+            team_id=team_id,
+            status=DataModelingJobStatus.RUNNING,
+            workflow_id__startswith=f"materialize-view-{dag_id}-",
+        )
     )
-    # Empty means "every node", matching how ExecuteDAGWorkflow reads the same field.
-    if not node_ids:
-        return list(jobs)
-    owned = set(node_ids)
-    return [job for job in jobs if _node_id_from_workflow_id(job.workflow_id or "", dag_id) in owned]
+
+
+def partition_running_jobs(
+    jobs: list[DataModelingJob], dag_id: str, node_ids: list[str] | None, now: dt.datetime
+) -> tuple[list[DataModelingJob], list[DataModelingJob]]:
+    """Split this DAG's running jobs into the ones we preempt and the ones we merely reap.
+
+    Two different jobs share this activity, and they want different scopes:
+
+    - *Preempt* the nodes this run is about to materialize. Cadence tiers of one DAG hold
+      disjoint node sets, so preempting DAG-wide lets one tier cancel another tier's live work.
+      An unset `node_ids` means a whole-DAG run (the legacy single v2 schedule), which owns
+      every node.
+    - *Reap* rows left behind by a workflow that is long gone, wherever they are in the DAG.
+      Those are corpses, not work in progress, so ownership must not gate cleaning them up —
+      a node in no tier is otherwise stuck Running forever. Gating on age is what keeps this
+      from touching another tier's live job.
+    """
+    owned = set(node_ids or [])
+    stale_before = now - STALE_RUNNING_JOB_AGE
+    ours: list[DataModelingJob] = []
+    abandoned: list[DataModelingJob] = []
+    for job in jobs:
+        # Empty node_ids means "every node", matching how ExecuteDAGWorkflow reads the same field.
+        if not node_ids or _node_id_from_workflow_id(job.workflow_id or "", dag_id) in owned:
+            ours.append(job)
+        # No timestamp means we cannot prove the row is a corpse, so leave it running.
+        elif job.updated_at is not None and job.updated_at < stale_before:
+            abandoned.append(job)
+    return ours, abandoned
 
 
 @database_sync_to_async_pool
-def _mark_jobs_as_preempted(job_ids: list[str]) -> int:
+def _mark_jobs_failed(job_ids: list[str], error: str) -> int:
     return DataModelingJob.objects.filter(id__in=job_ids, status=DataModelingJobStatus.RUNNING).update(
         status=DataModelingJobStatus.FAILED,
         rows_materialized=0,
-        error=PREEMPTED_ERROR,
+        error=error,
     )
 
 
 @activity.defn
 async def preempt_dag_run_activity(inputs: PreemptDAGRunInputs) -> None:
-    """Preempt in-flight materializations of the nodes this run is about to materialize.
+    """Preempt in-flight materializations of the nodes this run is about to materialize, and
+    reap rows anywhere in the DAG whose workflow died without closing them.
 
     Cancels each owned node's own MaterializeViewWorkflow rather than the parent
     ExecuteDAGWorkflow: parent cancellation cascades to every sibling child via
     ParentClosePolicy.REQUEST_CANCEL, so preempting one node that has since moved between
     cadence tiers would take down the whole run that still owns its siblings.
     A parent starts each of its nodes once, so there is no child to re-spawn behind us.
+
+    Reaped rows are only marked, never cancelled — there is no live workflow left to cancel,
+    and cancelling on another tier's behalf is exactly what this activity must not do.
     """
     bind_contextvars(team_id=inputs.team_id)
     logger = LOGGER.bind()
 
-    running_jobs = await _get_running_jobs_for_dag(inputs.team_id, inputs.dag_id, inputs.node_ids)
-    if not running_jobs:
+    running_jobs = await _get_running_jobs_for_dag(inputs.team_id, inputs.dag_id)
+    ours, abandoned = partition_running_jobs(running_jobs, inputs.dag_id, inputs.node_ids, timezone.now())
+    if not ours and not abandoned:
         await logger.adebug("No previous DAG run to preempt")
         return
 
+    if abandoned:
+        reaped = await _mark_jobs_failed([str(job.id) for job in abandoned], ABANDONED_ERROR)
+        await logger.ainfo(f"Reaped {reaped} abandoned jobs", dag_id=inputs.dag_id)
+
+    if not ours:
+        return
+
     await logger.ainfo(
-        f"Preempting previous DAG run: found {len(running_jobs)} running jobs",
+        f"Preempting previous DAG run: found {len(ours)} running jobs",
         dag_id=inputs.dag_id,
     )
-    child_workflow_ids = {job.workflow_id for job in running_jobs if job.workflow_id}
-    job_ids = [str(job.id) for job in running_jobs]
-    updated_count = await _mark_jobs_as_preempted(job_ids)
+    child_workflow_ids = {job.workflow_id for job in ours if job.workflow_id}
+    updated_count = await _mark_jobs_failed([str(job.id) for job in ours], PREEMPTED_ERROR)
     await logger.ainfo(f"Marked {updated_count} jobs as preempted", dag_id=inputs.dag_id)
     if child_workflow_ids:
         try:

--- a/posthog/temporal/data_modeling/activities/preempt_dag_run.py
+++ b/posthog/temporal/data_modeling/activities/preempt_dag_run.py
@@ -1,11 +1,9 @@
-import datetime as dt
 import dataclasses
-
-from django.utils import timezone
 
 from structlog import get_logger
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
+from temporalio.client import Client, WorkflowExecutionStatus
 
 from posthog.exceptions_capture import capture_exception
 from posthog.sync import database_sync_to_async_pool
@@ -17,11 +15,6 @@ LOGGER = get_logger(__name__)
 
 PREEMPTED_ERROR = "Preempted: a new DAG run started before this job completed"
 ABANDONED_ERROR = "Abandoned: the materialization workflow is no longer running"
-
-# A MaterializeViewWorkflow's activities cap out at 20 minutes with a 2-minute heartbeat, so a row
-# still marked Running well past that has lost its workflow and will never close itself. Kept
-# deliberately loose: over-waiting only delays cleanup, while under-waiting would fail a live job.
-STALE_RUNNING_JOB_AGE = dt.timedelta(hours=6)
 
 
 @dataclasses.dataclass
@@ -59,33 +52,51 @@ def _get_running_jobs_for_dag(team_id: int, dag_id: str) -> list[DataModelingJob
 
 
 def partition_running_jobs(
-    jobs: list[DataModelingJob], dag_id: str, node_ids: list[str] | None, now: dt.datetime
+    jobs: list[DataModelingJob], dag_id: str, node_ids: list[str] | None
 ) -> tuple[list[DataModelingJob], list[DataModelingJob]]:
-    """Split this DAG's running jobs into the ones we preempt and the ones we merely reap.
+    """Split this DAG's running jobs into the nodes this run owns and everything else.
 
-    Two different jobs share this activity, and they want different scopes:
+    Cadence tiers of one DAG hold disjoint node sets, so only the owned half may be preempted —
+    preempting DAG-wide is what lets one tier cancel another tier's live work. An unset
+    `node_ids` means a whole-DAG run (the legacy single v2 schedule), which owns every node.
 
-    - *Preempt* the nodes this run is about to materialize. Cadence tiers of one DAG hold
-      disjoint node sets, so preempting DAG-wide lets one tier cancel another tier's live work.
-      An unset `node_ids` means a whole-DAG run (the legacy single v2 schedule), which owns
-      every node.
-    - *Reap* rows left behind by a workflow that is long gone, wherever they are in the DAG.
-      Those are corpses, not work in progress, so ownership must not gate cleaning them up —
-      a node in no tier is otherwise stuck Running forever. Gating on age is what keeps this
-      from touching another tier's live job.
+    The rest are merely *candidates* for reaping: whether they are corpses is decided by asking
+    Temporal, not by anything on the row.
     """
     owned = set(node_ids or [])
-    stale_before = now - STALE_RUNNING_JOB_AGE
     ours: list[DataModelingJob] = []
-    abandoned: list[DataModelingJob] = []
+    others: list[DataModelingJob] = []
     for job in jobs:
         # Empty node_ids means "every node", matching how ExecuteDAGWorkflow reads the same field.
         if not node_ids or _node_id_from_workflow_id(job.workflow_id or "", dag_id) in owned:
             ours.append(job)
-        # No timestamp means we cannot prove the row is a corpse, so leave it running.
-        elif job.updated_at is not None and job.updated_at < stale_before:
+        else:
+            others.append(job)
+    return ours, others
+
+
+async def _abandoned_jobs(temporal: Client, candidates: list[DataModelingJob]) -> list[DataModelingJob]:
+    """Of these rows, the ones whose workflow is no longer running.
+
+    A row saying Running while its workflow is closed (or gone from Temporal's retention) is a
+    corpse: nothing will ever close it. Asking Temporal is the only way to tell a corpse from a
+    slow run — a job's wall-clock age cannot, because nothing bounds it. Activity
+    `start_to_close_timeout` caps one attempt, not queue wait, retries, or the workflow overall,
+    and MaterializeViewWorkflow is started with no execution timeout.
+    """
+    abandoned: list[DataModelingJob] = []
+    for job in candidates:
+        if not job.workflow_id:
+            continue
+        try:
+            description = await temporal.get_workflow_handle(job.workflow_id).describe()
+        except Exception:
+            # Not found: Temporal has no record of it, so nothing is running.
             abandoned.append(job)
-    return ours, abandoned
+            continue
+        if description.status != WorkflowExecutionStatus.RUNNING:
+            abandoned.append(job)
+    return abandoned
 
 
 @database_sync_to_async_pool
@@ -108,43 +119,46 @@ async def preempt_dag_run_activity(inputs: PreemptDAGRunInputs) -> None:
     cadence tiers would take down the whole run that still owns its siblings.
     A parent starts each of its nodes once, so there is no child to re-spawn behind us.
 
-    Reaped rows are only marked, never cancelled — there is no live workflow left to cancel,
-    and cancelling on another tier's behalf is exactly what this activity must not do.
+    Rows outside that node set are only reaped, and only once Temporal confirms their workflow
+    is no longer running: they are marked, never cancelled, because there is nothing left to
+    cancel and cancelling on another tier's behalf is exactly what this activity must not do.
     """
     bind_contextvars(team_id=inputs.team_id)
     logger = LOGGER.bind()
 
     running_jobs = await _get_running_jobs_for_dag(inputs.team_id, inputs.dag_id)
-    ours, abandoned = partition_running_jobs(running_jobs, inputs.dag_id, inputs.node_ids, timezone.now())
-    if not ours and not abandoned:
+    ours, others = partition_running_jobs(running_jobs, inputs.dag_id, inputs.node_ids)
+    if not ours and not others:
         await logger.adebug("No previous DAG run to preempt")
         return
 
-    if abandoned:
-        reaped = await _mark_jobs_failed([str(job.id) for job in abandoned], ABANDONED_ERROR)
-        await logger.ainfo(f"Reaped {reaped} abandoned jobs", dag_id=inputs.dag_id)
+    if ours:
+        await logger.ainfo(
+            f"Preempting previous DAG run: found {len(ours)} running jobs",
+            dag_id=inputs.dag_id,
+        )
+        updated_count = await _mark_jobs_failed([str(job.id) for job in ours], PREEMPTED_ERROR)
+        await logger.ainfo(f"Marked {updated_count} jobs as preempted", dag_id=inputs.dag_id)
 
-    if not ours:
+    try:
+        temporal = await async_connect()
+    except Exception as e:
+        # The preemption marks above already landed; without a client we can neither cancel
+        # nor prove anything is abandoned, so leave the rest for the next run.
+        capture_exception(e)
+        await logger.aexception(f"Failed to connect to Temporal: {str(e)}")
         return
 
-    await logger.ainfo(
-        f"Preempting previous DAG run: found {len(ours)} running jobs",
-        dag_id=inputs.dag_id,
-    )
-    child_workflow_ids = {job.workflow_id for job in ours if job.workflow_id}
-    updated_count = await _mark_jobs_failed([str(job.id) for job in ours], PREEMPTED_ERROR)
-    await logger.ainfo(f"Marked {updated_count} jobs as preempted", dag_id=inputs.dag_id)
-    if child_workflow_ids:
+    if others:
+        abandoned = await _abandoned_jobs(temporal, others)
+        if abandoned:
+            reaped = await _mark_jobs_failed([str(job.id) for job in abandoned], ABANDONED_ERROR)
+            await logger.ainfo(f"Reaped {reaped} abandoned jobs", dag_id=inputs.dag_id)
+
+    for workflow_id in {job.workflow_id for job in ours if job.workflow_id}:
         try:
-            temporal = await async_connect()
-            for workflow_id in child_workflow_ids:
-                try:
-                    handle = temporal.get_workflow_handle(workflow_id)
-                    await handle.cancel()
-                    await logger.ainfo(f"Requested cancellation of materialize workflow {workflow_id}")
-                except Exception as e:
-                    # workflow may have already completed — that's fine
-                    await logger.awarning(f"Could not cancel materialize workflow {workflow_id}: {str(e)}")
+            await temporal.get_workflow_handle(workflow_id).cancel()
+            await logger.ainfo(f"Requested cancellation of materialize workflow {workflow_id}")
         except Exception as e:
-            capture_exception(e)
-            await logger.aexception(f"Failed to connect to Temporal for workflow cancellation: {str(e)}")
+            # workflow may have already completed — that's fine
+            await logger.awarning(f"Could not cancel materialize workflow {workflow_id}: {str(e)}")

--- a/posthog/temporal/data_modeling/activities/preempt_dag_run.py
+++ b/posthog/temporal/data_modeling/activities/preempt_dag_run.py
@@ -19,22 +19,42 @@ PREEMPTED_ERROR = "Preempted: a new DAG run started before this job completed"
 class PreemptDAGRunInputs:
     team_id: int
     dag_id: str
+    node_ids: list[str] | None = None
+
+
+def _node_id_from_workflow_id(workflow_id: str, dag_id: str) -> str | None:
+    """Recover the node id from a child workflow id, or None if it doesn't belong to this DAG."""
+    prefix = f"materialize-view-{dag_id}-"
+    if not workflow_id.startswith(prefix):
+        return None
+    # The remainder is `{node_id}-{timestamp}`. Node ids are UUIDs, so take the first five
+    # dash-separated groups rather than assuming a fixed overall length.
+    groups = workflow_id[len(prefix) :].split("-")
+    return "-".join(groups[:5]) if len(groups) >= 5 else None
 
 
 @database_sync_to_async_pool
-def _get_running_jobs_for_dag(team_id: int, dag_id: str) -> list[DataModelingJob]:
-    """Find RUNNING DataModelingJob records belonging to a previous run of this DAG.
+def _get_running_jobs_for_dag(team_id: int, dag_id: str, node_ids: list[str] | None) -> list[DataModelingJob]:
+    """Find RUNNING DataModelingJob records belonging to a previous run of *these* nodes.
 
     Child workflow IDs follow the pattern `materialize-view-{dag_id}-{node_id}-{timestamp}`,
     so we can match jobs by their workflow_id prefix.
+
+    Cadence tiers of one DAG hold disjoint node sets and run on their own schedules, so a tier
+    must only preempt its own nodes — matching on `dag_id` alone lets one tier cancel another
+    tier's unrelated in-flight work. An unset `node_ids` means a whole-DAG run (the legacy
+    single v2 schedule), which owns every node and preempts accordingly.
     """
-    return list(
-        DataModelingJob.objects.filter(
-            team_id=team_id,
-            status=DataModelingJobStatus.RUNNING,
-            workflow_id__startswith=f"materialize-view-{dag_id}-",
-        )
+    jobs = DataModelingJob.objects.filter(
+        team_id=team_id,
+        status=DataModelingJobStatus.RUNNING,
+        workflow_id__startswith=f"materialize-view-{dag_id}-",
     )
+    # Empty means "every node", matching how ExecuteDAGWorkflow reads the same field.
+    if not node_ids:
+        return list(jobs)
+    owned = set(node_ids)
+    return [job for job in jobs if _node_id_from_workflow_id(job.workflow_id or "", dag_id) in owned]
 
 
 @database_sync_to_async_pool
@@ -48,16 +68,18 @@ def _mark_jobs_as_preempted(job_ids: list[str]) -> int:
 
 @activity.defn
 async def preempt_dag_run_activity(inputs: PreemptDAGRunInputs) -> None:
-    """Preempt a previous run of the same DAG by cancelling its parent workflow and marking jobs as failed.
+    """Preempt in-flight materializations of the nodes this run is about to materialize.
 
-    Cancelling the parent ExecuteDAGWorkflow cascades to all child MaterializeViewWorkflows
-    (via ParentClosePolicy.REQUEST_CANCEL), which avoids a race where new children could be
-    spawned after individual child cancellation.
+    Cancels each owned node's own MaterializeViewWorkflow rather than the parent
+    ExecuteDAGWorkflow: parent cancellation cascades to every sibling child via
+    ParentClosePolicy.REQUEST_CANCEL, so preempting one node that has since moved between
+    cadence tiers would take down the whole run that still owns its siblings.
+    A parent starts each of its nodes once, so there is no child to re-spawn behind us.
     """
     bind_contextvars(team_id=inputs.team_id)
     logger = LOGGER.bind()
 
-    running_jobs = await _get_running_jobs_for_dag(inputs.team_id, inputs.dag_id)
+    running_jobs = await _get_running_jobs_for_dag(inputs.team_id, inputs.dag_id, inputs.node_ids)
     if not running_jobs:
         await logger.adebug("No previous DAG run to preempt")
         return
@@ -66,24 +88,21 @@ async def preempt_dag_run_activity(inputs: PreemptDAGRunInputs) -> None:
         f"Preempting previous DAG run: found {len(running_jobs)} running jobs",
         dag_id=inputs.dag_id,
     )
-    # collect unique parent workflow IDs — cancelling the parent cascades to all children
-    parent_workflow_ids = {job.parent_workflow_id for job in running_jobs if job.parent_workflow_id}
+    child_workflow_ids = {job.workflow_id for job in running_jobs if job.workflow_id}
     job_ids = [str(job.id) for job in running_jobs]
-    # mark all running jobs as preempted
     updated_count = await _mark_jobs_as_preempted(job_ids)
     await logger.ainfo(f"Marked {updated_count} jobs as preempted", dag_id=inputs.dag_id)
-    # request cancellation of parent workflows — this cascades to all children
-    if parent_workflow_ids:
+    if child_workflow_ids:
         try:
             temporal = await async_connect()
-            for workflow_id in parent_workflow_ids:
+            for workflow_id in child_workflow_ids:
                 try:
                     handle = temporal.get_workflow_handle(workflow_id)
                     await handle.cancel()
-                    await logger.ainfo(f"Requested cancellation of parent workflow {workflow_id}")
+                    await logger.ainfo(f"Requested cancellation of materialize workflow {workflow_id}")
                 except Exception as e:
                     # workflow may have already completed — that's fine
-                    await logger.awarning(f"Could not cancel parent workflow {workflow_id}: {str(e)}")
+                    await logger.awarning(f"Could not cancel materialize workflow {workflow_id}: {str(e)}")
         except Exception as e:
             capture_exception(e)
             await logger.aexception(f"Failed to connect to Temporal for workflow cancellation: {str(e)}")

--- a/posthog/temporal/data_modeling/workflows/execute_dag.py
+++ b/posthog/temporal/data_modeling/workflows/execute_dag.py
@@ -203,6 +203,7 @@ class ExecuteDAGWorkflow(PostHogWorkflow):
             PreemptDAGRunInputs(
                 team_id=inputs.team_id,
                 dag_id=inputs.dag_id,
+                node_ids=inputs.node_ids,
             ),
             start_to_close_timeout=dt.timedelta(minutes=5),
             retry_policy=temporalio.common.RetryPolicy(

--- a/posthog/temporal/tests/data_modeling/test_preempt_dag_run.py
+++ b/posthog/temporal/tests/data_modeling/test_preempt_dag_run.py
@@ -1,0 +1,107 @@
+import uuid
+
+import pytest
+import unittest.mock
+
+import pytest_asyncio
+from temporalio.testing import ActivityEnvironment
+
+from posthog.sync import database_sync_to_async
+from posthog.temporal.data_modeling.activities.preempt_dag_run import (
+    PREEMPTED_ERROR,
+    PreemptDAGRunInputs,
+    preempt_dag_run_activity,
+)
+
+from products.data_modeling.backend.facade.models import DataModelingJob, DataModelingJobStatus
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
+
+DAG_ID = "019e4d6a-1d8a-7569-97f5-a78ab8467820"
+NODE_HOURLY = "11111111-1111-1111-1111-111111111111"
+NODE_QUARTER_HOURLY = "22222222-2222-2222-2222-222222222222"
+# Ran under the hourly tier, but a reconcile has since moved it to the 15-minute tier, so the
+# 15-minute run now owns a node whose in-flight job belongs to the hourly run.
+NODE_MIGRATED = "33333333-3333-3333-3333-333333333333"
+
+# Mirrors execute_dag.py: child id is materialize-view-{dag_id}-{node_id}-{ts}, and the
+# parent (tier) id is execute-dag-{dag_id}:{interval_seconds}-{ts}.
+PARENT_HOURLY = f"execute-dag-{DAG_ID}:3600-2026-07-24T13:00:00"
+PARENT_QUARTER_HOURLY = f"execute-dag-{DAG_ID}:900-2026-07-24T13:00:00"
+
+
+@pytest_asyncio.fixture
+async def tier_jobs(ateam):
+    """One RUNNING job per cadence tier of the same DAG, on disjoint nodes."""
+
+    async def make(node_id: str, parent_workflow_id: str) -> DataModelingJob:
+        return await database_sync_to_async(DataModelingJob.objects.create)(
+            team=ateam,
+            status=DataModelingJobStatus.RUNNING,
+            workflow_id=f"materialize-view-{DAG_ID}-{node_id}-2026-07-24T13:00:00",
+            parent_workflow_id=parent_workflow_id,
+        )
+
+    yield {
+        NODE_HOURLY: await make(NODE_HOURLY, PARENT_HOURLY),
+        NODE_QUARTER_HOURLY: await make(NODE_QUARTER_HOURLY, PARENT_QUARTER_HOURLY),
+        # Shares the hourly run's parent with NODE_HOURLY.
+        NODE_MIGRATED: await make(NODE_MIGRATED, PARENT_HOURLY),
+    }
+
+
+@pytest.mark.parametrize(
+    "node_ids,expected_preempted",
+    [
+        # The bug: the 15-minute tier must not touch the hourly tier's unrelated nodes.
+        pytest.param([NODE_QUARTER_HOURLY], [NODE_QUARTER_HOURLY], id="scopes_to_own_tier"),
+        # Claiming a node whose in-flight job belongs to another tier's run must not take that
+        # run's siblings down with it — which cancelling the shared parent workflow would.
+        pytest.param([NODE_MIGRATED], [NODE_MIGRATED], id="migrated_node_spares_its_old_runs_siblings"),
+        # Legacy single whole-DAG schedule carries no node set and still preempts everything.
+        pytest.param(None, [NODE_HOURLY, NODE_QUARTER_HOURLY, NODE_MIGRATED], id="no_node_ids_preempts_whole_dag"),
+        # A tier whose nodes have no running jobs preempts nothing at all.
+        pytest.param([str(uuid.uuid4())], [], id="unrelated_nodes_preempt_nothing"),
+    ],
+)
+async def test_preempt_is_scoped_to_the_tiers_own_nodes(
+    node_ids: list[str] | None,
+    expected_preempted: list[str],
+    ateam,
+    tier_jobs,
+) -> None:
+    cancelled: list[str] = []
+    handle = unittest.mock.MagicMock()
+    handle.cancel = unittest.mock.AsyncMock()
+
+    def get_workflow_handle(workflow_id: str) -> unittest.mock.MagicMock:
+        cancelled.append(workflow_id)
+        return handle
+
+    client = unittest.mock.MagicMock()
+    client.get_workflow_handle = unittest.mock.MagicMock(side_effect=get_workflow_handle)
+
+    with unittest.mock.patch(
+        "posthog.temporal.data_modeling.activities.preempt_dag_run.async_connect",
+        unittest.mock.AsyncMock(return_value=client),
+    ):
+        await ActivityEnvironment().run(
+            preempt_dag_run_activity,
+            PreemptDAGRunInputs(team_id=ateam.pk, dag_id=DAG_ID, node_ids=node_ids),
+        )
+
+    for node_id, job in tier_jobs.items():
+        await database_sync_to_async(job.refresh_from_db)()
+        if node_id in expected_preempted:
+            assert job.status == DataModelingJobStatus.FAILED
+            assert job.error == PREEMPTED_ERROR
+        else:
+            assert job.status == DataModelingJobStatus.RUNNING
+            assert job.error is None
+
+    # Only the owned nodes' own materialize workflows are cancelled. Cancelling a parent
+    # would cascade to its siblings via ParentClosePolicy.REQUEST_CANCEL, which is the
+    # over-broad cancellation this scoping exists to prevent.
+    assert sorted(cancelled) == sorted(tier_jobs[node_id].workflow_id for node_id in expected_preempted)
+    assert not {PARENT_HOURLY, PARENT_QUARTER_HOURLY} & set(cancelled)
+    assert handle.cancel.await_count == len(expected_preempted)

--- a/posthog/temporal/tests/data_modeling/test_preempt_dag_run.py
+++ b/posthog/temporal/tests/data_modeling/test_preempt_dag_run.py
@@ -1,13 +1,17 @@
 import uuid
+import datetime as dt
 
 import pytest
 import unittest.mock
+
+from django.utils import timezone
 
 import pytest_asyncio
 from temporalio.testing import ActivityEnvironment
 
 from posthog.sync import database_sync_to_async
 from posthog.temporal.data_modeling.activities.preempt_dag_run import (
+    ABANDONED_ERROR,
     PREEMPTED_ERROR,
     PreemptDAGRunInputs,
     preempt_dag_run_activity,
@@ -50,6 +54,30 @@ async def tier_jobs(ateam):
     }
 
 
+async def _run_activity(team_id: int, node_ids: list[str] | None) -> tuple[list[str], unittest.mock.MagicMock]:
+    """Run the activity against a stubbed Temporal client, recording which workflows it cancelled."""
+    cancelled: list[str] = []
+    handle = unittest.mock.MagicMock()
+    handle.cancel = unittest.mock.AsyncMock()
+
+    def get_workflow_handle(workflow_id: str) -> unittest.mock.MagicMock:
+        cancelled.append(workflow_id)
+        return handle
+
+    client = unittest.mock.MagicMock()
+    client.get_workflow_handle = unittest.mock.MagicMock(side_effect=get_workflow_handle)
+
+    with unittest.mock.patch(
+        "posthog.temporal.data_modeling.activities.preempt_dag_run.async_connect",
+        unittest.mock.AsyncMock(return_value=client),
+    ):
+        await ActivityEnvironment().run(
+            preempt_dag_run_activity,
+            PreemptDAGRunInputs(team_id=team_id, dag_id=DAG_ID, node_ids=node_ids),
+        )
+    return cancelled, handle
+
+
 @pytest.mark.parametrize(
     "node_ids,expected_preempted",
     [
@@ -70,25 +98,7 @@ async def test_preempt_is_scoped_to_the_tiers_own_nodes(
     ateam,
     tier_jobs,
 ) -> None:
-    cancelled: list[str] = []
-    handle = unittest.mock.MagicMock()
-    handle.cancel = unittest.mock.AsyncMock()
-
-    def get_workflow_handle(workflow_id: str) -> unittest.mock.MagicMock:
-        cancelled.append(workflow_id)
-        return handle
-
-    client = unittest.mock.MagicMock()
-    client.get_workflow_handle = unittest.mock.MagicMock(side_effect=get_workflow_handle)
-
-    with unittest.mock.patch(
-        "posthog.temporal.data_modeling.activities.preempt_dag_run.async_connect",
-        unittest.mock.AsyncMock(return_value=client),
-    ):
-        await ActivityEnvironment().run(
-            preempt_dag_run_activity,
-            PreemptDAGRunInputs(team_id=ateam.pk, dag_id=DAG_ID, node_ids=node_ids),
-        )
+    cancelled, handle = await _run_activity(ateam.pk, node_ids)
 
     for node_id, job in tier_jobs.items():
         await database_sync_to_async(job.refresh_from_db)()
@@ -105,3 +115,47 @@ async def test_preempt_is_scoped_to_the_tiers_own_nodes(
     assert sorted(cancelled) == sorted(tier_jobs[node_id].workflow_id for node_id in expected_preempted)
     assert not {PARENT_HOURLY, PARENT_QUARTER_HOURLY} & set(cancelled)
     assert handle.cancel.await_count == len(expected_preempted)
+
+
+# Absolute ages, deliberately not derived from STALE_RUNNING_JOB_AGE — offsets from the constant
+# would track any change to it and could never fail. A week is past any defensible threshold
+# (activities cap at 20 minutes); a minute is unambiguously still live.
+@pytest.mark.parametrize(
+    "age,expect_reaped",
+    [
+        pytest.param(dt.timedelta(days=7), True, id="abandoned_row_is_reaped"),
+        pytest.param(dt.timedelta(minutes=1), False, id="live_foreign_job_is_left_alone"),
+    ],
+)
+async def test_rows_outside_our_nodes_are_reaped_only_once_their_workflow_is_gone(
+    age: dt.timedelta,
+    expect_reaped: bool,
+    ateam,
+    tier_jobs,
+) -> None:
+    # A node in no tier: nothing ever "owns" it, so if ownership gated cleanup its row would
+    # stay Running forever and the UI would show it perpetually materializing.
+    orphan_node = "44444444-4444-4444-4444-444444444444"
+    orphan = await database_sync_to_async(DataModelingJob.objects.create)(
+        team=ateam,
+        status=DataModelingJobStatus.RUNNING,
+        workflow_id=f"materialize-view-{DAG_ID}-{orphan_node}-2026-01-01T00:00:00",
+        parent_workflow_id=PARENT_HOURLY,
+    )
+    # updated_at is auto_now, so age it with a queryset update rather than a save.
+    await database_sync_to_async(DataModelingJob.objects.filter(id=orphan.id).update)(updated_at=timezone.now() - age)
+
+    cancelled, _handle = await _run_activity(ateam.pk, [NODE_QUARTER_HOURLY])
+
+    await database_sync_to_async(orphan.refresh_from_db)()
+    if expect_reaped:
+        assert orphan.status == DataModelingJobStatus.FAILED
+        assert orphan.error == ABANDONED_ERROR
+    else:
+        assert orphan.status == DataModelingJobStatus.RUNNING
+        assert orphan.error is None
+
+    # Reaping only marks the row. There is no live workflow left to cancel, and cancelling on
+    # another tier's behalf is precisely what this activity must not do.
+    assert orphan.workflow_id not in cancelled
+    assert cancelled == [tier_jobs[NODE_QUARTER_HOURLY].workflow_id]

--- a/posthog/temporal/tests/data_modeling/test_preempt_dag_run.py
+++ b/posthog/temporal/tests/data_modeling/test_preempt_dag_run.py
@@ -1,12 +1,10 @@
 import uuid
-import datetime as dt
 
 import pytest
 import unittest.mock
 
-from django.utils import timezone
-
 import pytest_asyncio
+from temporalio.client import WorkflowExecutionStatus
 from temporalio.testing import ActivityEnvironment
 
 from posthog.sync import database_sync_to_async
@@ -27,11 +25,17 @@ NODE_QUARTER_HOURLY = "22222222-2222-2222-2222-222222222222"
 # Ran under the hourly tier, but a reconcile has since moved it to the 15-minute tier, so the
 # 15-minute run now owns a node whose in-flight job belongs to the hourly run.
 NODE_MIGRATED = "33333333-3333-3333-3333-333333333333"
+# In no tier at all, so no run ever owns it.
+NODE_ORPHAN = "44444444-4444-4444-4444-444444444444"
 
 # Mirrors execute_dag.py: child id is materialize-view-{dag_id}-{node_id}-{ts}, and the
 # parent (tier) id is execute-dag-{dag_id}:{interval_seconds}-{ts}.
 PARENT_HOURLY = f"execute-dag-{DAG_ID}:3600-2026-07-24T13:00:00"
 PARENT_QUARTER_HOURLY = f"execute-dag-{DAG_ID}:900-2026-07-24T13:00:00"
+
+
+def _child_workflow_id(node_id: str) -> str:
+    return f"materialize-view-{DAG_ID}-{node_id}-2026-07-24T13:00:00"
 
 
 @pytest_asyncio.fixture
@@ -42,7 +46,7 @@ async def tier_jobs(ateam):
         return await database_sync_to_async(DataModelingJob.objects.create)(
             team=ateam,
             status=DataModelingJobStatus.RUNNING,
-            workflow_id=f"materialize-view-{DAG_ID}-{node_id}-2026-07-24T13:00:00",
+            workflow_id=_child_workflow_id(node_id),
             parent_workflow_id=parent_workflow_id,
         )
 
@@ -54,14 +58,34 @@ async def tier_jobs(ateam):
     }
 
 
-async def _run_activity(team_id: int, node_ids: list[str] | None) -> tuple[list[str], unittest.mock.MagicMock]:
-    """Run the activity against a stubbed Temporal client, recording which workflows it cancelled."""
+async def _run_activity(
+    team_id: int,
+    node_ids: list[str] | None,
+    workflow_status: dict[str, WorkflowExecutionStatus | None] | None = None,
+) -> list[str]:
+    """Run the activity against a stubbed Temporal client, returning the workflows it cancelled.
+
+    `workflow_status` maps a workflow id to what describe() reports, where None means Temporal
+    has no record of it. Anything unlisted is reported as still RUNNING.
+    """
     cancelled: list[str] = []
-    handle = unittest.mock.MagicMock()
-    handle.cancel = unittest.mock.AsyncMock()
+    statuses = workflow_status or {}
 
     def get_workflow_handle(workflow_id: str) -> unittest.mock.MagicMock:
-        cancelled.append(workflow_id)
+        handle = unittest.mock.MagicMock()
+
+        async def cancel() -> None:
+            cancelled.append(workflow_id)
+
+        async def describe() -> unittest.mock.MagicMock:
+            if workflow_id in statuses and statuses[workflow_id] is None:
+                raise RuntimeError("workflow not found")
+            description = unittest.mock.MagicMock()
+            description.status = statuses.get(workflow_id, WorkflowExecutionStatus.RUNNING)
+            return description
+
+        handle.cancel = cancel
+        handle.describe = describe
         return handle
 
     client = unittest.mock.MagicMock()
@@ -75,7 +99,7 @@ async def _run_activity(team_id: int, node_ids: list[str] | None) -> tuple[list[
             preempt_dag_run_activity,
             PreemptDAGRunInputs(team_id=team_id, dag_id=DAG_ID, node_ids=node_ids),
         )
-    return cancelled, handle
+    return cancelled
 
 
 @pytest.mark.parametrize(
@@ -98,7 +122,7 @@ async def test_preempt_is_scoped_to_the_tiers_own_nodes(
     ateam,
     tier_jobs,
 ) -> None:
-    cancelled, handle = await _run_activity(ateam.pk, node_ids)
+    cancelled = await _run_activity(ateam.pk, node_ids)
 
     for node_id, job in tier_jobs.items():
         await database_sync_to_async(job.refresh_from_db)()
@@ -106,46 +130,48 @@ async def test_preempt_is_scoped_to_the_tiers_own_nodes(
             assert job.status == DataModelingJobStatus.FAILED
             assert job.error == PREEMPTED_ERROR
         else:
+            # Every other job's workflow reports RUNNING, so it is neither preempted nor reaped.
             assert job.status == DataModelingJobStatus.RUNNING
             assert job.error is None
 
     # Only the owned nodes' own materialize workflows are cancelled. Cancelling a parent
     # would cascade to its siblings via ParentClosePolicy.REQUEST_CANCEL, which is the
     # over-broad cancellation this scoping exists to prevent.
-    assert sorted(cancelled) == sorted(tier_jobs[node_id].workflow_id for node_id in expected_preempted)
+    assert sorted(cancelled) == sorted(_child_workflow_id(node_id) for node_id in expected_preempted)
     assert not {PARENT_HOURLY, PARENT_QUARTER_HOURLY} & set(cancelled)
-    assert handle.cancel.await_count == len(expected_preempted)
 
 
-# Absolute ages, deliberately not derived from STALE_RUNNING_JOB_AGE — offsets from the constant
-# would track any change to it and could never fail. A week is past any defensible threshold
-# (activities cap at 20 minutes); a minute is unambiguously still live.
 @pytest.mark.parametrize(
-    "age,expect_reaped",
+    "status,expect_reaped",
     [
-        pytest.param(dt.timedelta(days=7), True, id="abandoned_row_is_reaped"),
-        pytest.param(dt.timedelta(minutes=1), False, id="live_foreign_job_is_left_alone"),
+        pytest.param(WorkflowExecutionStatus.COMPLETED, True, id="closed_workflow_is_reaped"),
+        pytest.param(WorkflowExecutionStatus.TERMINATED, True, id="terminated_workflow_is_reaped"),
+        pytest.param(None, True, id="missing_workflow_is_reaped"),
+        # The one that age could not tell apart: still running, just slow. Nothing bounds a
+        # materialization's wall clock, so this must be decided by status, not elapsed time.
+        pytest.param(WorkflowExecutionStatus.RUNNING, False, id="slow_live_workflow_is_left_alone"),
     ],
 )
-async def test_rows_outside_our_nodes_are_reaped_only_once_their_workflow_is_gone(
-    age: dt.timedelta,
+async def test_rows_we_do_not_own_are_reaped_only_when_their_workflow_is_gone(
+    status: WorkflowExecutionStatus | None,
     expect_reaped: bool,
     ateam,
     tier_jobs,
 ) -> None:
-    # A node in no tier: nothing ever "owns" it, so if ownership gated cleanup its row would
-    # stay Running forever and the UI would show it perpetually materializing.
-    orphan_node = "44444444-4444-4444-4444-444444444444"
+    # A node in no tier: nothing ever owns it, so if ownership gated cleanup its row would stay
+    # Running forever and the UI would show it perpetually materializing.
     orphan = await database_sync_to_async(DataModelingJob.objects.create)(
         team=ateam,
         status=DataModelingJobStatus.RUNNING,
-        workflow_id=f"materialize-view-{DAG_ID}-{orphan_node}-2026-01-01T00:00:00",
+        workflow_id=_child_workflow_id(NODE_ORPHAN),
         parent_workflow_id=PARENT_HOURLY,
     )
-    # updated_at is auto_now, so age it with a queryset update rather than a save.
-    await database_sync_to_async(DataModelingJob.objects.filter(id=orphan.id).update)(updated_at=timezone.now() - age)
 
-    cancelled, _handle = await _run_activity(ateam.pk, [NODE_QUARTER_HOURLY])
+    cancelled = await _run_activity(
+        ateam.pk,
+        [NODE_QUARTER_HOURLY],
+        workflow_status={_child_workflow_id(NODE_ORPHAN): status},
+    )
 
     await database_sync_to_async(orphan.refresh_from_db)()
     if expect_reaped:
@@ -157,5 +183,4 @@ async def test_rows_outside_our_nodes_are_reaped_only_once_their_workflow_is_gon
 
     # Reaping only marks the row. There is no live workflow left to cancel, and cancelling on
     # another tier's behalf is precisely what this activity must not do.
-    assert orphan.workflow_id not in cancelled
-    assert cancelled == [tier_jobs[NODE_QUARTER_HOURLY].workflow_id]
+    assert cancelled == [_child_workflow_id(NODE_QUARTER_HOURLY)]

--- a/posthog/temporal/tests/data_modeling/test_preempt_dag_run.py
+++ b/posthog/temporal/tests/data_modeling/test_preempt_dag_run.py
@@ -5,6 +5,7 @@ import unittest.mock
 
 import pytest_asyncio
 from temporalio.client import WorkflowExecutionStatus
+from temporalio.service import RPCError, RPCStatusCode
 from temporalio.testing import ActivityEnvironment
 
 from posthog.sync import database_sync_to_async
@@ -58,18 +59,22 @@ async def tier_jobs(ateam):
     }
 
 
+NOT_FOUND = RPCError("workflow not found", RPCStatusCode.NOT_FOUND, b"")
+UNAVAILABLE = RPCError("temporal unavailable", RPCStatusCode.UNAVAILABLE, b"")
+
+
 async def _run_activity(
     team_id: int,
     node_ids: list[str] | None,
-    workflow_status: dict[str, WorkflowExecutionStatus | None] | None = None,
+    workflow_status: dict[str, WorkflowExecutionStatus | Exception] | None = None,
 ) -> list[str]:
     """Run the activity against a stubbed Temporal client, returning the workflows it cancelled.
 
-    `workflow_status` maps a workflow id to what describe() reports, where None means Temporal
-    has no record of it. Anything unlisted is reported as still RUNNING.
+    `workflow_status` maps a workflow id to what describe() does: a status to report, or an
+    exception to raise. Anything unlisted is reported as still RUNNING.
     """
     cancelled: list[str] = []
-    statuses = workflow_status or {}
+    statuses: dict[str, WorkflowExecutionStatus | Exception] = workflow_status or {}
 
     def get_workflow_handle(workflow_id: str) -> unittest.mock.MagicMock:
         handle = unittest.mock.MagicMock()
@@ -78,10 +83,11 @@ async def _run_activity(
             cancelled.append(workflow_id)
 
         async def describe() -> unittest.mock.MagicMock:
-            if workflow_id in statuses and statuses[workflow_id] is None:
-                raise RuntimeError("workflow not found")
+            outcome = statuses.get(workflow_id, WorkflowExecutionStatus.RUNNING)
+            if isinstance(outcome, Exception):
+                raise outcome
             description = unittest.mock.MagicMock()
-            description.status = statuses.get(workflow_id, WorkflowExecutionStatus.RUNNING)
+            description.status = outcome
             return description
 
         handle.cancel = cancel
@@ -146,14 +152,18 @@ async def test_preempt_is_scoped_to_the_tiers_own_nodes(
     [
         pytest.param(WorkflowExecutionStatus.COMPLETED, True, id="closed_workflow_is_reaped"),
         pytest.param(WorkflowExecutionStatus.TERMINATED, True, id="terminated_workflow_is_reaped"),
-        pytest.param(None, True, id="missing_workflow_is_reaped"),
+        pytest.param(NOT_FOUND, True, id="missing_workflow_is_reaped"),
         # The one that age could not tell apart: still running, just slow. Nothing bounds a
         # materialization's wall clock, so this must be decided by status, not elapsed time.
         pytest.param(WorkflowExecutionStatus.RUNNING, False, id="slow_live_workflow_is_left_alone"),
+        # A transient RPC failure proves nothing about the workflow. Treating it as "gone" would
+        # mark a live job Failed without cancelling it — the exact corruption this fix prevents,
+        # and unrecoverable because succeed_materialization won't overwrite a terminal status.
+        pytest.param(UNAVAILABLE, False, id="transient_rpc_error_leaves_row_alone"),
     ],
 )
 async def test_rows_we_do_not_own_are_reaped_only_when_their_workflow_is_gone(
-    status: WorkflowExecutionStatus | None,
+    status: WorkflowExecutionStatus | Exception,
     expect_reaped: bool,
     ateam,
     tier_jobs,
@@ -183,4 +193,29 @@ async def test_rows_we_do_not_own_are_reaped_only_when_their_workflow_is_gone(
 
     # Reaping only marks the row. There is no live workflow left to cancel, and cancelling on
     # another tier's behalf is precisely what this activity must not do.
+    assert cancelled == [_child_workflow_id(NODE_QUARTER_HOURLY)]
+
+
+async def test_owned_workflows_are_cancelled_even_if_reaping_blows_up(ateam, tier_jobs) -> None:
+    """Reaping makes one RPC per foreign row and can outrun the activity timeout. If that happened
+    after the owned rows were marked Failed, a retry would no longer see them as Running and their
+    workflows would never be cancelled — leaving the new run free to materialize the same node
+    concurrently. Preemption must therefore complete before reaping is attempted at all."""
+    await database_sync_to_async(DataModelingJob.objects.create)(
+        team=ateam,
+        status=DataModelingJobStatus.RUNNING,
+        workflow_id=_child_workflow_id(NODE_ORPHAN),
+        parent_workflow_id=PARENT_HOURLY,
+    )
+
+    with unittest.mock.patch(
+        "posthog.temporal.data_modeling.activities.preempt_dag_run._abandoned_jobs",
+        unittest.mock.AsyncMock(side_effect=RuntimeError("reaping exploded")),
+    ):
+        cancelled = await _run_activity(ateam.pk, [NODE_QUARTER_HOURLY])
+
+    owned = tier_jobs[NODE_QUARTER_HOURLY]
+    await database_sync_to_async(owned.refresh_from_db)()
+    assert owned.status == DataModelingJobStatus.FAILED
+    assert owned.error == PREEMPTED_ERROR
     assert cancelled == [_child_workflow_id(NODE_QUARTER_HOURLY)]


### PR DESCRIPTION
## Problem

A DAG on cadence tiers runs one `execute-dag` schedule per cadence, each passing a **disjoint** set of `node_ids` to the same workflow. `preempt_dag_run_activity` matched previous runs on dag id alone:

```python
workflow_id__startswith=f"materialize-view-{dag_id}-"
```

Child workflow ids carry no tier. So when two tiers overlapped, whichever ran second marked the **other** tier's running jobs `Failed` and cancelled their parent, which cascades to every child via `ParentClosePolicy.REQUEST_CANCEL`. Downstream levels never ran.

It also nudges healthy nodes toward suspension: `_count_leading_failures` counts leading `Failed` rows per (saved query, engine) toward `CONSECUTIVE_FAILURES_TO_SUSPEND`.

## Changes

The activity was doing two jobs under one scope. They now have different scopes:

| | scope | action | gate |
|---|---|---|---|
| **Preempt** — nodes this run is about to materialize | the run's node set | mark `Failed` **and cancel** | ownership |
| **Reap** — rows whose workflow died without closing them | whole DAG | mark `Failed` only | Temporal says the workflow is not running |

One DAG, hourly run in flight over A, B, C, and the 15-minute tier firing. **C** is contended (a reconcile moved it to the 15-minute tier). **A**, **B** are the hourly tier's alone. **Z** is a corpse: workflow long dead, row stuck `Running`, no freshness target so it sits in no tier.

Before:

```mermaid
flowchart LR
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;

    F{{"15-min tier fires<br/>owns C, D"}}
    M["match on dag id"]
    A["node A — live, hourly tier<br/>Failed + cancelled"]
    B["node B — live, hourly tier<br/>Failed + cancelled"]
    C["node C — live, contended<br/>Failed + cancelled"]
    Z["node Z — corpse, no tier<br/>Failed"]
    P["parent execute-dag:3600<br/>cancelled, cascades to every child"]

    F --> M
    M --> A
    M --> B
    M --> C
    M --> Z
    M --> P

    class F phYellow;
    class M phRed;
    class A,B,C,P phRed;
    class Z phGray;
```

Sweeping Z was the one good thing that scope bought. After:

```mermaid
flowchart LR
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;

    F{{"15-min tier fires<br/>owns C, D"}}
    PRE["preempt<br/>scope: my nodes"]
    REAP["reap<br/>scope: whole DAG<br/>workflow no longer running"]
    C["node C — live, contended<br/>Failed + its own workflow cancelled"]
    Z["node Z — corpse, no tier<br/>Failed, nothing cancelled"]
    AB["nodes A, B — live, hourly tier<br/>untouched"]
    P["parent execute-dag:3600<br/>untouched, run continues"]

    F --> PRE
    F --> REAP
    PRE --> C
    REAP --> Z
    PRE -.->|not mine, and live| AB
    PRE -.->|never cancel a parent| P

    class F phYellow;
    class PRE,REAP phBlue;
    class C phRed;
    class Z phYellow;
    class AB,P phGray;
```

Three decisions worth flagging:

- **Cancel the child, not the parent.** Scoping selection alone leaves the bug in a narrower window: a re-tiered node's in-flight job sits under the *old* tier's parent, so claiming it and cancelling that parent still kills the old run's siblings. The old docstring justified parent-cancel as avoiding a re-spawn race — that doesn't hold, since `_dag_execution_levels` starts each node at most once per run.
- **Reaping stays DAG-wide, gated on workflow status.** Scoping it by node set too would regress cleanup: a corpse on a node in no tier would stay `Running` forever, and "Sync now" would stop sweeping the rest of the DAG. Reaping *means* the row says `Running` while no workflow is, so we ask Temporal rather than infer it from row age. Age cannot distinguish a corpse from a slow run — nothing bounds a materialization's wall clock (`start_to_close_timeout` caps one attempt, not queue wait, retries, or the workflow, and `MaterializeViewWorkflow` has no execution timeout). Getting that wrong is unrecoverable: `succeed_materialization.py:104` returns early on a terminal status, so a live job marked `Failed` stays `Failed` even after it succeeds, and keeps feeding the suspension counter. Reaped rows are marked, never cancelled — there is nothing left to cancel.
- **Only `NOT_FOUND` proves absence.** `describe()` also raises on timeouts, unavailability and permission errors. Treating those as "gone" would mark a live foreign job `Failed` without cancelling it, which is unrecoverable. Everything else leaves the row for a later run.
- **Preempt fully, then reap.** Reaping makes one RPC per candidate row and can outrun the activity's 5-minute timeout. If that happened after the owned rows were marked, a retry would no longer see them as `Running` and their workflows would never be cancelled. Cancellation now runs immediately after connecting, and cancels before marking so a crash between the two is recoverable; reaping is wrapped so it can never undo it.
- **Legacy path unchanged.** Unset/empty `node_ids` still means whole-DAG, which is what the single v2 schedule passes.

## How did you test this code?

New `test_preempt_dag_run.py` — the activity had no direct test (`test_execute_dag_workflow.py` stubs it out). Ten cases:

| Case | Catches |
|---|---|
| `scopes_to_own_tier` | the reported bug — one tier marking another tier's jobs `Failed` |
| `migrated_node_spares_its_old_runs_siblings` | claiming a re-tiered node must not cancel the shared parent |
| `no_node_ids_preempts_whole_dag` | legacy single-schedule path still preempts DAG-wide |
| `unrelated_nodes_preempt_nothing` | a tier with no running jobs cancels nothing |
| `closed_workflow_is_reaped` / `terminated_workflow_is_reaped` / `missing_workflow_is_reaped` | a corpse in no tier still gets cleared, never cancelled |
| `slow_live_workflow_is_left_alone` | a slow but live job outside our node set is untouched — the case age could not tell apart |
| `transient_rpc_error_leaves_row_alone` | a timeout or unavailable `describe()` is not treated as absence |
| `owned_workflows_are_cancelled_even_if_reaping_blows_up` | reaping can never strand an owned workflow uncancelled |

Each behavior change was proven by its own red state, not assumed. Reverting the cancel target to `parent_workflow_id` turns most of the suite red; making reaping ignore workflow status turns `slow_live_workflow_is_left_alone` red; restoring the bare `except Exception` turns `transient_rpc_error_leaves_row_alone` red; moving cancellation back behind reaping turns `owned_workflows_are_cancelled_even_if_reaping_blows_up` red.

Run on this revision: `test_preempt_dag_run.py` 10 passed, `test_execute_dag_workflow.py` 38 passed, ruff clean, repo-wide mypy reports nothing in the changed files. No manual testing against a live Temporal cluster.

## Follow-ups, not in this PR

- Reaping is opportunistic — a corpse on a DAG with no live schedule is still never cleared, and it costs one `describe()` per foreign running row.
- A node the previous run hasn't *started* yet is not preempted; mutual exclusion wants a per-node claim, not a workflow-id match.
- `DataModelingJob` has no `node_id` column, which is the only reason this parses ids out of workflow ids.
- Preemption writes `Failed`, feeding the suspension counter. `Cancelled` is more accurate and `fail_materialization` already uses it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude) wrote this. Jovan spotted the bug by eyeballing a DAG's Temporal schedules, scoped the work to the contained half, and pushed back on whether tier scoping beat node scoping.

Skills invoked: `/writing-tests`. Two adversarial subagent reviews ran against the first revision and independently converged on the same defect — scoping selection without scoping cancellation leaves the bug alive. That produced the child-cancel change and the extra test cases.

**Why node scope, not tier scope.** Matching the `:{interval}` segment of `parent_workflow_id` was the obvious alternative. The invariant here is "one in-flight materialization per node", not "one run per schedule" — Temporal already enforces the latter via `ScheduleOverlapPolicy.SKIP` at both schedule creation sites. Tier scoping would let a re-tiered node materialize twice concurrently, and can never match a manual "Sync now" run (`execute-dag-{uuid4()}`, no tier segment).

**Deploy safety.** No workflow command added, removed, or reordered — only an activity input dataclass and the args to an existing `execute_activity` — so no `workflow.patched()` gate is needed. `temporalio.converter.value_to_type` ignores unknown dataclass fields, so an old worker mid-rollout degrades to current behavior.

Not fixed here: all cadence tiers of a DAG are phase-aligned by construction (the deterministic bucket in `schedule.py` salts on dag id with no interval), which is what makes overlap frequent. Separate PR, since it re-cadences every existing schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCDdbnhGCPDdSqrhoSQap2
