### PR TITLE
fix(llm-gateway): require streaming when max_tokens exceeds timeout

### DIFF
--- a/services/llm-gateway/README.md
+++ b/services/llm-gateway/README.md
@@ -314,6 +314,10 @@ Errors follow OpenAI's format:
 | 429    | Rate limit exceeded                         |
 | 504    | Request timeout                             |
 
+Non-streaming requests are rejected up front with a 400 (`code: "streaming_required"`) when `max_tokens` implies the generation cannot finish within the gateway's request timeout (300s by default, at a conservative 128K tokens/hour).
+Such a request could only ever burn the full timeout and return a 504, so the gateway fails fast instead: switch the caller to streaming and accumulate the stream if a single response is needed.
+This mirrors the Anthropic SDKs, which refuse non-streaming requests expected to exceed 10 minutes.
+
 ## Internal Django integration
 
 For calling from PostHog Django:

--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Final
 
 import structlog
 from fastapi import HTTPException
@@ -197,6 +197,45 @@ FORBIDDEN_REQUEST_PARAMS = frozenset(
     {"api_key", "api_base", "base_url", "api_version", "organization", "model_list", "fallbacks", "custom_llm_provider"}
 )
 
+# Worst-case output throughput the Anthropic SDKs assume (128K tokens/hour) when refusing
+# non-streaming requests that would outlive their 10-minute timeout. We apply the same
+# policy scaled to the gateway's request_timeout: a non-streaming request whose max_tokens
+# can't complete within the budget would only ever burn the full timeout and 504.
+NON_STREAMING_TOKENS_PER_SECOND: Final[float] = 128_000 / 3600
+
+_MAX_TOKENS_KEYS: Final = ("max_tokens", "max_completion_tokens", "max_output_tokens")
+
+
+def _requested_max_tokens(request_data: dict[str, Any]) -> int | None:
+    for key in _MAX_TOKENS_KEYS:
+        value = request_data.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            return value
+    return None
+
+
+def _raise_if_exceeds_non_streaming_budget(request_data: dict[str, Any], timeout: float) -> None:
+    max_tokens = _requested_max_tokens(request_data)
+    if max_tokens is None:
+        return
+    ceiling = int(timeout * NON_STREAMING_TOKENS_PER_SECOND)
+    if max_tokens > ceiling:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": {
+                    "message": (
+                        f"max_tokens={max_tokens} may not complete within the gateway's "
+                        f"{timeout:.0f}s non-streaming limit (at most {ceiling} tokens). "
+                        "Use streaming for long requests; SDKs can accumulate the stream "
+                        "into a complete response."
+                    ),
+                    "type": "invalid_request_error",
+                    "code": "streaming_required",
+                }
+            },
+        )
+
 
 def _sanitize_request_value(value: Any) -> Any:
     # Strip recursively: litellm forwards nested params (e.g. model_list[*].litellm_params.api_key)
@@ -259,6 +298,8 @@ async def handle_llm_request(
             timeout=settings.streaming_timeout,
             product=product,
         )
+
+    _raise_if_exceeds_non_streaming_budget(request_data, settings.request_timeout)
 
     CONCURRENT_REQUESTS.labels(provider=provider_config.name, model=model, product=product).inc()
     try:

--- a/services/llm-gateway/src/llm_gateway/models/openai.py
+++ b/services/llm-gateway/src/llm_gateway/models/openai.py
@@ -9,6 +9,8 @@ class ChatCompletionRequest(BaseModel):
     model: str
     messages: list[dict[str, Any]]
     stream: bool = False
+    max_tokens: int | None = None
+    max_completion_tokens: int | None = None
 
 
 class ResponsesRequest(BaseModel):

--- a/services/llm-gateway/tests/test_anthropic.py
+++ b/services/llm-gateway/tests/test_anthropic.py
@@ -212,6 +212,72 @@ class TestAnthropicMessagesEndpoint:
         assert response.status_code == 422
         assert expected_field in str(response.json())
 
+    @pytest.mark.parametrize(
+        "max_tokens,expected_status",
+        [
+            pytest.param(32000, 400, id="over_budget_rejected"),
+            pytest.param(8000, 200, id="within_budget_allowed"),
+        ],
+    )
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
+    def test_non_streaming_max_tokens_budget(
+        self,
+        mock_anthropic: MagicMock,
+        authenticated_client: TestClient,
+        provider_mock_response: dict,
+        max_tokens: int,
+        expected_status: int,
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.model_dump = MagicMock(return_value=provider_mock_response)
+        mock_anthropic.return_value = mock_response
+
+        response = authenticated_client.post(
+            "/v1/messages",
+            json={
+                "model": "claude-opus-4-8",
+                "max_tokens": max_tokens,
+                "messages": [{"role": "user", "content": "Hello"}],
+            },
+            headers={"Authorization": "Bearer phx_test_key"},
+        )
+
+        assert response.status_code == expected_status
+        if expected_status == 400:
+            assert response.json()["error"]["code"] == "streaming_required"
+            mock_anthropic.assert_not_called()
+        else:
+            mock_anthropic.assert_called_once()
+
+    @patch("llm_gateway.api.anthropic.litellm.anthropic_messages", new_callable=AsyncMock)
+    def test_streaming_request_exempt_from_max_tokens_budget(
+        self,
+        mock_anthropic: AsyncMock,
+        authenticated_client: TestClient,
+    ) -> None:
+        async def fake_stream():
+            yield b'event: message_start\ndata: {"type":"message_start"}\n\n'
+            yield b'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+        mock_anthropic.return_value = fake_stream()
+
+        with authenticated_client.stream(
+            "POST",
+            "/v1/messages",
+            json={
+                "model": "claude-opus-4-8",
+                "max_tokens": 128000,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+            headers={"Authorization": "Bearer phx_test_key"},
+        ) as response:
+            assert response.status_code == 200
+            body = "".join(response.iter_text())
+
+        assert "message_stop" in body
+        mock_anthropic.assert_called_once()
+
     @patch("llm_gateway.api.anthropic.litellm.anthropic_messages")
     def test_successful_request(
         self,

--- a/services/llm-gateway/tests/test_openai.py
+++ b/services/llm-gateway/tests/test_openai.py
@@ -67,6 +67,32 @@ class TestChatCompletionsEndpoint:
         assert response.status_code == 422
         assert expected_field in str(response.json())
 
+    @pytest.mark.parametrize(
+        "token_field,token_value",
+        [
+            pytest.param("max_tokens", 32000.0, id="max_tokens_float"),
+            pytest.param("max_completion_tokens", "32000", id="max_completion_tokens_string"),
+        ],
+    )
+    @patch("llm_gateway.api.openai.litellm.acompletion")
+    def test_non_streaming_token_limit_is_normalized_before_budget_check(
+        self,
+        mock_completion: MagicMock,
+        authenticated_client: TestClient,
+        valid_request_body: dict[str, Any],
+        token_field: str,
+        token_value: float | str,
+    ) -> None:
+        response = authenticated_client.post(
+            "/v1/chat/completions",
+            json={**valid_request_body, token_field: token_value},
+            headers={"Authorization": "Bearer phx_test_key"},
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"]["code"] == "streaming_required"
+        mock_completion.assert_not_called()
+
     @patch("llm_gateway.api.openai.litellm.acompletion")
     def test_successful_request(
         self,


### PR DESCRIPTION
## Problem

Non-streaming gateway requests are hard-capped by `request_timeout` (300s). Slow high-effort models can legitimately need longer than that, so a non-streaming request with a large `max_tokens` can only ever burn the full 300s of provider compute and then get killed with a 504. The caller waits five minutes for an unactionable error (and typically retries, doubling the waste), and the 504s show up as 5xx noise in the gateway's error-rate monitoring even though nothing is wrong with the gateway.

Anthropic's own policy is the model here: the API docs recommend streaming for anything long-running, and the official SDKs refuse non-streaming requests expected to exceed 10 minutes, estimated at a worst-case 128K tokens/hour ([long requests](https://platform.claude.com/docs/en/api/errors#long-requests)).

## Changes

- `handle_llm_request` now rejects non-streaming requests whose `max_tokens` cannot complete within `request_timeout`, using the same 128K tokens/hour worst-case rate the Anthropic SDKs use, scaled to the gateway's budget (~10.6K tokens at the default 300s). The caller gets an immediate 400 with `code: "streaming_required"` and a message telling it to stream instead.
- The guard sits before dispatch in the shared handler, so it covers every surface (Anthropic messages, Bedrock fallback, GLM routing, OpenAI chat/responses). It checks `max_tokens`, `max_completion_tokens`, and `max_output_tokens`, and skips requests that set none of them.
- Streaming requests are exempt. Streaming is the supported path for long generations (`streaming_timeout` only bounds time to stream start).
- Documented the new 400 in the gateway README's error handling section.

> [!NOTE]
> Behavior change for callers: a non-streaming request with `max_tokens` above ~10.6K now fails immediately with a 400 instead of sometimes succeeding near the timeout boundary. Those callers should switch to streaming (SDKs can accumulate the stream into a single response, e.g. `get_final_message()`).

## How did you test this code?

Automated tests only, all run locally by the agent:

- Added 2 parameterized cases to `tests/test_anthropic.py` covering the threshold in both directions (over-budget rejected with the provider never called, within-budget passes through). Guards against the guard being removed or mis-thresholded, which would silently reintroduce the burn-300s-then-504 behavior. No existing test exercised any max_tokens-based rejection.
- Added 1 streaming case asserting a `stream: true` request with `max_tokens: 128000` is exempt. Guards against the check accidentally being applied to the streaming branch, which would break all long streaming requests.
- Full llm-gateway suite passes: 1340 tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Gateway README updated in this PR (error handling section).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable 5) in a session driven by @cvolzer3, investigating why non-streaming requests to slow models were timing out at the gateway's 300s cap and generating 5xx noise. The session traced the timeout path in `api/handler.py`, confirmed via `$ai_generation` telemetry that affected non-streaming requests pile up just under 300s with 14-24K token outputs, and confirmed streaming requests are unaffected. Skills invoked: `/claude-api` (to verify Anthropic's documented long-request policy and the SDK's 128K tokens/hour constant) and `/writing-tests`. Alternatives considered and rejected: extending the timeout (moves the cliff, pins connections longer, and requires matching proxy timeout changes) and silently dropping 504s from monitoring (masks genuine provider hangs). Related alerting change ships separately in the charts repo.
