### PR TITLE
fix(linkedin_ads): classify exhausted retryable errors as retryable noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
@@ -115,6 +115,18 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
             "Integration matching query does not exist": "Your LinkedIn Ads connection is no longer available — it may have been disconnected. Please re-authorize the LinkedIn Ads integration.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `client.py`'s `_call_finder` already retries these in-process via tenacity (5 attempts,
+        # exponential backoff honoring Retry-After) before re-raising `LinkedinAdsRetryableError`. A
+        # 429/5xx/malformed-body that survives all 5 attempts is a transient LinkedIn/edge blip, not
+        # a bug — Temporal's activity retry recovers once the upstream issue clears, so keep it out
+        # of error tracking as noise. Match the stable message prefix LinkedIn's own status/body are
+        # appended to, not the volatile status code or body.
+        return {
+            "LinkedIn API error (retryable, ",
+            "LinkedIn API returned a malformed (non-JSON) response",
+        }
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -50,6 +50,31 @@ class TestLinkedInAdsSource:
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
 
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            'LinkedIn API error (retryable, 500): {"message":"Internal Server Error","status":500}',
+            'LinkedIn API error (retryable, 429): {"message":"Too many requests"}',
+            'LinkedIn API error (retryable, 503): {"message":"Service Unavailable"}',
+            "LinkedIn API returned a malformed (non-JSON) response: Expecting value: line 1 column 1 (char 0)",
+        ],
+    )
+    def test_retryable_errors_match_exhausted_transient_failures(self, observed_error):
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(pattern in observed_error for pattern in retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            'LinkedIn API error (404): {"status":404,"code":"RESOURCE_NOT_FOUND"}',
+            'LinkedIn daily rate limit reached (429): {"message":"throttled"}',
+            "Connection reset by peer",
+        ],
+    )
+    def test_retryable_errors_does_not_match_unrelated(self, other_error):
+        retryable_errors = self.source.get_retryable_errors()
+        assert not any(pattern in other_error for pattern in retryable_errors)
+
     def test_defaults_new_sources_to_202606(self):
         assert self.source.default_version == LINKEDIN_ADS_VERSION_202606
         assert set(self.source.supported_versions) == {"v1", LINKEDIN_ADS_VERSION_202606}


### PR DESCRIPTION
## Problem

Error tracking surfaced `LinkedinAdsRetryableError` ("LinkedIn API error (retryable, 500): ...") as a tracked exception for the LinkedIn Ads warehouse source ([issue](https://us.posthog.com/project/2/error_tracking/019f95f0-f348-7853-a8a2-8e965e5ae1d2)).

`LinkedinAdsClient._call_finder` already retries transient 5xx / short-window 429 / malformed-body responses in-process via `tenacity` (5 attempts, exponential backoff honoring `Retry-After`) before re-raising `LinkedinAdsRetryableError`. When those in-process retries are exhausted, the error reaches `_handle_import_error`, which only special-cases errors listed in `get_retryable_errors()` — and `LinkedInAdsSource` didn't override it. So the error fell through to the default branch, got logged at `exception` level, and was captured as a tracked issue, even though Temporal's own activity-level retry recovers the sync once the upstream blip clears.

This is the same pattern already fixed for other sources (Meta Ads, Mixpanel, HubSpot, etc.) — a transient, self-recovering failure being misclassified as a bug.

## Changes

- Added `get_retryable_errors()` to `LinkedInAdsSource`, matching the stable message prefixes `client.py` raises for exhausted-retry 5xx/429 and malformed-JSON responses.

## How did you test this code?

Added two parametrized test groups to `test_linkedin_source.py`:
- `test_retryable_errors_match_exhausted_transient_failures` — asserts exhausted 500/429/503/malformed-response messages match the new `get_retryable_errors()` patterns. Catches a regression where the retryable-noise classification silently stops matching.
- `test_retryable_errors_does_not_match_unrelated` — asserts unrelated errors (404, daily rate limit, generic connection reset) are *not* misclassified as retryable noise, which would otherwise hide a real bug from error tracking.

Ran the full `test_linkedin_source.py` suite locally (37 passed) plus `ruff check`/`ruff format` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (PostHog Code), triaging a real error-tracking issue for the `linkedin_ads` source.
- Confirmed the stack trace originates in `linkedin_ads/client.py`, then compared against the existing `get_retryable_errors()` convention used by Meta Ads/Mixpanel/HubSpot sources to reach the same fix shape.
- Decision: classified as "fixable bug" (missing retryable-noise classification), not "user/upstream error" — the error is a transient upstream 5xx already retried internally, not something to add to `NonRetryableErrors`.