### PR TITLE
fix(experiments): stop replay funnel steps echoing repeated events in player breakdown

### DIFF
--- a/products/experiments/backend/metric_events.py
+++ b/products/experiments/backend/metric_events.py
@@ -494,12 +494,14 @@ def scan_session_for_metric_events(
             if repeated_step_nodes[node_sig] > 1:
                 rank = step_rank.get(node_sig, 0)
                 step_rank[node_sig] = rank + 1
-                # timestamps are ascending and capped at MAX_METRIC_EVENT_TIMESTAMPS, so their
-                # length is min(count, cap): rank < len both proves the occurrence exists and gives
-                # us its timestamp. A later step of a single-occurrence funnel is therefore dropped.
-                if rank >= len(source_timestamps):
+                # A step is reached once the event has fired more times than its rank; drop only the
+                # steps the event never reached (gauge that on the true count, not the seek-point
+                # tuple). Seek points are capped at MAX_METRIC_EVENT_TIMESTAMPS, so a step reached
+                # past the cap (a >cap-step funnel of one event) keeps its place and points at the
+                # last available seek point rather than vanishing.
+                if rank >= source_count:
                     continue
-                occurrence = source_timestamps[rank]
+                occurrence = source_timestamps[min(rank, len(source_timestamps) - 1)]
                 source_count, source_first, source_timestamps = 1, occurrence, (occurrence,)
             source_hits.append(
                 MetricSourceHit(

--- a/products/experiments/backend/metric_events.py
+++ b/products/experiments/backend/metric_events.py
@@ -11,6 +11,7 @@ endpoint.
 """
 
 import logging
+from collections import Counter
 from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
@@ -472,20 +473,43 @@ def scan_session_for_metric_events(
         if totals is None:
             continue
         event_count, first_timestamp, timestamps = totals
+        # A funnel can list the same event as several steps (an "N-th occurrence" funnel: the same
+        # activation event repeated N times). Those steps share one aggregate group, so reading the
+        # group per step would echo the same events under every step, and a single occurrence would
+        # read as a completed N-step funnel. Assign the group's occurrences positionally instead:
+        # the k-th such step maps to the k-th occurrence, so it fires only once the event has fired
+        # k+1 times. Only funnel steps are positional — a ratio reusing one event on both sides
+        # still legitimately counts it on each side, so its identical sources keep echoing.
+        repeated_step_nodes = Counter(
+            node_key(source) for source in metric_source.sources if source.role == MetricSourceRole.STEP
+        )
+        step_rank: dict[str, int] = {}
         source_hits: list[MetricSourceHit] = []
         for source in metric_source.sources:
             source_totals = read_group((node_key(source),))
             if source_totals is None:
                 continue
+            source_count, source_first, source_timestamps = source_totals
+            node_sig = node_key(source)
+            if repeated_step_nodes[node_sig] > 1:
+                rank = step_rank.get(node_sig, 0)
+                step_rank[node_sig] = rank + 1
+                # timestamps are ascending and capped at MAX_METRIC_EVENT_TIMESTAMPS, so their
+                # length is min(count, cap): rank < len both proves the occurrence exists and gives
+                # us its timestamp. A later step of a single-occurrence funnel is therefore dropped.
+                if rank >= len(source_timestamps):
+                    continue
+                occurrence = source_timestamps[rank]
+                source_count, source_first, source_timestamps = 1, occurrence, (occurrence,)
             source_hits.append(
                 MetricSourceHit(
                     role=source.role,
                     name=source.name,
                     index=source.index,
                     total=source.total,
-                    event_count=source_totals[0],
-                    first_timestamp=source_totals[1],
-                    timestamps=source_totals[2],
+                    event_count=source_count,
+                    first_timestamp=source_first,
+                    timestamps=source_timestamps,
                 )
             )
         hits.append(

--- a/products/experiments/backend/test/test_metric_events.py
+++ b/products/experiments/backend/test/test_metric_events.py
@@ -438,6 +438,34 @@ class TestScanSessionForMetricEvents(ClickhouseTestMixin, MetricEventsTestMixin)
             (3, 1, datetime(2026, 1, 1, 10, 6, tzinfo=UTC)),
         ]
 
+    def test_funnel_repeated_step_reached_past_seek_point_cap_is_still_shown(self) -> None:
+        # Seek points are capped at MAX_METRIC_EVENT_TIMESTAMPS. A repeated step reached past that
+        # cap (only reachable by a funnel of >cap identical steps whose event fired >cap times) must
+        # still be shown: gauging "reached" on the capped seek-point tuple instead of the true event
+        # count would silently drop it. The step past the cap reuses the last available seek point.
+        funnel = _metric(
+            "funnel",
+            name="Third activation",
+            series=[_events_node("activated"), _events_node("activated"), _events_node("activated")],
+        )
+        times = [
+            datetime(2026, 1, 1, 10, 5, tzinfo=UTC),
+            datetime(2026, 1, 1, 10, 6, tzinfo=UTC),
+            datetime(2026, 1, 1, 10, 7, tzinfo=UTC),
+        ]
+        for ts in times:
+            self._create_session_event("activated", "s1", timestamp=ts.isoformat())
+        flush_persons_and_events()
+
+        with patch("products.experiments.backend.metric_events.MAX_METRIC_EVENT_TIMESTAMPS", 2):
+            hits = self._scan([funnel], "s1")
+
+        assert [(source.index, source.first_timestamp) for source in hits[0].sources] == [
+            (0, times[0]),
+            (1, times[1]),
+            (2, times[1]),
+        ]
+
     def test_retention_distinct_completion_in_session_reports_its_source(self) -> None:
         # A distinct return event that fires in the session must surface as a completion source,
         # even for a window that opens a day later — the analysis counts such a return when the

--- a/products/experiments/backend/test/test_metric_events.py
+++ b/products/experiments/backend/test/test_metric_events.py
@@ -375,6 +375,69 @@ class TestScanSessionForMetricEvents(ClickhouseTestMixin, MetricEventsTestMixin)
             (MetricSourceRole.STEP, "upgraded", 2, 3)
         ]
 
+    @parameterized.expand([("one_occurrence", 1), ("three_occurrences", 3)])
+    def test_funnel_repeated_step_event_maps_occurrences_to_steps_positionally(
+        self, _name: str, occurrences: int
+    ) -> None:
+        # An "N-th activation" funnel lists the same event as every step (production: a 3-step funnel
+        # of "product intent marked activated"). The steps share one aggregate group, so the scan
+        # used to echo that single group under all N steps — one occurrence read as a completed
+        # N-step funnel. Each identical step must instead map to a distinct occurrence: step k fires
+        # only once the event has fired k+1 times, at its k-th occurrence.
+        funnel = _metric(
+            "funnel",
+            name="Third activation",
+            series=[_events_node("activated"), _events_node("activated"), _events_node("activated")],
+        )
+        occurrence_times = [
+            datetime(2026, 1, 1, 10, 5, tzinfo=UTC),
+            datetime(2026, 1, 1, 10, 6, tzinfo=UTC),
+            datetime(2026, 1, 1, 10, 7, tzinfo=UTC),
+        ]
+        for ts in occurrence_times[:occurrences]:
+            self._create_session_event("activated", "s1", timestamp=ts.isoformat())
+        flush_persons_and_events()
+
+        hits = self._scan([funnel], "s1")
+
+        assert len(hits) == 1
+        hit = hits[0]
+        # The metric total still counts every occurrence; only the per-step breakdown is positional.
+        assert hit.event_count == occurrences
+        assert [
+            (source.role, source.index, source.total, source.event_count, source.first_timestamp)
+            for source in hit.sources
+        ] == [(MetricSourceRole.STEP, i, 3, 1, occurrence_times[i]) for i in range(occurrences)]
+
+    def test_funnel_repeated_step_ranks_by_same_event_position_not_series_index(self) -> None:
+        # Interleaved "A → B" funnels (production: insight date range changed / query completed,
+        # repeated) put a repeated event at non-adjacent steps. Each event's occurrences must be
+        # assigned by rank among that event's own steps, not by absolute series index: with query
+        # completed at steps 2 and 4, its first occurrence maps to step 2 and its second to step 4,
+        # while the never-fired date-change steps drop out. Using the absolute index would look for
+        # step 4's occurrence at position 3 and wrongly drop it.
+        funnel = _metric(
+            "funnel",
+            name="Date change -> query loaded x2",
+            series=[
+                _events_node("date changed"),
+                _events_node("query completed"),
+                _events_node("date changed"),
+                _events_node("query completed"),
+            ],
+        )
+        self._create_session_event("query completed", "s1", timestamp="2026-01-01T10:05:00Z")
+        self._create_session_event("query completed", "s1", timestamp="2026-01-01T10:06:00Z")
+        flush_persons_and_events()
+
+        hits = self._scan([funnel], "s1")
+
+        assert len(hits) == 1
+        assert [(source.index, source.event_count, source.first_timestamp) for source in hits[0].sources] == [
+            (1, 1, datetime(2026, 1, 1, 10, 5, tzinfo=UTC)),
+            (3, 1, datetime(2026, 1, 1, 10, 6, tzinfo=UTC)),
+        ]
+
     def test_retention_distinct_completion_in_session_reports_its_source(self) -> None:
         # A distinct return event that fires in the session must surface as a completion source,
         # even for a window that opens a day later — the analysis counts such a return when the


### PR DESCRIPTION
## Problem

[#73491](https://github.com/PostHog/posthog/pull/73491) added a per-source breakdown to the replay experiment sidebar, so a metric hit shows which side fired ("Step 2 of 3", numerator/denominator, retention start/return). A funnel that lists the same event as several steps broke it.

Some experiments measure "reached the N-th X" by repeating one event N times as an N-step funnel.
"Test new quickstart page" has a 3-step funnel where every step is `product intent marked activated`.
The scan keys aggregate groups by node signature, so those identical steps collapse to one group.
Reading the group per step then echoed the same events under every step: a single occurrence rendered as Step 1 of 3, Step 2 of 3, and Step 3 of 3 all at the same timestamp, reading as a completed funnel.

The interleaved "Date change → query loaded xN" funnels on "New insight date picker" hit the same shape, where `query completed` repeats at every other step.

The bug is display-only. The metric-level totals and the experiment analysis were always correct. This is the replay sidebar breakdown.

## Changes

Assign a repeated event's occurrences positionally in the read loop of `scan_session_for_metric_events`.
The k-th step of a repeated event maps to the k-th occurrence by ascending timestamp, so a step appears only once the event has fired k+1 times, at its own occurrence.
One `product intent marked activated` now shows only Step 1 of 3, not all three.

Ranks are keyed per event signature, so an interleaved funnel (A, B, A, B) distributes each event across its own steps and the never-fired steps drop out.
Only funnel steps are positional.
A ratio that reuses one event on both sides still counts it on each side, and distinct funnel steps keep their full count and all seek points.

## How did you test this code?

TDD, backend only.
I (Claude) wrote a failing test reproducing the production shape first, confirmed it failed on the old code, then fixed it.

- `test_metric_events.py` — added `test_funnel_repeated_step_event_maps_occurrences_to_steps_positionally` (1 occurrence → only Step 1 of 3; 3 occurrences → three steps at three distinct times) and `test_funnel_repeated_step_ranks_by_same_event_position_not_series_index` (interleaved A,B,A,B: a repeated event's occurrence is indexed by rank among its own steps, not absolute series position — the adjacent-repeat test can't catch this because there rank equals index). Full suite: 30 passed.
- Verified the diagnosis and behavior against production (project 2): the reported session had `product intent marked activated` fire exactly once; other sessions have 2-4 occurrences where the positional distribution matters.
- mypy clean on the module, ruff clean.

I did not click through the replay UI. The frontend renders whatever step subset the backend returns (it already handled partial step sets), so this is backend-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Marcel spotted the "all funnel steps fired at the same minute" anomaly on a production replay and asked me (Claude) to check whether it was bad data or a bug. I traced it to the per-source breakdown collapsing identical funnel steps into one aggregate group, verified against production that the event fired once.

Skills invoked: `/writing-tests` (gating the two new backend tests).

Chose positional occurrence assignment over collapsing repeated steps into one "event ×N" chip: positional keeps per-step seek points and the "of N" context, and matches how distinct-step funnels already render.
One residual known limitation remains for interleaved funnels — a later step can still show (e.g. "Step 8 of 8") when an earlier interleaved step never fired, since the scan reports session truth and deliberately doesn't model cross-event funnel ordering. Left as-is rather than expand scope.
