### PR TITLE
fix(slack): surface the specific reason when validate rejects credentials

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/slack/slack.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/slack/slack.py
@@ -558,7 +558,15 @@ def slack_source(
     )
 
 
-def validate_credentials(access_token: str) -> bool:
+def validate_credentials(access_token: str) -> tuple[bool, str | None]:
+    """Check a Slack token via ``auth.test``.
+
+    Returns ``(is_valid, error_code)``. On rejection ``error_code`` is Slack's own error
+    (for example ``invalid_auth`` or ``missing_scope``) so the caller can explain the exact
+    problem instead of a generic "invalid credentials". It is ``None`` when the check couldn't
+    complete (network error or an exhausted rate-limit/5xx retry), letting the caller tell a
+    rejected token apart from an unreachable Slack.
+    """
     url = "https://slack.com/api/auth.test"
     headers = {"Authorization": f"Bearer {access_token}"}
 
@@ -566,6 +574,9 @@ def validate_credentials(access_token: str) -> bool:
         response = _slack_get(url, headers=headers, timeout=10)
         response.raise_for_status()
         data = response.json()
-        return data.get("ok", False)
     except Exception:
-        return False
+        return False, None
+
+    if data.get("ok", False):
+        return True, None
+    return False, data.get("error") or None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/slack/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/slack/source.py
@@ -324,10 +324,19 @@ Prefer a manifest? Paste this when creating the app — it wires the request URL
         try:
             access_token, _authed_user, _cache_id = self._resolve_access_token(config, team_id)
 
-            if validate_slack_credentials(access_token):
+            is_valid, error_code = validate_slack_credentials(access_token)
+            if is_valid:
                 return True, None
 
-            return False, "Invalid Slack credentials"
+            if error_code is None:
+                return False, "Couldn't reach Slack to verify your credentials. Please try again in a moment."
+
+            # Reuse the per-error copy already curated for the sync path so create-time and
+            # sync-time messages stay consistent (e.g. missing_scope is a re-auth, not a bad token).
+            message = self.get_non_retryable_errors().get(error_code)
+            if message:
+                return False, message
+            return False, f"Slack rejected the credentials ({error_code}). Please reconnect the source."
         except Exception as e:
             return False, f"Failed to validate Slack credentials: {str(e)}"
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/slack/tests/test_slack_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/slack/tests/test_slack_source.py
@@ -1,7 +1,78 @@
+from unittest import mock
 from unittest.mock import MagicMock
 
+from parameterized import parameterized
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import WebhookSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.slack.slack import (
+    validate_credentials as validate_slack_credentials,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.slack.source import SlackSource
+
+SOURCE_VALIDATE_PATCH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.slack.source.validate_slack_credentials"
+)
+SLACK_GET_PATCH = "products.warehouse_sources.backend.temporal.data_imports.sources.slack.slack._slack_get"
+
+
+class TestSlackValidateCredentialsProbe:
+    @mock.patch(SLACK_GET_PATCH)
+    def test_returns_slack_error_code_on_rejection(self, mock_get):
+        response = MagicMock()
+        response.json.return_value = {"ok": False, "error": "missing_scope"}
+        mock_get.return_value = response
+        assert validate_slack_credentials("token") == (False, "missing_scope")
+
+    @mock.patch(SLACK_GET_PATCH)
+    def test_ok_true_is_valid(self, mock_get):
+        response = MagicMock()
+        response.json.return_value = {"ok": True}
+        mock_get.return_value = response
+        assert validate_slack_credentials("token") == (True, None)
+
+    @mock.patch(SLACK_GET_PATCH)
+    def test_unreachable_returns_none_code(self, mock_get):
+        # An exhausted retry or network error must not look like a definitive rejection.
+        mock_get.side_effect = Exception("boom")
+        assert validate_slack_credentials("token") == (False, None)
+
+
+class TestSlackSourceValidateCredentials:
+    def _validate(self, mock_result):
+        source = SlackSource()
+        with (
+            mock.patch(SOURCE_VALIDATE_PATCH, return_value=mock_result) as mock_validate,
+            mock.patch.object(source, "_resolve_access_token", return_value=("token", None, "cache")),
+        ):
+            result = source.validate_credentials(MagicMock(), team_id=1)
+        mock_validate.assert_called_once_with("token")
+        return result
+
+    @parameterized.expand(
+        [
+            # A valid token that only lacks scopes must guide a re-auth, not read as "invalid".
+            ("missing_scope", "missing_scope", "missing required scopes"),
+            ("invalid_auth", "invalid_auth", "token is invalid"),
+            ("token_revoked", "token_revoked", "revoked"),
+            # An unmapped Slack error still surfaces the specific code rather than a generic string.
+            ("unknown_code", "some_new_error", "some_new_error"),
+        ]
+    )
+    def test_rejection_maps_error_code_to_specific_message(self, _name, error_code, expected_substring):
+        is_valid, message = self._validate((False, error_code))
+        assert is_valid is False
+        assert message is not None
+        assert expected_substring in message
+
+    def test_unreachable_is_not_reported_as_invalid(self):
+        is_valid, message = self._validate((False, None))
+        assert is_valid is False
+        assert message == "Couldn't reach Slack to verify your credentials. Please try again in a moment."
+
+    def test_valid_credentials(self):
+        is_valid, message = self._validate((True, None))
+        assert is_valid is True
+        assert message is None
 
 
 class TestSlackSourceWebhookEventSync:


### PR DESCRIPTION
## Problem

When someone connects a Slack source, credential validation showed "Invalid Slack credentials" for every failure. Slack's `auth.test` returns distinct error codes (`invalid_auth`, `missing_scope`, `token_revoked`, `account_inactive`, ...), and they mean very different things. The `missing_scope` case is the worst: the token is valid, it just wasn't granted a scope, so telling the user their credentials are invalid sends them re-pasting a token that was never the problem. A transient / unreachable Slack looked identical too.

This came out of a triage of data-warehouse source-creation failures. Slack's generic message was one of a few hiding the real cause.

## Changes

The `auth.test` probe collapsed everything into a bool. It now returns `(is_valid, error_code)`:

- rejection → Slack's own error code (`invalid_auth`, `missing_scope`, ...)
- `None` → the check couldn't complete (network error, or an exhausted rate-limit / 5xx retry)

The source's `validate_credentials` maps the code through the per-error copy it already curates in `get_non_retryable_errors` for the sync path, so create-time and sync-time messages stay consistent (a `missing_scope` now points at a re-auth, not a bad token). An unmapped code still surfaces the specific code, and an unreachable Slack reports a transient failure instead of "invalid credentials".

No change to how the token is checked or to any sync behavior.

## How did you test this code?

Automated only (I'm Claude, agent-authored). Added two test classes to `tests/test_slack_source.py` and ran them with `uv run pytest`:

- `TestSlackValidateCredentialsProbe` — the probe returns the Slack error code on rejection, `(True, None)` when `ok`, and `(False, None)` when the request raises (so an exhausted retry isn't mistaken for a definitive rejection).
- `TestSlackSourceValidateCredentials` — parameterized over error codes to lock the mapping: `missing_scope` / `invalid_auth` / `token_revoked` each produce their specific message, an unknown code surfaces the raw code, and `None` produces the transient message rather than "invalid". This guards the regression where a valid-but-underscoped or transient failure gets reported as invalid credentials.

12 passed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code) during a triage pass over data-warehouse source-creation errors. I chose to reuse the source's existing `get_non_retryable_errors` copy rather than write a second mapping, so the two paths can't drift. Invoked the `/writing-tests` skill before adding the tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
