### PR TITLE
chore(replay): cover reported filter combinations in listing tests

### DIFF
--- a/posthog/session_recordings/queries/test/listing_recordings/test_session_recording_list_operands_queries.py
+++ b/posthog/session_recordings/queries/test/listing_recordings/test_session_recording_list_operands_queries.py
@@ -16,6 +16,22 @@ from posthog.session_recordings.queries.test.listing_recordings.test_utils impor
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
 from posthog.session_recordings.sql.session_replay_event_sql import TRUNCATE_SESSION_REPLAY_EVENTS_TABLE_SQL
 
+# the filter shape reported in #41687: two different events, the first carrying two of its own properties
+FLAG_CALLED_WITH_PROPERTIES = {
+    "id": "$feature_flag_called",
+    "name": "$feature_flag_called",
+    "type": "events",
+    "properties": [
+        {"key": "$feature_flag_response", "type": "event", "value": ["test"], "operator": "exact"},
+        {"key": "$feature_flag", "type": "event", "value": "onboarding-questionnaire", "operator": "exact"},
+    ],
+}
+ONBOARDING_INITIALIZED = {
+    "id": "onboarding-initialized",
+    "name": "onboarding-initialized",
+    "type": "events",
+}
+
 
 @freeze_time("2021-01-01T13:46:23")
 class TestSessionRecordingsListOperandsQueries(ClickhouseTestMixin, APIBaseTest):
@@ -192,6 +208,78 @@ class TestSessionRecordingsListOperandsQueries(ClickhouseTestMixin, APIBaseTest)
                 ],
             },
             [self.non_target_non_vip_session, self.non_target_vip_session, self.target_non_vip_session],
+        )
+
+    def _a_session_with_named_events(self, events: list[tuple[str, dict]], duration_seconds: int = 30) -> str:
+        session_id = str(uuid7())
+        user_id = str(uuid7())
+
+        produce_replay_summary(
+            distinct_id=user_id,
+            session_id=session_id,
+            first_timestamp=self.an_hour_ago,
+            last_timestamp=self.an_hour_ago + relativedelta(seconds=duration_seconds),
+            team_id=self.team.id,
+        )
+
+        for event_name, properties in events:
+            create_event(
+                team=self.team,
+                distinct_id=user_id,
+                timestamp=self.an_hour_ago,
+                event_name=event_name,
+                properties={"$session_id": session_id, "$window_id": "1", **properties},
+            )
+
+        return session_id
+
+    def _sessions_for_two_distinct_event_filters(self) -> tuple[str, str, str]:
+        matching_flag_event = (
+            "$feature_flag_called",
+            {"$feature_flag_response": "test", "$feature_flag": "onboarding-questionnaire"},
+        )
+        both = self._a_session_with_named_events([matching_flag_event, ("onboarding-initialized", {})])
+        only_flag = self._a_session_with_named_events([matching_flag_event])
+        only_onboarding = self._a_session_with_named_events([("onboarding-initialized", {})])
+        return both, only_flag, only_onboarding
+
+    def test_two_distinct_event_filters_anded_requires_both_events(self):
+        both, _only_flag, _only_onboarding = self._sessions_for_two_distinct_event_filters()
+
+        self._assert_query_matches_session_ids(
+            {"operand": "AND", "events": [FLAG_CALLED_WITH_PROPERTIES, ONBOARDING_INITIALIZED]},
+            [both],
+        )
+
+    def test_two_distinct_event_filters_ored_accepts_either_event(self):
+        both, only_flag, only_onboarding = self._sessions_for_two_distinct_event_filters()
+
+        self._assert_query_matches_session_ids(
+            {"operand": "OR", "events": [FLAG_CALLED_WITH_PROPERTIES, ONBOARDING_INITIALIZED]},
+            [both, only_flag, only_onboarding],
+        )
+
+    @parameterized.expand([("and_operand", "AND"), ("or_operand", "OR")])
+    def test_duration_control_still_excludes_sessions_matching_event_filters(self, _name: str, operand: str):
+        short_session = self._a_session_with_named_events([("onboarding-initialized", {})], duration_seconds=10)
+        long_session = self._a_session_with_named_events([("onboarding-initialized", {})], duration_seconds=120)
+
+        self._assert_query_matches_session_ids(
+            {
+                "operand": operand,
+                "events": [ONBOARDING_INITIALIZED],
+                "having_predicates": '[{"type":"recording","key":"duration","value":45,"operator":"lt"}]',
+            },
+            [short_session],
+        )
+
+        self._assert_query_matches_session_ids(
+            {
+                "operand": operand,
+                "events": [ONBOARDING_INITIALIZED],
+                "having_predicates": '[{"type":"recording","key":"duration","value":45,"operator":"gt"}]',
+            },
+            [long_session],
         )
 
 


### PR DESCRIPTION
## Problem

#41687 reports that replay filters return the wrong sessions, with three symptoms: sessions longer than the duration bound, sessions missing the filtered events, and no difference between match-all and match-any.

I went through it against master. The third symptom was real and is already fixed: both filter converters read the operand only from the **outer** filter group and flattened the inner group away, so a match-any toggle that landed on the inner group was silently treated as AND. [PR #65388](https://github.com/PostHog/posthog/pull/65388) fixed that in June by deriving the operand from anywhere in the tree. The reported payload has exactly that shape (outer AND wrapping an inner AND), so toggling the operand genuinely did nothing when the issue was filed.

The other two symptoms don't reproduce, and the reason no one could tell is that the gaps in our coverage sat exactly where the report pointed:

- The operand tests only ever used the **same** event id twice with different properties. Nothing covered two *different* events each carrying their own property filters, which is what the reporter had. A regression in per-entity property scoping (hoisting entity properties into the shared property list, an easy refactor to make) would decouple properties from their event and pass every existing test.
- `test_duration_always_anded_with_visited_page_under_or` covers the duration control against a recording property, but not against event filters. Those are different paths: event filters become per-filter session-id subqueries combined by the operand, while the duration control is a separate always-AND'd HAVING predicate. Nothing pinned that the two compose.

## Changes

Four tests, using the reporter's actual filter shape (`$feature_flag_called` with two of its own property filters, plus `onboarding-initialized`):

- match-all over two distinct events requires a session to contain **both**
- match-any over the same two accepts a session containing **either**
- the duration control still excludes sessions that match the event filters, parameterized over both operands and both bound directions

No production code changes. This is coverage plus a written-down answer for the next person who reads that issue.

## How did you test this code?

`pytest posthog/session_recordings/queries/test/listing_recordings/test_session_recording_list_operands_queries.py` — 12 passed (my 4 plus the 8 that were there, 5 snapshots unchanged), 13s locally against ClickHouse.

I verified each new test fails for the right reason rather than trusting that it passes: the AND case is the one that would go green-but-wrong under property hoisting, so it asserts the exact session set rather than a count.

What I could not do: confirm the reporter's own two symptoms against their data. The link in the issue points at a customer project from November 2025 and those recordings are long past retention, so the screenshot is the only surviving evidence. That's why this PR doesn't auto-close the issue.

> [!NOTE]
> Suggest closing #41687 as fixed by #65388 once someone's happy with the reasoning above. If a customer can still reproduce a duration or event-matching miss on current master, that's a new report with fresh data rather than this one.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) did this while working through the open `feature/replay` backlog. Skills invoked: `/superpowers:systematic-debugging` and `/writing-tests`.

Route I took, in case it saves a reviewer time: I started from a hypothesis that entity-level property filters were being flattened into the shared property list, which would explain "sessions that don't contain the filtered events" exactly. Reading `_event_predicates` in `events_subquery.py` killed that idea (each entity's properties are AND'd with its own event expression before becoming a subquery), so the tests here lock in the behavior I'd expected to find broken instead. The duration test exists because the routing between always-AND'd `having_predicates` and operand-following `_operand_having_predicates` is a genuinely fragile distinction that the code comments flag but no test covered for event filters.

Per `/writing-tests` I dropped a fourth idea (asserting the generated HogQL contained a particular AND/OR structure) as a change-detector test. These four assert result sets through the query runner instead.
