### PR TITLE
fix(ci): point devex alerts at project 2

### DIFF
--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -32,10 +32,9 @@
 const SLACK_API = 'https://slack.com/api'
 const INCIDENT_EVENT_TYPE = 'master_ci_incident'
 // Per-workflow links point at the engineering analytics workflow-detail page (not GitHub), scoped
-// to master via that product's `?q=` branch filter. Hosted in the team-devex project (347861) for
-// now, before it moves to its final home; it's the project with the PostHog/posthog GitHub source
-// synced. `owner`/`repo` come from the run context; the workflow's GitHub display name is the path key.
-const ENG_ANALYTICS_BASE = 'https://us.posthog.com/project/347861/engineering-analytics'
+// to master via that product's `?q=` branch filter. Project 2 owns the synced PostHog/posthog GitHub
+// source. `owner`/`repo` come from the run context; the workflow's GitHub display name is the path key.
+const ENG_ANALYTICS_BASE = 'https://us.posthog.com/project/2/engineering-analytics'
 // One page of channel history. #alerts-devex is low-traffic, so the open anchor
 // reliably stays within the newest 100 messages; a busier channel would need paging.
 const HISTORY_LIMIT = 100

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -180,7 +180,10 @@ describe('ci-alerts-devex', () => {
             assert.match(body, /Backend CI/)
             assert.match(body, /5 failed runs in a row/)
             // per-workflow link → engineering analytics workflow detail, scoped to master
-            assert.match(body, /engineering-analytics\/repos\/PostHog\/posthog\/actions\/workflows\/Backend%20CI\?q=master/)
+            assert.match(
+                body,
+                /https:\/\/us\.posthog\.com\/project\/2\/engineering-analytics\/repos\/PostHog\/posthog\/actions\/workflows\/Backend%20CI\?q=master/
+            )
             assert.equal(anchor.metadata.event_type, 'master_ci_incident')
             assert.equal(anchor.metadata.event_payload.status, 'active')
             assert.deepEqual(


### PR DESCRIPTION
## Problem

- The PostHog GitHub warehouse source moved to project 2.
- Scheduled report configuration is already updated, but master CI alert links still target the old project.

## Changes

- Point engineering analytics workflow links at project 2.
- Assert the complete project-scoped URL in the existing alert test.

## How did you test this code?

- node --test .github/scripts/ci-alerts-devex.test.js: 38 passed.
- hogli ci:preflight --fix: passed with no triggered failure classes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- Not needed. This changes an internal CI alert destination.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used GitHub and PostHog engineering analytics tooling. Session link is unavailable.
- Skills: /debugging-ci-failures, /writing-code-comments, /writing-tests, /wt.