### PR TITLE
fix(google_analytics): classify exhausted quota retries as retryable noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/google_analytics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/google_analytics.py
@@ -61,6 +61,8 @@ class GoogleAnalyticsQuotaExceededError(Exception):
     Deliberately NOT matched by `get_non_retryable_errors` so Temporal retries
     the activity later (the resumable source picks up from the last saved
     chunk), which is the right recovery for hourly/daily property token quotas.
+    Tagged `(retryable)` so `GoogleAnalyticsSource.get_retryable_errors` can
+    keep this self-recovering failure out of error tracking.
     """
 
 
@@ -207,7 +209,8 @@ def _run_report(
         if attempt == RUNREPORT_MAX_RETRIES:
             if is_quota:
                 raise GoogleAnalyticsQuotaExceededError(
-                    f"Data API quota for property '{pid}' still exhausted after {RUNREPORT_MAX_RETRIES} retries"
+                    f"Data API quota for property '{pid}' still exhausted after "
+                    f"{RUNREPORT_MAX_RETRIES} retries (retryable)"
                 )
             # A transient 5xx that never cleared — surface the HTTPError so Temporal retries the activity.
             response.raise_for_status()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
@@ -68,6 +68,13 @@ class GoogleAnalyticsSource(ResumableSource[GoogleAnalyticsSourceConfig, GoogleA
             "ACCESS_TOKEN_SCOPE_INSUFFICIENT": "Insufficient permissions. Please reconnect your Google Analytics account with the required scopes.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_run_report` already retries Data API quota exhaustion in-line with backoff; if it's
+        # still exhausted once those retries run out, the property's token quota refills over
+        # time and the resumable source picks up from the last saved chunk, so let Temporal
+        # retry the activity without paging it as a bug.
+        return {"(retryable)"}
+
     def get_schemas(
         self,
         config: GoogleAnalyticsSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
@@ -246,3 +246,9 @@ def test_non_retryable_errors_cover_auth_failures():
     assert "401 Client Error" in errors
     assert "403 Client Error" in errors
     assert "ACCESS_TOKEN_SCOPE_INSUFFICIENT" in errors
+
+
+def test_retryable_errors_cover_exhausted_quota_retries():
+    error_msg = "Data API quota for property '123456789' still exhausted after 5 retries (retryable)"
+    patterns = GoogleAnalyticsSource().get_retryable_errors()
+    assert any(pattern in error_msg for pattern in patterns)


### PR DESCRIPTION
## Problem

Error tracking surfaced a `GoogleAnalyticsQuotaExceededError` ("Data API quota for property '...' still exhausted after 5 retries") from `_run_report` in the Google Analytics data-warehouse source, tracked as an exception/bug.

Looking at the code, this failure is already handled correctly: `_run_report` retries a 429 (quota exhausted) response in-line with backoff, and only raises `GoogleAnalyticsQuotaExceededError` once those retries are exhausted. The error is deliberately *not* listed in `get_non_retryable_errors`, so Temporal retries the whole activity, and the resumable source manager picks up from the last saved chunk. It's a transient, self-recovering GA4 property token-quota issue, not a bug in our code.

The gap: the framework has a `get_retryable_errors()` hook (see `ResumableSource.get_retryable_errors` and its use in `_handle_import_error`) specifically for "source already retried this internally, still exhausted, but it's self-recovering" failures — matching errors get logged at `warning` instead of `exception`, keeping them out of error tracking. Several other sources already use it for the same pattern (Hubspot, Mixpanel, Meta Ads, Twelve Data, ...), but `GoogleAnalyticsSource` never overrode it, so this error fell through to the default exception-tracking path.

## Changes

- Tag the exhausted-quota message raised by `_run_report` with `(retryable)`, matching the convention used by other sources.
- Add `GoogleAnalyticsSource.get_retryable_errors()` matching that tag, so Temporal's retry-and-recover is logged as a warning instead of being tracked as an exception.
- No retry policy, backoff, or timeout behavior changes — this only changes how the already-correct retry outcome is logged/tracked.

## How did you test this code?

Added `test_retryable_errors_cover_exhausted_quota_retries`, asserting the tagged exhausted-quota message is matched by `get_retryable_errors()` (mirrors the existing `test_non_retryable_errors_cover_auth_failures` test for the non-retryable side).

Ran the full google_analytics source test suite locally:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/` — 88 passed
- `uv run ruff check` / `ruff format --check` on the changed files — clean
- `uv run mypy` on the changed files — no issues

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification change, no user-facing or API behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) investigated a PostHog error-tracking issue for the `google_analytics` warehouse source, confirmed the exception genuinely originates in `google_analytics.py`, read the surrounding retry/resumable-source code, and found the existing `get_retryable_errors()` convention used by sibling sources (Hubspot's [#73482](https://github.com/PostHog/posthog/pull/73482) was the most recent precedent) that this source was missing. No skills were invoked for this change; it's a small, source-scoped classification fix following an established in-repo pattern.