### PR TITLE
fix(ingestion): allow deleting a configured event filter

### DIFF
--- a/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.tsx
+++ b/frontend/src/scenes/data-pipelines/event-filtering/EventFilterScene.tsx
@@ -14,7 +14,15 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 import { useCallback, useMemo, useRef, useState } from 'react'
 
-import { LemonBanner, LemonButton, LemonDivider, LemonLabel, LemonModal, LemonSegmentedButton } from '@posthog/lemon-ui'
+import {
+    LemonBanner,
+    LemonButton,
+    LemonDialog,
+    LemonDivider,
+    LemonLabel,
+    LemonModal,
+    LemonSegmentedButton,
+} from '@posthog/lemon-ui'
 
 import { SceneExport } from 'scenes/sceneTypes'
 
@@ -36,9 +44,15 @@ export const scene: SceneExport = {
 }
 
 export function EventFilterScene(): JSX.Element {
-    const { filterForm, isFilterFormSubmitting, allTestsPass, filterFormErrors, showFilterFormErrors } =
-        useValues(eventFilterLogic)
-    const { setFilterFormValue, submitFilterForm, updateTreeNode } = useActions(eventFilterLogic)
+    const {
+        filterForm,
+        isFilterFormSubmitting,
+        allTestsPass,
+        filterFormErrors,
+        showFilterFormErrors,
+        canDeleteFilter,
+    } = useValues(eventFilterLogic)
+    const { setFilterFormValue, submitFilterForm, updateTreeNode, clearFilter } = useActions(eventFilterLogic)
     const [activeId, setActiveId] = useState<string | null>(null)
     const [showExpression, setShowExpression] = useState(false)
     const nodeIds = useRef(new NodeIdMap()).current
@@ -269,6 +283,30 @@ export function EventFilterScene(): JSX.Element {
                         <LemonButton type="primary" onClick={() => submitFilterForm()} loading={isFilterFormSubmitting}>
                             Save
                         </LemonButton>
+                        {canDeleteFilter && (
+                            <LemonButton
+                                type="secondary"
+                                status="danger"
+                                disabledReason={isFilterFormSubmitting ? 'Saving' : undefined}
+                                onClick={() =>
+                                    LemonDialog.open({
+                                        title: 'Delete filter',
+                                        description:
+                                            'This clears every condition and test case and disables the filter. No events will be dropped until you set it up again.',
+                                        primaryButton: {
+                                            status: 'danger',
+                                            children: 'Delete filter',
+                                            onClick: () => clearFilter(),
+                                        },
+                                        secondaryButton: {
+                                            children: 'Cancel',
+                                        },
+                                    })
+                                }
+                            >
+                                Delete filter
+                            </LemonButton>
+                        )}
                     </div>
                 </div>
             </Form>

--- a/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.test.ts
@@ -1,5 +1,11 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
 import {
     countConditions,
+    eventFilterLogic,
     evaluateFilterTree,
     FilterNode,
     normalizeRootToGroup,
@@ -332,5 +338,56 @@ describe('treeHasEmptyValues', () => {
         ['deeply nested empty value', and(or(cond(), not(cond('event_name', 'exact', '')))), true],
     ])('%s', (_name, tree, expected) => {
         expect(treeHasEmptyValues(tree)).toBe(expected)
+    })
+})
+
+describe('delete filter', () => {
+    let savedPayload: Record<string, any> | null = null
+
+    beforeEach(() => {
+        savedPayload = null
+        useMocks({
+            get: { '/api/environments/:team_id/event_filter/': () => [204, null] },
+            post: {
+                '/api/environments/:team_id/event_filter/': async ({ request }) => {
+                    savedPayload = (await request.json()) as Record<string, any>
+                    return [200, { id: 'abc', ...savedPayload }]
+                },
+            },
+        })
+        initKeaTests()
+        eventFilterLogic.mount()
+    })
+
+    it('keeps delete available after the last condition is removed from a saved filter', () => {
+        // The reported bug: removing the last condition used to hide the delete
+        // affordance and strand the user, because save is blocked on an empty tree.
+        eventFilterLogic.actions.setFilterFormValue('id', 'saved-id')
+        eventFilterLogic.actions.setFilterFormValue('filter_tree', or())
+
+        expect(eventFilterLogic.values.conditionCount).toBe(0)
+        expect(eventFilterLogic.values.canDeleteFilter).toBe(true)
+    })
+
+    it('offers no delete when there is no saved filter and no conditions', () => {
+        expect(eventFilterLogic.values.canDeleteFilter).toBe(false)
+    })
+
+    it('saves a disabled, empty config so an existing filter can be deleted', async () => {
+        eventFilterLogic.actions.setFilterFormValue('mode', 'live')
+        eventFilterLogic.actions.setFilterFormValue('filter_tree', or(cond('event_name', 'exact', 'pageview')))
+        eventFilterLogic.actions.setFilterFormValue('test_cases', [
+            { _key: 'k1', event_name: 'pageview', distinct_id: '', expected_result: 'drop' },
+        ])
+
+        await expectLogic(eventFilterLogic, () => eventFilterLogic.actions.clearFilter()).toDispatchActions([
+            'submitFilterFormSuccess',
+        ])
+
+        expect(savedPayload).not.toBeNull()
+        expect(savedPayload!.mode).toBe('disabled')
+        expect(savedPayload!.filter_tree).toEqual({ type: 'or', children: [] })
+        expect(savedPayload!.test_cases).toEqual([])
+        expect(eventFilterLogic.values.conditionCount).toBe(0)
     })
 })

--- a/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.ts
+++ b/frontend/src/scenes/data-pipelines/event-filtering/eventFilterLogic.ts
@@ -247,6 +247,7 @@ export function updateAtPath(node: FilterNode, path: TreePath, updater: (node: F
 export interface eventFilterLogicValues {
     allTestsPass: boolean
     breadcrumbs: Breadcrumb[]
+    canDeleteFilter: boolean
     conditionCount: number
     currentTeamId: number
     filterForm: EventFilterFormValues
@@ -270,6 +271,9 @@ export interface eventFilterLogicActions {
         pathKeys: TreePath
     }
     addTestCase: () => {
+        value: true
+    }
+    clearFilter: () => {
         value: true
     }
     convertToGroup: (
@@ -351,6 +355,7 @@ export interface eventFilterLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
         currentTeamId: (currentTeamId: number | null) => number
         conditionCount: (filterForm: EventFilterFormValues) => number
+        canDeleteFilter: (filterForm: EventFilterFormValues, conditionCount: number) => boolean
         testResults: (filterForm: EventFilterFormValues) => TestResult[]
         allTestsPass: (testResults: TestResult[], filterForm: EventFilterFormValues) => boolean
     }
@@ -380,6 +385,8 @@ export const eventFilterLogic = kea<eventFilterLogicType>([
         addTestCase: true,
         removeTestCase: (index: number) => ({ index }),
         updateTestCase: (index: number, updates: Partial<TestCase>) => ({ index, updates }),
+        // Reset to an empty, disabled filter and save it — i.e. delete the filter
+        clearFilter: true,
     }),
 
     forms(({ values }) => ({
@@ -427,6 +434,17 @@ export const eventFilterLogic = kea<eventFilterLogicType>([
         conditionCount: [
             (s) => [s.filterForm],
             (form: EventFilterFormValues): number => countConditions(form.filter_tree),
+        ],
+
+        /**
+         * Whether there's a filter to delete: one already saved (has an id) or one
+         * being built (has conditions). Gates the delete button on "a filter exists"
+         * rather than "the tree is non-empty right now" — otherwise removing the last
+         * condition hides the button and strands the user with no way to clear it.
+         */
+        canDeleteFilter: [
+            (s) => [s.filterForm, s.conditionCount],
+            (form: EventFilterFormValues, conditionCount: number): boolean => form.id !== null || conditionCount > 0,
         ],
 
         /** Run each test case against the current tree client-side for live preview. */
@@ -540,6 +558,12 @@ export const eventFilterLogic = kea<eventFilterLogicType>([
         updateTestCase: ({ index, updates }) => {
             const newCases = values.filterForm.test_cases.map((tc, i) => (i === index ? { ...tc, ...updates } : tc))
             actions.setFilterFormValue('test_cases', newCases)
+        },
+        clearFilter: () => {
+            actions.setFilterFormValue('mode', 'disabled')
+            actions.setFilterFormValue('filter_tree', { type: 'or', children: [] })
+            actions.setFilterFormValue('test_cases', [])
+            actions.submitFilterForm()
         },
     })),
 


### PR DESCRIPTION
## Problem

No way to delete an event ingestion filter once set up. Emptying a condition and saving errors "All conditions must have a value"; there's no delete button. Closes #62507

## Changes

Added a confirmed "Delete filter" button that saves an empty, disabled config via a new `clearFilter` action. Backend already clears on an empty tree, so this is frontend only. The button is gated on a `canDeleteFilter` selector so it doesn't vanish when you remove the last condition. Left the API strict (incomplete conditions still 400); #62759 pruned instead, happy to switch.

_Demo GIF to follow before marking ready for review._

## How did you test this code?

Three kea logic tests (`clearFilter` posts the cleared config; `canDeleteFilter` behaves at the edges), each failing with the fix reverted. 78/78 pass. No browser check yet; CI runs the full typecheck.

