### PR TITLE
fix(ci): stop playwright Visual Review runs dangling pending

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -1123,7 +1123,16 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 15
         needs: [playwright]
-        if: needs.playwright.outputs.vr_run_id != '' && needs.playwright.result == 'success'
+        # !cancelled() is load-bearing. select-specs is skipped on every full-run event (push to
+        # master, PR opened/reopened/ready_for_review), and GitHub propagates a skip down the whole
+        # needs chain — only a status-check function breaks the inheritance. The playwright job has
+        # its own !cancelled() so it runs, but this job inherited the skip anyway, leaving the VR run
+        # it created stuck pending and its commit status pending forever. The explicit result check
+        # restores the implicit success() that !cancelled() drops. Mirrors ci-storybook.yml.
+        if: |
+            !cancelled()
+            && needs.playwright.result == 'success'
+            && needs.playwright.outputs.vr_run_id != ''
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -1146,6 +1155,10 @@ jobs:
               run: cd products/visual_review/cli && npm ci && npm run build && npm link
 
             - name: Complete Visual Review run
+              # On master pushes the run was created with --purpose observe (tracking-only), but
+              # `vr run complete` still exits 1 whenever visual changes are detected. Treat that as
+              # informational on push; PRs still gate. Mirrors ci-storybook.yml.
+              continue-on-error: ${{ github.event_name == 'push' }}
               env:
                   VR_TOKEN: ${{ secrets.VR_API_TOKEN }}
               run: |


### PR DESCRIPTION
## TL;DR

A CI job that finishes off Visual Review runs was being skipped by accident, so those runs sat "pending" on PRs forever. One condition fixes it.

## Problem

The `vr-complete` job in `ci-e2e-playwright.yml` was skipped on every full-run event, even though the `playwright` job succeeded and really had created a Visual Review run. Nothing then completed that run, so its `PostHog Visual Review / playwright` commit status stayed `pending` indefinitely and PRs sat at `UNSTABLE` rather than `CLEAN`.

Cause is transitive skip propagation. `select-specs` only runs on PR `synchronize`, so it is skipped on push to master and on PR `opened` / `reopened` / `ready_for_review`. GitHub propagates a skip down the *entire* `needs` chain, not one level. The `playwright` job escapes it with its own `!cancelled()`, but `vr-complete` had no status-check function and inherited the skip anyway — its `vr_run_id` condition was never evaluated.

It has been broken since the `playwright` job gained `select-specs` as a dependency; `vr-complete`'s condition was left untouched at the time. Correlation across ~35 sampled runs is perfect: `select-specs` skipped ⟺ `vr-complete` skipped.

`ci-storybook.yml` already hit this exact bug and fixed it, with a comment naming the mechanism. Both changes here mirror that file.

## Changes

- `!cancelled()` on `vr-complete`, plus an explicit `needs.playwright.result == 'success'` to restore the implicit `success()` that `!cancelled()` drops.
- `continue-on-error` on the completion step for `push`, so tracking-only master runs don't redden when the CLI exits 1 on detected changes.

**Behavior change worth a reviewer's attention:** the gate starts actually gating on `opened` / `reopened` / `ready_for_review` runs, where it has silently been a no-op. That is the designed behavior and is already live on `synchronize` runs, but a PR marked ready with unapproved visual changes will now fail `Playwright tests pass` (a required check) until someone approves the run. If you'd rather stage that, say so and I'll split the `continue-on-error` rollout.

## How did you test this code?

`bin/hogli lint:workflows` passes all 6 checks. Parsed the YAML to confirm the block-scalar `if:` isn't swallowing the leading `!` as a tag, and that the condition and `continue-on-error` resolve as intended.

Can't exercise a workflow condition locally beyond that — real verification is this PR's own run, and then confirming the status goes green rather than dangling.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while babysitting CI on a set of approved PRs — three of them had a Visual Review run created with zero snapshots, `completed_at: null`, stuck pending.

First hypothesis was multi-line stdout from `vr run create` silently emptying `$GITHUB_OUTPUT`. Refuted: the CLI writes logs to stderr and only the bare UUID to stdout, the next step read `VR_RUN_ID` fine, and the job log shows `Set output 'vr_run_id'`. Skip propagation was confirmed instead by the perfect correlation above plus the fact that every *other* job surviving a skipped `select-specs` already carries a status function.

Not done here, deliberately: leaving `result == 'success'` in place (completing a failed run would classify missing baselines as REMOVED and post a spurious failure), and no reaper for already-dangling runs — there is no cancel endpoint, so that wants a Celery beat task in the currently-empty `products/visual_review/backend/tasks/schedules.py`.

Skills invoked: `/authoring-ci-workflows`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
