### PR TITLE
fix(data-warehouse): filter DAG canvas to search matches instead of dimming

### DIFF
--- a/frontend/src/scenes/data-warehouse/scene/dataModelingLogic.ts
+++ b/frontend/src/scenes/data-warehouse/scene/dataModelingLogic.ts
@@ -380,13 +380,13 @@ export interface dataModelingLogicMeta {
             nodes: Node[],
             edges: Edge[]
         ) => (baseName: string, mode: 'all' | 'downstream' | 'upstream') => Set<string>
+        parsedSearch: (debouncedSearchTerm: string) => ParsedSearch
         searchMatchedNodeIds: (
             nodes: Node[],
             debouncedSearchTerm: string,
             parsedSearch: ParsedSearch,
             highlightedNodeIds: (baseName: string, mode: 'all' | 'downstream' | 'upstream') => Set<string>
         ) => Set<string> | null
-        parsedSearch: (debouncedSearchTerm: string) => ParsedSearch
         filteredNodes: (dataModelingNodes: DataModelingNode[], searchTerm: string) => DataModelingNode[]
         selectedDag: (dags: DataModelingDAG[], selectedDagId: string | null) => DataModelingDAG | null
         availableDagIds: (filteredNodes: DataModelingNode[]) => string[]
@@ -850,9 +850,7 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
                     return highlightedNodeIds(parsedSearch.baseName, parsedSearch.mode)
                 }
                 const lowerBaseName = parsedSearch.baseName.toLowerCase()
-                return new Set(
-                    nodes.filter((n) => n.data.name.toLowerCase().includes(lowerBaseName)).map((n) => n.id)
-                )
+                return new Set(nodes.filter((n) => n.data.name.toLowerCase().includes(lowerBaseName)).map((n) => n.id))
             },
         ],
         filteredNodes: [

--- a/frontend/src/scenes/data-warehouse/scene/dataModelingLogic.ts
+++ b/frontend/src/scenes/data-warehouse/scene/dataModelingLogic.ts
@@ -140,6 +140,7 @@ export interface dataModelingLogicValues {
     reactFlowWrapper: RefObject<HTMLDivElement> | null
     runningNodeIds: Set<string>
     savedViewport: Viewport | null
+    searchMatchedNodeIds: Set<string> | null
     searchTerm: string
     selectedDag: DataModelingDAG | null
     selectedDagId: string | null
@@ -371,13 +372,20 @@ export interface dataModelingLogicMeta {
                     lastRunAt: string | null
                     status: DataModelingJobStatus
                 }
-            >
+            >,
+            searchMatchedNodeIds: Set<string> | null
         ) => Node[]
-        enrichedEdges: (edges: Edge[], hoveredNodeId: string | null) => Edge[]
+        enrichedEdges: (edges: Edge[], hoveredNodeId: string | null, searchMatchedNodeIds: Set<string> | null) => Edge[]
         highlightedNodeIds: (
             nodes: Node[],
             edges: Edge[]
         ) => (baseName: string, mode: 'all' | 'downstream' | 'upstream') => Set<string>
+        searchMatchedNodeIds: (
+            nodes: Node[],
+            debouncedSearchTerm: string,
+            parsedSearch: ParsedSearch,
+            highlightedNodeIds: (baseName: string, mode: 'all' | 'downstream' | 'upstream') => Set<string>
+        ) => Set<string> | null
         parsedSearch: (debouncedSearchTerm: string) => ParsedSearch
         filteredNodes: (dataModelingNodes: DataModelingNode[], searchTerm: string) => DataModelingNode[]
         selectedDag: (dags: DataModelingDAG[], selectedDagId: string | null) => DataModelingDAG | null
@@ -701,7 +709,13 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
             { resultEqualityCheck: equal },
         ],
         enrichedNodes: [
-            (s) => [s.nodes, s.runningNodeIds, s.highlightedNodeType, s.latestJobMetadataByNodeId],
+            (s) => [
+                s.nodes,
+                s.runningNodeIds,
+                s.highlightedNodeType,
+                s.latestJobMetadataByNodeId,
+                s.searchMatchedNodeIds,
+            ],
             (
                 nodes: Node[],
                 runningNodeIds: Set<string>,
@@ -712,17 +726,23 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
                         lastRunAt: string | null
                         status: DataModelingJobStatus
                     }
-                >
+                >,
+                searchMatchedNodeIds: Set<string> | null
             ): Node[] => {
-                return nodes.map((node) => {
+                const visibleNodes = searchMatchedNodeIds
+                    ? nodes.filter((node) => searchMatchedNodeIds.has(node.id))
+                    : nodes
+                return visibleNodes.map((node) => {
                     const isRunning = runningNodeIds.has(node.id)
                     const isTypeHighlighted = highlightedNodeType !== null && highlightedNodeType === node.data.type
+                    const isSearchMatch = searchMatchedNodeIds !== null
                     const metadata = latestJobMetadataByNodeId[node.id]
                     const lastJobStatus = metadata?.status ?? node.data.lastJobStatus
                     const lastRunAt = metadata?.lastRunAt ?? node.data.lastRunAt
                     if (
                         node.data.isRunning === isRunning &&
                         node.data.isTypeHighlighted === isTypeHighlighted &&
+                        node.data.isSearchMatch === isSearchMatch &&
                         node.data.lastJobStatus === lastJobStatus &&
                         node.data.lastRunAt === lastRunAt
                     ) {
@@ -734,6 +754,7 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
                             ...node.data,
                             isRunning,
                             isTypeHighlighted,
+                            isSearchMatch,
                             lastJobStatus,
                             lastRunAt,
                         },
@@ -746,12 +767,17 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
             },
         ],
         enrichedEdges: [
-            (s) => [s.edges, s.hoveredNodeId],
-            (edges: Edge[], hoveredNodeId: string | null): Edge[] => {
+            (s) => [s.edges, s.hoveredNodeId, s.searchMatchedNodeIds],
+            (edges: Edge[], hoveredNodeId: string | null, searchMatchedNodeIds: Set<string> | null): Edge[] => {
+                const visibleEdges = searchMatchedNodeIds
+                    ? edges.filter(
+                          (edge) => searchMatchedNodeIds.has(edge.source) && searchMatchedNodeIds.has(edge.target)
+                      )
+                    : edges
                 if (!hoveredNodeId) {
-                    return edges
+                    return visibleEdges
                 }
-                return edges.map((edge) => {
+                return visibleEdges.map((edge) => {
                     const isConnected = edge.source === hoveredNodeId || edge.target === hoveredNodeId
                     if (!isConnected) {
                         return edge
@@ -807,6 +833,27 @@ export const dataModelingLogic = kea<dataModelingLogicType>([
         parsedSearch: [
             (s) => [s.debouncedSearchTerm],
             (debouncedSearchTerm: string): ParsedSearch => parseSearchTerm(debouncedSearchTerm),
+        ],
+        /** Node ids to show on the graph canvas for the active search — null means no filter (show everything) */
+        searchMatchedNodeIds: [
+            (s) => [s.nodes, s.debouncedSearchTerm, s.parsedSearch, s.highlightedNodeIds],
+            (
+                nodes: Node[],
+                debouncedSearchTerm: string,
+                parsedSearch: ParsedSearch,
+                highlightedNodeIds: (baseName: string, mode: 'upstream' | 'downstream' | 'all') => Set<string>
+            ): Set<string> | null => {
+                if (debouncedSearchTerm.length === 0) {
+                    return null
+                }
+                if (parsedSearch.mode !== 'search') {
+                    return highlightedNodeIds(parsedSearch.baseName, parsedSearch.mode)
+                }
+                const lowerBaseName = parsedSearch.baseName.toLowerCase()
+                return new Set(
+                    nodes.filter((n) => n.data.name.toLowerCase().includes(lowerBaseName)).map((n) => n.id)
+                )
+            },
         ],
         filteredNodes: [
             (s) => [s.dataModelingNodes, s.searchTerm],

--- a/frontend/src/scenes/data-warehouse/scene/modeling/GraphView.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/modeling/GraphView.tsx
@@ -22,7 +22,7 @@ import { DataModelingNodeType } from '~/types'
 
 import { NODE_TYPE_TAG_SETTINGS } from 'products/data_modeling/frontend/lineage/nodeStyles'
 
-import { dataModelingLogic, parseSearchTerm } from '../dataModelingLogic'
+import { dataModelingLogic } from '../dataModelingLogic'
 import { REACT_FLOW_NODE_TYPES } from './Node'
 import { CreateModelNodeType, Edge, ElkDirection, Node } from './types'
 
@@ -157,8 +157,7 @@ export function NodeTypePanel(): JSX.Element {
 function GraphViewContent(): JSX.Element {
     const { isDarkModeOn } = useValues(themeLogic)
 
-    const { enrichedNodes, enrichedEdges, highlightedNodeIds, debouncedSearchTerm, savedViewport } =
-        useValues(dataModelingLogic)
+    const { enrichedNodes, enrichedEdges, debouncedSearchTerm, savedViewport } = useValues(dataModelingLogic)
     const { onEdgesChange, onNodesChange, setReactFlowInstance, setReactFlowWrapper } = useActions(dataModelingLogic)
 
     const reactFlowWrapper = useRef<HTMLDivElement>(null)
@@ -173,26 +172,15 @@ function GraphViewContent(): JSX.Element {
     }, [setReactFlowWrapper])
 
     useEffect(() => {
+        // enrichedNodes is already filtered down to the search matches, so fit to whatever remains
         if (debouncedSearchTerm.length > 0 && enrichedNodes.length > 0) {
-            const { baseName, mode } = parseSearchTerm(debouncedSearchTerm)
-            let matchingNodes: Node[]
-            if (mode !== 'search') {
-                const highlightedIds = highlightedNodeIds(baseName, mode)
-                matchingNodes = enrichedNodes.filter((n: Node) => highlightedIds.has(n.id))
-            } else {
-                matchingNodes = enrichedNodes.filter((n: Node) =>
-                    n.data.name.toLowerCase().includes(baseName.toLowerCase())
-                )
-            }
-            if (matchingNodes.length > 0) {
-                reactFlowInstance.fitView({
-                    nodes: matchingNodes,
-                    duration: 400,
-                    maxZoom: 1,
-                })
-            }
+            reactFlowInstance.fitView({
+                nodes: enrichedNodes,
+                duration: 400,
+                maxZoom: 1,
+            })
         }
-    }, [debouncedSearchTerm, enrichedNodes, reactFlowInstance, highlightedNodeIds])
+    }, [debouncedSearchTerm, enrichedNodes, reactFlowInstance])
 
     return (
         <div ref={reactFlowWrapper} className="relative w-full border rounded-lg overflow-hidden h-[calc(100vh-17rem)]">

--- a/frontend/src/scenes/data-warehouse/scene/modeling/Node.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/modeling/Node.tsx
@@ -11,7 +11,7 @@ import type { NodeData } from './types'
 
 const NodeComponent = React.memo(function NodeComponent(props: { id: string; data: NodeData }): JSX.Element {
     const { runNode, materializeNode, setHoveredNodeId } = useActions(dataModelingLogic)
-    const { layoutDirection, highlightedNodeIds, debouncedSearchTerm, parsedSearch } = useValues(dataModelingLogic)
+    const { layoutDirection } = useValues(dataModelingLogic)
 
     const { id } = props
     const {
@@ -22,21 +22,12 @@ const NodeComponent = React.memo(function NodeComponent(props: { id: string; dat
         downstreamCount,
         isRunning,
         isTypeHighlighted,
+        isSearchMatch,
         lastJobStatus,
         lastRunAt,
         syncInterval,
         userTag,
     } = props.data
-
-    const isSearchMatch = ((): boolean | undefined => {
-        if (debouncedSearchTerm.length === 0) {
-            return undefined
-        }
-        if (parsedSearch.mode !== 'search') {
-            return highlightedNodeIds(parsedSearch.baseName, parsedSearch.mode).has(id)
-        }
-        return name.toLowerCase().includes(parsedSearch.baseName.toLowerCase())
-    })()
 
     const handleNodeClick = useCallback((): void => {
         if (type === 'endpoint') {
@@ -69,8 +60,7 @@ const NodeComponent = React.memo(function NodeComponent(props: { id: string; dat
                 direction: layoutDirection,
                 state: {
                     isRunning: isRunning ?? false,
-                    isHighlighted: (isTypeHighlighted ?? false) || isSearchMatch === true,
-                    isDimmed: isSearchMatch === false,
+                    isHighlighted: (isTypeHighlighted ?? false) || (isSearchMatch ?? false),
                 },
                 callbacks: {
                     onClick: handleNodeClick,

--- a/products/data_modeling/frontend/lineage/LineageNode.tsx
+++ b/products/data_modeling/frontend/lineage/LineageNode.tsx
@@ -33,8 +33,6 @@ export type LineageNodeShape = Pick<
 export interface LineageNodeState {
     isCurrent?: boolean
     isRunning?: boolean
-    /** Dimmed when a search is active and this node is not a match */
-    isDimmed?: boolean
     /** Ringed when a search or type filter highlights this node */
     isHighlighted?: boolean
 }
@@ -194,7 +192,6 @@ export function LineageNode({ data }: { data: LineageNodeData }): JSX.Element {
             )}
             // eslint-disable-next-line react/forbid-dom-props
             style={{
-                opacity: state.isDimmed ? 0.5 : 1,
                 borderColor: state.isCurrent ? color : undefined,
             }}
             onMouseEnter={handleMouseEnter}


### PR DESCRIPTION
## Problem

On the data ops modeling DAG (`/data-ops?tab=modeling`), searching only dimmed non-matching nodes and edges instead of removing them. With a large DAG, the dimmed nodes still occupied space, so you couldn't actually see the results you searched for unless you selected a single node. This came up while looking at the scene for a project with many warehouse nodes.

## Changes

I added a `searchMatchedNodeIds` selector in `dataModelingLogic.ts` that consolidates the previously-duplicated match logic (plain search, plus the `name+` / `+name` / `+name+` expand syntax) into one place. `enrichedNodes` and `enrichedEdges` now filter down to that set when a search is active, instead of just tagging non-matches with a dimmed style. `GraphView.tsx`'s fit-view effect and `Node.tsx` were simplified to use the already-filtered result rather than recomputing matches. The now-unused `isDimmed` state/opacity styling was removed from `LineageNode.tsx`.

**Before (dimming, 15 seeded nodes, no search):**
![DAG canvas with no search filter - all 15 nodes shown](https://raw.githubusercontent.com/PostHog/pr-assets/a2300aba002583f42006376edb690bf33bcb066f/2026/07/92eb793a-1bf0-46d6-b6d3-2202640b32d8.png)

**After (filtering, searching "orders" — only matches remain):**
![Searching 'orders' now filters the canvas to only matching nodes/edges](https://raw.githubusercontent.com/PostHog/pr-assets/12787ee8635b6e8f6d2d47be8b6721b83dfe95a0/2026/07/3fd5719f-93ab-481e-aa51-e268b54578d0.png)

**Downstream expand syntax (`raw_events+`) still filters correctly to just that subgraph:**
![raw_events+ downstream-expand syntax filters to just that subgraph](https://raw.githubusercontent.com/PostHog/pr-assets/bfbe4251e8f921f88b01e933c7c75ef8680680ff/2026/07/0f7a66d1-3d86-4dc4-965f-6561f2169c15.png)

## How did you test this code?

I ran the local dev stack and drove it with a Playwright script (login via `setup_test`, seeded 15 `DataWarehouseSavedQuery` records across 4 dependency chains via `sync_saved_query_to_dag`), then screenshotted the canvas with no search, with a plain-text search, and with the `+` downstream-expand syntax — confirmed non-matching nodes/edges disappear from the canvas and the graph re-fits around the remaining matches.

I did not add an automated test for this — it's a rendering/filtering behavior best caught by the manual verification above; happy to add a Jest test on the `enrichedNodes`/`enrichedEdges` selectors if useful.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude Code) made this change based on a report that the DAG search filter only dimmed nodes instead of filtering them out. I read through `dataModelingLogic.ts`, `GraphView.tsx`, `Node.tsx`, and `LineageNode.tsx` to find the existing match-computation logic (duplicated across `Node.tsx` and `GraphView.tsx`), consolidated it into a single `searchMatchedNodeIds` selector, and switched the node/edge arrays fed to `<ReactFlow>` from being fully populated + dimmed to actually filtered. I then spun up the local dev stack, seeded test data, and verified the fix visually with Playwright screenshots since I don't have a project with an existing real DAG to check against.