### PR TITLE
fix(onboarding): drop "Max" from welcome Ask card copy

### DIFF
--- a/frontend/src/scenes/welcome/cards/AskMaxCard.tsx
+++ b/frontend/src/scenes/welcome/cards/AskMaxCard.tsx
@@ -31,13 +31,13 @@ export function AskMaxCard(): JSX.Element {
                 onClick={handleActivate}
                 data-attr="welcome-ask-max"
                 className="flex items-center gap-3 w-full p-4 text-left bg-transparent border-0 cursor-pointer hover:bg-accent-highlight-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--color-brand-yellow)] transition-colors"
-                aria-label="Got questions? Ask Max, PostHog AI"
+                aria-label="Got questions? Ask PostHog AI"
             >
                 <div className="flex-shrink-0 w-10 h-10 rounded-full bg-[var(--color-brand-yellow)]/15 flex items-center justify-center text-[var(--color-brand-yellow)]">
                     <IconSparkles className="text-xl" />
                 </div>
                 <div className="flex-1 min-w-0">
-                    <div className="font-semibold text-sm">Got questions? Ask Max, PostHog AI</div>
+                    <div className="font-semibold text-sm">Got questions? Ask PostHog AI</div>
                     <div className="text-xs text-muted">Find anything in your data or ask how to use a feature</div>
                 </div>
                 <IconArrowRight className="text-muted text-lg flex-shrink-0" />


### PR DESCRIPTION
## Problem

The onboarding welcome card told new users to "Ask Max, PostHog AI". We no longer front the AI as "Max", so the copy is wrong.

## Changes

Updated the welcome "Ask" card so both the visible heading and the matching `aria-label` read "Got questions? Ask PostHog AI".

## How did you test this code?

Copy-only change. I (PostHog Slack app / Claude) did not run the app manually. No automated tests were run — this is a static string change with no logic touched.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Adam requested the fix from a Slack thread. I located the string in `frontend/src/scenes/welcome/cards/AskMaxCard.tsx`, removed "Max," from both the rendered text and the `aria-label` to keep them in sync, and opened this PR.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1784917939381159?thread_ts=1784917939.381159&cid=C0ACRAMJUAG)*
