### PR TITLE
perf(replay): slide the image-scrub window instead of barriering every N

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
@@ -282,6 +282,47 @@ describe('ImageBatcher', () => {
         expect(store.writes.flat()).toHaveLength(8)
     })
 
+    it('never writes an image whose offset a slow predecessor is still holding back', async () => {
+        // Completions arrive out of order, so a slow first image leaves later ones finished but not
+        // retired. Writing those on a capacity flush persists bytes whose offsets cannot be stored
+        // yet, and a batch failure then rewrites them under a fresh shard key: the same content in
+        // two shards, and two index rows pointing at it. A flush must only ever cover what it can
+        // also commit.
+        const store = new FakeStore()
+        const offsets = new FakeOffsets()
+        let releaseSlow = (): void => {}
+        const slow = new Promise<void>((resolve) => (releaseSlow = resolve))
+        const gatedClient = {
+            scrub: (b: Buffer) => (b.toString() === 'slow' ? slow.then(() => b) : Promise.resolve(b)),
+        } as unknown as ScrubClient
+        const batcher = new ImageBatcher(
+            store as unknown as ImageShardStore,
+            offsets,
+            gatedClient,
+            { ...options, maxImages: 2, scrubConcurrency: 4 },
+            0
+        )
+
+        const batch: Message[] = [msg(0, 0, pt(1), Buffer.from('slow'))]
+        for (let i = 1; i < 5; i++) {
+            batch.push(msg(0, i, pt(1), Buffer.from(`img-${i}`)))
+        }
+        const running = batcher.handleBatch(batch, 1)
+        for (let tick = 0; tick < 20; tick++) {
+            await new Promise((resolve) => setImmediate(resolve))
+        }
+
+        // The fast images are done but unretired, so nothing may be written or committed yet.
+        expect(store.writes.flat()).toHaveLength(0)
+        expect(offsets.received).toHaveLength(0)
+
+        releaseSlow()
+        await running
+
+        expect(store.writes.flat()).toHaveLength(5)
+        expect(offsets.received.at(-1)).toEqual([{ topic: 'session_replay_image_scrub', partition: 0, offset: 5 }])
+    })
+
     it('rescrubs an image whose batch failed rather than pod-deduping the replay away', async () => {
         // A ref is marked seen only once its image is buffered. Marking it at plan time, or inside
         // scrubOne, reads as a harmless simplification and silently drops the image instead: the

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.test.ts
@@ -241,6 +241,47 @@ describe('ImageBatcher', () => {
         }
     )
 
+    it('refills a slot as soon as it frees rather than waiting on the slowest image in flight', async () => {
+        // Awaiting a whole group of scrubConcurrency before starting the next means one slow image
+        // holds its group's other slots idle until it finishes, so throughput tracks the slowest image
+        // in each group rather than the average one. On a spread-out scrub-time distribution that is
+        // most of the sidecar's capacity. A sliding window costs one slot for a slow image, not all of
+        // them, so every remaining image is already in flight before the slow one returns.
+        const store = new FakeStore()
+        let releaseSlow = (): void => {}
+        const slow = new Promise<void>((resolve) => (releaseSlow = resolve))
+        let started = 0
+        const gatedClient = {
+            scrub: (b: Buffer) => {
+                started += 1
+                return b.toString() === 'slow' ? slow.then(() => b) : Promise.resolve(b)
+            },
+        } as unknown as ScrubClient
+        const batcher = new ImageBatcher(
+            store as unknown as ImageShardStore,
+            new FakeOffsets(),
+            gatedClient,
+            options,
+            0
+        )
+
+        const batch: Message[] = [msg(0, 0, pt(1), Buffer.from('slow'))]
+        for (let i = 1; i < 8; i++) {
+            batch.push(msg(0, i, pt(1), Buffer.from(`img-${i}`)))
+        }
+        const running = batcher.handleBatch(batch, 1)
+        for (let tick = 0; tick < 20; tick++) {
+            await new Promise((resolve) => setImmediate(resolve))
+        }
+
+        // All 8 are in flight while the slow one is still blocked; a barrier would stall at 4.
+        expect(started).toBe(8)
+
+        releaseSlow()
+        await running
+        expect(store.writes.flat()).toHaveLength(8)
+    })
+
     it('rescrubs an image whose batch failed rather than pod-deduping the replay away', async () => {
         // A ref is marked seen only once its image is buffered. Marking it at plan time, or inside
         // scrubOne, reads as a harmless simplification and silently drops the image instead: the

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
@@ -27,6 +27,14 @@ interface ScrubbedRef {
     image: ScrubbedImage
 }
 
+/** Carries the window slot so a completion can be matched back to its position, which is what
+ *  lets offsets retire in order even though scrubs finish out of order. */
+interface SettledScrub {
+    slot: number
+    scrubbed: ScrubbedRef | null
+    error?: unknown
+}
+
 export interface ImageBatcherOptions {
     flushIntervalMs: number
     maxImages: number
@@ -41,7 +49,7 @@ export class ImageBatcher {
     private bufferBytes = 0
     private pendingOffsets = new Map<string, TopicPartitionOffset>()
     private lastFlushMs: number
-    private readonly chunkSize: number
+    private readonly maxInFlight: number
     private readonly scrubConcurrency: ConcurrencyController
     /**
      * Refs this pod has resolved, either by buffering the scrubbed bytes or by having the sidecar
@@ -62,64 +70,93 @@ export class ImageBatcher {
         private readonly options: ImageBatcherOptions,
         nowMs: number
     ) {
-        // The concurrency doubles as the chunk stride below; 0 would spin the loop forever and NaN
-        // would skip it entirely (committing offsets for unprocessed messages), so fail at boot.
-        this.chunkSize = Math.floor(options.scrubConcurrency)
-        if (!Number.isInteger(this.chunkSize) || this.chunkSize < 1) {
+        // 0 would admit nothing and spin the loop forever; NaN would skip it entirely, committing
+        // offsets for unprocessed messages. Fail at boot rather than either.
+        this.maxInFlight = Math.floor(options.scrubConcurrency)
+        if (!Number.isInteger(this.maxInFlight) || this.maxInFlight < 1) {
             throw new Error(`scrubConcurrency must be a positive number, got ${options.scrubConcurrency}`)
         }
         this.lastFlushMs = nowMs
-        this.scrubConcurrency = new ConcurrencyController(this.chunkSize)
+        this.scrubConcurrency = new ConcurrencyController(this.maxInFlight)
         this.seenRefs = new RefDedupCache('image_scrub_consumer', options.dedupMaxRefs)
     }
 
     public async handleBatch(messages: Message[], nowMs: number): Promise<void> {
-        // Skips must resolve before chunking: a duplicate left in a chunk still holds a concurrency
-        // slot and completes instantly, so the chunk ends with its one distinct image and the batch
-        // serializes behind the barriers, running one scrub at a time whatever scrubConcurrency says.
+        // Skips resolve up front so the window only ever holds real work: a duplicate admitted into a
+        // slot would occupy it and complete instantly, spending the pod's concurrency on no-ops.
         if (messages.length) {
             ImageScrubConsumerMetrics.observeBatchMessages(messages.length)
         }
         const planned = this.planBatch(messages)
 
-        // Scrub in concurrency-sized chunks with the capacity bounds applied between chunks: scrubbed
-        // outputs can dwarf their inputs (a sub-MB input can come back as a multi-MB full-resolution
-        // PNG), so retaining a whole poll batch of them before the first bound check can hold
-        // gigabytes. Peak memory is now ~maxBytes plus one chunk's outputs.
+        // A sliding window rather than fixed groups: every completion immediately admits the next
+        // image, so the sidecar never waits on the slowest member of a group before being given more
+        // work. Grouping used to gate throughput on E[slowest of N] instead of E[mean], which on a
+        // spread-out scrub-time distribution leaves a large share of the sidecar's cores idle.
         //
-        // The deadline covers scrub time only: the timer is armed per chunk with the remaining
-        // budget and disarmed before any mid-batch flush, so slow-but-succeeding S3 writes (each
-        // bounded by their own timeout) can't burn the scrub budget and turn into an abort/replay
-        // loop misattributed to the sidecar.
+        // Admission is what bounds memory: scrubbed outputs can dwarf their inputs (a sub-MB input
+        // can come back as a multi-MB full-resolution PNG), so submitting a whole poll batch at once
+        // could hold gigabytes. Peak is ~maxBytes plus the outputs of one window.
+        //
+        // The deadline covers scrub time only: the timer is armed around each wait and the elapsed
+        // time charged to the budget, so slow-but-succeeding S3 writes (each bounded by their own
+        // timeout) can't burn the scrub budget and turn into an abort/replay loop misattributed to
+        // the sidecar.
         const controller = new AbortController()
         let scrubBudgetMs = this.options.maxBatchScrubMs
         let spanStart = 0
-        for (let i = 0; i < planned.length; i += this.chunkSize) {
-            const chunk = planned.slice(i, i + this.chunkSize)
-            const chunkStartMs = performance.now()
+        let nextToSubmit = 0
+        let retired = 0
+        const settled = new Array<boolean>(planned.length).fill(false)
+        const inFlight = new Map<number, Promise<SettledScrub>>()
+
+        while (nextToSubmit < planned.length || inFlight.size > 0) {
+            while (nextToSubmit < planned.length && inFlight.size < this.maxInFlight && !this.overCapacity()) {
+                inFlight.set(nextToSubmit, this.submitScrub(nextToSubmit, planned[nextToSubmit], controller))
+                nextToSubmit++
+            }
+            // Only reachable over capacity with work left: flush to make room rather than spin.
+            if (inFlight.size === 0) {
+                await this.flushOrThrow(nowMs)
+                continue
+            }
+
+            const waitStartMs = performance.now()
             const timer = setTimeout(() => controller.abort(), scrubBudgetMs)
-            let scrubbed: ScrubbedRef[]
+            let done: SettledScrub
             try {
-                scrubbed = await this.scrubChunk(chunk, controller)
-            } catch (e) {
-                ImageScrubConsumerMetrics.incBatchFailed('scrub')
-                throw e
+                done = await Promise.race(inFlight.values())
             } finally {
                 clearTimeout(timer)
+                scrubBudgetMs -= performance.now() - waitStartMs
             }
-            scrubBudgetMs -= performance.now() - chunkStartMs
-            for (const { ref, image } of scrubbed) {
-                this.buffer.push(image)
-                this.bufferBytes += image.bytes.length
-                this.seenRefs.add(ref)
+            inFlight.delete(done.slot)
+            if (done.error !== undefined) {
+                controller.abort() // one failure dooms the batch, so cancel the siblings still in flight
+                ImageScrubConsumerMetrics.incBatchFailed('scrub')
+                throw done.error
             }
-            // The span also covers the skipped messages between this chunk's entries, which are done
-            // too and would otherwise replay forever. Offsets are only ever *stored* by a flush,
-            // after the buffer holding these images is durably written, so a mid-batch flush records
-            // exactly the progress it persisted and a later failure replays only from there.
-            const spanEnd = chunk[chunk.length - 1].index + 1
-            this.recordOffsets(messages.slice(spanStart, spanEnd))
-            spanStart = spanEnd
+            if (done.scrubbed) {
+                this.buffer.push(done.scrubbed.image)
+                this.bufferBytes += done.scrubbed.image.bytes.length
+                this.seenRefs.add(done.scrubbed.ref)
+            }
+
+            // Completions arrive out of order, so only the contiguous run from the front is safe to
+            // commit: anything past a still-running image would commit an offset for work that has
+            // not happened. The span also covers the skipped messages between retired entries, which
+            // are done too and would otherwise replay forever. Offsets are only ever *stored* by a
+            // flush, after the buffer holding these images is durably written.
+            settled[done.slot] = true
+            const retiredBefore = retired
+            while (retired < planned.length && settled[retired]) {
+                retired++
+            }
+            if (retired > retiredBefore) {
+                const spanEnd = planned[retired - 1].index + 1
+                this.recordOffsets(messages.slice(spanStart, spanEnd))
+                spanStart = spanEnd
+            }
             if (this.overCapacity()) {
                 await this.flushOrThrow(nowMs)
             }
@@ -164,22 +201,20 @@ export class ImageBatcher {
         }
     }
 
-    private async scrubChunk(planned: PlannedScrub[], controller: AbortController): Promise<ScrubbedRef[]> {
-        try {
-            const scrubbed = await Promise.all(
-                planned.map((p) =>
-                    this.scrubConcurrency.run({
-                        fn: () =>
-                            this.scrubOne(p, controller.signal).then((image) => (image ? { ref: p.ref, image } : null)),
-                        abortController: controller,
-                    })
-                )
+    /**
+     * Failures resolve rather than reject so the caller can race the whole window without the losing
+     * promises becoming unhandled rejections when the batch aborts.
+     */
+    private submitScrub(slot: number, p: PlannedScrub, controller: AbortController): Promise<SettledScrub> {
+        return this.scrubConcurrency
+            .run({
+                fn: () => this.scrubOne(p, controller.signal),
+                abortController: controller,
+            })
+            .then(
+                (image): SettledScrub => ({ slot, scrubbed: image ? { ref: p.ref, image } : null }),
+                (error): SettledScrub => ({ slot, scrubbed: null, error: error ?? new Error('scrub failed') })
             )
-            return scrubbed.filter((entry): entry is ScrubbedRef => entry !== null)
-        } catch (e) {
-            controller.abort() // one failure dooms the batch, so cancel the siblings still in flight
-            throw e
-        }
     }
 
     private async flushOrThrow(nowMs: number): Promise<void> {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub/image-batcher.ts
@@ -109,9 +109,20 @@ export class ImageBatcher {
         let retired = 0
         const settled = new Array<boolean>(planned.length).fill(false)
         const inFlight = new Map<number, Promise<SettledScrub>>()
+        // Results wait here until their slot retires, so the buffer only ever holds images whose
+        // offsets have been recorded. Without it a flush could persist an image while a still-running
+        // predecessor kept its offset unrecorded, and a later batch failure would rewrite it under a
+        // fresh shard key. Staged bytes count towards capacity, which is what bounds this.
+        const staged = new Array<ScrubbedRef | null>(planned.length).fill(null)
+        let stagedCount = 0
+        let stagedBytes = 0
 
         while (nextToSubmit < planned.length || inFlight.size > 0) {
-            while (nextToSubmit < planned.length && inFlight.size < this.maxInFlight && !this.overCapacity()) {
+            while (
+                nextToSubmit < planned.length &&
+                inFlight.size < this.maxInFlight &&
+                !this.overCapacity(stagedCount, stagedBytes)
+            ) {
                 inFlight.set(nextToSubmit, this.submitScrub(nextToSubmit, planned[nextToSubmit], controller))
                 nextToSubmit++
             }
@@ -137,9 +148,9 @@ export class ImageBatcher {
                 throw done.error
             }
             if (done.scrubbed) {
-                this.buffer.push(done.scrubbed.image)
-                this.bufferBytes += done.scrubbed.image.bytes.length
-                this.seenRefs.add(done.scrubbed.ref)
+                staged[done.slot] = done.scrubbed
+                stagedCount += 1
+                stagedBytes += done.scrubbed.image.bytes.length
             }
 
             // Completions arrive out of order, so only the contiguous run from the front is safe to
@@ -150,6 +161,18 @@ export class ImageBatcher {
             settled[done.slot] = true
             const retiredBefore = retired
             while (retired < planned.length && settled[retired]) {
+                const ready = staged[retired]
+                if (ready) {
+                    this.buffer.push(ready.image)
+                    this.bufferBytes += ready.image.bytes.length
+                    // Marked here rather than on completion: a staged image is a local that a thrown
+                    // batch discards, so a ref marked before retirement could be skipped on replay
+                    // without ever having been persisted.
+                    this.seenRefs.add(ready.ref)
+                    staged[retired] = null
+                    stagedCount -= 1
+                    stagedBytes -= ready.image.bytes.length
+                }
                 retired++
             }
             if (retired > retiredBefore) {
@@ -157,7 +180,7 @@ export class ImageBatcher {
                 this.recordOffsets(messages.slice(spanStart, spanEnd))
                 spanStart = spanEnd
             }
-            if (this.overCapacity()) {
+            if (this.overCapacity(stagedCount, stagedBytes)) {
                 await this.flushOrThrow(nowMs)
             }
         }
@@ -240,8 +263,12 @@ export class ImageBatcher {
         return { pseudoTeam: planned.pseudoTeam, hash: planned.hash, bytes }
     }
 
-    private overCapacity(): boolean {
-        return this.buffer.length >= this.options.maxImages || this.bufferBytes >= this.options.maxBytes
+    /** Staged results are counted so a slow slot holding back retirement still applies backpressure. */
+    private overCapacity(stagedCount = 0, stagedBytes = 0): boolean {
+        return (
+            this.buffer.length + stagedCount >= this.options.maxImages ||
+            this.bufferBytes + stagedBytes >= this.options.maxBytes
+        )
     }
 
     private shouldFlush(nowMs: number): boolean {


### PR DESCRIPTION
## Problem

The batcher awaited a whole group of `scrubConcurrency` images before starting the next, so each group finished at the pace of its slowest member. Throughput therefore tracked `E[slowest of N]` rather than `E[mean]`, and on a spread-out scrub-time distribution that is most of the sidecar's capacity.

It matches what the lane is doing. The sidecar sits at roughly **58% of its 2000m** while the topic backlog grows, which is about where the ratio of mean to slowest-of-8 lands for a moderately variable distribution. For a heavy tail it would be worse: a pure exponential gives `1/H₈ ≈ 37%`.

The `concurrentlyPerGroup` shape was a fair choice when duplicates still occupied slots, since a group of 8 that was 7 duplicates cost nothing to barrier. Once #73589 stopped admitting duplicates, every slot holds real work and the barrier became the binding constraint. A reviewer flagged this at the time ("the chunk barrier still gates concurrency on each chunk's slowest image") and I logged it as a nit rather than acting on it.

## Changes

Submit through the existing `ConcurrencyController` and retire completions as they land: a freed slot is refilled immediately, so one slow image costs one slot rather than all of them. Admission stays capped at `scrubConcurrency`, which is what still bounds the buffer, so peak memory is unchanged at roughly `maxBytes` plus one window's outputs.

> [!IMPORTANT]
> Completions now arrive **out of order**, so offsets retire only over the contiguous run from the front of the batch. Anything past a still-running image would commit an offset for work that has not happened. Results are staged per slot and moved into the buffer only as slots retire, so a flush covers exactly what it can also commit; staged bytes count towards capacity, which is what stops a slow slot growing the batch without bound. `seenRefs` is marked at retirement for the same reason: a staged result is a local that a thrown batch discards, so marking at completion could skip a ref on replay that was never persisted.

Failures resolve rather than reject so the window can be raced without the losing promises becoming unhandled rejections once the batch aborts. Abort, deadline accounting and the `batch_failed{cause="scrub"}` counter behave as before; the deadline timer is now armed around each wait and the elapsed time charged to the budget, so flush time still does not count against it.

No new dependency: `ConcurrencyController` already holds a `FastPriorityQueue` and starts the next queued item the moment a slot frees. The batcher simply stopped feeding it in barriered groups. Its `priority` parameter is unused here but is the obvious hook if this lane ever wants oldest-offset-first draining.

## How did you test this code?

`pnpm jest` over the ml-mirror and image-scrub trees plus the shared cache: **78 passed**, 16 suites. `tsc --noEmit` and eslint clean.

One new test, and it is the point of the change: **7 fast images and 1 slow one, concurrency 4.** It asserts all 8 are in flight while the slow one is still blocked. Red-greened by swapping the race back to an await over everything in flight, which reproduces the barrier exactly — it stalls at **4 started instead of 8**.

Every pre-existing test passed without modification, including the offset-span, mid-batch-flush, deadline and replay-after-failure cases. That was the main thing I wanted from them, since the out-of-order retirement is where this could have gone wrong quietly.

No test for the retirement ordering itself beyond the existing span tests. The failure mode is a committed offset for unscrubbed work, and the multi-partition flush test already covers that shape; a test that forced a specific completion order would be asserting the scheduler rather than the invariant.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal ingestion lane behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie, authored by Claude Code (Fable 5). Skills invoked: /writing-tests.

Robbie asked whether the lane pauses to flush to S3, which it does: `flushOrThrow` is awaited inline, so nothing is in flight to the sidecar while a shard and its index are written. That is real but bounded by flush frequency (1000 images, 128 MB, or 30s), so single-digit percent rather than the observed 42-point gap. Overlapping the flush is worth doing next and is deliberately not in this PR: it needs a second pending-offset set so an in-flight write cannot store offsets for images it did not persist.

Sidecar CPU is deliberately left at 2000m. Adding cores to a container using 58% of what it has would only idle harder, and would widen the KEDA dilution, since utilisation is computed pod-wide against requests and the consumer's idle 1000m already drags the pod to 39% against a 45% target. The CPU throttling panel in PostHog/grafana-dashboards#298 is what should decide a core bump.

