### PR TITLE
fix(cdp): guard meta ads fbc against malformed fbclid person properties

### DIFF
--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -180,7 +180,7 @@ if (res.status >= 400) {
                 "em": "{sha256Hex(lower(person.properties.email))}",
                 "fn": "{sha256Hex(lower(person.properties.first_name))}",
                 "ln": "{sha256Hex(lower(person.properties.last_name))}",
-                "fbc": "{startsWith(person.properties.fbclid ?? person.properties.$initial_fbclid ?? '', 'fb.') ? person.properties.fbclid ?? person.properties.$initial_fbclid : (match(person.properties.fbclid ?? person.properties.$initial_fbclid ?? '', '^[A-Za-z0-9_-]+$') ? f'fb.1.{toUnixTimestampMilli(now())}.{person.properties.fbclid ?? person.properties.$initial_fbclid}' : '')}",
+                "fbc": "{match(person.properties.fbclid ?? person.properties.$initial_fbclid ?? '', '^fb[.][0-9]+[.][0-9]+[.][A-Za-z0-9_-]+$') ? person.properties.fbclid ?? person.properties.$initial_fbclid : (match(person.properties.fbclid ?? person.properties.$initial_fbclid ?? '', '^[A-Za-z0-9_-]+$') ? f'fb.1.{toUnixTimestampMilli(now())}.{person.properties.fbclid ?? person.properties.$initial_fbclid}' : '')}",
                 "client_user_agent": "{event.properties.$raw_user_agent}",
             },
             "secret": False,

--- a/posthog/cdp/templates/meta_ads/template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/template_meta_ads.py
@@ -180,7 +180,7 @@ if (res.status >= 400) {
                 "em": "{sha256Hex(lower(person.properties.email))}",
                 "fn": "{sha256Hex(lower(person.properties.first_name))}",
                 "ln": "{sha256Hex(lower(person.properties.last_name))}",
-                "fbc": "{not empty(person.properties.fbclid ?? person.properties.$initial_fbclid) ? f'fb.1.{toUnixTimestampMilli(now())}.{person.properties.fbclid ?? person.properties.$initial_fbclid}' : ''}",
+                "fbc": "{startsWith(person.properties.fbclid ?? person.properties.$initial_fbclid ?? '', 'fb.') ? person.properties.fbclid ?? person.properties.$initial_fbclid : (match(person.properties.fbclid ?? person.properties.$initial_fbclid ?? '', '^[A-Za-z0-9_-]+$') ? f'fb.1.{toUnixTimestampMilli(now())}.{person.properties.fbclid ?? person.properties.$initial_fbclid}' : '')}",
                 "client_user_agent": "{event.properties.$raw_user_agent}",
             },
             "secret": False,

--- a/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
@@ -22,6 +22,7 @@ class TestMetaAdsFbcDefault(SimpleTestCase):
             ("full_fbc_cookie", {"fbclid": "fb.1.1752830400000.IwAR123"}, r"fb\.1\.1752830400000\.IwAR123"),
             # values Meta would reject (subcode 2804001) are skipped rather than sent
             ("url_encoded_junk", {"fbclid": "IwAR%3D123 456"}, r""),
+            ("prefixed_but_malformed", {"fbclid": "fb.junk"}, r""),
             ("missing_fbclid", {}, r""),
         ]
     )

--- a/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
+++ b/posthog/cdp/templates/meta_ads/test_template_meta_ads.py
@@ -1,5 +1,35 @@
+import re
+
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
+
+from posthog.hogql.compiler.bytecode import create_bytecode
+from posthog.hogql.parser import parse_string_template
+
 from posthog.cdp.templates.helpers import BaseHogFunctionTemplateTest
 from posthog.cdp.templates.meta_ads.template_meta_ads import template as template_meta_ads
+
+from common.hogvm.python.execute import execute_bytecode
+
+
+class TestMetaAdsFbcDefault(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("clean_fbclid", {"fbclid": "IwAR2F4-dbP0l7Mn1"}, r"fb\.1\.\d+\.IwAR2F4-dbP0l7Mn1"),
+            ("initial_fallback", {"$initial_fbclid": "AbC_123-x"}, r"fb\.1\.\d+\.AbC_123-x"),
+            # a full _fbc cookie value stored in the property must pass through, not get wrapped again
+            ("full_fbc_cookie", {"fbclid": "fb.1.1752830400000.IwAR123"}, r"fb\.1\.1752830400000\.IwAR123"),
+            # values Meta would reject (subcode 2804001) are skipped rather than sent
+            ("url_encoded_junk", {"fbclid": "IwAR%3D123 456"}, r""),
+            ("missing_fbclid", {}, r""),
+        ]
+    )
+    def test_fbc_default_expression(self, _name, person_properties, expected_pattern):
+        expr = next(i for i in template_meta_ads.inputs_schema if i["key"] == "userData")["default"]["fbc"]
+        bytecode = create_bytecode(parse_string_template(expr)).bytecode
+        result = execute_bytecode(bytecode, {"person": {"properties": person_properties}}).result
+        assert re.fullmatch(expected_pattern, result), f"got {result!r}"
 
 
 class TestTemplateMetaAds(BaseHogFunctionTemplateTest):


### PR DESCRIPTION
## Problem

The Meta Ads Conversions destination builds the `fbc` click ID as `fb.1.<timestamp>.<fbclid>` from the person's stored fbclid property.
Meta validates the assembled string strictly and rejects malformed values with `OAuthException` code 100, subcode 2804001 ("Click ID incorrectly formatted"), failing the whole event.

The default expression trusts the stored property blindly, which breaks in two ways seen in production ([Slack thread](https://posthog.slack.com/archives/C0AMDJGKNDD/p1784628977122859)):

- the property holds a full `_fbc` cookie value (`fb.1.<ts>.<id>`), so the template wraps it again into a nested `fb.1.<ts>.fb.1.<ts>.<id>`
- the property holds a value with characters outside the fbclid charset (URL-encoded junk, spaces)

Because the bad value is sticky on the person, events for affected persons fail on every send while everyone else works, which presents as an intermittent destination failure that's hard to debug.

## Changes

Hardens the template's default `fbc` expression in `posthog/cdp/templates/meta_ads/template_meta_ads.py`:

- values already starting with `fb.` are passed through unchanged (they're complete `_fbc` strings, re-wrapping corrupts them)
- bare fbclids matching `^[A-Za-z0-9_-]+$` are wrapped into `fb.1.<ms>.<fbclid>` as before
- anything else resolves to empty, so the field is skipped instead of erroring the event (Meta accepts a missing `fbc`, not a malformed one)

Only affects newly created destinations, since input defaults are copied at creation time.
Existing destinations keep their configured expression.

## How did you test this code?

Added `TestMetaAdsFbcDefault`, 5 parameterized cases compiling and executing the default `fbc` input template directly (the existing harness only tests the function body with concrete inputs, so the default expression was previously untested).
The pass-through and skip cases fail against the old expression, they lock in the exact production failure above.
Ran the full `test_template_meta_ads.py` file, 10/10 pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session driven by @mayteio, investigating the linked Slack report.
Root cause confirmed by querying the affected project's person properties, all invalid values were full `_fbc` cookie values stored where a bare fbclid should be.
Skills invoked: /writing-tests, /query-clickhouse-via-metabase.
Considered dropping already-prefixed `fb.` values instead of passing them through, rejected because they're valid `fbc` strings as-is and passing them through preserves attribution.
