### PR TITLE
fix(replay): surface the real error when S3 returns an unreadable response

### DIFF
--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
@@ -89,12 +89,12 @@ describe('uploadToS3', () => {
     })
 
     it('propagates upload errors', async () => {
-        mockDone.mockRejectedValue(new Error('AccessDenied'))
-        await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toThrow('AccessDenied')
+        const uploadError = Object.assign(new Error('AccessDenied'), { $response: { statusCode: 403 } })
+        mockDone.mockRejectedValue(uploadError)
+        await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toBe(uploadError)
     })
 
     it('translates an undecodable (non-XML) response into a clear retryable RasterizationError', async () => {
-        // The AWS XML parser's opaque failure when the object store returns a non-XML body (e.g. a proxy error page).
         const smithyErr = Object.assign(new Error("char 'E' is not expected.:1:1\n  Deserialization error"), {
             $response: { statusCode: 502, body: 'Error: bad gateway' },
         })
@@ -107,7 +107,6 @@ describe('uploadToS3', () => {
             retryable: true,
             cause: smithyErr,
         })
-        // The real upstream status + body surface instead of the parser's confusion.
         await expect(promise).rejects.toThrow(/status 502.*bad gateway/)
     })
 

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
@@ -95,7 +95,6 @@ describe('uploadToS3', () => {
             error: Object.assign(new Error("char 'E' is not expected.:1:1\n  Deserialization error"), {
                 $response: { statusCode: 502, body: '<html>502 Bad Gateway</html>' },
             }),
-            retryable: true,
             expectedMessage: /status 502.*response body: <html>502 Bad Gateway/,
         },
         {
@@ -103,7 +102,6 @@ describe('uploadToS3', () => {
             error: Object.assign(new Error('Deserialization error: to see the raw response, inspect …'), {
                 $response: { statusCode: 403, body: 'AccessDenied' },
             }),
-            retryable: false,
             expectedMessage: /status 403.*response body: AccessDenied/,
         },
         {
@@ -112,29 +110,25 @@ describe('uploadToS3', () => {
                 name: 'AccessDenied',
                 $metadata: { httpStatusCode: 403 },
             }),
-            retryable: false,
             expectedMessage: /status 403.*Access Denied/,
         },
         {
             failure: 'a failure with no HTTP response at all',
             error: new Error('socket hang up'),
-            retryable: true,
             expectedMessage: /status unknown.*socket hang up/,
         },
-    ])(
-        'reports $failure as a RasterizationError with retryable=$retryable',
-        async ({ error, retryable, expectedMessage }) => {
-            mockDone.mockRejectedValue(error)
+    ])('reports $failure with its status, leaving it retryable', async ({ error, expectedMessage }) => {
+        mockDone.mockRejectedValue(error)
 
-            await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toMatchObject({
-                name: 'RasterizationError',
-                code: 'S3_UPLOAD_FAILED',
-                retryable,
-                cause: error,
-                message: expect.stringMatching(expectedMessage),
-            })
-        }
-    )
+        await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toMatchObject({
+            name: 'RasterizationError',
+            code: 'S3_UPLOAD_FAILED',
+            // Wrapping the failure must not make it terminal, whatever status it came back with.
+            retryable: true,
+            cause: error,
+            message: expect.stringMatching(expectedMessage),
+        })
+    })
 
     it('names the upload target in the failure message', async () => {
         mockDone.mockRejectedValue(new Error('socket hang up'))

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
@@ -91,8 +91,8 @@ describe('uploadToS3', () => {
     it('reports a response the SDK could not read, leaving it retryable', async () => {
         // All the SDK reports is its parser's confusion; the raw body it choked on is on $responseBodyText.
         const undecodable = Object.assign(new Error("char 'E' is not expected.:1:1\n  Deserialization error"), {
-            $responseBodyText: 'Error: proxy denied',
-            $response: { statusCode: 407, body: 'Error: proxy denied' },
+            $responseBodyText: 'Error: proxy denied for s3://secret-bucket/tenant-42.mp4',
+            $response: { statusCode: 407 },
         })
         mockDone.mockRejectedValue(undecodable)
 
@@ -102,8 +102,9 @@ describe('uploadToS3', () => {
             // Translating the failure must not make it terminal.
             retryable: true,
             cause: undecodable,
-            message:
-                'S3 upload to s3://bucket/prefix/id.mp4 failed with an unreadable (non-XML) response (status 407): Error: proxy denied',
+            // This message is shown to team users as ReplayObservation.error_reason, so it must carry
+            // neither the bucket and key nor anything the object store put in the body.
+            message: 'S3 upload failed: the object store returned an unreadable (non-XML) response (status 407)',
         })
     })
 

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
@@ -88,32 +88,38 @@ describe('uploadToS3', () => {
         expect(mockOn).not.toHaveBeenCalled()
     })
 
-    it.each([
-        {
-            failure: 'a response the SDK could not parse',
-            // All the SDK reports is its parser's confusion; the gateway's real body is on $response.
-            error: Object.assign(new Error("char 'E' is not expected.:1:1\n  Deserialization error"), {
-                $response: { statusCode: 502, body: '<html>502 Bad Gateway</html>' },
-            }),
-            expectedMessage:
-                /^S3 upload to s3:\/\/bucket\/prefix\/id\.mp4 failed \(status 502\)[\s\S]*response body: <html>502 Bad Gateway<\/html>$/,
-        },
-        {
-            failure: 'a failure carrying no HTTP response',
-            error: new Error('socket hang up'),
-            expectedMessage: /^S3 upload to s3:\/\/bucket\/prefix\/id\.mp4 failed \(status unknown\): socket hang up$/,
-        },
-    ])('reports $failure, leaving it retryable', async ({ error, expectedMessage }) => {
-        mockDone.mockRejectedValue(error)
+    it('reports a response the SDK could not read, leaving it retryable', async () => {
+        // All the SDK reports is its parser's confusion; the raw body it choked on is on $responseBodyText.
+        const undecodable = Object.assign(new Error("char 'E' is not expected.:1:1\n  Deserialization error"), {
+            $responseBodyText: 'Error: proxy denied',
+            $response: { statusCode: 407, body: 'Error: proxy denied' },
+        })
+        mockDone.mockRejectedValue(undecodable)
 
         await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toMatchObject({
             name: 'RasterizationError',
-            code: 'S3_UPLOAD_FAILED',
-            // Wrapping an upload failure must not make it terminal.
+            code: 'S3_UPLOAD_UNDECODABLE_RESPONSE',
+            // Translating the failure must not make it terminal.
             retryable: true,
-            cause: error,
-            message: expect.stringMatching(expectedMessage),
+            cause: undecodable,
+            message:
+                'S3 upload to s3://bucket/prefix/id.mp4 failed with an unreadable (non-XML) response (status 407): Error: proxy denied',
         })
+    })
+
+    it.each([
+        {
+            failure: 'a modeled service error whose body parsed fine',
+            error: Object.assign(new Error('Access Denied'), {
+                name: 'AccessDenied',
+                $response: { statusCode: 403 },
+                $metadata: { httpStatusCode: 403 },
+            }),
+        },
+        { failure: 'a failure carrying no HTTP response', error: new Error('socket hang up') },
+    ])('rethrows $failure untouched, so callers still see the SDK error', async ({ error }) => {
+        mockDone.mockRejectedValue(error)
+        await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toBe(error)
     })
 })
 

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
@@ -88,44 +88,60 @@ describe('uploadToS3', () => {
         expect(mockOn).not.toHaveBeenCalled()
     })
 
-    it('propagates upload errors', async () => {
-        const uploadError = new Error('AccessDenied')
-        mockDone.mockRejectedValue(uploadError)
-        await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toBe(uploadError)
-    })
-
     it.each([
         {
-            status: '5xx',
-            message: "char 'E' is not expected.:1:1\n  Deserialization error",
-            statusCode: 502,
-            body: 'Error: bad gateway',
+            failure: 'a 5xx response the SDK could not parse',
+            // The SDK reports its parser's confusion, and hides the gateway's real body on $response.
+            error: Object.assign(new Error("char 'E' is not expected.:1:1\n  Deserialization error"), {
+                $response: { statusCode: 502, body: '<html>502 Bad Gateway</html>' },
+            }),
             retryable: true,
-            expectedDetail: /status 502.*bad gateway/,
+            expectedMessage: /status 502.*response body: <html>502 Bad Gateway/,
         },
         {
-            status: '4xx',
-            message: 'Deserialization error: to see the raw response, inspect …',
-            statusCode: 403,
-            body: 'AccessDenied',
+            failure: 'a 4xx response the SDK could not parse',
+            error: Object.assign(new Error('Deserialization error: to see the raw response, inspect …'), {
+                $response: { statusCode: 403, body: 'AccessDenied' },
+            }),
             retryable: false,
-            expectedDetail: /status 403.*AccessDenied/,
+            expectedMessage: /status 403.*response body: AccessDenied/,
+        },
+        {
+            failure: 'a modeled service error carrying only $metadata',
+            error: Object.assign(new Error('Access Denied'), {
+                name: 'AccessDenied',
+                $metadata: { httpStatusCode: 403 },
+            }),
+            retryable: false,
+            expectedMessage: /status 403.*Access Denied/,
+        },
+        {
+            failure: 'a failure with no HTTP response at all',
+            error: new Error('socket hang up'),
+            retryable: true,
+            expectedMessage: /status unknown.*socket hang up/,
         },
     ])(
-        'translates an undecodable (non-XML) $status response into a RasterizationError with retryable=$retryable',
-        async ({ message, statusCode, body, retryable, expectedDetail }) => {
-            const smithyErr = Object.assign(new Error(message), { $response: { statusCode, body } })
-            mockDone.mockRejectedValue(smithyErr)
+        'reports $failure as a RasterizationError with retryable=$retryable',
+        async ({ error, retryable, expectedMessage }) => {
+            mockDone.mockRejectedValue(error)
 
             await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toMatchObject({
                 name: 'RasterizationError',
-                code: 'S3_UPLOAD_UNDECODABLE_RESPONSE',
+                code: 'S3_UPLOAD_FAILED',
                 retryable,
-                cause: smithyErr,
-                message: expect.stringMatching(expectedDetail),
+                cause: error,
+                message: expect.stringMatching(expectedMessage),
             })
         }
     )
+
+    it('names the upload target in the failure message', async () => {
+        mockDone.mockRejectedValue(new Error('socket hang up'))
+        await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toThrow(
+            'S3 upload to s3://bucket/prefix/id.mp4 failed'
+        )
+    })
 })
 
 jest.mock('https-proxy-agent', () => ({

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
@@ -90,51 +90,30 @@ describe('uploadToS3', () => {
 
     it.each([
         {
-            failure: 'a 5xx response the SDK could not parse',
-            // The SDK reports its parser's confusion, and hides the gateway's real body on $response.
+            failure: 'a response the SDK could not parse',
+            // All the SDK reports is its parser's confusion; the gateway's real body is on $response.
             error: Object.assign(new Error("char 'E' is not expected.:1:1\n  Deserialization error"), {
                 $response: { statusCode: 502, body: '<html>502 Bad Gateway</html>' },
             }),
-            expectedMessage: /status 502.*response body: <html>502 Bad Gateway/,
+            expectedMessage:
+                /^S3 upload to s3:\/\/bucket\/prefix\/id\.mp4 failed \(status 502\)[\s\S]*response body: <html>502 Bad Gateway<\/html>$/,
         },
         {
-            failure: 'a 4xx response the SDK could not parse',
-            error: Object.assign(new Error('Deserialization error: to see the raw response, inspect …'), {
-                $response: { statusCode: 403, body: 'AccessDenied' },
-            }),
-            expectedMessage: /status 403.*response body: AccessDenied/,
-        },
-        {
-            failure: 'a modeled service error carrying only $metadata',
-            error: Object.assign(new Error('Access Denied'), {
-                name: 'AccessDenied',
-                $metadata: { httpStatusCode: 403 },
-            }),
-            expectedMessage: /status 403.*Access Denied/,
-        },
-        {
-            failure: 'a failure with no HTTP response at all',
+            failure: 'a failure carrying no HTTP response',
             error: new Error('socket hang up'),
-            expectedMessage: /status unknown.*socket hang up/,
+            expectedMessage: /^S3 upload to s3:\/\/bucket\/prefix\/id\.mp4 failed \(status unknown\): socket hang up$/,
         },
-    ])('reports $failure with its status, leaving it retryable', async ({ error, expectedMessage }) => {
+    ])('reports $failure, leaving it retryable', async ({ error, expectedMessage }) => {
         mockDone.mockRejectedValue(error)
 
         await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toMatchObject({
             name: 'RasterizationError',
             code: 'S3_UPLOAD_FAILED',
-            // Wrapping the failure must not make it terminal, whatever status it came back with.
+            // Wrapping an upload failure must not make it terminal.
             retryable: true,
             cause: error,
             message: expect.stringMatching(expectedMessage),
         })
-    })
-
-    it('names the upload target in the failure message', async () => {
-        mockDone.mockRejectedValue(new Error('socket hang up'))
-        await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toThrow(
-            'S3 upload to s3://bucket/prefix/id.mp4 failed'
-        )
     })
 })
 

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
@@ -89,34 +89,43 @@ describe('uploadToS3', () => {
     })
 
     it('propagates upload errors', async () => {
-        const uploadError = Object.assign(new Error('AccessDenied'), { $response: { statusCode: 403 } })
+        const uploadError = new Error('AccessDenied')
         mockDone.mockRejectedValue(uploadError)
         await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toBe(uploadError)
     })
 
-    it('translates an undecodable (non-XML) response into a clear retryable RasterizationError', async () => {
-        const smithyErr = Object.assign(new Error("char 'E' is not expected.:1:1\n  Deserialization error"), {
-            $response: { statusCode: 502, body: 'Error: bad gateway' },
-        })
-        mockDone.mockRejectedValue(smithyErr)
-
-        const promise = uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')
-        await expect(promise).rejects.toMatchObject({
-            name: 'RasterizationError',
-            code: 'S3_UPLOAD_UNDECODABLE_RESPONSE',
+    it.each([
+        {
+            status: '5xx',
+            message: "char 'E' is not expected.:1:1\n  Deserialization error",
+            statusCode: 502,
+            body: 'Error: bad gateway',
             retryable: true,
-            cause: smithyErr,
-        })
-        await expect(promise).rejects.toThrow(/status 502.*bad gateway/)
-    })
+            expectedDetail: /status 502.*bad gateway/,
+        },
+        {
+            status: '4xx',
+            message: 'Deserialization error: to see the raw response, inspect …',
+            statusCode: 403,
+            body: 'AccessDenied',
+            retryable: false,
+            expectedDetail: /status 403.*AccessDenied/,
+        },
+    ])(
+        'translates an undecodable (non-XML) $status response into a RasterizationError with retryable=$retryable',
+        async ({ message, statusCode, body, retryable, expectedDetail }) => {
+            const smithyErr = Object.assign(new Error(message), { $response: { statusCode, body } })
+            mockDone.mockRejectedValue(smithyErr)
 
-    it('marks a 4xx undecodable response as non-retryable', async () => {
-        const smithyErr = Object.assign(new Error('Deserialization error: to see the raw response, inspect …'), {
-            $response: { statusCode: 403, body: 'AccessDenied' },
-        })
-        mockDone.mockRejectedValue(smithyErr)
-        await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toMatchObject({ retryable: false })
-    })
+            await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toMatchObject({
+                name: 'RasterizationError',
+                code: 'S3_UPLOAD_UNDECODABLE_RESPONSE',
+                retryable,
+                cause: smithyErr,
+                message: expect.stringMatching(expectedDetail),
+            })
+        }
+    )
 })
 
 jest.mock('https-proxy-agent', () => ({

--- a/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/__tests__/storage.test.ts
@@ -92,6 +92,32 @@ describe('uploadToS3', () => {
         mockDone.mockRejectedValue(new Error('AccessDenied'))
         await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toThrow('AccessDenied')
     })
+
+    it('translates an undecodable (non-XML) response into a clear retryable RasterizationError', async () => {
+        // The AWS XML parser's opaque failure when the object store returns a non-XML body (e.g. a proxy error page).
+        const smithyErr = Object.assign(new Error("char 'E' is not expected.:1:1\n  Deserialization error"), {
+            $response: { statusCode: 502, body: 'Error: bad gateway' },
+        })
+        mockDone.mockRejectedValue(smithyErr)
+
+        const promise = uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')
+        await expect(promise).rejects.toMatchObject({
+            name: 'RasterizationError',
+            code: 'S3_UPLOAD_UNDECODABLE_RESPONSE',
+            retryable: true,
+            cause: smithyErr,
+        })
+        // The real upstream status + body surface instead of the parser's confusion.
+        await expect(promise).rejects.toThrow(/status 502.*bad gateway/)
+    })
+
+    it('marks a 4xx undecodable response as non-retryable', async () => {
+        const smithyErr = Object.assign(new Error('Deserialization error: to see the raw response, inspect …'), {
+            $response: { statusCode: 403, body: 'AccessDenied' },
+        })
+        mockDone.mockRejectedValue(smithyErr)
+        await expect(uploadToS3('/tmp/v.mp4', 'bucket', 'prefix', 'id')).rejects.toMatchObject({ retryable: false })
+    })
 })
 
 jest.mock('https-proxy-agent', () => ({

--- a/nodejs/src/session-replay/recording-rasterizer/storage.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/storage.ts
@@ -11,24 +11,32 @@ import { createLogger } from './logger'
 
 const log = createLogger()
 
-function undecodableS3ResponseError(err: unknown): RasterizationError | null {
-    if (!(err instanceof Error) || !/Deserialization error|is not expected/i.test(err.message)) {
-        return null
-    }
+// The AWS SDK keeps the HTTP response off its public error type and hangs it on non-enumerable
+// $response / $metadata properties instead. Reading them is the only way to say anything useful about a
+// failure whose body the SDK could not parse: an object store or proxy answering with plaintext or an
+// HTML error page rather than S3's XML makes the SDK's parser throw, and the error it raises then
+// describes the parser's confusion instead of the request. $response.body holds the raw body in that
+// case, so it is where the actual reason lives.
+type AwsResponseError = {
+    $response?: { statusCode?: number; body?: unknown }
+    $metadata?: { httpStatusCode?: number }
+}
 
-    // The AWS SDK stashes the raw response the XML parser choked on under $response, a property its
-    // public error type omits, so read it defensively to recover the real status and body.
-    const { statusCode, body } = (err as { $response?: { statusCode?: number; body?: unknown } }).$response ?? {}
-    const details = [`status ${statusCode ?? 'unknown'}`]
-    if (typeof body === 'string' && body.length > 0) {
-        details.push(`body: ${sanitizeForUTF8(body.slice(0, 500))}`)
-    }
-    // Without a status we cannot tell a client error from a server one, so retry rather than fail the render.
-    const retryable = statusCode === undefined || statusCode >= 500 || statusCode === 429
+function toUploadError(err: unknown, target: string): RasterizationError {
+    const { $response, $metadata } = (err ?? {}) as AwsResponseError
+    const status = $response?.statusCode ?? $metadata?.httpStatusCode
+    // $response.body is a string only when the SDK failed to parse it; otherwise it is the response stream.
+    const rawBody = $response?.body
+    const body = typeof rawBody === 'string' && rawBody.length > 0 ? sanitizeForUTF8(rawBody.slice(0, 500)) : null
+    // SDK messages run to several lines, and this one ends up as a Temporal failure message.
+    const reason = err instanceof Error ? err.message.replace(/\s+/g, ' ').slice(0, 300) : String(err)
+    // A 4xx will fail the same way on the next attempt. No status at all means a network or credential
+    // failure rather than a verdict from the store, so it gets the benefit of the doubt.
+    const retryable = status === undefined || status >= 500 || status === 429
     return new RasterizationError(
-        `S3 upload returned an undecodable (non-XML) response (${details.join(', ')})`,
+        `S3 upload to ${target} failed (status ${status ?? 'unknown'}): ${reason}${body ? `, response body: ${body}` : ''}`,
         retryable,
-        'S3_UPLOAD_UNDECODABLE_RESPONSE',
+        'S3_UPLOAD_FAILED',
         err
     )
 }
@@ -100,16 +108,12 @@ export async function uploadToS3(
         upload.on('httpUploadProgress', () => onProgress())
     }
 
+    const target = `s3://${bucket}/${key}`
     try {
         await upload.done()
     } catch (err) {
-        const undecodable = undecodableS3ResponseError(err)
-        if (!undecodable) {
-            throw err
-        }
-        log.warn({ err, bucket, key }, 'S3 upload returned an undecodable response')
-        throw undecodable
+        throw toUploadError(err, target)
     }
 
-    return `s3://${bucket}/${key}`
+    return target
 }

--- a/nodejs/src/session-replay/recording-rasterizer/storage.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/storage.ts
@@ -19,19 +19,12 @@ type UndecodableS3Response = {
     $response?: { statusCode?: number }
 }
 
-function undecodableResponseError(err: unknown, target: string): RasterizationError | null {
+function undecodableResponse(err: unknown): { status?: number; body: string } | null {
     const { $responseBodyText, $response } = (err ?? {}) as UndecodableS3Response
     if (typeof $responseBodyText !== 'string') {
         return null
     }
-    // Retryability is untouched: the workflow's retry policy keeps deciding, as it does for any other
-    // upload failure.
-    return new RasterizationError(
-        `S3 upload to ${target} failed with an unreadable (non-XML) response (status ${$response?.statusCode ?? 'unknown'}): ${$responseBodyText.slice(0, 500)}`,
-        true,
-        'S3_UPLOAD_UNDECODABLE_RESPONSE',
-        err
-    )
+    return { status: $response?.statusCode, body: $responseBodyText.slice(0, 500) }
 }
 
 let s3Client: S3Client | null = null
@@ -105,7 +98,24 @@ export async function uploadToS3(
     try {
         await upload.done()
     } catch (err) {
-        throw undecodableResponseError(err, target) ?? err
+        const undecodable = undecodableResponse(err)
+        if (!undecodable) {
+            throw err
+        }
+        // Bucket, key and the raw body stay in this log line. The thrown message reaches team users as
+        // ReplayObservation.error_reason, and the body is whatever an upstream proxy or gateway chose to
+        // return, so only the status code goes into it. Retryability is untouched: the workflow's retry
+        // policy keeps deciding, as it does for any other upload failure.
+        log.warn(
+            { bucket, key, status: undecodable.status, response_body: undecodable.body },
+            'S3 upload returned an unreadable response'
+        )
+        throw new RasterizationError(
+            `S3 upload failed: the object store returned an unreadable (non-XML) response (status ${undecodable.status ?? 'unknown'})`,
+            true,
+            'S3_UPLOAD_UNDECODABLE_RESPONSE',
+            err
+        )
     }
 
     return target

--- a/nodejs/src/session-replay/recording-rasterizer/storage.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/storage.ts
@@ -3,35 +3,34 @@ import { Upload } from '@aws-sdk/lib-storage'
 import * as fs from 'fs'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 
+import { sanitizeForUTF8 } from '~/common/utils/strings'
+
 import { config } from './config'
 import { RasterizationError } from './errors'
 import { createLogger } from './logger'
 
 const log = createLogger()
 
-type S3ResponseError = Error & {
-    $response?: { statusCode?: number; body?: unknown }
-    $metadata?: { httpStatusCode?: number }
-}
-
-function describeUndecodableS3Response(err: unknown): { message: string; retryable: boolean } | null {
+function undecodableS3ResponseError(err: unknown): RasterizationError | null {
     if (!(err instanceof Error) || !/Deserialization error|is not expected/i.test(err.message)) {
         return null
     }
 
-    // The AWS SDK hides the raw non-XML response on properties omitted from its public error type.
-    const responseError = err as S3ResponseError
-    const status = responseError.$response?.statusCode ?? responseError.$metadata?.httpStatusCode
-    const body = responseError.$response?.body
-    const bodyPreview = typeof body === 'string' ? body.slice(0, 500) : undefined
-    const detail = [status !== undefined ? `status ${status}` : null, bodyPreview ? `body: ${bodyPreview}` : null]
-        .filter(Boolean)
-        .join(', ')
-    const retryable = status === undefined || status >= 500 || status === 429
-    return {
-        message: `S3 upload returned an undecodable (non-XML) response${detail ? ` (${detail})` : ''}`,
-        retryable,
+    // The AWS SDK stashes the raw response the XML parser choked on under $response, a property its
+    // public error type omits, so read it defensively to recover the real status and body.
+    const { statusCode, body } = (err as { $response?: { statusCode?: number; body?: unknown } }).$response ?? {}
+    const details = [`status ${statusCode ?? 'unknown'}`]
+    if (typeof body === 'string' && body.length > 0) {
+        details.push(`body: ${sanitizeForUTF8(body.slice(0, 500))}`)
     }
+    // Without a status we cannot tell a client error from a server one, so retry rather than fail the render.
+    const retryable = statusCode === undefined || statusCode >= 500 || statusCode === 429
+    return new RasterizationError(
+        `S3 upload returned an undecodable (non-XML) response (${details.join(', ')})`,
+        retryable,
+        'S3_UPLOAD_UNDECODABLE_RESPONSE',
+        err
+    )
 }
 
 let s3Client: S3Client | null = null
@@ -104,12 +103,12 @@ export async function uploadToS3(
     try {
         await upload.done()
     } catch (err) {
-        const described = describeUndecodableS3Response(err)
-        if (described) {
-            log.warn({ err, bucket, key }, 'S3 upload returned an undecodable response')
-            throw new RasterizationError(described.message, described.retryable, 'S3_UPLOAD_UNDECODABLE_RESPONSE', err)
+        const undecodable = undecodableS3ResponseError(err)
+        if (!undecodable) {
+            throw err
         }
-        throw err
+        log.warn({ err, bucket, key }, 'S3 upload returned an undecodable response')
+        throw undecodable
     }
 
     return `s3://${bucket}/${key}`

--- a/nodejs/src/session-replay/recording-rasterizer/storage.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/storage.ts
@@ -30,12 +30,11 @@ function toUploadError(err: unknown, target: string): RasterizationError {
     const body = typeof rawBody === 'string' && rawBody.length > 0 ? sanitizeForUTF8(rawBody.slice(0, 500)) : null
     // SDK messages run to several lines, and this one ends up as a Temporal failure message.
     const reason = err instanceof Error ? err.message.replace(/\s+/g, ' ').slice(0, 300) : String(err)
-    // A 4xx will fail the same way on the next attempt. No status at all means a network or credential
-    // failure rather than a verdict from the store, so it gets the benefit of the doubt.
-    const retryable = status === undefined || status >= 500 || status === 429
+    // Reporting only: no upload failure is marked terminal here, so the workflow's retry policy keeps
+    // deciding what happens next.
     return new RasterizationError(
         `S3 upload to ${target} failed (status ${status ?? 'unknown'}): ${reason}${body ? `, response body: ${body}` : ''}`,
-        retryable,
+        true,
         'S3_UPLOAD_FAILED',
         err
     )

--- a/nodejs/src/session-replay/recording-rasterizer/storage.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/storage.ts
@@ -9,26 +9,24 @@ import { createLogger } from './logger'
 
 const log = createLogger()
 
-// A non-XML body from the object store (a proxy/gateway error page, a plaintext "Error…") makes the AWS SDK's
-// XML parser blow up with an opaque "char 'E' is not expected" / "Deserialization error … $response" — the raw
-// response is hidden on `err.$response`. Recover the real status + body so the failure is diagnosable instead of
-// surfacing the parser's confusion as the user-facing reason.
+type S3ResponseError = Error & {
+    $response?: { statusCode?: number; body?: unknown }
+    $metadata?: { httpStatusCode?: number }
+}
+
 function describeUndecodableS3Response(err: unknown): { message: string; retryable: boolean } | null {
-    if (!(err instanceof Error)) {
+    if (!(err instanceof Error) || !/Deserialization error|is not expected/i.test(err.message)) {
         return null
     }
-    const raw = (err as { $response?: unknown }).$response
-    const looksUndecodable = /Deserialization error|is not expected/i.test(err.message)
-    if (!raw && !looksUndecodable) {
-        return null
-    }
-    const response = (raw ?? {}) as { statusCode?: number; body?: unknown }
-    const status = response.statusCode ?? (err as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode
-    const bodyPreview = typeof response.body === 'string' ? response.body.slice(0, 500) : undefined
+
+    // The AWS SDK hides the raw non-XML response on properties omitted from its public error type.
+    const responseError = err as S3ResponseError
+    const status = responseError.$response?.statusCode ?? responseError.$metadata?.httpStatusCode
+    const body = responseError.$response?.body
+    const bodyPreview = typeof body === 'string' ? body.slice(0, 500) : undefined
     const detail = [status !== undefined ? `status ${status}` : null, bodyPreview ? `body: ${bodyPreview}` : null]
         .filter(Boolean)
         .join(', ')
-    // No status usually means a gateway/transport hiccup; 5xx/429 are transient too. Retry those, give up on 4xx.
     const retryable = status === undefined || status >= 500 || status === 429
     return {
         message: `S3 upload returned an undecodable (non-XML) response${detail ? ` (${detail})` : ''}`,

--- a/nodejs/src/session-replay/recording-rasterizer/storage.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/storage.ts
@@ -4,9 +4,37 @@ import * as fs from 'fs'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 
 import { config } from './config'
+import { RasterizationError } from './errors'
 import { createLogger } from './logger'
 
 const log = createLogger()
+
+// A non-XML body from the object store (a proxy/gateway error page, a plaintext "Error…") makes the AWS SDK's
+// XML parser blow up with an opaque "char 'E' is not expected" / "Deserialization error … $response" — the raw
+// response is hidden on `err.$response`. Recover the real status + body so the failure is diagnosable instead of
+// surfacing the parser's confusion as the user-facing reason.
+function describeUndecodableS3Response(err: unknown): { message: string; retryable: boolean } | null {
+    if (!(err instanceof Error)) {
+        return null
+    }
+    const raw = (err as { $response?: unknown }).$response
+    const looksUndecodable = /Deserialization error|is not expected/i.test(err.message)
+    if (!raw && !looksUndecodable) {
+        return null
+    }
+    const response = (raw ?? {}) as { statusCode?: number; body?: unknown }
+    const status = response.statusCode ?? (err as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode
+    const bodyPreview = typeof response.body === 'string' ? response.body.slice(0, 500) : undefined
+    const detail = [status !== undefined ? `status ${status}` : null, bodyPreview ? `body: ${bodyPreview}` : null]
+        .filter(Boolean)
+        .join(', ')
+    // No status usually means a gateway/transport hiccup; 5xx/429 are transient too. Retry those, give up on 4xx.
+    const retryable = status === undefined || status >= 500 || status === 429
+    return {
+        message: `S3 upload returned an undecodable (non-XML) response${detail ? ` (${detail})` : ''}`,
+        retryable,
+    }
+}
 
 let s3Client: S3Client | null = null
 
@@ -75,7 +103,16 @@ export async function uploadToS3(
         upload.on('httpUploadProgress', () => onProgress())
     }
 
-    await upload.done()
+    try {
+        await upload.done()
+    } catch (err) {
+        const described = describeUndecodableS3Response(err)
+        if (described) {
+            log.warn({ err, bucket, key }, 'S3 upload returned an undecodable response')
+            throw new RasterizationError(described.message, described.retryable, 'S3_UPLOAD_UNDECODABLE_RESPONSE', err)
+        }
+        throw err
+    }
 
     return `s3://${bucket}/${key}`
 }

--- a/nodejs/src/session-replay/recording-rasterizer/storage.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/storage.ts
@@ -3,37 +3,23 @@ import { Upload } from '@aws-sdk/lib-storage'
 import * as fs from 'fs'
 import { HttpsProxyAgent } from 'https-proxy-agent'
 
-import { sanitizeForUTF8 } from '~/common/utils/strings'
-
 import { config } from './config'
 import { RasterizationError } from './errors'
 import { createLogger } from './logger'
 
 const log = createLogger()
 
-// The AWS SDK keeps the HTTP response off its public error type and hangs it on non-enumerable
-// $response / $metadata properties instead. Reading them is the only way to say anything useful about a
-// failure whose body the SDK could not parse: an object store or proxy answering with plaintext or an
-// HTML error page rather than S3's XML makes the SDK's parser throw, and the error it raises then
-// describes the parser's confusion instead of the request. $response.body holds the raw body in that
-// case, so it is where the actual reason lives.
-type AwsResponseError = {
-    $response?: { statusCode?: number; body?: unknown }
-    $metadata?: { httpStatusCode?: number }
-}
-
 function toUploadError(err: unknown, target: string): RasterizationError {
-    const { $response, $metadata } = (err ?? {}) as AwsResponseError
-    const status = $response?.statusCode ?? $metadata?.httpStatusCode
-    // $response.body is a string only when the SDK failed to parse it; otherwise it is the response stream.
-    const rawBody = $response?.body
-    const body = typeof rawBody === 'string' && rawBody.length > 0 ? sanitizeForUTF8(rawBody.slice(0, 500)) : null
-    // SDK messages run to several lines, and this one ends up as a Temporal failure message.
-    const reason = err instanceof Error ? err.message.replace(/\s+/g, ' ').slice(0, 300) : String(err)
-    // Reporting only: no upload failure is marked terminal here, so the workflow's retry policy keeps
-    // deciding what happens next.
+    // The AWS SDK keeps the HTTP response off its public error type and hangs it on a non-enumerable
+    // $response instead. When it could not parse the body at all, because a proxy or gateway answered with
+    // plaintext or an HTML error page rather than S3's XML, $response.body holds that raw body and the
+    // error the SDK raises describes nothing but its own parser's confusion. Retryability is untouched:
+    // the workflow's retry policy keeps deciding, as it does for any other upload failure.
+    const { statusCode, body } = (err as { $response?: { statusCode?: number; body?: unknown } })?.$response ?? {}
+    const reason = err instanceof Error ? err.message : String(err)
+    const responseBody = typeof body === 'string' ? `, response body: ${body.slice(0, 500)}` : ''
     return new RasterizationError(
-        `S3 upload to ${target} failed (status ${status ?? 'unknown'}): ${reason}${body ? `, response body: ${body}` : ''}`,
+        `S3 upload to ${target} failed (status ${statusCode ?? 'unknown'}): ${reason}${responseBody}`,
         true,
         'S3_UPLOAD_FAILED',
         err

--- a/nodejs/src/session-replay/recording-rasterizer/storage.ts
+++ b/nodejs/src/session-replay/recording-rasterizer/storage.ts
@@ -9,19 +9,27 @@ import { createLogger } from './logger'
 
 const log = createLogger()
 
-function toUploadError(err: unknown, target: string): RasterizationError {
-    // The AWS SDK keeps the HTTP response off its public error type and hangs it on a non-enumerable
-    // $response instead. When it could not parse the body at all, because a proxy or gateway answered with
-    // plaintext or an HTML error page rather than S3's XML, $response.body holds that raw body and the
-    // error the SDK raises describes nothing but its own parser's confusion. Retryability is untouched:
-    // the workflow's retry policy keeps deciding, as it does for any other upload failure.
-    const { statusCode, body } = (err as { $response?: { statusCode?: number; body?: unknown } })?.$response ?? {}
-    const reason = err instanceof Error ? err.message : String(err)
-    const responseBody = typeof body === 'string' ? `, response body: ${body.slice(0, 500)}` : ''
+// The AWS SDK attaches $responseBodyText to an error only when it could not parse the response body at
+// all, and hangs the HTTP response itself on a non-enumerable $response. Both are absent from its public
+// error type. That pair identifies the one failure worth translating: a proxy or gateway answering with
+// plaintext or an HTML error page instead of S3's XML, where the error the SDK raises describes its own
+// parser rather than the request, and the raw body is the only place the real reason survives.
+type UndecodableS3Response = {
+    $responseBodyText?: string
+    $response?: { statusCode?: number }
+}
+
+function undecodableResponseError(err: unknown, target: string): RasterizationError | null {
+    const { $responseBodyText, $response } = (err ?? {}) as UndecodableS3Response
+    if (typeof $responseBodyText !== 'string') {
+        return null
+    }
+    // Retryability is untouched: the workflow's retry policy keeps deciding, as it does for any other
+    // upload failure.
     return new RasterizationError(
-        `S3 upload to ${target} failed (status ${statusCode ?? 'unknown'}): ${reason}${responseBody}`,
+        `S3 upload to ${target} failed with an unreadable (non-XML) response (status ${$response?.statusCode ?? 'unknown'}): ${$responseBodyText.slice(0, 500)}`,
         true,
-        'S3_UPLOAD_FAILED',
+        'S3_UPLOAD_UNDECODABLE_RESPONSE',
         err
     )
 }
@@ -97,7 +105,7 @@ export async function uploadToS3(
     try {
         await upload.done()
     } catch (err) {
-        throw toUploadError(err, target)
+        throw undecodableResponseError(err, target) ?? err
     }
 
     return target


### PR DESCRIPTION
## Problem

Session replay summaries were failing with a generic **"Summary failed"**, and error tracking only showed an opaque `char 'E' is not expected.:1:1 — Deserialization error: to see the raw response, inspect the hidden field {error}.$response`.

Root cause: the recording **rasterizer**'s S3 upload runs through the AWS SDK's XML response parser. When the object store (or a proxy/gateway in front of it) returns a **non-XML body** — a plaintext `Error…` or an HTML error page, where `char 'E'` is the first byte — the parser throws, the SDK wraps it in that opaque message and hides the actual response on a non-enumerable `err.$response`. That message propagated up through the `rasterize-recording` workflow → replay vision scanner (`RASTERIZATION_FAILED`) → session summary, so the user-facing failure reason described the parser's confusion rather than the request.

This does not fix whatever upstream returned the non-XML body (an infra/storage/proxy condition). It makes that condition **diagnosable**.

## Changes

When the SDK cannot read the response body at all, `uploadToS3` now raises a `RasterizationError` naming the condition and the real HTTP status, instead of letting the parser's complaint stand as the failure reason. **Every other upload failure is rethrown untouched**, so callers still see the SDK's own error types.

The thrown message is deliberately spare, because Replay Vision turns it into `ReplayObservation.error_reason` and the observations API returns that to team users. The bucket, key and the response body — whatever an upstream proxy chose to return — go to a log line instead, so a user sees:

```
S3 upload failed: the object store returned an unreadable (non-XML) response (status 407)
```

The parse failure happens inside the SDK, so there is no seam for the caller to catch it. The discriminator is structural rather than a match on the SDK's error text: `$responseBodyText` is attached to the error only when the body failed to parse, so its presence is exactly the condition being reported. If the SDK ever stops setting it, detection degrades to today's behavior of rethrowing the original error rather than misfiring on unrelated failures.

**Retry behavior is unchanged.** Nothing is marked terminal, so the translated failure stays retryable and the workflow's retry policy keeps deciding.

## How did you test this code?

`storage.test.ts` gains one test that an unreadable response is translated, asserting the exact user-facing message against a fixture whose response body contains a bucket and key — so a change that folds the target or the body back into the message fails — plus that it stays retryable. A second, parameterized test asserts a modeled service error and a failure with no HTTP response are both rethrown by identity, which is the guard that this stays narrow and callers keep the SDK's error types.

Ran locally (agent): `jest storage.test.ts` → 27 passed; `tsc --noEmit` reports nothing for the changed files; eslint and prettier clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Internal error-handling change, no user-facing docs. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a support thread reporting that replay summaries stopped working. Diagnosis worked backwards from PostHog error tracking: the `ChildWorkflowError` on the session-summary workflow and a sibling `ScannerFailureError` in `products/replay_vision/backend/temporal/workflow.py` shared the same deserialization message, whose stack pointed at the `rasterize-recording` child workflow — the Node rasterizer's S3 upload, not the Gemini call.

Considered classifying at the Python `_run_rasterize_child` boundary instead, but rejected it: that layer only sees the wrapped Temporal failure, whereas the Node upload site still holds the response. The existing `RASTERIZATION_FAILED` classification is untouched.

Verified against the installed SDK rather than assumed: `@aws-sdk/core`'s `parseXmlBody` defines `$responseBodyText` on the error when parsing fails, and `@smithy/middleware-serde` then attaches the response (carrying the status) and appends the deserialization hint. Those are the two properties this change reads.

Three things were tried and dropped. Marking unreadable 4xx responses as non-retryable is a change to production retry semantics that diagnosability does not require. Translating *every* upload failure into a `RasterizationError` read as simpler, but it changes the error type callers see, which is a risk for anything depending on the SDK's own error classes. Putting the target and the response body in the thrown message made the failure easiest to read, but review pointed out that message is user-facing via the observations API, so those moved to logs.

`uploadToS3` is the only AWS SDK call site in the rasterizer, which is what pins the failure to the upload: the exception chain that reaches error tracking (`ScannerFailureError` → `ChildWorkflowError` → `ActivityError` → `ApplicationError`) never names the operation itself.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0460HY55M0/p1784990908950439?thread_ts=1784990908.950439&cid=C0460HY55M0)*
