### PR TITLE
fix(cloudflare): distinguish invalid token from an unreachable API on validate

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/cloudflare.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/cloudflare.py
@@ -124,17 +124,26 @@ def _zone_fanout_resource(
     return resources[endpoint].add_map(_rename_parent_key)
 
 
-def validate_credentials(api_token: str) -> bool:
-    """Confirm the API token is valid with Cloudflare's token verify endpoint."""
+def validate_credentials(api_token: str) -> tuple[bool, int | None]:
+    """Confirm the API token is valid with Cloudflare's token verify endpoint.
+
+    Returns ``(is_valid, status_code)``. ``status_code`` is ``None`` when Cloudflare was
+    unreachable so the caller can tell a rejected token apart from a transient failure and
+    avoid telling the user their token is invalid when it may be fine.
+    """
     try:
         response = make_tracked_session(redact_values=(api_token,)).get(
             f"{CLOUDFLARE_BASE_URL}/user/tokens/verify",
             headers={"Authorization": f"Bearer {api_token}"},
             timeout=10,
         )
-        return response.status_code == 200 and bool(response.json().get("success"))
     except Exception:
-        return False
+        return False, None
+    try:
+        is_valid = response.status_code == 200 and bool(response.json().get("success"))
+    except Exception:
+        is_valid = False
+    return is_valid, response.status_code
 
 
 def cloudflare_source(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/source.py
@@ -116,10 +116,19 @@ Create an API token in the [Cloudflare dashboard](https://dash.cloudflare.com/pr
         schema_name: Optional[str] = None,
         api_version: str | None = None,
     ) -> tuple[bool, str | None]:
-        if validate_cloudflare_credentials(config.api_token):
+        is_valid, status = validate_cloudflare_credentials(config.api_token)
+        if is_valid:
             return True, None
 
-        return False, "Invalid Cloudflare API token"
+        if status is None or status == 429 or status >= 500:
+            return (
+                False,
+                "Couldn't reach Cloudflare to verify your API token. Please try again in a moment.",
+            )
+        return (
+            False,
+            "Invalid Cloudflare API token. Please check the token has read permissions and hasn't been revoked.",
+        )
 
     def source_for_pipeline(self, config: CloudflareSourceConfig, inputs: SourceInputs) -> SourceResponse:
         return cloudflare_source(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_client.py
@@ -79,7 +79,7 @@ class TestValidateCredentials:
     @mock.patch(CLOUDFLARE_SESSION_PATCH)
     def test_valid_on_verify_success(self, mock_session) -> None:
         mock_session.return_value.get.return_value = _response([], total_pages=1)
-        assert validate_credentials("token") is True
+        assert validate_credentials("token") == (True, 200)
 
     @mock.patch(CLOUDFLARE_SESSION_PATCH)
     def test_invalid_when_success_false(self, mock_session) -> None:
@@ -87,18 +87,19 @@ class TestValidateCredentials:
         resp.status_code = 200
         resp._content = json.dumps({"success": False, "result": None}).encode()
         mock_session.return_value.get.return_value = resp
-        assert validate_credentials("token") is False
+        assert validate_credentials("token") == (False, 200)
 
     @pytest.mark.parametrize("status_code", [401, 403, 500])
     @mock.patch(CLOUDFLARE_SESSION_PATCH)
     def test_invalid_on_error_status(self, mock_session, status_code) -> None:
         mock_session.return_value.get.return_value = _error_response(status_code)
-        assert validate_credentials("token") is False
+        # The status flows back so the caller can tell a rejected token from a 5xx/unreachable one.
+        assert validate_credentials("token") == (False, status_code)
 
     @mock.patch(CLOUDFLARE_SESSION_PATCH)
-    def test_invalid_on_exception(self, mock_session) -> None:
+    def test_unreachable_on_exception(self, mock_session) -> None:
         mock_session.return_value.get.side_effect = Exception("boom")
-        assert validate_credentials("token") is False
+        assert validate_credentials("token") == (False, None)
 
 
 class TestPagination:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_source.py
@@ -78,22 +78,30 @@ class TestCloudflareSource:
         assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
 
     @pytest.mark.parametrize(
-        "mock_return, expected_valid, expected_message",
+        "mock_return, expected_valid, expected_substring",
         [
-            (True, True, None),
-            (False, False, "Invalid Cloudflare API token"),
+            ((True, 200), True, None),
+            ((False, 401), False, "Invalid Cloudflare API token"),
+            ((False, 403), False, "Invalid Cloudflare API token"),
+            ((False, None), False, "Couldn't reach Cloudflare"),
+            ((False, 500), False, "Couldn't reach Cloudflare"),
+            ((False, 429), False, "Couldn't reach Cloudflare"),
         ],
     )
     @mock.patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.cloudflare.source.validate_cloudflare_credentials"
     )
-    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_substring):
         mock_validate.return_value = mock_return
 
         is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
 
         assert is_valid is expected_valid
-        assert error_message == expected_message
+        if expected_substring is None:
+            assert error_message is None
+        else:
+            assert error_message is not None
+            assert expected_substring in error_message
         mock_validate.assert_called_once_with(self.config.api_token)
 
     @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.cloudflare.source.cloudflare_source")


### PR DESCRIPTION
## Problem

When someone adds a Cloudflare source, credential validation showed "Invalid Cloudflare API token" for every failure. If Cloudflare was briefly unreachable, rate-limiting, or returning a 5xx during setup, the token could be perfectly valid and the message still told the user it was wrong. That's a dead end when the real fix is just to retry.

This came out of a triage of data-warehouse source-creation failures. Cloudflare's message was one of a few that hid the real cause behind a generic "invalid credentials" string.

## Changes

The token-verify helper (`GET /user/tokens/verify`) collapsed every outcome into a single bool, throwing away the HTTP status. It now returns `(is_valid, status_code)`, with `status_code` set to `None` when Cloudflare couldn't be reached at all. The source's `validate_credentials` then splits the failure:

- no status (network error / timeout), `5xx`, or `429` → couldn't reach Cloudflare, try again in a moment
- a definitive rejection (e.g. `401` / `403`, or a `200` with `success: false`) → invalid token, check permissions and that it hasn't been revoked

No change to how the token is verified or to any sync behavior.

## How did you test this code?

Automated only (I'm Claude, agent-authored). Ran the touched test modules with `uv run pytest`:

- `tests/test_cloudflare_client.py::TestValidateCredentials` — updated to assert the helper returns `(is_valid, status)`, and that an exception maps to `(False, None)` (unreachable) rather than being indistinguishable from a rejection.
- `tests/test_cloudflare_source.py::...::test_validate_credentials` — expanded the parameterized matrix to lock the status → message mapping (401/403 → invalid token, None/500/429 → unreachable). Guards the regression where a transient failure gets reported as an invalid token.

23 passed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code) as part of a triage pass over data-warehouse source-creation errors. Cloudflare's copy was clean but too generic — it discarded status information that made the difference between "your token is wrong" and "we couldn't reach Cloudflare". Invoked the `/writing-tests` skill before touching the test files.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
