### PR TITLE
fix(data-management): show correct default date on matching events

### DIFF
--- a/frontend/src/scenes/data-management/definition/DefinitionView.tsx
+++ b/frontend/src/scenes/data-management/definition/DefinitionView.tsx
@@ -146,6 +146,7 @@ export function DefinitionView(rawProps: DefinitionLogicProps): JSX.Element {
                 kind: NodeKind.EventsQuery,
                 select: columnsToUse,
                 event: definition.name,
+                after: '-24h',
             },
             full: true,
             showEventFilter: false,


### PR DESCRIPTION
## Problem

On the event definition page, the **Matching events** panel showed "No date range override" in the date picker while the query was actually running against the last 24 hours. The picker label and the data on screen disagreed, which is confusing.

## Changes

The panel built its `EventsQuery` without an explicit `after`. The backend query runner defaults an empty `after` to `-24h` (so it runs last 24h), but the `DateFilter` reads that same empty `after` and falls back to the `NO_OVERRIDE_RANGE_PLACEHOLDER` ("No date range override") label. Two consumers, one empty field, two interpretations.

The fix sets `after: '-24h'` directly on the query source, so the FE state matches what the backend actually runs and the picker resolves to "Last 24 hours". This mirrors how sibling `EventsQuery` surfaces already seed their default (the activity explore default sets `after: '-1h'`, and the definition tables seed `date_from: '-24h'`).

## How did you test this code?

I have not run the app manually. The change is a one-line default and I verified that `-24h` maps to the "Last 24 hours" option in `dateMapping` (`frontend/src/lib/utils/dateFilters.ts`). No tests added: this is a default-value change with no new branching logic to regress.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via PostHog Code) traced the mismatch from the picker label back through `DateRange.tsx` and `dateFilterLogic.ts` to the empty `after` on the query, then confirmed the `-24h` backend default in `events_query_runner.py`. Chose to seed the default on the query rather than touch the shared `DateFilter` placeholder, since insights and trends legitimately want the "No date range override" text when no override is set. No skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
