### PR TITLE
feat(logs): stamp per-row retention from retention rules in ingestion

### DIFF
--- a/nodejs/src/logs/config.ts
+++ b/nodejs/src/logs/config.ts
@@ -61,6 +61,10 @@ export type LogsIngestionConsumerConfig = {
     LOGS_METRICS_RULES_KILLSWITCH: boolean
     /** capture-logs OTLP metrics endpoint (e.g. `http://capture-logs:3308/i/v1/metrics`); empty disables emission. */
     LOGS_METRICS_RULES_EXPORT_URL: string
+    /** Comma-separated team IDs, or `*` for all teams, or empty to disable per-row retention rule evaluation entirely. */
+    LOGS_RETENTION_ENABLED_TEAMS: string
+    /** When `true`, retention rules are never evaluated (rows keep the team default via the batch header). */
+    LOGS_RETENTION_KILLSWITCH: boolean
     /**
      * When `true`, rows removed by drop rules are credited back to the billed usage metrics
      * (`bytes_ingested` / `records_ingested`). When `false` (default), the credit is only
@@ -112,6 +116,9 @@ export function getDefaultLogsIngestionConsumerConfig(): LogsIngestionConsumerCo
         LOGS_METRICS_RULES_ENABLED_TEAMS: isProdEnv() ? '' : '*',
         LOGS_METRICS_RULES_KILLSWITCH: false,
         LOGS_METRICS_RULES_EXPORT_URL: '',
+        // Off in prod until per-team rollout; on in dev for local end-to-end testing.
+        LOGS_RETENTION_ENABLED_TEAMS: isProdEnv() ? '' : '*',
+        LOGS_RETENTION_KILLSWITCH: false,
         LOGS_BILLING_PRORATE_ENABLED: false,
         LOGS_TRANSFORMATIONS_ENABLED_TEAMS: '',
         LOGS_TRANSFORMATIONS_KILLSWITCH: false,

--- a/nodejs/src/logs/log-record-avro.test.ts
+++ b/nodejs/src/logs/log-record-avro.test.ts
@@ -12,6 +12,7 @@ import {
     extractJsonAttributesFromBody,
     flattenJson,
     processLogMessageBuffer,
+    stampRetentionOnLogMessageBuffer,
 } from './log-record-avro'
 
 const LOG_RECORD_SCHEMA = avro.parse(`{
@@ -105,6 +106,12 @@ const LOG_RECORD_SCHEMA = avro.parse(`{
     "name": "bytes_uncompressed",
     "type": ["null", "long"],
     "doc": "Logical content size of the row (sum of byte lengths of string/map fields). Used by drop-rule accounting; does not include fixed-width numeric or timestamp fields."
+    },
+    {
+    "name": "retention_days",
+    "type": ["null", "int"],
+    "default": null,
+    "doc": "Per-row retention in days, stamped by the consumer from team retention rules."
     }
 ]
 }`)
@@ -216,6 +223,7 @@ describe('log-record-avro', () => {
                     event_name: null,
                     attributes: { key: 'value1' },
                     bytes_uncompressed: 123,
+                    retention_days: null,
                 },
                 {
                     uuid: 'test-uuid-2',
@@ -233,6 +241,7 @@ describe('log-record-avro', () => {
                     event_name: null,
                     attributes: { key: 'value2' },
                     bytes_uncompressed: 456,
+                    retention_days: null,
                 },
             ]
 
@@ -260,6 +269,7 @@ describe('log-record-avro', () => {
                     event_name: null,
                     attributes: null,
                     bytes_uncompressed: null,
+                    retention_days: null,
                 },
             ]
 
@@ -785,6 +795,43 @@ describe('log-record-avro', () => {
             const [_, __, decoded] = await decodeLogRecords(outputBuffer!)
 
             expect(Object.keys(decoded[0]?.attributes || {}).length).toBe(50)
+        })
+    })
+
+    describe('stampRetentionOnLogMessageBuffer', () => {
+        const baseRecord = (overrides: Partial<LogRecord>): LogRecord => ({
+            uuid: 'u',
+            trace_id: null,
+            span_id: null,
+            trace_flags: null,
+            timestamp: 1704067200000000,
+            observed_timestamp: 1704067200000000,
+            body: 'x',
+            severity_text: 'info',
+            severity_number: 9,
+            service_name: 'api',
+            resource_attributes: null,
+            instrumentation_scope: null,
+            event_name: null,
+            attributes: null,
+            bytes_uncompressed: 1,
+            retention_days: null,
+            ...overrides,
+        })
+
+        it('stamps per-record retention from the resolver, falling back to the default', async () => {
+            const records = [baseRecord({ service_name: 'api' }), baseRecord({ service_name: 'billing' })]
+            const inputBuffer = await encodeLogRecords(LOG_RECORD_SCHEMA, 'zstandard', records)
+
+            const { value: outputBuffer } = await stampRetentionOnLogMessageBuffer(
+                inputBuffer,
+                {},
+                (record) => (record.service_name === 'api' ? 90 : null),
+                14
+            )
+            const [_, __, decoded] = await decodeLogRecords(outputBuffer)
+
+            expect(decoded.map((r) => r.retention_days)).toEqual([90, 14])
         })
     })
 })

--- a/nodejs/src/logs/log-record-avro.ts
+++ b/nodejs/src/logs/log-record-avro.ts
@@ -44,6 +44,9 @@ export interface LogRecord {
     event_name: string | null
     attributes: Record<string, string> | null
     bytes_uncompressed?: number | null
+    /** Per-row retention in days, stamped by the consumer from team retention rules. Null/undefined
+     * leaves ClickHouse to fall back to the batch `retention-days` header (the team default). */
+    retention_days?: number | null
 }
 
 export async function decodeLogRecords(buffer: Buffer): Promise<[avro.Type | undefined, string, LogRecord[]]> {
@@ -368,3 +371,27 @@ export const processLogMessageBuffer = instrumented({
     onRecordsDecoded?: (records: LogRecord[]) => void,
     recordsTransform?: LogRecordsTransform
 ) => Promise<{ value: Buffer | null; pii: PiiScrubStats }>
+
+/**
+ * Decode → optional PII scrub / JSON enrich → stamp per-row `retention_days` → encode.
+ * Used on the retention-only path (retention rules exist but no head sampling): unlike
+ * `processLogMessageBuffer` it always decodes, since retention must be resolved per record.
+ * Each record's retention is `resolveRetentionDays(record) ?? defaultRetentionDays`.
+ */
+export async function stampRetentionOnLogMessageBuffer(
+    buffer: Buffer,
+    settings: LogsSettings,
+    resolveRetentionDays: (record: LogRecord) => number | null,
+    defaultRetentionDays: number
+): Promise<{ value: Buffer; pii: PiiScrubStats }> {
+    const [logRecordType, compressionCodec, records] = await decodeLogRecordsInstrumented(buffer)
+    if (!logRecordType) {
+        throw new Error('avro schema metadata not found')
+    }
+    const pii = await transformDecodedLogRecordsInPlace(records, settings)
+    for (const record of records) {
+        record.retention_days = resolveRetentionDays(record) ?? defaultRetentionDays
+    }
+    const value = await encodeLogRecordsInstrumented(logRecordType, compressionCodec, records)
+    return { value, pii }
+}

--- a/nodejs/src/logs/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.ts
@@ -26,13 +26,21 @@ import {
     recordLogsReceived,
 } from './ingestion-otel-metrics'
 import { type PiiScrubStats } from './log-pii-scrub'
-import { type LogRecord, type LogRecordsTransform, processLogMessageBuffer } from './log-record-avro'
+import {
+    type LogRecord,
+    type LogRecordsTransform,
+    processLogMessageBuffer,
+    stampRetentionOnLogMessageBuffer,
+} from './log-record-avro'
 import type { CompiledMetricRule } from './metrics-rules/compile-metric-rules'
 import { MetricRulesCache } from './metrics-rules/metric-rules-cache'
 import { LogsMetricsEmitter } from './metrics-rules/metrics-emitter'
 import { buildMetricRulesOtlpPayload } from './metrics-rules/otlp-payload'
 import { type BatchTallies, createBatchTallies, tallyRecords } from './metrics-rules/tally'
 import { LOGS_DLQ_OUTPUT, LOGS_OUTPUT, LogsDlqOutput, LogsOutput } from './outputs/outputs'
+import type { CompiledRetentionRuleSet } from './retention/evaluate-retention'
+import { safeEvaluateRetentionDays } from './retention/evaluate-retention'
+import { RetentionRulesCache } from './retention/retention-rules-cache'
 import type { CompiledRuleSet } from './sampling/evaluate'
 import { LogsSamplingService } from './sampling/logs-sampling.service'
 import { SamplingRulesCache } from './sampling/sampling-rules-cache'
@@ -51,6 +59,8 @@ export interface LogsIngestionConsumerDeps {
     metricsEmitter?: LogsMetricsEmitter
     /** When set, enabled teams run hog log transformations after the built-in processing. */
     logsTransformer?: LogsTransformerService
+    /** When set, enabled teams stamp per-row retention from retention rules before produce. */
+    retentionRulesCache?: RetentionRulesCache
     /**
      * Resolved outputs registry — must include `LOGS_OUTPUT`, `LOGS_DLQ_OUTPUT`,
      * and `APP_METRICS_OUTPUT`. The producer + topic for each is wired by the
@@ -274,6 +284,8 @@ export class LogsIngestionConsumer {
     private samplingService: LogsSamplingService
     private readonly samplingEnabledTeamsRaw: string
     private readonly samplingKillswitch: boolean
+    private readonly retentionEnabledTeamsRaw: string
+    private readonly retentionKillswitch: boolean
     private readonly billingProrateEnabled: boolean
     private readonly metricRulesEnabledTeamsRaw: string
     private readonly metricRulesKillswitch: boolean
@@ -321,6 +333,8 @@ export class LogsIngestionConsumer {
         this.samplingService = new LogsSamplingService(this.redis, mergedConfig.LOGS_LIMITER_TTL_SECONDS)
         this.samplingEnabledTeamsRaw = mergedConfig.LOGS_SAMPLING_ENABLED_TEAMS
         this.samplingKillswitch = mergedConfig.LOGS_SAMPLING_KILLSWITCH
+        this.retentionEnabledTeamsRaw = mergedConfig.LOGS_RETENTION_ENABLED_TEAMS
+        this.retentionKillswitch = mergedConfig.LOGS_RETENTION_KILLSWITCH
         this.billingProrateEnabled = mergedConfig.LOGS_BILLING_PRORATE_ENABLED
         this.metricRulesEnabledTeamsRaw = mergedConfig.LOGS_METRICS_RULES_ENABLED_TEAMS
         this.metricRulesKillswitch = mergedConfig.LOGS_METRICS_RULES_KILLSWITCH
@@ -347,6 +361,13 @@ export class LogsIngestionConsumer {
             return false
         }
         return teamIdMatchesCsv(this.transformationsEnabledTeamsRaw, teamId)
+    }
+
+    private isRetentionEvalEnabledForTeam(teamId: number): boolean {
+        if (this.retentionKillswitch) {
+            return false
+        }
+        return teamIdMatchesCsv(this.retentionEnabledTeamsRaw, teamId)
     }
 
     /**
@@ -409,6 +430,26 @@ export class LogsIngestionConsumer {
         const useSamplingPipeline = Boolean(ruleSet && ruleSet.rules.length > 0)
         const recordsTransform = await this.buildRecordsTransform(message, batchBudget)
 
+        // Per-row retention: resolve the team's retention rules when enabled. When any rule exists we
+        // stamp `retention_days` per record (falling back to the team default); ClickHouse then reads
+        // the per-row value. With no rules we leave it unset and the batch `retention-days` header —
+        // still emitted below — carries the team default, preserving the fast passthrough path.
+        const retentionCache = this.deps.retentionRulesCache
+        const retentionEvalEnabled = this.isRetentionEvalEnabledForTeam(message.teamId)
+        let retentionRuleSet: CompiledRetentionRuleSet | null = null
+        if (retentionCache && retentionEvalEnabled) {
+            retentionRuleSet = await retentionCache.getCompiledRuleSet(message.teamId)
+        }
+        const useRetention = Boolean(retentionRuleSet && retentionRuleSet.rules.length > 0)
+        const defaultRetentionDays = logsSettings.retention_days ?? DEFAULT_LOGS_RETENTION_DAYS
+        const retention = useRetention
+            ? {
+                  resolveRetentionDays: (record: LogRecord): number | null =>
+                      safeEvaluateRetentionDays(retentionRuleSet, record, message.teamId),
+                  defaultRetentionDays,
+              }
+            : undefined
+
         trace.getActiveSpan()?.setAttributes({
             'logs.sampling.killswitch': this.samplingKillswitch,
             'logs.sampling.enabled_teams_configured': Boolean((this.samplingEnabledTeamsRaw || '').trim()),
@@ -417,9 +458,15 @@ export class LogsIngestionConsumer {
             'logs.sampling.eval_enabled_for_team': samplingEvalEnabled,
             'logs.sampling.compiled_rule_count': ruleSet?.rules.length ?? 0,
             'logs.transformations.enabled_for_team': Boolean(recordsTransform),
+            'logs.retention.cache_present': Boolean(retentionCache),
+            'logs.retention.eval_enabled_for_team': retentionEvalEnabled,
+            'logs.retention.compiled_rule_count': retentionRuleSet?.rules.length ?? 0,
+            'logs.retention.use_retention': useRetention,
             'logs.sampling.pipeline': useSamplingPipeline
                 ? 'decode_sample_encode'
-                : 'passthrough_processLogMessageBuffer',
+                : useRetention
+                  ? 'decode_stamp_retention_encode'
+                  : 'passthrough_processLogMessageBuffer',
         })
 
         if (useSamplingPipeline && ruleSet) {
@@ -430,7 +477,8 @@ export class LogsIngestionConsumer {
                 message.teamId,
                 message.bytesUncompressed,
                 onRecordsDecoded,
-                recordsTransform
+                recordsTransform,
+                retention
             )
             if (sampled.recordsDropped > 0) {
                 logsSamplingRecordsDroppedCounter.inc({ team_id: message.teamId.toString() }, sampled.recordsDropped)
@@ -465,12 +513,45 @@ export class LogsIngestionConsumer {
             }
         }
 
-        // Passthrough (sampling disabled / no rules): drop rules removed nothing, so nothing to credit.
+        // Retention-only fast path: retention rules exist but there's no head sampling, no hog
+        // transform, and no metric-rule visitor. Decode once to stamp per-row retention, then encode.
+        if (retention && !recordsTransform && !onRecordsDecoded) {
+            const res = await stampRetentionOnLogMessageBuffer(
+                message.message.value!,
+                logsSettings,
+                retention.resolveRetentionDays,
+                retention.defaultRetentionDays
+            )
+            return {
+                outcome: 'produce',
+                processedValue: res.value,
+                pii: res.pii,
+                recordsDropped: 0,
+                recordsDroppedByRuleId: new Map(),
+                bytesDroppedByRuleId: new Map(),
+                contentBytesDropped: 0,
+                contentBytesTotal: 0,
+            }
+        }
+
+        // General non-sampling path (transformations and/or metric extraction, optionally with
+        // retention). Fold retention into the transform chain so it stamps survivors after any hog
+        // transform (which may drop records). Passthrough when nothing forces a decode.
+        const nonSamplingTransform: LogRecordsTransform | undefined = retention
+            ? async (records) => {
+                  if (recordsTransform) {
+                      await recordsTransform(records)
+                  }
+                  for (const record of records) {
+                      record.retention_days = retention.resolveRetentionDays(record) ?? retention.defaultRetentionDays
+                  }
+              }
+            : recordsTransform
         const res = await processLogMessageBuffer(
             message.message.value!,
             logsSettings,
             onRecordsDecoded,
-            recordsTransform
+            nonSamplingTransform
         )
         if (res.value === null) {
             return {

--- a/nodejs/src/logs/retention/compile-retention-rules.ts
+++ b/nodejs/src/logs/retention/compile-retention-rules.ts
@@ -1,0 +1,40 @@
+import { parseFilterGroup } from '../sampling/compile-rules'
+import { type CompiledRetentionRule, type CompiledRetentionRuleSet, VALID_RETENTION_DAYS } from './evaluate-retention'
+
+/**
+ * Defensive cap on enabled retention rules compiled (and thus scanned per record) for one team.
+ * `evaluateRetentionDays` runs O(rules × filter-nodes) for every log line on the shared ingestion
+ * worker, so an unbounded rule set is a cross-team DoS vector. The fetch also applies this as a SQL
+ * `LIMIT`; keeping first-match order (priority ASC, created_at ASC) means the cap keeps the
+ * highest-priority rules. This is a worker-protection backstop independent of any product-facing
+ * maximum the API may enforce at write time.
+ */
+export const MAX_ENABLED_RETENTION_RULES = 100
+
+export type RetentionRuleRow = {
+    id: string
+    config: Record<string, unknown>
+    /** Row version from DB; used by the cache watermark only, ignored by compileRetentionRuleSet. */
+    version?: number
+}
+
+export function compileRetentionRuleSet(rows: RetentionRuleRow[]): CompiledRetentionRuleSet {
+    const rules: CompiledRetentionRule[] = []
+    for (const row of rows.slice(0, MAX_ENABLED_RETENTION_RULES)) {
+        const config = row.config ?? {}
+        const retentionDays = config.retention_days
+        // Skip rows the API validator would have rejected — robustness against legacy or
+        // hand-crafted rows. A `true` boolean is not accepted (typeof true === 'boolean').
+        if (typeof retentionDays !== 'number' || !Number.isInteger(retentionDays)) {
+            continue
+        }
+        if (!VALID_RETENTION_DAYS.has(retentionDays)) {
+            continue
+        }
+        // parseFilterGroup bounds depth/breadth and pre-compiles regex leaves; returns null for
+        // a missing/malformed group, which evaluateRetentionDays treats as match-nothing.
+        const filterGroup = parseFilterGroup(config.filter_group)
+        rules.push({ id: row.id, filterGroup, retentionDays })
+    }
+    return { rules }
+}

--- a/nodejs/src/logs/retention/evaluate-retention.test.ts
+++ b/nodejs/src/logs/retention/evaluate-retention.test.ts
@@ -1,0 +1,80 @@
+import type { LogRecord } from '~/logs/log-record-avro'
+
+import { MAX_ENABLED_RETENTION_RULES, compileRetentionRuleSet } from './compile-retention-rules'
+import { evaluateRetentionDays, safeEvaluateRetentionDays } from './evaluate-retention'
+
+describe('logs retention rules', () => {
+    const record = (overrides: Partial<LogRecord> = {}): LogRecord => ({
+        uuid: null,
+        trace_id: null,
+        span_id: null,
+        trace_flags: null,
+        timestamp: null,
+        observed_timestamp: null,
+        body: 'x',
+        severity_text: 'info',
+        severity_number: 9,
+        service_name: 'api',
+        resource_attributes: null,
+        instrumentation_scope: null,
+        event_name: null,
+        attributes: null,
+        ...overrides,
+    })
+
+    const serviceRule = (id: string, service: string, retentionDays: number) => ({
+        id,
+        config: {
+            retention_days: retentionDays,
+            filter_group: {
+                type: 'AND',
+                values: [
+                    {
+                        type: 'AND',
+                        values: [
+                            { key: 'service.name', type: 'log_resource_attribute', operator: 'exact', value: service },
+                        ],
+                    },
+                ],
+            },
+        },
+    })
+
+    it('returns the first matching rule in priority order', () => {
+        // Rows arrive pre-ordered by priority; a later rule also matching must not win.
+        const ruleSet = compileRetentionRuleSet([serviceRule('a', 'api', 90), serviceRule('b', 'api', 30)])
+        expect(evaluateRetentionDays(ruleSet, record({ service_name: 'api' }))).toBe(90)
+    })
+
+    it('returns null when no rule matches so the caller applies the team default', () => {
+        const ruleSet = compileRetentionRuleSet([serviceRule('a', 'billing', 90)])
+        expect(evaluateRetentionDays(ruleSet, record({ service_name: 'api' }))).toBeNull()
+    })
+
+    it('drops rows whose retention_days is not an allowed tier', () => {
+        const ruleSet = compileRetentionRuleSet([serviceRule('a', 'api', 45), serviceRule('b', 'api', 30)])
+        expect(ruleSet.rules).toHaveLength(1)
+        expect(evaluateRetentionDays(ruleSet, record({ service_name: 'api' }))).toBe(30)
+    })
+
+    it('ignores a rule with a missing filter_group (matches nothing)', () => {
+        const ruleSet = compileRetentionRuleSet([{ id: 'a', config: { retention_days: 30 } }])
+        expect(evaluateRetentionDays(ruleSet, record({ service_name: 'api' }))).toBeNull()
+    })
+
+    it('caps compiled rules at MAX_ENABLED_RETENTION_RULES to bound per-record work', () => {
+        const rows = Array.from({ length: MAX_ENABLED_RETENTION_RULES + 50 }, (_, i) =>
+            serviceRule(`r${i}`, `svc${i}`, 30)
+        )
+        expect(compileRetentionRuleSet(rows).rules).toHaveLength(MAX_ENABLED_RETENTION_RULES)
+    })
+
+    it('fails open to null when evaluation throws', () => {
+        const poisoned = { rules: [{ id: 'a', retentionDays: 30, filterGroup: {} as any }] }
+        const spy = jest.spyOn(require('../sampling/filter-group-match'), 'matchFilterGroup').mockImplementation(() => {
+            throw new Error('boom')
+        })
+        expect(safeEvaluateRetentionDays(poisoned as any, record(), 1)).toBeNull()
+        spy.mockRestore()
+    })
+})

--- a/nodejs/src/logs/retention/evaluate-retention.ts
+++ b/nodejs/src/logs/retention/evaluate-retention.ts
@@ -1,0 +1,68 @@
+import { Counter } from 'prom-client'
+
+import { logger } from '~/common/utils/logger'
+import type { LogRecord } from '~/logs/log-record-avro'
+
+import { type FilterGroupNode, matchFilterGroup } from '../sampling/filter-group-match'
+
+/**
+ * Retention tiers a rule may assign. Kept in sync with `VALID_RETENTION_DAYS` in
+ * `products/logs/backend/presentation/views/retention_api.py` (write-time validation) and
+ * `RETENTION_USAGE_TIERS` in `logs-ingestion-consumer.ts`. Rows outside these tiers are
+ * dropped at compile time so a hand-crafted or legacy row can't stamp an arbitrary value.
+ */
+export const VALID_RETENTION_DAYS = new Set([14, 30, 90])
+
+export type CompiledRetentionRule = {
+    id: string
+    /** Selector for the logs this rule applies to. A rule with a null group matches nothing. */
+    filterGroup: FilterGroupNode | null
+    retentionDays: number
+}
+
+export type CompiledRetentionRuleSet = {
+    rules: CompiledRetentionRule[]
+}
+
+/**
+ * Incremented when a per-record retention evaluation throws. The record falls back to the
+ * team default (fail-open) so a malformed rule can never break ingestion, but the counter
+ * makes the silent failure observable.
+ */
+export const logsRetentionEvalErrorCounter = new Counter({
+    name: 'logs_ingestion_retention_eval_error_total',
+    help: 'Per-record retention evaluation threw an exception; record fell back to the team default (fail-open).',
+    labelNames: ['team_id'],
+})
+
+/**
+ * First matching rule (rules are pre-ordered by priority ASC, created_at ASC) sets the
+ * record's retention. Returns null when no rule matches — the caller then applies the team
+ * default. A rule with a null filterGroup matches nothing: never silently override retention
+ * for all traffic (the API requires an explicit filter_group).
+ */
+export function evaluateRetentionDays(ruleSet: CompiledRetentionRuleSet | null, record: LogRecord): number | null {
+    if (!ruleSet || ruleSet.rules.length === 0) {
+        return null
+    }
+    for (const rule of ruleSet.rules) {
+        if (rule.filterGroup && matchFilterGroup(rule.filterGroup, record)) {
+            return rule.retentionDays
+        }
+    }
+    return null
+}
+
+export function safeEvaluateRetentionDays(
+    ruleSet: CompiledRetentionRuleSet | null,
+    record: LogRecord,
+    teamId: number
+): number | null {
+    try {
+        return evaluateRetentionDays(ruleSet, record)
+    } catch (err) {
+        logsRetentionEvalErrorCounter.inc({ team_id: String(teamId) })
+        logger.warn('[logs-retention] evaluateRetentionDays threw — falling back to team default', { teamId, err })
+        return null
+    }
+}

--- a/nodejs/src/logs/retention/retention-rules-cache.test.ts
+++ b/nodejs/src/logs/retention/retention-rules-cache.test.ts
@@ -1,0 +1,43 @@
+import { PostgresRouter } from '~/common/utils/db/postgres'
+
+import { RetentionRulesCache } from './retention-rules-cache'
+
+describe('RetentionRulesCache', () => {
+    let query: jest.Mock
+    let cache: RetentionRulesCache
+
+    const rows = (retentionDays: number): { rows: { id: string; config: unknown; version: string }[] } => ({
+        rows: [{ id: 'r1', config: { retention_days: retentionDays }, version: '1' }],
+    })
+
+    beforeEach(() => {
+        query = jest.fn()
+        cache = new RetentionRulesCache({ query } as unknown as PostgresRouter)
+    })
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
+
+    it('compiles rules fetched from Postgres', async () => {
+        query.mockResolvedValueOnce(rows(30))
+        const compiled = await cache.getCompiledRuleSet(1)
+        expect(compiled.rules).toEqual([{ id: 'r1', filterGroup: null, retentionDays: 30 }])
+    })
+
+    it('fails open to no rules when the fetch throws and nothing is cached', async () => {
+        query.mockRejectedValueOnce(new Error('pg down'))
+        const compiled = await cache.getCompiledRuleSet(1)
+        expect(compiled.rules).toEqual([])
+    })
+
+    it('serves the last-known rules when a later refresh throws', async () => {
+        query.mockResolvedValueOnce(rows(30))
+        await cache.getCompiledRuleSet(1)
+
+        jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 60_000)
+        query.mockRejectedValueOnce(new Error('pg down'))
+        const stale = await cache.getCompiledRuleSet(1)
+        expect(stale.rules).toEqual([{ id: 'r1', filterGroup: null, retentionDays: 30 }])
+    })
+})

--- a/nodejs/src/logs/retention/retention-rules-cache.ts
+++ b/nodejs/src/logs/retention/retention-rules-cache.ts
@@ -1,0 +1,97 @@
+import { trace } from '@opentelemetry/api'
+
+import { instrumentFn } from '~/common/tracing/tracing-utils'
+import { PostgresRouter, PostgresUse } from '~/common/utils/db/postgres'
+import { logger } from '~/common/utils/logger'
+
+import { MAX_ENABLED_RETENTION_RULES, type RetentionRuleRow, compileRetentionRuleSet } from './compile-retention-rules'
+import type { CompiledRetentionRuleSet } from './evaluate-retention'
+
+const REFRESH_MS = 30_000
+
+const retentionCacheInstrumentOpts = { measureTime: false, sendException: false } as const
+
+type CacheEntry = {
+    compiled: CompiledRetentionRuleSet
+    versionWatermark: number
+    fetchedAtMs: number
+}
+
+export class RetentionRulesCache {
+    private cache = new Map<number, CacheEntry>()
+
+    constructor(private postgres: PostgresRouter) {}
+
+    public async getCompiledRuleSet(teamId: number): Promise<CompiledRetentionRuleSet> {
+        return instrumentFn(
+            {
+                key: 'logsIngestion.retention.getCompiledRuleSet',
+                ...retentionCacheInstrumentOpts,
+                getLoggingContext: () => ({ team_id: teamId }),
+            },
+            async () => {
+                const now = Date.now()
+                const existing = this.cache.get(teamId)
+                if (existing && now - existing.fetchedAtMs < REFRESH_MS) {
+                    trace.getActiveSpan()?.setAttributes({
+                        'logs.retention.cache_hit': true,
+                        'logs.retention.rule_count': existing.compiled.rules.length,
+                        'logs.retention.version_watermark': existing.versionWatermark,
+                    })
+                    return existing.compiled
+                }
+                let rows: RetentionRuleRow[]
+                try {
+                    rows = await this.fetchRules(teamId)
+                } catch (error) {
+                    // Fail open: this runs in the ingestion hot path, so a rules-fetch failure
+                    // (e.g. a Postgres blip) must never propagate and DLQ otherwise-valid logs.
+                    // Serve the last-known compiled rules when we have them; otherwise fall back to
+                    // no rules so the caller applies the team default via the batch `retention-days`
+                    // header. The stale `fetchedAtMs` means the next message retries the fetch.
+                    logger.warn('[logs-retention] rules fetch failed — falling back', {
+                        teamId,
+                        error: String(error),
+                    })
+                    trace.getActiveSpan()?.setAttributes({
+                        'logs.retention.fetch_failed': true,
+                        'logs.retention.served_stale': Boolean(existing),
+                    })
+                    return existing?.compiled ?? compileRetentionRuleSet([])
+                }
+                const compiled = compileRetentionRuleSet(rows)
+                const vw = rows.reduce((m, r) => Math.max(m, r.version ?? 0), 0)
+                this.cache.set(teamId, { compiled, versionWatermark: vw, fetchedAtMs: now })
+                trace.getActiveSpan()?.setAttributes({
+                    'logs.retention.cache_hit': false,
+                    'logs.retention.db_row_count': rows.length,
+                    'logs.retention.rule_count': compiled.rules.length,
+                    'logs.retention.version_watermark': vw,
+                })
+                return compiled
+            }
+        )
+    }
+
+    private async fetchRules(teamId: number): Promise<RetentionRuleRow[]> {
+        const res = await this.postgres.query<{
+            id: string
+            config: Record<string, unknown>
+            version: string
+        }>(
+            PostgresUse.COMMON_READ,
+            `SELECT id::text AS id, config, version
+             FROM logs_logsretentionrule
+             WHERE team_id = $1 AND enabled = true
+             ORDER BY priority ASC, created_at ASC
+             LIMIT ${MAX_ENABLED_RETENTION_RULES}`,
+            [teamId],
+            'logs-retention-rules-fetch'
+        )
+        return res.rows.map((r) => ({
+            id: r.id,
+            config: r.config ?? {},
+            version: parseInt(r.version, 10) || 0,
+        }))
+    }
+}

--- a/nodejs/src/logs/sampling/logs-sampling.service.ts
+++ b/nodejs/src/logs/sampling/logs-sampling.service.ts
@@ -119,7 +119,11 @@ export class LogsSamplingService {
         teamId?: number,
         headerBytesUncompressed: number = 0,
         onRecordsDecoded?: (records: LogRecord[]) => void,
-        recordsTransform?: LogRecordsTransform
+        recordsTransform?: LogRecordsTransform,
+        // When set, each surviving record is stamped with a per-row retention resolved from the
+        // team's retention rules (falling back to `defaultRetentionDays`). Folded into this decode
+        // cycle so a team with both sampling and retention rules only decodes/encodes once.
+        retention?: { resolveRetentionDays: (record: LogRecord) => number | null; defaultRetentionDays: number }
     ): Promise<ProcessBufferWithSamplingResult> {
         const [logRecordType, compressionCodec, records] = await decodeLogRecords(buffer)
         if (!logRecordType) {
@@ -236,6 +240,11 @@ export class LogsSamplingService {
                 // Sampling left survivors and the transform removed the rest — attribute
                 // the full-message drop to transformations, not the drop rules.
                 allDroppedBy: keptBeforeTransform > 0 ? 'transformations' : 'sampling',
+            }
+        }
+        if (retention) {
+            for (const record of kept) {
+                record.retention_days = retention.resolveRetentionDays(record) ?? retention.defaultRetentionDays
             }
         }
         const value = await encodeLogRecords(logRecordType, compressionCodec, kept)

--- a/nodejs/src/servers/ingestion-logs-server.ts
+++ b/nodejs/src/servers/ingestion-logs-server.ts
@@ -25,6 +25,7 @@ import {
     getDefaultKafkaWarpstreamLogsProducerEnvConfig,
 } from '~/logs/outputs/producers'
 import { createLogsOutputsRegistry } from '~/logs/outputs/registry'
+import { RetentionRulesCache } from '~/logs/retention/retention-rules-cache'
 import { SamplingRulesCache } from '~/logs/sampling/sampling-rules-cache'
 import { LogsTransformerService } from '~/logs/transformations/logs-transformer.service'
 
@@ -151,6 +152,7 @@ export class IngestionLogsServer implements NodeServer {
         const metricsEmitter = this.config.LOGS_METRICS_RULES_EXPORT_URL
             ? new LogsMetricsEmitter(this.config.LOGS_METRICS_RULES_EXPORT_URL)
             : undefined
+        const retentionRulesCache = new RetentionRulesCache(this.postgres)
 
         // 2. Resolve outputs (topic + producer per logical name, env-controlled)
         const outputs = createLogsOutputsRegistry().build(this.producerRegistry, this.config)
@@ -227,6 +229,7 @@ export class IngestionLogsServer implements NodeServer {
                 metricRulesCache,
                 metricsEmitter,
                 logsTransformer,
+                retentionRulesCache,
             })
             await consumer.start()
             return consumer.service


### PR DESCRIPTION
## Problem

The logs ingestion consumer stamps one `retention-days` header per Kafka batch from the team default. To honor per-log retention rules, it needs to evaluate the rules per record and stamp a per-**row** `retention_days` on the Avro payload.

This is PR 4 of 5. It relies on the Avro field (#73825) and ClickHouse read path (#73826) being live, and reads the rules table from #73827.

## Changes

- `RetentionRulesCache` (30s in-process TTL, reads `logs_logsretentionrule` via `COMMON_READ`) plus a per-record evaluator that returns the first matching rule's tier, reusing the sampling filter-group matcher and compile helpers.
- The consumer stamps `record.retention_days` on each surviving row:
  - **sampling rules present** → the resolver is passed into the existing sampling decode/encode, so a team with both rule kinds still decodes once;
  - **only retention rules present** → a new decode → stamp → encode path (`stampRetentionOnLogMessageBuffer`);
  - **neither** → the fast passthrough is untouched; the batch header still carries the team default.
- Rows matching no rule fall back to the team default. Evaluation fails open (keeps the row, stamps the default) with a `logs_ingestion_retention_eval_error_total` counter.
- Gated by `LOGS_RETENTION_ENABLED_TEAMS` (empty in prod until per-team rollout; `*` in dev) and a killswitch.

## How did you test this code?

I'm an agent (PostHog Code). Automated only:

- `hogli test nodejs/src/logs/retention` — evaluator/compiler unit tests: first-match ordering, no-match → `null`, non-tier rows dropped at compile time, missing filter_group matches nothing, and fail-open on a throwing matcher.
- `hogli test nodejs/src/logs/log-record-avro.test.ts` — new round-trip test asserts `stampRetentionOnLogMessageBuffer` stamps the resolver's value and falls back to the default per record; updated existing round-trip fixtures for the new schema field.
- `hogli test nodejs/src/logs/logs-ingestion-consumer.test.ts` + sampling service — 72 existing tests still pass. TypeScript check clean for the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8), directed by @frankh. Invoked `/writing-tests`.

The core design constraint: retention stamping is a per-row mutation that must ride inside whichever decode already runs, so a team with both sampling and retention rules never decodes twice. When only retention rules exist, a dedicated decode path replaces the fast passthrough for that team (same cost profile as enabling sampling). Deploy after #73826 is live, then enable per-team via the env var.

Known follow-up flagged in code: the per-tier billing usage metrics (`retentionBytesMetricName` / `teamStats.retentionDays`) assume one retention per team-batch and become approximate once a batch mixes tiers.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
