### PR TITLE
fix(insights): humanize query changes in insight activity log

### DIFF
--- a/frontend/src/lib/components/ActivityLog/activityLogLogic.insight.test.tsx
+++ b/frontend/src/lib/components/ActivityLog/activityLogLogic.insight.test.tsx
@@ -86,105 +86,162 @@ describe('the activity log logic', () => {
             expect(renderedDescription).toHaveTextContent('peter changed query definition on test insight')
         })
 
-        it('can handle change of insight query', async () => {
-            const insightMock = {
-                type: ActivityScope.INSIGHT,
-                action: 'changed',
-                field: 'query',
-                after: {
-                    kind: 'TrendsQuery',
-                    properties: {
-                        type: 'AND',
+        const trendsQuery = {
+            kind: 'TrendsQuery',
+            properties: {
+                type: 'AND',
+                values: [
+                    {
+                        type: 'OR',
                         values: [
                             {
-                                type: 'OR',
-                                values: [
-                                    {
-                                        type: 'event',
-                                        key: '$current_url',
-                                        operator: 'exact',
-                                        value: ['https://hedgebox.net/files/'],
-                                    },
-                                    {
-                                        type: 'event',
-                                        key: '$geoip_country_code',
-                                        operator: 'exact',
-                                        value: ['US', 'AU'],
-                                    },
-                                ],
+                                type: 'event',
+                                key: '$current_url',
+                                operator: 'exact',
+                                value: ['https://hedgebox.net/files/'],
+                            },
+                            {
+                                type: 'event',
+                                key: '$geoip_country_code',
+                                operator: 'exact',
+                                value: ['US', 'AU'],
                             },
                         ],
                     },
-                    filterTestAccounts: false,
-                    interval: 'day',
-                    dateRange: {
-                        date_from: '-7d',
-                    },
-                    series: [
+                ],
+            },
+            filterTestAccounts: false,
+            interval: 'day',
+            dateRange: {
+                date_from: '-7d',
+            },
+            series: [
+                {
+                    kind: 'EventsNode',
+                    name: '$pageview',
+                    custom_name: 'Views',
+                    event: '$pageview',
+                    properties: [
                         {
-                            kind: 'EventsNode',
-                            name: '$pageview',
-                            custom_name: 'Views',
-                            event: '$pageview',
-                            properties: [
-                                {
-                                    type: 'event',
-                                    key: '$browser',
-                                    operator: 'exact',
-                                    value: 'Chrome',
-                                },
-                                {
-                                    type: 'cohort',
-                                    key: 'id',
-                                    operator: 'in',
-                                    value: 2,
-                                },
-                            ],
-                            limit: 100,
+                            type: 'event',
+                            key: '$browser',
+                            operator: 'exact',
+                            value: 'Chrome',
+                        },
+                        {
+                            type: 'cohort',
+                            key: 'id',
+                            operator: 'in',
+                            value: 2,
                         },
                     ],
-                    trendsFilter: {
-                        display: 'ActionsAreaGraph',
-                    },
-                    breakdownFilter: {
-                        breakdown: '$geoip_country_code',
-                        breakdown_type: 'event',
-                    },
+                    limit: 100,
                 },
-            }
+            ],
+            trendsFilter: {
+                display: 'ActionsAreaGraph',
+            },
+            breakdownFilter: {
+                breakdown: '$geoip_country_code',
+                breakdown_type: 'event',
+            },
+        }
 
-            let logic = await insightTestSetup('test insight', 'updated', [insightMock as any])
-            let actual = logic.values.humanizedActivity
+        it.each([
+            ['a bare query node', trendsQuery],
+            ['a query wrapped in an InsightVizNode', { kind: 'InsightVizNode', source: trendsQuery }],
+        ])('can handle change of insight query as %s', async (_label, after) => {
+            const logic = await insightTestSetup('test insight', 'updated', [
+                {
+                    type: ActivityScope.INSIGHT,
+                    action: 'changed',
+                    field: 'query',
+                    after,
+                } as any,
+            ])
+            const actual = logic.values.humanizedActivity
 
-            let renderedDescription = render(<>{actual[0].description}</>).container
+            const renderedDescription = render(<>{actual[0].description}</>).container
             expect(renderedDescription).toHaveTextContent('peter changed query definition on test insight')
 
-            let renderedExtendedDescription = render(<>{actual[0].extendedDescription}</>).container
+            const renderedExtendedDescription = render(<>{actual[0].extendedDescription}</>).container
             expect(renderedExtendedDescription).toHaveTextContent(
                 "QueryACounting \"Views\"Pageviewby total countwhere event'sBrowser= equals Chromeand person belongs to cohortUser in ID 2FiltersEvent'sCurrent URL= equals https://hedgebox.net/files/or event'sCountry code= equals US or AUBreakdown byCountry code"
             )
-            ;(insightMock.after.breakdownFilter as BreakdownFilter) = {
-                breakdowns: [
-                    {
-                        property: '$geoip_country_code',
-                        type: 'event',
-                    },
-                    {
-                        property: '$session_duration',
-                        type: 'session',
-                    },
-                ],
-            }
+        })
 
-            logic = await insightTestSetup('test insight', 'updated', [insightMock as any])
-            actual = logic.values.humanizedActivity
+        it('can handle change of insight query with multiple breakdowns', async () => {
+            const logic = await insightTestSetup('test insight', 'updated', [
+                {
+                    type: ActivityScope.INSIGHT,
+                    action: 'changed',
+                    field: 'query',
+                    after: {
+                        ...trendsQuery,
+                        breakdownFilter: {
+                            breakdowns: [
+                                {
+                                    property: '$geoip_country_code',
+                                    type: 'event',
+                                },
+                                {
+                                    property: '$session_duration',
+                                    type: 'session',
+                                },
+                            ],
+                        } as BreakdownFilter,
+                    },
+                } as any,
+            ])
+            const actual = logic.values.humanizedActivity
 
-            renderedDescription = render(<>{actual[0].description}</>).container
+            const renderedDescription = render(<>{actual[0].description}</>).container
             expect(renderedDescription).toHaveTextContent('peter changed query definition on test insight')
 
-            renderedExtendedDescription = render(<>{actual[0].extendedDescription}</>).container
-            expect(renderedExtendedDescription).toHaveTextContent(
-                "QueryACounting \"Views\"Pageviewby total countwhere event'sBrowser= equals Chromeand person belongs to cohortUser in ID 2FiltersEvent'sCurrent URL= equals https://hedgebox.net/files/or event'sCountry code= equals US or AUBreakdown byCountry code"
+            const renderedExtendedDescription = render(<>{actual[0].extendedDescription}</>).container
+            expect(renderedExtendedDescription).toHaveTextContent('Breakdown byCountry codeSession duration')
+        })
+
+        it('can handle change of a SQL insight query', async () => {
+            const logic = await insightTestSetup('test insight', 'updated', [
+                {
+                    type: ActivityScope.INSIGHT,
+                    action: 'changed',
+                    field: 'query',
+                    after: {
+                        kind: 'DataVisualizationNode',
+                        source: {
+                            kind: 'HogQLQuery',
+                            query: 'select event from events',
+                        },
+                    },
+                } as any,
+            ])
+            const actual = logic.values.humanizedActivity
+
+            const renderedDescription = render(<>{actual[0].description}</>).container
+            expect(renderedDescription).toHaveTextContent('peter changed query definition on test insight')
+
+            const renderedExtendedDescription = render(<>{actual[0].extendedDescription}</>).container
+            expect(renderedExtendedDescription).toHaveTextContent('select event from events')
+        })
+
+        it('can handle change of a query it cannot summarize', async () => {
+            const logic = await insightTestSetup('test insight', 'updated', [
+                {
+                    type: ActivityScope.INSIGHT,
+                    action: 'changed',
+                    field: 'query',
+                    after: {
+                        kind: 'DataTableNode',
+                        source: { kind: 'EventsQuery', select: ['*'] },
+                    },
+                } as any,
+            ])
+            const actual = logic.values.humanizedActivity
+
+            expect(render(<>{actual[0].description}</>).container).toHaveTextContent(
+                'peter changed the query on test insight'
             )
         })
 

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -24,9 +24,14 @@ import { pluralize } from 'lib/utils/strings'
 import { urls } from 'scenes/urls'
 
 import { filtersToQueryNode } from '~/queries/nodes/InsightQuery/utils/filtersToQueryNode'
-import { queryNodeToFilter } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
-import { InsightQueryNode, QuerySchema, TrendsQuery } from '~/queries/schema/schema-general'
-import { isInsightQueryNode, hasBreakdownFilter } from '~/queries/utils'
+import { HogQLQuery, InsightQueryNode, QuerySchema } from '~/queries/schema/schema-general'
+import {
+    isDataTableNodeWithHogQLQuery,
+    isDataVisualizationNode,
+    isHogQLQuery,
+    isInsightQueryNode,
+    isInsightVizNode,
+} from '~/queries/utils'
 import { FilterType, InsightModel, InsightShortId } from '~/types'
 
 const nameOrLinkToInsight = (short_id?: InsightShortId | null, name?: string | null): string | JSX.Element => {
@@ -78,7 +83,11 @@ const insightActionsMapping: Record<
     filters: function onChangedFilter(change) {
         const filtersAfter = change?.after as Partial<FilterType>
 
-        return areObjectValuesEmpty(filtersAfter) ? null : summarizeChanges(filtersAfter)
+        return areObjectValuesEmpty(filtersAfter)
+            ? null
+            : summarizeQueryChanges(
+                  filtersToQueryNode(filtersAfter, { source: 'saved_insights_activity_descriptions' })
+              )
     },
     query: function onChangedQuery(change) {
         if (change?.action === 'deleted') {
@@ -87,9 +96,15 @@ const insightActionsMapping: Record<
         }
 
         const queryAfter = change?.after as QuerySchema
-        return isInsightQueryNode(queryAfter)
-            ? summarizeChanges(queryNodeToFilter(change?.after as InsightQueryNode))
-            : { description: ["cannot yet summarize changes to this insight's query: " + queryAfter?.kind] }
+        // saved insights store the actual query wrapped in an InsightVizNode (or in a
+        // DataVisualizationNode / DataTableNode for SQL insights), so summarize the source
+        const source =
+            isInsightVizNode(queryAfter) || isDataVisualizationNode(queryAfter) || isDataTableNodeWithHogQLQuery(queryAfter)
+                ? queryAfter.source
+                : queryAfter
+        return isInsightQueryNode(source) || isHogQLQuery(source)
+            ? summarizeQueryChanges(source)
+            : { description: ['changed the query'] }
     },
     deleted: function onSoftDelete(change, logItem, asNotification) {
         const isDeleted = detectBoolean(change?.after)
@@ -244,19 +259,14 @@ const insightActionsMapping: Record<
     filter_override_context: () => null,
 }
 
-function summarizeChanges(filtersAfter: Partial<FilterType>): ChangeMapping | null {
-    const query = filtersToQueryNode(filtersAfter, {
-        source: 'saved_insights_activity_descriptions',
-    })
-    const trendsQuery = query as TrendsQuery
-
+function summarizeQueryChanges(query: InsightQueryNode | HogQLQuery): ChangeMapping {
     return {
         description: ['changed query definition'],
         extendedDescription: (
             <div className="ActivityDescription">
                 <SeriesSummary query={query} />
-                <PropertiesSummary properties={query.properties} />
-                {hasBreakdownFilter(trendsQuery?.breakdownFilter) && <InsightBreakdownSummary query={query} />}
+                <PropertiesSummary properties={isHogQLQuery(query) ? query.filters?.properties : query.properties} />
+                <InsightBreakdownSummary query={query} />
             </div>
         ),
     }

--- a/frontend/src/scenes/saved-insights/activityDescriptions.tsx
+++ b/frontend/src/scenes/saved-insights/activityDescriptions.tsx
@@ -99,7 +99,9 @@ const insightActionsMapping: Record<
         // saved insights store the actual query wrapped in an InsightVizNode (or in a
         // DataVisualizationNode / DataTableNode for SQL insights), so summarize the source
         const source =
-            isInsightVizNode(queryAfter) || isDataVisualizationNode(queryAfter) || isDataTableNodeWithHogQLQuery(queryAfter)
+            isInsightVizNode(queryAfter) ||
+            isDataVisualizationNode(queryAfter) ||
+            isDataTableNodeWithHogQLQuery(queryAfter)
                 ? queryAfter.source
                 : queryAfter
         return isInsightQueryNode(source) || isHogQLQuery(source)


### PR DESCRIPTION
## TL;DR

When you edit what a saved insight measures, the activity log is supposed to say "changed query definition" with a summary of the new query. Instead it said "\<user> cannot yet summarize changes to this insight's query: InsightVizNode" for every edit. The describer only understood naked query nodes, while saved insights keep their query inside a wrapper node. This PR unwraps the wrapper before summarizing.

## Problem

Saved insights store their query as `{kind: "InsightVizNode", source: {kind: "TrendsQuery", ...}}` (or `DataVisualizationNode`/`DataTableNode` for SQL insights). The activity log describer gated on `isInsightQueryNode(change.after)`, which matches only bare source-level kinds, so every query edit fell through to the fallback. The fallback text then got spliced into the sentence after the actor's name, reading as if the user "cannot yet summarize" anything.

Closes #23615

## Changes

- Unwrap `InsightVizNode`, `DataVisualizationNode`, and `DataTableNode` containers in the insight activity describer and summarize the `source` query.
- Summarize the query node directly instead of round-tripping it through legacy filters. The round trip dropped data, e.g. only the first of multiple breakdowns survived.
- SQL insight edits now show the HogQL in the expanded summary, matching what insight details cards render.
- Queries the describer still can't summarize render as "changed the query" instead of the broken sentence.

## How did you test this code?

Extended the jest suite in `activityLogLogic.insight.test.tsx`:

- Parameterized the query-change test over bare and `InsightVizNode`-wrapped queries. The wrapped case is the production shape and catches this exact regression; the old test only used a bare `TrendsQuery`, which is why the bug never failed a test.
- A multiple-breakdowns case, catching the round-trip lossiness where the second breakdown disappeared.
- A SQL insight (`DataVisualizationNode` + `HogQLQuery`) case asserting the SQL renders in the summary.
- A fallback case asserting unsummarizable kinds read "changed the query".

All 23 tests in the suite pass locally. Full frontend TypeScript check (tsgo) and oxlint/oxfmt are clean. I could not run the app to screenshot the rendered activity log entry.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, the activity log summary format isn't documented.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude via PostHog Code, directed by @thmsobrmlr. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`. Investigated first against the live activity log entries of an affected insight to confirm the stored query shape, then traced the describer. Chose direct query-node summarization over the previous query-to-filters-to-query round trip since the summary components (`SeriesSummary`, `PropertiesSummary`, `InsightBreakdownSummary`) already accept query nodes, and extended the same unwrap to SQL insight containers because they hit the identical fallback.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

