### PR TITLE
feat(posthog-ai): let /ticket take optional details text

### DIFF
--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -328,6 +328,7 @@ function LegacyThread({ showTrailers }: { showTrailers: boolean }): JSX.Element 
                                         conversationId={conversationId}
                                         traceId={traceId}
                                         summary={ticketSummaryData.summary}
+                                        initialText={ticketSummaryData.initialText}
                                         targetArea={ticketSummaryData.targetArea}
                                     />
                                 ))}

--- a/frontend/src/scenes/max/TicketPrompt.tsx
+++ b/frontend/src/scenes/max/TicketPrompt.tsx
@@ -19,7 +19,7 @@ interface TicketPromptProps {
     traceId: string | null
     /** If provided, skip the input step and use this summary directly */
     summary?: string
-    /** If provided, pre-populate the input field with this text */
+    /** If provided, pre-populate the issue input (no summary) or the note field (with summary) */
     initialText?: string
     /** Target area inferred from the conversation; falls back to product analytics when absent */
     targetArea?: SupportTicketTargetArea | null
@@ -72,7 +72,7 @@ export function TicketPrompt({
             kind: 'bug',
             target_area: targetArea ?? 'analytics',
             severity_level: 'low',
-            message: summary ? '' : issueText,
+            message: summary ? (initialText ?? '') : issueText,
             tags: ['raised_from_posthog_ai_chat'],
             ai_conversation_id: conversationId,
             ai_trace_id: traceId,

--- a/frontend/src/scenes/max/slash-commands.tsx
+++ b/frontend/src/scenes/max/slash-commands.tsx
@@ -49,7 +49,7 @@ export const MAX_SLASH_COMMANDS: SlashCommand[] = [
     },
     {
         name: SlashCommandName.SlashTicket,
-        arg: '[details]',
+        arg: '[additional details]',
         description: 'Create a support ticket with a summary of this conversation',
         icon: <IconSupport />,
         requiresIdle: true,

--- a/frontend/src/scenes/max/slash-commands.tsx
+++ b/frontend/src/scenes/max/slash-commands.tsx
@@ -49,6 +49,7 @@ export const MAX_SLASH_COMMANDS: SlashCommand[] = [
     },
     {
         name: SlashCommandName.SlashTicket,
+        arg: '[details]',
         description: 'Create a support ticket with a summary of this conversation',
         icon: <IconSupport />,
         requiresIdle: true,

--- a/frontend/src/scenes/max/ticketUtils.test.ts
+++ b/frontend/src/scenes/max/ticketUtils.test.ts
@@ -33,6 +33,22 @@ describe('ticketUtils', () => {
             expect(getTicketSummaryData(thread, false)).toEqual({ summary: SUMMARY, messageIndex: 3, targetArea: null })
         })
 
+        it('passes text after /ticket through as initialText without altering the summary', () => {
+            const thread = [
+                human('How do I create an insight?'),
+                ai('You can create an insight by...'),
+                human('/ticket only the 4th question'),
+                ai(SUMMARY),
+            ]
+
+            expect(getTicketSummaryData(thread, false)).toEqual({
+                summary: SUMMARY,
+                initialText: 'only the 4th question',
+                messageIndex: 3,
+                targetArea: null,
+            })
+        })
+
         it('extracts the target area from the summary topic line', () => {
             const thread = [
                 human('My recordings are missing'),

--- a/frontend/src/scenes/max/ticketUtils.ts
+++ b/frontend/src/scenes/max/ticketUtils.ts
@@ -1,5 +1,7 @@
 import { SupportTicketTargetArea, TARGET_AREA_OPTIONS } from 'lib/components/Support/supportLogic'
 
+import { SlashCommandName } from '~/queries/schema/schema-assistant-messages'
+
 import { ThreadMessage } from './maxLogic'
 
 export interface TicketSummaryData {
@@ -7,6 +9,7 @@ export interface TicketSummaryData {
     discarded?: boolean
     messageIndex: number
     targetArea?: SupportTicketTargetArea | null
+    initialText?: string
 }
 
 export interface TicketPromptData {
@@ -43,9 +46,9 @@ export function parseTicketTargetArea(content: string): SupportTicketTargetArea 
  * Extracts the text after "/ticket " from a message, if any.
  */
 function extractTicketText(content: string): string | undefined {
-    if (content.startsWith('/ticket ')) {
-        const text = content.slice('/ticket '.length).trim()
-        return text || undefined
+    const prefix = `${SlashCommandName.SlashTicket} `
+    if (content.startsWith(prefix)) {
+        return content.slice(prefix.length).trim() || undefined
     }
     return undefined
 }
@@ -67,7 +70,7 @@ export function getTicketPromptData(threadGrouped: ThreadMessage[], streamingAct
     const isInitialTicketPrompt =
         firstMessage?.type === 'human' &&
         'content' in firstMessage &&
-        firstMessage.content.startsWith('/ticket') &&
+        firstMessage.content.startsWith(SlashCommandName.SlashTicket) &&
         lastMessage?.type === 'ai' &&
         'content' in lastMessage &&
         lastMessage.content.includes("I'll help you create a support ticket")
@@ -91,7 +94,7 @@ export function getTicketPromptData(threadGrouped: ThreadMessage[], streamingAct
 /**
  * Detects if /ticket was sent with an existing conversation and extracts summary data.
  * Returns:
- * - { summary, messageIndex } when a summary is ready for ticket creation
+ * - { summary, initialText, messageIndex } when a summary is ready for ticket creation
  * - { discarded: true, messageIndex } when user continued conversation after summary
  * - null when no ticket summary is applicable
  */
@@ -107,7 +110,7 @@ export function getTicketSummaryData(
     let ticketCommandIndex = -1
     for (let i = threadGrouped.length - 1; i >= 0; i--) {
         const msg = threadGrouped[i]
-        if (msg?.type === 'human' && 'content' in msg && msg.content.startsWith('/ticket')) {
+        if (msg?.type === 'human' && 'content' in msg && msg.content.startsWith(SlashCommandName.SlashTicket)) {
             ticketCommandIndex = i
             break
         }
@@ -145,17 +148,15 @@ export function getTicketSummaryData(
                 }
             }
 
-            // Extract any user-provided text from the /ticket command
+            // Text after "/ticket" pre-populates the note field in the ticket form
             const userText =
                 'content' in ticketCommandMessage
                     ? extractTicketText(ticketCommandMessage.content as string)
                     : undefined
 
-            // Combine user text with AI summary if both exist
-            const summary = userText ? `User notes: ${userText}\n\n${responseMessage.content}` : responseMessage.content
-
             return {
-                summary,
+                summary: responseMessage.content,
+                initialText: userText,
                 messageIndex: ticketCommandIndex + 1,
                 targetArea: parseTicketTargetArea(responseMessage.content),
             }


### PR DESCRIPTION
## Problem

The `/ticket` command in PostHog AI creates a support ticket from a conversation summary, but there was no visible way to add your own text to it. Unlike `/feedback` and `/remember`, the command declared no argument, so selecting it from the autocomplete submitted the bare command immediately. A customer raised this via a support ticket: they wanted to write something like `/ticket only 4th question` and couldn't.

Text after `/ticket ` was actually already parsed and passed through, but it was impossible to discover and the mid-conversation variant buried it inside the AI summary block as a `User notes:` prefix, where the user couldn't review or edit it.

## Changes

- `/ticket` now declares `arg: '[additional details]'` in `MAX_SLASH_COMMANDS`, matching `/feedback` and `/remember`. The autocomplete shows `/ticket [additional details]`, and selecting it inserts `/ticket ` into the input so the user can optionally type details before sending. Submitting with no details still works as before.
- Text after `/ticket` now pre-fills the "Anything to add? (optional)" note field in the ticket modal (mid-conversation) or the "Describe your issue" input (first message), instead of being merged into the summary. The user can review and edit their note before submitting, and the final ticket body keeps the same structure (note first, then the AI analysis).
- `ticketUtils.ts` now references the `SlashCommandName` enum instead of hardcoded `'/ticket'` string literals, consistent with `Thread.tsx` and the backend command handlers.

No backend changes: the slash command router already matches `/ticket <text>` by prefix.

> [!NOTE]
> Behavior change for plain `/ticket`: pressing Enter on the autocomplete item now inserts the command instead of sending it, so a bare ticket takes one extra Enter. This matches how the other argument-taking commands behave.

## How did you test this code?

Automated tests (all run locally):

- Added one case to `ticketUtils.test.ts` covering `/ticket <text>` mid-conversation, asserting the text comes through as `initialText` and the summary stays untouched. This catches the regression where a user's typed details silently never reach the ticket form, which no existing test covered.
- Existing suites pass: `ticketUtils.test.ts` (22), `maxThreadLogic.test.ts` (137), `QuestionInput.test.tsx` (6). Frontend typecheck and lint clean.

Manually tested by @christiaan-ph on a local stack, with tickets filing through the Conversations path:

1. Autocomplete: typing `/` lists the ticket command with its argument placeholder, and pressing Enter on the item inserts `/ticket ` into the input instead of sending.
2. Mid-conversation with details: in a conversation with history, sent `/ticket` plus details text. After the summary streamed in, "Create support ticket" opened the modal with "Anything to add? (optional)" pre-filled with the typed text, editable before submit.
3. Bare `/ticket` mid-conversation: same summary flow as before, note field empty, ticket created normally.
4. First-message variant: sent `/ticket my issue` as the first message of a new conversation. The "Describe your issue" input came pre-filled with "my issue" and submitted fine.

Database check on the created tickets: the mid-conversation ticket body is the note first, then the AI analysis block, then the conversation and trace ID footer, with no `User notes:` remnant anywhere. The bare-command ticket contains just the summary and footer, and the first-message ticket just the typed issue and footer.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code, directed by @christiaan-ph following a customer request. Skills invoked: `/writing-user-facing-copy`, `/writing-tests`. Investigation traced the existing pass-through (present since the original `/ticket` PR #42673) before concluding the gap was discoverability, not capability. Considered keeping the `User notes:` merge into the summary block and rejected it in favor of pre-filling the editable note field, since the composed ticket body comes out the same and the user gets to review their text. This touches the LangGraph thread path, which is normally frozen; this is a UX fix to the existing `/ticket` flow rather than net-new runtime capability.

Post-review updates: the head branch was renamed from `feat/max-ticket-command-details` to `feat/posthog-ai-ticket-command-details` to match the product name, which closed the original PR (#73887) since GitHub does not retarget a PR whose head branch is renamed. The argument placeholder was also changed from `[details]` to `[additional details]` after manual testing.
