### PR TITLE
fix(replay): unblock image-scrub concurrency with per-batch ref dedup

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
@@ -241,7 +241,88 @@ describe('ImageBatcher', () => {
         }
     )
 
-    it('dedupMaxRefs 0 disables dedup instead of skipping everything or throwing', async () => {
+    it('rescrubs an image whose batch failed rather than pod-deduping the replay away', async () => {
+        // A ref is marked seen only once its image is buffered. Marking it at plan time, or inside
+        // scrubOne, reads as a harmless simplification and silently drops the image instead: the
+        // replay is pod-deduped, its offset advances, and nothing ever writes it. No error, no
+        // counter, and every other test still green.
+        let attempts = 0
+        const flakyClient = {
+            scrub: (b: Buffer) => {
+                attempts += 1
+                return attempts === 1 ? Promise.reject(new Error('sidecar down')) : Promise.resolve(b)
+            },
+        } as unknown as ScrubClient
+        const store = new FakeStore()
+        const batcher = new ImageBatcher(
+            store as unknown as ImageShardStore,
+            new FakeOffsets(),
+            flakyClient,
+            options,
+            0
+        )
+        const sprite = Buffer.from('sprite')
+
+        await expect(batcher.handleBatch([msg(0, 0, pt(1), sprite)], 1)).rejects.toThrow('sidecar down')
+        await batcher.handleBatch([msg(0, 0, pt(1), sprite)], 2)
+
+        expect(store.writes.flat()).toHaveLength(1)
+    })
+
+    it('advances every partition past the duplicates it skipped, not just the one it scrubbed on', async () => {
+        // The span walk is the one place that can commit an offset for a message it never processed,
+        // and that failure is silent permanent loss. Both partitions here end on a duplicate, so the
+        // trailing skips are only covered if the final recordOffsets spans the whole batch.
+        const offsets = new FakeOffsets()
+        const batcher = new ImageBatcher(
+            new FakeStore() as unknown as ImageShardStore,
+            offsets,
+            scrubClient,
+            options,
+            0
+        )
+        const a = Buffer.from('a')
+        const b = Buffer.from('b')
+
+        await batcher.handleBatch(
+            [msg(0, 100, pt(1), a), msg(1, 200, pt(1), b), msg(0, 101, pt(1), a), msg(1, 201, pt(1), b)],
+            1
+        )
+
+        expect(offsets.received.at(-1)).toEqual(
+            expect.arrayContaining([
+                { topic: 'session_replay_image_scrub', partition: 0, offset: 102 },
+                { topic: 'session_replay_image_scrub', partition: 1, offset: 202 },
+            ])
+        )
+    })
+
+    it('stops re-sending an image the sidecar permanently rejected', async () => {
+        // A 422/413 is a verdict on the content, so every later copy would earn the same rejection.
+        // Without marking it, the most broken images are the ones that keep costing sidecar calls.
+        let calls = 0
+        const rejectingClient = {
+            scrub: () => {
+                calls += 1
+                return Promise.resolve(null)
+            },
+        } as unknown as ScrubClient
+        const batcher = new ImageBatcher(
+            new FakeStore() as unknown as ImageShardStore,
+            new FakeOffsets(),
+            rejectingClient,
+            options,
+            0
+        )
+        const broken = Buffer.from('broken')
+
+        await batcher.handleBatch([msg(0, 0, pt(1), broken)], 1)
+        await batcher.handleBatch([msg(0, 1, pt(1), broken)], 2)
+
+        expect(calls).toBe(1)
+    })
+
+    it('dedupMaxRefs 0 disables the cross-batch cache but never intra-batch dedup', async () => {
         const store = new FakeStore()
         const batcher = new ImageBatcher(
             store as unknown as ImageShardStore,
@@ -254,8 +335,11 @@ describe('ImageBatcher', () => {
         const sprite = Buffer.from('sprite')
         await batcher.handleBatch([msg(0, 0, pt(1), sprite)], 1)
         await batcher.handleBatch([msg(0, 1, pt(1), sprite)], 2)
-
         expect(store.writes.flat()).toHaveLength(2)
+
+        // Intra-batch dedup keeps no state between batches, so turning the cache off cannot reach it.
+        await batcher.handleBatch([msg(0, 2, pt(1), sprite), msg(0, 3, pt(1), sprite)], 3)
+        expect(store.writes.flat()).toHaveLength(3)
     })
 
     test.each([[0], [NaN], [-1]])('rejects scrubConcurrency %p at construction', (scrubConcurrency) => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
@@ -197,6 +197,50 @@ describe('ImageBatcher', () => {
         expect(offsets.received.at(-1)).toEqual([{ topic: 'session_replay_image_scrub', partition: 0, offset: 3 }])
     })
 
+    it.each([0, 1000])(
+        'scrubs the distinct images of a duplicate-heavy batch at full concurrency (dedupMaxRefs %p)',
+        async (dedupMaxRefs) => {
+            // Duplicates have to collapse before the batch is chunked. Left in, they occupy
+            // concurrency slots, so a chunk finishes as soon as its one distinct image does and the
+            // batch serializes behind the chunk barriers — the lane then runs one image in flight
+            // instead of scrubConcurrency, regardless of how many pods it has. Consecutive repeats
+            // are the realistic shape: one sprite recurs across a session's snapshots.
+            const store = new FakeStore()
+            let inFlight = 0
+            let maxInFlight = 0
+            let scrubs = 0
+            const trackingClient = {
+                scrub: async (b: Buffer) => {
+                    scrubs += 1
+                    inFlight += 1
+                    maxInFlight = Math.max(maxInFlight, inFlight)
+                    await new Promise((resolve) => setImmediate(resolve))
+                    inFlight -= 1
+                    return b
+                },
+            } as unknown as ScrubClient
+            const batcher = new ImageBatcher(
+                store as unknown as ImageShardStore,
+                new FakeOffsets(),
+                trackingClient,
+                { ...options, dedupMaxRefs },
+                0
+            )
+
+            const batch: Message[] = []
+            for (let sprite = 0; sprite < 4; sprite++) {
+                for (let repeat = 0; repeat < 8; repeat++) {
+                    batch.push(msg(0, batch.length, pt(1), Buffer.from(`sprite-${sprite}`)))
+                }
+            }
+            await batcher.handleBatch(batch, 1)
+
+            expect(scrubs).toBe(4)
+            expect(maxInFlight).toBe(4)
+            expect(store.writes.flat()).toHaveLength(4)
+        }
+    )
+
     it('dedupMaxRefs 0 disables dedup instead of skipping everything or throwing', async () => {
         const store = new FakeStore()
         const batcher = new ImageBatcher(

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
@@ -297,6 +297,49 @@ describe('ImageBatcher', () => {
         )
     })
 
+    it('leaves both partitions replayable when a chunk fails after a mid-batch flush', async () => {
+        // A mid-batch flush commits offsets for the prefix it persisted, and everything after it has
+        // to stay replayable. Multi-partition is where that can quietly go wrong, because each
+        // partition carries its own maximum and only one of them appears in a given chunk's span.
+        const store = new FakeStore()
+        const offsets = new FakeOffsets()
+        let scrubs = 0
+        const failLateClient = {
+            scrub: (b: Buffer) => {
+                scrubs += 1
+                return scrubs > 2 ? Promise.reject(new Error('sidecar down')) : Promise.resolve(b)
+            },
+        } as unknown as ScrubClient
+        const batcher = new ImageBatcher(
+            store as unknown as ImageShardStore,
+            offsets,
+            failLateClient,
+            { ...options, maxImages: 2, scrubConcurrency: 2 },
+            0
+        )
+
+        await expect(
+            batcher.handleBatch(
+                [
+                    msg(0, 10, pt(1), Buffer.from('a')),
+                    msg(1, 20, pt(1), Buffer.from('b')),
+                    msg(0, 11, pt(1), Buffer.from('c')),
+                    msg(1, 21, pt(1), Buffer.from('d')),
+                ],
+                1
+            )
+        ).rejects.toThrow('sidecar down')
+
+        expect(offsets.received).toHaveLength(1)
+        expect(offsets.received[0]).toHaveLength(2)
+        expect(offsets.received[0]).toEqual(
+            expect.arrayContaining([
+                { topic: 'session_replay_image_scrub', partition: 0, offset: 11 },
+                { topic: 'session_replay_image_scrub', partition: 1, offset: 21 },
+            ])
+        )
+    })
+
     it('stops re-sending an image the sidecar permanently rejected', async () => {
         // A 422/413 is a verdict on the content, so every later copy would earn the same rejection.
         // Without marking it, the most broken images are the ones that keep costing sidecar calls.

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
@@ -50,6 +50,7 @@ const options = {
     maxBytes: 1e9,
     scrubConcurrency: 4,
     maxBatchScrubMs: 30_000,
+    dedupMaxRefs: 1000,
 }
 
 describe('ImageBatcher', () => {
@@ -169,6 +170,48 @@ describe('ImageBatcher', () => {
 
         expect(slowStore.writes.flat()).toHaveLength(6)
         expect(offsets.stored).toBe(slowStore.writes.length)
+    })
+
+    it('scrubs each ref once: duplicates in and across batches skip the sidecar but still advance offsets', async () => {
+        // The topic is keyed by ref, so duplicate produces (per-mirror-pod producer dedup misses
+        // cross-pod repeats) are partition-affine; losing this dedup silently re-burns sidecar CPU
+        // per duplicate and writes duplicate shard entries.
+        const store = new FakeStore()
+        const offsets = new FakeOffsets()
+        let scrubs = 0
+        const countingClient = {
+            scrub: (b: Buffer) => {
+                scrubs += 1
+                return Promise.resolve(b)
+            },
+        } as unknown as ScrubClient
+        const batcher = new ImageBatcher(store as unknown as ImageShardStore, offsets, countingClient, options, 0)
+
+        const sprite = Buffer.from('sprite')
+        await batcher.handleBatch([msg(0, 0, pt(1), sprite), msg(0, 1, pt(1), sprite)], 1)
+        await batcher.handleBatch([msg(0, 2, pt(1), sprite)], 2)
+
+        expect(scrubs).toBe(1)
+        expect(store.writes.flat()).toHaveLength(1)
+        // The all-duplicate second batch still advances offsets, or the duplicates replay forever.
+        expect(offsets.received.at(-1)).toEqual([{ topic: 'session_replay_image_scrub', partition: 0, offset: 3 }])
+    })
+
+    it('dedupMaxRefs 0 disables dedup instead of skipping everything or throwing', async () => {
+        const store = new FakeStore()
+        const batcher = new ImageBatcher(
+            store as unknown as ImageShardStore,
+            new FakeOffsets(),
+            scrubClient,
+            { ...options, dedupMaxRefs: 0 },
+            0
+        )
+
+        const sprite = Buffer.from('sprite')
+        await batcher.handleBatch([msg(0, 0, pt(1), sprite)], 1)
+        await batcher.handleBatch([msg(0, 1, pt(1), sprite)], 2)
+
+        expect(store.writes.flat()).toHaveLength(2)
     })
 
     test.each([[0], [NaN], [-1]])('rejects scrubConcurrency %p at construction', (scrubConcurrency) => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
@@ -4,7 +4,7 @@ import { findOffsetsToCommit } from '~/common/kafka/consumer/consumer-v1'
 import { ConcurrencyController } from '~/common/utils/concurrencyController'
 import { RefDedupCache } from '~/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache'
 
-import { imageRef, isImageRef, parseImageRef } from './content-ref'
+import { parseImageRef } from './content-ref'
 import { ImageShardStore, ScrubbedImage } from './image-shard-store'
 import { ImageScrubConsumerMetrics } from './metrics'
 import { ScrubClient } from './scrub-client'
@@ -13,12 +13,18 @@ export interface OffsetStore {
     offsetsStore(offsets: TopicPartitionOffset[]): void
 }
 
-/** A message that survived planning, carrying its batch index so offsets can advance over the skips. */
+/** The batch index is what lets offsets advance across the messages planning skipped. */
 interface PlannedScrub {
     index: number
+    ref: string
     pseudoTeam: string
     hash: string
     value: Buffer
+}
+
+interface ScrubbedRef {
+    ref: string
+    image: ScrubbedImage
 }
 
 export interface ImageBatcherOptions {
@@ -38,17 +44,14 @@ export class ImageBatcher {
     private readonly chunkSize: number
     private readonly scrubConcurrency: ConcurrencyController
     /**
-     * Refs this pod has already scrubbed, as a best-effort stand-in for "these bytes are already in
-     * the ML bucket" — shards pack many images per object, so there is no per-hash key to ask S3
-     * about. The topic is keyed by ref, so every copy of an image lands on the same partition and
-     * therefore this pod: within its capacity the answer is exact, and past it we simply rescrub.
-     * Entries are added once an image is buffered for a shard write, so a marked ref is always one
-     * this pod holds or has written — a batch that throws keeps its buffer, and a rebalance without
-     * a restart can no longer skip a ref it never persisted.
-     *
-     * This only ever saves work that intra-batch dedup did not already save; sizing it is a
-     * throughput question, not a correctness one, and the cache's capacity probe metric is what
-     * says whether the size is actually costing us hits.
+     * Refs this pod has resolved, either by buffering the scrubbed bytes or by having the sidecar
+     * permanently reject them. A best-effort stand-in for asking S3 "are these bytes already in the
+     * bucket", which shards cannot answer: they pack many images per object, so no per-hash key
+     * exists. The topic is keyed by ref, so every copy of an image reaches this same pod and within
+     * capacity the answer is exact; past it we simply rescrub. Marking a scrubbed ref only after its
+     * buffer push is what stops a rebalance without a restart from skipping a ref it never persisted,
+     * since a batch that throws keeps its buffer. Sizing is a throughput question, not a correctness
+     * one.
      */
     private readonly seenRefs: RefDedupCache
 
@@ -71,11 +74,12 @@ export class ImageBatcher {
     }
 
     public async handleBatch(messages: Message[], nowMs: number): Promise<void> {
-        // Resolve every skip before chunking. A duplicate left in the chunk still consumes a
-        // concurrency slot and resolves as a no-op, so a chunk finishes as soon as its one distinct
-        // image does: with repeats outnumbering distinct images the batch serializes behind the
-        // chunk barriers and the pod runs one scrub at a time whatever scrubConcurrency says.
-        ImageScrubConsumerMetrics.observeBatchMessages(messages.length)
+        // Skips must resolve before chunking: a duplicate left in a chunk still holds a concurrency
+        // slot and completes instantly, so the chunk ends with its one distinct image and the batch
+        // serializes behind the barriers, running one scrub at a time whatever scrubConcurrency says.
+        if (messages.length) {
+            ImageScrubConsumerMetrics.observeBatchMessages(messages.length)
+        }
         const planned = this.planBatch(messages)
 
         // Scrub in concurrency-sized chunks with the capacity bounds applied between chunks: scrubbed
@@ -94,7 +98,7 @@ export class ImageBatcher {
             const chunk = planned.slice(i, i + this.chunkSize)
             const chunkStartMs = performance.now()
             const timer = setTimeout(() => controller.abort(), scrubBudgetMs)
-            let scrubbed: ScrubbedImage[]
+            let scrubbed: ScrubbedRef[]
             try {
                 scrubbed = await this.scrubChunk(chunk, controller)
             } catch (e) {
@@ -104,17 +108,15 @@ export class ImageBatcher {
                 clearTimeout(timer)
             }
             scrubBudgetMs -= performance.now() - chunkStartMs
-            for (const image of scrubbed) {
+            for (const { ref, image } of scrubbed) {
                 this.buffer.push(image)
                 this.bufferBytes += image.bytes.length
-                this.seenRefs.add(imageRef(image.pseudoTeam, image.hash))
+                this.seenRefs.add(ref)
             }
-            // Advance offsets per completed chunk, across the whole span of the batch it consumed —
-            // the skipped messages sitting between its entries are done too, and would otherwise
-            // replay forever. Offsets are only ever *stored* by a flush, after the buffer — which
-            // holds exactly these chunks' images — is durably written. A mid-batch flush thereby
-            // records the progress it persisted: a later failure in this batch replays only from
-            // the flush, instead of re-writing another copy of the flushed shard per replay.
+            // The span also covers the skipped messages between this chunk's entries, which are done
+            // too and would otherwise replay forever. Offsets are only ever *stored* by a flush,
+            // after the buffer holding these images is durably written, so a mid-batch flush records
+            // exactly the progress it persisted and a later failure replays only from there.
             const spanEnd = chunk[chunk.length - 1].index + 1
             this.recordOffsets(messages.slice(spanStart, spanEnd))
             spanStart = spanEnd
@@ -122,32 +124,23 @@ export class ImageBatcher {
                 await this.flushOrThrow(nowMs)
             }
         }
-        // Whatever trails the last scrubbed message is skips only (and a wholly-skipped batch is all
-        // trailer), so it needs the same treatment or those offsets never move.
+        // A batch whose tail is all skips, or which is nothing but skips, still has to move offsets.
         this.recordOffsets(messages.slice(spanStart))
         if (this.shouldFlush(nowMs)) {
             await this.flushOrThrow(nowMs)
         }
     }
 
-    /**
-     * Decide, for a whole batch at once, which messages actually reach the sidecar: the first
-     * occurrence of each ref, minus anything already scrubbed. Intra-batch dedup is unconditional —
-     * it needs no retained state, so unlike [[seenRefs]] it cannot be sized wrong or turned off.
-     */
+    /** Retains nothing between batches, so unlike [[seenRefs]] this dedup cannot be sized wrong or disabled. */
     private planBatch(messages: Message[]): PlannedScrub[] {
         const planned: PlannedScrub[] = []
         const batchRefs = new Set<string>()
         for (const [index, m] of messages.entries()) {
             const ref = m.key?.toString('utf8')
-            if (!ref || !isImageRef(ref) || !m.value) {
-                ImageScrubConsumerMetrics.incInvalidKey()
-                continue
-            }
             // The ref's hash is a producer-side per-team HMAC; this consumer doesn't hold the key and
             // trusts the producer (the topic's only writer) that the key names these bytes.
-            const parsed = parseImageRef(ref)
-            if (!parsed) {
+            const parsed = ref ? parseImageRef(ref) : null
+            if (!ref || !parsed || !m.value) {
                 ImageScrubConsumerMetrics.incInvalidKey()
                 continue
             }
@@ -160,7 +153,7 @@ export class ImageBatcher {
                 ImageScrubConsumerMetrics.incDeduped('pod')
                 continue
             }
-            planned.push({ index, pseudoTeam: parsed.pseudoTeam, hash: parsed.hash, value: m.value })
+            planned.push({ index, ref, pseudoTeam: parsed.pseudoTeam, hash: parsed.hash, value: m.value })
         }
         return planned
     }
@@ -171,17 +164,18 @@ export class ImageBatcher {
         }
     }
 
-    private async scrubChunk(planned: PlannedScrub[], controller: AbortController): Promise<ScrubbedImage[]> {
+    private async scrubChunk(planned: PlannedScrub[], controller: AbortController): Promise<ScrubbedRef[]> {
         try {
             const scrubbed = await Promise.all(
                 planned.map((p) =>
                     this.scrubConcurrency.run({
-                        fn: () => this.scrubOne(p, controller.signal),
+                        fn: () =>
+                            this.scrubOne(p, controller.signal).then((image) => (image ? { ref: p.ref, image } : null)),
                         abortController: controller,
                     })
                 )
             )
-            return scrubbed.filter((image): image is ScrubbedImage => image !== null)
+            return scrubbed.filter((entry): entry is ScrubbedRef => entry !== null)
         } catch (e) {
             controller.abort() // one failure dooms the batch, so cancel the siblings still in flight
             throw e
@@ -200,6 +194,10 @@ export class ImageBatcher {
     private async scrubOne(planned: PlannedScrub, signal: AbortSignal): Promise<ScrubbedImage | null> {
         const bytes = await this.scrubClient.scrub(planned.value, signal)
         if (bytes === null) {
+            // Null is only ever a 422/413, a verdict on the content itself, so no retry can succeed.
+            // Marking it stops every later copy from re-earning the same rejection, and there is
+            // nothing pending to persist, so this needs none of the care the success path does.
+            this.seenRefs.add(planned.ref)
             ImageScrubConsumerMetrics.incSkipped()
             return null
         }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
@@ -1,3 +1,4 @@
+import { LRUCache } from 'lru-cache'
 import { Message, TopicPartitionOffset } from 'node-rdkafka'
 
 import { findOffsetsToCommit } from '~/common/kafka/consumer/consumer-v1'
@@ -18,6 +19,7 @@ export interface ImageBatcherOptions {
     maxBytes: number
     scrubConcurrency: number
     maxBatchScrubMs: number
+    dedupMaxRefs: number
 }
 
 export class ImageBatcher {
@@ -27,6 +29,17 @@ export class ImageBatcher {
     private lastFlushMs: number
     private readonly chunkSize: number
     private readonly scrubConcurrency: ConcurrencyController
+    /**
+     * Refs this pod has already sent to the sidecar. The topic is keyed by ref, so every copy of an
+     * image lands on the same partition — a per-pod cache therefore dedupes exactly (within its
+     * capacity), and the producer's own dedup is per-mirror-pod, so cross-mirror-pod duplicates of
+     * hot sprites all arrive here. Marked before the scrub completes: if the scrub throws, the batch
+     * throws and the pod restarts (wiping this cache), and offsets are only stored after a durable
+     * flush, so a marked-but-unwritten ref can't have its offsets committed. The one gap is a
+     * rebalance without a restart, where a replayed ref is skipped and stays a dangling ref — which
+     * downstream reads as a placeholder by design.
+     */
+    private readonly seenRefs: LRUCache<string, true> | null
 
     constructor(
         private readonly store: ImageShardStore,
@@ -43,6 +56,7 @@ export class ImageBatcher {
         }
         this.lastFlushMs = nowMs
         this.scrubConcurrency = new ConcurrencyController(this.chunkSize)
+        this.seenRefs = options.dedupMaxRefs > 0 ? new LRUCache({ max: options.dedupMaxRefs }) : null
     }
 
     public async handleBatch(messages: Message[], nowMs: number): Promise<void> {
@@ -131,6 +145,11 @@ export class ImageBatcher {
             ImageScrubConsumerMetrics.incInvalidKey()
             return null
         }
+        if (this.seenRefs?.get(ref)) {
+            ImageScrubConsumerMetrics.incDeduped()
+            return null
+        }
+        this.seenRefs?.set(ref, true)
         const bytes = await this.scrubClient.scrub(m.value, signal)
         if (bytes === null) {
             ImageScrubConsumerMetrics.incSkipped()

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
@@ -1,16 +1,24 @@
-import { LRUCache } from 'lru-cache'
 import { Message, TopicPartitionOffset } from 'node-rdkafka'
 
 import { findOffsetsToCommit } from '~/common/kafka/consumer/consumer-v1'
 import { ConcurrencyController } from '~/common/utils/concurrencyController'
+import { RefDedupCache } from '~/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache'
 
-import { isImageRef, parseImageRef } from './content-ref'
+import { imageRef, isImageRef, parseImageRef } from './content-ref'
 import { ImageShardStore, ScrubbedImage } from './image-shard-store'
 import { ImageScrubConsumerMetrics } from './metrics'
 import { ScrubClient } from './scrub-client'
 
 export interface OffsetStore {
     offsetsStore(offsets: TopicPartitionOffset[]): void
+}
+
+/** A message that survived planning, carrying its batch index so offsets can advance over the skips. */
+interface PlannedScrub {
+    index: number
+    pseudoTeam: string
+    hash: string
+    value: Buffer
 }
 
 export interface ImageBatcherOptions {
@@ -30,16 +38,19 @@ export class ImageBatcher {
     private readonly chunkSize: number
     private readonly scrubConcurrency: ConcurrencyController
     /**
-     * Refs this pod has already sent to the sidecar. The topic is keyed by ref, so every copy of an
-     * image lands on the same partition — a per-pod cache therefore dedupes exactly (within its
-     * capacity), and the producer's own dedup is per-mirror-pod, so cross-mirror-pod duplicates of
-     * hot sprites all arrive here. Marked before the scrub completes: if the scrub throws, the batch
-     * throws and the pod restarts (wiping this cache), and offsets are only stored after a durable
-     * flush, so a marked-but-unwritten ref can't have its offsets committed. The one gap is a
-     * rebalance without a restart, where a replayed ref is skipped and stays a dangling ref — which
-     * downstream reads as a placeholder by design.
+     * Refs this pod has already scrubbed, as a best-effort stand-in for "these bytes are already in
+     * the ML bucket" — shards pack many images per object, so there is no per-hash key to ask S3
+     * about. The topic is keyed by ref, so every copy of an image lands on the same partition and
+     * therefore this pod: within its capacity the answer is exact, and past it we simply rescrub.
+     * Entries are added once an image is buffered for a shard write, so a marked ref is always one
+     * this pod holds or has written — a batch that throws keeps its buffer, and a rebalance without
+     * a restart can no longer skip a ref it never persisted.
+     *
+     * This only ever saves work that intra-batch dedup did not already save; sizing it is a
+     * throughput question, not a correctness one, and the cache's capacity probe metric is what
+     * says whether the size is actually costing us hits.
      */
-    private readonly seenRefs: LRUCache<string, true> | null
+    private readonly seenRefs: RefDedupCache
 
     constructor(
         private readonly store: ImageShardStore,
@@ -56,10 +67,17 @@ export class ImageBatcher {
         }
         this.lastFlushMs = nowMs
         this.scrubConcurrency = new ConcurrencyController(this.chunkSize)
-        this.seenRefs = options.dedupMaxRefs > 0 ? new LRUCache({ max: options.dedupMaxRefs }) : null
+        this.seenRefs = new RefDedupCache('image_scrub_consumer', options.dedupMaxRefs)
     }
 
     public async handleBatch(messages: Message[], nowMs: number): Promise<void> {
+        // Resolve every skip before chunking. A duplicate left in the chunk still consumes a
+        // concurrency slot and resolves as a no-op, so a chunk finishes as soon as its one distinct
+        // image does: with repeats outnumbering distinct images the batch serializes behind the
+        // chunk barriers and the pod runs one scrub at a time whatever scrubConcurrency says.
+        ImageScrubConsumerMetrics.observeBatchMessages(messages.length)
+        const planned = this.planBatch(messages)
+
         // Scrub in concurrency-sized chunks with the capacity bounds applied between chunks: scrubbed
         // outputs can dwarf their inputs (a sub-MB input can come back as a multi-MB full-resolution
         // PNG), so retaining a whole poll batch of them before the first bound check can hold
@@ -71,8 +89,9 @@ export class ImageBatcher {
         // loop misattributed to the sidecar.
         const controller = new AbortController()
         let scrubBudgetMs = this.options.maxBatchScrubMs
-        for (let i = 0; i < messages.length; i += this.chunkSize) {
-            const chunk = messages.slice(i, i + this.chunkSize)
+        let spanStart = 0
+        for (let i = 0; i < planned.length; i += this.chunkSize) {
+            const chunk = planned.slice(i, i + this.chunkSize)
             const chunkStartMs = performance.now()
             const timer = setTimeout(() => controller.abort(), scrubBudgetMs)
             let scrubbed: ScrubbedImage[]
@@ -88,30 +107,76 @@ export class ImageBatcher {
             for (const image of scrubbed) {
                 this.buffer.push(image)
                 this.bufferBytes += image.bytes.length
+                this.seenRefs.add(imageRef(image.pseudoTeam, image.hash))
             }
-            // Advance offsets per completed chunk (even all-skipped ones, or skipped messages
-            // replay forever). They are only ever *stored* by a flush, after the buffer — which
+            // Advance offsets per completed chunk, across the whole span of the batch it consumed —
+            // the skipped messages sitting between its entries are done too, and would otherwise
+            // replay forever. Offsets are only ever *stored* by a flush, after the buffer — which
             // holds exactly these chunks' images — is durably written. A mid-batch flush thereby
             // records the progress it persisted: a later failure in this batch replays only from
             // the flush, instead of re-writing another copy of the flushed shard per replay.
-            for (const offset of findOffsetsToCommit(chunk)) {
-                this.pendingOffsets.set(`${offset.topic}:${offset.partition}`, offset)
-            }
+            const spanEnd = chunk[chunk.length - 1].index + 1
+            this.recordOffsets(messages.slice(spanStart, spanEnd))
+            spanStart = spanEnd
             if (this.overCapacity()) {
                 await this.flushOrThrow(nowMs)
             }
         }
+        // Whatever trails the last scrubbed message is skips only (and a wholly-skipped batch is all
+        // trailer), so it needs the same treatment or those offsets never move.
+        this.recordOffsets(messages.slice(spanStart))
         if (this.shouldFlush(nowMs)) {
             await this.flushOrThrow(nowMs)
         }
     }
 
-    private async scrubChunk(messages: Message[], controller: AbortController): Promise<ScrubbedImage[]> {
+    /**
+     * Decide, for a whole batch at once, which messages actually reach the sidecar: the first
+     * occurrence of each ref, minus anything already scrubbed. Intra-batch dedup is unconditional —
+     * it needs no retained state, so unlike [[seenRefs]] it cannot be sized wrong or turned off.
+     */
+    private planBatch(messages: Message[]): PlannedScrub[] {
+        const planned: PlannedScrub[] = []
+        const batchRefs = new Set<string>()
+        for (const [index, m] of messages.entries()) {
+            const ref = m.key?.toString('utf8')
+            if (!ref || !isImageRef(ref) || !m.value) {
+                ImageScrubConsumerMetrics.incInvalidKey()
+                continue
+            }
+            // The ref's hash is a producer-side per-team HMAC; this consumer doesn't hold the key and
+            // trusts the producer (the topic's only writer) that the key names these bytes.
+            const parsed = parseImageRef(ref)
+            if (!parsed) {
+                ImageScrubConsumerMetrics.incInvalidKey()
+                continue
+            }
+            if (batchRefs.has(ref)) {
+                ImageScrubConsumerMetrics.incDeduped('batch')
+                continue
+            }
+            batchRefs.add(ref)
+            if (this.seenRefs.has(ref)) {
+                ImageScrubConsumerMetrics.incDeduped('pod')
+                continue
+            }
+            planned.push({ index, pseudoTeam: parsed.pseudoTeam, hash: parsed.hash, value: m.value })
+        }
+        return planned
+    }
+
+    private recordOffsets(messages: Message[]): void {
+        for (const offset of findOffsetsToCommit(messages)) {
+            this.pendingOffsets.set(`${offset.topic}:${offset.partition}`, offset)
+        }
+    }
+
+    private async scrubChunk(planned: PlannedScrub[], controller: AbortController): Promise<ScrubbedImage[]> {
         try {
             const scrubbed = await Promise.all(
-                messages.map((m) =>
+                planned.map((p) =>
                     this.scrubConcurrency.run({
-                        fn: () => this.scrubOne(m, controller.signal),
+                        fn: () => this.scrubOne(p, controller.signal),
                         abortController: controller,
                     })
                 )
@@ -132,31 +197,14 @@ export class ImageBatcher {
         }
     }
 
-    private async scrubOne(m: Message, signal: AbortSignal): Promise<ScrubbedImage | null> {
-        const ref = m.key?.toString('utf8')
-        if (!ref || !isImageRef(ref) || !m.value) {
-            ImageScrubConsumerMetrics.incInvalidKey()
-            return null
-        }
-        // The ref's hash is a producer-side per-team HMAC; this consumer doesn't hold the key and
-        // trusts the producer (the topic's only writer) that the key names these bytes.
-        const parsed = parseImageRef(ref)
-        if (!parsed) {
-            ImageScrubConsumerMetrics.incInvalidKey()
-            return null
-        }
-        if (this.seenRefs?.get(ref)) {
-            ImageScrubConsumerMetrics.incDeduped()
-            return null
-        }
-        this.seenRefs?.set(ref, true)
-        const bytes = await this.scrubClient.scrub(m.value, signal)
+    private async scrubOne(planned: PlannedScrub, signal: AbortSignal): Promise<ScrubbedImage | null> {
+        const bytes = await this.scrubClient.scrub(planned.value, signal)
         if (bytes === null) {
             ImageScrubConsumerMetrics.incSkipped()
             return null
         }
         ImageScrubConsumerMetrics.incScrubbed()
-        return { pseudoTeam: parsed.pseudoTeam, hash: parsed.hash, bytes }
+        return { pseudoTeam: planned.pseudoTeam, hash: planned.hash, bytes }
     }
 
     private overCapacity(): boolean {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/metrics.ts
@@ -1,4 +1,4 @@
-import { Counter } from 'prom-client'
+import { Counter, Histogram } from 'prom-client'
 
 export class ImageScrubConsumerMetrics {
     private static readonly scrubbed = new Counter({
@@ -11,7 +11,18 @@ export class ImageScrubConsumerMetrics {
     })
     private static readonly deduped = new Counter({
         name: 'ml_mirror_image_scrub_consumer_deduped_total',
-        help: 'Messages skipped because this pod already scrubbed the same ref (duplicate produce); dedup hit rate = deduped / (deduped + scrubbed + skipped)',
+        help: 'Messages skipped as duplicate produces of a ref, by scope: "batch" (another copy in the same poll batch) or "pod" (this pod scrubbed it earlier). Dedup hit rate = deduped / (deduped + scrubbed + skipped); the batch/pod split says how much the retained seen-ref cache is earning over free intra-batch dedup',
+        labelNames: ['scope'],
+    })
+    /**
+     * Intra-batch dedup can only collapse copies that arrive in the same poll batch, so its ceiling is
+     * set by how many messages a batch holds. Small batches are the one way it can be "undersized",
+     * and unlike the seen-ref cache the fix is poll configuration rather than memory.
+     */
+    private static readonly batchMessages = new Histogram({
+        name: 'ml_mirror_image_scrub_consumer_batch_messages',
+        help: 'Messages per poll batch. Read alongside deduped{scope="batch"}: consistently small batches cap how much intra-batch dedup can collapse, whatever the duplicate rate is',
+        buckets: [1, 10, 50, 100, 500, 1000, 5000, 10000],
     })
     private static readonly invalidKey = new Counter({
         name: 'ml_mirror_image_scrub_consumer_invalid_key_total',
@@ -44,11 +55,14 @@ export class ImageScrubConsumerMetrics {
     public static incSkipped(): void {
         this.skipped.inc()
     }
-    public static incDeduped(): void {
-        this.deduped.inc()
+    public static incDeduped(scope: 'batch' | 'pod'): void {
+        this.deduped.labels(scope).inc()
     }
     public static incInvalidKey(): void {
         this.invalidKey.inc()
+    }
+    public static observeBatchMessages(count: number): void {
+        this.batchMessages.observe(count)
     }
     public static observeShard(images: number, bytes: number): void {
         this.shardsWritten.inc()

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/metrics.ts
@@ -9,6 +9,10 @@ export class ImageScrubConsumerMetrics {
         name: 'ml_mirror_image_scrub_consumer_skipped_total',
         help: 'Images skipped because the sidecar rejected them as undecodable (resolve to nothing)',
     })
+    private static readonly deduped = new Counter({
+        name: 'ml_mirror_image_scrub_consumer_deduped_total',
+        help: 'Messages skipped because this pod already scrubbed the same ref (duplicate produce); dedup hit rate = deduped / (deduped + scrubbed + skipped)',
+    })
     private static readonly invalidKey = new Counter({
         name: 'ml_mirror_image_scrub_consumer_invalid_key_total',
         help: 'Messages dropped because the key is missing, not an image ref, or the value is empty — a sustained rate means producer/consumer ref-format drift is zeroing the lane',
@@ -39,6 +43,9 @@ export class ImageScrubConsumerMetrics {
     }
     public static incSkipped(): void {
         this.skipped.inc()
+    }
+    public static incDeduped(): void {
+        this.deduped.inc()
     }
     public static incInvalidKey(): void {
         this.invalidKey.inc()

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/metrics.ts
@@ -17,12 +17,16 @@ export class ImageScrubConsumerMetrics {
     /**
      * Intra-batch dedup can only collapse copies that arrive in the same poll batch, so its ceiling is
      * set by how many messages a batch holds. Small batches are the one way it can be "undersized",
-     * and unlike the seen-ref cache the fix is poll configuration rather than memory.
+     * and unlike the seen-ref cache the fix is poll configuration rather than memory. Buckets stop at
+     * the CONSUMER_BATCH_SIZE fetch cap, past which they could never be populated. This deliberately
+     * excludes empty polls, which is what makes it readable where consumer-v1's own batch-size
+     * histogram is not: that one samples before the empty check, and this lane runs with
+     * callEachBatchWhenEmpty, so idle polls bury the real distribution in the lowest bucket.
      */
     private static readonly batchMessages = new Histogram({
         name: 'ml_mirror_image_scrub_consumer_batch_messages',
-        help: 'Messages per poll batch. Read alongside deduped{scope="batch"}: consistently small batches cap how much intra-batch dedup can collapse, whatever the duplicate rate is',
-        buckets: [1, 10, 50, 100, 500, 1000, 5000, 10000],
+        help: 'Messages per non-empty poll batch. Read alongside deduped{scope="batch"}: consistently small batches cap how much intra-batch dedup can collapse, whatever the duplicate rate is',
+        buckets: [1, 10, 50, 100, 200, 300, 400, 500],
     })
     private static readonly invalidKey = new Counter({
         name: 'ml_mirror_image_scrub_consumer_invalid_key_total',

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
@@ -39,10 +39,22 @@ export type MlMirrorConfig = {
     SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_CONCURRENCY: number
     /**
      * Capacity of the consumer's per-pod seen-ref LRU. The topic is keyed by ref, so duplicates are
-     * partition-affine and a per-pod cache dedupes them exactly up to this many refs (~200 B each in
-     * a Map, so 1M ≈ 200 MB). 0 disables dedup.
+     * partition-affine and a per-pod cache dedupes them exactly up to this many refs. Budget ~200 B
+     * per entry, of which lru-cache commits about an eighth up front by preallocating its backing
+     * arrays. Sized against the 2000M consumer container in
+     * https://github.com/PostHog/charts/blob/main/apps/ingestion-sessionreplay-ml-image-scrub/values.yaml,
+     * which also has to hold MAX_BYTES of scrubbed images at ~2x during a flush. Start low and raise
+     * it off ml_mirror_ref_cache_capacity_probe_total rather than guessing.
+     *
+     * 0 disables only this cross-batch cache; duplicates within a poll batch always collapse.
      */
     SESSION_RECORDING_ML_IMAGE_SCRUB_DEDUP_MAX_REFS: number
+    /**
+     * The mirror-side twin of the knob above, bounding re-produces onto the scrub topic. Tunable for
+     * the same reason: it is a pure memory-for-throughput trade, and shedding it during a mirror
+     * memory incident should not need a code deploy of the shared replay ingester.
+     */
+    SESSION_RECORDING_ML_IMAGE_SCRUB_PRODUCED_REF_CACHE_MAX: number
     SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_TIMEOUT_MS: number
     SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_RETRIES: number
     // Per-write timeout (the S3 client has no built-in one). A flush does two writes, so it bounds at 2x this.
@@ -82,7 +94,8 @@ export function getDefaultMlMirrorConfig(): MlMirrorConfig {
         SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_IMAGES: 1000,
         SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_BYTES: 128 * 1024 * 1024,
         SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_CONCURRENCY: 8,
-        SESSION_RECORDING_ML_IMAGE_SCRUB_DEDUP_MAX_REFS: 1_000_000,
+        SESSION_RECORDING_ML_IMAGE_SCRUB_DEDUP_MAX_REFS: 250_000,
+        SESSION_RECORDING_ML_IMAGE_SCRUB_PRODUCED_REF_CACHE_MAX: 500_000,
         SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_TIMEOUT_MS: 10 * 1000,
         SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_RETRIES: 3,
         SESSION_RECORDING_ML_IMAGE_SCRUB_S3_WRITE_TIMEOUT_MS: 30 * 1000,

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/config.ts
@@ -37,6 +37,12 @@ export type MlMirrorConfig = {
     // Real peak memory is ~2x this: the flush does a Buffer.concat copy.
     SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_BYTES: number
     SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_CONCURRENCY: number
+    /**
+     * Capacity of the consumer's per-pod seen-ref LRU. The topic is keyed by ref, so duplicates are
+     * partition-affine and a per-pod cache dedupes them exactly up to this many refs (~200 B each in
+     * a Map, so 1M ≈ 200 MB). 0 disables dedup.
+     */
+    SESSION_RECORDING_ML_IMAGE_SCRUB_DEDUP_MAX_REFS: number
     SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_TIMEOUT_MS: number
     SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_RETRIES: number
     // Per-write timeout (the S3 client has no built-in one). A flush does two writes, so it bounds at 2x this.
@@ -76,6 +82,7 @@ export function getDefaultMlMirrorConfig(): MlMirrorConfig {
         SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_IMAGES: 1000,
         SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_BYTES: 128 * 1024 * 1024,
         SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_CONCURRENCY: 8,
+        SESSION_RECORDING_ML_IMAGE_SCRUB_DEDUP_MAX_REFS: 1_000_000,
         SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_TIMEOUT_MS: 10 * 1000,
         SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_RETRIES: 3,
         SESSION_RECORDING_ML_IMAGE_SCRUB_S3_WRITE_TIMEOUT_MS: 30 * 1000,

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/ml-mirror-pipeline.ts
@@ -35,6 +35,7 @@ export interface MlMirrorImageScrubProducer {
     outputs: IngestionOutputs<MlImageScrubOutput>
     /** The ML pseudonym HMAC key (also used by the block-metadata sink), for the per-team ref prefix. */
     pseudonymSecret: string | Buffer
+    producedRefCacheMax: number
 }
 
 export function createMlMirrorReplayPipeline(
@@ -153,7 +154,10 @@ export function createMlMirrorReplayPipeline(
                                                     )
                                                     const withImagesProduced = imageScrub
                                                         ? parsed.pipe(
-                                                              createProduceCollectedImagesStep(imageScrub.outputs)
+                                                              createProduceCollectedImagesStep(
+                                                                  imageScrub.outputs,
+                                                                  imageScrub.producedRefCacheMax
+                                                              )
                                                           )
                                                         : parsed
                                                     return withImagesProduced.pipe(

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-images-step.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-images-step.test.ts
@@ -66,6 +66,20 @@ describe('produceCollectedImagesStep', () => {
         ])
     })
 
+    it('evicts oldest refs at capacity instead of forgetting the whole working set', async () => {
+        const step = createProduceCollectedImagesStep(outputs, 2)
+        await run(step, { collectedImages: [image('image:aa:h1'), image('image:aa:h2')] })
+        await run(step, { collectedImages: [image('image:aa:h3')] })
+        // Only h1 (the oldest) made room for h3; h2 must still dedup — a wholesale clear-on-full
+        // would re-produce the entire hot working set every time the cap is hit.
+        await run(step, { collectedImages: [image('image:aa:h2'), image('image:aa:h1')] })
+        expect(queued.map((batch) => batch.map((m) => m.key))).toEqual([
+            ['image:aa:h1', 'image:aa:h2'],
+            ['image:aa:h3'],
+            ['image:aa:h1'],
+        ])
+    })
+
     it('swallows produce failures (a dangling ref reads as a placeholder downstream)', async () => {
         queueMessages.mockRejectedValueOnce(new Error('broker down'))
         const step = createProduceCollectedImagesStep(outputs)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-images-step.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-images-step.ts
@@ -8,15 +8,13 @@ import { ML_IMAGE_SCRUB_OUTPUT, MlImageScrubOutput } from '~/ingestion/pipelines
 import { RefDedupCache } from '~/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache'
 
 /**
- * The Rust collector dedupes within one message; this bounds cross-message re-produces (the same
- * sprite recurring in every snapshot of a session, and across the sessions one pod happens to hold).
- * It is the only thing standing between a hot sprite and one produce per recurrence, so capacity
- * translates directly into scrub-topic volume: a ref evicted before its next sighting is re-produced
- * and re-scrubbed. Budget ~200 B per entry (the ref plus the LRU's own bookkeeping, not the ~60 B of
- * string), so this is ~100 MB against the lane's 8 GB pods. Duplicates that slip past it are only
- * wasted topic bytes — the consumer dedupes by ref too, so re-produces are idempotent. LRU eviction,
- * never wholesale clears: clearing forgets every hot sprite at once and re-produces the whole working
- * set each time the cap is hit.
+ * The Rust collector only dedupes within one message, leaving this as the sole thing between a hot
+ * sprite and one produce per recurrence, so capacity translates directly into scrub-topic volume: a
+ * ref evicted before its next sighting is re-produced and re-scrubbed. Budget ~200 B per entry (the
+ * LRU's bookkeeping dominates the ~60 B ref), so this is ~100 MB against the 8000M mirror container
+ * in https://github.com/PostHog/charts/blob/main/apps/ingestion-sessionreplay-ml-mirror/values.yaml,
+ * which also holds the anonymizer's packed image buffers. Overflowing it costs topic bytes rather
+ * than correctness, since the consumer dedupes by ref too.
  */
 const PRODUCED_REF_CACHE_MAX = 500_000
 

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-images-step.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-images-step.ts
@@ -1,5 +1,3 @@
-import { LRUCache } from 'lru-cache'
-
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { logger } from '~/common/utils/logger'
 import { ok } from '~/ingestion/framework/results'
@@ -7,15 +5,20 @@ import { ProcessingStep } from '~/ingestion/framework/steps'
 import { SessionRecordingIngesterMetrics } from '~/ingestion/pipelines/sessionreplay/metrics'
 import { CollectedImage } from '~/ingestion/pipelines/sessionreplay/parse-and-anonymize-step'
 import { ML_IMAGE_SCRUB_OUTPUT, MlImageScrubOutput } from '~/ingestion/pipelines/sessionreplay/shared/outputs'
+import { RefDedupCache } from '~/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache'
 
 /**
  * The Rust collector dedupes within one message; this bounds cross-message re-produces (the same
- * sprite recurring in every snapshot of a session). Refs are ~60 bytes, so the ceiling is ~6 MB.
- * Duplicates that slip past it are only wasted topic bytes — the consumer dedupes by ref too, so
- * re-produces are idempotent. LRU eviction, never wholesale clears: clearing forgets every hot
- * sprite at once and re-produces the whole working set each time the cap is hit.
+ * sprite recurring in every snapshot of a session, and across the sessions one pod happens to hold).
+ * It is the only thing standing between a hot sprite and one produce per recurrence, so capacity
+ * translates directly into scrub-topic volume: a ref evicted before its next sighting is re-produced
+ * and re-scrubbed. Budget ~200 B per entry (the ref plus the LRU's own bookkeeping, not the ~60 B of
+ * string), so this is ~100 MB against the lane's 8 GB pods. Duplicates that slip past it are only
+ * wasted topic bytes — the consumer dedupes by ref too, so re-produces are idempotent. LRU eviction,
+ * never wholesale clears: clearing forgets every hot sprite at once and re-produces the whole working
+ * set each time the cap is hit.
  */
-const PRODUCED_REF_CACHE_MAX = 100_000
+const PRODUCED_REF_CACHE_MAX = 500_000
 
 /**
  * Produce collected original images to the scrub topic as a fire-and-forget side effect, keyed by
@@ -27,7 +30,7 @@ export function createProduceCollectedImagesStep<T extends { collectedImages?: C
     outputs: IngestionOutputs<MlImageScrubOutput>,
     producedRefCacheMax: number = PRODUCED_REF_CACHE_MAX
 ): ProcessingStep<T, T> {
-    const producedRefs = new LRUCache<string, true>({ max: producedRefCacheMax })
+    const producedRefs = new RefDedupCache('image_scrub_producer', producedRefCacheMax)
 
     return function produceCollectedImagesStep(input) {
         const images = input.collectedImages
@@ -35,7 +38,7 @@ export function createProduceCollectedImagesStep<T extends { collectedImages?: C
             return Promise.resolve(ok(input))
         }
 
-        const fresh = images.filter((image) => !producedRefs.get(image.ref))
+        const fresh = images.filter((image) => !producedRefs.has(image.ref))
         SessionRecordingIngesterMetrics.incrementMlImagesCollected('deduped', images.length - fresh.length)
         if (fresh.length === 0) {
             return Promise.resolve(ok({ ...input, collectedImages: undefined }))
@@ -43,7 +46,7 @@ export function createProduceCollectedImagesStep<T extends { collectedImages?: C
 
         let bytes = 0
         for (const image of fresh) {
-            producedRefs.set(image.ref, true)
+            producedRefs.add(image.ref)
             bytes += image.bytes.length
         }
         SessionRecordingIngesterMetrics.incrementMlImagesCollected('queued', fresh.length)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-images-step.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror/produce-collected-images-step.ts
@@ -1,3 +1,5 @@
+import { LRUCache } from 'lru-cache'
+
 import { IngestionOutputs } from '~/common/outputs/ingestion-outputs'
 import { logger } from '~/common/utils/logger'
 import { ok } from '~/ingestion/framework/results'
@@ -9,8 +11,9 @@ import { ML_IMAGE_SCRUB_OUTPUT, MlImageScrubOutput } from '~/ingestion/pipelines
 /**
  * The Rust collector dedupes within one message; this bounds cross-message re-produces (the same
  * sprite recurring in every snapshot of a session). Refs are ~60 bytes, so the ceiling is ~6 MB.
- * Duplicates that slip past it are only wasted topic bytes — the consumer's S3 layout is keyed by
- * hash, so re-produces are idempotent.
+ * Duplicates that slip past it are only wasted topic bytes — the consumer dedupes by ref too, so
+ * re-produces are idempotent. LRU eviction, never wholesale clears: clearing forgets every hot
+ * sprite at once and re-produces the whole working set each time the cap is hit.
  */
 const PRODUCED_REF_CACHE_MAX = 100_000
 
@@ -21,9 +24,10 @@ const PRODUCED_REF_CACHE_MAX = 100_000
  * is defined as equivalent to a placeholder for training joins.
  */
 export function createProduceCollectedImagesStep<T extends { collectedImages?: CollectedImage[] }>(
-    outputs: IngestionOutputs<MlImageScrubOutput>
+    outputs: IngestionOutputs<MlImageScrubOutput>,
+    producedRefCacheMax: number = PRODUCED_REF_CACHE_MAX
 ): ProcessingStep<T, T> {
-    const producedRefs = new Set<string>()
+    const producedRefs = new LRUCache<string, true>({ max: producedRefCacheMax })
 
     return function produceCollectedImagesStep(input) {
         const images = input.collectedImages
@@ -31,18 +35,15 @@ export function createProduceCollectedImagesStep<T extends { collectedImages?: C
             return Promise.resolve(ok(input))
         }
 
-        const fresh = images.filter((image) => !producedRefs.has(image.ref))
+        const fresh = images.filter((image) => !producedRefs.get(image.ref))
         SessionRecordingIngesterMetrics.incrementMlImagesCollected('deduped', images.length - fresh.length)
         if (fresh.length === 0) {
             return Promise.resolve(ok({ ...input, collectedImages: undefined }))
         }
 
-        if (producedRefs.size + fresh.length > PRODUCED_REF_CACHE_MAX) {
-            producedRefs.clear()
-        }
         let bytes = 0
         for (const image of fresh) {
-            producedRefs.add(image.ref)
+            producedRefs.set(image.ref, true)
             bytes += image.bytes.length
         }
         SessionRecordingIngesterMetrics.incrementMlImagesCollected('queued', fresh.length)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache.test.ts
@@ -29,6 +29,35 @@ describe('RefDedupCache', () => {
         expect(await probe(name, 'would_hit')).toBe(1)
     })
 
+    it('credits one eviction with one verdict, however often the evicted ref is probed', async () => {
+        // Reading the ghost through `get` renews its recency, so a ref that is probed but never
+        // re-added (the sidecar rejected it, or its produce failed) pins itself and scores would_hit
+        // on every later batch. That inflates the ratio in the "buy more memory" direction, on the
+        // one metric whose whole job is deciding whether to spend memory.
+        const name = 'test_repeat_probe'
+        const cache = new RefDedupCache(name, 2, 1)
+        cache.add('a')
+        cache.add('b')
+        cache.add('c') // evicts 'a'
+
+        for (let i = 0; i < 5; i++) {
+            expect(cache.has('a')).toBe(false)
+        }
+
+        expect(await probe(name, 'would_hit')).toBe(1)
+        expect(await probe(name, 'would_miss')).toBe(4)
+    })
+
+    it.each([
+        ['a typo parsed to NaN', NaN],
+        ['the source default copied verbatim, which parseFloat truncates', 1.5],
+        ['a negative that would otherwise silently disable dedup', -1],
+    ])('rejects %s at construction rather than at first use', (_case, max) => {
+        // lru-cache throws on these too, but names neither the cache nor the knob, so the lane
+        // crash-loops on a message an operator cannot act on.
+        expect(() => new RefDedupCache('test_validation', max)).toThrow(/test_validation ref cache max/)
+    })
+
     it('does not probe while the cache still has room, so an unfilled cache reads as sized correctly', async () => {
         // Evictions are the only thing that can put a ref in the ghost list, so a cache that never
         // fills must report no would_hit at all rather than blaming capacity for ordinary misses.

--- a/nodejs/src/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache.test.ts
@@ -1,0 +1,43 @@
+import { Counter, register } from 'prom-client'
+
+import { RefDedupCache } from './ref-dedup-cache'
+
+describe('RefDedupCache', () => {
+    async function probe(cache: string, verdict: 'would_hit' | 'would_miss'): Promise<number> {
+        const metric = register.getSingleMetric('ml_mirror_ref_cache_capacity_probe_total') as Counter | undefined
+        const data = await metric?.get()
+        const sample = data?.values.find((v) => v.labels.cache === cache && v.labels.verdict === verdict)
+        return sample?.value ?? 0
+    }
+
+    it('separates misses a bigger cache would have caught from ones it would not', async () => {
+        // The whole point of the probe is to tell "the working set does not fit" apart from "these
+        // duplicates were always too far apart to cache". Both verdicts have to move: a probe stuck
+        // on would_miss reads as a correctly sized cache and we stop looking, and one stuck on
+        // would_hit sends us buying memory that buys nothing. Sample every ref so it is deterministic.
+        const name = 'test_capacity_probe'
+        const cache = new RefDedupCache(name, 2, 1)
+        cache.add('a')
+        cache.add('b')
+        cache.add('c') // evicts 'a'
+
+        expect(cache.has('a')).toBe(false)
+        expect(await probe(name, 'would_hit')).toBe(1)
+
+        expect(cache.has('never-seen')).toBe(false)
+        expect(await probe(name, 'would_miss')).toBe(1)
+        expect(await probe(name, 'would_hit')).toBe(1)
+    })
+
+    it('does not probe while the cache still has room, so an unfilled cache reads as sized correctly', async () => {
+        // Evictions are the only thing that can put a ref in the ghost list, so a cache that never
+        // fills must report no would_hit at all rather than blaming capacity for ordinary misses.
+        const name = 'test_unfilled'
+        const cache = new RefDedupCache(name, 100, 1)
+        cache.add('a')
+
+        expect(cache.has('b')).toBe(false)
+        expect(await probe(name, 'would_hit')).toBe(0)
+        expect(await probe(name, 'would_miss')).toBe(1)
+    })
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache.ts
@@ -1,0 +1,117 @@
+import { LRUCache } from 'lru-cache'
+import { Counter, Gauge } from 'prom-client'
+
+/**
+ * One ref in this many is remembered after eviction. The ghost list holds keys only and, in sampled
+ * space, spans the same number of evictions as the cache holds entries, so a ghost hit means a cache
+ * of twice the capacity would still have been holding that ref. Sampling keeps the diagnostic near
+ * 6% of the cache's own memory, which is what makes it affordable to leave on across the fleet.
+ */
+const GHOST_SAMPLE_RATE = 16
+
+const evictionsTotal = new Counter({
+    name: 'ml_mirror_ref_cache_evictions_total',
+    help: 'Refs dropped from a dedup cache to make room for newer ones',
+    labelNames: ['cache'],
+})
+
+const capacityProbeTotal = new Counter({
+    name: 'ml_mirror_ref_cache_capacity_probe_total',
+    help: 'Sampled cache misses split by whether the ref was evicted recently enough that twice the capacity would still hold it. would_hit / (would_hit + would_miss) is the share of misses that doubling the cache would recover, so a value near zero means the cache is big enough and a high value means it is undersized',
+    labelNames: ['cache', 'verdict'],
+})
+
+const entriesGauge = new Gauge({
+    name: 'ml_mirror_ref_cache_entries',
+    help: 'Refs currently held in a dedup cache. Below the capacity gauge means the cache has never filled, so it cannot be undersized',
+    labelNames: ['cache'],
+})
+
+const capacityGauge = new Gauge({
+    name: 'ml_mirror_ref_cache_capacity',
+    help: 'Configured maximum for a dedup cache, so utilization reads off the metrics instead of the deployed config',
+    labelNames: ['cache'],
+})
+
+/** Independent of the ref format, so a change to how refs are built cannot skew which ones are sampled. */
+function sampleBucket(ref: string): number {
+    let hash = 0x811c9dc5
+    for (let i = 0; i < ref.length; i++) {
+        hash ^= ref.charCodeAt(i)
+        hash = Math.imul(hash, 0x01000193)
+    }
+    return hash >>> 0
+}
+
+/**
+ * An LRU of refs that reports whether its capacity is the thing limiting its hit rate.
+ *
+ * Hit rate alone cannot answer that: a low rate looks identical whether the duplicates are genuinely
+ * far apart or merely further apart than the cache can reach. The ghost list separates the two, which
+ * is the difference between buying hit rate with memory and wasting memory on a working set that was
+ * never going to fit.
+ */
+export class RefDedupCache {
+    private readonly cache: LRUCache<string, true> | null
+    private readonly ghost: LRUCache<string, true> | null
+
+    constructor(
+        private readonly name: string,
+        max: number,
+        private readonly ghostSampleRate: number = GHOST_SAMPLE_RATE
+    ) {
+        capacityGauge.labels(name).set(Math.max(0, max))
+        entriesGauge.labels(name).set(0)
+        if (max <= 0) {
+            this.cache = null
+            this.ghost = null
+            return
+        }
+        this.ghost = new LRUCache({ max: Math.max(1, Math.floor(max / ghostSampleRate)) })
+        this.cache = new LRUCache({
+            max,
+            dispose: (_value, key, reason) => {
+                if (reason !== 'evict') {
+                    return
+                }
+                evictionsTotal.labels(name).inc()
+                if (this.isSampled(key)) {
+                    this.ghost?.set(key, true)
+                }
+            },
+        })
+    }
+
+    public has(ref: string): boolean {
+        if (!this.cache) {
+            return false
+        }
+        if (this.cache.get(ref)) {
+            return true
+        }
+        if (this.isSampled(ref)) {
+            capacityProbeTotal.labels(this.name, this.ghost?.get(ref) ? 'would_hit' : 'would_miss').inc()
+        }
+        return false
+    }
+
+    public add(ref: string): void {
+        if (!this.cache) {
+            return
+        }
+        this.cache.set(ref, true)
+        entriesGauge.labels(this.name).set(this.cache.size)
+    }
+
+    public delete(ref: string): void {
+        if (!this.cache) {
+            return
+        }
+        this.cache.delete(ref)
+        entriesGauge.labels(this.name).set(this.cache.size)
+    }
+
+    private isSampled(ref: string): boolean {
+        return sampleBucket(ref) % this.ghostSampleRate === 0
+    }
+}

--- a/nodejs/src/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/shared/ref-dedup-cache.ts
@@ -2,10 +2,9 @@ import { LRUCache } from 'lru-cache'
 import { Counter, Gauge } from 'prom-client'
 
 /**
- * One ref in this many is remembered after eviction. The ghost list holds keys only and, in sampled
- * space, spans the same number of evictions as the cache holds entries, so a ghost hit means a cache
- * of twice the capacity would still have been holding that ref. Sampling keeps the diagnostic near
- * 6% of the cache's own memory, which is what makes it affordable to leave on across the fleet.
+ * In sampled space the ghost list spans as many evictions as the cache holds entries, so a ghost hit
+ * means a cache of twice the capacity would still have held that ref. Sampling keeps the diagnostic
+ * near 6% of the cache's own memory, which is what makes it affordable to leave on across the fleet.
  */
 const GHOST_SAMPLE_RATE = 16
 
@@ -21,10 +20,19 @@ const capacityProbeTotal = new Counter({
     labelNames: ['cache', 'verdict'],
 })
 
-const entriesGauge = new Gauge({
+/** Read at scrape time by the entries gauge, which keeps the hot path free of a gauge write per ref. */
+const liveCaches = new Map<string, RefDedupCache>()
+
+// Never referenced again: constructing it registers it, and it pulls its own values at scrape time.
+new Gauge({
     name: 'ml_mirror_ref_cache_entries',
     help: 'Refs currently held in a dedup cache. Below the capacity gauge means the cache has never filled, so it cannot be undersized',
     labelNames: ['cache'],
+    collect() {
+        for (const [name, cache] of liveCaches) {
+            this.labels(name).set(cache.size)
+        }
+    },
 })
 
 const capacityGauge = new Gauge({
@@ -60,9 +68,15 @@ export class RefDedupCache {
         max: number,
         private readonly ghostSampleRate: number = GHOST_SAMPLE_RATE
     ) {
-        capacityGauge.labels(name).set(Math.max(0, max))
-        entriesGauge.labels(name).set(0)
-        if (max <= 0) {
+        // These arrive from env, where `overrideConfigWithEnv` parseFloats whatever it is given: the
+        // source default is written `1_000_000`, which parses to 1, and a typo parses to NaN. Both
+        // reach lru-cache as a `max` it rejects with an error naming neither the knob nor the cache.
+        if (!Number.isInteger(max) || max < 0) {
+            throw new Error(`${name} ref cache max must be 0 or a positive integer, got ${max}`)
+        }
+        liveCaches.set(name, this)
+        capacityGauge.labels(name).set(max)
+        if (max === 0) {
             this.cache = null
             this.ghost = null
             return
@@ -90,25 +104,28 @@ export class RefDedupCache {
             return true
         }
         if (this.isSampled(ref)) {
-            capacityProbeTotal.labels(this.name, this.ghost?.get(ref) ? 'would_hit' : 'would_miss').inc()
+            // peek, not get: reading through `get` would renew the ghost entry's own recency, letting
+            // a ref that is probed but never re-added pin itself and score would_hit indefinitely.
+            // Dropping it on a hit keeps one eviction worth exactly one verdict.
+            const wouldHit = this.ghost?.peek(ref) === true
+            if (wouldHit) {
+                this.ghost?.delete(ref)
+            }
+            capacityProbeTotal.labels(this.name, wouldHit ? 'would_hit' : 'would_miss').inc()
         }
         return false
     }
 
     public add(ref: string): void {
-        if (!this.cache) {
-            return
-        }
-        this.cache.set(ref, true)
-        entriesGauge.labels(this.name).set(this.cache.size)
+        this.cache?.set(ref, true)
     }
 
     public delete(ref: string): void {
-        if (!this.cache) {
-            return
-        }
-        this.cache.delete(ref)
-        entriesGauge.labels(this.name).set(this.cache.size)
+        this.cache?.delete(ref)
+    }
+
+    public get size(): number {
+        return this.cache?.size ?? 0
     }
 
     private isSampled(ref: string): boolean {

--- a/nodejs/src/servers/ingestion-session-replay-ml-image-scrub-server.ts
+++ b/nodejs/src/servers/ingestion-session-replay-ml-image-scrub-server.ts
@@ -82,6 +82,7 @@ export class IngestionSessionReplayMlImageScrubServer implements NodeServer {
                 maxBytes: this.config.SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_BYTES,
                 scrubConcurrency: this.config.SESSION_RECORDING_ML_IMAGE_SCRUB_SCRUB_CONCURRENCY,
                 maxBatchScrubMs: this.config.SESSION_RECORDING_ML_IMAGE_SCRUB_MAX_BATCH_SCRUB_MS,
+                dedupMaxRefs: this.config.SESSION_RECORDING_ML_IMAGE_SCRUB_DEDUP_MAX_REFS,
             },
             Date.now()
         )

--- a/nodejs/src/servers/ingestion-session-replay-ml-mirror-server.ts
+++ b/nodejs/src/servers/ingestion-session-replay-ml-mirror-server.ts
@@ -166,7 +166,11 @@ export class IngestionSessionReplayMlMirrorServer implements NodeServer {
                         ),
                     },
                     this.config.SESSION_RECORDING_ML_IMAGE_SCRUB_PRODUCER_ENABLED
-                        ? { outputs, pseudonymSecret }
+                        ? {
+                              outputs,
+                              pseudonymSecret,
+                              producedRefCacheMax: this.config.SESSION_RECORDING_ML_IMAGE_SCRUB_PRODUCED_REF_CACHE_MAX,
+                          }
                         : undefined
                 ),
             // Isolate the mirror's session tracker/filter keys from the main lane. Sharing them would let


### PR DESCRIPTION
## Problem

The ml-mirror fleet produces original replay images to the `session_replay_image_scrub` topic (#70308), and the scrub lane drains them roughly 500x slower than they arrive.

I assumed this was duplicate volume. It mostly wasn't. **Each pod was scrubbing one image at a time**, despite both the consumer (`scrubConcurrency`) and the sidecar (`IMAGE_SCRUB_CONCURRENCY`) being configured for 8. Across a 4-pod lane that is 4 images in flight for the whole fleet.

The cause is where dedup sat relative to chunking. `handleBatch` sliced each poll batch into `scrubConcurrency`-sized chunks and awaited each one, but deduped duplicates stayed inside those chunks. Each took a concurrency slot and resolved as an instant no-op, so a chunk finished as soon as its single distinct image did, and the batch serialized behind the chunk barriers. Dedup was working correctly and, purely because of its position, was destroying throughput: the more duplicates, the closer effective concurrency got to 1.

Duplicates cluster, which is the worst case here. The topic is keyed by ref, so every copy of an image lands on one partition and arrives together.

## Changes

**Resolve every skip before chunking.** A new `planBatch` pass validates, dedupes, and consults the seen-ref cache up front, then only the survivors get chunked. Intra-batch dedup now holds no retained state, so unlike a cache it cannot be sized wrong or switched off.

**Offsets advance across the span a chunk consumed**, not just its own messages, so skipped copies still commit and the existing mid-batch flush and replay semantics are unchanged.

**Refs are marked seen once their image is buffered**, rather than before the scrub starts. That closes the dangling-ref gap the old code documented for a rebalance without a restart: a marked ref is now always one this pod holds or has written. Intra-batch dedup is what makes this safe, since it already prevents two concurrent scrubs of the same ref.

**Producer ref cache raised to 500k.** It is the only thing standing between a hot sprite and one produce per recurrence, and it was sized at roughly 20 MB on 8 GB pods.

**Both ref caches now report whether capacity is what limits their hit rate.** Evictions alone can't answer that: any bounded cache evicts once per insert at steady state, whether it is perfectly sized or a hundred times too small. So each cache keeps a sampled list of recently evicted refs and, on a miss, records whether a cache of twice the size would still have held it. `would_hit / (would_hit + would_miss)` is the share of misses more memory would recover. Sampling one ref in 16 keeps this near 6% of the cache's own memory, cheap enough to leave on.

> [!NOTE]
> `ml_mirror_image_scrub_consumer_deduped_total` gains a `scope` label (`batch` vs `pod`). Existing `sum()` queries still work. The split shows how much the retained cache earns over free intra-batch dedup, and tells us whether to keep it at all.

Also new: a `ml_mirror_image_scrub_consumer_batch_messages` histogram. Intra-batch dedup can only collapse copies that share a poll batch, so small batches are the one way it can be undersized, and there the fix is poll configuration rather than memory.

Capacity lands separately in PostHog/charts#13478, which takes the lane to the 128-partition ceiling.

## How dedup works now

Everything keys on the ref, `image:<pseudoTeam>:<hash>`, where the hash is a per-team HMAC of the image bytes. Being content-derived means two spellings of the same image collapse; being per-team means identical images belonging to different teams never do.

| Layer | Lives in | Scope | Guarantee |
| --- | --- | --- | --- |
| 1. Blur/collect memo | Rust anonymizer | One Kafka message | Exact |
| 2. Produced refs | Mirror pod (TS) | One pod, until eviction | Best effort, 500k |
| 3. `batchRefs` | Scrub consumer | One poll batch | **Exact, unconditional** |
| 4. `seenRefs` | Scrub consumer pod | One pod, until eviction | Best effort, 250k |

Layers 1 and 2 already existed. Layer 2 has a gap it cannot close: sessions are partitioned by session id across up to 256 mirror pods, so each pod is blind to the other 255 and a hot sprite is produced once per pod. That residual is what reaches the topic in volume.

The topic is keyed by ref, so every copy of a ref hashes to one partition and lands on exactly one consumer pod. Those cross-pod duplicates all converge in one place, which is what makes consumer-side dedup well targeted rather than scattered.

Layers 3 and 4 both resolve in `planBatch`, before any chunking. A message is checked against `batchRefs` first and only then against `seenRefs`, so `deduped{scope="pod"}` counts precisely the extra saves the retained cache bought over the free layer. `batchRefs` is a plain Set built per batch and discarded: no capacity, no config, no way to switch it off, which is what makes it the layer to rely on. `seenRefs` sits behind it and only ever saves work `batchRefs` did not already save.

> [!IMPORTANT]
> A scrubbed ref enters `seenRefs` only **after** its image is pushed to the shard buffer, so a marked ref is always one this pod holds or has written, and a batch that throws keeps its buffer. Moving that `add` to plan time reads as a harmless simplification and loses the image outright on a failed batch: the replay is deduped away, the offset advances, nothing is written, no error. There is a red-green test pinning exactly this. The one exception is a permanent 422/413, a verdict no retry can change with nothing pending to persist, which is marked immediately.

A skipped message is never scrubbed or written, but its offset still advances via the span walk. That is safe because the first copy is already buffered or in the bucket under the same hash, and the shard index is keyed by `(pseudo_team, hash)`, so one row per ref globally is what the training joins want.

Reading it in production: `deduped{scope}` splits the saving between the free layer and the paid one, `capacity_probe{verdict}` says whether layer 4 is undersized rather than merely full, `entries` against `capacity` rules undersizing out when the cache has never filled, and `batch_messages` covers the one way layer 3 can be limited, which is batches too small for duplicates to co-occur.

## How did you test this code?

I wrote the concurrency test first and watched it fail against the unfixed code. It recorded `maxInFlight` of 1, which is what pinned the diagnosis.

- `pnpm jest` over the two ml-mirror image-scrub directories and the new shared module: 24 passed.
- Wider `src/ingestion/pipelines/sessionreplay/`: 766 passed. Three suites fail for environmental reasons I did not introduce and confirmed individually: two `.integration.test.ts` files hit `ECONNREFUSED` with no local Postgres, and `parse-and-anonymize-step.test.ts` cannot resolve `@posthog/replay-anonymizer` because the Rust addon is not built in this worktree.
- `tsc --noEmit` clean on the changed files, eslint clean.

New tests and the regression each catches:

- **Duplicate-heavy batch scrubs at full concurrency** (parameterized over `dedupMaxRefs` 0 and 1000). Catches exactly this bug. Red before the fix at `maxInFlight` 1 and 32 scrubs; green at 4 and 4. Running it with the cache disabled is what proves intra-batch dedup is structural rather than a side effect of the LRU.
- **Capacity probe separates the two kinds of miss.** A probe stuck on `would_miss` reads as a correctly sized cache and we stop looking; one stuck on `would_hit` sends us buying memory that buys nothing. I verified it has teeth by breaking the ghost population and watching it go red, rather than trusting a green run.

No manual or production testing by the agent.

## 🔬 Review round

A multi-agent review of this branch (7 independent reviewers) found no data-loss path, and several reviewers verified the offset-span arithmetic and the seen-ref/buffer/flush invariant by writing throwaway probes. It did find defects in the observability this PR adds, plus sizing I had guessed rather than checked. 11 of 14 findings are fixed in `aaadbeeda4c`:

- **The capacity probe was biased toward "undersized".** It read the ghost list with `get()`, which renews an entry's recency, so a ref probed but never re-added pinned itself and scored `would_hit` forever. Reproduced at 50/50 by one reviewer. It now peeks and drops the entry on a hit, so one eviction earns one verdict.
- **The cache size arrived from env unvalidated**, flagged independently by all 7. `overrideConfigWithEnv` parseFloats its input, so `1_000_000` (the literal the default is written as) parses to **1**, and a typo parses to `NaN` and crash-looped the lane on an lru-cache error naming neither the knob nor the cache.
- **The sizing was guessed.** The consumer container is 2000M, not the 8000M the mirror gets, so the default drops 1M → 250k and both comments now link the chart values that bound them.
- **The batch histogram counted empty polls**, also flagged by all 7. This lane runs with `callEachBatchWhenEmpty`, so idle ticks buried the real distribution in the lowest bucket. Worth noting `consumer-v1`'s own batch-size histogram has the same flaw, since it samples before its empty check.
- Permanently rejected images (422/413) are now marked resolved instead of re-earning the same rejection on every recurrence; the producer cache became env-tunable; the entries gauge moved to a scrape-time callback; and the seen-ref key is carried rather than rebuilt.

Three findings are deliberately deferred: a produced-versus-persisted reconciliation alert (belongs in alerting rules), a scrub-version column on the index (a schema decision worth taking deliberately), and documenting the ref collision-resistance contract.

Both new regression tests were red-green verified against the real defect. The replay test is the one worth keeping honest: marking a ref at plan time instead of after its buffer push looks like a clean simplification and loses the image outright, with no error and every other test green.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal ingestion lane behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie, authored by Claude Code (Fable 5). Skills invoked: /writing-tests.

This PR started as consumer-side ref dedup plus an LRU fix on the producer. Robbie pushed back on two premises and both changes stuck. First, that cross-batch dedup was worth relying on: the consumer side is actually partition-affine, since the ref key sends every copy to one pod, so I kept that cache but demoted it to a tunable and added the probe metric to decide its fate on data. Second, that we could ask S3 whether a hash was already scrubbed. We can't as things stand, because scrubbed images are packed into shards with a separate parquet index and there is no per-hash key, and a HEAD per image would not be affordable at this rate. If we want durable cross-pod dedup later, Redis is the right shape, not S3.

Chasing that second question is what surfaced the real bug, which none of the original framing would have found.

One thing reviewers should weigh: the fix lets a pod use both sidecar cores instead of one, so expect roughly 2x per pod rather than 8x, with sidecar CPU now the binding per-pod constraint. Combined with the pod ceiling that is around 64x, and the rest has to come from dedup shrinking the real unique-image rate. If the new metrics show unique demand above roughly 50k img/s, the next lever is sidecar CPU, not more pods, since 128 partitions is a hard ceiling.



