### PR TITLE
fix(uptimerobot): stop tracking exhausted 429/5xx retries as exceptions

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/source.py
@@ -89,6 +89,12 @@ Use your account's **read-only API key**, created under [Integrations & API](htt
             AUTH_ERROR_PREFIX: "Your UptimeRobot API key is invalid or has been revoked. Create a new read-only API key under Integrations & API in your UptimeRobot dashboard, then reconnect.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # 429/5xx are already retried internally with backoff (see uptimerobot.py's tenacity-wrapped
+        # _post); if those retries still exhaust, the failure is transient and self-recovering, so
+        # let Temporal retry the activity without surfacing it as tracked exception noise.
+        return {"UptimeRobot API error (retryable)"}
+
     def get_schemas(
         self,
         config: UptimerobotSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/tests/test_uptimerobot_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/tests/test_uptimerobot_source.py
@@ -67,6 +67,20 @@ class TestUptimerobotSource:
         non_retryable_errors = self.source.get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
 
+    @pytest.mark.parametrize(
+        "error_message",
+        [
+            "UptimeRobot API error (retryable): status=429, method=getMonitors",
+            "UptimeRobot API error (retryable): status=500, method=getMonitors",
+            "UptimeRobot API error (retryable): status=503, method=getAlertContacts",
+        ],
+    )
+    def test_retryable_errors_match_exhausted_backoff(self, error_message):
+        # _post already retries 429/5xx internally with backoff; once those attempts are
+        # exhausted, this must stay classified as retryable so it doesn't get tracked as noise.
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(pattern in error_message for pattern in retryable_errors)
+
     def test_get_schemas_match_endpoints_with_correct_sync_modes(self):
         schemas = {schema.name: schema for schema in self.source.get_schemas(self.config, self.team_id)}
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a `UptimeRobotRetryableError` ("UptimeRobot API error (retryable): status=500, method=getMonitors") for the UptimeRobot data warehouse source. The stack trace confirms it originates in `_post` in [`uptimerobot.py`](products/warehouse_sources/backend/temporal/data_imports/sources/uptimerobot/uptimerobot.py), called via `get_rows` during a sync.

`_post` already retries 429/5xx responses internally with backoff (`tenacity`, up to 5 attempts). Once those in-process retries are exhausted, the error re-raises out of the activity, and Temporal's own activity retry policy retries the whole sync on its next scheduled attempt — the failure is transient and self-recovering on UptimeRobot's side, not a bug in our code or a customer credential/config problem.

The source didn't override `get_retryable_errors()`, so this exhausted-retry error fell through to the default "log at `exception` level and re-raise" path in `import_data_sync.py`, which is what surfaces it in error tracking as noise rather than a benign warning.

## Changes

Add `get_retryable_errors()` to `UptimerobotSource`, matching on the stable `"UptimeRobot API error (retryable)"` prefix already used in `_post`'s exception message. This mirrors the same pattern already used by several other sources (Notion, Twelve Data, Salesforce, Meta Ads, ...) for errors that are already retried internally before being re-raised for Temporal to retry the activity.

No change to retry/backoff behavior, and nothing added to `NonRetryableErrors` — the sync should keep retrying exactly as it does today, just without generating a tracked exception each time.

## How did you test this code?

Added a parameterized test case (`test_retryable_errors_match_exhausted_backoff`) asserting that 429/500/503 "retryable" messages from `_post` are recognized by `get_retryable_errors()`. Ran the full `test_uptimerobot_source.py` suite locally (`pytest`) — 20/20 pass.

## Docs update

N/A — no user-facing behavior change, this only affects internal error-tracking noise.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool used: Claude Code (PostHog Code), triggered by an error-tracking webhook alert.
- Investigated the issue via the PostHog error tracking MCP tools (issue details + sampled event stack trace), confirming the stack trace bottoms out in `_post` in this source's own module.
- Skills invoked: `/investigating-error-issue` (to pull issue details/stack trace), `/writing-tests` (before adding the new test case).
- Decision: classified this as a transient infrastructure error (UptimeRobot-side 500s), not a user/credential error and not a code bug — the existing retry/backoff was already reasonable. The actionable gap was that the source didn't classify the exhausted-retry error via `get_retryable_errors()`, an established convention in this codebase for exactly this "retries internally, then re-raises for Temporal" shape, used by several sibling sources.