### PR TITLE
fix(hogql): guard cpp lexer ctype calls against non-ASCII code points

### DIFF
--- a/common/hogql_parser/HogQLLexer.h
+++ b/common/hogql_parser/HogQLLexer.h
@@ -72,11 +72,17 @@ public:
 
 
 
+  /* ctype classifiers are UB outside [0,255]+EOF; LA() returns raw UTF-32 code
+     points, so guard to ASCII before delegating (C-locale semantics). */
+  static bool isAsciiAlpha(int ch) { return ch >= 0 && ch < 128 && std::isalpha(ch); }
+  static bool isAsciiAlnum(int ch) { return ch >= 0 && ch < 128 && std::isalnum(ch); }
+  static bool isAsciiSpace(int ch) { return ch >= 0 && ch < 128 && std::isspace(ch); }
+
   /** Skip over whitespace and end-of-line comments (`// …`, `-- …`, `# …`). */
   void skipWsAndComments(std::size_t& i) {
       for (;;) {
           int ch = _input->LA(i);
-          if (std::isspace(ch)) {                       // regular whitespace
+          if (isAsciiSpace(ch)) {                       // regular whitespace
               ++i;
               continue;
           }
@@ -106,14 +112,14 @@ public:
   bool isOpeningTag() {
       /* first char after '<' */
       int la1 = _input->LA(1);
-      if (!std::isalpha(la1) && la1 != '_')
+      if (!isAsciiAlpha(la1) && la1 != '_')
           return false;
 
       /* skip the tag name ([a-zA-Z0-9_-]*) */
       std::size_t i = 2;
       while (true) {
           int ch = _input->LA(i);
-          if (std::isalnum(ch) || ch == '_' || ch == '-')
+          if (isAsciiAlnum(ch) || ch == '_' || ch == '-')
               ++i;
           else
               break;
@@ -126,11 +132,11 @@ public:
           return true;
 
       /*  If the next char is whitespace, look further  */
-      if (std::isspace(ch)) {
+      if (isAsciiSpace(ch)) {
           skipWsAndComments(++i); // step past first space
           ch = _input->LA(i);
           /* tag iff next non-ws/non-comment char is alnum/underscore */
-          return std::isalnum(ch) || ch == '_' || ch == '>' || ch == '/';
+          return isAsciiAlnum(ch) || ch == '_' || ch == '>' || ch == '/';
       }
 
       /* anything else (operator chars, ')', '+', …) → not a tag */

--- a/common/hogql_parser/package.json
+++ b/common/hogql_parser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/hogql-parser",
-    "version": "1.3.77",
+    "version": "1.3.82",
     "description": "WebAssembly HogQL Parser - Parse HogQL queries in JavaScript/TypeScript",
     "keywords": [
         "antlr4",

--- a/common/hogql_parser/setup.py
+++ b/common/hogql_parser/setup.py
@@ -36,7 +36,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.3.77",
+    version="1.3.82",
     url="https://github.com/PostHog/posthog/tree/master/common/hogql_parser",
     description="HogQL parser for internal PostHog use",
     author="PostHog Inc.",

--- a/posthog/hogql/grammar/HogQLLexer.cpp.g4
+++ b/posthog/hogql/grammar/HogQLLexer.cpp.g4
@@ -8,11 +8,17 @@ lexer grammar HogQLLexer;
 
 @members {
 
+/* ctype classifiers are UB outside [0,255]+EOF; LA() returns raw UTF-32 code
+   points, so guard to ASCII before delegating (C-locale semantics). */
+static bool isAsciiAlpha(int ch) { return ch >= 0 && ch < 128 && std::isalpha(ch); }
+static bool isAsciiAlnum(int ch) { return ch >= 0 && ch < 128 && std::isalnum(ch); }
+static bool isAsciiSpace(int ch) { return ch >= 0 && ch < 128 && std::isspace(ch); }
+
 /** Skip over whitespace and end-of-line comments (`// …`, `-- …`, `# …`). */
 void skipWsAndComments(std::size_t& i) {
     for (;;) {
         int ch = _input->LA(i);
-        if (std::isspace(ch)) {                       // regular whitespace
+        if (isAsciiSpace(ch)) {                       // regular whitespace
             ++i;
             continue;
         }
@@ -42,14 +48,14 @@ void skipWsAndComments(std::size_t& i) {
 bool isOpeningTag() {
     /* first char after '<' */
     int la1 = _input->LA(1);
-    if (!std::isalpha(la1) && la1 != '_')
+    if (!isAsciiAlpha(la1) && la1 != '_')
         return false;
 
     /* skip the tag name ([a-zA-Z0-9_-]*) */
     std::size_t i = 2;
     while (true) {
         int ch = _input->LA(i);
-        if (std::isalnum(ch) || ch == '_' || ch == '-')
+        if (isAsciiAlnum(ch) || ch == '_' || ch == '-')
             ++i;
         else
             break;
@@ -62,11 +68,11 @@ bool isOpeningTag() {
         return true;
 
     /*  If the next char is whitespace, look further  */
-    if (std::isspace(ch)) {
+    if (isAsciiSpace(ch)) {
         skipWsAndComments(++i); // step past first space
         ch = _input->LA(i);
         /* tag iff next non-ws/non-comment char is alnum/underscore */
-        return std::isalnum(ch) || ch == '_' || ch == '>' || ch == '/';
+        return isAsciiAlnum(ch) || ch == '_' || ch == '>' || ch == '/';
     }
 
     /* anything else (operator chars, ')', '+', …) → not a tag */

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -329,6 +329,18 @@ def parser_test_factory(backend: HogQLParserBackend):
 
         @parameterized.expand(
             [
+                ("latin_small_e_acute", "let x := a<é", "U+00E9"),
+                ("cjk_unified", "let x := a<中", "U+4E2D"),
+                ("supplementary_plane_emoji", "let x := a<\U0001f600", "U+1F600"),
+            ]
+        )
+        def test_non_ascii_after_lt_rejected(self, _name: str, program: str, code_point: str):
+            with self.assertRaises((ExposedHogQLError, SyntaxError)) as caught:
+                self._program(program)
+            self.assertIn(code_point, str(caught.exception))
+
+        @parameterized.expand(
+            [
                 ("not_equals", "a != b"),
                 ("not_regex", "a !~ b"),
                 ("concat", "a || b"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser==1.3.77",
+    "hogql-parser==1.3.82",
     "hogql-parser-rs==1.3.106",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",

--- a/uv.lock
+++ b/uv.lock
@@ -3137,14 +3137,14 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "hogql-parser"
-version = "1.3.77"
+version = "1.3.82"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/b0/f8bfa5c99eb03a5590d534a6603ddd8b673c265fc7fe636f85118266b708/hogql_parser-1.3.77.tar.gz", hash = "sha256:54b2fea0d84355428f0007c56b52467c916aabb2edf4d81bdf6832981c33385d", size = 93002, upload-time = "2026-07-06T18:23:53.518Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/c3/e2efe1ed9fe592d8bc7158da53700d537bbb6c16b29f18c5b3523c83bcc8/hogql_parser-1.3.82.tar.gz", hash = "sha256:0e626a938bf8b7aa386ae75816079f7861c7deebd423e17f2b717c63f7bdec5f", size = 92997, upload-time = "2026-07-29T21:03:02.453Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/71/3c1b37e684534b9d8aac963dbf7ba04368ce224ce4f34f855b9452bf1517/hogql_parser-1.3.77-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff9f8110e97600736d7a3bf12d98eace6bd74452ea9c27f7e2ebfc07e511436", size = 658461, upload-time = "2026-07-06T18:23:46.691Z" },
-    { url = "https://files.pythonhosted.org/packages/95/9d/c9fd969c78d238fce27022f83fea8178ff9ff8983353898c7a571fdc093d/hogql_parser-1.3.77-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:6a957218ed655c1e7138c8b63a2ffce6af225a556d73d429edc8fbc13aec91e9", size = 668189, upload-time = "2026-07-06T18:23:48.787Z" },
-    { url = "https://files.pythonhosted.org/packages/23/a1/c5870de8a1574be62c065ef81b91a8b5e4764a4643955ef6d0569eb5212e/hogql_parser-1.3.77-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:ace2fd1f1ece2fdcbbcf8c0f6ba331818b6dd9f2cd35a389e61a5fabd0b0f4d3", size = 5107931, upload-time = "2026-07-06T18:23:50.118Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e3/2b344e224e4c69ded92a0a5eeb06bb132400c32de41d0e9d5915208deb79/hogql_parser-1.3.77-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:bb2937ce6885885435c0984617b99d2b702e6070c7eea5049296aa5fc1be4453", size = 5215426, upload-time = "2026-07-06T18:23:51.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/b6/281ecc67763893be82437c40b9a0cfaf2b48b9ebade887d6a803d3f47ee5/hogql_parser-1.3.82-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:56ca8562be5b467d4f57edf8ad3f4c234e86796dfba95a1fe9974f86f51a308e", size = 658392, upload-time = "2026-07-29T21:02:55.832Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a6/ca4227916a4533163df499c861f5572e1d968689a4b2ac25fec55a9b5fe9/hogql_parser-1.3.82-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:34745288712326ec96d41acb4ac79026c32ab1dda22c1805725ab16ee1e6b14f", size = 667948, upload-time = "2026-07-29T21:02:57.541Z" },
+    { url = "https://files.pythonhosted.org/packages/05/09/9fe3e013fe44460e9f7a390bd3adb428b77f4ad79e7903b4c8335216d60b/hogql_parser-1.3.82-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:9701ea608f42f72c02c09adae41436f2a5d0bae53268d7d69e9a45c24eb2346a", size = 5106255, upload-time = "2026-07-29T21:02:58.972Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/29/c7c084a44769b8b3a18822db499e96873a0399087c1750f86eae582768e2/hogql_parser-1.3.82-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5c2b7d615a7699eea1a2b600b9890c9b85bd1f667aa1c4fe98e734fd7465f5c4", size = 5215814, upload-time = "2026-07-29T21:03:00.665Z" },
 ]
 
 [[package]]
@@ -4645,7 +4645,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4656,7 +4656,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4683,9 +4683,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4696,7 +4696,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -5355,7 +5355,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5883,7 +5883,7 @@ requires-dist = [
     { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", specifier = "==1.3.77" },
+    { name = "hogql-parser", specifier = "==1.3.82" },
     { name = "hogql-parser-rs", specifier = "==1.3.106" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
@@ -7624,7 +7624,7 @@ name = "shadowcopy"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wmi", marker = "sys_platform != 'emscripten'" },
+    { name = "wmi" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/12/44/c00420a3b7bcdf830529b933392b566c876a4944a24f31e126eb6fd28647/shadowcopy-0.0.4.tar.gz", hash = "sha256:ed89817dda065f893607a04c0b7d6b3b34c3507a4711f441111a4bcb1b1826c0", size = 4138, upload-time = "2023-07-08T00:01:35.266Z" }
 wheels = [
@@ -8058,7 +8058,7 @@ name = "tbb"
 version = "2022.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tcmlib", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "tcmlib" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/59/8d381a2cfe8d36c4f4ff9f94769ff2809bfc16014d888360b0e24c7e5c6b/tbb-2022.3.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:534c089eca6bcf148408684c156229d5f09c01d323b685b15739f41985b529d7", size = 4178630, upload-time = "2026-01-22T05:30:20.589Z" },
@@ -8440,7 +8440,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools", marker = "platform_machine != 's390x' and sys_platform != 'emscripten'" },
+    { name = "setuptools" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/7b/0a685684ed5322d2af0bddefed7906674f67974aa88b0fae6e82e3b766f6/triton-3.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00be2964616f4c619193cb0d1b29a99bd4b001d7dc333816073f92cf2a8ccdeb", size = 155569223, upload-time = "2025-07-30T19:58:44.017Z" },
@@ -9147,7 +9147,7 @@ name = "wmi"
 version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform != 'emscripten'" },
+    { name = "pywin32" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d4/66/6364deb0a03415f96c66803d8c4379f808f2401da3bdb183348487b10510/WMI-1.5.1.tar.gz", hash = "sha256:b6a6be5711b1b6c8d55bda7a8befd75c48c12b770b9d227d31c1737dbf0d40a6", size = 26254, upload-time = "2020-04-28T08:22:58.096Z" }
 wheels = [


### PR DESCRIPTION
## Changes

Improve HogQL handling of non-ASCII code points

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests

Generated-By: PostHog Code
Task-Id: 6386f70c-aafa-4d6e-bc56-664b96fbfbc1
