### PR TITLE
feat(inbox): link report runs out to their task run page

### DIFF
--- a/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
@@ -1,7 +1,10 @@
 import { useActions, useValues } from 'kea'
+import { combineUrl } from 'kea-router'
 
-import { IconChevronDown, IconChevronRight, IconTerminal } from '@posthog/icons'
-import { Spinner } from '@posthog/lemon-ui'
+import { IconChevronDown, IconChevronRight, IconExternal, IconTerminal } from '@posthog/icons'
+import { Link, Spinner } from '@posthog/lemon-ui'
+
+import { urls } from 'scenes/urls'
 
 import { isTerminalRunStatus } from 'products/posthog_ai/frontend/api/logics'
 import { TaskRunStatusDot } from 'products/posthog_ai/frontend/api/primitives'
@@ -16,8 +19,8 @@ import { DetailSection } from './DetailSection'
  * Renders the report's linked tasks inline (latest status + purpose). Each row expands in place to
  * the task's run transcript via the shared `ReadonlyRunSurface` — live for an in-progress run, static
  * replay once terminal — mirroring the Code experience instead of navigating away to a separate run
- * page. The purpose label is derived from each task's `task_run` artefact; `repo_selection` runs are
- * filtered out.
+ * page. Each row also links out to the run's page in Tasks for the full surface. The purpose label is
+ * derived from each task's `task_run` artefact; `repo_selection` runs are filtered out.
  */
 export function ReportTasksSection({ report }: { report: SignalReport }): JSX.Element | null {
     const { reportTasks, reportTasksLoading } = useValues(inboxReportDetailLogic({ reportId: report.id, report }))
@@ -66,21 +69,35 @@ function TaskRow({
     const replayOnly = isTerminalRunStatus(task.latest_run?.status)
     const expanded = expandedTaskIds.includes(task.id)
 
+    // Deep link to the run's own page in Tasks — the inline transcript is a preview, this is the
+    // full surface (run history, composer). Falls back to the task when no run has started yet.
+    const taskUrl = runId ? combineUrl(urls.taskDetail(task.id), { runId }).url : urls.taskDetail(task.id)
+
     return (
         <div>
-            <button
-                type="button"
-                onClick={() => toggleExpandedTask(task.id)}
-                className="group flex w-full items-center gap-2 rounded px-1.5 py-1 text-left text-xs transition-colors hover:bg-fill-highlight-50"
-            >
-                {expanded ? (
-                    <IconChevronDown className="shrink-0 text-tertiary" />
-                ) : (
-                    <IconChevronRight className="shrink-0 text-tertiary" />
-                )}
-                <TaskRunStatusDot status={status} />
-                <span className="shrink-0 text-secondary">{purposeLabel}</span>
-            </button>
+            <div className="group flex w-full items-center gap-2 rounded px-1.5 py-1 text-xs transition-colors hover:bg-fill-highlight-50">
+                <button
+                    type="button"
+                    onClick={() => toggleExpandedTask(task.id)}
+                    className="flex min-w-0 flex-1 items-center gap-2 text-left"
+                >
+                    {expanded ? (
+                        <IconChevronDown className="shrink-0 text-tertiary" />
+                    ) : (
+                        <IconChevronRight className="shrink-0 text-tertiary" />
+                    )}
+                    <TaskRunStatusDot status={status} />
+                    <span className="truncate text-secondary">{purposeLabel}</span>
+                </button>
+                <Link
+                    to={taskUrl}
+                    aria-label={`Open ${purposeLabel} run in Tasks`}
+                    title="Open run in Tasks"
+                    className="shrink-0 text-tertiary opacity-60 transition-opacity hover:text-primary group-hover:opacity-100"
+                >
+                    <IconExternal className="size-3.5" />
+                </Link>
+            </div>
 
             {expanded ? (
                 <div className="mt-1.5 mb-1 ml-1.5">

--- a/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
@@ -93,7 +93,9 @@ function TaskRow({
                     to={taskUrl}
                     aria-label={`Open ${purposeLabel} run in Tasks`}
                     title="Open run in Tasks"
-                    className="shrink-0 text-tertiary opacity-60 transition-opacity hover:text-primary group-hover:opacity-100"
+                    // A 24px box keeps the tap target clear of the expand button on touch; the negative
+                    // margin absorbs it back into the row so rows keep their height.
+                    className="-my-1 flex size-6 shrink-0 items-center justify-center rounded text-tertiary opacity-60 transition-opacity hover:text-primary group-hover:opacity-100"
                 >
                     <IconExternal className="size-3.5" />
                 </Link>


### PR DESCRIPTION
## Problem

The Runs section on an inbox report detail shows each linked task run and expands it inline, but there was no way to get from a row to the run's actual page in Tasks. The inline transcript is a preview: it has no run history, no composer, no way to keep working the run. If you wanted any of that you had to go to /tasks and find the run by hand.

## Changes

Each row in the Runs section now has an external-link icon on the right that deep links to the run in Tasks: `/tasks/<taskId>?runId=<runId>`. That is the same deep-link shape the scout signal card already uses.

The `?runId` matters because the tasks detail scene otherwise defaults to the task's most recent run. Pinning it means the link opens the same run the row is showing — the one behind the status dot and the inline transcript, both of which read `task.latest_run`. If a linked task has not started a run yet, the link falls back to the plain task URL and the scene picks its own default.

The row markup changed slightly to make this work: the expand toggle used to be the whole row, and an anchor cannot be nested inside a button. The row is now a flex container with the toggle button on the left (still the click target for expanding) and the link as its own column, given a 24px box so it is not a fiddly target on touch.

<!-- No screenshot: I (Claude) do not have a running dev instance in this environment. -->

## How did you test this code?

I (Claude) ran oxlint and oxfmt on the changed file, both clean. I did not run the app or manually click through the inbox, and I did not add tests: this is a link and a row-layout change with no logic behind it, so there is no regression a new test would catch that a snapshot story does not.

The full frontend typecheck does not pass in this environment, but the failures are all unresolved workspace packages (`@posthog/quill-primitives` and friends that need building) on files this PR does not touch. Nothing in the output references the changed file.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change: this adds an affordance to an existing surface, it does not change a documented workflow.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked for a link from the Runs rows on a report detail view to the underlying task runs, with a screenshot of the section. I (Claude) wrote the change.

I kept it as an in-app link rather than opening a new tab, matching how the rest of the inbox links out (`SignalRunCard`, the scout cards). Happy to switch it to `targetBlank` if losing your place in the inbox mid-triage is the bigger annoyance.

Codex raised two points. I took the tap-target one and enlarged the link's hit box. I declined the other, which asked for the link to pin the report artefact's own `run_id` instead of `task.latest_run.id`; the reasoning is in the [thread](https://github.com/PostHog/posthog/pull/73679#discussion_r3649987852), and the short version is that this section renders one row per task rather than one row per artefact, so pinning only the link would make it disagree with the status dot and transcript beside it. An earlier draft of this description framed the `?runId` as protecting against re-runs, which overstated it and is what the finding keyed on. Corrected above.

No repo skills were invoked: the change touches no serializers, migrations, API types, or tests.