### PR TITLE
fix(data-modeling): gate DAG-level sync frequency on tiered teams

### DIFF
--- a/frontend/src/scenes/models/DagsTab.tsx
+++ b/frontend/src/scenes/models/DagsTab.tsx
@@ -62,18 +62,21 @@ export function DagsTab(): JSX.Element {
         {
             title: 'Sync frequency',
             key: 'sync_frequency',
-            render: (_, dag) => (
-                <LemonSelect<DataModelingSyncInterval>
-                    value={dag.sync_frequency ?? '24hour'}
-                    options={SYNC_FREQUENCY_OPTIONS}
-                    size="small"
-                    onChange={(value) => {
-                        if (value && value !== dag.sync_frequency) {
-                            updateDag({ ...dag, sync_frequency: value })
-                        }
-                    }}
-                />
-            ),
+            render: (_, dag) =>
+                dag.frequency_managed_by_nodes ? (
+                    <span className="text-muted">Managed per model</span>
+                ) : (
+                    <LemonSelect<DataModelingSyncInterval>
+                        value={dag.sync_frequency ?? '24hour'}
+                        options={SYNC_FREQUENCY_OPTIONS}
+                        size="small"
+                        onChange={(value) => {
+                            if (value && value !== dag.sync_frequency) {
+                                updateDag({ ...dag, sync_frequency: value })
+                            }
+                        }}
+                    />
+                ),
         },
         {
             key: 'actions',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6114,6 +6114,8 @@ export interface DataModelingDAG {
     name: string
     description: string
     sync_frequency: DataModelingSyncInterval | null
+    /** True when per-model freshness targets drive scheduling, making the DAG-level frequency read-only */
+    frequency_managed_by_nodes?: boolean
     node_count: number
     created_at: string
     updated_at: string

--- a/products/data_modeling/backend/presentation/views/dag.py
+++ b/products/data_modeling/backend/presentation/views/dag.py
@@ -1,13 +1,15 @@
 import re
-from typing import cast
+from typing import Any, cast
 
 from django.db.models import Count
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers, viewsets
 from rest_framework.exceptions import ValidationError
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
+from products.data_modeling.backend.facade.api import tiered_schedules_enabled
 from products.data_modeling.backend.facade.models import DAG, RESERVED_DAG_NAMES
 from products.warehouse_sources.backend.facade.models import (
     sync_frequency_interval_to_sync_frequency,
@@ -25,6 +27,14 @@ class DAGSerializer(serializers.ModelSerializer):
         allow_null=True,
         help_text="Sync frequency string (e.g. '24hour', '7day')",
     )
+    frequency_managed_by_nodes = serializers.SerializerMethodField(
+        read_only=True,
+        help_text=(
+            "True when this team's DAG schedules are driven by per-model freshness targets, so "
+            "`sync_frequency` no longer controls scheduling and writes to it are rejected. False "
+            "when the DAG-level frequency still applies."
+        ),
+    )
 
     class Meta:
         model = DAG
@@ -33,12 +43,14 @@ class DAGSerializer(serializers.ModelSerializer):
             "name",
             "description",
             "sync_frequency",
+            "frequency_managed_by_nodes",
             "node_count",
             "created_at",
             "updated_at",
         ]
         read_only_fields = [
             "id",
+            "frequency_managed_by_nodes",
             "node_count",
             "created_at",
             "updated_at",
@@ -47,6 +59,12 @@ class DAGSerializer(serializers.ModelSerializer):
             "name": {"help_text": "Human-readable name for this DAG"},
             "description": {"help_text": "Optional description of the DAG's purpose"},
         }
+
+    @extend_schema_field(serializers.BooleanField())
+    def get_frequency_managed_by_nodes(self, dag: DAG) -> bool:
+        # Resolved once per request in DAGViewSet.get_serializer_context — it is team-scoped,
+        # so evaluating the flag per DAG row would be redundant.
+        return bool(self.context.get("frequency_managed_by_nodes", False))
 
     def to_representation(self, instance: DAG) -> dict:
         data = super().to_representation(instance)
@@ -91,6 +109,10 @@ class DAGSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("System-managed DAGs cannot be edited.")
         sync_frequency = validated_data.pop("sync_frequency", None)
         if sync_frequency is not None:
+            if self.context.get("frequency_managed_by_nodes", False):
+                raise serializers.ValidationError(
+                    "Sync frequency is managed per model on this team. Edit each model's sync frequency instead."
+                )
             validated_data["sync_frequency_interval"] = sync_frequency_to_sync_frequency_interval(sync_frequency)
         return super().update(instance, validated_data)
 
@@ -103,6 +125,11 @@ class DAGViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
     def safely_get_queryset(self, queryset):
         return queryset.filter(team_id=self.team_id).annotate(node_count=Count("node")).order_by("name")
+
+    def get_serializer_context(self) -> dict[str, Any]:
+        context = super().get_serializer_context()
+        context["frequency_managed_by_nodes"] = tiered_schedules_enabled(self.team)
+        return context
 
     def perform_destroy(self, instance: DAG) -> None:
         if instance.is_default:

--- a/products/data_modeling/backend/presentation/views/dag.py
+++ b/products/data_modeling/backend/presentation/views/dag.py
@@ -110,10 +110,15 @@ class DAGSerializer(serializers.ModelSerializer):
         sync_frequency = validated_data.pop("sync_frequency", None)
         if sync_frequency is not None:
             if self.context.get("frequency_managed_by_nodes", False):
-                raise serializers.ValidationError(
-                    "Sync frequency is managed per model on this team. Edit each model's sync frequency instead."
-                )
-            validated_data["sync_frequency_interval"] = sync_frequency_to_sync_frequency_interval(sync_frequency)
+                # The frontend spreads the whole DAG into every PATCH, so an unchanged
+                # echo of the current frequency must pass; only a real change is rejected.
+                current = sync_frequency_interval_to_sync_frequency(instance.sync_frequency_interval)
+                if sync_frequency != current:
+                    raise serializers.ValidationError(
+                        "Sync frequency is managed per model on this team. Edit each model's sync frequency instead."
+                    )
+            else:
+                validated_data["sync_frequency_interval"] = sync_frequency_to_sync_frequency_interval(sync_frequency)
         return super().update(instance, validated_data)
 
 

--- a/products/data_modeling/backend/tests/api/test_dag_api.py
+++ b/products/data_modeling/backend/tests/api/test_dag_api.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from posthog.test.base import APIBaseTest
 from unittest import mock
 
@@ -218,15 +220,18 @@ class TestDAGViewSet(APIBaseTest):
             "products.data_modeling.backend.presentation.views.dag.tiered_schedules_enabled",
             return_value=True,
         ):
+            # The frontend spreads the whole DAG into the PATCH, echoing the current
+            # sync_frequency back unchanged — that echo must not trip the tiered rejection.
             response = self.client.patch(
                 f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/",
-                {"name": "renamed", "description": "still editable"},
+                {"name": "renamed", "description": "still editable", "sync_frequency": "24hour"},
             )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         dag.refresh_from_db()
         self.assertEqual(dag.name, "renamed")
         self.assertEqual(dag.description, "still editable")
+        self.assertEqual(dag.sync_frequency_interval, timedelta(days=1))
 
     def test_can_set_sync_frequency_on_non_tiered_team(self):
         dag = DAG.objects.create(team=self.team, name="my_dag")

--- a/products/data_modeling/backend/tests/api/test_dag_api.py
+++ b/products/data_modeling/backend/tests/api/test_dag_api.py
@@ -1,4 +1,5 @@
 from posthog.test.base import APIBaseTest
+from unittest import mock
 
 from parameterized import parameterized
 from rest_framework import status
@@ -175,6 +176,74 @@ class TestDAGViewSet(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         dag.refresh_from_db()
         self.assertEqual(dag.name, "my_dag")
+
+    @parameterized.expand([("tiered", True), ("not_tiered", False)])
+    def test_frequency_managed_by_nodes_tracks_tiered_schedules_flag(self, _name, enabled):
+        DAG.objects.create(team=self.team, name="my_dag")
+        DAG.objects.create(team=self.team, name="another_dag")
+
+        with mock.patch(
+            "products.data_modeling.backend.presentation.views.dag.tiered_schedules_enabled",
+            return_value=enabled,
+        ) as mock_flag:
+            response = self.client.get(f"/api/environments/{self.team.id}/data_modeling_dags/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual([d["frequency_managed_by_nodes"] for d in response.json()["results"]], [enabled, enabled])
+        # The flag is team-scoped, so it must be resolved once per request, not per DAG row.
+        mock_flag.assert_called_once()
+
+    def test_cannot_set_sync_frequency_on_tiered_team(self):
+        dag = DAG.objects.create(team=self.team, name="my_dag")
+        interval_before = dag.sync_frequency_interval
+
+        with mock.patch(
+            "products.data_modeling.backend.presentation.views.dag.tiered_schedules_enabled",
+            return_value=True,
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/",
+                {"sync_frequency": "15min"},
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("managed per model", response.json()["detail"])
+        dag.refresh_from_db()
+        self.assertEqual(dag.sync_frequency_interval, interval_before)
+
+    def test_can_still_rename_dag_on_tiered_team(self):
+        dag = DAG.objects.create(team=self.team, name="my_dag")
+
+        with mock.patch(
+            "products.data_modeling.backend.presentation.views.dag.tiered_schedules_enabled",
+            return_value=True,
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/",
+                {"name": "renamed", "description": "still editable"},
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        dag.refresh_from_db()
+        self.assertEqual(dag.name, "renamed")
+        self.assertEqual(dag.description, "still editable")
+
+    def test_can_set_sync_frequency_on_non_tiered_team(self):
+        dag = DAG.objects.create(team=self.team, name="my_dag")
+
+        with mock.patch(
+            "products.data_modeling.backend.presentation.views.dag.tiered_schedules_enabled",
+            return_value=False,
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.id}/data_modeling_dags/{dag.id}/",
+                {"sync_frequency": "15min"},
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["sync_frequency"], "15min")
+        dag.refresh_from_db()
+        self.assertIsNotNone(dag.sync_frequency_interval)
 
     def test_node_count_reflects_nodes(self):
         dag = DAG.objects.create(team=self.team, name="my_dag")

--- a/products/data_modeling/frontend/generated/api.schemas.ts
+++ b/products/data_modeling/frontend/generated/api.schemas.ts
@@ -21,6 +21,8 @@ export interface DagApi {
      * @nullable
      */
     sync_frequency?: string | null
+    /** True when this team's DAG schedules are driven by per-model freshness targets, so `sync_frequency` no longer controls scheduling and writes to it are rejected. False when the DAG-level frequency still applies. */
+    readonly frequency_managed_by_nodes: boolean
     readonly node_count: number
     readonly created_at: string
     /** @nullable */
@@ -50,6 +52,8 @@ export interface PatchedDAGApi {
      * @nullable
      */
     sync_frequency?: string | null
+    /** True when this team's DAG schedules are driven by per-model freshness targets, so `sync_frequency` no longer controls scheduling and writes to it are rejected. False when the DAG-level frequency still applies. */
+    readonly frequency_managed_by_nodes?: boolean
     readonly node_count?: number
     readonly created_at?: string
     /** @nullable */

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -16568,6 +16568,8 @@ export namespace Schemas {
          * @nullable
          */
       sync_frequency?: string | null;
+      /** True when this team's DAG schedules are driven by per-model freshness targets, so `sync_frequency` no longer controls scheduling and writes to it are rejected. False when the DAG-level frequency still applies. */
+      readonly frequency_managed_by_nodes: boolean;
       readonly node_count: number;
       readonly created_at: string;
       /** @nullable */
@@ -47277,6 +47279,8 @@ export namespace Schemas {
          * @nullable
          */
       sync_frequency?: string | null;
+      /** True when this team's DAG schedules are driven by per-model freshness targets, so `sync_frequency` no longer controls scheduling and writes to it are rejected. False when the DAG-level frequency still applies. */
+      readonly frequency_managed_by_nodes?: boolean;
       readonly node_count?: number;
       readonly created_at?: string;
       /** @nullable */


### PR DESCRIPTION
## Problem

The Models scene's DAGs tab shows a per-DAG "Sync frequency" dropdown.
On teams using tiered schedules (the `data-modeling-tiered-schedules` gate, where frequency intent lives on per-model freshness targets), that dropdown is a lie twice over.
Editing it writes `dag.sync_frequency_interval` and changes nothing in Temporal, so the user picks "15 minutes" and keeps getting their existing cadence.
And the column it writes is the seed fallback that `reconcile_freshness_schedules` reads, so a stale edit is a latent hazard for later conversion re-runs.

We watched this play out in production. A team set 15 minutes in this exact dropdown, the column stored it, and the daily schedule kept firing daily.

The frontend can't check the flag itself since it's evaluated server-side, which is the same problem #73611 solved for the saved-query panel with a server-computed field.

## Changes

- `DAGSerializer` exposes a read-only `frequency_managed_by_nodes` boolean, computed once per request in `DAGViewSet.get_serializer_context` via `tiered_schedules_enabled(team)` (not per row -- all rows share the team).
- `DagsTab` renders muted "Managed per model" text instead of the `LemonSelect` when the field is true. Non-tiered teams see no change.
- `DAGSerializer.update` now rejects a **changed** `sync_frequency` on tiered teams with a 400: "Sync frequency is managed per model on this team. Edit each model's sync frequency instead." An unchanged echo of the current value passes, since the frontend's full-object PATCH spread sends it on every update, including renames. Name and description edits still work. `create` is untouched, since rejecting there would break DAG creation for tiered orgs and the creation flow is a separate product question.
- Generated artifacts (`products/data_modeling/frontend/generated/api.schemas.ts`, `services/mcp/src/api/generated.ts`) regenerated via `hogli build:openapi`; the diff is exactly the new field.

> [!NOTE]
> On non-tiered v2 teams the dropdown remains and is still a Temporal no-op (the serializer only writes the column; nothing syncs the schedule spec from it). Whether to make it write through or remove it there is a product decision this PR deliberately doesn't take -- the saved-query panel currently points those users at this control ("Edit the DAG schedule instead"), so removing it without a replacement would strand them.

## How did you test this code?

Red-first, in three rounds (I, or actually Claude, ran these):

- Field test: parameterized flag on/off, asserting `frequency_managed_by_nodes` tracks the flag on every row and the flag is evaluated exactly once per request. Failed before the serializer change (`AttributeError` on the missing import), passes after. Catches the field regressing or going N-per-request.
- Write-rejection tests: tiered + changed `sync_frequency` PATCH is a 400 with the message and the column unchanged; tiered + rename PATCH **with the unchanged frequency echoed, exactly as `dagsLogic.updateDag` sends it** is a 200; non-tiered + `sync_frequency` PATCH is a 200 with the column written (pins existing behavior). The 400 test failed with `200 != 400` before the guard existed; the realistic rename test failed with `400 != 200` against the first, compare-free version of the guard.

`pytest products/data_modeling/backend/tests/api/test_dag_api.py` — 25 passed.
Repo-wide `mypy --cache-fine-grained .` clean, ruff clean, `pnpm --filter=@posthog/frontend fix` and `typescript:check` clean.

No jest test for the render ternary: there are no existing DagsTab tests and the API contract test covers the regression.
Not manually clicked through, since no local team is tiered by default. The tiered state is fixture-driven.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs cover this surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code ([session](https://claude.ai/code/session_018pJSWx71B1LvomzUAMg5V5)) under @sakce's direction, after the no-op was traced end to end in production during a tiered-schedules migration.
Skills invoked: /improving-drf-endpoints, /writing-tests, /adopting-generated-api-types, /fixing-flaky-tests.
The write-path rejection was added in a second round at @sakce's request after the first round only hid the control.
A third round fixed the Greptile P1 (the first guard rejected any supplied frequency, breaking renames because the frontend echoes the unchanged value on every PATCH; it now compares before rejecting).
Migrating `dagsLogic` off the manual `DataModelingDAG` type onto the generated `DagApi` client was considered and left for a follow-up, since it's a larger refactor than this fix warrants. The new field was added to the manual type in `frontend/src/types.ts`.
