### PR TITLE
feat(slack_app): request files:read scope so the bot can download attachments

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -45273,6 +45273,7 @@
                 "canvases:write",
                 "channels:manage",
                 "commands",
+                "files:read",
                 "files:write",
                 "im:history",
                 "mpim:history",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5505,6 +5505,7 @@ export enum SlackIntegrationScopeInReview {
     CANVASES_WRITE = 'canvases:write',
     CHANNELS_MANAGE = 'channels:manage',
     COMMANDS = 'commands',
+    FILES_READ = 'files:read',
     FILES_WRITE = 'files:write',
     IM_HISTORY = 'im:history',
     MPIM_HISTORY = 'mpim:history',

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3663,6 +3663,7 @@ class SlackIntegrationScopeInReview(StrEnum):
     CANVASES_WRITE = "canvases:write"
     CHANNELS_MANAGE = "channels:manage"
     COMMANDS = "commands"
+    FILES_READ = "files:read"
     FILES_WRITE = "files:write"
     IM_HISTORY = "im:history"
     MPIM_HISTORY = "mpim:history"


### PR DESCRIPTION
## Problem

Mentioning the bot with an image or file attached fails: it replies that the attachment "failed to download from Slack." The install never requests `files:read`, so the bot token can't read files. Slack returns an HTML interstitial instead of the bytes, the download path rejects it, and the attachment is skipped.

## Changes

Add `files:read` to `SlackIntegrationScopeInReview` (in `frontend/src/types.ts`) and regenerate the schema. In-review scopes are only requested in DEV/DEBUG, so this avoids `invalid_scope` on Cloud until Slack approves the public app.

> [!NOTE]
> Also requires adding `files:read` to the DEV Slack app manifest and reconnecting the integration to grant it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Vojta reported the bug and asked me (Claude) to investigate and open this PR.
