### PR TITLE
fix(data-warehouse): stop capturing expected connect errors on schema probe

### DIFF
--- a/products/warehouse_sources/backend/presentation/views/external_data_schema.py
+++ b/products/warehouse_sources/backend/presentation/views/external_data_schema.py
@@ -1625,7 +1625,14 @@ class ExternalDataSchemaViewset(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 config, self.team_id, names=[instance.name], api_version=effective_api_version
             )
         except Exception as e:
-            capture_exception(e)
+            # `validate_credentials` above just probed the same connection successfully, so a
+            # failure here that the source itself classifies as non-retryable (e.g. a connect-time
+            # timeout, which usually means an unreachable host or unconfigured firewall) is an
+            # expected customer/upstream condition, not a bug — don't flood error tracking with it.
+            # Mirrors `refresh_schemas`'s `_classify_refresh_schemas_error`.
+            error_text = str(e)
+            if not any(pattern and pattern in error_text for pattern in new_source.get_non_retryable_errors()):
+                capture_exception(e)
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": str(e)},

--- a/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
+++ b/products/warehouse_sources/backend/tests/api/test_external_data_schema.py
@@ -122,6 +122,45 @@ class TestExternalDataSchema(APIBaseTest):
             "detected_primary_keys": None,
         }
 
+    @parameterized.expand(
+        [
+            ("expected_source_error", Exception("Invalid API Key provided"), False),
+            ("unclassified_error", RuntimeError("schema parser exploded"), True),
+        ]
+    )
+    @mock.patch("products.warehouse_sources.backend.presentation.views.external_data_schema.capture_exception")
+    def test_incremental_fields_capture_depends_on_non_retryable_classification(
+        self, _name, raised_exception, should_capture, mock_capture_exception
+    ):
+        # `validate_credentials` above this call already probed the same connection successfully, so
+        # a failure the source itself classifies as non-retryable (e.g. bad credentials, an
+        # unreachable host) is an expected customer/upstream condition and must not flood error
+        # tracking - mirrors `refresh_schemas`'s equivalent classification.
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_type=ExternalDataSourceType.STRIPE,
+            job_inputs={"auth_method": {"selection": "api_key", "stripe_secret_key": "123"}},
+        )
+        schema = ExternalDataSchema.objects.create(
+            name="BalanceTransaction",
+            team=self.team,
+            source=source,
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+        )
+        with (
+            mock.patch.object(StripeSource, "validate_credentials", return_value=(True, None)),
+            mock.patch.object(StripeSource, "get_schemas", side_effect=raised_exception),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}/incremental_fields",
+            )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == str(raised_exception)
+        assert mock_capture_exception.called is should_capture
+
     def test_incremental_fields_probe_uses_schema_pin_over_source_pin(self):
         # A schema-level api_version override must win over the source pin in capability probes,
         # matching sync-time precedence — consolidating probe callers to the source pin would


### PR DESCRIPTION
## Problem

Error tracking flagged a `ConnectionTimeout` ("connection timeout expired") raised while `PostgresSource.get_schemas` connected to a customer's database during the `incremental_fields` endpoint's schema probe ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f9ef7-7d44-7c51-a154-4fa4009cd4a9)).

`PostgresSource.get_non_retryable_errors()` already classifies a connect-time timeout as an expected customer/upstream condition (usually an unreachable host or unconfigured firewall) rather than a bug we should fix — it's deliberate, per the comments around `_is_dropped_or_connect_timeout` in `postgres.py`. The same request's earlier `validate_credentials` call hits this identical failure and returns an actionable message without reporting it to error tracking. But `incremental_fields`'s own `get_schemas` probe right after wraps every exception in a blanket `capture_exception`, so the exact same condition the request just classified as expected gets reported as an unhandled error moments later.

`refresh_schemas` (and a couple of other schema-discovery call sites in `external_data_source.py`) already avoid this by checking the source's `get_non_retryable_errors()` before capturing. `incremental_fields` lives in a different file and didn't have the same check.

## Changes

- `incremental_fields` now skips `capture_exception` when the raised error matches one of the source's `get_non_retryable_errors()` patterns, mirroring the classification `refresh_schemas` already does elsewhere. Unclassified/unexpected errors are still captured and reported exactly as before — this only silences the already-known, already-classified cases.

## How did you test this code?

- Added a parameterized case to `test_incremental_fields_capture_depends_on_non_retryable_classification` in `test_external_data_schema.py`: one variant raises an error matching a known non-retryable pattern and asserts `capture_exception` is *not* called, the other raises an unclassified error and asserts it *is* still called. This catches exactly the regression here — no existing test exercised `incremental_fields`'s exception path at all.
- Ran `ruff check`/`ruff format --check` and `mypy` on the touched file — all pass.
- Could not run the Django test suite itself in this sandbox (no live Postgres/dev stack available to back `APIBaseTest`), consistent with other recent PRs in this area.

Ruled out a duplicate: [#71841](https://github.com/PostHog/posthog/pull/71841) is still open and touches the same `ConnectionTimeout` message, but it fixes a different code path — the read/sync reconnect loop exhausting its in-process retries mid-sync — not this schema-probe endpoint, so it doesn't cover this case.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the error tracking issue's full stack trace and code-variable dump, which showed the failure came from an HTTP request to `incremental_fields`, not a Temporal sync activity — so the source's `get_non_retryable_errors` dict (already correct) never gets consulted on this path. Traced the established convention (`_classify_refresh_schemas_error` in `external_data_source.py`, used by `refresh_schemas` and two other call sites) and applied the same idea directly in `external_data_schema.py`, without importing the shared helper — the two files already have a one-directional import (`external_data_source.py` imports from `external_data_schema.py`), so pulling the helper back the other way would create a cycle. Invoked `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*