### PR TITLE
fix(deps): repair pnpm lockfile entries for streamlit_apps package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,7 +425,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -4352,19 +4352,19 @@ importers:
         version: 0.38.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
-        version: 0.0.0(antd@5.26.0(date-fns@4.1.0)(luxon@3.7.2)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.6(react@18.3.1)))(kea@4.0.0-pre.6(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.0.0(antd@5.26.0(date-fns@4.1.0)(luxon@3.7.2)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1)))(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
       kea:
         specifier: 'catalog:'
-        version: 4.0.0-pre.6(react@18.3.1)
+        version: 4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1)
       kea-loaders:
         specifier: 'catalog:'
-        version: 3.1.1(kea@4.0.0-pre.6(react@18.3.1))
+        version: 3.1.1(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))
       kea-router:
         specifier: 'catalog:'
-        version: 3.4.1(kea@4.0.0-pre.6(react@18.3.1))
+        version: 3.4.1(kea@4.0.0-pre.6(patch_hash=139b8d1f1304f9d9da452a9a1244c94ea679dbcb85687d8999563146879fb6f5)(react@18.3.1))
       react:
         specifier: 18.3.1
         version: 18.3.1


### PR DESCRIPTION
## Problem

The streamlit apps frontend PR (#54880) merged with `pnpm-lock.yaml` entries for `products/streamlit_apps` that were resolved before the kea patch landed on master.
Its importer section referenced the unpatched `kea@4.0.0-pre.6` variant and an older `@types/node`, neither of which exists in the lockfile's packages section anymore.
Every resolving install now fails with:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for '@posthog/lemon-ui@0.0.0(...)(kea@4.0.0-pre.6(react@18.3.1))(...)' in pnpm-lock.yaml
```

pnpm itself diagnoses it as a badly resolved merge conflict.

## Changes

- Regenerated `pnpm-lock.yaml` with `pnpm install --no-frozen-lockfile`.
- The diff is 5 lines, all in the `products/streamlit_apps` importer: kea, kea-loaders, kea-router, and the transitive `@posthog/lemon-ui` entry now point at the patched kea variant, and jest at `@types/node@25.8.0`.

## How did you test this code?

- `pnpm install --no-frozen-lockfile` completes cleanly (previously failed with the error above).
- `pnpm install --frozen-lockfile` now passes, which is what CI runs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session. Reproduced the break in a fresh worktree off master (the husky post-checkout hook fails on it), regenerated the lockfile as pnpm's own error message instructs, and verified the frozen install passes.
