### PR TITLE
fix(snowflake): stop reporting known missing/unauthorized table as a bug

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/snowflake.py
@@ -539,7 +539,12 @@ class SnowflakeImplementation(
                 table_name=table_name,
                 exc_info=e,
             )
-            capture_exception(e)
+            # The table/schema was dropped, renamed, or its grant revoked after discovery —
+            # `SnowflakeSource.get_non_retryable_errors` already treats this exact phrase as
+            # user/upstream and non-actionable. Reporting it here would just be noise, since the
+            # pipeline already recovers via the None fallback above.
+            if "does not exist or not authorized" not in str(e):
+                capture_exception(e)
             return None
 
         column_index = next((i for i, row in enumerate(cursor.description) if row.name == "column_name"), -1)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -565,6 +565,28 @@ class TestGetPrimaryKeysForTable:
         cursor.execute.side_effect = Exception("does not exist or not authorized")
         assert impl.get_primary_keys_for_table(cursor, "DB", "PUBLIC", "t") is None
 
+    @pytest.mark.parametrize(
+        "error_msg,expect_capture",
+        [
+            # Table/schema dropped, renamed, or grant revoked after discovery — already classified
+            # as user/upstream and non-retryable by SnowflakeSource; not worth reporting as a bug.
+            (
+                "002003 (42S02): 01c5ed45-0a1f-ee98-0067-5f032313bb4a: SQL compilation error:\n"
+                "Table 'DB.PUBLIC.T' does not exist or not authorized.",
+                False,
+            ),
+            # Anything else is unexpected and should still be surfaced.
+            ("some other driver failure", True),
+        ],
+    )
+    def test_captures_only_unexpected_show_failures(self, impl, cursor, error_msg, expect_capture):
+        cursor.execute.side_effect = Exception(error_msg)
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.snowflake.capture_exception"
+        ) as mock_capture:
+            assert impl.get_primary_keys_for_table(cursor, "DB", "PUBLIC", "t") is None
+        assert mock_capture.called is expect_capture
+
 
 class TestGetRowsToSync:
     def test_returns_count(self, impl, cursor, logger):


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `ProgrammingError` from the Snowflake data-warehouse source: [issue](https://us.posthog.com/project/2/error_tracking/019f951a-2153-70d1-9015-c28e125fd3fc) firing from `get_primary_keys_for_table`.

```
002003 (42S02): SQL compilation error:
Table 'X.Y.Z' does not exist or not authorized.
```

This happens when a table/schema being synced was dropped, renamed, or had its grant revoked in Snowflake after the schema was discovered. The pipeline already handles this gracefully — `get_primary_keys_for_table` swallows the failure and returns `None`, so the sync falls back to a persisted or `id`-column primary key instead of crashing. But the function unconditionally calls `capture_exception` on every failure, so this known, user-caused condition (already recognized as non-retryable in `get_non_retryable_errors`) keeps generating noisy error-tracking issues even though nothing is broken in our code and no engineering action is needed.

## Changes

`get_primary_keys_for_table` now only reports the failure to error tracking when it *isn't* the known "does not exist or not authorized" condition. Genuinely unexpected `SHOW PRIMARY KEYS` failures are still captured. This matches the sibling schema-level `get_primary_keys`, which already only logs a warning for this class of failure without reporting it.

## How did you test this code?

Added a parameterized case to `TestGetPrimaryKeysForTable` asserting `capture_exception` is skipped for the known "does not exist or not authorized" message and still called for an unrelated/unexpected failure — no existing test asserted on this method's error-tracking behavior. Ran the full `test_snowflake.py` suite (106 passed), `ruff check`/`format`, and `mypy --cache-fine-grained .` repo-wide (no issues).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-reporting behavior only, no user-facing or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Investigated via the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the stack trace originates in this source's code and to pull representative event data.
- Read `products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/snowflake.py` and `source.py`, and the Stripe source's `get_non_retryable_errors` as a reference pattern, to classify the failure as user/upstream.
- Determined the failure is already handled correctly at the pipeline level (returns `None`, no crash/retry), so extending `get_non_retryable_errors` would have no effect here — the fix instead targets the error-tracking noise at the point the exception is caught.
- Invoked `/writing-tests` before adding the regression test.
- Searched open PRs for duplicates (by exception type, error phrase, and module path, plus the maintainer's own open PRs) — found none addressing this.