### PR TITLE
feat(aio): add daily digest scout template

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -183,6 +183,7 @@ export const FEATURE_FLAGS = {
     UX_HIDE_PROJECT_NOTICE: 'ux-hide-project-notice', // owner: #team-platform-ux, hides the project notice banner across all scenes
 
     // Feature flags used to control opt-in for different behaviors, should not be removed
+    AI_OBSERVABILITY_DAILY_DIGEST_SCOUT: 'ai-observability-daily-digest-scout', // owner: #team-ai-observability, gates the daily digest scout button
     AI_TRAINING: 'ai-training', // owner: @nicowaltz #team-replay #ai-research, gates the AI training opt-out UI and API enforcement
     AUDIT_LOGS_ACCESS: 'audit-logs-access', // owner: #team-platform-features, used to control access to audit logs
     AUTH_FLOW_VARIANT: 'auth-flow-variant', // owner: @fercgomes #team-growth multivariate=legacy,paper-desk — selects the auth flow experience (login, signup, invited signup, email verification); paper-desk is the new design, legacy is the existing design

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutConfigControls.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutConfigControls.tsx
@@ -1,14 +1,9 @@
-import { useMountedLogic, useValues } from 'kea'
+import { useValues } from 'kea'
 
 import { IconTrash } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonInput, LemonSelect, LemonSwitch, Link, Tooltip } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog, LemonInput, LemonSelect, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
 
-import { integrationsLogic } from 'lib/integrations/integrationsLogic'
-import { SlackChannelPicker } from 'lib/integrations/SlackIntegrationHelpers'
 import { teamLogic } from 'scenes/teamLogic'
-import { urls } from 'scenes/urls'
-
-import type { IntegrationType } from '~/types'
 
 import type {
     PatchedSignalScoutConfigUpdateApi as SignalScoutConfigUpdate,
@@ -25,6 +20,7 @@ import {
     SCOUT_DAILY_AT_SCHEDULE_MODE,
     timeToDailyCron,
 } from '../../../utils/scoutRunsWindow'
+import { ScoutSlackDestination } from './ScoutSlackDestination'
 
 interface ScoutConfigControlsProps {
     config: SignalScoutConfig
@@ -69,8 +65,6 @@ export function ScoutConfigForm({
     deleting,
     updating = false,
 }: ScoutConfigFormProps): JSX.Element {
-    useMountedLogic(integrationsLogic)
-    const { slackIntegrations, integrationsLoading } = useValues(integrationsLogic)
     const { timezone: projectTimezone } = useValues(teamLogic)
     const dailyTime = dailyCronToTime(config.run_cron_schedule)
     const scheduleMode = getScoutScheduleMode(config)
@@ -142,11 +136,8 @@ export function ScoutConfigForm({
                 </div>
             ) : null}
             <ScoutSlackDestination
-                config={config}
-                onUpdate={onUpdate}
-                integrations={slackIntegrations ?? []}
-                loading={integrationsLoading && slackIntegrations === undefined}
-                updating={updating}
+                destination={config.output_destinations?.slack}
+                onChange={(outputDestinations) => onUpdate(config.id, { output_destinations: outputDestinations })}
                 disabledReason={controlsDisabledReason}
             />
             {/* Only custom scouts are deletable. A canonical scout would be re-seeded from disk after
@@ -169,109 +160,6 @@ export function ScoutConfigForm({
                     </LemonButton>
                 </div>
             ) : null}
-        </div>
-    )
-}
-
-function ScoutSlackDestination({
-    config,
-    onUpdate,
-    integrations,
-    loading,
-    updating = false,
-    disabledReason,
-}: ScoutConfigControlsProps & {
-    integrations: IntegrationType[]
-    loading: boolean
-    disabledReason?: string
-}): JSX.Element {
-    const destination = config.output_destinations?.slack
-    const configuredIntegration = destination
-        ? integrations.find((integration) => integration.id === destination.integration_id)
-        : undefined
-    const selectedIntegration = configuredIntegration ?? (integrations.length === 1 ? integrations[0] : null)
-
-    const selectWorkspace = (integrationId: number): void => {
-        onUpdate(config.id, {
-            output_destinations: { slack: { integration_id: integrationId, channel: null } },
-        })
-    }
-
-    const selectChannel = (channel: string | null): void => {
-        if (!channel || !selectedIntegration) {
-            onUpdate(config.id, { output_destinations: {} })
-            return
-        }
-        onUpdate(config.id, {
-            output_destinations: {
-                slack: { integration_id: selectedIntegration.id, channel },
-            },
-        })
-    }
-
-    const disableSlack = (): void => {
-        onUpdate(config.id, { output_destinations: {} })
-    }
-
-    const hasChannel = Boolean(destination?.channel)
-
-    return (
-        <div className="flex flex-col gap-2 border-t border-primary pt-2">
-            <div className="flex flex-col min-w-0">
-                <span className="text-xs text-default">Slack destination</span>
-                <span className="text-[11.5px] text-muted">Post each scout run's output to a channel</span>
-            </div>
-            {loading ? (
-                <span className="text-xs text-muted">Loading Slack workspaces…</span>
-            ) : integrations.length === 0 ? (
-                <Link to={urls.settings('environment-integrations', 'integration-slack')}>
-                    Connect a Slack workspace
-                </Link>
-            ) : (
-                <div className="flex flex-col gap-2 max-w-md">
-                    {integrations.length > 1 ? (
-                        <LemonSelect
-                            size="small"
-                            value={selectedIntegration?.id ?? null}
-                            options={integrations.map((integration) => ({
-                                value: integration.id,
-                                label: integration.display_name || `Slack workspace ${integration.id}`,
-                            }))}
-                            onChange={(integrationId) => integrationId != null && selectWorkspace(integrationId)}
-                            placeholder="Select workspace"
-                            disabledReason={disabledReason ?? (updating ? 'Saving…' : undefined)}
-                        />
-                    ) : null}
-                    {selectedIntegration ? (
-                        <div className="flex items-center gap-2">
-                            <div className="flex-1 min-w-0">
-                                <SlackChannelPicker
-                                    integration={selectedIntegration}
-                                    value={configuredIntegration ? (destination?.channel ?? undefined) : undefined}
-                                    onChange={selectChannel}
-                                    disabled={updating || disabledReason !== undefined}
-                                />
-                            </div>
-                            {hasChannel ? (
-                                <LemonButton
-                                    size="small"
-                                    icon={<IconTrash />}
-                                    onClick={disableSlack}
-                                    tooltip="Turn off Slack notifications for this scout"
-                                    disabledReason={disabledReason ?? (updating ? 'Saving…' : undefined)}
-                                    aria-label="Turn off Slack notifications"
-                                />
-                            ) : null}
-                        </div>
-                    ) : null}
-                    <span className="text-[11.5px] text-muted">
-                        {hasChannel
-                            ? 'PostHog must be in the channel. Invite it with '
-                            : 'Pick a channel to turn notifications on. PostHog must be in the channel — invite it with '}
-                        <code>/invite @PostHog</code>.
-                    </span>
-                </div>
-            )}
         </div>
     )
 }

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutCreateButton.test.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutCreateButton.test.tsx
@@ -14,7 +14,12 @@ jest.mock('lib/utils/accessControlUtils', () => ({
 }))
 
 jest.mock('./ScoutCreateModal', () => ({
-    ScoutCreateModal: () => <div>Manual scout form</div>,
+    ScoutCreateModal: ({ initialValues }: { initialValues?: { name?: string } }) => (
+        <div>
+            Manual scout form
+            {initialValues?.name ? <span>{initialValues.name}</span> : null}
+        </div>
+    ),
 }))
 
 const mockGetAccessControlDisabledReason = getAccessControlDisabledReason as jest.MockedFunction<
@@ -71,6 +76,25 @@ describe('ScoutCreateButton', () => {
         fireEvent.click(await findByText('Create manually'))
 
         expect(await findByText('Manual scout form')).toBeTruthy()
+        expect(createdTaskDescriptions).toEqual([])
+    })
+
+    it('opens a prefilled manual form directly when configured for manual creation', async () => {
+        const { findByText, getByText, queryByLabelText } = render(
+            <ScoutCreateButton
+                creationMode="manual"
+                initialValues={{ name: 'signals-scout-daily-digest' }}
+                type="secondary"
+            >
+                Create daily digest
+            </ScoutCreateButton>
+        )
+
+        fireEvent.click(getByText('Create daily digest'))
+
+        expect(await findByText('Manual scout form')).toBeTruthy()
+        expect(await findByText('signals-scout-daily-digest')).toBeTruthy()
+        expect(queryByLabelText('Alternative ways to create a scout')).toBeNull()
         expect(createdTaskDescriptions).toEqual([])
     })
 

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutCreateButton.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutCreateButton.tsx
@@ -22,6 +22,7 @@ const LazyScoutCreateModal = React.lazy(async () => {
 export interface ScoutCreateButtonProps {
     children?: React.ReactNode
     className?: string
+    creationMode?: 'ai' | 'manual'
     initialValues?: ScoutCreateInitialValues
     onCreated?: (scout: SignalScoutCreateResponseApi) => void
     size?: LemonButtonProps['size']
@@ -34,6 +35,7 @@ export function ScoutCreateButton({
     onCreated,
     children = 'Create scout with AI',
     className,
+    creationMode = 'ai',
     size = 'small',
     type = 'primary',
     'data-attr': dataAttr,
@@ -43,41 +45,56 @@ export function ScoutCreateButton({
     const { runningChatPrompt } = useValues(scoutFleetLogic)
     const isStartingAiTask = runningChatPrompt === SCOUT_AUTHOR_PROMPT
     const anotherChatTaskIsStarting = runningChatPrompt !== null && !isStartingAiTask
+    const opensManualForm = creationMode === 'manual'
     const creationDisabledReason = getAccessControlDisabledReason(
         AccessControlResourceType.LlmSkill,
         AccessControlLevel.Editor
     )
+
+    const handleClick = (): void => {
+        if (opensManualForm) {
+            setIsManualModalOpen(true)
+            return
+        }
+        startScoutChatTask(SCOUT_AUTHOR_PROMPT, 'scout authoring task', 'Create scout with AI')
+    }
 
     return (
         <>
             <LemonButton
                 type={type}
                 size={size}
-                icon={<IconSparkles />}
-                loading={isStartingAiTask}
+                icon={opensManualForm ? <IconPlus /> : <IconSparkles />}
+                loading={!opensManualForm && isStartingAiTask}
                 disabledReason={
-                    anotherChatTaskIsStarting ? 'Starting another task…' : (creationDisabledReason ?? undefined)
+                    !opensManualForm && anotherChatTaskIsStarting
+                        ? 'Starting another task…'
+                        : (creationDisabledReason ?? undefined)
                 }
-                onClick={() => startScoutChatTask(SCOUT_AUTHOR_PROMPT, 'scout authoring task', 'Create scout with AI')}
-                sideAction={{
-                    icon: <IconChevronDown />,
-                    'aria-label': 'Alternative ways to create a scout',
-                    tooltip: 'Alternative ways to create a scout',
-                    dropdown: {
-                        placement: 'bottom-end',
-                        overlay: (
-                            <LemonButton
-                                fullWidth
-                                size={size}
-                                icon={<IconPlus />}
-                                disabledReason={creationDisabledReason}
-                                onClick={() => setIsManualModalOpen(true)}
-                            >
-                                Create manually
-                            </LemonButton>
-                        ),
-                    },
-                }}
+                onClick={handleClick}
+                sideAction={
+                    opensManualForm
+                        ? undefined
+                        : {
+                              icon: <IconChevronDown />,
+                              'aria-label': 'Alternative ways to create a scout',
+                              tooltip: 'Alternative ways to create a scout',
+                              dropdown: {
+                                  placement: 'bottom-end',
+                                  overlay: (
+                                      <LemonButton
+                                          fullWidth
+                                          size={size}
+                                          icon={<IconPlus />}
+                                          disabledReason={creationDisabledReason}
+                                          onClick={() => setIsManualModalOpen(true)}
+                                      >
+                                          Create manually
+                                      </LemonButton>
+                                  ),
+                              },
+                          }
+                }
                 className={className}
                 data-attr={dataAttr}
             >

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutCreateModal.test.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutCreateModal.test.tsx
@@ -1,0 +1,36 @@
+import { cleanup, render } from '@testing-library/react'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import { ScoutCreateModal } from './ScoutCreateModal'
+
+describe('ScoutCreateModal', () => {
+    beforeEach(() => {
+        initKeaTests()
+        useMocks({
+            get: {
+                '/api/environments/:team_id/integrations/': () => [200, { results: [] }],
+            },
+        })
+    })
+
+    afterEach(cleanup)
+
+    it('includes a Slack destination in the create form', async () => {
+        const { findByText } = render(
+            <ScoutCreateModal
+                isOpen
+                onClose={jest.fn()}
+                initialValues={{
+                    name: 'signals-scout-ai-observability-daily-digest',
+                    description: 'Creates a daily AI observability digest.',
+                    body: 'Review AI observability and create one actionable digest.',
+                }}
+            />
+        )
+
+        expect(await findByText('Slack destination')).toBeTruthy()
+        expect(await findByText('Connect a Slack workspace')).toBeTruthy()
+    })
+})

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutCreateModal.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutCreateModal.tsx
@@ -21,6 +21,7 @@ import {
     SCOUT_DAILY_AT_SCHEDULE_MODE,
     SIGNALS_SCOUT_SKILL_PREFIX,
 } from '../../../utils/scoutRunsWindow'
+import { ScoutSlackDestination } from './ScoutSlackDestination'
 
 export interface ScoutCreateModalProps {
     isOpen: boolean
@@ -186,6 +187,15 @@ export function ScoutCreateModal({ isOpen, onClose, initialValues, onCreated }: 
                         <span className="text-xs text-muted">
                             Turn off inbox findings to run the scout in dry-run mode.
                         </span>
+                        <LemonField name="config.output_destinations">
+                            {({ value, onChange }) => (
+                                <ScoutSlackDestination
+                                    destination={value?.slack}
+                                    onChange={onChange}
+                                    disabledReason={isScoutCreateFormSubmitting ? 'Creating the scout' : undefined}
+                                />
+                            )}
+                        </LemonField>
                     </div>
                 </div>
             </Form>

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutSlackDestination.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutSlackDestination.tsx
@@ -1,0 +1,113 @@
+import { useMountedLogic, useValues } from 'kea'
+
+import { IconTrash } from '@posthog/icons'
+import { LemonButton, LemonSelect, Link } from '@posthog/lemon-ui'
+
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { SlackChannelPicker } from 'lib/integrations/SlackIntegrationHelpers'
+import { urls } from 'scenes/urls'
+
+import type {
+    SignalScoutOutputDestinationsApi,
+    SignalScoutSlackDestinationApi,
+} from 'products/signals/frontend/generated/api.schemas'
+
+interface ScoutSlackDestinationProps {
+    destination?: SignalScoutSlackDestinationApi | null
+    disabledReason?: string
+    onChange: (outputDestinations: SignalScoutOutputDestinationsApi) => void
+}
+
+export function ScoutSlackDestination({
+    destination,
+    disabledReason,
+    onChange,
+}: ScoutSlackDestinationProps): JSX.Element {
+    useMountedLogic(integrationsLogic)
+    const { slackIntegrations, integrationsLoading } = useValues(integrationsLogic)
+    const integrations = slackIntegrations ?? []
+    const configuredIntegration = destination
+        ? integrations.find((integration) => integration.id === destination.integration_id)
+        : undefined
+    const selectedIntegration = configuredIntegration ?? (integrations.length === 1 ? integrations[0] : null)
+
+    const selectWorkspace = (integrationId: number): void => {
+        onChange({ slack: { integration_id: integrationId, channel: null } })
+    }
+
+    const selectChannel = (channel: string | null): void => {
+        if (!channel || !selectedIntegration) {
+            onChange({})
+            return
+        }
+        onChange({
+            slack: { integration_id: selectedIntegration.id, channel },
+        })
+    }
+
+    const disableSlack = (): void => {
+        onChange({})
+    }
+
+    const hasChannel = Boolean(destination?.channel)
+
+    return (
+        <div className="flex flex-col gap-2 border-t border-primary pt-2">
+            <div className="flex flex-col min-w-0">
+                <span className="text-xs text-default">Slack destination</span>
+                <span className="text-[11.5px] text-muted">Post each scout run's output to a channel</span>
+            </div>
+            {integrationsLoading && slackIntegrations === undefined ? (
+                <span className="text-xs text-muted">Loading Slack workspaces…</span>
+            ) : integrations.length === 0 ? (
+                <Link to={urls.settings('environment-integrations', 'integration-slack')}>
+                    Connect a Slack workspace
+                </Link>
+            ) : (
+                <div className="flex flex-col gap-2 max-w-md">
+                    {integrations.length > 1 ? (
+                        <LemonSelect
+                            size="small"
+                            value={selectedIntegration?.id ?? null}
+                            options={integrations.map((integration) => ({
+                                value: integration.id,
+                                label: integration.display_name || `Slack workspace ${integration.id}`,
+                            }))}
+                            onChange={(integrationId) => integrationId != null && selectWorkspace(integrationId)}
+                            placeholder="Select workspace"
+                            disabledReason={disabledReason}
+                        />
+                    ) : null}
+                    {selectedIntegration ? (
+                        <div className="flex items-center gap-2">
+                            <div className="flex-1 min-w-0">
+                                <SlackChannelPicker
+                                    integration={selectedIntegration}
+                                    value={configuredIntegration ? (destination?.channel ?? undefined) : undefined}
+                                    onChange={selectChannel}
+                                    disabled={disabledReason !== undefined}
+                                />
+                            </div>
+                            {hasChannel ? (
+                                <LemonButton
+                                    size="small"
+                                    icon={<IconTrash />}
+                                    onClick={disableSlack}
+                                    tooltip="Turn off Slack notifications for this scout"
+                                    disabledReason={disabledReason}
+                                    aria-label="Turn off Slack notifications"
+                                />
+                            ) : null}
+                        </div>
+                    ) : null}
+                    <span className="text-[11.5px] text-muted">
+                        {hasChannel
+                            ? 'PostHog must be in the channel. Invite it with '
+                            : 'Pick a channel to turn notifications on. PostHog must be in the channel. Invite it with '}
+                        <code>/invite @PostHog</code>.
+                    </span>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/scenes/inbox/logics/scoutCreateModalLogic.test.ts
+++ b/frontend/src/scenes/inbox/logics/scoutCreateModalLogic.test.ts
@@ -70,6 +70,12 @@ describe('scoutCreateModalLogic', () => {
                     enabled: false,
                     emit: false,
                     run_interval_minutes: 60,
+                    output_destinations: {
+                        slack: {
+                            integration_id: 42,
+                            channel: 'C123|#ai-observability',
+                        },
+                    },
                 },
             },
             onClose,
@@ -87,6 +93,12 @@ describe('scoutCreateModalLogic', () => {
                 emit: false,
                 run_interval_minutes: 60,
                 run_cron_schedule: null,
+                output_destinations: {
+                    slack: {
+                        integration_id: 42,
+                        channel: 'C123|#ai-observability',
+                    },
+                },
             },
         })
 
@@ -101,6 +113,12 @@ describe('scoutCreateModalLogic', () => {
                 emit: false,
                 run_interval_minutes: 60,
                 run_cron_schedule: null,
+                output_destinations: {
+                    slack: {
+                        integration_id: 42,
+                        channel: 'C123|#ai-observability',
+                    },
+                },
             },
         })
         expect(onCreated).toHaveBeenCalledWith(CREATED_SCOUT)

--- a/frontend/src/scenes/inbox/logics/scoutCreateModalLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutCreateModalLogic.ts
@@ -26,7 +26,8 @@ import {
 
 type ScoutCreateConfigFormValues = Required<
     Pick<SignalScoutConfigOptionsApi, 'enabled' | 'emit' | 'run_interval_minutes' | 'run_cron_schedule'>
->
+> &
+    Pick<SignalScoutConfigOptionsApi, 'output_destinations'>
 
 export type ScoutCreateFormValues = Pick<SignalScoutCreateApi, 'name' | 'description' | 'body'> & {
     config: ScoutCreateConfigFormValues

--- a/products/ai_observability/frontend/AIObservabilityDigestScoutButton.test.tsx
+++ b/products/ai_observability/frontend/AIObservabilityDigestScoutButton.test.tsx
@@ -1,0 +1,76 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { Provider } from 'kea'
+import type { ReactNode } from 'react'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
+import { initKeaTests } from '~/test/init'
+
+import {
+    AIObservabilityDigestScoutButton,
+    getAIObservabilityDigestScoutInitialValues,
+} from './AIObservabilityDigestScoutButton'
+
+jest.mock('scenes/inbox/components/config/scouts/ScoutCreateButton', () => ({
+    ScoutCreateButton: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+}))
+
+describe('AIObservabilityDigestScoutButton', () => {
+    let unmountFeatureFlagLogic: (() => void) | null = null
+
+    beforeEach(() => {
+        initKeaTests()
+        unmountFeatureFlagLogic = featureFlagLogic.mount()
+    })
+
+    afterEach(() => {
+        featureFlagLogic.actions.setFeatureFlags([], {})
+        unmountFeatureFlagLogic?.()
+        unmountFeatureFlagLogic = null
+        cleanup()
+    })
+
+    it.each([
+        { enabled: false, visible: false },
+        { enabled: true, visible: true },
+    ])('is visible=$visible when the AI observability feature flag is enabled=$enabled', ({ enabled, visible }) => {
+        featureFlagLogic.actions.setFeatureFlags(enabled ? [FEATURE_FLAGS.AI_OBSERVABILITY_DAILY_DIGEST_SCOUT] : [], {
+            [FEATURE_FLAGS.AI_OBSERVABILITY_DAILY_DIGEST_SCOUT]: enabled,
+        })
+
+        render(
+            <Provider>
+                <AIObservabilityDigestScoutButton />
+            </Provider>
+        )
+
+        expect(Boolean(screen.queryByRole('button', { name: 'Create daily digest' }))).toBe(visible)
+    })
+
+    it('prefills a daily 9 a.m. scout that discovers the dashboard and produces one actionable digest', () => {
+        const initialValues = getAIObservabilityDigestScoutInitialValues()
+
+        expect(initialValues).toMatchObject({
+            name: 'signals-scout-ai-observability-daily-digest',
+            config: {
+                enabled: true,
+                emit: true,
+                run_interval_minutes: 1440,
+                run_cron_schedule: '0 9 * * *',
+            },
+        })
+        expect(initialValues.body).toEqual(expect.stringContaining('dashboards-get-all'))
+        expect(initialValues.body).not.toEqual(expect.stringContaining('dashboard ID'))
+        expect(initialValues.body).toEqual(expect.stringContaining('posthog:exploring-ai-failures'))
+        expect(initialValues.body).toEqual(expect.stringContaining('posthog:analyzing-expensive-users'))
+        expect(initialValues.body).toEqual(expect.stringContaining('posthog:exploring-llm-evaluations'))
+        expect(initialValues.body).toEqual(expect.stringContaining('Do not repeat an unchanged issue'))
+        expect(initialValues.body).toEqual(expect.stringContaining('Create at most one report per run'))
+        expect(initialValues.body).toEqual(
+            expect.stringContaining('Every included item must lead to a concrete next action')
+        )
+    })
+})

--- a/products/ai_observability/frontend/AIObservabilityDigestScoutButton.test.tsx
+++ b/products/ai_observability/frontend/AIObservabilityDigestScoutButton.test.tsx
@@ -50,7 +50,7 @@ describe('AIObservabilityDigestScoutButton', () => {
         expect(Boolean(screen.queryByRole('button', { name: 'Create daily digest' }))).toBe(visible)
     })
 
-    it('prefills a daily 9 a.m. scout that discovers the dashboard and produces one actionable digest', () => {
+    it('prefills a daily 9 a.m. scout that reviews canonical AI observability data and always produces one digest', () => {
         const initialValues = getAIObservabilityDigestScoutInitialValues()
 
         expect(initialValues).toMatchObject({
@@ -62,13 +62,34 @@ describe('AIObservabilityDigestScoutButton', () => {
                 run_cron_schedule: '0 9 * * *',
             },
         })
-        expect(initialValues.body).toEqual(expect.stringContaining('dashboards-get-all'))
-        expect(initialValues.body).not.toEqual(expect.stringContaining('dashboard ID'))
-        expect(initialValues.body).toEqual(expect.stringContaining('posthog:exploring-ai-failures'))
-        expect(initialValues.body).toEqual(expect.stringContaining('posthog:analyzing-expensive-users'))
-        expect(initialValues.body).toEqual(expect.stringContaining('posthog:exploring-llm-evaluations'))
+        expect(initialValues.body).toEqual(expect.stringContaining('/project/{team_id}/ai-observability/dashboard'))
+        expect(initialValues.body).toEqual(expect.stringContaining('must not be used for this surface'))
+        expect(initialValues.body).toEqual(expect.stringContaining('preinstalled in the Scout runtime'))
+        for (const skillName of [
+            'exploring-ai-failures',
+            'exploring-llm-traces',
+            'analyzing-expensive-users',
+            'exploring-llm-costs',
+            'exploring-llm-evaluations',
+            'querying-posthog-data',
+        ]) {
+            expect(initialValues.body).toEqual(expect.stringContaining(`\`${skillName}\``))
+        }
+        expect(initialValues.body).toEqual(
+            expect.stringContaining('`skill-get` is only for loading this bound Scout skill')
+        )
+        expect(initialValues.body).toEqual(
+            expect.stringContaining("both this Scout's exact `skill_name` and its current `skill_version`")
+        )
+        expect(initialValues.body).toEqual(
+            expect.stringContaining('whose `created_by_skill` exactly matches this Scout')
+        )
         expect(initialValues.body).toEqual(expect.stringContaining('Do not repeat an unchanged issue'))
-        expect(initialValues.body).toEqual(expect.stringContaining('Create at most one report per run'))
+        expect(initialValues.body).toEqual(
+            expect.stringContaining('Every successful run must leave exactly one report')
+        )
+        expect(initialValues.body).toEqual(expect.stringContaining('No material regressions'))
+        expect(initialValues.body).toEqual(expect.stringContaining('list any incomplete surface'))
         expect(initialValues.body).toEqual(
             expect.stringContaining('Every included item must lead to a concrete next action')
         )

--- a/products/ai_observability/frontend/AIObservabilityDigestScoutButton.test.tsx
+++ b/products/ai_observability/frontend/AIObservabilityDigestScoutButton.test.tsx
@@ -47,7 +47,7 @@ describe('AIObservabilityDigestScoutButton', () => {
             </Provider>
         )
 
-        expect(Boolean(screen.queryByRole('button', { name: 'Create daily digest' }))).toBe(visible)
+        expect(Boolean(screen.queryByText('Create daily digest'))).toBe(visible)
     })
 
     it('prefills a daily 9 a.m. scout that reviews canonical AI observability data and always produces one digest', () => {

--- a/products/ai_observability/frontend/AIObservabilityDigestScoutButton.tsx
+++ b/products/ai_observability/frontend/AIObservabilityDigestScoutButton.tsx
@@ -16,36 +16,53 @@ export function getAIObservabilityDigestScoutInitialValues(): ScoutCreateInitial
 
 Create one concise, actionable AI observability digest for the previous complete 24 hours in the project's timezone. Compare it with the preceding 24 hours, the recent 7-day baseline, and the same weekday when traffic is seasonal. Never compare a complete period with a partial one.
 
+## Use the packaged analysis skills
+
+The following skills are preinstalled in the Scout runtime. Load them through the runtime's packaged-skill mechanism when their workflow is relevant:
+
+- \`exploring-ai-failures\`
+- \`exploring-llm-traces\`
+- \`analyzing-expensive-users\`
+- \`exploring-llm-costs\`
+- \`exploring-llm-evaluations\`
+- \`querying-posthog-data\`
+
+These are packaged runtime skills, not project skill-store entries. Use the runtime's packaged-skill loader, not \`skill-list\` or \`skill-get\`, to read them, and do not browse the skill store. \`skill-get\` is only for loading this bound Scout skill as directed by the harness.
+
 ## Avoid noise
 
-First read this scout's last 14 days of run summaries with \`scout-runs-list\`, relevant details with \`scout-runs-retrieve\`, and prior baselines or known noise with \`scout-scratchpad-search\`. Use \`inbox-reports-list\` to check recent digest and issue reports.
+First read this Scout's last 14 days of run summaries with \`scout-runs-list\`. Always filter by both this Scout's exact \`skill_name\` and its current \`skill_version\`; never use runs from another Scout, even when its name is similar. Retrieve relevant details with \`scout-runs-retrieve\`.
 
-Do not repeat an unchanged issue. Include a recurring issue only when it materially worsened, recovered, relapsed, gained useful new evidence, or now needs a different action. Past digests are context, not reports to edit.
+Search prior baselines or known noise with \`scout-scratchpad-search\`. Use only entries whose \`created_by_skill\` exactly matches this Scout, plus fleetwide guidance written by a human. Ignore entries created by other Scouts. Use \`inbox-reports-list\` only to deduplicate reports, not as Scout run history.
+
+Do not repeat an unchanged issue. Include a recurring issue only when it materially worsened, recovered, relapsed, gained useful new evidence, or now needs a different action. Avoiding noise suppresses issue bullets, not the daily digest itself.
 
 ## Review these surfaces
 
-- **Dashboard:** Discover the current dashboard at run time with \`dashboards-get-all\`, filtering for the \`llm-analytics\` tag or the "AI observability default" name. Then use \`dashboard-get\` and \`dashboard-insights-run\`. Review its insights for material changes in usage, cost, latency, errors, or performance.
-- **Errors:** Read \`posthog:exploring-ai-failures\` and \`posthog:exploring-llm-traces\`. Investigate new or changed error patterns and open representative traces. Exclude expected cancellations, test traffic, known provider incidents, and recorded noise.
-- **Costly users:** Read \`posthog:analyzing-expensive-users\` and \`posthog:exploring-llm-costs\`. Never report a user merely for ranking highly or spending a lot. Include a user-level pattern only when it is extraordinary against the project baseline and reveals a controllable cause, such as a retry loop, incorrect model choice, bloated context, missing caching, abuse, or a product bug. Minimize personal data.
-- **Online evaluations:** Read \`posthog:exploring-llm-evaluations\`. Inspect enabled evaluation configs and recent \`$ai_evaluation\` results for material pass-rate regressions, failure or N/A surges, missing expected results, or broken configuration. Localize the cause before including it.
+- **Dashboard:** The canonical dashboard is the product view at \`/project/{team_id}/ai-observability/dashboard\`. Review the same usage, cost, latency, error, and performance measures with the underlying AI observability trace, cost, evaluation, and HogQL MCP tools. Never substitute a saved dashboard selected by name, tag, or fuzzy match. \`dashboards-get-all\`, \`dashboard-get\`, and \`dashboard-insights-run\` operate on saved dashboards and must not be used for this surface. If the available tools cannot reproduce a canonical dashboard measure, mark the dashboard surface incomplete instead of using a lookalike.
+- **Errors and traces:** Use \`exploring-ai-failures\` and \`exploring-llm-traces\`. Inspect errors for new or changed patterns. When errors exist, open at least one representative trace before drawing a conclusion. Exclude expected cancellations, test traffic, known provider incidents, and recorded noise.
+- **Costly users:** Use \`analyzing-expensive-users\` and \`exploring-llm-costs\`. Inspect costly users and their workflows, not only model-level spend. Never report a user merely for ranking highly or spending a lot. Include a user-level pattern only when it is extraordinary against the project baseline and reveals a controllable cause, such as a retry loop, incorrect model choice, bloated context, missing caching, abuse, or a product bug. Minimize personal data.
+- **Online evaluations:** Use \`exploring-llm-evaluations\`. Inspect enabled evaluation configs and recent \`$ai_evaluation\` results for material pass-rate regressions, failure or N/A surges, missing expected results, or broken configuration. Localize the cause before including it.
 - **Code, when available:** Use read-only repository access only to validate a likely cause or identify the relevant code and owner. Cite the path or commit. Do not speculate or block the digest when code access is unavailable.
 
 Use the project's real dimensions. Validate aggregates with representative traces, evaluation runs, or direct evidence. Every included item must lead to a concrete next action on code, configuration, prompts, evaluations, model choice, caching, limits, or further investigation.
 
 ## Produce one digest
 
-Create at most one report per run. It is the daily digest, never one report per finding. If no actionable or extraordinary finding clears the bar, create no report.
+Every successful run must leave exactly one report for the date. It is the daily digest, never one report per finding. Before emitting, use \`inbox-reports-list\` to search for today's title and compare returned titles exactly. If an exact match exists, update that report with \`scout-edit-report\`; otherwise create it with \`scout-emit-report\`. Never create two digests for the same date.
 
-Title it \`AI observability daily digest: YYYY-MM-DD\`. Keep the summary under 180 words with one to three bullets, ordered by impact. Each bullet must state:
+Title it \`AI observability daily digest: YYYY-MM-DD\`. When no actionable or extraordinary finding clears the bar, still produce the report with the verdict \`No material regressions\` and a concise coverage summary.
+
+When there are findings, keep the summary under 180 words with one to three bullets, ordered by impact. Each bullet must state:
 
 - what changed, with the comparison window and only the numbers needed to judge it;
 - why it matters and which model, feature, workflow, evaluation, or user segment is affected;
 - the evidence-backed cause or best next investigation;
 - a specific next action, including the likely owner when known.
 
-Include direct links or IDs for the best evidence. Do not include routine metrics, unchanged leaderboards, raw query output, or filler. Write for a reader with no prior context.
+Include direct links or IDs for the best evidence. Do not include routine metrics, unchanged leaderboards, raw query output, or filler. Write for a reader with no prior context. End the report with the surfaces checked and explicitly list any incomplete surface and why it was incomplete.
 
-Update the scratchpad with useful baselines, noise, and dedupe decisions so tomorrow's run can avoid repeating work. Finish the run with one short note about what you checked and why you did or did not create the digest.`,
+Update the scratchpad with useful baselines, noise, and dedupe decisions so tomorrow's run can avoid repeating work. Finish the run with one short note about what you checked and whether you created or updated the digest.`,
         config: {
             enabled: true,
             emit: true,

--- a/products/ai_observability/frontend/AIObservabilityDigestScoutButton.tsx
+++ b/products/ai_observability/frontend/AIObservabilityDigestScoutButton.tsx
@@ -1,0 +1,75 @@
+import { useValues } from 'kea'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { ScoutCreateButton } from 'scenes/inbox/components/config/scouts/ScoutCreateButton'
+import type { ScoutCreateInitialValues } from 'scenes/inbox/logics/scoutCreateModalLogic'
+
+const AI_OBSERVABILITY_DIGEST_SCOUT_NAME = 'signals-scout-ai-observability-daily-digest'
+
+export function getAIObservabilityDigestScoutInitialValues(): ScoutCreateInitialValues {
+    return {
+        name: AI_OBSERVABILITY_DIGEST_SCOUT_NAME,
+        description:
+            'Creates a concise, low-noise daily digest from the AI observability dashboard, errors, costly users, and online evaluations.',
+        body: `# AI observability daily digest
+
+Create one concise, actionable AI observability digest for the previous complete 24 hours in the project's timezone. Compare it with the preceding 24 hours, the recent 7-day baseline, and the same weekday when traffic is seasonal. Never compare a complete period with a partial one.
+
+## Avoid noise
+
+First read this scout's last 14 days of run summaries with \`scout-runs-list\`, relevant details with \`scout-runs-retrieve\`, and prior baselines or known noise with \`scout-scratchpad-search\`. Use \`inbox-reports-list\` to check recent digest and issue reports.
+
+Do not repeat an unchanged issue. Include a recurring issue only when it materially worsened, recovered, relapsed, gained useful new evidence, or now needs a different action. Past digests are context, not reports to edit.
+
+## Review these surfaces
+
+- **Dashboard:** Discover the current dashboard at run time with \`dashboards-get-all\`, filtering for the \`llm-analytics\` tag or the "AI observability default" name. Then use \`dashboard-get\` and \`dashboard-insights-run\`. Review its insights for material changes in usage, cost, latency, errors, or performance.
+- **Errors:** Read \`posthog:exploring-ai-failures\` and \`posthog:exploring-llm-traces\`. Investigate new or changed error patterns and open representative traces. Exclude expected cancellations, test traffic, known provider incidents, and recorded noise.
+- **Costly users:** Read \`posthog:analyzing-expensive-users\` and \`posthog:exploring-llm-costs\`. Never report a user merely for ranking highly or spending a lot. Include a user-level pattern only when it is extraordinary against the project baseline and reveals a controllable cause, such as a retry loop, incorrect model choice, bloated context, missing caching, abuse, or a product bug. Minimize personal data.
+- **Online evaluations:** Read \`posthog:exploring-llm-evaluations\`. Inspect enabled evaluation configs and recent \`$ai_evaluation\` results for material pass-rate regressions, failure or N/A surges, missing expected results, or broken configuration. Localize the cause before including it.
+- **Code, when available:** Use read-only repository access only to validate a likely cause or identify the relevant code and owner. Cite the path or commit. Do not speculate or block the digest when code access is unavailable.
+
+Use the project's real dimensions. Validate aggregates with representative traces, evaluation runs, or direct evidence. Every included item must lead to a concrete next action on code, configuration, prompts, evaluations, model choice, caching, limits, or further investigation.
+
+## Produce one digest
+
+Create at most one report per run. It is the daily digest, never one report per finding. If no actionable or extraordinary finding clears the bar, create no report.
+
+Title it \`AI observability daily digest: YYYY-MM-DD\`. Keep the summary under 180 words with one to three bullets, ordered by impact. Each bullet must state:
+
+- what changed, with the comparison window and only the numbers needed to judge it;
+- why it matters and which model, feature, workflow, evaluation, or user segment is affected;
+- the evidence-backed cause or best next investigation;
+- a specific next action, including the likely owner when known.
+
+Include direct links or IDs for the best evidence. Do not include routine metrics, unchanged leaderboards, raw query output, or filler. Write for a reader with no prior context.
+
+Update the scratchpad with useful baselines, noise, and dedupe decisions so tomorrow's run can avoid repeating work. Finish the run with one short note about what you checked and why you did or did not create the digest.`,
+        config: {
+            enabled: true,
+            emit: true,
+            run_interval_minutes: 1440,
+            run_cron_schedule: '0 9 * * *',
+        },
+    }
+}
+
+export function AIObservabilityDigestScoutButton(): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    if (!featureFlags[FEATURE_FLAGS.AI_OBSERVABILITY_DAILY_DIGEST_SCOUT]) {
+        return null
+    }
+
+    return (
+        <ScoutCreateButton
+            creationMode="manual"
+            initialValues={getAIObservabilityDigestScoutInitialValues()}
+            type="secondary"
+            data-attr="create-ai-observability-digest-scout"
+        >
+            Create daily digest
+        </ScoutCreateButton>
+    )
+}

--- a/products/ai_observability/frontend/AIObservabilityScene.tsx
+++ b/products/ai_observability/frontend/AIObservabilityScene.tsx
@@ -32,6 +32,7 @@ import { isEventsQuery } from '~/queries/utils'
 import { AccessControlLevel, AccessControlResourceType, DashboardPlacement, EventType } from '~/types'
 
 import { aiObservabilityColumnRenderers } from './aiObservabilityColumnRenderers'
+import { AIObservabilityDigestScoutButton } from './AIObservabilityDigestScoutButton'
 import { AIObservabilityErrors } from './AIObservabilityErrors'
 import { AIObservabilityReloadAction } from './AIObservabilityReloadAction'
 import { AIObservabilitySessionsPlaylist } from './AIObservabilitySessionsPlaylist'
@@ -619,6 +620,7 @@ function AIObservabilitySceneContent(): JSX.Element {
                 }}
                 actions={
                     <>
+                        {activeTab === 'dashboard' ? <AIObservabilityDigestScoutButton /> : null}
                         <LemonButton
                             to={DOCS_URLS_BY_TAB[activeTab] || DEFAULT_DOCS_URL}
                             type="secondary"


### PR DESCRIPTION
## Problem

AI observability users need a quick way to create a useful daily Scout without manually rebuilding its schedule and investigation prompt. The digest should surface actionable changes without repeating unchanged findings.

## Changes

- Add a feature-flagged Create daily digest action to the AI observability dashboard.
- Open the manual Scout form with a daily 9 a.m. schedule and an actionable, low-noise digest prompt.
- Discover the current AI observability dashboard at run time and review dashboard insights, errors, extraordinary costly-user patterns, online evaluations, and available code context.
- Support direct manual creation through the reusable Scout button.
- Reuse the Slack workspace and channel destination control in both create and edit forms, and include the chosen destination in the create request.

## How did you test this code?

- Automated tests cover direct manual creation, prefilled values, single-report guidance, feature-flag visibility, destination visibility, and destination submission.
- Frontend type checking passed.
- I did not run manual browser testing or capture a screenshot.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update. This is a feature-flagged entry point for the existing Scout workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed Codex desktop to implement and prepare this PR. Session: local Codex desktop task with no public session link. Skills used: /writing-tests, /posthog-efficient-validation, /llma-git-workflow, and /create-pr.

The prompt discovers the dashboard at run time instead of storing a dashboard ID, creates at most one digest, requires concrete actions, and uses prior runs to suppress repeated noise. The button has its own AI observability feature flag so it can roll out independently. The create and edit forms now share one Slack destination component so their behavior stays aligned.