### PR TITLE
fix(data-imports): stop reporting wrapped poll timeouts as queue-db errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -360,6 +360,18 @@ class BatchConsumer:
         except TimeoutError:
             pass
 
+    async def _handle_poll_timeout(self, poll_start: float) -> None:
+        # error, not exception: the timeout is the designed recovery
+        # path and its traceback carries no diagnostic value.
+        logger.error(  # noqa: TRY400
+            self._event("poll_timed_out"),
+            timeout_seconds=self._config.poll_timeout_seconds,
+            consecutive_failures=self._consecutive_poll_failures + 1,
+        )
+        self._note_poll_failure("timeout", duration=time.monotonic() - poll_start)
+        await self._drop_conn("_poll_conn")
+        await self._wait_or_shutdown(self._poll_retry_delay())
+
     async def run(self) -> None:
         self._install_signal_handlers()
 
@@ -399,23 +411,26 @@ class BatchConsumer:
                     continue
 
                 poll_start = time.monotonic()
+                poll_timeout_ctx = asyncio.timeout(self._config.poll_timeout_seconds)
                 try:
                     conn = await self._ensure_poll_conn()
-                    async with asyncio.timeout(self._config.poll_timeout_seconds):
+                    async with poll_timeout_ctx:
                         batches = await self._fetch_batches(conn, available=available)
                 except TimeoutError:
-                    # error, not exception: the timeout is the designed recovery
-                    # path and its traceback carries no diagnostic value.
-                    logger.error(  # noqa: TRY400
-                        self._event("poll_timed_out"),
-                        timeout_seconds=self._config.poll_timeout_seconds,
-                        consecutive_failures=self._consecutive_poll_failures + 1,
-                    )
-                    self._note_poll_failure("timeout", duration=time.monotonic() - poll_start)
-                    await self._drop_conn("_poll_conn")
-                    await self._wait_or_shutdown(self._poll_retry_delay())
+                    await self._handle_poll_timeout(poll_start)
                     continue
                 except psycopg.OperationalError as e:
+                    if poll_timeout_ctx.expired():
+                        # asyncio.timeout() cancels the in-flight query on expiry, but
+                        # psycopg's async wait loop can catch that cancellation and
+                        # re-raise it as a generic OperationalError ("consuming input
+                        # failed: server closed the connection unexpectedly") instead
+                        # of letting a bare TimeoutError propagate. Timeout.expired()
+                        # reflects whether this context's own deadline fired regardless
+                        # of the exception type, so this is still the designed timeout
+                        # path above, not a real queue-DB outage.
+                        await self._handle_poll_timeout(poll_start)
+                        continue
                     logger.exception(self._event("poll_failed_queue_db_unreachable"))
                     capture_exception(e)
                     self._note_poll_failure("db_unreachable", duration=time.monotonic() - poll_start)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -697,6 +697,66 @@ class TestQueueOperationTimeouts:
             consumer._shutdown.set()
             await asyncio.wait_for(run_task, timeout=5.0)
 
+    @pytest.mark.asyncio
+    async def test_poll_timeout_wrapped_as_operational_error_is_not_reported(self):
+        # psycopg's async wait loop can catch the CancelledError that
+        # asyncio.timeout() raises on expiry and re-raise it as a generic
+        # OperationalError ("consuming input failed: server closed the
+        # connection unexpectedly") instead of letting TimeoutError propagate.
+        # This is still the designed poll-timeout path, not a queue-DB outage,
+        # so it must not be reported to error tracking.
+        config = ConsumerConfig(
+            database_url="postgres://unused:unused@localhost/unused",
+            poll_interval_seconds=0.01,
+            poll_timeout_seconds=0.05,
+        )
+        consumer = BatchConsumer(config=config, process_batch=AsyncMock())
+
+        second_poll_started = asyncio.Event()
+        fetch_calls = 0
+
+        async def fetch_wraps_cancellation_as_operational_error(*args: Any, **kwargs: Any) -> list[PendingBatch]:
+            nonlocal fetch_calls
+            fetch_calls += 1
+            if fetch_calls >= 2:
+                second_poll_started.set()
+                return []
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                raise psycopg.OperationalError(
+                    "consuming input failed: server closed the connection unexpectedly"
+                ) from None
+            return []
+
+        with (
+            patch.object(
+                consumer, "_connect", new_callable=AsyncMock, side_effect=lambda **kwargs: _make_healthy_conn()
+            ),
+            patch.object(consumer, "_install_signal_handlers"),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_stale_executing",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.get_unprocessed_and_lock",
+                side_effect=fetch_wraps_cancellation_as_operational_error,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.release_all_owned_leases",
+                new_callable=AsyncMock,
+            ),
+            patch(f"{batch_consumer_module.__name__}.capture_exception") as mock_capture,
+        ):
+            run_task = asyncio.create_task(consumer.run())
+            # A second poll can only start if the wrapped timeout was treated as recoverable.
+            await asyncio.wait_for(second_poll_started.wait(), timeout=2.0)
+            consumer._shutdown.set()
+            await asyncio.wait_for(run_task, timeout=5.0)
+
+        mock_capture.assert_not_called()
+
 
 class TestPollFailureLiveness:
     def test_withholds_liveness_after_threshold_consecutive_failures(self):


### PR DESCRIPTION
## Problem

Error tracking flagged an `OperationalError` ("consuming input failed: server closed the connection unexpectedly") in the v3 warehouse-sources batch consumer's poll loop ([issue](https://us.posthog.com/project/2/error_tracking/019f9658-cf90-7c02-be45-b07f050db7e4)).

The poll loop wraps each fetch in `asyncio.timeout(poll_timeout_seconds)` specifically so a slow/stuck claim query can't wedge the consumer forever. When the timeout fires, it cancels the in-flight query, and there's already a dedicated `except TimeoutError` branch for that: log it as the designed recovery path (no traceback, no error-tracking report) and back off.

The problem is psycopg's async wait loop can catch that cancellation internally and re-raise it as a generic `psycopg.OperationalError` instead of letting a clean `TimeoutError` propagate. That routes it into the sibling `except psycopg.OperationalError` branch instead - the one meant for genuine queue-DB outages, which does call `capture_exception`. So a routine, already-handled timeout was being reported to error tracking as if the queue DB were unreachable.

I confirmed via the exception chain in the captured event (`OperationalError` <- `TimeoutError` <- `CancelledError` inside `psycopg`'s wait loop) and by reading `asyncio.timeout()`'s implementation that this is exactly what happened - the stack trace's innermost frames are asyncio internals being cancelled, not a real connection failure.

## Changes

- `asyncio.timeout()` returns a `Timeout` context object whose `.expired()` method reports whether *this* context's own deadline fired, independent of which exception type ends up propagating. I kept a reference to it and check `.expired()` inside the `OperationalError` handler: if true, treat it exactly like the `TimeoutError` case (log, drop the connection, back off) instead of reporting it as a queue-DB outage.
- Extracted the shared timeout-handling steps into `_handle_poll_timeout()` so both branches stay in sync.

This is the same class of fix as [#73565](https://github.com/PostHog/posthog/pull/73565), which did the equivalent for the sink's periodic maintenance-query timeout - this one is the main poll loop instead.

## How did you test this code?

Added `test_poll_timeout_wrapped_as_operational_error_is_not_reported` in `postgres_queue/test_consumer.py::TestQueueOperationTimeouts`, alongside the existing hung-poll timeout test. It simulates a fetch that, once cancelled by the poll timeout, raises `psycopg.OperationalError` instead of letting `CancelledError` propagate (mirroring psycopg's real behavior), and asserts `capture_exception` is never called while the consumer still recovers and keeps polling.

Ran:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_consumer.py -q` - all pass (3 pre-existing errors in an unrelated test class need a live Postgres connection and aren't affected by this change)
- `uv run ruff check` / `ruff format --check` on both changed files - clean
- `uv run mypy --cache-fine-grained .` (repo-wide) - clean, 16918 files

## Docs update

N/A - internal error-classification fix, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from a PostHog error-tracking webhook alert with no human steering the investigation. I pulled the issue's stack trace and a representative event via the error-tracking MCP tools, read the batch consumer's poll loop and the psycopg call path, and traced the exception chain (`OperationalError` <- `TimeoutError` <- `CancelledError`) back to `asyncio.timeout()`'s cancellation being re-wrapped by psycopg. I checked open PRs first and found #73565 fixed the analogous bug in the maintenance-query path, confirming this was a distinct instance in the main poll loop rather than a duplicate.

No skills were invoked for this change (no migration, DRF, or frontend surface touched); `/writing-tests` was consulted before adding the regression test.