### PR TITLE
feat(replay): report image-scrub stage timings and source format mix

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/metrics.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/metrics.ts
@@ -46,6 +46,31 @@ const outputBytes = new Histogram({
     buckets: [64, 256, 1024, 4096, 16384, 65536],
     registers: [register],
 })
+// The total duration above says the scrub is slow; these say which stage to attack. Every one of
+// these numbers was already being measured per image and thrown away.
+const stageDuration = new Histogram({
+    name: 'ml_mirror_image_scrub_stage_duration_seconds',
+    help: 'Scrub wall time by stage. Sums to roughly the total, so the stage with the largest rate() share is where the CPU goes',
+    labelNames: ['stage'],
+    buckets: [0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2],
+    registers: [register],
+})
+// Which decoder we actually pay for. Only formats with a multi-resolution decode (JPEG, WebP) can
+// be shrunk on load; PNG has to be fully inflated whatever the target size, so the value of any
+// decode-side optimization is bounded by this distribution.
+const sourceFormat = new Counter({
+    name: 'ml_mirror_image_scrub_source_format_total',
+    help: 'Decoded images by source container format',
+    labelNames: ['format'],
+    registers: [register],
+})
+const sourceMegapixels = new Histogram({
+    name: 'ml_mirror_image_scrub_source_megapixels',
+    help: 'Source megapixels before the SCRUB_MAX_PIXELS downscale, by format. Mass above the 2.56 budget bucket is the only traffic a shrink-on-load path could speed up',
+    labelNames: ['format'],
+    buckets: [0.1, 0.25, 0.5, 1, 2, 2.56, 4, 8, 16, 50],
+    registers: [register],
+})
 // The scrub is a privacy control, so its OUTCOME signals matter as much as its error signals: a
 // runaway NSFW gate irreversibly blanking everything, or a detector flatlining at zero (persisting
 // un-redacted screenshots), must be distinguishable from healthy operation.
@@ -86,5 +111,20 @@ export const ScrubMetrics = {
         facesRedacted.inc(t.faces)
         textBoxesRedacted.inc(t.textBoxes)
         codesRedacted.inc(t.codes)
+
+        sourceFormat.labels(t.format).inc()
+        sourceMegapixels.labels(t.format).observe(t.inputPixels / 1e6)
+        stageDuration.labels('decode').observe(t.decodeMs / 1000)
+        stageDuration.labels('nsfw').observe(t.nsfwMs / 1000)
+        // A blanked image returns before detection and compose, so recording their zeros would
+        // drag those stages' quantiles toward zero rather than describing the work they do.
+        if (t.blanked) {
+            return
+        }
+        stageDuration.labels('face').observe(t.faceMs / 1000)
+        stageDuration.labels('text').observe(t.textMs / 1000)
+        stageDuration.labels('codes').observe(t.codesMs / 1000)
+        stageDuration.labels('compose').observe(t.composeMs / 1000)
+        stageDuration.labels('encode').observe(t.encodeMs / 1000)
     },
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/qr.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/qr.test.ts
@@ -35,7 +35,13 @@ describe('detectCodes', () => {
             .raw()
             .toBuffer({ resolveWithObject: true })
 
-        const boxes = await detectCodes({ data, W: info.width, H: info.height })
+        const boxes = await detectCodes({
+            data,
+            W: info.width,
+            H: info.height,
+            format: 'raw',
+            inputPixels: info.width * info.height,
+        })
 
         expect(boxes).toHaveLength(1)
         const b = boxes[0]

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/scrub.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/scrub.ts
@@ -65,6 +65,10 @@ export interface StageTimings {
     faces: number
     textBoxes: number
     codes: number
+    /** Source format and its pre-downscale size: which stage to attack depends on the corpus mix,
+     *  and only formats with a multi-resolution decode can be shrunk on load. */
+    format: string
+    inputPixels: number
 }
 
 const NSFW_THRESHOLD = numFromEnv('NSFW_THRESHOLD', 0.6, 0.05, 0.95) // NSFL+NSFW combined; deliberately loose, this is a safety net
@@ -124,6 +128,8 @@ export async function advancedScrub(
         faces: 0,
         textBoxes: 0,
         codes: 0,
+        format: 'unknown',
+        inputPixels: 0,
     }
     const t0 = performance.now()
     const tDec = performance.now()
@@ -137,6 +143,8 @@ export async function advancedScrub(
     }
     const { W, H } = src
     timings.decodeMs = performance.now() - tDec
+    timings.format = src.format
+    timings.inputPixels = src.inputPixels
 
     // 1. NSFW / gore gate FIRST: if it trips we skip all detection. Running it first (rather than
     //    overlapping detection) keeps each worker ~1 core, which packs better under multi-process

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/src-image.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/src-image.ts
@@ -18,6 +18,9 @@ export interface Src {
     data: Buffer
     W: number
     H: number
+    /** From the header sharp already read, so reporting the corpus mix costs nothing. */
+    format: string
+    inputPixels: number
 }
 
 export async function decodeSrc(input: Buffer): Promise<Src> {
@@ -36,7 +39,13 @@ export async function decodeSrc(input: Buffer): Promise<Src> {
         .flatten({ background: '#fff' })
         .raw()
         .toBuffer({ resolveWithObject: true })
-    return { data, W: info.width, H: info.height }
+    return {
+        data,
+        W: info.width,
+        H: info.height,
+        format: meta.format ?? 'unknown',
+        inputPixels: meta.width * meta.height,
+    }
 }
 
 /** A fresh sharp pipeline over the already-decoded raw pixels (no PNG decode). */


### PR DESCRIPTION
## Problem

The sidecar has always measured each scrub stage per image (`decode`, `nsfw`, `face`, `text`, `codes`, `compose`, `encode`) into `StageTimings`, used the non-timing fields for the redaction counters, and thrown every millisecond away. Only the total duration reached Prometheus, so "the scrub is slow" was as far as the metrics went and there was no way to say which stage to attack.

It also never recorded what it was decoding. That matters more than it sounds: only JPEG and WebP have a multi-resolution decode that can be shrunk on load, and the `SCRUB_MAX_PIXELS` downscale only engages above 2.56 MP at all. Without the format mix and the size distribution there is no way to tell whether a decode-side optimisation is worth anything or is aimed at a corner of the corpus.

## Changes

Three new sidecar metrics, all derived from values already computed on the hot path:

- `ml_mirror_image_scrub_stage_duration_seconds{stage}` — the timings that were already being measured and discarded. Read as `rate(..._sum)` for which stage holds the most CPU, and as a quantile for per-image cost; a stage can be cheap per image and still dominate by running on every one.
- `ml_mirror_image_scrub_source_format_total{format}` — from the header sharp already reads in `decodeSrc`, so it costs nothing.
- `ml_mirror_image_scrub_source_megapixels{format}` — size before the downscale, bucketed so the 2.56 MP budget is a bucket edge and the share above it reads straight off the histogram.

`Src` grows `format` and `inputPixels`; `StageTimings` carries them to the metrics layer so `src-image.ts` keeps no dependency on the metrics module.

> [!NOTE]
> A blanked image returns before detection and compose, so those stages are not observed for it. Recording their zeros would drag the quantiles toward zero rather than describing the work those stages actually do.

## How did you test this code?

I'm an agent and I could not run the sidecar's own suite: its `node_modules` are not installed in this worktree, so `pnpm test:unit` and its `tsc --noEmit` do not run here. CI covers both. What I did check:

- The only place that builds an `Src` literal is `src/qr.test.ts`, updated here. Everything else (`safety.ts`, `qr.ts`, `yunet.ts`, `dbnet.ts`, `scrub.ts`, and `dev/scrub-eval.ts`) receives one from `decodeSrc`, so the two new required fields cannot break them. I grepped for literal construction sites rather than assuming.
- No new work on the hot path: both values come from the `metadata()` call `decodeSrc` already makes.

No new unit test. These are counters over values the existing pipeline already produces, and a test asserting "the histogram observed what the timer measured" would restate the implementation rather than catch a realistic regression. The failure mode worth guarding, a metric silently reading zero, is caught by the dashboard panels being empty, which is how this gap was found in the first place.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal ingestion lane behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie, authored by Claude Code (Fable 5).

This commit was originally made on the branch behind #73589 after that PR had already merged, so it sat pushed but orphaned with no open PR and never reached master. It surfaced when the corresponding panels on the new image-scrub dashboard (PostHog/grafana-dashboards#295) came up empty. `ml_mirror_ref_cache_capacity_probe_total` from #73589 is on master and its panel is empty for a different reason: the lane's image is still pinned to a 22 July build.

The panels these feed are already built and merged, so they populate as soon as this deploys.
