### PR TITLE
fix(replay-vision): restore scanners 0052 moved off the preview model

### DIFF
--- a/products/replay_vision/backend/migrations/0054_revert_remapped_preview_scanners.py
+++ b/products/replay_vision/backend/migrations/0054_revert_remapped_preview_scanners.py
@@ -1,0 +1,52 @@
+from django.db import migrations
+from django.db.migrations.recorder import MigrationRecorder
+from django.db.models import Exists, IntegerField, OuterRef
+from django.db.models.fields.json import KeyTextTransform
+from django.db.models.functions import Cast
+
+PREVIEW = "gemini-3-flash-preview"
+REMAPPED_TARGET = "gemini-3.6-flash"
+LEGACY_FLASH = "gemini-3.5-flash"
+
+
+def _remap_applied_at(connection):
+    row = (
+        MigrationRecorder(connection).migration_qs.filter(app="replay_vision", name="0052_remap_scanner_models").first()
+    )
+    return row.applied if row else None
+
+
+def _do_revert(apps, remapped_at):
+    ReplayScanner = apps.get_model("replay_vision", "ReplayScanner")
+    ReplayObservation = apps.get_model("replay_vision", "ReplayObservation")
+
+    # A scanner on 3.6-flash created before 0052 ran was necessarily remapped there: 3.6-flash only
+    # became selectable in the same deploy, so before it the scanner was on preview or 3.5-flash.
+    # Revert those to the 5-credit preview default, except the ones we can positively see were on the
+    # 15-credit 3.5-flash tier (a snapshot at their current version recorded 3.5-flash). Scanners
+    # created after the remap were never touched by it, so they keep whatever they chose.
+    was_legacy_flash = (
+        ReplayObservation.objects.filter(scanner_id=OuterRef("pk"), scanner_snapshot__model=LEGACY_FLASH)
+        .annotate(snap_version=Cast(KeyTextTransform("scanner_version", "scanner_snapshot"), IntegerField()))
+        .filter(snap_version=OuterRef("scanner_version"))
+    )
+    ReplayScanner.objects.filter(model=REMAPPED_TARGET, created_at__lt=remapped_at).exclude(
+        Exists(was_legacy_flash)
+    ).update(model=PREVIEW)
+
+
+def revert_remapped_preview_scanners(apps, schema_editor):
+    remapped_at = _remap_applied_at(schema_editor.connection)
+    if remapped_at is None:
+        return  # 0052 never ran here (fresh install): nothing was remapped.
+    _do_revert(apps, remapped_at)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("replay_vision", "0053_alter_replayscanner_model"),
+    ]
+
+    operations = [
+        migrations.RunPython(revert_remapped_preview_scanners, migrations.RunPython.noop, elidable=True),
+    ]

--- a/products/replay_vision/backend/migrations/max_migration.txt
+++ b/products/replay_vision/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0053_alter_replayscanner_model
+0054_revert_remapped_preview_scanners

--- a/products/replay_vision/backend/tests/test_migration_revert_preview.py
+++ b/products/replay_vision/backend/tests/test_migration_revert_preview.py
@@ -1,0 +1,88 @@
+import datetime as dt
+import importlib
+
+from posthog.test.base import APIBaseTest
+
+from django.apps import apps
+from django.utils import timezone
+
+from products.replay_vision.backend.models.replay_observation import (
+    ObservationStatus,
+    ObservationTrigger,
+    ReplayObservation,
+)
+from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerModel, ScannerType
+
+m54 = importlib.import_module("products.replay_vision.backend.migrations.0054_revert_remapped_preview_scanners")
+
+PREVIEW = "gemini-3-flash-preview"
+FLASH = "gemini-3.6-flash"
+LEGACY_FLASH = "gemini-3.5-flash"
+
+REMAP_AT = dt.datetime(2026, 7, 21, 22, 15, tzinfo=dt.UTC)
+BEFORE = REMAP_AT - dt.timedelta(days=2)
+AFTER = REMAP_AT + dt.timedelta(days=1)
+
+
+class TestRevertRemappedPreviewScanners(APIBaseTest):
+    def _scanner(self, name: str, model: str, created_at: dt.datetime, version: int = 1) -> ReplayScanner:
+        scanner = ReplayScanner.objects.create(
+            team=self.team,
+            name=name,
+            scanner_type=ScannerType.MONITOR,
+            scanner_config={"prompt": "p"},
+            model=model,
+            scanner_version=version,
+        )
+        # created_at is auto_now_add, so override it with a raw UPDATE.
+        ReplayScanner.objects.filter(pk=scanner.pk).update(created_at=created_at)
+        scanner.refresh_from_db()
+        return scanner
+
+    def _observation(self, scanner: ReplayScanner, session_id: str, snap_model: str, snap_version: int) -> None:
+        ReplayObservation.objects.create(
+            scanner=scanner,
+            team=self.team,
+            session_id=session_id,
+            status=ObservationStatus.SUCCEEDED,
+            completed_at=timezone.now(),
+            triggered_by=ObservationTrigger.SCHEDULE,
+            scanner_snapshot={
+                "name": scanner.name,
+                "scanner_type": "monitor",
+                "scanner_version": snap_version,
+                "model": snap_model,
+                "provider": "google",
+                "emits_signals": False,
+                "scanner_config": {"prompt": "p"},
+            },
+        )
+
+    def test_reverts_pre_remap_36_scanners_except_positively_legacy_flash(self) -> None:
+        # Pre-remap, snapshot at current version proves preview: a clear remap victim.
+        confident = self._scanner("confident", FLASH, BEFORE, version=2)
+        self._observation(confident, "a1", PREVIEW, 2)
+
+        # Pre-remap, no snapshot evidence at current version: uncertain, swept back to preview.
+        uncertain = self._scanner("uncertain", FLASH, BEFORE)
+
+        # Pre-remap, snapshot at current version recorded the 15-credit 3.5-flash tier: keep 3.6.
+        legacy_flash = self._scanner("legacy_flash", FLASH, BEFORE, version=1)
+        self._observation(legacy_flash, "c1", LEGACY_FLASH, 1)
+
+        # Created after the remap, so 0052 never touched it: keep 3.6.
+        post_remap = self._scanner("post_remap", FLASH, AFTER)
+
+        # A different model is out of scope entirely.
+        untouched = self._scanner("lite", ScannerModel.GEMINI_3_5_FLASH_LITE, BEFORE)
+
+        m54._do_revert(apps, REMAP_AT)
+
+        for scanner in (confident, uncertain, legacy_flash, post_remap, untouched):
+            scanner.refresh_from_db()
+
+        assert confident.model == ScannerModel.GEMINI_3_FLASH_PREVIEW
+        assert uncertain.model == ScannerModel.GEMINI_3_FLASH_PREVIEW
+        assert legacy_flash.model == FLASH
+        assert post_remap.model == FLASH
+        assert untouched.model == ScannerModel.GEMINI_3_5_FLASH_LITE


### PR DESCRIPTION
## Problem

`0052_remap_scanner_models` collapsed two Gemini models into one:

| Before 0052 | credits/obs | After 0052 |
| --- | --- | --- |
| `gemini-3-flash-preview` | 5 | `gemini-3.6-flash` |
| `gemini-3.5-flash` | 15 | `gemini-3.6-flash` |

Scanners sitting on the cheaper preview default silently started billing 3x per observation. `0053` restored `gemini-3-flash-preview` as a selectable model and the new default, but the scanners `0052` had already moved were left stuck on `gemini-3.6-flash`.

Because `0052` folded two source models into one target, the current column can't tell a real preview victim from a legitimate 15-credit `gemini-3.5-flash` scanner, so a blind inverse of the remap would wrongly demote the latter.

## Changes

`0054_revert_remapped_preview_scanners` keys the revert on **creation time**. `gemini-3.6-flash` only became selectable in the `0052` deploy, so any scanner on 3.6 that **existed before `0052` ran** was necessarily put there by the remap (it was on preview or 3.5-flash before). The migration:

1. derives the exact remap timestamp per region from `django_migrations` (the `0052` row), so it works unchanged in US and EU,
2. reverts every `gemini-3.6-flash` scanner created before that time to `gemini-3-flash-preview`,
3. except those a frozen observation snapshot at their **current version** positively shows were on the 15-credit `gemini-3.5-flash` tier.

Scanners created after the remap were never touched by it (they defaulted to or explicitly chose 3.6), so they keep their model. The revert uses a raw `.update()`, mirroring `0052`, so `scanner_version` isn't bumped and it reads as a correction rather than a config change.

> [!NOTE]
> Pre-remap scanners with no snapshot evidence at their current version are treated as preview victims and swept back to preview. A small number of those may have actually been on 3.5-flash and never produced an observation, so they get moved to the current default (preview) rather than staying on 3.6. This is intentional and self-correctable (the owner can re-select 3.6). The alternative, a point-in-time restore of the pre-remap scanner table, was considered and judged not worth it for this tail.

> [!WARNING]
> Run the dry-run count on prod-US and prod-EU before merge. The predicate is identical to the migration, so the count is exactly what will change.

<details><summary>Dry-run SELECT (run per region before merge)</summary>

```sql
WITH t AS (
  SELECT applied AS remapped_at FROM django_migrations
  WHERE app='replay_vision' AND name='0052_remap_scanner_models'
)
SELECT s.team_id, count(*) AS scanners_to_revert
FROM replay_vision_replayscanner s, t
WHERE s.model = 'gemini-3.6-flash'
  AND s.created_at < t.remapped_at
  AND NOT EXISTS (
    SELECT 1 FROM replay_vision_replayobservation o
    WHERE o.scanner_id = s.id
      AND (o.scanner_snapshot->>'scanner_version')::int = s.scanner_version
      AND o.scanner_snapshot->>'model' = 'gemini-3.5-flash')
GROUP BY s.team_id ORDER BY 2 DESC;
```
</details>

## How did you test this code?

`products/replay_vision/backend/tests/test_migration_revert_preview.py` runs the revert once over five scanners spanning the distinct cases: pre-remap with a preview snapshot (reverted), pre-remap with no evidence (reverted, the swept-in case), pre-remap positively 3.5-flash (kept on 3.6), created after the remap (kept), and a different model entirely (untouched). No existing test exercises `0054`.

I (Claude) also ran `makemigrations replay_vision --check` (no drift, pure data migration) and `ruff`. I validated the predicate against the prod-US and prod-EU read replicas via Metabase and confirmed the row counts reconcile across every bucket. This was a read-only validation; the migration itself has not run against prod.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs. Internal data migration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Arnaud asked how to reverse the scanners `0052` accidentally moved off the 5-credit preview model, and where the pre-migration state still lives. I (Claude) traced it: the Django activity log is a dead end (`ReplayScanner` is not activity-logged, and `0052` used `.update()` which bypasses signals), but the frozen `ReplayObservation.scanner_snapshot` preserves the old model, and creation time plus the `0052` timestamp conclusively separates victims from scanners created later.

Skills invoked: `/systematic-debugging` (root cause), `/django-migrations`, `/writing-tests`.

Decisions: rejected a blind inverse of `_MODEL_REMAP` (lossy, would demote real 3.5-flash scanners). First drafted a snapshot-only revert, then switched to the creation-time rule after validating against prod: it's more complete (catches pre-remap scanners that left no current-version snapshot) and conclusively excludes scanners created after the remap. Chose to sweep the small no-evidence tail into preview rather than do a point-in-time restore to resolve it exactly.
