### PR TITLE
fix(postmark): distinguish token, permission, and unreachable errors on validate

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/postmark.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/postmark.py
@@ -84,17 +84,18 @@ def _get_headers(server_token: str) -> dict[str, str]:
     }
 
 
-def validate_credentials(server_token: str) -> bool:
+def validate_credentials(server_token: str) -> tuple[bool, int | None]:
     # /message-streams is a cheap read-only call any valid server token can make. Postmark
-    # returns 401 (ErrorCode 10) for an invalid/missing token and 200 otherwise.
-    ok, _status = validate_via_probe(
+    # returns 401 (ErrorCode 10) for an invalid/missing token and 200 otherwise. Return the
+    # status so the caller can tell a rejected token (401) from a permissions problem (403) or
+    # an unreachable/erroring API (None/5xx), rather than reporting them all as "invalid token".
+    return validate_via_probe(
         # `X-Postmark-Server-Token` is not in the sample-capture header denylist, so mask the
         # token by value to keep it out of any captured HTTP sample.
         lambda: make_tracked_session(redact_values=(server_token,)),
         f"{POSTMARK_BASE_URL}/message-streams",
         headers=_get_headers(server_token),
     )
-    return ok
 
 
 def postmark_source(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/source.py
@@ -112,10 +112,21 @@ The token grants read access to the following server-level resources:
         schema_name: Optional[str] = None,
         api_version: str | None = None,
     ) -> tuple[bool, str | None]:
-        if validate_postmark_credentials(config.server_token):
+        is_valid, status = validate_postmark_credentials(config.server_token)
+        if is_valid:
             return True, None
 
-        return False, "Invalid Postmark server API token"
+        if status == 403:
+            return (
+                False,
+                "Your Postmark server API token doesn't have the required permissions. Please check the token and try again.",
+            )
+        if status is None or status == 429 or status >= 500:
+            return (
+                False,
+                "Couldn't reach Postmark to verify your token. Please try again in a moment.",
+            )
+        return False, "Invalid Postmark server API token. Please check the token and try again."
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/tests/test_postmark.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/tests/test_postmark.py
@@ -80,7 +80,8 @@ class TestValidateCredentials:
     @mock.patch(POSTMARK_SESSION_PATCH)
     def test_validate_credentials(self, _name: str, status_code: int, expected: bool, mock_session: mock.MagicMock):
         mock_session.return_value.get.return_value = mock.MagicMock(status_code=status_code)
-        assert validate_credentials("test-token") is expected
+        # The status flows back to the caller so it can distinguish rejection causes.
+        assert validate_credentials("test-token") == (expected, status_code)
 
         # The probe session masks the token by value so it never lands in a captured HTTP sample.
         assert mock_session.call_args.kwargs["redact_values"] == ("test-token",)
@@ -90,9 +91,9 @@ class TestValidateCredentials:
         assert get_kwargs["headers"]["X-Postmark-Server-Token"] == "test-token"
 
     @mock.patch(POSTMARK_SESSION_PATCH)
-    def test_validate_credentials_network_error_returns_false(self, mock_session: mock.MagicMock):
+    def test_validate_credentials_network_error_returns_none_status(self, mock_session: mock.MagicMock):
         mock_session.return_value.get.side_effect = Exception("boom")
-        assert validate_credentials("test-token") is False
+        assert validate_credentials("test-token") == (False, None)
 
 
 class TestFlatEndpoint:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/tests/test_postmark_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postmark/tests/test_postmark_source.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+from parameterized import parameterized
+
 from posthog.schema import SourceFieldInputConfig, SourceFieldInputConfigType
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
@@ -68,7 +70,7 @@ class TestPostmarkSource:
         "products.warehouse_sources.backend.temporal.data_imports.sources.postmark.source.validate_postmark_credentials"
     )
     def test_validate_credentials_success(self, mock_validate):
-        mock_validate.return_value = True
+        mock_validate.return_value = (True, 200)
 
         is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
 
@@ -76,16 +78,26 @@ class TestPostmarkSource:
         assert error_message is None
         mock_validate.assert_called_once_with(self.config.server_token)
 
+    @parameterized.expand(
+        [
+            ("invalid_token_401", 401, "Invalid Postmark server API token"),
+            ("missing_permissions_403", 403, "doesn't have the required permissions"),
+            ("unreachable_none", None, "Couldn't reach Postmark"),
+            ("server_error_500", 500, "Couldn't reach Postmark"),
+            ("rate_limited_429", 429, "Couldn't reach Postmark"),
+        ]
+    )
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.postmark.source.validate_postmark_credentials"
     )
-    def test_validate_credentials_failure(self, mock_validate):
-        mock_validate.return_value = False
+    def test_validate_credentials_failure_maps_status(self, _name, status, expected_substring, mock_validate):
+        mock_validate.return_value = (False, status)
 
         is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
 
         assert is_valid is False
-        assert error_message == "Invalid Postmark server API token"
+        assert error_message is not None
+        assert expected_substring in error_message
 
     def test_get_resumable_source_manager(self):
         inputs = mock.MagicMock()


### PR DESCRIPTION
## Problem

When someone adds a Postmark source, credential validation showed the same message, "Invalid Postmark server API token", for every failure. A token that was actually valid but lacked permissions, or a transient Postmark outage / rate-limit / network blip during setup, all read as "your token is invalid". That sends people down the wrong path re-pasting a token that was fine.

This came out of a triage of data-warehouse source-creation failures. Postmark's generic message was one of a few that hid the real cause.

## Changes

`validate_credentials` in the Postmark source already probed `/message-streams` through the shared `validate_via_probe` helper, which returns `(is_valid, status_code)` precisely so callers can tell rejection causes apart. It was throwing the status away. Now it uses it:

- `403` → the token lacks required permissions
- no status (network error / timeout) or `5xx` / `429` → couldn't reach Postmark, try again in a moment
- anything else (e.g. `401`) → invalid token

The specific-cause messages mirror what the source's `get_non_retryable_errors` already surfaces on the sync path, so the create-time and sync-time copy stay consistent.

## How did you test this code?

Automated only (I'm Claude, agent-authored). Ran the two touched test modules with `uv run pytest`:

- `tests/test_postmark.py::TestValidateCredentials` — updated to assert the probe returns `(is_valid, status)` and that a network error maps to `(False, None)`.
- `tests/test_postmark_source.py` — added a parameterized case matrix that locks the status → message mapping (401 → invalid token, 403 → permissions, None/500/429 → unreachable). This guards against a regression that silently reports a transient failure or a permissions gap as "invalid token", which no existing test caught.

19 passed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code) as part of a triage pass over data-warehouse source-creation errors. I classified each source's error copy, and Postmark was one where the message was clean but too generic — it discarded status information that was already available. Invoked the `/writing-tests` skill before touching the test files.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
