### PR TITLE
fix(aio): stop dropping posthog_ custom properties on otel paths

### DIFF
--- a/nodejs/src/ingestion/pipelines/ai/otel/middleware/custom-metadata.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/middleware/custom-metadata.test.ts
@@ -1,0 +1,28 @@
+import { promotePosthogCustomMetadata } from './custom-metadata'
+
+describe('promotePosthogCustomMetadata', () => {
+    it.each([
+        ['posthog_tags', 'tags', ['beta', 'internal']],
+        ['posthog_environment', 'environment', 'prod'],
+    ])('promotes <namespace>%s to %s with the prefix stripped', (suffix, name, value) => {
+        const props: Record<string, unknown> = { [`ns.${suffix}`]: value }
+        promotePosthogCustomMetadata(props, 'ns.')
+        expect(props[name]).toEqual(value)
+    })
+
+    it.each([
+        ['a non-posthog key', 'ns.org_id', 'org_id'],
+        ['a reserved $-prefixed name', 'ns.posthog_$ai_model', '$ai_model'],
+        ['the reserved distinct_id name', 'ns.posthog_distinct_id', 'distinct_id'],
+    ])('does not promote %s', (_label, key, resultName) => {
+        const props: Record<string, unknown> = { [key]: 'value' }
+        promotePosthogCustomMetadata(props, 'ns.')
+        expect(props[resultName]).toBeUndefined()
+    })
+
+    it('does not overwrite an existing property', () => {
+        const props: Record<string, unknown> = { tags: ['keep'], 'ns.posthog_tags': ['drop'] }
+        promotePosthogCustomMetadata(props, 'ns.')
+        expect(props['tags']).toEqual(['keep'])
+    })
+})

--- a/nodejs/src/ingestion/pipelines/ai/otel/middleware/custom-metadata.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/middleware/custom-metadata.test.ts
@@ -4,6 +4,7 @@ describe('promotePosthogCustomMetadata', () => {
     it.each([
         ['posthog_tags', 'tags', ['beta', 'internal']],
         ['posthog_environment', 'environment', 'prod'],
+        ['posthog_constructor', 'constructor', 'ctor-value'],
     ])('promotes <namespace>%s to %s with the prefix stripped', (suffix, name, value) => {
         const props: Record<string, unknown> = { [`ns.${suffix}`]: value }
         promotePosthogCustomMetadata(props, 'ns.')
@@ -24,5 +25,11 @@ describe('promotePosthogCustomMetadata', () => {
         const props: Record<string, unknown> = { tags: ['keep'], 'ns.posthog_tags': ['drop'] }
         promotePosthogCustomMetadata(props, 'ns.')
         expect(props['tags']).toEqual(['keep'])
+    })
+
+    it('skips __proto__ instead of polluting the prototype', () => {
+        const props: Record<string, unknown> = { 'ns.posthog___proto__': { polluted: true } }
+        promotePosthogCustomMetadata(props, 'ns.')
+        expect(Object.getPrototypeOf(props)).toBe(Object.prototype)
     })
 })

--- a/nodejs/src/ingestion/pipelines/ai/otel/middleware/custom-metadata.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/middleware/custom-metadata.ts
@@ -1,5 +1,5 @@
 const CUSTOM_METADATA_MARKER = 'posthog_'
-const RESERVED_CUSTOM_NAMES = new Set(['distinct_id'])
+const RESERVED_CUSTOM_NAMES = new Set(['distinct_id', '__proto__'])
 
 export function promotePosthogCustomMetadata(props: Record<string, unknown>, namespacePrefix: string): void {
     const prefix = `${namespacePrefix}${CUSTOM_METADATA_MARKER}`
@@ -11,7 +11,7 @@ export function promotePosthogCustomMetadata(props: Record<string, unknown>, nam
         if (!name || name.startsWith('$') || RESERVED_CUSTOM_NAMES.has(name)) {
             continue
         }
-        if (props[name] === undefined) {
+        if (!Object.prototype.hasOwnProperty.call(props, name)) {
             props[name] = props[key]
         }
     }

--- a/nodejs/src/ingestion/pipelines/ai/otel/middleware/custom-metadata.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/middleware/custom-metadata.ts
@@ -1,0 +1,18 @@
+const CUSTOM_METADATA_MARKER = 'posthog_'
+const RESERVED_CUSTOM_NAMES = new Set(['distinct_id'])
+
+export function promotePosthogCustomMetadata(props: Record<string, unknown>, namespacePrefix: string): void {
+    const prefix = `${namespacePrefix}${CUSTOM_METADATA_MARKER}`
+    for (const key of Object.keys(props)) {
+        if (!key.startsWith(prefix)) {
+            continue
+        }
+        const name = key.slice(prefix.length)
+        if (!name || name.startsWith('$') || RESERVED_CUSTOM_NAMES.has(name)) {
+            continue
+        }
+        if (props[name] === undefined) {
+            props[name] = props[key]
+        }
+    }
+}

--- a/nodejs/src/ingestion/pipelines/ai/otel/middleware/traceloop.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/middleware/traceloop.test.ts
@@ -209,6 +209,17 @@ describe('traceloop middleware', () => {
             expect(event.properties!['$ai_stop_reason']).toBe('end_turn')
         })
 
+        it('promotes posthog_-prefixed association properties as custom properties', () => {
+            const event = createEvent('$ai_generation', {
+                'llm.request.type': 'chat',
+                'traceloop.association.properties.posthog_env': 'prod',
+            })
+            traceloop.process(event, () => mapOtelAttributes(event))
+
+            expect(event.properties!['env']).toBe('prod')
+            expect(event.properties!['traceloop.association.properties.posthog_env']).toBeUndefined()
+        })
+
         it('maps finish_reason to $ai_stop_reason when stop_reason is absent', () => {
             const event = createEvent('$ai_generation', {
                 'llm.request.type': 'chat',

--- a/nodejs/src/ingestion/pipelines/ai/otel/middleware/traceloop.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/middleware/traceloop.ts
@@ -1,5 +1,6 @@
 import { PluginEvent } from '~/plugin-scaffold'
 
+import { promotePosthogCustomMetadata } from './custom-metadata'
 import { OtelLibraryMiddleware } from './types'
 
 const STRIP_KEYS = [
@@ -170,6 +171,7 @@ function process(event: PluginEvent, next: () => void): void {
     for (const key of STRIP_KEYS) {
         delete props[key]
     }
+    promotePosthogCustomMetadata(props, 'traceloop.association.properties.')
     for (const key of Object.keys(props)) {
         if (key.startsWith('traceloop.association.properties.')) {
             delete props[key]

--- a/nodejs/src/ingestion/pipelines/ai/otel/middleware/vercel-ai.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/middleware/vercel-ai.test.ts
@@ -261,7 +261,18 @@ describe('vercel-ai middleware', () => {
             expect(event.properties![`ai.telemetry.metadata.${key}`]).toBeUndefined()
         })
 
-        it('uses posthog_distinct_id as the event distinct_id', () => {
+        it('promotes posthog_-prefixed telemetry metadata as a custom property', () => {
+            const event = createEvent('$ai_generation', {
+                'ai.operationId': 'ai.generateText.doGenerate',
+                'ai.telemetry.metadata.posthog_tags': ['beta'],
+            })
+            convertOtelEvent(event)
+
+            expect(event.properties!['tags']).toEqual(['beta'])
+            expect(event.properties!['ai.telemetry.metadata.posthog_tags']).toBeUndefined()
+        })
+
+        it('uses posthog_distinct_id as the event distinct_id without creating a bare distinct_id property', () => {
             const event = createEvent('$ai_generation', {
                 'ai.operationId': 'ai.generateText.doGenerate',
                 'ai.telemetry.metadata.posthog_distinct_id': 'user-1',
@@ -269,6 +280,7 @@ describe('vercel-ai middleware', () => {
             convertOtelEvent(event)
 
             expect(event.distinct_id).toBe('user-1')
+            expect(event.properties!['distinct_id']).toBeUndefined()
         })
 
         it('ignores empty posthog_distinct_id metadata', () => {

--- a/nodejs/src/ingestion/pipelines/ai/otel/middleware/vercel-ai.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/middleware/vercel-ai.ts
@@ -2,6 +2,7 @@ import { parseJSON } from '~/common/utils/json-parse'
 import { mustAddReasoningCost } from '~/ingestion/pipelines/ai/costs/output-costs'
 import { PluginEvent } from '~/plugin-scaffold'
 
+import { promotePosthogCustomMetadata } from './custom-metadata'
 import { OtelLibraryMiddleware } from './types'
 
 // Vercel AI SDK attributes to strip after processing. Includes both
@@ -257,6 +258,8 @@ function process(event: PluginEvent, next: () => void): void {
     if (isTopLevel && isNonEmptyString(spanNameOverride)) {
         props['$ai_span_name'] = spanNameOverride
     }
+
+    promotePosthogCustomMetadata(props, 'ai.telemetry.metadata.')
 
     // Strip Vercel-specific telemetry metadata and request headers after preserving
     // the PostHog identifiers we rely on for event linkage and session grouping.


### PR DESCRIPTION
## Problem

Custom properties sent as `posthog_`-prefixed OTel metadata were silently dropped on two AI observability ingestion paths.
The Vercel AI SDK path strips the whole `ai.telemetry.metadata.*` namespace, and the Traceloop/OpenLLMetry path strips `traceloop.association.properties.*`.
Both strips ran with only a narrow allowlist, so anyone attaching custom dimensions (the mechanism people use to filter generations, e.g. `tags` or `environment`) lost them.

The generic OTel and Pydantic AI paths already forward custom attributes as-is, so this was an inconsistency rather than intended behavior: `posthog_`-namespaced metadata is meant to survive.

Origin: [internal thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784830103107569).

## Changes

- New shared helper `promotePosthogCustomMetadata(props, namespacePrefix)`.
  It promotes `<namespace>posthog_<name>` to a top-level `<name>` property (prefix stripped), only when `<name>` is unset, skipping `$`-prefixed keys and `distinct_id` so custom metadata can't clobber reserved properties or the event distinct id.
- Wired into both stripping middlewares, before their strip runs: `ai.telemetry.metadata.` (Vercel) and `traceloop.association.properties.` (Traceloop).
- Generic OTel and Pydantic paths untouched — they already pass custom attributes through unprefixed.
- No change to reserved-key handling: `posthog_distinct_id` keeps its existing identity treatment.

Because the promotion runs per event, custom properties land on each `$ai_generation`, so generations are individually filterable.

## How did you test this code?

Automated only. I (Claude) ran these; no manual or end-to-end testing was done.

- New unit test on the helper covering the guard matrix: prefix strip (string and array values), non-`posthog_` keys ignored, `$`-prefixed skipped, `distinct_id` skipped, only-if-undefined.
- One wiring test per middleware proving the promotion runs before the strip: Vercel `ai.telemetry.metadata.posthog_tags` → `tags`, Traceloop `traceloop.association.properties.posthog_env` → `env`.
- Full `nodejs/src/ingestion/pipelines/ai/otel/` suite: 208 passing (6 suites). Prettier clean. `tsc --noEmit` clean for the changed files (only pre-existing, unrelated `@posthog/replay-anonymizer` module-resolution errors remain in this environment).

The changed lines are covered by the tests above.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing doc change. This restores expected behavior (`posthog_` metadata passing through), so there is nothing new to document. Safe to add `skip-inkeep-docs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — I directed the work, so assign me as the DRI.

Built with Claude Code (Opus). Skills invoked: `/writing-tests` (to gate the test additions) and `/pr-link` (for this PR link).

The work started scoped to the Vercel path only, matching the incoming request. While verifying I checked all three middlewares plus the generic mapper and found Traceloop blanket-strips its own custom-metadata namespace (`traceloop.association.properties.*`) the same way Vercel does, while the generic OTel and Pydantic paths already forward custom attributes. So the proper fix generalizes to both stripping paths, which is why the promotion moved into a shared helper wired into each. I deliberately left the pass-through paths alone rather than forcing a uniform `posthog_` rename that would only break existing property names.

I first framed this as a feature and added an onboarding-doc note, then reverted it: `posthog_` properties surviving the strip is expected behavior, so this is a bug fix, not a documented feature.
