### PR TITLE
feat(warehouse): add HubSpot leads table (default-disabled)

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -683,8 +683,10 @@ class OauthIntegration:
                 client_secret=settings.HUBSPOT_APP_CLIENT_SECRET,
                 scope="tickets crm.objects.contacts.write sales-email-read crm.objects.companies.read crm.objects.deals.read crm.objects.contacts.read crm.objects.quotes.read crm.objects.companies.write",
                 additional_authorize_params={
-                    # NOTE: these scopes are only available on certain hubspot plans and as such are optional
-                    "optional_scope": "analytics.behavioral_events.send behavioral_events.event_definitions.read_write"
+                    # NOTE: these scopes are only available on certain hubspot plans and as such are optional.
+                    # crm.objects.leads.read is Sales Hub Pro+/Enterprise only — requesting it as a
+                    # mandatory scope would fail the whole authorization for portals that lack it.
+                    "optional_scope": "analytics.behavioral_events.send behavioral_events.event_definitions.read_write crm.objects.leads.read"
                 },
                 id_path="hub_id",
                 name_path="hub_domain",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/hubspot.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs/hubspot.py
@@ -14,6 +14,7 @@ class HubspotCustomPropertiesConfig(config.Config):
     quotes_properties: str | None = None
     emails_properties: str | None = None
     meetings_properties: str | None = None
+    leads_properties: str | None = None
 
 
 @config.config

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/canonical_descriptions.py
@@ -139,7 +139,6 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "hs_lead_name": "The lead's name.",
             "hs_lead_type": "The type of lead (e.g. new business).",
             "hs_lead_label": "The current status label of the lead (e.g. warm, cold).",
-            "hs_lead_source": "The analytics source of the lead at creation, set automatically by HubSpot.",
             "hs_pipeline": "The pipeline the lead is in.",
             "hs_pipeline_stage": "The pipeline stage the lead is in (e.g. new, attempting, connected, qualified).",
             "hs_createdate": "Date the lead was created in HubSpot.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/canonical_descriptions.py
@@ -131,4 +131,19 @@ CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
             "hs_meeting_source": "How the meeting was created (e.g. CRM_UI, MEETINGS_PUBLIC).",
         },
     },
+    "leads": {
+        "description": "A potential customer tracked in HubSpot CRM, associated with a contact or company.",
+        "docs_url": "https://developers.hubspot.com/docs/api/crm/leads",
+        "columns": {
+            "hs_object_id": "HubSpot's unique internal identifier for the lead.",
+            "hs_lead_name": "The lead's name.",
+            "hs_lead_type": "The type of lead (e.g. new business).",
+            "hs_lead_label": "The current status label of the lead (e.g. warm, cold).",
+            "hs_lead_source": "The analytics source of the lead at creation, set automatically by HubSpot.",
+            "hs_pipeline": "The pipeline the lead is in.",
+            "hs_pipeline_stage": "The pipeline stage the lead is in (e.g. new, attempting, connected, qualified).",
+            "hs_createdate": "Date the lead was created in HubSpot.",
+            "hs_lastmodifieddate": "Date any property on the lead was last modified.",
+        },
+    },
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/settings.py
@@ -40,6 +40,7 @@ TICKET = "ticket"
 QUOTE = "quote"
 EMAILS = "emails"
 MEETINGS = "meetings"
+LEAD = "lead"
 
 CRM_CONTACTS_ENDPOINT = "/crm/v3/objects/contacts?associations=deals,tickets,quotes"
 CRM_COMPANIES_ENDPOINT = "/crm/v3/objects/companies?associations=contacts,deals,tickets,quotes"
@@ -70,6 +71,7 @@ OBJECT_TYPE_SINGULAR = {
     "quotes": QUOTE,
     "emails": EMAILS,
     "meetings": MEETINGS,
+    "leads": LEAD,
 }
 
 OBJECT_TYPE_PLURAL = {v: k for k, v in OBJECT_TYPE_SINGULAR.items()}
@@ -83,6 +85,7 @@ ENDPOINTS = (
     OBJECT_TYPE_PLURAL[QUOTE],
     OBJECT_TYPE_PLURAL[EMAILS],
     OBJECT_TYPE_PLURAL[MEETINGS],
+    OBJECT_TYPE_PLURAL[LEAD],
 )
 
 # CRM search API constants — shared between windowing and pagination logic
@@ -175,6 +178,20 @@ DEFAULT_MEETINGS_PROPS = [
     "hs_attachment_ids",
 ]
 
+# Lead-specific standard properties are all hs_-prefixed, so custom-property auto-discovery (which
+# only pulls non-hs_ props) won't surface them — they must be listed here explicitly.
+DEFAULT_LEAD_PROPS = [
+    "hs_createdate",
+    "hs_lastmodifieddate",
+    "hs_lead_label",
+    "hs_lead_name",
+    "hs_lead_source",
+    "hs_lead_type",
+    "hs_object_id",
+    "hs_pipeline",
+    "hs_pipeline_stage",
+]
+
 DEFAULT_PROPS = {
     OBJECT_TYPE_PLURAL[CONTACT]: DEFAULT_CONTACT_PROPS,
     OBJECT_TYPE_PLURAL[COMPANY]: DEFAULT_COMPANY_PROPS,
@@ -183,6 +200,7 @@ DEFAULT_PROPS = {
     OBJECT_TYPE_PLURAL[QUOTE]: DEFAULT_QUOTE_PROPS,
     OBJECT_TYPE_PLURAL[EMAILS]: DEFAULT_EMAIL_PROPS,
     OBJECT_TYPE_PLURAL[MEETINGS]: DEFAULT_MEETINGS_PROPS,
+    OBJECT_TYPE_PLURAL[LEAD]: DEFAULT_LEAD_PROPS,
 }
 
 
@@ -205,6 +223,9 @@ class HubspotEndpointConfig:
     # Name of the HubSpot property used both as the search filter and as the incremental cursor
     # (e.g. hs_lastmodifieddate). None means the endpoint does not support incremental sync.
     cursor_filter_property_field: Optional[str] = None
+    # Whether this endpoint is selected for sync by default. False keeps a table off unless the
+    # user opts in — used for objects that need an OAuth scope existing connections lack (leads).
+    should_sync_default: bool = True
 
 
 HUBSPOT_ENDPOINTS: dict[str, HubspotEndpointConfig] = {
@@ -263,5 +284,17 @@ HUBSPOT_ENDPOINTS: dict[str, HubspotEndpointConfig] = {
         partition_key="hs_timestamp",
         cursor_filter_property_field="hs_lastmodifieddate",
         incremental_fields=[_incremental_field("hs_lastmodifieddate")],
+    ),
+    # Leads need the `crm.objects.leads.read` scope, which existing connections weren't granted,
+    # and the object must be enabled in the portal (Sales Hub Pro+). Default-disabled so existing
+    # customers aren't opted in — they reconnect (picking up the scope) before enabling it.
+    "leads": HubspotEndpointConfig(
+        name="leads",
+        path="/crm/v3/objects/leads",
+        associations=[],
+        partition_key="hs_createdate",
+        cursor_filter_property_field="hs_lastmodifieddate",
+        incremental_fields=[_incremental_field("hs_lastmodifieddate")],
+        should_sync_default=False,
     ),
 }

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/settings.py
@@ -185,7 +185,6 @@ DEFAULT_LEAD_PROPS = [
     "hs_lastmodifieddate",
     "hs_lead_label",
     "hs_lead_name",
-    "hs_lead_source",
     "hs_lead_type",
     "hs_object_id",
     "hs_pipeline",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/source.py
@@ -172,6 +172,7 @@ class HubspotSource(ResumableSource[HubspotSourceConfig | HubspotSourceOldConfig
                     supports_incremental=supports_incremental,
                     supports_append=supports_incremental,
                     incremental_fields=endpoint_config.incremental_fields,
+                    should_sync_default=endpoint_config.should_sync_default,
                 )
             )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/hubspot/test/test_source_routing.py
@@ -51,7 +51,7 @@ class TestGetSchemas:
         schemas = src.get_schemas(MagicMock(), team_id=1)
 
         by_name = {s.name: s for s in schemas}
-        # All seven endpoints currently have cursor properties, so all should support incremental.
+        # Every endpoint currently has a cursor property, so all should support incremental.
         assert set(by_name.keys()) == set(HUBSPOT_ENDPOINTS.keys())
         for name, schema in by_name.items():
             endpoint_config = HUBSPOT_ENDPOINTS[name]
@@ -62,6 +62,15 @@ class TestGetSchemas:
             if expected_field:
                 assert schema.incremental_fields
                 assert schema.incremental_fields[0]["field"] == expected_field
+
+    def test_leads_is_default_disabled_others_default_enabled(self) -> None:
+        # Leads needs the crm.objects.leads.read scope existing connections lack, so it must start
+        # off; flipping it on by default would 403 every existing customer's sync.
+        src = HubspotSource()
+        by_name = {s.name: s for s in src.get_schemas(MagicMock(), team_id=1)}
+
+        assert by_name["leads"].should_sync_default is False
+        assert all(s.should_sync_default for name, s in by_name.items() if name != "leads")
 
     def test_filters_by_names(self) -> None:
         src = HubspotSource()


### PR DESCRIPTION
## Problem

The HubSpot data warehouse source syncs 7 CRM objects (contacts, companies, deals, tickets, quotes, emails, meetings) but not Leads.
Customers on Sales Hub who work leads in HubSpot can't pull that object into PostHog.

This adds Leads as an 8th syncable table.
It has to start disabled for existing connections, and that's the crux of the change (more below).

## Changes

New `leads` endpoint on the HubSpot source: `/crm/v3/objects/leads`, incremental on `hs_lastmodifieddate`, partitioned on `hs_createdate`.
It follows the same shape as the existing objects, so most of the machinery (search-path routing, association backfill, primary key, the per-object custom-property picker) extends to it for free.

Two things make leads different from the other 7:

> [!WARNING]
> Leads needs the `crm.objects.leads.read` OAuth scope, and that scope is Sales Hub Pro+/Enterprise only.

- **Default-disabled.** Existing HubSpot connections were authorized before this scope existed, so their tokens don't carry it. If leads defaulted on, every existing customer's sync would start 403-ing. A new `should_sync_default` field on `HubspotEndpointConfig` (set `False` only for leads, mirroring the pattern Algolia and Airbrake already use) threads through `get_schemas`, so leads starts off in both the new-source wizard and `auto_enable_new_schemas` for existing sources. Nothing else needed changing.
- **Scope added as optional, not mandatory.** `crm.objects.leads.read` goes in HubSpot's `optional_scope`, next to the existing plan-gated behavioral-events scopes. Requesting it in the mandatory `scope` string would fail the whole OAuth authorization for any portal whose plan doesn't include leads.

A customer who wants leads reconnects HubSpot (picking up the optional scope where their plan allows), then enables the table. A customer who enables it without the scope hits the existing `403 ... reconnect your HubSpot account` error from `get_non_retryable_errors` - that path is unchanged.

Property handling needed no leads-specific wiring. The per-object custom-properties textarea is generated off `DEFAULT_PROPS.items()` and read via `getattr(config, f"{schema_name}_properties")`, so adding `leads` to `DEFAULT_PROPS` produces a `leads_properties` field automatically (regenerated into the source config). One nuance: lead standard properties are all `hs_`-prefixed, and auto-discovery only pulls non-`hs_` props, so `DEFAULT_LEAD_PROPS` lists them explicitly.

Files:
- `settings.py` - `leads` endpoint, `DEFAULT_LEAD_PROPS`, `should_sync_default` field, catalog wiring (`ENDPOINTS`, `OBJECT_TYPE_SINGULAR/PLURAL`, `DEFAULT_PROPS`)
- `source.py` - thread `should_sync_default` into `SourceSchema`
- `integration.py` - add `crm.objects.leads.read` to `optional_scope`
- `canonical_descriptions.py` - `leads` table + column descriptions
- `generated_configs/hubspot.py` - regenerated (`leads_properties`)

## How did you test this code?

Automated, run by me (Claude):

- `hogli test .../hubspot/test/` - all 152 HubSpot tests pass, including a new assertion that leads is `should_sync_default=False` while the other 7 stay on. That test guards the core requirement: flipping leads on by default would 403 existing customers.
- A standalone consistency check that `ENDPOINTS`, `HUBSPOT_ENDPOINTS`, `DEFAULT_PROPS`, `OBJECT_TYPE_SINGULAR` and the canonical descriptions all agree on the endpoint set, and that leads' cursor + `hs_object_id` are present in its default props (the parametrized `TestSettingsShape` suite covers this too).
- ruff lint/format, `ty check`, and `hogli ci:preflight --strict` all clean.

I did **not** run a live end-to-end sync against a real HubSpot portal - that needs credentials and a Sales Hub Pro+ account with leads enabled. Worth a manual verification before/after merge: confirm leads shows up **unchecked** in the source wizard, and that enabling it on a scoped connection produces a `leads` table.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The user-facing source doc lives in the posthog.com repo and its table list auto-renders via `<SourceTables />`, so no doc change is needed here.
A short "leads is off by default, reconnect to enable" note there would be a good follow-up.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) - Luke directed this; I (Claude) did the implementation.

Started as a scoping question ("how much work to add a leads table, default-disabled for existing customers"). Exploration surfaced the two non-obvious constraints that shaped the design: the missing OAuth scope (there's no reconnect-prompt mechanism for HubSpot the way there is for Slack's `missing_scopes()`, so we rely on the existing reactive 403), and that the scope is plan-gated (hence `optional_scope`, not `scope` - requesting a plan-unavailable scope fails the whole authorization).

One thing I rejected: building a proactive scope-upgrade/reconnect prompt for existing customers. Luke chose to lean on the existing error path instead, so that's out of scope here.

Skills invoked: `/writing-tests` (gated the one test I added - it catches the default-disabled regression no existing test did).

Note for reviewers: `pnpm generate:source-configs` also rewrote ~15 unrelated generated configs (formatter line-wraps on some, genuine pre-existing drift on stripe/slack). I reverted all of those; this PR only touches `generated_configs/hubspot.py`. That drift is worth a separate look by the warehouse-sources owners.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
