### PR TITLE
chore(ci): stop turbo replaying cached build logs

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -234,7 +234,7 @@ jobs:
         needs: changes
         runs-on: depot-ubuntu-24.04-4
         # Tests fit comfortably in 30, but a rust change misses the turbo cache and cold-builds the
-        # replay-anonymizer addon's whole dependency tree first (no rust caching in this job yet).
+        # replay-anonymizer addon first, which sccache and the rust cache below only partly absorb.
         timeout-minutes: 45
         strategy:
             fail-fast: false

--- a/turbo.json
+++ b/turbo.json
@@ -43,6 +43,9 @@
             "dependsOn": ["^build"],
             "inputs": ["src", "Cargo.toml", "!**/*.pyc"],
             "outputs": ["dist", "index.node", ".turbo"],
+            // Replayed cargo output on a cache hit reads as a live compile, so consumers of the
+            // dependency graph (CI test steps especially) look like they are building the world.
+            "outputLogs": "new-only",
             "env": ["RUST_VERSION", "SHARD_INDEX", "SHARD_COUNT"],
             "passThroughEnv": [
                 "RUSTUP_HOME",


### PR DESCRIPTION
## Problem

The Node.js test jobs looked like they were compiling the world before running any tests. In [this run](https://github.com/PostHog/posthog/actions/runs/30192735511/job/89768886659), the "Test with Jest" step opens with ~900 lines of `Compiling proc-macro2`, `Compiling napi`, `Compiling replay-anonymizer-node`, `Finished release profile in 52.98s` — a full cargo dependency tree, three times over across the shards.

None of it was real. Every `build` task was a turbo cache hit:

```
Tasks:    5 successful, 5 total
Cached:    5 cached, 5 total
  Time:    1.044s >>> FULL TURBO
```

turbo's default `outputLogs: "full"` replays a cached task's stored output verbatim, so `cache hit, replaying logs` is followed by the whole compile transcript from whichever machine originally built it. The giveaway is `cp "$TARGET_DIR/release/libreplay_anonymizer_node.dylib"` — a macOS artifact name, replayed onto an Ubuntu runner.

Two costs: reading a Node CI log means scrolling past a fake compile to find the jest output, and the fake compile is indistinguishable from the real one, which is exactly the signal you want when a rust change *does* miss the cache.

## Changes

Set `outputLogs: "new-only"` on the `build` task. Cache misses still print in full; cache hits collapse to one line:

```
@posthog/replay-headless:build: cache hit, suppressing logs 6d2f471f142ebfb1
```

`test` keeps the default, so jest output is unaffected.

Also corrected a stale parenthetical on the `tests` job timeout. It claims there is "no rust caching in this job yet", but [#73307](https://github.com/PostHog/posthog/pull/73307) added sccache and `Swatinem/rust-cache` to all four node jobs an hour before that comment was written.

No timing change — the builds were already cached, and this only affects what gets printed.

## How did you test this code?

Verified the config resolves, then confirmed both branches of the behavior locally:

```bash
./node_modules/.bin/turbo run build --filter=@posthog/replay-headless
```

- First run (`cache miss, executing`) printed the package's full build output.
- Second run printed `cache hit, suppressing logs` and nothing else.
- `turbo run build --dry-run=json` reports `outputLogs= new-only` on the resolved task definition, so turbo 2.9.14 accepts the key.

`bin/hogli lint:workflows` (6 checks, 105 workflows) and `bin/hogli ci:preflight` both pass. No tests added: this changes turbo's log verbosity, and asserting on CI log text would be a worse test than the two-run check above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Driven by Robbie, who flagged that the node test jobs appeared to be doing a lot of building.

The investigation went the opposite way from the premise. I pulled step timings for every Node job in the run and for a dozen surrounding runs on both the branch and master. "Prepare Node.js workspace" never exceeded 16s anywhere, and on master the whole `@posthog/nodejs:test` task is frequently a cache hit finishing in 1-2s. So there was no build time to reclaim — the ~900 replayed lines inside the jest step were the entire phenomenon.

Considered and rejected: passing `--output-logs=new-only` on the CI invocations instead. That flag is per-run, not per-task, so it would also suppress cached jest output — the task-level key in `turbo.json` is the only way to quiet `build` while leaving `test` verbose. Also considered pre-building the rust addons in one job and having the shards download, but the measurements don't support it; the cold path is rare and already absorbed by sccache plus the 45min timeout.

Deliberately left alone: the `Prepare Node.js workspace` step still walks the same build graph the jest step re-walks. That's real duplication, but at one suppressed line each it isn't worth restructuring the job for.

The `build` task is shared with the frontend and other packages, so this quiets cached build logs monorepo-wide. I checked that nothing in `.github/workflows/` or `bin/` greps build output (`ci-turbo.yml` uses `--dry-run`, which is unaffected).
