### PR TITLE
feat(error-tracking): register canonical exception properties

### DIFF
--- a/frontend/src/lib/utils/events.test.ts
+++ b/frontend/src/lib/utils/events.test.ts
@@ -226,7 +226,7 @@ describe('events utils', () => {
             ['$pageleave', '$pathname'],
             ['$screen', '$screen_name'],
             ['$feature_flag_called', '$feature_flag'],
-            ['$exception', '$exception_type'],
+            ['$exception', '$exception_types'],
             ['$ai_generation', '$ai_model'],
             ['$ai_trace', '$ai_span_name'],
             ['$ai_span', '$ai_span_name'],

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1502,6 +1502,11 @@
             "description": "The structured fingerprint pieces used to group issues, captured per exception in a chain. Each entry records the type, id, and contributing pieces.",
             "label": "Exception fingerprint record"
         },
+        "$exception_fingerprint_version": {
+            "description": "The version of the fingerprinting algorithm used to group the exception.",
+            "label": "Exception fingerprint version",
+            "system": true
+        },
         "$exception_functions": {
             "description": "A function contained in the exception.",
             "label": "Exception function"
@@ -1534,10 +1539,6 @@
             "label": "Exception list",
             "system": true
         },
-        "$exception_message": {
-            "description": "The message detected on the error.",
-            "label": "Exception message"
-        },
         "$exception_personURL": {
             "description": "The PostHog person that experienced the exception.",
             "label": "Exception person URL"
@@ -1551,23 +1552,9 @@
             "label": "Exception releases",
             "type": "String"
         },
-        "$exception_source": {
-            "description": "The source of the exception.",
-            "examples": [
-                "JS file"
-            ],
-            "label": "Exception source"
-        },
         "$exception_sources": {
             "description": "A source file included in the exception.",
             "label": "Exception source"
-        },
-        "$exception_type": {
-            "description": "Exception categorized into types.",
-            "examples": [
-                "Error"
-            ],
-            "label": "Exception type"
         },
         "$exception_types": {
             "description": "The type of the exception.",
@@ -3922,7 +3909,7 @@
         "$exception": {
             "description": "An unexpected error or unhandled exception in your application.",
             "label": "Exception",
-            "primary_property": "$exception_type"
+            "primary_property": "$exception_types"
         },
         "$feature_enrollment_update": {
             "description": "When a user enrolls with a feature.",
@@ -5897,6 +5884,11 @@
             "description": "The structured fingerprint pieces used to group issues, captured per exception in a chain. Each entry records the type, id, and contributing pieces.",
             "label": "Exception fingerprint record"
         },
+        "$exception_fingerprint_version": {
+            "description": "The version of the fingerprinting algorithm used to group the exception.",
+            "label": "Exception fingerprint version",
+            "system": true
+        },
         "$exception_functions": {
             "description": "A function contained in the exception.",
             "label": "Exception function"
@@ -5929,10 +5921,6 @@
             "label": "Exception list",
             "system": true
         },
-        "$exception_message": {
-            "description": "The message detected on the error.",
-            "label": "Exception message"
-        },
         "$exception_personURL": {
             "description": "The PostHog person that experienced the exception.",
             "label": "Exception person URL"
@@ -5946,23 +5934,9 @@
             "label": "Exception releases",
             "type": "String"
         },
-        "$exception_source": {
-            "description": "The source of the exception.",
-            "examples": [
-                "JS file"
-            ],
-            "label": "Exception source"
-        },
         "$exception_sources": {
             "description": "A source file included in the exception.",
             "label": "Exception source"
-        },
-        "$exception_type": {
-            "description": "Exception categorized into types.",
-            "examples": [
-                "Error"
-            ],
-            "label": "Exception type"
         },
         "$exception_types": {
             "description": "The type of the exception.",

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -1468,31 +1468,9 @@
             ],
             "label": "Event type"
         },
-        "$exception_DOMException_code": {
-            "description": "If a DOMException was thrown, it also has a DOMException code.",
-            "label": "DOMException code"
-        },
         "$exception_capture_enabled_server_side": {
             "description": "Whether exception autocapture was enabled in remote config.",
             "label": "Exception capture enabled server side"
-        },
-        "$exception_capture_endpoint": {
-            "description": "Endpoint used by posthog-js exception autocapture.",
-            "examples": [
-                "/e/"
-            ],
-            "label": "Exception capture endpoint"
-        },
-        "$exception_capture_endpoint_suffix": {
-            "description": "Endpoint used by posthog-js exception autocapture.",
-            "examples": [
-                "/e/"
-            ],
-            "label": "Exception capture endpoint suffix"
-        },
-        "$exception_colno": {
-            "description": "Which column of the line in the exception source that caused the exception.",
-            "label": "Exception source column number"
         },
         "$exception_fingerprint": {
             "description": "A fingerprint used to group issues, can be set clientside.",
@@ -1515,10 +1493,6 @@
             "description": "Whether this was a handled or unhandled exception.",
             "label": "Exception was handled"
         },
-        "$exception_is_synthetic": {
-            "description": "Whether this was detected as a synthetic exception.",
-            "label": "Exception is synthetic"
-        },
         "$exception_issue_id": {
             "description": "The id of the issue the fingerprint was associated with at ingest time.",
             "label": "Exception issue ID"
@@ -1530,31 +1504,33 @@
             ],
             "label": "Exception level"
         },
-        "$exception_lineno": {
-            "description": "Which line in the exception source that caused the exception.",
-            "label": "Exception source line number"
-        },
         "$exception_list": {
             "description": "List of one or more associated exceptions.",
             "label": "Exception list",
             "system": true
-        },
-        "$exception_personURL": {
-            "description": "The PostHog person that experienced the exception.",
-            "label": "Exception person URL"
-        },
-        "$exception_proposed_fingerprint": {
-            "description": "The fingerprint used to group issues. Auto generated unless provided clientside.",
-            "label": "Exception proposed fingerprint"
         },
         "$exception_releases": {
             "description": "The releases in which this exception has been observed.",
             "label": "Exception releases",
             "type": "String"
         },
+        "$exception_source": {
+            "description": "The SDK integration or runtime hook that captured the exception.",
+            "examples": [
+                "panic",
+                "rails",
+                "php_exception_handler"
+            ],
+            "label": "Exception capture source"
+        },
         "$exception_sources": {
             "description": "A source file included in the exception.",
             "label": "Exception source"
+        },
+        "$exception_steps": {
+            "description": "Application-defined steps captured before the exception to provide context about the actions leading up to it.",
+            "label": "Exception steps",
+            "system": true
         },
         "$exception_types": {
             "description": "The type of the exception.",
@@ -5850,31 +5826,9 @@
             ],
             "label": "Event type"
         },
-        "$exception_DOMException_code": {
-            "description": "If a DOMException was thrown, it also has a DOMException code.",
-            "label": "DOMException code"
-        },
         "$exception_capture_enabled_server_side": {
             "description": "Whether exception autocapture was enabled in remote config.",
             "label": "Exception capture enabled server side"
-        },
-        "$exception_capture_endpoint": {
-            "description": "Endpoint used by posthog-js exception autocapture.",
-            "examples": [
-                "/e/"
-            ],
-            "label": "Exception capture endpoint"
-        },
-        "$exception_capture_endpoint_suffix": {
-            "description": "Endpoint used by posthog-js exception autocapture.",
-            "examples": [
-                "/e/"
-            ],
-            "label": "Exception capture endpoint suffix"
-        },
-        "$exception_colno": {
-            "description": "Which column of the line in the exception source that caused the exception.",
-            "label": "Exception source column number"
         },
         "$exception_fingerprint": {
             "description": "A fingerprint used to group issues, can be set clientside.",
@@ -5897,10 +5851,6 @@
             "description": "Whether this was a handled or unhandled exception.",
             "label": "Exception was handled"
         },
-        "$exception_is_synthetic": {
-            "description": "Whether this was detected as a synthetic exception.",
-            "label": "Exception is synthetic"
-        },
         "$exception_issue_id": {
             "description": "The id of the issue the fingerprint was associated with at ingest time.",
             "label": "Exception issue ID"
@@ -5912,31 +5862,33 @@
             ],
             "label": "Exception level"
         },
-        "$exception_lineno": {
-            "description": "Which line in the exception source that caused the exception.",
-            "label": "Exception source line number"
-        },
         "$exception_list": {
             "description": "List of one or more associated exceptions.",
             "label": "Exception list",
             "system": true
-        },
-        "$exception_personURL": {
-            "description": "The PostHog person that experienced the exception.",
-            "label": "Exception person URL"
-        },
-        "$exception_proposed_fingerprint": {
-            "description": "The fingerprint used to group issues. Auto generated unless provided clientside.",
-            "label": "Exception proposed fingerprint"
         },
         "$exception_releases": {
             "description": "The releases in which this exception has been observed.",
             "label": "Exception releases",
             "type": "String"
         },
+        "$exception_source": {
+            "description": "The SDK integration or runtime hook that captured the exception.",
+            "examples": [
+                "panic",
+                "rails",
+                "php_exception_handler"
+            ],
+            "label": "Exception capture source"
+        },
         "$exception_sources": {
             "description": "A source file included in the exception.",
             "label": "Exception source"
+        },
+        "$exception_steps": {
+            "description": "Application-defined steps captured before the exception to provide context about the actions leading up to it.",
+            "label": "Exception steps",
+            "system": true
         },
         "$exception_types": {
             "description": "The type of the exception.",

--- a/frontend/src/taxonomy/taxonomy.tsx
+++ b/frontend/src/taxonomy/taxonomy.tsx
@@ -113,13 +113,7 @@ export const POSTHOG_EVENT_PROMOTED_PROPERTIES = {
         '$csp_user_agent',
     ],
     $set: ['$set', '$set_once'],
-    $exception: [
-        '$exception_issue_id',
-        '$exception_functions',
-        '$exception_sources',
-        '$exception_types',
-        '$exception_values',
-    ],
+    $exception: ['$exception_functions', '$exception_sources', '$exception_types', '$exception_values'],
     $mcp_tool_call: [
         '$mcp_tool_name',
         '$mcp_tool_category',

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -226,7 +226,7 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$exception": {
             "label": "Exception",
             "description": "An unexpected error or unhandled exception in your application.",
-            "primary_property": "$exception_type",
+            "primary_property": "$exception_types",
         },
         "$web_vitals": {
             "label": "Web vitals",
@@ -1023,18 +1023,14 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "description": "Exception categorized by severity.",
             "examples": ["error"],
         },
-        "$exception_type": {
-            "label": "Exception type",
-            "description": "Exception categorized into types.",
-            "examples": ["Error"],
-        },
-        "$exception_message": {
-            "label": "Exception message",
-            "description": "The message detected on the error.",
-        },
         "$exception_fingerprint": {
             "label": "Exception fingerprint",
             "description": "A fingerprint used to group issues, can be set clientside.",
+        },
+        "$exception_fingerprint_version": {
+            "label": "Exception fingerprint version",
+            "description": "The version of the fingerprinting algorithm used to group the exception.",
+            "system": True,
         },
         "$exception_fingerprint_record": {
             "label": "Exception fingerprint record",
@@ -1047,11 +1043,6 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$exception_issue_id": {
             "label": "Exception issue ID",
             "description": "The id of the issue the fingerprint was associated with at ingest time.",
-        },
-        "$exception_source": {
-            "label": "Exception source",
-            "description": "The source of the exception.",
-            "examples": ["JS file"],
         },
         "$exception_lineno": {
             "label": "Exception source line number",

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -1013,6 +1013,11 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         },
         "$exception_values": {"label": "Exception message", "description": "The description of the exception."},
         "$exception_sources": {"label": "Exception source", "description": "A source file included in the exception."},
+        "$exception_steps": {
+            "label": "Exception steps",
+            "description": "Application-defined steps captured before the exception to provide context about the actions leading up to it.",
+            "system": True,
+        },
         "$exception_list": {
             "label": "Exception list",
             "description": "List of one or more associated exceptions.",
@@ -1036,52 +1041,23 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "label": "Exception fingerprint record",
             "description": "The structured fingerprint pieces used to group issues, captured per exception in a chain. Each entry records the type, id, and contributing pieces.",
         },
-        "$exception_proposed_fingerprint": {
-            "label": "Exception proposed fingerprint",
-            "description": "The fingerprint used to group issues. Auto generated unless provided clientside.",
-        },
         "$exception_issue_id": {
             "label": "Exception issue ID",
             "description": "The id of the issue the fingerprint was associated with at ingest time.",
         },
-        "$exception_lineno": {
-            "label": "Exception source line number",
-            "description": "Which line in the exception source that caused the exception.",
-        },
-        "$exception_colno": {
-            "label": "Exception source column number",
-            "description": "Which column of the line in the exception source that caused the exception.",
-        },
-        "$exception_DOMException_code": {
-            "label": "DOMException code",
-            "description": "If a DOMException was thrown, it also has a DOMException code.",
-        },
-        "$exception_is_synthetic": {
-            "label": "Exception is synthetic",
-            "description": "Whether this was detected as a synthetic exception.",
+        "$exception_source": {
+            "label": "Exception capture source",
+            "description": "The SDK integration or runtime hook that captured the exception.",
+            "examples": ["panic", "rails", "php_exception_handler"],
         },
         "$exception_handled": {
             "label": "Exception was handled",
             "description": "Whether this was a handled or unhandled exception.",
         },
-        "$exception_personURL": {
-            "label": "Exception person URL",
-            "description": "The PostHog person that experienced the exception.",
-        },
         "$cymbal_errors": {
             "label": "Exception processing errors",
             "description": "Errors encountered while trying to process exceptions.",
             "system": True,
-        },
-        "$exception_capture_endpoint": {
-            "label": "Exception capture endpoint",
-            "description": "Endpoint used by posthog-js exception autocapture.",
-            "examples": ["/e/"],
-        },
-        "$exception_capture_endpoint_suffix": {
-            "label": "Exception capture endpoint suffix",
-            "description": "Endpoint used by posthog-js exception autocapture.",
-            "examples": ["/e/"],
         },
         "$exception_capture_enabled_server_side": {
             "label": "Exception capture enabled server side",

--- a/products/cdp/backend/prompts.py
+++ b/products/cdp/backend/prompts.py
@@ -1308,18 +1308,14 @@ Here is the taxonomy for event properties:
             "description": "Exception categorized by severity.",
             "examples": ["error"],
         },
-        "$exception_type": {
-            "label": "Exception type",
-            "description": "Exception categorized into types.",
-            "examples": ["Error"],
-        },
-        "$exception_message": {
-            "label": "Exception message",
-            "description": "The message detected on the error.",
-        },
         "$exception_fingerprint": {
             "label": "Exception fingerprint",
             "description": "A fingerprint used to group issues, can be set clientside.",
+        },
+        "$exception_fingerprint_version": {
+            "label": "Exception fingerprint version",
+            "description": "The version of the fingerprinting algorithm used to group the exception.",
+            "system": True,
         },
         "$exception_proposed_fingerprint": {
             "label": "Exception proposed fingerprint",
@@ -1328,11 +1324,6 @@ Here is the taxonomy for event properties:
         "$exception_issue_id": {
             "label": "Exception issue ID",
             "description": "The id of the issue the fingerprint was associated with at ingest time.",
-        },
-        "$exception_source": {
-            "label": "Exception source",
-            "description": "The source of the exception.",
-            "examples": ["JS file"],
         },
         "$exception_lineno": {
             "label": "Exception source line number",

--- a/products/cdp/backend/prompts.py
+++ b/products/cdp/backend/prompts.py
@@ -1299,6 +1299,11 @@ Here is the taxonomy for event properties:
         },
         "$exception_values": {"label": "Exception message", "description": "The description of the exception."},
         "$exception_sources": {"label": "Exception source", "description": "A source file included in the exception."},
+        "$exception_steps": {
+            "label": "Exception steps",
+            "description": "Application-defined steps captured before the exception to provide context about the actions leading up to it.",
+            "system": True,
+        },
         "$exception_list": {
             "label": "Exception list",
             "description": "List of one or more associated exceptions.",
@@ -1317,51 +1322,22 @@ Here is the taxonomy for event properties:
             "description": "The version of the fingerprinting algorithm used to group the exception.",
             "system": True,
         },
-        "$exception_proposed_fingerprint": {
-            "label": "Exception proposed fingerprint",
-            "description": "The fingerprint used to group issues. Auto generated unless provided clientside.",
-        },
         "$exception_issue_id": {
             "label": "Exception issue ID",
             "description": "The id of the issue the fingerprint was associated with at ingest time.",
         },
-        "$exception_lineno": {
-            "label": "Exception source line number",
-            "description": "Which line in the exception source that caused the exception.",
-        },
-        "$exception_colno": {
-            "label": "Exception source column number",
-            "description": "Which column of the line in the exception source that caused the exception.",
-        },
-        "$exception_DOMException_code": {
-            "label": "DOMException code",
-            "description": "If a DOMException was thrown, it also has a DOMException code.",
-        },
-        "$exception_is_synthetic": {
-            "label": "Exception is synthetic",
-            "description": "Whether this was detected as a synthetic exception.",
+        "$exception_source": {
+            "label": "Exception capture source",
+            "description": "The SDK integration or runtime hook that captured the exception.",
+            "examples": ["panic", "rails", "php_exception_handler"],
         },
         "$exception_handled": {
             "label": "Exception was handled",
             "description": "Whether this was a handled or unhandled exception.",
         },
-        "$exception_personURL": {
-            "label": "Exception person URL",
-            "description": "The PostHog person that experienced the exception.",
-        },
         "$cymbal_errors": {
             "label": "Exception processing errors",
             "description": "Errors encountered while trying to process exceptions.",
-        },
-        "$exception_capture_endpoint": {
-            "label": "Exception capture endpoint",
-            "description": "Endpoint used by posthog-js exception autocapture.",
-            "examples": ["/e/"],
-        },
-        "$exception_capture_endpoint_suffix": {
-            "label": "Exception capture endpoint suffix",
-            "description": "Endpoint used by posthog-js exception autocapture.",
-            "examples": ["/e/"],
         },
         "$exception_capture_enabled_server_side": {
             "label": "Exception capture enabled server side",

--- a/rust/property-defs-rs/src/api/v1/constants.rs
+++ b/rust/property-defs-rs/src/api/v1/constants.rs
@@ -68,7 +68,7 @@ pub const EVENTS_HIDDEN_PROPERTY_DEFINITIONS: [&str; 14] = [
 // **IMPORTANT** we need to keep this in sync the w/Django original!! see below for more details:
 // https://github.com/PostHog/posthog/blob/master/posthog/taxonomy/property_definition_api.py#L326-L339
 // https://github.com/PostHog/posthog/blob/master/posthog/taxonomy/taxonomy.py#L1627-L1631
-pub static PROPERTY_DEFINITION_ALIASES: [(&str, &str); 242] = [
+pub static PROPERTY_DEFINITION_ALIASES: [(&str, &str); 249] = [
     (
         "$last_posthog_reset",
         "timestamp of last call to `reset` in the web sdk",
@@ -104,15 +104,28 @@ pub static PROPERTY_DEFINITION_ALIASES: [(&str, &str); 242] = [
     ("$sentry_tags", "sentry tags"),
     ("$exception_list", "exception list"),
     ("$exception_level", "exception level"),
-    ("$exception_type", "exception type"),
-    ("$exception_message", "exception message"),
+    ("$exception_types", "exception type"),
+    ("$exception_values", "exception message"),
+    ("$exception_sources", "exception source"),
+    ("$exception_functions", "exception function"),
     ("$exception_fingerprint", "exception fingerprint"),
+    (
+        "$exception_fingerprint_version",
+        "exception fingerprint version",
+    ),
+    (
+        "$exception_fingerprint_record",
+        "exception fingerprint record",
+    ),
     (
         "$exception_proposed_fingerprint",
         "exception proposed fingerprint",
     ),
     ("$exception_issue_id", "exception issue id"),
-    ("$exception_source", "exception source"),
+    ("$exception_releases", "exception releases"),
+    ("$debug_images", "debug images"),
+    ("$issue_name", "issue name"),
+    ("$issue_description", "issue description"),
     ("$exception_lineno", "exception source line number"),
     ("$exception_colno", "exception source column number"),
     ("$exception_DOMException_code", "domexception code"),

--- a/rust/property-defs-rs/src/api/v1/constants.rs
+++ b/rust/property-defs-rs/src/api/v1/constants.rs
@@ -68,7 +68,7 @@ pub const EVENTS_HIDDEN_PROPERTY_DEFINITIONS: [&str; 14] = [
 // **IMPORTANT** we need to keep this in sync the w/Django original!! see below for more details:
 // https://github.com/PostHog/posthog/blob/master/posthog/taxonomy/property_definition_api.py#L326-L339
 // https://github.com/PostHog/posthog/blob/master/posthog/taxonomy/taxonomy.py#L1627-L1631
-pub static PROPERTY_DEFINITION_ALIASES: [(&str, &str); 249] = [
+pub static PROPERTY_DEFINITION_ALIASES: [(&str, &str); 243] = [
     (
         "$last_posthog_reset",
         "timestamp of last call to `reset` in the web sdk",
@@ -108,6 +108,7 @@ pub static PROPERTY_DEFINITION_ALIASES: [(&str, &str); 249] = [
     ("$exception_values", "exception message"),
     ("$exception_sources", "exception source"),
     ("$exception_functions", "exception function"),
+    ("$exception_steps", "exception steps"),
     ("$exception_fingerprint", "exception fingerprint"),
     (
         "$exception_fingerprint_version",
@@ -117,27 +118,14 @@ pub static PROPERTY_DEFINITION_ALIASES: [(&str, &str); 249] = [
         "$exception_fingerprint_record",
         "exception fingerprint record",
     ),
-    (
-        "$exception_proposed_fingerprint",
-        "exception proposed fingerprint",
-    ),
     ("$exception_issue_id", "exception issue id"),
+    ("$exception_source", "exception capture source"),
     ("$exception_releases", "exception releases"),
     ("$debug_images", "debug images"),
     ("$issue_name", "issue name"),
     ("$issue_description", "issue description"),
-    ("$exception_lineno", "exception source line number"),
-    ("$exception_colno", "exception source column number"),
-    ("$exception_DOMException_code", "domexception code"),
-    ("$exception_is_synthetic", "exception is synthetic"),
     ("$exception_handled", "exception was handled"),
-    ("$exception_personURL", "exception person url"),
     ("$cymbal_errors", "exception processing errors"),
-    ("$exception_capture_endpoint", "exception capture endpoint"),
-    (
-        "$exception_capture_endpoint_suffix",
-        "exception capture endpoint",
-    ),
     (
         "$exception_capture_enabled_server_side",
         "exception capture enabled server side",


### PR DESCRIPTION
## Problem

Error tracking emits canonical plural exception properties, but the shared taxonomy still prioritizes a singular property and includes metadata that current SDKs and Cymbal never emit.

## Changes

- Register canonical plural exception properties across the Python, frontend, CDP prompt, and Rust property definitions.
- Register `$exception_steps` as an internal structured property without promoting it as a normal filter.
- Use `$exception_types` as the built-in primary property for exception events.
- Remove obsolete exception metadata that is neither sent by current SDKs nor produced by Cymbal.
- Remove deprecated `$exception_type` and `$exception_message` metadata while retaining `$exception_source`, which current backend SDKs use to identify the capture hook.

## How did you test this code?

- `./bin/hogli test frontend/src/lib/utils/events.test.ts` – verifies the canonical exception primary property.
- `./bin/hogli test posthog/taxonomy/test/test_event_properties_taxonomy.py`
- `cargo fmt --all -- --check`
- `cargo clippy -p property-defs-rs --all-targets -- -D warnings`
- `cargo test -p property-defs-rs`
- `cargo shear`
- `ruff check posthog/taxonomy/taxonomy.py products/cdp/backend/prompts.py`
- `ruff format --check posthog/taxonomy/taxonomy.py products/cdp/backend/prompts.py`
- `uv run mypy --cache-fine-grained .`
- `./bin/hogli ci:preflight --fix`

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed for this taxonomy-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used the Pi coding agent to split the original issue-filter change into dependency-ordered PRs and audit exception properties against Cymbal and the SDK repositories in the adjacent workspace. The `/split-pr`, `/error-tracking`, `/writing-tests`, and `/running-ci-preflight` skills guided the split and validation. The audit removed deprecated singular type and message metadata, retained the actively emitted capture-source property, and removed properties with no current producer.

<!-- pr-stack:start -->
## PR stack

Merge in this order:
1. **https://github.com/PostHog/posthog/pull/73911 – this PR**
2. https://github.com/PostHog/posthog/pull/73912
3. https://github.com/PostHog/posthog/pull/73914

Depends on: none
Followed by: https://github.com/PostHog/posthog/pull/73912

This PR is based on `master`; review only this taxonomy foundation. After this PR is squash-merged, rebase PR 2 by replaying only its unique commit onto the resulting `master` commit, force-push with lease, and retarget PR 2 to `master`. Rebase PR 3 onto the rewritten PR 2 branch. Do not retarget descendants blindly.
<!-- pr-stack:end -->