### PR TITLE
fix(experiments): keep full event set in validation rejection log

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -1160,9 +1160,8 @@ class ExperimentService:
         multi-team project can pick an event ingested by a sibling team. We
         mirror that scope here to avoid rejecting legitimate selections.
         """
-        event_names, _ = self._extract_entity_nodes(metrics)
-        if known_event_names:
-            event_names -= known_event_names
+        all_event_names, _ = self._extract_entity_nodes(metrics)
+        event_names = all_event_names - known_event_names if known_event_names else all_event_names
         if not event_names:
             return
 
@@ -1189,7 +1188,7 @@ class ExperimentService:
                 team_id=self.team.id,
                 project_id=project_id,
                 unknown_events=sorted(unknown),
-                all_extracted_events=sorted(event_names),
+                all_extracted_events=sorted(all_event_names),
                 metrics_count=len(metrics) if metrics else 0,
             )
             unknown_str = ", ".join(f"'{name}'" for name in sorted(unknown))

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -856,7 +856,7 @@ class ExperimentService:
                 "Each ActionsNode must reference an existing action belonging to this project."
             )
 
-    def validate_metric_event_names(self, metrics: list[dict] | None) -> None:
+    def validate_metric_event_names(self, metrics: list[dict] | None, exclude_events: set[str] | None = None) -> None:
         """Validate that all EventsNode event names have been seen by this project.
 
         The frontend event picker already prevents selecting unknown events, so an
@@ -865,12 +865,19 @@ class ExperimentService:
         an experiment before deploying the emitting code) can pass
         ``allow_unknown_events=True`` to bypass this check.
 
+        ``exclude_events`` skips event names the caller already knows are legitimate —
+        used on update to avoid re-rejecting an unknown event that was already stored
+        on the experiment (a PATCH re-sends the full metrics list, so a metadata-only
+        edit would otherwise fail on a pre-existing not-yet-ingested event).
+
         Scope must match the picker: the EventDefinition list endpoint is
         project-scoped (see posthog/api/event_definition.py), so a user in a
         multi-team project can pick an event ingested by a sibling team. We
         mirror that scope here to avoid rejecting legitimate selections.
         """
         event_names, _ = self._extract_entity_nodes(metrics)
+        if exclude_events:
+            event_names -= exclude_events
         if not event_names:
             return
 
@@ -2800,12 +2807,19 @@ class ExperimentService:
         # _sync_ordering_with_metric_changes runs later and appends the new
         # regenerated uuids as additions; _sync_ordering_for_saved_metrics_on_update
         # handles saved-metric link uuids independently.
+        # Only validate event names that this PATCH newly introduces. A PATCH re-sends
+        # the full metrics list even for an unrelated edit, so re-validating already-stored
+        # events would re-reject one that was legitimately persisted with allow_unknown_events
+        # (e.g. via the MCP experiment-create tool). Newly added unknown events are still caught.
+        stored_event_names, _ = self._extract_entity_nodes(
+            [*(experiment.metrics or []), *(experiment.metrics_secondary or [])]
+        )
         if "metrics" in update_data:
             update_data["metrics"] = self._assign_uuids_to_metrics(update_data["metrics"], seen=seen_metric_uuids)
             self.validate_experiment_metrics(update_data["metrics"])
             self.validate_metric_action_ids(update_data["metrics"], self.team.id)
             if not allow_unknown_events:
-                self.validate_metric_event_names(update_data["metrics"])
+                self.validate_metric_event_names(update_data["metrics"], exclude_events=stored_event_names)
         if "metrics_secondary" in update_data:
             update_data["metrics_secondary"] = self._assign_uuids_to_metrics(
                 update_data["metrics_secondary"], seen=seen_metric_uuids
@@ -2813,7 +2827,7 @@ class ExperimentService:
             self.validate_experiment_metrics(update_data["metrics_secondary"])
             self.validate_metric_action_ids(update_data["metrics_secondary"], self.team.id)
             if not allow_unknown_events:
-                self.validate_metric_event_names(update_data["metrics_secondary"])
+                self.validate_metric_event_names(update_data["metrics_secondary"], exclude_events=stored_event_names)
 
         enforce_warehouse_metric_access(
             [

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -58,6 +58,29 @@ from products.warehouse_sources.backend.facade.models import DataWarehouseCreden
 
 from ee.models.rbac.access_control import AccessControl
 
+# Metrics for the "already-stored unknown event" regression tests. VA_NARRATOR_SELECTED
+# is never ingested (no EventDefinition row), mirroring the reported scenario where an
+# MCP-created experiment persists an unknown event.
+_STORED_UNKNOWN_METRIC_CASES = [
+    (
+        "mean",
+        {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {"kind": "EventsNode", "event": "VA_NARRATOR_SELECTED"},
+        },
+    ),
+    (
+        "ratio",
+        {
+            "kind": "ExperimentMetric",
+            "metric_type": "ratio",
+            "numerator": {"kind": "EventsNode", "event": "VA_NARRATOR_SELECTED"},
+            "denominator": {"kind": "EventsNode", "event": "VA_NARRATOR_SHOWN"},
+        },
+    ),
+]
+
 
 # Note that we use allow_unknown_events here since allowing it was the behavior before validating it
 # and to continue allowing it here keeps test setup simple (instead of creating events before)
@@ -6513,6 +6536,51 @@ class TestExperimentService(APIBaseTest):
                     ],
                 },
             )
+
+    @parameterized.expand(
+        [
+            (f"{mname}_{field}", field, metric)
+            for field in ("metrics", "metrics_secondary")
+            for mname, metric in _STORED_UNKNOWN_METRIC_CASES
+        ]
+    )
+    def test_update_resending_stored_unknown_event_does_not_raise(self, name: str, field: str, metric: dict) -> None:
+        # Regression: a PATCH re-sends the FULL metrics list even for an unrelated edit
+        # (e.g. a rename). The update guard must not re-reject an unknown event that was
+        # already legitimately stored via allow_unknown_events, or the experiment gets
+        # stuck — every later metrics-touching PATCH fails on a value it already stores.
+        service = self._service()
+        experiment = service.create_experiment(
+            name=f"Resend Stored Unknown {name}",
+            feature_flag_key=f"resend-stored-unknown-{name.replace('_', '-')}-flag",
+            allow_unknown_events=True,
+            **{field: [deepcopy(metric)]},
+        )
+
+        # No allow_unknown_events here — the metadata-only edit re-sends the stored metric.
+        updated = service.update_experiment(experiment, {"name": "Renamed", field: [deepcopy(metric)]})
+        assert getattr(updated, field) is not None and len(getattr(updated, field)) == 1
+
+    @parameterized.expand(["metrics", "metrics_secondary"])
+    def test_update_introducing_new_unknown_event_still_raises(self, field: str) -> None:
+        # The exclusion only covers already-stored events: a newly added typo must still fail.
+        stored_metric = deepcopy(_STORED_UNKNOWN_METRIC_CASES[0][1])
+        service = self._service()
+        experiment = service.create_experiment(
+            name=f"Introduce Unknown {field}",
+            feature_flag_key=f"introduce-unknown-{field.replace('_', '-')}-flag",
+            allow_unknown_events=True,
+            **{field: [stored_metric]},
+        )
+
+        new_metric = {
+            "kind": "ExperimentMetric",
+            "metric_type": "mean",
+            "source": {"kind": "EventsNode", "event": "brand_new_typo"},
+        }
+        with self.assertRaises(ValidationError) as ctx:
+            service.update_experiment(experiment, {field: [deepcopy(stored_metric), new_metric]})
+        assert "brand_new_typo" in str(ctx.exception.detail)
 
     def test_update_experiment_with_nonexistent_action_raises(self):
         service = self._service()

--- a/products/experiments/backend/test/test_experiment_service.py
+++ b/products/experiments/backend/test/test_experiment_service.py
@@ -6550,11 +6550,12 @@ class TestExperimentService(APIBaseTest):
         # already legitimately stored via allow_unknown_events, or the experiment gets
         # stuck — every later metrics-touching PATCH fails on a value it already stores.
         service = self._service()
+        metric_kwarg: dict[str, Any] = {field: [deepcopy(metric)]}
         experiment = service.create_experiment(
             name=f"Resend Stored Unknown {name}",
             feature_flag_key=f"resend-stored-unknown-{name.replace('_', '-')}-flag",
             allow_unknown_events=True,
-            **{field: [deepcopy(metric)]},
+            **metric_kwarg,
         )
 
         # No allow_unknown_events here — the metadata-only edit re-sends the stored metric.
@@ -6566,11 +6567,12 @@ class TestExperimentService(APIBaseTest):
         # The exclusion only covers already-stored events: a newly added typo must still fail.
         stored_metric = deepcopy(_STORED_UNKNOWN_METRIC_CASES[0][1])
         service = self._service()
+        metric_kwarg: dict[str, Any] = {field: [stored_metric]}
         experiment = service.create_experiment(
             name=f"Introduce Unknown {field}",
             feature_flag_key=f"introduce-unknown-{field.replace('_', '-')}-flag",
             allow_unknown_events=True,
-            **{field: [stored_metric]},
+            **metric_kwarg,
         )
 
         new_metric = {


### PR DESCRIPTION
## Problem

An engineer debugging a rejected experiment metric update reads the `experiment_metric_event_validation_rejected` log to see what the payload referenced.
On update, its `all_extracted_events` field omits every event name already stored on the experiment, so the logged payload shape is incomplete.
`validate_metric_event_names` subtracts the stored names from the same set it later logs. ReviewHog flagged this on this PR's original diff.

## Changes

- The validator keeps the full extracted set in `all_event_names` and validates a subtracted copy.
- The rejection log's `all_extracted_events` field reports the full extracted set again, consistent with `metrics_count`.
- Validation behavior is unchanged.

> [!NOTE]
> This PR originally exempted already-stored unknown events from update re-validation, so a metadata-only PATCH could not get stuck on an event stored with `allow_unknown_events=True`.
> #77649 shipped the same exemption on master while this PR was open, broader (action IDs too) and with regression tests.
> The branch was rebased down to this surviving log fix; the duplicated code and tests were dropped.

## How did you test this code?

- No new tests: the change only restores a diagnostic log field, and existing tests cover the changed lines.
- Ran on the rebased branch: `test_update_keeps_metric_whose_event_was_never_ingested` (exemption path), `test_update_rejects_new_unknown_event_alongside_resent_stale_one` and `test_metric_with_unknown_event_raises` (rejection paths that execute the changed log call). All pass.
- `ruff check`, `ruff format --check`, repo-wide `uv run mypy --cache-fine-grained .`, and `hogli ci:preflight --fix` pass locally.

## Automatic notifications

- [ ] Publish to changelog?

## Docs update

None, this only changes an internal diagnostic log field.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude in PostHog Code, directed by @rodrigoi (PR assignee).
Skills invoked: /writing-pr-descriptions, /improving-drf-endpoints and /writing-tests (in the original session).
Rebasing onto master surfaced that #77649 already shipped this PR's original fix, so the branch was rewritten to keep only the ReviewHog-flagged log fix, and the original tests were dropped as duplicates of master's coverage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
