### PR TITLE
fix(tests): isolate temporal CI flakes

### DIFF
--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -949,16 +949,15 @@ async def test_run_workflow_revert_materialization(
 
     with (
         unittest.mock.patch("posthog.temporal.data_modeling.run_workflow.hogql_table", mock_hogql_table),
-        unittest.mock.patch(
-            "posthog.temporal.data_modeling.run_workflow.get_query_row_count",
-            new_callable=unittest.mock.AsyncMock,
-            return_value=0,
-        ),
+        unittest.mock.patch("posthog.temporal.data_modeling.run_workflow.get_query_row_count", return_value=0),
         unittest.mock.patch("posthog.temporal.data_modeling.run_workflow.get_s3_client"),
+        # Reaches object storage before hogql_table runs; left real, an unready bucket fails into
+        # the generic error branch, which satisfies every assertion below without reverting anything.
+        unittest.mock.patch("posthog.temporal.data_modeling.run_workflow._get_credentials", return_value={}),
         unittest.mock.patch("products.data_modeling.backend.logic.enrich_view_semantics._start_enrichment_workflow"),
         unittest.mock.patch(
             "products.data_warehouse.backend.logic.data_load.saved_query_service.delete_saved_query_schedule"
-        ),
+        ) as mock_delete_schedule,
     ):
         async with await WorkflowEnvironment.start_time_skipping() as env:
             async with temporalio.worker.Worker(
@@ -994,6 +993,10 @@ async def test_run_workflow_revert_materialization(
 
     await database_sync_to_async(saved_query.refresh_from_db)()
     assert saved_query.is_materialized is False
+    # Only the revert path clears latest_error and drops the schedule; the assertions above hold
+    # for any failed workflow, so these are what pin the revert.
+    assert saved_query.latest_error is None
+    mock_delete_schedule.assert_called_once()
 
 
 async def test_run_workflow_timeout_does_not_pause_schedule_without_consecutive_failures(

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -933,65 +933,67 @@ async def test_run_workflow_with_minio_bucket_with_errors(
 
 
 async def test_run_workflow_revert_materialization(
-    minio_client,
     ateam,
-    bucket_name,
-    pageview_events,
     saved_queries,
-    temporal_client,
-    test_time,
 ):
     workflow_id = str(uuid.uuid4())
-    inputs = RunWorkflowInputs(team_id=ateam.pk)
+    task_queue = "data-modeling-revert-test"
+    saved_query = saved_queries[0]
+    inputs = RunWorkflowInputs(
+        team_id=ateam.pk,
+        select=[Selector(label=saved_query.id.hex, ancestors=0, descendants=0)],
+    )
 
     def mock_hogql_table(_query, _team, _logger):
         raise Exception("Unknown table")
 
     with (
-        override_settings(
-            BUCKET_URL=f"s3://{bucket_name}",
-            DATAWAREHOUSE_LOCAL_ACCESS_KEY=settings.OBJECT_STORAGE_ACCESS_KEY_ID,
-            DATAWAREHOUSE_LOCAL_ACCESS_SECRET=settings.OBJECT_STORAGE_SECRET_ACCESS_KEY,
-            DATAWAREHOUSE_LOCAL_BUCKET_REGION="us-east-1",
-            DATAWAREHOUSE_BUCKET_DOMAIN="objectstorage:19000",
-        ),
-        freeze_time(test_time),
         unittest.mock.patch("posthog.temporal.data_modeling.run_workflow.hogql_table", mock_hogql_table),
+        unittest.mock.patch(
+            "posthog.temporal.data_modeling.run_workflow.get_query_row_count",
+            new_callable=unittest.mock.AsyncMock,
+            return_value=0,
+        ),
+        unittest.mock.patch("posthog.temporal.data_modeling.run_workflow.get_s3_client"),
+        unittest.mock.patch("products.data_modeling.backend.logic.enrich_view_semantics._start_enrichment_workflow"),
+        unittest.mock.patch(
+            "products.data_warehouse.backend.logic.data_load.saved_query_service.delete_saved_query_schedule"
+        ),
     ):
-        async with temporalio.worker.Worker(
-            temporal_client,
-            task_queue=settings.DATA_MODELING_TASK_QUEUE,
-            workflows=[RunWorkflow],
-            activities=[
-                start_run_activity,
-                build_dag_activity,
-                run_dag_activity,
-                finish_run_activity,
-                create_job_model_activity,
-                fail_jobs_activity,
-                cleanup_running_jobs_activity,
-            ],
-            workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
-        ):
-            # Ensure the team exists in the DB context before running workflow
-            await database_sync_to_async(Team.objects.get)(pk=ateam.pk)
-            await temporal_client.execute_workflow(
-                RunWorkflow.run,
-                inputs,
-                id=workflow_id,
-                task_queue=settings.DATA_MODELING_TASK_QUEUE,
-                retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
-                execution_timeout=dt.timedelta(seconds=30),
-            )
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with temporalio.worker.Worker(
+                env.client,
+                task_queue=task_queue,
+                workflows=[RunWorkflow],
+                activities=[
+                    start_run_activity,
+                    build_dag_activity,
+                    run_dag_activity,
+                    finish_run_activity,
+                    create_job_model_activity,
+                    fail_jobs_activity,
+                    cleanup_running_jobs_activity,
+                ],
+                workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
+            ):
+                # Ensure the team exists in the DB context before running workflow
+                await database_sync_to_async(Team.objects.get)(pk=ateam.pk)
+                await env.client.execute_workflow(
+                    RunWorkflow.run,
+                    inputs,
+                    id=workflow_id,
+                    task_queue=task_queue,
+                    retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
+                    execution_timeout=dt.timedelta(seconds=30),
+                )
 
     job = await DataModelingJob.objects.aget(workflow_id=workflow_id)
     assert job is not None
     assert job.status == DataModelingJob.Status.FAILED
     assert job.rows_materialized == 0
 
-    for query in saved_queries:
-        await database_sync_to_async(query.refresh_from_db)()
-        assert query.is_materialized is False
+    await database_sync_to_async(saved_query.refresh_from_db)()
+    assert saved_query.is_materialized is False
 
 
 async def test_run_workflow_timeout_does_not_pause_schedule_without_consecutive_failures(

--- a/posthog/temporal/tests/data_modeling/test_run_workflow.py
+++ b/posthog/temporal/tests/data_modeling/test_run_workflow.py
@@ -932,18 +932,7 @@ async def test_run_workflow_with_minio_bucket_with_errors(
     assert job.rows_materialized == 0
 
 
-async def test_run_workflow_revert_materialization(
-    ateam,
-    saved_queries,
-):
-    workflow_id = str(uuid.uuid4())
-    task_queue = "data-modeling-revert-test"
-    saved_query = saved_queries[0]
-    inputs = RunWorkflowInputs(
-        team_id=ateam.pk,
-        select=[Selector(label=saved_query.id.hex, ancestors=0, descendants=0)],
-    )
-
+async def test_materialize_model_reverts_materialization_on_unknown_table(ateam):
     def mock_hogql_table(_query, _team, _logger):
         raise Exception("Unknown table")
 
@@ -951,52 +940,39 @@ async def test_run_workflow_revert_materialization(
         unittest.mock.patch("posthog.temporal.data_modeling.run_workflow.hogql_table", mock_hogql_table),
         unittest.mock.patch("posthog.temporal.data_modeling.run_workflow.get_query_row_count", return_value=0),
         unittest.mock.patch("posthog.temporal.data_modeling.run_workflow.get_s3_client"),
-        # Reaches object storage before hogql_table runs; left real, an unready bucket fails into
-        # the generic error branch, which satisfies every assertion below without reverting anything.
+        # Reaches object storage before hogql_table runs, so an unready bucket would land in the
+        # generic error branch rather than the revert one under test.
         unittest.mock.patch("posthog.temporal.data_modeling.run_workflow._get_credentials", return_value={}),
         unittest.mock.patch("products.data_modeling.backend.logic.enrich_view_semantics._start_enrichment_workflow"),
         unittest.mock.patch(
             "products.data_warehouse.backend.logic.data_load.saved_query_service.delete_saved_query_schedule"
-        ) as mock_delete_schedule,
+        ),
     ):
-        async with await WorkflowEnvironment.start_time_skipping() as env:
-            async with temporalio.worker.Worker(
-                env.client,
-                task_queue=task_queue,
-                workflows=[RunWorkflow],
-                activities=[
-                    start_run_activity,
-                    build_dag_activity,
-                    run_dag_activity,
-                    finish_run_activity,
-                    create_job_model_activity,
-                    fail_jobs_activity,
-                    cleanup_running_jobs_activity,
-                ],
-                workflow_runner=temporalio.worker.UnsandboxedWorkflowRunner(),
-            ):
-                # Ensure the team exists in the DB context before running workflow
-                await database_sync_to_async(Team.objects.get)(pk=ateam.pk)
-                await env.client.execute_workflow(
-                    RunWorkflow.run,
-                    inputs,
-                    id=workflow_id,
-                    task_queue=task_queue,
-                    retry_policy=temporalio.common.RetryPolicy(maximum_attempts=1),
-                    execution_timeout=dt.timedelta(seconds=30),
-                )
+        saved_query = await DataWarehouseSavedQuery.objects.acreate(
+            team=ateam,
+            name="my_model",
+            query={"query": "select 1 as one", "kind": "HogQLQuery"},
+            is_materialized=True,
+            sync_frequency_interval=dt.timedelta(hours=1),
+            status=DataWarehouseSavedQuery.Status.COMPLETED,
+        )
+        job = await database_sync_to_async(DataModelingJob.objects.create)(
+            team=ateam,
+            status=DataModelingJob.Status.RUNNING,
+            workflow_id=str(uuid.uuid4()),
+        )
 
-    job = await DataModelingJob.objects.aget(workflow_id=workflow_id)
-    assert job is not None
+        with pytest.raises(Exception, match="Table reference missing"):
+            await materialize_model(saved_query.id.hex, ateam, saved_query, job, unittest.mock.AsyncMock())
+
+    await database_sync_to_async(job.refresh_from_db)()
     assert job.status == DataModelingJob.Status.FAILED
     assert job.rows_materialized == 0
 
     await database_sync_to_async(saved_query.refresh_from_db)()
     assert saved_query.is_materialized is False
-    # Only the revert path clears latest_error and drops the schedule; the assertions above hold
-    # for any failed workflow, so these are what pin the revert.
-    assert saved_query.latest_error is None
-    mock_delete_schedule.assert_called_once()
+    assert saved_query.sync_frequency_interval is None
+    assert saved_query.status is None
 
 
 async def test_run_workflow_timeout_does_not_pause_schedule_without_consecutive_failures(

--- a/posthog/temporal/tests/utils/events.py
+++ b/posthog/temporal/tests/utils/events.py
@@ -14,6 +14,8 @@ from posthog.models.raw_sessions.sessions_v2 import RAW_SESSION_TABLE_BACKFILL_S
 from posthog.temporal.common.clickhouse import ClickHouseClient, ClickHouseError
 from posthog.temporal.tests.utils.datetimes import date_range
 
+# Far enough above any real test team's sequential pk that synthetic rows can never
+# land on a team a later test asserts counts for.
 OTHER_TEAM_ID_OFFSET = 1_000_000_000
 
 

--- a/posthog/temporal/tests/utils/events.py
+++ b/posthog/temporal/tests/utils/events.py
@@ -14,6 +14,8 @@ from posthog.models.raw_sessions.sessions_v2 import RAW_SESSION_TABLE_BACKFILL_S
 from posthog.temporal.common.clickhouse import ClickHouseClient, ClickHouseError
 from posthog.temporal.tests.utils.datetimes import date_range
 
+OTHER_TEAM_ID_OFFSET = 1_000_000_000
+
 
 @retry(
     retry=retry_if_exception_type(
@@ -279,7 +281,7 @@ async def generate_test_events_in_clickhouse(
     # Events generated for a different team
     events_from_other_team = generate_test_events(
         count=count_other_team,
-        team_id=team_id + random.randint(1, 1000),
+        team_id=team_id + OTHER_TEAM_ID_OFFSET,
         possible_datetimes=possible_datetimes,
         event_name=event_name,
         properties=properties,


### PR DESCRIPTION
## Problem

- Synthetic "other team" events used `team_id + random.randint(1, 1000)`, which can land on another test's sequential team id and add exactly 10 rows: [records_total flake](https://github.com/PostHog/posthog/actions/runs/30274094448) and [exclude_events flake](https://github.com/PostHog/posthog/actions/runs/30268631287), both `assert 1015 == 1005`.
- `test_run_workflow_revert_materialization` booted a Temporal worker on the shared task queue and called S3 inside a 30 second timeout: [WorkflowFailureError](https://github.com/PostHog/posthog/actions/runs/30271601064).

## Changes

- Synthetic team rows get a fixed distant offset instead of a random near-real one.
- The revert test drops to a direct [`materialize_model`](https://github.com/PostHog/posthog/blob/cb2002a2c5aa9b0301c9b5574980074c87431953/posthog/temporal/tests/data_modeling/test_run_workflow.py#L935) call, which is how seven other tests in the file already exercise it. Its saved query starts materialized, so the assertions are real state flips rather than model defaults.

### Why this is a fair trade

The workflow harness was carrying one branch: [`elif "Unknown table"` routes to `revert_materialization`](https://github.com/PostHog/posthog/blob/cb2002a2c5aa9b0301c9b5574980074c87431953/posthog/temporal/data_modeling/run_workflow.py#L637-L647). Everything else it touched is already covered closer to the code:

| If this regresses | What fails |
|---|---|
| the `"Unknown table"` branch stops reverting | this test |
| `revert_materialization` itself (state, table soft-delete, model paths, schedule delete, rollback) | `TestRevertMaterialization`, 4 cases, no ClickHouse or Temporal |
| the workflow stops marking a job FAILED on model error | `test_run_workflow_with_minio_bucket_with_errors`, real Worker, same assertions |
| `materialize_model` output | the 7 existing direct tests |

Net: same unique coverage, no shared Temporal state, no object storage, 62s of CI down to 0.40s.

## How did you test this code?

- Two negative controls on the new test: a non-"Unknown table" error fails the `pytest.raises` match, and stubbing `revert_materialization` fails on `is_materialized`. Both passed the assertions this PR started with, which is what prompted the rewrite.
- [All 14 Temporal shards green](https://github.com/PostHog/posthog/actions/runs/30300647723) on the previous revision: revert test in shard 3, internal-stage tests in shard 12.
- Locally: forced collision 4 passed, batch stress 40 passed, full file 41 passed / 2 skipped.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable; test-only changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used /wt, /fixing-flaky-tests, /writing-tests and /writing-code-comments. I then had Claude Code run /code-review and /simplify.
- The review caught the one real S3 call left in the path: `_get_credentials` runs before the mocked `hogql_table` and creates the bucket, so an unready object store failed into the generic error branch while every assertion still passed.
- The first attempt kept the workflow harness and added a `select`. Rerunning without the selector produced an identical DAG, since `build_dag_from_selectors` walks every matched path. Asking what the test still uniquely proved is what moved it down to `materialize_model`.

