### PR TITLE
feat(signals): run inbox report discuss on opus 5

### DIFF
--- a/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
+++ b/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
@@ -7,7 +7,13 @@ import api from 'lib/api'
 import { urls } from 'scenes/urls'
 
 import { OriginProduct } from 'products/posthog_ai/frontend/types/taskTypes'
-import { RunSourceEnumApi, TaskExecutionModeEnumApi } from 'products/tasks/frontend/generated/api.schemas'
+import {
+    ClaudeRuntimeAdapterEnumApi,
+    ClaudeTaskRunCreateSchemaApi,
+    ReasoningEffortEnumApi,
+    RunSourceEnumApi,
+    TaskExecutionModeEnumApi,
+} from 'products/tasks/frontend/generated/api.schemas'
 
 import {
     SIGNAL_REPORT_TASK_DISCUSSION_RELATIONSHIP,
@@ -25,6 +31,18 @@ import {
 // written early in a research run, so a generous limit keeps it on the fetched page even for
 // reports with many findings.
 const REPO_SELECTION_ARTEFACT_FETCH_LIMIT = 1000
+
+// The run endpoint rejects a model without its runtime adapter, so the two are always sent together.
+type ClaudeRuntimeSelection = Pick<ClaudeTaskRunCreateSchemaApi, 'runtime_adapter' | 'model' | 'reasoning_effort'>
+
+// Discuss is a short question-and-answer about a report rather than a long implementation run, so it
+// pins the stronger model instead of taking the server-side default of Sonnet: the answer quality is
+// what the user is here for, and the extra cost is bounded by the length of the conversation.
+const DISCUSS_RUNTIME: ClaudeRuntimeSelection = {
+    runtime_adapter: ClaudeRuntimeAdapterEnumApi.Claude,
+    model: 'claude-opus-5',
+    reasoning_effort: ReasoningEffortEnumApi.High,
+}
 
 function buildCreatePrReportPrompt(report: SignalReport, feedback?: string): string {
     const base = `Act on PostHog Inbox report "${report.title ?? report.id}" (id ${report.id}). Investigate the root cause using the report's contributing findings, implement the fix, and open a PR.${
@@ -48,7 +66,8 @@ async function createReportTask(
     relationship: SignalReportTaskRelationship,
     prompt: string,
     fallbackTitle: string,
-    requireRepository = false
+    requireRepository = false,
+    runtimeSelection?: ClaudeRuntimeSelection
 ): Promise<void> {
     // Use the repository the signals pipeline already selected for this report (its
     // `repo_selection` artefact), matching the desktop app and the auto-start flow. Never fall
@@ -90,14 +109,15 @@ async function createReportTask(
     // Kick off a cloud run so the task actually executes — creating it alone lands the user on a
     // "This task hasn't been run yet" screen. `run_source` ties the run to the report and makes any
     // PR bot-authored server-side, mirroring the auto-start pipeline's `create_and_run_task`.
-    await api.tasks.run(task.id, {
+    const runOptions = {
         run_source: RunSourceEnumApi.SignalReport,
         signal_report_id: report.id,
         // Interactive, not the default background: the user lands on the run page right away, and the
         // agent-server only relays AskUserQuestion (and other approval prompts) to the client on
         // non-background runs — a background run's questions are parked and never rendered as a form.
         mode: TaskExecutionModeEnumApi.Interactive,
-    })
+    }
+    await api.tasks.run(task.id, runtimeSelection ? { ...runOptions, ...runtimeSelection } : runOptions)
 
     router.actions.push(urls.taskDetail(task.id))
 }
@@ -176,7 +196,9 @@ export const inboxTaskKickoffLogic = kea<inboxTaskKickoffLogicType>([
                     report,
                     SIGNAL_REPORT_TASK_DISCUSSION_RELATIONSHIP,
                     buildDiscussReportPrompt(reportUrl, question),
-                    'Discuss report'
+                    'Discuss report',
+                    false,
+                    DISCUSS_RUNTIME
                 )
                 actions.discussReportSuccess()
             } catch (error: any) {


### PR DESCRIPTION
## Problem

Pressing Discuss on an inbox report creates a task and immediately starts a cloud run.
The kickoff never sends a runtime selection, so the run falls through to the server side default model, Sonnet 5.

Discuss is the one inbox flow where somebody is asking a real question about a report and then reading the answer.
Answer quality is the whole product there, so it should get the stronger model rather than the generic default.

## Changes

The discuss kickoff now pins the Claude runtime to Opus 5 at high reasoning effort.
Create PR runs are untouched and still take the server default.

The run endpoint rejects a model sent without its runtime adapter, so the two travel together as one selection object, threaded through the shared `createReportTask` helper as an optional argument:

```diff
-    await api.tasks.run(task.id, {
+    const runOptions = {
         run_source: RunSourceEnumApi.SignalReport,
         signal_report_id: report.id,
         mode: TaskExecutionModeEnumApi.Interactive,
-    })
+    }
+    await api.tasks.run(task.id, runtimeSelection ? { ...runOptions, ...runtimeSelection } : runOptions)
```

High matches `DEFAULT_COMPOSER_EFFORT` used elsewhere in the composer.
Opus 5 also accepts xhigh and max if we want to push it further later.

No visual change, so no screenshots.

> [!NOTE]
> This covers the cloud inbox only. PostHog Desktop has its own discuss flow that calls the same tasks API from another repo, and it still gets the default model until the same selection is added there.

## How did you test this code?

Claude did the work, so to be explicit about what was and was not verified:

- Ran `pnpm --filter=@posthog/frontend typescript:check`. Clean for `scenes/inbox`. The run reports 195 errors overall, all pre-existing in that container because the quill packages are not built there, none in touched files.
- Ran `pnpm --filter=@posthog/frontend fix` (oxlint plus oxfmt), clean.
- Ran `hogli ci:preflight --strict`, green.
- No manual testing of the flow. The sandbox had no running stack, so nobody clicked Discuss and watched a run come up on Opus.

No new automated tests. The existing inbox test file only covers pure helpers, and a test asserting one constant field in the run payload would need fresh api mocking scaffolding to catch a regression that the generated request types already make hard to introduce. Happy to add one if a reviewer disagrees.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed. No user facing copy, API, or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude (Claude Code on the web, Opus 5) to make Discuss use a better model than the Sonnet default. It traced the flow from `DiscussReportButton` through `inboxTaskKickoffLogic` to the tasks run endpoint, confirmed the default comes from `DEFAULT_MODEL_BY_RUNTIME_ADAPTER` in the tasks temporal utils rather than anything signals specific, and found that the run serializer requires runtime adapter and model together. Skill invoked: `/writing-code-comments`.

The alternative considered was doing this server side, keying the model off the task's `signal_report_task_relationship` being `discussion`. That would cover Desktop and any future client in one place, but it reaches across the tasks and signals product boundary for what is currently a client side decision, so it was left out of this PR. Worth revisiting if we want Desktop on Opus too.