### PR TITLE
chore(dev): auto-migrate ClickHouse/ZooKeeper to named docker volumes

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -152,30 +152,41 @@ fi
 # containers fails to bind — and that aborts the entire `docker compose up`,
 # sometimes leaving a container detached from the compose network. In a TTY, offer
 # to tear foreign stacks down; otherwise stay advisory. Delegated to hogli (tested
-# there, see doctor_ports in hogli_commands/doctor.py); skipped if hogli isn't on
-# PATH, same as doctor:zombies above.
+# there, see doctor_ports in hogli_commands/doctor.py).
+#
+# Also runs the one-time migration for the July 2026 named-volume switch: the named
+# volume is absent until the first `up` after the switch, which would otherwise
+# reset a clickhouse container's data that already exists under this project.
+# Auto-salvages the old anonymous volumes when the mapping is unambiguous, otherwise
+# prints the same manual-salvage warning as before. Must run before `docker compose
+# up` below (see doctor_migrate_volumes in hogli_commands/doctor.py).
+#
+# Both skipped if hogli isn't on PATH, same as doctor:zombies above. Without hogli
+# there's no auto-migration either, so warn plainly instead of silently losing data.
 if command -v hogli &>/dev/null; then
     hogli doctor:ports || true
+    hogli doctor:migrate-volumes || true
+else
+    named_volume_reset_notice() {
+        command -v docker &>/dev/null || return 0
+        docker volume inspect "${COMPOSE_PROJECT_NAME}_clickhouse-data" &>/dev/null && return 0
+        if ! docker ps -a --filter 'label=com.docker.compose.service=clickhouse' \
+            --format '{{.Label "com.docker.compose.project"}}' 2>/dev/null \
+            | grep -qx "$COMPOSE_PROJECT_NAME"; then
+            # No clickhouse container left — either a fresh clone (nothing to lose) or
+            # `docker compose down` (removes containers but keeps volumes). Postgres has
+            # no profile gate, so its volume surviving is a reliable "not a fresh clone"
+            # signal, same as _has_prior_install in hogli_commands/doctor.py.
+            docker volume inspect "${COMPOSE_PROJECT_NAME}_postgres-15-data" &>/dev/null || return 0
+        fi
+        echo "⚠️  Switching ClickHouse/ZooKeeper to named docker volumes. This first start"
+        echo "   recreates them empty, so local ClickHouse data resets once (happens once"
+        echo "   per machine). Install hogli to auto-migrate your existing data instead. See"
+        echo "   'Local ClickHouse suddenly empty' in"
+        echo "   docs/published/handbook/engineering/developing-locally.md to salvage old data."
+    }
+    named_volume_reset_notice || true
 fi
-
-# One-time notice for the July 2026 named-volume switch: the named volume is
-# absent until the first `up` after the switch, and if a clickhouse container
-# already exists under this project, its data is about to be reset. See the
-# "Local ClickHouse suddenly empty" gotcha in developing-locally.md. Fail-open,
-# like the port pre-flight above.
-named_volume_reset_notice() {
-    command -v docker &>/dev/null || return 0
-    docker volume inspect "${COMPOSE_PROJECT_NAME}_clickhouse-data" &>/dev/null && return 0
-    docker ps -a --filter 'label=com.docker.compose.service=clickhouse' \
-        --format '{{.Label "com.docker.compose.project"}}' 2>/dev/null \
-        | grep -qx "$COMPOSE_PROJECT_NAME" || return 0
-    echo "⚠️  Switching ClickHouse/ZooKeeper to named docker volumes. This first start"
-    echo "   recreates them empty, so local ClickHouse data resets once (happens once"
-    echo "   per machine). Run 'hogli migrations:run' after, or 'hogli dev:reset' for a"
-    echo "   full wipe plus demo data. See 'Local ClickHouse suddenly empty' in"
-    echo "   docs/published/handbook/engineering/developing-locally.md to salvage old data."
-}
-named_volume_reset_notice || true
 
 # Geo files
 ./bin/download-mmdb

--- a/docs/published/handbook/engineering/developing-locally.md
+++ b/docs/published/handbook/engineering/developing-locally.md
@@ -215,13 +215,14 @@ The feature-flags container needs the GeoLite database in `/share`. If it's miss
 
 **Local ClickHouse suddenly empty (July 2026 named-volume switch)**
 ClickHouse and ZooKeeper store their data in named docker volumes (`clickhouse-data`, `zookeeper-data`), so their state survives container recreation.
-The first `hogli start` after updating past the July 2026 switch to named volumes recreates both containers with fresh volumes (the data previously lived in anonymous volumes that container recreation discards), so local ClickHouse data is reset once.
-Run `hogli migrations:run` to recreate the ClickHouse schema, or `hogli dev:reset` for a full wipe plus demo data.
-This happens once per machine, since the docker stack is shared across worktrees.
-The old anonymous volumes are left dangling; reclaim the disk space with `docker volume prune` (check first with `docker volume ls -f dangling=true`).
+The first `hogli start` after updating past the July 2026 switch to named volumes would otherwise recreate both containers with fresh volumes (the data previously lived in anonymous volumes that container recreation discards).
+`hogli start` runs `hogli doctor:migrate-volumes` before bringing the stack up, which salvages the old anonymous volumes into the new named ones automatically whenever it can prove the mapping is unambiguous — no action needed, and it's a no-op on every subsequent start once migrated.
 
-If you had local ClickHouse data you still need, it isn't gone until you prune — it sits in those dangling volumes.
-To salvage it, stop the stack (`hogli docker:services:down`), then identify the old volumes by peeking inside each dangling candidate:
+If it prints a warning instead of migrating (an ambiguous or missing old container — for example two clickhouse containers left over under this same compose project, or the old container already removed by a prior cleanup), it deliberately didn't guess, and local ClickHouse data resets once instead.
+Run `hogli migrations:run` to recreate the ClickHouse schema, or `hogli dev:reset` for a full wipe plus demo data.
+The old anonymous volumes are left dangling in that case; reclaim the disk space with `docker volume prune` (check first with `docker volume ls -f dangling=true`) once you're done, or salvage them manually if you still need that data:
+
+Stop the stack (`hogli docker:services:down`), then identify the old volumes by peeking inside each dangling candidate:
 
 ```bash
 docker volume ls -qf dangling=true
@@ -232,7 +233,7 @@ The ClickHouse volume contains `store` and `metadata`; the ZooKeeper snapshot vo
 Copy each old volume into its named replacement. The `posthog_` prefix below is the compose project name (`$COMPOSE_PROJECT_NAME`, `posthog` by default); substitute yours if you've overridden it:
 
 ```bash
-docker run --rm -v <old-clickhouse-volume>:/from -v posthog_clickhouse-data:/to alpine sh -c 'rm -rf /to/* && cp -a /from/. /to/'
+docker run --rm -v <old-clickhouse-volume>:/from:ro -v posthog_clickhouse-data:/to alpine sh -c 'rm -rf /to/* && cp -a /from/. /to/'
 ```
 
 Repeat for `posthog_zookeeper-data` (snapshots) and `posthog_zookeeper-datalog` (transaction logs).

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -863,6 +863,9 @@ tools:
     doctor:ports:
         click: hogli_commands.doctor:doctor_ports
         description: Pre-flight check for host ports the dev stack needs
+    doctor:migrate-volumes:
+        click: hogli_commands.doctor:doctor_migrate_volumes
+        description: Auto-migrate ClickHouse/ZooKeeper data to the new named docker volumes
     doctor:report:
         click: hogli_commands.doctor:doctor_report
         description: Dump a paste-ready dev-environment diagnostics report for devex triage

--- a/tools/hogli-commands/hogli_commands/doctor.py
+++ b/tools/hogli-commands/hogli_commands/doctor.py
@@ -4,12 +4,15 @@ import os
 import re
 import sys
 import enum
+import json
 import time
+import fcntl
 import select
 import shutil
 import signal
 import hashlib
 import platform
+import tempfile
 import importlib
 import subprocess
 from collections.abc import Callable, Iterable, Sequence
@@ -1606,6 +1609,11 @@ def _sanitize_compose_name(name: str) -> str:
     return _COMPOSE_NAME_RE.sub("", name)
 
 
+def _compose_project_name() -> str:
+    """The dev stack's compose project — pinned so worktrees share one stack."""
+    return os.environ.get("COMPOSE_PROJECT_NAME") or "posthog"
+
+
 @dataclass
 class PortHolder:
     port: int
@@ -1615,7 +1623,7 @@ class PortHolder:
     process_holder: str | None = None  # "COMMAND (pid N)", if lsof-held
 
 
-def _scan_port_holders(project_name: str) -> list[PortHolder]:
+def _scan_port_holders() -> list[PortHolder]:
     """Attribute each always-on infra port to whatever holds it.
 
     One `docker ps` covers every port; the Ports column looks like
@@ -1637,13 +1645,18 @@ def _scan_port_holders(project_name: str) -> list[PortHolder]:
             unheld.append((port, name))
             continue
         parts = match.split("|", 2)
-        container = parts[0] if parts else ""
+        container = parts[0]
         project = _sanitize_compose_name(parts[1]) if len(parts) > 1 else ""
         holders.append(PortHolder(port=port, name=name, container=container, project=project))
 
     if unheld:
         holders.extend(_scan_unheld_via_lsof(unheld))
     return holders
+
+
+def _foreign_holders(holders: Sequence[PortHolder], project_name: str) -> list[PortHolder]:
+    """Docker-held ports belonging to some compose project other than ours."""
+    return [h for h in holders if h.container is not None and h.project != project_name]
 
 
 def _scan_unheld_via_lsof(unheld: Sequence[tuple[int, str]]) -> list[PortHolder]:
@@ -1669,7 +1682,7 @@ def _scan_unheld_via_lsof(unheld: Sequence[tuple[int, str]]) -> list[PortHolder]
             fields = line.split()
             if len(fields) < 9:
                 continue
-            if fields[8].endswith(needle):
+            if fields[8].endswith(needle) and fields[1].isdigit():
                 # Strip control bytes a process name could smuggle to the terminal.
                 command = re.sub(r"[\x00-\x1f\x7f]", "", fields[0])
                 holder = f"{command} (pid {fields[1]})"
@@ -1678,11 +1691,9 @@ def _scan_unheld_via_lsof(unheld: Sequence[tuple[int, str]]) -> list[PortHolder]
     return holders
 
 
-def _posthog_shaped_projects(candidates: set[str]) -> set[str]:
-    """Of the candidate foreign projects, keep only ones that look like a
-    PostHog dev stack: a clickhouse container in any state (a partial stack
-    may hold ports while its clickhouse is stopped). An unrelated project
-    that happens to hold postgres/redis ports gets reported, not torn down.
+def _containers_for_service(service: str) -> list[tuple[str, str]]:
+    """(container ID, sanitized compose project) for every container in any
+    state running `service`, across all compose projects on this machine.
     """
     output = (
         _run_output(
@@ -1691,14 +1702,28 @@ def _posthog_shaped_projects(candidates: set[str]) -> set[str]:
                 "ps",
                 "-a",
                 "--filter",
-                "label=com.docker.compose.service=clickhouse",
+                f"label=com.docker.compose.service={service}",
                 "--format",
-                '{{.Label "com.docker.compose.project"}}',
+                '{{.ID}}|{{.Label "com.docker.compose.project"}}',
             ]
         )
         or ""
     )
-    clickhouse_projects = {_sanitize_compose_name(line) for line in output.splitlines()}
+    pairs = []
+    for line in output.splitlines():
+        parts = line.split("|", 1)
+        if len(parts) == 2:
+            pairs.append((parts[0], _sanitize_compose_name(parts[1])))
+    return pairs
+
+
+def _posthog_shaped_projects(candidates: set[str]) -> set[str]:
+    """Of the candidate foreign projects, keep only ones that look like a
+    PostHog dev stack: a clickhouse container in any state (a partial stack
+    may hold ports while its clickhouse is stopped). An unrelated project
+    that happens to hold postgres/redis ports gets reported, not torn down.
+    """
+    clickhouse_projects = {project for _container_id, project in _containers_for_service("clickhouse")}
     return candidates & clickhouse_projects
 
 
@@ -1708,7 +1733,7 @@ def _confirm_stack_teardown(stack: str, timeout: float = 30.0) -> bool:
     Runs on every `hogli start`, so a hung or piped stdin must never block;
     timeout, EOF, or any non-"y" answer means "leave it running".
     """
-    click.echo(f"   Stop foreign stack '{stack}' now? [y/N] ", nl=False)
+    click.echo(f"   Remove foreign stack '{stack}' (compose down, volumes kept)? [y/N] ", nl=False)
     ready, _, _ = select.select([sys.stdin], [], [], timeout)
     if not ready:
         click.echo()
@@ -1732,10 +1757,10 @@ def doctor_ports(yes: bool) -> None:
     if shutil.which("docker") is None:
         return
 
-    project_name = os.environ.get("COMPOSE_PROJECT_NAME") or "posthog"
-    holders = _scan_port_holders(project_name)
+    project_name = _compose_project_name()
+    holders = _scan_port_holders()
 
-    foreign = [h for h in holders if h.container is not None and h.project != project_name]
+    foreign = _foreign_holders(holders, project_name)
     report_lines = [
         f"     • port {h.port} ({h.name}): container '{h.container}' from compose project '{h.project or '<none>'}'"
         for h in foreign
@@ -1783,6 +1808,324 @@ def doctor_ports(yes: bool) -> None:
             click.echo(f"   Stopped '{stack}'.")
         else:
             click.echo(f"   ⚠️  Could not stop '{stack}' (see docker's output above) — its ports may still be held.")
+
+
+# ---------------------------------------------------------------------------
+# doctor:migrate-volumes — auto-salvage anonymous ClickHouse/ZooKeeper volumes
+# ---------------------------------------------------------------------------
+
+# (compose service, mount destination inside the container, named-volume
+# suffix, human label). Must match the volumes: blocks for clickhouse/
+# zookeeper in docker-compose.dev.yml.
+_VOLUME_MIGRATIONS: tuple[tuple[str, str, str, str], ...] = (
+    ("clickhouse", "/var/lib/clickhouse", "clickhouse-data", "ClickHouse data"),
+    ("zookeeper", "/data", "zookeeper-data", "ZooKeeper snapshots"),
+    ("zookeeper", "/datalog", "zookeeper-datalog", "ZooKeeper transaction log"),
+    ("zookeeper", "/logs", "zookeeper-logs", "ZooKeeper server logs"),
+)
+
+# A prior install always has postgres's named volume, even after `docker compose
+# down` removes every container — postgres has no `profiles:` gate either, so its
+# absence is a reliable "this really is a fresh clone" signal.
+_PRIOR_INSTALL_VOLUME_SUFFIX = "postgres-15-data"
+
+
+@dataclass(frozen=True)
+class VolumeMigrationStep:
+    """One old anonymous volume to copy into its new named-volume replacement."""
+
+    container_id: str
+    source_volume: str
+    dest_volume: str
+    volume_suffix: str
+    label: str
+
+
+def _matching_containers(project_name: str, service: str) -> list[str]:
+    """Container IDs (any state) for `service` under this compose project."""
+    return [cid for cid, project in _containers_for_service(service) if project == project_name]
+
+
+def _has_prior_install(project_name: str) -> bool:
+    """Whether this looks like an existing install rather than a fresh clone.
+
+    `docker compose down` removes containers but keeps volumes, so a developer
+    who stopped the stack before updating has no clickhouse container left to
+    check but still has this one.
+    """
+    return _run_output(["docker", "volume", "inspect", f"{project_name}_{_PRIOR_INSTALL_VOLUME_SUFFIX}"]) is not None
+
+
+def _find_service_container(project_name: str, service: str) -> str | None:
+    """Return the one container ID for `service` under this project, or None
+    if there isn't exactly one — zero (already removed) and multiple
+    (ambiguous) are both unsafe to guess from.
+    """
+    matches = _matching_containers(project_name, service)
+    return matches[0] if len(matches) == 1 else None
+
+
+def _container_mounts(container_id: str) -> list[dict[str, object]] | None:
+    """Return the container's `docker inspect` Mounts array, or None if it
+    can't be fetched or isn't the list shape `docker inspect` always gives
+    for a live container (e.g. the container vanished between listing and
+    inspecting it).
+    """
+    output = _run_output(["docker", "inspect", container_id, "--format", "{{json .Mounts}}"])
+    if output is None:
+        return None
+    try:
+        mounts = json.loads(output)
+    except json.JSONDecodeError:
+        return None
+    return mounts if isinstance(mounts, list) else None
+
+
+def _find_volume_mount(mounts: list[dict[str, object]], destination: str) -> str | None:
+    """Return the single volume name backing `destination`, or None if it's
+    missing, duplicated, or not a plain named/anonymous volume mount (e.g. a
+    bind mount) — anything but a clean 1:1 match is unsafe to copy from.
+    """
+    matches: list[str] = []
+    for m in mounts:
+        name = m.get("Name")
+        if m.get("Destination") == destination and m.get("Type") == "volume" and isinstance(name, str) and name:
+            matches.append(name)
+    return matches[0] if len(matches) == 1 else None
+
+
+def _plan_volume_migration(project_name: str) -> list[VolumeMigrationStep] | None:
+    """Resolve every old anonymous volume this migration needs, or None if
+    any single one can't be pinned down unambiguously.
+
+    ClickHouse and ZooKeeper state must move together — a replicated table
+    with only one side restored fails with "replica already exists" — so any
+    ambiguity anywhere aborts the whole plan rather than migrating one
+    service and not the other. This function is read-only (no stop, no
+    copy): the caller only commits to touching anything once the full plan
+    resolves cleanly.
+    """
+    containers: dict[str, str] = {}
+    for service, _destination, _suffix, _label in _VOLUME_MIGRATIONS:
+        if service in containers:
+            continue
+        container_id = _find_service_container(project_name, service)
+        if container_id is None:
+            return None
+        containers[service] = container_id
+
+    mounts_by_container: dict[str, list[dict[str, object]] | None] = {}
+    plan: list[VolumeMigrationStep] = []
+    for service, destination, suffix, label in _VOLUME_MIGRATIONS:
+        container_id = containers[service]
+        if container_id not in mounts_by_container:
+            mounts_by_container[container_id] = _container_mounts(container_id)
+        mounts = mounts_by_container[container_id]
+        if mounts is None:
+            return None
+        source_volume = _find_volume_mount(mounts, destination)
+        if source_volume is None:
+            return None
+        dest_volume = f"{project_name}_{suffix}"
+        if source_volume == dest_volume:
+            # Already on the named volume: a retry after a partial migration must not
+            # mount the same volume as both /from and /to, or the copy's `rm -rf /to/*`
+            # would destroy the data it's supposed to be saving.
+            return None
+        plan.append(
+            VolumeMigrationStep(
+                container_id=container_id,
+                source_volume=source_volume,
+                dest_volume=dest_volume,
+                volume_suffix=suffix,
+                label=label,
+            )
+        )
+    return plan
+
+
+def _create_dest_volume(project_name: str, step: VolumeMigrationStep) -> bool:
+    """Pre-create the destination with the labels compose stamps on its own
+    volumes. Left to `docker run -v`'s auto-create, the volume has none, so
+    compose warns it "was not created by Docker Compose" on every later `up`.
+    """
+    return _run_ok(
+        [
+            "docker",
+            "volume",
+            "create",
+            "--label",
+            f"com.docker.compose.project={project_name}",
+            "--label",
+            f"com.docker.compose.volume={step.volume_suffix}",
+            step.dest_volume,
+        ],
+        timeout=15,
+    )
+
+
+def _copy_volume(source_volume: str, dest_volume: str) -> bool:
+    """Copy `source_volume` into `dest_volume` via a throwaway alpine
+    container. The command asserts the destination ended up non-empty —
+    `cp -a` can exit 0 on a no-op copy just as easily as a real one, so a
+    clean exit code alone doesn't prove data landed.
+    """
+    container = f"hogli-migrate-volumes-{os.getpid()}"
+    ok = _run_ok(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--name",
+            container,
+            "-v",
+            f"{source_volume}:/from:ro",
+            "-v",
+            f"{dest_volume}:/to",
+            "alpine",
+            "sh",
+            "-c",
+            'rm -rf /to/* && cp -a /from/. /to/ && [ -n "$(ls -A /to)" ]',
+        ],
+        timeout=900,
+    )
+    if not ok:
+        # A subprocess timeout kills the docker client, not the container it launched —
+        # without removing it explicitly, the container keeps holding the destination
+        # volume, so a later `docker volume rm -f` fails with "volume is in use" and
+        # rollback silently leaves a torn copy behind.
+        _run_output(["docker", "rm", "-f", container], timeout=30)
+    return ok
+
+
+def _remove_volumes(volume_names: Iterable[str]) -> None:
+    names = list(volume_names)
+    if names:
+        _run_output(["docker", "volume", "rm", "-f", *names], timeout=15)
+
+
+def _restart_containers(container_ids: Iterable[str]) -> None:
+    ids = list(container_ids)
+    if ids:
+        _run_output(["docker", "start", *ids], timeout=30)
+
+
+def _execute_volume_migration(plan: Sequence[VolumeMigrationStep], project_name: str) -> bool:
+    """Stop the old containers, copy every planned volume, and verify each
+    one. A live `cp -a` against an actively-written ClickHouse/ZooKeeper data
+    dir can read a torn snapshot, so the containers are stopped first — the
+    same "stop the stack, then copy" order the manual salvage doc already
+    tells developers to follow. Any failure, including an interrupt, rolls
+    back: remove whatever new named volumes were already created and restart
+    whatever was stopped, so `docker compose up` sees today's fallback
+    situation (no named volumes yet) rather than a mix of migrated and
+    un-migrated state.
+    """
+    container_ids = sorted({step.container_id for step in plan})
+    if not _run_ok(["docker", "stop", *container_ids], timeout=30):
+        # `docker stop` on multiple containers can partially succeed (e.g. one
+        # already vanished) and still exit non-zero overall — restart whatever
+        # did stop rather than leaving a working dev stack unexpectedly down.
+        _restart_containers(container_ids)
+        return False
+
+    migrated: list[str] = []
+    for step in plan:
+        click.echo(f"   Migrating {step.label}…")
+        try:
+            copied = _create_dest_volume(project_name, step) and _copy_volume(step.source_volume, step.dest_volume)
+        except BaseException:
+            # Ctrl-C during a multi-GB copy must not leave a torn destination volume and
+            # a stopped stack behind for the next run to mistake for a completed migration.
+            _remove_volumes([*migrated, step.dest_volume])
+            _restart_containers(container_ids)
+            raise
+        if not copied:
+            click.echo(f"   ⚠️  {step.label} migration failed, rolling back…")
+            # `docker run -v <dest>:/to ...` auto-creates the destination volume
+            # before the container's command runs, so a failed (or partially
+            # completed, e.g. disk-full mid-copy) attempt still leaves step's own
+            # volume behind — remove it too, not just the ones that fully
+            # succeeded, or a torn copy can survive rollback and later get
+            # mistaken for a completed migration by the idempotency check.
+            _remove_volumes([*migrated, step.dest_volume])
+            _restart_containers(container_ids)
+            return False
+        migrated.append(step.dest_volume)
+    return True
+
+
+def _print_volume_reset_warning() -> None:
+    click.echo("⚠️  Switching ClickHouse/ZooKeeper to named docker volumes. This first start")
+    click.echo("   recreates them empty, so local ClickHouse data resets once (happens once")
+    click.echo("   per machine). Run 'hogli migrations:run' after, or 'hogli dev:reset' for a")
+    click.echo("   full wipe plus demo data. See 'Local ClickHouse suddenly empty' in")
+    click.echo("   docs/published/handbook/engineering/developing-locally.md to salvage old data.")
+
+
+_MIGRATION_LOCK_DIR = Path(tempfile.gettempdir())
+
+
+@click.command(
+    name="doctor:migrate-volumes",
+    help="Auto-migrate ClickHouse/ZooKeeper data to the new named docker volumes",
+)
+def doctor_migrate_volumes() -> None:
+    """One-time migration for the named-volume switch in docker-compose.dev.yml.
+
+    ClickHouse and ZooKeeper moved from anonymous to named volumes so that
+    recreating a container no longer wipes ZooKeeper's replica-registration
+    state. The very first `docker compose up` after that switch would
+    otherwise create the named volumes empty. This salvages the prior
+    anonymous volumes into them automatically whenever the old→new mapping
+    is unambiguous, and falls back to the same manual-salvage guidance as
+    before when it isn't. Must run before `docker compose up` (see
+    bin/start) — once that recreates the containers, the old anonymous
+    volumes are no longer discoverable from their mounts. Fail-open, like
+    doctor:ports: never blocks `bin/start`.
+    """
+    if shutil.which("docker") is None:
+        return
+
+    project_name = _compose_project_name()
+    # `bin/start`'s own lock file is per-worktree, but every worktree shares this
+    # compose project — without this, two worktrees starting at once could both plan
+    # a migration for the same destination volumes, and one's failure rollback would
+    # delete data the other just copied. Blocks rather than skips, so the second
+    # worktree waits out the first's migration instead of racing it; the OS releases
+    # the lock automatically if the holding process dies, so a crash can't wedge it.
+    lock_path = _MIGRATION_LOCK_DIR / f"hogli-migrate-volumes-{project_name}.lock"
+    try:
+        with open(lock_path, "w") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            _do_migrate_volumes(project_name)
+    except OSError:
+        return  # couldn't lock (e.g. interrupted) — fail-open, same as every other step here
+
+
+def _do_migrate_volumes(project_name: str) -> None:
+    # `docker volume inspect` exits non-zero unless *every* named volume exists, so a
+    # migration interrupted partway through is retried instead of mistaken as finished.
+    dest_volumes = [f"{project_name}_{suffix}" for _service, _dest, suffix, _label in _VOLUME_MIGRATIONS]
+    if _run_output(["docker", "volume", "inspect", *dest_volumes]) is not None:
+        return  # already migrated (or a fresh named-volume install) — nothing to do
+
+    if not _matching_containers(project_name, "clickhouse"):
+        # No clickhouse container left to salvage from — either a fresh clone, or a
+        # stack that was stopped with `docker compose down` (which keeps volumes but
+        # removes containers). Only warn in the latter case; a fresh clone has nothing
+        # to lose and shouldn't see a reset notice.
+        if _has_prior_install(project_name):
+            _print_volume_reset_warning()
+        return
+
+    plan = _plan_volume_migration(project_name)
+    if plan is not None and _execute_volume_migration(plan, project_name):
+        click.echo("✅ Migrated ClickHouse/ZooKeeper data to the new named docker volumes automatically.")
+        click.echo("   ClickHouse and ZooKeeper are stopped; run 'hogli start' to bring them back up.")
+        return
+
+    _print_volume_reset_warning()
 
 
 # ---------------------------------------------------------------------------
@@ -1977,9 +2320,8 @@ def _check_ports() -> CheckResult:
     """Quick scan for a foreign stack holding a port the dev stack needs."""
     if shutil.which("docker") is None:
         return CheckResult(name="Port conflicts", status=CheckStatus.OK, summary="docker not installed")
-    project_name = os.environ.get("COMPOSE_PROJECT_NAME") or "posthog"
-    holders = _scan_port_holders(project_name)
-    foreign = [h for h in holders if h.container is not None and h.project != project_name]
+    project_name = _compose_project_name()
+    foreign = _foreign_holders(_scan_port_holders(), project_name)
     if foreign:
         return CheckResult(
             name="Port conflicts",
@@ -2085,6 +2427,26 @@ def _run_output(cmd: Sequence[str], timeout: float = 5.0) -> str | None:
     if result.returncode != 0:
         return None
     return result.stdout.strip() or None
+
+
+def _run_ok(cmd: Sequence[str], timeout: float = 5.0) -> bool:
+    """Run a command and report whether it exited zero.
+
+    Unlike `_run_output`, success doesn't depend on stdout being non-empty —
+    for commands whose exit code alone carries the result (e.g. a shell
+    script with no output on success), treating empty stdout as failure
+    would misreport a clean run. On failure, echoes captured stderr so a
+    docker-level error (permission denied, disk full, daemon hiccup) isn't
+    silently lost before the caller falls back to the generic warning.
+    """
+    try:
+        result = subprocess.run(list(cmd), capture_output=True, text=True, timeout=timeout, check=False)
+    except (FileNotFoundError, OSError, subprocess.SubprocessError) as exc:
+        click.echo(f"   ⚠️  {cmd[0]}: {exc}")
+        return False
+    if result.returncode != 0 and result.stderr.strip():
+        click.echo(f"   ⚠️  {result.stderr.strip()}")
+    return result.returncode == 0
 
 
 def _format_kv_block(pairs: Sequence[tuple[str, str]]) -> list[str]:

--- a/tools/hogli-commands/hogli_commands/tests/test_doctor.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_doctor.py
@@ -1,6 +1,11 @@
 import os
+import json
 import time
+import fcntl
 import hashlib
+import threading
+import subprocess
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -14,6 +19,10 @@ from hogli_commands.doctor import (
     _collect_import_targets,
     _config_procs,
     _confirm_stack_teardown,
+    _container_mounts,
+    _copy_volume,
+    _find_service_container,
+    _find_volume_mount,
     _format_kv_block,
     _generated_config_path,
     _get_process_cwds,
@@ -24,16 +33,31 @@ from hogli_commands.doctor import (
     _phrocs_socket_path,
     _posthog_shaped_projects,
     _probe_command_imports,
+    _run_ok,
     _sanitize_compose_name,
     _scan_port_holders,
     _scan_unheld_via_lsof,
     _select_flox_logs_to_remove,
     _tail,
+    doctor_migrate_volumes,
     doctor_ports,
 )
 
 _QUARTER_BUDGET = FLOX_LOG_MAX_TOTAL_BYTES // 4
 _TWO_FIFTHS_BUDGET = int(FLOX_LOG_MAX_TOTAL_BYTES * 0.4)
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_compose_project(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Several tests in this module hardcode "posthog"-prefixed volume/project
+    # names, matching production code that reads COMPOSE_PROJECT_NAME from the
+    # environment — without this, a developer with a legitimately overridden
+    # project name (e.g. COMPOSE_PROJECT_NAME=ai-gateway) gets a red suite here.
+    monkeypatch.setenv("COMPOSE_PROJECT_NAME", "posthog")
+    # doctor_migrate_volumes locks a file named after the project to serialize
+    # across worktrees; point it at a per-test directory so parallel test runs
+    # don't contend on the same real /tmp path.
+    monkeypatch.setattr("hogli_commands.doctor._MIGRATION_LOCK_DIR", tmp_path)
 
 
 @pytest.mark.parametrize(
@@ -225,7 +249,7 @@ def test_get_process_cwds_parses_and_batches(monkeypatch: pytest.MonkeyPatch) ->
 
     def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
         captured["cmd"] = cmd
-        return SimpleNamespace(returncode=1, stdout="p100\nn/repo/a\np200\nn/repo/b\n")
+        return SimpleNamespace(returncode=1, stdout="p100\nn/repo/a\np200\nn/repo/b\n", stderr="")
 
     monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
 
@@ -402,13 +426,27 @@ def test_sanitize_compose_name_strips_shell_metacharacters() -> None:
     assert _sanitize_compose_name("posthog-evil$(touch /tmp/pwned);rm -rf /") == "posthog-eviltouchtmppwnedrm-rf"
 
 
-def _fake_docker_ps(monkeypatch: pytest.MonkeyPatch, port_scan_stdout: str = "", clickhouse_stdout: str = "") -> None:
+def _fake_docker_ps(
+    monkeypatch: pytest.MonkeyPatch,
+    port_scan_stdout: str = "",
+    clickhouse_stdout: str = "",
+    extra: Callable[[list[str]], SimpleNamespace | None] | None = None,
+) -> None:
+    """Fake the two `docker ps` calls `doctor:ports` makes. `extra`, if given,
+    handles any other command (e.g. the teardown `docker compose` call) —
+    callers that need one don't have to reimplement the `docker ps` branches.
+    """
+
     def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
         if cmd[:2] == ["docker", "ps"] and "-a" not in cmd:
-            return SimpleNamespace(returncode=0, stdout=port_scan_stdout)
+            return SimpleNamespace(returncode=0, stdout=port_scan_stdout, stderr="")
         if cmd[:3] == ["docker", "ps", "-a"]:
-            return SimpleNamespace(returncode=0, stdout=clickhouse_stdout)
-        return SimpleNamespace(returncode=1, stdout="")
+            return SimpleNamespace(returncode=0, stdout=clickhouse_stdout, stderr="")
+        if extra is not None:
+            result = extra(cmd)
+            if result is not None:
+                return result
+        return SimpleNamespace(returncode=1, stdout="", stderr="")
 
     monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
 
@@ -434,7 +472,7 @@ def test_scan_port_holders_matches_published_port_forms(
     # code-reviewer-testing's top concern on the bash version: a substring
     # match between port 9000 and 19000 would misattribute a collision.
     _fake_docker_ps(monkeypatch, port_scan_stdout=ports_line)
-    holders = {h.port: h for h in _scan_port_holders("posthog")}
+    holders = {h.port: h for h in _scan_port_holders()}
     if expected_holder is None:
         assert holders[expected_port].container is None
     else:
@@ -444,13 +482,13 @@ def test_scan_port_holders_matches_published_port_forms(
 
 def test_scan_port_holders_own_project_is_not_flagged_foreign(monkeypatch: pytest.MonkeyPatch) -> None:
     _fake_docker_ps(monkeypatch, port_scan_stdout="clickhouse|posthog|127.0.0.1:8123->8123/tcp")
-    holders = {h.port: h for h in _scan_port_holders("posthog")}
+    holders = {h.port: h for h in _scan_port_holders()}
     assert holders[8123].project == "posthog"
 
 
 def test_scan_port_holders_sanitizes_malicious_project_label(monkeypatch: pytest.MonkeyPatch) -> None:
     _fake_docker_ps(monkeypatch, port_scan_stdout="evilbox|posthog-evil$(rm -rf /)|127.0.0.1:8010->8000/tcp")
-    holders = {h.port: h for h in _scan_port_holders("posthog")}
+    holders = {h.port: h for h in _scan_port_holders()}
     assert holders[8010].project == "posthog-evilrm-rf"
 
 
@@ -461,7 +499,7 @@ def test_posthog_shaped_projects_filters_by_clickhouse_label(monkeypatch: pytest
     # port, is still offered for teardown — not just one whose CH is running.
     def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
         assert "label=com.docker.compose.service=clickhouse" in cmd
-        return SimpleNamespace(returncode=0, stdout="stopped-proj\n")
+        return SimpleNamespace(returncode=0, stdout="ch1|stopped-proj\n", stderr="")
 
     monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
     result = _posthog_shaped_projects({"stopped-proj", "unrelated-proj"})
@@ -479,7 +517,7 @@ def test_scan_unheld_via_lsof_disambiguates_port_and_range(monkeypatch: pytest.M
 
     def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
         assert cmd[0] == "lsof"
-        return SimpleNamespace(returncode=0, stdout=lsof_output)
+        return SimpleNamespace(returncode=0, stdout=lsof_output, stderr="")
 
     monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
     monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/lsof")
@@ -517,7 +555,7 @@ def test_doctor_ports_reports_foreign_stack_noninteractively(monkeypatch: pytest
     _fake_docker_ps(
         monkeypatch,
         port_scan_stdout="evilbox|foreign-proj|127.0.0.1:8010->8000/tcp",
-        clickhouse_stdout="foreign-proj\n",
+        clickhouse_stdout="ch1|foreign-proj\n",
     )
     # CliRunner's stdin/stdout are never a TTY, so this exercises the
     # non-interactive (print-only, no subprocess teardown) branch.
@@ -527,32 +565,588 @@ def test_doctor_ports_reports_foreign_stack_noninteractively(monkeypatch: pytest
     assert "docker compose -p foreign-proj -f docker-compose.dev.yml down --remove-orphans" in result.output
 
 
-def test_doctor_ports_tears_down_when_confirmed(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("confirmed", "expected_teardown_calls"),
+    [
+        pytest.param(True, 1, id="confirmed-tears-down"),
+        pytest.param(False, 0, id="declined-leaves-stack-alone"),
+    ],
+)
+def test_doctor_ports_teardown_respects_confirmation(
+    monkeypatch: pytest.MonkeyPatch, confirmed: bool, expected_teardown_calls: int
+) -> None:
     # CliRunner always simulates a non-tty stdin/stdout with no override hook,
     # so the interactive branch is exercised by calling the command function
-    # directly instead of through Click's dispatcher.
+    # directly instead of through Click's dispatcher. A declined prompt must
+    # leave the foreign stack running, not tear it down anyway.
     monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/docker")
     monkeypatch.setattr("hogli_commands.doctor.sys.stdin.isatty", lambda: True)
     monkeypatch.setattr("hogli_commands.doctor.sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("hogli_commands.doctor._confirm_stack_teardown", lambda *_a, **_k: confirmed)
 
     teardown_calls: list[list[str]] = []
 
-    def dispatch(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
-        if cmd[:2] == ["docker", "ps"] and "-a" not in cmd:
-            return SimpleNamespace(returncode=0, stdout="evilbox|foreign-proj|127.0.0.1:8010->8000/tcp")
-        if cmd[:3] == ["docker", "ps", "-a"]:
-            return SimpleNamespace(returncode=0, stdout="foreign-proj\n")
+    def record_teardown(cmd: list[str]) -> SimpleNamespace | None:
         if cmd[:2] == ["docker", "compose"]:
             teardown_calls.append(cmd)
-            return SimpleNamespace(returncode=0, stdout="")
-        return SimpleNamespace(returncode=1, stdout="")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return None
 
-    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", dispatch)
+    _fake_docker_ps(
+        monkeypatch,
+        port_scan_stdout="evilbox|foreign-proj|127.0.0.1:8010->8000/tcp",
+        clickhouse_stdout="ch1|foreign-proj\n",
+        extra=record_teardown,
+    )
 
-    # --yes skips the interactive prompt; verifies the exact teardown argv
-    # (a reordered or dropped arg here would tear down the wrong compose file).
     assert doctor_ports.callback is not None
-    doctor_ports.callback(yes=True)
-    assert teardown_calls == [
-        ["docker", "compose", "-p", "foreign-proj", "-f", "docker-compose.dev.yml", "down", "--remove-orphans"]
+    doctor_ports.callback(yes=False)
+    assert len(teardown_calls) == expected_teardown_calls
+    if confirmed:
+        # Verifies the exact teardown argv — a reordered or dropped arg here
+        # would tear down the wrong compose file.
+        assert teardown_calls == [
+            ["docker", "compose", "-p", "foreign-proj", "-f", "docker-compose.dev.yml", "down", "--remove-orphans"]
+        ]
+
+
+# ---------------------------------------------------------------------------
+# doctor:migrate-volumes
+# ---------------------------------------------------------------------------
+
+
+def _mounts_json(entries: Sequence[tuple[str, str, str]]) -> str:
+    """entries: (destination, volume name, mount type)."""
+    return json.dumps([{"Destination": dest, "Name": name, "Type": type_} for dest, name, type_ in entries])
+
+
+# Realistic mounts for a container built from docker-compose.dev.yml: the
+# clickhouse service has one named-volume mount plus several bind mounts for
+# config files; zookeeper has three named-volume mounts.
+_CLICKHOUSE_MOUNTS = _mounts_json(
+    [
+        ("/idl", "", "bind"),
+        ("/etc/clickhouse-server/config.xml", "", "bind"),
+        ("/var/lib/clickhouse", "old-ch-vol", "volume"),
     ]
+)
+_ZOOKEEPER_MOUNTS = _mounts_json(
+    [
+        ("/datalog", "old-zk-datalog-vol", "volume"),
+        ("/data", "old-zk-data-vol", "volume"),
+        ("/logs", "old-zk-logs-vol", "volume"),
+    ]
+)
+
+
+@pytest.mark.parametrize(
+    ("ids_by_service", "service", "project", "expected"),
+    [
+        pytest.param({"clickhouse": []}, "clickhouse", "posthog", None, id="no-containers"),
+        pytest.param({"clickhouse": ["ch1"]}, "clickhouse", "posthog", "ch1", id="single-match"),
+        pytest.param({"clickhouse": ["ch1", "ch2"]}, "clickhouse", "posthog", None, id="ambiguous-two-matches"),
+    ],
+)
+def test_find_service_container(
+    monkeypatch: pytest.MonkeyPatch,
+    ids_by_service: dict[str, list[str]],
+    service: str,
+    project: str,
+    expected: str | None,
+) -> None:
+    def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+        svc = cmd[4].split("=")[-1]
+        ids = ids_by_service.get(svc, [])
+        return SimpleNamespace(returncode=0, stdout="\n".join(f"{cid}|{project}" for cid in ids), stderr="")
+
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
+    assert _find_service_container(project, service) == expected
+
+
+def test_find_service_container_ignores_matches_from_other_projects(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A container from a sibling worktree's compose project must not be mistaken
+    # for this project's — that would copy the wrong developer's data.
+    def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(returncode=0, stdout="ch1|other-project\n", stderr="")
+
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
+    assert _find_service_container("posthog", "clickhouse") is None
+
+
+@pytest.mark.parametrize(
+    ("mounts", "destination", "expected"),
+    [
+        pytest.param(
+            [
+                {"Destination": "/idl", "Name": "", "Type": "bind"},
+                {"Destination": "/var/lib/clickhouse", "Name": "old-ch-vol", "Type": "volume"},
+            ],
+            "/var/lib/clickhouse",
+            "old-ch-vol",
+            id="single-volume-match-among-bind-mounts",
+        ),
+        pytest.param(
+            [{"Destination": "/idl", "Name": "", "Type": "bind"}],
+            "/var/lib/clickhouse",
+            None,
+            id="destination-not-mounted",
+        ),
+        pytest.param(
+            [
+                {"Destination": "/logs", "Name": "vol-a", "Type": "volume"},
+                {"Destination": "/logs", "Name": "vol-b", "Type": "volume"},
+            ],
+            "/logs",
+            None,
+            id="duplicate-destination-is-ambiguous",
+        ),
+        pytest.param(
+            [{"Destination": "/var/lib/clickhouse", "Name": "/host/path", "Type": "bind"}],
+            "/var/lib/clickhouse",
+            None,
+            id="bind-mount-is-not-a-volume",
+        ),
+    ],
+)
+def test_find_volume_mount(mounts: list[dict[str, object]], destination: str, expected: str | None) -> None:
+    assert _find_volume_mount(mounts, destination) == expected
+
+
+@pytest.mark.parametrize(
+    ("run_output", "expected"),
+    [
+        pytest.param(_CLICKHOUSE_MOUNTS, json.loads(_CLICKHOUSE_MOUNTS), id="valid-mounts-json"),
+        pytest.param("not json", None, id="unparseable-inspect-output"),
+        pytest.param(None, None, id="inspect-failed"),
+    ],
+)
+def test_container_mounts(
+    monkeypatch: pytest.MonkeyPatch, run_output: str | None, expected: list[dict[str, object]] | None
+) -> None:
+    monkeypatch.setattr("hogli_commands.doctor._run_output", lambda *_a, **_k: run_output)
+    assert _container_mounts("some-container") == expected
+
+
+@pytest.mark.parametrize(
+    ("returncode", "expected"),
+    [
+        pytest.param(1, False, id="copy-or-verify-fails"),
+        pytest.param(0, True, id="copy-and-verify-succeed"),
+    ],
+)
+def test_copy_volume(monkeypatch: pytest.MonkeyPatch, returncode: int, expected: bool) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+        calls.append(cmd)
+        return SimpleNamespace(returncode=returncode, stdout="", stderr="")
+
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
+    monkeypatch.setattr("hogli_commands.doctor.os.getpid", lambda: 4242)
+    assert _copy_volume("old-vol", "new-vol") == expected
+    # The destination-empty check now lives inside the copy container's own
+    # command (there's no second container call left to catch it separately)
+    # — lock in that the check itself doesn't silently disappear.
+    assert calls[0] == [
+        "docker",
+        "run",
+        "--rm",
+        "--name",
+        "hogli-migrate-volumes-4242",
+        "-v",
+        "old-vol:/from:ro",
+        "-v",
+        "new-vol:/to",
+        "alpine",
+        "sh",
+        "-c",
+        'rm -rf /to/* && cp -a /from/. /to/ && [ -n "$(ls -A /to)" ]',
+    ]
+    # A failed copy cleans up the named container so a later `docker volume rm -f`
+    # on the destination doesn't fail with "volume is in use".
+    if not expected:
+        assert calls[1] == ["docker", "rm", "-f", "hogli-migrate-volumes-4242"]
+
+
+def _fake_migrate_dispatcher(
+    *,
+    project: str = "posthog",
+    named_volume_exists: bool = False,
+    clickhouse_ids: Sequence[str] = ("ch1",),
+    zookeeper_ids: Sequence[str] = ("zk1",),
+    mounts_by_container: dict[str, str] | None = None,
+    copy_returncode_by_dest: dict[str, int] | None = None,
+    stop_returncode: int = 0,
+) -> tuple[Callable[..., SimpleNamespace], list[list[str]]]:
+    """Fake `subprocess.run` covering every docker call doctor_migrate_volumes
+    can make, keyed off the same argv shapes the implementation builds.
+    Records every call so tests can assert exactly what ran (or didn't).
+    """
+    calls: list[list[str]] = []
+    mounts_by_container = mounts_by_container or {"ch1": _CLICKHOUSE_MOUNTS, "zk1": _ZOOKEEPER_MOUNTS}
+    copy_returncode_by_dest = copy_returncode_by_dest or {}
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
+        calls.append(cmd)
+
+        if cmd[:3] == ["docker", "volume", "inspect"]:
+            return SimpleNamespace(
+                returncode=0 if named_volume_exists else 1, stdout="[]" if named_volume_exists else ""
+            )
+
+        if cmd[:3] == ["docker", "ps", "-a"]:
+            service = cmd[4].split("=")[-1]
+            ids = clickhouse_ids if service == "clickhouse" else zookeeper_ids
+            return SimpleNamespace(returncode=0, stdout="\n".join(f"{cid}|{project}" for cid in ids), stderr="")
+
+        if cmd[:2] == ["docker", "inspect"]:
+            return SimpleNamespace(returncode=0, stdout=mounts_by_container.get(cmd[2], "[]"), stderr="")
+
+        if cmd[:2] == ["docker", "stop"]:
+            return SimpleNamespace(returncode=stop_returncode, stdout="", stderr="")
+
+        if cmd[:3] == ["docker", "volume", "create"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        if cmd[:2] == ["docker", "run"] and "sh" in cmd:
+            # argv: docker run --rm --name <container> -v <src>:/from:ro -v <dest>:/to alpine sh -c ...
+            dest = cmd[8].split(":")[0]
+            return SimpleNamespace(returncode=copy_returncode_by_dest.get(dest, 0), stdout="", stderr="")
+
+        if cmd[:3] == ["docker", "volume", "rm"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        if cmd[:2] == ["docker", "start"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        return SimpleNamespace(returncode=1, stdout="", stderr="")
+
+    return fake_run, calls
+
+
+def test_doctor_migrate_volumes_noop_when_already_migrated(monkeypatch: pytest.MonkeyPatch) -> None:
+    # This runs on every `hogli start`; once the named volume exists, it must
+    # be a single fast check, not a full docker ps/inspect sweep every time.
+    monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/docker")
+    fake_run, calls = _fake_migrate_dispatcher(named_volume_exists=True)
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(doctor_migrate_volumes, [])
+    assert result.exit_code == 0
+    assert result.output == ""
+    # All four destination volumes are checked in one call — the idempotency
+    # check must not rely on clickhouse-data alone, or a migration interrupted
+    # after the first volume would be mistaken for fully complete forever.
+    assert calls == [
+        [
+            "docker",
+            "volume",
+            "inspect",
+            "posthog_clickhouse-data",
+            "posthog_zookeeper-data",
+            "posthog_zookeeper-datalog",
+            "posthog_zookeeper-logs",
+        ]
+    ]
+
+
+def test_doctor_migrate_volumes_noop_on_fresh_install(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No named volumes yet *and* no prior clickhouse container or postgres
+    # volume means there was never any old data — must stay silent, not warn
+    # a brand new checkout.
+    monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/docker")
+    fake_run, calls = _fake_migrate_dispatcher(named_volume_exists=False, clickhouse_ids=(), zookeeper_ids=())
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(doctor_migrate_volumes, [])
+    assert result.exit_code == 0
+    assert result.output == ""
+    # dest-volumes inspect + clickhouse existence check + prior-install (postgres) check
+    assert len(calls) == 3
+
+
+def test_doctor_migrate_volumes_warns_when_stack_was_stopped(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `docker compose down` removes containers but keeps volumes, so a developer
+    # who stopped the stack (rather than never having one) has no clickhouse
+    # container to salvage from, but still has real prior data. Silence here
+    # would mean an empty ClickHouse with no explanation.
+    monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/docker")
+    fake_run, calls = _fake_migrate_dispatcher(named_volume_exists=False, clickhouse_ids=(), zookeeper_ids=())
+
+    def with_prior_install(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        if cmd[:3] == ["docker", "volume", "inspect"] and cmd[3:] == ["posthog_postgres-15-data"]:
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        return fake_run(cmd, **kwargs)
+
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", with_prior_install)
+
+    result = CliRunner().invoke(doctor_migrate_volumes, [])
+    assert result.exit_code == 0
+    assert "Switching ClickHouse/ZooKeeper to named docker volumes" in result.output
+    assert "developing-locally.md" in result.output
+    assert not any(c[:2] == ["docker", "stop"] for c in calls)
+
+
+def test_doctor_migrate_volumes_happy_path_migrates_both_services(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/docker")
+    monkeypatch.setattr("hogli_commands.doctor.os.getpid", lambda: 4242)
+    fake_run, calls = _fake_migrate_dispatcher()
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(doctor_migrate_volumes, [])
+    assert result.exit_code == 0
+    assert "Migrated ClickHouse/ZooKeeper data" in result.output
+
+    # Both containers are stopped together before anything is copied — a live
+    # `cp -a` against an actively-written data dir can read a torn snapshot.
+    assert ["docker", "stop", "ch1", "zk1"] in calls
+
+    # Each destination is pre-created with compose's own labels before the copy,
+    # so compose doesn't warn "not created by Docker Compose" on every later `up`.
+    assert [
+        "docker",
+        "volume",
+        "create",
+        "--label",
+        "com.docker.compose.project=posthog",
+        "--label",
+        "com.docker.compose.volume=clickhouse-data",
+        "posthog_clickhouse-data",
+    ] in calls
+
+    # Exact copy argv for both services — a reordered or missing flag here
+    # would silently copy from (or into) the wrong volume.
+    assert [
+        "docker",
+        "run",
+        "--rm",
+        "--name",
+        "hogli-migrate-volumes-4242",
+        "-v",
+        "old-ch-vol:/from:ro",
+        "-v",
+        "posthog_clickhouse-data:/to",
+        "alpine",
+        "sh",
+        "-c",
+        'rm -rf /to/* && cp -a /from/. /to/ && [ -n "$(ls -A /to)" ]',
+    ] in calls
+    assert [
+        "docker",
+        "run",
+        "--rm",
+        "--name",
+        "hogli-migrate-volumes-4242",
+        "-v",
+        "old-zk-data-vol:/from:ro",
+        "-v",
+        "posthog_zookeeper-data:/to",
+        "alpine",
+        "sh",
+        "-c",
+        'rm -rf /to/* && cp -a /from/. /to/ && [ -n "$(ls -A /to)" ]',
+    ] in calls
+    assert [
+        "docker",
+        "run",
+        "--rm",
+        "--name",
+        "hogli-migrate-volumes-4242",
+        "-v",
+        "old-zk-datalog-vol:/from:ro",
+        "-v",
+        "posthog_zookeeper-datalog:/to",
+        "alpine",
+        "sh",
+        "-c",
+        'rm -rf /to/* && cp -a /from/. /to/ && [ -n "$(ls -A /to)" ]',
+    ] in calls
+
+
+@pytest.mark.parametrize(
+    ("clickhouse_ids", "zookeeper_ids", "mounts_by_container"),
+    [
+        pytest.param(("ch1",), (), None, id="zookeeper-container-already-removed"),
+        pytest.param(("ch1", "ch2"), ("zk1",), None, id="ambiguous-clickhouse-containers"),
+        pytest.param(
+            ("ch1",),
+            ("zk1",),
+            {
+                "ch1": _CLICKHOUSE_MOUNTS,
+                # zookeeper's own container and two of its three volumes resolve
+                # fine — only /logs is duplicated. The whole plan must still be
+                # discarded, not just the ambiguous piece.
+                "zk1": _mounts_json(
+                    [
+                        ("/datalog", "old-zk-datalog-vol", "volume"),
+                        ("/data", "old-zk-data-vol", "volume"),
+                        ("/logs", "vol-a", "volume"),
+                        ("/logs", "vol-b", "volume"),
+                    ]
+                ),
+            },
+            id="one-side-ambiguous-migrates-neither",
+        ),
+    ],
+)
+def test_doctor_migrate_volumes_falls_back_without_touching_anything(
+    monkeypatch: pytest.MonkeyPatch,
+    clickhouse_ids: Sequence[str],
+    zookeeper_ids: Sequence[str],
+    mounts_by_container: dict[str, str] | None,
+) -> None:
+    monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/docker")
+    fake_run, calls = _fake_migrate_dispatcher(
+        clickhouse_ids=clickhouse_ids, zookeeper_ids=zookeeper_ids, mounts_by_container=mounts_by_container
+    )
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(doctor_migrate_volumes, [])
+    assert result.exit_code == 0
+    assert "Switching ClickHouse/ZooKeeper to named docker volumes" in result.output
+    assert "developing-locally.md" in result.output
+    # Never guess: an ambiguous or missing piece must abort before any stop
+    # or copy call, not just skip that one piece.
+    assert not any(c[:2] == ["docker", "stop"] for c in calls)
+    assert not any(c[:2] == ["docker", "run"] for c in calls)
+
+
+def test_doctor_migrate_volumes_copy_failure_rolls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    # ClickHouse and zookeeper-data copy cleanly, but zookeeper-datalog fails
+    # verification. Restoring only clickhouse+zookeeper-data would leave a
+    # replicated table with "replica already exists" once ClickHouse starts
+    # against restored state but ZooKeeper doesn't know about it.
+    monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/docker")
+    fake_run, calls = _fake_migrate_dispatcher(copy_returncode_by_dest={"posthog_zookeeper-datalog": 1})
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(doctor_migrate_volumes, [])
+    assert result.exit_code == 0
+    assert "Switching ClickHouse/ZooKeeper to named docker volumes" in result.output
+    assert "Migrated" not in result.output
+
+    # The two volumes that copied successfully before the failure are rolled
+    # back in one call, alongside the failed step's own (possibly
+    # partially-written) volume — `docker run -v <dest>:/to ...` auto-creates
+    # the destination volume before its command runs, so it must be removed
+    # too, or a torn copy can survive rollback and get mistaken for a
+    # completed migration on the next run. The containers we stopped are
+    # restarted.
+    assert [
+        "docker",
+        "volume",
+        "rm",
+        "-f",
+        "posthog_clickhouse-data",
+        "posthog_zookeeper-data",
+        "posthog_zookeeper-datalog",
+    ] in calls
+    assert ["docker", "start", "ch1", "zk1"] in calls
+    # The step after the failed one must never run.
+    assert not any(c[:2] == ["docker", "run"] and "posthog_zookeeper-logs:/to" in c for c in calls)
+
+
+def test_doctor_migrate_volumes_copy_timeout_rolls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A large ClickHouse volume on a slow disk can exceed the copy timeout.
+    # subprocess.run raising TimeoutExpired must not skip rollback and leave
+    # the old containers stopped with a half-written destination volume.
+    monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/docker")
+    fake_run, calls = _fake_migrate_dispatcher()
+
+    def timing_out_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        if cmd[:2] == ["docker", "run"] and "posthog_clickhouse-data:/to" in cmd:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=120)
+        return fake_run(cmd, **kwargs)
+
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", timing_out_run)
+
+    result = CliRunner().invoke(doctor_migrate_volumes, [])
+    assert result.exit_code == 0
+    assert "Switching ClickHouse/ZooKeeper to named docker volumes" in result.output
+    assert ["docker", "volume", "rm", "-f", "posthog_clickhouse-data"] in calls
+    assert ["docker", "start", "ch1", "zk1"] in calls
+
+
+def test_doctor_migrate_volumes_interrupt_rolls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Ctrl-C during a multi-GB copy raises KeyboardInterrupt, which isn't a
+    # subprocess.SubprocessError, so it wouldn't be caught by the same except
+    # clause that handles a copy failure or timeout. Without an explicit
+    # rollback on it, the destination volume survives half-written and the
+    # next start's idempotency check mistakes it for a completed migration.
+    monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/docker")
+    fake_run, calls = _fake_migrate_dispatcher()
+
+    def interrupted_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        if cmd[:2] == ["docker", "run"] and "posthog_clickhouse-data:/to" in cmd:
+            raise KeyboardInterrupt
+        return fake_run(cmd, **kwargs)
+
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", interrupted_run)
+
+    assert doctor_migrate_volumes.callback is not None
+    with pytest.raises(KeyboardInterrupt):
+        doctor_migrate_volumes.callback()
+    assert ["docker", "volume", "rm", "-f", "posthog_clickhouse-data"] in calls
+    assert ["docker", "start", "ch1", "zk1"] in calls
+
+
+def test_doctor_migrate_volumes_stop_failure_restarts_containers(monkeypatch: pytest.MonkeyPatch) -> None:
+    # `docker stop` on multiple containers can exit non-zero after partially
+    # succeeding (e.g. one already vanished). Without a restart here, a
+    # container that *did* stop would stay down even though no migration
+    # happened — leaving a working dev stack unexpectedly offline.
+    monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/docker")
+    fake_run, calls = _fake_migrate_dispatcher(stop_returncode=1)
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
+
+    result = CliRunner().invoke(doctor_migrate_volumes, [])
+    assert result.exit_code == 0
+    assert "Switching ClickHouse/ZooKeeper to named docker volumes" in result.output
+    assert ["docker", "start", "ch1", "zk1"] in calls
+    # Nothing was copied, so nothing needs to be rolled back.
+    assert not any(c[:2] == ["docker", "run"] for c in calls)
+
+
+def test_run_ok_echoes_stderr_on_failure(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    # `_run_ok` used to swallow captured stderr entirely on failure, so a real
+    # docker-level error (permission denied, disk full, daemon hiccup) was
+    # indistinguishable from any other failure once the caller fell back to its
+    # generic warning.
+    monkeypatch.setattr(
+        "hogli_commands.doctor.subprocess.run",
+        lambda *_a, **_k: SimpleNamespace(returncode=1, stdout="", stderr="permission denied\n"),
+    )
+    assert _run_ok(["docker", "volume", "create", "x"]) is False
+    assert "permission denied" in capsys.readouterr().out
+
+
+def test_doctor_migrate_volumes_serializes_across_concurrent_worktrees(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # `bin/start`'s own lock is per-worktree, but every worktree shares one compose
+    # project, so two worktrees starting at once could both plan a migration for the
+    # same destination volumes — one's rollback then deletes data the other just
+    # copied. Prove a held lock blocks a concurrent invocation instead of letting it
+    # race in unlocked.
+    monkeypatch.setattr("hogli_commands.doctor.shutil.which", lambda _: "/usr/bin/docker")
+    fake_run, calls = _fake_migrate_dispatcher(named_volume_exists=True)
+    monkeypatch.setattr("hogli_commands.doctor.subprocess.run", fake_run)
+
+    lock_path = tmp_path / "hogli-migrate-volumes-posthog.lock"
+    holder = open(lock_path, "w")
+    fcntl.flock(holder, fcntl.LOCK_EX)
+
+    done = threading.Event()
+    thread = threading.Thread(target=lambda: (doctor_migrate_volumes.callback(), done.set()))  # type: ignore[misc]
+    thread.start()
+    try:
+        # Still blocked on the lock: no docker call has run yet.
+        assert not done.wait(timeout=0.1)
+        assert calls == []
+    finally:
+        fcntl.flock(holder, fcntl.LOCK_UN)
+        holder.close()
+
+    thread.join(timeout=5)
+    assert done.is_set()
+    assert calls  # released promptly and ran through once unblocked

--- a/tools/phrocs/internal/docker/docker_test.go
+++ b/tools/phrocs/internal/docker/docker_test.go
@@ -3,11 +3,13 @@ package docker
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/charmbracelet/x/ansi"
+	"github.com/posthog/posthog/phrocs/internal/config"
 )
 
 func installFakeDocker(t *testing.T, script string) {
@@ -121,6 +123,32 @@ func TestStripComposeLogsTail(t *testing.T) {
 				t.Fatalf("StripComposeLogsTail() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestStripComposeLogsTailOnRealDockerComposeProcShell strips the actual
+// docker-compose proc shell phrocs loads at runtime (bin/mprocs.yaml, via
+// config.LoadRegistry), not just the hand-written fixtures above. If a future
+// edit to that shell leaves a dangling else/fi after stripping, the
+// docker-compose proc fails to parse and the whole dev stack fails to start,
+// with none of the fixture-based cases above able to catch it.
+func TestStripComposeLogsTailOnRealDockerComposeProcShell(t *testing.T) {
+	cfg, err := config.LoadRegistry()
+	if err != nil || cfg == nil {
+		t.Skip("bin/mprocs.yaml not found from this working directory")
+	}
+	proc, ok := cfg.Procs["docker-compose"]
+	if !ok {
+		t.Fatal("docker-compose proc not found in bin/mprocs.yaml")
+	}
+
+	stripped := StripComposeLogsTail(proc.Shell)
+
+	if strings.Contains(stripped, "logs") && strings.Contains(stripped, "--tail") {
+		t.Fatalf("expected the logs tail to be stripped, got: %q", stripped)
+	}
+	if err := exec.Command("bash", "-n", "-c", stripped).Run(); err != nil {
+		t.Fatalf("stripped shell is not valid bash: %v\nshell: %q", err, stripped)
 	}
 }
 

--- a/tools/phrocs/subcommands_test.go
+++ b/tools/phrocs/subcommands_test.go
@@ -102,6 +102,24 @@ func TestRunWait_shortTimeoutBeforeBindIsNotReachable(t *testing.T) {
 	}
 }
 
+func TestPhrocsStopped_sandboxSuppressesDockerHint(t *testing.T) {
+	// In a sandbox, docker infra is managed externally, so telling the user
+	// to run `hogli docker:services:down` points at infra phrocs doesn't own.
+	t.Setenv("POSTHOG_SANDBOX", "1")
+	_, out := captureStdout(t, func() int { return phrocsStopped("phrocs stopped") })
+	if strings.Contains(out, "docker:services:down") {
+		t.Fatalf("sandbox must not print the docker teardown hint: %q", out)
+	}
+}
+
+func TestPhrocsStopped_printsDockerHintOutsideSandbox(t *testing.T) {
+	t.Setenv("POSTHOG_SANDBOX", "")
+	_, out := captureStdout(t, func() int { return phrocsStopped("phrocs stopped") })
+	if !strings.Contains(out, "docker:services:down") {
+		t.Fatalf("expected the docker teardown hint outside a sandbox: %q", out)
+	}
+}
+
 func TestRunStop_quitPathRemovesPidfile(t *testing.T) {
 	t.Chdir(t.TempDir())
 	if err := os.MkdirAll(generatedDir(), 0o755); err != nil {


### PR DESCRIPTION
## Problem

The dev stack is switching ClickHouse and ZooKeeper to named docker volumes (this branch's base, #73306) so container recreation doesn't wipe ZooKeeper's replica-registration state. The first `docker compose up` after that switch would otherwise create the new named volumes empty, since the existing data still lives in the old anonymous volumes.

## Changes

Adds `hogli doctor:migrate-volumes`, which salvages the old anonymous ClickHouse and ZooKeeper volumes into the new named ones automatically whenever the mapping is unambiguous, and falls back to the existing manual-salvage docs when it isn't. `bin/start` calls it fail-open before `docker compose up`, alongside the port pre-flight from #73306.

A few robustness fixes on top of the initial version:

- The migration's "already done" check now verifies all four destination volumes, not just `clickhouse-data`, so an interrupted or timed-out run doesn't get mistaken for a completed one.
- The copy loop rolls back on Ctrl-C too, not just on a clean failure.
- Destination volumes are pre-created with compose's own labels so `docker compose up` doesn't warn about them afterward.
- A few smaller cleanups: dropped an unused parameter, removed a wrapper function that was hiding a one-line check, and closed a couple of test coverage gaps (the decline branch of the port-teardown prompt, the sandbox guard in phrocs' stop hint, and the real `bin/mprocs.yaml` shell instead of only a hand-written fixture).

## How did you test this code?

Ran the Python suite for the hogli-commands changes (`pytest hogli_commands/tests/test_doctor.py`, 93 passing, both with `COMPOSE_PROJECT_NAME` unset and overridden) and `go test ./...` plus `go vet` for the phrocs changes, all green. `ruff check`/`ruff format` clean.

I didn't spin up a real dev stack with pre-existing anonymous volumes to exercise the migration end to end; the automated coverage above is what I have.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `docs/published/handbook/engineering/developing-locally.md` with the new troubleshooting section and command references as part of this change.