### PR TITLE
fix(data-imports): back off full interval after duckgres enablement refresh failure

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
@@ -182,7 +182,11 @@ class DuckgresBatchConsumerAdapter:
             if self._team_ids_fetched_at is None:
                 # Never had a set: claim nothing rather than everything.
                 self._team_ids = []
-                self._team_ids_fetched_at = now
+            # Always advance the timestamp, even on failure: otherwise a control-plane
+            # outage that starts after a successful resolution leaves it stuck in the
+            # past, and every poll tick (~2s) re-triggers this branch instead of the
+            # intended ENABLEMENT_REFRESH_SECONDS backoff.
+            self._team_ids_fetched_at = now
         return self._team_ids
 
     async def _run_maintenance(self, conn: psycopg.AsyncConnection[Any], team_ids: list[int] | None) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_consumer.py
@@ -16,6 +16,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     PermanentBatchApplyError,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer import (
+    ENABLEMENT_REFRESH_SECONDS,
     DuckgresBatchConsumer,
     DuckgresBatchConsumerAdapter,
     DuckgresConsumerConfig,
@@ -453,6 +454,29 @@ class TestDuckgresEnablementGating:
         assert batches == []
         mock_planner.assert_not_called()
         mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_enablement_refresh_failure_after_success_waits_full_interval_before_retrying(self):
+        # A control-plane outage that starts after a prior successful resolution must
+        # back off for the full refresh interval, same as a fresh outage would — a
+        # stuck fetched_at previously made every ~2s poll tick retry immediately.
+        adapter = DuckgresBatchConsumerAdapter()
+        adapter._team_ids = [1, 2]
+        adapter._team_ids_fetched_at = time.monotonic() - ENABLEMENT_REFRESH_SECONDS - 1
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer.database_sync_to_async_pool",
+        ) as mock_wrapper:
+            mock_wrapper.return_value = AsyncMock(side_effect=RuntimeError("duckgres control plane unreachable"))
+
+            team_ids = await adapter._enabled_team_ids()
+            assert team_ids == [1, 2]
+            assert mock_wrapper.call_count == 1
+
+            # Polling again right away must not re-attempt the refresh.
+            team_ids_again = await adapter._enabled_team_ids()
+            assert team_ids_again == [1, 2]
+            assert mock_wrapper.call_count == 1
 
 
 class TestMidClaimRetire:


### PR DESCRIPTION
## Problem

Error tracking surfaced a `RuntimeError` ("duckgres control plane unreachable; keeping the previous sink enablement") from `products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/enablement.py`, raised through `DuckgresBatchConsumerAdapter._enabled_team_ids` in `consumer.py`.

`_enabled_team_ids` caches the duckgres-enabled team set and only re-resolves it every `ENABLEMENT_REFRESH_SECONDS` (60s) — the poll loop itself runs every ~2s. On a refresh failure, the `except` block correctly keeps the previous team set (so a transient blip doesn't blind the sink), but it only advanced `_team_ids_fetched_at` when this was the *very first* resolution ever attempted:

```python
except Exception as e:
    ...
    if self._team_ids_fetched_at is None:
        self._team_ids = []
        self._team_ids_fetched_at = now
```

Once a refresh had already succeeded at least once, a *later* failure left `_team_ids_fetched_at` stuck at its last successful timestamp. Since real time keeps advancing past it, the cache guard (`now - self._team_ids_fetched_at < ENABLEMENT_REFRESH_SECONDS`) never holds again, so every subsequent poll tick re-attempted the refresh instead of waiting for the intended 60s window — hammering the control plane during an outage and reporting the same error to error tracking roughly every 2 seconds instead of once per minute.

The sampled events for this issue all lacked any `warehouse_sources_*` sync context, consistent with the failure coming from this background cache refresh rather than any specific source/schema/sync.

## Changes

- `consumer.py`: `_enabled_team_ids` now always advances `_team_ids_fetched_at` on a refresh failure, not just on the first-ever resolution. The previous team set is still retained on failure (unchanged), but the next retry now waits the full `ENABLEMENT_REFRESH_SECONDS` interval instead of firing on every poll tick.

## How did you test this code?

Added `test_enablement_refresh_failure_after_success_waits_full_interval_before_retrying` in `test_consumer.py`, covering a refresh failure that happens *after* a prior successful resolution (the case the old code mishandled). It asserts the previous team set is retained and that a second immediate poll does not re-trigger the refresh. Verified it fails against the pre-fix code (2 refresh attempts instead of 1) and passes with the fix.

Ran:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_consumer.py -q` — 26 passed (3 pre-existing errors in `TestLiveApplyStamp` need a live Postgres connection and are unaffected by this change)
- `uv run mypy --cache-fine-grained .` — clean, 16964 files
- `ruff check` / `ruff format --check` — clean
- `hogli ci:preflight --fix` — 0 failures

## Docs update

N/A — internal reliability fix to a background cache refresh, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged this from a PostHog error-tracking webhook alert with no human steering the investigation. I pulled the issue's stack trace, impact, and sampled `$exception` events via the PostHog MCP error-tracking tools, confirmed all sampled events lacked `warehouse_sources_*` sync context (pointing at background/shared code rather than a specific source), then read `enablement.py` and `consumer.py` to trace the raise site back through `_enabled_team_ids`'s caching logic. Comparing the refresh-guard condition against the except-block's timestamp update revealed the bug: the timestamp only advances on the very first failure, so a later failure re-triggers on every ~2s poll tick instead of backing off for the full 60s window — which also matches the observed ~2s-apart event cadence in error tracking.

Checked for duplicates: searched open PRs by exception message, module path, and function name, and reviewed the maintainer's (Gilbert09) own open PRs. Found two related-but-distinct prior fixes in this same file/class ([#73565](https://github.com/PostHog/posthog/pull/73565), [#73649](https://github.com/PostHog/posthog/pull/73649)) that reclassify *timeout* exceptions so they're not double-reported to error tracking — neither touches the enablement cache or this retry-cadence bug, so this isn't a duplicate.

Invoked `/writing-tests` before adding the regression test.
---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*