### PR TITLE
chore(insights): pin breakdown override null-inherit vs empty-clear

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
@@ -452,6 +452,31 @@ class TestTrendsDashboardFilters(BaseTest):
         )
         assert query_runner.query.trendsFilter is None
 
+    @parameterized.expand(
+        [
+            (
+                "null breakdown inherits the insight breakdown",
+                None,
+                BreakdownFilter(breakdown="abc", breakdown_limit=5),
+            ),
+            ("empty breakdown clears the insight breakdown", BreakdownFilter(), BreakdownFilter()),
+        ]
+    )
+    def test_breakdown_override_null_inherits_empty_clears(self, _name, override_breakdown, expected_breakdown):
+        query_runner = self._create_query_runner(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            None,
+            breakdown=BreakdownFilter(breakdown="abc", breakdown_limit=5),
+        )
+
+        query_runner.apply_dashboard_filters(DashboardFilter(breakdown_filter=override_breakdown, date_from="-14d"))
+
+        assert query_runner.query.dateRange is not None
+        assert query_runner.query.dateRange.date_from == "-14d"
+        assert query_runner.query.breakdownFilter == expected_breakdown
+
     def test_compare_is_removed_for_all_time_range(self):
         query_runner = self._create_query_runner(
             "2024-07-07",

--- a/posthog/hogql_queries/test/test_merge_filters_by_priority.py
+++ b/posthog/hogql_queries/test/test_merge_filters_by_priority.py
@@ -42,6 +42,19 @@ class TestMergeFiltersByPriority(SimpleTestCase):
         assert merged["filterTestAccounts"] is True
         assert merged["breakdown_filter"] == {"breakdown": "$browser", "breakdown_type": "event"}
 
+    @parameterized.expand(
+        [
+            ("null tile breakdown inherits dashboard breakdown", None, {"breakdown": "$os", "breakdown_type": "event"}),
+            ("empty tile breakdown clears dashboard breakdown", {}, {}),
+        ]
+    )
+    def test_tile_breakdown_null_inherits_empty_clears(self, _name, tile_breakdown, expected_breakdown):
+        merged = merge_filters_by_priority(
+            {"breakdown_filter": {"breakdown": "$os", "breakdown_type": "event"}},
+            {"breakdown_filter": tile_breakdown},
+        )
+        assert merged["breakdown_filter"] == expected_breakdown
+
     def test_properties_on_different_keys_are_and_combined_dashboard_first(self):
         dashboard_prop = {"key": "$country", "value": "US", "type": "event"}
         tile_prop = {"key": "$browser", "value": "Chrome", "type": "event"}


### PR DESCRIPTION
## TL;DR

Dashboard and tile filters can override an insight's breakdown. A null override means "leave the insight's breakdown alone", not "remove it". This adds tests that lock in that rule so nobody breaks it by accident. No behavior change.

## Problem

A code-review thread flagged that a null `breakdown_filter` override can't clear a breakdown saved on the insight: both `QueryRunner.apply_dashboard_filters` and the `_SCALAR_OVERRIDE_FIELDS` merge treat null as "not specified", so the insight keeps its own breakdown. No test pinned this either way, so the intended rule was easy to break.

I traced both paths. They agree, and the rule is deliberate:

- null override -> inherit the insight's breakdown
- empty `BreakdownFilter()` override -> clear the breakdown
- populated override -> replace the breakdown

This matches the other override fields, where null means inherit. `filterTestAccounts` is the only one with a real tri-state, because `false` means "force off". There is no dashboard concept of "force no breakdown", so null = inherit is right. The frontend already maps an emptied breakdown to null, so the clear path is not reachable from the dashboard UI today. That is a UI choice, not a bug.

## Changes

Tests only, no production change:

- Runner path (`test_trends_dashboard_filters.py`): a null override leaves the insight's saved breakdown intact; an empty `BreakdownFilter()` clears it.
- Merge path (`test_merge_filters_by_priority.py`): the same rule for the dashboard/tile layer merge.

## How did you test this code?

I ran the merge suite locally: `pytest posthog/hogql_queries/test/test_merge_filters_by_priority.py` (40 passed). The runner test needs Postgres, which I could not run in this environment. It uses the same build-runner-then-apply pattern as the existing breakdown tests in that file.

Regression each group catches:

- Runner: if someone drops the truthiness guard on `dashboard_filter.breakdown_filter`, a null override would wipe an insight's saved breakdown whenever any dashboard filter applies. No existing test covered null or empty against a query that has a saved breakdown.
- Merge: if the `is not None` scalar check flips to a truthy check, null vs empty semantics change silently. Not covered before.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Tests only, no docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thomas asked me (Claude, via PostHog Code) to investigate a code-review thread about null breakdown overrides. I traced both the merge and runner paths, confirmed they agree and that null = inherit is intended, then pinned the contract with tests. Skill invoked: /writing-tests. I considered adding a "clear via null" behavior and rejected it, since it would break the common inherit case and needs a UI and product decision.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
