### PR TITLE
fix(postgres): handle malformed host names during host validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
@@ -97,7 +97,10 @@ def _is_host_safe(host: str, team_id: int) -> tuple[bool, str | None]:
             if not _is_safe_public_ip(resolved_ip):
                 _log("block", "resolved_ip", _INTERNAL_IP_ERROR, resolved_ips)
                 return False, _INTERNAL_IP_ERROR
-    except socket.gaierror:
+    except (socket.gaierror, UnicodeError):
+        # getaddrinfo IDNA-encodes the host, so a malformed hostname (e.g. a DNS label over 63
+        # bytes) raises UnicodeError ("label too long") instead of gaierror. Either way the host
+        # can't be resolved — return the actionable message rather than crashing.
         _log("block", "dns_failure", _DNS_FAILURE_ERROR)
         return (
             False,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
@@ -141,6 +141,15 @@ class TestIsHostSafe(SimpleTestCase):
             assert "resolve" in error
 
     @override_settings(CLOUD_DEPLOYMENT="US")
+    def test_malformed_host_label_blocked(self):
+        # A single DNS label over 63 bytes makes getaddrinfo's IDNA encoding raise UnicodeError,
+        # not gaierror — this must be handled gracefully instead of crashing.
+        valid, error = _is_host_safe("a" * 92, team_id=999)
+        assert not valid
+        assert error is not None
+        assert "resolve" in error
+
+    @override_settings(CLOUD_DEPLOYMENT="US")
     def test_blocked_host_logs_warning(self):
         with patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins.logger"


### PR DESCRIPTION
## Problem

Error tracking surfaced an uncaught `UnicodeEncodeError` (`'idna' codec can't encode characters ...: label too long`) originating in the Postgres source's host validation. It fires when a user saves a source whose host contains a malformed hostname — specifically a DNS label longer than 63 bytes.

The call path is `PostgresSource.validate_credentials` → `ValidateDatabaseHostMixin.is_database_host_valid` → `_is_host_safe`, the shared host-safety helper every database source uses. That helper calls `socket.getaddrinfo`, which IDNA-encodes the host before any network lookup. A label over 63 bytes makes the IDNA codec raise `UnicodeError` ("label too long"), but the code only caught `socket.gaierror`. So instead of the graceful "couldn't resolve the host" validation message it already returns for unresolvable hosts, the exception escaped, got captured as error-tracking noise, and the user saw a generic "could not connect" message with no hint about what was wrong.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f9ea8-bf8e-7250-b4e3-568975046e81

## Changes

This is a fixable bug, not a user/upstream retry-classification case — the host validation runs at setup time and a malformed hostname should produce an actionable validation error, not a crash.

`_is_host_safe` now catches `UnicodeError` alongside `socket.gaierror` around `getaddrinfo`. Both mean the host can't be resolved, so both return the same "couldn't resolve the host, check it's spelled correctly" message. Because the fix lives in the shared mixin, every database source that validates a host through it (Postgres, MySQL, and the rest) is covered.

## How did you test this code?

Added `test_malformed_host_label_blocked` to `TestIsHostSafe`. It passes a real 92-character single-label host so it exercises the true IDNA path (the encoding fails offline, before any DNS call, so the test is deterministic and network-free) and asserts the helper returns a graceful "couldn't resolve" error instead of raising. This catches a revert of the `UnicodeError` handling — the existing `test_unresolvable_host_blocked` only covers `socket.gaierror` and would keep passing while the crash returned.

I (Claude) ran the full `TestIsHostSafe` class locally: 32 passed. `ruff check` clean on both files. I did not perform manual end-to-end testing against a live source.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue and implemented the fix with Claude Code. Confirmed the issue via the PostHog error-tracking tools (single team affected, top in-app frame `_is_host_safe` at `common/mixins.py:94`), traced the call path from the Postgres source into the shared mixin, and reproduced the `UnicodeError` from `getaddrinfo` on an over-long label offline. Considered the shared-helper layer the right place to fix since the crash is not Postgres-specific. Invoked the `/writing-tests` skill to keep the regression test to a single behavior-level case rather than mocking internals.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
