### PR TITLE
fix(shopify): treat 401 from the Admin API as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
@@ -76,6 +76,18 @@ SHOPIFY_PAYMENT_REQUIRED_ERROR_MESSAGE = (
     "the import will resume."
 )
 
+# 401 from the Admin API GraphQL endpoint itself (as opposed to the OAuth token endpoint
+# above) — the token was accepted when minted but is no longer valid for the store, e.g. the
+# app was uninstalled or the token revoked mid-sync. Re-minting on retry can't fix that, so
+# `ShopifySource.get_non_retryable_errors` matches on the stable status text (not the
+# per-store URL) to fail the job fast.
+SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MATCH = "401 Client Error: Unauthorized"
+SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MESSAGE = (
+    "Shopify rejected the request with 401 Unauthorized — your Shopify access token is no "
+    "longer valid, likely because the app was uninstalled or access was revoked. Please "
+    "reconnect your Shopify integration."
+)
+
 
 @dataclasses.dataclass
 class ShopifyResumeConfig:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/source.py
@@ -32,6 +32,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.se
 from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify import (
     SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
     SHOPIFY_GRAPHQL_ACCESS_DENIED_ERROR,
+    SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MATCH,
+    SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MESSAGE,
     SHOPIFY_PAYMENT_REQUIRED_ERROR_MATCH,
     SHOPIFY_PAYMENT_REQUIRED_ERROR_MESSAGE,
     SHOPIFY_STORE_NOT_FOUND_ERROR,
@@ -82,6 +84,10 @@ class ShopifySource(ResumableSource[ShopifySourceConfig, ShopifyResumeConfig]):
             # 402 Payment Required from the Admin API — the store is frozen for an unpaid
             # bill. Retrying cannot recover; the shop owner must settle their Shopify balance.
             SHOPIFY_PAYMENT_REQUIRED_ERROR_MATCH: SHOPIFY_PAYMENT_REQUIRED_ERROR_MESSAGE,
+            # 401 from the Admin API GraphQL endpoint itself — the token was valid at mint
+            # time but Shopify now rejects it. Retrying cannot recover; the user must
+            # reconnect their integration.
+            SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MATCH: SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MESSAGE,
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_non_retryable_errors.py
@@ -3,6 +3,7 @@ import pytest
 import requests
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify import (
+    SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MATCH,
     SHOPIFY_PAYMENT_REQUIRED_ERROR_MATCH,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.source import ShopifySource
@@ -40,6 +41,15 @@ def test_payment_required_is_non_retryable():
     patterns = ShopifySource().get_non_retryable_errors()
     assert any(pattern in error_message for pattern in patterns), (
         f"402 Payment Required error '{error_message}' should match a non-retryable pattern"
+    )
+
+
+def test_graphql_unauthorized_is_non_retryable():
+    error_message = _http_error_message(401, "Unauthorized")
+    assert SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MATCH in error_message
+    patterns = ShopifySource().get_non_retryable_errors()
+    assert any(pattern in error_message for pattern in patterns), (
+        f"401 Unauthorized error '{error_message}' should match a non-retryable pattern"
     )
 
 


### PR DESCRIPTION
## Problem

Error tracking surfaced an `HTTPError` from the Shopify data-warehouse import source: `401 Client Error: Unauthorized` from the Admin API GraphQL endpoint (`products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py`, in `execute()`).

This 401 comes from the GraphQL request itself, not from the OAuth token-minting endpoint (which already has non-retryable handling for its own 401/404). It means the token was accepted when minted but is no longer valid for the store — most likely because the app was uninstalled or access was revoked mid-sync. Retrying can't recover from this; the user needs to reconnect their integration.

Neither the local `tenacity` retry (which only retries `ShopifyRetryableError`/connection/timeout errors) nor the transport-level `urllib3` retry (`status_forcelist=(429, 500, 502, 503, 504)`) covers this, so today the activity fails and gets retried by Temporal's default policy — uselessly, since the token won't become valid on its own.

## Changes

- Added `SHOPIFY_GRAPHQL_UNAUTHORIZED_ERROR_MATCH`/`_MESSAGE` in `shopify.py`, matching on the stable `raise_for_status` status text (not the per-store URL).
- Registered it in `ShopifySource.get_non_retryable_errors()` in `source.py`, alongside the existing 402/404/access-denied entries, so the sync fails fast with a clear message instead of retrying.

## How did you test this code?

Added `test_graphql_unauthorized_is_non_retryable` to `tests/test_non_retryable_errors.py`, following the same pattern as the existing 402 test — builds the exact message `requests.raise_for_status()` produces for a 401 and asserts it's recognized as non-retryable. This catches a regression where the match string drifts from the real `requests` message format.

Ran the full `test_non_retryable_errors.py` suite locally (`uv run pytest ... -q`) — all 11 tests pass. Also ran `ruff check`/`ruff format --check` on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via a PostHog error-tracking issue link, confirmed the failure originates in `shopify.py`'s `execute()` (stack trace traced through `_make_paginated_shopify_request` → `get_rows` → `execute` → `raise_for_status`), then classified it as a user/upstream error (revoked/invalid token) rather than a code bug, following the existing pattern in `stripe/source.py`'s `get_non_retryable_errors`. Searched open PRs for duplicates (by exception type, module path, and the maintainer's own open PRs) — found none addressing this.