### PR TITLE
feat(conversations): staff-only Plan column with tag-derived triage sort

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6563,13 +6563,13 @@ snapshots:
     scenes-app-notebooks-nodes-customer-journey--with-optional-steps--light:
         hash: v1.k794b7964.121bfeb17a2130a74bda0cb2ba561f6c56e11c13834033a3ef39dd40432271cc.pSCqPjfCB9aUr8yyJ1xkpyRu8z5jlnGD8kHMWg-Ynpg
     scenes-app-notebooks-nodes-support-tickets--empty--dark:
-        hash: v1.k794b7964.c10ab277396f4beab2f74bd77e785c75ede9f45b685c4255f9f89741035acf49.xcNVKC2tTI9utsycdzLuJmWfAsvCvh_Zib3ioZFfiTA
+        hash: v1.k794b7964.5a04d61784a3c9b2d3da23df09c408c6c6c3f3c7261ec4a4a2d88ace3225f09c.3IjPAy5Z34Diq97v7AUN-qvRSZ7cmf1MZ4NyHgCf9yY
     scenes-app-notebooks-nodes-support-tickets--empty--light:
-        hash: v1.k794b7964.8f8b52acc8bb55637bd7f08900e425729d2260849d4f736596afaa809a4db2d7.XS5NtFMSF3rgnNJsHwnpuDCZv4JAImonICFoLfT5zHI
+        hash: v1.k794b7964.f5558720a864ec918d1edde7b332df03b933fe7b8ab85c464634f858def9dcad.tEkVKMHVabzSA-doaMKmRr5EOGSWAideSOEWp2CKHx0
     scenes-app-notebooks-nodes-support-tickets--with-tickets--dark:
-        hash: v1.k794b7964.3cf38fb9c9a40942eece565d903573597c3d904666c6384a5bab2cbcf9644a5d.E9uJYL0s1GLzlbYJOal_S-NOkj6ht4j_DzLSWuq4WW4
+        hash: v1.k794b7964.2e67f3c43553b24d9d2fe98c009b3e4d713a94efed1c9213314d18d85f66a22b.3Tm02nOTsVIYJeL2GRnxd3WuExdt4RNPyfSti0wGgJ8
     scenes-app-notebooks-nodes-support-tickets--with-tickets--light:
-        hash: v1.k794b7964.5006f99a89dd836d27796f18c961195c3d1481a2f098ed4366350f9d9ed3ad17.DmBrFHnDUAo9rYBJKBNmfJY5MZnmjixLZo06TMwyYS8
+        hash: v1.k794b7964.cd2be56392c11133b3c6600bb0c25d653fec4a88988cba3b122867d4e5f493af.olUnWKNlWwle4dB5uB8eMIE886zepY6KryrB-_YAcxk
     scenes-app-oauth-authorize--all-scopes-optional--dark:
         hash: v1.k794b7964.03746d2e3646b97e4af61e54557db2ccb6268512cda02721b819fa30980af155.ZPcclnqMQQh8Qi_v2Z3cnVA1_LaYFx8XXncRQ8NQAdc
     scenes-app-oauth-authorize--all-scopes-optional--light:

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -639,11 +639,11 @@ class TestTicketAPI(APIBaseTest):
         full = self._list_ordered_ids("plan")
         self.assertEqual(full, expected_ids)
 
-        paged = []
+        paged: list[str] = []
         for offset in range(0, 5, 2):
             response = self.client.get(
                 f"/api/projects/{self.team.id}/conversations/tickets/",
-                data={"order_by": "plan", "limit": 2, "offset": offset},
+                data={"order_by": "plan", "limit": "2", "offset": str(offset)},
             )
             self.assertEqual(response.status_code, status.HTTP_200_OK)
             paged.extend(r["id"] for r in response.json()["results"])

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -579,6 +579,7 @@ class TestTicketAPI(APIBaseTest):
         # Real deadlines sort first (ascending/descending), no-SLA tickets last, ties broken by
         # -ticket_number — a single total order, so the pages concatenate back to exactly it.
         self.assertEqual(seen, [str(tickets[key].id) for key in expected])
+
     def _list_ordered_ids(self, order_by):
         response = self.client.get(f"/api/projects/{self.team.id}/conversations/tickets/", data={"order_by": order_by})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -629,12 +630,13 @@ class TestTicketAPI(APIBaseTest):
     def test_order_by_plan_paginates_deterministically_within_ties(self, mock_on_commit):
         """Tickets tied on plan rank AND SLA (e.g. all null) need a stable
         tiebreak, or LimitOffsetPagination can skip/duplicate rows between
-        page queries. Ties order by id, so page slices always agree."""
+        page queries. Ties order by -ticket_number (the whitelisted
+        orderings' tiebreak), so page slices always agree."""
         self.user.is_staff = True
         self.user.save()
         self.ticket.delete()
         tied = [self._ticket_with_tags("plan_enterprise") for _ in range(5)]  # all sla_due_at=None
-        expected_ids = sorted(str(t.id) for t in tied)
+        expected_ids = [str(t.id) for t in sorted(tied, key=lambda t: t.ticket_number, reverse=True)]
 
         full = self._list_ordered_ids("plan")
         self.assertEqual(full, expected_ids)

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -626,6 +626,29 @@ class TestTicketAPI(APIBaseTest):
         ids = self._list_ordered_ids("plan")
         self.assertEqual(ids, [str(sooner.id), str(later.id), str(no_sla.id)])
 
+    def test_order_by_plan_paginates_deterministically_within_ties(self, mock_on_commit):
+        """Tickets tied on plan rank AND SLA (e.g. all null) need a stable
+        tiebreak, or LimitOffsetPagination can skip/duplicate rows between
+        page queries. Ties order by id, so page slices always agree."""
+        self.user.is_staff = True
+        self.user.save()
+        self.ticket.delete()
+        tied = [self._ticket_with_tags("plan_enterprise") for _ in range(5)]  # all sla_due_at=None
+        expected_ids = sorted(str(t.id) for t in tied)
+
+        full = self._list_ordered_ids("plan")
+        self.assertEqual(full, expected_ids)
+
+        paged = []
+        for offset in range(0, 5, 2):
+            response = self.client.get(
+                f"/api/projects/{self.team.id}/conversations/tickets/",
+                data={"order_by": "plan", "limit": 2, "offset": offset},
+            )
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            paged.extend(r["id"] for r in response.json()["results"])
+        self.assertEqual(paged, expected_ids)
+
     def test_order_by_plan_composes_with_tag_filters(self, mock_on_commit):
         """Plan ordering works on top of the tag filters' DISTINCT queryset,
         without duplicating multi-matched rows."""

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -579,6 +579,79 @@ class TestTicketAPI(APIBaseTest):
         # Real deadlines sort first (ascending/descending), no-SLA tickets last, ties broken by
         # -ticket_number — a single total order, so the pages concatenate back to exactly it.
         self.assertEqual(seen, [str(tickets[key].id) for key in expected])
+    def _list_ordered_ids(self, order_by):
+        response = self.client.get(f"/api/projects/{self.team.id}/conversations/tickets/", data={"order_by": order_by})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return [r["id"] for r in response.json()["results"]]
+
+    def test_order_by_plan_ranks_by_tag_groups(self, mock_on_commit):
+        """Staff-only plan ordering ranks tickets by their plan-tag group, Triage first."""
+        self.user.is_staff = True
+        self.user.save()
+        # setUp's self.ticket is untagged → Triage (rank 0)
+        free = self._ticket_with_tags("plan_free")
+        churn = self._ticket_with_tags("churn_risk")
+        enterprise = self._ticket_with_tags("plan_enterprise")
+
+        ids = self._list_ordered_ids("plan")
+        self.assertEqual(ids, [str(self.ticket.id), str(churn.id), str(enterprise.id), str(free.id)])
+
+        ids_desc = self._list_ordered_ids("-plan")
+        self.assertEqual(ids_desc, [str(free.id), str(enterprise.id), str(churn.id), str(self.ticket.id)])
+
+    def test_order_by_plan_multi_tag_uses_highest_priority_group(self, mock_on_commit):
+        """A ticket carrying several plan tags ranks with the highest-priority one."""
+        self.user.is_staff = True
+        self.user.save()
+        enterprise = self._ticket_with_tags("plan_enterprise")
+        churny_free = self._ticket_with_tags("plan_free", "churn_risk")
+
+        ids = self._list_ordered_ids("plan")
+        # churn_risk (rank 1) outranks plan_enterprise (rank 3); setUp's untagged ticket is Triage (rank 0)
+        self.assertEqual(ids, [str(self.ticket.id), str(churny_free.id), str(enterprise.id)])
+
+    def test_order_by_plan_ties_break_by_sla_nulls_last(self, mock_on_commit):
+        """Within one plan group, sooner SLA deadlines come first; no SLA sorts last."""
+        self.user.is_staff = True
+        self.user.save()
+        self.ticket.delete()  # keep only the enterprise trio in play
+        later = self._ticket_with_tags("plan_enterprise")
+        later.sla_due_at = timezone.now() + timedelta(hours=10)
+        later.save()
+        sooner = self._ticket_with_tags("plan_enterprise")
+        sooner.sla_due_at = timezone.now() + timedelta(hours=1)
+        sooner.save()
+        no_sla = self._ticket_with_tags("plan_enterprise")
+
+        ids = self._list_ordered_ids("plan")
+        self.assertEqual(ids, [str(sooner.id), str(later.id), str(no_sla.id)])
+
+    def test_order_by_plan_composes_with_tag_filters(self, mock_on_commit):
+        """Plan ordering works on top of the tag filters' DISTINCT queryset,
+        without duplicating multi-matched rows."""
+        self.user.is_staff = True
+        self.user.save()
+        self.ticket.delete()
+        free = self._ticket_with_tags("plan_free", "vip")
+        enterprise = self._ticket_with_tags("plan_enterprise", "vip", "beta")  # matches both filter tags
+        self._ticket_with_tags("plan_top20")  # no vip/beta → filtered out
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/conversations/tickets/",
+            data={"tags": json.dumps(["vip", "beta"]), "order_by": "plan"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = [r["id"] for r in response.json()["results"]]
+        self.assertEqual(ids, [str(enterprise.id), str(free.id)])
+
+    def test_order_by_plan_requires_staff(self, mock_on_commit):
+        """Non-staff requests fall back to the default ordering instead of plan rank."""
+        self.assertFalse(self.user.is_staff)
+        free = self._ticket_with_tags("plan_free")  # created after self.ticket → more recently updated
+
+        ids = self._list_ordered_ids("plan")
+        # Default -updated_at order (newest first), NOT plan order (which would put untagged/Triage first)
+        self.assertEqual(ids, [str(free.id), str(self.ticket.id)])
 
     def test_filter_multiple_priorities_excludes_null(self, mock_on_commit):
         """Test that multiple priority filter excludes tickets with NULL priority."""

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -585,12 +585,16 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
 
         # Staff-only: rank by the plan-tag tiering (see backend/plan_tags.py),
         # ties broken by SLA deadline (soonest first, no deadline last) so one
-        # click yields the triage order. Non-staff requests fall through to the
-        # default ordering like any other unknown order_by value.
+        # click yields the triage order, then by id — without a unique final
+        # key, rows tied on rank+SLA (e.g. no deadline) have no stable order
+        # and LimitOffsetPagination can skip or duplicate them across pages.
+        # Non-staff requests fall through to the default ordering like any
+        # other unknown order_by value.
         if order_by in ("plan", "-plan") and self.request.user.is_staff:
             return queryset.annotate(plan_rank=plan_rank_annotation()).order_by(
                 "-plan_rank" if order_by.startswith("-") else "plan_rank",
                 F("sla_due_at").asc(nulls_last=True),
+                "id",
             )
 
         if order_by not in allowed_orderings:

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -57,6 +57,7 @@ from products.conversations.backend.events import (
 from products.conversations.backend.models import EmailChannel, Ticket, TicketAssignment
 from products.conversations.backend.models.constants import Channel, ChannelDetail, Priority, Status
 from products.conversations.backend.person_lookup import _get_persons_by_email
+from products.conversations.backend.plan_tags import plan_rank_annotation
 
 from ee.models.rbac.role import Role
 
@@ -581,6 +582,17 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
             "-ticket_number",
         }
         order_by = self.request.query_params.get("order_by", "-updated_at")
+
+        # Staff-only: rank by the plan-tag tiering (see backend/plan_tags.py),
+        # ties broken by SLA deadline (soonest first, no deadline last) so one
+        # click yields the triage order. Non-staff requests fall through to the
+        # default ordering like any other unknown order_by value.
+        if order_by in ("plan", "-plan") and self.request.user.is_staff:
+            return queryset.annotate(plan_rank=plan_rank_annotation()).order_by(
+                "-plan_rank" if order_by.startswith("-") else "plan_rank",
+                F("sla_due_at").asc(nulls_last=True),
+            )
+
         if order_by not in allowed_orderings:
             order_by = "-updated_at"
 
@@ -813,8 +825,12 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
                     "-created_at",
                     "ticket_number",
                     "-ticket_number",
+                    "snoozed_until",
+                    "-snoozed_until",
+                    "plan",
+                    "-plan",
                 ],
-                description="Sort order. Prefix with `-` for descending. Defaults to `-updated_at`.",
+                description="Sort order. Prefix with `-` for descending. Defaults to `-updated_at`. `plan` (staff only) ranks by the plan-tag tiering with SLA tiebreak; non-staff requests fall back to the default.",
             ),
         ],
     )

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -585,16 +585,17 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
 
         # Staff-only: rank by the plan-tag tiering (see backend/plan_tags.py),
         # ties broken by SLA deadline (soonest first, no deadline last) so one
-        # click yields the triage order, then by id — without a unique final
-        # key, rows tied on rank+SLA (e.g. no deadline) have no stable order
-        # and LimitOffsetPagination can skip or duplicate them across pages.
-        # Non-staff requests fall through to the default ordering like any
-        # other unknown order_by value.
+        # click yields the triage order, then by -ticket_number (the same
+        # unique tiebreak the whitelisted orderings use below) — without a
+        # unique final key, rows tied on rank+SLA (e.g. no deadline) have no
+        # stable order and LimitOffsetPagination can skip or duplicate them
+        # across pages. Non-staff requests fall through to the default
+        # ordering like any other unknown order_by value.
         if order_by in ("plan", "-plan") and self.request.user.is_staff:
             return queryset.annotate(plan_rank=plan_rank_annotation()).order_by(
                 "-plan_rank" if order_by.startswith("-") else "plan_rank",
                 F("sla_due_at").asc(nulls_last=True),
-                "id",
+                "-ticket_number",
             )
 
         if order_by not in allowed_orderings:

--- a/products/conversations/backend/plan_tags.py
+++ b/products/conversations/backend/plan_tags.py
@@ -1,0 +1,61 @@
+# The support team's plan/priority tiering, derived from ticket tags. Group
+# order IS the priority order (index 0 = Triage = highest). A ticket takes the
+# highest-priority group with a matching tag; tickets with no matching tag
+# rank with Triage (they still need routing).
+#
+# MUST stay in lockstep with the frontend copy in
+# products/conversations/frontend/scenes/tickets/planTags.ts (the column's
+# labels live there; ranks here). Tag vocabulary sources: the "Customer and
+# account tags" section of https://posthog.com/handbook/support/posthog-support,
+# the live SLA workflow's tags, and the Zendesk import's tag names.
+from django.db.models import Case, Exists, IntegerField, OuterRef, Value, When
+
+# rank → exact tag names (no prefix matching)
+PLAN_GROUP_TAGS: list[list[str]] = [
+    ["support_needs_triage"],  # 0 Triage (also the untagged fallback)
+    ["churn_risk"],  # 1 Churn risk
+    ["plan_top20", "top_20"],  # 2 Top 20
+    [  # 3 Enterprise
+        "plan_enterprise",
+        "goodwill_enterprise",
+        "unknown_slack_default_enterprise",
+        "unknown_msteams_default_enterprise",
+    ],
+    ["plan_onboarding", "new_customer_onboarding"],  # 4 Onboarding
+    ["plan_scale", "plan_teams_legacy", "plan_teams", "plan_yc"],  # 5 Scale & Teams & YC
+    [  # 6 Boost & Startup & Pay-as-you-go paying
+        "plan_boost",
+        "plan_startup",
+        "plan_pay-as-you-go_paying",
+        "plan_pay-as-you-go",
+        "plan_paid",
+    ],
+    ["plan_pay-as-you-go_free"],  # 7 Pay-as-you-go free
+    ["plan_free"],  # 8 Free plan
+    ["community"],  # 9 Community
+]
+
+
+def plan_rank_annotation() -> Case:
+    """A per-ticket plan rank for ORDER BY: the first (highest-priority) group
+    with a matching tag wins, courtesy of Case evaluating Whens in order.
+    Untagged/unmatched tickets take the default rank 0 (Triage).
+
+    Perf note: this is one correlated EXISTS per group (10 today). Each can be
+    served by TaggedItem's partial unique index on (tag, ticket) probed
+    tag-first (the group's tag ids are few), but there is no ticket-leading
+    index — if staff usage makes this sort hot at scale, consider adding one.
+    """
+    from posthog.models.tagged_item import TaggedItem
+
+    return Case(
+        *[
+            When(
+                Exists(TaggedItem.objects.filter(ticket=OuterRef("pk"), tag__name__in=tags)),
+                then=Value(rank),
+            )
+            for rank, tags in enumerate(PLAN_GROUP_TAGS)
+        ],
+        default=Value(0),
+        output_field=IntegerField(),
+    )

--- a/products/conversations/backend/plan_tags.py
+++ b/products/conversations/backend/plan_tags.py
@@ -10,6 +10,8 @@
 # the live SLA workflow's tags, and the Zendesk import's tag names.
 from django.db.models import Case, Exists, IntegerField, OuterRef, Value, When
 
+from posthog.models.tagged_item import TaggedItem
+
 # rank → exact tag names (no prefix matching)
 PLAN_GROUP_TAGS: list[list[str]] = [
     ["support_needs_triage"],  # 0 Triage (also the untagged fallback)
@@ -46,8 +48,6 @@ def plan_rank_annotation() -> Case:
     tag-first (the group's tag ids are few), but there is no ticket-leading
     index — if staff usage makes this sort hot at scale, consider adding one.
     """
-    from posthog.models.tagged_item import TaggedItem
-
     return Case(
         *[
             When(

--- a/products/conversations/backend/plan_tags.py
+++ b/products/conversations/backend/plan_tags.py
@@ -43,10 +43,10 @@ def plan_rank_annotation() -> Case:
     with a matching tag wins, courtesy of Case evaluating Whens in order.
     Untagged/unmatched tickets take the default rank 0 (Triage).
 
-    Perf note: this is one correlated EXISTS per group (10 today). Each can be
-    served by TaggedItem's partial unique index on (tag, ticket) probed
-    tag-first (the group's tag ids are few), but there is no ticket-leading
-    index — if staff usage makes this sort hot at scale, consider adding one.
+    Perf note: this is one correlated EXISTS per group (10 today). Each is
+    served by TaggedItem's ticket-leading index (posthog_taggeditem_ticket_id_idx,
+    migration 1033) with the tag-name filter applied to the handful of rows a
+    ticket carries.
     """
     return Case(
         *[

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -1229,7 +1229,7 @@ export type ConversationsTicketsListParams = {
      */
     offset?: number
     /**
-     * Sort order. Prefix with `-` for descending. Defaults to `-updated_at`.
+     * Sort order. Prefix with `-` for descending. Defaults to `-updated_at`. `plan` (staff only) ranks by the plan-tag tiering with SLA tiebreak; non-staff requests fall back to the default.
      */
     order_by?: string
     /**

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -24,6 +24,7 @@ import { pluralize } from 'lib/utils/strings'
 import { SceneExport } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
+import { userLogic } from 'scenes/userLogic'
 
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
@@ -113,6 +114,8 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
     const { searchParams } = useValues(router)
     const { currentTeam } = useValues(teamLogic)
     const aiEnabled = !!currentTeam?.conversations_settings?.ai_suggestions_enabled
+    const { user } = useValues(userLogic)
+    const staff = !!user?.is_staff
 
     const getKey = useMemo(() => (t: Ticket) => t.id, [])
     const bulk = useBulkSelection<Ticket, string>({ pageRecords: tickets, getKey })
@@ -168,11 +171,12 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
                 />
             ),
         }
-        return [checkboxCol, ...buildTicketColumns(visibleColumns, { aiEnabled, embedded })]
+        return [checkboxCol, ...buildTicketColumns(visibleColumns, { aiEnabled, embedded, staff })]
     }, [
         visibleColumns,
         embedded,
         aiEnabled,
+        staff,
         isSomeOnPageSelected,
         isAllOnPageSelected,
         toggleAllOnPage,

--- a/products/conversations/frontend/scenes/tickets/TicketColumnsDropdown.tsx
+++ b/products/conversations/frontend/scenes/tickets/TicketColumnsDropdown.tsx
@@ -4,6 +4,7 @@ import { IconChevronDown } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonDivider, LemonDropdown } from '@posthog/lemon-ui'
 
 import { IconTuning } from 'lib/lemon-ui/icons'
+import { userLogic } from 'scenes/userLogic'
 
 import { isTicketColumnMandatory, offerableTicketColumns, ticketColumnLabel } from './ticketColumns'
 import { ticketColumnsLogic } from './ticketColumnsLogic'
@@ -16,8 +17,9 @@ interface TicketColumnsDropdownProps {
 export function TicketColumnsDropdown({ aiEnabled, embedded = false }: TicketColumnsDropdownProps): JSX.Element {
     const { visibleColumns } = useValues(ticketColumnsLogic)
     const { toggleColumn, setVisibleColumns } = useActions(ticketColumnsLogic)
+    const { user } = useValues(userLogic)
 
-    const offerable = offerableTicketColumns({ aiEnabled, embedded })
+    const offerable = offerableTicketColumns({ aiEnabled, embedded, staff: !!user?.is_staff })
     const shownCount = offerable.filter((key) => visibleColumns.includes(key) || isTicketColumnMandatory(key)).length
     const allShown = shownCount === offerable.length
 

--- a/products/conversations/frontend/scenes/tickets/planTags.test.ts
+++ b/products/conversations/frontend/scenes/tickets/planTags.test.ts
@@ -1,0 +1,80 @@
+import { PLAN_GROUPS, planLabel, planRank } from './planTags'
+
+describe('PLAN_GROUPS', () => {
+    it('lists the groups in triage-first priority order', () => {
+        expect(PLAN_GROUPS.map((g) => g.label)).toEqual([
+            'Triage',
+            'Churn risk',
+            'Top 20',
+            'Enterprise',
+            'Onboarding',
+            'Scale & Teams & YC',
+            'Boost & Startup & Pay-as-you-go paying',
+            'Pay-as-you-go free',
+            'Free plan',
+            'Community',
+        ])
+    })
+
+    it('never routes one tag to two groups', () => {
+        const all = PLAN_GROUPS.flatMap((g) => g.tags)
+        expect(new Set(all).size).toBe(all.length)
+    })
+})
+
+describe('planLabel', () => {
+    it.each([
+        // Live SLA-workflow and handbook vocabulary
+        ['support_needs_triage', 'Triage'],
+        ['churn_risk', 'Churn risk'],
+        ['top_20', 'Top 20'],
+        ['plan_enterprise', 'Enterprise'],
+        ['goodwill_enterprise', 'Enterprise'],
+        ['unknown_slack_default_enterprise', 'Enterprise'],
+        ['unknown_msteams_default_enterprise', 'Enterprise'],
+        ['new_customer_onboarding', 'Onboarding'],
+        ['plan_scale', 'Scale & Teams & YC'],
+        ['plan_teams', 'Scale & Teams & YC'],
+        ['plan_yc', 'Scale & Teams & YC'],
+        ['plan_boost', 'Boost & Startup & Pay-as-you-go paying'],
+        ['plan_startup', 'Boost & Startup & Pay-as-you-go paying'],
+        ['plan_paid', 'Boost & Startup & Pay-as-you-go paying'],
+        ['plan_free', 'Free plan'],
+        ['community', 'Community'],
+        // Zendesk-import vocabulary (many imported tickets still carry these)
+        ['plan_top20', 'Top 20'],
+        ['plan_onboarding', 'Onboarding'],
+        ['plan_teams_legacy', 'Scale & Teams & YC'],
+        ['plan_pay-as-you-go_paying', 'Boost & Startup & Pay-as-you-go paying'],
+        ['plan_pay-as-you-go', 'Boost & Startup & Pay-as-you-go paying'],
+        ['plan_pay-as-you-go_free', 'Pay-as-you-go free'],
+    ])('routes %s to %s', (tag, label) => {
+        expect(planLabel([tag])).toBe(label)
+    })
+
+    it('takes the highest-priority group when several tags match', () => {
+        expect(planLabel(['plan_free', 'plan_enterprise', 'churn_risk'])).toBe('Churn risk')
+    })
+
+    it('falls back to Triage for untagged or unmatched tickets', () => {
+        expect(planLabel([])).toBe('Triage')
+        expect(planLabel(undefined)).toBe('Triage')
+        expect(planLabel(['team_replay', 'support_sme_analytics'])).toBe('Triage')
+    })
+
+    it('requires exact tag matches, not prefixes or substrings', () => {
+        expect(planLabel(['plan_enterprise_trial'])).toBe('Triage')
+        expect(planLabel(['community_forum'])).toBe('Triage')
+    })
+})
+
+describe('planRank', () => {
+    it('ranks follow the group order, untagged with Triage', () => {
+        expect(planRank(['support_needs_triage'])).toBe(0)
+        expect(planRank([])).toBe(0)
+        expect(planRank(['community'])).toBe(PLAN_GROUPS.length - 1)
+        expect(planRank(['churn_risk'])).toBeLessThan(planRank(['plan_enterprise']))
+        expect(planRank(['plan_pay-as-you-go'])).toBeLessThan(planRank(['plan_pay-as-you-go_free']))
+        expect(planRank(['plan_pay-as-you-go_free'])).toBeLessThan(planRank(['plan_free']))
+    })
+})

--- a/products/conversations/frontend/scenes/tickets/planTags.ts
+++ b/products/conversations/frontend/scenes/tickets/planTags.ts
@@ -1,0 +1,62 @@
+// The customer's plan tier, derived from ticket tags — the support team's
+// triage ladder. Group order IS the priority order (Triage first, Community
+// last): a ticket takes the highest-priority group with a matching tag, and
+// tickets with no matching tag fall into Triage (they still need routing).
+//
+// Tag vocabulary sources, all kept so every era of ticket groups correctly:
+// - The "Customer and account tags" section of
+//   https://posthog.com/handbook/support/posthog-support (source of truth)
+// - The live "Support:: SLA:: identify plan types and set NRT SLAs" workflow
+//   (top_20, plan_teams, plan_paid, new_customer_onboarding, ...)
+// - The Zendesk import (plan_top20, plan_teams_legacy, plan_pay-as-you-go*,
+//   ... — surveyed against the zendesk.tickets warehouse table, 2026-07-20)
+//
+// Matching is exact (no prefixes): plan_enterprise_trial is NOT Enterprise.
+
+export interface PlanGroup {
+    label: string
+    tags: string[]
+}
+
+export const PLAN_GROUPS: PlanGroup[] = [
+    { label: 'Triage', tags: ['support_needs_triage'] },
+    { label: 'Churn risk', tags: ['churn_risk'] },
+    { label: 'Top 20', tags: ['plan_top20', 'top_20'] },
+    {
+        label: 'Enterprise',
+        tags: [
+            'plan_enterprise',
+            'goodwill_enterprise',
+            'unknown_slack_default_enterprise',
+            'unknown_msteams_default_enterprise',
+        ],
+    },
+    { label: 'Onboarding', tags: ['plan_onboarding', 'new_customer_onboarding'] },
+    { label: 'Scale & Teams & YC', tags: ['plan_scale', 'plan_teams_legacy', 'plan_teams', 'plan_yc'] },
+    {
+        label: 'Boost & Startup & Pay-as-you-go paying',
+        tags: ['plan_boost', 'plan_startup', 'plan_pay-as-you-go_paying', 'plan_pay-as-you-go', 'plan_paid'],
+    },
+    { label: 'Pay-as-you-go free', tags: ['plan_pay-as-you-go_free'] },
+    { label: 'Free plan', tags: ['plan_free'] },
+    { label: 'Community', tags: ['community'] },
+]
+
+const TAG_RANK = new Map<string, number>(PLAN_GROUPS.flatMap((group, rank) => group.tags.map((tag) => [tag, rank])))
+
+/** Index into PLAN_GROUPS of the ticket's group — the best (lowest) rank
+ *  across its tags, or Triage (0) when none match. */
+export function planRank(tags: string[] | undefined): number {
+    let best = Number.POSITIVE_INFINITY
+    for (const tag of tags ?? []) {
+        const rank = TAG_RANK.get(tag)
+        if (rank !== undefined && rank < best) {
+            best = rank
+        }
+    }
+    return best === Number.POSITIVE_INFINITY ? 0 : best
+}
+
+export function planLabel(tags: string[] | undefined): string {
+    return PLAN_GROUPS[planRank(tags)].label
+}

--- a/products/conversations/frontend/scenes/tickets/ticketColumns.test.ts
+++ b/products/conversations/frontend/scenes/tickets/ticketColumns.test.ts
@@ -1,11 +1,13 @@
 import { TICKET_COLUMN_ORDER, TicketColumnKey, buildTicketColumns } from './ticketColumns'
 
-const keysOf = (visible: TicketColumnKey[], context: { aiEnabled: boolean; embedded: boolean }): string[] =>
-    buildTicketColumns(visible, context).map((column) => ('key' in column ? String(column.key) : ''))
+const keysOf = (
+    visible: TicketColumnKey[],
+    context: { aiEnabled: boolean; embedded: boolean; staff: boolean }
+): string[] => buildTicketColumns(visible, context).map((column) => ('key' in column ? String(column.key) : ''))
 
 describe('buildTicketColumns', () => {
     const all = TICKET_COLUMN_ORDER
-    const context = { aiEnabled: true, embedded: false }
+    const context = { aiEnabled: true, embedded: false, staff: true }
 
     it.each([
         ['hides a deselected column', ['ticket_number', 'status'], 'tags', false],
@@ -16,10 +18,15 @@ describe('buildTicketColumns', () => {
     })
 
     it.each([
-        ['ai_triage', { aiEnabled: false, embedded: false }, 'ai_triage'],
-        ['customer', { aiEnabled: true, embedded: true }, 'customer'],
+        ['ai_triage', { aiEnabled: false, embedded: false, staff: true }, 'ai_triage'],
+        ['customer', { aiEnabled: true, embedded: true, staff: true }, 'customer'],
+        ['plan', { aiEnabled: true, embedded: false, staff: false }, 'plan'],
     ])('never renders %s when the context excludes it', (_name, ctx, key) => {
         expect(keysOf(all, ctx)).not.toContain(key)
+    })
+
+    it('renders the plan column for staff', () => {
+        expect(keysOf(all, context)).toContain('plan')
     })
 
     it('renders in canonical order regardless of selection order', () => {

--- a/products/conversations/frontend/scenes/tickets/ticketColumns.tsx
+++ b/products/conversations/frontend/scenes/tickets/ticketColumns.tsx
@@ -20,6 +20,7 @@ import {
     aiTriageResultTagType,
     aiTriageTicketTypeLabel,
 } from '../../types'
+import { planLabel } from './planTags'
 
 export type TicketColumnKey =
     | 'ticket_number'
@@ -28,6 +29,7 @@ export type TicketColumnKey =
     | 'status'
     | 'ai_triage'
     | 'priority'
+    | 'plan'
     | 'sla_due_at'
     | 'assignee'
     | 'channel'
@@ -39,6 +41,9 @@ interface TicketColumnDefinition {
     label: string
     /** Only offered (and only rendered) when AI suggestions are enabled for the team. */
     aiOnly?: boolean
+    /** Only offered (and only rendered) to PostHog staff — internal triage
+     *  concepts that aren't (yet) meaningful or configurable for customers. */
+    staffOnly?: boolean
     /** Hidden in embedded tables, which are already scoped to one person. */
     hiddenWhenEmbedded?: boolean
     /** Identifies the row, so it can't be hidden. */
@@ -207,6 +212,23 @@ const TICKET_COLUMNS: Record<TicketColumnKey, TicketColumnDefinition> = {
                 ),
         },
     },
+    plan: {
+        label: 'Plan',
+        staffOnly: true,
+        column: {
+            title: 'Plan',
+            key: 'plan',
+            sorter: true,
+            render: (_, ticket) => {
+                const label = planLabel(ticket.tags)
+                return (
+                    <span className="text-xs whitespace-nowrap" title={label}>
+                        {label}
+                    </span>
+                )
+            },
+        },
+    },
     sla_due_at: {
         label: 'SLA',
         column: {
@@ -305,6 +327,7 @@ export const TICKET_COLUMN_ORDER: TicketColumnKey[] = [
     'status',
     'ai_triage',
     'priority',
+    'plan',
     'sla_due_at',
     'assignee',
     'channel',
@@ -326,13 +349,18 @@ export function isTicketColumnMandatory(key: TicketColumnKey): boolean {
 interface TicketColumnContext {
     aiEnabled: boolean
     embedded: boolean
+    /** Whether the viewer is PostHog staff (user.is_staff). */
+    staff: boolean
 }
 
 /** The columns a user can actually choose between, given the current context. */
-export function offerableTicketColumns({ aiEnabled, embedded }: TicketColumnContext): TicketColumnKey[] {
+export function offerableTicketColumns({ aiEnabled, embedded, staff }: TicketColumnContext): TicketColumnKey[] {
     return TICKET_COLUMN_ORDER.filter((key) => {
         const definition = TICKET_COLUMNS[key]
         if (definition.aiOnly && !aiEnabled) {
+            return false
+        }
+        if (definition.staffOnly && !staff) {
             return false
         }
         if (definition.hiddenWhenEmbedded && embedded) {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -73653,7 +73653,7 @@ export namespace Schemas {
      */
     offset?: number;
     /**
-     * Sort order. Prefix with `-` for descending. Defaults to `-updated_at`.
+     * Sort order. Prefix with `-` for descending. Defaults to `-updated_at`. `plan` (staff only) ranks by the plan-tag tiering with SLA tiebreak; non-staff requests fall back to the default.
      */
     order_by?: string;
     /**

--- a/services/mcp/src/generated/conversations/api.ts
+++ b/services/mcp/src/generated/conversations/api.ts
@@ -68,7 +68,9 @@ export const ConversationsTicketsListQueryParams = /* @__PURE__ */ zod.object({
     order_by: zod
         .string()
         .optional()
-        .describe('Sort order. Prefix with `-` for descending. Defaults to `-updated_at`.'),
+        .describe(
+            'Sort order. Prefix with `-` for descending. Defaults to `-updated_at`. `plan` (staff only) ranks by the plan-tag tiering with SLA tiebreak; non-staff requests fall back to the default.'
+        ),
     priority: zod
         .string()
         .optional()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/conversations-tickets-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/conversations-tickets-list.json
@@ -49,7 +49,7 @@
             "type": "number"
         },
         "order_by": {
-            "description": "Sort order. Prefix with `-` for descending. Defaults to `-updated_at`.",
+            "description": "Sort order. Prefix with `-` for descending. Defaults to `-updated_at`. `plan` (staff only) ranks by the plan-tag tiering with SLA tiebreak; non-staff requests fall back to the default.",
             "type": "string"
         },
         "priority": {


### PR DESCRIPTION
## Problem

Support staff triage tickets by customer tier (the "PostHog priority" ladder from the Zendesk days: Top 20 and churn risk first, then Enterprise, down to Community). That tiering lives in ticket tags (applied by the SLA workflow, the support handbook's customer/account tags, and the Zendesk import), but the tickets list can't see it: there's no column showing a ticket's tier, and no way to sort by it. Staff currently maintain this view in external tooling.

## Changes

Staff-only (`user.is_staff`), invisible and inert for customers:

- **New "Plan" column** between Priority and SLA, derived from ticket tags via an ordered group list (`planTags.ts`): Triage > Churn risk > Top 20 > Enterprise > Onboarding > Scale & Teams & YC > Boost & Startup & Pay-as-you-go paying > Pay-as-you-go free > Free plan > Community. A ticket takes the highest-priority group with a matching tag; unmatched tickets show Triage. Exact-match only, and the vocabulary merges all three tag eras (handbook, live SLA workflow, Zendesk import) so imported tickets group correctly.
- **New `staffOnly` flag** on ticket column definitions, mirroring the existing `aiOnly` pattern: non-staff see neither the column nor its entry in the columns dropdown.
- **Server-side sorting** (`order_by=plan` / `-plan`): a `CASE`/`EXISTS` rank annotation over `TaggedItem` (`plan_tags.py`, the backend twin of `planTags.ts`), gated on `request.user.is_staff` in the queryset; non-staff requests fall back to the default ordering like any unknown `order_by`. Ties break by SLA deadline (soonest first, none last), so one click on the header yields the full triage order: tier ladder with the most urgent tickets leading each tier.
- OpenAPI `order_by` enum updated (also adds the previously missing `snoozed_until` values).

## Notes for reviewers

- The tag-to-group mapping intentionally exists twice (frontend labels + backend ranks), with cross-referencing comments; happy to restructure if you prefer a single source (e.g. served to the frontend).
- Perf: the rank annotation is one correlated `EXISTS` per group (10). Each can be served by `TaggedItem`'s partial unique index on `(tag, ticket)` probed tag-first, but there is no ticket-leading index; if this sort gets hot at scale, a `(ticket, tag)` index may be worth adding. Flagged in the docstring rather than shipping a speculative core-model migration here.
- This is an interim staff convenience until tiering is user-configurable (future design conversation with the Conversations team); the derived-from-tags approach keeps it fully reversible with no schema changes.

## How did you test this code?

- TDD: 5 new Django tests (`test_order_by_plan_*`: rank order asc/desc, multi-tag highest-wins, SLA tiebreak with nulls last, composition with tag filters + DISTINCT, non-staff fallback), 30+ Jest cases for the tag mapping, and staff-gating cases in `ticketColumns.test.ts`. All green, plus ruff/oxlint/oxfmt/tsgo clean.
- Verified in the local UI against 20 seeded tickets covering every group, all three tag vocabularies, breached SLAs, and a multi-tag ticket: column labels, dropdown gating, sort ascending/descending, and SLA ordering within tiers all behave as described.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*