### PR TITLE
feat(replay_vision): tag scanner generations with scanner and session ids

### DIFF
--- a/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
+++ b/products/replay_vision/backend/temporal/activities/call_scanner_provider.py
@@ -74,16 +74,18 @@ async def call_scanner_provider_activity(inputs: CallScannerProviderInputs) -> S
 async def _call_scanner_provider(inputs: CallScannerProviderInputs) -> ScannerCallOutput:
     if inputs.snapshot_override is not None:
         snapshot = inputs.snapshot_override
-        team_name, llm_inputs = await asyncio.gather(
+        scanner_id, team_name, llm_inputs = await asyncio.gather(
+            sync_to_async(_load_scanner_id)(inputs.observation_id, inputs.team_id),
             sync_to_async(_load_team_name)(inputs.team_id),
             _load_llm_inputs(inputs.observation_id),
         )
     else:
-        snapshot, team_name, llm_inputs = await asyncio.gather(
+        loaded, team_name, llm_inputs = await asyncio.gather(
             sync_to_async(_load_snapshot)(inputs.observation_id, inputs.team_id),
             sync_to_async(_load_team_name)(inputs.team_id),
             _load_llm_inputs(inputs.observation_id),
         )
+        snapshot, scanner_id = loaded
     scanner = scanner_from_snapshot(snapshot)
 
     preamble_text = scanner.preamble(
@@ -100,6 +102,7 @@ async def _call_scanner_provider(inputs: CallScannerProviderInputs) -> ScannerCa
         video_part=video_part,
         preamble_text=preamble_text,
         team_id=inputs.team_id,
+        scanner_id=scanner_id,
         llm_inputs=llm_inputs,
     )
     duration_ms = int(llm_inputs.metadata.duration_seconds * 1000)
@@ -152,17 +155,32 @@ def _extract_segments(text: str, duration_ms: int) -> tuple[str, list[Segment]]:
     return "".join(plain_parts), segments
 
 
-def _load_snapshot(observation_id: UUID, team_id: int) -> ScannerSnapshot:
-    raw = (
+def _load_snapshot(observation_id: UUID, team_id: int) -> tuple[ScannerSnapshot, UUID]:
+    row = (
         ReplayObservation.objects.filter(pk=observation_id, team_id=team_id)
-        .values_list("scanner_snapshot", flat=True)
+        .values_list("scanner_snapshot", "scanner_id")
         .first()
     )
-    if raw is None:
+    if row is None:
         raise ScannerFailureError(
             f"ReplayObservation {observation_id} not found for team {team_id}", kind=FailureKind.INTERNAL_ERROR
         )
-    return ScannerSnapshot.load_for(observation_id, raw)
+    raw, scanner_id = row
+    return ScannerSnapshot.load_for(observation_id, raw), scanner_id
+
+
+def _load_scanner_id(observation_id: UUID, team_id: int) -> UUID:
+    """Scanner FK off the observation row — the snapshot doesn't carry it, and the override path skips `_load_snapshot`."""
+    scanner_id = (
+        ReplayObservation.objects.filter(pk=observation_id, team_id=team_id)
+        .values_list("scanner_id", flat=True)
+        .first()
+    )
+    if scanner_id is None:
+        raise ScannerFailureError(
+            f"ReplayObservation {observation_id} not found for team {team_id}", kind=FailureKind.INTERNAL_ERROR
+        )
+    return scanner_id
 
 
 def _load_team_name(team_id: int) -> str:
@@ -188,6 +206,7 @@ async def _run_mission(
     video_part: types.Part,
     preamble_text: str,
     team_id: int,
+    scanner_id: UUID,
     llm_inputs: ScannerLlmInputs,
 ) -> tuple[BaseScannerOutput, list[SignalFinding]]:
     """Cache the video, run every mission step as a tool-using turn, then assemble the output + side-mission findings.
@@ -197,12 +216,17 @@ async def _run_mission(
     """
     api_key = gemini_api_key()
     # Attribute every scanner generation to Replay Vision in LLM analytics so costs and traces roll up to the product.
+    # scanner_id + session_id identify the observation (scanner × session) so per-observation cost can be joined back
+    # to `$recording_observed` in LLM analytics — the bare-uuid traces don't encode it.
     client = genai.AsyncClient(
         api_key=api_key,
         posthog_properties={
             "ai_product": "replay_vision",
             "feature": "scanner",
             "scanner_type": snapshot.scanner_type.value,
+            "scanner_id": str(scanner_id),
+            "scanner_name": snapshot.name,
+            "session_id": llm_inputs.session_id,
         },
     )
     cache_client = GoogleGenAIClient(api_key=api_key)


### PR DESCRIPTION
## Problem

Every `$ai_generation` a scanner run emits only carried `ai_product: replay_vision` and `feature: scanner` (plus `scanner_type`). There was no way to group the calls back to the observation (scanner × session) they belong to. The old trace format encoded team + session in `$ai_trace_id`, but the current path emits bare-uuid traces with one call each, so per-observation cost analysis was broken.

We need per-observation token cost and margin, by model and by customer, computed directly in LLM analytics (join to `$recording_observed` on `session_id` + `scanner_id`). Today we can only do per-call analysis multiplied by an average calls-per-observation, which blurs the underwater-observation tail that matters for pricing validation.

## Changes

Add `scanner_id`, `scanner_name`, and `session_id` to the `posthog_properties` on the instrumented Gemini client in `call_scanner_provider` (the single scan gen call site — scheduled, on-demand, and retry scans all flow through `ApplyScannerWorkflow` → this activity, and evaluation re-runs share it too).

`scanner_name` (`snapshot.name`) and `session_id` (`llm_inputs.session_id`) were already in scope. `scanner_id` was not on the snapshot or the activity inputs, so it's now read off the `ReplayObservation` row: folded into the existing `_load_snapshot` query on the main path, and via a small `_load_scanner_id` lookup on the snapshot-override (evaluation) path.

Trace id behavior is unchanged.

> [!NOTE]
> The suggestion/theme/tag call sites (`feedback_themes`, `prompt_suggestions`, `tag_suggestions`) and the `vision_action_group_summary` call are separate features, not scanner runs, so they're left as-is.

## How did you test this code?

Ran the existing unit tests for the activity: `products/replay_vision/backend/tests/test_call_scanner_provider.py` (13 passed). Ruff check + format clean. I (the agent) did not run manual end-to-end scans.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app agent from a Slack thread. Confirmed which values were already in scope in the activity by reading it, found that `scanner_id` was the only missing one (it lives on the `ReplayObservation` FK, not the snapshot), and sourced it from the row rather than threading a new field through the two workflow input types. No skills were required for this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1784927488302609)*
