### PR TITLE
feat(logs): add per-row retention_days field to capture-logs Avro schema

### DIFF
--- a/rust/capture-logs/src/avro_schema.rs
+++ b/rust/capture-logs/src/avro_schema.rs
@@ -90,6 +90,12 @@ pub const AVRO_SCHEMA: &str = r#"
     "name": "bytes_uncompressed",
     "type": ["null", "long"],
     "doc": "Logical content size of the row (sum of byte lengths of string/map fields). Used by drop-rule accounting; does not include fixed-width numeric or timestamp fields."
+    },
+    {
+    "name": "retention_days",
+    "type": ["null", "int"],
+    "default": null,
+    "doc": "Per-row retention in days, stamped by the Node consumer from team retention rules. Null when unset — ClickHouse then falls back to the batch `retention-days` header. capture-logs always writes null; it does not evaluate team rules."
     }
 ]
 }"#;

--- a/rust/capture-logs/src/endpoints/datadog.rs
+++ b/rust/capture-logs/src/endpoints/datadog.rs
@@ -256,6 +256,7 @@ pub fn datadog_log_to_kafka_row(
         event_name,
         attributes,
         bytes_uncompressed: None,
+        retention_days: None,
     }
     .with_computed_bytes();
     (row, was_overridden)

--- a/rust/capture-logs/src/log_record.rs
+++ b/rust/capture-logs/src/log_record.rs
@@ -39,6 +39,9 @@ pub struct KafkaLogRow {
     pub event_name: String,
     pub attributes: HashMap<String, String>,
     pub bytes_uncompressed: Option<i64>,
+    // Per-row retention in days. capture-logs always writes None — the Node consumer stamps
+    // this from team retention rules. Null lets ClickHouse fall back to the batch header.
+    pub retention_days: Option<i32>,
 }
 
 /// Sum byte lengths of the row's string and map content. Fixed-width fields
@@ -175,6 +178,7 @@ impl KafkaLogRow {
             service_name,
             attributes,
             bytes_uncompressed: None,
+            retention_days: None,
         }
         .with_computed_bytes();
         debug!("log: {:?}", log_row);
@@ -390,6 +394,7 @@ mod tests {
             event_name: "evt".to_string(),
             attributes,
             bytes_uncompressed: None,
+            retention_days: None,
         }
     }
 
@@ -484,6 +489,37 @@ mod tests {
             }
         }
         assert_eq!(found_long, Some(expected));
+    }
+
+    #[test]
+    fn test_retention_days_serialises_into_avro_payload() {
+        use apache_avro::types::Value;
+
+        let mut row = sample_row();
+        row.retention_days = Some(30);
+
+        let schema = Schema::parse_str(AVRO_SCHEMA).expect("schema parses");
+        let mut writer = Writer::with_codec(&schema, Vec::new(), Codec::Null);
+        writer.append_ser(&row).expect("append_ser ok");
+        let payload = writer.into_inner().expect("flush ok");
+
+        let reader = Reader::new(payload.as_slice()).expect("reader ok");
+        let mut found_int: Option<i32> = None;
+        for value in reader {
+            let value = value.expect("decode ok");
+            if let Value::Record(fields) = value {
+                for (name, field_value) in fields {
+                    if name == "retention_days" {
+                        if let Value::Union(_, inner) = field_value {
+                            if let Value::Int(v) = *inner {
+                                found_int = Some(v);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        assert_eq!(found_int, Some(30));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Logs retention is currently a single per-team value (`Team.logs_settings.retention_days` ∈ {14, 30, 90}) stamped as a per-**batch** Kafka header during ingestion. We want retention to be configurable per-**log** via ordered rules, which means retention has to travel per-row through the pipeline rather than once per batch.

This is PR 1 of 5 in that effort — the wire-format foundation.

## Changes

Adds a nullable `retention_days` field to the log Avro schema (`["null","int"]`, default `null`) and the `KafkaLogRow` struct in `capture-logs`. The producer always writes `null` — it doesn't evaluate team rules. The Node ingestion consumer (a later PR) stamps the per-row value; ClickHouse (a later PR) reads it and falls back to the existing batch `retention-days` header when it's null.

Nothing behaves differently yet: every row ships `null`, so ClickHouse keeps using the batch header exactly as today. This PR just makes the field exist on the wire so the later PRs can populate and read it.

## How did you test this code?

I'm an agent (PostHog Code). Automated only:

- `hogli test rust/capture-logs` — 41 crate tests pass, including a new `test_retention_days_serialises_into_avro_payload` that asserts the union encodes into the Avro payload as an int (mirrors the existing `bytes_uncompressed` serialization test).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8), directed by @frankh. First of a 5-PR stack for granular logs retention. The design deliberately ships `retention_days` (not a pre-computed `original_expiry_timestamp`) so the single expiry-arithmetic site stays in the ClickHouse MV, which is already TTL-tested.

**Deploy order matters:** this Rust producer must roll out before the ClickHouse schema PR so the field exists in the stream before ClickHouse declares the column. See the ClickHouse PR for the full ordering + the `input_format_avro_allow_missing_fields` safety net.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
