### PR TITLE
fix(conversations): point MCP ticket links at the app route

### DIFF
--- a/products/conversations/mcp/tools.yaml
+++ b/products/conversations/mcp/tools.yaml
@@ -6,7 +6,7 @@
 # All other fields (title, description, enrich_url, etc.) are yours to configure.
 category: Conversations
 feature: conversations
-url_prefix: /conversations/tickets
+url_prefix: /support/tickets
 ui_apps: {}
 tools:
     conversations-tickets-ai-feedback-create:

--- a/services/mcp/src/tools/generated/conversations.ts
+++ b/services/mcp/src/tools/generated/conversations.ts
@@ -67,7 +67,7 @@ const conversationsTicketsList = (): ToolBase<
                 ])
             ),
         } as typeof result
-        return await withPostHogUrl(context, filtered, '/conversations/tickets')
+        return await withPostHogUrl(context, filtered, '/support/tickets')
     },
 })
 
@@ -164,7 +164,7 @@ const conversationsTicketsRetrieve = (): ToolBase<
             'created_at',
             'updated_at',
         ]) as typeof result
-        return await withPostHogUrl(context, filtered, `/conversations/tickets/${filtered.id}`)
+        return await withPostHogUrl(context, filtered, `/support/tickets/${filtered.id}`)
     },
 })
 
@@ -201,7 +201,7 @@ const conversationsTicketsUpdate = (): ToolBase<
             path: `/api/projects/${encodeURIComponent(String(projectId))}/conversations/tickets/${encodeURIComponent(String(params.id))}/`,
             body,
         })
-        return await withPostHogUrl(context, result, `/conversations/tickets/${result.id}`)
+        return await withPostHogUrl(context, result, `/support/tickets/${result.id}`)
     },
 })
 
@@ -227,7 +227,7 @@ const conversationsViewsList = (): ToolBase<
             ...result,
             results: (result.results ?? []).map((item: any) => pickResponseFields(item, ['short_id', 'name'])),
         } as typeof result
-        return await withPostHogUrl(context, filtered, '/conversations/tickets')
+        return await withPostHogUrl(context, filtered, '/support/tickets')
     },
 })
 

--- a/services/mcp/tests/tools/conversations.integration.test.ts
+++ b/services/mcp/tests/tools/conversations.integration.test.ts
@@ -34,7 +34,8 @@ describe('Conversations', { concurrent: false }, () => {
             expect(typeof data.count).toBe('number')
             expect(Array.isArray(data.results)).toBe(true)
             expect(typeof data._posthogUrl).toBe('string')
-            expect(data._posthogUrl).toContain('/conversations/tickets')
+            // The app route, not the API path — agents hand these links to humans.
+            expect(data._posthogUrl).toContain('/support/tickets')
         })
 
         it('should respect the limit parameter', async () => {


### PR DESCRIPTION
## Problem

Every ticket link the conversations MCP hands back is a 404.

`url_prefix` in a product's MCP config is the **frontend app route** used to build the `_posthogUrl` link on tool results. Conversations had it set to the API path:

```diff
-url_prefix: /conversations/tickets
+url_prefix: /support/tickets
```

So `conversations-tickets-list`, `conversations-tickets-retrieve`, `conversations-tickets-update`, and `conversations-views-list` all returned links like `/project/2/conversations/tickets/<uuid>`. There is no such scene, so agents were handing people links that land on "Page not found". Conversations was the only product of 47 pointing `url_prefix` at an API path.

The ticket scene is at `/support/tickets/:ticketId` and already accepts a UUID, redirecting to the cleaner ticket-number URL, so the id the MCP returns works as-is.

## Changes

One line in `products/conversations/mcp/tools.yaml` plus the regenerated handler. The API request paths are untouched; only the human-facing link changed.

> [!NOTE]
> While checking this, I found 12 other products whose `url_prefix` doesn't resolve against the canonical app route table (`services/mcp/src/tools/links/app-url-manifest.json`), including `customer_analytics` pointing at `/customer-analytics` when the routes use underscores. Some are probably the same bug, others are routes simply absent from the manifest. I left them out to keep this reviewable by one team, and there's a case for a build-time check that `url_prefix` resolves against that manifest, which would have caught this class of bug.

## How did you test this code?

The existing integration test asserted the buggy value (`toContain('/conversations/tickets')`), which is why this shipped. Updated it to assert the app route, so a revert of `url_prefix` now fails in CI (`ci-mcp.yml` runs `test:integration`).

What I (Claude) actually ran locally:

- `pnpm --filter=@posthog/mcp run generate-tools` — regenerated; only the 4 intended link sites changed, no schema drift
- `vitest run tests/unit` — 2404 passed / 86 files
- `lint-tool-names`, `format:check` — pass
- `hogli ci:preflight` — no failures; the openapi advisory is trigger-based guidance, and re-running the generators produced no drift

I did not run the integration suite locally (it needs live API credentials) and I did not click through a ticket link in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed. `url_prefix` is internal MCP config.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while I was checking something unrelated: I clicked ticket links the MCP had returned and got a row of "Page not found" tabs. Claude Opus 5 traced it from the dead URL back to `url_prefix`, confirmed against `products/conversations/manifest.tsx` that the real route is `/support/tickets/:ticketId`, and confirmed the scene tolerates a UUID before settling on the one-line fix.

Skills invoked: `/implementing-mcp-tools` (which is where the "`url_prefix` is the frontend app route" contract is stated) and `/writing-tests`.

Two things considered and rejected for this PR: hand-editing the generated handler (regenerating properly instead), and adding a build-time validator for all 47 products' `url_prefix` values, which fails on 13 existing entries and needs each owning team's input. Flagged above instead.
