### PR TITLE
fix(insights): await axis-title overlay in chart tests

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlLineGraph.test.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlLineGraph.test.tsx
@@ -338,8 +338,12 @@ describe('SqlLineGraph', () => {
             )
 
             await screen.findByLabelText(/chart with/i)
-            expect(getHogChart().xAxisLabel()).toBe(expectedX)
-            expect(getHogChart().yAxisLabel()).toBe(expectedY)
+            // Axis titles are a layout-dependent overlay that commits a tick after the
+            // chart's aria-label appears, so read them through waitFor rather than synchronously.
+            await waitFor(() => {
+                expect(getHogChart().xAxisLabel()).toBe(expectedX)
+                expect(getHogChart().yAxisLabel()).toBe(expectedY)
+            })
         })
     })
 

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
@@ -231,13 +231,17 @@ describe('TrendsBarChart (ActionsBarValue)', () => {
         })
 
         await screen.findByLabelText(/chart with/i, undefined, { timeout: 5000 })
-        expect(getHogChart().xAxisLabel()).toBe('Total events')
-        expect(getHogChart().yAxisLabel()).toBe('Series')
-        expect(
-            getHogChart()
-                .element.querySelector<SVGTextElement>('[data-attr="hog-chart-axis-title-y"]')
-                ?.getAttribute('transform')
-        ).toContain('rotate(-90')
+        // Axis titles are a layout-dependent overlay that commits a tick after the
+        // chart's aria-label appears, so read them through waitFor rather than synchronously.
+        await waitFor(() => {
+            expect(getHogChart().xAxisLabel()).toBe('Total events')
+            expect(getHogChart().yAxisLabel()).toBe('Series')
+            expect(
+                getHogChart()
+                    .element.querySelector<SVGTextElement>('[data-attr="hog-chart-axis-title-y"]')
+                    ?.getAttribute('transform')
+            ).toContain('rotate(-90')
+        })
     })
 
     // Five hedgehog breakdowns → by default one series carrying five per-bar colors across five


### PR DESCRIPTION
## TL;DR

A couple of chart tests read the axis titles a fraction too early, so they sometimes failed for no reason. Now they wait for the titles to show up.

## Problem

`TrendsBarChart › renders custom axis titles in horizontal aggregated mode` went red on an unrelated PR with `Expected: "Total events" / Received: null`.

The chart's accessible name and its axis titles do not land on the same render. `ariaLabel` is a `useMemo` over props, so `Chart with N data series` is in the DOM immediately. The axis-title overlay needs layout dimensions, which arrive from a `useEffect` a tick later. Reading the titles straight after `findByLabelText(/chart with/i)` therefore races the overlay.

Same flake was already fixed in the sibling `TrendsLineChart` test; the bar-chart and SQL-line-graph copies were missed.

## Changes

Wrap the axis-title reads in `waitFor`, matching the existing `TrendsLineChart` fix:

- `products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx` — the one that actually flaked
- `frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlLineGraph.test.tsx` — same unguarded pattern, not yet observed failing

No coverage change: same assertions, just awaited.

## How did you test this code?

Ran both suites locally: `pnpm exec jest ../products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx ../frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlLineGraph.test.tsx` — 2 suites, 62 tests, all passing.

No manual browser testing; this is a test-only change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while babysitting CI on a set of approved PRs. The bar-chart test failure was traced to the render-ordering race above rather than to the PR it reddened; the fix mirrors commit `ce9cb9f2`, which fixed the identical race in `TrendsLineChart` and left the comment explaining it.

Skills invoked: `/writing-tests` (which routes flake fixes like this one to `/fixing-flaky-tests` — no new coverage, so the value gate does not apply).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
