### PR TITLE
feat(observability): add trace_id/span_id to request log lines

### DIFF
--- a/posthog/settings/logs.py
+++ b/posthog/settings/logs.py
@@ -5,6 +5,7 @@ import threading
 from typing import Any
 
 import structlog
+from opentelemetry import trace
 
 from posthog.settings.base_variables import DEBUG, IS_INTERACTIVE_SHELL, TEST
 
@@ -49,6 +50,19 @@ def add_pid_and_tid(
     return event_dict
 
 
+def add_otel_trace_context(
+    logger: logging.Logger, method_name: str, event_dict: structlog.types.EventDict
+) -> structlog.types.EventDict:
+    # Correlate log lines with the active OTel trace (parented off the incoming Envoy `traceparent`)
+    # so logs can be matched to their distributed trace. Read at emit time so nested spans get the
+    # right span_id; a clean no-op when no valid span is in scope (e.g. OTel disabled).
+    span_context = trace.get_current_span().get_span_context()
+    if span_context.is_valid:
+        event_dict["trace_id"] = format(span_context.trace_id, "032x")
+        event_dict["span_id"] = format(span_context.span_id, "016x")
+    return event_dict
+
+
 # To enable standard library logs to be formatted via structlog, we add this
 # `foreign_pre_chain` to both formatters.
 foreign_pre_chain: list[structlog.types.Processor] = [
@@ -57,6 +71,7 @@ foreign_pre_chain: list[structlog.types.Processor] = [
     structlog.stdlib.add_logger_name,
     structlog.stdlib.add_log_level,
     add_pid_and_tid,
+    add_otel_trace_context,
     structlog.stdlib.PositionalArgumentsFormatter(),
     structlog.processors.StackInfoRenderer(),
     structlog.processors.format_exc_info,

--- a/posthog/settings/test_logs.py
+++ b/posthog/settings/test_logs.py
@@ -1,6 +1,12 @@
 import logging
 import logging.config
 
+from opentelemetry import (
+    context as otel_context,
+    trace,
+)
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+
 from posthog.settings import logs
 
 
@@ -13,6 +19,28 @@ def test_level_filters_split_info_from_warnings() -> None:
 
     assert max_info.filter(_record(logging.INFO))
     assert not max_info.filter(_record(logging.WARNING))
+
+
+def test_add_otel_trace_context_binds_ids_from_active_span() -> None:
+    span_context = SpanContext(
+        trace_id=0x4BF92F3577B34DA6A3CE929D0E0E4736,
+        span_id=0x00F067AA0BA902B7,
+        is_remote=True,
+        trace_flags=TraceFlags(TraceFlags.SAMPLED),
+    )
+    token = otel_context.attach(trace.set_span_in_context(NonRecordingSpan(span_context)))
+    try:
+        event_dict = logs.add_otel_trace_context(logging.getLogger("test"), "info", {"event": "x"})
+    finally:
+        otel_context.detach(token)
+    assert event_dict["trace_id"] == "4bf92f3577b34da6a3ce929d0e0e4736"
+    assert event_dict["span_id"] == "00f067aa0ba902b7"
+
+
+def test_add_otel_trace_context_is_noop_without_active_span() -> None:
+    event_dict = logs.add_otel_trace_context(logging.getLogger("test"), "info", {"event": "x"})
+    assert "trace_id" not in event_dict
+    assert "span_id" not in event_dict
 
 
 def test_logging_config_can_be_applied() -> None:


### PR DESCRIPTION
## Problem

Web request logs ship as stdout JSON (`posthog/settings/logs.py`) and carry no link to their distributed trace. OpenTelemetry's `DjangoInstrumentor` already opens a server span for every request, parented off the incoming Envoy `traceparent`, but nothing copies that trace identity into the log lines. So you can't jump from a log line to the trace it belongs to.

This is the follow-up to [#73832](https://github.com/PostHog/posthog/pull/73832), which fixed the same correlation gap for the OTLP-shipped Temporal logs. That fix set native `LogRecord` trace fields because that path ships over OTLP. The web path has no OTLP shipping - logs go to stdout as JSON - so here the trace ids belong in the log line itself.

## Changes

Add a structlog processor, `add_otel_trace_context`, to the shared `foreign_pre_chain` so it runs for every log line (structlog-native and stdlib-routed). It reads the active span's context and stamps `trace_id` (32-hex) and `span_id` (16-hex) onto the event dict.

- Read at **emit time**, not once per request, so a line logged inside a nested span gets that span's `span_id`, not just the request root.
- **No-op** when no valid span is in scope (OTel disabled under `TEST=1` / `OTEL_SDK_DISABLED`, or code paths with no span) - the `is_valid` guard means nothing is stamped rather than a bogus all-zero id.
- Because it's in the logging chain rather than a web middleware, it also correlates Celery task logs (via `CeleryInstrumentor`) and anything else emitting under an active span - not just web requests.

No OTLP shipping is added. This only enriches the existing stdout JSON.

## How did you test this code?

Automated tests only, in `posthog/settings/test_logs.py`:

- `test_add_otel_trace_context_binds_ids_from_active_span` - attaches a known span context and asserts the processor stamps the expected zero-padded `trace_id` / `span_id`. Catches a regression in the hex formatting (dropped leading zeros, wrong width) that would break trace lookups.
- `test_add_otel_trace_context_is_noop_without_active_span` - asserts nothing is stamped when no span is active. Catches removal of the `is_valid` guard, which would emit a bogus all-zero id on every log line in contexts with no trace.

```
hogli test posthog/settings/test_logs.py
# 6 passed
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank drove this; I (Claude via PostHog Code) implemented it, as the agreed follow-up to #73832. We considered standing up OTLP log shipping for the web path (native trace fields, like the Temporal mirror) but chose not to: it's a large volume/cost/data-exposure change, and the pragmatic win is stamping the ids onto the stdout JSON that already exists. Implemented as a logging-chain processor rather than a one-shot bind in `per_request_logging_context_middleware`, so span_id is correct inside nested spans and the correlation isn't limited to web requests.

Skills invoked: `/writing-tests` (to gate the test additions).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
