### PR TITLE
perf(replay): run each scrub on its own inference worker

### DIFF
--- a/Dockerfile.ml-mirror-image-scrub
+++ b/Dockerfile.ml-mirror-image-scrub
@@ -53,16 +53,22 @@ RUN groupadd -g 10001 posthog && \
 
 # Native pools are bounded so they cannot oversubscribe a CPU-limited pod. sharp is pinned to one
 # thread per operation at module load in src/blur.ts (sharp.concurrency(1) + cache(false), imported
-# by every scrub path), and OpenMP likewise; ORT sizes its per-session pool from the cgroup quota
-# (src/cores.ts) because onnxruntime-node's run is synchronous, so only one inference executes at a
-# time however many requests are in flight.
+# by every scrub path), and OpenMP likewise. ORT is sized in src/cores.ts as cores/SCRUB_WORKERS,
+# since onnxruntime-node's run blocks its thread: each worker runs one inference at a time, so it is
+# threads times workers that has to fit the quota. With one worker per core that lands on 1 each.
 ENV OMP_NUM_THREADS=1
 
 # libuv reads this when it first creates its thread pool and never resizes, which happens before any
-# entry-module code under a loader like tsx, so it cannot be set from JS. Every sharp operation is
-# queued onto this pool, so it wants to cover IMAGE_SCRUB_CONCURRENCY in-flight requests rather than
-# the libuv default of 4. Keep the two in step if either changes.
+# entry-module code under a loader like tsx, so it cannot be set from JS. The pool is process-wide
+# and shared by every worker thread, and each worker's sharp stages queue onto it, so size it by
+# SCRUB_WORKERS (one core per worker) rather than by request concurrency. Below the worker count the
+# sharp stages re-serialise on a pod with more cores than this.
 ENV UV_THREADPOOL_SIZE=8
+
+# Each worker loads its own three ONNX sessions, zxing wasm module and V8 isolate, because sessions
+# cannot be shared across isolates. Memory therefore scales with SCRUB_WORKERS, which defaults to the
+# core count: size the pod's memory limit against cores, not against a single process, or a
+# many-core node OOM-kills the sidecar into a crash loop. Set SCRUB_WORKERS to cap it explicitly.
 
 # Prove at build time that the models parse, the native/wasm runtimes load, and a scrub runs end to
 # end — a broken model download or prebuilt-binary mismatch fails the image build, not the deploy.

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/cores.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/cores.ts
@@ -9,6 +9,23 @@ const ORT_THREADS_MAX = 32
 /** Assumed allotment when no quota is readable. Small on purpose: see the fallback in containerCores. */
 const NO_QUOTA_CORES = 4
 
+/** Enough to cover any pod this lane is deployed on; guards a bad env value from forking hundreds. */
+const SCRUB_WORKERS_MAX = 32
+
+/**
+ * Inference worker threads, one per core by default.
+ *
+ * onnxruntime-node's `run` blocks the thread that calls it, so a single-threaded process can only
+ * ever have one inference executing however many requests are in flight. A thread each is what
+ * converts cores into concurrent scrubs.
+ */
+export const SCRUB_WORKERS = numFromEnv(
+    'SCRUB_WORKERS',
+    Math.min(SCRUB_WORKERS_MAX, containerCores()),
+    1,
+    SCRUB_WORKERS_MAX
+)
+
 /**
  * Intra-op threads for every ONNX session, defined once so the three models cannot drift apart.
  *
@@ -16,13 +33,16 @@ const NO_QUOTA_CORES = 4
  * an unclamped `containerCores()` above the ceiling would throw at module load and refuse to start
  * the sidecar, which is reachable whenever there is no quota to read and the host is large.
  *
- * Sized to the whole allotment because onnxruntime-node's `run` is synchronous (verified against
- * v1.27.0: `js/node/lib/backend.ts` calls the native `run` inside `setImmediate`, and
- * `inference_session_wrap.h` declares only a `[sync]` Run), so inferences cannot overlap and exactly
- * one executes at a time. Divide this by the number of concurrent inferences if that stops being
- * true, whether by an upstream `RunAsync` or by moving inference onto worker threads.
+ * Divided by the worker count because each worker runs its own inference concurrently with the
+ * others, so the per-session pools multiply. Threads times workers is what has to fit the allotment:
+ * exceeding it is paid back as CFS throttling, which is the cost this sizing exists to avoid.
  */
-export const ORT_THREADS = numFromEnv('ORT_THREADS', Math.min(ORT_THREADS_MAX, containerCores()), 1, ORT_THREADS_MAX)
+export const ORT_THREADS = numFromEnv(
+    'ORT_THREADS',
+    Math.min(ORT_THREADS_MAX, Math.max(1, Math.floor(containerCores() / SCRUB_WORKERS))),
+    1,
+    ORT_THREADS_MAX
+)
 
 /**
  * Cores this process may actually use, as opposed to the ones it can see.

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/fake-scrub-worker.mjs
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/fake-scrub-worker.mjs
@@ -14,9 +14,13 @@ parentPort.on('message', async (job) => {
         parentPort.postMessage({ id: job.id, failure: { message: 'bad bytes', undecodable: true } })
         return
     }
-    // Long enough that a pool running jobs serially takes visibly longer than one running them at once.
-    const jobMs = 40
-    await new Promise((resolve) => setTimeout(resolve, jobMs))
+    // Reports its own interval so the test can assert overlap directly rather than inferring
+    // concurrency from total elapsed time, which turns into a flake on a loaded runner.
+    const startedAt = performance.now()
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    const finishedAt = performance.now()
     const out = new Uint8Array(Buffer.from(`done:${kind}:w${workerData.index}`))
-    parentPort.postMessage({ id: job.id, out, timings: { totalMs: jobMs } }, [out.buffer])
+    parentPort.postMessage({ id: job.id, out, timings: { totalMs: finishedAt - startedAt, startedAt, finishedAt } }, [
+        out.buffer,
+    ])
 })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/fake-scrub-worker.mjs
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/fake-scrub-worker.mjs
@@ -19,10 +19,15 @@ parentPort.on('message', async (job) => {
     const startedAt = performance.now()
     await new Promise((resolve) => setTimeout(resolve, 25))
     const finishedAt = performance.now()
-    const out = new Uint8Array(Buffer.from(`done:${kind}:w${workerData.index}`))
-    parentPort.postMessage({ id: job.id, out, timings: { totalMs: finishedAt - startedAt, startedAt, finishedAt } }, [
-        out.buffer,
-    ])
+    // Buffer.from(string) under 4 KiB comes out of Node's shared pool, which is the BLANK_PNG shape:
+    // the backing ArrayBuffer is 8 KiB and is not transferable.
+    const out =
+        kind === 'pooled-buffer'
+            ? Buffer.from('blank')
+            : new Uint8Array(Buffer.from(`done:${kind}:w${workerData.index}`))
+    // No transfer list, mirroring the real worker: a pool-backed ArrayBuffer cannot be transferred,
+    // and attempting it would throw here rather than exercising the path under test.
+    parentPort.postMessage({ id: job.id, out, timings: { totalMs: finishedAt - startedAt, startedAt, finishedAt } })
     if (kind === 'die-when-idle') {
         // Answers first, then dies holding no job: the pool has nothing to fail and has to notice
         // the loss on its own. Replacements get a different kind, so they stay healthy.

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/fake-scrub-worker.mjs
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/fake-scrub-worker.mjs
@@ -23,4 +23,9 @@ parentPort.on('message', async (job) => {
     parentPort.postMessage({ id: job.id, out, timings: { totalMs: finishedAt - startedAt, startedAt, finishedAt } }, [
         out.buffer,
     ])
+    if (kind === 'die-when-idle') {
+        // Answers first, then dies holding no job: the pool has nothing to fail and has to notice
+        // the loss on its own. Replacements get a different kind, so they stay healthy.
+        setTimeout(() => process.exit(11), 5)
+    }
 })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/fake-scrub-worker.mjs
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/fake-scrub-worker.mjs
@@ -1,0 +1,22 @@
+// Stand-in worker for pool.test.ts: speaks the same protocol without loading any model. Plain .mjs
+// so spawning it needs no TypeScript loader, which keeps the test measuring the pool rather than the
+// runner. The input bytes select the behaviour.
+import { parentPort, workerData } from 'node:worker_threads'
+
+parentPort.postMessage({ ready: true })
+
+parentPort.on('message', async (job) => {
+    const kind = Buffer.from(job.input).toString()
+    if (kind === 'crash') {
+        process.exit(7)
+    }
+    if (kind === 'undecodable') {
+        parentPort.postMessage({ id: job.id, failure: { message: 'bad bytes', undecodable: true } })
+        return
+    }
+    // Long enough that a pool running jobs serially takes visibly longer than one running them at once.
+    const jobMs = 40
+    await new Promise((resolve) => setTimeout(resolve, jobMs))
+    const out = new Uint8Array(Buffer.from(`done:${kind}:w${workerData.index}`))
+    parentPort.postMessage({ id: job.id, out, timings: { totalMs: jobMs } }, [out.buffer])
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/main.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/main.ts
@@ -5,6 +5,10 @@ import { ScrubMetrics } from './metrics.ts'
 import { startPool } from './pool.ts'
 import { startServer } from './server.ts'
 
+// Resolved here rather than in pool.ts: entry points run under tsx, where import.meta works, while
+// jest's CJS transform cannot load a src/ module that contains it (see the note in qr.ts).
+const WORKER_URL = new URL('./scrub-worker.ts', import.meta.url)
+
 const cfg = loadConfig()
 // Thread sizing is derived (workers and ORT threads from the cgroup quota) or set outside the process
 // (UV_THREADPOOL_SIZE in the Dockerfile), so log what this process actually resolved: a pool sized
@@ -16,7 +20,7 @@ console.log(
 
 // Every worker loads its models before this resolves, so no listener exists until the whole pool can
 // scrub and the readiness probe cannot pass on a half-started pool.
-const pool = await startPool(SCRUB_WORKERS)
+const pool = await startPool(SCRUB_WORKERS, WORKER_URL)
 
 const { scrub, metrics } = startServer(
     cfg.port,
@@ -38,10 +42,13 @@ for (const sig of ['SIGINT', 'SIGTERM'] as const) {
         let remaining = 2
         const exitWhenBothClosed = (): void => {
             if (--remaining === 0) {
-                clearTimeout(force)
-                // Workers hold no unflushed state, so they are torn down after the listeners rather
-                // than drained: an in-flight scrub whose socket is already closing has nowhere to go.
-                void pool.close().finally(() => process.exit(0))
+                // The backstop stays armed across pool.close(): terminating a worker wedged inside a
+                // native ORT call is exactly the step that can hang, and clearing the timer first
+                // would disarm it for the only part of shutdown that needs it.
+                void pool.close().finally(() => {
+                    clearTimeout(force)
+                    process.exit(0)
+                })
             }
         }
         for (const server of [scrub, metrics]) {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/main.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/main.ts
@@ -1,27 +1,30 @@
+/* eslint-disable no-console -- sidecar logs to stdout */
 import { loadConfig } from './config.ts'
-import { ORT_THREADS } from './cores.ts'
+import { ORT_THREADS, SCRUB_WORKERS } from './cores.ts'
 import { ScrubMetrics } from './metrics.ts'
-import { advancedScrub, loadModels } from './scrub.ts'
+import { startPool } from './pool.ts'
 import { startServer } from './server.ts'
 
 const cfg = loadConfig()
-// The thread pools are sized outside the process (UV_THREADPOOL_SIZE in the Dockerfile, ORT_THREADS
-// from the cgroup quota), so log what this process actually resolved: a pool sized wrong shows up as
-// latency rather than as an error, and there is otherwise no way to tell from a running pod.
+// Thread sizing is derived (workers and ORT threads from the cgroup quota) or set outside the process
+// (UV_THREADPOOL_SIZE in the Dockerfile), so log what this process actually resolved: a pool sized
+// wrong shows up as latency rather than as an error, with no other way to tell from a running pod.
 console.log(
-    `[image-scrub] concurrency=${cfg.maxConcurrency} ortThreads=${ORT_THREADS} ` +
+    `[image-scrub] concurrency=${cfg.maxConcurrency} workers=${SCRUB_WORKERS} ortThreads=${ORT_THREADS} ` +
         `uvThreadpoolSize=${process.env.UV_THREADPOOL_SIZE ?? '4 (libuv default)'}`
 )
 
-// Models load before any listener exists, so the readiness probe can't pass until the scrub can run.
-const models = await loadModels()
+// Every worker loads its models before this resolves, so no listener exists until the whole pool can
+// scrub and the readiness probe cannot pass on a half-started pool.
+const pool = await startPool(SCRUB_WORKERS)
+
 const { scrub, metrics } = startServer(
     cfg.port,
     cfg.metricsPort,
     cfg.maxConcurrency,
     cfg.maxBodyBytes,
     async (input) => {
-        const { out, t } = await advancedScrub(input, models)
+        const { out, t } = await pool.scrub(input)
         ScrubMetrics.observeScrubOutcome(t)
         return out
     }
@@ -36,7 +39,9 @@ for (const sig of ['SIGINT', 'SIGTERM'] as const) {
         const exitWhenBothClosed = (): void => {
             if (--remaining === 0) {
                 clearTimeout(force)
-                process.exit(0)
+                // Workers hold no unflushed state, so they are torn down after the listeners rather
+                // than drained: an in-flight scrub whose socket is already closing has nowhere to go.
+                void pool.close().finally(() => process.exit(0))
             }
         }
         for (const server of [scrub, metrics]) {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.test.ts
@@ -1,7 +1,10 @@
+import { pathToFileURL } from 'node:url'
+
 import { UndecodableImageError } from './blur.ts'
 import { type ScrubPool, type ScrubResult, startPool } from './pool.ts'
 
-const FAKE_WORKER = new URL('./fake-scrub-worker.mjs', import.meta.url)
+// cwd-relative rather than import.meta, which jest's CJS transform cannot load (see qr.ts).
+const FAKE_WORKER = pathToFileURL(`${process.cwd()}/src/fake-scrub-worker.mjs`)
 
 /** The stand-in worker reports its own interval on top of the real timings, so the test can assert
  *  overlap rather than infer it from elapsed wall time, which only measures how loaded the runner is. */
@@ -63,6 +66,19 @@ describe('startPool', () => {
 
         const results = await Promise.all(['x', 'y'].map((k) => pool.scrub(Buffer.from(k))))
         expect(peakOverlap(results)).toBe(2)
+    })
+
+    it('survives a reply whose buffer is pool-backed', async () => {
+        // A small Buffer shares Node's 8 KiB pool, and that pool ArrayBuffer cannot be transferred.
+        // BLANK_PNG is exactly this shape, so transferring the reply threw DataCloneError on the
+        // NSFW-gated path, killing the worker and turning a successful blank into a retriable 500.
+        pool = await startPool(1, FAKE_WORKER)
+
+        const result = await pool.scrub(Buffer.from('pooled-buffer'))
+
+        expect(result.out.length).toBeGreaterThan(0)
+        const again = await pool.scrub(Buffer.from('still-alive'))
+        expect(again.out.toString()).toMatch(/^done:still-alive/)
     })
 
     it('rebuilds an UndecodableImageError from the wire', async () => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.test.ts
@@ -52,6 +52,19 @@ describe('startPool', () => {
         expect(results.map((r) => r.out.toString().split(':')[1])).toEqual(['q0', 'q1', 'q2', 'q3', 'q4', 'q5'])
     })
 
+    it('replaces a worker that dies while idle', async () => {
+        // A worker holding no job leaves nothing to reject, so a pool that only reacts to in-flight
+        // failures loses it silently and never recovers the capacity. The only visible symptom would
+        // be throughput quietly dropping, which is indistinguishable from the load easing off.
+        pool = await startPool(2, FAKE_WORKER)
+
+        await pool.scrub(Buffer.from('die-when-idle'))
+        await new Promise((resolve) => setTimeout(resolve, 400))
+
+        const results = await Promise.all(['x', 'y'].map((k) => pool.scrub(Buffer.from(k))))
+        expect(peakOverlap(results)).toBe(2)
+    })
+
     it('rebuilds an UndecodableImageError from the wire', async () => {
         // Structured clone drops the prototype, and this class is what the HTTP layer keys the
         // permanent 422 on. Lose it and every undecodable image becomes a retriable 500 that the

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.test.ts
@@ -1,8 +1,26 @@
 import { UndecodableImageError } from './blur.ts'
-import { type ScrubPool, startPool } from './pool.ts'
+import { type ScrubPool, type ScrubResult, startPool } from './pool.ts'
 
 const FAKE_WORKER = new URL('./fake-scrub-worker.mjs', import.meta.url)
-const JOB_MS = 40
+
+/** The stand-in worker reports its own interval on top of the real timings, so the test can assert
+ *  overlap rather than infer it from elapsed wall time, which only measures how loaded the runner is. */
+type TimedRun = ScrubResult['t'] & { startedAt: number; finishedAt: number }
+
+function peakOverlap(results: ScrubResult[]): number {
+    const edges = results.flatMap((r) => [
+        { at: (r.t as TimedRun).startedAt, delta: 1 },
+        { at: (r.t as TimedRun).finishedAt, delta: -1 },
+    ])
+    edges.sort((a, b) => a.at - b.at || a.delta - b.delta)
+    let live = 0
+    let peak = 0
+    for (const edge of edges) {
+        live += edge.delta
+        peak = Math.max(peak, live)
+    }
+    return peak
+}
 
 describe('startPool', () => {
     let pool: ScrubPool
@@ -11,42 +29,40 @@ describe('startPool', () => {
         await pool?.close()
     })
 
-    it('runs one job per worker at once instead of serialising them', async () => {
+    it('runs a job on every worker at once instead of serialising them', async () => {
         // The whole reason the pool exists: onnxruntime-node's run blocks its thread, so concurrency
-        // has to come from having several threads. If dispatch ever serialises, throughput silently
-        // collapses to one image at a time and nothing else in the suite would notice.
+        // only comes from having several. If dispatch ever serialises, throughput collapses to one
+        // image at a time and nothing else in the suite would notice.
         pool = await startPool(3, FAKE_WORKER)
 
-        const started = Date.now()
         const results = await Promise.all(['a', 'b', 'c'].map((k) => pool.scrub(Buffer.from(k))))
-        const elapsed = Date.now() - started
 
-        expect(elapsed).toBeLessThan(JOB_MS * 2)
+        expect(peakOverlap(results)).toBe(3)
         expect(results.map((r) => r.out.toString().split(':')[1])).toEqual(['a', 'b', 'c'])
-        expect(new Set(results.map((r) => r.out.toString().split(':')[2])).size).toBe(3)
     })
 
-    it('queues past the worker count rather than dropping or overlapping jobs', async () => {
+    it('never exceeds the worker count, queueing the rest', async () => {
+        // A job handed to a busy worker would be lost or would overwrite its in-flight reply, so the
+        // ceiling matters as much as the parallelism.
         pool = await startPool(2, FAKE_WORKER)
 
-        const started = Date.now()
-        const results = await Promise.all(Array.from({ length: 4 }, (_unused, i) => pool.scrub(Buffer.from(`q${i}`))))
-        const elapsed = Date.now() - started
+        const results = await Promise.all(Array.from({ length: 6 }, (_unused, i) => pool.scrub(Buffer.from(`q${i}`))))
 
-        expect(elapsed).toBeGreaterThanOrEqual(JOB_MS * 2)
-        expect(results.map((r) => r.out.toString().split(':')[1])).toEqual(['q0', 'q1', 'q2', 'q3'])
+        expect(peakOverlap(results)).toBe(2)
+        expect(results.map((r) => r.out.toString().split(':')[1])).toEqual(['q0', 'q1', 'q2', 'q3', 'q4', 'q5'])
     })
 
     it('rebuilds an UndecodableImageError from the wire', async () => {
         // Structured clone drops the prototype, and this class is what the HTTP layer keys the
-        // permanent 422 on. Lose it and every undecodable image becomes a retriable 500 instead.
+        // permanent 422 on. Lose it and every undecodable image becomes a retriable 500 that the
+        // consumer then attempts four times.
         pool = await startPool(1, FAKE_WORKER)
 
         await expect(pool.scrub(Buffer.from('undecodable'))).rejects.toBeInstanceOf(UndecodableImageError)
     })
 
     it('fails the in-flight job when a worker dies, and keeps serving afterwards', async () => {
-        // Without this the request hangs until the consumer's timeout and the pool quietly shrinks.
+        // Otherwise the request hangs until the consumer's timeout and the pool quietly shrinks.
         pool = await startPool(2, FAKE_WORKER)
 
         await expect(pool.scrub(Buffer.from('crash'))).rejects.toThrow(/exited with code 7/)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.test.ts
@@ -1,0 +1,57 @@
+import { UndecodableImageError } from './blur.ts'
+import { type ScrubPool, startPool } from './pool.ts'
+
+const FAKE_WORKER = new URL('./fake-scrub-worker.mjs', import.meta.url)
+const JOB_MS = 40
+
+describe('startPool', () => {
+    let pool: ScrubPool
+
+    afterEach(async () => {
+        await pool?.close()
+    })
+
+    it('runs one job per worker at once instead of serialising them', async () => {
+        // The whole reason the pool exists: onnxruntime-node's run blocks its thread, so concurrency
+        // has to come from having several threads. If dispatch ever serialises, throughput silently
+        // collapses to one image at a time and nothing else in the suite would notice.
+        pool = await startPool(3, FAKE_WORKER)
+
+        const started = Date.now()
+        const results = await Promise.all(['a', 'b', 'c'].map((k) => pool.scrub(Buffer.from(k))))
+        const elapsed = Date.now() - started
+
+        expect(elapsed).toBeLessThan(JOB_MS * 2)
+        expect(results.map((r) => r.out.toString().split(':')[1])).toEqual(['a', 'b', 'c'])
+        expect(new Set(results.map((r) => r.out.toString().split(':')[2])).size).toBe(3)
+    })
+
+    it('queues past the worker count rather than dropping or overlapping jobs', async () => {
+        pool = await startPool(2, FAKE_WORKER)
+
+        const started = Date.now()
+        const results = await Promise.all(Array.from({ length: 4 }, (_unused, i) => pool.scrub(Buffer.from(`q${i}`))))
+        const elapsed = Date.now() - started
+
+        expect(elapsed).toBeGreaterThanOrEqual(JOB_MS * 2)
+        expect(results.map((r) => r.out.toString().split(':')[1])).toEqual(['q0', 'q1', 'q2', 'q3'])
+    })
+
+    it('rebuilds an UndecodableImageError from the wire', async () => {
+        // Structured clone drops the prototype, and this class is what the HTTP layer keys the
+        // permanent 422 on. Lose it and every undecodable image becomes a retriable 500 instead.
+        pool = await startPool(1, FAKE_WORKER)
+
+        await expect(pool.scrub(Buffer.from('undecodable'))).rejects.toBeInstanceOf(UndecodableImageError)
+    })
+
+    it('fails the in-flight job when a worker dies, and keeps serving afterwards', async () => {
+        // Without this the request hangs until the consumer's timeout and the pool quietly shrinks.
+        pool = await startPool(2, FAKE_WORKER)
+
+        await expect(pool.scrub(Buffer.from('crash'))).rejects.toThrow(/exited with code 7/)
+
+        const after = await pool.scrub(Buffer.from('after'))
+        expect(after.out.toString()).toMatch(/^done:after/)
+    })
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.ts
@@ -1,0 +1,139 @@
+/* eslint-disable no-console -- sidecar logs to stdout */
+import { Worker } from 'node:worker_threads'
+
+import { UndecodableImageError } from './blur.ts'
+import { type StageTimings } from './scrub.ts'
+import { type ScrubReply } from './worker-protocol.ts'
+
+const WORKER_URL = new URL('./scrub-worker.ts', import.meta.url)
+
+export interface ScrubResult {
+    out: Buffer
+    t: StageTimings
+}
+
+export interface ScrubPool {
+    scrub(input: Buffer): Promise<ScrubResult>
+    close(): Promise<void>
+}
+
+interface Pending {
+    resolve: (r: ScrubResult) => void
+    reject: (e: Error) => void
+}
+
+interface Slot {
+    worker: Worker
+    /** The job this worker is running, since it takes exactly one at a time: `run` blocks its thread. */
+    job: { id: number; pending: Pending } | null
+}
+
+/**
+ * A fixed set of inference workers, one job each at a time.
+ *
+ * Resolves only once every worker has loaded its models, so a worker that cannot start (a missing
+ * model, or a loader that does not reach worker threads) fails startup loudly rather than leaving
+ * the pool quietly short-handed. That matters because the listener is bound after this returns, so
+ * the readiness probe never passes on a broken pool.
+ */
+export async function startPool(size: number, workerUrl: URL = WORKER_URL): Promise<ScrubPool> {
+    const slots: Slot[] = []
+    const queue: { id: number; input: Buffer; pending: Pending }[] = []
+    let nextJobId = 0
+    let closing = false
+
+    const pump = (): void => {
+        if (closing) {
+            return
+        }
+        for (const slot of slots) {
+            if (slot.job || queue.length === 0) {
+                continue
+            }
+            const next = queue.shift()!
+            slot.job = { id: next.id, pending: next.pending }
+            slot.worker.postMessage({ id: next.id, input: next.input })
+        }
+    }
+
+    const spawn = async (index: number): Promise<void> => {
+        const worker = new Worker(workerUrl, { workerData: { index } })
+        const slot: Slot = { worker, job: null }
+        slots[index] = slot
+
+        await new Promise<void>((ready, failed) => {
+            const onReady = (msg: ScrubReply): void => {
+                if ('ready' in msg) {
+                    worker.off('message', onReady)
+                    worker.off('error', failed)
+                    ready()
+                }
+            }
+            worker.on('message', onReady)
+            worker.once('error', failed)
+        })
+
+        worker.on('message', (msg: ScrubReply) => {
+            if ('ready' in msg || !slot.job || slot.job.id !== msg.id) {
+                return
+            }
+            const { pending } = slot.job
+            slot.job = null
+            if ('failure' in msg) {
+                const error = msg.failure.undecodable
+                    ? new UndecodableImageError(msg.failure.message)
+                    : new Error(msg.failure.message)
+                pending.reject(error)
+            } else {
+                pending.resolve({
+                    out: Buffer.from(msg.out.buffer, msg.out.byteOffset, msg.out.byteLength),
+                    t: msg.timings,
+                })
+            }
+            pump()
+        })
+
+        // A worker that dies takes its in-flight job with it, so fail that request rather than let it
+        // hang until the consumer's timeout, and replace the worker or the pool shrinks silently.
+        worker.on('error', (error) => failSlotAndReplace(index, slot, error))
+        worker.on('exit', (code) => {
+            if (!closing && slot.job) {
+                failSlotAndReplace(index, slot, new Error(`scrub worker exited with code ${code}`))
+            }
+        })
+    }
+
+    const failSlotAndReplace = (index: number, slot: Slot, error: Error): void => {
+        if (closing) {
+            return
+        }
+        slot.job?.pending.reject(error)
+        slot.job = null
+        console.error(`[image-scrub] worker ${index} died, replacing: ${error.message}`)
+        void slot.worker.terminate().catch(() => {})
+        spawn(index)
+            .then(pump)
+            .catch((e: unknown) => console.error(`[image-scrub] worker ${index} could not restart: ${String(e)}`))
+    }
+
+    await Promise.all(Array.from({ length: size }, (_unused, i) => spawn(i)))
+
+    return {
+        scrub(input: Buffer): Promise<ScrubResult> {
+            if (closing) {
+                return Promise.reject(new Error('scrub pool is closing'))
+            }
+            return new Promise<ScrubResult>((resolve, reject) => {
+                queue.push({ id: nextJobId++, input, pending: { resolve, reject } })
+                pump()
+            })
+        },
+        async close(): Promise<void> {
+            closing = true
+            for (const { job } of slots) {
+                job?.pending.reject(new Error('scrub pool is closing'))
+            }
+            await Promise.all(slots.map((s) => s.worker.terminate()))
+        },
+    }
+}

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.ts
@@ -6,6 +6,8 @@ import { type StageTimings } from './scrub.ts'
 import { type ScrubReply } from './worker-protocol.ts'
 
 const WORKER_URL = new URL('./scrub-worker.ts', import.meta.url)
+const RESTART_BACKOFF_BASE_MS = 500
+const RESTART_BACKOFF_MAX_MS = 30_000
 
 export interface ScrubResult {
     out: Buffer
@@ -26,6 +28,11 @@ interface Slot {
     worker: Worker
     /** The job this worker is running, since it takes exactly one at a time: `run` blocks its thread. */
     job: { id: number; pending: Pending } | null
+    /** False until the worker reports ready and again once retired. A worker that never finished
+     *  starting will not answer, so dispatching to it strands the job until the consumer times out. */
+    usable: boolean
+    /** A crash raises both `error` and `exit`, so replacement has to be idempotent per slot. */
+    retired: boolean
 }
 
 /**
@@ -41,13 +48,14 @@ export async function startPool(size: number, workerUrl: URL = WORKER_URL): Prom
     const queue: { id: number; input: Buffer; pending: Pending }[] = []
     let nextJobId = 0
     let closing = false
+    const restartFailures: number[] = []
 
     const pump = (): void => {
         if (closing) {
             return
         }
         for (const slot of slots) {
-            if (slot.job || queue.length === 0) {
+            if (!slot?.usable || slot.job || queue.length === 0) {
                 continue
             }
             const next = queue.shift()!
@@ -58,9 +66,11 @@ export async function startPool(size: number, workerUrl: URL = WORKER_URL): Prom
 
     const spawn = async (index: number): Promise<void> => {
         const worker = new Worker(workerUrl, { workerData: { index } })
-        const slot: Slot = { worker, job: null }
+        const slot: Slot = { worker, job: null, usable: false, retired: false }
         slots[index] = slot
 
+        // Startup failures reject rather than retire, so a worker that cannot load fails startPool
+        // instead of respawning forever against whatever is broken.
         await new Promise<void>((ready, failed) => {
             const onReady = (msg: ScrubReply): void => {
                 if ('ready' in msg) {
@@ -79,6 +89,7 @@ export async function startPool(size: number, workerUrl: URL = WORKER_URL): Prom
             }
             const { pending } = slot.job
             slot.job = null
+            restartFailures[index] = 0
             if ('failure' in msg) {
                 const error = msg.failure.undecodable
                     ? new UndecodableImageError(msg.failure.message)
@@ -93,27 +104,42 @@ export async function startPool(size: number, workerUrl: URL = WORKER_URL): Prom
             pump()
         })
 
-        // A worker that dies takes its in-flight job with it, so fail that request rather than let it
-        // hang until the consumer's timeout, and replace the worker or the pool shrinks silently.
-        worker.on('error', (error) => failSlotAndReplace(index, slot, error))
-        worker.on('exit', (code) => {
-            if (!closing && slot.job) {
-                failSlotAndReplace(index, slot, new Error(`scrub worker exited with code ${code}`))
-            }
-        })
+        // A worker that dies takes any in-flight job with it, so fail that request rather than let it
+        // hang until the consumer's timeout. Replacement is unconditional: a worker that dies while
+        // idle carries no job to fail, and leaving it would shrink the pool with nothing to show it.
+        worker.on('error', (error) => retireAndReplace(index, slot, error))
+        worker.on('exit', (code) => retireAndReplace(index, slot, new Error(`scrub worker exited with code ${code}`)))
+        slot.usable = true
     }
 
-    const failSlotAndReplace = (index: number, slot: Slot, error: Error): void => {
-        if (closing) {
+    const retireAndReplace = (index: number, slot: Slot, error: Error): void => {
+        if (closing || slot.retired) {
             return
         }
+        slot.retired = true
+        slot.usable = false
         slot.job?.pending.reject(error)
         slot.job = null
-        console.error(`[image-scrub] worker ${index} died, replacing: ${error.message}`)
         void slot.worker.terminate().catch(() => {})
-        spawn(index)
-            .then(pump)
-            .catch((e: unknown) => console.error(`[image-scrub] worker ${index} could not restart: ${String(e)}`))
+
+        // Backoff, because a worker that dies on every start (an OOM loading models, a corrupt model
+        // file) would otherwise respawn in a tight loop, spending the CPU the survivors need and
+        // burying the first failure in log noise. Reset once a replacement completes a job.
+        const failures = (restartFailures[index] ?? 0) + 1
+        restartFailures[index] = failures
+        const delayMs = Math.min(RESTART_BACKOFF_MAX_MS, RESTART_BACKOFF_BASE_MS * 2 ** (failures - 1))
+        console.error(
+            `[image-scrub] worker ${index} died (${failures} in a row), replacing in ${delayMs}ms: ${error.message}`
+        )
+        const timer = setTimeout(() => {
+            if (closing) {
+                return
+            }
+            spawn(index)
+                .then(pump)
+                .catch((e: unknown) => console.error(`[image-scrub] worker ${index} could not restart: ${String(e)}`))
+        }, delayMs)
+        timer.unref()
     }
 
     await Promise.all(Array.from({ length: size }, (_unused, i) => spawn(i)))
@@ -130,10 +156,14 @@ export async function startPool(size: number, workerUrl: URL = WORKER_URL): Prom
         },
         async close(): Promise<void> {
             closing = true
-            for (const { job } of slots) {
-                job?.pending.reject(new Error('scrub pool is closing'))
+            for (const pendingJob of queue.splice(0)) {
+                pendingJob.pending.reject(new Error('scrub pool is closing'))
             }
-            await Promise.all(slots.map((s) => s.worker.terminate()))
+            // Slots can be absent while a replacement is still waiting out its backoff.
+            for (const slot of slots) {
+                slot?.job?.pending.reject(new Error('scrub pool is closing'))
+            }
+            await Promise.all(slots.filter(Boolean).map((s) => s.worker.terminate()))
         },
     }
 }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/pool.ts
@@ -5,7 +5,6 @@ import { UndecodableImageError } from './blur.ts'
 import { type StageTimings } from './scrub.ts'
 import { type ScrubReply } from './worker-protocol.ts'
 
-const WORKER_URL = new URL('./scrub-worker.ts', import.meta.url)
 const RESTART_BACKOFF_BASE_MS = 500
 const RESTART_BACKOFF_MAX_MS = 30_000
 
@@ -42,8 +41,12 @@ interface Slot {
  * model, or a loader that does not reach worker threads) fails startup loudly rather than leaving
  * the pool quietly short-handed. That matters because the listener is bound after this returns, so
  * the readiness probe never passes on a broken pool.
+ *
+ * The worker URL is a parameter rather than resolved here because jest's CJS transform cannot load a
+ * module containing import.meta, the same constraint qr.ts documents. Entry points run under tsx,
+ * where it works.
  */
-export async function startPool(size: number, workerUrl: URL = WORKER_URL): Promise<ScrubPool> {
+export async function startPool(size: number, workerUrl: URL): Promise<ScrubPool> {
     const slots: Slot[] = []
     const queue: { id: number; input: Buffer; pending: Pending }[] = []
     let nextJobId = 0
@@ -84,7 +87,14 @@ export async function startPool(size: number, workerUrl: URL = WORKER_URL): Prom
         })
 
         worker.on('message', (msg: ScrubReply) => {
-            if ('ready' in msg || !slot.job || slot.job.id !== msg.id) {
+            if ('ready' in msg) {
+                return
+            }
+            if (!slot.job || slot.job.id !== msg.id) {
+                // Should be unreachable: one job per slot, replies keyed by id. If it ever happens the
+                // job it belonged to never settles, which strands a concurrency slot in the server for
+                // the process's lifetime, so say so rather than drop it silently.
+                console.error(`[image-scrub] worker ${index} replied for job ${msg.id} with none in flight`)
                 return
             }
             const { pending } = slot.job

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/scrub-worker.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/scrub-worker.ts
@@ -22,17 +22,25 @@ port.postMessage({ ready: true } satisfies ScrubReply)
 
 port.on('message', (job: ScrubJob) => {
     const input = Buffer.from(job.input.buffer, job.input.byteOffset, job.input.byteLength)
-    advancedScrub(input, models).then(
-        ({ out, t }) => port.postMessage({ id: job.id, out, timings: t } satisfies ScrubReply, [out.buffer]),
-        (error: unknown) =>
+    // Catch rather than pass a rejection handler, so a throw while replying is reported as a failed
+    // job instead of becoming an unhandled rejection that takes the whole worker down with it.
+    advancedScrub(input, models)
+        .then(({ out, t }) => {
+            // Deliberately copied rather than transferred. The output can be the shared BLANK_PNG
+            // constant, which lives in Node's small-buffer pool, and an 8 KiB pool ArrayBuffer is not
+            // transferable: attempting it throws DataCloneError on exactly the NSFW-gated path this
+            // service exists to handle. A PNG-sized copy costs microseconds against a scrub.
+            port.postMessage({ id: job.id, out, timings: t } satisfies ScrubReply)
+        })
+        .catch((error: unknown) => {
+            // Structured clone drops the prototype, so the one distinction the HTTP layer acts on
+            // (422 permanent versus 500 retriable) has to travel as data rather than as a class.
             port.postMessage({
                 id: job.id,
-                // Structured clone drops the prototype, so the one distinction the HTTP layer acts on
-                // (422 permanent versus 500 retriable) has to travel as data rather than as a class.
                 failure: {
                     message: error instanceof Error ? error.message : String(error),
                     undecodable: error instanceof UndecodableImageError,
                 },
             } satisfies ScrubReply)
-    )
+        })
 })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/scrub-worker.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/scrub-worker.ts
@@ -1,0 +1,38 @@
+/**
+ * One inference worker: owns its own ONNX sessions and scrubs one image at a time.
+ *
+ * The whole scrub runs here rather than just the model calls, because onnxruntime-node's `run`
+ * blocks the thread it is called on, so leaving anything else on that thread only serialises it
+ * behind the inference. Sessions cannot be shared across isolates, so each worker loads its own.
+ */
+import { parentPort } from 'node:worker_threads'
+
+import { UndecodableImageError } from './blur.ts'
+import { advancedScrub, loadModels } from './scrub.ts'
+import { type ScrubJob, type ScrubReply } from './worker-protocol.ts'
+
+if (!parentPort) {
+    throw new Error('scrub-worker must be started as a worker thread')
+}
+const port = parentPort
+
+// Loaded before the ready signal, so the pool only reports itself up once every worker can scrub.
+const models = await loadModels()
+port.postMessage({ ready: true } satisfies ScrubReply)
+
+port.on('message', (job: ScrubJob) => {
+    const input = Buffer.from(job.input.buffer, job.input.byteOffset, job.input.byteLength)
+    advancedScrub(input, models).then(
+        ({ out, t }) => port.postMessage({ id: job.id, out, timings: t } satisfies ScrubReply, [out.buffer]),
+        (error: unknown) =>
+            port.postMessage({
+                id: job.id,
+                // Structured clone drops the prototype, so the one distinction the HTTP layer acts on
+                // (422 permanent versus 500 retriable) has to travel as data rather than as a class.
+                failure: {
+                    message: error instanceof Error ? error.message : String(error),
+                    undecodable: error instanceof UndecodableImageError,
+                },
+            } satisfies ScrubReply)
+    )
+})

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/smoke.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/smoke.ts
@@ -12,8 +12,10 @@ import sharp from 'sharp'
 
 import { startPool } from './pool.ts'
 
+const WORKER_URL = new URL('./scrub-worker.ts', import.meta.url)
+
 async function main(): Promise<void> {
-    const pool = await startPool(2)
+    const pool = await startPool(2, WORKER_URL)
     const png = await sharp({ create: { width: 64, height: 64, channels: 3, background: '#fff' } })
         .png()
         .toBuffer()

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/smoke.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/smoke.ts
@@ -1,21 +1,29 @@
 /**
- * Startup smoke test: loads the models and runs one scrub end to end. Run at image-build time (see
- * Dockerfile.ml-mirror-image-scrub) with networking disabled, so a missing/corrupt model, a
+ * Startup smoke test: starts the worker pool and runs two scrubs end to end. Run at image-build time
+ * (see Dockerfile.ml-mirror-image-scrub) with networking disabled, so a missing/corrupt model, a
  * prebuilt-binary mismatch, or an accidental runtime network dependency fails the build instead of
  * crash-looping the deploy.
+ *
+ * It goes through the pool rather than calling advancedScrub directly so the build also proves the
+ * runner's TypeScript loader reaches worker threads. Nothing else here would catch that, and its
+ * failure mode is a pod that never becomes ready.
  */
 import sharp from 'sharp'
 
-import { advancedScrub, disposeModels, loadModels } from './scrub.ts'
+import { startPool } from './pool.ts'
 
 async function main(): Promise<void> {
-    const models = await loadModels()
+    const pool = await startPool(2)
     const png = await sharp({ create: { width: 64, height: 64, channels: 3, background: '#fff' } })
         .png()
         .toBuffer()
-    const { t } = await advancedScrub(png, models)
-    await disposeModels(models)
-    console.log(`smoke scrub OK (${Math.round(t.totalMs)}ms)`)
+    // Two at once, so the build fails if a second worker cannot start or the pool mis-routes replies.
+    const [first, second] = await Promise.all([pool.scrub(png), pool.scrub(png)])
+    if (first.out.length === 0 || second.out.length === 0) {
+        throw new Error('smoke scrub produced empty output')
+    }
+    await pool.close()
+    console.log(`smoke scrub OK (${Math.round(first.t.totalMs)}ms, ${Math.round(second.t.totalMs)}ms)`)
 }
 
 main().catch((e) => {

--- a/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/worker-protocol.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/ml-mirror-image-scrub-sidecar/src/worker-protocol.ts
@@ -1,0 +1,12 @@
+import { type StageTimings } from './scrub.ts'
+
+export interface ScrubJob {
+    id: number
+    input: Uint8Array
+}
+
+/** A worker sends `ready` once, then exactly one reply per job. */
+export type ScrubReply =
+    | { ready: true }
+    | { id: number; out: Uint8Array; timings: StageTimings }
+    | { id: number; failure: { message: string; undecodable: boolean } }


### PR DESCRIPTION
> [!NOTE]
> Stacked on #73643. Review that first; this diff is only the worker pool.

## Problem

`onnxruntime-node`'s `run` blocks the thread that calls it — verified at the pinned v1.27.0, where `js/node/lib/backend.ts` wraps the native call in `setImmediate` and `inference_session_wrap.h` declares only a `[sync]` `Run`. A single-threaded sidecar therefore has exactly one inference executing however many requests are in flight.

Detection is two thirds of scrub time, which explains the shape we measured: ~60% CPU with roughly 7 of 8 concurrency slots occupied and per-stage p95s in seconds. Requests spend most of their life queued behind one thread, and `IMAGE_SCRUB_CONCURRENCY=8` buys nothing for the part that dominates.

#73643 works around this by giving that single inference every core. This removes the constraint instead.

## Changes

**Each worker owns its sessions and runs the whole scrub**, not just the model calls. Anything left on the calling thread would only serialise behind the inference, so the split is per request rather than per stage. The main thread keeps express and the metrics registry, so there is one of each and no cross-process aggregation to get wrong — the reason for `worker_threads` over `cluster`.

**Workers default to one per core, and `ORT_THREADS` is divided by the worker count.** Threads × workers is what has to fit the allotment. That restores the one-core-per-worker model the package was built around and that a single process at concurrency 8 had drifted away from.

> [!IMPORTANT]
> Failures cross the boundary as data, not as classes. Structured clone drops the prototype, and `err instanceof UndecodableImageError` is what `server.ts` keys the permanent 422 on — lose it and every undecodable image becomes a retriable 500, which the consumer then retries four times. It is rebuilt on the main thread from an explicit flag.

**Startup fails loudly.** The pool resolves only once every worker has loaded its models, and the listener binds after that, so readiness cannot pass on a half-started pool.

## How did you test this code?

I'm an agent. The sidecar's `node_modules` are not installed here and the root `tsconfig.json` excludes this package, so I could not run its jest suite or typecheck. CI runs both.

**The pool's dispatch logic is verified**, by transcribing it against real `worker_threads` with a stand-in worker:

```
ok  3 jobs run in parallel across 3 workers -> 41ms
ok  replies route to the right job -> done:a:w0 done:b:w1 done:c:w2
ok  distinct workers were used
ok  6 jobs queue into two waves -> 82ms
ok  undecodable reconstructs UndecodableImageError
ok  crash rejects its in-flight job -> scrub worker exited with code 7
ok  pool still serves after a worker died
ok  rejects after close
```

41ms rather than 120ms for three 40ms jobs is the property the change exists for. That is now `pool.test.ts` against `fake-scrub-worker.mjs`, a plain `.mjs` stand-in so the test measures the pool rather than the runner.

**Transfer strategy was measured before choosing one.** A 3 MB frame across the boundary: structured clone 0.285 ms, `transferList` 0.051 ms, `SharedArrayBuffer` 0.018 ms. Against a scrub of 100 ms+ all three are noise, so the design uses plain messaging and skips `SharedArrayBuffer` lifetime management entirely. Output buffers are transferred since they are already owned by the worker and free to hand over.

**What I could not verify locally**, and the main risk: that tsx's TypeScript loader reaches worker threads. tsx v4 patches `Worker`, but I have no way to run it here. This is why `smoke.ts` now goes through the pool with two workers — it runs at image-build time with `--network=none`, so the Docker build fails if workers cannot start, rather than the pod failing readiness after deploy.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed beyond the Dockerfile threading comment updated in #73643.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie, authored by Claude Code (Opus 5). Skills invoked: /writing-tests, /writing-code-comments.

Robbie asked whether ONNX could be moved off the main thread, on the reasoning that a library blocking the event loop for its whole inference is a flaw. It is: the C API has had `OrtApi::RunAsync` since ~1.15 and the Node binding never exposed it, while the `setImmediate` wrapper presents the blocking call as async. Worth an upstream issue on both counts.

Two earlier hypotheses of mine were wrong and measurement killed both, which is why this one was measured before being built: compose's JS pixel loops looked like the main-thread bottleneck but are only milliseconds, and a native sharp rewrite of compose turned out 31x slower than the hand-rolled loops.

Once this lands, `IMAGE_SCRUB_CONCURRENCY` becomes meaningful again — it should sit slightly above the worker count so a brief main-thread stall does not idle a worker, rather than at 8 against a single inference thread.
