### PR TITLE
fix(google_sheets): stop tracking transient 5xx/429 Sheets API errors as exceptions

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -75,6 +75,21 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
             "Requested entity was not found": "Import failed: the Google Sheet or worksheet could not be found. It may have been deleted or moved, or is no longer shared with our service account. Please check the spreadsheet URL and its sharing settings.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_retry_on_transient_api_error` already retries these Sheets API responses in-process
+        # (see `_RETRYABLE_API_ERROR_CODES` in google_sheets.py) before re-raising once its attempt
+        # budget is exhausted. gspread's `APIError.__str__` embeds the HTTP status as a stable
+        # "[<code>]" substring — match on that rather than the message text, which Google can
+        # reword. Temporal then retries the whole activity, so the failure is transient and
+        # self-recovering.
+        return {
+            "APIError: [429]",
+            "APIError: [500]",
+            "APIError: [502]",
+            "APIError: [503]",
+            "APIError: [504]",
+        }
+
     def get_schemas(
         self,
         config: GoogleSheetsSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -456,6 +456,18 @@ def test_error_string_matches_a_non_retryable_key(error):
     assert any(key in str(error) for key in non_retryable_errors)
 
 
+@pytest.mark.parametrize("status_code", [429, 500, 502, 503, 504])
+def test_error_string_matches_a_retryable_key(status_code):
+    """`_retry_on_transient_api_error` already retries these status codes in-process before
+    re-raising; the framework then logs at `warning` instead of `exception` only if the re-raised
+    error matches one of `get_retryable_errors()`'s keys. If a code drops out of this set, the
+    transient error starts polluting error tracking again even though Temporal still retries it."""
+    error = _api_error(status_code, "The service is currently unavailable.")
+    retryable_errors = GoogleSheetsSource().get_retryable_errors()
+
+    assert any(key in str(error) for key in retryable_errors)
+
+
 @pytest.mark.parametrize(
     "call_site",
     [


### PR DESCRIPTION
## Problem

Error tracking surfaced a `gspread.exceptions.APIError: [503]: The service is currently unavailable.` from the Google Sheets data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019fa1e8-8871-7ba3-bb43-552526dc540a)).

That 503 (like 429/500/502/504) is already in `_RETRYABLE_API_ERROR_CODES` in `google_sheets.py` — `_retry_on_transient_api_error` retries it in-process with linear backoff (up to 9 retries) before re-raising, and Temporal retries the whole activity on top of that. So this isn't a bug in the retry logic itself and isn't a user/credentials/config problem — it's a transient upstream error that's already handled and self-recovering.

The framework has a purpose-built hook for exactly this case: `get_retryable_errors()` on the source class routes a matching re-raised error to `logger.awarning` instead of `logger.aexception`, keeping benign/self-recovering errors out of error tracking (see `import_data_sync.py`'s `_handle_import_error` and the `sources/README.md` "Retryable Errors" section; mysql, clickhouse, and mongodb sources already override it for their own transient errors). `GoogleSheetsSource` never overrode it, so every retried 429/5xx from the Sheets API was still logged as an exception and captured, even though the sync typically completes fine on a subsequent Temporal retry.

## Changes

- Added `GoogleSheetsSource.get_retryable_errors()`, matching gspread's stable `APIError: [<code>]` substring for each code in `_RETRYABLE_API_ERROR_CODES` (429, 500, 502, 503, 504). The status code is embedded directly in `gspread.exceptions.APIError.__str__`, so it's a stable match unlike the accompanying message text, which Google can reword.

## How did you test this code?

- Added `test_error_string_matches_a_retryable_key`, parameterized over the five retryable status codes, asserting each renders an `APIError` string that matches a key in `get_retryable_errors()`. This mirrors the existing `test_error_string_matches_a_non_retryable_key` test for the non-retryable side, and catches a real regression: if a code drops out of this set (or gspread's string format changes), the transient error silently starts polluting error tracking again even though Temporal still retries it successfully.
- Ran the full `google_sheets` test suite locally (71 passed) and `ruff check`/`ruff format` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification behavior, no user-facing or API surface change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged a live error-tracking issue for the Google Sheets warehouse source end to end (confirm issue → read stack trace and call path → assess transient-vs-fixable → implement → test → open PR), using Claude Code (Sonnet 5) plus a research subagent to trace the full capture path from the Temporal activity interceptor down to the source's error-classification hooks.
- Skills invoked: `/writing-tests` (gate before adding the parameterized test).
- Decision: considered adding these codes to `get_non_retryable_errors()` but rejected it — a 503/429 is genuinely retryable and the code already retries it successfully; `get_non_retryable_errors()` would incorrectly stop the sync early. The correct lever was the existing (but unused-by-this-source) `get_retryable_errors()` hook, which exists specifically to mark already-retried transient errors so they're logged as `warning` instead of tracked as exceptions.