### PR TITLE
feat(observability): correlate OTLP-shipped logs with the active trace

### DIFF
--- a/posthog/otel_logs.py
+++ b/posthog/otel_logs.py
@@ -140,12 +140,13 @@ def otel_log_mirror_processor(
         # service.name filter would miss it.
         _ensure_provider(service_name)
 
+        from opentelemetry import trace  # noqa: PLC0415
         from opentelemetry.sdk._logs import LogRecord  # noqa: PLC0415
         from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
         from opentelemetry.trace import TraceFlags  # noqa: PLC0415
 
         resource = Resource.create({"service.name": service_name})
-        trace_flags = TraceFlags(TraceFlags.DEFAULT)
+        default_trace_flags = TraceFlags(TraceFlags.DEFAULT)
     except Exception:
         # Telemetry setup must never break worker startup; degrade to a no-op.
         return _passthrough
@@ -169,13 +170,20 @@ def otel_log_mirror_processor(
             attributes = _scalar_attributes(event_dict, allowlist)
             attributes.update(_exception_type(event_dict))
             timestamp = time.time_ns()
-            # Zero trace/span ids: the OTLP encoder serializes them as bytes and crashes on the default None.
+            # Correlate the record with the active trace (parented off the incoming traceparent) when one
+            # is in scope. Fall back to 0, never None: the OTLP encoder serializes these as bytes and
+            # crashes on None, and it treats 0 as "unset" so an uncorrelated record still ships cleanly.
+            span_context = trace.get_current_span().get_span_context()
+            if span_context.is_valid:
+                trace_id, span_id, trace_flags = span_context.trace_id, span_context.span_id, span_context.trace_flags
+            else:
+                trace_id, span_id, trace_flags = 0, 0, default_trace_flags
             provider.get_logger(service_name, version="1").emit(
                 LogRecord(
                     timestamp=timestamp,
                     observed_timestamp=timestamp,
-                    trace_id=0,
-                    span_id=0,
+                    trace_id=trace_id,
+                    span_id=span_id,
                     trace_flags=trace_flags,
                     severity_text=severity_text,
                     severity_number=severity_number,

--- a/posthog/test/test_otel_logs.py
+++ b/posthog/test/test_otel_logs.py
@@ -5,10 +5,15 @@ from unittest import mock
 
 from django.test import SimpleTestCase, override_settings
 
+from opentelemetry import (
+    context as otel_context,
+    trace,
+)
 from opentelemetry._logs import SeverityNumber
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import InMemoryLogExporter, SimpleLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 from parameterized import parameterized
 
 from posthog import otel_logs
@@ -57,6 +62,27 @@ class TestOtelLogMirror(SimpleTestCase):
         assert "response_preview" not in record.attributes
         assert record.attributes["logger"] == f"{_PREFIX}.activities.call_scanner_provider"
         assert record.resource.attributes["service.name"] == "replay-vision"
+
+    def test_ships_trace_and_span_ids_from_active_span(self) -> None:
+        span_context = SpanContext(
+            trace_id=0x4BF92F3577B34DA6A3CE929D0E0E4736,
+            span_id=0x00F067AA0BA902B7,
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        token = otel_context.attach(trace.set_span_in_context(NonRecordingSpan(span_context)))
+        try:
+            records = self._run({"event": "x", "logger": f"{_PREFIX}.x"})
+        finally:
+            otel_context.detach(token)
+        assert records[0].trace_id == 0x4BF92F3577B34DA6A3CE929D0E0E4736
+        assert records[0].span_id == 0x00F067AA0BA902B7
+        assert records[0].trace_flags == TraceFlags.SAMPLED
+
+    def test_trace_and_span_ids_default_to_zero_without_active_span(self) -> None:
+        records = self._run({"event": "x", "logger": f"{_PREFIX}.x"})
+        assert records[0].trace_id == 0
+        assert records[0].span_id == 0
 
     def test_ignores_loggers_outside_the_prefix(self) -> None:
         records = self._run({"event": "shutting down", "logger": "temporalio.worker"})


### PR DESCRIPTION
## Problem

The OTLP log mirror in `posthog/otel_logs.py` hardcoded `trace_id=0` / `span_id=0` on every `LogRecord` it shipped into the Logs product (the `0` was there only because the OTLP encoder crashes on the default `None`). So a shipped log record carried no link to its distributed trace, and you couldn't jump from a log line to the trace it came from.

This is the mirror used by the Replay Vision Temporal pipeline (`build_vision_log_mirror`), gated on `OTLP_LOGS_INGEST_*`.

## Changes

Read the active OTel span at emit time and set the record's native `trace_id` / `span_id` / `trace_flags` from its span context. That span is parented off the incoming `traceparent` (Envoy → OTel W3C propagation) when one exists, so the shipped record now correlates with the real distributed trace.

When no valid span is in scope, fall back to `0` (never `None`): the encoder treats `0` as "unset", so an uncorrelated record still ships cleanly.

The ids go on the record's native trace fields, not the log body or attributes. Nothing is added to the rendered log string.

```diff
-            # Zero trace/span ids: the OTLP encoder serializes them as bytes and crashes on the default None.
+            span_context = trace.get_current_span().get_span_context()
+            if span_context.is_valid:
+                trace_id, span_id, trace_flags = span_context.trace_id, span_context.span_id, span_context.trace_flags
+            else:
+                trace_id, span_id, trace_flags = 0, 0, default_trace_flags
             provider.get_logger(service_name, version="1").emit(
                 LogRecord(
                     ...
-                    trace_id=0,
-                    span_id=0,
+                    trace_id=trace_id,
+                    span_id=span_id,
                     trace_flags=trace_flags,
```

> [!NOTE]
> Correlation only lands when an OTel span is actually active in the emitting context. The `is_valid` guard keeps this a clean no-op (ids stay `0`) when the mirror runs somewhere without a span, so nothing regresses.

## How did you test this code?

Automated tests only, in `posthog/test/test_otel_logs.py`, extending the existing `InMemoryLogExporter` harness so they assert against the real emitted `LogRecord`:

- `test_ships_trace_and_span_ids_from_active_span` — attaches a known span context and asserts the record's `trace_id` / `span_id` / `trace_flags` match. Catches a regression back to the hardcoded `0`, or swapped/mis-read ids.
- `test_trace_and_span_ids_default_to_zero_without_active_span` — asserts the record ships with `0`/`0` when no span is active. Catches removal of the `is_valid` fallback (which would ship a bogus id or crash the encoder).

```
hogli test posthog/test/test_otel_logs.py
# 17 passed
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank drove this; I (Claude via PostHog Code) implemented it. The request started as "make the Django middleware assign trace ids from the Envoy `traceparent`". Investigation showed the middleware's request logs already ship as stdout JSON and OTel already extracts `traceparent` for its spans - the real gap was that the OTLP-shipped log records zeroed out their trace ids. An earlier revision of this branch instead bound `trace_id`/`span_id` as extra fields on the JSON log line; we dropped that in favor of populating the OTLP record's native trace fields, which is where trace-log correlation actually belongs.

Skills invoked: `/writing-tests` (to gate the test additions).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
