### PR TITLE
chore(ci): disable the scheduled pr conflict autoresolver

### DIFF
--- a/.agents/skills/autoresolving-pr-conflicts/SKILL.md
+++ b/.agents/skills/autoresolving-pr-conflicts/SKILL.md
@@ -53,7 +53,7 @@ Attempt state lives in a sticky PR comment ending with:
 
 One sticky comment per PR, upserted (update the existing comment if present, else create).
 Skip any PR whose latest marker matches the current `(headRefOid, master OID)` pair.
-This format is shared with the CI-based implementation proposed in PR #73036, so never assume this loop is the marker's only writer.
+This format is shared with the CI-based implementation in `.github/workflows/pr-autoresolve-conflicts.yml`, so never assume this loop is the marker's only writer.
 
 Marker state is only trusted from our own App: a commenter could otherwise plant a marker to fake "already attempted" and get a PR skipped.
 The helper filters to comments authored by `AUTORESOLVE_BOT_LOGIN` (the Loop App's `<slug>[bot]` login), which must be set in the run environment; it fails closed without it.

--- a/.agents/skills/autoresolving-pr-conflicts/references/loop-setup.md
+++ b/.agents/skills/autoresolving-pr-conflicts/references/loop-setup.md
@@ -73,6 +73,7 @@ Keep that boundary least-privilege:
 
 ## Relationship to the CI implementation
 
-PR #73036 proposes the same job as a GitHub Actions workflow.
-Both use the same `autoresolve-attempt` marker format, so if both end up deployed they never double-attempt the same `(head, master)` state.
-Prefer running exactly one of them long-term; the Loop version keeps API traffic on a dedicated rate-limit bucket and burns no Actions runners.
+`.github/workflows/pr-autoresolve-conflicts.yml` runs the same job as a GitHub Actions workflow.
+Its schedule is disabled and it stays dispatchable by hand, so it is a fallback rather than a second scheduled sweep.
+Both write the same `autoresolve-attempt` marker format, so if both do end up running they never double-attempt the same `(head, master)` state.
+Keep exactly one of them scheduled; the Loop version keeps API traffic on a dedicated rate-limit bucket and burns no Actions runners.

--- a/.github/workflows/pr-autoresolve-conflicts.yml
+++ b/.github/workflows/pr-autoresolve-conflicts.yml
@@ -1,20 +1,24 @@
 name: Auto-resolve PR conflicts
 
-# Resolves conflicts on every open same-repo PR targeting master, on a schedule, before the author
-# looks. Forks are skipped (can't be pushed to). Never auto-merges. Graphite-stacked PRs (base
-# `graphite-base/*`) can't be merged with master, so they're flagged for the author to restack.
+# Resolves conflicts on every open same-repo PR targeting master, before the author looks. Forks are
+# skipped (can't be pushed to). Never auto-merges. Graphite-stacked PRs (base `graphite-base/*`)
+# can't be merged with master, so they're flagged for the author to restack.
+#
+# Manual dispatch only — the 15-minute schedule is disabled. The same sweep now runs as a Loop
+# (.agents/skills/autoresolving-pr-conflicts), which burns no Actions runners and keeps its GitHub
+# API traffic on a dedicated rate-limit bucket. Both write the same `autoresolve-attempt` marker, so
+# running both would be redundant rather than harmful. To fall back to this implementation, restore
+# the `schedule:` trigger below and pause the Loop.
 #
 # Deterministic fixes (lockfiles, migration numbering, generated types) skip the model; the backend
 # stack comes up only for `build:openapi`. A marker comment records the last-attempted (head, master)
-# so nothing re-runs on an unchanged conflict. Polling batches conflicts, which is cheaper than a run
-# per merge; runs on GitHub-hosted runners (cheapest for a public repo).
+# so nothing re-runs on an unchanged conflict. Runs on GitHub-hosted runners (cheapest for a public
+# repo).
 #
 # Token safety (as in pr-resolve-outdated-bot-comments.yml): `resolve` runs PR-controlled code with
 # NO write token; `finalize` holds the App token but only consumes result DATA via trusted scripts.
 
 on:
-    schedule:
-        - cron: '*/15 * * * 1-5' # every 15 minutes, weekdays only (no point resolving over the weekend)
     workflow_dispatch:
         inputs:
             pr_number:


### PR DESCRIPTION
## Problem

We have two implementations of the same job: the GitHub Actions workflow in `.github/workflows/pr-autoresolve-conflicts.yml` (added in #73036) and the Loop-based one added in #73298 (`.agents/skills/autoresolving-pr-conflicts/`). Running both on a schedule is redundant work.

`loop-setup.md` already said to pick one long-term. This picks the Loop.

## Changes

Dropped the 15-minute weekday cron from the workflow. Kept `workflow_dispatch`, so the workflow stays runnable by hand as a fallback instead of being deleted.

```diff
 on:
-    schedule:
-        - cron: '*/15 * * * 1-5'
     workflow_dispatch:
```

Also refreshed the header comment and two stale skill doc references that described the CI implementation as an unmerged proposal.

> [!NOTE]
> Nothing autoresolves conflicts on a schedule after this merges, until the Loop is created. That is intentional. To fall back, restore the `schedule:` trigger and pause the Loop.

Why the Loop over the workflow: it burns no Actions runners, and its GitHub API traffic sits on the App installation's own rate-limit bucket rather than the shared per-repo `GITHUB_TOKEN` pool that CI jobs compete over. Both write the same `autoresolve-attempt` marker, so if both ever run they still will not double-attempt the same `(head, master)` state.

## How did you test this code?

No automated tests here, this only removes a trigger. I (Claude) ran:

- `bin/hogli lint:workflows` - 6 checks pass across 105 workflows
- `bin/hogli ci:preflight` - 0 failures (workflow-lint and markdown-format triggered)

I did not dispatch the workflow manually to confirm `workflow_dispatch` still works on its own. The `pr_number` input path is unchanged and the `detect` job already reads it, so the risk is low, but a reviewer may want to dispatch it once after merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Skill docs updated in this PR. No posthog.com docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 via Claude Code. I was setting up the Loop from #73298 and hit the "prefer exactly one of them" note in `loop-setup.md`, so this disables the CI one first.

Considered deleting the workflow file outright. Kept it dispatchable instead: the Loop is not created yet, and if it does not work out, restoring a cron line beats resurrecting 480 lines of workflow from git history.

The two doc edits are in scope rather than drive-by. `loop-setup.md` described the CI implementation as "proposed in PR #73036", which is now wrong twice over: it merged, and its schedule is off. `SKILL.md` carried the same stale PR reference in the marker-format note.

Skills invoked: `/autoresolving-pr-conflicts` (read for context on the marker contract, not executed).

One thing I could not do: an unrelated modified `pnpm-lock.yaml` was sitting uncommitted in my worktree, which blocked merging master in. It is not mine, so I left it alone and pushed without the merge. The branch is behind master, but nothing here touches the lockfile.
