### PR TITLE
fix(mcp-analytics): let the live activity feed fill the activity tab row

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6434,6 +6434,10 @@ snapshots:
         hash: v1.k794b7964.4d75bf1926fdf1fdebad47ad4fd07f4035634bca040c9aeb0fd58e18adaa4fb4.3sBwvXuvVbhUPQY3T9JG4G3LwQL6Tvv_a22YYhQJifo
     scenes-app-marketing-analytics-cell-actions--source-cell-action-unmapped--light:
         hash: v1.k794b7964.c15b997111d34fb17ad2dd192b97c01d0a7ab3a320c5edf9a3e20b0b63a4ff9b.UHxcXJdZkFGXRnzIMFWO99QMD_gZm0V47g8f1j4OFS0
+    scenes-app-mcp-analytics--activity--dark:
+        hash: v1.k794b7964.0a9b801eadb1b5b60d7a98d7e0336a6d5d9f53c045bbead971088c05b43ee3e3.twQut9LuFQOHpJjKr1otu72YMQpA8Yz84kCkbjzkjw4
+    scenes-app-mcp-analytics--activity--light:
+        hash: v1.k794b7964.8d97d605756fbd44be89c7b26d468b5e35e6a8175a99a9962cda0e1eda218e0b.2Jm7BC29mrDfx__vZqOpQnb5D56Ldd4_kJdML6geR0k
     scenes-app-mcp-analytics--dashboard--dark:
         hash: v1.k794b7964.05490a43bcb92252f0270f3302f92f2ef896f9373e9a832e2a166714f4ea9e9d.hZfs_sWw_pq-GRMv5LKpUxYktqR8xoniQdom5iIW7Xw
     scenes-app-mcp-analytics--dashboard--light:

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboard.stories.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboard.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react'
 
 import { FEATURE_FLAGS } from 'lib/constants'
+import { dayjs } from 'lib/dayjs'
 import { App } from 'scenes/App'
 import { urls } from 'scenes/urls'
 
@@ -313,6 +314,143 @@ const CLUSTER_SNAPSHOT = {
     ],
 }
 
+// [tool, intent, durationMs, client, errorMessage]
+const ACTIVITY_CALLS: [string, string | null, number | null, string, string | null][] = [
+    [
+        'feature-flag-get-all',
+        'Searching PROD feature flags for scope-related keys as a broader sanity check.',
+        174,
+        '',
+        null,
+    ],
+    [
+        'switch-project',
+        'Switching to the PROD project to cross-check the participant scope config flag.',
+        154,
+        '',
+        null,
+    ],
+    ['execute-sql', 'Corroborate homepage INP p75 with its actual seven-day sample count.', 772, '', null],
+    [
+        'session-recording-summarize',
+        "Verify whether the candidate's staff-route activity exposed protected content.",
+        88000,
+        '',
+        null,
+    ],
+    [
+        'read-data-schema',
+        'Locate existing background prefetch events for the post-deployment smoke check.',
+        601,
+        '',
+        null,
+    ],
+    ['exec', 'Signals scout run: discover durable-memory write tool.', null, '', null],
+    ['logs-services-create', 'Checking whether backend log services could corroborate a failed signup.', 274, '', null],
+    [
+        'exec',
+        'Learning read-data-schema tool schema to discover available events and properties.',
+        2,
+        'claude-code',
+        null,
+    ],
+    ['exec', 'Learning execute-sql tool schema to run custom queries for adoption metrics.', 1, 'claude-code', null],
+    [
+        'scout-scratchpad-search',
+        'Retrieve the full coverage map before refreshing the player-refresh watchpoint.',
+        47,
+        '',
+        null,
+    ],
+    [
+        'read-data-schema',
+        'Verify the captured Web Vitals property for homepage INP sample counting.',
+        517,
+        'claude-code',
+        null,
+    ],
+    ['query-trends', 'Chart weekly active agents to see whether adoption is still climbing.', 1320, 'cursor', null],
+    [
+        'insight-create',
+        'Save the retention breakdown so the team can track it without re-querying.',
+        940,
+        'cursor',
+        null,
+    ],
+    [
+        'cohort-create',
+        'Build a cohort of agents that hit an error in their first session.',
+        1620,
+        'claude-ai',
+        'Cohort name already exists in this project',
+    ],
+    ['dashboard-create', 'Assemble the adoption dashboard from the insights created earlier.', 1180, 'claude-ai', null],
+    ['execute-sql', 'Break down tool errors by client to find which harness fails most.', 3525, 'posthog-cli', null],
+    [
+        'feature-flag-list',
+        'Audit which flags are still referenced before proposing cleanups.',
+        510,
+        'posthog-cli',
+        null,
+    ],
+    ['query-trends', 'Compare this week against last to confirm the drop is not seasonal.', 2122, '', null],
+    [
+        'exec',
+        'Retry the durable-memory write now that the schema is known.',
+        30000,
+        'windsurf',
+        'Tool timed out after 30s',
+    ],
+    ['read-data-schema', 'Final schema sweep to confirm no event was missed in the audit.', 380, '', null],
+]
+
+const ACTIVITY_OVERVIEW = {
+    // A project still under the ~300-call metrics gate, which is who lands on this tab.
+    stats: {
+        total_calls: 284,
+        distinct_tools: 9,
+        distinct_sessions: 23,
+        distinct_clients: 6,
+        calls_with_intent: 236,
+        error_calls: 12,
+        missing_capability_reports: 7,
+    },
+    // Top 5 of 9 tools, so these sum under total_calls; their errors sum to error_calls.
+    top_tools: [
+        { tool: 'exec', calls: 96, errors: 5 },
+        { tool: 'execute-sql', calls: 64, errors: 4 },
+        { tool: 'read-data-schema', calls: 43, errors: 1 },
+        { tool: 'query-trends', calls: 31, errors: 1 },
+        { tool: 'insight-create', calls: 22, errors: 1 },
+    ],
+    // Sums to stats.total_calls, so the card agrees with the summary line above it.
+    clients: [
+        { client: '', calls: 148 },
+        { client: 'claude-code', calls: 71 },
+        { client: 'cursor', calls: 33 },
+        { client: 'claude-ai', calls: 18 },
+        { client: 'posthog-cli', calls: 9 },
+        { client: 'windsurf', calls: 5 },
+    ],
+    recent_calls: ACTIVITY_CALLS.map(([tool, intent, duration_ms, client_name, error_message], index) => ({
+        // Spaced off the story's mockDate so the relative "when" column stays deterministic.
+        timestamp: dayjs('2026-06-07T12:00:00Z')
+            .subtract(index * 37, 'second')
+            .toISOString(),
+        tool,
+        intent,
+        is_error: error_message !== null,
+        error_message,
+        duration_ms,
+        client_name,
+    })),
+}
+
+const INTENT_DIGEST = {
+    digest: 'Agents are extensively analyzing and validating feature flags, especially participant and scope-related flags, across multiple projects to ensure correct configuration and deployment. They are investigating user behavior, event schemas, and telemetry to support product analytics, adoption, and revenue reporting, and to diagnose issues such as interface unresponsiveness, conversion tracking failures, and LLM-related errors. Additionally, they are auditing dashboards, saved insights, and survey data to verify data freshness and rebuild product usage metrics.',
+    intent_count: 100,
+}
+
 const meta: Meta = {
     component: App,
     title: 'Scenes-App/MCP Analytics',
@@ -320,6 +458,7 @@ const meta: Meta = {
         mswDecorator({
             get: {
                 '/api/projects/:team_id/mcp_analytics/intent_clusters/': CLUSTER_SNAPSHOT,
+                '/api/projects/:team_id/mcp_analytics/sessions/activity_overview/': ACTIVITY_OVERVIEW,
                 '/api/environments/:team_id/mcp_analytics/sessions/': SESSION_LIST,
                 '/api/environments/:team_id/mcp_analytics/sessions/:session_id/tool_calls/': TOOL_CALL_LIST,
                 '/api/projects/:team_id/property_definitions': ({ request }) => {
@@ -333,6 +472,8 @@ const meta: Meta = {
                 ],
             },
             post: {
+                // POST, not GET — the endpoint generates the digest (and caches it) on call.
+                '/api/projects/:team_id/mcp_analytics/sessions/intent_digest/': INTENT_DIGEST,
                 '/api/environments/:team_id/query/:kind': async ({ request }) => {
                     const body = (await request.json()) as Record<string, any>
                     const query: string = body?.query?.query ?? ''
@@ -426,6 +567,15 @@ export const Dashboard: Story = {}
 export const DashboardWithMenuBar: Story = {
     parameters: {
         featureFlags: [FEATURE_FLAGS.MCP_ANALYTICS, FEATURE_FLAGS.SCENE_MENU_BAR],
+    },
+}
+
+// The default landing tab for low-volume projects. The feed mock carries the endpoint's full
+// 20-row cap so the feed overflows its viewport — the case where it has to scroll rather than
+// stretch the grid past the sidebar.
+export const Activity: Story = {
+    parameters: {
+        pageUrl: urls.mcpAnalyticsActivity(),
     },
 }
 

--- a/products/mcp_analytics/frontend/dashboard/Card.tsx
+++ b/products/mcp_analytics/frontend/dashboard/Card.tsx
@@ -19,7 +19,8 @@ export function Card({
                     <CardTitle>{title}</CardTitle>
                 </CardHeader>
             ) : null}
-            <CardContent className="flex flex-1 flex-col">{children}</CardContent>
+            {/* min-h-0 lets a height-constrained card's content shrink instead of overflowing the card's clip. */}
+            <CardContent className="flex flex-1 flex-col min-h-0">{children}</CardContent>
         </QuillCard>
     )
 }

--- a/products/mcp_analytics/frontend/earlyData/MCPAnalyticsEarlyData.tsx
+++ b/products/mcp_analytics/frontend/earlyData/MCPAnalyticsEarlyData.tsx
@@ -47,8 +47,11 @@ export function MCPAnalyticsActivityDashboard(): JSX.Element {
     return (
         <div className="flex flex-col gap-4" data-attr="mcp-analytics-activity">
             <SummaryCard />
-            <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
-                <div className="lg:col-span-3">
+            <div className="grid grid-cols-1 lg:grid-cols-4 gap-4 lg:min-h-[36rem]">
+                {/* Matched column heights are the goal: the sidebar sets the row height and the feed
+                    fills it. Taking the feed out of flow is what makes that one-directional — in
+                    flow its own row count would be the taller side and stretch the grid. */}
+                <div className="lg:relative lg:col-span-3">
                     <LiveActivityCard />
                 </div>
                 <div className="flex flex-col gap-4">
@@ -116,9 +119,10 @@ function LiveActivityCard(): JSX.Element {
     const { recentCalls, overviewLoading } = useValues(mcpEarlyDataLogic)
 
     return (
-        <Card title="Live activity" className="h-full" flush>
-            {/* Roughly the top 10 rows visible; the rest scroll. */}
-            <div className="max-h-[36rem] overflow-y-auto">
+        <Card title="Live activity" className="h-full lg:absolute lg:inset-0" flush>
+            {/* Fills the card so the feed ends where the sidebar does; the rest scrolls. Stacked
+                layouts have no sidebar to match, so they fall back to a fixed cap. */}
+            <div className="flex-1 min-h-0 max-h-[36rem] lg:max-h-none overflow-y-auto">
                 <LemonTable<EarlyRecentCall>
                     embedded
                     dataSource={recentCalls}


### PR DESCRIPTION
## Problem

On the MCP analytics Activity tab, the live activity feed stopped well short of the bottom of its own card. The right sidebar (AI digest + clients + checklist) set the height of the row, and the feed card stretched to match, but the table inside it stopped around 10 rows and left a large empty gap below.

The feed is the hero of this tab, so it should use as much of that height as it can, with the sidebar remaining the column that decides how tall the row is.

## Changes

Two constraints were fighting each other. The card stretched to the row height via `h-full`, but the scroll viewport inside it was content-sized under a fixed `max-h-[36rem]`. Once the sidebar grew past 36rem, the difference showed up as dead space: 528px of it at 1600px wide.

Matched column heights are the goal, so the sidebar sets the row height and the feed fills it.

- The feed column is taken out of flow at `lg+` (`lg:relative` on the column, `lg:absolute lg:inset-0` on the card). This is what makes the relationship one-directional. Simply dropping the cap would leave the feed at its natural height and the sidebar short, which removes the dead space but gives up the matched heights.
- The scroll viewport is `flex-1 min-h-0` so it fills whatever height the row gives it. Below `lg` there is no sidebar to match, so the `36rem` cap still applies (`lg:max-h-none`).
- `min-h-0` on the shared `Card` content box. Without it the content box will not shrink under its own children, so the viewport rendered taller than the card and rows were silently clipped by the card's `overflow: hidden`, with no way to scroll to them. I hit exactly this on the first attempt and the measurements caught it.

Before, 576px viewport in an 1104px card:

![before](https://raw.githubusercontent.com/PostHog/pr-assets/49a06d896eed17aa1cd29789214bbed3d9b7eef7/2026/07/db4cbf4b-71fa-4fda-9bc1-7640acd3cd08.png)

After, 1059px viewport in the same 1104px card, ending level with the sidebar:

![after](https://raw.githubusercontent.com/PostHog/pr-assets/93feb34370f42c47d80348f76261f11a612c0e19/2026/07/9b3afe75-32a3-4a67-bc99-249e785cb178.png)

> [!NOTE]
> `min-h-0` lands on the shared `products/mcp_analytics/frontend/dashboard/Card.tsx`, so it applies to every card in this product. `min-height: 0` only relaxes a floor, so with nothing pushing down it cannot change rendered height. Every current call site is grid- or flex-stretched rather than height-constrained, so today it only takes effect on this feed. Flagging it because it is the widest-reaching line in the diff.

## How did you test this code?

The Activity tab had no Storybook story, so I added one. Its mock carries the endpoint's full 20-row `recent_calls` cap, which is what makes the feed overflow its viewport and exercises the scrolling path rather than the comfortable one.

I did not test this against a real project with live data. Everything below is Storybook plus scripted measurement of the rendered boxes, run by me (Claude) via Playwright against the new story:

| Case | Card | Feed viewport | Result |
| --- | --- | --- | --- |
| Desktop 1600px, before | 1104px | 576px | 528px dead space |
| Desktop 1600px, after | 1104px | 1059px | 45px, exactly header + padding |
| Stacked 900px | 621px | 576px | 36rem cap holds, scrolls |
| Short sidebar (911px row) | 911px | 866px | feed tracks the sidebar down |

In every after-case the content is taller than the viewport, the viewport scrolls, and nothing is clipped. Automated suites: `jest products/mcp_analytics` 155 passed, `tsgo --noEmit` clean, `hogli ci:preflight --strict` clean.

Not covered: the near-empty feed under a tall sidebar. I checked it renders sensibly, and it is unchanged by this PR (the blank space simply moves from below the viewport to inside it) but it is inherent to matched-height columns.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change. This is a layout fix with no user-facing copy or API surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, via PostHog Code) wrote this from a screenshot of the bug. The work was mostly diagnosis: the first fix looked correct and was worse, rendering a 1238px viewport inside an 1188px card so rows were unreachable behind the card's clip. Measuring the boxes rather than eyeballing screenshots is what caught it and led to the `min-h-0` root cause.

`codex review` is my usual pre-PR gate but was out of quota, so I ran a Claude `code-reviewer` subagent instead. It independently verified the `min-h-0` blast radius by auditing every `Card` call site and measuring a two-stretched-cards case, and confirmed the layout claims with its own headless repro. Acted on its findings: dropped a redundant wrapper div it proved was a no-op (measured byte-identical without it), shortened an over-long comment, and fixed three mock-data inconsistencies (top-level errors exceeding the total, a 31ms call labelled a 30s timeout, and call volumes that put the project above the metrics gate this tab exists below). It also argued for simply dropping the cap; I kept the height-matching approach because matched columns are the actual request here, and recorded that tradeoff in the commit message rather than leaving it implicit.

One deliberate scope call: the story mock started out mirroring real figures and client names from the reporting screenshot. Since this repo is public I replaced them with synthetic values that sum consistently to the summary line.

No skills applied here beyond the repo conventions in CLAUDE.md.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
