### PR TITLE
fix(signals): Divorce Inbox manual "Create PR" from tasks flag

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -156,6 +156,7 @@ __all__ = [
     "get_task_run_stream_info",
     "get_task_summaries",
     "is_internal_debug_team",
+    "is_signal_report_task",
     "is_task_controllable_by_user",
     "is_valid_sandbox_env_var_key",
     "latest_task_run_pr_merged_subquery",
@@ -504,6 +505,24 @@ def get_task_id_for_run(run_id: str | UUID, team_id: int) -> UUID | None:
 def task_exists(task_id: str | UUID, team_id: int) -> bool:
     """Whether a (non-deleted) task exists for the team."""
     return Task.objects.filter(id=task_id, team_id=team_id).exists()
+
+
+def is_signal_report_task(task_id: str | UUID, team_id: int) -> bool:
+    """Whether the task is a genuine Signals report task rather than a PostHog Code task.
+
+    True only when the origin is ``SIGNAL_REPORT`` and it links to a report in this team. The Inbox
+    "Create PR" / "Discuss" actions create such tasks, and acting on them is entitled through
+    self-driving (the ``product-autonomy`` Inbox, which is generally available) — not the PostHog
+    Code (``tasks``) product. So the ``run`` gate skips the Code entitlement for them, matching
+    auto-start, which runs the same tasks server-side without a Code check. The report link is
+    team-scoped by the write serializer, so a caller can't forge it onto another team's report.
+    """
+    return Task.objects.filter(
+        id=task_id,
+        team_id=team_id,
+        origin_product=Task.OriginProduct.SIGNAL_REPORT,
+        signal_report__isnull=False,
+    ).exists()
 
 
 def count_in_progress_runs_for_github_integration(team_id: int, integration_id: int) -> int:

--- a/products/tasks/backend/logic/services/code_usage_gate.py
+++ b/products/tasks/backend/logic/services/code_usage_gate.py
@@ -152,14 +152,18 @@ def code_access_required_response(user) -> Response | None:
     )
 
 
-def cloud_usage_limit_response(user, team_id: int) -> Response | None:
+def cloud_usage_limit_response(user, team_id: int, *, require_tasks_access: bool = True) -> Response | None:
     """Return a blocking response when Desktop access or usage limits deny a cloud run, else None.
 
     Entitlement checks fail closed. Usage checks fail open when the gateway can't be reached.
     Every usage check is counted by outcome (`checked_allowed` / `checked_blocked` / `fail_open`)
     so a degraded gateway silently removing this cost backstop is visible, not just logged.
+
+    ``require_tasks_access`` lets callers whose run is entitled through another product skip the
+    PostHog Code (`tasks`) entitlement check while still applying the usage-limit cost backstop —
+    e.g. running a self-driving report task from the Inbox (see ``is_signal_report_task``).
     """
-    if response := code_access_required_response(user):
+    if require_tasks_access and (response := code_access_required_response(user)):
         return response
 
     usage = get_posthog_code_usage(user, team_id)

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -587,7 +587,16 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if not tasks_facade.task_visible(pk, self.team_id, self._user_id(), for_control=True):
             raise NotFound()
 
-        if (limit_response := cloud_usage_limit_response(request.user, self.team_id)) is not None:
+        # Self-driving report tasks (Inbox "Create PR" / "Discuss") are entitled through the Inbox
+        # (`product-autonomy`), not the PostHog Code (`tasks`) product, so they skip the Code
+        # entitlement check — mirroring auto-start, which runs the same tasks server-side without it.
+        # Usage limits still apply as a cost backstop.
+        require_tasks_access = not tasks_facade.is_signal_report_task(pk, self.team_id)
+        if (
+            limit_response := cloud_usage_limit_response(
+                request.user, self.team_id, require_tasks_access=require_tasks_access
+            )
+        ) is not None:
             return limit_response
 
         result = tasks_facade.run_task(pk, self.team_id, self._user_id(), validated_data=dict(request.validated_data))

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -9435,6 +9435,48 @@ class TestCloudUsageGate(BaseTaskAPITest):
         self.assertTrue(TaskRun.objects.filter(task=task).exists())
         mock_workflow.assert_called_once()
 
+    def _signal_report_task(self):
+        from products.signals.backend.models import SignalReport
+
+        report = SignalReport.objects.create(team=self.team)
+        return Task.objects.create(
+            team=self.team,
+            created_by=self.user,
+            title="Act on report",
+            description="Act on report",
+            origin_product=Task.OriginProduct.SIGNAL_REPORT,
+            signal_report=report,
+        )
+
+    @parameterized.expand(
+        [
+            ("under_limit_runs", CodeUsageStatus(False, None, None, False), status.HTTP_200_OK),
+            ("over_limit_still_blocked", OVER_LIMIT, status.HTTP_429_TOO_MANY_REQUESTS),
+        ]
+    )
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    @patch("products.tasks.backend.logic.services.code_usage_gate.get_posthog_code_usage")
+    def test_run_signal_report_task_bypasses_code_access_but_keeps_usage_backstop(
+        self, _name, gate_return, expected_status, mock_gate, _mock_workflow
+    ):
+        # Self-driving is entitled through the Inbox (`product-autonomy`), not PostHog Code, so a
+        # signal-report task runs with the `tasks` flag off — where a plain task 403s (see
+        # test_run_without_code_access_returns_403_before_usage_check). The usage cost-backstop must
+        # still fire, so an over-limit team is blocked even on the entitlement-bypassed path.
+        self.set_tasks_feature_flag(False)
+        mock_gate.return_value = gate_return
+        task = self._signal_report_task()
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/run/",
+            {"mode": "background"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, expected_status)
+        mock_gate.assert_called_once()
+        self.assertEqual(TaskRun.objects.filter(task=task).exists(), expected_status == status.HTTP_200_OK)
+
 
 class TestGetPosthogCodeUsage(TestCase):
     @override_settings(CLOUD_DEPLOYMENT="US")


### PR DESCRIPTION
## Problem

Self-driving (Inbox) is generally available, but "Create PR" and "Discuss" features run through the `/tasks` `run` endpoint, which gates on `has_tasks_access`. That check only passes for the PostHog Code (`tasks`) allowlist, which is much too stringent.

So a self-driving user who isn't on the `tasks` allowlist can get reports but gets a 403 "PostHog Desktop access is required to run tasks in the cloud" when they do "Create PR" manually. For most reports, the PR is already created (auto-started) without this gate - however Scout reports don't come with a PR (yet).

## Changes

The `run` endpoint now skips the `tasks` check for signal-report tasks.

I think we should ultimately clean things up and just remove the `tasks` gating, but that's linked to the "PostHog AI on sandboxes" migration, and I don't want to muck with that. 

## How did you test this code?

_Claude:_

Added a parameterized case to `TestCloudUsageGate`: a `signal_report` task runs with the `tasks` flag **off** (where a plain task 403s — already covered by `test_run_without_code_access_returns_403_before_usage_check`), and an over-limit team is still blocked with a 429. That locks in the entitlement bypass while proving the usage cost-backstop survives it.