### PR TITLE
fix(experiments): zero-fill variants when a breakdown metric has no rows

### DIFF
--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -730,20 +730,18 @@ class ExperimentQueryRunner(QueryRunner):
         """
         variants_seen = [v.key for _, v in variants]
 
-        has_breakdown = (
-            self.metric.breakdownFilter is not None
-            and self.metric.breakdownFilter.breakdowns
-            and len(self.metric.breakdownFilter.breakdowns) > 0
-        )
+        # Fan out over the breakdown combinations actually present in the results, not over the
+        # metric's breakdown config: a metric can declare breakdowns and still come back with no
+        # rows at all (no data yet), and there is then nothing to fan out over — fall back to the
+        # single breakdown-less zero row so the baseline variant still exists.
+        breakdown_tuples = {bv for bv, _ in variants if bv is not None}
 
         # Type annotation required for empty list so mypy knows the expected element type:
         # list of tuples containing (breakdown_values, stats) where breakdown_values can be None
         variants_missing: list[tuple[tuple[str, ...] | None, ExperimentStatsBase]] = []
         for key in self.variants:
             if key not in variants_seen:
-                if has_breakdown:
-                    # Extract all breakdown value combinations that exist in the results
-                    breakdown_tuples = {bv for bv, _ in variants if bv is not None}
+                if breakdown_tuples:
                     # Use extend to add MULTIPLE tuples - one for each breakdown combination
                     # Each missing variant needs to appear across ALL breakdown values to maintain consistency
                     variants_missing.extend(

--- a/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_add_missing_variants.py
+++ b/products/experiments/backend/hogql_queries/test/experiment_query_runner/test_add_missing_variants.py
@@ -4,6 +4,8 @@ from freezegun import freeze_time
 
 from django.test import override_settings
 
+from parameterized import parameterized
+
 from posthog.schema import (
     Breakdown,
     BreakdownFilter,
@@ -162,11 +164,18 @@ class TestAddMissingVariants(ExperimentQueryRunnerBaseTest):
         assert ("MacOS", "Chrome") in breakdown_values
         assert ("Windows", "Firefox") in breakdown_values
 
+    @parameterized.expand(
+        [
+            ("without_breakdown", None),
+            ("with_breakdown", BreakdownFilter(breakdowns=[Breakdown(property="$browser")])),
+        ]
+    )
     @freeze_time("2020-01-01T12:00:00Z")
-    def test_empty_variants_list(self):
+    def test_empty_variants_list(self, _name, breakdown_filter):
         """Should add all configured variants when input is empty."""
         metric = ExperimentMeanMetric(
             source=EventsNode(event="purchase", math=ExperimentMetricMathType.TOTAL),
+            breakdownFilter=breakdown_filter,
         )
         query = ExperimentQuery(experiment_id=self.experiment.id, kind="ExperimentQuery", metric=metric)
         runner = ExperimentQueryRunner(query=query, team=self.team)


### PR DESCRIPTION
## Problem

Experiment metric recalculation was failing with `ValueError: No control variant found`, surfaced as a non-retryable `ApplicationError` out of the Temporal activity.
Affected metrics get a `FAILED` `ExperimentMetricResult` row instead of a result.

The captured frame locals on the error issue point at one shape: a funnel metric **with a breakdown** on an experiment whose flag has both `control` and `test`, but where the ClickHouse query came back with **zero rows** (no data in the window yet).
`_calculate` saw `variants == []`, so `split_baseline_and_test_variants` had nothing to find a baseline in.

## Changes

`_add_missing_variants` zero-fills any configured variant missing from the results.
For a metric with breakdowns it fans that fill out once per breakdown combination, but it reads those combinations *from the results themselves*.
With an empty result set there is nothing to fan out over, so `extend([])` added nothing for every missing variant and the zero-fill silently did nothing.

Now the fan-out is driven by the breakdown values actually present, with a fallback to the single breakdown-less zero row when there are none.
A no-data breakdown metric ends up on exactly the path a no-data metric without a breakdown already took: all-zero variants, `breakdown_results` unset.

> [!NOTE]
> Behavior is unchanged whenever the query returns any rows – `breakdown_tuples` is non-empty and the fan-out is identical to before.

The `isinstance(e, ValueError)` → non-retryable mapping in the recalculation activity stays as is.
It is still the right call for a genuinely misconfigured baseline variant key, which is a separate way to reach the same raise and out of scope here.

## How did you test this code?

Automated only, no manual testing – I did not reproduce this against a live experiment.

- Parameterized the existing `test_empty_variants_list` in `test_add_missing_variants.py` over with/without a breakdown filter. The new `with_breakdown` case is the regression: it fails on master with `assert 0 == 2` (empty result set, nothing zero-filled) and passes with the fix. No existing test covered it – `test_empty_variants_list` had no breakdown, and the breakdown cases all had rows.
- `test_add_missing_variants.py` (10 passed), `test_breakdown.py` (22 passed, 19 snapshots) – the latter guards the existing per-breakdown-group zero-fill, which this change must not disturb.
- ruff check and format clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code) did the work from a production error issue and stack trace I handed it.
Rather than guessing between the possible triggers for this raise, it pulled the captured frame locals off the issue via the PostHog MCP, which made the cause unambiguous: breakdown metric, zero rows, empty `variants`.

Two fixes were on the table. Guarding in `_calculate` when `variants` comes back empty, or fixing the fan-out in `_add_missing_variants` where the intent already lived. It took the second – smaller diff, keeps the zero-fill logic in one place, and it also hoists a set comprehension that was being rebuilt inside the loop for every missing variant.

Skills invoked: `/writing-tests`, which is why this is one parameterized case on an existing test rather than a new near-duplicate test function.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
