### PR TITLE
fix(cli): normalize Windows paths before spawning Node

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2093,6 +2093,7 @@ dependencies = [
  "colored",
  "crossterm 0.28.1",
  "dirs",
+ "dunce",
  "globset",
  "inquire",
  "libc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5.31", features = ["derive", "env"] }
 dirs = "6.0.0"
+dunce = "1.0.5"
 inquire = "0.7.5"
 chrono = "0.4.42"
 posthog-symbol-data = "0.5.0"

--- a/cli/src/api_proxy.rs
+++ b/cli/src/api_proxy.rs
@@ -108,7 +108,7 @@ impl ApiProxyError {
 }
 
 fn canonicalize_file(path: &Path) -> Option<PathBuf> {
-    let resolved = path.canonicalize().ok()?;
+    let resolved = dunce::canonicalize(path).ok()?;
     if resolved.is_file() {
         Some(resolved)
     } else {
@@ -152,8 +152,7 @@ fn materialize_embedded_script(
         .map_err(|source| materialize_failed(MaterializeStep::CreateDir, source))?;
     fs::write(&path, bundle)
         .map_err(|source| materialize_failed(MaterializeStep::Write, source))?;
-    let resolved = path
-        .canonicalize()
+    let resolved = dunce::canonicalize(&path)
         .map_err(|source| materialize_failed(MaterializeStep::Canonicalize, source))?;
     if !resolved.is_file() {
         return Err(materialize_failed(
@@ -212,11 +211,10 @@ fn find_script() -> Result<PathBuf, ApiProxyError> {
         }
         let path = PathBuf::from(path);
         let resolved =
-            path.canonicalize()
-                .map_err(|source| ApiProxyError::ConfiguredPathMissing {
-                    path: path.display().to_string(),
-                    source,
-                })?;
+            dunce::canonicalize(&path).map_err(|source| ApiProxyError::ConfiguredPathMissing {
+                path: path.display().to_string(),
+                source,
+            })?;
         if !resolved.is_file() {
             return Err(ApiProxyError::ConfiguredPathNotAFile {
                 path: resolved.display().to_string(),
@@ -386,18 +384,21 @@ mod tests {
 
         assert_eq!(
             resolved,
-            temp_dir
-                .path()
-                .join("api-cli")
-                .join(env!("CARGO_PKG_VERSION"))
-                .join(API_CLI_BUNDLE)
-                .canonicalize()
-                .expect("canonicalize materialized bundle")
+            dunce::canonicalize(
+                temp_dir
+                    .path()
+                    .join("api-cli")
+                    .join(env!("CARGO_PKG_VERSION"))
+                    .join(API_CLI_BUNDLE)
+            )
+            .expect("canonicalize materialized bundle")
         );
         assert_eq!(
-            fs::read(resolved).expect("read materialized bundle"),
+            fs::read(&resolved).expect("read materialized bundle"),
             b"embedded bundle"
         );
+        #[cfg(windows)]
+        assert!(!resolved.to_string_lossy().starts_with(r"\\?\"));
     }
 
     #[test]
@@ -453,7 +454,7 @@ mod tests {
 
         assert_eq!(
             resolved,
-            legacy_bundle.canonicalize().expect("canonicalize legacy")
+            dunce::canonicalize(legacy_bundle).expect("canonicalize legacy")
         );
     }
 
@@ -488,8 +489,7 @@ mod tests {
 
         assert_eq!(
             resolved,
-            embedded_bundle_path(&install_dir)
-                .canonicalize()
+            dunce::canonicalize(embedded_bundle_path(&install_dir))
                 .expect("canonicalize embedded bundle")
         );
         assert_eq!(


### PR DESCRIPTION
## Problem

On Windows, the CLI canonicalizes the API bundle path to a verbatim `\\?\` path before passing it to Node. Recent Node releases can resolve that path as `C:` and exit with `EISDIR`.

Closes #73389

## Changes

Use `dunce::canonicalize` for paths passed to Node so Windows paths remain normalized without the verbatim prefix. Add a Windows assertion that prevents this regression.

## How did you test this code?

- `cargo test embedded_bundle_is_materialized_into_a_versioned_install_dir -- --nocapture`
- `cargo fmt --all -- --check`
- Ran `posthog-cli api skill list` with Node 22.23.1, 24.18.0, and 26.5.0. Each returned 210 skills with exit code 0.
- The relevant tests passed. The full suite encountered a Windows newline mismatch in sourcemap::test_pair_inject, which this PR does not modify.
- Clippy was blocked by a `needless_borrows_for_generic_args` finding in unchanged code at `src/login.rs:195`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation changes are needed. This corrects Windows path handling without changing CLI usage.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed the investigation and fix. Codex identified the Windows verbatim path interaction, implemented path normalization, added regression coverage, and ran validation. The repository `writing-tests` skill and GitHub publication guidance were used.

Codex used PowerShell, Git, Cargo, and Node.js, plus the repository `writing-tests` skill and GitHub publication guidance. We reproduced the Windows verbatim path failure, chose `dunce::canonicalize` to avoid manual path rewriting, and added Windows regression coverage