### PR TITLE
fix(nav): light up whole home row when hovering its gear

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/NavLink.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/NavLink.tsx
@@ -47,13 +47,17 @@ export function NavLink({
     return (
         <ButtonGroupPrimitive
             fullWidth
-            className="group/wrapper flex justify-center [&>span]:w-full [&>span]:flex [&>span]:justify-center"
+            className="group/nav-link flex justify-center [&>span]:w-full [&>span]:flex [&>span]:justify-center"
         >
             <Link
                 buttonProps={{
                     menuItem: !isCollapsed,
                     iconOnly: isCollapsed,
-                    className: 'group -outline-offset-2',
+                    // Hovering the side action has to light up the whole row too, like tree items do
+                    className: cn(
+                        'group -outline-offset-2',
+                        hasSideActionRight && 'group-hover/nav-link:bg-fill-button-tertiary-hover'
+                    ),
                     active: isActive,
                     hasSideActionRight,
                 }}
@@ -93,7 +97,7 @@ export function NavLink({
             </Link>
             {hasSideActionRight && sideAction && (
                 <ButtonPrimitive
-                    className="group -outline-offset-2"
+                    className="-outline-offset-2"
                     iconOnly
                     isSideActionRight
                     onClick={(e) => {
@@ -104,7 +108,7 @@ export function NavLink({
                     tooltipPlacement="right"
                     data-attr={sideAction['data-attr']}
                 >
-                    <IconGear className="size-3 text-tertiary opacity-70 group-hover:text-primary group-hover:opacity-100" />
+                    <IconGear className="size-3 text-tertiary opacity-70 group-hover/nav-link:text-primary group-hover/nav-link:opacity-100" />
                 </ButtonPrimitive>
             )}
         </ButtonGroupPrimitive>


### PR DESCRIPTION
## TL;DR

Hovering the settings gear on the Home nav item only highlighted the gear, not the row behind it. Every other nav row highlights fully. Now Home does too.

## Problem

The left nav has two row implementations. Tree rows (Session replay, Product analytics) hang their hover background off a group hover, so hovering the side action lights up the whole row. The Home row uses a bespoke `NavLink` that relies on the link's own `:hover`, so hovering its gear left the row flat. Same visual pattern, two different behaviors, sitting next to each other in the same panel.

## Changes

`NavLink` now puts its hover background on the wrapper group, matching `LemonTree` rows. The gear icon brightens on row hover as well.

Only affects the Home item, the sole `NavLink` with a side action.

I could not take screenshots. The dev stack was not available in this environment.

## How did you test this code?

No manual testing, no browser. Here is what I (Claude) actually ran.

Diagnosis: I sampled pixels from the reported screenshots. The Home row sat at the panel background while the tree rows sat one hover fill lighter, and label text was identical across all three. That pinned the defect to the row background and ruled out a text-color fix.

Compiled the Tailwind bundle with the new file as the only source and confirmed all three new utilities emit, including `background-color: var(--color-bg-fill-button-tertiary-hover)` under `:where(.group/nav-link):hover *`. Not just a plausible class name.

Checked cascade order in that same output, since these utilities carry `!important`. The group-hover rule lands after `.bg-fill-button-tertiary-active`, so an active Home row now brightens on hover. That is a behavior change, and it is the same thing tree rows already do, so it lands on the right side of the inconsistency.

`oxlint` and `oxfmt --check` clean on the file. `tsgo --noEmit` reports 195 errors both with and without the change, so nothing new. Those 195 are pre-existing here: `@posthog/quill` exports missing in unrelated product folders, none in files this PR touches.

Worth a quick manual look before merge: hover the Home row body, hover its gear, and compare against Session replay and Product analytics. Also check Home while it is the active page, and collapsed (no gear, so nothing should change).

No tests added. This is a CSS class change with no logic to assert on.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, driven by a report of inconsistent hover on the Home nav icon with three screenshots.

The alternative was rewriting Home to use `LemonTree`. Rejected as far too big for a hover bug. Instead `NavLink` borrows the one class that matters. I also dropped a `group` class from the gear button that nothing consumed any more, and renamed the wrapper's `group/wrapper` to `group/nav-link`, which was declared but never referenced. No skills invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
