### PR TITLE
fix(mcp): default get-llm-total-costs-for-project to active project

### DIFF
--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -5,6 +5,7 @@
             "type": "object",
             "properties": {
                 "projectId": {
+                    "description": "Project ID. Defaults to the active project when omitted.",
                     "type": "integer",
                     "exclusiveMinimum": 0,
                     "maximum": 9007199254740991
@@ -12,8 +13,7 @@
                 "days": {
                     "type": "number"
                 }
-            },
-            "required": ["projectId"]
+            }
         },
         "AgentResolveResourceSchema": {
             "type": "object",

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -366,7 +366,12 @@ export const InsightQueryInputSchema = z.preprocess(
 )
 
 export const AIObservabilityGetCostsSchema = z.object({
-    projectId: z.number().int().positive(),
+    projectId: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe('Project ID. Defaults to the active project when omitted.'),
     days: z.number().optional(),
 })
 

--- a/services/mcp/src/tools/aiObservability/getLLMCosts.ts
+++ b/services/mcp/src/tools/aiObservability/getLLMCosts.ts
@@ -14,7 +14,8 @@ export const getLLMCostsHandler: ToolBase<typeof schema, Result>['handler'] = as
     context: Context,
     params: Params
 ) => {
-    const { projectId, days } = params
+    const { days } = params
+    const projectId = params.projectId ? String(params.projectId) : await context.stateManager.getProjectId()
 
     const trendsQuery = {
         kind: 'TrendsQuery',
@@ -38,7 +39,7 @@ export const getLLMCostsHandler: ToolBase<typeof schema, Result>['handler'] = as
         },
     }
 
-    const costsResult = await context.api.query({ projectId: String(projectId) }).execute({ queryBody: trendsQuery })
+    const costsResult = await context.api.query({ projectId }).execute({ queryBody: trendsQuery })
     if (!costsResult.success) {
         throw new Error(`Failed to get LLM costs: ${costsResult.error.message}`)
     }

--- a/services/mcp/tests/tools/aiObservability.integration.test.ts
+++ b/services/mcp/tests/tools/aiObservability.integration.test.ts
@@ -67,6 +67,13 @@ describe('AI observability', { concurrent: false }, () => {
             const costsData = parseToolResponse(result)
             expect(Array.isArray(costsData.results)).toBe(true)
         })
+
+        it('should fall back to the active project when projectId is omitted', async () => {
+            const result = await costsTool.handler(context, {})
+
+            const costsData = parseToolResponse(result)
+            expect(Array.isArray(costsData.results)).toBe(true)
+        })
     })
 
     describe('AI observability workflow', () => {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/get-llm-total-costs-for-project.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/get-llm-total-costs-for-project.json
@@ -5,11 +5,11 @@
             "type": "number"
         },
         "projectId": {
+            "description": "Project ID. Defaults to the active project when omitted.",
             "exclusiveMinimum": 0,
             "maximum": 9007199254740991,
             "type": "integer"
         }
     },
-    "required": ["projectId"],
     "type": "object"
 }


### PR DESCRIPTION
## Problem

The `get-llm-total-costs-for-project` MCP tool declares `projectId` as a required input. Agents don't know the numeric project id, so a large share of this tool's calls fail validation with `missing required parameter: projectId` (visible in the MCP tool-call analytics). Every other tool in the server resolves the project from context via `context.stateManager.getProjectId()`.

## Changes

- Make `projectId` optional on `AIObservabilityGetCostsSchema`, with a description noting it defaults to the active project.
- In the handler, fall back to `context.stateManager.getProjectId()` when `projectId` is omitted, dropping the now-redundant `String()` wrap. This aligns the tool with the `getProjectId()` convention documented in `src/tools/README.md`.
- Regenerated the shared `schema/tool-inputs.json` and the `get-llm-total-costs-for-project` tool-schema snapshot from the Zod source (not hand-edited).

## How did you test this code?

- Added an integration test case asserting the tool falls back to the active project when `projectId` is omitted (`aiObservability.integration.test.ts`).
- Regenerated `schema/tool-inputs.json` and the tool-schema snapshot with the repo's own generator + oxfmt so they match what CI produces; the resulting diffs are confined to this one schema (description added, `projectId` removed from `required`).
- I (an agent) could not run the full `tsgo` typecheck, `oxfmt`/`oxlint` across the whole package, or the live integration test here, since that needs a full monorepo install and live PostHog credentials. The change is type-safe by inspection: `getProjectId()` returns `Promise<string>` and `String(params.projectId)` is a `string`, matching `context.api.query({ projectId })`. Please let CI run these.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread and implemented by the PostHog Slack app (Claude). The fix was originally scoped against the archived `posthog/mcp` repo; on discovering the code now lives in this monorepo under `services/mcp`, I re-applied it here and regenerated the derived schema artifacts to match. No repo skills were invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1784914076262909?thread_ts=1784914076.262909&cid=C087XQ7K9K7)*
