### PR TITLE
fix(hogql): tolerate non-string $session_id in events query

### DIFF
--- a/posthog/hogql_queries/events_query_runner.py
+++ b/posthog/hogql_queries/events_query_runner.py
@@ -453,7 +453,7 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
                         properties = result[star_idx].get("properties", {})
                         if isinstance(properties, dict):
                             session_id = properties.get("$session_id")
-                            if session_id:
+                            if isinstance(session_id, str) and session_id:
                                 properties["$has_recording"] = session_id in session_recordings_map
 
         person_indices: list[int] = []
@@ -565,7 +565,7 @@ class EventsQueryRunner(AnalyticsQueryRunner[EventsQueryResponse]):
                 properties = result[star_idx].get("properties", {})
                 if isinstance(properties, dict):
                     session_id = properties.get("$session_id")
-                    if session_id and session_id != "":
+                    if isinstance(session_id, str) and session_id:
                         session_ids.add(session_id)
 
         # If no session IDs, return empty set

--- a/posthog/hogql_queries/test/test_events_query_runner.py
+++ b/posthog/hogql_queries/test/test_events_query_runner.py
@@ -133,6 +133,32 @@ class TestEventsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual({"p_true", "p_false"}, {row[0]["distinct_id"] for row in results})
 
+    def test_star_select_tolerates_non_string_session_id(self):
+        # Malformed SDK payloads can send $session_id as a dict/list/number. The session-recording
+        # batch check used to `set.add(session_id)` it, raising `TypeError: unhashable type` and 500ing
+        # the whole explore query. A valid string session must still be processed; bad ones are skipped.
+        self._create_events(
+            data=[
+                ("good", "2020-01-11T12:00:01Z", {"$session_id": "0190-good-session"}),
+                ("dict", "2020-01-11T12:00:02Z", {"$session_id": {"bytes": {"0": 1}}}),
+                ("list", "2020-01-11T12:00:03Z", {"$session_id": [1, 2, 3]}),
+                ("int", "2020-01-11T12:00:04Z", {"$session_id": 12345}),
+            ]
+        )
+        flush_persons_and_events()
+
+        with freeze_time("2020-01-11T12:01:00"):
+            query = EventsQuery(kind="EventsQuery", after="-24h", orderBy=["timestamp ASC"], select=["*"])
+            response = EventsQueryRunner(query=query, team=self.team).run()
+
+        assert isinstance(response, CachedEventsQueryResponse)
+        by_distinct_id = {row[0]["distinct_id"]: row[0]["properties"] for row in response.results}
+        assert set(by_distinct_id) == {"good", "dict", "list", "int"}
+        # String session id is checked for a recording (none exists, so False); non-string ones are skipped.
+        assert by_distinct_id["good"]["$has_recording"] is False
+        for distinct_id in ("dict", "list", "int"):
+            assert "$has_recording" not in by_distinct_id[distinct_id]
+
     def test_person_id_expands_to_distinct_ids(self):
         _create_person(
             team_id=self.team.pk,


### PR DESCRIPTION
## Problem

The Activity → Explore data table can return an HTTP 500 (`{"detail":"A server error occurred."}`) on its `EventsQuery` request whenever an event in the result set has a `$session_id` property that is not a string. Some SDK payloads send `$session_id` as a JSON object (e.g. `{"bytes": {...}}`, a malformed UUID serialization) rather than a UUID string. That is enough to break the whole explore view for that project and time range.

## Changes

`EventsQueryRunner`'s session-recording check reads `properties["$session_id"]` for every row when `*` is selected. It added that value to a `set` and used it as a set-membership key. When the value is a `dict` (or any unhashable type) `set.add(...)` raises `TypeError: unhashable type: 'dict'`. That exception is not one of the classified query exceptions, so it fell through to the generic 500 rather than degrading gracefully.

The fix guards both `$session_id` read sites in `posthog/hogql_queries/events_query_runner.py` with `isinstance(session_id, str)`, so non-string session ids are skipped (no recording lookup, no `$has_recording` tag) instead of crashing. The underlying data is a client instrumentation bug, but a bad `$session_id` on one event should never 500 the query.

> [!NOTE]
> The same malformed data also produced a broken "view recording" link (`/replay/[object Object]`) on the frontend. That is fixed separately in [#73896](https://github.com/PostHog/posthog/pull/73896). The two are independent and can merge in any order.

## How did you test this code?

Added a regression test `test_star_select_tolerates_non_string_session_id` in `posthog/hogql_queries/test/test_events_query_runner.py`. It runs a `select=["*"]` query over a result set mixing a valid string `$session_id` with `dict`, `list`, and `int` values. It catches a regression no existing test did: reverting the guard makes it fail with exactly `TypeError: unhashable type: 'dict'` at the `set.add` site; with the fix it passes, the string-session row still gets `$has_recording`, and the non-string rows are skipped. The `dict`/`list` cases cover the crash (unhashable); the `int` case guards that hashable-but-non-string values are skipped too, so a narrower "catch TypeError" fix wouldn't satisfy it.

I (Claude) ran that test plus the neighbouring `*`-select tests locally against the dev stack and they pass. I did not do manual UI testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) diagnosed this from a HAR of the failing request. The root cause was confirmed against production, not guessed: EU `system.query_log` showed every ClickHouse query for the request succeeded (`exception_code = 0`), and the EU app log stream (`ClickHouse Logs PROD EU`, `logs_distributed`) carried the captured traceback pointing at `batch_check_session_recordings` line 569. I then confirmed the offending data — the top-100 rows for that project and day had 65 events whose `$session_id` was a JSON object.

Skills invoked: `/query-clickhouse-via-metabase` (query_log + log stream tracing) and `/writing-tests` (test value gate). Along the way I ruled out three plausible-but-wrong hypotheses: shared AST nodes in the presorted-optimization branch, `orjson.loads` on malformed `properties`, and `chain_to_elements` choking on modern Tailwind CSS class names (reproduced the parser on the real chains — all parsed fine).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
