### PR TITLE
fix(logs): stop excludeAttributes shadowing the attributes field

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -692,10 +692,12 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMi
                     "where": self.where(),
                     "live_logs_checkpoint": LIVE_LOGS_CHECKPOINT_QUERY,
                     # Attribute maps dominate payload size. When excluded we still SELECT a column
-                    # (an empty map) so the positional result mapping in _calculate stays stable.
-                    "attributes": parse_expr("map() AS attributes" if self.query.excludeAttributes else "attributes"),
+                    # (an empty map) so the positional result mapping in _calculate stays stable. The
+                    # placeholder must stay unaliased — aliasing it to `attributes`/`resource_attributes`
+                    # would shadow the physical field a WHERE-clause attribute filter needs to resolve.
+                    "attributes": parse_expr("map()" if self.query.excludeAttributes else "attributes"),
                     "resource_attributes": parse_expr(
-                        "map() AS resource_attributes" if self.query.excludeAttributes else "resource_attributes"
+                        "map()" if self.query.excludeAttributes else "resource_attributes"
                     ),
                 },
             )

--- a/products/logs/backend/test/test_exclude_attributes.py
+++ b/products/logs/backend/test/test_exclude_attributes.py
@@ -34,12 +34,12 @@ class TestLogsExcludeAttributes(ClickhouseTestMixin, APIBaseTest):
         sync_execute("TRUNCATE TABLE IF EXISTS logs32")
         super().tearDownClass()
 
-    def _run(self, *, exclude: bool) -> list[dict]:
+    def _run(self, *, exclude: bool, filter_group: dict | None = None) -> list[dict]:
         query = LogsQuery(
             dateRange=DateRange(date_from=DATE_FROM, date_to=DATE_TO),
             serviceNames=["argo-rollouts"],
             severityLevels=[],
-            filterGroup={"type": "AND", "values": []},
+            filterGroup=filter_group or {"type": "AND", "values": []},
             excludeAttributes=exclude,
         )
         return LogsQueryRunner(query, self.team).run().results
@@ -60,3 +60,23 @@ class TestLogsExcludeAttributes(ClickhouseTestMixin, APIBaseTest):
         else:
             self.assertTrue(results[0]["attributes"])
             self.assertEqual(results[0]["resource_attributes"]["service.name"], "argo-rollouts")
+
+    def test_value_filter_with_excluded_attributes(self):
+        # Excluding attributes must not shadow the physical `attributes` field a value-comparison
+        # log_attribute filter resolves against. Before the fix this raised a QueryError (400):
+        # "Cannot access property 'logtag__str' on 'attributes'".
+        filter_group = {
+            "type": "AND",
+            "values": [
+                {
+                    "type": "AND",
+                    "values": [
+                        {"key": "logtag", "operator": "exact", "type": "log_attribute", "value": "F"},
+                    ],
+                }
+            ],
+        }
+        results = self._run(exclude=True, filter_group=filter_group)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["attributes"], {})
+        self.assertEqual(results[0]["resource_attributes"], {})


### PR DESCRIPTION
## Problem

The logs query API (`POST /api/projects/<id>/logs/query/`) returned a 400 on every value-comparison filter over a log attribute (`type: log_attribute`, operator `exact` / `icontains`) whenever `excludeAttributes: true` was set:

```
Cannot access property 'traceId__str' on 'attributes'. This can happen when a column alias shadows a table field. Try renaming the alias.
```

That is exactly the combination the MCP `query-logs` tool produces: its prompt encourages `excludeAttributes: true` to keep result payloads compact, and then it narrows results with an attribute filter. `is_set`, `log_resource_attribute` filters, and the raw SQL equivalent `WHERE attributes['traceId'] = '…'` all worked, so the data was queryable. The filter compilation was the thing breaking.

## Changes

With `excludeAttributes` set, `to_query()` selected `map() AS attributes` (and `map() AS resource_attributes`) to keep the result payload small. That alias shadowed the physical `attributes` table field. A value-comparison `log_attribute` filter compiles to a WHERE reference like `attributes.traceId__str` (the key gets a type suffix so it targets the typed `attributes_map_str` map). During HogQL resolution the `attributes` segment bound to the empty `map()` alias instead of the real column. That alias type has no `get_child`, so resolution raised the `QueryError` above.

The others sidestepped the shadowed field entirely: `is_set` carries no value and is dropped before the WHERE clause, `log_resource_attribute` resolves through the separate `log_attributes` rollup subquery, and raw SQL / the frontend never set `excludeAttributes`.

The fix drops the aliases. Results are mapped positionally in `_calculate`, so the SELECT column name is never read. An unaliased `map()` still holds its position (returning an empty map) without shadowing the field, so the filter resolves against the real column and, under the forced `Workload.LOGS` OPTIMIZED property-groups mode, routes to the physical `attributes_map_str` column and filters correctly.

This also fixes custom columns that reference `attributes.<key>` while `excludeAttributes` is set, which hit the same shadow today.

```diff
- "attributes": parse_expr("map() AS attributes" if self.query.excludeAttributes else "attributes"),
- "resource_attributes": parse_expr(
-     "map() AS resource_attributes" if self.query.excludeAttributes else "resource_attributes"
- ),
+ "attributes": parse_expr("map()" if self.query.excludeAttributes else "attributes"),
+ "resource_attributes": parse_expr(
+     "map()" if self.query.excludeAttributes else "resource_attributes"
+ ),
```

## How did you test this code?

Added one regression case to `test_exclude_attributes.py`: `excludeAttributes=True` combined with an `exact` `log_attribute` filter on a key present in the fixture. It asserts the query returns the matching row with empty attribute maps. No existing test covered `excludeAttributes` together with an active attribute filter (the existing exclude tests use an empty `filterGroup`, and the property-groups regression test never sets `excludeAttributes`).

I verified both directions: the new test passes with the fix and fails with the exact reported `QueryError` when the fix is reverted. The existing `test_log_attribute_filter_resolves_regardless_of_property_groups_mode` (both params) still passes. `ruff check` / `format` are clean. I did not run the fix against a live cluster.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (actually Claude, PostHog Code) traced this from the reported error text. Two parallel exploration passes converged on the shadowing mechanism in `LogsQueryRunner.to_query()`; I confirmed it by reverting the fix and reproducing the exact `QueryError` in the new test. Invoked the `/writing-tests` skill before adding the regression case. Considered a broader HogQL-scoping fix (WHERE binding to SELECT aliases) but rejected it as too risky and out of scope for a targeted bug fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
