### PR TITLE
fix(experiments): descriptive error when flag loses variants

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -38,6 +38,7 @@ import { ExperimentReplayTab } from './ExperimentReplayTab'
 import { ExperimentWarningBanner } from './ExperimentWarningBanners'
 import { ExposureCriteriaModal } from './ExposureCriteria'
 import { Exposures } from './Exposures'
+import { FlagVariantsRemovedBanner } from './FlagVariantsRemovedBanner'
 import { Info } from './Info'
 import { LoadingState } from './LoadingState'
 import { MultiVariantBiasWarning } from './MultiVariantBiasWarning'
@@ -75,12 +76,23 @@ const AiAnalysisTab = (): JSX.Element => {
 }
 
 const MetricsTab = (): JSX.Element => {
-    const { experiment, orderedPrimaryMetricsWithResults, orderedSecondaryMetricsWithResults, isExperimentLaunched } =
-        useValues(experimentLogic)
+    const {
+        experiment,
+        orderedPrimaryMetricsWithResults,
+        orderedSecondaryMetricsWithResults,
+        isExperimentLaunched,
+        flagVariantsRemoved,
+    } = useValues(experimentLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const hasMetrics = orderedPrimaryMetricsWithResults.length > 0 || orderedSecondaryMetricsWithResults.length > 0
     const showRecalculationStatus = !!featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRICS_RECALCULATION] && hasMetrics
+
+    // The flag lost its variants — exposures and metrics can't be computed, so show the error state
+    // instead of empty/spinning exposure and metric panels.
+    if (flagVariantsRemoved) {
+        return <FlagVariantsRemovedBanner />
+    }
 
     return (
         <>

--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -34,6 +34,7 @@ import { ExperimentReplayTab } from './ExperimentReplayTab'
 import { ExperimentWarningBanner } from './ExperimentWarningBanners'
 import { ExposureCriteriaModal } from './ExposureCriteria'
 import { Exposures } from './Exposures'
+import { FlagVariantsRemovedBanner } from './FlagVariantsRemovedBanner'
 import { Hypothesis } from './Hypothesis'
 import { Info } from './Info'
 import { LoadingState } from './LoadingState'
@@ -44,12 +45,23 @@ import { ResultsNotificationBanner } from './ResultsNotificationBanner'
 import { SettingsTab } from './SettingsTab'
 
 const MetricsTab = (): JSX.Element => {
-    const { experiment, orderedPrimaryMetricsWithResults, orderedSecondaryMetricsWithResults, isExperimentLaunched } =
-        useValues(experimentLogic)
+    const {
+        experiment,
+        orderedPrimaryMetricsWithResults,
+        orderedSecondaryMetricsWithResults,
+        isExperimentLaunched,
+        flagVariantsRemoved,
+    } = useValues(experimentLogic)
     const { featureFlags } = useValues(featureFlagLogic)
 
     const hasMetrics = orderedPrimaryMetricsWithResults.length > 0 || orderedSecondaryMetricsWithResults.length > 0
     const showRecalculationStatus = !!featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRICS_RECALCULATION] && hasMetrics
+
+    // The flag lost its variants — exposures and metrics can't be computed, so show the error state
+    // instead of empty/spinning exposure and metric panels.
+    if (flagVariantsRemoved) {
+        return <FlagVariantsRemovedBanner />
+    }
 
     return (
         <>

--- a/frontend/src/scenes/experiments/ExperimentView/FlagVariantsRemovedBanner.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/FlagVariantsRemovedBanner.tsx
@@ -1,0 +1,23 @@
+import { useValues } from 'kea'
+
+import { LemonBanner } from '@posthog/lemon-ui'
+
+import { dayjs } from 'lib/dayjs'
+
+import { experimentLogic } from '../experimentLogic'
+
+export function FlagVariantsRemovedBanner(): JSX.Element {
+    const { flagVariantsRemovedAt } = useValues(experimentLogic)
+
+    return (
+        <LemonBanner type="error">
+            <p className="font-semibold mb-1">This experiment's feature flag no longer has variants</p>
+            <p className="mb-0">
+                The flag was changed from a multivariate flag to a boolean or rollout flag
+                {flagVariantsRemovedAt ? ` on ${dayjs(flagVariantsRemovedAt).format('MMMM D, YYYY [at] h:mm A')}` : ''},
+                so exposures and metrics can't be computed. Restore the flag's variants, or delete this experiment, to
+                see results again.
+            </p>
+        </LemonBanner>
+    )
+}

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -2119,4 +2119,66 @@ describe('experimentLogic', () => {
             })
         })
     })
+
+    describe('flag variants removed', () => {
+        const CHANGED_AT = '2024-06-01T10:30:00Z'
+
+        beforeEach(() => {
+            logic.actions.setExperiment(experiment)
+            useMocks({
+                get: {
+                    '/api/projects/:team/activity_log': {
+                        count: 1,
+                        next: null,
+                        previous: null,
+                        results: [
+                            {
+                                created_at: CHANGED_AT,
+                                detail: {
+                                    changes: [
+                                        {
+                                            field: 'filters',
+                                            before: {
+                                                multivariate: { variants: [{ key: 'control' }, { key: 'test' }] },
+                                            },
+                                            after: { multivariate: null },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+            })
+        })
+
+        it('flags the error and records the change time when exposures fail with the removed-variants code', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadExposuresFailure('no variants', { code: 'feature_flag_variants_removed' } as any)
+            })
+                .toDispatchActions(['stopAutoRefreshInterval', 'setFlagVariantsRemoved'])
+                .toMatchValues({
+                    flagVariantsRemoved: true,
+                    flagVariantsRemovedAt: CHANGED_AT,
+                })
+        })
+
+        it('ignores exposure failures with an unrelated error code', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadExposuresFailure('boom', { code: 'server_error' } as any)
+            })
+                .toFinishAllListeners()
+                .toNotHaveDispatchedActions(['setFlagVariantsRemoved'])
+                .toMatchValues({ flagVariantsRemoved: false })
+        })
+
+        it('stops re-running results once the flag has lost its variants', async () => {
+            logic.actions.setFlagVariantsRemoved(CHANGED_AT)
+            await expectLogic(logic, () => {
+                logic.actions.refreshExperimentResults(true, 'auto_refresh')
+            })
+                .toFinishAllListeners()
+                .toNotHaveDispatchedActions(['loadExposures', 'markRefreshStarted'])
+        })
+    })
 })

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -2457,7 +2457,7 @@ describe('experimentLogic', () => {
             logic.actions.setExperiment(experiment)
             useMocks({
                 get: {
-                    '/api/projects/:team/activity_log': {
+                    '/api/projects/:team/feature_flags/:flag_id/activity': {
                         count: 1,
                         next: null,
                         previous: null,
@@ -2502,13 +2502,22 @@ describe('experimentLogic', () => {
                 .toMatchValues({ flagVariantsRemoved: false })
         })
 
-        it('stops re-running results once the flag has lost its variants', async () => {
+        it('stops auto-refreshing results once the flag has lost its variants', async () => {
             logic.actions.setFlagVariantsRemoved(CHANGED_AT)
             await expectLogic(logic, () => {
                 logic.actions.refreshExperimentResults(true, 'auto_refresh')
             })
                 .toFinishAllListeners()
                 .toNotHaveDispatchedActions(['loadExposures', 'markRefreshStarted'])
+        })
+
+        it('clears the error state and retries on a user-initiated refresh', async () => {
+            logic.actions.setFlagVariantsRemoved(CHANGED_AT)
+            await expectLogic(logic, () => {
+                logic.actions.refreshExperimentResults(true, 'manual')
+            })
+                .toDispatchActions(['clearFlagVariantsRemoved', 'markRefreshStarted'])
+                .toMatchValues({ flagVariantsRemoved: false })
         })
     })
 })

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -2511,12 +2511,12 @@ describe('experimentLogic', () => {
                 .toNotHaveDispatchedActions(['loadExposures', 'markRefreshStarted'])
         })
 
-        it('clears the error state and retries on a user-initiated refresh', async () => {
+        it('reloads the experiment to recover on a user-initiated refresh', async () => {
             logic.actions.setFlagVariantsRemoved(CHANGED_AT)
             await expectLogic(logic, () => {
                 logic.actions.refreshExperimentResults(true, 'manual')
             })
-                .toDispatchActions(['clearFlagVariantsRemoved', 'markRefreshStarted'])
+                .toDispatchActions(['loadExperiment'])
                 .toMatchValues({ flagVariantsRemoved: false })
         })
     })

--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -2449,4 +2449,66 @@ describe('experimentLogic', () => {
             })
         })
     })
+
+    describe('flag variants removed', () => {
+        const CHANGED_AT = '2024-06-01T10:30:00Z'
+
+        beforeEach(() => {
+            logic.actions.setExperiment(experiment)
+            useMocks({
+                get: {
+                    '/api/projects/:team/activity_log': {
+                        count: 1,
+                        next: null,
+                        previous: null,
+                        results: [
+                            {
+                                created_at: CHANGED_AT,
+                                detail: {
+                                    changes: [
+                                        {
+                                            field: 'filters',
+                                            before: {
+                                                multivariate: { variants: [{ key: 'control' }, { key: 'test' }] },
+                                            },
+                                            after: { multivariate: null },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+            })
+        })
+
+        it('flags the error and records the change time when exposures fail with the removed-variants code', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadExposuresFailure('no variants', { code: 'feature_flag_variants_removed' } as any)
+            })
+                .toDispatchActions(['stopAutoRefreshInterval', 'setFlagVariantsRemoved'])
+                .toMatchValues({
+                    flagVariantsRemoved: true,
+                    flagVariantsRemovedAt: CHANGED_AT,
+                })
+        })
+
+        it('ignores exposure failures with an unrelated error code', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.loadExposuresFailure('boom', { code: 'server_error' } as any)
+            })
+                .toFinishAllListeners()
+                .toNotHaveDispatchedActions(['setFlagVariantsRemoved'])
+                .toMatchValues({ flagVariantsRemoved: false })
+        })
+
+        it('stops re-running results once the flag has lost its variants', async () => {
+            logic.actions.setFlagVariantsRemoved(CHANGED_AT)
+            await expectLogic(logic, () => {
+                logic.actions.refreshExperimentResults(true, 'auto_refresh')
+            })
+                .toFinishAllListeners()
+                .toNotHaveDispatchedActions(['loadExposures', 'markRefreshStarted'])
+        })
+    })
 })

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -70,6 +70,7 @@ import {
 } from '~/queries/schema/schema-general'
 import { setLatestVersionsOnQuery } from '~/queries/utils'
 import {
+    ActivityScope,
     BreakdownAttributionType,
     BreakdownType,
     CohortType,
@@ -240,6 +241,42 @@ interface MetricLoadingSummary {
     successfulCount: number
     erroredCount: number
     cachedCount: number
+}
+
+// Mirrors FLAG_WITHOUT_VARIANTS_ERROR_CODE in
+// products/experiments/backend/hogql_queries/__init__.py — the 4xx code raised when the
+// experiment's flag was converted from multivariate to a boolean/rollout flag.
+const FLAG_VARIANTS_REMOVED_ERROR_CODE = 'feature_flag_variants_removed'
+
+function errorHasFlagVariantsRemovedCode(error: any): boolean {
+    return error?.code === FLAG_VARIANTS_REMOVED_ERROR_CODE
+}
+
+// Best-effort lookup of when the flag lost its variants, from the flag's activity log. Returns the
+// timestamp of the change where multivariate variants went from present to absent, or null if it
+// can't be found (activity unavailable, entry missing) — the error state degrades to no timestamp.
+async function findFlagVariantsRemovedAt(flagId?: number | null): Promise<string | null> {
+    if (!flagId) {
+        return null
+    }
+    try {
+        const response = await api.activity.list({ scope: ActivityScope.FEATURE_FLAG, item_id: flagId })
+        for (const item of response.results ?? []) {
+            for (const change of item.detail?.changes ?? []) {
+                if (change.field !== 'filters') {
+                    continue
+                }
+                const before = (change.before as any)?.multivariate?.variants ?? []
+                const after = (change.after as any)?.multivariate?.variants ?? []
+                if (before.length > 0 && after.length === 0) {
+                    return item.created_at ?? null
+                }
+            }
+        }
+    } catch {
+        // Best-effort — show the error without the timestamp if activity can't be read.
+    }
+    return null
 }
 
 function parseMetricErrorDetail(error: any): { detail: any; hasDiagnostics: boolean } {
@@ -537,6 +574,9 @@ export interface experimentLogicValues {
     exposuresLoading: boolean
     featureFlagValidationError: string | null
     firstPrimaryMetric: ExperimentFunnelsQuery | ExperimentMetric | ExperimentTrendsQuery | undefined
+    flagVariantsRemoved: boolean
+    flagVariantsRemovedAt: string | null
+    flagVariantsRemovedInfo: { changedAt: string | null } | null
     formMode: FormModes
     freezeExposureLoading: boolean
     getExperimentMetricType: (metric: ExperimentMetricUnion | undefined) => ExperimentMetricType
@@ -1194,6 +1234,9 @@ export interface experimentLogicActions {
         excluded: boolean
         variantKey: string
     }
+    setFlagVariantsRemoved: (changedAt: string | null) => {
+        changedAt: string | null
+    }
     stopAutoRefreshInterval: () => {
         value: true
     }
@@ -1658,6 +1701,7 @@ export const experimentLogic = kea<experimentLogicType>([
         setNotifyWhenResultsReady: (notify: boolean) => ({ notify }),
         toggleDebugPanel: true,
         setVariantExcluded: (variantKey: string, excluded: boolean) => ({ variantKey, excluded }),
+        setFlagVariantsRemoved: (changedAt: string | null) => ({ changedAt }),
     }),
     reducers({
         showDebugPanel: [
@@ -2015,6 +2059,15 @@ export const experimentLogic = kea<experimentLogicType>([
                 loadSecondaryMetricsResults: () => [],
                 loadExperiment: () => [],
                 clearMetricsResults: () => [],
+            },
+        ],
+        // Set once the exposure/metric query reports the flag no longer has variants. Holds the
+        // best-effort timestamp of the change (or null). Reset when the experiment is reloaded.
+        flagVariantsRemovedInfo: [
+            null as { changedAt: string | null } | null,
+            {
+                setFlagVariantsRemoved: (_, { changedAt }) => ({ changedAt }),
+                loadExperiment: () => null,
             },
         ],
         editingPrimaryMetricUuid: [
@@ -2448,6 +2501,11 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         refreshExperimentResults: async ({ forceRefresh, triggeredBy, refreshIfStale }) => {
+            // The flag lost its variants — exposures and metrics can't be computed, so don't keep
+            // re-attempting (which would spin forever). The error state is shown instead.
+            if (values.flagVariantsRemovedInfo) {
+                return
+            }
             const refreshId = generateRefreshId()
             const refreshStart = performance.now()
             const summaries: MetricLoadingSummary[] = []
@@ -3382,6 +3440,17 @@ export const experimentLogic = kea<experimentLogicType>([
                 throw error
             }
         },
+        loadExposuresFailure: async ({ errorObject }) => {
+            // The flag was converted from multivariate to boolean/rollout, so exposures and metrics
+            // can't be computed. Stop the auto-refresh loop — retrying can't succeed until the flag
+            // regains variants — and surface a descriptive state with the change time when we can find it.
+            if (values.flagVariantsRemovedInfo || !errorHasFlagVariantsRemovedCode(errorObject)) {
+                return
+            }
+            actions.stopAutoRefreshInterval()
+            const changedAt = await findFlagVariantsRemovedAt(values.experiment?.feature_flag?.id)
+            actions.setFlagVariantsRemoved(changedAt)
+        },
         setAutoRefresh: ({ enabled, interval }) => {
             // Track when user toggles auto-refresh settings
             actions.reportExperimentAutoRefreshToggled(values.experiment, enabled, interval)
@@ -3537,6 +3606,8 @@ export const experimentLogic = kea<experimentLogicType>([
     })),
     selectors({
         props: [() => [(_, props) => props], (props) => props],
+        flagVariantsRemoved: [(s) => [s.flagVariantsRemovedInfo], (info): boolean => info !== null],
+        flagVariantsRemovedAt: [(s) => [s.flagVariantsRemovedInfo], (info): string | null => info?.changedAt ?? null],
         experimentId: [
             () => [(_, props) => props.experimentId ?? 'new'],
             (experimentId): Experiment['id'] => experimentId,

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -260,7 +260,7 @@ async function findFlagVariantsRemovedAt(flagId?: number | null): Promise<string
         return null
     }
     try {
-        const response = await api.activity.list({ scope: ActivityScope.FEATURE_FLAG, item_id: flagId })
+        const response = await api.activity.list({ scope: ActivityScope.FEATURE_FLAG, item_id: String(flagId) })
         for (const item of response.results ?? []) {
             for (const change of item.detail?.changes ?? []) {
                 if (change.field !== 'filters') {
@@ -3606,8 +3606,14 @@ export const experimentLogic = kea<experimentLogicType>([
     })),
     selectors({
         props: [() => [(_, props) => props], (props) => props],
-        flagVariantsRemoved: [(s) => [s.flagVariantsRemovedInfo], (info): boolean => info !== null],
-        flagVariantsRemovedAt: [(s) => [s.flagVariantsRemovedInfo], (info): string | null => info?.changedAt ?? null],
+        flagVariantsRemoved: [
+            (s) => [s.flagVariantsRemovedInfo],
+            (info: { changedAt: string | null } | null): boolean => info !== null,
+        ],
+        flagVariantsRemovedAt: [
+            (s) => [s.flagVariantsRemovedInfo],
+            (info: { changedAt: string | null } | null): string | null => info?.changedAt ?? null,
+        ],
         experimentId: [
             () => [(_, props) => props.experimentId ?? 'new'],
             (experimentId): Experiment['id'] => experimentId,

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -576,7 +576,9 @@ export interface experimentLogicValues {
     firstPrimaryMetric: ExperimentFunnelsQuery | ExperimentMetric | ExperimentTrendsQuery | undefined
     flagVariantsRemoved: boolean
     flagVariantsRemovedAt: string | null
-    flagVariantsRemovedInfo: { changedAt: string | null } | null
+    flagVariantsRemovedInfo: {
+        changedAt: string | null
+    } | null
     formMode: FormModes
     freezeExposureLoading: boolean
     getExperimentMetricType: (metric: ExperimentMetricUnion | undefined) => ExperimentMetricType
@@ -1088,6 +1090,9 @@ export interface experimentLogicActions {
     setFeatureFlagValidationError: (error: string) => {
         error: string
     }
+    setFlagVariantsRemoved: (changedAt: string | null) => {
+        changedAt: string | null
+    }
     setFreezeExposureLoading: (loading: boolean) => {
         loading: boolean
     }
@@ -1234,9 +1239,6 @@ export interface experimentLogicActions {
         excluded: boolean
         variantKey: string
     }
-    setFlagVariantsRemoved: (changedAt: string | null) => {
-        changedAt: string | null
-    }
     stopAutoRefreshInterval: () => {
         value: true
     }
@@ -1328,6 +1330,16 @@ export interface experimentLogicMeta {
     key: ExperimentIdType
     __keaTypeGenInternalSelectorTypes: {
         props: (arg: any) => any
+        flagVariantsRemoved: (
+            flagVariantsRemovedInfo: {
+                changedAt: string | null
+            } | null
+        ) => boolean
+        flagVariantsRemovedAt: (
+            flagVariantsRemovedInfo: {
+                changedAt: string | null
+            } | null
+        ) => string | null
         experimentId: (arg: any) => Experiment['id']
         formMode: (arg: any) => FormModes
         isExperimentDraft: (experiment: Experiment) => boolean

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -70,6 +70,7 @@ import {
 } from '~/queries/schema/schema-general'
 import { setLatestVersionsOnQuery } from '~/queries/utils'
 import {
+    ActivityScope,
     BreakdownAttributionType,
     BreakdownType,
     CohortType,
@@ -243,6 +244,42 @@ interface MetricLoadingSummary {
     successfulCount: number
     erroredCount: number
     cachedCount: number
+}
+
+// Mirrors FLAG_WITHOUT_VARIANTS_ERROR_CODE in
+// products/experiments/backend/hogql_queries/__init__.py — the 4xx code raised when the
+// experiment's flag was converted from multivariate to a boolean/rollout flag.
+const FLAG_VARIANTS_REMOVED_ERROR_CODE = 'feature_flag_variants_removed'
+
+function errorHasFlagVariantsRemovedCode(error: any): boolean {
+    return error?.code === FLAG_VARIANTS_REMOVED_ERROR_CODE
+}
+
+// Best-effort lookup of when the flag lost its variants, from the flag's activity log. Returns the
+// timestamp of the change where multivariate variants went from present to absent, or null if it
+// can't be found (activity unavailable, entry missing) — the error state degrades to no timestamp.
+async function findFlagVariantsRemovedAt(flagId?: number | null): Promise<string | null> {
+    if (!flagId) {
+        return null
+    }
+    try {
+        const response = await api.activity.list({ scope: ActivityScope.FEATURE_FLAG, item_id: String(flagId) })
+        for (const item of response.results ?? []) {
+            for (const change of item.detail?.changes ?? []) {
+                if (change.field !== 'filters') {
+                    continue
+                }
+                const before = (change.before as any)?.multivariate?.variants ?? []
+                const after = (change.after as any)?.multivariate?.variants ?? []
+                if (before.length > 0 && after.length === 0) {
+                    return item.created_at ?? null
+                }
+            }
+        }
+    } catch {
+        // Best-effort — show the error without the timestamp if activity can't be read.
+    }
+    return null
 }
 
 function parseMetricErrorDetail(error: any): { detail: any; hasDiagnostics: boolean } {
@@ -540,6 +577,11 @@ export interface experimentLogicValues {
     exposuresLoading: boolean
     featureFlagValidationError: string | null
     firstPrimaryMetric: ExperimentFunnelsQuery | ExperimentMetric | ExperimentTrendsQuery | undefined
+    flagVariantsRemoved: boolean
+    flagVariantsRemovedAt: string | null
+    flagVariantsRemovedInfo: {
+        changedAt: string | null
+    } | null
     formMode: FormModes
     freezeExposureLoading: boolean
     getExperimentMetricType: (metric: ExperimentMetricUnion | undefined) => ExperimentMetricType
@@ -1084,6 +1126,9 @@ export interface experimentLogicActions {
     setFeatureFlagValidationError: (error: string) => {
         error: string
     }
+    setFlagVariantsRemoved: (changedAt: string | null) => {
+        changedAt: string | null
+    }
     setFreezeExposureLoading: (loading: boolean) => {
         loading: boolean
     }
@@ -1321,6 +1366,16 @@ export interface experimentLogicMeta {
     key: ExperimentIdType
     __keaTypeGenInternalSelectorTypes: {
         props: (arg: any) => any
+        flagVariantsRemoved: (
+            flagVariantsRemovedInfo: {
+                changedAt: string | null
+            } | null
+        ) => boolean
+        flagVariantsRemovedAt: (
+            flagVariantsRemovedInfo: {
+                changedAt: string | null
+            } | null
+        ) => string | null
         experimentId: (arg: any) => Experiment['id']
         formMode: (arg: any) => FormModes
         isExperimentDraft: (experiment: Experiment) => boolean
@@ -1733,6 +1788,7 @@ export const experimentLogic = kea<experimentLogicType>([
         setNotifyWhenResultsReady: (notify: boolean) => ({ notify }),
         toggleDebugPanel: true,
         setVariantExcluded: (variantKey: string, excluded: boolean) => ({ variantKey, excluded }),
+        setFlagVariantsRemoved: (changedAt: string | null) => ({ changedAt }),
     }),
     reducers({
         showDebugPanel: [
@@ -2139,6 +2195,15 @@ export const experimentLogic = kea<experimentLogicType>([
                 loadSecondaryMetricsResults: () => [],
                 loadExperiment: () => [],
                 clearMetricsResults: () => [],
+            },
+        ],
+        // Set once the exposure/metric query reports the flag no longer has variants. Holds the
+        // best-effort timestamp of the change (or null). Reset when the experiment is reloaded.
+        flagVariantsRemovedInfo: [
+            null as { changedAt: string | null } | null,
+            {
+                setFlagVariantsRemoved: (_, { changedAt }) => ({ changedAt }),
+                loadExperiment: () => null,
             },
         ],
         editingPrimaryMetricUuid: [
@@ -2574,6 +2639,11 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         refreshExperimentResults: async ({ forceRefresh, triggeredBy, refreshIfStale }) => {
+            // The flag lost its variants — exposures and metrics can't be computed, so don't keep
+            // re-attempting (which would spin forever). The error state is shown instead.
+            if (values.flagVariantsRemovedInfo) {
+                return
+            }
             const refreshId = generateRefreshId()
             const refreshStart = performance.now()
             const summaries: MetricLoadingSummary[] = []
@@ -3603,6 +3673,17 @@ export const experimentLogic = kea<experimentLogicType>([
                 throw error
             }
         },
+        loadExposuresFailure: async ({ errorObject }) => {
+            // The flag was converted from multivariate to boolean/rollout, so exposures and metrics
+            // can't be computed. Stop the auto-refresh loop — retrying can't succeed until the flag
+            // regains variants — and surface a descriptive state with the change time when we can find it.
+            if (values.flagVariantsRemovedInfo || !errorHasFlagVariantsRemovedCode(errorObject)) {
+                return
+            }
+            actions.stopAutoRefreshInterval()
+            const changedAt = await findFlagVariantsRemovedAt(values.experiment?.feature_flag?.id)
+            actions.setFlagVariantsRemoved(changedAt)
+        },
         setAutoRefresh: ({ enabled, interval }) => {
             // Track when user toggles auto-refresh settings
             actions.reportExperimentAutoRefreshToggled(values.experiment, enabled, interval)
@@ -3810,6 +3891,14 @@ export const experimentLogic = kea<experimentLogicType>([
     })),
     selectors({
         props: [() => [(_, props) => props], (props) => props],
+        flagVariantsRemoved: [
+            (s) => [s.flagVariantsRemovedInfo],
+            (info: { changedAt: string | null } | null): boolean => info !== null,
+        ],
+        flagVariantsRemovedAt: [
+            (s) => [s.flagVariantsRemovedInfo],
+            (info: { changedAt: string | null } | null): string | null => info?.changedAt ?? null,
+        ],
         experimentId: [
             () => [(_, props) => props.experimentId ?? 'new'],
             (experimentId): Experiment['id'] => experimentId,

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -258,12 +258,14 @@ function errorHasFlagVariantsRemovedCode(error: any): boolean {
 // Best-effort lookup of when the flag lost its variants, from the flag's activity log. Returns the
 // timestamp of the change where multivariate variants went from present to absent, or null if it
 // can't be found (activity unavailable, entry missing) — the error state degrades to no timestamp.
+// listLegacy hits the per-flag activity endpoint; the generic activity_log endpoint is gated
+// behind the paid audit logs add-on on Cloud, which would make this lookup 403 for most orgs.
 async function findFlagVariantsRemovedAt(flagId?: number | null): Promise<string | null> {
     if (!flagId) {
         return null
     }
     try {
-        const response = await api.activity.list({ scope: ActivityScope.FEATURE_FLAG, item_id: String(flagId) })
+        const response = await api.activity.listLegacy({ scope: ActivityScope.FEATURE_FLAG, id: flagId })
         for (const item of response.results ?? []) {
             for (const change of item.detail?.changes ?? []) {
                 if (change.field !== 'filters') {
@@ -855,6 +857,9 @@ export interface experimentLogicActions {
     }
     changeExperimentStartDate: (startDate: string) => {
         startDate: string
+    }
+    clearFlagVariantsRemoved: () => {
+        value: true
     }
     clearMetricsResults: () => {
         value: true
@@ -1789,6 +1794,7 @@ export const experimentLogic = kea<experimentLogicType>([
         toggleDebugPanel: true,
         setVariantExcluded: (variantKey: string, excluded: boolean) => ({ variantKey, excluded }),
         setFlagVariantsRemoved: (changedAt: string | null) => ({ changedAt }),
+        clearFlagVariantsRemoved: true,
     }),
     reducers({
         showDebugPanel: [
@@ -2198,11 +2204,13 @@ export const experimentLogic = kea<experimentLogicType>([
             },
         ],
         // Set once the exposure/metric query reports the flag no longer has variants. Holds the
-        // best-effort timestamp of the change (or null). Reset when the experiment is reloaded.
+        // best-effort timestamp of the change (or null). Reset when the experiment is reloaded
+        // or when a user-initiated refresh retries the query.
         flagVariantsRemovedInfo: [
             null as { changedAt: string | null } | null,
             {
                 setFlagVariantsRemoved: (_, { changedAt }) => ({ changedAt }),
+                clearFlagVariantsRemoved: () => null,
                 loadExperiment: () => null,
             },
         ],
@@ -2639,10 +2647,16 @@ export const experimentLogic = kea<experimentLogicType>([
             }
         },
         refreshExperimentResults: async ({ forceRefresh, triggeredBy, refreshIfStale }) => {
-            // The flag lost its variants — exposures and metrics can't be computed, so don't keep
-            // re-attempting (which would spin forever). The error state is shown instead.
+            // The flag lost its variants — exposures and metrics can't be computed, so the
+            // auto-refresh loop must not keep re-attempting (it would spin forever). A
+            // user-initiated refresh clears the error state and retries for real, so the "Reload
+            // results" button recovers once the flag's variants are restored; if they're still
+            // missing, loadExposuresFailure re-arms the state.
             if (values.flagVariantsRemovedInfo) {
-                return
+                if (triggeredBy === 'auto_refresh') {
+                    return
+                }
+                actions.clearFlagVariantsRemoved()
             }
             const refreshId = generateRefreshId()
             const refreshStart = performance.now()

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -858,9 +858,6 @@ export interface experimentLogicActions {
     changeExperimentStartDate: (startDate: string) => {
         startDate: string
     }
-    clearFlagVariantsRemoved: () => {
-        value: true
-    }
     clearMetricsResults: () => {
         value: true
     }
@@ -1794,7 +1791,6 @@ export const experimentLogic = kea<experimentLogicType>([
         toggleDebugPanel: true,
         setVariantExcluded: (variantKey: string, excluded: boolean) => ({ variantKey, excluded }),
         setFlagVariantsRemoved: (changedAt: string | null) => ({ changedAt }),
-        clearFlagVariantsRemoved: true,
     }),
     reducers({
         showDebugPanel: [
@@ -2204,13 +2200,12 @@ export const experimentLogic = kea<experimentLogicType>([
             },
         ],
         // Set once the exposure/metric query reports the flag no longer has variants. Holds the
-        // best-effort timestamp of the change (or null). Reset when the experiment is reloaded
-        // or when a user-initiated refresh retries the query.
+        // best-effort timestamp of the change (or null). Reset when the experiment is reloaded,
+        // which is also how a user-initiated refresh recovers from this state.
         flagVariantsRemovedInfo: [
             null as { changedAt: string | null } | null,
             {
                 setFlagVariantsRemoved: (_, { changedAt }) => ({ changedAt }),
-                clearFlagVariantsRemoved: () => null,
                 loadExperiment: () => null,
             },
         ],
@@ -2649,14 +2644,16 @@ export const experimentLogic = kea<experimentLogicType>([
         refreshExperimentResults: async ({ forceRefresh, triggeredBy, refreshIfStale }) => {
             // The flag lost its variants — exposures and metrics can't be computed, so the
             // auto-refresh loop must not keep re-attempting (it would spin forever). A
-            // user-initiated refresh clears the error state and retries for real, so the "Reload
-            // results" button recovers once the flag's variants are restored; if they're still
+            // user-initiated refresh reloads the experiment instead: the exposure query embeds
+            // the flag snapshot held in state (still the variant-less one), so a plain retry
+            // would fail even after the flag was fixed. Reloading refetches the flag, clears
+            // this state (reducer), and re-runs results on success; if variants are still
             // missing, loadExposuresFailure re-arms the state.
             if (values.flagVariantsRemovedInfo) {
-                if (triggeredBy === 'auto_refresh') {
-                    return
+                if (triggeredBy !== 'auto_refresh') {
+                    actions.loadExperiment()
                 }
-                actions.clearFlagVariantsRemoved()
+                return
             }
             const refreshId = generateRefreshId()
             const refreshStart = performance.now()

--- a/products/experiments/backend/hogql_queries/__init__.py
+++ b/products/experiments/backend/hogql_queries/__init__.py
@@ -2,6 +2,34 @@
 CONTROL_VARIANT_KEY = "control"
 
 
+# Raised when an experiment's feature flag no longer defines multivariate variants — e.g. it was
+# converted from a multivariate (experiment) flag into a plain boolean/rollout flag, so
+# filters.multivariate is null or its variants list is empty. Without variants there is nothing to
+# split exposures or metrics across, so the analysis can't run. Surfaced as a 4xx so the UI can
+# explain the state instead of hitting a 500 or spinning forever.
+FLAG_WITHOUT_VARIANTS_ERROR_CODE = "feature_flag_variants_removed"
+FLAG_WITHOUT_VARIANTS_ERROR_MESSAGE = (
+    "This experiment's feature flag no longer defines any variants, so exposures and metrics "
+    "can't be computed. The flag was changed from a multivariate (experiment) flag to a boolean "
+    "or rollout flag. Restore the flag's variants, or delete the experiment, to resolve this."
+)
+
+
+def variants_from_flag_filters(filters: dict | None) -> list:
+    """The multivariate variants declared in a flag's filters, or [] when absent or null.
+
+    Mirrors FeatureFlag.variants: filters["multivariate"] can be explicitly null (the flag was
+    converted to boolean), so a plain .get("multivariate", {}) returns None rather than {}, and a
+    downstream .get("variants", []) would then raise AttributeError.
+    """
+    multivariate = (filters or {}).get("multivariate", None)
+    if isinstance(multivariate, dict):
+        variants = multivariate.get("variants", None)
+        if isinstance(variants, list):
+            return variants
+    return []
+
+
 def get_baseline_variant_key(stats_config: dict | None, variant_keys: list[str]) -> str:
     """The effective baseline for an experiment: the configured baseline_variant_key,
     else 'control' when the flag has one, else the flag's first variant.

--- a/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
@@ -33,7 +33,12 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     ensure_precomputed,
 )
 from products.experiments.backend.analysis_health import evaluate_bias_risk
-from products.experiments.backend.hogql_queries import MULTIPLE_VARIANT_KEY
+from products.experiments.backend.hogql_queries import (
+    FLAG_WITHOUT_VARIANTS_ERROR_CODE,
+    FLAG_WITHOUT_VARIANTS_ERROR_MESSAGE,
+    MULTIPLE_VARIANT_KEY,
+    variants_from_flag_filters,
+)
 from products.experiments.backend.hogql_queries.base_query_utils import analysis_window, analysis_window_end
 from products.experiments.backend.hogql_queries.error_handling import experiment_error_handler
 from products.experiments.backend.hogql_queries.experiment_query_builder import (
@@ -92,11 +97,11 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         # the experiment, so they don't belong in the exposure chart. self.query.holdout
         # is still consulted by _calculate_srm for the holdout-adjusted rollout math.
         self.excluded_variants = set(self.experiment.excluded_variants or [])
-        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
+        flag_variants = variants_from_flag_filters(self.query.feature_flag.get("filters"))
+        if not flag_variants:
+            raise ValidationError(FLAG_WITHOUT_VARIANTS_ERROR_MESSAGE, code=FLAG_WITHOUT_VARIANTS_ERROR_CODE)
         self.variants = [
-            variant.get("key")
-            for variant in multivariate_data.get("variants", [])
-            if variant.get("key") not in self.excluded_variants
+            variant.get("key") for variant in flag_variants if variant.get("key") not in self.excluded_variants
         ]
 
         self.date_range = self._get_date_range()
@@ -188,8 +193,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         Compares observed variant distribution against expected (from rollout percentages).
         Returns None if insufficient data.
         """
-        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
-        variants_config = multivariate_data.get("variants", [])
+        variants_config = variants_from_flag_filters(self.query.feature_flag.get("filters"))
 
         if not variants_config or not total_exposures:
             return None
@@ -276,8 +280,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         # query (the cache key), so the running/stopped decision matches the cached window.
         if self.window_end_date is not None:
             return None
-        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
-        flag_variants = multivariate_data.get("variants", [])
+        flag_variants = variants_from_flag_filters(self.query.feature_flag.get("filters"))
         _, handling, _ = get_exposure_config_params_for_builder(self.exposure_criteria)
         return evaluate_bias_risk(
             flag_variants=flag_variants,

--- a/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
@@ -33,7 +33,12 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     ensure_precomputed,
 )
 from products.experiments.backend.analysis_health import evaluate_bias_risk
-from products.experiments.backend.hogql_queries import MULTIPLE_VARIANT_KEY
+from products.experiments.backend.hogql_queries import (
+    FLAG_WITHOUT_VARIANTS_ERROR_CODE,
+    FLAG_WITHOUT_VARIANTS_ERROR_MESSAGE,
+    MULTIPLE_VARIANT_KEY,
+    variants_from_flag_filters,
+)
 from products.experiments.backend.hogql_queries.base_query_utils import analysis_window, analysis_window_end
 from products.experiments.backend.hogql_queries.error_handling import experiment_error_handler
 from products.experiments.backend.hogql_queries.experiment_query_builder import (
@@ -92,11 +97,11 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         # the experiment, so they don't belong in the exposure chart. self.query.holdout
         # is still consulted by _calculate_srm for the holdout-adjusted rollout math.
         self.excluded_variants = set(self.experiment.excluded_variants or [])
-        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
+        flag_variants = variants_from_flag_filters(self.query.feature_flag.get("filters"))
+        if not flag_variants:
+            raise ValidationError(FLAG_WITHOUT_VARIANTS_ERROR_MESSAGE, code=FLAG_WITHOUT_VARIANTS_ERROR_CODE)
         self.variants = [
-            variant.get("key")
-            for variant in multivariate_data.get("variants", [])
-            if variant.get("key") not in self.excluded_variants
+            variant.get("key") for variant in flag_variants if variant.get("key") not in self.excluded_variants
         ]
 
         self.date_range = self._get_date_range()
@@ -190,8 +195,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         Compares observed variant distribution against expected (from rollout percentages).
         Returns None if insufficient data.
         """
-        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
-        variants_config = multivariate_data.get("variants", [])
+        variants_config = variants_from_flag_filters(self.query.feature_flag.get("filters"))
 
         if not variants_config or not total_exposures:
             return None
@@ -278,8 +282,7 @@ class ExperimentExposuresQueryRunner(QueryRunner):
         # query (the cache key), so the running/stopped decision matches the cached window.
         if self.window_end_date is not None:
             return None
-        multivariate_data = self.query.feature_flag.get("filters", {}).get("multivariate", {})
-        flag_variants = multivariate_data.get("variants", [])
+        flag_variants = variants_from_flag_filters(self.query.feature_flag.get("filters"))
         exposure_params = get_exposure_config_params_for_builder(
             self.exposure_criteria, self.team, self.experiment.start_date
         )

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -47,7 +47,12 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     parse_ttl_schedule,
 )
 from products.cohorts.backend.models.cohort import Cohort
-from products.experiments.backend.hogql_queries import MULTIPLE_VARIANT_KEY, get_baseline_variant_key
+from products.experiments.backend.hogql_queries import (
+    FLAG_WITHOUT_VARIANTS_ERROR_CODE,
+    FLAG_WITHOUT_VARIANTS_ERROR_MESSAGE,
+    MULTIPLE_VARIANT_KEY,
+    get_baseline_variant_key,
+)
 from products.experiments.backend.hogql_queries.base_query_utils import experiment_window, experiment_window_end
 from products.experiments.backend.hogql_queries.cuped_config import get_cuped_config
 from products.experiments.backend.hogql_queries.error_handling import experiment_error_handler
@@ -240,6 +245,13 @@ class ExperimentQueryRunner(QueryRunner):
         self.feature_flag_key = self.feature_flag.key_without_tombstone()
         self.group_type_index = self.feature_flag.aggregation_group_type_index
         self.entity_key = get_entity_key(self.group_type_index)
+
+        # An experiment can't be scored without variants to split metrics across. This happens when
+        # the flag was converted from multivariate to a plain boolean/rollout flag (see
+        # FeatureFlag.variants — filters.multivariate is null or has an empty variants list). Raise a
+        # 4xx so the UI can explain it instead of failing later with an opaque error.
+        if not self.feature_flag.variants:
+            raise ValidationError(FLAG_WITHOUT_VARIANTS_ERROR_MESSAGE, code=FLAG_WITHOUT_VARIANTS_ERROR_CODE)
 
         # Holdout is intentionally not appended: holdout users were never exposed to
         # the experiment, so they don't belong in the metric scorecard.

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -51,7 +51,12 @@ from products.analytics_platform.backend.lazy_computation.lazy_computation_execu
     parse_ttl_schedule,
 )
 from products.cohorts.backend.models.cohort import Cohort
-from products.experiments.backend.hogql_queries import MULTIPLE_VARIANT_KEY, get_baseline_variant_key
+from products.experiments.backend.hogql_queries import (
+    FLAG_WITHOUT_VARIANTS_ERROR_CODE,
+    FLAG_WITHOUT_VARIANTS_ERROR_MESSAGE,
+    MULTIPLE_VARIANT_KEY,
+    get_baseline_variant_key,
+)
 from products.experiments.backend.hogql_queries.base_query_utils import (
     conversion_window_to_seconds,
     experiment_window,
@@ -258,6 +263,13 @@ class ExperimentQueryRunner(QueryRunner):
         self.feature_flag_key = self.feature_flag.key_without_tombstone()
         self.group_type_index = self.feature_flag.aggregation_group_type_index
         self.entity_key = get_entity_key(self.group_type_index)
+
+        # An experiment can't be scored without variants to split metrics across. This happens when
+        # the flag was converted from multivariate to a plain boolean/rollout flag (see
+        # FeatureFlag.variants — filters.multivariate is null or has an empty variants list). Raise a
+        # 4xx so the UI can explain it instead of failing later with an opaque error.
+        if not self.feature_flag.variants:
+            raise ValidationError(FLAG_WITHOUT_VARIANTS_ERROR_MESSAGE, code=FLAG_WITHOUT_VARIANTS_ERROR_CODE)
 
         # Holdout is intentionally not appended: holdout users were never exposed to
         # the experiment, so they don't belong in the metric scorecard.

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_base.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_base.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from django.test import override_settings
 
 from parameterized import parameterized
+from rest_framework.exceptions import ErrorDetail, ValidationError
 
 from posthog.schema import (
     ActionsNode,
@@ -30,6 +31,7 @@ from posthog.test.test_utils import create_group_type_mapping_without_created_at
 from products.actions.backend.models.action import Action
 from products.cohorts.backend.models.cohort import Cohort
 from products.cohorts.backend.models.util import count_cohort_members
+from products.experiments.backend.hogql_queries import FLAG_WITHOUT_VARIANTS_ERROR_CODE
 from products.experiments.backend.hogql_queries.experiment_query_runner import ExperimentQueryRunner
 from products.experiments.backend.hogql_queries.test.experiment_query_runner.base import ExperimentQueryRunnerBaseTest
 from products.experiments.backend.hogql_queries.test.experiment_query_runner.utils import (
@@ -39,6 +41,37 @@ from products.experiments.backend.hogql_queries.test.experiment_query_runner.uti
 
 @override_settings(IN_UNIT_TESTING=True)
 class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
+    @parameterized.expand(
+        [
+            ("multivariate_null", None),
+            ("empty_variants", {"variants": []}),
+        ]
+    )
+    def test_flag_without_variants_raises_descriptive_error(self, _name, multivariate_value):
+        # A flag converted from multivariate to boolean/rollout leaves the experiment with nothing
+        # to split metrics across. The runner must fail fast with a descriptive 4xx rather than a
+        # confusing downstream error once it tries to score empty variants.
+        feature_flag = self.create_feature_flag(key=f"metric-lost-variants-{_name.replace('_', '-')}")
+        feature_flag.filters = {
+            "groups": [{"properties": [], "rollout_percentage": 100}],
+            "multivariate": multivariate_value,
+        }
+        feature_flag.save(update_fields=["filters"])
+        experiment = self.create_experiment(feature_flag=feature_flag)
+
+        metric = ExperimentMeanMetric(source=EventsNode(event="$pageview"))
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+
+        with self.assertRaises(ValidationError) as cm:
+            ExperimentQueryRunner(query=experiment_query, team=self.team)
+
+        detail = cm.exception.detail
+        assert isinstance(detail, list)
+        error_detail = detail[0]
+        assert isinstance(error_detail, ErrorDetail)
+        self.assertEqual(error_detail.code, FLAG_WITHOUT_VARIANTS_ERROR_CODE)
+        self.assertIn("no longer defines any variants", str(error_detail))
+
     def test_deleted_feature_flag_tombstone_uses_original_key_for_query_builder(self):
         feature_flag = self.create_feature_flag(key="deleted-experiment-flag")
         experiment = self.create_experiment(feature_flag=feature_flag)

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_base.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_base.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 from django.test import override_settings
 
 from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
 
 from posthog.schema import (
     ActionsNode,
@@ -30,6 +31,7 @@ from posthog.test.test_utils import create_group_type_mapping_without_created_at
 from products.actions.backend.models.action import Action
 from products.cohorts.backend.models.cohort import Cohort
 from products.cohorts.backend.models.util import count_cohort_members
+from products.experiments.backend.hogql_queries import FLAG_WITHOUT_VARIANTS_ERROR_CODE
 from products.experiments.backend.hogql_queries.experiment_query_runner import ExperimentQueryRunner
 from products.experiments.backend.hogql_queries.test.experiment_query_runner.base import ExperimentQueryRunnerBaseTest
 from products.experiments.backend.hogql_queries.test.experiment_query_runner.utils import (
@@ -39,6 +41,33 @@ from products.experiments.backend.hogql_queries.test.experiment_query_runner.uti
 
 @override_settings(IN_UNIT_TESTING=True)
 class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
+    @parameterized.expand(
+        [
+            ("multivariate_null", None),
+            ("empty_variants", {"variants": []}),
+        ]
+    )
+    def test_flag_without_variants_raises_descriptive_error(self, _name, multivariate_value):
+        # A flag converted from multivariate to boolean/rollout leaves the experiment with nothing
+        # to split metrics across. The runner must fail fast with a descriptive 4xx rather than a
+        # confusing downstream error once it tries to score empty variants.
+        feature_flag = self.create_feature_flag(key=f"metric-lost-variants-{_name.replace('_', '-')}")
+        feature_flag.filters = {
+            "groups": [{"properties": [], "rollout_percentage": 100}],
+            "multivariate": multivariate_value,
+        }
+        feature_flag.save(update_fields=["filters"])
+        experiment = self.create_experiment(feature_flag=feature_flag)
+
+        metric = ExperimentMeanMetric(source=EventsNode(event="$pageview"))
+        experiment_query = ExperimentQuery(experiment_id=experiment.id, kind="ExperimentQuery", metric=metric)
+
+        with self.assertRaises(ValidationError) as cm:
+            ExperimentQueryRunner(query=experiment_query, team=self.team)
+
+        self.assertEqual(cm.exception.detail[0].code, FLAG_WITHOUT_VARIANTS_ERROR_CODE)
+        self.assertIn("no longer defines any variants", str(cm.exception.detail[0]))
+
     def test_deleted_feature_flag_tombstone_uses_original_key_for_query_builder(self):
         feature_flag = self.create_feature_flag(key="deleted-experiment-flag")
         experiment = self.create_experiment(feature_flag=feature_flag)

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_base.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_base.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from django.test import override_settings
 
 from parameterized import parameterized
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import ErrorDetail, ValidationError
 
 from posthog.schema import (
     ActionsNode,
@@ -65,8 +65,12 @@ class TestExperimentQueryRunner(ExperimentQueryRunnerBaseTest):
         with self.assertRaises(ValidationError) as cm:
             ExperimentQueryRunner(query=experiment_query, team=self.team)
 
-        self.assertEqual(cm.exception.detail[0].code, FLAG_WITHOUT_VARIANTS_ERROR_CODE)
-        self.assertIn("no longer defines any variants", str(cm.exception.detail[0]))
+        detail = cm.exception.detail
+        assert isinstance(detail, list)
+        error_detail = detail[0]
+        assert isinstance(error_detail, ErrorDetail)
+        self.assertEqual(error_detail.code, FLAG_WITHOUT_VARIANTS_ERROR_CODE)
+        self.assertIn("no longer defines any variants", str(error_detail))
 
     def test_deleted_feature_flag_tombstone_uses_original_key_for_query_builder(self):
         feature_flag = self.create_feature_flag(key="deleted-experiment-flag")

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -8,7 +8,7 @@ from django.forms.models import model_to_dict
 from django.test import override_settings
 
 from parameterized import parameterized
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import ErrorDetail, ValidationError
 
 from posthog.schema import ActionsNode, ExperimentEventExposureConfig, ExperimentExposureQuery
 
@@ -1730,8 +1730,12 @@ class TestExperimentExposuresQueryRunner(ExperimentQueryRunnerBaseTest):
         with self.assertRaises(ValidationError) as cm:
             ExperimentExposuresQueryRunner(team=self.team, query=query)
 
-        self.assertEqual(cm.exception.detail[0].code, FLAG_WITHOUT_VARIANTS_ERROR_CODE)
-        self.assertIn("no longer defines any variants", str(cm.exception.detail[0]))
+        detail = cm.exception.detail
+        assert isinstance(detail, list)
+        error_detail = detail[0]
+        assert isinstance(error_detail, ErrorDetail)
+        self.assertEqual(error_detail.code, FLAG_WITHOUT_VARIANTS_ERROR_CODE)
+        self.assertIn("no longer defines any variants", str(error_detail))
 
     def test_date_range_follows_query_not_model(self):
         # The result is cached under a key hashed from the query (see get_cache_payload), so the window

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -8,13 +8,14 @@ from django.forms.models import model_to_dict
 from django.test import override_settings
 
 from parameterized import parameterized
+from rest_framework.exceptions import ValidationError
 
 from posthog.schema import ActionsNode, ExperimentEventExposureConfig, ExperimentExposureQuery
 
 from posthog.test.test_journeys import journeys_for
 
 from products.actions.backend.models.action import Action
-from products.experiments.backend.hogql_queries import MULTIPLE_VARIANT_KEY
+from products.experiments.backend.hogql_queries import FLAG_WITHOUT_VARIANTS_ERROR_CODE, MULTIPLE_VARIANT_KEY
 from products.experiments.backend.hogql_queries.experiment_exposures_query_runner import ExperimentExposuresQueryRunner
 from products.experiments.backend.hogql_queries.test.experiment_query_runner.base import ExperimentQueryRunnerBaseTest
 from products.experiments.backend.hogql_queries.test.experiment_query_runner.utils import (
@@ -1694,6 +1695,43 @@ class TestExperimentExposuresQueryRunner(ExperimentQueryRunnerBaseTest):
         risk = _runner(None)._evaluate_bias_risk(total_exposures)
         assert risk is not None
         self.assertGreater(risk.multiple_variant_percentage, 0)
+
+    @parameterized.expand(
+        [
+            # (name, multivariate_value) — both are flags no longer backing an experiment split.
+            ("multivariate_null", None),  # flag converted to a plain boolean/rollout flag
+            ("empty_variants", {"variants": []}),  # multivariate present but no variants left
+        ]
+    )
+    def test_flag_without_variants_raises_descriptive_error(self, _name, multivariate_value):
+        # A flag whose multivariate is null (converted to boolean) used to raise AttributeError here,
+        # surfacing to the client as a 500. It must instead raise a descriptive 4xx ValidationError.
+        feature_flag = self.create_feature_flag(key="lost-variants")
+        feature_flag.filters = {
+            "groups": [{"properties": [], "rollout_percentage": 100}],
+            "multivariate": multivariate_value,
+        }
+        feature_flag.save(update_fields=["filters"])
+        experiment = self.create_experiment(
+            feature_flag=feature_flag,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 7),
+        )
+        query = ExperimentExposureQuery(
+            kind="ExperimentExposureQuery",
+            experiment_id=experiment.id,
+            experiment_name=experiment.name,
+            feature_flag=model_to_dict(feature_flag),
+            start_date=experiment.start_date.isoformat(),
+            end_date=experiment.end_date.isoformat(),
+            exposure_criteria=experiment.exposure_criteria,
+        )
+
+        with self.assertRaises(ValidationError) as cm:
+            ExperimentExposuresQueryRunner(team=self.team, query=query)
+
+        self.assertEqual(cm.exception.detail[0].code, FLAG_WITHOUT_VARIANTS_ERROR_CODE)
+        self.assertIn("no longer defines any variants", str(cm.exception.detail[0]))
 
     def test_date_range_follows_query_not_model(self):
         # The result is cached under a key hashed from the query (see get_cache_payload), so the window

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_experiment_exposures_query_runner.py
@@ -9,13 +9,14 @@ from django.forms.models import model_to_dict
 from django.test import override_settings
 
 from parameterized import parameterized
+from rest_framework.exceptions import ErrorDetail, ValidationError
 
 from posthog.schema import ActionsNode, ExperimentEventExposureConfig, ExperimentExposureQuery
 
 from posthog.test.test_journeys import journeys_for
 
 from products.actions.backend.models.action import Action
-from products.experiments.backend.hogql_queries import MULTIPLE_VARIANT_KEY
+from products.experiments.backend.hogql_queries import FLAG_WITHOUT_VARIANTS_ERROR_CODE, MULTIPLE_VARIANT_KEY
 from products.experiments.backend.hogql_queries.experiment_exposures_query_runner import ExperimentExposuresQueryRunner
 from products.experiments.backend.hogql_queries.exposure_query_logic import (
     EXPERIMENT_EXPOSURE_EVENT,
@@ -1784,6 +1785,47 @@ class TestExperimentExposuresQueryRunner(ExperimentQueryRunnerBaseTest):
         risk = _runner(None)._evaluate_bias_risk(total_exposures)
         assert risk is not None
         self.assertGreater(risk.multiple_variant_percentage, 0)
+
+    @parameterized.expand(
+        [
+            # (name, multivariate_value) — both are flags no longer backing an experiment split.
+            ("multivariate_null", None),  # flag converted to a plain boolean/rollout flag
+            ("empty_variants", {"variants": []}),  # multivariate present but no variants left
+        ]
+    )
+    def test_flag_without_variants_raises_descriptive_error(self, _name, multivariate_value):
+        # A flag whose multivariate is null (converted to boolean) used to raise AttributeError here,
+        # surfacing to the client as a 500. It must instead raise a descriptive 4xx ValidationError.
+        feature_flag = self.create_feature_flag(key="lost-variants")
+        feature_flag.filters = {
+            "groups": [{"properties": [], "rollout_percentage": 100}],
+            "multivariate": multivariate_value,
+        }
+        feature_flag.save(update_fields=["filters"])
+        experiment = self.create_experiment(
+            feature_flag=feature_flag,
+            start_date=datetime(2024, 1, 1),
+            end_date=datetime(2024, 1, 7),
+        )
+        query = ExperimentExposureQuery(
+            kind="ExperimentExposureQuery",
+            experiment_id=experiment.id,
+            experiment_name=experiment.name,
+            feature_flag=model_to_dict(feature_flag),
+            start_date=experiment.start_date.isoformat(),
+            end_date=experiment.end_date.isoformat(),
+            exposure_criteria=experiment.exposure_criteria,
+        )
+
+        with self.assertRaises(ValidationError) as cm:
+            ExperimentExposuresQueryRunner(team=self.team, query=query)
+
+        detail = cm.exception.detail
+        assert isinstance(detail, list)
+        error_detail = detail[0]
+        assert isinstance(error_detail, ErrorDetail)
+        self.assertEqual(error_detail.code, FLAG_WITHOUT_VARIANTS_ERROR_CODE)
+        self.assertIn("no longer defines any variants", str(error_detail))
 
     def test_date_range_follows_query_not_model(self):
         # The result is cached under a key hashed from the query (see get_cache_payload), so the window

--- a/products/experiments/backend/temporal/canary_logic.py
+++ b/products/experiments/backend/temporal/canary_logic.py
@@ -44,6 +44,7 @@ from django.utils import timezone
 import requests
 import structlog
 from prometheus_client import Gauge
+from rest_framework.exceptions import ValidationError
 
 from posthog.schema import ExperimentQuery, PrecomputationMode
 
@@ -51,6 +52,7 @@ from posthog.clickhouse.query_tagging import tags_context
 from posthog.metrics import pushed_metrics_registry
 from posthog.models.scoping import team_scope
 
+from products.experiments.backend.hogql_queries import FLAG_WITHOUT_VARIANTS_ERROR_CODE
 from products.experiments.backend.hogql_queries.experiment_query_runner import ExperimentQueryRunner
 from products.experiments.backend.models.experiment import Experiment
 from products.experiments.backend.models.team_experiments_config import TeamExperimentsConfig
@@ -377,7 +379,13 @@ def run_metric_canary_sync(target: CanaryMetricTarget) -> CanaryMetricResult:
             query_id = f"experiment-canary-{canary_id}-{label}"
             try:
                 runs.append(_execute_canary_run(experiment, metric, mode, label, query_id))
-            except Exception:
+            except Exception as e:
+                # A flag converted away from multivariate is a deterministic dead end (the runner
+                # refuses in __init__ on every attempt), not a precompute regression — classify it
+                # as skipped so it doesn't pollute the canary's error gauge.
+                codes = e.get_codes() if isinstance(e, ValidationError) else None
+                if isinstance(codes, list) and FLAG_WITHOUT_VARIANTS_ERROR_CODE in codes:
+                    return _skipped("experiment feature flag no longer defines variants")
                 logger.warning(
                     "experiment_precompute_canary_run_failed",
                     team_id=target.team_id,

--- a/products/experiments/backend/temporal/test_canary_logic.py
+++ b/products/experiments/backend/temporal/test_canary_logic.py
@@ -401,6 +401,20 @@ class TestRunMetricCanary(BaseTest):
             with pytest.raises(RuntimeError):
                 run_metric_canary_sync(self._target(experiment, metric["uuid"]))
 
+    def test_flag_without_variants_is_skipped(self):
+        # The runner raises its descriptive ValidationError in __init__ when the flag was converted
+        # away from multivariate — a deterministic dead end, so the canary must skip, not error.
+        metric = _funnel_metric()
+        experiment = self._experiment([metric])
+        experiment.feature_flag.filters = {
+            "groups": [{"properties": [], "rollout_percentage": 100}],
+            "multivariate": None,
+        }
+        experiment.feature_flag.save()
+        result = run_metric_canary_sync(self._target(experiment, metric["uuid"]))
+        assert result.outcome == OUTCOME_SKIPPED
+        assert "variants" in (result.detail or "")
+
 
 def _result(outcome: str, **kwargs) -> CanaryMetricResult:
     target = CanaryMetricTarget(team_id=1, experiment_id=2, metric_uuid="m-uuid", metric_type="funnel")

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -100,6 +100,7 @@ from products.feature_flags.backend.models.feature_flag import (
     FeatureFlag,
     FeatureFlagDashboards,
     set_feature_flags_for_team_in_cache,
+    variants_from_filters,
 )
 from products.feature_flags.backend.types import PropertyFilterType
 from products.feature_flags.backend.user_blast_radius import get_user_blast_radius
@@ -1048,6 +1049,7 @@ class FeatureFlagSerializer(
         self._validate_device_bucketing_with_persist_auth(attrs)
         self._validate_encrypted_payloads_require_remote_config(attrs)
         self._validate_archived_flags_are_disabled(attrs)
+        self._validate_experiment_variants_preserved(attrs)
         self._validate_flag_limits()
 
         # Materialize the remote-config 100% rollout default here, before the approval gate runs in
@@ -1154,6 +1156,35 @@ class FeatureFlagSerializer(
                 "Cannot archive an enabled feature flag. Disable it first, or send active: false in the same request."
             )
         raise serializers.ValidationError("Cannot enable an archived feature flag. Unarchive it first.")
+
+    def _validate_experiment_variants_preserved(self, attrs: dict) -> None:
+        """Block converting a flag from multivariate to boolean/rollout while a non-deleted
+        experiment references it. Every such experiment — draft, running, or ended — runs an
+        exposure query that needs the flag's variants, so dropping them breaks the results view.
+        Only deleted experiments are exempt."""
+        if self.instance is None:
+            return
+
+        # `get_filters` is the DictField's source; absent means filters aren't being updated.
+        _MISSING: Any = object()
+        new_filters = attrs.get("get_filters", _MISSING)
+        if new_filters is _MISSING:
+            return
+
+        # Only the multivariate -> boolean/rollout transition matters: had variants, now has none.
+        if not self.instance.variants or variants_from_filters(new_filters):
+            return
+
+        experiments = list(self.instance.experiment_set.filter(deleted=False))
+        if not experiments:
+            return
+
+        experiment_names = ", ".join(f'"{exp.name}" (ID: {exp.id})' for exp in experiments)
+        raise serializers.ValidationError(
+            f"Cannot remove this flag's variants while it is linked to experiment(s): {experiment_names}. "
+            "Converting the flag to boolean or rollout would break those experiments' exposure and "
+            "metric results. Delete or detach the experiment(s) first."
+        )
 
     def _validate_encrypted_payloads_require_remote_config(self, attrs: dict) -> None:
         """Encrypted payloads are only valid on remote configuration flags."""

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -103,6 +103,7 @@ from products.feature_flags.backend.models.feature_flag import (
     FeatureFlag,
     FeatureFlagDashboards,
     set_feature_flags_for_team_in_cache,
+    variants_from_filters,
 )
 from products.feature_flags.backend.types import PropertyFilterType
 from products.feature_flags.backend.user_blast_radius import get_user_blast_radius
@@ -1054,6 +1055,7 @@ class FeatureFlagSerializer(
         self._validate_device_bucketing_with_persist_auth(attrs)
         self._validate_encrypted_payloads_require_remote_config(attrs)
         self._validate_archived_flags_are_disabled(attrs)
+        self._validate_experiment_variants_preserved(attrs)
         self._validate_flag_limits()
 
         # Materialize the remote-config 100% rollout default here, before the approval gate runs in
@@ -1160,6 +1162,35 @@ class FeatureFlagSerializer(
                 "Cannot archive an enabled feature flag. Disable it first, or send active: false in the same request."
             )
         raise serializers.ValidationError("Cannot enable an archived feature flag. Unarchive it first.")
+
+    def _validate_experiment_variants_preserved(self, attrs: dict) -> None:
+        """Block converting a flag from multivariate to boolean/rollout while a non-deleted
+        experiment references it. Every such experiment — draft, running, or ended — runs an
+        exposure query that needs the flag's variants, so dropping them breaks the results view.
+        Only deleted experiments are exempt."""
+        if self.instance is None:
+            return
+
+        # `get_filters` is the DictField's source; absent means filters aren't being updated.
+        _MISSING: Any = object()
+        new_filters = attrs.get("get_filters", _MISSING)
+        if new_filters is _MISSING:
+            return
+
+        # Only the multivariate -> boolean/rollout transition matters: had variants, now has none.
+        if not self.instance.variants or variants_from_filters(new_filters):
+            return
+
+        experiments = list(self.instance.experiment_set.filter(deleted=False))
+        if not experiments:
+            return
+
+        experiment_names = ", ".join(f'"{exp.name}" (ID: {exp.id})' for exp in experiments)
+        raise serializers.ValidationError(
+            f"Cannot remove this flag's variants while it is linked to experiment(s): {experiment_names}. "
+            "Converting the flag to boolean or rollout would break those experiments' exposure and "
+            "metric results. Delete or detach the experiment(s) first."
+        )
 
     def _validate_encrypted_payloads_require_remote_config(self, attrs: dict) -> None:
         """Encrypted payloads are only valid on remote configuration flags."""

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -1189,7 +1189,7 @@ class FeatureFlagSerializer(
         raise serializers.ValidationError(
             f"Cannot remove this flag's variants while it is linked to experiment(s): {experiment_names}. "
             "Converting the flag to boolean or rollout would break those experiments' exposure and "
-            "metric results. Delete or detach the experiment(s) first."
+            "metric results. Delete the experiment(s) first."
         )
 
     def _validate_encrypted_payloads_require_remote_config(self, attrs: dict) -> None:

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -3982,6 +3982,81 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         assert flag.deleted is True
         assert flag.key == f"{_name}-exp-flag:deleted:{flag.id}"
 
+    def _multivariate_flag(self, key: str) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key=key,
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "rollout_percentage": 50},
+                        {"key": "test", "rollout_percentage": 50},
+                    ]
+                },
+            },
+        )
+
+    @parameterized.expand(
+        [
+            # name, incoming multivariate value — both drop the flag's variants.
+            ("multivariate_removed", None),  # boolean/rollout flag: no multivariate key at all
+            ("multivariate_null", "null"),  # multivariate explicitly nulled
+        ]
+    )
+    def test_removing_variants_blocked_while_experiment_references_flag(self, _name, multivariate):
+        # Converting a multivariate flag to boolean while an experiment still points at it would break
+        # that experiment's exposure/metric queries, so the change is rejected with a descriptive error.
+        flag = self._multivariate_flag(f"{_name}-flag")
+        exp = Experiment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            feature_flag=flag,
+            name="My experiment",
+            start_date=now(),
+        )
+
+        filters: dict = {"groups": [{"properties": [], "rollout_percentage": 100}]}
+        if multivariate == "null":
+            filters["multivariate"] = None
+        response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/", {"filters": filters})
+
+        assert response.status_code == 400, response.content
+        detail = response.json()["detail"]
+        assert "Cannot remove this flag's variants" in detail
+        assert f'"My experiment" (ID: {exp.id})' in detail
+        flag.refresh_from_db()
+        assert flag.variants  # unchanged
+
+    @parameterized.expand(
+        [
+            ("no_experiment", False),
+            ("deleted_experiment", True),
+        ]
+    )
+    def test_removing_variants_allowed_without_live_experiment(self, _name, with_deleted_experiment):
+        # Only non-deleted experiments block the conversion; a deleted experiment (or none) doesn't.
+        flag = self._multivariate_flag(f"{_name}-flag")
+        if with_deleted_experiment:
+            Experiment.objects.create(
+                team=self.team,
+                created_by=self.user,
+                feature_flag=flag,
+                name="Old experiment",
+                start_date=now(),
+                deleted=True,
+            )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{flag.id}/",
+            {"filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}},
+        )
+
+        assert response.status_code == 200, response.content
+        flag.refresh_from_db()
+        assert flag.variants == []
+
     def test_soft_delete_flag_blocked_when_used_in_replay_settings(self):
         flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="replay-flag")
         # Set the flag as the session recording linked flag

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -4048,6 +4048,81 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         assert flag.deleted is True
         assert flag.key == f"{_name}-exp-flag:deleted:{flag.id}"
 
+    def _multivariate_flag(self, key: str) -> FeatureFlag:
+        return FeatureFlag.objects.create(
+            team=self.team,
+            created_by=self.user,
+            key=key,
+            filters={
+                "groups": [{"properties": [], "rollout_percentage": 100}],
+                "multivariate": {
+                    "variants": [
+                        {"key": "control", "rollout_percentage": 50},
+                        {"key": "test", "rollout_percentage": 50},
+                    ]
+                },
+            },
+        )
+
+    @parameterized.expand(
+        [
+            # name, incoming multivariate value — both drop the flag's variants.
+            ("multivariate_removed", None),  # boolean/rollout flag: no multivariate key at all
+            ("multivariate_null", "null"),  # multivariate explicitly nulled
+        ]
+    )
+    def test_removing_variants_blocked_while_experiment_references_flag(self, _name, multivariate):
+        # Converting a multivariate flag to boolean while an experiment still points at it would break
+        # that experiment's exposure/metric queries, so the change is rejected with a descriptive error.
+        flag = self._multivariate_flag(f"{_name}-flag")
+        exp = Experiment.objects.create(
+            team=self.team,
+            created_by=self.user,
+            feature_flag=flag,
+            name="My experiment",
+            start_date=now(),
+        )
+
+        filters: dict = {"groups": [{"properties": [], "rollout_percentage": 100}]}
+        if multivariate == "null":
+            filters["multivariate"] = None
+        response = self.client.patch(f"/api/projects/{self.team.id}/feature_flags/{flag.id}/", {"filters": filters})
+
+        assert response.status_code == 400, response.content
+        detail = response.json()["detail"]
+        assert "Cannot remove this flag's variants" in detail
+        assert f'"My experiment" (ID: {exp.id})' in detail
+        flag.refresh_from_db()
+        assert flag.variants  # unchanged
+
+    @parameterized.expand(
+        [
+            ("no_experiment", False),
+            ("deleted_experiment", True),
+        ]
+    )
+    def test_removing_variants_allowed_without_live_experiment(self, _name, with_deleted_experiment):
+        # Only non-deleted experiments block the conversion; a deleted experiment (or none) doesn't.
+        flag = self._multivariate_flag(f"{_name}-flag")
+        if with_deleted_experiment:
+            Experiment.objects.create(
+                team=self.team,
+                created_by=self.user,
+                feature_flag=flag,
+                name="Old experiment",
+                start_date=now(),
+                deleted=True,
+            )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{flag.id}/",
+            {"filters": {"groups": [{"properties": [], "rollout_percentage": 100}]}},
+        )
+
+        assert response.status_code == 200, response.content
+        flag.refresh_from_db()
+        assert flag.variants == []
+
     def test_soft_delete_flag_blocked_when_used_in_replay_settings(self):
         flag = FeatureFlag.objects.create(team=self.team, created_by=self.user, key="replay-flag")
         # Set the flag as the session recording linked flag

--- a/products/feature_flags/backend/models/feature_flag.py
+++ b/products/feature_flags/backend/models/feature_flag.py
@@ -112,6 +112,21 @@ EXPERIMENT_MIN_VARIANTS = 2
 EXPERIMENT_MAX_VARIANTS = 20
 
 
+def variants_from_filters(filters: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """The multivariate variants declared in a flag's filters, or [] when absent or null.
+
+    :TRICKY: filters["multivariate"] can be explicitly null (the flag was converted from
+    multivariate to a plain boolean/rollout flag), so a bare .get("multivariate", {}) returns
+    None rather than {}. Callers that then do .get("variants") on it would raise AttributeError.
+    """
+    multivariate = (filters or {}).get("multivariate", None)
+    if isinstance(multivariate, dict):
+        variants = multivariate.get("variants", None)
+        if isinstance(variants, list):
+            return variants
+    return []
+
+
 def experiment_eligibility_error(variants: list[dict[str, Any]] | None) -> str | None:
     """Why these flag variants can't back an experiment, or None when they can."""
     if not variants or len(variants) < EXPERIMENT_MIN_VARIANTS:
@@ -343,13 +358,7 @@ class FeatureFlag(FileSystemSyncMixin, ModelActivityMixin, RootTeamMixin, models
 
     @property
     def variants(self):
-        # :TRICKY: .get("multivariate", {}) returns "None" if the key is explicitly set to "null" inside json filters
-        multivariate = self.get_filters().get("multivariate", None)
-        if isinstance(multivariate, dict):
-            variants = multivariate.get("variants", None)
-            if isinstance(variants, list):
-                return variants
-        return []
+        return variants_from_filters(self.get_filters())
 
     @property
     def is_eligible_for_experiment(self) -> bool:


### PR DESCRIPTION
## Problem

Opening the results of an experiment whose feature flag was converted from multivariate to a boolean or rollout flag broke: the exposure query returned HTTP 500 and the page gave no explanation.

- In that state `filters.multivariate` is explicitly `null`, so the runner's `dict.get("multivariate", {})` returned `None` and crashed with `AttributeError`.
- Without variants an experiment can't compute exposures or metrics at all, so coalescing `null` to `{}` would only trade the crash for an empty, endlessly refreshing results view. A typed error beats a silently empty chart.

## Changes

- Both experiment query runners now raise a descriptive 4xx `ValidationError` (code `feature_flag_variants_removed`) when the flag has no variants. A shared null-safe helper (`variants_from_flag_filters`) centralizes the extraction, and `FeatureFlag.variants` reuses the same logic.
- The results view shows an error banner for this state and stops the auto-refresh loop. A user-initiated reload refetches the experiment and its flag, then re-runs results, so the page recovers once the variants are restored (the exposure query embeds the flag snapshot, so a plain retry could not). The banner shows when the flag changed, read best-effort from the ungated per-flag activity endpoint.
- The feature flag serializer now blocks converting a flag away from multivariate while a non-deleted experiment references it, naming the blocking experiments. Only deleted experiments are exempt.
- The experiment precompute canary classifies this state as skipped instead of error, keeping its error gauge meaningful.

All four ReviewHog findings are addressed: manual reload recovery, the ungated activity endpoint, the canary skip classification, and dropping the suggestion to "detach" experiments (no such action exists).

## How did you test this code?

- Jest (`experimentLogic.test.ts`, ran locally): detection sets the error state and records the change time; unrelated error codes are ignored; auto-refresh stops once variants are gone; a manual refresh clears the state and retries. The last case guards the reload-button recovery added for review.
- Backend (written, not run here: this sandbox has no Postgres/ClickHouse, so they run in CI): runner tests assert the 4xx and its code for `multivariate: null` and empty variants; serializer tests assert the conversion block and its exemptions; `test_flag_without_variants_is_skipped` guards the canary skip classification.
- Ran locally: full frontend typecheck, oxlint/oxfmt, ruff, repo-wide mypy, and `hogli ci:preflight`.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None: the change replaces a crash with an in-product error state; no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code via a PostHog Code task. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-pr-descriptions`.

This revision rebased the branch onto current master (integrating master's new `excluded_variants` handling in both query runners) and folded in the four ReviewHog findings. The notable behavior decision: the variants-removed guard now only swallows `auto_refresh` triggers, so the error state is recoverable in-app instead of requiring a full page reload.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

