### PR TITLE
feat(actions): surface what each action matches on the actions list

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -28,6 +28,14 @@ snapshots:
         hash: v1.k794b7964.b0c1c0b0b8d1a0c77cd873a1cc0b391924cd64ff7de46b1b4d309a50d98eca8a.ddWvJC0f1_fBpYhfDKtUrKeuZSrY5xR8ViHWVdiIfqk
     components-account-project-switcher--with-pending-invite--light:
         hash: v1.k794b7964.769ba5491bf515d4c18234cbb1b0965e4af8f190b5823914c8955194bb28d356.5QmxWM1jcZVZCAYm6oCJrI2XXnzoIHP19CyfFNvmiog
+    components-action-step-description--step-variants--dark:
+        hash: v1.k794b7964.19f9bee33652dbf2425e6df03ae732ed625840c249efc00589e0a1c0457b45d4.rVZ9Ek86XyAHV2eXwI_PDDTdDVv0QnEup4nMHmBjRKk
+    components-action-step-description--step-variants--light:
+        hash: v1.k794b7964.f91bca5d0440119473c64efa27f00ee07963ff9b1b2d14a783c694e2df79fc5b.rD9GMhkLfFVt7B2KYgR2LByMfDeX50mrHrKyLgu-oFY
+    components-action-step-description--summary-with-tooltip--dark:
+        hash: v1.k794b7964.6c5cd88f5aa3d41c98e0eeeff971b922bbccf36f60403a84b580a61f9aa29afb.rEnc5arM9Mv69K2iPjoLgoW7dy7xruBpLLXaYMZlyb0
+    components-action-step-description--summary-with-tooltip--light:
+        hash: v1.k794b7964.3bce9d23f964dddb8aa880ac92507478730c02653598580c051d620f99eaaf65.HeFECSKIWtxNuvm1I3nU8WsJfXcgS2PMRcDfMf9eOZU
     components-activitylog--data-management-activity--dark:
         hash: v1.k794b7964.f0e992490f5c3f9da065c404b4a0223d3d199b59436e3b0d244bd2b35a6bbe8c.-KxR1O9wEFHCZHlP-QJYheStDn9cQgtzbea9o2fS3sY
     components-activitylog--data-management-activity--light:
@@ -5651,9 +5659,9 @@ snapshots:
     scenes-app-data-management-actions--action--light:
         hash: v1.k794b7964.beb09296b4cd231bcc6b8067b8976e50e541095f18ec43f4523349ca0efc89a4.dEJitejN7lJT0FU6gQAaF5ydaZd_RGES2jbQNI4WuDw
     scenes-app-data-management-actions--actions-list--dark:
-        hash: v1.k794b7964.ca9dc87e9b047b9517ae4b695afdd1a870dcdbe9a4236d3a338f28cbc5b6b0b2.aMImKzSqyTT0xMBsptP3VBcwhgJ70B-PycLb7JyBgOg
+        hash: v1.k794b7964.9f9b23bfb4431c3c1a5f881b171b8a25023f2dc0ef9e691e082984463a3c90f9.zRTh4Nciph_51htqF6G-W7dWAKfhZJieNI7gz5RnopI
     scenes-app-data-management-actions--actions-list--light:
-        hash: v1.k794b7964.fb167ebe3d37f3fe0edc13ee8dc9c7c3afa9aeceb909fe37c3a7e0823a0d99f8.K80gNN2Et9DhAoi3v2ojwsGNZtyXTppbS9XjdiUWR6A
+        hash: v1.k794b7964.4d0504ac873c3c206bbe5b25826e799db95d6d5135bdd0cadc2e90569978c7d3.E87ZnWHKbQXbovA8jqN1cp7GTqLVNZB74m6M2h-zxtU
     scenes-app-data-management-actions--new-action--dark:
         hash: v1.k794b7964.ba971e6b4e8a8e72c512b1edc53fc699eff7142f207aed6e1d22e4cc79d18c9c.WK1mMQL1L81fqQ7rDdXG0tr5I9kdtzLDkznyHOd7bN8
     scenes-app-data-management-actions--new-action--light:

--- a/products/actions/frontend/components/ActionsTable.tsx
+++ b/products/actions/frontend/components/ActionsTable.tsx
@@ -19,8 +19,8 @@ import { createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/column
 import { LemonTableLink } from 'lib/lemon-ui/LemonTable/LemonTableLink'
 import { Sorting } from 'lib/lemon-ui/LemonTable/sorting'
 import { LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable/types'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { stripHTTP } from 'lib/utils/url'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
@@ -35,8 +35,8 @@ import {
 } from '~/types'
 
 import { ACTIONS_PER_PAGE, actionsLogic } from '../logics/actionsLogic'
+import { ActionStepConditions, ActionStepSummary } from '../utils/actionStepDescription'
 import { deleteActionWithWarning } from '../utils/deleteAction'
-import { SCREEN_NAME_MATCHING_LABEL, type ScreenNameMatching, isScreenNameFilter } from '../utils/screenName'
 import { NewActionButton } from './NewActionButton'
 
 export function ActionsTable(): JSX.Element {
@@ -108,75 +108,18 @@ export function ActionsTable(): JSX.Element {
             title: 'Type',
             key: 'type',
             render: function RenderType(_, action: ActionType): JSX.Element {
+                if (!action.steps?.length) {
+                    return <i>Empty – set this action up</i>
+                }
                 return (
                     <span>
-                        {action.steps?.length ? (
-                            action.steps.map((step, index) => (
-                                <div key={index}>
-                                    {(() => {
-                                        let url = stripHTTP(step.url || '')
-                                        url = url.slice(0, 40) + (url.length > 40 ? '...' : '')
-                                        switch (step.event) {
-                                            case '$autocapture':
-                                                return 'Autocapture'
-                                            case '$pageview':
-                                                switch (step.url_matching) {
-                                                    case 'regex':
-                                                        return (
-                                                            <>
-                                                                Page view URL matches regex <strong>{url}</strong>
-                                                            </>
-                                                        )
-                                                    case 'exact':
-                                                        return (
-                                                            <>
-                                                                Page view URL matches exactly <strong>{url}</strong>
-                                                            </>
-                                                        )
-                                                    default:
-                                                        return (
-                                                            <>
-                                                                Page view URL contains <strong>{url}</strong>
-                                                            </>
-                                                        )
-                                                }
-                                            case '$screen': {
-                                                const screenFilter = step.properties?.find(isScreenNameFilter)
-                                                if (screenFilter && 'value' in screenFilter && screenFilter.value) {
-                                                    const operator =
-                                                        'operator' in screenFilter
-                                                            ? (screenFilter.operator as ScreenNameMatching)
-                                                            : 'icontains'
-                                                    return (
-                                                        <>
-                                                            Screen name {SCREEN_NAME_MATCHING_LABEL[operator]}{' '}
-                                                            <strong>
-                                                                {Array.isArray(screenFilter.value)
-                                                                    ? screenFilter.value.join(', ')
-                                                                    : String(screenFilter.value)}
-                                                            </strong>
-                                                        </>
-                                                    )
-                                                }
-                                                return 'Mobile screen'
-                                            }
-                                            case '':
-                                            case null:
-                                            case undefined:
-                                                return 'Any event'
-                                            default:
-                                                return (
-                                                    <>
-                                                        Event: <strong>{step.event}</strong>
-                                                    </>
-                                                )
-                                        }
-                                    })()}
+                        {action.steps.map((step, index) => (
+                            <Tooltip key={index} title={<ActionStepConditions step={step} />} placement="right">
+                                <div className="w-fit">
+                                    <ActionStepSummary step={step} />
                                 </div>
-                            ))
-                        ) : (
-                            <i>Empty – set this action up</i>
-                        )}
+                            </Tooltip>
+                        ))}
                     </span>
                 )
             },

--- a/products/actions/frontend/utils/actionStepDescription.stories.tsx
+++ b/products/actions/frontend/utils/actionStepDescription.stories.tsx
@@ -1,0 +1,127 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+
+import { ActionStepType } from '~/types'
+
+import { ActionStepConditions, ActionStepSummary } from './actionStepDescription'
+
+const meta: Meta<typeof ActionStepSummary> = {
+    title: 'Components/Action Step Description',
+    component: ActionStepSummary,
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    'How a single action step is described on the actions list. `ActionStepSummary` is the one-line, scannable label shown in the Type column — autocapture steps carry their most identifying detail (text, else selector, else link) so the list is not a wall of "Autocapture". `ActionStepConditions` is the full breakdown shown in the hover tooltip.',
+            },
+        },
+    },
+    tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj<typeof ActionStepSummary>
+
+const VARIANTS: { label: string; step: ActionStepType }[] = [
+    {
+        label: 'Autocapture — text',
+        step: { event: '$autocapture', text: 'Sign up', text_matching: 'exact' },
+    },
+    {
+        label: 'Autocapture — selector only',
+        step: { event: '$autocapture', selector: 'button.signup-btn' },
+    },
+    {
+        label: 'Autocapture — link (href) only',
+        step: { event: '$autocapture', href: 'https://posthog.com/pricing', href_matching: 'contains' },
+    },
+    {
+        label: 'Autocapture — text + selector + property filter',
+        step: {
+            event: '$autocapture',
+            text: 'Buy now',
+            text_matching: 'exact',
+            selector: 'div.pricing button.cta',
+            properties: [{ key: '$current_url', value: '/pricing', operator: 'icontains', type: 'event' }] as any,
+        },
+    },
+    {
+        label: 'Autocapture — no identifying detail',
+        step: { event: '$autocapture' },
+    },
+    {
+        label: 'Page view — URL contains',
+        step: { event: '$pageview', url: 'posthog.com/pricing', url_matching: 'contains' },
+    },
+    {
+        label: 'Page view — URL matches regex',
+        step: { event: '$pageview', url: 'posthog\\.com/blog/.*', url_matching: 'regex' },
+    },
+    {
+        label: 'Mobile screen — screen name',
+        step: {
+            event: '$screen',
+            properties: [{ key: '$screen_name', value: 'HomeScreen', operator: 'exact', type: 'event' }] as any,
+        },
+    },
+    {
+        label: 'Custom event',
+        step: { event: 'purchase_completed' },
+    },
+    {
+        label: 'Any event',
+        step: { event: null },
+    },
+]
+
+export const StepVariants: Story = {
+    render: () => (
+        <div className="flex flex-col gap-2 max-w-4xl">
+            <div className="flex items-center gap-4 text-xs font-semibold text-secondary">
+                <span className="w-64 shrink-0">Step</span>
+                <span className="w-72 shrink-0">Summary (Type column)</span>
+                <span>Conditions (hover tooltip)</span>
+            </div>
+            {VARIANTS.map(({ label, step }) => (
+                <div key={label} className="flex items-start gap-4 border rounded p-2 bg-surface-primary">
+                    <span className="text-xs text-secondary w-64 shrink-0">{label}</span>
+                    <div className="w-72 shrink-0">
+                        <ActionStepSummary step={step} />
+                    </div>
+                    <div className="text-xs">
+                        <ActionStepConditions step={step} />
+                    </div>
+                </div>
+            ))}
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'Left: the one-line summary rendered in the Type column. Right: the full condition breakdown that appears in the hover tooltip, shown inline here so it is visible without hovering.',
+            },
+        },
+    },
+}
+
+export const SummaryWithTooltip: Story = {
+    render: () => (
+        <div className="flex flex-col gap-2 max-w-2xl">
+            <span className="text-xs text-secondary">Hover a row to see the full conditions tooltip.</span>
+            {VARIANTS.map(({ label, step }) => (
+                <Tooltip key={label} title={<ActionStepConditions step={step} />} placement="right">
+                    <div className="w-fit border rounded p-2 bg-surface-primary">
+                        <ActionStepSummary step={step} />
+                    </div>
+                </Tooltip>
+            ))}
+        </div>
+    ),
+    parameters: {
+        docs: {
+            description: {
+                story: 'The exact interaction used on the actions list: the summary is the trigger, hovering reveals the conditions breakdown.',
+            },
+        },
+    },
+}

--- a/products/actions/frontend/utils/actionStepDescription.tsx
+++ b/products/actions/frontend/utils/actionStepDescription.tsx
@@ -1,0 +1,151 @@
+import { genericOperatorToHumanName, propertyValueToHumanName } from 'lib/components/DefinitionPopover/utils'
+import { stripHTTP } from 'lib/utils/url'
+
+import { ActionStepType } from '~/types'
+
+import { SCREEN_NAME_MATCHING_LABEL, type ScreenNameMatching, isScreenNameFilter } from './screenName'
+
+const MAX_INLINE_LENGTH = 40
+
+function truncate(value: string): string {
+    return value.length > MAX_INLINE_LENGTH ? value.slice(0, MAX_INLINE_LENGTH) + '…' : value
+}
+
+function stringMatchingVerb(matching?: string | null): string {
+    return matching === 'regex' ? 'matches regex' : matching === 'exact' ? 'equals' : 'contains'
+}
+
+/** The single most recognizable detail of an autocapture step: its text, else selector, else link. */
+function autocaptureIdentifier(step: ActionStepType): JSX.Element | null {
+    if (step.text) {
+        return (
+            <>
+                “<strong>{truncate(step.text)}</strong>”
+            </>
+        )
+    }
+    if (step.selector) {
+        return <strong className="font-mono">{truncate(step.selector)}</strong>
+    }
+    if (step.href) {
+        return (
+            <>
+                link <strong className="font-mono">{truncate(stripHTTP(step.href))}</strong>
+            </>
+        )
+    }
+    return null
+}
+
+/**
+ * One-line, scannable summary of a single action step for the actions list. Autocapture steps carry
+ * their most identifying detail inline so a list of them isn't just a wall of "Autocapture".
+ */
+export function ActionStepSummary({ step }: { step: ActionStepType }): JSX.Element {
+    switch (step.event) {
+        case '$autocapture': {
+            const identifier = autocaptureIdentifier(step)
+            return identifier ? <>Autocapture on {identifier}</> : <>Autocapture</>
+        }
+        case '$pageview': {
+            const url = truncate(stripHTTP(step.url || ''))
+            const label =
+                step.url_matching === 'regex'
+                    ? 'Page view URL matches regex'
+                    : step.url_matching === 'exact'
+                      ? 'Page view URL matches exactly'
+                      : 'Page view URL contains'
+            return (
+                <>
+                    {label} <strong>{url}</strong>
+                </>
+            )
+        }
+        case '$screen': {
+            const screenFilter = step.properties?.find(isScreenNameFilter)
+            if (screenFilter && 'value' in screenFilter && screenFilter.value) {
+                const operator =
+                    'operator' in screenFilter ? (screenFilter.operator as ScreenNameMatching) : 'icontains'
+                return (
+                    <>
+                        Screen name {SCREEN_NAME_MATCHING_LABEL[operator]}{' '}
+                        <strong>
+                            {Array.isArray(screenFilter.value)
+                                ? screenFilter.value.join(', ')
+                                : String(screenFilter.value)}
+                        </strong>
+                    </>
+                )
+            }
+            return <>Mobile screen</>
+        }
+        case '':
+        case null:
+        case undefined:
+            return <>Any event</>
+        default:
+            return (
+                <>
+                    Event: <strong>{step.event}</strong>
+                </>
+            )
+    }
+}
+
+function Mono({ children }: { children: React.ReactNode }): JSX.Element {
+    return <span className="font-mono">{children}</span>
+}
+
+/**
+ * Full breakdown of every condition in a step, for the hover tooltip on the actions list. Surfaces the
+ * selector / text / href / url / property filters that the one-line summary can't fit.
+ */
+export function ActionStepConditions({ step }: { step: ActionStepType }): JSX.Element {
+    const conditions: JSX.Element[] = []
+    if (step.selector) {
+        conditions.push(
+            <li key="sel">
+                Element matches CSS selector <Mono>{step.selector}</Mono>
+            </li>
+        )
+    }
+    if (step.text) {
+        conditions.push(
+            <li key="text">
+                Text {stringMatchingVerb(step.text_matching)} <Mono>{step.text}</Mono>
+            </li>
+        )
+    }
+    if (step.href) {
+        conditions.push(
+            <li key="href">
+                Link href {stringMatchingVerb(step.href_matching)} <Mono>{step.href}</Mono>
+            </li>
+        )
+    }
+    if (step.url) {
+        conditions.push(
+            <li key="url">
+                URL {stringMatchingVerb(step.url_matching)} <Mono>{step.url}</Mono>
+            </li>
+        )
+    }
+    step.properties?.forEach((property, index) => {
+        if ('key' in property) {
+            conditions.push(
+                <li key={`property-${index}`}>
+                    <Mono>{property.key}</Mono> {genericOperatorToHumanName(property)}{' '}
+                    <Mono>{propertyValueToHumanName(property.value)}</Mono>
+                </li>
+            )
+        }
+    })
+    return (
+        <div className="flex flex-col gap-1">
+            <div>
+                <ActionStepSummary step={step} />
+            </div>
+            {conditions.length > 0 && <ul className="list-disc pl-4 space-y-0.5 text-secondary">{conditions}</ul>}
+        </div>
+    )
+}


### PR DESCRIPTION
## Problem

From the actions index (`/data-management/actions`) it's very hard to tell what an action actually does. The Type column already summarizes `$pageview` and named-event steps, but for `$autocapture` steps — the most common and least self-explanatory kind — it just printed the word "Autocapture" with none of the discriminating detail, so a list of autocapture actions reads as an undifferentiated wall of "Autocapture".

Raised in a Slack thread.

## Changes

- Autocapture steps now show their most identifying detail inline: the element text, else the CSS selector, else the link — e.g. *Autocapture on "Sign up"* or *Autocapture on `button.signup`*.
- Hovering any step reveals a tooltip with the full condition breakdown (selector / text / href / url / property filters), reusing the same human-readable phrasing used elsewhere in the app.
- Extracted the step → summary rendering out of `ActionsTable` into a shared `actionStepDescription` helper (summary + conditions), so the logic lives in one place. Existing `$pageview` / `$screen` / named-event / empty phrasings are preserved.

No API or backend changes.

## How did you test this code?

Not able to run the frontend typecheck/linters or the app in this environment (no `node_modules` in the working checkout). Changes were verified by inspection against the existing component patterns and the reused helper signatures. No automated tests were added; a reviewer running the frontend locally should confirm the Type column rendering and tooltip.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app agent from a Slack thread. The requester picked the approach (enrich the inline summary + full detail on hover) from a few options offered. No repo skills applied to this change. The main implementation decision was to render the tooltip detail with Lemon-friendly markup in a product-local helper rather than importing the quill-coupled `ActionMatchGroups` component into the LemonTable, avoiding mixing quill and Lemon inside one component.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1784944143863349?thread_ts=1784944143.863349&cid=C0ACRAMJUAG)*
