### PR TITLE
fix(data-imports): catch ArrowNotImplementedError during Delta schema evolution

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -782,6 +782,9 @@ def test_evolve_pyarrow_schema_whole_valued_floats_cast_into_stored_integer_colu
         (pa.bool_(), pa.array(["true", "processed"], type=pa.string())),
         # A value that overflows the stored decimal precision (Cannot convert ... overflow).
         (pa.decimal128(3, 1), pa.array([1.0, 999999999.0], type=pa.float64())),
+        # A cast pyarrow has no kernel for at all — raised as ArrowNotImplementedError, not
+        # ArrowInvalid (e.g. a source column that used to be numeric now arrives as a time).
+        (pa.float64(), pa.array([datetime.time(12, 30, 0), datetime.time(1, 0, 0)], type=pa.time64("us"))),
     ],
 )
 def test_evolve_pyarrow_schema_incompatible_cast_raises_actionable_error(

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
@@ -295,7 +295,7 @@ def evolve_pyarrow_schema(incoming_table: pa.Table, delta_schema: deltalake.Sche
             else:
                 try:
                     casted_column = incoming_column.cast(delta_field.type).combine_chunks()
-                except pa.ArrowInvalid as e:
+                except (pa.ArrowInvalid, pa.ArrowNotImplementedError) as e:
                     # Reaching this cast already means the incoming type differs from the stored
                     # Delta type (see the guard above) and the timestamp path didn't apply, so a
                     # failure here is a deterministic, unretryable incompatibility: the source
@@ -303,12 +303,13 @@ def evolve_pyarrow_schema(incoming_table: pa.Table, delta_schema: deltalake.Sche
                     # shapes are an integer column widened upstream (Postgres `integer` → `bigint`),
                     # an integer-created column now receiving fractional values ("Float value 19.99
                     # was truncated converting to int64"), non-numeric text arriving for a numeric
-                    # column ("Failed to parse string: '80-150' as a scalar of type int32"), or a
-                    # value that overflows the stored decimal precision. delta-rs cannot change a
-                    # column's type in place, so retrying is futile — surface an actionable error
-                    # telling the user to reset and fully re-sync. Lossless widening (e.g. a
-                    # whole-valued float into an integer column) still casts fine and never reaches
-                    # here.
+                    # column ("Failed to parse string: '80-150' as a scalar of type int32"), a
+                    # value that overflows the stored decimal precision, or a cast pyarrow has no
+                    # kernel for at all (e.g. `time64` → `double`, raised as ArrowNotImplementedError
+                    # rather than ArrowInvalid). delta-rs cannot change a column's type in place, so
+                    # retrying is futile — surface an actionable error telling the user to reset and
+                    # fully re-sync. Lossless widening (e.g. a whole-valued float into an integer
+                    # column) still casts fine and never reaches here.
                     raise SchemaColumnTypeChangedException(
                         f"Source column type changed: '{delta_field.name}' has values that no longer "
                         f"fit its stored type {delta_field.type} (incoming data is now "


### PR DESCRIPTION
## Problem

Error tracking surfaced a MySQL incremental sync crashing with:

```
ArrowNotImplementedError: Unsupported cast from time64[us] to double using function cast_double
```

The failing frame is in shared pipeline code (`evolve_pyarrow_schema`), not the MySQL connector, so it's a general bug rather than a source-specific one.

When a batch column's incoming pyarrow type no longer matches the type already stored for that column in the Delta table, `evolve_pyarrow_schema` tries to cast the incoming column to the stored type. If the cast fails, that's supposed to be a deterministic, unretryable schema mismatch (e.g. a source column that used to be numeric now arriving as a time), and the code raises an actionable `SchemaColumnTypeChangedException` telling the user to reset and re-sync.

pyarrow can fail that cast two different ways though: `ArrowInvalid` (a value doesn't fit the target type) or `ArrowNotImplementedError` (there's no cast kernel at all for that type pair — which is exactly what `time64[us] → double` hits). The code only caught `ArrowInvalid`, so this second failure mode escaped as a raw, retried exception instead of the actionable one, and the sync kept crashing on retry indefinitely.

## Changes

Widen the `except` clause in `evolve_pyarrow_schema` (`products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py`) to catch `ArrowNotImplementedError` alongside `ArrowInvalid`, so this failure mode also becomes a `SchemaColumnTypeChangedException` and stops retrying.

## How did you test this code?

Added a parametrized case to the existing `test_evolve_pyarrow_schema_incompatible_cast_raises_actionable_error` test: a `time64[us]` column being merged into a Delta column stored as `double`. Verified it reproduces the exact reported stack trace (same `ArrowNotImplementedError` and message) and fails without the fix, then passes with it.

Ran:
- `pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py` — 129 passed
- `ruff check` / `ruff format --check` on changed files — clean
- `mypy --cache-fine-grained .` (repo-wide) — clean, 16926 source files

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-handling fix, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from a live PostHog error tracking issue for the data-imports pipeline, reproduced the exact cast failure locally with pyarrow, and traced it to `evolve_pyarrow_schema` only catching one of the two exception types pyarrow's cast machinery can raise. Confirmed via `pa.ArrowNotImplementedError.__mro__` that it's a sibling of `ArrowInvalid` (both derive from `ArrowException`), not a subclass, which is why the original `except pa.ArrowInvalid` missed it.

Searched open PRs (by exception type, message substring, and module path, plus a scan of the maintainer's own open PRs) and found no existing PR fixing this same root cause — one open PR (#73230) touches nearby `SchemaColumnTypeChangedException` handling but fixes an unrelated call-signature bug in the error handler, not this cast-exception gap.

No skills were invoked beyond `/writing-tests` (test addition follows its parametrize-over-new-case guidance).