### PR TITLE
fix(openai_ads): classify exhausted retryable errors as retryable noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai_ads/source.py
@@ -31,6 +31,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.openai_ads
 from products.warehouse_sources.backend.temporal.data_imports.sources.openai_ads.settings import (
     ENDPOINTS,
     INCREMENTAL_FIELDS,
+    OPENAI_ADS_BASE_URL,
     OPENAI_ADS_ENDPOINTS,
 )
 from products.warehouse_sources.backend.types import ExternalDataSourceType
@@ -84,6 +85,19 @@ Create an API key in the Settings tab of [OpenAI Ads Manager](https://ads.openai
         return {
             "401 Client Error: Unauthorized for url: https://api.ads.openai.com": "Your OpenAI Ads API key is invalid or has been revoked. Create a new API key in the Settings tab of OpenAI Ads Manager, then reconnect.",
             "403 Client Error: Forbidden for url: https://api.ads.openai.com": "Your OpenAI Ads API key does not have access to this ad account. Create a key for this ad account in the Settings tab of OpenAI Ads Manager, then reconnect.",
+        }
+
+    def get_retryable_errors(self) -> set[str]:
+        # The shared RESTClient (rest_client.py) already retries 429/5xx responses, connection
+        # resets, timeouts, and malformed-JSON bodies in-process via tenacity (5 attempts,
+        # exponential backoff honoring Retry-After) before re-raising RESTClientRetryableError.
+        # A failure that survives all 5 attempts is a transient OpenAI Ads / edge blip, not a bug —
+        # Temporal's activity retry recovers once the upstream issue clears, so keep it out of
+        # error tracking as noise. The status code and path vary per request; the API host doesn't,
+        # so match on that rather than the volatile parts of the message.
+        return {
+            f"for {OPENAI_ADS_BASE_URL}",
+            f"from {OPENAI_ADS_BASE_URL}",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/openai_ads/tests/test_openai_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/openai_ads/tests/test_openai_ads_source.py
@@ -129,6 +129,46 @@ class TestNonRetryableErrors:
         assert not any(key in other_error for key in non_retryable)
 
 
+class TestRetryableErrors:
+    @parameterized.expand(
+        [
+            ("server_error", "HTTP 500 for https://api.ads.openai.com/v1/campaigns"),
+            ("rate_limited", "HTTP 429 for https://api.ads.openai.com/v1/ad_account/insights"),
+            (
+                "connection_error",
+                "Connection error (ConnectionError) for https://api.ads.openai.com/v1/ad_groups",
+            ),
+            (
+                "timeout",
+                "Request timed out (ReadTimeout) for https://api.ads.openai.com/v1/ads",
+            ),
+            (
+                "malformed_json",
+                "Malformed JSON response from https://api.ads.openai.com/v1/campaigns: Expecting value: line 1 column 1 (char 0)",
+            ),
+        ]
+    )
+    def test_exhausted_transient_failures_are_recognized(self, _name: str, observed_error: str) -> None:
+        retryable = OpenAIAdsSource().get_retryable_errors()
+        assert any(pattern in observed_error for pattern in retryable)
+
+    @parameterized.expand(
+        [
+            (
+                "unauthorized",
+                "401 Client Error: Unauthorized for url: https://api.ads.openai.com/v1/campaigns",
+            ),
+            (
+                "not_found",
+                "404 Client Error: Not Found for url: https://api.ads.openai.com/v1/campaigns/123",
+            ),
+        ]
+    )
+    def test_credential_and_client_errors_are_not_misclassified(self, _name: str, other_error: str) -> None:
+        retryable = OpenAIAdsSource().get_retryable_errors()
+        assert not any(pattern in other_error for pattern in retryable)
+
+
 class TestDocumentedTables:
     def test_canonical_descriptions_cover_every_endpoint(self) -> None:
         # The docs' Supported tables section keys canonical entries by endpoint name — a drifted


### PR DESCRIPTION
## Problem

Error tracking surfaced `RESTClientRetryableError` ("HTTP 500 for https://api.ads.openai.com/v1/campaigns") as a tracked exception for the OpenAI Ads warehouse source ([issue](https://us.posthog.com/project/2/error_tracking/019f98a5-e2dd-7f60-81e1-a78df1c03c84)).

The shared `RESTClient` (`common/rest_source/rest_client.py`) already retries 429/5xx responses, connection resets, timeouts, and malformed-JSON bodies in-process via tenacity (5 attempts, exponential backoff honoring `Retry-After`) before re-raising `RESTClientRetryableError`. When those in-process retries are exhausted, the error reaches `_handle_import_error`, which only special-cases errors listed in a source's `get_retryable_errors()` — and `OpenAIAdsSource` didn't override it. So the error fell through to the default branch, got logged at `exception` level, and was captured as a tracked issue, even though Temporal's own activity-level retry recovers the sync once the upstream blip clears.

This is the same pattern already fixed for other sources (LinkedIn Ads, HubSpot, Meta Ads, etc.) — a transient, self-recovering failure being misclassified as a bug.

## Changes

- Added `get_retryable_errors()` to `OpenAIAdsSource`, matching on the stable API host (`https://api.ads.openai.com`) rather than the volatile status code or request path that vary per failure.

## How did you test this code?

Added a parameterized test group to `test_openai_ads_source.py`:
- `test_exhausted_transient_failures_are_recognized` — asserts exhausted 500/429/connection-error/timeout/malformed-JSON messages match the new `get_retryable_errors()` patterns. Catches a regression where the retryable-noise classification silently stops matching.
- `test_credential_and_client_errors_are_not_misclassified` — asserts unrelated errors (401, 404) are *not* misclassified as retryable noise, which would otherwise hide a real bug from error tracking.

Ran the full `test_openai_ads_source.py` and `test_openai_ads.py` suites locally (30 passed), plus `ruff check`/`ruff format` and a full-repo `mypy` run on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — no user-facing behavior change, just error-tracking noise reduction.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (PostHog Code), triaging a real error-tracking issue for the `openai_ads` source.
- Confirmed the stack trace originates in `openai_ads.py`'s `_fan_out_rows`/`_list_pages`, calling into the shared `RESTClient`, then compared against the existing `get_retryable_errors()` convention used by LinkedIn Ads/HubSpot/Meta Ads sources to reach the same fix shape.
- Decision: classified as a "fixable bug" (missing retryable-noise classification), not a "user/upstream error" — the error is a transient upstream 5xx already retried internally by tenacity, not something to add to `get_non_retryable_errors()`.
- Skills invoked: `/writing-tests` before adding the new test cases.