### PR TITLE
refactor(producer): Split new file opening and resuming from state 

### DIFF
--- a/posthog/temporal/common/asyncpa.py
+++ b/posthog/temporal/common/asyncpa.py
@@ -46,7 +46,7 @@ class AsyncMessageReader:
 
         if self._buffer[:4] != CONTINUATION_BYTES:
             raise InvalidMessageFormat(
-                f"Encapsulated IPC message format must begin with continuation bytes, received: '{self._buffer}'"
+                f"Encapsulated IPC message format must begin with continuation bytes, received: '{self._buffer[:4]}'"
             )
 
         await self.read_until(8)

--- a/products/batch_exports/backend/temporal/pipeline/producer.py
+++ b/products/batch_exports/backend/temporal/pipeline/producer.py
@@ -1,6 +1,5 @@
 import typing
 import asyncio
-import collections
 import dataclasses
 
 from django.conf import settings
@@ -31,17 +30,20 @@ class S3FileResumeState:
 
     Used to resume from the last record batch boundary when retrying a failed
     read, instead of re-reading (and re-emitting) the whole file.
+
+    Attributes:
+        offset: Absolute byte offset of the next unread IPC message.
+        schema: Cached schema, so a resumed stream (which lacks the schema
+            message) can be parsed.
+        object_size: Full object size.
+        etag: Object ETag so a resumed range GET can assert (via IfMatch) it is
+            reading the same object, and fail loudly with a 412 if not.
     """
 
-    # Absolute byte offset of the next unread IPC message.
-    offset: int = 0
-    # Cached schema, so a resumed stream (which lacks the schema message) can be parsed.
-    schema: pa.Schema | None = None
-    # Full object size, from the first (non-ranged) GET.
-    object_size: int | None = None
-    # ETag from the first GET, so a resumed range GET can assert (via IfMatch) it is
-    # reading the same object and fail loudly with a 412 if not.
-    etag: str | None = None
+    offset: int
+    schema: pa.Schema | None
+    object_size: int
+    etag: str
 
 
 class Producer:
@@ -145,44 +147,51 @@ class Producer:
         self.logger.info(f"Producer found {len(keys)} files in S3 stage, with prefix '{stage_folder}'")
         return keys
 
-    async def _open_staging_file(
+    async def _resume_staging_file(
         self, s3_client: "S3Client", key: str, state: S3FileResumeState
     ) -> StreamingBody | None:
-        """Open the S3 staging file for `key`, resuming from `state` if a previous attempt made progress.
+        """Resume the S3 staging file for `key` from `state`.
 
-        Returns the byte stream to read, or `None` if the file was already fully consumed.
+        Returns the remaining byte stream to read resuming from `state` as
+        returned by `_open_staging_file` or `None` if the `state` indicates that
+        the file was already fully consumed.
         """
-        if state.offset > 0:
-            assert state.schema is not None and state.object_size is not None and state.etag is not None
+        if state.offset >= state.object_size:
+            # Defensive: a previous attempt consumed every batch (e.g. the file lacks
+            # an EOS marker); a range GET here would fail with 416 InvalidRange.
+            self.logger.info("Stream already fully consumed, nothing to resume", key=key, offset=state.offset)
+            return None
 
-            if state.offset >= state.object_size:
-                # Defensive: a previous attempt consumed every batch (e.g. the file lacks
-                # an EOS marker); a range GET here would fail with 416 InvalidRange.
-                self.logger.info("Stream already fully consumed, nothing to resume", key=key, offset=state.offset)
-                return None
-
-            self.logger.info("Resuming stream after retryable failure", key=key, offset=state.offset)
-            # `IfMatch` guards against the object changing under us: staging files are write-once
-            # today, but if that ever changes, ranging into a different object fails with a 412
-            # instead of silently yielding the wrong data.
-            s3_ob = await s3_client.get_object(
-                Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET,
-                Key=key,
-                Range=f"bytes={state.offset}-",
-                IfMatch=state.etag,
-            )
-        else:
-            self.logger.info("Starting stream", key=key)
-            s3_ob = await s3_client.get_object(Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key)
+        self.logger.info("Resuming stream after retryable failure", key=key, offset=state.offset)
+        # `IfMatch` guards against the object changing under us: staging files are write-once
+        # today, but if that ever changes, ranging into a different object fails with a 412
+        # instead of silently yielding the wrong data.
+        s3_ob = await s3_client.get_object(
+            Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET,
+            Key=key,
+            Range=f"bytes={state.offset}-",
+            IfMatch=state.etag,
+        )
 
         assert "Body" in s3_ob, "Body not found in S3 object"
 
-        if state.offset == 0:
-            # On a range GET, `ContentLength` is the length of the range, not the object.
-            state.object_size = s3_ob["ContentLength"]
-            state.etag = s3_ob["ETag"]
-
         return s3_ob["Body"]
+
+    async def _open_staging_file(self, s3_client: "S3Client", key: str) -> tuple[StreamingBody, S3FileResumeState]:
+        """Open the S3 staging file for `key`.
+
+        Returns the full byte stream to read, as well as the initial state
+        required to eventually resume this byte stream in case we fail part way
+        through.
+        """
+        self.logger.info("Starting stream", key=key)
+        s3_ob = await s3_client.get_object(Bucket=settings.BATCH_EXPORT_INTERNAL_STAGING_BUCKET, Key=key)
+
+        assert "Body" in s3_ob, "Body not found in S3 object"
+
+        return s3_ob["Body"], S3FileResumeState(
+            offset=0, schema=None, object_size=s3_ob["ContentLength"], etag=s3_ob["ETag"]
+        )
 
     async def _stream_record_batches_from_s3(
         self,
@@ -194,20 +203,30 @@ class Producer:
     ):
         # Per-key resume state, surviving across retries of `stream_from_s3_file` so a retry
         # continues from the last fully-enqueued record batch instead of re-emitting duplicates.
-        resume_states: dict[str, S3FileResumeState] = collections.defaultdict(S3FileResumeState)
+        resume_states: dict[str, S3FileResumeState] = {}
 
-        async def stream_from_s3_file(key):
+        async def stream_from_s3_file(key: str) -> None:
+            is_starting = key not in resume_states or resume_states[key].offset == 0
+
+            if is_starting:
+                stream, new_state = await self._open_staging_file(s3_client, key)
+                resume_states[key] = new_state
+
+            else:
+                maybe_stream = await self._resume_staging_file(s3_client, key, resume_states[key])
+                if maybe_stream is None:
+                    return
+
+                stream = maybe_stream
+
             state = resume_states[key]
             base_offset = state.offset
 
-            stream = await self._open_staging_file(s3_client, key, state)
-            if stream is None:
-                return
-
-            # read in 128KB chunks of data from S3. On a resumed read `state.schema` is set (it is
-            # only cached once `state.offset` advances past 0), so the reader skips the schema message.
             reader = asyncpa.AsyncRecordBatchReader(
-                stream.iter_chunks(chunk_size=128 * 1024),
+                stream.iter_chunks(chunk_size=128 * 1024),  # 128 KiB
+                # Schema will be set on the state if we managed to fully read and
+                # enqueue at least one batch before failing and retrying. This is
+                # required as the schema message is only present at the start.
                 schema=state.schema,
             )
 
@@ -220,7 +239,8 @@ class Producer:
 
                 # Only advance the resume point once every slice of this batch is enqueued.
                 state.offset = base_offset + reader.bytes_consumed
-                state.schema = reader.schema
+                if not state.schema:
+                    state.schema = reader.schema
 
             self.logger.info("Finished stream", key=key)
 

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
@@ -209,7 +209,9 @@ async def test_resume_staging_file_short_circuits_when_fully_consumed():
     # Resume state that has already consumed the whole object: a range GET would 416.
     state = S3FileResumeState(
         offset=len(ipc_bytes),
-        schema=pa.schema([("id", pa.int64()), ("text", pa.string())]),
+        # Mypy takes the common suppertype of StringType and Int64Type, which is not
+        # datatype but object, so this fails. Until the stub is fixed, just ignore
+        schema=pa.schema([("id", pa.int64()), ("text", pa.string())]),  # type: ignore
         object_size=len(ipc_bytes),
         etag=FAKE_ETAG,
     )

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_producer.py
@@ -200,7 +200,7 @@ async def test_stream_record_batches_from_s3_resumes_across_multiple_failures():
     ]
 
 
-async def test_open_staging_file_short_circuits_when_fully_consumed():
+async def test_resume_staging_file_short_circuits_when_fully_consumed():
     key = "batch-export-data/file_0.arrow"
     _, ipc_bytes = generate_arrow_ipc_file(total_batches=1)
     fake_s3_client = FakeS3Client({key: ipc_bytes})
@@ -215,7 +215,7 @@ async def test_open_staging_file_short_circuits_when_fully_consumed():
     )
     # keep mypy happy
     s3_client = typing.cast("S3Client", fake_s3_client)
-    stream = await producer._open_staging_file(s3_client, key, state)
+    stream = await producer._resume_staging_file(s3_client, key, state)
 
     assert stream is None
     assert fake_s3_client.get_object_requests == []


### PR DESCRIPTION
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Small review changes on top of #71599.

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
