### PR TITLE
fix(clickhouse): stop reporting HTTP read timeouts from duplicate-PK probe

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -866,10 +866,15 @@ _DUPLICATE_PK_CHECK_SETTINGS: dict[str, Any] = {
 #     caps before `read_overflow_mode='break'` truncates on rows — the probe
 #     behaving exactly as designed. Some managed servers also enforce a memory
 #     cap below our `max_memory_usage`, surfacing the same way.
+#   - "Read timed out": the probe's `max_execution_time` only bounds server-side
+#     execution, not ClickHouse Cloud's cold-resume wake-up latency or a scan
+#     the server hasn't yet gotten around to capping — so the HTTP client's own
+#     read timeout can fire first. Same designed fallback as the budget caps.
 _EXPECTED_PROBE_FAILURE_SUBSTRINGS: tuple[str, ...] = (
     "is unknown or readonly",
     "MEMORY_LIMIT_EXCEEDED",
     "TIMEOUT_EXCEEDED",
+    "Read timed out",
 )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -1111,6 +1111,9 @@ class TestHasDuplicatePrimaryKeys:
             "Setting optimize_aggregation_in_order is unknown or readonly",
             # Server-side memory cap below our probe's max_memory_usage.
             "Code: 241. DB::Exception: Query memory limit exceeded ... (MEMORY_LIMIT_EXCEEDED)",
+            # HTTP client read timeout firing before the server-side
+            # max_execution_time cap does (e.g. ClickHouse Cloud cold-resume).
+            "Error HTTPSConnectionPool(host='example.clickhouse.cloud', port=8443): Read timed out. (read timeout=120)",
         ],
     )
     def test_expected_probe_failures_not_captured(self, error_msg):


### PR DESCRIPTION
## Problem

The ClickHouse warehouse source runs a bounded, best-effort probe (`_has_duplicate_primary_keys`) before an incremental sync to check whether a table's sorting key has duplicates. On any query failure it already falls back safely — it assumes duplicates exist and forces append mode, so incremental merges never run against an unverified key.

To keep error tracking useful, the probe only reports failures to Sentry when they're genuinely unexpected — a small allowlist (`_EXPECTED_PROBE_FAILURE_SUBSTRINGS`) already excludes known environment limits like a readonly session setting or the probe exhausting its own memory/time budget (`MEMORY_LIMIT_EXCEEDED` / `TIMEOUT_EXCEEDED`).

An HTTP client-side read timeout wasn't on that list. This surfaced in error tracking as an `OperationalError` ("Read timed out") from `products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py`. The probe's own `max_execution_time` setting only bounds server-side query execution — it doesn't cover ClickHouse Cloud's documented cold-resume wake-up latency (an idle service can take 30-60s just to wake up before it even starts executing), so the HTTP client's read timeout can fire first. That's the exact same "designed fallback, not a bug" category the existing allowlist already covers — the probe degrades to append mode either way, so capturing it just adds noise.

## Changes

- Add `"Read timed out"` to `_EXPECTED_PROBE_FAILURE_SUBSTRINGS` in `clickhouse.py`, so this failure mode is treated the same as the other expected-limit cases already on the list.
- No functional/retry behavior changes — the probe already caught this exception and fell back safely; this only stops it from being reported to error tracking.

## How did you test this code?

Extended the existing `test_expected_probe_failures_not_captured` parametrized test in `test_clickhouse.py` with a read-timeout case matching the observed error shape (host/port redacted with a placeholder). This locks in that a `Read timed out` `ClickHouseError` is recognized as an expected probe failure and doesn't call `capture_exception`, guarding against exactly the noise this PR fixes.

Ran the full `TestHasDuplicatePrimaryKeys` test class: all 11 cases pass, including the new one. Also ran `ruff check` and `ruff format --check` on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a PostHog error-tracking issue reporting an `OperationalError` ("Read timed out") from this source's `_has_duplicate_primary_keys` probe. Confirmed the stack trace's in-app frame lands in `clickhouse.py`, then read the probe's error-handling logic and its existing `_EXPECTED_PROBE_FAILURE_SUBSTRINGS` allowlist (with its documented rationale for suppressing designed-fallback noise). Concluded this was neither a customer/upstream error needing `NonRetryableErrors` nor a functional bug — the probe already handles the failure safely — but a missing entry in the noise-suppression allowlist, consistent with the existing precedent for `MEMORY_LIMIT_EXCEEDED`/`TIMEOUT_EXCEEDED`. Searched open PRs (by keyword and by author) before opening this one; found #71749 also touches this file (adding 429/503/504 retry wrapping around query calls) but it doesn't touch the expected-failure classification this PR changes. Invoked `/writing-tests` before extending the test.