### PR TITLE
feat(workflows): sweep parked runs on deleted timing steps and condition edits

### DIFF
--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -2238,9 +2238,9 @@ class HogFlowViewSet(
 
     def _maybe_reschedule_timing_edits(self, before: Optional[HogFlow], after: HogFlow) -> None:
         """Kick off a reschedule sweep of parked runs when a go-live config change could move
-        their wake times earlier (issue #66380): shortened delays, moved wait windows, and
-        deleted timing steps (whose parked runs should skip forward or exit now, not at their
-        old wake time).
+        their wake times earlier or change what they resolve to (issue #66380): shortened
+        delays, moved wait windows, edited wait conditions, and deleted timing steps (whose
+        parked runs should skip forward or exit now, not at their old wake time).
 
         Called wherever the LIVE config changes - a direct save (the builder path, where save
         is go-live), the graph endpoint, or publish - and never for draft writes, which don't

--- a/products/workflows/backend/api/hog_flow.py
+++ b/products/workflows/backend/api/hog_flow.py
@@ -2238,7 +2238,9 @@ class HogFlowViewSet(
 
     def _maybe_reschedule_timing_edits(self, before: Optional[HogFlow], after: HogFlow) -> None:
         """Kick off a reschedule sweep of parked runs when a go-live config change could move
-        their wake times earlier (issue #66380): shortened delays and moved wait windows.
+        their wake times earlier (issue #66380): shortened delays, moved wait windows, and
+        deleted timing steps (whose parked runs should skip forward or exit now, not at their
+        old wake time).
 
         Called wherever the LIVE config changes - a direct save (the builder path, where save
         is go-live), the graph endpoint, or publish - and never for draft writes, which don't

--- a/products/workflows/backend/services/timing_reschedule.py
+++ b/products/workflows/backend/services/timing_reschedule.py
@@ -108,11 +108,19 @@ def get_timing_reschedule_action_ids(
       the week, so it isn't statically decidable.
     - type changed across the timing boundary: parked runs' action_id still points at the
       step, and the new handler should run on the sweep's schedule, not the old wake time.
-    - added/deleted actions never trigger: nothing is parked on a new step, and deleted
-      steps are the graceful-exit path's concern.
+    - deleted timing actions: runs parked on the removed step should wake now and take the
+      skip-forward/graceful-exit path at the sweep's schedule, not at their old wake time
+      (which for a wait_until_condition can be the full max_wait deadline once the poll
+      backstop is gone).
+    - added actions never trigger: nothing is parked on a new step.
     """
     before_by_id = {a["id"]: a for a in (before_actions or []) if isinstance(a, dict) and a.get("id")}
-    action_ids: set[str] = set()
+    after_ids = {a["id"] for a in (after_actions or []) if isinstance(a, dict) and a.get("id")}
+    action_ids: set[str] = {
+        action_id
+        for action_id, before in before_by_id.items()
+        if action_id not in after_ids and before.get("type") in TIMING_ACTION_TYPES
+    }
 
     for action in after_actions or []:
         if not isinstance(action, dict) or not action.get("id"):

--- a/products/workflows/backend/services/timing_reschedule.py
+++ b/products/workflows/backend/services/timing_reschedule.py
@@ -100,9 +100,10 @@ def get_timing_reschedule_action_ids(
     - delay: trigger on a shortened effective duration; unparseable durations trigger
       conservatively (the worker throws on them at wake, and a spurious sweep is a cheap
       no-op re-park).
-    - wait_until_condition: trigger on a shortened max_wait_duration, same comparison as
-      delay. Condition edits never trigger - they don't move a parked run's wake time
-      (the matcher and the poll both evaluate live config at wake).
+    - wait_until_condition: trigger on a shortened max_wait_duration (same comparison as
+      delay) and on any condition edit - a swept run re-evaluates the live condition at
+      wake (advance if it now matches, re-park if not), which keeps fixes to broken
+      conditions taking effect promptly once the poll re-check is gone.
     - wait_until_time_window: trigger on any timing-config change - whether a window edit
       moves a given run's wake earlier depends on each person's timezone and position in
       the week, so it isn't statically decidable.
@@ -148,6 +149,8 @@ def get_timing_reschedule_action_ids(
                 if before_config.get(duration_key) != after_config.get(duration_key):
                     action_ids.add(action["id"])
             elif after_seconds < before_seconds:
+                action_ids.add(action["id"])
+            if after_type == "wait_until_condition" and before_config.get("condition") != after_config.get("condition"):
                 action_ids.add(action["id"])
         elif after_type == "wait_until_time_window":
             if any(before_config.get(key) != after_config.get(key) for key in _TIME_WINDOW_CONFIG_KEYS):

--- a/products/workflows/backend/test/test_timing_reschedule.py
+++ b/products/workflows/backend/test/test_timing_reschedule.py
@@ -85,13 +85,13 @@ class TestTimingRescheduleDiff(SimpleTestCase):
             ("max_wait_unchanged", _condition(), _condition(), False),
             ("max_wait_clamped_shortening", _condition(max_wait="7d"), _condition(max_wait="168h"), True),
             ("max_wait_unparseable_after", _condition(max_wait="7d"), _condition(max_wait="banana"), True),
-            # Condition edits never move a parked run's wake time (the matcher and the poll
-            # both evaluate live config), so they must not trigger a sweep
+            # An edited condition must re-evaluate against parked runs promptly (e.g. fixing a
+            # filter that could never match) - the sweep wake replaces the poll re-check
             (
                 "condition_only_change",
                 _condition(),
                 _condition(condition={"filters": {"events": [{"id": "$identify"}]}}),
-                False,
+                True,
             ),
         ]
     )

--- a/products/workflows/backend/test/test_timing_reschedule.py
+++ b/products/workflows/backend/test/test_timing_reschedule.py
@@ -130,15 +130,26 @@ class TestTimingRescheduleDiff(SimpleTestCase):
         result = get_timing_reschedule_action_ids([before], [after])
         assert result == (["a"] if expect_sweep else [])
 
-    def test_added_and_deleted_timing_actions_do_not_sweep(self):
+    @parameterized.expand(
+        [
+            ("deleted_delay", _delay(action_id="a"), True),
+            ("deleted_time_window", _window(action_id="a"), True),
+            ("deleted_wait_condition", _condition(action_id="a"), True),
+            ("deleted_non_timing", {"id": "a", "type": "function", "config": {}}, False),
+        ]
+    )
+    def test_deleted_actions(self, _name, before_action, expect_sweep):
+        result = get_timing_reschedule_action_ids([before_action], [])
+        assert result == (["a"] if expect_sweep else [])
+
+    def test_added_timing_actions_do_not_sweep(self):
         assert get_timing_reschedule_action_ids([], [_delay()]) == []
-        assert get_timing_reschedule_action_ids([_delay()], []) == []
         assert get_timing_reschedule_action_ids(None, None) == []
 
     def test_multiple_changed_actions_are_sorted_and_deduped(self):
-        before = [_delay("delay_b", "7d"), _delay("delay_a", "7d"), _window("wait_1")]
+        before = [_delay("delay_b", "7d"), _delay("delay_a", "7d"), _window("wait_1"), _condition("cond_gone")]
         after = [_delay("delay_b", "1d"), _delay("delay_a", "1d"), _window("wait_1", day="weekend")]
-        assert get_timing_reschedule_action_ids(before, after) == ["delay_a", "delay_b", "wait_1"]
+        assert get_timing_reschedule_action_ids(before, after) == ["cond_gone", "delay_a", "delay_b", "wait_1"]
 
     def test_pathological_diff_over_cap_sweeps_nothing(self):
         before = [_delay(f"delay_{i}", "7d") for i in range(101)]


### PR DESCRIPTION
## Problem

A run parked on a delay or wait step that a go-live edit then deletes doesn't notice the deletion until its old wake time.
Today the `wait_until_condition` poll caps that at ~10 minutes, but for delays and time windows it can already be days, and once the poll backstop is removed (#72541) a deleted wait step would strand its parked runs until the full `max_wait` deadline before they skip forward or exit.

Edited wait conditions have the same shape: today the poll re-checks the live condition every ~10 minutes, so fixing a condition that could never match unsticks parked runs mid-wait. Post-poll, that fix wouldn't apply until a new stream signal or the deadline.

These are readiness gates 2 and 3 from [the review discussion on #72541](https://github.com/PostHog/posthog/pull/72541#issuecomment-5044150317) and part of #66380: deleted wait steps need a wake at deletion time, and condition edits need to keep applying to parked runs promptly.

## Changes

Deleted timing steps and edited wait conditions now trigger the existing reschedule sweep, the same mechanism that already handles shortened delays and moved wait windows (#71298, rolled out via `workflows-timing-reschedule`, which also gates this behavior).

- `get_timing_reschedule_action_ids` includes timing-typed action ids present in the before config but absent after the edit. Previously it had an explicit deleted-actions carve-out that deferred to the poll-driven graceful-exit path.
- It also triggers on a changed `condition` for `wait_until_condition` steps. A swept run re-evaluates the live condition at wake: advance if it now matches, re-park if not - preserving today's poll-driven "fix takes effect promptly" behavior without the poll.
- Swept runs wake on the sweep's spread schedule, re-evaluate live config, and take the already-shipped skip-forward (#71844) or graceful-exit (#70740) path immediately instead of at their old wake time.
- No new call sites and no worker changes: every deletion route (direct save, patch-graph, publish) already flows through `_maybe_reschedule_timing_edits`, and the worker's `rescheduleParkedJobs` looks parked jobs up by action id without validating against current flow config, so deleted ids need nothing extra.

## How did you test this code?

TDD against the service diff function in `test_timing_reschedule.py` (all `SimpleTestCase`, no DB):

- New parameterized `test_deleted_actions`: deleting a delay, time window, or wait condition sweeps; deleting a non-timing step doesn't. Catches a regression where the deleted-actions carve-out is reintroduced and parked runs on deleted steps silently sit until their deadline, with no poll to save them post-#72541.
- Extended the sorted/deduped multi-action test with a deleted condition step mixed into edits, guarding that deletions and edits combine into one sweep set.
- Flipped the `condition_only_change` case from no-sweep to sweep - it previously asserted the carve-out that relied on the poll re-check. Catches a regression where condition edits stop reaching parked runs.
- The previous `deleted actions do not sweep` assertion is removed since it asserted the old behavior; the added-actions and None-config assertions it also carried are kept in `test_added_timing_actions_do_not_sweep`.

Confirmed red before implementing each change, then 48 passed in the file.
Existing endpoint tests already cover the wiring from update/patch/publish through to the Celery enqueue, which this PR doesn't touch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Behavior is covered by the flag rollout docs work tracked on #66380; no standalone doc page exists for sweep internals.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Claude Code) at Harley's direction as the follow-up committed to on #72541.
Skill invoked: `/writing-tests` (gated the test changes - rewrote the carve-out assertion into the parameterized deletion cases rather than adding a new test function).
Scope decisions: deletion detection filters to timing-typed steps only, since runs only park on timing steps; non-timing deletions stay out of the sweep set to keep it a no-op for ordinary graph edits.
Condition-edit sweeping was chosen over accepting degraded semantics and documenting them - the sweep wake fully replaces the poll re-check for parked runs, so there's no behavior change to document.



