### PR TITLE
feat(replay-vision): show each template's output type on the picker card

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5573,7 +5573,7 @@ snapshots:
     scenes-app-dashboards--show-across-viewports--narrow--dark:
         hash: v1.k794b7964.e919c4955d7113170ab00269c5f628c318afe14f26dc8aafb046b172e17f362e.YDXD84rrb2KR1I36pHMxEsGZ0sN0os_cBBdNIf89Pu8
     scenes-app-dashboards--show-across-viewports--narrow--light:
-        hash: v1.k794b7964.a46d840722e971910236d6fcd8a8f69e0b1db5ee9d472d62055b02d6569f7a99.kHEdVPNUm5DRKSlMFS12SLKf1TyChQJZKKuZ2PKvtfA
+        hash: v1.k794b7964.2a88f06991ca4c13ad27ee62db8eaa037c542301e28c24934eedc1bbb78cb338.3Ne0cm6_2xQiGE1wGcRzmw0QBd3QrEYkELz3PCg9J48
     scenes-app-dashboards--show-across-viewports--superwide--dark:
         hash: v1.k794b7964.9948b52cf842206c1584057a6a16b8caed7a32d95f103dbea07089a02df75a53.AuXGqOvw-P-XuzOL2Zl-BkBPb1-Q3R1949f5-IkTjZA
     scenes-app-dashboards--show-across-viewports--superwide--light:

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTemplatePicker.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTemplatePicker.tsx
@@ -44,21 +44,19 @@ function TemplateCard({ template }: { template: ScannerTemplate | 'blank' }): JS
                     </span>
                 </div>
                 <div className="flex-1 flex flex-col justify-start w-full">
-                    <div className="flex items-center justify-center gap-2 mb-2">
-                        <h3 className="text-base font-semibold text-default mb-0">
-                            {isBlank ? 'Create from scratch' : template.name}
-                        </h3>
-                        {!isBlank && <ScannerTypeBadge scannerType={template.scanner_type} size="small" />}
-                    </div>
+                    <h3 className="text-base font-semibold text-default mb-2">
+                        {isBlank ? 'Create from scratch' : template.name}
+                    </h3>
                     <p className="text-sm text-secondary leading-relaxed mb-0">
                         {isBlank
                             ? 'Build a fully custom scanner with your own prompt and configuration.'
                             : template.description}
                     </p>
-                    {/* mt-auto pins the output token to the card's bottom edge so it lines up across the grid,
-                        regardless of how many lines each description takes. */}
+                    {/* Type chip + its output, stacked and pinned to the card's bottom edge (mt-auto) so this
+                        footer lines up across the grid regardless of how many lines each description takes. */}
                     {!isBlank && (
-                        <div className="mt-auto pt-4 flex justify-center">
+                        <div className="mt-auto pt-4 flex flex-col items-center gap-1.5">
+                            <ScannerTypeBadge scannerType={template.scanner_type} size="small" />
                             <LemonSnack type="regular">
                                 <span className="text-muted">Output:</span>{' '}
                                 {scannerTypeOutputHint(template.scanner_type)}

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTemplatePicker.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTemplatePicker.tsx
@@ -8,6 +8,7 @@ import { urls } from 'scenes/urls'
 import { ScannerTypeBadge } from '../../components/ScannerTypeBadge'
 import { replayScannerLogic } from '../replayScannerLogic'
 import { ScannerTemplate, ScannerTemplateIcon, defaultScannerTemplates, newScanner } from '../scannerTemplates'
+import { scannerTypeOutputHint } from '../types'
 
 const TEMPLATE_ICONS: Record<ScannerTemplateIcon, JSX.Element> = {
     warning: <IconWarning />,
@@ -53,6 +54,11 @@ function TemplateCard({ template }: { template: ScannerTemplate | 'blank' }): JS
                             ? 'Build a fully custom scanner with your own prompt and configuration.'
                             : template.description}
                     </p>
+                    {!isBlank && (
+                        <p className="text-xs text-muted mt-2 mb-0">
+                            Output: {scannerTypeOutputHint(template.scanner_type)}
+                        </p>
+                    )}
                 </div>
             </div>
         </button>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTemplatePicker.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTemplatePicker.tsx
@@ -56,7 +56,7 @@ function TemplateCard({ template }: { template: ScannerTemplate | 'blank' }): JS
                         footer lines up across the grid regardless of how many lines each description takes. */}
                     {!isBlank && (
                         <div className="mt-auto pt-4 flex flex-col items-center gap-1.5">
-                            <ScannerTypeBadge scannerType={template.scanner_type} size="small" />
+                            <ScannerTypeBadge scannerType={template.scanner_type} size="medium" />
                             <LemonSnack type="regular">
                                 <span className="text-muted">Output:</span>{' '}
                                 {scannerTypeOutputHint(template.scanner_type)}

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTemplatePicker.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTemplatePicker.tsx
@@ -3,6 +3,7 @@ import { combineUrl, router } from 'kea-router'
 
 import { IconCheckCircle, IconNotebook, IconPlus, IconTarget, IconThumbsDown, IconWarning } from '@posthog/icons'
 
+import { LemonSnack } from 'lib/lemon-ui/LemonSnack/LemonSnack'
 import { urls } from 'scenes/urls'
 
 import { ScannerTypeBadge } from '../../components/ScannerTypeBadge'
@@ -42,22 +43,27 @@ function TemplateCard({ template }: { template: ScannerTemplate | 'blank' }): JS
                         {isBlank ? <IconPlus /> : TEMPLATE_ICONS[template.icon]}
                     </span>
                 </div>
-                <div className="flex-1 flex flex-col justify-start">
+                <div className="flex-1 flex flex-col justify-start w-full">
                     <div className="flex items-center justify-center gap-2 mb-2">
                         <h3 className="text-base font-semibold text-default mb-0">
                             {isBlank ? 'Create from scratch' : template.name}
                         </h3>
                         {!isBlank && <ScannerTypeBadge scannerType={template.scanner_type} size="small" />}
                     </div>
-                    <p className="text-sm text-secondary leading-relaxed">
+                    <p className="text-sm text-secondary leading-relaxed mb-0">
                         {isBlank
                             ? 'Build a fully custom scanner with your own prompt and configuration.'
                             : template.description}
                     </p>
+                    {/* mt-auto pins the output token to the card's bottom edge so it lines up across the grid,
+                        regardless of how many lines each description takes. */}
                     {!isBlank && (
-                        <p className="text-xs text-muted mt-2 mb-0">
-                            Output: {scannerTypeOutputHint(template.scanner_type)}
-                        </p>
+                        <div className="mt-auto pt-4 flex justify-center">
+                            <LemonSnack type="regular">
+                                <span className="text-muted">Output:</span>{' '}
+                                {scannerTypeOutputHint(template.scanner_type)}
+                            </LemonSnack>
+                        </div>
                     )}
                 </div>
             </div>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTemplatePicker.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTemplatePicker.tsx
@@ -3,7 +3,6 @@ import { combineUrl, router } from 'kea-router'
 
 import { IconCheckCircle, IconNotebook, IconPlus, IconTarget, IconThumbsDown, IconWarning } from '@posthog/icons'
 
-import { LemonSnack } from 'lib/lemon-ui/LemonSnack/LemonSnack'
 import { urls } from 'scenes/urls'
 
 import { ScannerTypeBadge } from '../../components/ScannerTypeBadge'
@@ -52,15 +51,17 @@ function TemplateCard({ template }: { template: ScannerTemplate | 'blank' }): JS
                             ? 'Build a fully custom scanner with your own prompt and configuration.'
                             : template.description}
                     </p>
-                    {/* Type chip + its output, stacked and pinned to the card's bottom edge (mt-auto) so this
-                        footer lines up across the grid regardless of how many lines each description takes. */}
+                    {/* Type chip carries its output inline (e.g. "Monitor · yes or no"), pinned to the card's
+                        bottom edge (mt-auto) so it lines up across the grid regardless of description length. */}
                     {!isBlank && (
-                        <div className="mt-auto pt-4 flex flex-col items-center gap-1.5">
-                            <ScannerTypeBadge scannerType={template.scanner_type} size="medium" />
-                            <LemonSnack type="regular">
-                                <span className="text-muted">Output:</span>{' '}
-                                {scannerTypeOutputHint(template.scanner_type)}
-                            </LemonSnack>
+                        <div className="mt-auto pt-4 flex justify-center">
+                            <ScannerTypeBadge
+                                scannerType={template.scanner_type}
+                                size="medium"
+                                suffix={
+                                    <span className="opacity-75">· {scannerTypeOutputHint(template.scanner_type)}</span>
+                                }
+                            />
                         </div>
                     )}
                 </div>

--- a/products/replay_vision/frontend/replay_scanners/types.ts
+++ b/products/replay_vision/frontend/replay_scanners/types.ts
@@ -189,6 +189,19 @@ export function scannerTypeLabel(scannerType: ScannerType | null | undefined): s
     return SCANNER_TYPE_OPTIONS.find((opt) => opt.value === scannerType)?.label ?? scannerType
 }
 
+// A plain-language description of what each scanner type produces per session, for people who don't yet
+// know the type names. Kept short so it reads as a chip subtitle / tooltip.
+const SCANNER_TYPE_OUTPUT_HINT: Record<ScannerType, string> = {
+    monitor: 'yes or no',
+    classifier: 'a tag from a set you define',
+    scorer: 'a number score',
+    summarizer: 'a text summary',
+}
+
+export function scannerTypeOutputHint(scannerType: ScannerType): string {
+    return SCANNER_TYPE_OUTPUT_HINT[scannerType]
+}
+
 export function createdByLabel(user: ScannerCreatedBy | null): string {
     if (!user) {
         return ''


### PR DESCRIPTION
## Problem

The scanner template picker shows a scanner-type chip (Monitor / Classifier / Scorer / Summarizer) on each template card, but those names mean nothing to someone new to Replay Vision — you can't tell what a template actually produces without already knowing the type system.

## Changes

Add a plain-language **"Output: …"** line to each template card, derived from the scanner type:

- Monitor → `Output: yes or no`
- Classifier → `Output: a tag from a set you define`
- Scorer → `Output: a number score`
- Summarizer → `Output: a text summary`

New `scannerTypeOutputHint(type)` helper in `types.ts` (single source of truth), rendered as a small muted line under the description on `ScannerTemplatePicker`. The "Create from scratch" card has no type, so it shows no hint.

## How did you test this code?  
![Screenshot 2026-07-27 at 2.10.24 PM.png](https://app.graphite.com/user-attachments/assets/5fd971c2-14cb-4538-afa7-647662a176e3.png)



Copy/UI-only change. `tsgo` typecheck clean, oxlint + oxfmt clean, `hogli ci:preflight --strict` clean. No test added: the hint is a static per-type string with no branching logic, so a test would only mirror the map (change-detector) — nothing a realistic regression would break that the type system doesn't already catch.

The agent did not exercise the UI in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover this surface; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: @ksvat

Built with PostHog Code (Claude Opus 4.8). Standalone branch off master (not part of the Overview/digest stack). Considered a tooltip on the shared `ScannerTypeBadge` instead, but a visible line on the card is more discoverable for the newcomer this is aimed at, and keeps the widely-reused badge untouched.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)