### PR TITLE
fix(insights): show renamed series name in trends legend

### DIFF
--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -456,11 +456,9 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
     @parameterized.expand(
         [
-            # (series, expected action.custom_name) — the legend/tooltip render `custom_name` over the raw event.
             ("custom_name set via rename modal", EventsNode(event="$pageview", custom_name="Renamed"), "Renamed"),
             ("name set via query editor / API", EventsNode(event="$pageview", name="Renamed"), "Renamed"),
             ("custom_name wins over name", EventsNode(event="$pageview", name="A", custom_name="B"), "B"),
-            # A `name` echoing the event is not a rename — must not leak into custom_name.
             ("name echoing the event is not a rename", EventsNode(event="$pageview", name="$pageview"), None),
             ("no override", EventsNode(event="$pageview"), None),
         ]

--- a/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_query_runner.py
@@ -454,6 +454,31 @@ class TestTrendsQueryRunner(ClickhouseTestMixin, APIBaseTest):
 
         self.assertEqual("$pageview", response.results[0]["label"])
 
+    @parameterized.expand(
+        [
+            # (series, expected action.custom_name) — the legend/tooltip render `custom_name` over the raw event.
+            ("custom_name set via rename modal", EventsNode(event="$pageview", custom_name="Renamed"), "Renamed"),
+            ("name set via query editor / API", EventsNode(event="$pageview", name="Renamed"), "Renamed"),
+            ("custom_name wins over name", EventsNode(event="$pageview", name="A", custom_name="B"), "B"),
+            # A `name` echoing the event is not a rename — must not leak into custom_name.
+            ("name echoing the event is not a rename", EventsNode(event="$pageview", name="$pageview"), None),
+            ("no override", EventsNode(event="$pageview"), None),
+        ]
+    )
+    def test_trends_series_custom_name(self, _name, series, expected_custom_name):
+        self._create_test_events()
+
+        response = self._run_trends_query(
+            self.default_date_from,
+            self.default_date_to,
+            IntervalType.DAY,
+            [series],
+            None,
+            None,
+        )
+
+        self.assertEqual(expected_custom_name, response.results[0]["action"]["custom_name"])
+
     def test_trends_count(self):
         self._create_test_events()
 

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -73,7 +73,7 @@ from posthog.hogql_queries.insights.utils.breakdowns import (
     has_breakdown_filter,
 )
 from posthog.hogql_queries.insights.utils.utils import get_response_hogql
-from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
+from posthog.hogql_queries.query_runner import AnalyticsQueryRunner, resolve_series_custom_name
 from posthog.hogql_queries.utils.formula_ast import FormulaAST
 from posthog.hogql_queries.utils.query_compare_to_date_range import QueryCompareToDateRange
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -608,7 +608,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
                         "type": "events",
                         "order": series.series_order,
                         "name": series_label or "All events",
-                        "custom_name": self.series_custom_name(series.series, series_label),
+                        "custom_name": resolve_series_custom_name(series.series, series_label),
                         "math": series.series.math,
                         "math_property": series.series.math_property,
                         "math_hogql": series.series.math_hogql,
@@ -645,7 +645,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
                         "type": "events",
                         "order": series.series_order,
                         "name": series_label or "All events",
-                        "custom_name": self.series_custom_name(series.series, series_label),
+                        "custom_name": resolve_series_custom_name(series.series, series_label),
                         "math": series.series.math,
                         "math_property": series.series.math_property,
                         "math_hogql": series.series.math_hogql,
@@ -841,18 +841,6 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
             now=datetime.now(),
             exact_timerange=self.exact_timerange,
         )
-
-    def series_custom_name(
-        self, series: Union[EventsNode, ActionsNode, DataWarehouseNode, GroupNode], series_label: str | None
-    ) -> str | None:
-        # A series' display override. `custom_name` is set by the in-app "Rename graph series" modal;
-        # a `name` that differs from the event/action label is a rename applied via the query editor or
-        # API. Either should win over the raw event name in legends and tooltips.
-        if series.custom_name:
-            return series.custom_name
-        if series.name and series.name != series_label:
-            return series.name
-        return None
 
     def series_event(self, series: Union[EventsNode, ActionsNode, DataWarehouseNode, GroupNode]) -> str | None:
         if isinstance(series, EventsNode):

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -848,12 +848,10 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
         # A series' display override. `custom_name` is set by the in-app "Rename graph series" modal;
         # a `name` that differs from the event/action label is a rename applied via the query editor or
         # API. Either should win over the raw event name in legends and tooltips.
-        custom_name = getattr(series, "custom_name", None)
-        if custom_name:
-            return custom_name
-        name = getattr(series, "name", None)
-        if name and name != series_label:
-            return name
+        if series.custom_name:
+            return series.custom_name
+        if series.name and series.name != series_label:
+            return series.name
         return None
 
     def series_event(self, series: Union[EventsNode, ActionsNode, DataWarehouseNode, GroupNode]) -> str | None:

--- a/posthog/hogql_queries/insights/trends/trends_query_runner.py
+++ b/posthog/hogql_queries/insights/trends/trends_query_runner.py
@@ -608,7 +608,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
                         "type": "events",
                         "order": series.series_order,
                         "name": series_label or "All events",
-                        "custom_name": series.series.custom_name,
+                        "custom_name": self.series_custom_name(series.series, series_label),
                         "math": series.series.math,
                         "math_property": series.series.math_property,
                         "math_hogql": series.series.math_hogql,
@@ -645,7 +645,7 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
                         "type": "events",
                         "order": series.series_order,
                         "name": series_label or "All events",
-                        "custom_name": series.series.custom_name,
+                        "custom_name": self.series_custom_name(series.series, series_label),
                         "math": series.series.math,
                         "math_property": series.series.math_property,
                         "math_hogql": series.series.math_hogql,
@@ -841,6 +841,20 @@ class TrendsQueryRunner(AnalyticsQueryRunner[TrendsQueryResponse]):
             now=datetime.now(),
             exact_timerange=self.exact_timerange,
         )
+
+    def series_custom_name(
+        self, series: Union[EventsNode, ActionsNode, DataWarehouseNode, GroupNode], series_label: str | None
+    ) -> str | None:
+        # A series' display override. `custom_name` is set by the in-app "Rename graph series" modal;
+        # a `name` that differs from the event/action label is a rename applied via the query editor or
+        # API. Either should win over the raw event name in legends and tooltips.
+        custom_name = getattr(series, "custom_name", None)
+        if custom_name:
+            return custom_name
+        name = getattr(series, "name", None)
+        if name and name != series_label:
+            return name
+        return None
 
     def series_event(self, series: Union[EventsNode, ActionsNode, DataWarehouseNode, GroupNode]) -> str | None:
         if isinstance(series, EventsNode):

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -1293,6 +1293,19 @@ R = TypeVar("R", bound=BaseModel)
 CR = TypeVar("CR", bound=GenericCachedQueryResponse)
 
 
+def resolve_series_custom_name(series: Any, raw_label: str | None) -> str | None:
+    # A series' display override for legends and tooltips. `custom_name` is set by the in-app
+    # "Rename graph series" modal; a `name` that differs from the raw event/action label is a rename
+    # applied via the query editor or API. Either should win over the raw event name.
+    custom_name = getattr(series, "custom_name", None)
+    if custom_name:
+        return custom_name
+    name = getattr(series, "name", None)
+    if name and name != raw_label:
+        return name
+    return None
+
+
 class QueryRunner(ABC, Generic[Q, R, CR]):
     query: Q
     response: R
@@ -2135,10 +2148,11 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
         if not results or not isinstance(results, list):
             return cached_response, False
 
-        custom_names_by_order: dict[int, str | None] = {}
-        for i, s in enumerate(series):
-            custom_name = getattr(s, "custom_name", None)
-            custom_names_by_order[i] = custom_name
+        series_by_order = dict(enumerate(series))
+        # Only TrendsQuery surfaces a `name`-based rename into custom_name on the fresh path (see
+        # TrendsQueryRunner's use of resolve_series_custom_name). Stickiness/lifecycle use custom_name
+        # only, so honoring `name` here would desync their cached responses from a fresh computation.
+        honor_name = isinstance(self.query, TrendsQuery)
 
         was_modified = False
         for result in results:
@@ -2148,11 +2162,17 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             if not isinstance(action, dict):
                 continue
             order = action.get("order")
-            if order is not None and order in custom_names_by_order:
-                new_name = custom_names_by_order[order]
-                if action.get("custom_name") != new_name:
-                    action["custom_name"] = new_name
-                    was_modified = True
+            if order is None or order not in series_by_order:
+                continue
+            s = series_by_order[order]
+            if honor_name:
+                # The cached action's `name` holds the raw event/action label (`series_label or "All events"`).
+                new_name = resolve_series_custom_name(s, action.get("name"))
+            else:
+                new_name = getattr(s, "custom_name", None)
+            if action.get("custom_name") != new_name:
+                action["custom_name"] = new_name
+                was_modified = True
 
         return cached_response, was_modified
 

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -983,6 +983,20 @@ class TestApplySeriesCustomNames(BaseTest):
                 [{"action": {"order": 0, "custom_name": None}, "data": [1]}],
             ),
             (
+                # Guards the Greptile P1: a `name`-based rename (set via query editor / API, not the
+                # modal) must survive cache normalization, not revert to the raw event name.
+                "applies_name_based_rename_from_cache",
+                TrendsQuery(series=[EventsNode(event="$pageview", name="Renamed")]),
+                [{"action": {"order": 0, "name": "$pageview", "custom_name": None}, "data": [1]}],
+                [{"action": {"order": 0, "name": "$pageview", "custom_name": "Renamed"}, "data": [1]}],
+            ),
+            (
+                "name_echoing_the_event_is_not_a_rename",
+                TrendsQuery(series=[EventsNode(event="$pageview", name="$pageview")]),
+                [{"action": {"order": 0, "name": "$pageview", "custom_name": None}, "data": [1]}],
+                [{"action": {"order": 0, "name": "$pageview", "custom_name": None}, "data": [1]}],
+            ),
+            (
                 "skips_results_without_action",
                 TrendsQuery(series=[EventsNode(event="$pageview", custom_name="Name")]),
                 [{"action": None, "data": [1]}, {"data": [2]}],


### PR DESCRIPTION
## Problem

On a trends line chart, the new in-chart quill legend shows the raw event name instead of a renamed series name — so two series that filter the same event on different properties are indistinguishable.

The legend derives each series' label from the query *result*'s `action`, which honors `custom_name` but not a series `name`. `series_event()` returns the raw event, so `action.name` is the event and `action.custom_name` only reflects `series.custom_name`. A series renamed via the query editor or API (which sets `name`) never reaches the legend. The legacy legend rendered labels from the frontend query *definition* (which carries `name`), so this regressed once the quill in-chart legend became the default.

Raised in a Slack support thread (linked below).

## Changes

Surface a series' display override into the result `action.custom_name`: use `custom_name` when set, otherwise a `name` that differs from the raw event/action label (a `name` echoing the event is not a rename and is ignored). This mirrors the frontend label resolver and restores parity now that the quill legend reads from the query result. Applied in both the aggregate and time-series result branches of the trends query runner.

## How did you test this code?

Added a parameterized regression test (`test_trends_series_custom_name`) covering: `custom_name` set, `name` set, `custom_name` winning over `name`, a `name` echoing the event (no rename → `None`), and no override. It guards the reported regression — a revert to reading only `series.custom_name` fails the `name` case.

The sandbox has no Postgres/ClickHouse, so I couldn't execute the DB-backed suite here; the cases collect correctly and the `series_custom_name` resolution logic was verified standalone against the real schema nodes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and authored by the PostHog Slack app. Traced the legend label path (`getTrendsSeriesDisplayLabel` → `getDisplayNameFromEntityFilter`) to the backend result builder, and found the `name`-vs-`custom_name` gap by inspecting the affected insight's series config. Chose a backend fix (one resolver used by both result branches) over re-plumbing series nodes through every chart, so legend and tooltip stay consistent across surfaces. Invoked the `/writing-tests` skill before adding the test.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1784901266426799?thread_ts=1784901266.426799&cid=C0ACRAMJUAG)*
