### PR TITLE
feat(conversations): apply saved ticket views server-side via ?view= param

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -572,6 +572,10 @@ SPECTACULAR_SETTINGS = {
         "TicketStatusEnum": "products.conversations.backend.models.constants.Status",
         # Shared by Ticket.priority and TicketViewFilters.priority (same choice set).
         "TicketPriorityEnum": "products.conversations.backend.models.constants.Priority",
+        "TicketChannelFilterEnum": "products.conversations.backend.api.ticket_filters.TICKET_CHANNEL_FILTER_CHOICES",
+        "TicketSlaFilterEnum": "products.conversations.backend.api.ticket_filters.TICKET_SLA_FILTER_CHOICES",
+        "TicketTagsMatchEnum": "products.conversations.backend.api.ticket_filters.TICKET_TAGS_MATCH_CHOICES",
+        "TicketSortOrderEnum": "products.conversations.backend.api.ticket_filters.TICKET_SORT_ORDER_CHOICES",
         "BatchImportStatusEnum": "products.managed_migrations.backend.models.batch_imports.BatchImport.Status",
         # Shared by ExperimentMetricsRecalculation.status and ActiveRecalculationRun.status (same choice set).
         "MetricsRecalculationStatusEnum": (

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -570,6 +570,8 @@ SPECTACULAR_SETTINGS = {
         "EvaluationTargetEnum": "products.ai_observability.backend.models.evaluations.EvaluationTarget",
         "IntegrationKindEnum": "posthog.models.integration.Integration.IntegrationKind",
         "TicketStatusEnum": "products.conversations.backend.models.constants.Status",
+        # Shared by Ticket.priority and TicketViewFilters.priority (same choice set).
+        "TicketPriorityEnum": "products.conversations.backend.models.constants.Priority",
         "BatchImportStatusEnum": "products.managed_migrations.backend.models.batch_imports.BatchImport.Status",
         # Shared by ExperimentMetricsRecalculation.status and ActiveRecalculationRun.status (same choice set).
         "MetricsRecalculationStatusEnum": (

--- a/products/conversations/backend/api/tests/test_ticket_views.py
+++ b/products/conversations/backend/api/tests/test_ticket_views.py
@@ -139,7 +139,7 @@ class TestTicketViewAPI(APIBaseTest):
             "priority": ["high", "medium"],
             "channel": "slack",
             "sla": "breached",
-            "assignee": "user:1",
+            "assignee": [{"type": "user", "id": 1}],
             "tags": ["bug", "urgent"],
             "dateFrom": "-7d",
             "dateTo": None,
@@ -160,12 +160,21 @@ class TestTicketViewAPI(APIBaseTest):
         response = self.client.post(self.base_url, payload, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_create_rejects_invalid_filter_values(self):
+    @parameterized.expand(
+        [
+            ("bad_status", {"status": ["bogus"]}),
+            # A dropped assignee entry would save a view matching more tickets than
+            # asked for, so writes must reject malformed entries outright.
+            ("assignee_string_token", {"assignee": ["user:1"]}),
+            ("assignee_unknown_type", {"assignee": [{"type": "team", "id": 1}]}),
+        ]
+    )
+    def test_create_rejects_invalid_filter_values(self, _label, filters):
         # Wiring guard: the endpoint must run TicketViewFiltersSerializer, so a filter
         # value the canonical shape rejects never reaches the database.
         response = self.client.post(
             self.base_url,
-            {"name": "Bad view", "filters": {"status": ["bogus"]}},
+            {"name": "Bad view", "filters": filters},
             format="json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -354,6 +363,38 @@ class TestTicketViewFiltersValidation(SimpleTestCase):
     def test_rejects_invalid_filter_values(self, _label, filters):
         serializer = TicketViewFiltersSerializer(data=filters)
         assert not serializer.is_valid()
+
+    @parameterized.expand(
+        [
+            ("string_token", ["user:1"], []),
+            ("mixed_entries", ["me", "user:1"], ["me"]),
+            ("legacy_all", "all", []),
+        ]
+    )
+    def test_lenient_mode_drops_invalid_assignee_entries(self, _label, assignee, expected):
+        # The ?view= read path validates stored blobs without strict_writes: a legacy or
+        # corrupted assignee entry must not 400 the whole view, just fall away.
+        serializer = TicketViewFiltersSerializer(data={"assignee": assignee})
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["assignee"] == expected
+
+    @parameterized.expand(
+        [
+            ("string_token", ["user:1"]),
+            ("single_bogus_string", "bogus"),
+            ("unknown_type", [{"type": "team", "id": 1}]),
+            ("missing_id", [{"type": "user"}]),
+        ]
+    )
+    def test_strict_writes_rejects_invalid_assignee_entries(self, _label, assignee):
+        serializer = TicketViewFiltersSerializer(data={"assignee": assignee}, context={"strict_writes": True})
+        assert not serializer.is_valid()
+        assert "assignee" in serializer.errors
+
+    def test_strict_writes_accepts_legacy_all_sentinel(self):
+        serializer = TicketViewFiltersSerializer(data={"assignee": "all"}, context={"strict_writes": True})
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["assignee"] == []
 
     def test_field_rejects_oversized_payload(self):
         field = TicketViewFiltersField()

--- a/products/conversations/backend/api/tests/test_ticket_views.py
+++ b/products/conversations/backend/api/tests/test_ticket_views.py
@@ -1,12 +1,17 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from django.test import SimpleTestCase
+
 from parameterized import parameterized
 from rest_framework import status
+from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIClient
 
 from posthog.models.team.team import Team
 
+from products.conversations.backend.api.ticket_filters import TicketViewFiltersSerializer
+from products.conversations.backend.api.ticket_views import TicketViewFiltersField
 from products.conversations.backend.models import TicketView, TicketViewFavorite
 
 
@@ -155,6 +160,23 @@ class TestTicketViewAPI(APIBaseTest):
         response = self.client.post(self.base_url, payload, format="json")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_create_rejects_invalid_filter_values(self):
+        # Wiring guard: the endpoint must run TicketViewFiltersSerializer, so a filter
+        # value the canonical shape rejects never reaches the database.
+        response = self.client.post(
+            self.base_url,
+            {"name": "Bad view", "filters": {"status": ["bogus"]}},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert not TicketView.objects.filter(team=self.team).exists()
+
+    def test_unknown_filter_keys_survive_round_trip(self):
+        # Filters are stored raw, so keys a newer frontend adds must not be dropped
+        # by an older backend's stricter validation.
+        data = self._create_via_api(filters={"status": ["open"], "futureKey": True})
+        assert data["filters"] == {"status": ["open"], "futureKey": True}
+
     # --- Read-only fields ---
 
     def test_short_id_ignored_on_create(self):
@@ -266,3 +288,76 @@ class TestTicketViewAPI(APIBaseTest):
         client = APIClient()
         response = client.get(self.base_url)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestTicketViewFiltersValidation(SimpleTestCase):
+    # No DB: TicketViewFiltersSerializer validation runs entirely in memory. The wiring
+    # guard in TestTicketViewAPI proves the endpoint invokes it.
+
+    @parameterized.expand(
+        [
+            ("empty", {}),
+            (
+                "frontend_defaults",
+                {
+                    "status": [],
+                    "priority": [],
+                    "channel": "all",
+                    "sla": "all",
+                    "aiTriageResult": [],
+                    "assignee": "all",
+                    "tags": [],
+                    "tagsMatch": "any",
+                    "tagsExclude": [],
+                    "sorting": {"columnKey": "updated_at", "order": -1},
+                    "search": "",
+                },
+            ),
+            (
+                "fully_populated",
+                {
+                    "status": ["open", "pending"],
+                    "priority": ["high", "critical"],
+                    "channel": "email",
+                    "sla": "at-risk",
+                    "aiTriageResult": ["escalated_no_reply", "in_progress"],
+                    "assignee": ["me", "unassigned", {"type": "user", "id": 1}, {"type": "role", "id": "abc"}],
+                    "tags": ["billing"],
+                    "tagsMatch": "all",
+                    "tagsExclude": ["spam"],
+                    "dateFrom": "-30d",
+                    "dateTo": None,
+                    "sorting": {"columnKey": "created_at", "order": 1},
+                    "search": "refund",
+                },
+            ),
+            ("legacy_single_assignee", {"assignee": {"type": "user", "id": 5}}),
+            ("null_sorting", {"sorting": None}),
+            ("unknown_keys_ignored", {"futureKey": True}),
+        ]
+    )
+    def test_accepts_saved_view_shapes(self, _label, filters):
+        serializer = TicketViewFiltersSerializer(data=filters)
+        assert serializer.is_valid(), serializer.errors
+
+    @parameterized.expand(
+        [
+            ("bad_status", {"status": ["bogus"]}),
+            ("bad_channel", {"channel": "phone"}),
+            ("bad_sla", {"sla": "late"}),
+            ("bad_tags_match", {"tagsMatch": "some"}),
+            ("bad_triage_result", {"aiTriageResult": ["nope"]}),
+            ("sorting_missing_order", {"sorting": {"columnKey": "updated_at"}}),
+            ("search_too_long", {"search": "x" * 201}),
+        ]
+    )
+    def test_rejects_invalid_filter_values(self, _label, filters):
+        serializer = TicketViewFiltersSerializer(data=filters)
+        assert not serializer.is_valid()
+
+    def test_field_rejects_oversized_payload(self):
+        field = TicketViewFiltersField()
+        oversized = {"tags": ["x" * 100] * 150}
+        with self.assertRaises(ValidationError) as ctx:
+            field.run_validation(oversized)
+        assert "too large" in str(ctx.exception)

--- a/products/conversations/backend/api/tests/test_ticket_views.py
+++ b/products/conversations/backend/api/tests/test_ticket_views.py
@@ -163,10 +163,8 @@ class TestTicketViewAPI(APIBaseTest):
     @parameterized.expand(
         [
             ("bad_status", {"status": ["bogus"]}),
-            # A dropped assignee entry would save a view matching more tickets than
-            # asked for, so writes must reject malformed entries outright.
+            # Only rejected in strict mode, so this case proves the write path passes strict_writes.
             ("assignee_string_token", {"assignee": ["user:1"]}),
-            ("assignee_unknown_type", {"assignee": [{"type": "team", "id": 1}]}),
         ]
     )
     def test_create_rejects_invalid_filter_values(self, _label, filters):

--- a/products/conversations/backend/api/tests/test_ticket_views.py
+++ b/products/conversations/backend/api/tests/test_ticket_views.py
@@ -112,7 +112,10 @@ class TestTicketViewAPI(APIBaseTest):
     def test_update_filters_keeps_name(self):
         created = self._create_via_api()
 
-        new_filters = {"status": ["resolved"], "assignee": {"type": "role", "id": "abc"}}
+        new_filters = {
+            "status": ["resolved"],
+            "assignee": {"type": "role", "id": "9c9a4c7e-9ab5-4f30-9b74-3d1e9f9d3a01"},
+        }
         response = self.client.patch(
             f"{self.base_url}{created['short_id']}/",
             {"filters": new_filters},
@@ -367,6 +370,8 @@ class TestTicketViewFiltersValidation(SimpleTestCase):
             ("string_token", ["user:1"], []),
             ("mixed_entries", ["me", "user:1"], ["me"]),
             ("legacy_all", "all", []),
+            ("user_non_numeric_id", [{"type": "user", "id": "abc"}], []),
+            ("role_non_uuid_id", [{"type": "role", "id": "not-a-uuid"}], []),
         ]
     )
     def test_lenient_mode_drops_invalid_assignee_entries(self, _label, assignee, expected):
@@ -382,6 +387,9 @@ class TestTicketViewFiltersValidation(SimpleTestCase):
             ("single_bogus_string", "bogus"),
             ("unknown_type", [{"type": "team", "id": 1}]),
             ("missing_id", [{"type": "user"}]),
+            # An unresolvable id would save a view that silently matches all assignees.
+            ("user_non_numeric_id", [{"type": "user", "id": "abc"}]),
+            ("role_non_uuid_id", [{"type": "role", "id": "not-a-uuid"}]),
         ]
     )
     def test_strict_writes_rejects_invalid_assignee_entries(self, _label, assignee):

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -2709,6 +2709,26 @@ class TestTicketViewParamFilter(APIBaseTest):
 
         assert self._list_ids(view=view.short_id) == {str(open_high.id)}
 
+    def test_invalid_stored_list_entry_keeps_valid_entries(self):
+        # One bad legacy entry must narrow to the valid rest, not drop the whole
+        # key and widen the view to all statuses.
+        open_ticket = self._create_ticket(status=Status.OPEN)
+        self._create_ticket(status=Status.RESOLVED)
+        view = self._create_view({"status": ["open", "bogus_legacy_status"]})
+
+        assert self._list_ids(view=view.short_id) == {str(open_ticket.id)}
+
+    def test_stored_tags_all_key_is_not_applied(self):
+        # tagsAll is a param-only key: the app can't render it, so a stored view
+        # carrying one (written via the raw round-trip) must not apply it either.
+        tagged = self._create_ticket()
+        tag = Tag.objects.create(name="urgent", team_id=self.team.id)
+        tagged.tagged_items.create(tag=tag)
+        untagged = self._create_ticket()
+        view = self._create_view({"tagsAll": ["urgent"]})
+
+        assert self._list_ids(view=view.short_id) == {str(tagged.id), str(untagged.id)}
+
     def test_invalid_param_value_does_not_clear_view_filter(self):
         open_ticket = self._create_ticket(status=Status.OPEN)
         self._create_ticket(status=Status.RESOLVED)

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -30,8 +30,9 @@ from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 from posthog.test.persons import create_person
 
+from products.conversations.backend.api.ticket_filters import query_params_to_view_filters
 from products.conversations.backend.api.tickets import TicketReplyRequestSerializer
-from products.conversations.backend.models import Ticket, TicketAssignment
+from products.conversations.backend.models import Ticket, TicketAssignment, TicketView
 from products.conversations.backend.models.constants import Channel, ChannelDetail, Priority, Status
 from products.conversations.backend.person_lookup import PERSON_EMAIL_LOOKUP_QUERY, _get_persons_by_email
 
@@ -2634,3 +2635,111 @@ class TestTicketAccessControl(APIBaseTest):
             format="json",
         )
         self.assertEqual(response.status_code, expected_status, response.json())
+
+
+class TestTicketViewParamFilter(APIBaseTest):
+    def _create_ticket(self, **kwargs) -> Ticket:
+        defaults = {
+            "team": self.team,
+            "channel_source": Channel.WIDGET,
+            "widget_session_id": f"session-{Ticket.objects.count()}",
+            "distinct_id": "user-123",
+            "status": Status.NEW,
+        }
+        defaults.update(kwargs)
+        return Ticket.objects.create_with_number(**defaults)
+
+    def _create_view(self, filters: dict) -> TicketView:
+        return TicketView.objects.create(team=self.team, name="Saved view", filters=filters, created_by=self.user)
+
+    def _list_ids(self, **params) -> set[str]:
+        response = self.client.get(f"/api/projects/{self.team.id}/conversations/tickets/", data=params)
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        return {r["id"] for r in response.json()["results"]}
+
+    def test_view_param_matches_equivalent_flat_params(self):
+        open_high = self._create_ticket(status=Status.OPEN, priority=Priority.HIGH)
+        self._create_ticket(status=Status.OPEN, priority=Priority.LOW)
+        self._create_ticket(status=Status.RESOLVED, priority=Priority.HIGH)
+        view = self._create_view({"status": ["open"], "priority": ["high"]})
+
+        via_view = self._list_ids(view=view.short_id)
+        via_params = self._list_ids(status="open", priority="high")
+        assert via_view == via_params == {str(open_high.id)}
+
+    def test_explicit_param_overrides_view_filter(self):
+        self._create_ticket(status=Status.OPEN)
+        resolved = self._create_ticket(status=Status.RESOLVED)
+        view = self._create_view({"status": ["open"]})
+
+        assert self._list_ids(view=view.short_id, status="resolved") == {str(resolved.id)}
+
+    def test_unknown_view_short_id_returns_400(self):
+        response = self.client.get(f"/api/projects/{self.team.id}/conversations/tickets/", data={"view": "nonexistent"})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_other_teams_view_returns_400(self):
+        other_team = Team.objects.create(organization=self.organization, name="Team 2")
+        other_view = TicketView.objects.create(
+            team=other_team, name="Other", filters={"status": ["open"]}, created_by=self.user
+        )
+
+        response = self.client.get(
+            f"/api/projects/{self.team.id}/conversations/tickets/", data={"view": other_view.short_id}
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_view_assignee_me_resolves_to_requesting_user(self):
+        mine = self._create_ticket()
+        TicketAssignment.objects.create(ticket=mine, user=self.user)
+        other_user = User.objects.create_and_join(self.organization, "other@posthog.com", None)
+        theirs = self._create_ticket()
+        TicketAssignment.objects.create(ticket=theirs, user=other_user)
+        self._create_ticket()  # unassigned
+        view = self._create_view({"assignee": ["me"]})
+
+        assert self._list_ids(view=view.short_id) == {str(mine.id)}
+
+    def test_invalid_stored_key_dropped_and_rest_of_view_applies(self):
+        open_high = self._create_ticket(status=Status.OPEN, priority=Priority.HIGH)
+        self._create_ticket(status=Status.OPEN, priority=Priority.LOW)
+        view = self._create_view({"status": ["bogus_legacy_status"], "priority": ["high"]})
+
+        assert self._list_ids(view=view.short_id) == {str(open_high.id)}
+
+    def test_invalid_param_value_does_not_clear_view_filter(self):
+        open_ticket = self._create_ticket(status=Status.OPEN)
+        self._create_ticket(status=Status.RESOLVED)
+        view = self._create_view({"status": ["open"]})
+
+        assert self._list_ids(view=view.short_id, status="bogus") == {str(open_ticket.id)}
+
+    @parameterized.expand(
+        [
+            ("status", "status", "bogus,nonsense"),
+            ("priority", "priority", "bogus"),
+            ("assignee", "assignee", "bogus"),
+        ]
+    )
+    def test_all_invalid_param_values_leave_key_unset(self, _label, param, value):
+        assert param not in query_params_to_view_filters({param: value})
+
+    def test_legacy_view_filters_blob_applies_without_error(self):
+        # Old saved views carry 'all' sentinels, a single-value assignee, and keys the
+        # backend never validated. Applying one must filter nothing and respect sorting.
+        first = self._create_ticket()
+        second = self._create_ticket()
+        view = self._create_view(
+            {
+                "channel": "all",
+                "sla": "all",
+                "assignee": "all",
+                "search": "",
+                "futureKey": True,
+                "sorting": {"columnKey": "created_at", "order": 1},
+            }
+        )
+
+        response = self.client.get(f"/api/projects/{self.team.id}/conversations/tickets/", data={"view": view.short_id})
+        assert response.status_code == status.HTTP_200_OK
+        assert [r["id"] for r in response.json()["results"]] == [str(first.id), str(second.id)]

--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -110,6 +110,8 @@ class TestTicketAPI(APIBaseTest):
         [
             ("tags_matches_any", {"tags": '["alpha", "beta"]'}, {"alpha_beta", "alpha", "beta_gamma"}),
             ("tags_all_matches_every", {"tags_all": '["alpha", "beta"]'}, {"alpha_beta"}),
+            # tags and tags_all must compose (AND), not clobber each other.
+            ("tags_composes_with_tags_all", {"tags": '["gamma"]', "tags_all": '["beta"]'}, {"beta_gamma"}),
             ("tags_exclude_drops_tagged", {"tags_exclude": '["gamma"]'}, {"alpha_beta", "alpha"}),
             (
                 "tags_all_composes_with_tags_exclude",
@@ -2716,13 +2718,16 @@ class TestTicketViewParamFilter(APIBaseTest):
 
     @parameterized.expand(
         [
-            ("status", "status", "bogus,nonsense"),
-            ("priority", "priority", "bogus"),
-            ("assignee", "assignee", "bogus"),
+            ("status", "status", "bogus,nonsense", "status"),
+            ("priority", "priority", "bogus", "priority"),
+            ("assignee_token", "assignee", "bogus", "assignee"),
+            ("assignee_bad_user_id", "assignee", "user:abc", "assignee"),
+            ("assignee_bad_role_id", "assignee", "role:not-a-uuid", "assignee"),
+            ("order_by", "order_by", "bogus", "sorting"),
         ]
     )
-    def test_all_invalid_param_values_leave_key_unset(self, _label, param, value):
-        assert param not in query_params_to_view_filters({param: value})
+    def test_all_invalid_param_values_leave_key_unset(self, _label, param, value, key):
+        assert key not in query_params_to_view_filters({param: value})
 
     def test_legacy_view_filters_blob_applies_without_error(self):
         # Old saved views carry 'all' sentinels, a single-value assignee, and keys the

--- a/products/conversations/backend/api/ticket_filters.py
+++ b/products/conversations/backend/api/ticket_filters.py
@@ -91,7 +91,18 @@ def normalize_assignee_filter(value: Any) -> list[Any]:
     }
 )
 class TicketViewAssigneeFilterField(serializers.Field):
+    """Lenient by default so legacy stored blobs still apply (an unrecognized entry is
+    dropped, and the legacy 'all' sentinel means no filter). Writes pass
+    context={"strict_writes": True}: silently dropping a malformed entry there would
+    save a view that quietly matches more assignees than the caller asked for."""
+
     def to_internal_value(self, data: Any) -> list[Any]:
+        if self.context.get("strict_writes"):
+            entries = data if isinstance(data, list) else [data]
+            if any(not _is_assignee_entry(entry) and entry != "all" for entry in entries):
+                raise serializers.ValidationError(
+                    "Each assignee entry must be 'me', 'unassigned', or an object with type ('user' or 'role') and id."
+                )
         return normalize_assignee_filter(data)
 
     def to_representation(self, value: Any) -> Any:

--- a/products/conversations/backend/api/ticket_filters.py
+++ b/products/conversations/backend/api/ticket_filters.py
@@ -16,7 +16,7 @@ from collections.abc import Mapping
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
-from django.db.models import CharField, Exists, OuterRef, Q, QuerySet
+from django.db.models import CharField, F, OrderBy, Q, QuerySet
 from django.db.models.functions import Cast
 from django.utils import timezone
 
@@ -47,8 +47,19 @@ AI_TRIAGE_FILTER_VALUES = [
     "in_progress",
 ]
 
-ALLOWED_ORDER_COLUMNS = {"updated_at", "sla_due_at", "snoozed_until", "created_at", "ticket_number"}
-DEFAULT_ORDER_BY = "-updated_at"
+ALLOWED_ORDER_COLUMNS = ("updated_at", "sla_due_at", "snoozed_until", "created_at", "ticket_number")
+
+VALID_STATUS_VALUES = frozenset(s.value for s in Status)
+VALID_PRIORITY_VALUES = frozenset(p.value for p in Priority)
+VALID_CHANNEL_VALUES = frozenset(c.value for c in Channel)
+
+# Named choice sets for ChoiceFields below, registered in ENUM_NAME_OVERRIDES
+# (posthog/settings/web.py) so drf-spectacular doesn't mint generic globals like
+# ChannelEnum/SlaEnum/OrderEnum in the shared OpenAPI namespace.
+TICKET_CHANNEL_FILTER_CHOICES = [*(c.value for c in Channel), "all"]
+TICKET_SLA_FILTER_CHOICES = [*SLA_FILTER_VALUES, "all"]
+TICKET_TAGS_MATCH_CHOICES = ["any", "all"]
+TICKET_SORT_ORDER_CHOICES = [1, -1]
 
 
 def _is_assignee_entry(value: Any) -> bool:
@@ -111,10 +122,10 @@ class TicketViewAssigneeFilterField(serializers.Field):
 
 class TicketViewSortingSerializer(serializers.Serializer):
     columnKey = serializers.CharField(
-        help_text="Ticket column to sort by (updated_at, sla_due_at, snoozed_until, created_at, ticket_number). "
+        help_text=f"Ticket column to sort by ({', '.join(ALLOWED_ORDER_COLUMNS)}). "
         "Unknown columns fall back to updated_at."
     )
-    order = serializers.ChoiceField(choices=[1, -1], help_text="1 for ascending, -1 for descending.")
+    order = serializers.ChoiceField(choices=TICKET_SORT_ORDER_CHOICES, help_text="1 for ascending, -1 for descending.")
 
 
 class TicketViewFiltersSerializer(serializers.Serializer):
@@ -132,12 +143,12 @@ class TicketViewFiltersSerializer(serializers.Serializer):
         help_text="Ticket priorities to include. Empty or omitted means all priorities.",
     )
     channel = serializers.ChoiceField(
-        choices=[*(c.value for c in Channel), "all"],
+        choices=TICKET_CHANNEL_FILTER_CHOICES,
         required=False,
         help_text="Channel the ticket originated from. 'all' disables the filter.",
     )
     sla = serializers.ChoiceField(
-        choices=[*SLA_FILTER_VALUES, "all"],
+        choices=TICKET_SLA_FILTER_CHOICES,
         required=False,
         help_text="SLA state: 'breached' is past due, 'at-risk' is due within the next hour, "
         "'on-track' has more than an hour remaining. 'all' disables the filter.",
@@ -159,7 +170,7 @@ class TicketViewFiltersSerializer(serializers.Serializer):
         help_text="Tag names to match, combined according to tagsMatch.",
     )
     tagsMatch = serializers.ChoiceField(
-        choices=["any", "all"],
+        choices=TICKET_TAGS_MATCH_CHOICES,
         required=False,
         help_text="'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).",
     )
@@ -189,6 +200,21 @@ class TicketViewFiltersSerializer(serializers.Serializer):
         help_text="Free-text search. A numeric value matches a ticket number exactly; otherwise matches "
         "the customer's name or email, the email subject, or message content.",
     )
+
+
+def parse_stored_view_filters(stored: Any) -> dict[str, Any]:
+    """Leniently validate a stored TicketView.filters blob into the canonical shape.
+
+    Stored blobs predate write validation, so a legacy value must not make the view
+    unusable: offending keys are dropped and the rest still apply."""
+    if not isinstance(stored, dict):
+        return {}
+    serializer = TicketViewFiltersSerializer(data=stored)
+    if not serializer.is_valid():
+        cleaned = {key: value for key, value in stored.items() if key not in serializer.errors}
+        serializer = TicketViewFiltersSerializer(data=cleaned)
+        serializer.is_valid()
+    return dict(serializer.validated_data)
 
 
 def _decode_assignee_param(raw: str) -> list[Any]:
@@ -227,18 +253,22 @@ def query_params_to_view_filters(params: Mapping[str, str]) -> dict[str, Any]:
     rather than rejected, matching the endpoint's long-standing behavior."""
     filters: dict[str, Any] = {}
 
+    # Guard every list on being non-empty: a param whose values all parse away must not
+    # set the key, or merging onto a saved view would clear that filter and widen results.
     status_param = params.get("status")
     if status_param:
-        valid_statuses = {s.value for s in Status}
-        filters["status"] = [s.strip() for s in status_param.split(",") if s.strip() in valid_statuses]
+        statuses = [s.strip() for s in status_param.split(",") if s.strip() in VALID_STATUS_VALUES]
+        if statuses:
+            filters["status"] = statuses
 
     priority_param = params.get("priority")
     if priority_param:
-        valid_priorities = {p.value for p in Priority}
-        filters["priority"] = [p.strip() for p in priority_param.split(",") if p.strip() in valid_priorities]
+        priorities = [p.strip() for p in priority_param.split(",") if p.strip() in VALID_PRIORITY_VALUES]
+        if priorities:
+            filters["priority"] = priorities
 
     channel_source = params.get("channel_source")
-    if channel_source and channel_source in {c.value for c in Channel}:
+    if channel_source and channel_source in VALID_CHANNEL_VALUES:
         filters["channel"] = channel_source
 
     sla_param = params.get("sla")
@@ -253,7 +283,9 @@ def query_params_to_view_filters(params: Mapping[str, str]) -> dict[str, Any]:
 
     assignee_param = params.get("assignee")
     if assignee_param:
-        filters["assignee"] = _decode_assignee_param(assignee_param)
+        assignees = _decode_assignee_param(assignee_param)
+        if assignees:
+            filters["assignee"] = assignees
 
     tags_param = params.get("tags")
     if tags_param:
@@ -295,13 +327,26 @@ def query_params_to_view_filters(params: Mapping[str, str]) -> dict[str, Any]:
     return filters
 
 
-def _sorting_to_order_by(sorting: Mapping[str, Any] | None) -> str:
-    if not sorting:
-        return DEFAULT_ORDER_BY
-    column = sorting.get("columnKey")
-    if column not in ALLOWED_ORDER_COLUMNS:
-        return DEFAULT_ORDER_BY
-    return column if sorting.get("order") == 1 else f"-{column}"
+def _sorting_to_order_expressions(sorting: Mapping[str, Any] | None) -> tuple[OrderBy | str, str]:
+    column, descending = "updated_at", True
+    if sorting and sorting.get("columnKey") in ALLOWED_ORDER_COLUMNS:
+        column = sorting["columnKey"]
+        descending = sorting.get("order") != 1
+
+    primary: OrderBy | str
+    if column in ("sla_due_at", "snoozed_until"):
+        # A ticket with no SLA (or no snooze) sorts to the bottom either direction — an
+        # absent deadline isn't more urgent than a real one, and it keeps the large NULL
+        # block off the first pages so the SLA-sorted rows are what the user actually sees.
+        primary = F(column).desc(nulls_last=True) if descending else F(column).asc(nulls_last=True)
+    else:
+        primary = f"-{column}" if descending else column
+
+    # ticket_number is unique per team (the queryset is already team-scoped), so it breaks
+    # ties deterministically. Without it, rows equal on the primary key — every no-SLA
+    # ticket shares NULL sla_due_at — have no stable order across the separate LIMIT/OFFSET
+    # page queries, so pages overlap or drop rows and the sort looks lost past page 1.
+    return primary, "-ticket_number"
 
 
 def _assignee_filter_q(entries: list[Any], user: User | None) -> Q:
@@ -336,34 +381,36 @@ def _assignee_filter_q(entries: list[Any], user: User | None) -> Q:
     return assignee_q
 
 
-def _apply_search(queryset: QuerySet, search: str) -> QuerySet:
+def is_ticket_number_search(search: str) -> bool:
     # A leading "#" is how ticket numbers are shown in the UI (e.g. "#1234"), so
     # treat "#1234" the same as "1234" and match the ticket number exactly.
     # Restrict to ASCII digits: str.isdigit() also accepts characters like "²"
     # that int() then rejects, which would 500 the request.
-    ticket_number_search = search[1:] if search.startswith("#") else search
-    if ticket_number_search.isascii() and ticket_number_search.isdigit():
-        return queryset.filter(ticket_number=int(ticket_number_search))
+    ticket_number_search = search.removeprefix("#")
+    return ticket_number_search.isascii() and ticket_number_search.isdigit()
 
-    # EXISTS subquery: matches any comment in the ticket's conversation.
-    # Uses the (team_id, scope, item_id) composite index on Comment to
-    # narrow to per-ticket comments; EXISTS short-circuits on first match.
-    # If this becomes slow at scale (10k+ candidate tickets with broad
-    # filters), consider adding a GIN trigram index on Comment.content:
-    #   GinIndex(name="comment_content_trigram", fields=["content"],
-    #            opclasses=["gin_trgm_ops"])
+
+def _apply_search(queryset: QuerySet, search: str, team: Team) -> QuerySet:
+    if is_ticket_number_search(search):
+        return queryset.filter(ticket_number=int(search.removeprefix("#")))
+
+    # Comment match as a non-correlated subquery: self-contained, so Postgres hashes
+    # it once per query (scanning posthog_comment through its trigram index) instead
+    # of probing comments per ticket the way a correlated EXISTS would. The ticket id
+    # is cast to text rather than item_id to uuid — the id side is always a valid
+    # UUID, while a malformed item_id row would make the whole search error.
     comment_match = Comment.objects.filter(
-        team_id=OuterRef("team_id"),
+        team_id=team.id,
         scope="conversations_ticket",
-        item_id=Cast(OuterRef("id"), output_field=CharField()),
-        content__icontains=search,
         deleted=False,
-    )
-    return queryset.filter(
+        content__icontains=search,
+    ).values("item_id")
+
+    return queryset.alias(id_text=Cast("id", output_field=CharField())).filter(
         Q(anonymous_traits__name__icontains=search)
         | Q(anonymous_traits__email__icontains=search)
         | Q(email_subject__icontains=search)
-        | Exists(comment_match)
+        | Q(id_text__in=comment_match)
     )
 
 
@@ -371,8 +418,7 @@ def apply_ticket_filters(queryset: QuerySet, filters: Mapping[str, Any], *, team
     """Apply a canonical TicketViewFilters mapping to a Ticket queryset and order it.
 
     `filters` must already be validated/normalized, either by TicketViewFiltersSerializer
-    (saved-view path) or by query_params_to_view_filters (flat-param path). This is the
-    only place filter values become ORM predicates.
+    (saved-view path) or by query_params_to_view_filters (flat-param path).
     """
     statuses = filters.get("status") or []
     if statuses:
@@ -440,6 +486,6 @@ def apply_ticket_filters(queryset: QuerySet, filters: Mapping[str, Any], *, team
 
     search = filters.get("search")
     if search and len(search) <= MAX_SEARCH_LENGTH:
-        queryset = _apply_search(queryset, search)
+        queryset = _apply_search(queryset, search, team)
 
-    return queryset.order_by(_sorting_to_order_by(filters.get("sorting")))
+    return queryset.order_by(*_sorting_to_order_expressions(filters.get("sorting")))

--- a/products/conversations/backend/api/ticket_filters.py
+++ b/products/conversations/backend/api/ticket_filters.py
@@ -59,7 +59,9 @@ VALID_CHANNEL_VALUES = frozenset(c.value for c in Channel)
 TICKET_CHANNEL_FILTER_CHOICES = [*(c.value for c in Channel), "all"]
 TICKET_SLA_FILTER_CHOICES = [*SLA_FILTER_VALUES, "all"]
 TICKET_TAGS_MATCH_CHOICES = ["any", "all"]
-TICKET_SORT_ORDER_CHOICES = [1, -1]
+# Tuple pairs, not bare ints: drf-spectacular's override loader only accepts strings
+# in plain value lists and crashes on anything else.
+TICKET_SORT_ORDER_CHOICES = [(1, 1), (-1, -1)]
 
 
 def _is_assignee_entry(value: Any) -> bool:
@@ -68,7 +70,23 @@ def _is_assignee_entry(value: Any) -> bool:
     if not isinstance(value, dict):
         return False
     entry_id = value.get("id")
-    return value.get("type") in ("user", "role") and isinstance(entry_id, str | int) and not isinstance(entry_id, bool)
+    if not isinstance(entry_id, str | int) or isinstance(entry_id, bool):
+        return False
+    # The id must resolve to a real user pk / role UUID: an unresolvable entry would
+    # silently apply no filter at query time, widening results past what was asked for.
+    if value.get("type") == "user":
+        try:
+            int(entry_id)
+        except (TypeError, ValueError):
+            return False
+        return True
+    if value.get("type") == "role":
+        try:
+            uuid.UUID(str(entry_id))
+        except ValueError:
+            return False
+        return True
+    return False
 
 
 def normalize_assignee_filter(value: Any) -> list[Any]:
@@ -174,6 +192,12 @@ class TicketViewFiltersSerializer(serializers.Serializer):
         required=False,
         help_text="'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).",
     )
+    tagsAll = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text="Tag names the ticket must all carry (AND). Applied on top of tags/tagsMatch, "
+        "so both an any-of and an all-of constraint can be active at once.",
+    )
     tagsExclude = serializers.ListField(
         child=serializers.CharField(),
         required=False,
@@ -227,7 +251,7 @@ def _decode_assignee_param(raw: str) -> list[Any]:
             entries.append({"type": "user", "id": entry[5:]})
         elif entry.startswith("role:"):
             entries.append({"type": "role", "id": entry[5:]})
-    return entries
+    return [entry for entry in entries if _is_assignee_entry(entry)]
 
 
 def _decode_json_tag_list(raw: str) -> list[str] | None:
@@ -240,10 +264,11 @@ def _decode_json_tag_list(raw: str) -> list[str] | None:
     return None
 
 
-def _order_by_to_sorting(order_by: str) -> dict[str, Any]:
-    if order_by.startswith("-"):
-        return {"columnKey": order_by[1:], "order": -1}
-    return {"columnKey": order_by, "order": 1}
+def _order_by_to_sorting(order_by: str) -> dict[str, Any] | None:
+    column = order_by.removeprefix("-")
+    if column not in ALLOWED_ORDER_COLUMNS:
+        return None
+    return {"columnKey": column, "order": -1 if order_by.startswith("-") else 1}
 
 
 def query_params_to_view_filters(params: Mapping[str, str]) -> dict[str, Any]:
@@ -298,8 +323,9 @@ def query_params_to_view_filters(params: Mapping[str, str]) -> dict[str, Any]:
     if tags_all_param:
         tags = _decode_json_tag_list(tags_all_param)
         if tags:
-            filters["tags"] = tags
-            filters["tagsMatch"] = "all"
+            # Separate key from tags/tagsMatch so tags= and tags_all= compose (AND)
+            # instead of the later param clobbering the earlier one.
+            filters["tagsAll"] = tags
 
     tags_exclude_param = params.get("tags_exclude")
     if tags_exclude_param:
@@ -322,7 +348,9 @@ def query_params_to_view_filters(params: Mapping[str, str]) -> dict[str, Any]:
 
     order_by = params.get("order_by")
     if order_by:
-        filters["sorting"] = _order_by_to_sorting(order_by)
+        sorting = _order_by_to_sorting(order_by)
+        if sorting:
+            filters["sorting"] = sorting
 
     return filters
 
@@ -467,6 +495,12 @@ def apply_ticket_filters(queryset: QuerySet, filters: Mapping[str, Any], *, team
             queryset = queryset.distinct()
         else:
             queryset = queryset.filter(tagged_items__tag__name__in=tags).distinct()
+
+    tags_all = [str(tag) for tag in filters.get("tagsAll") or []][:MAX_TAG_FILTER_VALUES]
+    if tags_all:
+        for tag_name in tags_all:
+            queryset = queryset.filter(tagged_items__tag__name=tag_name)
+        queryset = queryset.distinct()
 
     tags_exclude = [str(tag) for tag in filters.get("tagsExclude") or []][:MAX_TAG_FILTER_VALUES]
     if tags_exclude:

--- a/products/conversations/backend/api/ticket_filters.py
+++ b/products/conversations/backend/api/ticket_filters.py
@@ -192,12 +192,6 @@ class TicketViewFiltersSerializer(serializers.Serializer):
         required=False,
         help_text="'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).",
     )
-    tagsAll = serializers.ListField(
-        child=serializers.CharField(),
-        required=False,
-        help_text="Tag names the ticket must all carry (AND). Applied on top of tags/tagsMatch, "
-        "so both an any-of and an all-of constraint can be active at once.",
-    )
     tagsExclude = serializers.ListField(
         child=serializers.CharField(),
         required=False,
@@ -226,16 +220,38 @@ class TicketViewFiltersSerializer(serializers.Serializer):
     )
 
 
+def _salvage_list_entries(key: str, value: Any) -> list[Any] | None:
+    """Keep the individually-valid entries of an errored list value, so one bad legacy
+    entry narrows the filter to the valid rest instead of dropping the key (widening)."""
+    field = TicketViewFiltersSerializer().fields.get(key)
+    if not isinstance(field, serializers.ListField) or not isinstance(value, list):
+        return None
+    valid_entries = []
+    for entry in value:
+        try:
+            field.child.run_validation(entry)
+        except serializers.ValidationError:
+            continue
+        valid_entries.append(entry)
+    return valid_entries or None
+
+
 def parse_stored_view_filters(stored: Any) -> dict[str, Any]:
     """Leniently validate a stored TicketView.filters blob into the canonical shape.
 
     Stored blobs predate write validation, so a legacy value must not make the view
-    unusable: offending keys are dropped and the rest still apply."""
+    unusable: invalid list entries and offending keys are dropped and the rest still
+    apply."""
     if not isinstance(stored, dict):
         return {}
     serializer = TicketViewFiltersSerializer(data=stored)
     if not serializer.is_valid():
-        cleaned = {key: value for key, value in stored.items() if key not in serializer.errors}
+        cleaned: dict[str, Any] = {}
+        for key, value in stored.items():
+            if key not in serializer.errors:
+                cleaned[key] = value
+            elif (salvaged := _salvage_list_entries(key, value)) is not None:
+                cleaned[key] = salvaged
         serializer = TicketViewFiltersSerializer(data=cleaned)
         serializer.is_valid()
     return dict(serializer.validated_data)
@@ -324,7 +340,10 @@ def query_params_to_view_filters(params: Mapping[str, str]) -> dict[str, Any]:
         tags = _decode_json_tag_list(tags_all_param)
         if tags:
             # Separate key from tags/tagsMatch so tags= and tags_all= compose (AND)
-            # instead of the later param clobbering the earlier one.
+            # instead of the later param clobbering the earlier one. Deliberately NOT
+            # part of the saved-view serializer contract: the app can't render a
+            # tagsAll filter, so a view holding one would behave differently in the
+            # app than via ?view=.
             filters["tagsAll"] = tags
 
     tags_exclude_param = params.get("tags_exclude")

--- a/products/conversations/backend/api/ticket_filters.py
+++ b/products/conversations/backend/api/ticket_filters.py
@@ -1,0 +1,434 @@
+"""Canonical ticket filter shape and the single place it becomes ORM predicates.
+
+`TicketViewFiltersSerializer` is the source of truth for the saved-view filter
+contract: it validates writes to `TicketView.filters`, is what the `?view=`
+param validates stored blobs against, and generates the frontend TypeScript and
+MCP schemas via OpenAPI. `apply_ticket_filters` is the only implementation of
+filtering, fed by two adapters: validated view filters, and the flat snake_case
+query params (`query_params_to_view_filters`).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Mapping
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+from django.db.models import CharField, Exists, OuterRef, Q, QuerySet
+from django.db.models.functions import Cast
+from django.utils import timezone
+
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+from posthog.models.comment import Comment
+from posthog.utils import relative_date_parse
+
+from products.conversations.backend.models.constants import Channel, Priority, Status
+
+if TYPE_CHECKING:
+    from posthog.models import Team, User
+
+MAX_TAG_FILTER_VALUES = 50
+# Matches MAX_ASSIGNEE_FILTER_ENTRIES in products/conversations/frontend/components/Assignee.
+MAX_ASSIGNEE_FILTER_ENTRIES = 100
+MAX_SEARCH_LENGTH = 200
+
+SLA_FILTER_VALUES = ["breached", "at-risk", "on-track"]
+AI_TRIAGE_FILTER_VALUES = [
+    "persisted",
+    "escalated_with_best",
+    "escalated_no_reply",
+    "skipped_unactionable",
+    "blocked_unsafe",
+    "blocked_unsafe_reply",
+    "in_progress",
+]
+
+ALLOWED_ORDER_COLUMNS = {"updated_at", "sla_due_at", "snoozed_until", "created_at", "ticket_number"}
+DEFAULT_ORDER_BY = "-updated_at"
+
+
+def _is_assignee_entry(value: Any) -> bool:
+    if value in ("unassigned", "me"):
+        return True
+    if not isinstance(value, dict):
+        return False
+    entry_id = value.get("id")
+    return value.get("type") in ("user", "role") and isinstance(entry_id, str | int) and not isinstance(entry_id, bool)
+
+
+def normalize_assignee_filter(value: Any) -> list[Any]:
+    """Mirrors the frontend's normalizeAssigneeFilter: accepts the current array shape or
+    the legacy single-value shape ('all', 'unassigned', or one assignee object) still
+    present in old saved views, keeping only valid entries."""
+    entries = value if isinstance(value, list) else [value]
+    return [entry for entry in entries if _is_assignee_entry(entry)][:MAX_ASSIGNEE_FILTER_ENTRIES]
+
+
+@extend_schema_field(
+    {
+        "type": "array",
+        "items": {
+            "oneOf": [
+                {"type": "string", "enum": ["me", "unassigned"]},
+                {
+                    "type": "object",
+                    "properties": {
+                        "type": {"type": "string", "enum": ["user", "role"]},
+                        "id": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+                    },
+                    "required": ["type", "id"],
+                },
+            ]
+        },
+        "description": (
+            "Assignees to match (any of): 'unassigned', 'me' (resolved to the requesting user), "
+            "or an object with type ('user' or 'role') and id."
+        ),
+    }
+)
+class TicketViewAssigneeFilterField(serializers.Field):
+    def to_internal_value(self, data: Any) -> list[Any]:
+        return normalize_assignee_filter(data)
+
+    def to_representation(self, value: Any) -> Any:
+        return value
+
+
+class TicketViewSortingSerializer(serializers.Serializer):
+    columnKey = serializers.CharField(
+        help_text="Ticket column to sort by (updated_at, sla_due_at, snoozed_until, created_at, ticket_number). "
+        "Unknown columns fall back to updated_at."
+    )
+    order = serializers.ChoiceField(choices=[1, -1], help_text="1 for ascending, -1 for descending.")
+
+
+class TicketViewFiltersSerializer(serializers.Serializer):
+    """Canonical shape of a saved ticket view's filters. Every field is optional; an omitted
+    field (or an 'all' sentinel) leaves that dimension unfiltered."""
+
+    status = serializers.ListField(
+        child=serializers.ChoiceField(choices=Status.choices),
+        required=False,
+        help_text="Ticket statuses to include. Empty or omitted means all statuses.",
+    )
+    priority = serializers.ListField(
+        child=serializers.ChoiceField(choices=Priority.choices),
+        required=False,
+        help_text="Ticket priorities to include. Empty or omitted means all priorities.",
+    )
+    channel = serializers.ChoiceField(
+        choices=[*(c.value for c in Channel), "all"],
+        required=False,
+        help_text="Channel the ticket originated from. 'all' disables the filter.",
+    )
+    sla = serializers.ChoiceField(
+        choices=[*SLA_FILTER_VALUES, "all"],
+        required=False,
+        help_text="SLA state: 'breached' is past due, 'at-risk' is due within the next hour, "
+        "'on-track' has more than an hour remaining. 'all' disables the filter.",
+    )
+    aiTriageResult = serializers.ListField(
+        child=serializers.ChoiceField(choices=AI_TRIAGE_FILTER_VALUES),
+        required=False,
+        help_text="AI triage outcomes to include. 'in_progress' matches tickets still being triaged.",
+    )
+    assignee = TicketViewAssigneeFilterField(
+        required=False,
+        help_text="Assignees to match (any of): 'unassigned', 'me' (resolved to the requesting user), "
+        "or an object with type ('user' or 'role') and id. The legacy single-value shape is accepted "
+        "and normalized to a list.",
+    )
+    tags = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text="Tag names to match, combined according to tagsMatch.",
+    )
+    tagsMatch = serializers.ChoiceField(
+        choices=["any", "all"],
+        required=False,
+        help_text="'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).",
+    )
+    tagsExclude = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text="Tickets carrying any of these tags are excluded.",
+    )
+    dateFrom = serializers.CharField(
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        help_text="Only include tickets updated on or after this date. Accepts absolute dates (2026-01-01) "
+        "or relative ones (-7d). 'all' or null disables the bound.",
+    )
+    dateTo = serializers.CharField(
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        help_text="Only include tickets updated on or before this date. Same format as dateFrom.",
+    )
+    sorting = TicketViewSortingSerializer(required=False, allow_null=True, help_text="Sort order for the ticket list.")
+    search = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        max_length=MAX_SEARCH_LENGTH,
+        help_text="Free-text search. A numeric value matches a ticket number exactly; otherwise matches "
+        "the customer's name or email, the email subject, or message content.",
+    )
+
+
+def _decode_assignee_param(raw: str) -> list[Any]:
+    entries: list[Any] = []
+    for raw_entry in raw.split(",")[:MAX_ASSIGNEE_FILTER_ENTRIES]:
+        entry = raw_entry.strip()
+        if entry.lower() in ("unassigned", "me"):
+            entries.append(entry.lower())
+        elif entry.startswith("user:"):
+            entries.append({"type": "user", "id": entry[5:]})
+        elif entry.startswith("role:"):
+            entries.append({"type": "role", "id": entry[5:]})
+    return entries
+
+
+def _decode_json_tag_list(raw: str) -> list[str] | None:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(value, list) and value:
+        return [str(tag) for tag in value]
+    return None
+
+
+def _order_by_to_sorting(order_by: str) -> dict[str, Any]:
+    if order_by.startswith("-"):
+        return {"columnKey": order_by[1:], "order": -1}
+    return {"columnKey": order_by, "order": 1}
+
+
+def query_params_to_view_filters(params: Mapping[str, str]) -> dict[str, Any]:
+    """Translate the flat snake_case ticket-list query params into the canonical
+    TicketViewFilters shape. Only keys whose param is present are set, so values coming
+    from a saved view survive unless explicitly overridden. Invalid values are dropped
+    rather than rejected, matching the endpoint's long-standing behavior."""
+    filters: dict[str, Any] = {}
+
+    status_param = params.get("status")
+    if status_param:
+        valid_statuses = {s.value for s in Status}
+        filters["status"] = [s.strip() for s in status_param.split(",") if s.strip() in valid_statuses]
+
+    priority_param = params.get("priority")
+    if priority_param:
+        valid_priorities = {p.value for p in Priority}
+        filters["priority"] = [p.strip() for p in priority_param.split(",") if p.strip() in valid_priorities]
+
+    channel_source = params.get("channel_source")
+    if channel_source and channel_source in {c.value for c in Channel}:
+        filters["channel"] = channel_source
+
+    sla_param = params.get("sla")
+    if sla_param and sla_param in SLA_FILTER_VALUES:
+        filters["sla"] = sla_param
+
+    ai_triage_result_param = params.get("ai_triage_result")
+    if ai_triage_result_param:
+        results = [r.strip() for r in ai_triage_result_param.split(",") if r.strip() in AI_TRIAGE_FILTER_VALUES]
+        if results:
+            filters["aiTriageResult"] = results
+
+    assignee_param = params.get("assignee")
+    if assignee_param:
+        filters["assignee"] = _decode_assignee_param(assignee_param)
+
+    tags_param = params.get("tags")
+    if tags_param:
+        tags = _decode_json_tag_list(tags_param)
+        if tags:
+            filters["tags"] = tags
+            filters["tagsMatch"] = "any"
+
+    tags_all_param = params.get("tags_all")
+    if tags_all_param:
+        tags = _decode_json_tag_list(tags_all_param)
+        if tags:
+            filters["tags"] = tags
+            filters["tagsMatch"] = "all"
+
+    tags_exclude_param = params.get("tags_exclude")
+    if tags_exclude_param:
+        tags = _decode_json_tag_list(tags_exclude_param)
+        if tags:
+            filters["tagsExclude"] = tags
+
+    search = params.get("search")
+    if search and len(search) <= MAX_SEARCH_LENGTH:
+        filters["search"] = search
+
+    date_from = params.get("date_from")
+    if date_from:
+        # 'all' passes through so an explicit param can disable a view's saved lower bound.
+        filters["dateFrom"] = date_from
+
+    date_to = params.get("date_to")
+    if date_to:
+        filters["dateTo"] = date_to
+
+    order_by = params.get("order_by")
+    if order_by:
+        filters["sorting"] = _order_by_to_sorting(order_by)
+
+    return filters
+
+
+def _sorting_to_order_by(sorting: Mapping[str, Any] | None) -> str:
+    if not sorting:
+        return DEFAULT_ORDER_BY
+    column = sorting.get("columnKey")
+    if column not in ALLOWED_ORDER_COLUMNS:
+        return DEFAULT_ORDER_BY
+    return column if sorting.get("order") == 1 else f"-{column}"
+
+
+def _assignee_filter_q(entries: list[Any], user: User | None) -> Q:
+    user_ids: list[int] = []
+    role_ids: list[uuid.UUID] = []
+    include_unassigned = False
+    for entry in entries:
+        if entry == "unassigned":
+            include_unassigned = True
+        elif entry == "me":
+            # Dynamic per-viewer token: resolve to the requesting user so a
+            # shared saved view scoped to "me" means each viewer's own tickets.
+            if user is not None:
+                user_ids.append(user.id)
+        elif isinstance(entry, dict) and entry.get("type") == "user":
+            try:
+                user_ids.append(int(entry["id"]))
+            except (ValueError, TypeError):
+                pass
+        elif isinstance(entry, dict) and entry.get("type") == "role":
+            try:
+                role_ids.append(uuid.UUID(str(entry["id"])))
+            except (ValueError, AttributeError):
+                pass
+    assignee_q = Q()
+    if user_ids:
+        assignee_q |= Q(assignment__user_id__in=user_ids)
+    if role_ids:
+        assignee_q |= Q(assignment__role_id__in=role_ids)
+    if include_unassigned:
+        assignee_q |= Q(assignment__isnull=True)
+    return assignee_q
+
+
+def _apply_search(queryset: QuerySet, search: str) -> QuerySet:
+    # A leading "#" is how ticket numbers are shown in the UI (e.g. "#1234"), so
+    # treat "#1234" the same as "1234" and match the ticket number exactly.
+    # Restrict to ASCII digits: str.isdigit() also accepts characters like "²"
+    # that int() then rejects, which would 500 the request.
+    ticket_number_search = search[1:] if search.startswith("#") else search
+    if ticket_number_search.isascii() and ticket_number_search.isdigit():
+        return queryset.filter(ticket_number=int(ticket_number_search))
+
+    # EXISTS subquery: matches any comment in the ticket's conversation.
+    # Uses the (team_id, scope, item_id) composite index on Comment to
+    # narrow to per-ticket comments; EXISTS short-circuits on first match.
+    # If this becomes slow at scale (10k+ candidate tickets with broad
+    # filters), consider adding a GIN trigram index on Comment.content:
+    #   GinIndex(name="comment_content_trigram", fields=["content"],
+    #            opclasses=["gin_trgm_ops"])
+    comment_match = Comment.objects.filter(
+        team_id=OuterRef("team_id"),
+        scope="conversations_ticket",
+        item_id=Cast(OuterRef("id"), output_field=CharField()),
+        content__icontains=search,
+        deleted=False,
+    )
+    return queryset.filter(
+        Q(anonymous_traits__name__icontains=search)
+        | Q(anonymous_traits__email__icontains=search)
+        | Q(email_subject__icontains=search)
+        | Exists(comment_match)
+    )
+
+
+def apply_ticket_filters(queryset: QuerySet, filters: Mapping[str, Any], *, team: Team, user: User | None) -> QuerySet:
+    """Apply a canonical TicketViewFilters mapping to a Ticket queryset and order it.
+
+    `filters` must already be validated/normalized, either by TicketViewFiltersSerializer
+    (saved-view path) or by query_params_to_view_filters (flat-param path). This is the
+    only place filter values become ORM predicates.
+    """
+    statuses = filters.get("status") or []
+    if statuses:
+        queryset = queryset.filter(status__in=statuses)
+
+    priorities = filters.get("priority") or []
+    if priorities:
+        queryset = queryset.filter(priority__in=priorities)
+
+    channel = filters.get("channel")
+    if channel and channel != "all":
+        queryset = queryset.filter(channel_source=channel)
+
+    sla = filters.get("sla")
+    if sla and sla != "all":
+        now = timezone.now()
+        if sla == "breached":
+            queryset = queryset.filter(sla_due_at__lt=now)
+        elif sla == "at-risk":
+            queryset = queryset.filter(sla_due_at__gte=now, sla_due_at__lte=now + timedelta(hours=1))
+        elif sla == "on-track":
+            queryset = queryset.filter(sla_due_at__gt=now + timedelta(hours=1))
+
+    triage_results = set(filters.get("aiTriageResult") or [])
+    if triage_results:
+        triage_q = Q()
+        normal_results = triage_results - {"in_progress"}
+        if normal_results:
+            triage_q |= Q(ai_triage__result__in=normal_results)
+        if "in_progress" in triage_results:
+            triage_q |= Q(ai_triage__status="in_progress")
+        queryset = queryset.filter(triage_q)
+
+    assignee_entries = normalize_assignee_filter(filters.get("assignee"))
+    if assignee_entries:
+        assignee_q = _assignee_filter_q(assignee_entries, user)
+        if assignee_q:
+            queryset = queryset.filter(assignee_q)
+
+    tags = [str(tag) for tag in filters.get("tags") or []][:MAX_TAG_FILTER_VALUES]
+    if tags:
+        if filters.get("tagsMatch") == "all":
+            # One filter per tag (not __in) so this is AND: the ticket must carry every tag.
+            for tag_name in tags:
+                queryset = queryset.filter(tagged_items__tag__name=tag_name)
+            queryset = queryset.distinct()
+        else:
+            queryset = queryset.filter(tagged_items__tag__name__in=tags).distinct()
+
+    tags_exclude = [str(tag) for tag in filters.get("tagsExclude") or []][:MAX_TAG_FILTER_VALUES]
+    if tags_exclude:
+        queryset = queryset.exclude(tagged_items__tag__name__in=tags_exclude)
+
+    date_from = filters.get("dateFrom")
+    if date_from and date_from != "all":
+        parsed = relative_date_parse(date_from, team.timezone_info)
+        if parsed:
+            queryset = queryset.filter(updated_at__gte=parsed)
+
+    date_to = filters.get("dateTo")
+    if date_to and date_to != "all":
+        parsed = relative_date_parse(date_to, team.timezone_info)
+        if parsed:
+            queryset = queryset.filter(updated_at__lte=parsed)
+
+    search = filters.get("search")
+    if search and len(search) <= MAX_SEARCH_LENGTH:
+        queryset = _apply_search(queryset, search)
+
+    return queryset.order_by(_sorting_to_order_by(filters.get("sorting")))

--- a/products/conversations/backend/api/ticket_views.py
+++ b/products/conversations/backend/api/ticket_views.py
@@ -3,12 +3,14 @@ from typing import TYPE_CHECKING, Any, cast
 
 from django.db.models import Exists, OuterRef
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import mixins, serializers, viewsets
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
 from posthog.event_usage import report_user_action
 
+from products.conversations.backend.api.ticket_filters import TicketViewFiltersSerializer
 from products.conversations.backend.models import TicketView, TicketViewFavorite
 
 if TYPE_CHECKING:
@@ -17,22 +19,34 @@ if TYPE_CHECKING:
 MAX_FILTERS_SIZE_BYTES = 10_000
 
 
+@extend_schema_field(TicketViewFiltersSerializer)
+class TicketViewFiltersField(serializers.JSONField):
+    """Validates writes against the canonical filter shape but stores and returns the raw
+    dict, so unknown keys survive round-trips and legacy blobs render unchanged."""
+
+    def to_internal_value(self, data: Any) -> dict:
+        value = super().to_internal_value(data)
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Expected a JSON object.")
+        if len(json.dumps(value)) > MAX_FILTERS_SIZE_BYTES:
+            raise serializers.ValidationError("Filters payload is too large.")
+        filters_serializer = TicketViewFiltersSerializer(data=value)
+        filters_serializer.is_valid(raise_exception=True)
+        return value
+
+
 class TicketViewSerializer(serializers.ModelSerializer):
     created_by = UserBasicSerializer(read_only=True)
-    filters = serializers.DictField(
+    filters = TicketViewFiltersField(
         required=False,
         default=dict,
-        help_text="Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys.",
+        help_text="Saved ticket filter criteria: status, priority, channel, sla, aiTriageResult, assignee, "
+        "tags, tagsMatch, tagsExclude, dateFrom, dateTo, sorting, and search.",
     )
     is_favorited = serializers.BooleanField(
         required=False,
         help_text="Whether the current user has favorited this view. Favorited views sort to the top of the list. Favorites are personal to each user.",
     )
-
-    def validate_filters(self, value: dict) -> dict:
-        if len(json.dumps(value)) > MAX_FILTERS_SIZE_BYTES:
-            raise serializers.ValidationError("Filters payload is too large.")
-        return value
 
     class Meta:
         model = TicketView

--- a/products/conversations/backend/api/ticket_views.py
+++ b/products/conversations/backend/api/ticket_views.py
@@ -30,7 +30,7 @@ class TicketViewFiltersField(serializers.JSONField):
             raise serializers.ValidationError("Expected a JSON object.")
         if len(json.dumps(value)) > MAX_FILTERS_SIZE_BYTES:
             raise serializers.ValidationError("Filters payload is too large.")
-        filters_serializer = TicketViewFiltersSerializer(data=value)
+        filters_serializer = TicketViewFiltersSerializer(data=value, context={"strict_writes": True})
         filters_serializer.is_valid(raise_exception=True)
         return value
 

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -431,6 +431,9 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
         if search:
             self._search_path = "ticket_number" if is_ticket_number_search(search) else "text"
 
+        # Hide tickets the user has been explicitly denied object-level access to (list action only).
+        queryset = self._filter_queryset_by_access_level(queryset)
+
         user = cast("User", self.request.user) if self.request.user and self.request.user.is_authenticated else None
         return apply_ticket_filters(queryset, filters, team=self.team, user=user)
 

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -4,14 +4,11 @@ import json
 import time
 import uuid
 from collections.abc import Sequence
-from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from django.db import transaction
-from django.db.models import CharField, F, OrderBy, Q, QuerySet, Sum
-from django.db.models.functions import Cast
+from django.db.models import Q, QuerySet, Sum
 from django.http import Http404
-from django.utils import timezone
 
 import structlog
 import posthoganalytics
@@ -24,7 +21,7 @@ from rest_framework import (
     viewsets,
 )
 from rest_framework.decorators import action
-from rest_framework.exceptions import MethodNotAllowed
+from rest_framework.exceptions import MethodNotAllowed, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -44,9 +41,15 @@ from posthog.personhog_client.caller_tag import personhog_caller_tag
 from posthog.rate_limit import ComposeTicketBurstThrottle, ComposeTicketSustainedThrottle
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
-from posthog.utils import relative_date_parse
 
 from products.conversations.backend.api.serializers import TicketAssignmentSerializer
+from products.conversations.backend.api.ticket_filters import (
+    AI_TRIAGE_FILTER_VALUES,
+    apply_ticket_filters,
+    is_ticket_number_search,
+    parse_stored_view_filters,
+    query_params_to_view_filters,
+)
 from products.conversations.backend.cache import (
     get_cached_unread_count,
     invalidate_unread_count_cache,
@@ -58,11 +61,14 @@ from products.conversations.backend.events import (
     capture_ticket_status_changed,
 )
 from products.conversations.backend.metrics import TICKET_SEARCH_DURATION_SECONDS
-from products.conversations.backend.models import EmailChannel, Ticket, TicketAssignment
-from products.conversations.backend.models.constants import Channel, ChannelDetail, Priority, Status
+from products.conversations.backend.models import EmailChannel, Ticket, TicketAssignment, TicketView
+from products.conversations.backend.models.constants import Channel, ChannelDetail, Status
 from products.conversations.backend.person_lookup import _get_persons_by_email
 
 from ee.models.rbac.role import Role
+
+if TYPE_CHECKING:
+    from posthog.models import User
 
 logger = structlog.get_logger(__name__)
 
@@ -214,9 +220,6 @@ class TicketPagination(pagination.LimitOffsetPagination):
 class TicketMessagePagination(pagination.LimitOffsetPagination):
     default_limit = 50
     max_limit = 200
-
-
-MAX_TAG_FILTER_VALUES = 50
 
 
 class TicketPersonSerializer(serializers.Serializer):
@@ -376,102 +379,22 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
     # Which search branch safely_get_queryset applied, for the latency histogram.
     _search_path: str | None = None
 
-    def _filter_by_text_search(self, queryset: QuerySet, search: str) -> QuerySet:
-        # Comment match as a non-correlated subquery: self-contained, so Postgres hashes
-        # it once per query (scanning posthog_comment through its trigram index) instead
-        # of probing comments per ticket the way a correlated EXISTS would. The ticket id
-        # is cast to text rather than item_id to uuid — the id side is always a valid
-        # UUID, while a malformed item_id row would make the whole search error.
-        comment_match = Comment.objects.filter(
-            team_id=self.team_id,
-            scope="conversations_ticket",
-            deleted=False,
-            content__icontains=search,
-        ).values("item_id")
-
-        return queryset.alias(id_text=Cast("id", output_field=CharField())).filter(
-            Q(anonymous_traits__name__icontains=search)
-            | Q(anonymous_traits__email__icontains=search)
-            | Q(email_subject__icontains=search)
-            | Q(id_text__in=comment_match)
-        )
-
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
         """Filter tickets by team."""
         queryset = queryset.filter(team_id=self.team_id)
         queryset = queryset.select_related("assignment", "assignment__user", "assignment__role", "email_config")
 
-        status_param = self.request.query_params.get("status")
-        if status_param:
-            valid_statuses = [s.value for s in Status]
-            statuses = [s.strip() for s in status_param.split(",") if s.strip() in valid_statuses]
-            if len(statuses) == 1:
-                queryset = queryset.filter(status=statuses[0])
-            elif len(statuses) > 1:
-                queryset = queryset.filter(status__in=statuses)
-
-        priority_param = self.request.query_params.get("priority")
-        if priority_param:
-            valid_priorities = [p.value for p in Priority]
-            priorities = [p.strip() for p in priority_param.split(",") if p.strip() in valid_priorities]
-            if len(priorities) == 1:
-                queryset = queryset.filter(priority=priorities[0])
-            elif len(priorities) > 1:
-                queryset = queryset.filter(priority__in=priorities)
-
-        channel_source = self.request.query_params.get("channel_source")
-        if channel_source and channel_source in [c.value for c in Channel]:
-            queryset = queryset.filter(channel_source=channel_source)
+        filters: dict[str, Any] = {}
+        view_short_id = self.request.query_params.get("view")
+        if view_short_id:
+            filters = self._get_view_filters(view_short_id)
+        # Explicit query params override the saved view's values, so a caller can apply
+        # a view and still narrow it further.
+        filters.update(query_params_to_view_filters(self.request.query_params))
 
         channel_detail = self.request.query_params.get("channel_detail")
         if channel_detail and channel_detail in [d.value for d in ChannelDetail]:
             queryset = queryset.filter(channel_detail=channel_detail)
-
-        assignee_param = self.request.query_params.get("assignee")
-        if assignee_param:
-            user_ids: list[int] = []
-            role_ids: list[uuid.UUID] = []
-            include_unassigned = False
-            for raw_entry in assignee_param.split(",")[:100]:
-                entry = raw_entry.strip()
-                if entry.lower() == "unassigned":
-                    include_unassigned = True
-                elif entry.lower() == "me":
-                    # Dynamic per-viewer token: resolve to the requesting user so a
-                    # shared saved view scoped to "me" means each viewer's own tickets.
-                    if self.request.user and self.request.user.is_authenticated:
-                        user_ids.append(self.request.user.id)
-                elif entry.startswith("user:"):
-                    try:
-                        user_ids.append(int(entry[5:]))
-                    except ValueError:
-                        pass
-                elif entry.startswith("role:"):
-                    try:
-                        role_ids.append(uuid.UUID(entry[5:]))
-                    except (ValueError, AttributeError):
-                        pass
-            assignee_q = Q()
-            if user_ids:
-                assignee_q |= Q(assignment__user_id__in=user_ids)
-            if role_ids:
-                assignee_q |= Q(assignment__role_id__in=role_ids)
-            if include_unassigned:
-                assignee_q |= Q(assignment__isnull=True)
-            if assignee_q:
-                queryset = queryset.filter(assignee_q)
-
-        date_from = self.request.query_params.get("date_from")
-        if date_from and date_from != "all":
-            parsed = relative_date_parse(date_from, self.team.timezone_info)
-            if parsed:
-                queryset = queryset.filter(updated_at__gte=parsed)
-
-        date_to = self.request.query_params.get("date_to")
-        if date_to:
-            parsed = relative_date_parse(date_to, self.team.timezone_info)
-            if parsed:
-                queryset = queryset.filter(updated_at__lte=parsed)
 
         # Related-ticket matching: a ticket belongs to the same customer if it shares one of the
         # person's merged distinct_ids OR the same email address. Email widens the match to tickets
@@ -497,30 +420,6 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
         if match_q:
             queryset = queryset.filter(match_q)
 
-        search = self.request.query_params.get("search")
-        if search and len(search) <= 200:
-            # A leading "#" is how ticket numbers are shown in the UI (e.g. "#1234"), so
-            # treat "#1234" the same as "1234" and match the ticket number exactly.
-            # Restrict to ASCII digits: str.isdigit() also accepts characters like "²"
-            # that int() then rejects, which would 500 the request.
-            ticket_number_search = search[1:] if search.startswith("#") else search
-            if ticket_number_search.isascii() and ticket_number_search.isdigit():
-                self._search_path = "ticket_number"
-                queryset = queryset.filter(ticket_number=int(ticket_number_search))
-            else:
-                self._search_path = "text"
-                queryset = self._filter_by_text_search(queryset, search)
-
-        sla_param = self.request.query_params.get("sla")
-        if sla_param:
-            now = timezone.now()
-            if sla_param == "breached":
-                queryset = queryset.filter(sla_due_at__lt=now)
-            elif sla_param == "at-risk":
-                queryset = queryset.filter(sla_due_at__gte=now, sla_due_at__lte=now + timedelta(hours=1))
-            elif sla_param == "on-track":
-                queryset = queryset.filter(sla_due_at__gt=now + timedelta(hours=1))
-
         snoozed_param = self.request.query_params.get("snoozed")
         if snoozed_param is not None:
             if snoozed_param.lower() == "true":
@@ -528,92 +427,20 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
             elif snoozed_param.lower() == "false":
                 queryset = queryset.filter(snoozed_until__isnull=True)
 
-        tags_param = self.request.query_params.get("tags")
-        if tags_param:
-            try:
-                tags_list = json.loads(tags_param)
-                if isinstance(tags_list, list) and tags_list:
-                    queryset = queryset.filter(tagged_items__tag__name__in=tags_list[:MAX_TAG_FILTER_VALUES]).distinct()
-            except json.JSONDecodeError:
-                pass
+        search = filters.get("search")
+        if search:
+            self._search_path = "ticket_number" if is_ticket_number_search(search) else "text"
 
-        tags_all_param = self.request.query_params.get("tags_all")
-        if tags_all_param:
-            try:
-                tags_all_list = json.loads(tags_all_param)
-                if isinstance(tags_all_list, list) and tags_all_list:
-                    # One filter per tag (not __in) so this is AND: the ticket must carry every tag.
-                    for tag_name in tags_all_list[:MAX_TAG_FILTER_VALUES]:
-                        queryset = queryset.filter(tagged_items__tag__name=tag_name)
-                    queryset = queryset.distinct()
-            except json.JSONDecodeError:
-                pass
+        user = cast("User", self.request.user) if self.request.user and self.request.user.is_authenticated else None
+        return apply_ticket_filters(queryset, filters, team=self.team, user=user)
 
-        tags_exclude_param = self.request.query_params.get("tags_exclude")
-        if tags_exclude_param:
-            try:
-                tags_exclude_list = json.loads(tags_exclude_param)
-                if isinstance(tags_exclude_list, list) and tags_exclude_list:
-                    queryset = queryset.exclude(tagged_items__tag__name__in=tags_exclude_list[:MAX_TAG_FILTER_VALUES])
-            except json.JSONDecodeError:
-                pass
-
-        ai_triage_result_param = self.request.query_params.get("ai_triage_result")
-        if ai_triage_result_param:
-            valid_results = {
-                "persisted",
-                "escalated_with_best",
-                "escalated_no_reply",
-                "skipped_unactionable",
-                "blocked_unsafe",
-                "blocked_unsafe_reply",
-                "in_progress",
-            }
-            results = {r.strip() for r in ai_triage_result_param.split(",") if r.strip() in valid_results}
-            if results:
-                q = Q()
-                normal_results = results - {"in_progress"}
-                if normal_results:
-                    q |= Q(ai_triage__result__in=normal_results)
-                if "in_progress" in results:
-                    q |= Q(ai_triage__status="in_progress")
-                queryset = queryset.filter(q)
-
-        allowed_orderings = {
-            "updated_at",
-            "-updated_at",
-            "sla_due_at",
-            "-sla_due_at",
-            "snoozed_until",
-            "-snoozed_until",
-            "created_at",
-            "-created_at",
-            "ticket_number",
-            "-ticket_number",
-        }
-        order_by = self.request.query_params.get("order_by", "-updated_at")
-        if order_by not in allowed_orderings:
-            order_by = "-updated_at"
-
-        # Hide tickets the user has been explicitly denied object-level access to (list action only).
-        queryset = self._filter_queryset_by_access_level(queryset)
-
-        field_name = order_by.lstrip("-")
-        primary: OrderBy | str
-        if field_name in ("sla_due_at", "snoozed_until"):
-            # A ticket with no SLA (or no snooze) sorts to the bottom either direction — an
-            # absent deadline isn't more urgent than a real one, and it keeps the large NULL
-            # block off the first pages so the SLA-sorted rows are what the user actually sees.
-            descending = order_by.startswith("-")
-            primary = F(field_name).desc(nulls_last=True) if descending else F(field_name).asc(nulls_last=True)
-        else:
-            primary = order_by
-
-        # ticket_number is unique per team (the queryset is already team-scoped), so it breaks
-        # ties deterministically. Without it, rows equal on the primary key — every no-SLA
-        # ticket shares NULL sla_due_at — have no stable order across the separate LIMIT/OFFSET
-        # page queries, so pages overlap or drop rows and the sort looks lost past page 1.
-        return queryset.order_by(primary, "-ticket_number")
+    def _get_view_filters(self, short_id: str) -> dict[str, Any]:
+        """Resolve a saved ticket view into the canonical filter shape for apply_ticket_filters."""
+        try:
+            view = TicketView.objects.get(team_id=self.team_id, short_id=short_id)
+        except TicketView.DoesNotExist:
+            raise ValidationError({"view": "No saved ticket view matches this short_id."})
+        return parse_stored_view_filters(view.filters)
 
     def safely_get_object(self, queryset):
         """
@@ -703,6 +530,16 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
 
     @extend_schema(
         parameters=[
+            OpenApiParameter(
+                "view",
+                OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description=(
+                    "Apply a saved ticket view's filters by its `short_id` (list views via the "
+                    "`conversations/views` endpoint). Any filter param passed explicitly overrides "
+                    "the view's saved value for that dimension. Returns 400 if no view matches."
+                ),
+            ),
             OpenApiParameter(
                 "status",
                 OpenApiTypes.STR,
@@ -814,6 +651,21 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, AccessContro
                 OpenApiTypes.STR,
                 location=OpenApiParameter.QUERY,
                 description='JSON-encoded array of tag names; returns tickets that have NONE of them (NOT), e.g. `["escalated"]`.',
+            ),
+            OpenApiParameter(
+                "ai_triage_result",
+                OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description=(
+                    "Filter by AI triage outcome. Accepts a single value or a comma-separated list. "
+                    f"Valid values: {', '.join(f'`{v}`' for v in AI_TRIAGE_FILTER_VALUES)}."
+                ),
+            ),
+            OpenApiParameter(
+                "snoozed",
+                OpenApiTypes.BOOL,
+                location=OpenApiParameter.QUERY,
+                description="Filter by snooze state: `true` returns only snoozed tickets, `false` only non-snoozed.",
             ),
             OpenApiParameter(
                 "order_by",

--- a/products/conversations/frontend/components/SavedViews/ticketViewsLogic.ts
+++ b/products/conversations/frontend/components/SavedViews/ticketViewsLogic.ts
@@ -12,7 +12,7 @@ import {
     conversationsViewsList,
     conversationsViewsPartialUpdate,
 } from '../../generated/api'
-import type { PatchedTicketViewApi, TicketViewApiFilters } from '../../generated/api.schemas'
+import type { PatchedTicketViewApi, TicketViewFiltersApi } from '../../generated/api.schemas'
 import { supportTicketsSceneLogic } from '../../scenes/tickets/supportTicketsSceneLogic'
 import type { SavedTicketView, TicketViewFilters } from '../../types'
 
@@ -187,7 +187,7 @@ export const ticketViewsLogic = kea<ticketViewsLogicType>([
                 createView: async ({ name, filters }: { name: string; filters: TicketViewFilters }) => {
                     const created = (await conversationsViewsCreate(String(values.currentTeamId), {
                         name,
-                        filters: filters as TicketViewApiFilters,
+                        filters: filters as TicketViewFiltersApi,
                     })) as unknown as SavedTicketView
                     lemonToast.success('View saved')
                     return [created, ...values.views]

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -1187,8 +1187,6 @@ export interface TicketViewFiltersApi {
      * * `any` - any
      * * `all` - all */
     tagsMatch?: TicketTagsMatchEnumApi
-    /** Tag names the ticket must all carry (AND). Applied on top of tags/tagsMatch, so both an any-of and an all-of constraint can be active at once. */
-    tagsAll?: string[]
     /** Tickets carrying any of these tags are excluded. */
     tagsExclude?: string[]
     /**

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -1057,17 +1057,164 @@ export interface TicketErrorApi {
 }
 
 /**
- * Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys.
+ * * `widget` - widget
+ * * `email` - email
+ * * `slack` - slack
+ * * `teams` - teams
+ * * `github` - github
+ * * `all` - all
  */
-export type TicketViewApiFilters = { [key: string]: unknown }
+export type ChannelEnumApi = (typeof ChannelEnumApi)[keyof typeof ChannelEnumApi]
+
+export const ChannelEnumApi = {
+    Widget: 'widget',
+    Email: 'email',
+    Slack: 'slack',
+    Teams: 'teams',
+    Github: 'github',
+    All: 'all',
+} as const
+
+/**
+ * * `breached` - breached
+ * * `at-risk` - at-risk
+ * * `on-track` - on-track
+ * * `all` - all
+ */
+export type SlaEnumApi = (typeof SlaEnumApi)[keyof typeof SlaEnumApi]
+
+export const SlaEnumApi = {
+    Breached: 'breached',
+    AtRisk: 'at-risk',
+    OnTrack: 'on-track',
+    All: 'all',
+} as const
+
+/**
+ * * `persisted` - persisted
+ * * `escalated_with_best` - escalated_with_best
+ * * `escalated_no_reply` - escalated_no_reply
+ * * `skipped_unactionable` - skipped_unactionable
+ * * `blocked_unsafe` - blocked_unsafe
+ * * `blocked_unsafe_reply` - blocked_unsafe_reply
+ * * `in_progress` - in_progress
+ */
+export type AiTriageResultEnumApi = (typeof AiTriageResultEnumApi)[keyof typeof AiTriageResultEnumApi]
+
+export const AiTriageResultEnumApi = {
+    Persisted: 'persisted',
+    EscalatedWithBest: 'escalated_with_best',
+    EscalatedNoReply: 'escalated_no_reply',
+    SkippedUnactionable: 'skipped_unactionable',
+    BlockedUnsafe: 'blocked_unsafe',
+    BlockedUnsafeReply: 'blocked_unsafe_reply',
+    InProgress: 'in_progress',
+} as const
+
+/**
+ * * `any` - any
+ * * `all` - all
+ */
+export type TagsMatchEnumApi = (typeof TagsMatchEnumApi)[keyof typeof TagsMatchEnumApi]
+
+export const TagsMatchEnumApi = {
+    Any: 'any',
+    All: 'all',
+} as const
+
+/**
+ * * `1` - 1
+ * * `-1` - -1
+ */
+export type OrderEnumApi = (typeof OrderEnumApi)[keyof typeof OrderEnumApi]
+
+export const OrderEnumApi = {
+    Number1: 1,
+    NumberMinus1: -1,
+} as const
+
+export interface TicketViewSortingApi {
+    /** Ticket column to sort by (updated_at, sla_due_at, snoozed_until, created_at, ticket_number). Unknown columns fall back to updated_at. */
+    columnKey: string
+    /** 1 for ascending, -1 for descending.
+     *
+     * * `1` - 1
+     * * `-1` - -1 */
+    order: OrderEnumApi
+}
+
+export type TicketViewFiltersApiAssigneeItem =
+    | 'me'
+    | 'unassigned'
+    | {
+          type: 'user' | 'role'
+          id: string | number
+      }
+
+/**
+ * Canonical shape of a saved ticket view's filters. Every field is optional; an omitted
+ * field (or an 'all' sentinel) leaves that dimension unfiltered.
+ */
+export interface TicketViewFiltersApi {
+    /** Ticket statuses to include. Empty or omitted means all statuses. */
+    status?: TicketStatusEnumApi[]
+    /** Ticket priorities to include. Empty or omitted means all priorities. */
+    priority?: TicketPriorityEnumApi[]
+    /** Channel the ticket originated from. 'all' disables the filter.
+     *
+     * * `widget` - widget
+     * * `email` - email
+     * * `slack` - slack
+     * * `teams` - teams
+     * * `github` - github
+     * * `all` - all */
+    channel?: ChannelEnumApi
+    /** SLA state: 'breached' is past due, 'at-risk' is due within the next hour, 'on-track' has more than an hour remaining. 'all' disables the filter.
+     *
+     * * `breached` - breached
+     * * `at-risk` - at-risk
+     * * `on-track` - on-track
+     * * `all` - all */
+    sla?: SlaEnumApi
+    /** AI triage outcomes to include. 'in_progress' matches tickets still being triaged. */
+    aiTriageResult?: AiTriageResultEnumApi[]
+    /** Assignees to match (any of): 'unassigned', 'me' (resolved to the requesting user), or an object with type ('user' or 'role') and id. The legacy single-value shape is accepted and normalized to a list. */
+    assignee?: TicketViewFiltersApiAssigneeItem[]
+    /** Tag names to match, combined according to tagsMatch. */
+    tags?: string[]
+    /** 'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).
+     *
+     * * `any` - any
+     * * `all` - all */
+    tagsMatch?: TagsMatchEnumApi
+    /** Tickets carrying any of these tags are excluded. */
+    tagsExclude?: string[]
+    /**
+     * Only include tickets updated on or after this date. Accepts absolute dates (2026-01-01) or relative ones (-7d). 'all' or null disables the bound.
+     * @nullable
+     */
+    dateFrom?: string | null
+    /**
+     * Only include tickets updated on or before this date. Same format as dateFrom.
+     * @nullable
+     */
+    dateTo?: string | null
+    /** Sort order for the ticket list. */
+    sorting?: TicketViewSortingApi | null
+    /**
+     * Free-text search. A numeric value matches a ticket number exactly; otherwise matches the customer's name or email, the email subject, or message content.
+     * @maxLength 200
+     */
+    search?: string
+}
 
 export interface TicketViewApi {
     readonly id: string
     readonly short_id: string
     /** @maxLength 400 */
     name: string
-    /** Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys. */
-    filters?: TicketViewApiFilters
+    /** Saved ticket filter criteria: status, priority, channel, sla, aiTriageResult, assignee, tags, tagsMatch, tagsExclude, dateFrom, dateTo, sorting, and search. */
+    filters?: TicketViewFiltersApi
     readonly created_at: string
     readonly created_by: UserBasicApi
     /** Whether the current user has favorited this view. Favorited views sort to the top of the list. Favorites are personal to each user. */
@@ -1083,18 +1230,13 @@ export interface PaginatedTicketViewListApi {
     results: TicketViewApi[]
 }
 
-/**
- * Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys.
- */
-export type PatchedTicketViewApiFilters = { [key: string]: unknown }
-
 export interface PatchedTicketViewApi {
     readonly id?: string
     readonly short_id?: string
     /** @maxLength 400 */
     name?: string
-    /** Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys. */
-    filters?: PatchedTicketViewApiFilters
+    /** Saved ticket filter criteria: status, priority, channel, sla, aiTriageResult, assignee, tags, tagsMatch, tagsExclude, dateFrom, dateTo, sorting, and search. */
+    filters?: TicketViewFiltersApi
     readonly created_at?: string
     readonly created_by?: UserBasicApi
     /** Whether the current user has favorited this view. Favorited views sort to the top of the list. Favorites are personal to each user. */
@@ -1203,6 +1345,10 @@ export type ConversationsListParams = {
 
 export type ConversationsTicketsListParams = {
     /**
+     * Filter by AI triage outcome. Accepts a single value or a comma-separated list. Valid values: `persisted`, `escalated_with_best`, `escalated_no_reply`, `skipped_unactionable`, `blocked_unsafe`, `blocked_unsafe_reply`, `in_progress`.
+     */
+    ai_triage_result?: string
+    /**
      * Filter by assignee. Accepts a single value or a comma-separated list (matches any, max 100 entries). Each entry is `unassigned` (no assignee), `me` (the requesting user), `user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`.
      */
     assignee?: string
@@ -1255,6 +1401,10 @@ export type ConversationsTicketsListParams = {
      */
     sla?: ConversationsTicketsListSla
     /**
+     * Filter by snooze state: `true` returns only snoozed tickets, `false` only non-snoozed.
+     */
+    snoozed?: boolean
+    /**
      * Filter by status. Accepts a single value or a comma-separated list (e.g. `new,open,pending`). Valid values: `new`, `open`, `pending`, `on_hold`, `resolved`.
      */
     status?: string
@@ -1270,6 +1420,10 @@ export type ConversationsTicketsListParams = {
      * JSON-encoded array of tag names; returns tickets that have NONE of them (NOT), e.g. `["escalated"]`.
      */
     tags_exclude?: string
+    /**
+     * Apply a saved ticket view's filters by its `short_id` (list views via the `conversations/views` endpoint). Any filter param passed explicitly overrides the view's saved value for that dimension. Returns 400 if no view matches.
+     */
+    view?: string
 }
 
 export type ConversationsTicketsListChannelDetail =

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -1064,9 +1064,9 @@ export interface TicketErrorApi {
  * * `github` - github
  * * `all` - all
  */
-export type ChannelEnumApi = (typeof ChannelEnumApi)[keyof typeof ChannelEnumApi]
+export type TicketChannelFilterEnumApi = (typeof TicketChannelFilterEnumApi)[keyof typeof TicketChannelFilterEnumApi]
 
-export const ChannelEnumApi = {
+export const TicketChannelFilterEnumApi = {
     Widget: 'widget',
     Email: 'email',
     Slack: 'slack',
@@ -1081,9 +1081,9 @@ export const ChannelEnumApi = {
  * * `on-track` - on-track
  * * `all` - all
  */
-export type SlaEnumApi = (typeof SlaEnumApi)[keyof typeof SlaEnumApi]
+export type TicketSlaFilterEnumApi = (typeof TicketSlaFilterEnumApi)[keyof typeof TicketSlaFilterEnumApi]
 
-export const SlaEnumApi = {
+export const TicketSlaFilterEnumApi = {
     Breached: 'breached',
     AtRisk: 'at-risk',
     OnTrack: 'on-track',
@@ -1115,9 +1115,9 @@ export const AiTriageResultEnumApi = {
  * * `any` - any
  * * `all` - all
  */
-export type TagsMatchEnumApi = (typeof TagsMatchEnumApi)[keyof typeof TagsMatchEnumApi]
+export type TicketTagsMatchEnumApi = (typeof TicketTagsMatchEnumApi)[keyof typeof TicketTagsMatchEnumApi]
 
-export const TagsMatchEnumApi = {
+export const TicketTagsMatchEnumApi = {
     Any: 'any',
     All: 'all',
 } as const
@@ -1126,9 +1126,9 @@ export const TagsMatchEnumApi = {
  * * `1` - 1
  * * `-1` - -1
  */
-export type OrderEnumApi = (typeof OrderEnumApi)[keyof typeof OrderEnumApi]
+export type TicketSortOrderEnumApi = (typeof TicketSortOrderEnumApi)[keyof typeof TicketSortOrderEnumApi]
 
-export const OrderEnumApi = {
+export const TicketSortOrderEnumApi = {
     Number1: 1,
     NumberMinus1: -1,
 } as const
@@ -1140,7 +1140,7 @@ export interface TicketViewSortingApi {
      *
      * * `1` - 1
      * * `-1` - -1 */
-    order: OrderEnumApi
+    order: TicketSortOrderEnumApi
 }
 
 export type TicketViewFiltersApiAssigneeItem =
@@ -1168,14 +1168,14 @@ export interface TicketViewFiltersApi {
      * * `teams` - teams
      * * `github` - github
      * * `all` - all */
-    channel?: ChannelEnumApi
+    channel?: TicketChannelFilterEnumApi
     /** SLA state: 'breached' is past due, 'at-risk' is due within the next hour, 'on-track' has more than an hour remaining. 'all' disables the filter.
      *
      * * `breached` - breached
      * * `at-risk` - at-risk
      * * `on-track` - on-track
      * * `all` - all */
-    sla?: SlaEnumApi
+    sla?: TicketSlaFilterEnumApi
     /** AI triage outcomes to include. 'in_progress' matches tickets still being triaged. */
     aiTriageResult?: AiTriageResultEnumApi[]
     /** Assignees to match (any of): 'unassigned', 'me' (resolved to the requesting user), or an object with type ('user' or 'role') and id. The legacy single-value shape is accepted and normalized to a list. */
@@ -1186,7 +1186,9 @@ export interface TicketViewFiltersApi {
      *
      * * `any` - any
      * * `all` - all */
-    tagsMatch?: TagsMatchEnumApi
+    tagsMatch?: TicketTagsMatchEnumApi
+    /** Tag names the ticket must all carry (AND). Applied on top of tags/tagsMatch, so both an any-of and an all-of constraint can be active at once. */
+    tagsAll?: string[]
     /** Tickets carrying any of these tags are excluded. */
     tagsExclude?: string[]
     /**

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -365,13 +365,131 @@ export const ConversationsTicketsComposeCreateBody = /* @__PURE__ */ zod.object(
 
 export const conversationsViewsCreateBodyNameMax = 400
 
+export const conversationsViewsCreateBodyFiltersOneSearchMax = 200
+
 export const ConversationsViewsCreateBody = /* @__PURE__ */ zod.object({
     name: zod.string().max(conversationsViewsCreateBodyNameMax),
     filters: zod
-        .record(zod.string(), zod.unknown())
+        .object({
+            status: zod
+                .array(
+                    zod
+                        .enum(['new', 'open', 'pending', 'on_hold', 'resolved'])
+                        .describe(
+                            '\* `new` - New\n\* `open` - Open\n\* `pending` - Pending\n\* `on_hold` - On hold\n\* `resolved` - Resolved'
+                        )
+                )
+                .optional()
+                .describe('Ticket statuses to include. Empty or omitted means all statuses.'),
+            priority: zod
+                .array(
+                    zod
+                        .enum(['low', 'medium', 'high', 'critical'])
+                        .describe('\* `low` - Low\n\* `medium` - Medium\n\* `high` - High\n\* `critical` - Critical')
+                )
+                .optional()
+                .describe('Ticket priorities to include. Empty or omitted means all priorities.'),
+            channel: zod
+                .enum(['widget', 'email', 'slack', 'teams', 'github', 'all'])
+                .describe(
+                    '\* `widget` - widget\n\* `email` - email\n\* `slack` - slack\n\* `teams` - teams\n\* `github` - github\n\* `all` - all'
+                )
+                .optional()
+                .describe(
+                    "Channel the ticket originated from. 'all' disables the filter.\n\n\* `widget` - widget\n\* `email` - email\n\* `slack` - slack\n\* `teams` - teams\n\* `github` - github\n\* `all` - all"
+                ),
+            sla: zod
+                .enum(['breached', 'at-risk', 'on-track', 'all'])
+                .describe('\* `breached` - breached\n\* `at-risk` - at-risk\n\* `on-track` - on-track\n\* `all` - all')
+                .optional()
+                .describe(
+                    "SLA state: 'breached' is past due, 'at-risk' is due within the next hour, 'on-track' has more than an hour remaining. 'all' disables the filter.\n\n\* `breached` - breached\n\* `at-risk` - at-risk\n\* `on-track` - on-track\n\* `all` - all"
+                ),
+            aiTriageResult: zod
+                .array(
+                    zod
+                        .enum([
+                            'persisted',
+                            'escalated_with_best',
+                            'escalated_no_reply',
+                            'skipped_unactionable',
+                            'blocked_unsafe',
+                            'blocked_unsafe_reply',
+                            'in_progress',
+                        ])
+                        .describe(
+                            '\* `persisted` - persisted\n\* `escalated_with_best` - escalated_with_best\n\* `escalated_no_reply` - escalated_no_reply\n\* `skipped_unactionable` - skipped_unactionable\n\* `blocked_unsafe` - blocked_unsafe\n\* `blocked_unsafe_reply` - blocked_unsafe_reply\n\* `in_progress` - in_progress'
+                        )
+                )
+                .optional()
+                .describe("AI triage outcomes to include. 'in_progress' matches tickets still being triaged."),
+            assignee: zod
+                .array(
+                    zod.union([
+                        zod.enum(['me', 'unassigned']),
+                        zod.object({
+                            type: zod.enum(['user', 'role']),
+                            id: zod.union([zod.string(), zod.number()]),
+                        }),
+                    ])
+                )
+                .optional()
+                .describe(
+                    "Assignees to match (any of): 'unassigned', 'me' (resolved to the requesting user), or an object with type ('user' or 'role') and id. The legacy single-value shape is accepted and normalized to a list."
+                ),
+            tags: zod.array(zod.string()).optional().describe('Tag names to match, combined according to tagsMatch.'),
+            tagsMatch: zod
+                .enum(['any', 'all'])
+                .describe('\* `any` - any\n\* `all` - all')
+                .optional()
+                .describe(
+                    "'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).\n\n\* `any` - any\n\* `all` - all"
+                ),
+            tagsExclude: zod
+                .array(zod.string())
+                .optional()
+                .describe('Tickets carrying any of these tags are excluded.'),
+            dateFrom: zod
+                .string()
+                .nullish()
+                .describe(
+                    "Only include tickets updated on or after this date. Accepts absolute dates (2026-01-01) or relative ones (-7d). 'all' or null disables the bound."
+                ),
+            dateTo: zod
+                .string()
+                .nullish()
+                .describe('Only include tickets updated on or before this date. Same format as dateFrom.'),
+            sorting: zod
+                .union([
+                    zod.object({
+                        columnKey: zod
+                            .string()
+                            .describe(
+                                'Ticket column to sort by (updated_at, sla_due_at, snoozed_until, created_at, ticket_number). Unknown columns fall back to updated_at.'
+                            ),
+                        order: zod
+                            .union([zod.literal(1), zod.literal(-1)])
+                            .describe('\* `1` - 1\n\* `-1` - -1')
+                            .describe('1 for ascending, -1 for descending.\n\n\* `1` - 1\n\* `-1` - -1'),
+                    }),
+                    zod.null(),
+                ])
+                .optional()
+                .describe('Sort order for the ticket list.'),
+            search: zod
+                .string()
+                .max(conversationsViewsCreateBodyFiltersOneSearchMax)
+                .optional()
+                .describe(
+                    "Free-text search. A numeric value matches a ticket number exactly; otherwise matches the customer's name or email, the email subject, or message content."
+                ),
+        })
+        .describe(
+            "Canonical shape of a saved ticket view's filters. Every field is optional; an omitted\nfield (or an 'all' sentinel) leaves that dimension unfiltered."
+        )
         .optional()
         .describe(
-            'Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys.'
+            'Saved ticket filter criteria: status, priority, channel, sla, aiTriageResult, assignee, tags, tagsMatch, tagsExclude, dateFrom, dateTo, sorting, and search.'
         ),
     is_favorited: zod
         .boolean()
@@ -383,13 +501,131 @@ export const ConversationsViewsCreateBody = /* @__PURE__ */ zod.object({
 
 export const conversationsViewsPartialUpdateBodyNameMax = 400
 
+export const conversationsViewsPartialUpdateBodyFiltersOneSearchMax = 200
+
 export const ConversationsViewsPartialUpdateBody = /* @__PURE__ */ zod.object({
     name: zod.string().max(conversationsViewsPartialUpdateBodyNameMax).optional(),
     filters: zod
-        .record(zod.string(), zod.unknown())
+        .object({
+            status: zod
+                .array(
+                    zod
+                        .enum(['new', 'open', 'pending', 'on_hold', 'resolved'])
+                        .describe(
+                            '\* `new` - New\n\* `open` - Open\n\* `pending` - Pending\n\* `on_hold` - On hold\n\* `resolved` - Resolved'
+                        )
+                )
+                .optional()
+                .describe('Ticket statuses to include. Empty or omitted means all statuses.'),
+            priority: zod
+                .array(
+                    zod
+                        .enum(['low', 'medium', 'high', 'critical'])
+                        .describe('\* `low` - Low\n\* `medium` - Medium\n\* `high` - High\n\* `critical` - Critical')
+                )
+                .optional()
+                .describe('Ticket priorities to include. Empty or omitted means all priorities.'),
+            channel: zod
+                .enum(['widget', 'email', 'slack', 'teams', 'github', 'all'])
+                .describe(
+                    '\* `widget` - widget\n\* `email` - email\n\* `slack` - slack\n\* `teams` - teams\n\* `github` - github\n\* `all` - all'
+                )
+                .optional()
+                .describe(
+                    "Channel the ticket originated from. 'all' disables the filter.\n\n\* `widget` - widget\n\* `email` - email\n\* `slack` - slack\n\* `teams` - teams\n\* `github` - github\n\* `all` - all"
+                ),
+            sla: zod
+                .enum(['breached', 'at-risk', 'on-track', 'all'])
+                .describe('\* `breached` - breached\n\* `at-risk` - at-risk\n\* `on-track` - on-track\n\* `all` - all')
+                .optional()
+                .describe(
+                    "SLA state: 'breached' is past due, 'at-risk' is due within the next hour, 'on-track' has more than an hour remaining. 'all' disables the filter.\n\n\* `breached` - breached\n\* `at-risk` - at-risk\n\* `on-track` - on-track\n\* `all` - all"
+                ),
+            aiTriageResult: zod
+                .array(
+                    zod
+                        .enum([
+                            'persisted',
+                            'escalated_with_best',
+                            'escalated_no_reply',
+                            'skipped_unactionable',
+                            'blocked_unsafe',
+                            'blocked_unsafe_reply',
+                            'in_progress',
+                        ])
+                        .describe(
+                            '\* `persisted` - persisted\n\* `escalated_with_best` - escalated_with_best\n\* `escalated_no_reply` - escalated_no_reply\n\* `skipped_unactionable` - skipped_unactionable\n\* `blocked_unsafe` - blocked_unsafe\n\* `blocked_unsafe_reply` - blocked_unsafe_reply\n\* `in_progress` - in_progress'
+                        )
+                )
+                .optional()
+                .describe("AI triage outcomes to include. 'in_progress' matches tickets still being triaged."),
+            assignee: zod
+                .array(
+                    zod.union([
+                        zod.enum(['me', 'unassigned']),
+                        zod.object({
+                            type: zod.enum(['user', 'role']),
+                            id: zod.union([zod.string(), zod.number()]),
+                        }),
+                    ])
+                )
+                .optional()
+                .describe(
+                    "Assignees to match (any of): 'unassigned', 'me' (resolved to the requesting user), or an object with type ('user' or 'role') and id. The legacy single-value shape is accepted and normalized to a list."
+                ),
+            tags: zod.array(zod.string()).optional().describe('Tag names to match, combined according to tagsMatch.'),
+            tagsMatch: zod
+                .enum(['any', 'all'])
+                .describe('\* `any` - any\n\* `all` - all')
+                .optional()
+                .describe(
+                    "'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).\n\n\* `any` - any\n\* `all` - all"
+                ),
+            tagsExclude: zod
+                .array(zod.string())
+                .optional()
+                .describe('Tickets carrying any of these tags are excluded.'),
+            dateFrom: zod
+                .string()
+                .nullish()
+                .describe(
+                    "Only include tickets updated on or after this date. Accepts absolute dates (2026-01-01) or relative ones (-7d). 'all' or null disables the bound."
+                ),
+            dateTo: zod
+                .string()
+                .nullish()
+                .describe('Only include tickets updated on or before this date. Same format as dateFrom.'),
+            sorting: zod
+                .union([
+                    zod.object({
+                        columnKey: zod
+                            .string()
+                            .describe(
+                                'Ticket column to sort by (updated_at, sla_due_at, snoozed_until, created_at, ticket_number). Unknown columns fall back to updated_at.'
+                            ),
+                        order: zod
+                            .union([zod.literal(1), zod.literal(-1)])
+                            .describe('\* `1` - 1\n\* `-1` - -1')
+                            .describe('1 for ascending, -1 for descending.\n\n\* `1` - 1\n\* `-1` - -1'),
+                    }),
+                    zod.null(),
+                ])
+                .optional()
+                .describe('Sort order for the ticket list.'),
+            search: zod
+                .string()
+                .max(conversationsViewsPartialUpdateBodyFiltersOneSearchMax)
+                .optional()
+                .describe(
+                    "Free-text search. A numeric value matches a ticket number exactly; otherwise matches the customer's name or email, the email subject, or message content."
+                ),
+        })
+        .describe(
+            "Canonical shape of a saved ticket view's filters. Every field is optional; an omitted\nfield (or an 'all' sentinel) leaves that dimension unfiltered."
+        )
         .optional()
         .describe(
-            'Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys.'
+            'Saved ticket filter criteria: status, priority, channel, sla, aiTriageResult, assignee, tags, tagsMatch, tagsExclude, dateFrom, dateTo, sorting, and search.'
         ),
     is_favorited: zod
         .boolean()

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -445,12 +445,6 @@ export const ConversationsViewsCreateBody = /* @__PURE__ */ zod.object({
                 .describe(
                     "'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).\n\n\* `any` - any\n\* `all` - all"
                 ),
-            tagsAll: zod
-                .array(zod.string())
-                .optional()
-                .describe(
-                    'Tag names the ticket must all carry (AND). Applied on top of tags\/tagsMatch, so both an any-of and an all-of constraint can be active at once.'
-                ),
             tagsExclude: zod
                 .array(zod.string())
                 .optional()
@@ -586,12 +580,6 @@ export const ConversationsViewsPartialUpdateBody = /* @__PURE__ */ zod.object({
                 .optional()
                 .describe(
                     "'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).\n\n\* `any` - any\n\* `all` - all"
-                ),
-            tagsAll: zod
-                .array(zod.string())
-                .optional()
-                .describe(
-                    'Tag names the ticket must all carry (AND). Applied on top of tags\/tagsMatch, so both an any-of and an all-of constraint can be active at once.'
                 ),
             tagsExclude: zod
                 .array(zod.string())

--- a/products/conversations/frontend/generated/api.zod.ts
+++ b/products/conversations/frontend/generated/api.zod.ts
@@ -445,6 +445,12 @@ export const ConversationsViewsCreateBody = /* @__PURE__ */ zod.object({
                 .describe(
                     "'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).\n\n\* `any` - any\n\* `all` - all"
                 ),
+            tagsAll: zod
+                .array(zod.string())
+                .optional()
+                .describe(
+                    'Tag names the ticket must all carry (AND). Applied on top of tags\/tagsMatch, so both an any-of and an all-of constraint can be active at once.'
+                ),
             tagsExclude: zod
                 .array(zod.string())
                 .optional()
@@ -580,6 +586,12 @@ export const ConversationsViewsPartialUpdateBody = /* @__PURE__ */ zod.object({
                 .optional()
                 .describe(
                     "'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).\n\n\* `any` - any\n\* `all` - all"
+                ),
+            tagsAll: zod
+                .array(zod.string())
+                .optional()
+                .describe(
+                    'Tag names the ticket must all carry (AND). Applied on top of tags\/tagsMatch, so both an any-of and an all-of constraint can be active at once.'
                 ),
             tagsExclude: zod
                 .array(zod.string())

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -317,6 +317,9 @@ export function SupportTicketsTableFilters({ embedded = false }: SupportTicketsT
                     onChange={setSearchQuery}
                     size="small"
                     className="min-w-64"
+                    // Matches MAX_SEARCH_LENGTH in ticket_filters.py — the backend ignores
+                    // longer searches and rejects saving them in a view.
+                    maxLength={200}
                 />
                 <Tooltip
                     title={

--- a/products/conversations/frontend/types.ts
+++ b/products/conversations/frontend/types.ts
@@ -1,9 +1,8 @@
-import type { Sorting } from 'lib/lemon-ui/LemonTable/sorting'
-
 import type { AccessControlLevel } from '~/types'
 
 import { MAX_ASSIGNEE_FILTER_ENTRIES } from './components/Assignee'
 import type { AssigneeFilterEntry, TicketAssignee } from './components/Assignee'
+import type { TicketViewFiltersApi } from './generated/api.schemas'
 
 export type { AssigneeFilterEntry }
 
@@ -94,20 +93,13 @@ export interface KnowledgeGapSuggestion {
     created_at: string
 }
 
-export interface TicketViewFilters {
-    status?: TicketStatus[]
-    priority?: TicketPriority[]
-    channel?: TicketChannel | 'all'
-    sla?: TicketSlaState | 'all'
-    aiTriageResult?: AITriageFilterValue[]
+/**
+ * Canonical saved-view filter shape, generated from the backend's TicketViewFiltersSerializer.
+ * `assignee` is widened locally: the API stores filters raw, so old saved views can still
+ * return the legacy single-value shape — always read it through normalizeAssigneeFilter.
+ */
+export type TicketViewFilters = Omit<TicketViewFiltersApi, 'assignee'> & {
     assignee?: AssigneeFilterEntry[] | AssigneeFilterValue
-    tags?: string[]
-    tagsMatch?: TicketTagsMatch
-    tagsExclude?: string[]
-    dateFrom?: string | null
-    dateTo?: string | null
-    sorting?: Sorting | null
-    search?: string
 }
 
 export interface SavedTicketView {

--- a/products/conversations/mcp/tools.yaml
+++ b/products/conversations/mcp/tools.yaml
@@ -40,12 +40,12 @@ tools:
         title: List support tickets
         description: >
             List support tickets in the project. Supports filtering by status (new, open, pending, on_hold, resolved),
-            priority (low, medium, high, critical), channel_source (widget, email, slack), assignee, tags, SLA state,
-            AI triage result, date range, and search. To work with a saved ticket view, pass its short_id as the
-            `view` parameter (find it via the list-saved-ticket-views tool); the view's saved filters are applied
-            server-side, and any filter parameter passed explicitly overrides the view's value for that dimension.
-            Results are paginated and ordered by updated_at descending by default. Returns ticket metadata including
-            status, priority, message counts, and timestamps.
+            priority (low, medium, high, critical), channel_source (widget, email, slack), assignee, tags, SLA state, AI
+            triage result, date range, and search. To work with a saved ticket view, pass its short_id as the `view`
+            parameter (find it via the list-saved-ticket-views tool); the view's saved filters are applied server-side,
+            and any filter parameter passed explicitly overrides the view's value for that dimension. Results are
+            paginated and ordered by updated_at descending by default. Returns ticket metadata including status,
+            priority, message counts, and timestamps.
         response:
             include:
                 - id

--- a/products/conversations/mcp/tools.yaml
+++ b/products/conversations/mcp/tools.yaml
@@ -40,9 +40,12 @@ tools:
         title: List support tickets
         description: >
             List support tickets in the project. Supports filtering by status (new, open, pending, on_hold, resolved),
-            priority (low, medium, high, critical), channel_source (widget, email, slack), assignee, date range, and
-            search. Results are paginated and ordered by updated_at descending by default. Returns ticket metadata
-            including status, priority, message counts, and timestamps.
+            priority (low, medium, high, critical), channel_source (widget, email, slack), assignee, tags, SLA state,
+            AI triage result, date range, and search. To work with a saved ticket view, pass its short_id as the
+            `view` parameter (find it via the list-saved-ticket-views tool); the view's saved filters are applied
+            server-side, and any filter parameter passed explicitly overrides the view's value for that dimension.
+            Results are paginated and ordered by updated_at descending by default. Returns ticket metadata including
+            status, priority, message counts, and timestamps.
         response:
             include:
                 - id
@@ -171,7 +174,8 @@ tools:
         description: >
             List the saved ticket views in the project. Each view is a named, saved set of ticket filters — for example
             the per-team views named "Team <name>". Returns each view's short_id and name; a view opens in the app at
-            /support/tickets?view=<short_id>.
+            /support/tickets?view=<short_id>. To get the tickets a view contains, pass its short_id as the `view`
+            parameter of the list-support-tickets tool.
         response:
             include:
                 - short_id

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -1397,7 +1397,7 @@
         }
     },
     "conversations-tickets-list": {
-        "description": "List support tickets in the project. Supports filtering by status (new, open, pending, on_hold, resolved), priority (low, medium, high, critical), channel_source (widget, email, slack), assignee, date range, and search. Results are paginated and ordered by updated_at descending by default. Returns ticket metadata including status, priority, message counts, and timestamps.",
+        "description": "List support tickets in the project. Supports filtering by status (new, open, pending, on_hold, resolved), priority (low, medium, high, critical), channel_source (widget, email, slack), assignee, tags, SLA state, AI triage result, date range, and search. To work with a saved ticket view, pass its short_id as the `view` parameter (find it via the list-saved-ticket-views tool); the view's saved filters are applied server-side, and any filter parameter passed explicitly overrides the view's value for that dimension. Results are paginated and ordered by updated_at descending by default. Returns ticket metadata including status, priority, message counts, and timestamps.",
         "category": "Conversations",
         "feature": "conversations",
         "summary": "List support tickets",
@@ -1467,7 +1467,7 @@
         }
     },
     "conversations-views-list": {
-        "description": "List the saved ticket views in the project. Each view is a named, saved set of ticket filters — for example the per-team views named \"Team <name>\". Returns each view's short_id and name; a view opens in the app at /support/tickets?view=<short_id>.",
+        "description": "List the saved ticket views in the project. Each view is a named, saved set of ticket filters — for example the per-team views named \"Team <name>\". Returns each view's short_id and name; a view opens in the app at /support/tickets?view=<short_id>. To get the tickets a view contains, pass its short_id as the `view` parameter of the list-support-tickets tool.",
         "category": "Conversations",
         "feature": "conversations",
         "summary": "List saved ticket views",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -1412,7 +1412,7 @@
         }
     },
     "conversations-tickets-list": {
-        "description": "List support tickets in the project. Supports filtering by status (new, open, pending, on_hold, resolved), priority (low, medium, high, critical), channel_source (widget, email, slack), assignee, date range, and search. Results are paginated and ordered by updated_at descending by default. Returns ticket metadata including status, priority, message counts, and timestamps.",
+        "description": "List support tickets in the project. Supports filtering by status (new, open, pending, on_hold, resolved), priority (low, medium, high, critical), channel_source (widget, email, slack), assignee, tags, SLA state, AI triage result, date range, and search. To work with a saved ticket view, pass its short_id as the `view` parameter (find it via the list-saved-ticket-views tool); the view's saved filters are applied server-side, and any filter parameter passed explicitly overrides the view's value for that dimension. Results are paginated and ordered by updated_at descending by default. Returns ticket metadata including status, priority, message counts, and timestamps.",
         "category": "Conversations",
         "feature": "conversations",
         "summary": "List support tickets",
@@ -1482,7 +1482,7 @@
         }
     },
     "conversations-views-list": {
-        "description": "List the saved ticket views in the project. Each view is a named, saved set of ticket filters — for example the per-team views named \"Team <name>\". Returns each view's short_id and name; a view opens in the app at /support/tickets?view=<short_id>.",
+        "description": "List the saved ticket views in the project. Each view is a named, saved set of ticket filters — for example the per-team views named \"Team <name>\". Returns each view's short_id and name; a view opens in the app at /support/tickets?view=<short_id>. To get the tickets a view contains, pass its short_id as the `view` parameter of the list-support-tickets tool.",
         "category": "Conversations",
         "feature": "conversations",
         "summary": "List saved ticket views",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -48055,8 +48055,6 @@ export namespace Schemas {
        * * `any` - any
        * * `all` - all */
       tagsMatch?: TicketTagsMatchEnum;
-      /** Tag names the ticket must all carry (AND). Applied on top of tags/tagsMatch, so both an any-of and an all-of constraint can be active at once. */
-      tagsAll?: string[];
       /** Tickets carrying any of these tags are excluded. */
       tagsExclude?: string[];
       /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -13580,26 +13580,6 @@ export namespace Schemas {
       GithubIssue: 'github_issue',
     } as const;
 
-    /**
-     * * `widget` - widget
-     * * `email` - email
-     * * `slack` - slack
-     * * `teams` - teams
-     * * `github` - github
-     * * `all` - all
-     */
-    export type ChannelEnum = typeof ChannelEnum[keyof typeof ChannelEnum];
-
-
-    export const ChannelEnum = {
-      Widget: 'widget',
-      Email: 'email',
-      Slack: 'slack',
-      Teams: 'teams',
-      Github: 'github',
-      All: 'all',
-    } as const;
-
     export type ChannelFeedMessageDTOPayload = { [key: string]: unknown };
 
     /**
@@ -42685,18 +42665,6 @@ export namespace Schemas {
     } as const;
 
     /**
-     * * `1` - 1
-     * * `-1` - -1
-     */
-    export type OrderEnum = typeof OrderEnum[keyof typeof OrderEnum];
-
-
-    export const OrderEnum = {
-      Number1: 1,
-      NumberMinus1: -1,
-    } as const;
-
-    /**
      * * `log_count` - log_count
      * * `error_count` - error_count
      * * `last_seen` - last_seen
@@ -47977,15 +47945,35 @@ export namespace Schemas {
     }
 
     /**
+     * * `widget` - widget
+     * * `email` - email
+     * * `slack` - slack
+     * * `teams` - teams
+     * * `github` - github
+     * * `all` - all
+     */
+    export type TicketChannelFilterEnum = typeof TicketChannelFilterEnum[keyof typeof TicketChannelFilterEnum];
+
+
+    export const TicketChannelFilterEnum = {
+      Widget: 'widget',
+      Email: 'email',
+      Slack: 'slack',
+      Teams: 'teams',
+      Github: 'github',
+      All: 'all',
+    } as const;
+
+    /**
      * * `breached` - breached
      * * `at-risk` - at-risk
      * * `on-track` - on-track
      * * `all` - all
      */
-    export type SlaEnum = typeof SlaEnum[keyof typeof SlaEnum];
+    export type TicketSlaFilterEnum = typeof TicketSlaFilterEnum[keyof typeof TicketSlaFilterEnum];
 
 
-    export const SlaEnum = {
+    export const TicketSlaFilterEnum = {
       Breached: 'breached',
       AtRisk: 'at-risk',
       OnTrack: 'on-track',
@@ -47996,12 +47984,24 @@ export namespace Schemas {
      * * `any` - any
      * * `all` - all
      */
-    export type TagsMatchEnum = typeof TagsMatchEnum[keyof typeof TagsMatchEnum];
+    export type TicketTagsMatchEnum = typeof TicketTagsMatchEnum[keyof typeof TicketTagsMatchEnum];
 
 
-    export const TagsMatchEnum = {
+    export const TicketTagsMatchEnum = {
       Any: 'any',
       All: 'all',
+    } as const;
+
+    /**
+     * * `1` - 1
+     * * `-1` - -1
+     */
+    export type TicketSortOrderEnum = typeof TicketSortOrderEnum[keyof typeof TicketSortOrderEnum];
+
+
+    export const TicketSortOrderEnum = {
+      Number1: 1,
+      NumberMinus1: -1,
     } as const;
 
     export interface TicketViewSorting {
@@ -48011,7 +48011,7 @@ export namespace Schemas {
        *
        * * `1` - 1
        * * `-1` - -1 */
-      order: OrderEnum;
+      order: TicketSortOrderEnum;
     }
 
     export type TicketViewFiltersAssigneeItem = 'me' | 'unassigned' | {
@@ -48036,14 +48036,14 @@ export namespace Schemas {
        * * `teams` - teams
        * * `github` - github
        * * `all` - all */
-      channel?: ChannelEnum;
+      channel?: TicketChannelFilterEnum;
       /** SLA state: 'breached' is past due, 'at-risk' is due within the next hour, 'on-track' has more than an hour remaining. 'all' disables the filter.
        *
        * * `breached` - breached
        * * `at-risk` - at-risk
        * * `on-track` - on-track
        * * `all` - all */
-      sla?: SlaEnum;
+      sla?: TicketSlaFilterEnum;
       /** AI triage outcomes to include. 'in_progress' matches tickets still being triaged. */
       aiTriageResult?: AiTriageResultEnum[];
       /** Assignees to match (any of): 'unassigned', 'me' (resolved to the requesting user), or an object with type ('user' or 'role') and id. The legacy single-value shape is accepted and normalized to a list. */
@@ -48054,7 +48054,9 @@ export namespace Schemas {
        *
        * * `any` - any
        * * `all` - all */
-      tagsMatch?: TagsMatchEnum;
+      tagsMatch?: TicketTagsMatchEnum;
+      /** Tag names the ticket must all carry (AND). Applied on top of tags/tagsMatch, so both an any-of and an all-of constraint can be active at once. */
+      tagsAll?: string[];
       /** Tickets carrying any of these tags are excluded. */
       tagsExclude?: string[];
       /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8190,6 +8190,28 @@ export namespace Schemas {
       feedback_text?: string;
     }
 
+    /**
+     * * `persisted` - persisted
+     * * `escalated_with_best` - escalated_with_best
+     * * `escalated_no_reply` - escalated_no_reply
+     * * `skipped_unactionable` - skipped_unactionable
+     * * `blocked_unsafe` - blocked_unsafe
+     * * `blocked_unsafe_reply` - blocked_unsafe_reply
+     * * `in_progress` - in_progress
+     */
+    export type AiTriageResultEnum = typeof AiTriageResultEnum[keyof typeof AiTriageResultEnum];
+
+
+    export const AiTriageResultEnum = {
+      Persisted: 'persisted',
+      EscalatedWithBest: 'escalated_with_best',
+      EscalatedNoReply: 'escalated_no_reply',
+      SkippedUnactionable: 'skipped_unactionable',
+      BlockedUnsafe: 'blocked_unsafe',
+      BlockedUnsafeReply: 'blocked_unsafe_reply',
+      InProgress: 'in_progress',
+    } as const;
+
     export interface InsightsThresholdBounds {
       /** Alert fires when the value drops below this number. */
       lower?: number | null;
@@ -13556,6 +13578,26 @@ export namespace Schemas {
       WidgetEmbedded: 'widget_embedded',
       WidgetApi: 'widget_api',
       GithubIssue: 'github_issue',
+    } as const;
+
+    /**
+     * * `widget` - widget
+     * * `email` - email
+     * * `slack` - slack
+     * * `teams` - teams
+     * * `github` - github
+     * * `all` - all
+     */
+    export type ChannelEnum = typeof ChannelEnum[keyof typeof ChannelEnum];
+
+
+    export const ChannelEnum = {
+      Widget: 'widget',
+      Email: 'email',
+      Slack: 'slack',
+      Teams: 'teams',
+      Github: 'github',
+      All: 'all',
     } as const;
 
     export type ChannelFeedMessageDTOPayload = { [key: string]: unknown };
@@ -42643,6 +42685,18 @@ export namespace Schemas {
     } as const;
 
     /**
+     * * `1` - 1
+     * * `-1` - -1
+     */
+    export type OrderEnum = typeof OrderEnum[keyof typeof OrderEnum];
+
+
+    export const OrderEnum = {
+      Number1: 1,
+      NumberMinus1: -1,
+    } as const;
+
+    /**
      * * `log_count` - log_count
      * * `error_count` - error_count
      * * `last_seen` - last_seen
@@ -47923,16 +47977,111 @@ export namespace Schemas {
     }
 
     /**
-     * Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys.
+     * * `breached` - breached
+     * * `at-risk` - at-risk
+     * * `on-track` - on-track
+     * * `all` - all
      */
-    export type TicketViewFilters = { [key: string]: unknown };
+    export type SlaEnum = typeof SlaEnum[keyof typeof SlaEnum];
+
+
+    export const SlaEnum = {
+      Breached: 'breached',
+      AtRisk: 'at-risk',
+      OnTrack: 'on-track',
+      All: 'all',
+    } as const;
+
+    /**
+     * * `any` - any
+     * * `all` - all
+     */
+    export type TagsMatchEnum = typeof TagsMatchEnum[keyof typeof TagsMatchEnum];
+
+
+    export const TagsMatchEnum = {
+      Any: 'any',
+      All: 'all',
+    } as const;
+
+    export interface TicketViewSorting {
+      /** Ticket column to sort by (updated_at, sla_due_at, snoozed_until, created_at, ticket_number). Unknown columns fall back to updated_at. */
+      columnKey: string;
+      /** 1 for ascending, -1 for descending.
+       *
+       * * `1` - 1
+       * * `-1` - -1 */
+      order: OrderEnum;
+    }
+
+    export type TicketViewFiltersAssigneeItem = 'me' | 'unassigned' | {
+      type: 'user' | 'role';
+      id: string | number;
+    };
+
+    /**
+     * Canonical shape of a saved ticket view's filters. Every field is optional; an omitted
+     * field (or an 'all' sentinel) leaves that dimension unfiltered.
+     */
+    export interface TicketViewFilters {
+      /** Ticket statuses to include. Empty or omitted means all statuses. */
+      status?: TicketStatusEnum[];
+      /** Ticket priorities to include. Empty or omitted means all priorities. */
+      priority?: TicketPriorityEnum[];
+      /** Channel the ticket originated from. 'all' disables the filter.
+       *
+       * * `widget` - widget
+       * * `email` - email
+       * * `slack` - slack
+       * * `teams` - teams
+       * * `github` - github
+       * * `all` - all */
+      channel?: ChannelEnum;
+      /** SLA state: 'breached' is past due, 'at-risk' is due within the next hour, 'on-track' has more than an hour remaining. 'all' disables the filter.
+       *
+       * * `breached` - breached
+       * * `at-risk` - at-risk
+       * * `on-track` - on-track
+       * * `all` - all */
+      sla?: SlaEnum;
+      /** AI triage outcomes to include. 'in_progress' matches tickets still being triaged. */
+      aiTriageResult?: AiTriageResultEnum[];
+      /** Assignees to match (any of): 'unassigned', 'me' (resolved to the requesting user), or an object with type ('user' or 'role') and id. The legacy single-value shape is accepted and normalized to a list. */
+      assignee?: TicketViewFiltersAssigneeItem[];
+      /** Tag names to match, combined according to tagsMatch. */
+      tags?: string[];
+      /** 'any' returns tickets with at least one of tags (OR); 'all' requires every tag (AND).
+       *
+       * * `any` - any
+       * * `all` - all */
+      tagsMatch?: TagsMatchEnum;
+      /** Tickets carrying any of these tags are excluded. */
+      tagsExclude?: string[];
+      /**
+         * Only include tickets updated on or after this date. Accepts absolute dates (2026-01-01) or relative ones (-7d). 'all' or null disables the bound.
+         * @nullable
+         */
+      dateFrom?: string | null;
+      /**
+         * Only include tickets updated on or before this date. Same format as dateFrom.
+         * @nullable
+         */
+      dateTo?: string | null;
+      /** Sort order for the ticket list. */
+      sorting?: TicketViewSorting | null;
+      /**
+         * Free-text search. A numeric value matches a ticket number exactly; otherwise matches the customer's name or email, the email subject, or message content.
+         * @maxLength 200
+         */
+      search?: string;
+    }
 
     export interface TicketView {
       readonly id: string;
       readonly short_id: string;
       /** @maxLength 400 */
       name: string;
-      /** Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys. */
+      /** Saved ticket filter criteria: status, priority, channel, sla, aiTriageResult, assignee, tags, tagsMatch, tagsExclude, dateFrom, dateTo, sorting, and search. */
       filters?: TicketViewFilters;
       readonly created_at: string;
       readonly created_by: UserBasic;
@@ -56041,18 +56190,13 @@ export namespace Schemas {
       readonly user_access_level?: string | null;
     }
 
-    /**
-     * Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys.
-     */
-    export type PatchedTicketViewFilters = { [key: string]: unknown };
-
     export interface PatchedTicketView {
       readonly id?: string;
       readonly short_id?: string;
       /** @maxLength 400 */
       name?: string;
-      /** Saved ticket filter criteria. May contain status, priority, channel, sla, assignee, tags, dateFrom, dateTo, and sorting keys. */
-      filters?: PatchedTicketViewFilters;
+      /** Saved ticket filter criteria: status, priority, channel, sla, aiTriageResult, assignee, tags, tagsMatch, tagsExclude, dateFrom, dateTo, sorting, and search. */
+      filters?: TicketViewFilters;
       readonly created_at?: string;
       readonly created_by?: UserBasic;
       /** Whether the current user has favorited this view. Favorited views sort to the top of the list. Favorites are personal to each user. */
@@ -76592,6 +76736,10 @@ export namespace Schemas {
 
     export type ConversationsTicketsListParams = {
     /**
+     * Filter by AI triage outcome. Accepts a single value or a comma-separated list. Valid values: `persisted`, `escalated_with_best`, `escalated_no_reply`, `skipped_unactionable`, `blocked_unsafe`, `blocked_unsafe_reply`, `in_progress`.
+     */
+    ai_triage_result?: string;
+    /**
      * Filter by assignee. Accepts a single value or a comma-separated list (matches any, max 100 entries). Each entry is `unassigned` (no assignee), `me` (the requesting user), `user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`.
      */
     assignee?: string;
@@ -76644,6 +76792,10 @@ export namespace Schemas {
      */
     sla?: ConversationsTicketsListSla;
     /**
+     * Filter by snooze state: `true` returns only snoozed tickets, `false` only non-snoozed.
+     */
+    snoozed?: boolean;
+    /**
      * Filter by status. Accepts a single value or a comma-separated list (e.g. `new,open,pending`). Valid values: `new`, `open`, `pending`, `on_hold`, `resolved`.
      */
     status?: string;
@@ -76659,6 +76811,10 @@ export namespace Schemas {
      * JSON-encoded array of tag names; returns tickets that have NONE of them (NOT), e.g. `["escalated"]`.
      */
     tags_exclude?: string;
+    /**
+     * Apply a saved ticket view's filters by its `short_id` (list views via the `conversations/views` endpoint). Any filter param passed explicitly overrides the view's saved value for that dimension. Returns 400 if no view matches.
+     */
+    view?: string;
     };
 
     export type ConversationsTicketsListChannelDetail = typeof ConversationsTicketsListChannelDetail[keyof typeof ConversationsTicketsListChannelDetail];

--- a/services/mcp/src/generated/conversations/api.ts
+++ b/services/mcp/src/generated/conversations/api.ts
@@ -20,6 +20,12 @@ export const ConversationsTicketsListParams = /* @__PURE__ */ zod.object({
 })
 
 export const ConversationsTicketsListQueryParams = /* @__PURE__ */ zod.object({
+    ai_triage_result: zod
+        .string()
+        .optional()
+        .describe(
+            'Filter by AI triage outcome. Accepts a single value or a comma-separated list. Valid values: `persisted`, `escalated_with_best`, `escalated_no_reply`, `skipped_unactionable`, `blocked_unsafe`, `blocked_unsafe_reply`, `in_progress`.'
+        ),
     assignee: zod
         .string()
         .optional()
@@ -87,6 +93,10 @@ export const ConversationsTicketsListQueryParams = /* @__PURE__ */ zod.object({
         .describe(
             'Filter by SLA state. `breached` = past `sla_due_at`, `at-risk` = due within the next hour, `on-track` = more than an hour remaining.'
         ),
+    snoozed: zod
+        .boolean()
+        .optional()
+        .describe('Filter by snooze state: `true` returns only snoozed tickets, `false` only non-snoozed.'),
     status: zod
         .string()
         .optional()
@@ -110,6 +120,12 @@ export const ConversationsTicketsListQueryParams = /* @__PURE__ */ zod.object({
         .optional()
         .describe(
             'JSON-encoded array of tag names; returns tickets that have NONE of them (NOT), e.g. `[\"escalated\"]`.'
+        ),
+    view: zod
+        .string()
+        .optional()
+        .describe(
+            "Apply a saved ticket view's filters by its `short_id` (list views via the `conversations\/views` endpoint). Any filter param passed explicitly overrides the view's saved value for that dimension. Returns 400 if no view matches."
         ),
 })
 

--- a/services/mcp/src/tools/generated/conversations.ts
+++ b/services/mcp/src/tools/generated/conversations.ts
@@ -36,6 +36,7 @@ const conversationsTicketsList = (): ToolBase<
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/conversations/tickets/`,
             query: {
+                ai_triage_result: params.ai_triage_result,
                 assignee: params.assignee,
                 channel_detail: params.channel_detail,
                 channel_source: params.channel_source,
@@ -49,10 +50,12 @@ const conversationsTicketsList = (): ToolBase<
                 priority: params.priority,
                 search: params.search,
                 sla: params.sla,
+                snoozed: params.snoozed,
                 status: params.status,
                 tags: params.tags,
                 tags_all: params.tags_all,
                 tags_exclude: params.tags_exclude,
+                view: params.view,
             },
         })
         const filtered = {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/conversations-tickets-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/conversations-tickets-list.json
@@ -1,6 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "ai_triage_result": {
+            "description": "Filter by AI triage outcome. Accepts a single value or a comma-separated list. Valid values: `persisted`, `escalated_with_best`, `escalated_no_reply`, `skipped_unactionable`, `blocked_unsafe`, `blocked_unsafe_reply`, `in_progress`.",
+            "type": "string"
+        },
         "assignee": {
             "description": "Filter by assignee. Accepts a single value or a comma-separated list (matches any, max 100 entries). Each entry is `unassigned` (no assignee), `me` (the requesting user), `user:<user_id>`, or `role:<role_uuid>`, e.g. `assignee=unassigned,user:123`.",
             "type": "string"
@@ -65,6 +69,10 @@
             "enum": ["at-risk", "breached", "on-track"],
             "type": "string"
         },
+        "snoozed": {
+            "description": "Filter by snooze state: `true` returns only snoozed tickets, `false` only non-snoozed.",
+            "type": "boolean"
+        },
         "status": {
             "description": "Filter by status. Accepts a single value or a comma-separated list (e.g. `new,open,pending`). Valid values: `new`, `open`, `pending`, `on_hold`, `resolved`.",
             "type": "string"
@@ -79,6 +87,10 @@
         },
         "tags_exclude": {
             "description": "JSON-encoded array of tag names; returns tickets that have NONE of them (NOT), e.g. `[\"escalated\"]`.",
+            "type": "string"
+        },
+        "view": {
+            "description": "Apply a saved ticket view's filters by its `short_id` (list views via the `conversations/views` endpoint). Any filter param passed explicitly overrides the view's saved value for that dimension. Returns 400 if no view matches.",
             "type": "string"
         }
     },


### PR DESCRIPTION
## Problem

Saved ticket views ("Ticket Views") store their filters as an opaque JSON blob that only the frontend knows how to interpret. Opening a view in the app works because `supportTicketsSceneLogic` unpacks the blob and re-encodes it into snake_case query params, but nothing outside the frontend can do that. In practice:

- An agent using the MCP tools can list saved views (`conversations-views-list` returns `short_id` + `name`) but has no way to get the tickets a view contains.
- The filter shape existed in three hand-maintained vocabularies (the camelCase saved-view blob, the snake_case list-endpoint params, and the URL-param encoding), with the camelCase-to-snake_case translation living only in frontend TypeScript, free to drift from the backend's filtering.

## Changes

`GET /conversations/tickets/?view=<short_id>` now applies a saved view's filters server-side, and the filter shape is a single backend-owned contract.

```mermaid
flowchart LR
    View[(TicketView.filters<br/>raw JSON)] --> Ser{{TicketViewFiltersSerializer<br/>canonical shape}}
    Params[flat query params<br/>status, tags, order_by, ...] --> Adapter[query_params_to_view_filters]
    Ser --> Apply{{apply_ticket_filters<br/>one filters-to-ORM implementation}}
    Adapter --> Apply
    Apply --> QS[filtered, ordered queryset]
    Ser -. hogli build:openapi .-> TS[generated TS + MCP schemas]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Ser,Apply phBlue;
    class Params,View phGray;
    class QS,TS phYellow;
```

- **New `products/conversations/backend/api/ticket_filters.py`**: `TicketViewFiltersSerializer` is the source of truth for the saved-view filter shape (all fields optional, `help_text` on everything, legacy single-value `assignee` normalized). `apply_ticket_filters` is the only place filter values become ORM predicates, and `query_params_to_view_filters` adapts the existing flat snake_case params into the same canonical shape.
- **`TicketViewSet.safely_get_queryset`** now resolves `?view=<short_id>` (team-scoped, 400 with a clear message on unknown or invalid views), overlays explicit query params on top of the view's values so a caller can apply a view and narrow further, and funnels everything through the single applier. The `me` assignee token still resolves per-caller, so a shared view scoped to "me" means each caller's own tickets.
- **`TicketView.filters` writes are validated** against the canonical shape via a `JSONField` subclass (`@extend_schema_field`), while storing and returning the raw dict so unknown keys and legacy blobs survive round-trips unchanged. The 10KB size guard stays.
- **Frontend** deletes the hand-written `TicketViewFilters` interface and derives it from the generated `TicketViewFiltersApi` (with `assignee` widened locally for the legacy single-value shape old rows can still return). No behavior change.
- **MCP**: the `conversations-tickets-list` tool now documents the `view` param and the views-list to tickets-list workflow; no new tool needed. Also documented the previously-missing `ai_triage_result` and `snoozed` params in the OpenAPI schema.

> [!NOTE]
> No breaking change. The flat query params keep working exactly as before (behavior-preserving refactor, verified by the existing 201-test suite), and existing saved-view blobs continue to validate and render unchanged.

## How did you test this code?

Automated (all run locally by the agent):

- Full `products/conversations/backend/api/tests/` ticket + views suites: 223 passed, including all pre-existing filter tests against the refactored path (behavior-preservation guard).
- New `TestTicketViewParamFilter` (6 tests): `?view=` equals the equivalent flat params, explicit param overrides the view, unknown/other-team `short_id` returns 400, `me` resolves to the requesting user, and a legacy blob (`'all'` sentinels, single-value assignee, unknown keys) applies without error and respects sorting. Each catches a regression no existing test did, since the `view` param is new.
- New `TestTicketViewFiltersValidation` (no-DB `SimpleTestCase`, parameterized): the canonical shape accepts everything the frontend saves today (defaults, legacy assignee, unknown keys) and rejects invalid enum values and oversized payloads. Guards against tightening validation in a way that breaks existing saved views.
- New endpoint wiring guards: invalid filters rejected with 400 on create, unknown keys survive round-trips.
- Frontend: `supportTicketsSceneLogic.test.ts` (17 passed), `typescript:check` clean for conversations files.
- Repo-wide `uv run mypy --cache-fine-grained .` clean, `hogli ci:preflight --fix` green, `hogli build:openapi` clean after adding the `TicketPriorityEnum` name override.

Not done manually: I did not click through the app UI; the frontend change is type-only.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The `view` param is documented in the OpenAPI schema and MCP tool descriptions, which are the generated public surfaces for this API.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked while producing this PR: `/improving-drf-endpoints`, `/writing-tests`, `/adopting-generated-api-types`, `/implementing-mcp-tools`, `/writing-code-comments`.

Decisions along the way: a first design added a backend-only camelCase-to-snake_case translator, rejected as fragile (two hand-mirrored copies of the same mapping, the exact failure mode session-recording playlists live with). Prior art review (insights `query`, `DashboardFilter`, error tracking's `PropertyGroupFilterValue`) pointed to "one validated shape + one applier" instead. The shape lives in a DRF serializer rather than the `frontend/src/queries/schema` pipeline because that pipeline is explicitly for frontend-authored query types, and a serializer gives the MCP tool schema for free. A full wire-format unification (dropping the flat params for a filter object) was considered and deliberately deferred: it would break existing API/MCP consumers and the flat params are the better ergonomics for agents anyway.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
