### PR TITLE
fix(data-warehouse): guide users when an OAuth source connection fails

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -3328,7 +3328,7 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                     source_type: source,
                 })
             } else {
-                lemonToast.error(`Something went wrong.`)
+                lemonToast.error(`Couldn't finish connecting your source. Please try again, and if it keeps happening contact support.`)
             }
         },
         submitSourceConnectionDetailsSuccess: () => {

--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceWizardLogic.tsx
@@ -3328,7 +3328,9 @@ export const sourceWizardLogic = kea<sourceWizardLogicType>([
                     source_type: source,
                 })
             } else {
-                lemonToast.error(`Couldn't finish connecting your source. Please try again, and if it keeps happening contact support.`)
+                lemonToast.error(
+                    `Couldn't finish connecting your source. Please try again, and if it keeps happening contact support.`
+                )
             }
         },
         submitSourceConnectionDetailsSuccess: () => {


### PR DESCRIPTION
## Problem

In the data-warehouse new-source wizard, when an OAuth provider redirected back with a `source` value the frontend couldn't match to a known connector, the wizard surfaced a bare `Something went wrong.` toast. It reports that a failure happened but gives no context and no next step, so users are left stuck at the end of an OAuth round-trip with no idea how to recover.

## Changes

Replace the bare error with a message that says what happened and points to the next action, following the house rule that errors should guide rather than dead-end:

> Couldn't finish connecting your source. Please try again, and if it keeps happening contact support.

No behavior change beyond the copy: the same branch fires in the same conditions.

## How did you test this code?

No manual/browser testing was performed by the agent. Change is a single user-facing string in an existing error branch; `oxlint` passes on the touched file. The surrounding logic is unchanged.

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Change identified while reviewing friction in the data-warehouse new-source onboarding flow: several OAuth-based source connections ended on a generic error with no recovery guidance. Scoped the fix to the one clearly-generic dead-end message in `sourceWizardLogic`'s `handleRedirect` handler. Considered broader error-copy changes (per-connector credential validation messages) but rejected them as a systemic framework default better fixed at the scaffold level rather than cherry-picked. Invoked the `/writing-user-facing-copy` skill to shape the replacement copy (sentence case, states what happened, points to a next step, no em-dash).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
