### PR TITLE
fix(llm-gateway): drain in-flight streams on SIGTERM

### DIFF
--- a/services/llm-gateway/Dockerfile
+++ b/services/llm-gateway/Dockerfile
@@ -36,9 +36,14 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/_liveness')" || exit 1
 
+# --graceful-timeout bounds the drain on SIGTERM: gunicorn SIGKILLs the worker once it
+# expires, cutting any stream still in flight. The 30s default is far shorter than a long
+# streaming turn, so deploys and scale-downs sever live responses. 600s fits inside the pod's
+# 660s terminationGracePeriodSeconds after the 15s preStop sleep (charts/llm-gateway).
 CMD ["gunicorn", "llm_gateway.main:app", \
      "--bind", "0.0.0.0:8080", \
      "--workers", "1", \
      "--worker-class", "uvicorn.workers.UvicornWorker", \
+     "--graceful-timeout", "600", \
      "--access-logfile", "-", \
      "--error-logfile", "-"]


### PR DESCRIPTION
## Problem

by default we have `--graceful-timeout` of 30s. On SIGTERM the worker is SIGKILLed 30 seconds later, cutting any streaming response still in flight. The pod's `terminationGracePeriodSeconds` cannot extend that and every deploy and every KEDA scale-down therefore severs live streams. Streaming turns routinely run for minutes, so a 30s drain covers almost none of them, and the client sees a transport-level cut with no error frame.

## Changes

- `services/llm-gateway/Dockerfile`: add `--graceful-timeout 600` to the gunicorn CMD, with a comment recording why the default is wrong here and how the value relates to the pod's grace period

Sizing: 15s preStop + 600s drain = 615s, inside the pod's 660s `terminationGracePeriodSeconds`. Matches ai-gateway's posture (`AI_GATEWAY_SHUTDOWN_TIMEOUT: 11m`)

