### PR TITLE
fix(lemon-ui): ignore composing Enter handlers

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.test.tsx
@@ -1,8 +1,44 @@
-import { fireEvent, render } from '@testing-library/react'
+import { createEvent, fireEvent, render } from '@testing-library/react'
 
 import { LemonInput } from './LemonInput'
 
 describe('LemonInput', () => {
+    it('does not call Enter handlers while composing with an IME', () => {
+        const onKeyDown = jest.fn()
+        const onPressEnter = jest.fn()
+        const { container } = render(<LemonInput onKeyDown={onKeyDown} onPressEnter={onPressEnter} />)
+        const input = container.querySelector('input')!
+        const event = createEvent.keyDown(input, { key: 'Enter' })
+        Object.defineProperty(event, 'isComposing', { value: true })
+
+        fireEvent(input, event)
+
+        expect(onKeyDown).not.toHaveBeenCalled()
+        expect(onPressEnter).not.toHaveBeenCalled()
+    })
+
+    it('calls Enter handlers after composition ends', () => {
+        const onKeyDown = jest.fn()
+        const onPressEnter = jest.fn()
+        const { container } = render(<LemonInput onKeyDown={onKeyDown} onPressEnter={onPressEnter} />)
+
+        fireEvent.keyDown(container.querySelector('input')!, { key: 'Enter' })
+
+        expect(onPressEnter).toHaveBeenCalledTimes(1)
+        expect(onKeyDown).toHaveBeenCalledTimes(1)
+    })
+
+    it('forwards non-Enter key handlers', () => {
+        const onKeyDown = jest.fn()
+        const onPressEnter = jest.fn()
+        const { container } = render(<LemonInput onKeyDown={onKeyDown} onPressEnter={onPressEnter} />)
+
+        fireEvent.keyDown(container.querySelector('input')!, { key: 'a' })
+
+        expect(onKeyDown).toHaveBeenCalledTimes(1)
+        expect(onPressEnter).not.toHaveBeenCalled()
+    })
+
     it('does not refocus the native input when it handles the click itself', () => {
         const { container } = render(<LemonInput type="time" />)
         const wrapper = container.querySelector<HTMLElement>('.LemonInput')

--- a/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
+++ b/frontend/src/lib/lemon-ui/LemonInput/LemonInput.tsx
@@ -98,6 +98,7 @@ export const LemonInput = React.forwardRef<HTMLDivElement, LemonInputProps>(func
         onChange,
         onFocus,
         onBlur,
+        onKeyDown,
         onPressEnter,
         status = 'default',
         allowClear, // Default handled inside the component
@@ -274,9 +275,13 @@ export const LemonInput = React.forwardRef<HTMLDivElement, LemonInputProps>(func
                         if (stopPropagation) {
                             event.stopPropagation()
                         }
-                        if (onPressEnter && event.key === 'Enter' && !event.nativeEvent.isComposing) {
+                        if (event.key === 'Enter' && event.nativeEvent.isComposing) {
+                            return
+                        }
+                        if (onPressEnter && event.key === 'Enter') {
                             onPressEnter(event)
                         }
+                        onKeyDown?.(event)
                     }}
                     {...props}
                 />

--- a/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.test.tsx
@@ -1,0 +1,64 @@
+import { createEvent, fireEvent, render } from '@testing-library/react'
+
+import { LemonTextArea } from './LemonTextArea'
+
+describe('LemonTextArea', () => {
+    it('does not call Enter or submit handlers while composing with an IME', () => {
+        const onKeyDown = jest.fn()
+        const onPressEnter = jest.fn()
+        const onPressCmdEnter = jest.fn()
+        const { container } = render(
+            <>
+                <LemonTextArea onKeyDown={onKeyDown} onPressEnter={onPressEnter} />
+                <LemonTextArea onKeyDown={onKeyDown} onPressCmdEnter={onPressCmdEnter} />
+            </>
+        )
+        const [enterTextArea, cmdEnterTextArea] = Array.from(container.querySelectorAll('textarea'))
+        const enterEvent = createEvent.keyDown(enterTextArea, { key: 'Enter' })
+        const cmdEnterEvent = createEvent.keyDown(cmdEnterTextArea, { key: 'Enter', ctrlKey: true })
+        Object.defineProperty(enterEvent, 'isComposing', { value: true })
+        Object.defineProperty(cmdEnterEvent, 'isComposing', { value: true })
+
+        fireEvent(enterTextArea, enterEvent)
+        fireEvent(cmdEnterTextArea, cmdEnterEvent)
+
+        expect(onKeyDown).not.toHaveBeenCalled()
+        expect(onPressEnter).not.toHaveBeenCalled()
+        expect(onPressCmdEnter).not.toHaveBeenCalled()
+    })
+
+    it('calls Enter handlers after composition ends', () => {
+        const onKeyDown = jest.fn()
+        const onPressEnter = jest.fn()
+        const { container } = render(<LemonTextArea onKeyDown={onKeyDown} onPressEnter={onPressEnter} value="Draft" />)
+
+        fireEvent.keyDown(container.querySelector('textarea')!, { key: 'Enter' })
+
+        expect(onPressEnter).toHaveBeenCalledWith('Draft')
+        expect(onKeyDown).toHaveBeenCalledTimes(1)
+    })
+
+    it('calls Cmd/Ctrl + Enter handlers after composition ends', () => {
+        const onKeyDown = jest.fn()
+        const onPressCmdEnter = jest.fn()
+        const { container } = render(
+            <LemonTextArea onKeyDown={onKeyDown} onPressCmdEnter={onPressCmdEnter} value="Draft" />
+        )
+
+        fireEvent.keyDown(container.querySelector('textarea')!, { key: 'Enter', ctrlKey: true })
+
+        expect(onPressCmdEnter).toHaveBeenCalledWith('Draft')
+        expect(onKeyDown).toHaveBeenCalledTimes(1)
+    })
+
+    it('forwards non-Enter key handlers', () => {
+        const onKeyDown = jest.fn()
+        const onPressEnter = jest.fn()
+        const { container } = render(<LemonTextArea onKeyDown={onKeyDown} onPressEnter={onPressEnter} />)
+
+        fireEvent.keyDown(container.querySelector('textarea')!, { key: 'a' })
+
+        expect(onKeyDown).toHaveBeenCalledTimes(1)
+        expect(onPressEnter).not.toHaveBeenCalled()
+    })
+})

--- a/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTextArea/LemonTextArea.tsx
@@ -85,7 +85,10 @@ export const LemonTextArea = React.forwardRef<HTMLTextAreaElement, LemonTextArea
                     if (stopPropagation) {
                         e.stopPropagation()
                     }
-                    if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                    if (e.key === 'Enter' && e.nativeEvent.isComposing) {
+                        return
+                    }
+                    if (e.key === 'Enter') {
                         const target = e.currentTarget
                         // When shift is pressed, we always just want to add a new line
                         if (!e.shiftKey) {


### PR DESCRIPTION
## Problem

Closes #60044

Pressing Enter while an IME is composing can trigger a submit handler instead of confirming the candidate character. This affects shared Lemon inputs used with Japanese, Chinese, and Korean IMEs.

## Changes

- Keep LemonInput's composition check from being overwritten by a consumer onKeyDown prop.
- Ignore composing Enter in LemonInput and LemonTextArea before submit callbacks or consumer key handlers run.
- Cover composing Enter, ordinary Enter, Cmd/Ctrl+Enter, and non-Enter keys.

## How did you test this code?

- LemonInput.test.tsx and LemonTextArea.test.tsx: 2 suites, 8 tests passed. The new tests cover composing Enter and preserve ordinary Enter, Cmd/Ctrl+Enter, and non-Enter behavior.
- pnpm --filter=@posthog/frontend fix passed.
- I rendered the LemonTextArea Basic Storybook story locally. The screenshot is attached below.
- I could not complete the full frontend typecheck in the disposable checkout because generated workspace packages are missing there. Its errors did not reference these files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed for this interaction fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used Codex for repository navigation, the test loop, and final diff review. Skills used: tdd, ponytail, code-review, and unslop.

I kept the patch to the two shared Lemon components. It does not change raw native inputs elsewhere in the monorepo.