### PR TITLE
fix(data-modeling): don't charge a clickhouse describe to the resolver deadline

### DIFF
--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -373,8 +373,7 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
     context.output_format = "ArrowStream"
     settings.preferred_block_size_bytes = MB_100_IN_BYTES
 
-    # a fresh factory, so this pass gets its own deadline clock. Reusing the one above would
-    # charge it for the DESCRIBE round trip, which is ClickHouse time, not view resolution.
+    # a fresh factory: reusing the one above would charge this pass for the DESCRIBE round trip
     arrow_prepared_hogql_query = await database_sync_to_async_pool(prepare_ast_for_printing)(
         query_node,
         context=context,

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -373,13 +373,15 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
     context.output_format = "ArrowStream"
     settings.preferred_block_size_bytes = MB_100_IN_BYTES
 
+    # a fresh factory, so this pass gets its own deadline clock. Reusing the one above would
+    # charge it for the DESCRIBE round trip, which is ClickHouse time, not view resolution.
     arrow_prepared_hogql_query = await database_sync_to_async_pool(prepare_ast_for_printing)(
         query_node,
         context=context,
         dialect="clickhouse",
         stack=[],
         settings=settings,
-        resolver_factory=factory,
+        resolver_factory=bounded_resolver_factory_for_view(view_name),
     )
 
     if arrow_prepared_hogql_query is None:

--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -373,7 +373,8 @@ async def hogql_table(query: str, team: Team, logger: FilteringBoundLogger, view
     context.output_format = "ArrowStream"
     settings.preferred_block_size_bytes = MB_100_IN_BYTES
 
-    # a fresh factory: reusing the one above would charge this pass for the DESCRIBE round trip
+    # each prepare pass owns its deadline clock, so the DESCRIBE round trip above is not charged
+    # to view resolution
     arrow_prepared_hogql_query = await database_sync_to_async_pool(prepare_ast_for_printing)(
         query_node,
         context=context,

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1,6 +1,6 @@
 import asyncio
 import contextlib
-from collections.abc import Collection, Iterable
+from collections.abc import AsyncIterator, Collection, Iterable
 from typing import Any, cast
 
 import pytest
@@ -12,6 +12,8 @@ from django.test import override_settings
 import pyarrow as pa
 import deltalake
 import pytest_asyncio
+
+from posthog.hogql.resolver import ResolverFactory
 
 from posthog.sync import database_sync_to_async
 from posthog.temporal.data_modeling.activities import (
@@ -1060,6 +1062,8 @@ class TestMaterializeViewActivity:
 
 
 class _EmptyArrowClient:
+    describe_body = b"id\tInt64\n"
+
     def __init__(self, schema: pa.Schema):
         self.schema = schema
         self.arrow_query_calls = 0
@@ -1075,7 +1079,7 @@ class _EmptyArrowClient:
     @contextlib.asynccontextmanager
     async def apost_query(self, query, *data, query_parameters=None, query_id=None):
         if query.startswith("DESCRIBE TABLE"):
-            body = b"id\tInt64\n"
+            body = self.describe_body
         else:
             self.schema_query_calls += 1
             buffer = pa.BufferOutputStream()
@@ -1114,7 +1118,7 @@ class TestHogqlTableEmptyResults:
 
 
 class _SlowDescribeClient(_EmptyArrowClient):
-    """Reports a DateTime column, so the arrow re-prepare runs, after a slow DESCRIBE."""
+    describe_body = b"ts\tDateTime\n"
 
     def __init__(self, schema: pa.Schema, describe_seconds: float):
         super().__init__(schema)
@@ -1122,19 +1126,9 @@ class _SlowDescribeClient(_EmptyArrowClient):
 
     @contextlib.asynccontextmanager
     async def apost_query(self, query, *data, query_parameters=None, query_id=None):
-        assert query.startswith("DESCRIBE TABLE")
         await asyncio.sleep(self.describe_seconds)
-
-        class _Response:
-            content: Any
-
-            def __init__(self) -> None:
-                self.content = self
-
-            async def read(self) -> bytes:
-                return b"ts\tDateTime\n"
-
-        yield _Response()
+        async with super().apost_query(query, *data, query_parameters=query_parameters, query_id=query_id) as response:
+            yield response
 
 
 class TestHogqlTableResolutionDeadline:
@@ -1148,10 +1142,10 @@ class TestHogqlTableResolutionDeadline:
         )
 
         @contextlib.asynccontextmanager
-        async def fake_get_client(**kwargs):
+        async def fake_get_client(**kwargs: Any) -> AsyncIterator[_SlowDescribeClient]:
             yield client
 
-        def short_deadline_factory(view_name, **kwargs):
+        def short_deadline_factory(view_name: str | None, **kwargs: Any) -> ResolverFactory:
             return bounded_resolver_factory_for_view(view_name, **{**kwargs, "deadline_seconds": deadline_seconds})
 
         with (

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1139,11 +1139,9 @@ class _SlowDescribeClient(_EmptyArrowClient):
 
 class TestHogqlTableResolutionDeadline:
     async def test_slow_describe_does_not_exhaust_the_resolution_deadline(self, ateam):
-        # regression: a DateTime column sends hogql_table back through prepare_ast_for_printing
-        # to wrap the select in toTimeZone. That second pass used to share the first pass's
-        # deadline anchor, which is stamped before the DESCRIBE round trip — so a DESCRIBE
-        # slower than the deadline made the re-prepare raise ResolutionTimeoutError on its
-        # first visit, blaming the user's view for time spent in ClickHouse.
+        # regression: a DateTime column sends hogql_table back through prepare_ast_for_printing to
+        # wrap the select in toTimeZone. That second pass used to share the first pass's deadline
+        # anchor, so a DESCRIBE slower than the deadline made it raise ResolutionTimeoutError.
         deadline_seconds = 1.0
         client = _SlowDescribeClient(
             pa.schema([pa.field("ts", pa.timestamp("us"))]), describe_seconds=deadline_seconds + 0.2

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 from collections.abc import Collection, Iterable
 from typing import Any, cast
@@ -33,6 +34,7 @@ from posthog.temporal.data_modeling.activities.materialize_view import (
 )
 
 from products.data_modeling.backend.facade.api import compute_enrichment_hash
+from products.data_modeling.backend.facade.modeling import bounded_resolver_factory_for_view
 from products.data_modeling.backend.facade.models import (
     DAG,
     DataModelingJob,
@@ -1109,3 +1111,60 @@ class TestHogqlTableEmptyResults:
         assert batches[0][0].num_rows == 0
         assert client.arrow_query_calls == 1
         assert client.schema_query_calls == 0
+
+
+class _SlowDescribeClient(_EmptyArrowClient):
+    """Reports a DateTime column, so the arrow re-prepare runs, after a slow DESCRIBE."""
+
+    def __init__(self, schema: pa.Schema, describe_seconds: float):
+        super().__init__(schema)
+        self.describe_seconds = describe_seconds
+
+    @contextlib.asynccontextmanager
+    async def apost_query(self, query, *data, query_parameters=None, query_id=None):
+        assert query.startswith("DESCRIBE TABLE")
+        await asyncio.sleep(self.describe_seconds)
+
+        class _Response:
+            content: Any
+
+            def __init__(self) -> None:
+                self.content = self
+
+            async def read(self) -> bytes:
+                return b"ts\tDateTime\n"
+
+        yield _Response()
+
+
+class TestHogqlTableResolutionDeadline:
+    async def test_slow_describe_does_not_exhaust_the_resolution_deadline(self, ateam):
+        # regression: a DateTime column sends hogql_table back through prepare_ast_for_printing
+        # to wrap the select in toTimeZone. That second pass used to share the first pass's
+        # deadline anchor, which is stamped before the DESCRIBE round trip — so a DESCRIBE
+        # slower than the deadline made the re-prepare raise ResolutionTimeoutError on its
+        # first visit, blaming the user's view for time spent in ClickHouse.
+        deadline_seconds = 1.0
+        client = _SlowDescribeClient(
+            pa.schema([pa.field("ts", pa.timestamp("us"))]), describe_seconds=deadline_seconds + 0.2
+        )
+
+        @contextlib.asynccontextmanager
+        async def fake_get_client(**kwargs):
+            yield client
+
+        def short_deadline_factory(view_name, **kwargs):
+            return bounded_resolver_factory_for_view(view_name, **{**kwargs, "deadline_seconds": deadline_seconds})
+
+        with (
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.materialize_view.get_clickhouse_client", fake_get_client
+            ),
+            unittest.mock.patch(
+                "posthog.temporal.data_modeling.activities.materialize_view.bounded_resolver_factory_for_view",
+                short_deadline_factory,
+            ),
+        ):
+            batches = [batch async for batch in hogql_table("SELECT now() AS ts", ateam, LOGGER.bind())]
+
+        assert [name for name, _ in batches[0][1]] == ["ts"]


### PR DESCRIPTION
## Problem

`hogql_table` prepares the query, runs `DESCRIBE TABLE` to learn the column types, and — if any type
needs an arrow conversion — prepares it a second time to wrap the select in `toTimeZone`/`toString`.
Both passes shared one `BoundedResolver` deadline anchor, stamped before the DESCRIBE.

So the DESCRIBE round trip counted against the 60s view-resolution budget. When it ran long, the
second pass raised on its first `visit()`:

```
ResolutionTimeoutError: View resolution exceeded deadline (127.30s > 60.00s)
```

The resolver had done no work at that point. The error is user-facing (`BoundedResolverError`
inherits `QueryError`) and blames the user's view for time spent in ClickHouse.

v1 runs the same DESCRIBE → re-prepare sequence but passes no `resolver_factory`, so it has no
deadline to exhaust. Only the v2 DAG path is affected.

## Changes

- Give the second prepare its own factory, so each pass gets its own deadline clock. The 60s still
  bounds resolution end-to-end within a pass; it just no longer counts a ClickHouse query.
- Regression test: a fake client whose DESCRIBE sleeps past a pinned short deadline and reports a
  DateTime column, which is what forces the second pass.

Deliberately the small fix. The re-prepare-after-DESCRIBE shape costs an extra ClickHouse analysis
pass per materialization and is worth removing, but that's a separate change.

## How did you test this code?

Automated only — I'm an agent and did not exercise this against a running worker.

- Proved the red state first: with the fix reverted, the new test fails with
  `View resolution exceeded deadline (1.21s > 1.00s)`, where 1.2s is the fake DESCRIBE.
- `pytest posthog/temporal/tests/data_modeling/test_materialize_view_activities.py` — 33 passed.
- `ruff check` / `ruff format --check` clean.

The new test catches a regression no existing test did: every other test in the file mocks
`hogql_table` wholesale, so nothing covered the DESCRIBE ↔ deadline interaction.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while investigating a scheduled materialization failing with `ResolutionTimeoutError` on a
query that runs fine in the SQL editor. Three sources agreed on the diagnosis: the
`data_modeling_dag_resolution_duration_seconds` histogram showed no resolution anywhere exceeding a
couple of seconds over 24h, the worker logs showed each attempt spending nearly all its wall clock
between the ClickHouse connect and the failure, and `query_log` showed the matching `DESCRIBE TABLE`
running long enough on its own to exhaust the budget.

Rejected: raising `DEFAULT_RESOLUTION_DEADLINE_SECONDS` (hides the problem), and re-anchoring the
existing factory in place (the shared anchor is load-bearing *within* a pass — nested
`resolve_lazy_tables`/`resolve_in_cohorts` calls each build a fresh resolver from the factory, and
resetting mid-pass would let the budget compound).

Agent: Claude Code (Opus 5). Skills invoked: `/quick-fix-pr`.
