### PR TITLE
fix(data-warehouse): let users reconnect from the source account picker

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/IntegrationAccountSelector.tsx
@@ -2,8 +2,9 @@ import { useActions, useValues } from 'kea'
 import { FormContext } from 'kea-forms'
 import { useContext, useEffect, useMemo, useRef } from 'react'
 
-import { LemonInput, LemonInputSelect, LemonTag } from '@posthog/lemon-ui'
+import { LemonInput, LemonInputSelect, LemonTag, Link } from '@posthog/lemon-ui'
 
+import api from 'lib/api'
 import { integrationAccountsLogic } from 'lib/integrations/integrationAccountsLogic'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { LemonField } from 'lib/lemon-ui/LemonField'
@@ -113,6 +114,19 @@ function IntegrationAccountSelectorInner({
 
 function captionHelp(caption?: string): JSX.Element | undefined {
     return caption ? <LemonMarkdown className="text-xs">{caption}</LemonMarkdown> : undefined
+}
+
+/** Re-run OAuth for the connected integration in place, so a failed account load is recoverable
+ *  without hunting for the disconnect/reconnect action elsewhere on the page. */
+function ReconnectLink({ integrationKind }: { integrationKind: string }): JSX.Element {
+    return (
+        <Link
+            disableClientSideRouting
+            to={api.integrations.authorizeUrl({ kind: integrationKind, next: window.location.pathname })}
+        >
+            Reconnect
+        </Link>
+    )
 }
 
 function AccountTextField({
@@ -338,6 +352,7 @@ function MultiAccountFieldInner({
 
 function IntegrationAccountFieldWithDropdown({
     integrationId,
+    integrationKind,
     sourceType,
     fieldName,
     fieldLabel,
@@ -398,11 +413,15 @@ function IntegrationAccountFieldWithDropdown({
                             emptyMessage="No accounts accessible by this integration."
                             loadingMessage="Loading accounts…"
                         />
-                        {accountsError && <p className="m-0 text-xs text-warning">{accountsError}</p>}
+                        {accountsError && (
+                            <p className="m-0 text-xs text-warning">
+                                {accountsError} <ReconnectLink integrationKind={integrationKind} />
+                            </p>
+                        )}
                         {accountsLoaded && !accountsLoading && !accountsError && accounts.length === 0 && (
                             <p className="m-0 text-xs text-warning">
                                 No accounts are accessible for this connection. Check that the connected account has the
-                                right permissions, then reconnect the integration.
+                                right permissions, then <ReconnectLink integrationKind={integrationKind} />.
                             </p>
                         )}
                         {savedValueMissing && (


### PR DESCRIPTION
## Problem

In the data-warehouse new-source wizard, several OAuth sources (Google Search Console, Google Ads, and the other ad/analytics connectors) load a dropdown of the connected account's accessible accounts/properties after you link the integration. When that load fails, or comes back empty, because the credentials were rejected, the token expired, or the account is missing the right property permissions, the picker shows a warning that ends with "reconnect the integration" or "reconnect your account".

The trouble: there was nothing to click. The actual reconnect action lives in a different component higher up the page and only appears for a subset of failures (a server-flagged `TOKEN_REFRESH_FAILED` or a detected missing-scope). A one-off rejection surfaced through the account listing doesn't set that state, so the user was told to reconnect with no affordance to do it, and had to go find the disconnect/reconnect action themselves. This recurred across multiple onboarding sessions where users got stuck re-authenticating Google-based sources.

## Changes

Add a `Reconnect` link to the account picker's error and empty states. It reuses the same `api.integrations.authorizeUrl({ kind, next })` re-auth flow the existing reconnect banner uses, so a failed account load is now recoverable right where the error appears.

> [!NOTE]
> Copy/UX only. No change to sync behavior, schemas, or the happy path; the link renders solely in the already-failed states.

## How did you test this code?

No manual/browser testing was performed by the agent, and the JS toolchain (oxlint/oxfmt/tsc) isn't installed in this environment, so I couldn't run lint or typecheck here. The change is small and mirrors the established `Link` + `authorizeUrl` idiom already used in `IntegrationView` and `SlackIntegrationHelpers` (same helper, same `next: window.location.pathname`). No test added: the file has no existing test harness and a render test would need heavy kea form + logic mocking for a two-line link addition.

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Identified while reviewing friction in the data-warehouse new-source onboarding flow: the single most recurring blocker was users stuck re-authenticating OAuth sources, told to "reconnect" with no button to do so. Scoped the fix to the single-select account picker (`IntegrationAccountSelector`), which backs the ad/analytics sources where this friction showed up; left the multi-select variant (GitHub only) untouched since it wasn't implicated. Rejected building a full reconnect banner into the picker (redundant with the existing one) in favor of a plain link matching the existing pattern. Invoked `/writing-user-facing-copy` to check the link label and empty-state wording.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
