### PR TITLE
feat(data-warehouse): implement criteo source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -170,6 +170,7 @@ the row lists both.
 | courier                          | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | coveralls                        | HTTP                        | requests                                                        | ✅                          |
 | crates_io                        | HTTP                        | requests                                                        | ✅                          |
+| criteo                           | HTTP                        | requests                                                        | ✅                          |
 | cronitor                         | HTTP                        | requests                                                        | ✅                          |
 | crunchbase                       | HTTP                        | requests                                                        | ✅                          |
 | culture_amp                      | HTTP                        | requests                                                        | ✅                          |
@@ -857,7 +858,6 @@ doesn't conflict with concurrent PRs.
 - cosmosdb
 - couchbase
 - crisp
-- criteo
 - crossref
 - crowdstrike_falcon
 - cube_cloud

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/canonical_descriptions.py
@@ -1,0 +1,109 @@
+"""Canonical, documentation-sourced descriptions for Criteo endpoints and columns.
+
+Sourced from the Criteo Marketing Solutions API reference
+(https://developers.criteo.com/marketing-solutions/reference). Keyed by the endpoint names in
+`settings.py` `CRITEO_ENDPOINTS`, which match the `ExternalDataSchema.name` of a synced Criteo table.
+Columns absent here fall back to LLM enrichment.
+"""
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "advertisers": {
+        "description": "The portfolio of advertisers the API credentials have been granted access to.",
+        "docs_url": "https://developers.criteo.com/marketing-solutions/reference/advertiser/2026-01advertisersme",
+        "columns": {
+            "id": "Unique identifier of the advertiser.",
+            "type": "Resource type returned by the API for this entity.",
+            "advertiserName": "Name of the advertiser (the client name in Criteo).",
+        },
+    },
+    "campaigns": {
+        "description": "A campaign, which defines the advertising objective and success criteria its ad sets are optimized against.",
+        "docs_url": "https://developers.criteo.com/marketing-solutions/reference/campaign/2026-01marketing-solutionscampaignssearch",
+        "columns": {
+            "id": "Unique identifier of the campaign.",
+            "type": "Resource type returned by the API for this entity.",
+            "name": "Name of the campaign.",
+            "advertiserId": "Identifier of the advertiser the campaign belongs to.",
+            "goal": "Marketing goal of the campaign: unspecified, acquisition, or retention.",
+            "budgetAutomation": "Whether Criteo automatically distributes the campaign budget across its ad sets.",
+            "spendLimit": "Spend limit configuration for the campaign: limit type, amount, and renewal period.",
+        },
+    },
+    "ad_sets": {
+        "description": "An ad set within a campaign, carrying the bidding, budget, schedule, and targeting configuration Criteo delivers against.",
+        "docs_url": "https://developers.criteo.com/marketing-solutions/reference/campaign/2026-01marketing-solutionsad-setssearch",
+        "columns": {
+            "id": "Unique identifier of the ad set.",
+            "type": "Resource type returned by the API for this entity.",
+            "name": "Name of the ad set.",
+            "advertiserId": "Identifier of the advertiser the ad set belongs to.",
+            "campaignId": "Identifier of the campaign the ad set belongs to.",
+            "datasetId": "Identifier of the dataset (product catalog) the ad set advertises from.",
+            "mediaType": "Media the ad set delivers: display or video.",
+            "objective": "Optimization objective of the ad set, for example clicks, conversions, revenue, or visits.",
+            "destinationEnvironment": "Where users are sent on click: web or app.",
+            "videoChannel": "Video channel for video ad sets: olv (online video) or ctv (connected TV).",
+            "bidding": "Bidding configuration, including bid strategy, bid amount, and cost controller.",
+            "budget": "Budget configuration, including budget strategy, amount, and delivery smoothing.",
+            "schedule": "Start and end dates that bound the ad set's delivery.",
+            "targeting": "Targeting configuration, including delivery, frequency capping, geo, and subscription settings.",
+            "attributionConfiguration": "Click and view attribution windows used when crediting conversions to the ad set.",
+        },
+    },
+    "ads": {
+        "description": "An ad, pairing a creative with an ad set for delivery. Retrieved per advertiser in the portfolio.",
+        "docs_url": "https://developers.criteo.com/marketing-solutions/reference/creative/2026-01marketing-solutionsadvertisers-ads",
+        "columns": {
+            "id": "Unique identifier of the ad.",
+            "type": "Resource type returned by the API for this entity.",
+            "name": "Name of the ad.",
+            "description": "Description of the ad.",
+            "adSetId": "Identifier of the ad set the ad is delivered in.",
+            "creativeId": "Identifier of the creative the ad renders.",
+            "inventoryType": "Inventory the ad is eligible for: Native, Display, or Video.",
+            "startDate": "Date the ad starts being served.",
+            "endDate": "Date the ad stops being served, if set.",
+            "_advertiser_id": "Identifier of the advertiser this row was retrieved for. Added by PostHog, since the ads listing is queried per advertiser.",
+        },
+    },
+    "audiences": {
+        "description": "An audience: a reusable set of users, defined by an algebra of audience segments, that ad sets can target.",
+        "docs_url": "https://developers.criteo.com/marketing-solutions/reference/audience/2026-01marketing-solutionsaudiencessearch",
+        "columns": {
+            "id": "Unique identifier of the audience.",
+            "type": "Resource type returned by the API for this entity.",
+            "name": "Name of the audience.",
+            "description": "Description of the audience.",
+            "advertiserId": "Identifier of the advertiser the audience belongs to.",
+            "adSetIds": "Identifiers of the ad sets currently targeting this audience.",
+            "algebra": "Set expression combining audience segments (include, exclude, intersect) that defines the audience.",
+            "createdAt": "When the audience was created.",
+            "updatedAt": "When the audience was last modified.",
+        },
+    },
+    "campaign_stats": {
+        "description": "Daily delivery, cost, and post-click conversion statistics per advertiser and campaign, from the Criteo statistics report.",
+        "docs_url": "https://developers.criteo.com/marketing-solutions/docs/campaign-statistics",
+        "columns": {
+            "Day": "Day the statistics are aggregated over, in the reporting time zone.",
+            "AdvertiserId": "Identifier of the advertiser the row covers.",
+            "Advertiser": "Name of the advertiser the row covers.",
+            "CampaignId": "Identifier of the campaign the row covers.",
+            "Campaign": "Name of the campaign the row covers.",
+            "Displays": "Number of ad impressions served on publishers via Criteo.",
+            "Clicks": "Number of clicks driven by the ads.",
+            "AdvertiserCost": "Total advertising spend, in the reporting currency.",
+            "Visits": "Users who triggered at least one event within an hour of clicking.",
+            "SalesAllPc30d": "Transactions attributed post-click within a 30-day window.",
+            "RevenueGeneratedAllPc30d": "Revenue from transactions attributed post-click within a 30-day window, in the reporting currency.",
+            "ConversionRateAllPc30d": "Share of clicks that converted, post-click within a 30-day window, as a decimal.",
+            "RoasAllPc30d": "Return on ad spend: attributed revenue divided by cost, post-click within a 30-day window.",
+            "Cpc": "Average cost per click, in the reporting currency.",
+            "ClickThroughRate": "Clicks divided by displays, as a decimal.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/criteo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/criteo.py
@@ -1,0 +1,459 @@
+import dataclasses
+from collections.abc import Callable, Iterator
+from datetime import UTC, date, datetime, timedelta
+from typing import Any, Optional
+
+import requests
+from dateutil import parser as date_parser
+from urllib3.util.retry import Retry
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.datetime_utils import (
+    coerce_datetime_to_utc,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import (
+    OAuth2Auth,
+    OAuth2AuthRequestError,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.criteo.settings import (
+    CRITEO_API_VERSION,
+    CRITEO_BASE_URL,
+    CRITEO_ENDPOINTS,
+    CRITEO_TOKEN_URL,
+    DEFAULT_REPORT_CURRENCY,
+    DEFAULT_REPORT_TIMEZONE,
+    REPORT_DIMENSIONS,
+    REPORT_METRICS,
+    CriteoEndpointConfig,
+)
+
+# The audiences search caps `limit` at 100; the ads listing accepts the same, so one size fits both.
+PAGE_SIZE = 100
+# (connect, read). The statistics report is computed synchronously, so the read budget has to cover a
+# multi-day window over a whole portfolio.
+REQUEST_TIMEOUT_SECONDS = (10, 180)
+# Days of statistics per report call. The endpoint returns at most 100k rows per response, and the row
+# count is days x campaigns x advertisers, so keep the window small enough that a large portfolio stays
+# under the cap.
+REPORT_WINDOW_DAYS = 7
+# Criteo serves up to two years of statistics, so that's where a first (non-incremental) sync starts.
+REPORT_MAX_HISTORY_DAYS = 730
+
+CRITEO_NO_ADVERTISERS_ERROR = (
+    "Criteo returned no advertisers for these credentials. Ask an advertiser admin to grant your "
+    "Criteo Partners Portal app access via its consent URL, then reconnect."
+)
+
+
+@dataclasses.dataclass
+class CriteoResumeConfig:
+    # Next `offset` to request for an offset-paginated endpoint.
+    offset: Optional[int] = None
+    # Advertiser the fan-out was on when state was saved; earlier advertisers are already synced.
+    advertiser_id: Optional[str] = None
+    # First day (ISO) of the next statistics report window to request.
+    next_start_date: Optional[str] = None
+
+
+class CriteoReportShapeError(Exception):
+    """The statistics report returned a body we can't read rows out of."""
+
+
+def _retry_policy() -> Retry:
+    # Criteo's search and report endpoints are read-only POSTs, so retrying them is safe; the shared
+    # default only retries idempotent verbs and would leave every Criteo call unretried. Criteo
+    # rate-limits at the app level (429), so retries need real headroom.
+    return Retry(
+        total=4,
+        backoff_factor=1.0,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=frozenset(["GET", "HEAD", "OPTIONS", "POST"]),
+        raise_on_status=False,
+    )
+
+
+def _make_auth(client_id: str, client_secret: str) -> OAuth2Auth:
+    """Criteo mints 900-second bearer tokens from client credentials posted in the request body.
+
+    The framework auth caches the token for the run and re-mints shortly before expiry, which any sync
+    outliving a 15-minute window needs."""
+    return OAuth2Auth(
+        token_url=CRITEO_TOKEN_URL,
+        client_id=client_id,
+        client_secret=client_secret,
+        grant_type="client_credentials",
+        client_auth_method="body",
+    )
+
+
+class CriteoClient:
+    """Minimal Criteo Marketing Solutions client over the tracked session.
+
+    Criteo's collections are POST searches with JSON filter bodies, the ads listing fans out per
+    advertiser, and statistics come from a date-windowed report call — none of which the declarative
+    REST config expresses — so requests are issued directly here. Token minting/refresh and 429/5xx
+    backoff still come from the framework."""
+
+    def __init__(self, client_id: str, client_secret: str, api_version: str = CRITEO_API_VERSION) -> None:
+        self._auth = _make_auth(client_id, client_secret)
+        self._api_version = api_version
+        self._session = make_tracked_session(
+            retry=_retry_policy(),
+            redact_values=(client_secret,),
+        )
+
+    def url(self, path: str) -> str:
+        return f"{CRITEO_BASE_URL}/{self._api_version}{path}"
+
+    def get(self, path: str, params: Optional[dict[str, Any]] = None) -> Any:
+        response = self._session.get(self.url(path), params=params, auth=self._auth, timeout=REQUEST_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        return response.json()
+
+    def post(self, path: str, body: dict[str, Any], params: Optional[dict[str, Any]] = None) -> Any:
+        response = self._session.post(
+            self.url(path), json=body, params=params, auth=self._auth, timeout=REQUEST_TIMEOUT_SECONDS
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def _resources(payload: Any) -> list[dict[str, Any]]:
+    """Rows out of Criteo's `{"data": [...], "errors": [], "warnings": []}` envelope."""
+    if not isinstance(payload, dict):
+        return []
+    data = payload.get("data")
+    if not isinstance(data, list):
+        return []
+    return [item for item in data if isinstance(item, dict)]
+
+
+def _total_items(payload: Any) -> Optional[int]:
+    if not isinstance(payload, dict):
+        return None
+    meta = payload.get("meta")
+    if not isinstance(meta, dict):
+        return None
+    total = meta.get("totalItems")
+    return total if isinstance(total, int) and not isinstance(total, bool) else None
+
+
+def _flatten_resource(resource: dict[str, Any], extra: Optional[dict[str, Any]] = None) -> dict[str, Any]:
+    """Lift a Criteo resource's `attributes` into the row root.
+
+    Every entity comes back as `{"id", "type", "attributes": {...}}`; keeping that nesting would make
+    the whole payload a single struct column. The envelope `id` wins over any `id` echoed inside
+    `attributes`, since that's the identifier the primary key is declared on."""
+    attributes = resource.get("attributes")
+    row: dict[str, Any] = dict(attributes) if isinstance(attributes, dict) else {}
+    row["id"] = resource.get("id")
+    row["type"] = resource.get("type")
+    if extra:
+        row.update(extra)
+    return row
+
+
+def get_advertiser_ids(client: CriteoClient) -> list[str]:
+    payload = client.get(CRITEO_ENDPOINTS["advertisers"].path)
+    return [str(resource["id"]) for resource in _resources(payload) if resource.get("id") is not None]
+
+
+def _portfolio_rows(client: CriteoClient) -> Iterator[list[dict[str, Any]]]:
+    payload = client.get(CRITEO_ENDPOINTS["advertisers"].path)
+    rows = [_flatten_resource(resource) for resource in _resources(payload)]
+    if rows:
+        yield rows
+
+
+def _search_rows(client: CriteoClient, config: CriteoEndpointConfig) -> Iterator[list[dict[str, Any]]]:
+    # The campaigns and ad-sets searches document no pagination — an unfiltered search returns the
+    # whole portfolio in one response.
+    payload = client.post(config.path, dict(config.body or {}))
+    rows = [_flatten_resource(resource) for resource in _resources(payload)]
+    if rows:
+        yield rows
+
+
+def _paged_rows(
+    client: CriteoClient,
+    config: CriteoEndpointConfig,
+    path: str,
+    *,
+    start_offset: int,
+    extra: Optional[dict[str, Any]],
+    save_offset: Callable[[int], None],
+) -> Iterator[list[dict[str, Any]]]:
+    offset = start_offset
+    while True:
+        params = {"limit": PAGE_SIZE, "offset": offset}
+        payload = (
+            client.post(path, dict(config.body), params=params)
+            if config.body is not None
+            else client.get(path, params=params)
+        )
+        resources = _resources(payload)
+        if resources:
+            yield [_flatten_resource(resource, extra) for resource in resources]
+
+        # A short page is the authoritative end of the collection; `meta.totalItems` is only present on
+        # some endpoints, so it's an extra stop condition rather than the primary one.
+        if len(resources) < PAGE_SIZE:
+            return
+        offset += PAGE_SIZE
+        total = _total_items(payload)
+        if total is not None and offset >= total:
+            return
+        # Saved after the batch was yielded, so a crash re-yields the last page (merge dedupes on the
+        # primary key) instead of skipping it.
+        save_offset(offset)
+
+
+def _per_advertiser_rows(
+    client: CriteoClient,
+    config: CriteoEndpointConfig,
+    *,
+    resume: Optional[CriteoResumeConfig],
+    save_state: Callable[[CriteoResumeConfig], None],
+) -> Iterator[list[dict[str, Any]]]:
+    advertiser_ids = get_advertiser_ids(client)
+    if not advertiser_ids:
+        raise ValueError(CRITEO_NO_ADVERTISERS_ERROR)
+
+    resume_advertiser = resume.advertiser_id if resume else None
+    if resume is not None and resume_advertiser is not None and resume_advertiser in advertiser_ids:
+        advertiser_ids = advertiser_ids[advertiser_ids.index(resume_advertiser) :]
+        start_offset = resume.offset or 0
+    else:
+        # An unknown saved advertiser (the portfolio changed between attempts) restarts the fan-out
+        # rather than silently skipping advertisers.
+        start_offset = 0
+
+    for index, advertiser_id in enumerate(advertiser_ids):
+
+        def save_offset(offset: int, advertiser_id: str = advertiser_id) -> None:
+            save_state(CriteoResumeConfig(advertiser_id=advertiser_id, offset=offset))
+
+        yield from _paged_rows(
+            client,
+            config,
+            config.path.format(advertiser_id=advertiser_id),
+            start_offset=start_offset,
+            extra={"_advertiser_id": advertiser_id},
+            save_offset=save_offset,
+        )
+        start_offset = 0
+        # Checkpoint the boundary as the *next* advertiser, so a retry doesn't re-walk the one that
+        # just finished. Nothing is saved after the last advertiser: the run is complete and clears state.
+        if index + 1 < len(advertiser_ids):
+            save_state(CriteoResumeConfig(advertiser_id=advertiser_ids[index + 1]))
+
+
+def _today() -> date:
+    return datetime.now(UTC).date()
+
+
+def _report_timestamp(day: date) -> str:
+    return f"{day.isoformat()}T00:00:00Z"
+
+
+def _as_date(value: Any) -> Optional[date]:
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    coerced = coerce_datetime_to_utc(value)
+    if coerced is not None:
+        return coerced.date()
+    if isinstance(value, str) and value.strip():
+        try:
+            return date_parser.parse(value).date()
+        except (ValueError, OverflowError):
+            return None
+    return None
+
+
+def report_start_day(db_incremental_field_last_value: Any, today: date) -> date:
+    """First report day to request.
+
+    The watermark arrives already shifted back by the schema's configured lookback, so it is used as
+    given; it's only clamped to Criteo's two-year retention and to today so a future watermark can't
+    produce an empty backwards range."""
+    floor = today - timedelta(days=REPORT_MAX_HISTORY_DAYS)
+    watermark = _as_date(db_incremental_field_last_value)
+    if watermark is None:
+        return floor
+    return min(max(floor, watermark), today)
+
+
+def _report_payload_rows(payload: Any) -> list[dict[str, Any]]:
+    """Rows out of a statistics report response.
+
+    The endpoint returns the report in the requested format rather than the JSON:API envelope the rest
+    of the API uses, so a `json` report body is a bare array of rows. Criteo doesn't publish a JSON
+    response schema, so the plausible wrapped shapes are accepted too, and anything else fails loud
+    rather than silently syncing zero rows."""
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, dict)]
+    if isinstance(payload, dict):
+        for key in ("Rows", "rows", "data"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [row for row in value if isinstance(row, dict)]
+    raise CriteoReportShapeError(
+        f"Criteo statistics report returned an unexpected body shape: {type(payload).__name__}"
+    )
+
+
+def _report_rows(
+    client: CriteoClient,
+    config: CriteoEndpointConfig,
+    *,
+    currency: str,
+    timezone: str,
+    start_day: date,
+    end_day: date,
+    save_state: Callable[[CriteoResumeConfig], None],
+) -> Iterator[list[dict[str, Any]]]:
+    advertiser_ids = get_advertiser_ids(client)
+    if not advertiser_ids:
+        raise ValueError(CRITEO_NO_ADVERTISERS_ERROR)
+
+    window_start = start_day
+    while window_start <= end_day:
+        window_end = min(window_start + timedelta(days=REPORT_WINDOW_DAYS - 1), end_day)
+        payload = client.post(
+            config.path,
+            {
+                "advertiserIds": ",".join(advertiser_ids),
+                "dimensions": list(REPORT_DIMENSIONS),
+                "metrics": list(REPORT_METRICS),
+                "currency": currency,
+                "timezone": timezone,
+                "format": "json",
+                "startDate": _report_timestamp(window_start),
+                "endDate": _report_timestamp(window_end),
+            },
+        )
+        rows = _report_payload_rows(payload)
+        if rows:
+            yield rows
+
+        window_start = window_end + timedelta(days=1)
+        if window_start <= end_day:
+            save_state(CriteoResumeConfig(next_start_date=window_start.isoformat()))
+
+
+def get_rows(
+    client_id: str,
+    client_secret: str,
+    endpoint: str,
+    api_version: str,
+    resumable_source_manager: ResumableSourceManager[CriteoResumeConfig],
+    report_currency: Optional[str] = None,
+    report_timezone: Optional[str] = None,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> Iterator[list[dict[str, Any]]]:
+    config = CRITEO_ENDPOINTS[endpoint]
+    client = CriteoClient(client_id, client_secret, api_version)
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+
+    def save_state(state: CriteoResumeConfig) -> None:
+        resumable_source_manager.save_state(state)
+
+    if config.kind == "portfolio":
+        yield from _portfolio_rows(client)
+    elif config.kind == "search":
+        yield from _search_rows(client, config)
+    elif config.kind == "paged" and config.per_advertiser:
+        yield from _per_advertiser_rows(client, config, resume=resume, save_state=save_state)
+    elif config.kind == "paged":
+        yield from _paged_rows(
+            client,
+            config,
+            config.path,
+            start_offset=(resume.offset or 0) if resume else 0,
+            extra=None,
+            save_offset=lambda offset: save_state(CriteoResumeConfig(offset=offset)),
+        )
+    else:
+        today = _today()
+        resumed_start = _as_date(resume.next_start_date) if resume and resume.next_start_date else None
+        start_day = resumed_start or report_start_day(
+            db_incremental_field_last_value if should_use_incremental_field else None, today
+        )
+        yield from _report_rows(
+            client,
+            config,
+            currency=report_currency or DEFAULT_REPORT_CURRENCY,
+            timezone=report_timezone or DEFAULT_REPORT_TIMEZONE,
+            start_day=start_day,
+            end_day=today,
+            save_state=save_state,
+        )
+
+    resumable_source_manager.clear_state()
+
+
+def validate_credentials(client_id: str, client_secret: str, api_version: str) -> tuple[bool, Optional[str]]:
+    """Mint a token and read the advertiser portfolio.
+
+    Minting alone only proves the client credentials exist — a Criteo app also has to be granted access
+    by an advertiser admin through a consent URL before any data is readable, and that shows up as a
+    403 (or an empty portfolio) here rather than at the token endpoint."""
+    client = CriteoClient(client_id, client_secret, api_version)
+    try:
+        advertiser_ids = get_advertiser_ids(client)
+    except OAuth2AuthRequestError:
+        return False, "Criteo rejected these credentials. Check your client ID and client secret."
+    except requests.HTTPError as error:
+        status = error.response.status_code if error.response is not None else None
+        if status == 401:
+            return False, "Criteo rejected these credentials. Check your client ID and client secret."
+        if status == 403:
+            return False, CRITEO_NO_ADVERTISERS_ERROR
+        return False, "Could not reach the Criteo API. Please try again."
+    except requests.RequestException:
+        return False, "Could not reach the Criteo API. Please try again."
+
+    if not advertiser_ids:
+        return False, CRITEO_NO_ADVERTISERS_ERROR
+    return True, None
+
+
+def criteo_source(
+    client_id: str,
+    client_secret: str,
+    endpoint: str,
+    api_version: str,
+    resumable_source_manager: ResumableSourceManager[CriteoResumeConfig],
+    report_currency: Optional[str] = None,
+    report_timezone: Optional[str] = None,
+    should_use_incremental_field: bool = False,
+    db_incremental_field_last_value: Optional[Any] = None,
+) -> SourceResponse:
+    config = CRITEO_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            client_id=client_id,
+            client_secret=client_secret,
+            endpoint=endpoint,
+            api_version=api_version,
+            resumable_source_manager=resumable_source_manager,
+            report_currency=report_currency,
+            report_timezone=report_timezone,
+            should_use_incremental_field=should_use_incremental_field,
+            db_incremental_field_last_value=db_incremental_field_last_value,
+        ),
+        primary_keys=list(config.primary_key),
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if config.partition_key else None,
+        partition_format="month" if config.partition_key else None,
+        partition_keys=[config.partition_key] if config.partition_key else None,
+        # The report is walked oldest window first, and every listing endpoint is a full refresh, so
+        # rows always arrive in ascending cursor order.
+        sort_mode="asc",
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/settings.py
@@ -1,0 +1,134 @@
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import incremental_field
+from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
+
+CRITEO_BASE_URL = "https://api.criteo.com"
+CRITEO_TOKEN_URL = f"{CRITEO_BASE_URL}/oauth2/token"
+
+# Criteo date-versions the Marketing Solutions API and sunsets old versions, so the version segment
+# is part of every path. Pin the one the request layer below actually calls.
+CRITEO_API_VERSION = "2026-01"
+
+# "portfolio" — the single advertisers/me listing.
+# "search"    — a POST search endpoint that returns the whole collection in one response.
+# "paged"     — a listing with `limit`/`offset` query pagination.
+# "report"    — the synchronous statistics report, walked in date windows.
+EndpointKind = Literal["portfolio", "search", "paged", "report"]
+
+# `Day` is the report's date grain and the only server-side time filter Criteo exposes
+# (startDate/endDate on the report body), so it's the one incremental cursor available.
+_DAY_INCREMENTAL_FIELDS: list[IncrementalField] = [incremental_field("Day", IncrementalFieldType.Date)]
+
+# Criteo keeps revising conversion and revenue metrics for weeks after the click, so each incremental
+# run re-reads a trailing window instead of freezing a day at its first-imported value. Mirrors the
+# 30-day rollback other warehouse vendors use for Criteo reporting.
+STATS_LOOKBACK_SECONDS = 30 * 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class CriteoEndpointConfig:
+    name: str
+    # Path under the version segment. `{advertiser_id}` is filled per advertiser when fanning out.
+    path: str
+    kind: EndpointKind
+    primary_key: list[str]
+    # OAuth scope Criteo requires for the endpoint, surfaced in the source caption. None where the
+    # reference documents no scope beyond a valid token (the portfolio listing).
+    scope: Optional[str] = None
+    # Fanned out over every advertiser in the portfolio; rows carry `_advertiser_id`.
+    per_advertiser: bool = False
+    # POST body sent alongside the pagination params, for the search endpoints.
+    body: Optional[dict[str, object]] = None
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+    # Stable creation-time (or report-day) field used for datetime partitioning.
+    partition_key: Optional[str] = None
+    default_incremental_lookback_seconds: Optional[int] = None
+
+
+CRITEO_ENDPOINTS: dict[str, CriteoEndpointConfig] = {
+    "advertisers": CriteoEndpointConfig(
+        name="advertisers",
+        path="/advertisers/me",
+        kind="portfolio",
+        primary_key=["id"],
+    ),
+    "campaigns": CriteoEndpointConfig(
+        name="campaigns",
+        path="/marketing-solutions/campaigns/search",
+        kind="search",
+        primary_key=["id"],
+        scope="MarketingSolutions_Campaign_Read",
+        # Empty filters means "everything in the portfolio".
+        body={"filters": {}},
+    ),
+    "ad_sets": CriteoEndpointConfig(
+        name="ad_sets",
+        path="/marketing-solutions/ad-sets/search",
+        kind="search",
+        primary_key=["id"],
+        scope="MarketingSolutions_Campaign_Read",
+        body={"filters": {}},
+    ),
+    "ads": CriteoEndpointConfig(
+        name="ads",
+        path="/marketing-solutions/advertisers/{advertiser_id}/ads",
+        kind="paged",
+        # The reference doesn't state that ad ids are unique across advertisers, so the advertiser the
+        # row was fanned out from is part of the key.
+        primary_key=["_advertiser_id", "id"],
+        scope="MarketingSolutions_Creative_Read",
+        per_advertiser=True,
+    ),
+    "audiences": CriteoEndpointConfig(
+        name="audiences",
+        path="/marketing-solutions/audiences/search",
+        kind="paged",
+        primary_key=["id"],
+        scope="MarketingSolutions_Audience_Read",
+        body={"data": {"attributes": {}}},
+        partition_key="createdAt",
+    ),
+    "campaign_stats": CriteoEndpointConfig(
+        name="campaign_stats",
+        path="/statistics/report",
+        kind="report",
+        primary_key=["AdvertiserId", "CampaignId", "Day"],
+        incremental_fields=list(_DAY_INCREMENTAL_FIELDS),
+        partition_key="Day",
+        default_incremental_lookback_seconds=STATS_LOOKBACK_SECONDS,
+    ),
+}
+
+# Report grain: one row per advertiser, campaign and day. Adding the human-readable name dimensions
+# alongside the ids keeps the table joinable and readable without a second lookup.
+REPORT_DIMENSIONS: tuple[str, ...] = ("Day", "AdvertiserId", "Advertiser", "CampaignId", "Campaign")
+
+# Delivery, cost and 30-day post-click conversion metrics — the set that covers spend/ROAS reporting
+# without pulling all ~180 metrics Criteo offers.
+REPORT_METRICS: tuple[str, ...] = (
+    "Displays",
+    "Clicks",
+    "AdvertiserCost",
+    "Visits",
+    "SalesAllPc30d",
+    "RevenueGeneratedAllPc30d",
+    "ConversionRateAllPc30d",
+    "RoasAllPc30d",
+    "Cpc",
+    "ClickThroughRate",
+)
+
+# Report currency and timezone are required/defaulted by the endpoint; used when the form leaves them blank.
+DEFAULT_REPORT_CURRENCY = "USD"
+DEFAULT_REPORT_TIMEZONE = "UTC"
+
+ENDPOINTS = tuple(CRITEO_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in CRITEO_ENDPOINTS.items() if config.incremental_fields
+}
+
+# The report table merges restated days rather than appending them, so append-only is not offered.
+MERGE_ONLY_ENDPOINTS: tuple[str, ...] = ("campaign_stats",)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/source.py
@@ -1,22 +1,69 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import (
+    OAUTH2_PERMANENT_ERROR_MARKER,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import (
+    SourceSchema,
+    build_endpoint_schemas,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.criteo.criteo import (
+    CRITEO_NO_ADVERTISERS_ERROR,
+    CriteoResumeConfig,
+    criteo_source,
+    validate_credentials as validate_criteo_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.criteo.settings import (
+    CRITEO_API_VERSION,
+    CRITEO_BASE_URL,
+    CRITEO_ENDPOINTS,
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+    MERGE_ONLY_ENDPOINTS,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.criteo import CriteoSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class CriteoSource(SimpleSource[CriteoSourceConfig]):
+class CriteoSource(ResumableSource[CriteoSourceConfig, CriteoResumeConfig]):
+    supported_versions = (CRITEO_API_VERSION,)
+    default_version = CRITEO_API_VERSION
+    api_docs_url = "https://developers.criteo.com/marketing-solutions/reference"
+
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.CRITEO
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            # Permanent token-exchange failures (invalid_client, unauthorized_client, …) all carry the
+            # framework's stable marker; transient 429/5xx token errors don't.
+            OAUTH2_PERMANENT_ERROR_MARKER: "Criteo rejected these credentials. Please check your client ID and client secret.",
+            f"403 Client Error: Forbidden for url: {CRITEO_BASE_URL}": "Criteo denied access. Please check that your app has the scope this table needs and that an advertiser admin has granted it access.",
+            CRITEO_NO_ADVERTISERS_ERROR: None,
+        }
 
     @property
     def get_source_config(self) -> SourceConfig:
@@ -24,7 +71,115 @@ class CriteoSource(SimpleSource[CriteoSourceConfig]):
             name=SchemaExternalDataSourceType.CRITEO,
             category=DataWarehouseSourceCategory.ADVERTISING,
             label="Criteo",
+            caption="""Enter your Criteo API credentials to pull your Criteo Marketing Solutions data into the PostHog Data warehouse.
+
+Create an app in the [Criteo Partners Portal](https://partners.criteo.com), generate client credentials for it, then have an advertiser admin grant the app access through its consent URL. No data is readable until that grant is in place. Add the read scopes for the tables you want: `MarketingSolutions_Campaign_Read` for campaigns and ad sets, `MarketingSolutions_Creative_Read` for ads, and `MarketingSolutions_Audience_Read` for audiences.
+
+Campaign statistics are pulled per day. Set the currency you report in, otherwise USD is used.""",
             iconPath="/static/services/criteo.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/criteo",
+            releaseStatus=ReleaseStatus.ALPHA,
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="client_id",
+                        label="Client ID",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=True,
+                        placeholder="",
+                        secret=False,
+                    ),
+                    SourceFieldInputConfig(
+                        name="client_secret",
+                        label="Client secret",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                    SourceFieldInputConfig(
+                        name="report_currency",
+                        label="Reporting currency",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=False,
+                        placeholder="USD",
+                        secret=False,
+                        caption="Three-letter currency code for campaign statistics. Defaults to USD.",
+                    ),
+                    SourceFieldInputConfig(
+                        name="report_timezone",
+                        label="Reporting time zone",
+                        type=SourceFieldInputConfigType.TEXT,
+                        required=False,
+                        placeholder="UTC",
+                        secret=False,
+                        caption="Time zone the statistics days are bucketed in, for example Europe/Paris. Defaults to UTC.",
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.criteo.canonical_descriptions import (
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_schemas(
+        self,
+        config: CriteoSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+        api_version: str | None = None,
+    ) -> list[SourceSchema]:
+        schemas = build_endpoint_schemas(
+            ENDPOINTS,
+            INCREMENTAL_FIELDS,
+            names,
+            merge_only=MERGE_ONLY_ENDPOINTS,
+        )
+        for schema in schemas:
+            schema.default_incremental_lookback_seconds = CRITEO_ENDPOINTS[
+                schema.name
+            ].default_incremental_lookback_seconds
+        return schemas
+
+    def validate_credentials(
+        self,
+        config: CriteoSourceConfig,
+        team_id: int,
+        schema_name: Optional[str] = None,
+        api_version: str | None = None,
+    ) -> tuple[bool, str | None]:
+        return validate_criteo_credentials(
+            config.client_id, config.client_secret, self.resolve_api_version(api_version)
+        )
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[CriteoResumeConfig]:
+        # Endpoints store incompatible cursors (an offset, a fanned-out advertiser, a report day), so
+        # each keeps its resume state in its own slot.
+        return ResumableSourceManager[CriteoResumeConfig](inputs, CriteoResumeConfig).with_namespace(inputs.schema_name)
+
+    def source_for_pipeline(
+        self,
+        config: CriteoSourceConfig,
+        resumable_source_manager: ResumableSourceManager[CriteoResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return criteo_source(
+            client_id=config.client_id,
+            client_secret=config.client_secret,
+            endpoint=inputs.schema_name,
+            api_version=self.resolve_api_version(inputs.api_version),
+            resumable_source_manager=resumable_source_manager,
+            report_currency=config.report_currency,
+            report_timezone=config.report_timezone,
+            should_use_incremental_field=inputs.should_use_incremental_field,
+            db_incremental_field_last_value=inputs.db_incremental_field_last_value
+            if inputs.should_use_incremental_field
+            else None,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/tests/test_criteo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/tests/test_criteo.py
@@ -1,0 +1,656 @@
+from collections.abc import Collection, Iterable
+from datetime import UTC, date, datetime, timedelta
+from typing import Any, Optional, cast
+
+import pytest
+from unittest import mock
+
+import requests
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import (
+    OAuth2AuthRequestError,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.criteo.criteo import (
+    CRITEO_NO_ADVERTISERS_ERROR,
+    PAGE_SIZE,
+    REPORT_MAX_HISTORY_DAYS,
+    REPORT_WINDOW_DAYS,
+    CriteoClient,
+    CriteoReportShapeError,
+    CriteoResumeConfig,
+    _flatten_resource,
+    _make_auth,
+    _report_payload_rows,
+    _resources,
+    _retry_policy,
+    _total_items,
+    criteo_source,
+    get_rows,
+    report_start_day,
+    validate_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.criteo.settings import (
+    CRITEO_API_VERSION,
+    CRITEO_ENDPOINTS,
+    CRITEO_TOKEN_URL,
+    ENDPOINTS,
+    REPORT_DIMENSIONS,
+    REPORT_METRICS,
+)
+
+_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.criteo.criteo"
+
+
+class FakeResumeManager(ResumableSourceManager[CriteoResumeConfig]):
+    """In-memory stand-in for the Redis-backed manager."""
+
+    def __init__(self, state: Optional[CriteoResumeConfig] = None) -> None:
+        self.state = state
+        self.saved: list[CriteoResumeConfig] = []
+        self.clear_calls = 0
+
+    def can_resume(self) -> bool:
+        return self.state is not None
+
+    def load_state(self) -> Optional[CriteoResumeConfig]:
+        return self.state
+
+    def save_state(self, data: CriteoResumeConfig) -> None:
+        self.saved.append(data)
+
+    def clear_state(self) -> None:
+        self.clear_calls += 1
+
+
+def _response(payload: Any) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.status_code = 200
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _error_response(status: int) -> mock.MagicMock:
+    response = mock.MagicMock()
+    response.status_code = status
+    inner = mock.MagicMock()
+    inner.status_code = status
+    response.raise_for_status.side_effect = requests.HTTPError(f"{status} Client Error", response=inner)
+    return response
+
+
+def _envelope(*ids: str, total: Optional[int] = None, **attributes: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "data": [{"id": id_, "type": "Resource", "attributes": {"name": f"name-{id_}", **attributes}} for id_ in ids],
+        "errors": [],
+        "warnings": [],
+    }
+    if total is not None:
+        payload["meta"] = {"limit": PAGE_SIZE, "offset": 0, "totalItems": total}
+    return payload
+
+
+def _page(count: int, *, prefix: str = "row", total: Optional[int] = None) -> dict[str, Any]:
+    return _envelope(*[f"{prefix}-{index}" for index in range(count)], total=total)
+
+
+def _rows(source_response: SourceResponse) -> list[dict[str, Any]]:
+    return [row for page in cast("Iterable[Any]", source_response.items()) for row in page]
+
+
+def _collect(
+    endpoint: str,
+    manager: FakeResumeManager,
+    **kwargs: Any,
+) -> list[dict[str, Any]]:
+    pages = get_rows(
+        client_id="cid",
+        client_secret="sec",
+        endpoint=endpoint,
+        api_version=CRITEO_API_VERSION,
+        resumable_source_manager=manager,
+        **kwargs,
+    )
+    return [row for page in pages for row in page]
+
+
+class TestEnvelopeParsing:
+    @pytest.mark.parametrize(
+        "payload, expected_count",
+        [
+            ({"data": [{"id": "1"}, {"id": "2"}]}, 2),
+            ({"data": []}, 0),
+            ({"data": None}, 0),
+            ({"data": [{"id": "1"}, "not-a-resource"]}, 1),
+            ({}, 0),
+            ([], 0),
+            (None, 0),
+        ],
+    )
+    def test_resources_tolerates_odd_bodies(self, payload: Any, expected_count: int) -> None:
+        assert len(_resources(payload)) == expected_count
+
+    @pytest.mark.parametrize(
+        "payload, expected",
+        [
+            ({"meta": {"totalItems": 7}}, 7),
+            ({"meta": {"totalItems": True}}, None),
+            ({"meta": {}}, None),
+            ({"meta": "nope"}, None),
+            ({}, None),
+            ("nope", None),
+        ],
+    )
+    def test_total_items(self, payload: Any, expected: Optional[int]) -> None:
+        assert _total_items(payload) == expected
+
+
+class TestFlattenResource:
+    def test_attributes_become_the_row(self) -> None:
+        row = _flatten_resource(
+            {"id": "1", "type": "Campaign", "attributes": {"name": "Retargeting", "goal": "acquisition"}}
+        )
+
+        assert row == {"id": "1", "type": "Campaign", "name": "Retargeting", "goal": "acquisition"}
+
+    def test_envelope_id_wins_over_an_echoed_attribute_id(self) -> None:
+        # Some entities echo `id` inside attributes; the envelope id is the one the primary key uses.
+        row = _flatten_resource({"id": "outer", "type": "AdSet", "attributes": {"id": "inner"}})
+
+        assert row["id"] == "outer"
+
+    def test_extra_fields_are_merged(self) -> None:
+        row = _flatten_resource({"id": "1", "attributes": {}}, {"_advertiser_id": "adv-1"})
+
+        assert row["_advertiser_id"] == "adv-1"
+
+    @pytest.mark.parametrize("attributes", [None, "not-a-dict", []])
+    def test_missing_attributes_still_yields_an_identifiable_row(self, attributes: Any) -> None:
+        row = _flatten_resource({"id": "1", "type": "Ad", "attributes": attributes})
+
+        assert row == {"id": "1", "type": "Ad"}
+
+
+class TestTransportPolicy:
+    def test_read_only_posts_are_retried(self) -> None:
+        # Criteo's searches and the report are POSTs; the shared default only retries idempotent
+        # verbs, which would leave every Criteo call unretried on a 429.
+        policy = _retry_policy()
+
+        assert "POST" in cast(Collection[str], policy.allowed_methods)
+        assert 429 in cast(Collection[int], policy.status_forcelist)
+
+    def test_auth_is_client_credentials_in_the_body(self) -> None:
+        auth = _make_auth("cid", "sec")
+
+        assert auth.token_url == CRITEO_TOKEN_URL
+        assert auth.grant_type == "client_credentials"
+        assert auth.client_auth_method == "body"
+        # The secret must be redactable wherever it surfaces in logs or samples.
+        assert "sec" in auth.secret_values()
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_urls_carry_the_pinned_api_version(self, make_session: mock.MagicMock) -> None:
+        client = CriteoClient("cid", "sec", "2026-01")
+
+        assert client.url("/advertisers/me") == "https://api.criteo.com/2026-01/advertisers/me"
+        assert make_session.call_args.kwargs["redact_values"] == ("sec",)
+
+
+@mock.patch(f"{_MODULE}.make_tracked_session")
+class TestPortfolioAndSearch:
+    def test_portfolio_rows_are_flattened(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.get.return_value = _response(_envelope("13", "14", advertiserName="Acme"))
+
+        rows = _collect("advertisers", FakeResumeManager())
+
+        assert [row["id"] for row in rows] == ["13", "14"]
+        assert rows[0]["advertiserName"] == "Acme"
+        assert session.get.call_args.args[0].endswith("/advertisers/me")
+
+    @pytest.mark.parametrize(
+        "endpoint, expected_path",
+        [
+            ("campaigns", "/marketing-solutions/campaigns/search"),
+            ("ad_sets", "/marketing-solutions/ad-sets/search"),
+        ],
+    )
+    def test_search_endpoints_post_an_unfiltered_body(
+        self, make_session: mock.MagicMock, endpoint: str, expected_path: str
+    ) -> None:
+        session = make_session.return_value
+        session.post.return_value = _response(_envelope("1", "2"))
+
+        rows = _collect(endpoint, FakeResumeManager())
+
+        assert [row["id"] for row in rows] == ["1", "2"]
+        assert session.post.call_args.args[0].endswith(expected_path)
+        # Empty filters means "everything in the portfolio"; the search is not paginated.
+        assert session.post.call_args.kwargs["json"] == {"filters": {}}
+        assert session.post.call_count == 1
+
+    def test_empty_search_yields_no_pages(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.post.return_value = _response(_envelope())
+
+        assert _collect("campaigns", FakeResumeManager()) == []
+
+    def test_state_is_cleared_once_the_stream_completes(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.post.return_value = _response(_envelope("1"))
+        manager = FakeResumeManager()
+
+        _collect("campaigns", manager)
+
+        assert manager.clear_calls == 1
+
+
+@mock.patch(f"{_MODULE}.make_tracked_session")
+class TestOffsetPagination:
+    def test_audiences_walks_offsets_until_a_short_page(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.post.side_effect = [_response(_page(PAGE_SIZE)), _response(_page(3, prefix="last"))]
+        manager = FakeResumeManager()
+
+        rows = _collect("audiences", manager)
+
+        assert len(rows) == PAGE_SIZE + 3
+        assert [call.kwargs["params"]["offset"] for call in session.post.call_args_list] == [0, PAGE_SIZE]
+        # Checkpointed after the first full page was yielded, and not again on the terminal page.
+        assert [state.offset for state in manager.saved] == [PAGE_SIZE]
+
+    def test_audiences_sends_the_search_body_alongside_the_page_params(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.post.return_value = _response(_page(1))
+
+        _collect("audiences", FakeResumeManager())
+
+        assert session.post.call_args.kwargs["json"] == {"data": {"attributes": {}}}
+        assert session.post.call_args.kwargs["params"] == {"limit": PAGE_SIZE, "offset": 0}
+
+    def test_pagination_stops_at_the_reported_total(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        # A full page whose `meta.totalItems` says the collection is exhausted must not be followed.
+        session.post.return_value = _response(_page(PAGE_SIZE, total=PAGE_SIZE))
+
+        rows = _collect("audiences", FakeResumeManager())
+
+        assert len(rows) == PAGE_SIZE
+        assert session.post.call_count == 1
+
+    def test_audiences_resumes_from_the_saved_offset(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.post.return_value = _response(_page(2))
+
+        _collect("audiences", FakeResumeManager(CriteoResumeConfig(offset=200)))
+
+        assert session.post.call_args.kwargs["params"]["offset"] == 200
+
+
+@mock.patch(f"{_MODULE}.make_tracked_session")
+class TestAdsFanOut:
+    def test_rows_carry_the_advertiser_they_were_fetched_for(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        portfolio = _response(_envelope("adv-1", "adv-2"))
+        session.get.side_effect = [portfolio, _response(_envelope("ad-1")), _response(_envelope("ad-2"))]
+
+        rows = _collect("ads", FakeResumeManager())
+
+        assert [(row["_advertiser_id"], row["id"]) for row in rows] == [("adv-1", "ad-1"), ("adv-2", "ad-2")]
+        # The parent advertiser is part of the primary key, so it has to be on every row.
+        assert CRITEO_ENDPOINTS["ads"].primary_key == ["_advertiser_id", "id"]
+
+    def test_checkpoint_points_at_the_next_advertiser(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.get.side_effect = [
+            _response(_envelope("adv-1", "adv-2", "adv-3")),
+            _response(_envelope("ad-1")),
+            _response(_envelope("ad-2")),
+            _response(_envelope("ad-3")),
+        ]
+        manager = FakeResumeManager()
+
+        _collect("ads", manager)
+
+        # A retry must not re-walk the advertiser that just finished, and the final advertiser saves
+        # nothing because the run completed.
+        assert [state.advertiser_id for state in manager.saved] == ["adv-2", "adv-3"]
+
+    def test_resume_skips_already_synced_advertisers(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.get.side_effect = [
+            _response(_envelope("adv-1", "adv-2", "adv-3")),
+            _response(_envelope("ad-2")),
+            _response(_envelope("ad-3")),
+        ]
+
+        rows = _collect("ads", FakeResumeManager(CriteoResumeConfig(advertiser_id="adv-2")))
+
+        assert [row["_advertiser_id"] for row in rows] == ["adv-2", "adv-3"]
+
+    def test_resume_applies_the_saved_offset_only_to_the_resumed_advertiser(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.get.side_effect = [
+            _response(_envelope("adv-1", "adv-2")),
+            _response(_page(PAGE_SIZE, prefix="adv1")),
+            _response(_page(1, prefix="adv1-last")),
+            _response(_page(1, prefix="adv2")),
+        ]
+
+        _collect("ads", FakeResumeManager(CriteoResumeConfig(advertiser_id="adv-1", offset=PAGE_SIZE)))
+
+        offsets = [call.kwargs["params"]["offset"] for call in session.get.call_args_list[1:]]
+        # adv-1 picks up mid-collection; adv-2 starts from the beginning.
+        assert offsets == [PAGE_SIZE, PAGE_SIZE * 2, 0]
+
+    def test_unknown_saved_advertiser_restarts_the_fan_out(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.get.side_effect = [
+            _response(_envelope("adv-1", "adv-2")),
+            _response(_envelope("ad-1")),
+            _response(_envelope("ad-2")),
+        ]
+
+        rows = _collect("ads", FakeResumeManager(CriteoResumeConfig(advertiser_id="adv-gone", offset=500)))
+
+        # Restarting is the safe choice: honoring a stale offset would skip rows silently.
+        assert [row["_advertiser_id"] for row in rows] == ["adv-1", "adv-2"]
+        assert session.get.call_args_list[1].kwargs["params"]["offset"] == 0
+
+    def test_empty_portfolio_fails_with_the_consent_message(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.get.return_value = _response(_envelope())
+
+        with pytest.raises(ValueError, match="advertiser admin"):
+            _collect("ads", FakeResumeManager())
+
+
+class TestReportStartDay:
+    TODAY = date(2026, 7, 26)
+    RETENTION_FLOOR = TODAY - timedelta(days=REPORT_MAX_HISTORY_DAYS)
+
+    @pytest.mark.parametrize(
+        "watermark, expected",
+        [
+            # No watermark: pull Criteo's full two-year retention.
+            (None, RETENTION_FLOOR),
+            (date(2026, 7, 1), date(2026, 7, 1)),
+            (datetime(2026, 7, 1, 12, tzinfo=UTC), date(2026, 7, 1)),
+            ("2026-07-01", date(2026, 7, 1)),
+            # A future watermark can't produce a backwards range.
+            (date(2027, 1, 1), TODAY),
+            # Older than retention clamps to the floor.
+            (date(2015, 1, 1), RETENTION_FLOOR),
+            # Unparseable values fall back to a full pull rather than syncing nothing.
+            ("not-a-date", RETENTION_FLOOR),
+        ],
+    )
+    def test_start_day(self, watermark: Any, expected: date) -> None:
+        assert report_start_day(watermark, self.TODAY) == expected
+
+    def test_retention_floor_matches_the_documented_two_years(self) -> None:
+        assert (self.TODAY - report_start_day(None, self.TODAY)).days == REPORT_MAX_HISTORY_DAYS
+
+
+class TestReportPayloadRows:
+    @pytest.mark.parametrize(
+        "payload, expected_count",
+        [
+            ([{"Day": "2026-07-01"}, {"Day": "2026-07-02"}], 2),
+            ([], 0),
+            ([{"Day": "2026-07-01"}, "junk"], 1),
+            ({"Rows": [{"Day": "2026-07-01"}]}, 1),
+            ({"rows": [{"Day": "2026-07-01"}]}, 1),
+            ({"data": [{"Day": "2026-07-01"}]}, 1),
+        ],
+    )
+    def test_accepted_shapes(self, payload: Any, expected_count: int) -> None:
+        assert len(_report_payload_rows(payload)) == expected_count
+
+    @pytest.mark.parametrize("payload", [None, "text", 42, {"unexpected": 1}])
+    def test_unreadable_shape_fails_loud(self, payload: Any) -> None:
+        # Silently syncing zero rows would look like "no data" instead of a broken response.
+        with pytest.raises(CriteoReportShapeError):
+            _report_payload_rows(payload)
+
+
+@mock.patch(f"{_MODULE}.make_tracked_session")
+class TestStatisticsReport:
+    TODAY = date(2026, 7, 26)
+
+    def _wire(self, session: mock.MagicMock, windows: int) -> None:
+        session.get.return_value = _response(_envelope("adv-1", "adv-2"))
+        session.post.side_effect = [_response([{"Day": f"window-{index}"}]) for index in range(windows)]
+
+    def test_the_window_runs_from_the_watermark_to_today(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        self._wire(session, windows=1)
+
+        with mock.patch(f"{_MODULE}._today", return_value=self.TODAY):
+            rows = _collect(
+                "campaign_stats",
+                FakeResumeManager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=date(2026, 7, 20),
+            )
+
+        body = session.post.call_args.kwargs["json"]
+        # Seven days fit in one window, and the range never runs past today.
+        assert (body["startDate"], body["endDate"]) == ("2026-07-20T00:00:00Z", "2026-07-26T00:00:00Z")
+        assert session.post.call_count == 1
+        assert [row["Day"] for row in rows] == ["window-0"]
+
+    def test_a_range_longer_than_one_window_is_split(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        self._wire(session, windows=3)
+
+        with mock.patch(f"{_MODULE}._today", return_value=self.TODAY):
+            _collect(
+                "campaign_stats",
+                FakeResumeManager(),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=date(2026, 7, 8),
+            )
+
+        ranges = [
+            (call.kwargs["json"]["startDate"][:10], call.kwargs["json"]["endDate"][:10])
+            for call in session.post.call_args_list
+        ]
+        # 19 days over a 7-day window: three calls, none overlapping, none past today.
+        assert ranges == [
+            ("2026-07-08", "2026-07-14"),
+            ("2026-07-15", "2026-07-21"),
+            ("2026-07-22", "2026-07-26"),
+        ]
+        assert REPORT_WINDOW_DAYS == 7
+
+    def test_window_body_carries_every_advertiser_dimension_and_metric(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        self._wire(session, windows=1)
+
+        with mock.patch(f"{_MODULE}._today", return_value=self.TODAY):
+            _collect(
+                "campaign_stats",
+                FakeResumeManager(),
+                report_currency="EUR",
+                report_timezone="Europe/Paris",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=self.TODAY,
+            )
+
+        body = session.post.call_args.kwargs["json"]
+        assert body["advertiserIds"] == "adv-1,adv-2"
+        assert body["dimensions"] == list(REPORT_DIMENSIONS)
+        assert body["metrics"] == list(REPORT_METRICS)
+        assert body["currency"] == "EUR"
+        assert body["timezone"] == "Europe/Paris"
+        assert body["format"] == "json"
+
+    def test_blank_currency_and_timezone_fall_back_to_defaults(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        self._wire(session, windows=1)
+
+        with mock.patch(f"{_MODULE}._today", return_value=self.TODAY):
+            _collect(
+                "campaign_stats",
+                FakeResumeManager(),
+                report_currency=None,
+                report_timezone="",
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=self.TODAY,
+            )
+
+        body = session.post.call_args.kwargs["json"]
+        assert body["currency"] == "USD"
+        assert body["timezone"] == "UTC"
+
+    def test_each_completed_window_is_checkpointed(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        self._wire(session, windows=2)
+        manager = FakeResumeManager()
+
+        with mock.patch(f"{_MODULE}._today", return_value=self.TODAY):
+            _collect(
+                "campaign_stats",
+                manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=date(2026, 7, 15),
+            )
+
+        # Saved after the window's rows were yielded, and not after the final window.
+        assert [state.next_start_date for state in manager.saved] == ["2026-07-22"]
+        assert manager.clear_calls == 1
+
+    def test_resume_picks_up_at_the_saved_window(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        self._wire(session, windows=1)
+
+        with mock.patch(f"{_MODULE}._today", return_value=self.TODAY):
+            _collect(
+                "campaign_stats",
+                FakeResumeManager(CriteoResumeConfig(next_start_date="2026-07-22")),
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=date(2026, 7, 1),
+            )
+
+        # The saved window wins over the watermark, so resumed work isn't redone.
+        assert session.post.call_args.kwargs["json"]["startDate"] == "2026-07-22T00:00:00Z"
+        assert session.post.call_count == 1
+
+    def test_full_refresh_pulls_the_whole_retention_window(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.get.return_value = _response(_envelope("adv-1"))
+        session.post.return_value = _response([])
+
+        with mock.patch(f"{_MODULE}._today", return_value=self.TODAY):
+            _collect("campaign_stats", FakeResumeManager(), should_use_incremental_field=False)
+
+        floor = self.TODAY - timedelta(days=REPORT_MAX_HISTORY_DAYS)
+        assert session.post.call_args_list[0].kwargs["json"]["startDate"] == f"{floor.isoformat()}T00:00:00Z"
+
+    def test_empty_portfolio_fails_with_the_consent_message(self, make_session: mock.MagicMock) -> None:
+        session = make_session.return_value
+        session.get.return_value = _response(_envelope())
+
+        with mock.patch(f"{_MODULE}._today", return_value=self.TODAY), pytest.raises(ValueError) as error:
+            _collect("campaign_stats", FakeResumeManager())
+
+        assert str(error.value) == CRITEO_NO_ADVERTISERS_ERROR
+
+
+@mock.patch(f"{_MODULE}.make_tracked_session")
+class TestValidateCredentials:
+    def test_valid_when_the_portfolio_lists_advertisers(self, make_session: mock.MagicMock) -> None:
+        make_session.return_value.get.return_value = _response(_envelope("13"))
+
+        assert validate_credentials("cid", "sec", CRITEO_API_VERSION) == (True, None)
+
+    def test_token_rejection_reports_bad_credentials(self, make_session: mock.MagicMock) -> None:
+        make_session.return_value.get.side_effect = OAuth2AuthRequestError("invalid_client", is_permanent=True)
+
+        valid, message = validate_credentials("cid", "sec", CRITEO_API_VERSION)
+
+        assert valid is False
+        assert message is not None and "client ID" in message
+
+    @pytest.mark.parametrize(
+        "status, expected_fragment",
+        [
+            (401, "client ID"),
+            # A valid token with no grant is the consent step, not a bad secret.
+            (403, "advertiser admin"),
+            (500, "Could not reach"),
+        ],
+    )
+    def test_http_status_is_mapped_to_an_actionable_message(
+        self, make_session: mock.MagicMock, status: int, expected_fragment: str
+    ) -> None:
+        make_session.return_value.get.return_value = _error_response(status)
+
+        valid, message = validate_credentials("cid", "sec", CRITEO_API_VERSION)
+
+        assert valid is False
+        assert message is not None and expected_fragment in message
+
+    def test_transport_failure_never_raises(self, make_session: mock.MagicMock) -> None:
+        make_session.return_value.get.side_effect = requests.ConnectionError("boom")
+
+        assert validate_credentials("cid", "sec", CRITEO_API_VERSION)[0] is False
+
+    def test_authenticated_but_ungranted_app_is_rejected(self, make_session: mock.MagicMock) -> None:
+        # The token mints and /advertisers/me answers, but the app was never granted an advertiser.
+        make_session.return_value.get.return_value = _response(_envelope())
+
+        assert validate_credentials("cid", "sec", CRITEO_API_VERSION) == (False, CRITEO_NO_ADVERTISERS_ERROR)
+
+
+class TestCriteoSourceResponse:
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_response_shape_per_endpoint(self, endpoint: str) -> None:
+        config = CRITEO_ENDPOINTS[endpoint]
+        response = criteo_source(
+            client_id="cid",
+            client_secret="sec",
+            endpoint=endpoint,
+            api_version=CRITEO_API_VERSION,
+            resumable_source_manager=FakeResumeManager(),
+        )
+
+        assert response.name == endpoint
+        assert response.primary_keys == config.primary_key
+        assert response.sort_mode == "asc"
+        if config.partition_key:
+            assert response.partition_mode == "datetime"
+            assert response.partition_keys == [config.partition_key]
+            assert response.partition_format == "month"
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_rows_flow_through_the_source_response(self, make_session: mock.MagicMock) -> None:
+        make_session.return_value.post.return_value = _response(_envelope("1", "2"))
+
+        response = criteo_source(
+            client_id="cid",
+            client_secret="sec",
+            endpoint="campaigns",
+            api_version=CRITEO_API_VERSION,
+            resumable_source_manager=FakeResumeManager(),
+        )
+
+        assert [row["id"] for row in _rows(response)] == ["1", "2"]
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_building_the_response_issues_no_request(self, make_session: mock.MagicMock) -> None:
+        # The response is built on the API request thread; only `items()` may touch the network.
+        criteo_source(
+            client_id="cid",
+            client_secret="sec",
+            endpoint="advertisers",
+            api_version=CRITEO_API_VERSION,
+            resumable_source_manager=FakeResumeManager(),
+        )
+
+        make_session.return_value.get.assert_not_called()
+        make_session.return_value.post.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/tests/test_criteo_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/criteo/tests/test_criteo_source.py
@@ -1,0 +1,261 @@
+from collections.abc import Iterable
+from typing import Any, Optional, cast
+
+import pytest
+from unittest import mock
+
+from posthog.schema import ReleaseStatus, SourceFieldInputConfig, SourceFieldInputConfigType
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.auth import (
+    OAUTH2_PERMANENT_ERROR_MARKER,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.criteo.criteo import (
+    CRITEO_NO_ADVERTISERS_ERROR,
+    CriteoResumeConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.criteo.settings import (
+    CRITEO_API_VERSION,
+    CRITEO_ENDPOINTS,
+    ENDPOINTS,
+    STATS_LOOKBACK_SECONDS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.criteo.source import CriteoSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.criteo import CriteoSourceConfig
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+_SOURCE_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.criteo.source"
+
+
+def _inputs(schema_name: str, **overrides: Any) -> SourceInputs:
+    defaults: dict[str, Any] = {
+        "schema_name": schema_name,
+        "schema_id": "schema-1",
+        "source_id": "source-1",
+        "team_id": 1,
+        "should_use_incremental_field": False,
+        "db_incremental_field_last_value": None,
+        "db_incremental_field_earliest_value": None,
+        "incremental_field": None,
+        "incremental_field_type": None,
+        "job_id": "job-1",
+        "logger": mock.MagicMock(),
+        "reset_pipeline": False,
+    }
+    defaults.update(overrides)
+    return SourceInputs(**defaults)
+
+
+class TestCriteoSource:
+    def setup_method(self) -> None:
+        self.source = CriteoSource()
+        self.team_id = 123
+        self.config = CriteoSourceConfig(client_id="client-id", client_secret="client-secret")
+
+    def test_source_type(self) -> None:
+        assert self.source.source_type == ExternalDataSourceType.CRITEO
+
+    def test_get_source_config(self) -> None:
+        config = self.source.get_source_config
+
+        assert config.name.value == "Criteo"
+        assert config.label == "Criteo"
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is None
+        assert config.iconPath == "/static/services/criteo.png"
+
+        field_names = [f.name for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+        assert field_names == ["client_id", "client_secret", "report_currency", "report_timezone"]
+
+    def test_client_secret_is_the_only_secret_field(self) -> None:
+        config = self.source.get_source_config
+        input_fields = [f for f in config.fields if isinstance(f, SourceFieldInputConfig)]
+
+        secret_fields = [f for f in input_fields if f.secret]
+        assert [f.name for f in secret_fields] == ["client_secret"]
+        assert secret_fields[0].type == SourceFieldInputConfigType.PASSWORD
+
+    def test_report_fields_are_optional(self) -> None:
+        config = self.source.get_source_config
+        optional = {
+            f.name: f.required
+            for f in config.fields
+            if isinstance(f, SourceFieldInputConfig) and f.name.startswith("report_")
+        }
+        # Both fall back to Criteo's own defaults (USD / UTC) when left blank.
+        assert optional == {"report_currency": False, "report_timezone": False}
+
+    def test_api_version_metadata_pins_the_version_the_paths_use(self) -> None:
+        assert self.source.supported_versions == (CRITEO_API_VERSION,)
+        assert self.source.default_version == CRITEO_API_VERSION
+        assert self.source.api_docs_url.startswith("https://")
+
+    def test_lists_tables_without_credentials(self) -> None:
+        # `get_schemas` walks a static catalog, so the public docs can render the table list.
+        assert self.source.lists_tables_without_credentials is True
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            f"HTTP 401 from the OAuth2 token endpoint: invalid_client {OAUTH2_PERMANENT_ERROR_MARKER}",
+            f"HTTP 400 from the OAuth2 token endpoint {OAUTH2_PERMANENT_ERROR_MARKER}",
+            "403 Client Error: Forbidden for url: https://api.criteo.com/2026-01/marketing-solutions/ads",
+            CRITEO_NO_ADVERTISERS_ERROR,
+        ],
+    )
+    def test_non_retryable_errors_match_permanent_failures(self, observed_error: str) -> None:
+        assert any(key in observed_error for key in self.source.get_non_retryable_errors())
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "403 Client Error: Forbidden for url: https://api.stripe.com/v1/charges",
+            "500 Server Error for url: https://api.criteo.com/2026-01/statistics/report",
+            # A transient token error shares the endpoint phrasing but carries no permanent marker.
+            "HTTP 503 from the OAuth2 token endpoint",
+            # A mid-sync 401 is re-minted, not a disable condition.
+            "401 Client Error: Unauthorized for url: https://api.criteo.com/2026-01/advertisers/me",
+        ],
+    )
+    def test_non_retryable_errors_ignore_transient_and_unrelated(self, observed_error: str) -> None:
+        assert not any(key in observed_error for key in self.source.get_non_retryable_errors())
+
+    def test_get_schemas_lists_every_endpoint(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id)
+        assert [s.name for s in schemas] == list(ENDPOINTS)
+
+    @pytest.mark.parametrize("endpoint", [name for name in ENDPOINTS if name != "campaign_stats"])
+    def test_entity_endpoints_are_full_refresh(self, endpoint: str) -> None:
+        schema = next(s for s in self.source.get_schemas(self.config, self.team_id) if s.name == endpoint)
+        # None of the entity endpoints expose a server-side updated-since filter.
+        assert schema.supports_incremental is False
+        assert schema.supports_append is False
+        assert schema.incremental_fields == []
+
+    def test_campaign_stats_is_incremental_merge_only_with_lookback(self) -> None:
+        schema = next(s for s in self.source.get_schemas(self.config, self.team_id) if s.name == "campaign_stats")
+
+        assert schema.supports_incremental is True
+        # Appending restated days would double-count them; the report table has to merge.
+        assert schema.supports_append is False
+        assert [f["field"] for f in schema.incremental_fields] == ["Day"]
+        assert schema.default_incremental_lookback_seconds == STATS_LOOKBACK_SECONDS
+
+    def test_get_schemas_filters_by_names(self) -> None:
+        schemas = self.source.get_schemas(self.config, self.team_id, names=["campaigns", "campaign_stats"])
+        assert [s.name for s in schemas] == ["campaigns", "campaign_stats"]
+
+    def test_canonical_descriptions_cover_every_endpoint(self) -> None:
+        descriptions = self.source.get_canonical_descriptions()
+        assert set(descriptions.keys()) == set(ENDPOINTS)
+        for name, entry in descriptions.items():
+            assert entry["description"]
+            assert entry["docs_url"].startswith("https://")
+            # Every declared primary-key column must be documented, since those are the columns a
+            # consumer joins on.
+            assert set(CRITEO_ENDPOINTS[name].primary_key) <= set(entry["columns"])
+
+    @pytest.mark.parametrize(
+        "returned, expected",
+        [
+            ((True, None), (True, None)),
+            ((False, CRITEO_NO_ADVERTISERS_ERROR), (False, CRITEO_NO_ADVERTISERS_ERROR)),
+        ],
+    )
+    def test_validate_credentials_passes_through_transport_result(
+        self, returned: tuple[bool, Optional[str]], expected: tuple[bool, Optional[str]]
+    ) -> None:
+        with mock.patch(f"{_SOURCE_MODULE}.validate_criteo_credentials", return_value=returned) as validate:
+            assert self.source.validate_credentials(self.config, self.team_id) == expected
+
+        validate.assert_called_once_with("client-id", "client-secret", CRITEO_API_VERSION)
+
+    def test_validate_credentials_honors_a_pinned_api_version(self) -> None:
+        with mock.patch(f"{_SOURCE_MODULE}.validate_criteo_credentials", return_value=(True, None)) as validate:
+            self.source.validate_credentials(self.config, self.team_id, api_version="2025-10")
+
+        assert validate.call_args.args[2] == "2025-10"
+
+    def test_resumable_manager_is_bound_to_the_resume_class_and_namespaced_per_schema(self) -> None:
+        manager = self.source.get_resumable_source_manager(_inputs("ads"))
+        other = self.source.get_resumable_source_manager(_inputs("audiences"))
+
+        assert manager._data_class is CriteoResumeConfig
+        # Endpoints store incompatible cursors, so their Redis slots must not collide.
+        assert manager._key != other._key
+        assert manager._key.endswith(":ads")
+
+    @pytest.mark.parametrize("endpoint", list(ENDPOINTS))
+    def test_source_for_pipeline_declares_the_endpoint_primary_keys(self, endpoint: str) -> None:
+        response = self.source.source_for_pipeline(
+            self.config, self.source.get_resumable_source_manager(_inputs(endpoint)), _inputs(endpoint)
+        )
+
+        assert response.name == endpoint
+        assert response.primary_keys == CRITEO_ENDPOINTS[endpoint].primary_key
+        assert response.sort_mode == "asc"
+
+    def test_source_for_pipeline_plumbs_the_incremental_watermark(self) -> None:
+        module = "products.warehouse_sources.backend.temporal.data_imports.sources.criteo.source.criteo_source"
+        inputs = _inputs(
+            "campaign_stats",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value="2026-01-05",
+            api_version=CRITEO_API_VERSION,
+        )
+        manager = self.source.get_resumable_source_manager(inputs)
+
+        with mock.patch(module) as criteo_source:
+            self.source.source_for_pipeline(
+                CriteoSourceConfig(
+                    client_id="client-id",
+                    client_secret="client-secret",
+                    report_currency="EUR",
+                    report_timezone="Europe/Paris",
+                ),
+                manager,
+                inputs,
+            )
+
+        kwargs = criteo_source.call_args.kwargs
+        assert kwargs["db_incremental_field_last_value"] == "2026-01-05"
+        assert kwargs["should_use_incremental_field"] is True
+        assert kwargs["report_currency"] == "EUR"
+        assert kwargs["report_timezone"] == "Europe/Paris"
+        assert kwargs["api_version"] == CRITEO_API_VERSION
+
+    def test_source_for_pipeline_withholds_the_watermark_on_a_full_refresh(self) -> None:
+        module = "products.warehouse_sources.backend.temporal.data_imports.sources.criteo.source.criteo_source"
+        inputs = _inputs(
+            "campaign_stats", should_use_incremental_field=False, db_incremental_field_last_value="2026-01-05"
+        )
+
+        with mock.patch(module) as criteo_source:
+            self.source.source_for_pipeline(self.config, self.source.get_resumable_source_manager(inputs), inputs)
+
+        assert criteo_source.call_args.kwargs["db_incremental_field_last_value"] is None
+
+    @pytest.mark.parametrize(
+        "endpoint, expected_partition_key",
+        [
+            ("advertisers", None),
+            ("campaigns", None),
+            ("audiences", "createdAt"),
+            ("campaign_stats", "Day"),
+        ],
+    )
+    def test_partitioning_uses_stable_keys_only(self, endpoint: str, expected_partition_key: Optional[str]) -> None:
+        response = self.source.source_for_pipeline(
+            self.config, self.source.get_resumable_source_manager(_inputs(endpoint)), _inputs(endpoint)
+        )
+
+        if expected_partition_key is None:
+            assert response.partition_mode is None
+            assert response.partition_keys is None
+        else:
+            assert response.partition_mode == "datetime"
+            assert response.partition_keys == [expected_partition_key]
+
+    def test_documented_tables_render_for_public_docs(self) -> None:
+        tables = cast("Iterable[dict[str, Any]]", self.source.get_documented_tables())
+        assert {table["name"] for table in tables} == set(ENDPOINTS)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/criteo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/criteo.py
@@ -6,4 +6,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common imp
 
 @config.config
 class CriteoSourceConfig(config.Config):
-    pass
+    client_id: str
+    client_secret: str
+    report_currency: str | None = None
+    report_timezone: str | None = None


### PR DESCRIPTION
## Problem

`criteo` was a scaffolded stub in the data warehouse source registry.
It appeared in the enum and the catalog but had no `get_schemas`, no client and no tests, so it could not actually be connected.

Criteo is a common retargeting channel for ecommerce customers and is missing from paid channel reporting.

## Changes

Implements the `criteo` source end to end.

- Transport: hand-rolled (CriteoClient over make_tracked_session + framework OAuth2Auth): Criteo's collections are POST searches with JSON filter bodies, the ads listing fans out per advertiser with offset pagination, and statistics come from a date-windowed synchronous report call that needs a comma-joined advertiser-id list; none of that is expressible in the declarative rest_source config, and mixing declarative resources with a bespoke report stream would have been more code than one uniform client. Token minting/refresh (900s tokens) still comes from rest_source.auth.OAuth2Auth, and 429/5xx backoff from the tracked session (with a custom Retry that adds POST, since the shared DEFAULT_RETRY only retries idempotent verbs and would have left every Criteo call unretried)
- Base class: `ResumableSource[CriteoSourceConfig, CriteoResumeConfig]`
- Credentials the customer supplies: client_id + client_secret (OAuth2 client credentials, POST https://api.criteo.com/oauth2/token, body-mode client auth, 900s bearer auto-refreshed). No Integration kind, no OAuth app, no new env var. Two optional non-secret fields: report_currency (defaults USD) and report_timezone (defaults UTC), both required/defaulted by the statistics report endpoint
- Tables exposed (6): `advertisers`, `campaigns`, `ad_sets`, `ads`, `audiences`, `campaign_stats`
- Incremental sync: yes for campaign_stats only (field `Day`, IncrementalFieldType.Date, driven by the report body's startDate/endDate; merge-only, supports_append=False, default_incremental_lookback_seconds=30 days for conversion restatement). All five entity endpoints are full refresh, the campaigns/ad-sets/audiences searches and the ads listing expose no updated-since filter

Shipped as `releaseStatus=ReleaseStatus.ALPHA`.
The diff is limited to this source's own directory, its generated config and its icon, plus a one line move in `SOURCES.md` from the scaffolded list to the implemented table.

### Notes for review

- Frontend/public/services/criteo.png ALREADY EXISTED in master and is the correct Criteo wordmark (256x256, orange). I fetched the Logo.dev 512px version, compared, and reverted to the committed file to keep the diff minimal, so the icon path is NOT in this commit and iconPath is unchanged.
- `unreleasedSource=True` deleted, `releaseStatus=ReleaseStatus.ALPHA` set. No test asserts unreleasedSource is True (one asserts it is None).
- API VERSION: pinned `2026-01` (supported_versions/default_version), which is what the live docs reference and what every path in the code calls. Probed api.criteo.com directly: /2025-10/, /2026-01/ and /2026-07/ all answer 401 (route exists), /2026-04/ 404s. 2026-07 is undocumented (no docs page, no reference .md), so it looks like a preview, a future version bump is the...
- 1. campaigns/search and ad-sets/search document NO pagination: I treat them as single-response endpoints. If Criteo silently caps the result set, those two tables would truncate. Worth confirming against a real portfolio; if they do accept limit/offset query params, flipping their `kind` from "search" to "paged" is a one-line settings change.
- 2. POST /{version}/statistics/report with format=json: the SDK types the response as a file (SplFileObject) and Criteo publishes no JSON response schema. `_report_payload_rows` treats a bare array as the expected shape, also accepts Rows/rows/data wrappers, and raises CriteoReportShapeError on anything else (fail loud rather than silently syncing 0 rows). Row keys are assumed to equal the...
- 3. REPORT_WINDOW_DAYS=7 is a heuristic for the documented 100k-row-per-response cap (rows = days x advertisers x campaigns). A portfolio with >14k campaigns could still exceed it; a real-account check would let us tune it.
- 4. Scopes verified from the reference for campaigns/ad-sets (MarketingSolutions_Campaign_Read), ads (MarketingSolutions_Creative_Read), audiences (MarketingSolutions_Audience_Read). No scope is documented for /advertisers/me or /statistics/report, so none is claimed for them.

## How did you test this code?

Automated tests only, at both levels the source skill asks for.
`tests/test_criteo_source.py` covers the source class: the schemas it exposes, credential validation and error classification.
`tests/test_criteo.py` covers the transport: authentication, pagination or windowing termination, and row normalization.
All HTTP calls are mocked, so the suite makes no live vendor calls.
118 tests pass, 0 failing.

Repo wide mypy and the full `sources/` pytest suite were run across the whole batch this source was built in, not just this directory.

I have not exercised this against a live vendor account, so credential handling and endpoint behavior are verified against the vendor's published API documentation rather than a real sync. That is the main thing worth a careful review.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The posthog.com source doc is not written yet and is tracked separately, per the documenting-warehouse-sources guide.
