### PR TITLE
feat: enforce warehouse-source access control when querying

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -791,12 +791,25 @@ class Database(BaseModel):
         """
         Returns True if the user can't query this warehouse table.
         Userless context (no UserAccessControl) fails closed - every table is denied.
+        Table-level rules take precedence; a table without its own rules also requires viewer
+        access to its parent source, so restricting a source covers all its tables.
         """
         uac = self.user_access_control
-        if uac is not None and (
-            uac.is_organization_admin or uac.check_access_level_for_object(table, required_level="viewer")
-        ):
-            return False
+        if uac is not None:
+            if uac.is_organization_admin:
+                return False
+            table_allowed = uac.check_access_level_for_object(table, required_level="viewer")
+            source = table.external_data_source
+            # Only object rules on the source cascade to querying its tables; resource-level
+            # external_data_source rules keep governing the source APIs only.
+            source_allowed = (
+                source is None
+                or uac.has_object_rules("warehouse_table", str(table.pk))
+                or not uac.has_object_rules("external_data_source", str(source.pk))
+                or uac.check_access_level_for_object(source, required_level="viewer")
+            )
+            if table_allowed and source_allowed:
+                return False
 
         # Add table names to denied tables so the query raises "You don't have access" instead of "Unknown table"
         self._denied_tables.add(table.name)

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -795,13 +795,9 @@ class Database(BaseModel):
         and its parent source's access applies, so restricting a source covers all its tables while a
         table-specific grant still overrides it.
         """
-        from posthog.rbac.user_access_control import access_level_satisfied_for_resource  # noqa: PLC0415
-
         uac = self.user_access_control
-        if uac is not None:
-            level = uac.warehouse_table_effective_level(table, table.external_data_source)
-            if level is not None and access_level_satisfied_for_resource("warehouse_table", level, "viewer"):
-                return False
+        if uac is not None and uac.check_warehouse_table_access(table, table.external_data_source, "viewer"):
+            return False
 
         # Add table names to denied tables so the query raises "You don't have access" instead of "Unknown table"
         self._denied_tables.add(table.name)

--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -791,24 +791,16 @@ class Database(BaseModel):
         """
         Returns True if the user can't query this warehouse table.
         Userless context (no UserAccessControl) fails closed - every table is denied.
-        Table-level rules take precedence; a table without its own rules also requires viewer
-        access to its parent source, so restricting a source covers all its tables.
+        A rule on the table itself takes precedence; otherwise the more restrictive of the table's
+        and its parent source's access applies, so restricting a source covers all its tables while a
+        table-specific grant still overrides it.
         """
+        from posthog.rbac.user_access_control import access_level_satisfied_for_resource  # noqa: PLC0415
+
         uac = self.user_access_control
         if uac is not None:
-            if uac.is_organization_admin:
-                return False
-            table_allowed = uac.check_access_level_for_object(table, required_level="viewer")
-            source = table.external_data_source
-            # Only object rules on the source cascade to querying its tables; resource-level
-            # external_data_source rules keep governing the source APIs only.
-            source_allowed = (
-                source is None
-                or uac.has_object_rules("warehouse_table", str(table.pk))
-                or not uac.has_object_rules("external_data_source", str(source.pk))
-                or uac.check_access_level_for_object(source, required_level="viewer")
-            )
-            if table_allowed and source_allowed:
+            level = uac.warehouse_table_effective_level(table, table.external_data_source)
+            if level is not None and access_level_satisfied_for_resource("warehouse_table", level, "viewer"):
                 return False
 
         # Add table names to denied tables so the query raises "You don't have access" instead of "Unknown table"

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -612,6 +612,139 @@ class TestWarehouseTableAccessControl(BaseTest):
         assert "Unknown" not in str(cm.exception)
 
 
+@patch("posthoganalytics.feature_enabled", new=Mock(return_value=True))
+class TestWarehouseSourceAccessControl(BaseTest):
+    """
+    Object rules on an external data source cascade to querying its tables.
+    Table-level rules take precedence; resource-level external_data_source rules stay out of querying.
+    """
+
+    def setUp(self):
+        super().setUp()
+        import uuid
+
+        from posthog.constants import AvailableFeature
+
+        from products.warehouse_sources.backend.facade.models import (
+            DataWarehouseCredential,
+            DataWarehouseTable,
+            ExternalDataSource,
+        )
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+        ]
+        self.organization.save()
+
+        membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        membership.level = OrganizationMembership.Level.MEMBER
+        membership.save()
+
+        credential = DataWarehouseCredential.objects.create(access_key="blah", access_secret="blah", team=self.team)
+        self.source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            source_type="Stripe",
+            prefix="locked",
+        )
+        self.other_source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            source_type="Stripe",
+            prefix="other",
+        )
+        self.locked_source_table = DataWarehouseTable.objects.create(
+            name="locked_source_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=credential,
+            url_pattern="s3://bucket/locked/*",
+            columns={"id": "String"},
+            external_data_source=self.source,
+        )
+        self.other_source_table = DataWarehouseTable.objects.create(
+            name="other_source_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=credential,
+            url_pattern="s3://bucket/other/*",
+            columns={"id": "String"},
+            external_data_source=self.other_source,
+        )
+
+    def _create_ac(self, *, resource, access_level, resource_id=None, member=None):
+        from ee.models.rbac.access_control import AccessControl
+
+        return AccessControl.objects.create(
+            team=self.team,
+            resource=resource,
+            resource_id=resource_id,
+            access_level=access_level,
+            organization_member=member,
+        )
+
+    def _membership(self):
+        return OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+
+    def test_source_object_none_denies_only_its_tables(self):
+        self._create_ac(
+            resource="external_data_source",
+            resource_id=str(self.source.id),
+            access_level="none",
+            member=self._membership(),
+        )
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "locked_source_table" in database._denied_tables
+        assert "other_source_table" not in database._denied_tables
+        # Cache correctness: the source deny must partition the query cache key too.
+        assert database.user_access_control is not None
+        assert str(self.source.id) in database.user_access_control.blocked_resource_ids_by_scope.get(
+            "external_data_source", set()
+        )
+
+    def test_source_object_viewer_keeps_tables_queryable(self):
+        self._create_ac(
+            resource="external_data_source",
+            resource_id=str(self.source.id),
+            access_level="viewer",
+            member=self._membership(),
+        )
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "locked_source_table" not in database._denied_tables
+
+    def test_table_rule_overrides_restricted_source(self):
+        self._create_ac(
+            resource="external_data_source",
+            resource_id=str(self.source.id),
+            access_level="none",
+            member=self._membership(),
+        )
+        self._create_ac(
+            resource="warehouse_table",
+            resource_id=str(self.locked_source_table.id),
+            access_level="viewer",
+            member=self._membership(),
+        )
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "locked_source_table" not in database._denied_tables
+
+    def test_source_resource_level_rules_do_not_gate_querying(self):
+        self._create_ac(resource="external_data_source", access_level="none")
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert "locked_source_table" not in database._denied_tables
+        assert "other_source_table" not in database._denied_tables
+
+
 class TestWarehouseTableAccessControlFlagOff(BaseTest):
     """Regression guard: with hogql-warehouse-access-control off, nothing is filtered."""
 

--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -614,10 +614,9 @@ class TestWarehouseTableAccessControl(BaseTest):
 
 @patch("posthoganalytics.feature_enabled", new=Mock(return_value=True))
 class TestWarehouseSourceAccessControl(BaseTest):
-    """
-    Object rules on an external data source cascade to querying its tables.
-    Table-level rules take precedence; resource-level external_data_source rules stay out of querying.
-    """
+    """Querying a warehouse table follows most-specific-wins across the table and its source: a rule on
+    the table itself overrides the source, otherwise the more restrictive of the table's and the
+    source's access applies (each including object and resource-level rules)."""
 
     def setUp(self):
         super().setUp()
@@ -664,6 +663,16 @@ class TestWarehouseSourceAccessControl(BaseTest):
             columns={"id": "String"},
             external_data_source=self.source,
         )
+        # A second table under the same source, for cases that deny one table but keep the source.
+        self.sibling_source_table = DataWarehouseTable.objects.create(
+            name="sibling_source_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=credential,
+            url_pattern="s3://bucket/sibling/*",
+            columns={"id": "String"},
+            external_data_source=self.source,
+        )
         self.other_source_table = DataWarehouseTable.objects.create(
             name="other_source_table",
             format=DataWarehouseTable.TableFormat.Parquet,
@@ -688,7 +697,11 @@ class TestWarehouseSourceAccessControl(BaseTest):
     def _membership(self):
         return OrganizationMembership.objects.get(user=self.user, organization=self.organization)
 
+    def _denied(self):
+        return Database.create_for(team=self.team, user=self.user)._denied_tables
+
     def test_source_object_none_denies_only_its_tables(self):
+        # A source restricted (object none) covers its own tables, not other sources'.
         self._create_ac(
             resource="external_data_source",
             resource_id=str(self.source.id),
@@ -699,6 +712,7 @@ class TestWarehouseSourceAccessControl(BaseTest):
         database = Database.create_for(team=self.team, user=self.user)
 
         assert "locked_source_table" in database._denied_tables
+        assert "sibling_source_table" in database._denied_tables
         assert "other_source_table" not in database._denied_tables
         # Cache correctness: the source deny must partition the query cache key too.
         assert database.user_access_control is not None
@@ -714,11 +728,10 @@ class TestWarehouseSourceAccessControl(BaseTest):
             member=self._membership(),
         )
 
-        database = Database.create_for(team=self.team, user=self.user)
+        assert "locked_source_table" not in self._denied()
 
-        assert "locked_source_table" not in database._denied_tables
-
-    def test_table_rule_overrides_restricted_source(self):
+    def test_table_grant_overrides_restricted_source(self):
+        # Specific table allowed, its source denied -> table still queryable, its siblings are not.
         self._create_ac(
             resource="external_data_source",
             resource_id=str(self.source.id),
@@ -732,17 +745,66 @@ class TestWarehouseSourceAccessControl(BaseTest):
             member=self._membership(),
         )
 
-        database = Database.create_for(team=self.team, user=self.user)
+        denied = self._denied()
+        assert "locked_source_table" not in denied
+        assert "sibling_source_table" in denied
 
-        assert "locked_source_table" not in database._denied_tables
+    def test_table_deny_overrides_allowed_source(self):
+        # Specific table denied, its source allowed -> only that table is denied, siblings queryable.
+        self._create_ac(
+            resource="warehouse_table",
+            resource_id=str(self.locked_source_table.id),
+            access_level="none",
+            member=self._membership(),
+        )
 
-    def test_source_resource_level_rules_do_not_gate_querying(self):
-        self._create_ac(resource="external_data_source", access_level="none")
+        denied = self._denied()
+        assert "locked_source_table" in denied
+        assert "sibling_source_table" not in denied
 
-        database = Database.create_for(team=self.team, user=self.user)
+    def test_source_object_allowed_but_all_tables_resource_denied(self):
+        # Source allowed (object) but all tables denied (resource-level warehouse_objects) -> tables denied.
+        self._create_ac(
+            resource="external_data_source",
+            resource_id=str(self.source.id),
+            access_level="editor",
+            member=self._membership(),
+        )
+        self._create_ac(resource="warehouse_objects", access_level="none", member=self._membership())
 
-        assert "locked_source_table" not in database._denied_tables
-        assert "other_source_table" not in database._denied_tables
+        assert "locked_source_table" in self._denied()
+
+    def test_all_tables_resource_allowed_but_source_object_denied(self):
+        # All tables allowed (resource-level warehouse_objects) but a specific source denied (object) -> its tables denied.
+        self._create_ac(resource="warehouse_objects", access_level="editor", member=self._membership())
+        self._create_ac(
+            resource="external_data_source",
+            resource_id=str(self.source.id),
+            access_level="none",
+            member=self._membership(),
+        )
+
+        denied = self._denied()
+        assert "locked_source_table" in denied
+        assert "other_source_table" not in denied
+
+    def test_source_resource_level_none_denies_all_tables(self):
+        # A resource-level source deny (all sources) gates querying every source's tables.
+        self._create_ac(resource="external_data_source", access_level="none", member=self._membership())
+
+        denied = self._denied()
+        assert "locked_source_table" in denied
+        assert "other_source_table" in denied
+
+    def test_org_admin_bypasses_source_restriction(self):
+        membership = self._membership()
+        membership.level = OrganizationMembership.Level.ADMIN
+        membership.save()
+        self._create_ac(
+            resource="external_data_source", resource_id=str(self.source.id), access_level="none", member=membership
+        )
+
+        assert "locked_source_table" not in self._denied()
 
 
 class TestWarehouseTableAccessControlFlagOff(BaseTest):

--- a/posthog/hogql_queries/access_controlled_resources.py
+++ b/posthog/hogql_queries/access_controlled_resources.py
@@ -112,11 +112,16 @@ def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str
                 # otherwise a user denied an underlying table could be served a cached view result.
                 scopes.add("warehouse_table")
 
+        # A source's access gates querying its tables (Database._is_warehouse_table_denied), so a
+        # source denial must partition the cache key too - a cache hit skips the build-time gate.
+        if "warehouse_table" in scopes:
+            scopes.add("external_data_source")
+
         return scopes
 
     # Structured insight queries (Trends/Funnels/Lifecycle/...) read warehouse data via a
     # DataWarehouseNode in their tree rather than by table name.
-    return {"warehouse_table", "warehouse_view"} if _references_data_warehouse(query) else set()
+    return {"warehouse_table", "warehouse_view", "external_data_source"} if _references_data_warehouse(query) else set()
 
 
 def _references_data_warehouse(value) -> bool:

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -2549,7 +2549,12 @@ class AnalyticsQueryRunner(QueryRunner, Generic[AR]):
             return None
         blocked = user_access_control.blocked_resource_ids_by_scope
         if queried_resources is not None:
-            blocked = {resource: ids for resource, ids in blocked.items() if resource in queried_resources}
+            implicated = set(queried_resources)
+            # A restricted source denies its unruled tables at build time (_is_warehouse_table_denied),
+            # and a cache hit skips that build — so warehouse reads must partition on blocked sources too.
+            if implicated & WAREHOUSE_ACCESS_SCOPES:
+                implicated.add("external_data_source")
+            blocked = {resource: ids for resource, ids in blocked.items() if resource in implicated}
         if not blocked:
             return None
         return {resource: sorted(ids) for resource, ids in sorted(blocked.items())}

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -2549,12 +2549,7 @@ class AnalyticsQueryRunner(QueryRunner, Generic[AR]):
             return None
         blocked = user_access_control.blocked_resource_ids_by_scope
         if queried_resources is not None:
-            implicated = set(queried_resources)
-            # A restricted source denies its unruled tables at build time (_is_warehouse_table_denied),
-            # and a cache hit skips that build — so warehouse reads must partition on blocked sources too.
-            if implicated & WAREHOUSE_ACCESS_SCOPES:
-                implicated.add("external_data_source")
-            blocked = {resource: ids for resource, ids in blocked.items() if resource in implicated}
+            blocked = {resource: ids for resource, ids in blocked.items() if resource in queried_resources}
         if not blocked:
             return None
         return {resource: sorted(ids) for resource, ids in sorted(blocked.items())}

--- a/posthog/hogql_queries/test/test_access_controlled_resources.py
+++ b/posthog/hogql_queries/test/test_access_controlled_resources.py
@@ -89,13 +89,21 @@ class TestQueriedAccessControlledResources(BaseTest):
 
     def test_structured_query_with_data_warehouse_series(self):
         query = TrendsQuery(series=[EventsNode(event="$pageview"), self._dw_node()])
-        assert queried_access_controlled_resources(query, self.team) == {"warehouse_table", "warehouse_view"}
+        assert queried_access_controlled_resources(query, self.team) == {
+            "external_data_source",
+            "warehouse_table",
+            "warehouse_view",
+        }
 
     def test_nested_data_warehouse_node_is_detected(self):
         # The node is two levels deep (actors query -> source insight -> series), so a shallow
         # series-only check would miss it; the recursive walk must catch it (else the cache leaks).
         query = InsightActorsQuery(source=TrendsQuery(series=[self._dw_node()]))
-        assert queried_access_controlled_resources(query, self.team) == {"warehouse_table", "warehouse_view"}
+        assert queried_access_controlled_resources(query, self.team) == {
+            "external_data_source",
+            "warehouse_table",
+            "warehouse_view",
+        }
 
     def test_references_data_warehouse_covers_all_variants_and_nesting(self):
         variants = [
@@ -117,7 +125,7 @@ class TestQueriedAccessControlledResources(BaseTest):
     def test_warehouse_table_scope(self):
         self._create_warehouse_table("my_warehouse_table")
         result = queried_access_controlled_resources(HogQLQuery(query="select * from my_warehouse_table"), self.team)
-        assert result == {"warehouse_table"}
+        assert result == {"external_data_source", "warehouse_table"}
 
     def test_external_warehouse_table_matched_by_raw_name(self):
         # External tables are queryable under BOTH their raw name and the prefixed
@@ -139,7 +147,7 @@ class TestQueriedAccessControlledResources(BaseTest):
         assert get_data_warehouse_table_name(source, table.name) != table.name
 
         result = queried_access_controlled_resources(HogQLQuery(query="select * from stripe_customers"), self.team)
-        assert result == {"warehouse_table"}
+        assert result == {"external_data_source", "warehouse_table"}
 
     def test_warehouse_view_scope(self):
         DataWarehouseSavedQuery.objects.create(
@@ -148,14 +156,14 @@ class TestQueriedAccessControlledResources(BaseTest):
         result = queried_access_controlled_resources(HogQLQuery(query="select * from my_warehouse_view"), self.team)
         # warehouse_table is included too: a non-materialized view reads underlying tables, and a cache
         # hit skips that resolution, so the user's table denials must partition the key.
-        assert result == {"warehouse_view", "warehouse_table"}
+        assert result == {"external_data_source", "warehouse_table", "warehouse_view"}
 
     def test_warehouse_and_system_scopes_combined(self):
         self._create_warehouse_table("my_warehouse_table")
         result = queried_access_controlled_resources(
             HogQLQuery(query="select 1 from my_warehouse_table, system.notebooks"), self.team
         )
-        assert result == {"warehouse_table", "notebook"}
+        assert result == {"external_data_source", "warehouse_table", "notebook"}
 
     def test_catalog_fetch_loads_only_name_fields(self):
         source = ExternalDataSource.objects.create(
@@ -175,7 +183,7 @@ class TestQueriedAccessControlledResources(BaseTest):
         # longer covers what get_data_warehouse_table_name reads (rows silently defer-load per
         # row) or the default manager's externaldataschema_set prefetch leaked back in.
         with self.assertNumQueries(2):
-            assert queried_access_controlled_resources(query, self.team) == {"warehouse_table"}
+            assert queried_access_controlled_resources(query, self.team) == {"external_data_source", "warehouse_table"}
 
     def test_warehouse_table_of_another_team_not_matched(self):
         from posthog.models import Team

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -792,13 +792,15 @@ class UserAccessControl:
         # If no access control exists
         return access_level_satisfied_for_resource(resource, access_level, required_level)
 
+    def has_object_rules(self, resource: APIScopeObject, resource_id: str) -> bool:
+        """Whether any access control rules on this specific object apply to this user."""
+        return bool(self._get_access_controls(self._access_controls_filters_for_object(resource, resource_id)))
+
     def warehouse_table_effective_level(self, table: Optional[Model], source: Model) -> Optional[AccessControlLevel]:
         """Effective access level for a synced table: the table's own `warehouse_table` rules if any
         apply to this user, otherwise the source's level. `table` is None before the first sync.
         Used by both the schema serializer and WarehouseTableSyncPermission."""
-        if table is not None and self._get_access_controls(
-            self._access_controls_filters_for_object("warehouse_table", str(table.pk))
-        ):
+        if table is not None and self.has_object_rules("warehouse_table", str(table.pk)):
             return self.get_user_access_level(table)
         return self.get_user_access_level(source)
 

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -796,13 +796,22 @@ class UserAccessControl:
         """Whether any access control rules on this specific object apply to this user."""
         return bool(self._get_access_controls(self._access_controls_filters_for_object(resource, resource_id)))
 
-    def warehouse_table_effective_level(self, table: Optional[Model], source: Model) -> Optional[AccessControlLevel]:
-        """Effective access level for a synced table: the table's own `warehouse_table` rules if any
-        apply to this user, otherwise the source's level. `table` is None before the first sync.
-        Used by both the schema serializer and WarehouseTableSyncPermission."""
+    def warehouse_table_effective_level(
+        self, table: Optional[Model], source: Optional[Model]
+    ) -> Optional[AccessControlLevel]:
+        """Effective access to a synced table, most-specific first. An object rule on the table itself
+        wins outright. Otherwise the more restrictive of the table's and the source's access applies,
+        each resolved from its own object and resource-level rules. `table` is None before the first
+        sync, `source` is None for self-managed tables. Used by the query gate,
+        WarehouseTableSyncPermission, and the schema serializer."""
+        table_level = None if table is None else self.get_user_access_level(table)
         if table is not None and self.has_object_rules("warehouse_table", str(table.pk)):
-            return self.get_user_access_level(table)
-        return self.get_user_access_level(source)
+            return table_level
+        source_level = self.get_user_access_level(source) if source is not None else None
+        if table_level is None or source_level is None:
+            return table_level if source_level is None else source_level
+        order = ACCESS_CONTROL_LEVELS_RESOURCE
+        return source_level if order.index(source_level) <= order.index(table_level) else table_level
 
     def check_can_modify_access_levels_for_object(self, obj: Model) -> bool:
         """

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -802,8 +802,8 @@ class UserAccessControl:
         """Effective access to a synced table, most-specific first. An object rule on the table itself
         wins outright. Otherwise the more restrictive of the table's and the source's access applies,
         each resolved from its own object and resource-level rules. `table` is None before the first
-        sync, `source` is None for self-managed tables. Used by the query gate,
-        WarehouseTableSyncPermission, and the schema serializer."""
+        sync, `source` is None for self-managed tables. Exposed for the schema serializer;
+        enforcement should call `check_warehouse_table_access`."""
         table_level = None if table is None else self.get_user_access_level(table)
         if table is not None and self.has_object_rules("warehouse_table", str(table.pk)):
             return table_level
@@ -812,6 +812,14 @@ class UserAccessControl:
             return table_level if source_level is None else source_level
         order = ACCESS_CONTROL_LEVELS_RESOURCE
         return source_level if order.index(source_level) <= order.index(table_level) else table_level
+
+    def check_warehouse_table_access(
+        self, table: Optional[Model], source: Optional[Model], required_level: AccessControlLevel
+    ) -> bool:
+        """Whether the user reaches `required_level` on a synced table, per
+        `warehouse_table_effective_level`. Entry point for the query gate and the sync permission."""
+        level = self.warehouse_table_effective_level(table, source)
+        return level is not None and access_level_satisfied_for_resource("warehouse_table", level, required_level)
 
     def check_can_modify_access_levels_for_object(self, obj: Model) -> bool:
         """

--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -22,7 +22,7 @@ from posthog.api.utils import action
 from posthog.exceptions_capture import capture_exception
 from posthog.models.user import User
 from posthog.permissions import is_service_auth
-from posthog.rbac.user_access_control import UserAccessControlSerializerMixin, access_level_satisfied_for_resource
+from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 from posthog.utils import str_to_bool
 
 from products.data_warehouse.backend.facade.api import (
@@ -1351,8 +1351,7 @@ class WarehouseTableSyncPermission(BasePermission):
         uac = view.user_access_control
         if uac is None or uac.is_organization_admin:
             return True
-        level = uac.warehouse_table_effective_level(obj.table, obj.source)
-        return level is not None and access_level_satisfied_for_resource("warehouse_table", level, "editor")
+        return uac.check_warehouse_table_access(obj.table, obj.source, "editor")
 
 
 @extend_schema(extensions={"x-product": "warehouse_sources"})


### PR DESCRIPTION
> Stacked on #72440 (per-table access control)

## Problem

**Querying** a source's tables still ignored the source's access rules. Enforcement only works for the warehouse tables and views resource. So a member restricted from a source (for example a Zendesk) could still `SELECT * from zendesk.tickets`. 

## Changes

Query enforcement for warehouse sources, most-specific rule first. A rule on the table itself wins outright: a table granted inside a denied source stays queryable, a table denied inside an allowed source doesn't. Without table rules the more restrictive of the table's and the source's access applies, each resolved from its own object and resource-level rules — so denying all tables covers an allowed source, and denying one source covers tables allowed at the resource level.

- `_is_warehouse_table_denied` (the gate every HogQL build funnels through) resolves the level through `warehouse_table_effective_level` and denies below viewer. Userless builds stay fail-closed, org admins bypass.
- The query cache partitions on source access — warehouse reads declare `external_data_source` as a queried resource — so a restricted user is not served a cached result someone with access populated.

> [!NOTE]
> Views aren't part of the cascade: `DataWarehouseSavedQuery` has no `external_data_source` FK (it's authored SQL that can reference several sources or none), so there's no parent source to inherit from. Non-materialized views re-resolve to their underlying tables at execution, so a denied table still stops them; a materialized view is its own snapshot governed by its `warehouse_view` rule. The `warehouse_objects` resource still covers tables and views alike.

## How did you test this code?

`hogli test posthog/hogql/printer/test/test_hogql_access_control.py` — `TestWarehouseSourceAccessControl` covers the precedence matrix: source denied covers its tables (and lands in the cache key) but not other sources', source viewer keeps them queryable, a table grant overrides a denied source, a table deny overrides an allowed source, source allowed + all-tables denied at resource level, all-tables allowed + source denied, resource-level source deny, and org-admin bypass. 

`hogli test posthog/hogql_queries/test/test_access_controlled_resources.py` — updated for `external_data_source` now being in scope wherever warehouse tables are read.

Plus the 6 schema-AC tests from #72440 (they share the helper)

Also manually in the SQL editor against a local source restricted for a non-admin member: querying an unruled table is denied, a table with its own grant still works, admin bypasses.

## Automatic notifications

- [ ] Publish to changelog? — No, gated behind the `hogql-warehouse-access-control` flag
- [ ] Alert Sales and Marketing teams? — No

## 🤖 Agent context

Main design decision (Alex pushed on this): modeling the source→table cascade. Rejected extending `RESOURCE_INHERITANCE_MAP` — it's resource-*type* inheritance and can't express object-*instance* parent links (this table's source is that source row), and there's no precedent for object-A deriving access from object-B's rules. A generic object-inheritance layer would touch every resolver in `UserAccessControl` (object resolution, queryset filtering, the blocked-ids set feeding cache keys) — too much blast radius on security-critical code for one FK pair. Instead the precedence is expressed once via `warehouse_table_effective_level` + `has_object_rules` and called at the three enforcement sites. If a second parent→child object pair shows up, that helper generalizes into an object-parent map with an FK resolver as its own refactor.

A first pass had this as min(source, table) and then as "only per-source object rules cascade" — both wrong, corrected to the precedence above after Alex worked through the cross-level cases.
