### PR TITLE
fix(buildbetter): stop retrying webhook auth failures

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buildbetter/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buildbetter/source.py
@@ -61,6 +61,7 @@ class BuildBetterSource(ResumableSource[BuildBetterSourceConfig, BuildBetterResu
             "401 Client Error": "BuildBetter authentication failed. Please check your API key.",
             "403 Client Error": "BuildBetter access forbidden. Please check your API key permissions.",
             "Authentication hook unauthorized this request": "BuildBetter authentication failed. Please check your API key.",
+            "webhook authentication request failed": "BuildBetter authentication failed. Please check your API key.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/buildbetter/test_buildbetter.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/buildbetter/test_buildbetter.py
@@ -12,6 +12,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.buildbette
     buildbetter_source,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.buildbetter.settings import BUILDBETTER_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.buildbetter.source import BuildBetterSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 
 
@@ -239,3 +240,31 @@ class TestBuildbetterSource:
         assert batches == [[{"id": "x"}]]
         assert response.primary_keys == ["id"]
         manager.can_resume.assert_called_once()
+
+
+class TestBuildBetterSourceNonRetryableErrors:
+    def setup_method(self) -> None:
+        self.source = BuildBetterSource()
+
+    @parameterized.expand(
+        [
+            ("401_client_error", "401 Client Error: Unauthorized for url: https://api.buildbetter.app/v1/graphql"),
+            ("403_client_error", "403 Client Error: Forbidden for url: https://api.buildbetter.app/v1/graphql"),
+            ("auth_hook_unauthorized", "BuildBetter GraphQL error: Authentication hook unauthorized this request"),
+            ("webhook_auth_request_failed", "BuildBetter GraphQL error: webhook authentication request failed"),
+        ]
+    )
+    def test_matches_auth_failures(self, _name: str, observed_error: str) -> None:
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @parameterized.expand(
+        [
+            ("read_timeout", "HTTPSConnectionPool(host='api.buildbetter.app', port=443): Read timed out."),
+            ("server_error", "BuildBetter: server error 503"),
+            ("connection_reset", "Connection reset by peer"),
+        ]
+    )
+    def test_does_not_match_transient_errors(self, _name: str, other_error: str) -> None:
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)


### PR DESCRIPTION
## Problem

BuildBetter's GraphQL API sometimes rejects a request with the error `webhook authentication request failed`. This source already treats a sibling message, `Authentication hook unauthorized this request`, as a non-retryable authentication failure (i.e. a bad/expired API key), but this specific wording wasn't recognized, so the sync kept retrying indefinitely instead of surfacing an actionable error to the user.

Found via an error tracking issue: [BuildBetter GraphQL error: webhook authentication request failed](https://us.posthog.com/project/2/error_tracking/019f95ce-fb42-7e70-8848-f5428fb0864f).

## Changes

Extended `BuildBetterSource.get_non_retryable_errors()` with the `webhook authentication request failed` message, mapped to the same friendly "check your API key" message as the other auth-failure entries, mirroring the pattern in `stripe/source.py`.

## How did you test this code?

Added a parameterized test class (`TestBuildBetterSourceNonRetryableErrors`) asserting the new message (plus the existing 401/403/auth-hook messages) is recognized as non-retryable, and that transient errors (read timeout, 5xx, connection reset) are not. Ran the full `test_buildbetter.py` suite locally (15 passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal retry-classification change, no user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a real error tracking issue for the BuildBetter data warehouse source. Confirmed the stack trace originates in `buildbetter.py`'s `execute()` (the GraphQL error-handling branch), read the surrounding code and existing non-retryable-error patterns (Stripe's `get_non_retryable_errors` as reference), and searched open PRs/the maintainer's own PRs for a duplicate fix before proceeding — found none (a prior, unrelated BuildBetter PR from the same branch prefix was already closed).

Decision: classified this as a user/upstream auth error (extend `NonRetryableErrors`) rather than a code bug, since the message groups with the existing `Authentication hook unauthorized this request` entry — both point to BuildBetter's own auth-webhook mechanism rejecting the request, most plausibly due to a bad/expired API key.

Skills invoked: `/writing-tests` before adding test coverage.