### PR TITLE
feat(mcp): trim warehouse source tool payloads

### DIFF
--- a/products/warehouse_sources/mcp/tools.yaml
+++ b/products/warehouse_sources/mcp/tools.yaml
@@ -374,13 +374,27 @@ tools:
             instead of telling the user the data isn't available. Lists every configured import source with its type
             (Postgres, Stripe, Hubspot, etc.), connection status, prefix, schemas, latest error, and last sync
             timestamp. If nothing relevant is connected, offer to set one up with 'data-warehouse-source-setup'.
-            Per-schema column definitions are omitted to keep the payload small — to look up a single table's sync
-            status by name use external-data-schemas-list with a search, and to see a table's columns use
-            external-data-schemas-retrieve.
+            Each schema is summarized (name, status, sync type/frequency, last sync, error, table name, row count) —
+            column definitions and full sync configuration (incremental field, primary keys, row filters, column
+            selection) are on external-data-schemas-retrieve. To look up a single table's sync status by name use
+            external-data-schemas-list with a search.
         response:
             exclude:
                 - schemas.*.table.columns
                 - schemas.*.available_columns
+                - schemas.*.label
+                - schemas.*.description
+                - schemas.*.incremental_field
+                - schemas.*.incremental_field_type
+                - schemas.*.incremental_field_lookback_seconds
+                - schemas.*.sync_time_of_day
+                - schemas.*.primary_key_columns
+                - schemas.*.cdc_table_mode
+                - schemas.*.enabled_columns
+                - schemas.*.row_filters
+                - schemas.*.source
+                - schemas.*.api_version
+                - schemas.*.api_version_deprecation
     external-data-sources-oauth-accounts-retrieve:
         operation: external_data_sources_oauth_accounts_retrieve
         enabled: false
@@ -474,7 +488,13 @@ tools:
         title: Get data warehouse source
         description: >
             Get a single data warehouse source by ID. Returns full details including source type, connection status,
-            prefix, all table schemas with their sync statuses, latest error, and last sync timestamp.
+            prefix, all table schemas with their sync statuses, latest error, and last sync timestamp. Per-schema
+            column definitions are omitted to keep the payload small — use external-data-schemas-retrieve for a
+            single table's columns.
+        response:
+            exclude:
+                - schemas.*.table.columns
+                - schemas.*.available_columns
     external-data-sources-revenue-analytics-config-partial-update:
         operation: external_data_sources_revenue_analytics_config_partial_update
         enabled: false
@@ -540,7 +560,8 @@ tools:
             source type: the required fields (host, port, database, credentials, etc.), field types, and OAuth flows, so
             you know what a connection needs. ALWAYS pass 'source_type' with the specific kind(s) you need
             (comma-separated, e.g. 'Postgres,Stripe') — the unfiltered response describes every source and is very large
-            (hundreds of KB). Only omit 'source_type' if you genuinely need to enumerate every available type. To
+            (hundreds of KB). Only omit 'source_type' if you genuinely need to enumerate every available type — and
+            when enumerating, pass fields: ['*.name', '*.caption'] to skip the large per-source field definitions. To
             actually connect a source, prefer 'data-warehouse-source-setup'.
         response:
             include:
@@ -550,3 +571,4 @@ tools:
                 - '*.featured'
                 - '*.unreleasedSource'
                 - '*.fields'
+            selectable: true

--- a/products/warehouse_sources/mcp/tools.yaml
+++ b/products/warehouse_sources/mcp/tools.yaml
@@ -373,10 +373,10 @@ tools:
             support-ticket, or product-database question — call this first so you JOIN against an existing source
             instead of telling the user the data isn't available. Lists every configured import source with its type
             (Postgres, Stripe, Hubspot, etc.), connection status, prefix, schemas, latest error, and last sync
-            timestamp. If nothing relevant is connected, offer to set one up with 'data-warehouse-source-setup'.
-            Each schema is summarized (name, status, sync type/frequency, last sync, error, table name, row count) —
-            column definitions and full sync configuration (incremental field, primary keys, row filters, column
-            selection) are on external-data-schemas-retrieve. To look up a single table's sync status by name use
+            timestamp. If nothing relevant is connected, offer to set one up with 'data-warehouse-source-setup'. Each
+            schema is summarized (name, status, sync type/frequency, last sync, error, table name, row count) — column
+            definitions and full sync configuration (incremental field, primary keys, row filters, column selection) are
+            on external-data-schemas-retrieve. To look up a single table's sync status by name use
             external-data-schemas-list with a search.
         response:
             exclude:
@@ -488,9 +488,9 @@ tools:
         title: Get data warehouse source
         description: >
             Get a single data warehouse source by ID. Returns full details including source type, connection status,
-            prefix, all table schemas with their sync statuses, latest error, and last sync timestamp. Per-schema
-            column definitions are omitted to keep the payload small — use external-data-schemas-retrieve for a
-            single table's columns.
+            prefix, all table schemas with their sync statuses, latest error, and last sync timestamp. Per-schema column
+            definitions are omitted to keep the payload small — use external-data-schemas-retrieve for a single table's
+            columns.
         response:
             exclude:
                 - schemas.*.table.columns
@@ -560,8 +560,8 @@ tools:
             source type: the required fields (host, port, database, credentials, etc.), field types, and OAuth flows, so
             you know what a connection needs. ALWAYS pass 'source_type' with the specific kind(s) you need
             (comma-separated, e.g. 'Postgres,Stripe') — the unfiltered response describes every source and is very large
-            (hundreds of KB). Only omit 'source_type' if you genuinely need to enumerate every available type — and
-            when enumerating, pass fields: ['*.name', '*.caption'] to skip the large per-source field definitions. To
+            (hundreds of KB). Only omit 'source_type' if you genuinely need to enumerate every available type — and when
+            enumerating, pass fields: ['*.name', '*.caption'] to skip the large per-source field definitions. To
             actually connect a source, prefer 'data-warehouse-source-setup'.
         response:
             include:

--- a/products/warehouse_sources/skills/setting-up-a-data-warehouse-source/SKILL.md
+++ b/products/warehouse_sources/skills/setting-up-a-data-warehouse-source/SKILL.md
@@ -133,11 +133,12 @@ to `external-data-sources-create` — you need the db-schema response to build a
 
 Call `external-data-sources-wizard` **with `source_type` set to the kind(s) you need** (comma-separated, e.g.
 `Postgres,Stripe`). The unfiltered response describes every supported source and is hundreds of KB — large enough to
-blow your context budget. Only omit `source_type` when you genuinely need to enumerate every available type, and
-expect a big payload if you do. The response is a dict keyed by source type. Each entry describes:
+blow your context budget. Only omit `source_type` when you genuinely need to enumerate every available type, and when
+you do, pass `fields: ['*.name', '*.caption']` so the response carries just the names instead of every source's config
+field definitions. The response is a dict keyed by source type. Each entry describes:
 
 - `name` — the canonical source_type string you'll pass to later calls (e.g. `"Postgres"`, `"Stripe"`, `"Hubspot"`).
-- `label` / `caption` — human-readable.
+- `caption` — human-readable description.
 - `fields` — the config fields needed (host, port, database, api_key, client_id/secret, ...). Each has `name`,
   `type` (input, password, switch, select, file-upload), and `required`.
 - `featured`, `unreleasedSource` — use to gauge readiness. Skip sources marked `unreleasedSource: true` unless the

--- a/products/warehouse_sources/skills/suggesting-data-imports/SKILL.md
+++ b/products/warehouse_sources/skills/suggesting-data-imports/SKILL.md
@@ -42,7 +42,9 @@ Also query `system.information_schema.tables` with `posthog:execute-sql` to see 
 
 ### 3. Identify the right source type
 
-If the data isn't imported yet, call `posthog:external-data-sources-wizard` to see available source types. Match the user's need to a source:
+If the data isn't imported yet, call `posthog:external-data-sources-wizard` to see available source types — when
+enumerating without `source_type`, pass `fields: ['*.name', '*.caption']` to skip the large per-source config field
+definitions. Match the user's need to a source:
 
 **Common patterns:**
 
@@ -98,7 +100,7 @@ Common join patterns:
 - `posthog:external-data-sources-list`: Check existing source connections
 - `posthog:external-data-schemas-list`: Check what tables are already imported
 - `posthog:execute-sql` over `system.information_schema.*`: See all queryable tables including views
-- `posthog:external-data-sources-wizard`: Get available source types
+- `posthog:external-data-sources-wizard`: Get available source types (pass `fields: ['*.name', '*.caption']` when enumerating)
 - `posthog:data-warehouse-source-connect-link`: Get a secure browser/OAuth link to collect credentials
 - `posthog:data-warehouse-source-setup`: One-step create (validate, discover tables, apply sync defaults, create)
 - `posthog:execute-sql`: Run queries to demonstrate what's possible

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4352,7 +4352,7 @@
         }
     },
     "external-data-sources-list": {
-        "description": "Check what external data is already connected before answering any revenue, billing, subscription, CRM, support-ticket, or product-database question — call this first so you JOIN against an existing source instead of telling the user the data isn't available. Lists every configured import source with its type (Postgres, Stripe, Hubspot, etc.), connection status, prefix, schemas, latest error, and last sync timestamp. If nothing relevant is connected, offer to set one up with 'data-warehouse-source-setup'. Per-schema column definitions are omitted to keep the payload small — to look up a single table's sync status by name use external-data-schemas-list with a search, and to see a table's columns use external-data-schemas-retrieve.",
+        "description": "Check what external data is already connected before answering any revenue, billing, subscription, CRM, support-ticket, or product-database question — call this first so you JOIN against an existing source instead of telling the user the data isn't available. Lists every configured import source with its type (Postgres, Stripe, Hubspot, etc.), connection status, prefix, schemas, latest error, and last sync timestamp. If nothing relevant is connected, offer to set one up with 'data-warehouse-source-setup'. Each schema is summarized (name, status, sync type/frequency, last sync, error, table name, row count) — column definitions and full sync configuration (incremental field, primary keys, row filters, column selection) are on external-data-schemas-retrieve. To look up a single table's sync status by name use external-data-schemas-list with a search.",
         "category": "Warehouse sources",
         "feature": "warehouse_sources",
         "summary": "List data warehouse sources",
@@ -4422,7 +4422,7 @@
         }
     },
     "external-data-sources-retrieve": {
-        "description": "Get a single data warehouse source by ID. Returns full details including source type, connection status, prefix, all table schemas with their sync statuses, latest error, and last sync timestamp.",
+        "description": "Get a single data warehouse source by ID. Returns full details including source type, connection status, prefix, all table schemas with their sync statuses, latest error, and last sync timestamp. Per-schema column definitions are omitted to keep the payload small — use external-data-schemas-retrieve for a single table's columns.",
         "category": "Warehouse sources",
         "feature": "warehouse_sources",
         "summary": "Get data warehouse source",
@@ -4464,7 +4464,7 @@
         }
     },
     "external-data-sources-wizard": {
-        "description": "Use this whenever the user needs data PostHog doesn't capture natively — revenue and payments (Stripe, Chargebee), CRM contacts and deals (Hubspot, Salesforce), support tickets (Zendesk), e-commerce orders (Shopify), ad spend, or their own application/production database (Postgres, MySQL, BigQuery, Snowflake) — or when a HogQL query fails because the table doesn't exist yet. Importing turns that data into queryable warehouse tables you can JOIN against product events. Returns the configuration metadata for every supported source type: the required fields (host, port, database, credentials, etc.), field types, and OAuth flows, so you know what a connection needs. ALWAYS pass 'source_type' with the specific kind(s) you need (comma-separated, e.g. 'Postgres,Stripe') — the unfiltered response describes every source and is very large (hundreds of KB). Only omit 'source_type' if you genuinely need to enumerate every available type. To actually connect a source, prefer 'data-warehouse-source-setup'.",
+        "description": "Use this whenever the user needs data PostHog doesn't capture natively — revenue and payments (Stripe, Chargebee), CRM contacts and deals (Hubspot, Salesforce), support tickets (Zendesk), e-commerce orders (Shopify), ad spend, or their own application/production database (Postgres, MySQL, BigQuery, Snowflake) — or when a HogQL query fails because the table doesn't exist yet. Importing turns that data into queryable warehouse tables you can JOIN against product events. Returns the configuration metadata for every supported source type: the required fields (host, port, database, credentials, etc.), field types, and OAuth flows, so you know what a connection needs. ALWAYS pass 'source_type' with the specific kind(s) you need (comma-separated, e.g. 'Postgres,Stripe') — the unfiltered response describes every source and is very large (hundreds of KB). Only omit 'source_type' if you genuinely need to enumerate every available type — and when enumerating, pass fields: ['*.name', '*.caption'] to skip the large per-source field definitions. To actually connect a source, prefer 'data-warehouse-source-setup'.",
         "category": "Warehouse sources",
         "feature": "warehouse_sources",
         "summary": "List data warehouse source types you can import",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -4577,7 +4577,7 @@
         }
     },
     "external-data-sources-list": {
-        "description": "Check what external data is already connected before answering any revenue, billing, subscription, CRM, support-ticket, or product-database question — call this first so you JOIN against an existing source instead of telling the user the data isn't available. Lists every configured import source with its type (Postgres, Stripe, Hubspot, etc.), connection status, prefix, schemas, latest error, and last sync timestamp. If nothing relevant is connected, offer to set one up with 'data-warehouse-source-setup'. Per-schema column definitions are omitted to keep the payload small — to look up a single table's sync status by name use external-data-schemas-list with a search, and to see a table's columns use external-data-schemas-retrieve.",
+        "description": "Check what external data is already connected before answering any revenue, billing, subscription, CRM, support-ticket, or product-database question — call this first so you JOIN against an existing source instead of telling the user the data isn't available. Lists every configured import source with its type (Postgres, Stripe, Hubspot, etc.), connection status, prefix, schemas, latest error, and last sync timestamp. If nothing relevant is connected, offer to set one up with 'data-warehouse-source-setup'. Each schema is summarized (name, status, sync type/frequency, last sync, error, table name, row count) — column definitions and full sync configuration (incremental field, primary keys, row filters, column selection) are on external-data-schemas-retrieve. To look up a single table's sync status by name use external-data-schemas-list with a search.",
         "category": "Warehouse sources",
         "feature": "warehouse_sources",
         "summary": "List data warehouse sources",
@@ -4661,7 +4661,7 @@
         }
     },
     "external-data-sources-retrieve": {
-        "description": "Get a single data warehouse source by ID. Returns full details including source type, connection status, prefix, all table schemas with their sync statuses, latest error, and last sync timestamp.",
+        "description": "Get a single data warehouse source by ID. Returns full details including source type, connection status, prefix, all table schemas with their sync statuses, latest error, and last sync timestamp. Per-schema column definitions are omitted to keep the payload small — use external-data-schemas-retrieve for a single table's columns.",
         "category": "Warehouse sources",
         "feature": "warehouse_sources",
         "summary": "Get data warehouse source",
@@ -4703,7 +4703,7 @@
         }
     },
     "external-data-sources-wizard": {
-        "description": "Use this whenever the user needs data PostHog doesn't capture natively — revenue and payments (Stripe, Chargebee), CRM contacts and deals (Hubspot, Salesforce), support tickets (Zendesk), e-commerce orders (Shopify), ad spend, or their own application/production database (Postgres, MySQL, BigQuery, Snowflake) — or when a HogQL query fails because the table doesn't exist yet. Importing turns that data into queryable warehouse tables you can JOIN against product events. Returns the configuration metadata for every supported source type: the required fields (host, port, database, credentials, etc.), field types, and OAuth flows, so you know what a connection needs. ALWAYS pass 'source_type' with the specific kind(s) you need (comma-separated, e.g. 'Postgres,Stripe') — the unfiltered response describes every source and is very large (hundreds of KB). Only omit 'source_type' if you genuinely need to enumerate every available type. To actually connect a source, prefer 'data-warehouse-source-setup'.",
+        "description": "Use this whenever the user needs data PostHog doesn't capture natively — revenue and payments (Stripe, Chargebee), CRM contacts and deals (Hubspot, Salesforce), support tickets (Zendesk), e-commerce orders (Shopify), ad spend, or their own application/production database (Postgres, MySQL, BigQuery, Snowflake) — or when a HogQL query fails because the table doesn't exist yet. Importing turns that data into queryable warehouse tables you can JOIN against product events. Returns the configuration metadata for every supported source type: the required fields (host, port, database, credentials, etc.), field types, and OAuth flows, so you know what a connection needs. ALWAYS pass 'source_type' with the specific kind(s) you need (comma-separated, e.g. 'Postgres,Stripe') — the unfiltered response describes every source and is very large (hundreds of KB). Only omit 'source_type' if you genuinely need to enumerate every available type — and when enumerating, pass fields: ['*.name', '*.caption'] to skip the large per-source field definitions. To actually connect a source, prefer 'data-warehouse-source-setup'.",
         "category": "Warehouse sources",
         "feature": "warehouse_sources",
         "summary": "List data warehouse source types you can import",

--- a/services/mcp/src/tools/generated/warehouse_sources.ts
+++ b/services/mcp/src/tools/generated/warehouse_sources.ts
@@ -645,7 +645,23 @@ const externalDataSourcesList = (): ToolBase<
         const filtered = {
             ...result,
             results: (result.results ?? []).map((item: any) =>
-                omitResponseFields(item, ['schemas.*.table.columns', 'schemas.*.available_columns'])
+                omitResponseFields(item, [
+                    'schemas.*.table.columns',
+                    'schemas.*.available_columns',
+                    'schemas.*.label',
+                    'schemas.*.description',
+                    'schemas.*.incremental_field',
+                    'schemas.*.incremental_field_type',
+                    'schemas.*.incremental_field_lookback_seconds',
+                    'schemas.*.sync_time_of_day',
+                    'schemas.*.primary_key_columns',
+                    'schemas.*.cdc_table_mode',
+                    'schemas.*.enabled_columns',
+                    'schemas.*.row_filters',
+                    'schemas.*.source',
+                    'schemas.*.api_version',
+                    'schemas.*.api_version_deprecation',
+                ])
             ),
         } as typeof result
         return await withPostHogUrl(context, filtered, '/data-management/sources')
@@ -792,7 +808,11 @@ const externalDataSourcesRetrieve = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/external_data_sources/${encodeURIComponent(String(params.id))}/`,
         })
-        return result
+        const filtered = omitResponseFields(result, [
+            'schemas.*.table.columns',
+            'schemas.*.available_columns',
+        ]) as typeof result
+        return filtered
     },
 })
 
@@ -865,7 +885,15 @@ const externalDataSourcesWebhookInfoRetrieve = (): ToolBase<
     },
 })
 
-const ExternalDataSourcesWizardSchema = ExternalDataSourcesWizardRetrieveQueryParams
+const ExternalDataSourcesWizardSchema = ExternalDataSourcesWizardRetrieveQueryParams.extend({
+    fields: z
+        .array(z.enum(['*.name', '*.caption', '*.docsUrl', '*.featured', '*.unreleasedSource', '*.fields']))
+        .min(1)
+        .optional()
+        .describe(
+            'Optional subset of response fields to return, each a dot-path from the allowlist. Omit to return all fields. Request only the fields your task needs to keep responses small.'
+        ),
+})
 
 const externalDataSourcesWizard = (): ToolBase<typeof ExternalDataSourcesWizardSchema, unknown> => ({
     name: 'external-data-sources-wizard',
@@ -879,14 +907,12 @@ const externalDataSourcesWizard = (): ToolBase<typeof ExternalDataSourcesWizardS
                 source_type: params.source_type,
             },
         })
-        const filtered = pickResponseFields(result, [
-            '*.name',
-            '*.caption',
-            '*.docsUrl',
-            '*.featured',
-            '*.unreleasedSource',
-            '*.fields',
-        ]) as typeof result
+        const filtered = pickResponseFields(
+            result,
+            params.fields?.length
+                ? params.fields
+                : ['*.name', '*.caption', '*.docsUrl', '*.featured', '*.unreleasedSource', '*.fields']
+        ) as typeof result
         return filtered
     },
 })

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/external-data-sources-wizard.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/external-data-sources-wizard.json
@@ -1,6 +1,15 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "fields": {
+            "description": "Optional subset of response fields to return, each a dot-path from the allowlist. Omit to return all fields. Request only the fields your task needs to keep responses small.",
+            "items": {
+                "enum": ["*.name", "*.caption", "*.docsUrl", "*.featured", "*.unreleasedSource", "*.fields"],
+                "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+        },
         "source_type": {
             "description": "Comma-separated source type(s) to return config for, e.g. 'Postgres' or 'Postgres,Stripe'. Strongly recommended: the unfiltered response describes every supported source and is very large. Omit only to enumerate the available types.",
             "type": "string"


### PR DESCRIPTION
## Problem

MCP tool responses are injected verbatim into an agent's context window, and the warehouse sources tools return far more than agents need:

- `external-data-sources-retrieve` has no response filtering, so getting one source inlines every schema's full column list twice (`table.columns` and `available_columns` are near duplicates). Measured on a small 5-table source: 15.5 KB, about 70% of it columns. Wide database sources exceed 90%.
- `external-data-sources-list` already strips columns, but still inlines full 24-field schema objects where most fields are sync configuration (row filters, incremental settings, column selection) that is irrelevant to "what's connected and is it healthy". On an internal dogfood project with ~80 sources, a default list call returns ~400 KB, roughly 100k tokens in a single tool response.
- `external-data-sources-wizard` has a fixed response allowlist, so enumerating available source types still pulls the large per-source `fields` form definitions.

Same lens as #73526 and #73534, applied to agent context instead of browser payloads.

## Changes

- **retrieve**: add `response.exclude` for `schemas.*.table.columns` and `schemas.*.available_columns`, mirroring the list tool. The description now routes agents to `external-data-schemas-retrieve` for a single table's columns.
- **list**: extend `response.exclude` with 13 per-schema config-detail fields. Each schema keeps a health summary: `id`, `name`, `status`, `should_sync`, `sync_type`, `sync_frequency`, `incremental`, `last_synced_at`, `latest_error`, and `table` (HogQL name and row count).
- **wizard**: `response.selectable: true` adds an optional `fields` param constrained to the existing include allowlist. The description tells enumerating agents to pass `['*.name', '*.caption']`.

All filtering happens in the generated MCP handlers (`omitResponseFields` / `pickResponseFields`); regenerated outputs are committed.

### Impact (measured baseline, computed after)

| Call | Before | After | Reduction |
| --- | --- | --- | --- |
| retrieve, small 5-table source | 15.5 KB | ~4.6 KB | ~70% |
| retrieve, wide database source | dominated by columns | columns removed | 90%+ |
| list, project with ~80 sources | ~400 KB (~100k tokens) | ~200 KB | ~45-55% |
| wizard, enumerating types with `fields: ['*.name', '*.caption']` | full allowlist per type | name + caption only | ~80-90% |

### Side effects and risks

- **No REST API change.** Filtering is MCP-server-side only; the Django endpoints, the app UI, and generated frontend types are untouched.
- **No data becomes unreachable.** Column definitions and full sync configuration remain available through `external-data-schemas-retrieve`, and both tool descriptions now say so. An agent that previously read a config field (e.g. `incremental_field`) from the sources list output now needs one extra targeted call.
- **Skills verified.** No skill under `products/warehouse_sources/skills/` reads the excluded fields from these two tools' outputs; they use them for `status`/`latest_error` and already route config reads through `external-data-schemas-retrieve`.
- **Wizard param is additive.** Omitting `fields` keeps today's behavior, and the generated handler enumerates query params, so `fields` cannot leak into the upstream API request.

## How did you test this code?

- `pnpm --filter=@posthog/mcp run typecheck` and `run test`: 2445 tests pass. The wizard input-schema snapshot was regenerated and now locks in the new optional `fields` param.
- Regenerated everything with `hogli build:openapi` and committed all outputs; `pnpm --filter=@posthog/mcp run fix` clean.
- The baseline payload numbers come from real MCP calls made before the change. I (well, Claude) could not run the patched MCP server against production data, so the "after" numbers are computed by removing the excluded fields from those same measured responses.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

MCP tool docs are generated from the YAML definitions; no manual docs to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel spotted UI papercuts while dogfooding (#73526, #73534) and asked for the same treatment on the MCP surface of warehouse sources. Claude Code (Fable) explored the tool configs, measured real response sizes over MCP, and produced a ranked plan; this PR is the first (YAML-only) slice of it.

Skills invoked: `/implementing-mcp-tools`.

Decisions along the way: extended `exclude` on the list tool rather than switching to `include` + `selectable`, so new source-level serializer fields are not silently dropped; left the backend `include_columns` gating for retrieve untouched because the source settings UI consumes `available_columns` from that endpoint; confirmed the YAML-disabled jobs/db-schema/sync-logs operations are intentional (hand-written tools cover them) before scoping this change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
