### PR TITLE
fix(data-imports): retry transient S3 write errors in the v3 pipeline writer

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/test_writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/test_writer.py
@@ -1,8 +1,64 @@
 import json
+import errno
+
+import pytest
+from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.s3.writer import build_schema_dict
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.s3.writer import (
+    _write_parquet_to_s3,
+    build_schema_dict,
+)
+
+
+def _fake_s3(open_side_effect: list) -> MagicMock:
+    s3 = MagicMock()
+    s3.open.return_value.__enter__.side_effect = open_side_effect
+    # A MagicMock's auto-mocked __exit__ returns a truthy MagicMock by default, which would
+    # suppress the exception pyarrow.parquet.write_table raises inside the `with` block.
+    s3.open.return_value.__exit__.return_value = False
+    return s3
+
+
+class TestWriteParquetToS3:
+    @patch("tenacity.nap.time.sleep")
+    @patch("pyarrow.parquet.write_table")
+    def test_retries_transient_os_error_then_succeeds(self, mock_write_table, _mock_sleep) -> None:
+        # s3fs translates a truncated-upload S3 response (e.g. IncompleteBody) into a plain
+        # OSError; a single dropped connection shouldn't fail the whole batch write.
+        f = MagicMock()
+        s3 = _fake_s3([f, f])
+        mock_write_table.side_effect = [OSError(errno.EINVAL, "The request body terminated unexpectedly"), None]
+
+        _write_parquet_to_s3(s3, "bucket/part-0000.parquet", pa.table({"id": [1]}), "zstd")
+
+        assert mock_write_table.call_count == 2
+
+    @patch("tenacity.nap.time.sleep")
+    @patch("pyarrow.parquet.write_table")
+    def test_reraises_after_persistent_os_error(self, mock_write_table, _mock_sleep) -> None:
+        f = MagicMock()
+        s3 = _fake_s3([f, f, f, f])
+        mock_write_table.side_effect = OSError(errno.EINVAL, "The request body terminated unexpectedly")
+
+        with pytest.raises(OSError):
+            _write_parquet_to_s3(s3, "bucket/part-0000.parquet", pa.table({"id": [1]}), "zstd")
+
+        assert mock_write_table.call_count == 4
+
+    @patch("pyarrow.parquet.write_table")
+    def test_does_not_retry_permission_error(self, mock_write_table) -> None:
+        # PermissionError (e.g. AccessDenied/InvalidAccessKeyId) is an OSError subclass but not
+        # transient — retrying it just delays a failure that will happen on every attempt.
+        f = MagicMock()
+        s3 = _fake_s3([f])
+        mock_write_table.side_effect = PermissionError("Access Denied")
+
+        with pytest.raises(PermissionError):
+            _write_parquet_to_s3(s3, "bucket/part-0000.parquet", pa.table({"id": [1]}), "zstd")
+
+        assert mock_write_table.call_count == 1
 
 
 class TestBuildSchemaDict:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/writer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/writer.py
@@ -8,6 +8,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from structlog.types import FilteringBoundLogger
 from temporalio import activity
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential_jitter
 
 from products.data_warehouse.backend.facade.api import get_s3_client
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
@@ -51,6 +52,28 @@ def build_schema_dict(schema: pa.Schema) -> dict:
         ],
         "pandas_metadata": schema.pandas_metadata,
     }
+
+
+def _is_transient_s3_write_error(exc: BaseException) -> bool:
+    # s3fs translates most S3-side write failures (IncompleteBody, InternalError,
+    # SlowDown/ServiceUnavailable, ...) into a plain OSError. PermissionError,
+    # FileNotFoundError, and TimeoutError are also OSError subclasses but signal
+    # non-transient causes (bad credentials, deleted bucket) that retrying won't fix,
+    # so only the exact base type is treated as retryable here.
+    return type(exc) is OSError
+
+
+@retry(
+    retry=retry_if_exception(_is_transient_s3_write_error),
+    stop=stop_after_attempt(4),
+    wait=wait_exponential_jitter(initial=1, max=10),
+    reraise=True,
+)
+def _write_parquet_to_s3(
+    s3: s3fs.S3FileSystem, s3_path: str, pa_table: pa.Table, compression: ParquetCompression
+) -> None:
+    with s3.open(s3_path, "wb") as f:
+        pq.write_table(pa_table, f, compression=compression)
 
 
 class S3BatchWriter:
@@ -103,8 +126,7 @@ class S3BatchWriter:
         write_start = time.perf_counter()
         try:
             s3_path_without_protocol = strip_s3_protocol(s3_path)
-            with self._s3.open(s3_path_without_protocol, "wb") as f:
-                pq.write_table(pa_table, f, compression=self._compression)
+            _write_parquet_to_s3(self._s3, s3_path_without_protocol, pa_table, self._compression)
         except Exception as e:
             if activity.in_activity():
                 get_s3_write_errors_metric(type(e).__name__).add(1)


### PR DESCRIPTION
## Problem

A Databricks incremental sync's `$exception` event surfaced `OSError: [Errno 22] The request body terminated unexpectedly` from `posthog/temporal/common/posthog_client.py` — the activity execution wrapper, not the true source of the failure.

Following the stack down through the v3 pipeline shows the real origin: `S3BatchWriter.write_batch` (`products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/s3/writer.py`) writing a parquet batch to S3 via `s3fs`. The chained exception is a `botocore.exceptions.ClientError` with code `IncompleteBody` from a `PutObject` call — the upload body was truncated mid-transfer. `s3fs` translates this into a plain `OSError` (`s3fs/errors.py`'s `ERROR_CODE_TO_EXCEPTION` maps `IncompleteBody` to `IOError(errno.EINVAL, ...)`), and its own internal retry loop only retries a `ClientError` for `SlowDown`/rate-limit/SHA-mismatch messages — `IncompleteBody` isn't one of them, so `s3fs` gives up after one attempt.

This isn't specific to Databricks — any v3 pipeline source writing batches through this shared writer can hit the same class of transient S3 upload hiccup. Since `write_batch` had no retry of its own, a single dropped connection during upload failed the entire import activity, which can mean redoing the whole extraction from the source rather than just re-uploading one small parquet file.

## Changes

- Wrapped the S3 parquet write (`s3.open(...)` + `pq.write_table(...)`) in a `tenacity`-backed retry (`_write_parquet_to_s3`), matching the existing retry pattern used elsewhere in `data_imports` (e.g. the Fastly source).
- The retry only fires for the exact `OSError` type that `s3fs` uses for transient S3-side write failures (`IncompleteBody`, `InternalError`, `SlowDown`/`ServiceUnavailable`, ...). `PermissionError`, `FileNotFoundError`, and `TimeoutError` are `OSError` subclasses too, but signal non-transient causes (bad credentials, deleted bucket) — those still fail immediately rather than wasting retries on backoff.
- No change to `NonRetryableErrors`, source classification, or the Temporal activity's own retry policy — this only adds a bounded, scoped retry around one small S3 write.

## How did you test this code?

Added `TestWriteParquetToS3` in `test_writer.py`:
- retries a transient `OSError` (e.g. an `IncompleteBody`-shaped error) and succeeds on a later attempt
- re-raises after persistent transient failures, once retries are exhausted
- does **not** retry a `PermissionError` (single attempt, immediate failure)

Ran `ruff check`/`ruff format --check` on the changed files and a full-repo `mypy --cache-fine-grained .` — both clean. Couldn't run `hogli`/`ci:preflight` in this environment (no `node_modules`/`hogli` available), so ran the equivalent lint/type/test checks manually instead.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal pipeline resiliency fix, no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (an agent) triaged a webhook-delivered PostHog error-tracking issue (`OSError: [Errno 22] The request body terminated unexpectedly`) end to end: pulled the issue's stack trace and `warehouse_sources_*` properties via the PostHog MCP tools, traced the failure from the reported `posthog_client.py` frame down to the true origin in the v3 pipeline's S3 writer, and read the installed `s3fs`/`fsspec` source to confirm exactly how `IncompleteBody` gets translated into `OSError` and why `s3fs`'s own retry loop skips it.

Decision: this is a shared-pipeline transient-infra bug (not a NonRetryableErrors candidate, and not source-specific), so I added a small, scoped `tenacity` retry around just the S3 write rather than touching retry classification or the activity-level retry policy. Checked for duplicate open PRs (searched by exception type, message substring, and file path, plus scanned the maintainer's own open PRs) — none touch this file or this failure mode.