### PR TITLE
feat(settings): link docs from the invite modal

### DIFF
--- a/frontend/src/scenes/settings/organization/InviteModal.tsx
+++ b/frontend/src/scenes/settings/organization/InviteModal.tsx
@@ -420,7 +420,14 @@ export function InviteModal({ isOpen, onClose }: { isOpen: boolean; onClose: () 
                         <p>
                             Invite others to your organization to collaborate together in PostHog. An invite is specific
                             to an email address and expires after 3 days. Name can be provided for the team member's
-                            convenience.
+                            convenience.{' '}
+                            <Link
+                                to="https://posthog.com/docs/settings/organizations#adding-new-members"
+                                target="_blank"
+                                targetBlankIcon
+                            >
+                                Docs
+                            </Link>
                         </p>
                     ) : (
                         <p>


### PR DESCRIPTION
## Problem

The invite modal explains the invite rules but anyone wanting more detail, most usefully the invite rate limits, has to go find the docs themselves.

## Changes

Adds a `Docs` link at the end of the modal description, pointing at the organization members docs. Uses the same `Link` with `target="_blank" targetBlankIcon` pattern already used elsewhere in this file, so it renders with the external-link icon like other in-app docs links.

## How did you test this code?

No automated tests were added. Ran the local stack and verified an identical `Docs` link renders correctly via Playwright, asserting text, `href`, `target="_blank"` and visibility. Ran `pnpm --filter=@posthog/frontend fix` (oxlint + oxfmt) clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Companion docs PRs: PostHog/posthog.com#18954 documents the invite rate limits, PostHog/posthog.com#18960 links them from the page this modal now points at.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)
