### PR TITLE
fix(snowflake): classify chunk-download HTTP 400 as retryable noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -302,6 +302,19 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             "HTTP 403: Forbidden": "Snowflake refused the request with an HTTP 403 (forbidden). This usually means a network policy or firewall on your account is blocking PostHog's access, or your role's access to the data was revoked. Check your Snowflake network access rules and role grants, then resync.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        return {
+            # Snowflake connector error 290400 (ER_HTTP_GENERAL_ERROR + 400): downloading a query
+            # result chunk got HTTP 400, which the connector's own `is_retryable_http_code` already
+            # retries with backoff before re-raising the plain `BadRequest` once its download retry
+            # budget is exhausted (`result_batch.py::_download`). Unlike the persistent-403 case
+            # above, every Temporal-level retry of `get_rows` opens a fresh connection and re-executes
+            # the query from scratch, getting a brand new set of chunk URLs — a stale one from the
+            # previous attempt doesn't carry over. Self-recovering, so keep retrying instead of
+            # stopping the sync. The errno prefix is volatile, so we match the stable status text.
+            "HTTP 400: Bad Request",
+        }
+
     def reconcile_schema_metadata(
         self,
         source: "ExternalDataSource",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -886,6 +886,29 @@ class TestSnowflakeSourceNonRetryableErrors:
         assert not is_non_retryable, f"Error should remain retryable: {error_msg}"
 
 
+class TestSnowflakeSourceRetryableErrors:
+    @pytest.fixture
+    def source(self):
+        return SnowflakeSource()
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # The real shape from production: the connector's BadRequest formats as "<errno>: <errno>: <msg>".
+            "290400: 290400: HTTP 400: Bad Request",
+            "HTTP 400: Bad Request",
+        ],
+    )
+    def test_chunk_download_bad_request_is_retryable(self, source, error_msg):
+        # Downloading a query result chunk got HTTP 400, and the connector's own retry budget
+        # (`result_batch.py::_download`) was already exhausted before `BadRequest` re-raised. Without
+        # this classification `_handle_import_error` logs it at `exception` on every occurrence,
+        # flooding error tracking with a self-recovering failure.
+        retryable = source.get_retryable_errors()
+        is_retryable = any(pattern in error_msg for pattern in retryable)
+        assert is_retryable, f"Chunk-download bad-request error should be classified retryable: {error_msg}"
+
+
 class TestSnowflakeValidateCredentials:
     @pytest.fixture
     def source(self):


### PR DESCRIPTION
## Problem

Error tracking surfaced a `BadRequest: 290400: 290400: HTTP 400: Bad Request` originating from the Snowflake source's `get_rows` (`products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/snowflake.py:655`), during `fetch_arrow_batches()`.

The stack trace shows the failure comes from the Snowflake connector's own chunk-download path (`result_batch.py::_download`). The connector already treats HTTP 400 as retryable and retries the chunk download internally with backoff — it only raises the bare `BadRequest` once its own retry budget is exhausted. That's the same shape as the existing HTTP 403 handling already in this file: a request that the connector retried and gave up on before it ever reached us.

The key difference from 403 is what a further retry actually does. Our `get_rows()` opens a brand new connection and re-executes the query from scratch on every Temporal-level activity retry, so it gets an entirely new set of chunk download URLs — a stale one from a prior attempt can't carry over. That makes this self-recovering rather than a persistent access-denied condition, so it shouldn't stop the sync; it should just stay out of error tracking as noise, the same way several other sources already classify their own exhausted-retry errors (e.g. [#73632](https://github.com/PostHog/posthog/pull/73632), [#73596](https://github.com/PostHog/posthog/pull/73596), [#73482](https://github.com/PostHog/posthog/pull/73482)).

## Changes

- `SnowflakeSource.get_retryable_errors()`: match the stable `"HTTP 400: Bad Request"` status text (not the volatile errno prefix), so `_handle_import_error` logs it at `warning` and lets Temporal retry the whole activity, instead of logging an `exception` on every occurrence.

## How did you test this code?

Added `TestSnowflakeSourceRetryableErrors` with two parametrized cases (the real production message shape, and the bare status text) asserting `get_retryable_errors()` matches. This catches a future regression where the classification is silently removed or the match string drifts, which would reintroduce this self-recovering chunk-download failure as tracked exception noise.

Ran the full `test_snowflake.py` suite locally (106 passed) plus `ruff check`/`ruff format --check` on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal retry classification only, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Investigated via PostHog's error-tracking MCP tools (issue details + stack trace) to confirm the failure originates in this source's code, then read the vendored `snowflake-connector-python` source to confirm HTTP 400 is retried internally by the connector before surfacing.
- Skills invoked: `/investigating-error-issue` (issue triage), `/writing-tests` (test value gate before adding the regression test).
- Considered adding this to `get_non_retryable_errors()` (mirroring the existing 403 entry) but rejected it: unlike 403, a fresh Temporal-level retry re-executes the query and gets new chunk URLs, so this is self-recovering rather than needing customer action. `get_retryable_errors()` is the existing mechanism for exactly this shape of problem, already used by many other sources in this codebase.
- Checked open PRs (including the maintainer's own) for a duplicate fix; found none addressing this specific chunk-download 400 error.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*