### PR TITLE
feat(skills): add writing-user-facing-copy and writing-code-comments skills

### DIFF
--- a/.agents/skills/writing-code-comments/SKILL.md
+++ b/.agents/skills/writing-code-comments/SKILL.md
@@ -63,20 +63,19 @@ Delete it; the version history has it if it's needed again. Commented-out code i
 
 ## Style
 
-Write comments the way you'd write technical documentation: explicit, complete, and precise. State the reasoning in full so the reader does not have to infer any of it. A longer comment that spells out the cause and effect is better than a short one that leaves parts implicit.
+Write comments the way you'd write technical documentation: explicit and precise. State the reasoning so the reader does not have to infer it. Length is not a target in either direction: don't clip a comment to look terse, and don't pad it to look thorough. Say what needs saying and stop.
 
-- **Be explicit and technical.** State the cause and effect in full. Name the actual conditions, values, and consequences. A reader should not have to reconstruct your reasoning from a hint.
-- **Complete sentences, not fragments.** Write "Feature X does Y because Z, so callers must W." Don't compress it into a clipped fragment.
-- **Longer is fine when it adds information.** Prefer one thorough sentence (or two) that fully explains the why over a terse one that only gestures at it. Cut words that add nothing, not words that add precision.
-- **No short-punchy-fragment-with-a-dash style.** The clipped `# do the thing — it's faster` shape is the AI tell to avoid. Rewrite it as a full sentence with a real connective ("because", "so that", "which means"), no em-dash.
+- **Be explicit and technical.** State the cause and effect. Name the actual conditions, values, and consequences. A reader should not have to reconstruct your reasoning from a hint.
+- **Let length follow the content.** One line is fine when one line covers it; use more when the reasoning needs more. Neither brevity nor length is the goal.
+- **No em-dash.** The tell to avoid is the clipped two-part phrase joined by a dash, like `# do the thing — it's faster`. Use a real connective instead ("because", "so that", "which means", "to avoid").
 - **Explain why, not what.** The what is in the code; the why usually is not.
 - **Preserve existing comments when moving or refactoring code**, unless the change makes them wrong. Don't drop an existing why just because you're relocating the function.
 - **Match the surrounding density.** Don't add a comment to every line of a file that had none; don't strip a well-commented module bare.
 
-Contrast:
+The fix for the em-dash is the connective, not more words. A short comment is fine once the dash is gone:
 
 - ❌ `# batch here — avoids N+1`
-- ✅ `# Fetch all the memberships in one query here because doing it per-row triggers an N+1 against posthog_organizationmembership, which dominated the request time on large orgs.`
+- ✅ `# batch here to avoid an N+1 against posthog_organizationmembership`
 
 ## When you're tempted to comment
 

--- a/.agents/skills/writing-code-comments/SKILL.md
+++ b/.agents/skills/writing-code-comments/SKILL.md
@@ -3,7 +3,7 @@ name: writing-code-comments
 description: >
   Gates whether a code comment should exist and forces the ones that stay to explain why, not what.
   Use ALWAYS before writing or editing a comment in any language (Python, TypeScript, Go, Rust, SQL), and when reviewing a diff that adds comments.
-  Kills the comment types that clutter this codebase: narration that restates the code, change-history and chat-context notes ("previously did X", "per PR #123", "AI:"), commented-out code, and redundant docstrings.
+  Removes the comment types that clutter the codebase: narration that restates the code, change-history and chat-context notes ("previously did X", "per PR #123", "AI:"), commented-out code, and redundant docstrings.
   Keeps the ones that earn their place: a non-obvious why, a warning about a non-local consequence, a pointer to context a future reader can't reconstruct.
   Not for user-facing copy (see `/writing-user-facing-copy`) or commit messages.
 ---
@@ -65,10 +65,10 @@ Delete it; the version history has it if it's needed again. Commented-out code i
 
 - **Default to one line.** If a comment needs a paragraph, consider whether the code should be simpler first.
 - **Explain why, not what.** The what is in the code.
-- **Preserve existing comments when moving or refactoring code**, unless the change makes them wrong. Don't drop a hard-won why just because you're relocating the function.
-- **Write plainly.** The same anti-tells as prose apply: no punchy one-liners, no editorializing, no em-dashes. A comment is for the next engineer, not an audience.
+- **Preserve existing comments when moving or refactoring code**, unless the change makes them wrong. Don't drop an existing why just because you're relocating the function.
+- **Write plainly.** The same anti-tells as prose apply: no punchy one-liners, no editorializing, no em-dashes. Write the comment for the next engineer who has to change this code.
 - **Match the surrounding density.** Don't add a comment to every line of a file that had none; don't strip a well-commented module bare.
 
 ## When you're tempted to comment
 
-Try, in order: (1) a better name, (2) a smaller function, (3) a type. Reach for a comment only when none of those can carry the meaning, which is exactly when a comment is worth its keep.
+Try, in order: (1) a better name, (2) a smaller function, (3) a type. Reach for a comment only when none of those can carry the meaning.

--- a/.agents/skills/writing-code-comments/SKILL.md
+++ b/.agents/skills/writing-code-comments/SKILL.md
@@ -18,7 +18,7 @@ Before writing a comment, answer:
 
 > **What does this tell a future reader that the code itself doesn't?**
 
-If the answer is "it restates what the code does", delete it and let the code speak. Rename the variable or extract a function instead.
+If the answer is "it restates what the code does", delete it. Rename the variable or extract a function instead.
 
 A comment worth keeping answers a *why* the code can't:
 

--- a/.agents/skills/writing-code-comments/SKILL.md
+++ b/.agents/skills/writing-code-comments/SKILL.md
@@ -20,7 +20,7 @@ Before writing a comment, answer:
 
 If the answer is "it restates what the code does", delete it. Rename the variable or extract a function instead.
 
-A comment worth keeping answers a *why* the code can't:
+A comment worth keeping answers a _why_ the code can't:
 
 - ✅ `# ATOMIC_REQUESTS is off, so wrap the two writes that must commit together`
 - ✅ `// Stripe sends the amount in cents; the rest of our system uses dollars`

--- a/.agents/skills/writing-code-comments/SKILL.md
+++ b/.agents/skills/writing-code-comments/SKILL.md
@@ -63,11 +63,20 @@ Delete it; the version history has it if it's needed again. Commented-out code i
 
 ## Style
 
-- **Default to one line.** If a comment needs a paragraph, consider whether the code should be simpler first.
-- **Explain why, not what.** The what is in the code.
+Write comments the way you'd write technical documentation: explicit, complete, and precise. A comment that earns its place is worth stating fully. Length is not the enemy; vagueness is. Spell out the reasoning so nothing is left implicit for the reader to infer.
+
+- **Be explicit and technical.** State the cause and effect in full. Name the actual conditions, values, and consequences. A reader should not have to reconstruct your reasoning from a hint.
+- **Complete sentences, not fragments.** Write "Feature X does Y because Z, so callers must W." Don't compress it into a clipped fragment.
+- **Longer is fine when it adds information.** Prefer one thorough sentence (or two) that fully explains the why over a terse one that only gestures at it. Cut words that add nothing, not words that add precision.
+- **No short-punchy-fragment-with-a-dash style.** The clipped `# do the thing — it's faster` shape is the AI tell to avoid. Rewrite it as a full sentence with a real connective ("because", "so that", "which means"), no em-dash.
+- **Explain why, not what.** The what is in the code; the why usually is not.
 - **Preserve existing comments when moving or refactoring code**, unless the change makes them wrong. Don't drop an existing why just because you're relocating the function.
-- **Write plainly.** The same anti-tells as prose apply: no punchy one-liners, no editorializing, no em-dashes. Write the comment for the next engineer who has to change this code.
 - **Match the surrounding density.** Don't add a comment to every line of a file that had none; don't strip a well-commented module bare.
+
+Contrast:
+
+- ❌ `# batch here — avoids N+1`
+- ✅ `# Fetch all the memberships in one query here because doing it per-row triggers an N+1 against posthog_organizationmembership, which dominated the request time on large orgs.`
 
 ## When you're tempted to comment
 

--- a/.agents/skills/writing-code-comments/SKILL.md
+++ b/.agents/skills/writing-code-comments/SKILL.md
@@ -63,7 +63,7 @@ Delete it; the version history has it if it's needed again. Commented-out code i
 
 ## Style
 
-Write comments the way you'd write technical documentation: explicit, complete, and precise. A comment that earns its place is worth stating fully. Length is not the enemy; vagueness is. Spell out the reasoning so nothing is left implicit for the reader to infer.
+Write comments the way you'd write technical documentation: explicit, complete, and precise. State the reasoning in full so the reader does not have to infer any of it. A longer comment that spells out the cause and effect is better than a short one that leaves parts implicit.
 
 - **Be explicit and technical.** State the cause and effect in full. Name the actual conditions, values, and consequences. A reader should not have to reconstruct your reasoning from a hint.
 - **Complete sentences, not fragments.** Write "Feature X does Y because Z, so callers must W." Don't compress it into a clipped fragment.

--- a/.agents/skills/writing-code-comments/SKILL.md
+++ b/.agents/skills/writing-code-comments/SKILL.md
@@ -47,7 +47,7 @@ Never record how the code got here. That belongs in the commit message and PR de
 
 ### Commented-out code
 
-Delete it. Git remembers. A block of dead code behind `#` is worse than no code: readers can't tell if it's a note, a rollback plan, or an accident.
+Delete it; the version history has it if it's needed again. Commented-out code is ambiguous to the next reader, who can't tell whether it's a note, a rollback plan, or an accident.
 
 ### Redundant docstrings and type restatements
 

--- a/.agents/skills/writing-code-comments/SKILL.md
+++ b/.agents/skills/writing-code-comments/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: writing-code-comments
+description: >
+  Gates whether a code comment should exist and forces the ones that stay to explain why, not what.
+  Use ALWAYS before writing or editing a comment in any language (Python, TypeScript, Go, Rust, SQL), and when reviewing a diff that adds comments.
+  Kills the comment types that clutter this codebase: narration that restates the code, change-history and chat-context notes ("previously did X", "per PR #123", "AI:"), commented-out code, and redundant docstrings.
+  Keeps the ones that earn their place: a non-obvious why, a warning about a non-local consequence, a pointer to context a future reader can't reconstruct.
+  Not for user-facing copy (see `/writing-user-facing-copy`) or commit messages.
+---
+
+# Writing code comments
+
+Run this before adding or editing any comment. The default is no comment. Good code with clear names carries most of its meaning on its own; a comment earns its place only when it tells a reader something the code cannot.
+
+## The gate: one question
+
+Before writing a comment, answer:
+
+> **What does this tell a future reader that the code itself doesn't?**
+
+If the answer is "it restates what the code does", delete it and let the code speak. Rename the variable or extract a function instead.
+
+A comment worth keeping answers a *why* the code can't:
+
+- ✅ `# ATOMIC_REQUESTS is off, so wrap the two writes that must commit together`
+- ✅ `// Stripe sends the amount in cents; the rest of our system uses dollars`
+- ✅ `# Kept in sync with the enum in migrations/0042; update both`
+
+## Delete these
+
+### Narration that restates the code
+
+- ❌ `# increment the counter` above `counter += 1`
+- ❌ `// loop over users` above `for user of users`
+- ❌ `# return the result` above `return result`
+
+If a block needs narration to be followed, the fix is smaller functions and better names, not a comment.
+
+### Change history and chat context
+
+Never record how the code got here. That belongs in the commit message and PR description, where it's attached to the diff and searchable. In the source it's noise that goes stale immediately.
+
+- ❌ `# previously used a set here, switched to a list for ordering`
+- ❌ `// per PR #1234` / `# as discussed` / `# changed because the old way broke`
+- ❌ `# AI: generated this helper` / `// agent: refactored`
+- ❌ `# TODO(2024-01): remove after migration` left in long after the migration
+
+### Commented-out code
+
+Delete it. Git remembers. A block of dead code behind `#` is worse than no code: readers can't tell if it's a note, a rollback plan, or an accident.
+
+### Redundant docstrings and type restatements
+
+- ❌ A docstring that repeats the function name in prose: `"""Gets the user by id."""` on `get_user_by_id`
+- ❌ `# type: string` on an already-typed field
+- ❌ Python test doc comments (the repo convention is none; the test name says it)
+
+## Keep these
+
+- A **why** that isn't obvious from the code: a workaround, a performance trade-off, a spec quirk, an ordering constraint.
+- A **warning** about a consequence that lives elsewhere: "changing this breaks the cache key", "callers rely on this being sorted".
+- A **pointer** to context a reader can't reconstruct from the repo: a link to the spec, ticket, or the reason a surprising value was chosen.
+
+## Style
+
+- **Default to one line.** If a comment needs a paragraph, consider whether the code should be simpler first.
+- **Explain why, not what.** The what is in the code.
+- **Preserve existing comments when moving or refactoring code**, unless the change makes them wrong. Don't drop a hard-won why just because you're relocating the function.
+- **Write plainly.** The same anti-tells as prose apply: no punchy one-liners, no editorializing, no em-dashes. A comment is for the next engineer, not an audience.
+- **Match the surrounding density.** Don't add a comment to every line of a file that had none; don't strip a well-commented module bare.
+
+## When you're tempted to comment
+
+Try, in order: (1) a better name, (2) a smaller function, (3) a type. Reach for a comment only when none of those can carry the meaning, which is exactly when a comment is worth its keep.

--- a/.agents/skills/writing-user-facing-copy/SKILL.md
+++ b/.agents/skills/writing-user-facing-copy/SKILL.md
@@ -64,7 +64,7 @@ After drafting, re-read and cut anything that's there to sound good rather than 
 
 ### Errors and empty states point to a next step
 
-Say what happened and the next action. Never leave the user staring at a failure with nothing to do.
+Say what happened and give the next action. Don't stop at reporting that something failed.
 
 - ❌ "Something went wrong."
 - ✅ "Couldn't load your insights. Refresh the page, and if it keeps happening contact support."

--- a/.agents/skills/writing-user-facing-copy/SKILL.md
+++ b/.agents/skills/writing-user-facing-copy/SKILL.md
@@ -18,7 +18,7 @@ Does not apply to: code comments, commit messages, log lines, variable/function 
 
 ## Voice
 
-Write like a calm, competent person typed it. Neutral and humane.
+Write the way a person would. Neutral and humane.
 
 - **Sentence case.** Capitalize only the first word and proper nouns. "Save as view", not "Save As View". "Product analytics", not "Product Analytics".
 - **Be direct and friendly.** Short sentences. Say what happened and what to do next.

--- a/.agents/skills/writing-user-facing-copy/SKILL.md
+++ b/.agents/skills/writing-user-facing-copy/SKILL.md
@@ -48,6 +48,20 @@ Also avoid the sentence *shapes* that lean on that dash, because they read as ma
 
 Write the plain version instead.
 
+### No punchy or clever phrasing
+
+This is the failure mode that slips through even when you know the rule, so check for it specifically. It applies to every string, including headings, section titles, and button labels, not just body text.
+
+The tells:
+
+- **Antithesis** ("X, not Y" / "X, they don't Y") used for effect. ❌ "Errors guide, they don't dead-end." → ✅ "Errors point to a next step."
+- **A heading written to sound weighty.** ❌ "The rules that are easy to break" → ✅ "Common mistakes".
+- **A clever or dramatic closing line.** ❌ "Never leave the user staring at a failure." → ✅ "Say what happened and what to do next."
+- **Filler that sounds like a principle but adds nothing.** ❌ "This is a tool people use to get work done." → cut it.
+- **Emphasis the sentence doesn't need.** ❌ "This will completely transform how you work." → ✅ "This changes how X works."
+
+After drafting, re-read and cut anything that's there to sound good rather than to inform. If a line would feel out of place said plainly out loud to a colleague, rewrite it.
+
 ### Errors and empty states point to a next step
 
 Say what happened and the next action. Never leave the user staring at a failure with nothing to do.

--- a/.agents/skills/writing-user-facing-copy/SKILL.md
+++ b/.agents/skills/writing-user-facing-copy/SKILL.md
@@ -40,10 +40,10 @@ Prefer rewriting the sentence so the dash isn't needed. If a connector is unavoi
 - ✅ "Save this view. You can reuse it later."
 - ✅ "Save this view to reuse it later."
 
-Also avoid the sentence *shapes* that lean on that dash, because they read as machine-written:
+Also avoid the sentence _shapes_ that lean on that dash, because they read as machine-written:
 
-- ❌ "This isn't just a filter, it's a saved view."  (the "not just X, but Y" construction)
-- ❌ "It's fast, it's simple, it's yours."  (rule-of-three padding)
+- ❌ "This isn't just a filter, it's a saved view." (the "not just X, but Y" construction)
+- ❌ "It's fast, it's simple, it's yours." (rule-of-three padding)
 - ❌ Hedging preambles like "It's worth noting that…", "Keep in mind that…".
 
 Write the plain version instead.

--- a/.agents/skills/writing-user-facing-copy/SKILL.md
+++ b/.agents/skills/writing-user-facing-copy/SKILL.md
@@ -21,13 +21,13 @@ Does not apply to: code comments, commit messages, log lines, variable/function 
 Write the way a person would. Neutral and humane.
 
 - **Sentence case.** Capitalize only the first word and proper nouns. "Save as view", not "Save As View". "Product analytics", not "Product Analytics".
-- **Be direct and friendly.** Short sentences. Say what happened and what to do next.
+- **Be direct and friendly.** Say what happened and what to do next.
 - **Plain language, no jargon.** Use the label the user sees, not the internal name. `surveyPopupDelaySeconds` becomes "Delay the survey popup".
 - **Don't editorialize.** State what is, not how exciting it is. Cut "powerful", "seamless", "effortless", "simply", "just", "easily", "supercharge", "unlock".
-- **No sales-y or edgy copy.** No marketing hooks, no clever one-liners, no hype. This is a tool people use to get work done.
+- **No sales-y or edgy copy.** No marketing hooks, no clever one-liners, no hype.
 - **American English spelling.** "color", "analyze", "canceled".
 
-## The rules that are easy to break
+## Specific rules
 
 ### No em-dashes
 
@@ -48,7 +48,7 @@ Also avoid the sentence *shapes* that lean on that dash, because they read as ma
 
 Write the plain version instead.
 
-### Errors and empty states guide, they don't dead-end
+### Errors and empty states point to a next step
 
 Say what happened and the next action. Never leave the user staring at a failure with nothing to do.
 

--- a/.agents/skills/writing-user-facing-copy/SKILL.md
+++ b/.agents/skills/writing-user-facing-copy/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: writing-user-facing-copy
+description: >
+  Sets the voice and word choices for any text a person reads in PostHog: UI labels, buttons, tooltips, empty and error states, notifications, in-app messages, onboarding, docs, and support replies.
+  Use ALWAYS before writing or editing user-facing copy, and whenever a code change adds or changes a string a user will see.
+  Enforces a humane, neutral tone: no editorializing, no sales-y or edgy one-liners, no em-dashes (use hyphens or rewrite), sentence case, plain language.
+  Also carries feature-naming rules that are easy to get wrong, most importantly how to talk about the Wizard (name it "Wizard" once, then call it "the setup agent" / "the agent").
+  Not for internal code comments, commit messages, or variable names.
+---
+
+# Writing user-facing copy
+
+This is the operational gate for anything a person reads in the product or around it.
+Run it before writing or editing user-facing text, and whenever a code change introduces or changes a visible string.
+
+Applies to: UI labels, buttons, form fields, tooltips, empty states, error and success messages, toasts and notifications, onboarding flows, emails, docs, and support replies.
+Does not apply to: code comments, commit messages, log lines, variable/function names, or other developer-only text.
+
+## Voice
+
+Write like a calm, competent person typed it. Neutral and humane.
+
+- **Sentence case.** Capitalize only the first word and proper nouns. "Save as view", not "Save As View". "Product analytics", not "Product Analytics".
+- **Be direct and friendly.** Short sentences. Say what happened and what to do next.
+- **Plain language, no jargon.** Use the label the user sees, not the internal name. `surveyPopupDelaySeconds` becomes "Delay the survey popup".
+- **Don't editorialize.** State what is, not how exciting it is. Cut "powerful", "seamless", "effortless", "simply", "just", "easily", "supercharge", "unlock".
+- **No sales-y or edgy copy.** No marketing hooks, no clever one-liners, no hype. This is a tool people use to get work done.
+- **American English spelling.** "color", "analyze", "canceled".
+
+## The rules that are easy to break
+
+### No em-dashes
+
+Do not use em-dashes (—) anywhere in user-facing copy.
+Do not substitute an en-dash either.
+
+Prefer rewriting the sentence so the dash isn't needed. If a connector is unavoidable, use a hyphen with spaces, a comma, a colon, or split into two sentences.
+
+- ❌ "Save this view — you can reuse it later."
+- ✅ "Save this view. You can reuse it later."
+- ✅ "Save this view to reuse it later."
+
+Also avoid the sentence *shapes* that lean on that dash, because they read as machine-written:
+
+- ❌ "This isn't just a filter, it's a saved view."  (the "not just X, but Y" construction)
+- ❌ "It's fast, it's simple, it's yours."  (rule-of-three padding)
+- ❌ Hedging preambles like "It's worth noting that…", "Keep in mind that…".
+
+Write the plain version instead.
+
+### Errors and empty states guide, they don't dead-end
+
+Say what happened and the next action. Never leave the user staring at a failure with nothing to do.
+
+- ❌ "Something went wrong."
+- ✅ "Couldn't load your insights. Refresh the page, and if it keeps happening contact support."
+
+## How to talk about features
+
+Use the names users see, and stay consistent across every surface.
+
+### Wizard
+
+The setup tool is named **Wizard**. It confuses users as a description, because "wizard" reads like an old-style step-by-step form, not an AI. Users already have a mental model for AI agents.
+
+- Use "Wizard" **only** as the feature's proper name (the thing you're pointing at).
+- To explain what it does, always call it **"the setup agent"** or **"the agent"**.
+
+Examples:
+
+- ✅ "Wizard sets up PostHog for you. The setup agent installs the SDK and wires up your first events."
+- ✅ "Ask the agent to add error tracking."
+- ❌ "Use the wizard to walk through setup." (using "wizard" as a description)
+- ❌ "The wizard will guide you through each step." (reinforces the wrong mental model)
+
+For any other feature, use its product-facing name exactly as it appears in the UI, and describe it in the terms users already understand.
+
+## When unsure
+
+If you can't tell whether copy reads well, or whether a term is the right user-facing name, ask a human before shipping it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,7 @@ See [.agents/security.md](.agents/security.md) for security guidelines — least
 
 ## User-facing copy
 
-For any text a person reads (UI labels, tooltips, empty/error states, notifications, docs, support replies). When unsure whether copy reads well, ask a human.
+For any text a person reads (UI labels, tooltips, empty/error states, notifications, docs, support replies). Invoke `/writing-user-facing-copy` before writing or editing it — that skill carries the full voice, em-dash, and feature-naming rules. When unsure whether copy reads well, ask a human.
 
 - Sentence case, not Title Case: capitalize only the first word and proper nouns ('Product analytics', 'Save as view').
 - Avoid the tells of AI-generated text: em dashes (—), "not just X, but Y", rule-of-three padding, hedging preambles. Write like a person typed it; if you can't tell, ask a human.
@@ -196,6 +196,7 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 - `/clickhouse-migrations` — any ClickHouse migration
 - `/adopting-generated-api-types` — any frontend file using `lib/api`, `api.get<`, `api.create<`, or handwritten API types
 - `/writing-tests` — adding or substantially changing any test (pytest, Jest, or Playwright)
+- `/writing-user-facing-copy` — writing or editing any text a user reads (UI labels, tooltips, empty/error states, notifications, docs, support replies), or any code change that adds or changes a visible string
 
 **Invoke when in the area:**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,7 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 - `/adopting-generated-api-types` — any frontend file using `lib/api`, `api.get<`, `api.create<`, or handwritten API types
 - `/writing-tests` — adding or substantially changing any test (pytest, Jest, or Playwright)
 - `/writing-user-facing-copy` — writing or editing any text a user reads (UI labels, tooltips, empty/error states, notifications, docs, support replies), or any code change that adds or changes a visible string
+- `/writing-code-comments` — writing or editing a code comment in any language, or reviewing a diff that adds comments
 
 **Invoke when in the area:**
 


### PR DESCRIPTION
## Problem

Closes GROW-223

We don't have a single place codifying how PostHog writing should read, and two surfaces suffer for it:

1. **User-facing copy** — tone, em-dash usage, and feature naming get decided ad hoc, so strings drift in voice. In particular the Wizard feature name confuses users when it's used as a description rather than a proper name.
2. **Code comments** — the codebase accumulates comments that restate the code, log change history or chat context, or sit commented-out. There was no operational gate for whether a comment should exist.

## Changes

Two cross-cutting skills under `.agents/skills/`, both registered in the mandatory "Always invoke" list in `AGENTS.md`.

- **`writing-user-facing-copy`** — humane, neutral voice; no editorializing, sales-y or clever phrasing; no em-dashes; sentence case; plain language. Includes the Wizard naming rule (use "Wizard" only as the proper name; describe it as "the setup agent" / "the agent"). Has a concrete "No punchy or clever phrasing" section with before/after examples for the tells that slip through even when the rule is known.
- **`writing-code-comments`** — gates whether a comment should exist and forces the survivors to explain why, not what. Deletes narration, change-history/chat-context notes, commented-out code, and redundant docstrings; keeps a non-obvious why, a non-local warning, or a pointer to context a reader can't reconstruct.

The existing user-facing copy section in `AGENTS.md` now points at the copy skill so guidance stays in one place.

**Why:** so agents and engineers reach for one consistent set of rules instead of deciding tone and comment hygiene case by case.

## How did you test this code?

The skill build/lint tooling (`hogli lint:skills`) requires the flox venv, which isn't available in this environment, so I could not run it here. I matched the frontmatter and directory structure of existing `.agents/skills/` entries and verified both skills' own prose obeys their rules (no em-dashes outside deliberate ❌ examples). No production code changed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) at a human's direction. Invoked `/writing-skills` to follow skill-authoring conventions. The user supplied the copy tone rules and the Wizard naming rule, then reviewed iteratively — several rounds specifically pushed back on my own edgy phrasing leaking into the copy skill, which is what motivated the concrete anti-tell examples and the companion code-comments skill. The comments skill was drafted from the existing `AGENTS.md`/`CLAUDE.md` comment conventions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
