### PR TITLE
feat: polish warehouse source access control UI

### DIFF
--- a/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/ConfigurationTab.tsx
@@ -145,7 +145,7 @@ export function ConfigurationTab({
         case 'descriptions':
             // Deep-link guard: the section nav already hides this when the flag is off.
             return featureFlags[FEATURE_FLAGS.DATA_WAREHOUSE_SEMANTIC_ENRICHMENT] ? (
-                <DescriptionsSection schema={schema} />
+                <DescriptionsSection schema={schema} source={source} />
             ) : (
                 <></>
             )
@@ -1230,6 +1230,7 @@ function DescriptionRow({
     source,
     saving,
     onSave,
+    disabledReason,
 }: {
     columnName: string
     label: string
@@ -1238,6 +1239,7 @@ function DescriptionRow({
     source?: string
     saving: boolean
     onSave: (columnName: string, description: string) => void
+    disabledReason?: string
 }): JSX.Element {
     const [value, setValue] = useState(description)
     // Keep local state in sync when the annotation reloads (e.g. after a save or AI enrichment).
@@ -1257,6 +1259,7 @@ function DescriptionRow({
                 onChange={setValue}
                 placeholder="Describe what this means…"
                 onPressEnter={() => dirty && onSave(columnName, value)}
+                disabled={!!disabledReason}
             />
             <DescriptionSourceTag source={source} />
             <LemonButton
@@ -1264,7 +1267,7 @@ function DescriptionRow({
                 type="secondary"
                 onClick={() => onSave(columnName, value)}
                 loading={saving}
-                disabledReason={!dirty ? 'No changes to save' : undefined}
+                disabledReason={disabledReason ?? (!dirty ? 'No changes to save' : undefined)}
             >
                 Save
             </LemonButton>
@@ -1272,8 +1275,15 @@ function DescriptionRow({
     )
 }
 
-function DescriptionsSection({ schema }: { schema: ExternalDataSourceSchema }): JSX.Element {
+function DescriptionsSection({
+    schema,
+    source,
+}: {
+    schema: ExternalDataSourceSchema
+    source: SchemaSceneSource | null
+}): JSX.Element {
     const tableId = schema.table?.id
+    const { disabledReason: accessDisabledReason } = useSourceEditorAccess(source)
 
     if (!tableId) {
         return (
@@ -1286,15 +1296,23 @@ function DescriptionsSection({ schema }: { schema: ExternalDataSourceSchema }): 
         )
     }
 
-    return <DescriptionsSectionContent tableId={tableId} columns={schema.available_columns ?? []} />
+    return (
+        <DescriptionsSectionContent
+            tableId={tableId}
+            columns={schema.available_columns ?? []}
+            disabledReason={accessDisabledReason}
+        />
+    )
 }
 
 function DescriptionsSectionContent({
     tableId,
     columns,
+    disabledReason,
 }: {
     tableId: string
     columns: { name: string; data_type?: string; is_nullable?: boolean }[]
+    disabledReason?: string
 }): JSX.Element {
     const logic = columnAnnotationsLogic({ tableId })
     const { annotationByColumn, annotationsLoading, savingColumn } = useValues(logic)
@@ -1316,6 +1334,7 @@ function DescriptionsSectionContent({
                     source={tableAnnotation?.description_source}
                     saving={savingColumn === ''}
                     onSave={saveDescription}
+                    disabledReason={disabledReason}
                 />
                 {annotationsLoading && columns.length === 0 ? (
                     <LemonSkeleton className="w-full h-8 mt-2" />
@@ -1334,6 +1353,7 @@ function DescriptionsSectionContent({
                                 source={annotation?.description_source}
                                 saving={savingColumn === column.name}
                                 onSave={saveDescription}
+                                disabledReason={disabledReason}
                             />
                         )
                     })

--- a/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
@@ -15,6 +15,7 @@ import {
 import { actionToUrl, urlToAction } from 'kea-router'
 import { useEffect } from 'react'
 
+import { IconArrowUpRight } from '@posthog/icons'
 import { LemonBanner, LemonSkeleton } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
@@ -28,11 +29,18 @@ import { DataPipelinesSelfManagedSource } from 'scenes/data-pipelines/DataPipeli
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
-import { ActivityScope, Breadcrumb, ExternalDataSource, ExternalDataSourceApiVersionDeprecation } from '~/types'
+import {
+    ActivityScope,
+    Breadcrumb,
+    ExternalDataSource,
+    ExternalDataSourceApiVersionDeprecation,
+    SidePanelTab,
+} from '~/types'
 
 import { cleanSourceId, isSelfManagedSourceId } from 'products/data_warehouse/frontend/utils'
 
@@ -257,6 +265,7 @@ function ManagedSourceTabs({
     const settingsLogic = sourceSettingsLogic({ id: sourceId, availableSources: {} })
     const { featureFlags } = useValues(featureFlagLogic)
     const { source, sourceLoading } = useValues(settingsLogic)
+    const { openSidePanel } = useActions(sidePanelStateLogic)
 
     useAttachedLogic(settingsLogic, attachTo)
 
@@ -287,7 +296,10 @@ function ManagedSourceTabs({
         return <LemonSkeleton className="w-full h-12" />
     }
 
-    const tabs: LemonTab<SourceSceneTab>[] = [
+    // 'access-control' is a content-less pseudo-tab: selecting it opens the side panel
+    // (where the source scene already registers the access-control context) and the
+    // active tab stays put, so it's deliberately not part of SOURCE_SCENE_TABS/URLs.
+    const tabs: LemonTab<SourceSceneTab | 'access-control'>[] = [
         { label: 'Schemas', key: 'schemas', content: <SchemasTab id={sourceId} /> },
     ]
 
@@ -315,6 +327,16 @@ function ManagedSourceTabs({
         content: <ActivityLog id={sourceId} scope={ActivityScope.EXTERNAL_DATA_SOURCE} />,
     })
 
+    tabs.push({
+        label: (
+            <span className="flex items-center gap-1">
+                Access control
+                <IconArrowUpRight />
+            </span>
+        ),
+        key: 'access-control',
+    })
+
     return (
         <>
             {source?.api_version_deprecation && (
@@ -323,7 +345,18 @@ function ManagedSourceTabs({
                     deprecation={source.api_version_deprecation}
                 />
             )}
-            <LemonTabs activeKey={currentTab} tabs={tabs} onChange={setCurrentTab} sceneInset />
+            <LemonTabs
+                activeKey={currentTab}
+                tabs={tabs}
+                onChange={(tab) => {
+                    if (tab === 'access-control') {
+                        openSidePanel(SidePanelTab.AccessControl)
+                        return
+                    }
+                    setCurrentTab(tab)
+                }}
+                sceneInset
+            />
         </>
     )
 }

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/SchemasTab.tsx
@@ -588,6 +588,7 @@ function ManagedSchemaTable({
                                     type="secondary"
                                     size="xsmall"
                                     to={urls.dataWarehouseSourceSchema(prefixedSourceId, schema.id, 'configuration')}
+                                    disabledReason={editDisabledReason}
                                 >
                                     Configure
                                 </LemonButton>


### PR DESCRIPTION
## Problem

Access control for warehouse sources already works: you can give members `Viewer` access to a specific source (for example a Zendesk source you're freezing) so they can't sync or delete it. But it's not obvious where to configure that — you have to know to open the side panel on the source page, there's no visible entry point.

A couple of actions also aren't disabled when user has `Viewer` access

- The per-row "Configure" button on the Schemas tab stays clickable for members without editor access
- On the schema detail page, the Descriptions inputs and Save buttons are not disabled for members without editor access, so saving fails with a 403 toast instead of being visibly unavailable. 

## Changes

<img width="1852" height="1368" alt="2026-07-24 21 58 01" src="https://github.com/user-attachments/assets/6616b597-ab96-4e99-904b-9bb4d8529832" />


- "Access control" entry in the source scene's tab bar, after History. It's a content-less pseudo-tab with an icon: selecting it opens the existing side panel (the source scene already registers the access control context) and the active tab stays put, so it's deliberately not in the URL tab list.

<img width="901" height="419" alt="image" src="https://github.com/user-attachments/assets/ff05a0e2-d38a-40dc-bfdd-f37d2cb5fbe7" />

- "Configure" gets the same `disabledReason` as the row's "..." menu.
- Descriptions inputs and Save buttons disable with a reason when the user lacks editor access to the source, matching the other sections of the schema detail page.

<img width="1416" height="447" alt="image" src="https://github.com/user-attachments/assets/2a91b28f-027c-4ccc-9b1d-1667cd0db9d3" />

<img width="1414" height="742" alt="image" src="https://github.com/user-attachments/assets/7d9262af-e192-4f81-b527-beb112bd4a31" />


> [!NOTE]
> Overlaps with #72440, I'll resolve conflicts once it's merged

## How did you test this code?

Mannually

## Automatic notifications

- [ ] Publish to changelog? — No
- [ ] Alert Sales and Marketing teams? — No