### PR TITLE
fix(signals-inbox): add affordance to turn off scout Slack notifications

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutConfigControls.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutConfigControls.tsx
@@ -209,6 +209,12 @@ function ScoutSlackDestination({
         })
     }
 
+    const disableSlack = (): void => {
+        onUpdate(config.id, { output_destinations: {} })
+    }
+
+    const hasChannel = Boolean(destination?.channel)
+
     return (
         <div className="flex flex-col gap-2 border-t border-primary pt-2">
             <div className="flex flex-col min-w-0">
@@ -237,15 +243,32 @@ function ScoutSlackDestination({
                         />
                     ) : null}
                     {selectedIntegration ? (
-                        <SlackChannelPicker
-                            integration={selectedIntegration}
-                            value={configuredIntegration ? (destination?.channel ?? undefined) : undefined}
-                            onChange={selectChannel}
-                            disabled={updating || disabledReason !== undefined}
-                        />
+                        <div className="flex items-center gap-2">
+                            <div className="flex-1 min-w-0">
+                                <SlackChannelPicker
+                                    integration={selectedIntegration}
+                                    value={configuredIntegration ? (destination?.channel ?? undefined) : undefined}
+                                    onChange={selectChannel}
+                                    disabled={updating || disabledReason !== undefined}
+                                />
+                            </div>
+                            {hasChannel ? (
+                                <LemonButton
+                                    size="small"
+                                    icon={<IconTrash />}
+                                    onClick={disableSlack}
+                                    tooltip="Turn off Slack notifications for this scout"
+                                    disabledReason={disabledReason ?? (updating ? 'Saving…' : undefined)}
+                                    aria-label="Turn off Slack notifications"
+                                />
+                            ) : null}
+                        </div>
                     ) : null}
                     <span className="text-[11.5px] text-muted">
-                        PostHog must be in the channel. Invite it with <code>/invite @PostHog</code>.
+                        {hasChannel
+                            ? 'PostHog must be in the channel. Invite it with '
+                            : 'Pick a channel to turn notifications on. PostHog must be in the channel — invite it with '}
+                        <code>/invite @PostHog</code>.
                     </span>
                 </div>
             )}


### PR DESCRIPTION
## Problem

In the Scout troop config, the Slack destination only offered a way to set or change a channel — there was no clear way to turn notifications *off*. The only workarounds were backspacing the channel field or switching workspaces without selecting a channel, both undiscoverable. This came up in a Slack thread where scout output was noisy in a channel and it wasn't obvious how to disable it.

## Changes

Added an explicit "turn off" button (trash icon) next to the channel picker in the scout Slack destination, shown once a channel is configured. Clicking it clears `output_destinations` — the backend already treats an empty object as "delivery disabled". Also tweaked the helper copy so it nudges toward picking a channel to turn notifications on.

Frontend-only change; no serializer or API changes.

## How did you test this code?

Node tooling (oxlint/oxfmt/tsc) isn't installed in this environment, so I could not run lint/typecheck/format here — please rely on CI for those. No automated tests were added; the change is a small presentational affordance wired to the existing `updateScoutConfig` path already covered by the disable-by-clearing behavior.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The reported gap: the scout troop config UI let you set/change a Slack channel but had no affordance to disable notifications. I located the picker in `ScoutSlackDestination` (`frontend/src/scenes/inbox/components/config/scouts/ScoutConfigControls.tsx`), confirmed the backend already supports disabling via an empty `output_destinations`, and added a `LemonButton` clear affordance rather than a new toggle, matching the existing clear-on-empty semantics. No skills required a migration or serializer change.


---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785155614505029?thread_ts=1785155614.505029&cid=C09SK2PAGKF)*
