### PR TITLE
perf(flags): use LEFT JOIN for team flag config lookup

### DIFF
--- a/nodejs/src/common/utils/team-manager.ts
+++ b/nodejs/src/common/utils/team-manager.ts
@@ -134,13 +134,11 @@ export class TeamManager {
                 t.logs_settings,
                 t.extra_settings,
                 extract('epoch' from t.drop_events_older_than) as drop_events_older_than_seconds,
-                COALESCE(
-                    (SELECT minimal_flag_called_events FROM feature_flags_teamfeatureflagsconfig WHERE team_id = t.id),
-                    false
-                ) AS minimal_flag_called_events,
+                COALESCE(cfg.minimal_flag_called_events, false) AS minimal_flag_called_events,
                 o.available_product_features
             FROM posthog_team t
             JOIN posthog_organization o ON o.id = t.organization_id
+            LEFT JOIN feature_flags_teamfeatureflagsconfig cfg ON cfg.team_id = t.id
             WHERE t.id = ANY($1) OR t.api_token = ANY($2)
             `,
             [teamIds, tokens],


### PR DESCRIPTION
## Problem

`TeamManager` batches team lookups, so one fetch can pull many teams in a single query. Pulling `minimal_flag_called_events` through a correlated subquery makes Postgres re-run that subquery once per team row, turning one batch fetch into N extra lookups on `feature_flags_teamfeatureflagsconfig`.

## Changes

The config value now comes from a `LEFT JOIN`:

```diff
-                COALESCE(
-                    (SELECT minimal_flag_called_events FROM feature_flags_teamfeatureflagsconfig WHERE team_id = t.id),
-                    false
-                ) AS minimal_flag_called_events,
+                COALESCE(cfg.minimal_flag_called_events, false) AS minimal_flag_called_events,
                 o.available_product_features
             FROM posthog_team t
             JOIN posthog_organization o ON o.id = t.organization_id
+            LEFT JOIN feature_flags_teamfeatureflagsconfig cfg ON cfg.team_id = t.id
```

`team_id` is the primary key of `feature_flags_teamfeatureflagsconfig` (it's a `OneToOneField(primary_key=True)`), so at most one row matches per team and the join cannot fan out team rows. `COALESCE` still yields `false` for teams with no config row, so the output is identical.

## How did you test this code?

Ran `nodejs/src/common/utils/team-manager.test.ts` locally, 16 passed. It already covers the three cases this query feeds: default `false` when no config row exists, `true` when one does, and no cross-team leakage when only one of two teams has a row.

No new tests. This rewrites one query to produce the same output, and the existing suite already asserts that output.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?