### PR TITLE
chore(tasks): stamp loop_id on all task run analytics events

### DIFF
--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -418,6 +418,10 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
                 "environment": task_run.environment,
                 "is_resume": is_resume,
                 "has_pending_message": has_pending,
+                # Loop attribution: this event uses Task.capture_event (not TaskRun's),
+                # so carry it from the run state the same way TaskRun.capture_event does.
+                "loop_id": state.get("loop_id"),
+                "loop_trigger_id": state.get("loop_trigger_id"),
             },
         )
         return task_run

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -139,6 +139,12 @@ class TaskProcessingContext:
         return value if isinstance(value, str) else None
 
     @property
+    def loop_trigger_id(self) -> str | None:
+        """Set alongside loop_id when a loop trigger fired this run."""
+        value = (self.state or {}).get("loop_trigger_id")
+        return value if isinstance(value, str) else None
+
+    @property
     def runtime_adapter(self) -> str | None:
         value = (self.state or {}).get("runtime_adapter")
         return value if isinstance(value, str) else None

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1012,6 +1012,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 "task_id": self.context.task_id,
                 "repository": self.context.repository,
                 "team_id": self.context.team_id,
+                "loop_id": self.context.loop_id,
+                "loop_trigger_id": self.context.loop_trigger_id,
             },
         )
 
@@ -1064,6 +1066,8 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 "agent_launch_ms": sandbox_output.launch_ms,
                 "agent_ready_wait_ms": agent_server_output.ready_wait_ms,
                 "agent_session_init_ms": agent_server_output.session_init_ms,
+                "loop_id": self.context.loop_id,
+                "loop_trigger_id": self.context.loop_trigger_id,
             },
         )
         return sandbox_id, agent_server_output.sandbox_url, agent_server_output.connect_token

--- a/products/tasks/backend/tests/test_models.py
+++ b/products/tasks/backend/tests/test_models.py
@@ -847,6 +847,21 @@ class TestTaskRun(TestCase):
         self.assertEqual(len(props["error_message"]), 500)
         self.assertTrue(props["error_message"].endswith("Error: the root cause sits at the tail"))
 
+    @parameterized.expand(
+        [
+            ("loop_run", {"loop_id": "loop-abc", "loop_trigger_id": "trig-xyz"}, "loop-abc", "trig-xyz"),
+            ("non_loop_run", {}, None, None),
+        ]
+    )
+    def test_task_run_created_carries_loop_attribution(self, _name, extra_state, expected_loop_id, expected_trigger_id):
+        with patch("products.tasks.backend.models.posthoganalytics.capture") as mock_capture:
+            self.task.create_run(extra_state=extra_state or None)
+        created = [c for c in mock_capture.call_args_list if c.kwargs.get("event") == "task_run_created"]
+        self.assertEqual(len(created), 1)
+        props = created[0].kwargs["properties"]
+        self.assertEqual(props["loop_id"], expected_loop_id)
+        self.assertEqual(props["loop_trigger_id"], expected_trigger_id)
+
     def test_output_jsonfield(self):
         run = TaskRun.objects.create(
             task=self.task,


### PR DESCRIPTION
## Problem

Loop-spawned task runs are effectively unattributable in product analytics. `loop_id` / `loop_trigger_id` are documented as standard TaskRun properties, but in practice they only reach the events routed through `TaskRun.capture_event` — `task_run_completed` and `task_run_failed`. Over a recent 14-day window: `loop_id` was present on 0 of 112k `task_run_created`, 0 of 109k `task_run_started`, 0 of 107k `sandbox_started`, and 0 of 11k `task_run_failed`, and only on the handful of `task_run_completed` that came from real loop runs. So you can't build a "how is loop X performing" trend or failure breakdown without this.

Two capture paths bypass the loop linkage:

- `task_run_created` uses `Task.capture_event`, which never had the loop fields.
- `task_run_started` and `sandbox_started` are workflow events that assemble their own property dicts and pass them through `track_workflow_event`.

(`task_run_failed` from the workflow path is already correct — its analytics capture is owned by `_capture_terminal_analytics`, which goes through `TaskRun.capture_event`. The near-zero count there just reflects how few loop runs fail.)

## Changes

Stamp `loop_id` / `loop_trigger_id` in the three places that were missing them:

- `Task.create_run` adds them to the `task_run_created` properties, read from the run state the same way `TaskRun.capture_event` does.
- The `task_run_started` and `sandbox_started` workflow events read them off the processing context, which gains a `loop_trigger_id` accessor mirroring the existing `loop_id`.

These are additive analytics properties only — no change to the workflow command sequence, so in-flight executions replay deterministically (per the Temporal versioning rule, only activity-input property dicts change).

## How did you test this code?

Added one parameterized test, `TestTaskRun::test_task_run_created_carries_loop_attribution` (loop run → both ids present; non-loop run → both `None`). It's the wiring guard that `create_run` stamps loop attribution onto the analytics event; it catches a regression that drops the fields or breaks the state→properties wiring, which no existing test covered (the existing tests assert Prometheus counters, not analytics properties). Ran locally, both cases pass. The workflow-event additions are not unit-tested — exercising them means standing up the Temporal workflow, and they reuse the already-tested `loop_id` accessor, so the cost outweighs the value.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Came out of a question about whether the conflict-autoresolver Loop's runs can be tracked in product analytics. Investigation (via the PostHog MCP) showed the task lifecycle events flow but carry no loop linkage on most events; this closes that gap so loop runs become sliceable. Traced the four capture sites (`Task.capture_event`, `TaskRun.capture_event`, the workflow `_track_workflow_event` path, and the `update_task_run_status` terminal activity) to confirm exactly which were missing the fields before editing. Invoked `/writing-tests` before adding the test. Claude Code (Fable 5).

Routing to the tasks/Code team as owners of this product.
