### PR TITLE
fix(storybook): retry iframe navigation on cold-start timeout

### DIFF
--- a/common/storybook/.storybook/test-runner.ts
+++ b/common/storybook/.storybook/test-runner.ts
@@ -126,6 +126,14 @@ const JEST_TIMEOUT_MS = 60000 // Multi-viewport snapshots can take substantially
 const PLAYWRIGHT_TIMEOUT_MS = 10000 // Must be shorter than JEST_TIMEOUT_MS
 const VIEWPORT_SETTLE_TIMEOUT_MS = 5000
 
+// Each story file gets a fresh browser context, so `prepare` reloads the whole preview bundle with a
+// cold HTTP cache. Under CI contention that tail overruns Playwright's 30s default. RETRY_TIMES can't
+// save it: `jest.retryTimes` is registered from setupFilesAfterEnv, which runs *after* the environment
+// setup this navigation happens in, so the throw kills the suite file outright. Hence retrying here.
+const NAVIGATION_TIMEOUT_MS = 45000
+const NAVIGATION_ATTEMPTS = 3
+const NAVIGATION_LIVENESS_TIMEOUT_MS = 10000
+
 const ATTEMPT_COUNT_PER_ID: Record<string, number> = {}
 
 // Storybook channel events that mean a forced remount's play function failed. Shared between the
@@ -174,14 +182,7 @@ export default {
             const headers = await testRunnerConfig.getHttpHeaders(iframeURL)
             await browserContext.setExtraHTTPHeaders(headers)
         }
-        await page.goto(iframeURL, { waitUntil: 'load' }).catch((err) => {
-            if (err.message?.includes('ERR_CONNECTION_REFUSED')) {
-                throw new Error(
-                    `Could not access the Storybook instance at ${targetURL}. Are you sure it's running?\n\n${err.message}`
-                )
-            }
-            throw err
-        })
+        await gotoStorybookIframe(page, iframeURL, targetURL)
     },
 
     setup() {
@@ -331,6 +332,44 @@ export default {
         skip: ['test-skip'], // NOTE: This is overridden by the CI action ci-storybook.yml to include browser specific skipping
     },
 } as TestRunnerConfig
+
+async function gotoStorybookIframe(page: Page, iframeURL: string, targetURL: string | undefined): Promise<void> {
+    const unreachable = (detail: string): Error =>
+        new Error(`Could not access the Storybook instance at ${targetURL}. Are you sure it's running?\n\n${detail}`)
+
+    for (let attempt = 1; attempt <= NAVIGATION_ATTEMPTS; attempt++) {
+        try {
+            await page.goto(iframeURL, { waitUntil: 'load', timeout: NAVIGATION_TIMEOUT_MS })
+            return
+        } catch (error) {
+            const detail = (error as Error).message ?? String(error)
+            if (detail.includes('ERR_CONNECTION_REFUSED')) {
+                throw unreachable(detail)
+            }
+            if (attempt === NAVIGATION_ATTEMPTS) {
+                throw new Error(
+                    `Loading ${iframeURL} timed out on all ${NAVIGATION_ATTEMPTS} attempts of ${NAVIGATION_TIMEOUT_MS}ms.\n\n${detail}`
+                )
+            }
+            // Only a slow bundle load earns another attempt. A server that can't serve its index within
+            // seconds has wedged, and retrying every story file would burn the shard's whole timeout
+            // budget before reporting anything useful.
+            const serverResponds = await page.request
+                .get(targetURL ?? iframeURL, { timeout: NAVIGATION_LIVENESS_TIMEOUT_MS })
+                .then((response) => response.ok())
+                .catch(() => false)
+            if (!serverResponds) {
+                throw unreachable(detail)
+            }
+            // eslint-disable-next-line no-console
+            console.warn(
+                `[test-runner] Navigating to ${iframeURL} timed out after ${NAVIGATION_TIMEOUT_MS}ms, retrying (${
+                    attempt + 1
+                }/${NAVIGATION_ATTEMPTS})`
+            )
+        }
+    }
+}
 
 async function expectStoryToMatchSnapshot(
     page: Page,


### PR DESCRIPTION
## TL;DR

Storybook CI shards sometimes died because the browser took longer than 30 seconds to load the page, and nothing retried. Now it waits a bit longer and tries up to three times.

## Problem

Roughly 1 in 6 completed `ci-storybook.yml` runs on master dies with:

```
Test suite failed to run: page.goto: Timeout 30000ms exceeded
navigating to "http://127.0.0.1:6006/iframe.html"
```

It is not a story bug — the shard and the stories differ every time, and the very next navigation in the same worker completes in ~10s. Each story file gets a fresh browser context, so `prepare` reloads the whole preview bundle with a cold HTTP cache; under CI contention that first navigation overruns Playwright's 30s default.

`RETRY_TIMES` cannot help. `jest.retryTimes` is registered from a `setupFilesAfterEnv` hook, which the runner loads *after* the jest environment's `setup()` — and that setup is where this navigation happens. The throw escapes uncaught and takes the whole suite file with it, so the retry is structurally unreachable for this failure class.

## Changes

In `common/storybook/.storybook/test-runner.ts`, the iframe navigation now gets its own 45s budget and up to three attempts. A retry reuses the same page, so chunks that already landed are cached and the retry is cheap.

Between attempts it probes the server: if it cannot serve its index within 10s it has wedged rather than stalled, so fail immediately with the existing "Are you sure it's running?" message. Without that probe, a wedged-but-listening server would burn the shard's 30-minute cap retrying every story file and report nothing useful. `ERR_CONNECTION_REFUSED` still fails fast on the first attempt.

## How did you test this code?

`pnpm --filter=@posthog/frontend typescript:check` passes. Oxfmt and Oxlint clean on the file.

I did not reproduce the timeout locally — it needs a loaded CI runner. The change is confined to error paths, so the healthy path is unchanged apart from the raised timeout ceiling. Verification is this PR's own storybook run plus watching the master flake rate afterwards.

No tests added: this is CI harness error-handling, and a test would have to fake a stalled HTTP server to exercise it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while babysitting CI on a set of approved PRs — two of them were red purely from this flake. Sampled the last 80 master runs to confirm the rate and pulled logs from every failure in the last-40 window; 8 of 10 were this exact timeout, 6 of those on the first navigation of a worker, all on the stock GitHub runner rather than Depot.

Considered and rejected: bumping the timeout alone (a gamble on an unmeasured stall length, and it cannot recover from a hang), and cutting `--maxWorkers` (roughly doubles shard wall time against a 30-minute cap).

Separately noticed a genuine recurring failure that this does **not** fix: `EmptyStates.stories.tsx` → `Insights/Error & Empty States › LongLoading` times out waiting for `[data-attr=insight-loading-waiting-message]`, same shard, multiple days. Worth its own ticket.

Skills invoked: none directly applicable (`/writing-tests` consulted; no tests added).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
