### PR TITLE
fix(databricks): retry transient SSL peer-close on connect

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/databricks.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/databricks.py
@@ -9,6 +9,7 @@ PostHog-layer wrapper that holds an instance and validates credentials.
 
 from __future__ import annotations
 
+import time
 import collections
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
@@ -66,6 +67,43 @@ DATABRICKS_SYSTEM_SCHEMA = "information_schema"
 # `fetchmany_arrow` size. CloudFetch already chunks the result set into presigned cloud-storage
 # files behind the cursor, so this only bounds how many rows we materialize per yielded batch.
 DEFAULT_DATABRICKS_FETCH_SIZE = 10_000
+
+# Number of times `connect` will open a fresh Databricks SQL connection before giving up. Mirrors
+# the MySQL/Postgres sources' own in-process connect retry budget.
+_MAX_CONNECT_ATTEMPTS = 5
+
+# The connector's own request-retry loop (`ThriftBackend.make_request`) only retries HTTP 429/503
+# responses and `GetOperationStatus` polling failures — a bare SSL error raised while opening the
+# session (including fetching the initial OAuth service-principal token from `/oidc/v1/token`) is
+# classified non-retryable and raised immediately on the first attempt. `[SSL:
+# UNEXPECTED_EOF_WHILE_READING]` is the peer closing the TLS connection mid-handshake — an
+# overloaded endpoint, a proxy/load-balancer idle cull, or a momentary network blip, all of which a
+# fresh attempt recovers from. Mirrors the MySQL source's `_is_transient_connect_drop`.
+_SSL_UNEXPECTED_EOF_TOKEN = "[SSL: UNEXPECTED_EOF_WHILE_READING]"
+
+
+def _is_transient_connect_ssl_eof(e: BaseException) -> bool:
+    """Return True if connect failed on a transient SSL peer-close mid-handshake."""
+    return isinstance(e, databricks_sql.Error) and _SSL_UNEXPECTED_EOF_TOKEN in str(e)
+
+
+def _connect_with_transient_retry(**kwargs: Any) -> Any:
+    """Open a Databricks SQL connection, retrying a transient SSL peer-close on connect."""
+    attempt = 0
+    while True:
+        try:
+            return databricks_sql.connect(**kwargs)
+        except Exception as e:
+            attempt += 1
+            if attempt >= _MAX_CONNECT_ATTEMPTS or not _is_transient_connect_ssl_eof(e):
+                raise
+            structlog.get_logger().warning(
+                "Transient Databricks connection error during connect; retrying",
+                attempt=attempt,
+                max_attempts=_MAX_CONNECT_ATTEMPTS,
+                exc_info=e,
+            )
+            time.sleep(min(2 * attempt, 30))
 
 
 def filter_databricks_incremental_fields(
@@ -160,7 +198,7 @@ class DatabricksImplementation(SQLSourceImplementation[DatabricksSourceConfig, A
             auth_connect_args = {"access_token": config.auth_type.access_token}
 
         log_connection_open(db_host=host, via="vendor_https")
-        connection = databricks_sql.connect(
+        connection = _connect_with_transient_retry(
             server_hostname=host,
             http_path=config.http_path,
             catalog=config.catalog,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/databricks/tests/test_databricks.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
+from databricks.sql.exc import RequestError
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.implementation import TableStats
@@ -18,6 +19,13 @@ from products.warehouse_sources.backend.types import IncrementalFieldType
 
 _CONNECT_PATH = (
     "products.warehouse_sources.backend.temporal.data_imports.sources.databricks.databricks.databricks_sql.connect"
+)
+_SLEEP_PATH = "products.warehouse_sources.backend.temporal.data_imports.sources.databricks.databricks.time.sleep"
+
+_SSL_EOF_ERROR_MSG = (
+    "Error during request to server: HTTPSConnectionPool(host='x', port=443): Max retries exceeded"
+    " with url: /oidc/v1/token (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING]"
+    " EOF occurred in violation of protocol')))"
 )
 
 # ---------------------------------------------------------------------------
@@ -182,6 +190,34 @@ class TestConnect:
                 with impl.connect(_make_config()):
                     raise RuntimeError("boom")
             mock_connect.return_value.close.assert_called_once()
+
+    def test_transient_ssl_eof_on_connect_is_retried(self, impl):
+        # The connector's own retry loop treats a bare SSL error during `open_session` (including
+        # the OAuth token fetch) as non-retryable and raises immediately — connect() must recover
+        # a transient peer-close instead of failing the sync on the first blip.
+        mock_conn = MagicMock()
+        with patch(_CONNECT_PATH, side_effect=[RequestError(_SSL_EOF_ERROR_MSG, {}, "x"), mock_conn]) as mock_connect:
+            with patch(_SLEEP_PATH):
+                with impl.connect(_make_config()) as conn:
+                    assert conn is mock_conn
+            assert mock_connect.call_count == 2
+
+    def test_transient_ssl_eof_exhausts_retries_and_raises(self, impl):
+        with patch(_CONNECT_PATH, side_effect=RequestError(_SSL_EOF_ERROR_MSG, {}, "x")) as mock_connect:
+            with patch(_SLEEP_PATH):
+                with pytest.raises(RequestError):
+                    with impl.connect(_make_config()):
+                        pass
+            assert mock_connect.call_count == 5
+
+    def test_non_transient_connect_error_is_not_retried(self, impl):
+        # A permission/config error must surface on the first attempt — only the specific
+        # transient SSL peer-close signature is worth retrying.
+        with patch(_CONNECT_PATH, side_effect=RequestError("[PERMISSION_DENIED] nope", {}, "x")) as mock_connect:
+            with pytest.raises(RequestError):
+                with impl.connect(_make_config()):
+                    pass
+            assert mock_connect.call_count == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Error tracking flagged a `RequestError` from the Databricks import source, raised from a request to the OAuth token endpoint during connect:

```
Error during request to server: HTTPSConnectionPool(host='...', port=443): Max retries exceeded
with url: /oidc/v1/token (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING]
... occurred in violation of protocol')))
```

Digging into the vendored `databricks-sql-connector`, its own request-retry loop (`ThriftBackend.make_request`) only retries HTTP 429/503 responses and `GetOperationStatus` polling failures. A bare SSL error raised while opening the session — including fetching the initial OAuth service-principal token — is classified non-retryable and raised immediately on the very first attempt, with no built-in retry.

The SSL EOF signature is the peer closing the TLS connection mid-handshake: an overloaded endpoint, a proxy/load-balancer idle cull, or a momentary network blip, all of which a fresh attempt recovers from. It's not a credential or config problem, so it shouldn't be classified as a non-retryable error either — it should just be retried. This is the same class of transient connect-time drop the MySQL and Postgres sources already handle with their own in-process connect retries.

## Changes

Added a bounded in-process retry around `DatabricksImplementation.connect()`:
- Recognizes the SSL peer-close-mid-handshake signature specifically (not a general catch-all).
- Retries up to 5 attempts with a short backoff, mirroring the MySQL source's existing budget.
- Anything else re-raises immediately on the first attempt, unchanged from today.

## How did you test this code?

Added 3 cases to `TestConnect` in `test_databricks.py`:
- a transient SSL EOF error followed by a successful connect is retried and returns the connection (catches: the retry wrapper never firing, or firing but not returning the eventual success)
- the same error repeated exhausts the attempt budget and re-raises (catches: an infinite retry loop, or a budget that silently swallows the failure)
- a different connect error (e.g. a permission error) is not retried and surfaces on the first attempt (catches: over-broadly matching any exception as transient)

Ran the full `test_databricks.py` suite (75 tests, all passing), `ruff check`/`format`, and `uv run mypy --cache-fine-grained .` repo-wide (clean).

The patch-coverage bot flags 2 uncovered lines (210, 219) — both are the `pass` body of a `with impl.connect(...):` block in the two tests asserting that `connect()` raises. The body never executes because the context manager raises before yielding, so these lines are inherently unreachable; nothing to add a test for.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - no user-facing behavior or config change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triggered by a PostHog error-tracking issue for the `databricks` warehouse source. I confirmed the stack trace originates in `DatabricksImplementation.connect()`, traced the failure into the vendored connector's retry logic to establish this is genuinely un-retried today, and checked for an existing open PR covering this (none found).
- Followed the MySQL source's transient-connect-drop retry pattern as precedent for classifying and retrying this specific transient signature, scoped narrowly to avoid widening non-retryable-error matching.
- Ran the `/writing-tests` skill before adding the new test cases.

