### PR TITLE
refactor(logs): deduplicate alerting timing metrics

### DIFF
--- a/products/logs/backend/temporal/metrics.py
+++ b/products/logs/backend/temporal/metrics.py
@@ -1,7 +1,6 @@
 """Prometheus metrics and Temporal interceptor for logs alerting."""
 
 import gc
-import time
 import typing
 import datetime as dt
 
@@ -12,12 +11,10 @@ from temporalio import activity, workflow
 from temporalio.common import MetricMeter
 from temporalio.worker import ActivityInboundInterceptor, ExecuteActivityInput, Interceptor
 
-from posthog.temporal.common.logger import get_write_only_logger
+from posthog.temporal.common.metrics import ExecutionTimeRecorder
 
 from products.logs.backend.alert_error_classifier import AlertErrorCode
 from products.logs.backend.alert_state_machine import AlertState, NotificationAction
-
-logger = get_write_only_logger(__name__)
 
 _NOTIFICATION_FAILURE_LABELS: dict[NotificationAction, str] = {
     NotificationAction.FIRE: "firing",
@@ -281,51 +278,6 @@ def record_schedule_to_start_latency(activity_type: str, latency_ms: int) -> Non
         latency_ms,
         {"activity_type": activity_type},
     )
-
-
-# TODO: Extract ExecutionTimeRecorder to posthog/temporal/common/ — copied from
-# posthog/temporal/ai_observability/metrics.py to avoid cross-product import.
-class ExecutionTimeRecorder:
-    """Context manager to record execution time to a histogram metric."""
-
-    def __init__(
-        self,
-        histogram_name: str,
-        /,
-        description: str | None = None,
-        histogram_attributes: Attributes | None = None,
-    ) -> None:
-        self.histogram_name = histogram_name
-        self.description = description
-        self.histogram_attributes = histogram_attributes or {}
-        self._start_counter: float | None = None
-
-    def __enter__(self) -> typing.Self:
-        self._start_counter = time.perf_counter()
-        return self
-
-    def __exit__(
-        self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: object
-    ) -> None:
-        if self._start_counter is None:
-            raise RuntimeError("Start counter not initialized, did you call `__enter__`?")
-
-        end_counter = time.perf_counter()
-        delta_ms = int((end_counter - self._start_counter) * 1000)
-        delta = dt.timedelta(milliseconds=delta_ms)
-
-        attributes = dict(self.histogram_attributes)
-        if exc_value is not None:
-            attributes["status"] = "FAILED"
-        else:
-            attributes["status"] = "COMPLETED"
-
-        meter = get_metric_meter(attributes)
-        hist = meter.create_histogram_timedelta(name=self.histogram_name, description=self.description, unit="ms")
-        try:
-            hist.record(value=delta)
-        except Exception:
-            logger.exception("Failed to record execution time to histogram '%s'", self.histogram_name)
 
 
 class LogsAlertingMetricsInterceptor(Interceptor):

--- a/products/logs/backend/test/test_logs_alerting_metrics.py
+++ b/products/logs/backend/test/test_logs_alerting_metrics.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from contextlib import nullcontext
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -45,32 +46,44 @@ class TestRecordHistogram:
         mock_hist.record.assert_called_once_with(dt.timedelta(milliseconds=150))
 
 
-class TestExecutionTimeRecorder:
-    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
-    def test_records_completed_on_success(self, mock_get_meter: MagicMock):
-        mock_meter = MagicMock()
-        mock_hist = MagicMock()
-        mock_meter.create_histogram_timedelta.return_value = mock_hist
-        mock_get_meter.return_value = mock_meter
+@pytest.mark.parametrize(
+    "execution_error,expected_status,expected_exception",
+    [
+        pytest.param(None, "COMPLETED", "", id="completed"),
+        pytest.param(ValueError("boom"), "FAILED", "ValueError", id="failed"),
+    ],
+)
+def test_execution_time_recorder_attributes(
+    execution_error: Exception | None, expected_status: str, expected_exception: str
+) -> None:
+    mock_meter = MagicMock()
+    mock_histogram = MagicMock()
+    mock_meter.create_histogram_timedelta.return_value = mock_histogram
+    mock_get_meter = MagicMock(return_value=mock_meter)
 
-        with ExecutionTimeRecorder("test_histogram"):
-            pass
+    with (
+        patch("products.logs.backend.temporal.metrics.get_metric_meter", new=mock_get_meter),
+        patch("posthog.temporal.common.metrics.get_metric_meter", new=mock_get_meter),
+        pytest.raises(ValueError, match="boom") if execution_error else nullcontext(),
+    ):
+        with ExecutionTimeRecorder(
+            "logs_alerting_cycle_duration_ms",
+            description="Full alert check cycle duration",
+            histogram_attributes={"activity_type": "discover_cohorts_activity"},
+        ):
+            if execution_error:
+                raise execution_error
 
-        call_args = mock_get_meter.call_args[0][0]
-        assert call_args["status"] == "COMPLETED"
-
-    @patch("products.logs.backend.temporal.metrics.get_metric_meter")
-    def test_records_failed_on_exception(self, mock_get_meter: MagicMock):
-        mock_meter = MagicMock()
-        mock_hist = MagicMock()
-        mock_meter.create_histogram_timedelta.return_value = mock_hist
-        mock_get_meter.return_value = mock_meter
-
-        try:
-            with ExecutionTimeRecorder("test_histogram"):
-                raise ValueError("boom")
-        except ValueError:
-            pass
-
-        call_args = mock_get_meter.call_args[0][0]
-        assert call_args["status"] == "FAILED"
+    mock_get_meter.assert_called_once_with(
+        {
+            "activity_type": "discover_cohorts_activity",
+            "status": expected_status,
+            "exception": expected_exception,
+        }
+    )
+    mock_meter.create_histogram_timedelta.assert_called_once_with(
+        name="logs_alerting_cycle_duration_ms",
+        description="Full alert check cycle duration",
+        unit="ms",
+    )
+    mock_histogram.record.assert_called_once()


### PR DESCRIPTION
## Problem

Logs alerting duplicated the shared Temporal `ExecutionTimeRecorder`, and the copies had started to drift. Using the shared implementation keeps error handling and metric attributes consistent.

## Changes

- Replace the logs-specific recorder with the shared implementation.
- Keep metric recording best-effort so it cannot fail the activity or mask its exception.
- Cover completed and failed metric attributes in a parameterized test.

> [!NOTE]
> `logs_alerting_cycle_duration_ms` gains an `exception` label. It is empty on success and contains the exception class on failure. Queries that require the exact label set may need updating, and the new series identity may cause a brief rollout discontinuity. Cardinality is bounded because exception messages are not recorded.

## How did you test this code?

- `.codex/with-flox hogli test products/logs/backend/test/test_logs_alerting_metrics.py` (7 passed)

The test verifies the activity, status, and exception attributes.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update is needed. This refactors an internal metrics helper without changing user-facing behavior or configuration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)