### PR TITLE
feat(dashboards): open the colors modal from the dashboard filters "…" menu

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardEditBarAdvancedFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBarAdvancedFilters.tsx
@@ -126,7 +126,7 @@ export function DashboardEditBarAdvancedFilters(): JSX.Element {
                         <>
                             <LemonDivider className="my-0" />
                             <LemonLabel info="Pin a breakdown value to a color, or pick a color theme, so every insight on this dashboard draws it the same way.">
-                                Colors
+                                Breakdown colors
                             </LemonLabel>
                             <LemonButton
                                 type="secondary"

--- a/frontend/src/scenes/dashboard/DashboardEditBarAdvancedFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBarAdvancedFilters.tsx
@@ -1,16 +1,18 @@
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
-import { IconEllipsis, IconGear } from '@posthog/icons'
+import { IconEllipsis, IconGear, IconPalette } from '@posthog/icons'
 import { LemonBadge, LemonButton, LemonDivider, LemonLabel, LemonSegmentedButton } from '@posthog/lemon-ui'
 
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { Popover } from 'lib/lemon-ui/Popover'
 import { DashboardEventSource } from 'lib/utils/eventUsageLogic'
+import { dashboardInsightColorsModalLogic } from 'scenes/dashboard/dashboardInsightColorsModalLogic'
 import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
-import { DashboardMode } from '~/types'
+import { DashboardMode, DashboardPlacement } from '~/types'
 
 type TestAccountFilterChoice = 'inherit' | 'filter-out' | 'include'
 
@@ -28,19 +30,36 @@ const CHOICE_HINTS: Record<TestAccountFilterChoice, string> = {
 
 /**
  * "…" at the end of the dashboard edit bar, opening a panel for overrides that are too rarely
- * used to earn a spot in the bar itself. Currently hosts the test account filter override.
+ * used to earn a spot in the bar itself. Hosts the test account filter override and the
+ * breakdown color override.
  */
 export function DashboardEditBarAdvancedFilters(): JSX.Element {
-    const { dashboardMode, effectiveEditBarFilters } = useValues(dashboardLogic)
+    const {
+        dashboard,
+        dashboardMode,
+        placement,
+        canEditDashboard,
+        effectiveEditBarFilters,
+        effectiveBreakdownColors,
+        dataColorThemeId,
+    } = useValues(dashboardLogic)
     const { setFilterTestAccounts, setDashboardMode } = useActions(dashboardLogic)
+    const { showInsightColorsModal } = useActions(dashboardInsightColorsModalLogic)
     const { currentTeam } = useValues(teamLogic)
+    const hasDashboardColors = useFeatureFlag('PRODUCT_ANALYTICS_DASHBOARD_COLORS')
     const [visible, setVisible] = useState(false)
 
     const filterTestAccounts = effectiveEditBarFilters.filterTestAccounts ?? null
     const choice: TestAccountFilterChoice =
         filterTestAccounts === null ? 'inherit' : filterTestAccounts ? 'filter-out' : 'include'
-    const overrideCount = choice === 'inherit' ? 0 : 1
     const hasTestAccountFilters = (currentTeam?.test_account_filters || []).length > 0
+    // Only the full dashboard scene mounts DashboardInsightColorsModal, so elsewhere the button would no-op.
+    const showColors =
+        hasDashboardColors && canEditDashboard && !!dashboard && placement === DashboardPlacement.Dashboard
+    // Auto-assigned colors aren't an override — only pinned values and a picked theme are.
+    const hasColorOverrides =
+        effectiveBreakdownColors.some((config) => config.source !== 'auto') || dataColorThemeId != null
+    const overrideCount = (choice === 'inherit' ? 0 : 1) + (showColors && hasColorOverrides ? 1 : 0)
 
     return (
         <Popover
@@ -50,7 +69,7 @@ export function DashboardEditBarAdvancedFilters(): JSX.Element {
             overlay={
                 <div className="flex w-80 flex-col gap-2 p-2">
                     <div>
-                        <h4 className="mb-0 font-semibold">Advanced filters</h4>
+                        <h4 className="mb-0 font-semibold">Advanced options</h4>
                         <p className="mb-0 text-xs text-secondary">
                             Overrides applied to every insight on this dashboard.
                         </p>
@@ -103,13 +122,35 @@ export function DashboardEditBarAdvancedFilters(): JSX.Element {
                         ]}
                     />
                     <p className="mb-0 text-xs text-secondary">{CHOICE_HINTS[choice]}</p>
+                    {showColors && (
+                        <>
+                            <LemonDivider className="my-0" />
+                            <LemonLabel info="Pin a breakdown value to a color, or pick a color theme, so every insight on this dashboard draws it the same way.">
+                                Colors
+                            </LemonLabel>
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                fullWidth
+                                center
+                                icon={<IconPalette />}
+                                onClick={() => {
+                                    setVisible(false)
+                                    showInsightColorsModal(dashboard.id)
+                                }}
+                                data-attr="dashboard-advanced-customize-colors"
+                            >
+                                Customize colors
+                            </LemonButton>
+                        </>
+                    )}
                 </div>
             }
         >
             <LemonButton
                 size="small"
                 icon={<IconEllipsis />}
-                tooltip="Advanced filters"
+                tooltip="Advanced options"
                 active={visible}
                 onClick={() => setVisible(!visible)}
                 sideIcon={overrideCount ? <LemonBadge.Number count={overrideCount} size="small" /> : undefined}


### PR DESCRIPTION
## TL;DR

The dashboard color override lived in the scene panel and the scene menu bar. Now there is also a "Customize colors" button in the "…" panel at the end of the dashboard filter bar, right where you are already changing how the dashboard looks.

## Problem

Breakdown colors change how every insight on a dashboard renders, same as the filters in the edit bar. But the only ways in were the right-hand scene panel and the scene menu bar, both away from the bar. If you are already in the filter bar adjusting a breakdown, the colors for that breakdown are two clicks away in a different part of the page.

## Changes

- New "Colors" section in `DashboardEditBarAdvancedFilters`, with a "Customize colors" button that closes the popover and opens the existing `DashboardInsightColorsModal`.
- Shown only when the `dashboard-colors` flag is on, you can edit the dashboard, and the placement is the full dashboard scene. Other placements do not mount the modal, so the button would silently do nothing there.
- The "…" badge counts an active color override (a pinned value or a picked theme) alongside the test account override. Auto-assigned colors do not count, they are not something you set.
- Panel heading and tooltip go from "Advanced filters" to "Advanced options", since the panel no longer holds filters alone.

No logic or data model changes. The button reuses `dashboardInsightColorsModalLogic.showInsightColorsModal`, the same action the two existing entry points call.

## How did you test this code?

I (Claude, via PostHog Code) could not run the app or click through this. What I did run:

- `pnpm --filter=@posthog/frontend fix` (oxlint + oxfmt): clean, no changes to the file.
- `pnpm --filter=@posthog/frontend typescript:check`: zero errors in the changed file. The run does report pre-existing errors elsewhere, all from unbuilt quill workspace packages in this sandbox, none in code this PR touches.

No automated tests added: the change is a conditional render plus an existing action call, and I could not name a regression it would catch that the flag and placement gates do not make obvious on sight.

A reviewer should check the popover with the flag on and off, on a dashboard and on the project homepage.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, no documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude through PostHog Code. Skills invoked: none, this is a small frontend change with no migration, serializer, or new test.

Two decisions worth flagging. First, the placement gate: `DashboardInsightColorsModal` is only rendered by `DashboardHeader`, which itself only renders for `DashboardPlacement.Dashboard`. The filter bar shows on other placements too, so without the gate the button would open nothing on the project homepage and similar surfaces. Second, the badge count: I chose to count all color overrides as one, not one per pinned value, so a dashboard with a dozen pinned colors does not show a badge of 12.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
