### PR TITLE
chore(dags): guard dagster code locations against import-order breakage

### DIFF
--- a/posthog/dags/tests/test_locations_load.py
+++ b/posthog/dags/tests/test_locations_load.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_LOCATIONS_DIR = Path(__file__).parent.parent / "locations"
+_REPO_ROOT = Path(__file__).parents[3]
+_LOCATION_MODULES = sorted(p.stem for p in _LOCATIONS_DIR.glob("*.py") if p.stem != "__init__")
+
+
+@pytest.mark.parametrize("location", _LOCATION_MODULES)
+def test_code_location_loads_in_fresh_interpreter(location: str) -> None:
+    snippet = (
+        "import django; django.setup(); import importlib; "
+        f"m = importlib.import_module('posthog.dags.locations.{location}'); "
+        "assert m.defs is not None"
+    )
+    env = {**os.environ, "DJANGO_SETTINGS_MODULE": "posthog.settings", "TEST": "1"}
+    env.pop("DEBUG", None)
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        env=env,
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, f"code location {location!r} failed to load:\n{result.stderr[-5000:]}"


### PR DESCRIPTION
## Problem

On Jul 21 a circular import (fixed in #73327) broke the Dagster `clickhouse` code location: every job in it vanished from the UI and its schedules 

## Changes

- New test `posthog/dags/tests/test_locations_load.py`: one parametrized case per code location (11 today, discovered by globbing `posthog/dags/locations/`), each importing the location module in a **fresh interpreter subprocess** — the same load shape Dagster's code server uses — and asserting the module exposes `defs`. A failure prints the child's stderr, which surfaces the root cause directly (e.g. the exact circular-import traceback from the incident).

Fresh-interpreter subprocesses are the point: importing in-process cannot catch order-dependent failures (that's exactly how the incident evaded CI).

## How did you test this code?

I'm an agent (Claude Code). Validated both directions:

- On current master (with #73327): all 11 cases pass, 43s total (~4s/location, parallelizable by pytest-split across the Dagster shards).
- With the #73327 bug locally re-introduced: the `clickhouse` case fails with the exact incident `ImportError: cannot import name 'get_enabled_materialized_columns' ... (circular import)` in the assertion message.

Test-justification: catches a regression class that just caused a 2-day prod schedule outage and that no existing test catches (CI was green throughout the incident); each location is a parametrized case of one test; no DB or cluster needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up hardening requested by the assignee after the #73327 incident. The `/writing-tests` skill gate was applied; subprocess-per-location was chosen deliberately over in-process import because in-process ordering is what masked the incident.
