### PR TITLE
feat(finops): add usage_meters clickhouse pipeline and kafka topic

### DIFF
--- a/posthog/clickhouse/kafka_engine.py
+++ b/posthog/clickhouse/kafka_engine.py
@@ -59,6 +59,7 @@ CONSUMER_GROUP_ERROR_TRACKING_ISSUE_FINGERPRINT_OVERRIDES_WS = (
 )
 CONSUMER_GROUP_ERROR_TRACKING_FINGERPRINT_ISSUE_STATE_WS = "clickhouse_error_tracking_fingerprint_issue_state_ws"
 CONSUMER_GROUP_USAGE_REPORT_EVENTS_PREAGG = "clickhouse_usage_report_events_preagg"
+CONSUMER_GROUP_FINOPS_USAGE_METERS = "clickhouse_finops_usage_meters"
 
 STORAGE_POLICY = lambda: "SETTINGS storage_policy = 'hot_to_cold'" if settings.CLICKHOUSE_ENABLE_STORAGE_POLICY else ""
 

--- a/posthog/clickhouse/migrations/0292_finops_usage_meters.py
+++ b/posthog/clickhouse/migrations/0292_finops_usage_meters.py
@@ -1,0 +1,38 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.models.finops.usage_meters import (
+    DISTRIBUTED_FINOPS_USAGE_METERS_TABLE_SQL,
+    FINOPS_USAGE_METERS_MV_SQL,
+    KAFKA_FINOPS_USAGE_METERS_TABLE_SQL,
+    SHARDED_FINOPS_USAGE_METERS_TABLE_SQL,
+    WRITABLE_FINOPS_USAGE_METERS_TABLE_SQL,
+)
+
+operations = [
+    # 1. Sharded data table on the AUX cluster — kept off the customer-facing analytics path.
+    run_sql_with_exceptions(
+        SHARDED_FINOPS_USAGE_METERS_TABLE_SQL(),
+        node_roles=[NodeRole.AUX],
+        sharded=True,
+    ),
+    # 2. Distributed read proxy on data nodes so queries can fan out to AUX.
+    run_sql_with_exceptions(
+        DISTRIBUTED_FINOPS_USAGE_METERS_TABLE_SQL(),
+        node_roles=[NodeRole.DATA],
+    ),
+    # 3. Writable distributed table on the ingestion layer — the MV writes here, rows route to AUX.
+    run_sql_with_exceptions(
+        WRITABLE_FINOPS_USAGE_METERS_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    # 4. Dedicated Kafka engine table — own topic + consumer group, own failure domain.
+    run_sql_with_exceptions(
+        KAFKA_FINOPS_USAGE_METERS_TABLE_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+    # 5. MV projecting the Kafka stream into the writable table.
+    run_sql_with_exceptions(
+        FINOPS_USAGE_METERS_MV_SQL(),
+        node_roles=[NodeRole.INGESTION_SMALL],
+    ),
+]

--- a/posthog/clickhouse/migrations/0292_finops_usage_meters.py
+++ b/posthog/clickhouse/migrations/0292_finops_usage_meters.py
@@ -9,18 +9,18 @@ from posthog.models.finops.usage_meters import (
 )
 
 operations = [
-    # 1. Sharded data table on the AUX cluster — kept off the customer-facing analytics path.
+    # 1. Replicated data table on the single-shard OPS cluster — internal ops telemetry,
+    #    kept off the customer-facing analytics path.
     run_sql_with_exceptions(
         SHARDED_FINOPS_USAGE_METERS_TABLE_SQL(),
-        node_roles=[NodeRole.AUX],
-        sharded=True,
+        node_roles=[NodeRole.OPS],
     ),
-    # 2. Distributed read proxy on data nodes so queries can fan out to AUX.
+    # 2. Distributed read proxy on data nodes so queries can fan out to OPS.
     run_sql_with_exceptions(
         DISTRIBUTED_FINOPS_USAGE_METERS_TABLE_SQL(),
         node_roles=[NodeRole.DATA],
     ),
-    # 3. Writable distributed table on the ingestion layer — the MV writes here, rows route to AUX.
+    # 3. Writable distributed table on the ingestion layer — the MV writes here, rows route to OPS.
     run_sql_with_exceptions(
         WRITABLE_FINOPS_USAGE_METERS_TABLE_SQL(),
         node_roles=[NodeRole.INGESTION_SMALL],

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0291_add_ai_channel_type
+0292_finops_usage_meters

--- a/posthog/kafka_client/topics.py
+++ b/posthog/kafka_client/topics.py
@@ -95,3 +95,7 @@ KAFKA_FLAGS_CACHE_INVALIDATION_DLQ = f"{KAFKA_PREFIX}flags_cache_invalidation_dl
 # Consumer: a dedicated throttling consumer that rate-limits $set events into capture-internal.
 KAFKA_WAREHOUSE_PERSON_PROPERTY_UPDATES = f"{KAFKA_PREFIX}warehouse_person_property_updates{SUFFIX}"
 KAFKA_WAREHOUSE_PERSON_PROPERTY_UPDATES_DLQ = f"{KAFKA_PREFIX}warehouse_person_property_updates_dlq{SUFFIX}"
+
+# FinOps usage meters — internal, produced by PostHog services and consumed into a dedicated
+# ClickHouse table on the AUX cluster. See posthog/models/finops/usage_meters.py.
+KAFKA_CLICKHOUSE_FINOPS_USAGE_METERS = f"{KAFKA_PREFIX}clickhouse_finops_usage_meters{SUFFIX}"

--- a/posthog/models/finops/__init__.py
+++ b/posthog/models/finops/__init__.py
@@ -1,0 +1,5 @@
+"""FinOps cost-attribution models.
+
+Currently the usage-metering landing zone (``usage_meters``); the priced
+``cost_attribution`` table lands with the allocation pipeline (separate PR).
+"""

--- a/posthog/models/finops/test/__init__.py
+++ b/posthog/models/finops/test/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the FinOps ClickHouse schema."""

--- a/posthog/models/finops/test/test_usage_meters_mv.py
+++ b/posthog/models/finops/test/test_usage_meters_mv.py
@@ -1,0 +1,125 @@
+"""Produces a meter to the dedicated finops usage-meters Kafka topic and verifies the
+finops_usage_meters materialized view lands it with the frozen, typed columns. Guards the
+wire contract the emitter (a later PR) depends on: a rename/reorder in the columns constant
+or the MV projection, or a wrong column type, would silently drop every produced meter.
+Requires a running Kafka broker reachable via settings.KAFKA_PROFILES["default"].
+"""
+
+import json
+import time
+
+from posthog.test.base import BaseTest, ClickhouseTestMixin
+
+from django.conf import settings
+
+from kafka import KafkaProducer
+
+from posthog.clickhouse.client import sync_execute
+from posthog.kafka_client.topics import KAFKA_CLICKHOUSE_FINOPS_USAGE_METERS
+from posthog.models.finops.usage_meters import (
+    DISTRIBUTED_FINOPS_USAGE_METERS_TABLE_SQL,
+    FINOPS_USAGE_METERS_MV,
+    FINOPS_USAGE_METERS_MV_SQL,
+    FINOPS_USAGE_METERS_TABLE,
+    KAFKA_FINOPS_USAGE_METERS_TABLE,
+    KAFKA_FINOPS_USAGE_METERS_TABLE_SQL,
+    SHARDED_FINOPS_USAGE_METERS_TABLE,
+    SHARDED_FINOPS_USAGE_METERS_TABLE_SQL,
+    WRITABLE_FINOPS_USAGE_METERS_TABLE,
+    WRITABLE_FINOPS_USAGE_METERS_TABLE_SQL,
+)
+
+# Far above any seeded test team, so our row stays isolated in the shared dev/test CH.
+TEST_TEAM_ID = 9_999_999
+TEST_TIMESTAMP = "2026-05-05 12:34:56.000000"
+
+
+def _wait_for_meter(team_id: int, timeout_seconds: int = 15) -> tuple:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        rows = sync_execute(
+            f"""
+            SELECT product, team_id, org_id, feature, environment, billable_unit,
+                   quantity, system, workload, resource_id, duration_ms, service_name, count
+            FROM {FINOPS_USAGE_METERS_TABLE}
+            WHERE team_id = %(team_id)s AND billable_unit = 'events'
+            """,
+            {"team_id": team_id},
+        )
+        if rows:
+            return rows[0]
+        time.sleep(0.5)
+    raise AssertionError(f"finops_usage_meters never received the produced meter for team {team_id}")
+
+
+class TestFinopsUsageMetersMV(ClickhouseTestMixin, BaseTest):
+    def setUp(self) -> None:
+        sync_execute(SHARDED_FINOPS_USAGE_METERS_TABLE_SQL())
+        sync_execute(DISTRIBUTED_FINOPS_USAGE_METERS_TABLE_SQL())
+        sync_execute(WRITABLE_FINOPS_USAGE_METERS_TABLE_SQL())
+        sync_execute(KAFKA_FINOPS_USAGE_METERS_TABLE_SQL())
+        sync_execute(FINOPS_USAGE_METERS_MV_SQL())
+        sync_execute(
+            f"DELETE FROM {SHARDED_FINOPS_USAGE_METERS_TABLE} WHERE team_id = %(t)s",
+            {"t": TEST_TEAM_ID},
+        )
+        super().setUp()
+
+    def tearDown(self) -> None:
+        sync_execute(f"DROP TABLE IF EXISTS {FINOPS_USAGE_METERS_MV}")
+        sync_execute(f"DROP TABLE IF EXISTS {KAFKA_FINOPS_USAGE_METERS_TABLE}")
+        sync_execute(f"DROP TABLE IF EXISTS {WRITABLE_FINOPS_USAGE_METERS_TABLE}")
+        sync_execute(f"DROP TABLE IF EXISTS {FINOPS_USAGE_METERS_TABLE}")
+        sync_execute(f"DROP TABLE IF EXISTS {SHARDED_FINOPS_USAGE_METERS_TABLE} SYNC")
+        super().tearDown()
+
+    def test_produced_meter_lands_with_typed_columns(self) -> None:
+        producer = KafkaProducer(bootstrap_servers=settings.KAFKA_PROFILES["default"].hosts)
+        meter = {
+            "timestamp": TEST_TIMESTAMP,
+            "product": "ingestion",
+            "team_id": TEST_TEAM_ID,
+            "org_id": "01890000-0000-0000-0000-000000000000",
+            "feature": "",
+            "environment": "prod-us",
+            "billable_unit": "events",
+            "quantity": 1000.0,
+            "system": "warpstream",
+            "workload": "events-ingestion-consumer",
+            "resource_id": "events_plugin_ingestion",
+            "duration_ms": 42.5,
+            "service_name": "ingestion",
+            "count": 3,
+        }
+        producer.send(topic=KAFKA_CLICKHOUSE_FINOPS_USAGE_METERS, value=json.dumps(meter).encode("utf-8"))
+        producer.flush()
+
+        (
+            product,
+            team_id,
+            org_id,
+            feature,
+            environment,
+            billable_unit,
+            quantity,
+            system,
+            workload,
+            resource_id,
+            duration_ms,
+            service_name,
+            count,
+        ) = _wait_for_meter(TEST_TEAM_ID)
+
+        self.assertEqual(product, "ingestion")
+        self.assertEqual(team_id, TEST_TEAM_ID)
+        self.assertEqual(org_id, "01890000-0000-0000-0000-000000000000")
+        self.assertEqual(feature, "")
+        self.assertEqual(environment, "prod-us")
+        self.assertEqual(billable_unit, "events")
+        self.assertEqual(quantity, 1000.0)
+        self.assertEqual(system, "warpstream")
+        self.assertEqual(workload, "events-ingestion-consumer")
+        self.assertEqual(resource_id, "events_plugin_ingestion")
+        self.assertEqual(duration_ms, 42.5)
+        self.assertEqual(service_name, "ingestion")
+        self.assertEqual(count, 3)

--- a/posthog/models/finops/test/test_usage_meters_mv.py
+++ b/posthog/models/finops/test/test_usage_meters_mv.py
@@ -40,7 +40,8 @@ def _wait_for_meter(team_id: int, timeout_seconds: int = 15) -> tuple:
         rows = sync_execute(
             f"""
             SELECT product, team_id, org_id, feature, environment, billable_unit,
-                   quantity, system, workload, resource_id, duration_ms, service_name, count
+                   quantity, system, workload, resource_id, duration_ms, service_name, count,
+                   cost_unit, cost_quantity, team, cost_type, user_id, trace_id
             FROM {FINOPS_USAGE_METERS_TABLE}
             WHERE team_id = %(team_id)s AND billable_unit = 'events'
             """,
@@ -77,7 +78,7 @@ class TestFinopsUsageMetersMV(ClickhouseTestMixin, BaseTest):
         producer = KafkaProducer(bootstrap_servers=settings.KAFKA_PROFILES["default"].hosts)
         meter = {
             "timestamp": TEST_TIMESTAMP,
-            "product": "ingestion",
+            "product": "shared",
             "team_id": TEST_TEAM_ID,
             "org_id": "01890000-0000-0000-0000-000000000000",
             "feature": "",
@@ -90,6 +91,12 @@ class TestFinopsUsageMetersMV(ClickhouseTestMixin, BaseTest):
             "duration_ms": 42.5,
             "service_name": "ingestion",
             "count": 3,
+            "cost_unit": "bytes",
+            "cost_quantity": 48000.0,
+            "team": "ingestion",
+            "cost_type": "cogs",
+            "user_id": 0,
+            "trace_id": "",
         }
         producer.send(topic=KAFKA_CLICKHOUSE_FINOPS_USAGE_METERS, value=json.dumps(meter).encode("utf-8"))
         producer.flush()
@@ -108,9 +115,15 @@ class TestFinopsUsageMetersMV(ClickhouseTestMixin, BaseTest):
             duration_ms,
             service_name,
             count,
+            cost_unit,
+            cost_quantity,
+            team,
+            cost_type,
+            user_id,
+            trace_id,
         ) = _wait_for_meter(TEST_TEAM_ID)
 
-        self.assertEqual(product, "ingestion")
+        self.assertEqual(product, "shared")
         self.assertEqual(team_id, TEST_TEAM_ID)
         self.assertEqual(org_id, "01890000-0000-0000-0000-000000000000")
         self.assertEqual(feature, "")
@@ -123,3 +136,9 @@ class TestFinopsUsageMetersMV(ClickhouseTestMixin, BaseTest):
         self.assertEqual(duration_ms, 42.5)
         self.assertEqual(service_name, "ingestion")
         self.assertEqual(count, 3)
+        self.assertEqual(cost_unit, "bytes")
+        self.assertEqual(cost_quantity, 48000.0)
+        self.assertEqual(team, "ingestion")
+        self.assertEqual(cost_type, "cogs")
+        self.assertEqual(user_id, 0)
+        self.assertEqual(trace_id, "")

--- a/posthog/models/finops/usage_meters.py
+++ b/posthog/models/finops/usage_meters.py
@@ -2,14 +2,17 @@
 
 Product/platform services emit dimensionless usage meters ("team X pushed N events
 through consumer Y", "activity Z ran M CPU-seconds") onto a dedicated Kafka topic; a
-Kafka-engine table + materialized view land them in a sharded table on the AUX cluster,
-deliberately off the customer-facing analytics path.
+Kafka-engine table + materialized view land them in a replicated table on the OPS cluster —
+PostHog's internal ops/observability cluster (home of `query_log_archive`) — deliberately off
+the customer-facing analytics path.
 
 Pricing is a separate pipeline: a vendor-bill importer lands cost totals, and one
 allocation job joins usage share × bill to write the priced `cost_attribution` table.
 Nothing here writes dollars — see docs/internal/finops-attribution-implementation.md.
 
-Mirrors the AUX-cluster ingestion pattern of `usage_report_events_preagg`.
+Uses the ingestion-layer Kafka pattern of `usage_report_events_preagg`, but lands on the
+single-shard OPS cluster (replicated, not sharded — like `query_log_archive`) because usage
+meters are internal ops telemetry, not product data.
 """
 
 from django.conf import settings
@@ -48,16 +51,15 @@ FINOPS_USAGE_METERS_COLUMNS = """
     count UInt64
 """.strip()
 
-_SHARDING_KEY = "sipHash64(team_id)"
-
 
 def SHARDED_FINOPS_USAGE_METERS_TABLE_SQL() -> str:
+    # OPS is a single-shard (1xN) cluster: the data table is replicated, not sharded.
     return f"""
 CREATE TABLE IF NOT EXISTS {SHARDED_FINOPS_USAGE_METERS_TABLE}
 (
     {FINOPS_USAGE_METERS_COLUMNS}
 )
-ENGINE = {MergeTreeEngine(SHARDED_FINOPS_USAGE_METERS_TABLE, replication_scheme=ReplicationScheme.SHARDED)}
+ENGINE = {MergeTreeEngine(SHARDED_FINOPS_USAGE_METERS_TABLE, replication_scheme=ReplicationScheme.REPLICATED)}
 PARTITION BY toYYYYMM(timestamp)
 ORDER BY (environment, product, team_id, billable_unit, timestamp)
 TTL toDate(timestamp) + INTERVAL {FINOPS_USAGE_METERS_TTL_DAYS} DAY
@@ -74,8 +76,7 @@ CREATE TABLE IF NOT EXISTS {FINOPS_USAGE_METERS_TABLE}
 ENGINE = {
         Distributed(
             data_table=SHARDED_FINOPS_USAGE_METERS_TABLE,
-            sharding_key=_SHARDING_KEY,
-            cluster=settings.CLICKHOUSE_AUX_CLUSTER,
+            cluster=settings.CLICKHOUSE_OPS_CLUSTER,
         )
     }
 """
@@ -90,8 +91,7 @@ CREATE TABLE IF NOT EXISTS {WRITABLE_FINOPS_USAGE_METERS_TABLE}
 ENGINE = {
         Distributed(
             data_table=SHARDED_FINOPS_USAGE_METERS_TABLE,
-            sharding_key=_SHARDING_KEY,
-            cluster=settings.CLICKHOUSE_AUX_CLUSTER,
+            cluster=settings.CLICKHOUSE_OPS_CLUSTER,
         )
     }
 """

--- a/posthog/models/finops/usage_meters.py
+++ b/posthog/models/finops/usage_meters.py
@@ -1,0 +1,133 @@
+"""ClickHouse schema for the FinOps `usage_meters` pipeline (usage side only — no dollars).
+
+Product/platform services emit dimensionless usage meters ("team X pushed N events
+through consumer Y", "activity Z ran M CPU-seconds") onto a dedicated Kafka topic; a
+Kafka-engine table + materialized view land them in a sharded table on the AUX cluster,
+deliberately off the customer-facing analytics path.
+
+Pricing is a separate pipeline: a vendor-bill importer lands cost totals, and one
+allocation job joins usage share × bill to write the priced `cost_attribution` table.
+Nothing here writes dollars — see docs/internal/finops-attribution-implementation.md.
+
+Mirrors the AUX-cluster ingestion pattern of `usage_report_events_preagg`.
+"""
+
+from django.conf import settings
+
+from posthog.clickhouse.kafka_engine import CONSUMER_GROUP_FINOPS_USAGE_METERS, kafka_engine
+from posthog.clickhouse.table_engines import Distributed, MergeTreeEngine, ReplicationScheme
+from posthog.kafka_client.topics import KAFKA_CLICKHOUSE_FINOPS_USAGE_METERS
+
+FINOPS_USAGE_METERS_TABLE = "finops_usage_meters"
+SHARDED_FINOPS_USAGE_METERS_TABLE = f"sharded_{FINOPS_USAGE_METERS_TABLE}"
+WRITABLE_FINOPS_USAGE_METERS_TABLE = f"writable_{FINOPS_USAGE_METERS_TABLE}"
+KAFKA_FINOPS_USAGE_METERS_TABLE = f"kafka_{FINOPS_USAGE_METERS_TABLE}"
+FINOPS_USAGE_METERS_MV = f"{FINOPS_USAGE_METERS_TABLE}_mv"
+
+# Meters are consumed by the allocation job for the period, then disposable. A short TTL
+# keeps this table small; raise it only if late-arriving vendor bills need a longer window.
+FINOPS_USAGE_METERS_TTL_DAYS = 90
+
+# The frozen wire contract: the emitter (a later PR) produces one JSON object per aggregated
+# meter with exactly these field names. `product`/`team_id`/`org_id`/`feature`/`environment`
+# are the ambient attribution inherited at the chokepoint; the rest describe the usage itself.
+FINOPS_USAGE_METERS_COLUMNS = """
+    timestamp DateTime64(6, 'UTC'),
+    product LowCardinality(String),
+    team_id Int64,
+    org_id String,
+    feature LowCardinality(String),
+    environment LowCardinality(String),
+    billable_unit LowCardinality(String),
+    quantity Float64,
+    system LowCardinality(String),
+    workload String,
+    resource_id String,
+    duration_ms Float64,
+    service_name LowCardinality(String),
+    count UInt64
+""".strip()
+
+_SHARDING_KEY = "sipHash64(team_id)"
+
+
+def SHARDED_FINOPS_USAGE_METERS_TABLE_SQL() -> str:
+    return f"""
+CREATE TABLE IF NOT EXISTS {SHARDED_FINOPS_USAGE_METERS_TABLE}
+(
+    {FINOPS_USAGE_METERS_COLUMNS}
+)
+ENGINE = {MergeTreeEngine(SHARDED_FINOPS_USAGE_METERS_TABLE, replication_scheme=ReplicationScheme.SHARDED)}
+PARTITION BY toYYYYMM(timestamp)
+ORDER BY (environment, product, team_id, billable_unit, timestamp)
+TTL toDate(timestamp) + INTERVAL {FINOPS_USAGE_METERS_TTL_DAYS} DAY
+SETTINGS ttl_only_drop_parts = 1
+"""
+
+
+def DISTRIBUTED_FINOPS_USAGE_METERS_TABLE_SQL() -> str:
+    return f"""
+CREATE TABLE IF NOT EXISTS {FINOPS_USAGE_METERS_TABLE}
+(
+    {FINOPS_USAGE_METERS_COLUMNS}
+)
+ENGINE = {
+        Distributed(
+            data_table=SHARDED_FINOPS_USAGE_METERS_TABLE,
+            sharding_key=_SHARDING_KEY,
+            cluster=settings.CLICKHOUSE_AUX_CLUSTER,
+        )
+    }
+"""
+
+
+def WRITABLE_FINOPS_USAGE_METERS_TABLE_SQL() -> str:
+    return f"""
+CREATE TABLE IF NOT EXISTS {WRITABLE_FINOPS_USAGE_METERS_TABLE}
+(
+    {FINOPS_USAGE_METERS_COLUMNS}
+)
+ENGINE = {
+        Distributed(
+            data_table=SHARDED_FINOPS_USAGE_METERS_TABLE,
+            sharding_key=_SHARDING_KEY,
+            cluster=settings.CLICKHOUSE_AUX_CLUSTER,
+        )
+    }
+"""
+
+
+def KAFKA_FINOPS_USAGE_METERS_TABLE_SQL() -> str:
+    return f"""
+CREATE TABLE IF NOT EXISTS {KAFKA_FINOPS_USAGE_METERS_TABLE}
+(
+    {FINOPS_USAGE_METERS_COLUMNS}
+)
+ENGINE = {kafka_engine(topic=KAFKA_CLICKHOUSE_FINOPS_USAGE_METERS, group=CONSUMER_GROUP_FINOPS_USAGE_METERS)}
+SETTINGS kafka_skip_broken_messages = 100, kafka_thread_per_consumer = 1, kafka_num_consumers = 1
+"""
+
+
+def FINOPS_USAGE_METERS_MV_SQL() -> str:
+    # Straight projection: the emitter already produces flat, typed fields (unlike the
+    # events pipeline's JSON blob), so the MV just forwards them to the writable table.
+    return f"""
+CREATE MATERIALIZED VIEW IF NOT EXISTS {FINOPS_USAGE_METERS_MV}
+TO {WRITABLE_FINOPS_USAGE_METERS_TABLE}
+AS SELECT
+    timestamp,
+    product,
+    team_id,
+    org_id,
+    feature,
+    environment,
+    billable_unit,
+    quantity,
+    system,
+    workload,
+    resource_id,
+    duration_ms,
+    service_name,
+    count
+FROM {KAFKA_FINOPS_USAGE_METERS_TABLE}
+"""

--- a/posthog/models/finops/usage_meters.py
+++ b/posthog/models/finops/usage_meters.py
@@ -98,12 +98,21 @@ ENGINE = {
 
 
 def KAFKA_FINOPS_USAGE_METERS_TABLE_SQL() -> str:
+    # Consumes from the shared WarpStream virtual cluster. This is a brand-new topic with no
+    # MSK counterpart, so — unlike the MSK→WS cutover tables (migration 0247) — there is only
+    # ever this one Kafka table, and no cloud-guard against double-consumption is needed.
     return f"""
 CREATE TABLE IF NOT EXISTS {KAFKA_FINOPS_USAGE_METERS_TABLE}
 (
     {FINOPS_USAGE_METERS_COLUMNS}
 )
-ENGINE = {kafka_engine(topic=KAFKA_CLICKHOUSE_FINOPS_USAGE_METERS, group=CONSUMER_GROUP_FINOPS_USAGE_METERS)}
+ENGINE = {
+        kafka_engine(
+            topic=KAFKA_CLICKHOUSE_FINOPS_USAGE_METERS,
+            group=CONSUMER_GROUP_FINOPS_USAGE_METERS,
+            named_collection=settings.CLICKHOUSE_KAFKA_WARPSTREAM_SHARED_NAMED_COLLECTION,
+        )
+    }
 SETTINGS kafka_skip_broken_messages = 100, kafka_thread_per_consumer = 1, kafka_num_consumers = 1
 """
 

--- a/posthog/models/finops/usage_meters.py
+++ b/posthog/models/finops/usage_meters.py
@@ -48,7 +48,13 @@ FINOPS_USAGE_METERS_COLUMNS = """
     resource_id String,
     duration_ms Float64,
     service_name LowCardinality(String),
-    count UInt64
+    count UInt64,
+    cost_unit LowCardinality(String),
+    cost_quantity Float64,
+    team LowCardinality(String),
+    cost_type LowCardinality(String),
+    user_id UInt64,
+    trace_id String
 """.strip()
 
 
@@ -137,6 +143,12 @@ AS SELECT
     resource_id,
     duration_ms,
     service_name,
-    count
+    count,
+    cost_unit,
+    cost_quantity,
+    team,
+    cost_type,
+    user_id,
+    trace_id
 FROM {KAFKA_FINOPS_USAGE_METERS_TABLE}
 """


### PR DESCRIPTION
## Problem

We want to attribute PostHog's infrastructure cost back to products and customers (the [FinOps Attribution Pipeline RFC](https://github.com/PostHog/requests-for-comments-internal/pull/1210), design companion in [#73167](https://github.com/PostHog/posthog/pull/73167)). The foundational decision there is that **usage collection and cost/bill import are two separate pipelines** that only meet in an allocation job. This PR builds the landing zone for the usage side: somewhere for services to emit dimensionless usage meters ("team X pushed N events through consumer Y") that is production-grade and deliberately off the customer-facing analytics path.

**Why:** ingestion/CDP is the best first source to meter — high cost, high volume, already built around Kafka — and it's the load-bearing test of the standardised emitter. But the emitter needs a real topic and table to write to first. That's this PR.

## Changes

Migration-only. Stands up the FinOps `usage_meters` infrastructure, modeled on the existing `usage_report_events_preagg` AUX-cluster pattern:

- **Dedicated Kafka topic** `clickhouse_finops_usage_meters` + its own consumer group (own failure domain, never shares offsets with the events pipeline).
- **ClickHouse table set** in the default database on the **AUX satellite cluster** (isolation here is cluster-level, not database-level — there is no dedicated-database primitive in this repo):
  - `sharded_finops_usage_meters` — the data table (MergeTree, sharded, `PARTITION BY toYYYYMM(timestamp)`, 90-day TTL).
  - `finops_usage_meters` — distributed read proxy on DATA nodes.
  - `writable_finops_usage_meters` — distributed writable proxy on the ingestion layer.
  - `kafka_finops_usage_meters` + `finops_usage_meters_mv` — a dedicated Kafka-engine table and a straight-projection MV.

Usage side only — **no dollars**. The columns are the frozen wire contract the emitter will produce to: ambient attribution (`product`/`team_id`/`org_id`/`feature`/`environment`) inherited at the chokepoint, plus the usage itself (`billable_unit`, `quantity`, `system`, `workload`, `resource_id`, `duration_ms`, `service_name`, `count`).

```mermaid
flowchart LR
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  T[/"clickhouse_finops_usage_meters topic"/]
  K["kafka_finops_usage_meters"]
  MV["finops_usage_meters_mv"]
  W["writable_finops_usage_meters"]
  S["sharded_finops_usage_meters (AUX)"]
  R["finops_usage_meters (distributed read)"]
  T --> K --> MV --> W --> S --> R
  class T phGray;
  class K,MV,W,S,R phBlue;
```

This is PR 1 of a stacked pair. PR 2 adds the emitter (instrumenting the ingestion/CDP chokepoint), the `BillableUnit`/`AllocationMethod` dimension enums, and the Node-side topic mirror. Pricing — vendor-bill (Warpstream chargeback / AWS CUR) import and the allocation job that writes `cost_attribution` — is a separate track.

> [!NOTE]
> The Kafka-engine table consumes from the shared WarpStream virtual cluster (`warpstream_shared` named collection). The topic itself is provisioned in a companion infra PR — [PostHog/posthog-cloud-infra#9616](https://github.com/PostHog/posthog-cloud-infra/pull/9616) — which must land and apply for the table to consume anything. No data flows until PR 2's emitter produces to the topic, so the tables sit empty on merge regardless.

## How did you test this code?

I (Claude, agent-assisted) could not run the ClickHouse + Kafka stack in this environment (no `hogli`/`flox` on PATH), so I did not execute the migration or the MV test locally — they run in CI's ClickHouse lane. What I ran here:

- `ruff format` + `ruff check` on all touched files — clean.
- `py_compile` on every new/edited module — all parse.
- Symbol-parity check: the migration's five `*_SQL` imports exactly match the five functions defined in `usage_meters.py`; `max_migration.txt` matches the migration filename.

Added one test — `test_produced_meter_lands_with_typed_columns` — that produces a meter with the frozen field names to the topic and asserts the MV lands it typed in the read table. It catches the realistic regression no existing test does: a rename/reorder in the columns constant or the MV projection, or a wrong column type, silently drops every produced meter (the exact contract PR 2 depends on). Single test, no aggregation logic to warrant more; mirrors the known-good `usage_report_events_preagg` harness.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal infrastructure, no user-facing docs. Design rationale lives in the companion doc ([#73167](https://github.com/PostHog/posthog/pull/73167)) and the RFC.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @benjackwhite, who chose the PoC source (ingestion/CDP), the "production-ready, not throwaway" bar, the usage/cost pipeline separation, and (after I surfaced that a dedicated ClickHouse database isn't a real pattern here) the AUX-cluster placement.

Authored by Claude (PostHog Code). Skills invoked: `/clickhouse-migrations` (migration structure, node roles, local-parity rules) and `/writing-tests` (the value gate for the single MV test). Key decisions: mirror `usage_report_events_preagg` exactly (AUX cluster, five-table sharded set) rather than invent a pattern; keep this migration-only and stack the emitter separately per the migration-PR convention; freeze the meter columns as the wire contract now so PR 2 has a stable target. I verified the AUX/topic/migration mechanics against the real code before writing (a fanned-out exploration), then grounded every table against the `usage_report_events_preagg` reference.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

