### PR TITLE
fix(data-modeling): reject control characters in DAG names

### DIFF
--- a/products/data_modeling/backend/presentation/views/dag.py
+++ b/products/data_modeling/backend/presentation/views/dag.py
@@ -1,3 +1,4 @@
+import re
 from typing import cast
 
 from django.db.models import Count
@@ -12,6 +13,9 @@ from products.warehouse_sources.backend.facade.models import (
     sync_frequency_interval_to_sync_frequency,
     sync_frequency_to_sync_frequency_interval,
 )
+
+# C0 controls, DEL, C1 controls, and the Unicode line/paragraph separators.
+CONTROL_CHARACTERS = re.compile(r"[\x00-\x1f\x7f-\x9f\u2028\u2029]")
 
 
 class DAGSerializer(serializers.ModelSerializer):
@@ -58,6 +62,11 @@ class DAGSerializer(serializers.ModelSerializer):
         return value
 
     def validate_name(self, value: str) -> str:
+        # DAG names are echoed into management-command output, the confirmation prompt of
+        # destructive fleet tooling, and logs. A control character there can erase or rewrite the
+        # surrounding text, so reject it at the boundary rather than escaping at each display site.
+        if CONTROL_CHARACTERS.search(value):
+            raise serializers.ValidationError("Name cannot contain control characters.")
         is_rename = self.instance is not None and value != self.instance.name
         if is_rename:
             instance = cast(DAG, self.instance)

--- a/products/data_modeling/backend/tests/api/test_dag_api.py
+++ b/products/data_modeling/backend/tests/api/test_dag_api.py
@@ -1,5 +1,6 @@
 from posthog.test.base import APIBaseTest
 
+from parameterized import parameterized
 from rest_framework import status
 
 from products.data_modeling.backend.models import DAG, Node, NodeType
@@ -118,6 +119,50 @@ class TestDAGViewSet(APIBaseTest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertFalse(DAG.objects.filter(team=self.team, name="PostHog Revenue Analytics").exists())
+
+    @parameterized.expand(
+        [
+            ("escape", "evil\x1b[2Kreplaced"),
+            ("carriage_return", "evil\rreplaced"),
+            ("newline", "evil\nreplaced"),
+            ("null", "evil\x00replaced"),
+            ("delete", "evil\x7freplaced"),
+        ]
+    )
+    def test_cannot_create_dag_with_control_characters_in_name(self, _name, dag_name):
+        # DAG names are echoed into management-command output and the confirmation prompt of
+        # destructive fleet tooling; a control character there rewrites what an operator reads
+        # before typing "y". NUL additionally reaches Postgres as a driver-level DataError (a 500)
+        # without this guard — the name is never queried back here for that reason.
+        before = DAG.objects.filter(team=self.team).count()
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/data_modeling_dags/",
+            {"name": dag_name},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(DAG.objects.filter(team=self.team).count(), before)
+
+    def test_cannot_rename_dag_to_a_name_with_control_characters(self):
+        dag = DAG.objects.create(team=self.team, name="my_dag")
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/",
+            {"name": "my_dag\x1b[2Kevil"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        dag.refresh_from_db()
+        self.assertEqual(dag.name, "my_dag")
+
+    def test_ordinary_punctuation_in_a_name_is_still_allowed(self):
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/data_modeling_dags/",
+            {"name": "Ünïcode — dbt/staging (v2)"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_cannot_rename_dag_to_reserved_name(self):
         dag = DAG.objects.create(team=self.team, name="my_dag")


### PR DESCRIPTION
## Problem

DAG names are free-form user input with no character validation, and they are echoed verbatim into management-command output, logs, and — in the fleet tooling that consolidates DAGs — a confirmation prompt an operator reads before approving a destructive action. A name containing terminal control characters can erase or rewrite that surrounding text, so what the operator reads is not what will happen.

Two smaller problems come along for free:

- A NUL byte in a name reaches Postgres as a driver-level `DataError`, so a bad name is a 500 rather than a 400.
- ` ` / ` ` break line-oriented tooling that processes names (Python's own `str.splitlines()` splits on them).

Reported by an automated security review on #73650 (rated Low). Scope is honest: exploiting it requires being a member of the team whose own DAGs are at risk, and the payoff is misleading an operator about that same team's data — no privilege escalation and no cross-team reach. This is display-integrity hardening, not a privilege bug.

## Changes

`DAGSerializer.validate_name` rejects C0 controls, DEL, C1 controls, and the Unicode line/paragraph separators. Ordinary punctuation, accents, em dashes, and emoji are unaffected.

Fixing it at the boundary rather than escaping at each display site is deliberate: names flow to many sinks (CLI output, logs, future tooling) and each one would otherwise need its own escaping, which is the kind of thing that gets forgotten in the next command someone writes.

Two related name sources were checked and deliberately left alone, because they are already safe:

- **Saved query names** are validated against `^[A-Za-z_$][A-Za-z0-9_.$]*$` — identifier-safe, no control characters possible.
- **Node names** are overwritten from the saved query on every `save()`, so a node backed by a query inherits that validated name.

That leaves the DAG name as the only free-form name in this area.

## How did you test this code?

Seven new cases in `test_dag_api.py`, written failing first (six failed before the validator, and the legitimate-punctuation case passed throughout, confirming the guard is not over-broad):

- Parameterized create attempts for escape, carriage return, newline, NUL, and DEL — each must be a 400 and must not create a DAG.
- A rename attempt, which must 400 and leave the existing name untouched.
- A positive case (`Ünïcode — dbt/staging (v2)`) that must still be a 201.

`products/data_modeling/backend/tests/api/` plus `test_node.py`: **83 passed**. `ruff check` and `ruff format` clean.

I also checked US production before writing this, to confirm the change cannot break existing rows: **0 of 11,649 DAG names and 0 of 78,590 node names contain control characters.** No backfill or data migration is needed — the validator is purely preventive.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed — no documented workflow changes, and no legitimate name is newly rejected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The automated finding on #73650 originally suggested sanitizing names at each display site in the affected command. Jovan pushed back and asked whether the validator was the right place instead; that turned out to be both simpler and more complete, so the output-sanitizing approach was dropped and this replaced it. Claude (Claude Code) checked which name sources are actually user-controlled (saved query and node names already are not), confirmed zero affected production rows, and wrote the tests red-first.
