### PR TITLE
feat(notebooks): stop suggesting the same dataframe name for every python cell

### DIFF
--- a/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/NotebookNodePythonV2.tsx
@@ -202,9 +202,11 @@ const Component = ({
                 <input
                     type="text"
                     // The dataframe name this cell's result is exposed as to later cells.
+                    // Optional: left empty, the cell binds nothing and later cells can't read it.
                     className="rounded border border-border px-1.5 py-0.5 text-xs font-mono bg-bg-light text-default focus:outline-none focus:ring-1 focus:ring-primary"
                     value={attributes.returnVariable ?? ''}
                     onChange={(event) => updateAttributes({ returnVariable: event.target.value })}
+                    placeholder="Dataframe name (optional)"
                     spellCheck={false}
                 />
             </div>
@@ -305,8 +307,10 @@ export const NotebookNodePythonV2 = createPostHogWidgetNode<NotebookNodePythonV2
         code: {
             default: '',
         },
+        // Optional: empty means the cell binds no dataframe, so nothing downstream can read it.
+        // A cell that predates the optional name carries its persisted name and keeps exporting it.
         returnVariable: {
-            default: 'df',
+            default: '',
         },
         runId: {
             default: null,

--- a/frontend/src/scenes/notebooks/Nodes/components/notebookDataframeTree.test.tsx
+++ b/frontend/src/scenes/notebooks/Nodes/components/notebookDataframeTree.test.tsx
@@ -73,8 +73,8 @@ describe('buildDataframeTreeSection', () => {
     })
 
     it('collapses duplicate names, keeping the last', () => {
-        // Python names are deliberately not disambiguated and default to `df`, so two un-run
-        // Python cells is enough to emit `df` twice — duplicate ids in a virtualized tree.
+        // Python names are deliberately not disambiguated (they are the kernel variables), so
+        // two cells sharing a name emit it twice — duplicate ids in a virtualized tree.
         const section = buildDataframeTreeSection([pythonNode('df'), pythonNode('df')], [])
         expect(children(section)).toHaveLength(1)
         const ids = (section[0].children ?? []).map((c) => c.id)

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeContent.ts
@@ -498,10 +498,10 @@ export const collectNotebookFrameNodes = (content?: JSONContent | null): Noteboo
         if (node.type === NotebookNodeType.SQLV2 || node.type === NotebookNodeType.PythonV2) {
             const attrs = node.attrs ?? {}
             const isSql = node.type === NotebookNodeType.SQLV2
-            // A missing SQL attribute predates the optional name (legacy 'sql_df' default);
+            // A missing attribute predates the optional name (legacy 'sql_df'/'df' defaults);
             // an explicit blank or invalid one binds no dataframe — nothing to browse.
             const rawReturnVariable =
-                typeof attrs.returnVariable === 'string' ? attrs.returnVariable : isSql ? 'sql_df' : ''
+                typeof attrs.returnVariable === 'string' ? attrs.returnVariable : isSql ? 'sql_df' : 'df'
             let name: string | null
             if (isSql) {
                 name = isReferenceableSqlV2FrameName(rawReturnVariable)
@@ -511,7 +511,7 @@ export const collectNotebookFrameNodes = (content?: JSONContent | null): Noteboo
                     usedReturnVariables.add(normalizeSqlIdentifier(name))
                 }
             } else {
-                name = rawReturnVariable.trim() || 'df'
+                name = rawReturnVariable.trim()
             }
             if (name) {
                 const result = attrs.result ?? null
@@ -546,8 +546,10 @@ export type PythonKernelNodeSummary = {
 // Kernel-run Python cells (revamped notebooks): each binds its result to `returnVariable` in
 // the kernel namespace. Unlike the SQL collectors the names are NOT disambiguated — they are
 // exactly the kernel variables, so a duplicated returnVariable means last-run-wins, matching
-// kernel semantics. Markdown-aware (unlike the legacy collectPythonNodes) because revamped
-// markdown notebooks store their cells as `<PythonV2 …/>` component tags.
+// kernel semantics. A blank name is a display-only cell that binds nothing (see the SQLV2
+// collector); only a missing attribute takes the legacy 'df' default. Markdown-aware (unlike
+// the legacy collectPythonNodes) because revamped markdown notebooks store their cells as
+// `<PythonV2 …/>` component tags.
 export const collectPythonKernelNodes = (content?: JSONContent | null): PythonKernelNodeSummary[] => {
     if (!content || typeof content !== 'object') {
         return []
@@ -561,10 +563,7 @@ export const collectPythonKernelNodes = (content?: JSONContent | null): PythonKe
         }
         if (node.type === NotebookNodeType.PythonV2) {
             const attrs = node.attrs ?? {}
-            const returnVariable =
-                typeof attrs.returnVariable === 'string' && attrs.returnVariable.trim()
-                    ? attrs.returnVariable.trim()
-                    : 'df'
+            const returnVariable = typeof attrs.returnVariable === 'string' ? attrs.returnVariable.trim() : 'df'
             nodes.push({ nodeId: attrs.nodeId ?? '', returnVariable })
         }
         if (node.type === NotebookNodeType.MarkdownNotebook) {
@@ -827,11 +826,8 @@ export const buildNotebookDependencyGraph = (content?: JSONContent | null): Note
             const attrs = node.attrs ?? {}
             pythonV2Index += 1
             // The returnVariable IS the kernel variable, never disambiguated — the same
-            // last-write-wins semantics as collectPythonKernelNodes.
-            const returnVariable =
-                typeof attrs.returnVariable === 'string' && attrs.returnVariable.trim()
-                    ? attrs.returnVariable.trim()
-                    : 'df'
+            // last-write-wins semantics as collectPythonKernelNodes. Blank = exports nothing.
+            const returnVariable = typeof attrs.returnVariable === 'string' ? attrs.returnVariable.trim() : 'df'
             const code = typeof attrs.code === 'string' ? attrs.code : ''
             nodes.push({
                 nodeId: attrs.nodeId ?? '',

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.test.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.test.ts
@@ -91,11 +91,19 @@ describe('notebookNodeSQLV2Logic', () => {
         it('collects python cells as local refs under their kernel variable name', () => {
             // Journey 5: a SQL node referencing new_events must reroute to DuckDB, which only
             // happens if the python cell's returnVariable reaches the backend as a local ref.
-            const document = doc(sqlNode('a', 'df1'), pythonNode('py', 'new_events'), pythonNode('py2'))
+            // A blank name binds nothing in the kernel, so it exports no ref — otherwise every
+            // unnamed cell would claim the same name and shadow the others. Only a cell with no
+            // attribute at all predates the optional name and keeps the legacy 'df'.
+            const document = doc(
+                sqlNode('a', 'df1'),
+                pythonNode('py', 'new_events'),
+                pythonNode('py2', ''),
+                pythonNode('py3')
+            )
             expect(collectSqlV2Refs(document, 'self')).toEqual({
                 df1: hogql('a'),
                 new_events: local('py'),
-                df: local('py2'), // returnVariable defaults to 'df', matching the python cell UI
+                df: local('py3'),
             })
         })
 

--- a/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
+++ b/frontend/src/scenes/notebooks/Nodes/notebookNodeSQLV2Logic.ts
@@ -55,7 +55,8 @@ export function collectSqlV2Refs(doc: JSONContent | null | undefined, selfNodeId
         }
     }
     for (const node of collectPythonKernelNodes(doc)) {
-        if (node.nodeId && node.nodeId !== selfNodeId && !(node.returnVariable in refs)) {
+        // An unnamed python cell binds nothing in the kernel, so there is no frame to reference.
+        if (node.nodeId && node.nodeId !== selfNodeId && node.returnVariable && !(node.returnVariable in refs)) {
             refs[node.returnVariable] = { node_id: node.nodeId, kind: 'local' }
         }
     }


### PR DESCRIPTION
## Problem

Every new PythonV2 cell pre-filled its dataframe name with `df`. Add three python cells to a notebook and all three claim the same kernel variable, so whichever ran last wins and the earlier ones silently stop being what downstream cells read. The suggestion is also usually wrong: `df` says nothing about what the cell produces.

The SQLV2 cell already solved this. Its name is optional and starts empty, and an unnamed cell is display-only.

## Changes

Python cells now start with an empty dataframe name and a `Dataframe name (optional)` placeholder, matching SQL cells.

An explicitly blank name means the cell binds nothing: it exports no ref to later cells, contributes nothing to the dependency graph, and doesn't show up in the dataframe tree. A cell with no `returnVariable` attribute at all still gets the legacy `df`, so notebooks written before the name became optional keep working. That is the same missing-vs-blank rule the SQL collector already uses for `sql_df`.

Nothing changes for the backend. `output_name` was already optional, and a python run without one falls back to the last expression for its preview.

> [!NOTE]
> Existing python cells are unaffected. They carry their persisted `returnVariable` in the document, so they keep exporting whatever name they already had.

## How did you test this code?

Automated, run by me (Claude):

- `notebookNodeContent.test.ts`, `notebookNodeSQLV2Logic.test.ts`, `notebookDataframeTree.test.tsx`, `notebookNodeStalenessLogic.test.ts`, then the whole `frontend/src/scenes/notebooks/` jest suite. All pass.
- `pnpm --filter=@posthog/frontend typescript:check` is clean for these files (the only errors in my checkout are pre-existing hogvm-package ones in `lib/hog.ts` and the hog repl, unrelated to this diff).

Test changes: extended the existing "collects python cells as local refs" case with a blank-named cell and a no-attribute cell. That catches the regression this PR is about, which is unnamed python cells all resolving to `df` and shadowing each other, while pinning the legacy fallback so old documents don't silently lose their frame. No new test file, no new case for behavior an existing test already covers.

I did not run the app manually, so no screenshots.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe the dataframe name field yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this on my direction. Skills invoked: `/writing-code-comments` and `/writing-tests`.

The decision worth reviewing is the missing-vs-blank split. The simplest change would have been to flip the tiptap default to empty and leave the collectors' `|| 'df'` fallback alone, but then an unnamed cell would still bind `df` internally while showing an empty box, which is worse than today. Making blank mean "exports nothing" is what the SQLV2 cell already does, so the two cell types now behave the same. Keeping the fallback for a *missing* attribute is the compatibility hedge for markdown-authored cells that never wrote the prop.

Not included: identifier validation on the python name. The SQL cell validates its name and the python one still doesn't, which matters a bit more now that people will actually type into an empty box. Happy to follow up if you want it in the same shape.
