### PR TITLE
fix(google_analytics): surface reconnect message when OAuth connection is gone

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
@@ -13,6 +13,8 @@ from posthog.schema import (
     SourceFieldOauthConfig,
 )
 
+from posthog.models.integration import Integration
+
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
     SourceInputs,
     SourceResponse,
@@ -149,6 +151,13 @@ class GoogleAnalyticsSource(ResumableSource[GoogleAnalyticsSourceConfig, GoogleA
 
         try:
             session = google_analytics_session(config.google_analytics_integration_id, team_id)
+        except Integration.DoesNotExist:
+            # The stored OAuth integration row has been deleted/disconnected before validation runs.
+            # Caught explicitly so an unrelated model's DoesNotExist still surfaces as a real bug below.
+            return (
+                False,
+                "The Google Analytics connection for this source no longer exists. Please reconnect your Google account.",
+            )
         except Exception as e:
             return False, f"Could not load Google Analytics credentials: {e}"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
@@ -6,6 +6,8 @@ from google.auth.exceptions import RefreshError
 
 from posthog.schema import ReleaseStatus, SourceFieldOauthConfig
 
+from posthog.models.integration import Integration
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.googleanalytics import (
     GoogleAnalyticsSourceConfig,
 )
@@ -223,6 +225,20 @@ def test_validate_credentials_handles_session_failure():
 
     assert ok is False
     assert "Could not load Google Analytics credentials" in (message or "")
+
+
+def test_validate_credentials_handles_missing_integration():
+    # A deleted/disconnected OAuth row makes `google_analytics_session` raise the typed
+    # `Integration.DoesNotExist`; surface a reconnect message instead of the raw ORM error.
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.google_analytics.source.google_analytics_session",
+        side_effect=Integration.DoesNotExist(),
+    ):
+        ok, message = GoogleAnalyticsSource().validate_credentials(_config(), team_id=1)
+
+    assert ok is False
+    assert "no longer exists" in (message or "")
+    assert "matching query" not in (message or "")
 
 
 def test_validate_credentials_succeeds_when_metadata_readable():


### PR DESCRIPTION
## Problem

In the data-warehouse new-source wizard, validating a Google Analytics source whose stored OAuth integration row has been deleted or disconnected surfaced a raw Django ORM error to the user (a bare "matching query does not exist" string). It reports that something failed but gives the user nothing to act on.

The sibling Google Ads and Google Search Console sources already catch this exact case and return an actionable reconnect message — Google Analytics was the odd one out, catching the typed `DoesNotExist` in a broad handler that echoed the raw error.

## Changes

Catch `Integration.DoesNotExist` explicitly in `validate_credentials` and return the same guidance the sibling sources use:

> The Google Analytics connection for this source no longer exists. Please reconnect your Google account.

The catch is model-specific, so an unrelated model's `DoesNotExist` still falls through to the generic handler and stays visible as a real bug. No sync behavior or schema changes.

## How did you test this code?

No manual/browser testing was performed by the agent. Added a unit test asserting that a `DoesNotExist` from the session helper yields the reconnect message and no longer leaks the raw ORM string; it catches the regression of the internal error reaching users, which no existing test covered (the existing generic-failure test only exercises an arbitrary `Exception`). Ran the source's `validate_credentials` test group locally — all pass. `ruff check`/`ruff format` clean on the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Identified while triaging failed data-warehouse source-creation attempts: the Google Analytics connector leaked a raw Django `DoesNotExist` when the OAuth row was missing. Cross-checked the Google Ads and Google Search Console sources, which already handle the identical case with a friendly reconnect message, and mirrored their pattern (explicit typed catch, generic fallback preserved). Invoked `/writing-user-facing-copy` conventions for the message and `/writing-tests` for the added test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
