### PR TITLE
feat(conversations): show source channel banner at top of ticket thread

### DIFF
--- a/products/conversations/frontend/components/Chat/ChatView.tsx
+++ b/products/conversations/frontend/components/Chat/ChatView.tsx
@@ -2,7 +2,14 @@ import { JSONContent } from '@tiptap/core'
 
 import { LemonCard } from '@posthog/lemon-ui'
 
-import type { AiReplyFeedbackRating, ChatMessage, Ticket, TicketChannel, TicketStatus } from '../../types'
+import type {
+    AiReplyFeedbackRating,
+    ChatMessage,
+    Ticket,
+    TicketChannel,
+    TicketChannelDetail,
+    TicketStatus,
+} from '../../types'
 import { MessageInput } from './MessageInput'
 import { MessageList } from './MessageList'
 
@@ -24,8 +31,12 @@ export interface ChatViewProps {
     header?: React.ReactNode
     minHeight?: string
     maxHeight?: string
-    /** Channel the ticket came from; drives the reply placeholder and send-button logo */
+    /** Channel the ticket came from; drives the reply placeholder and send-button logo, and pins a source banner to the top of the thread */
     channel?: TicketChannel
+    /** Optional channel detail shown in the thread's source banner */
+    channelDetail?: TicketChannelDetail | null
+    /** Optional deep link to the originating thread, making the source banner clickable */
+    channelThreadUrl?: string | null
     /** Whether to show the "Send as private" option in the message input */
     showPrivateOption?: boolean
     /** Number of team messages that haven't been read by the customer */
@@ -72,6 +83,8 @@ export function ChatView({
     minHeight,
     maxHeight,
     channel,
+    channelDetail,
+    channelThreadUrl,
     showPrivateOption = false,
     unreadCustomerCount,
     showDeliveryStatus = false,
@@ -103,6 +116,9 @@ export function ChatView({
                 hasMoreMessages={hasMoreMessages}
                 olderMessagesLoading={olderMessagesLoading}
                 onLoadOlderMessages={onLoadOlderMessages}
+                channel={channel}
+                channelDetail={channelDetail}
+                channelThreadUrl={channelThreadUrl}
                 emptyMessage="No messages yet. Start the conversation!"
                 minHeight={listMinHeight}
                 maxHeight={listMaxHeight}

--- a/products/conversations/frontend/components/Chat/MessageList.tsx
+++ b/products/conversations/frontend/components/Chat/MessageList.tsx
@@ -2,7 +2,14 @@ import { useEffect, useRef } from 'react'
 
 import { Spinner } from '@posthog/lemon-ui'
 
-import type { AiReplyFeedbackRating, ChatMessage, MessageDeliveryStatus } from '../../types'
+import type {
+    AiReplyFeedbackRating,
+    ChatMessage,
+    MessageDeliveryStatus,
+    TicketChannel,
+    TicketChannelDetail,
+} from '../../types'
+import { ChannelsTag } from '../Channels/ChannelsTag'
 import { Message } from './Message'
 
 export interface MessageListProps {
@@ -28,6 +35,12 @@ export interface MessageListProps {
     /** Whether AI reply feedback controls are enabled */
     showAiReplyFeedback?: boolean
     onSubmitAiReplyFeedback?: (messageId: string, rating: AiReplyFeedbackRating, feedbackText?: string) => void
+    /** Channel the conversation came from; when set, pins a source banner to the top of the thread */
+    channel?: TicketChannel
+    /** Optional channel detail (e.g. Slack channel message vs bot mention) shown in the source banner */
+    channelDetail?: TicketChannelDetail | null
+    /** Optional deep link to the originating thread, making the source banner clickable */
+    channelThreadUrl?: string | null
 }
 
 export function MessageList({
@@ -47,6 +60,9 @@ export function MessageList({
     feedbackByMessageId = {},
     showAiReplyFeedback = false,
     onSubmitAiReplyFeedback,
+    channel,
+    channelDetail,
+    channelThreadUrl,
 }: MessageListProps): JSX.Element {
     const messagesEndRef = useRef<HTMLDivElement>(null)
     const containerRef = useRef<HTMLDivElement>(null)
@@ -110,6 +126,12 @@ export function MessageList({
             className={`flex-1 overflow-y-auto space-y-1.5 ${className}`}
             style={{ minHeight, maxHeight }}
         >
+            {channel && (
+                <div className="sticky top-0 z-10 -mx-1 mb-1 flex items-center gap-1.5 border-b bg-surface-primary px-1 pb-1.5">
+                    <span className="text-muted-alt text-xs">Conversation via</span>
+                    <ChannelsTag channel={channel} detail={channelDetail} to={channelThreadUrl} />
+                </div>
+            )}
             {olderMessagesLoading && (
                 <div className="flex items-center justify-center py-2">
                     <Spinner className="text-sm" />

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -216,6 +216,8 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                         onSendMessage={sendMessage}
                         onLoadOlderMessages={loadOlderMessages}
                         channel={ticket?.channel_source}
+                        channelDetail={ticket?.channel_detail}
+                        channelThreadUrl={getChannelThreadUrl(ticket ?? null)}
                         showPrivateOption
                         unreadCustomerCount={ticket?.unread_customer_count}
                         showDeliveryStatus={ticket?.channel_source === 'widget'}


### PR DESCRIPTION
## Problem

For support agents, a ticket's origin channel (Slack / email / widget / Teams / GitHub) was only visible in the ticket sidebar and — recently — on the reply composer. When you open a thread and start reading top-down, there was no obvious signal of where the conversation came from. That's led to at least one agent typing out an email-style reply before realizing the thread was actually a Slack conversation. The composer branding (e.g. the "Reply in Slack…" placeholder) helps, but it's easy to miss and comes late.

**Why:** make the source channel obvious the moment you start reading a thread, not only once you go to reply.

## Changes

Pin a small **"Conversation via `<channel>`"** banner to the top of the message thread in the agent-facing ticket view, reusing the existing `ChannelsTag` (same icon + label already shown in the sidebar and the tickets list). It's rendered by `MessageList` whenever a channel is passed, so it stays with the message list and any surface that reuses it gets it for free. `ChatView` forwards the channel, its detail, and the deep link to the originating thread (so the banner is clickable straight through to e.g. the Slack thread).

Scoped to the agent-facing ticket scene; the customer-facing in-app widget view is left unchanged (its ticket type carries no channel and the banner would add nothing there).

## How did you test this code?

Not able to run the app or typecheck in this environment (dependencies weren't installed). Verified the changes against the type definitions by hand — `TicketChannel`/`TicketChannelDetail` types, the `ChannelsTag`/`getChannelThreadUrl` signatures, and the props threaded through `ChatView` → `MessageList`. No automated tests were added; a follow-up could add a component test asserting the banner renders for a given channel. Recommend a quick visual check across channels (Slack/email/widget) before un-drafting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a support-team Slack thread. The requester wanted the message source to be clearer when first reading a thread (icons preferred over the text-only composer hint). Considered per-message source icons but rejected them: channel is a ticket-level property, so every message in a thread shares it and per-bubble icons would be redundant noise — a single top-of-thread banner conveys it once. Reused the existing `ChannelsTag` rather than introducing new iconography.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1784907836435219?thread_ts=1784907836.435219&cid=C075D3C5HST)*