### PR TITLE
fix(bigquery): skip duplicate-key probe noise on broken view definitions

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -715,6 +715,18 @@ def _is_bigquery_resource_exceeded(error: BadRequest) -> bool:
     return "resourcesExceeded" in reasons or BIGQUERY_RESOURCES_EXCEEDED_ERROR in str(error)
 
 
+def _is_bigquery_view_parse_failure(error: BadRequest) -> bool:
+    """True for BigQuery's `failed to parse view` query failures.
+
+    BigQuery raises this when the table being probed is itself a view whose definition no
+    longer compiles (a column, UDF, or upstream table it references was renamed or dropped).
+    See the `"failed to parse view"` key in `BigQuerySource.get_non_retryable_errors` for the
+    main read path — that's a customer-side view problem we can't fix, so this best-effort
+    probe should degrade gracefully instead of treating it as an actionable crash.
+    """
+    return "failed to parse view" in str(error)
+
+
 def _has_duplicate_primary_keys(table: bigquery.Table, client: bigquery.Client, primary_keys: list[str] | None) -> bool:
     if not primary_keys or len(primary_keys) == 0:
         return False
@@ -741,6 +753,17 @@ def _has_duplicate_primary_keys(table: bigquery.Table, client: bigquery.Client, 
             # on every sync.
             structlog.get_logger().warning(
                 "Skipping duplicate primary key check for BigQuery table %s.%s: query exceeded BigQuery memory limits",
+                table.dataset_id,
+                table.table_id,
+            )
+            return False
+        if _is_bigquery_view_parse_failure(e):
+            # The table being probed is itself a broken view — its own definition doesn't
+            # compile, so BigQuery rejects the probe before it can even run. That's a
+            # customer-side view problem this check can't fix, and this check is best-effort,
+            # so skip it quietly rather than capturing non-actionable noise on every sync.
+            structlog.get_logger().warning(
+                "Skipping duplicate primary key check for BigQuery table %s.%s: view failed to parse",
                 table.dataset_id,
                 table.table_id,
             )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -1307,6 +1307,27 @@ def test_has_duplicate_primary_keys_skips_resource_exceeded_quietly(exception):
     mock_capture.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "exception",
+    [
+        BadRequest(
+            "Name is_qualified not found inside visit; failed to parse view 'my_dataset.my_view' at [5:19]; "
+            "reason: invalidQuery, location: query, message: Name is_qualified not found inside visit; "
+            "failed to parse view 'my_dataset.my_view' at [5:19]"
+        ),
+        BadRequest("Invalid table-valued function EXTERNAL_QUERY; failed to parse view 'my_dataset.my_view' at [1:1]"),
+    ],
+)
+def test_has_duplicate_primary_keys_skips_view_parse_failure_quietly(exception):
+    """A `failed to parse view` BigQuery error during the best-effort duplicate-key probe must NOT
+    be captured to error tracking — the probed table is itself a broken view, a customer-side
+    problem that otherwise fires on every sync of that table."""
+    result, mock_capture = _run_has_duplicate_primary_keys(exception)
+
+    assert result is False
+    mock_capture.assert_not_called()
+
+
 def test_has_duplicate_primary_keys_captures_unexpected_bad_request():
     """A non-resource BadRequest (e.g. a genuinely malformed probe query) is still captured so we
     don't lose visibility into real bugs."""


### PR DESCRIPTION
## Problem

The BigQuery warehouse source runs a bounded, best-effort probe (`_has_duplicate_primary_keys`) to check whether a synced table has duplicate primary keys. On failure it already degrades gracefully — it just skips the check and returns `False` — but it only avoids reporting the failure to error tracking when the cause is a known `resourcesExceeded` data-volume limit.

An error-tracking issue surfaced a `BadRequest` from this probe: `Name is_qualified not found inside visit; failed to parse view '<dataset>.<view>' at [5:19]`. The stack trace confirmed the failure lands in `_has_duplicate_primary_keys` in `products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py`. This happens when the table being probed is itself a BigQuery view whose own definition no longer compiles (a column, UDF, or upstream table it references was renamed or dropped) — a customer-side view problem, not something we can fix by retrying. `BigQuerySource.get_non_retryable_errors` already classifies this same `"failed to parse view"` wording as non-retryable on the main read path, but that classifier never runs here: the probe catches the `BadRequest` itself and calls `capture_exception` unconditionally, spamming error tracking with a non-actionable issue on every sync of the affected table.

## Changes

- Add `_is_bigquery_view_parse_failure`, mirroring the existing `_is_bigquery_resource_exceeded` helper.
- In `_has_duplicate_primary_keys`, skip the check quietly (with a warning log) when the failure matches, instead of capturing it to error tracking. No retry/functional behavior changes — the probe already degraded to "skip this check" on any exception; this only stops the known, non-actionable case from being reported as a bug.

## How did you test this code?

Extended the existing parametrized tests in `test_source.py` (which already cover the `resourcesExceeded` and "unexpected error" cases for this probe) with a new `test_has_duplicate_primary_keys_skips_view_parse_failure_quietly`, covering both the generic parse-failure wording and the `EXTERNAL_QUERY` variant. Ran the full `bigquery` test module (154 passed), `ruff check`/`ruff format --check`, and `mypy` on the changed file.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a PostHog error-tracking issue reporting a `BadRequest` ("failed to parse view") from this source's `_has_duplicate_primary_keys` probe. Confirmed the stack trace's top in-app frame lands in `bigquery.py`, then read the probe's error handling and the existing `resourcesExceeded` precedent for quiet, non-actionable failures. Concluded this was neither a config/credentials problem needing `NonRetryableErrors` (that classifier already exists for this exact wording, but never runs here since the probe swallows the exception itself) nor a functional bug — the probe already falls back safely — but a missing entry in the noise-suppression handling, consistent with the `resourcesExceeded` precedent. Searched open PRs by exception wording, module path, and by author (`Gilbert09`) before opening this one; found #73621 fixes an analogous gap in the ClickHouse source's duplicate-key probe, but it doesn't touch BigQuery's code path this PR changes.