### PR TITLE
fix(experiments): tolerate non-dict parameters when projecting flag config

### DIFF
--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -263,7 +263,10 @@ class ExperimentBaseSerializer(UserAccessControlSerializerMixin, serializers.Mod
         """
         if flag is None:
             return
-        parameters = dict(data.get("parameters") or {})
+        stored = data.get("parameters")
+        # The JSON column can legally hold a non-dict on legacy rows (see migration 0026); the flag
+        # is the source of truth for the keys below, so a malformed blob is simply dropped.
+        parameters = dict(stored) if isinstance(stored, dict) else {}
 
         parameters["feature_flag_variants"] = _with_split_percent(flag.variants)
 

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -2304,6 +2304,28 @@ class TestExperimentCRUD(_HoistFlagConfigClientMixin, APILicensedTest):
         self.assertEqual(list_parameters["feature_flag_variants"], expected_variants)
         self.assertEqual(list_parameters["aggregation_group_type_index"], 1)
 
+    @parameterized.expand([("string", "{}"), ("list", ["control"])])
+    def test_non_dict_parameters_column_does_not_break_reads(self, _name, stored_parameters):
+        ff_key = f"ff-bad-parameters-{_name}"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {"name": "Legacy blob", "feature_flag_key": ff_key},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        experiment_id = response.json()["id"]
+
+        # Legacy rows can hold a non-dict here; .update() bypasses the serializer, as those writes did.
+        Experiment.objects.filter(id=experiment_id).update(parameters=stored_parameters)
+
+        detail = self.client.get(f"/api/projects/{self.team.id}/experiments/{experiment_id}")
+        self.assertEqual(detail.status_code, status.HTTP_200_OK)
+        self.assertEqual([v["key"] for v in detail.json()["parameters"]["feature_flag_variants"]], ["control", "test"])
+
+        listed = self.client.get(f"/api/projects/{self.team.id}/experiments/")
+        self.assertEqual(listed.status_code, status.HTTP_200_OK)
+        parameters = next(e["parameters"] for e in listed.json()["results"] if e["id"] == experiment_id)
+        self.assertEqual([v["key"] for v in parameters["feature_flag_variants"]], ["control", "test"])
+
     def test_feature_flag_config_is_not_persisted_into_parameters(self):
         """Create and update consume feature-flag config to build/sync the flag, but never store it
         in the deprecated `parameters` column. Non-flag keys (e.g. variant_notes) are preserved.


### PR DESCRIPTION
## Problem

`GET /api/projects/:id/experiments/` was returning a 500 for entire teams:

```
ValueError: dictionary update sequence element #0 has length 1; 2 is required
  products/experiments/backend/presentation/serializers.py:266 in _project_feature_flag_config
```

`Experiment.parameters` is a `JSONField(default=dict, null=True)`, so the column can legally hold a string or a list, and some legacy rows do. Migration `0026_strip_feature_flag_config_from_parameters` already knows this and skips non-dict rows explicitly.

The flag-config read projection did `dict(data.get("parameters") or {})`, which raises on those values. Because the projection runs per row inside the list serializer, one bad row took down the whole list response rather than just its own entry.

## Changes

One `isinstance` guard in `ExperimentBaseSerializer._project_feature_flag_config`, which both the list and detail serializers share:

```python
stored = data.get("parameters")
parameters = dict(stored) if isinstance(stored, dict) else {}
```

The linked feature flag is the source of truth for every key this method writes, so dropping a malformed legacy blob loses nothing.

Deliberately not in scope: write-side validation that rejects a non-dict `parameters` with a 400 (the API cannot create new bad rows today, since `_strip_feature_flag_config` raises `AttributeError` first), and a data migration to normalize the existing rows (unnecessary once reads tolerate them).

## How did you test this code?

Added a parameterized test in `test_presentation_api.py` covering the two shapes that trigger the ValueError, a JSON string and a list. It writes the bad value with `.update()` to bypass serializer validation, mimicking how those rows got there, then asserts both the list and detail endpoints return 200 with the flag's config projected into `parameters`. No existing test exercises a non-dict column value, and the previous code raised on both shapes.

```
hogli test products/experiments/backend/test/test_presentation_api.py -k non_dict_parameters
2 passed
```

No manual testing. I did not reproduce against a real affected row.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code) wrote this from a production error-tracking stack trace. The first instinct was to guard at the crash site only, but tracing callers showed the projection is shared by the list and detail serializers via `to_representation`, so a single guard there covers both paths. Migration `0026`'s existing non-dict check confirmed these rows are real rather than hypothetical, which also ruled out "validate harder on write" as the fix for the reported symptom.

Skills invoked: `/improving-drf-endpoints` rules for the serializer, `/writing-tests` value gate for the new test.
