### PR TITLE
fix(signals): Stop dropping support tickets that contain images

### DIFF
--- a/products/signals/backend/contracts.py
+++ b/products/signals/backend/contracts.py
@@ -185,6 +185,11 @@ class JiraIssueSignalInput(SignalInputBase):
 # ── Conversations ───────────────────────────────────────────────────────────────
 
 
+class ConversationsTicketImage(ContractModel):
+    url: str
+    author: str
+
+
 class ConversationsTicketSignalExtra(SignalExtraBase):
     ticket_number: int
     channel_source: str
@@ -193,6 +198,9 @@ class ConversationsTicketSignalExtra(SignalExtraBase):
     priority: str | None
     created_at: str
     email_subject: str | None
+    # Publicly fetchable media URLs pasted into the thread, so the research agent can inspect
+    # screenshots directly. Absent (rather than empty) when the thread has no attachments.
+    images: list[ConversationsTicketImage] | None = None
 
 
 class ConversationsTicketSignalInput(SignalInputBase):

--- a/products/signals/backend/emission/pipeline.py
+++ b/products/signals/backend/emission/pipeline.py
@@ -18,6 +18,8 @@ from posthog.sync import database_sync_to_async
 
 from products.signals.backend.emission.registry import SignalEmitter, SignalEmitterOutput, SignalSourceTableConfig
 from products.signals.backend.facade.api import emit_signal
+from products.signals.backend.temporal import metrics
+from products.signals.backend.temporal.drop_telemetry import summarize_drop_error
 
 logger = structlog.get_logger(__name__)
 
@@ -30,6 +32,9 @@ LLM_CONCURRENCY_LIMIT = 20
 EMIT_CONCURRENCY_LIMIT = 50
 # Temporal gRPC payload size limit (2 MB)
 TEMPORAL_PAYLOAD_MAX_BYTES = 2 * 1024 * 1024
+# Shares the drop-stage namespace with drop_telemetry's grouping_* stages, so the
+# signals_dropped_total counter can be summed across the whole pipeline.
+EMIT_DROP_STAGE = "emission"
 # Maximum number of attempts for LLM calls (summarization & actionability)
 LLM_MAX_ATTEMPTS = 3
 # Per-call timeout for LLM requests (seconds)
@@ -84,6 +89,7 @@ def _capture_pipeline_stage(
     team: Team,
     organization: Organization,
     output: SignalEmitterOutput,
+    properties: dict[str, Any] | None = None,
 ) -> None:
     try:
         posthoganalytics.capture(
@@ -93,6 +99,7 @@ def _capture_pipeline_stage(
                 "source_product": output.source_product,
                 "source_type": output.source_type,
                 "source_id": output.source_id,
+                **(properties or {}),
             },
             groups=groups(organization, team),
         )
@@ -379,6 +386,7 @@ def _estimate_output_payload_bytes(output: SignalEmitterOutput) -> int:
 
 async def _emit_signals(
     team: Team,
+    organization: Organization,
     outputs: list[SignalEmitterOutput],
     extra: dict[str, Any],
 ) -> int:
@@ -420,7 +428,20 @@ async def _emit_signals(
                 )
                 return True
             except Exception as e:
-                logger.exception(f"Error emitting signal for record: {e}", **extra)
+                # Fetchers record emission optimistically, so a record lost here is lost for good.
+                # Close the funnel (entered - summarized - filtered - emit_failed = emitted) and
+                # count the drop, or the loss is invisible outside logs.
+                error_type, _ = summarize_drop_error(e)
+                logger.exception(
+                    f"Error emitting signal for record: {e}",
+                    signal_source_type=output.source_type,
+                    signal_source_id=output.source_id,
+                    **extra,
+                )
+                _capture_pipeline_stage(
+                    "signal_data_source_emit_failed", team, organization, output, {"error_type": error_type}
+                )
+                metrics.increment_dropped(stage=EMIT_DROP_STAGE, reason=error_type)
                 return False
             finally:
                 completed_count += 1
@@ -501,6 +522,7 @@ async def run_signal_pipeline(
 
     signals_emitted = await _emit_signals(
         team=team,
+        organization=organization,
         outputs=outputs,
         extra=extra,
     )

--- a/products/signals/backend/emission/tests/test_emit_signals.py
+++ b/products/signals/backend/emission/tests/test_emit_signals.py
@@ -483,7 +483,7 @@ class TestEmitSignals:
             patch(f"{PIPELINE_MODULE_PATH}.emit_signal", new_callable=AsyncMock) as mock_emit,
             patch(f"{PIPELINE_MODULE_PATH}.activity"),
         ):
-            count = await _emit_signals(team=team, outputs=[output], extra={})
+            count = await _emit_signals(team=team, organization=MagicMock(), outputs=[output], extra={})
 
         assert count == 1
         mock_emit.assert_called_once_with(
@@ -510,9 +510,15 @@ class TestEmitSignals:
         with (
             patch(f"{PIPELINE_MODULE_PATH}.emit_signal", side_effect=mock_emit),
             patch(f"{PIPELINE_MODULE_PATH}.activity"),
+            patch(f"{PIPELINE_MODULE_PATH}.posthoganalytics.capture") as capture,
         ):
-            count = await _emit_signals(team=MagicMock(), outputs=outputs, extra={})
+            count = await _emit_signals(team=MagicMock(), organization=MagicMock(), outputs=outputs, extra={})
 
+        # Records dropped here are never retried, so the loss has to be measurable, not log-only.
+        capture.assert_called_once()
+        assert capture.call_args.kwargs["event"] == "signal_data_source_emit_failed"
+        assert capture.call_args.kwargs["properties"]["source_id"] == "2"
+        assert capture.call_args.kwargs["properties"]["error_type"] == "Exception"
         assert count == 2
         assert call_count == 3
 
@@ -532,7 +538,7 @@ class TestEmitSignals:
             patch(f"{PIPELINE_MODULE_PATH}.emit_signal", new_callable=AsyncMock) as mock_emit,
             patch(f"{PIPELINE_MODULE_PATH}.activity"),
         ):
-            count = await _emit_signals(team=MagicMock(), outputs=[output], extra={})
+            count = await _emit_signals(team=MagicMock(), organization=MagicMock(), outputs=[output], extra={})
 
         assert count == 1
         mock_emit.assert_called_once()
@@ -548,7 +554,7 @@ class TestEmitSignals:
             patch(f"{PIPELINE_MODULE_PATH}.activity"),
         ):
             with pytest.raises(RuntimeError, match="All 1 signal emissions failed"):
-                await _emit_signals(team=MagicMock(), outputs=[output], extra={})
+                await _emit_signals(team=MagicMock(), organization=MagicMock(), outputs=[output], extra={})
 
         mock_emit.assert_not_called()
 
@@ -561,7 +567,7 @@ class TestEmitSignals:
             patch(f"{PIPELINE_MODULE_PATH}.activity"),
         ):
             with pytest.raises(RuntimeError, match="All 2 signal emissions failed"):
-                await _emit_signals(team=MagicMock(), outputs=outputs, extra={})
+                await _emit_signals(team=MagicMock(), organization=MagicMock(), outputs=outputs, extra={})
 
 
 class TestPipelineStageTelemetry:

--- a/products/signals/backend/temporal/drop_telemetry.py
+++ b/products/signals/backend/temporal/drop_telemetry.py
@@ -37,7 +37,7 @@ class CaptureSignalDroppedInput:
     extra: dict = field(default_factory=dict)
 
 
-def _summarize_drop_error(error: BaseException) -> tuple[str, str]:
+def summarize_drop_error(error: BaseException) -> tuple[str, str]:
     """Extract the most specific (type, message) from a (possibly wrapped) activity error.
 
     Temporal wraps the real failure: an ActivityError's `cause` is an ApplicationError
@@ -93,7 +93,7 @@ async def capture_signal_dropped(signal: EmitSignalInputs, error: BaseException,
     """Best-effort signal_dropped telemetry from workflow code; never raises into the grouping flow."""
     if not workflow.patched(_PATCH_SIGNAL_DROPPED):
         return
-    error_type, error_message = _summarize_drop_error(error)
+    error_type, error_message = summarize_drop_error(error)
     try:
         await workflow.execute_activity(
             capture_signal_dropped_activity,

--- a/products/signals/backend/test/test_drop_telemetry.py
+++ b/products/signals/backend/test/test_drop_telemetry.py
@@ -177,7 +177,7 @@ async def test_helper_swallows_activity_failure():
         ),
     ],
 )
-def testsummarize_drop_error(error, expected_type, expected_message):
+def test_summarize_drop_error(error, expected_type, expected_message):
     error_type, message = summarize_drop_error(error)
     assert error_type == expected_type
     assert expected_message in message

--- a/products/signals/backend/test/test_drop_telemetry.py
+++ b/products/signals/backend/test/test_drop_telemetry.py
@@ -5,9 +5,9 @@ from temporalio.exceptions import ActivityError, ApplicationError
 
 from products.signals.backend.temporal.drop_telemetry import (
     CaptureSignalDroppedInput,
-    _summarize_drop_error,
     capture_signal_dropped,
     capture_signal_dropped_activity,
+    summarize_drop_error,
 )
 from products.signals.backend.temporal.types import EmitSignalInputs
 
@@ -177,8 +177,8 @@ async def test_helper_swallows_activity_failure():
         ),
     ],
 )
-def test_summarize_drop_error(error, expected_type, expected_message):
-    error_type, message = _summarize_drop_error(error)
+def testsummarize_drop_error(error, expected_type, expected_message):
+    error_type, message = summarize_drop_error(error)
     assert error_type == expected_type
     assert expected_message in message
     assert "\n" not in message

--- a/products/signals/eval/fixtures/conversations_tickets.json
+++ b/products/signals/eval/fixtures/conversations_tickets.json
@@ -26,6 +26,9 @@
     "messages": [
       ["customer", "Can't find the reset button on an experiment. We're keeping the bulk of the settings, but have made changes to the experiment and just want to reset the data. The AI seems to think this exists, I just can't find it. Hoping someone can point me in the right direction. Thanks."],
       ["support", "Hi, thanks for reaching out, sorry for the confusion here. We've recently had some UI changes and the AI hasn't quite caught up where everything is located now. You can find the 'reset' button in the side bar menu on the experiment."]
+    ],
+    "image_attachments": [
+      {"url": "https://us.posthog.com/uploaded_media/00000000-0000-0000-0000-0000000000a1", "author": "customer"}
     ]
   },
   {

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -540,6 +540,11 @@ export interface JiraIssueSignalExtraApi {
     updated: string | null
 }
 
+export interface ConversationsTicketImageApi {
+    url: string
+    author: string
+}
+
 export interface ConversationsTicketSignalExtraApi {
     ticket_number: number
     channel_source: string
@@ -548,6 +553,7 @@ export interface ConversationsTicketSignalExtraApi {
     priority: string | null
     created_at: string
     email_subject: string | null
+    images?: ConversationsTicketImageApi[] | null
 }
 
 export interface ErrorTrackingSignalExtraApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -15231,6 +15231,11 @@ export namespace Schemas {
       readonly task: ConversationTask | null;
     }
 
+    export interface ConversationsTicketImage {
+      url: string;
+      author: string;
+    }
+
     export interface ConversationsTicketSignalExtra {
       ticket_number: number;
       channel_source: string;
@@ -15239,6 +15244,7 @@ export namespace Schemas {
       priority: string | null;
       created_at: string;
       email_subject: string | null;
+      images?: ConversationsTicketImage[] | null;
     }
 
     export interface ConversionGoalSummary {


### PR DESCRIPTION
## Problem

Every PostHog support ticket with an inline image has been silently dropped by the Signals pipeline since the image feature shipped in April. No signals emitted. :/

As well put by Claude:
> The emitter builds `extra["images"]` from the thread's attachments (`conversations_tickets.py`), but `ConversationsTicketSignalExtra` never declared an `images` field, and every contract model is `extra="forbid"`. So `validate_signal_input` raised inside `_emit_signals`, which caught it with a bare `except Exception`, logged a line with no ticket identifier, and returned `False`. Sibling tickets in the same batch succeeded, so nothing ever raised.

Why this was uncaught:

- We weren't dogfooding this part of the product as we should be.
- `test_schema_validation.py` does validate emitters, but the tests didn't include the `image_attachments` case.

## Changes

Declaring the missing fields. Add better observability.

## How did you test this code?

Updated tests.