### PR TITLE
fix(mcp): classify exec dispatcher rejections as validation, not internal

### DIFF
--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -331,12 +331,12 @@ export class ToolExecutor {
             return response
         } catch (error: unknown) {
             const metricTool = execToolName()
+            const classification = classifyToolError(error, metricTool)
             if (!execMetrics.innerToolName) {
                 // Match the inner-tool path, which labels rejected input `validation_error`.
-                const status = error instanceof ExecCommandError ? 'validation_error' : 'error'
+                const status = classification.errorType === 'validation' ? 'validation_error' : 'error'
                 toolCallsTotal.inc({ tool: 'exec', status })
             }
-            const classification = classifyToolError(error, metricTool)
 
             void trackToolCall(
                 metricTool,

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -7,6 +7,7 @@ import {
     type ToolResultPayload,
 } from '@/lib/build-tool-result'
 import {
+    ExecCommandError,
     handleToolError,
     MissingOrganizationContextError,
     MissingProjectContextError,
@@ -516,6 +517,13 @@ function resolveToolErrorClassification(error: unknown): ToolErrorClassification
             ...(error.inputKeys.length ? { validationInputKeys: error.inputKeys } : {}),
         }
     }
+    // The exec dispatcher rejected the command before any inner tool ran (mistyped
+    // tool, bad JSON, unknown verb). That's an agent-recoverable input mistake, not
+    // a server fault — bucket it as `validation` so it stays out of the `internal`
+    // rate ops alerts on, and so a retry-looping agent can't masquerade as an outage.
+    if (error instanceof ExecCommandError) {
+        return { errorType: 'validation' }
+    }
     if (findPostHogPermissionError(error)) {
         return { errorType: 'permission' }
     }
@@ -573,6 +581,11 @@ function resolveSafeErrorMessage(error: unknown): string | undefined {
     // Documented value-free: offending field paths + issue codes, never input values.
     if (error instanceof ToolInputValidationError) {
         return error.message
+    }
+    // Value-free: the reason enum only. The dispatcher's human message can echo the
+    // caller's tool name or a JSON-parser fragment, so it's never captured.
+    if (error instanceof ExecCommandError) {
+        return `Exec command rejected: ${error.reason}`
     }
     if (error instanceof Error && error.name === 'TimeoutError') {
         return 'Tool call timed out'

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -517,13 +517,9 @@ function resolveToolErrorClassification(error: unknown): ToolErrorClassification
             ...(error.inputKeys.length ? { validationInputKeys: error.inputKeys } : {}),
         }
     }
-    // The exec dispatcher rejected the command before any inner tool ran (mistyped
-    // tool, bad JSON, unknown verb). That's an agent-recoverable input mistake, not
-    // a server fault — bucket it as `validation` so it stays out of the `internal`
-    // rate ops alerts on, and so a retry-looping agent can't masquerade as an outage.
-    // `missing_scope` is the exception: the agent can't fix it by sending different
-    // input, the connection has to be reauthorized — which is exactly what the
-    // permission-rate alert watches for.
+    // Agent-recoverable command mistakes, so keep them out of the `internal` rate
+    // ops alerts on. `missing_scope` is the exception: no input the agent sends
+    // fixes it, the connection has to be reauthorized.
     if (error instanceof ExecCommandError) {
         return { errorType: error.reason === 'missing_scope' ? 'permission' : 'validation' }
     }

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -521,8 +521,11 @@ function resolveToolErrorClassification(error: unknown): ToolErrorClassification
     // tool, bad JSON, unknown verb). That's an agent-recoverable input mistake, not
     // a server fault — bucket it as `validation` so it stays out of the `internal`
     // rate ops alerts on, and so a retry-looping agent can't masquerade as an outage.
+    // `missing_scope` is the exception: the agent can't fix it by sending different
+    // input, the connection has to be reauthorized — which is exactly what the
+    // permission-rate alert watches for.
     if (error instanceof ExecCommandError) {
-        return { errorType: 'validation' }
+        return { errorType: error.reason === 'missing_scope' ? 'permission' : 'validation' }
     }
     if (findPostHogPermissionError(error)) {
         return { errorType: 'permission' }

--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -332,7 +332,9 @@ export class ToolExecutor {
         } catch (error: unknown) {
             const metricTool = execToolName()
             if (!execMetrics.innerToolName) {
-                toolCallsTotal.inc({ tool: 'exec', status: 'error' })
+                // Match the inner-tool path, which labels rejected input `validation_error`.
+                const status = error instanceof ExecCommandError ? 'validation_error' : 'error'
+                toolCallsTotal.inc({ tool: 'exec', status })
             }
             const classification = classifyToolError(error, metricTool)
 

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -155,21 +155,13 @@ export type ExecCommandErrorReason =
     | 'needs_confirmation'
 
 /**
- * Thrown by the single-exec `exec` dispatcher when it rejects a command before
- * any inner tool runs — an unknown command verb, an unknown / deprecated /
- * scope-gated tool name, malformed JSON input, a usage error, or an unknown
- * `learn` topic. These are agent-recoverable mistakes (the LLM mistyped a tool
- * name or sent bad JSON), not server faults, so they must classify as
- * `validation` rather than falling through to the `internal` bucket. Left as a
- * plain `Error`, a single retry-looping agent inflates the internal-error rate
- * ops alerts watch, the failures carry no `$mcp_error_message`, and every
- * slip-up mints an `exec`-fingerprinted error-tracking issue via
- * `captureException`.
+ * Thrown by the `exec` dispatcher when it rejects a command before any inner
+ * tool runs. Typed so these classify as agent mistakes rather than falling
+ * through to the `internal` bucket ops alerts on.
  *
- * `reason` is a value-free enum for telemetry; the human `message` is returned
- * to the agent verbatim so it can self-correct, but is never captured into
- * project-readable analytics (it can echo the caller's tool name or a JSON
- * parser fragment) — `$mcp_error_message` is derived from `reason` instead.
+ * `message` goes back to the agent verbatim so it can self-correct, but is
+ * never captured into analytics — it can echo the caller's tool name or a JSON
+ * parser fragment. `$mcp_error_message` is derived from the `reason` enum.
  */
 export class ExecCommandError extends Error {
     public readonly reason: ExecCommandErrorReason
@@ -472,10 +464,8 @@ export function handleToolError(error: any, tool?: string, distinctId?: string, 
         }
     }
 
-    // Recoverable: the exec dispatcher rejected the command before any handler ran
-    // (unknown tool/verb, bad JSON, usage). Return the guidance so the agent can
-    // self-correct, and skip exception capture — otherwise every agent slip-up
-    // mints a fresh `exec`-fingerprinted error-tracking issue.
+    // Recoverable: return the guidance so the agent can self-correct, and skip
+    // exception capture — otherwise every slip-up mints a fresh error-tracking issue.
     if (error instanceof ExecCommandError) {
         return {
             content: [

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -152,6 +152,7 @@ export type ExecCommandErrorReason =
     | 'usage'
     | 'invalid_regex'
     | 'unknown_learn_topic'
+    | 'needs_confirmation'
 
 /**
  * Thrown by the single-exec `exec` dispatcher when it rejects a command before

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -143,6 +143,43 @@ export class ToolInputValidationError extends Error {
     }
 }
 
+export type ExecCommandErrorReason =
+    | 'unknown_command'
+    | 'unknown_tool'
+    | 'deprecated_tool'
+    | 'missing_scope'
+    | 'invalid_json'
+    | 'usage'
+    | 'invalid_regex'
+    | 'unknown_learn_topic'
+
+/**
+ * Thrown by the single-exec `exec` dispatcher when it rejects a command before
+ * any inner tool runs — an unknown command verb, an unknown / deprecated /
+ * scope-gated tool name, malformed JSON input, a usage error, or an unknown
+ * `learn` topic. These are agent-recoverable mistakes (the LLM mistyped a tool
+ * name or sent bad JSON), not server faults, so they must classify as
+ * `validation` rather than falling through to the `internal` bucket. Left as a
+ * plain `Error`, a single retry-looping agent inflates the internal-error rate
+ * ops alerts watch, the failures carry no `$mcp_error_message`, and every
+ * slip-up mints an `exec`-fingerprinted error-tracking issue via
+ * `captureException`.
+ *
+ * `reason` is a value-free enum for telemetry; the human `message` is returned
+ * to the agent verbatim so it can self-correct, but is never captured into
+ * project-readable analytics (it can echo the caller's tool name or a JSON
+ * parser fragment) — `$mcp_error_message` is derived from `reason` instead.
+ */
+export class ExecCommandError extends Error {
+    public readonly reason: ExecCommandErrorReason
+
+    constructor(message: string, reason: ExecCommandErrorReason) {
+        super(message)
+        this.name = 'ExecCommandError'
+        this.reason = reason
+    }
+}
+
 export interface PostHogApiErrorOptions {
     status: number
     statusText: string
@@ -423,6 +460,22 @@ export function handleToolError(error: any, tool?: string, distinctId?: string, 
     // an agent slip-up, not a bug. The message already names the offending
     // field(s); skip exception capture like the API 4xx branch below.
     if (error instanceof ToolInputValidationError) {
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: `Error: [${toolName}]: ${error.message}`,
+                },
+            ],
+            isError: true,
+        }
+    }
+
+    // Recoverable: the exec dispatcher rejected the command before any handler ran
+    // (unknown tool/verb, bad JSON, usage). Return the guidance so the agent can
+    // self-correct, and skip exception capture — otherwise every agent slip-up
+    // mints a fresh `exec`-fingerprinted error-tracking issue.
+    if (error instanceof ExecCommandError) {
         return {
             content: [
                 {

--- a/services/mcp/src/lib/errors.ts
+++ b/services/mcp/src/lib/errors.ts
@@ -434,39 +434,16 @@ export function findRecoverableApiError(error: unknown): PostHogApiError | PostH
 export function handleToolError(error: any, tool?: string, distinctId?: string, sessionUuid?: string): CallToolResult {
     const toolName = tool || 'unknown'
 
-    // Recoverable: agent can fix it via switch-project / projects-get. Skip
-    // exception capture (this is expected user state, not a bug) and return the
-    // typed error's pre-formatted multi-line message verbatim.
-    if (error instanceof MissingProjectContextError || error instanceof MissingOrganizationContextError) {
-        return {
-            content: [
-                {
-                    type: 'text',
-                    text: `Error: [${toolName}]: ${error.message}`,
-                },
-            ],
-            isError: true,
-        }
-    }
-
-    // Recoverable: input rejected by the tool's schema before any handler ran —
-    // an agent slip-up, not a bug. The message already names the offending
-    // field(s); skip exception capture like the API 4xx branch below.
-    if (error instanceof ToolInputValidationError) {
-        return {
-            content: [
-                {
-                    type: 'text',
-                    text: `Error: [${toolName}]: ${error.message}`,
-                },
-            ],
-            isError: true,
-        }
-    }
-
-    // Recoverable: return the guidance so the agent can self-correct, and skip
-    // exception capture — otherwise every slip-up mints a fresh error-tracking issue.
-    if (error instanceof ExecCommandError) {
+    // Recoverable: expected agent or user state, not a bug — no project picked,
+    // input the schema rejected, a mistyped exec command. Each of these classes
+    // pre-formats a message the agent can self-correct from, so return it verbatim
+    // and skip exception capture, which would mint an issue per slip-up.
+    if (
+        error instanceof MissingProjectContextError ||
+        error instanceof MissingOrganizationContextError ||
+        error instanceof ToolInputValidationError ||
+        error instanceof ExecCommandError
+    ) {
         return {
             content: [
                 {

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -333,7 +333,12 @@ export function createExecTool(
                 case 'learn': {
                     const helpCatalog = options.helpCatalog
                     if (!helpCatalog) {
-                        throw new ExecCommandError('The learning catalog is not available for this client.', 'usage')
+                        // `learn` is only advertised when a catalog exists, so without one
+                        // it's an unsupported verb rather than a misuse of a real command.
+                        throw new ExecCommandError(
+                            'The learning catalog is not available for this client.',
+                            'unknown_command'
+                        )
                     }
                     if (!rest) {
                         return JSON.stringify(helpCatalog.list())

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -351,15 +351,9 @@ export function createExecTool(
                             .list()
                             .map((item) => item.id)
                             .join(', ')
-                        if (unknownTopicIds.length === 1) {
-                            throw new ExecCommandError(
-                                `Unknown learning topic: "${unknownTopicIds[0]}". Available: ${available}`,
-                                'unknown_learn_topic'
-                            )
-                        }
                         const unknownTopics = unknownTopicIds.map((topicId) => `"${topicId}"`).join(', ')
                         throw new ExecCommandError(
-                            `Unknown learning topics: ${unknownTopics}. Available: ${available}`,
+                            `Unknown learning topic${unknownTopicIds.length === 1 ? '' : 's'}: ${unknownTopics}. Available: ${available}`,
                             'unknown_learn_topic'
                         )
                     }
@@ -540,6 +534,8 @@ export function createExecTool(
                         throw new ExecCommandError('Usage: call [--json] [--confirm] <tool_name> <json_input>', 'usage')
                     }
                     if (!context) {
+                        // Deliberately untyped: a wiring fault, not an agent mistake, so it
+                        // belongs in the `internal` bucket its siblings are kept out of.
                         throw new Error('Cannot call PostHog tools without an API context')
                     }
                     const { forceJson, confirmed, rest: callArgs } = parseCallFlags(rest)

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -546,7 +546,7 @@ export function createExecTool(
                     if (options.requireDestructiveConfirmation && tool.annotations.destructiveHint && !confirmed) {
                         throw new ExecCommandError(
                             `Tool "${tool.name}" is destructive. Re-run with "call --confirm ${tool.name} ..." after verifying the target IDs. Use "info ${tool.name}" to inspect the tool first.`,
-                            'usage'
+                            'needs_confirmation'
                         )
                     }
                     let input: Record<string, unknown>

--- a/services/mcp/src/tools/exec.ts
+++ b/services/mcp/src/tools/exec.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 
 import { markExecPayload, buildToolResultPayload, estimateResponseTokens } from '@/lib/build-tool-result'
 import { isPostHogCodeConsumer } from '@/lib/client-detection'
-import { findRecoverableApiError, PostHogApiError, ToolInputValidationError } from '@/lib/errors'
+import { ExecCommandError, findRecoverableApiError, PostHogApiError, ToolInputValidationError } from '@/lib/errors'
 import { estimateTokens } from '@/lib/estimate-tokens'
 import { formatResponse } from '@/lib/response'
 
@@ -285,16 +285,18 @@ function findTool(tools: Tool<ZodObjectAny>[], scopeGatedTools: ScopeGatedTool[]
     if (!tool) {
         const redirect = DEPRECATED_TOOL_REDIRECTS[name]
         if (redirect) {
-            throw new Error(redirect(tools))
+            throw new ExecCommandError(redirect(tools), 'deprecated_tool')
         }
         const scopeGatedTool = scopeGatedTools.find((candidate) => candidate.name === name)
         if (scopeGatedTool) {
-            throw new Error(
-                `Tool "${name}" exists, but this MCP connection is missing the required scope(s): ${scopeGatedTool.missingScopes.join(', ')}. Reconnect or reauthorize the PostHog MCP connection and approve these scopes. Logging in to PostHog in a browser does not update MCP permissions.`
+            throw new ExecCommandError(
+                `Tool "${name}" exists, but this MCP connection is missing the required scope(s): ${scopeGatedTool.missingScopes.join(', ')}. Reconnect or reauthorize the PostHog MCP connection and approve these scopes. Logging in to PostHog in a browser does not update MCP permissions.`,
+                'missing_scope'
             )
         }
-        throw new Error(
-            `Unknown tool: "${name}". Run "search ${name}" to find the current tool name before claiming the capability is unavailable.`
+        throw new ExecCommandError(
+            `Unknown tool: "${name}". Run "search ${name}" to find the current tool name before claiming the capability is unavailable.`,
+            'unknown_tool'
         )
     }
     return tool
@@ -331,7 +333,7 @@ export function createExecTool(
                 case 'learn': {
                     const helpCatalog = options.helpCatalog
                     if (!helpCatalog) {
-                        throw new Error('The learning catalog is not available for this client.')
+                        throw new ExecCommandError('The learning catalog is not available for this client.', 'usage')
                     }
                     if (!rest) {
                         return JSON.stringify(helpCatalog.list())
@@ -345,10 +347,16 @@ export function createExecTool(
                             .map((item) => item.id)
                             .join(', ')
                         if (unknownTopicIds.length === 1) {
-                            throw new Error(`Unknown learning topic: "${unknownTopicIds[0]}". Available: ${available}`)
+                            throw new ExecCommandError(
+                                `Unknown learning topic: "${unknownTopicIds[0]}". Available: ${available}`,
+                                'unknown_learn_topic'
+                            )
                         }
                         const unknownTopics = unknownTopicIds.map((topicId) => `"${topicId}"`).join(', ')
-                        throw new Error(`Unknown learning topics: ${unknownTopics}. Available: ${available}`)
+                        throw new ExecCommandError(
+                            `Unknown learning topics: ${unknownTopics}. Available: ${available}`,
+                            'unknown_learn_topic'
+                        )
                     }
                     const resolvedEntries = entries.filter((entry) => entry !== undefined)
                     if (resolvedEntries.length === 1) {
@@ -363,13 +371,14 @@ export function createExecTool(
 
                 case 'search': {
                     if (!rest) {
-                        throw new Error('Usage: search <words or regex_pattern>')
+                        throw new ExecCommandError('Usage: search <words or regex_pattern>', 'usage')
                     }
                     // Bound the user-supplied pattern length to limit the blast
                     // radius of a pathological (catastrophic-backtracking) regex.
                     if (rest.length > MAX_SEARCH_PATTERN_LENGTH) {
-                        throw new Error(
-                            `Search pattern too long (${rest.length} chars, max ${MAX_SEARCH_PATTERN_LENGTH}). Use a shorter, more targeted pattern.`
+                        throw new ExecCommandError(
+                            `Search pattern too long (${rest.length} chars, max ${MAX_SEARCH_PATTERN_LENGTH}). Use a shorter, more targeted pattern.`,
+                            'usage'
                         )
                     }
 
@@ -385,7 +394,7 @@ export function createExecTool(
                             matches = searchToolsRegex(allTools, rest).map((t) => t.name)
                             gatedMatches = searchToolsRegex(scopeGatedTools, rest)
                         } catch {
-                            throw new Error(`Invalid regex pattern: "${rest}"`)
+                            throw new ExecCommandError(`Invalid regex pattern: "${rest}"`, 'invalid_regex')
                         }
                     } else {
                         const ranked = searchToolsRanked(allTools, rest)
@@ -430,12 +439,12 @@ export function createExecTool(
 
                 case 'info': {
                     if (!rest) {
-                        throw new Error('Usage: info [--json] <tool_name>')
+                        throw new ExecCommandError('Usage: info [--json] <tool_name>', 'usage')
                     }
                     const forceJson = rest.startsWith('--json ') || rest === '--json'
                     const infoArgs = forceJson ? rest.slice('--json'.length).trim() : rest
                     if (!infoArgs) {
-                        throw new Error('Usage: info [--json] <tool_name>')
+                        throw new ExecCommandError('Usage: info [--json] <tool_name>', 'usage')
                     }
                     const tool = findTool(allTools, scopeGatedTools, infoArgs)
                     // `io: 'input'` mirrors the advertised `tools/list` schema and the executor's
@@ -477,7 +486,7 @@ export function createExecTool(
 
                 case 'schema': {
                     if (!rest) {
-                        throw new Error('Usage: schema <tool_name> [field_path]')
+                        throw new ExecCommandError('Usage: schema <tool_name> [field_path]', 'usage')
                     }
                     const { verb: schemaToolName, rest: fieldPath } = parseCommand(rest)
                     const schemaTool = findTool(allTools, scopeGatedTools, schemaToolName)
@@ -497,7 +506,10 @@ export function createExecTool(
                     const resolved = resolveSchemaPath(fullJsonSchema, fieldPath)
                     if (!resolved) {
                         const available = listAvailablePaths(fullJsonSchema)
-                        throw new Error(`Unknown path "${fieldPath}". Available: ${available.join(', ')}`)
+                        throw new ExecCommandError(
+                            `Unknown path "${fieldPath}". Available: ${available.join(', ')}`,
+                            'usage'
+                        )
                     }
 
                     const serialized = JSON.stringify({
@@ -520,20 +532,21 @@ export function createExecTool(
 
                 case 'call': {
                     if (!rest) {
-                        throw new Error('Usage: call [--json] [--confirm] <tool_name> <json_input>')
+                        throw new ExecCommandError('Usage: call [--json] [--confirm] <tool_name> <json_input>', 'usage')
                     }
                     if (!context) {
                         throw new Error('Cannot call PostHog tools without an API context')
                     }
                     const { forceJson, confirmed, rest: callArgs } = parseCallFlags(rest)
                     if (!callArgs) {
-                        throw new Error('Usage: call [--json] [--confirm] <tool_name> <json_input>')
+                        throw new ExecCommandError('Usage: call [--json] [--confirm] <tool_name> <json_input>', 'usage')
                     }
                     const { verb: toolName, rest: jsonBody } = parseCommand(callArgs)
                     const tool = findTool(allTools, scopeGatedTools, toolName)
                     if (options.requireDestructiveConfirmation && tool.annotations.destructiveHint && !confirmed) {
-                        throw new Error(
-                            `Tool "${tool.name}" is destructive. Re-run with "call --confirm ${tool.name} ..." after verifying the target IDs. Use "info ${tool.name}" to inspect the tool first.`
+                        throw new ExecCommandError(
+                            `Tool "${tool.name}" is destructive. Re-run with "call --confirm ${tool.name} ..." after verifying the target IDs. Use "info ${tool.name}" to inspect the tool first.`,
+                            'usage'
                         )
                     }
                     let input: Record<string, unknown>
@@ -544,7 +557,7 @@ export function createExecTool(
                             input = JSON.parse(jsonBody) as Record<string, unknown>
                         } catch (err) {
                             const detail = err instanceof Error ? err.message : String(err)
-                            throw new Error(`Invalid JSON input: ${detail}`)
+                            throw new ExecCommandError(`Invalid JSON input: ${detail}`, 'invalid_json')
                         }
                     }
 
@@ -696,8 +709,9 @@ export function createExecTool(
                 }
 
                 default:
-                    throw new Error(
-                        `Unknown command: "${verb}". Supported commands: ${options.helpCatalog ? 'learn, ' : ''}tools, search, info, schema, call`
+                    throw new ExecCommandError(
+                        `Unknown command: "${verb}". Supported commands: ${options.helpCatalog ? 'learn, ' : ''}tools, search, info, schema, call`,
+                        'unknown_command'
                     )
             }
         },

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -431,22 +431,10 @@ describe('ToolExecutor metrics', () => {
             expect(callsFor(mockToolErrorsInc, 'exec')).toHaveLength(0)
         })
 
-        it('emits exec-level error for framework failures before inner dispatch', async () => {
-            await executor.handleToolCall(
-                { name: 'exec', arguments: { command: 'call nonexistent-tool-xyz {}' } },
-                execState()
-            )
-
-            const execErrors = callsFor(mockToolCallsInc, 'exec')
-            expect(execErrors.length).toBeGreaterThan(0)
-            expect(execErrors[0].status).toBe('validation_error')
-
-            expect(callsFor(mockToolErrorsInc, 'exec').length).toBeGreaterThan(0)
-        })
-
         // Dispatcher rejections are agent mistakes, not server faults: they must not
-        // land in the `internal` bucket the error-rate alert watches, and they must
-        // carry a value-free message so the failure is debuggable from analytics.
+        // land in the `internal` bucket the error-rate alert watches, they stay
+        // attributed to `exec` (no inner tool ran), and they must carry a value-free
+        // message so the failure is debuggable from analytics.
         it.each([
             ['call nonexistent-tool-xyz {}', 'unknown_tool'],
             ['frobnicate', 'unknown_command'],
@@ -454,6 +442,7 @@ describe('ToolExecutor metrics', () => {
         ])('classifies %s as validation', async (command, reason) => {
             await executor.handleToolCall({ name: 'exec', arguments: { command } }, execState())
 
+            expect(callsFor(mockToolCallsInc, 'exec')).toEqual([{ tool: 'exec', status: 'validation_error' }])
             expect(callsFor(mockToolErrorsInc, 'exec')).toEqual([{ tool: 'exec', error_type: 'validation' }])
             expect(trackToolCallExtras('exec')).toMatchObject({
                 $mcp_error_type: 'validation',

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -487,5 +487,19 @@ describe('ToolExecutor metrics', () => {
                 $mcp_error_message: 'Exec command rejected: invalid_json',
             })
         })
+
+        it('classifies a scope-gated tool as permission, not validation', async () => {
+            // The agent can't fix this by sending different input — the connection has
+            // to be reauthorized, which is what the permission-rate alert watches for.
+            const state = execState()
+            state.scopeGatedTools = [{ name: 'gated-tool', missingScopes: ['insight:read'] }] as any
+
+            await executor.handleToolCall({ name: 'exec', arguments: { command: 'info gated-tool' } }, state)
+
+            expect(callsFor(mockToolErrorsInc, 'exec')).toEqual([{ tool: 'exec', error_type: 'permission' }])
+            expect(trackToolCallExtras('exec')).toMatchObject({
+                $mcp_error_message: 'Exec command rejected: missing_scope',
+            })
+        })
     })
 })

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -439,7 +439,7 @@ describe('ToolExecutor metrics', () => {
 
             const execErrors = callsFor(mockToolCallsInc, 'exec')
             expect(execErrors.length).toBeGreaterThan(0)
-            expect(execErrors[0].status).toBe('error')
+            expect(execErrors[0].status).toBe('validation_error')
 
             expect(callsFor(mockToolErrorsInc, 'exec').length).toBeGreaterThan(0)
         })

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -443,5 +443,49 @@ describe('ToolExecutor metrics', () => {
 
             expect(callsFor(mockToolErrorsInc, 'exec').length).toBeGreaterThan(0)
         })
+
+        it('classifies dispatcher command rejections as validation, not internal', async () => {
+            // An unknown inner tool is an agent mistake, not a server fault: it must
+            // not land in the `internal` bucket the error-rate alert watches.
+            await executor.handleToolCall(
+                { name: 'exec', arguments: { command: 'call nonexistent-tool-xyz {}' } },
+                execState()
+            )
+
+            expect(callsFor(mockToolErrorsInc, 'exec')).toEqual([{ tool: 'exec', error_type: 'validation' }])
+        })
+
+        it('stamps a value-free $mcp_error_message for a dispatcher command rejection', async () => {
+            await executor.handleToolCall(
+                { name: 'exec', arguments: { command: 'call nonexistent-tool-xyz {}' } },
+                execState()
+            )
+
+            expect(trackToolCallExtras('exec')).toMatchObject({
+                $mcp_error_type: 'validation',
+                $mcp_error_message: 'Exec command rejected: unknown_tool',
+            })
+        })
+
+        it('classifies an unknown command verb as validation', async () => {
+            await executor.handleToolCall({ name: 'exec', arguments: { command: 'frobnicate' } }, execState())
+
+            expect(callsFor(mockToolErrorsInc, 'exec')).toEqual([{ tool: 'exec', error_type: 'validation' }])
+            expect(trackToolCallExtras('exec')).toMatchObject({
+                $mcp_error_message: 'Exec command rejected: unknown_command',
+            })
+        })
+
+        it('classifies malformed JSON input as validation', async () => {
+            await executor.handleToolCall(
+                { name: 'exec', arguments: { command: 'call docs-search {not json}' } },
+                execState()
+            )
+
+            expect(callsFor(mockToolErrorsInc, 'exec')).toEqual([{ tool: 'exec', error_type: 'validation' }])
+            expect(trackToolCallExtras('exec')).toMatchObject({
+                $mcp_error_message: 'Exec command rejected: invalid_json',
+            })
+        })
     })
 })

--- a/services/mcp/tests/hono/tool-executor-metrics.test.ts
+++ b/services/mcp/tests/hono/tool-executor-metrics.test.ts
@@ -444,47 +444,20 @@ describe('ToolExecutor metrics', () => {
             expect(callsFor(mockToolErrorsInc, 'exec').length).toBeGreaterThan(0)
         })
 
-        it('classifies dispatcher command rejections as validation, not internal', async () => {
-            // An unknown inner tool is an agent mistake, not a server fault: it must
-            // not land in the `internal` bucket the error-rate alert watches.
-            await executor.handleToolCall(
-                { name: 'exec', arguments: { command: 'call nonexistent-tool-xyz {}' } },
-                execState()
-            )
+        // Dispatcher rejections are agent mistakes, not server faults: they must not
+        // land in the `internal` bucket the error-rate alert watches, and they must
+        // carry a value-free message so the failure is debuggable from analytics.
+        it.each([
+            ['call nonexistent-tool-xyz {}', 'unknown_tool'],
+            ['frobnicate', 'unknown_command'],
+            ['call docs-search {not json}', 'invalid_json'],
+        ])('classifies %s as validation', async (command, reason) => {
+            await executor.handleToolCall({ name: 'exec', arguments: { command } }, execState())
 
             expect(callsFor(mockToolErrorsInc, 'exec')).toEqual([{ tool: 'exec', error_type: 'validation' }])
-        })
-
-        it('stamps a value-free $mcp_error_message for a dispatcher command rejection', async () => {
-            await executor.handleToolCall(
-                { name: 'exec', arguments: { command: 'call nonexistent-tool-xyz {}' } },
-                execState()
-            )
-
             expect(trackToolCallExtras('exec')).toMatchObject({
                 $mcp_error_type: 'validation',
-                $mcp_error_message: 'Exec command rejected: unknown_tool',
-            })
-        })
-
-        it('classifies an unknown command verb as validation', async () => {
-            await executor.handleToolCall({ name: 'exec', arguments: { command: 'frobnicate' } }, execState())
-
-            expect(callsFor(mockToolErrorsInc, 'exec')).toEqual([{ tool: 'exec', error_type: 'validation' }])
-            expect(trackToolCallExtras('exec')).toMatchObject({
-                $mcp_error_message: 'Exec command rejected: unknown_command',
-            })
-        })
-
-        it('classifies malformed JSON input as validation', async () => {
-            await executor.handleToolCall(
-                { name: 'exec', arguments: { command: 'call docs-search {not json}' } },
-                execState()
-            )
-
-            expect(callsFor(mockToolErrorsInc, 'exec')).toEqual([{ tool: 'exec', error_type: 'validation' }])
-            expect(trackToolCallExtras('exec')).toMatchObject({
-                $mcp_error_message: 'Exec command rejected: invalid_json',
+                $mcp_error_message: `Exec command rejected: ${reason}`,
             })
         })
 


### PR DESCRIPTION
## Problem

The single-exec `exec` dispatcher throws a plain `Error` for every agent-recoverable command failure — an unknown inner tool, an unknown command verb, malformed JSON input, a scope-gated tool, an unknown `learn` topic, or a usage error. Because none of those are a typed error class, they fall through `resolveToolErrorClassification` to the catch-all `internal` bucket. Three things follow from that:

- **They inflate the `internal` error rate.** Ops alerting keys on `mcp_tool_errors_total{error_type=~"...internal..."}`, so ordinary agent mistakes read as server faults — and a single agent retrying a bad command in a tight loop can masquerade as an outage.
- **They're undebuggable from analytics.** `resolveSafeErrorMessage` only captures messages from an allowlist of typed errors, so these arrive with a blank `$mcp_error_message`.
- **They spam error tracking.** `handleToolError` runs `captureException` on them, minting a fresh `exec`-fingerprinted error-tracking issue for each slip-up.

This surfaced while investigating an `internal` error signature on the `exec` dispatcher (~0 ms duration, empty message) that spanned many tenants and harnesses — see the [Slack thread](https://posthog.slack.com/archives/C0BKT3R76RK/p1785083202535329?thread_ts=1785083202.535329&cid=C0BKT3R76RK) for context.

## Changes

- Add `ExecCommandError` (in `lib/errors.ts`) carrying a value-free `reason` enum (`unknown_tool`, `unknown_command`, `invalid_json`, `missing_scope`, `deprecated_tool`, `usage`, `invalid_regex`, `unknown_learn_topic`).
- Throw it from the recoverable branches of the `exec` dispatcher instead of a plain `Error`. The agent-facing messages are unchanged.
- Classify `ExecCommandError` as `validation` (not `internal`), and stamp a value-free `$mcp_error_message` derived from `reason` — never the raw message, which can echo a caller tool name or a JSON-parser fragment.
- Short-circuit exception capture for it in `handleToolError`, like the other recoverable branches.

Genuine unexpected throws inside the dispatcher stay plain `Error`s and remain `internal`, so that bucket regains its meaning as "real server fault."

**Why:** an alert kept re-firing on the dispatcher's `internal` error rate; the errors turned out to be agent-side command mistakes miscategorized as server faults, with no captured message to debug from.

## How did you test this code?

Added unit tests in `tests/hono/tool-executor-metrics.test.ts` asserting a dispatcher rejection (unknown tool, unknown command verb, malformed JSON) is classified as `validation` and carries a value-free `$mcp_error_message` — the regression being that these previously landed in the `internal` bucket with a blank message.

Ran locally:

- `test:hono tests/hono/tool-executor-metrics.test.ts` — 26 passed (incl. the 4 new/updated cases).
- `vitest run tests/unit/exec.test.ts` — 105 passed (dispatcher error messages unchanged; `ExecCommandError extends Error` so existing `.rejects.toThrow('message')` assertions still hold).

`pnpm --filter=@posthog/mcp run typecheck` fails in this environment only on pre-existing `@posthog/quill` / `@posthog/quill-charts` module-resolution errors under `src/ui-apps/` (workspace packages not built here); none of those files are touched by this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from Slack by the PostHog Slack app (Claude). The dispatcher `internal` signature was traced to plain-`Error` throws in `services/mcp/src/tools/exec.ts` being bucketed by `resolveToolErrorClassification` as `internal`, and to `resolveSafeErrorMessage` / `handleToolError` treating them as unexpected faults. Chose to add a dedicated typed error and reuse the existing `validation` bucket rather than introduce a new `$mcp_error_type` enum value, to avoid a taxonomy/dashboard migration. `$mcp_error_message` intentionally carries only the `reason` enum to stay value-free. No repo skills were required for these files.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BKT3R76RK/p1785083202535329?thread_ts=1785083202.535329&cid=C0BKT3R76RK)*
