### PR TITLE
refactor(billing): rename member flag and harden usage/spend access

### DIFF
--- a/ee/api/billing.py
+++ b/ee/api/billing.py
@@ -34,7 +34,7 @@ logger = structlog.get_logger(__name__)
 
 BILLING_SERVICE_JWT_AUD = "posthog:license-key"
 
-MEMBER_BILLING_USAGE_ACCESS_FLAG = "member-billing-usage-access"
+MEMBER_BILLING_USAGE_SPEND_READ_ACCESS_FLAG = "member-billing-usage-spend-read-access"
 OWNER_ONLY_BILLING_FLAG = "owner-only-billing"
 
 
@@ -64,14 +64,15 @@ def _org_flag_enabled(flag_key: str, organization: Organization) -> bool:
     )
 
 
-class CanViewBillingUsage(permissions.BasePermission):
+class CanReadBillingUsageSpend(permissions.BasePermission):
     """
-    Permission for the read-only billing usage/spend endpoints. Org admins (level >= ADMIN) are
-    always allowed. Plain members are allowed only when the `member-billing-usage-access` flag is
-    enabled for the organization and `owner-only-billing` is not (evaluation fails closed).
+    Permission for the read-only billing usage/spend endpoints. The required membership level is
+    computed to mirror the frontend's getMinimumBillingUsageSpendReadAccessLevel: owner-only-billing
+    requires Owner, otherwise the member-billing-usage-spend-read-access flag lowers the bar to
+    Member, otherwise Admin is required. Flag evaluation fails closed.
     """
 
-    message = "You need to be an organization administrator to view billing usage data."
+    message = "You don't have access to billing usage data for this organization."
 
     def has_permission(self, request: Request, view: Any) -> bool:
         try:
@@ -81,11 +82,17 @@ class CanViewBillingUsage(permissions.BasePermission):
         membership = OrganizationMembership.objects.filter(user=cast(User, request.user), organization=org).first()
         if membership is None:
             return False
-        if membership.level >= OrganizationMembership.Level.ADMIN:
-            return True
-        return _org_flag_enabled(MEMBER_BILLING_USAGE_ACCESS_FLAG, org) and not _org_flag_enabled(
-            OWNER_ONLY_BILLING_FLAG, org
-        )
+        return membership.level >= self._minimum_level(org)
+
+    def _minimum_level(self, organization: Organization) -> int:
+        # owner-only-billing is evaluated before any admin short-circuit: when it is on, even admins
+        # are rejected here instead of relying on the billing service/cache to reject them later. This
+        # keeps the PostHog API, the frontend, and the billing service in agreement on precedence.
+        if _org_flag_enabled(OWNER_ONLY_BILLING_FLAG, organization):
+            return OrganizationMembership.Level.OWNER
+        if _org_flag_enabled(MEMBER_BILLING_USAGE_SPEND_READ_ACCESS_FLAG, organization):
+            return OrganizationMembership.Level.MEMBER
+        return OrganizationMembership.Level.ADMIN
 
 
 class BillingSerializer(serializers.Serializer):
@@ -587,7 +594,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["GET"],
         detail=False,
         url_path="usage",
-        permission_classes=[permissions.IsAuthenticated, CanViewBillingUsage],
+        permission_classes=[permissions.IsAuthenticated, CanReadBillingUsageSpend],
     )
     def usage(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         return self._usage_or_spend_response(request, self.get_billing_manager().get_usage_data)
@@ -596,7 +603,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         methods=["GET"],
         detail=False,
         url_path="spend",
-        permission_classes=[permissions.IsAuthenticated, CanViewBillingUsage],
+        permission_classes=[permissions.IsAuthenticated, CanReadBillingUsageSpend],
     )
     def spend(self, request: Request, *args: Any, **kwargs: Any) -> HttpResponse:
         """Endpoint to fetch spend data (proxy to billing service)."""
@@ -615,8 +622,7 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         # projects never reach the billing service (which cannot enforce per-team access itself).
         accessible_team_ids: Optional[list[int]] = None
         if not self._is_org_admin(request, organization):
-            user = cast(User, request.user)
-            accessible_team_ids = list(user.teams.filter(organization=organization).values_list("id", flat=True))
+            accessible_team_ids = self._member_accessible_team_ids(organization)
             accessible_set = set(accessible_team_ids)
             raw_team_ids = params_to_pass.get("team_ids")
             if raw_team_ids:
@@ -664,6 +670,27 @@ class BillingViewset(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         return OrganizationMembership.objects.filter(
             user=cast(User, request.user), organization=organization, level__gte=OrganizationMembership.Level.ADMIN
         ).exists()
+
+    def _member_accessible_team_ids(self, organization: Organization) -> list[int]:
+        """
+        Team ids in this organization the current user can access, mirroring the visibility rules in
+        OrganizationSerializer._fetch_visible_teams (new RBAC access levels + legacy project
+        membership) but scoped to the passed organization.
+
+        We deliberately avoid User.teams here: that property decides whether to apply private-project
+        filtering from the user's *first* organization, so a member of multiple orgs could otherwise
+        leak a private project from this org when their first org lacks the access-control feature.
+        This list is the security boundary — billing only receives an org id plus these team ids.
+        """
+        user_access_control = self.user_access_control
+        if user_access_control is not None:
+            teams = user_access_control.filter_queryset_by_access_level(
+                organization.teams.all(), include_all_if_admin=True
+            )
+        else:
+            teams = organization.teams.none()
+        teams = teams.filter(id__in=self.user_permissions.team_ids_visible_for_user)
+        return list(teams.values_list("id", flat=True))
 
     def _get_teams_map(self, organization: Organization, team_ids: Optional[Sequence[int]] = None) -> dict[int, str]:
         """

--- a/ee/api/test/test_billing.py
+++ b/ee/api/test/test_billing.py
@@ -19,10 +19,14 @@ from rest_framework import status
 
 from posthog.cloud_utils import TEST_clear_instance_license_cache, get_cached_instance_license
 from posthog.constants import AvailableFeature
-from posthog.models.organization import OrganizationMembership
+from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.team import Team
 
-from ee.api.billing import MEMBER_BILLING_USAGE_ACCESS_FLAG, OWNER_ONLY_BILLING_FLAG, BillingUsageRequestSerializer
+from ee.api.billing import (
+    MEMBER_BILLING_USAGE_SPEND_READ_ACCESS_FLAG,
+    OWNER_ONLY_BILLING_FLAG,
+    BillingUsageRequestSerializer,
+)
 from ee.api.test.base import APILicensedTest
 from ee.billing.billing_types import BillingPeriod, CustomerInfo, CustomerProduct
 from ee.billing.quota_limiting import QuotaResource
@@ -1223,7 +1227,7 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
         mock_flag_eval.side_effect = lambda key, *args, **kwargs: {
-            MEMBER_BILLING_USAGE_ACCESS_FLAG: member_access_flag,
+            MEMBER_BILLING_USAGE_SPEND_READ_ACCESS_FLAG: member_access_flag,
             OWNER_ONLY_BILLING_FLAG: owner_only_flag,
         }[key]
         mock_get_usage_data.return_value = self.MOCK_USAGE_DATA
@@ -1239,24 +1243,64 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
             expected_data = self.MOCK_USAGE_DATA if endpoint == "usage" else self.MOCK_SPEND_DATA
             self.assertEqual(response.json(), expected_data)
 
+    @parameterized.expand(
+        [
+            ("usage", False, status.HTTP_200_OK),
+            ("spend", False, status.HTTP_200_OK),
+            ("usage", True, status.HTTP_403_FORBIDDEN),
+            ("spend", True, status.HTTP_403_FORBIDDEN),
+        ]
+    )
+    @patch("ee.billing.billing_manager.BillingManager.get_spend_data")
+    @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
+    @patch("ee.api.billing.feature_enabled_or_false")
+    def test_admin_access_respects_owner_only_billing(
+        self,
+        endpoint: str,
+        owner_only_flag: bool,
+        expected_status: int,
+        mock_flag_eval: MagicMock,
+        mock_get_usage_data: MagicMock,
+        mock_get_spend_data: MagicMock,
+    ):
+        # Admins keep access without the member flag, but owner-only-billing must win even for
+        # admins so the PostHog API agrees with the frontend and the billing service. The member
+        # flag is off throughout, which also proves admin access does not depend on it.
+        mock_flag_eval.side_effect = lambda key, *args, **kwargs: {
+            MEMBER_BILLING_USAGE_SPEND_READ_ACCESS_FLAG: False,
+            OWNER_ONLY_BILLING_FLAG: owner_only_flag,
+        }[key]
+        mock_get_usage_data.return_value = self.MOCK_USAGE_DATA
+        mock_get_spend_data.return_value = self.MOCK_SPEND_DATA
+
+        response = self.client.get(f"/api/billing/{endpoint}/")
+
+        self.assertEqual(response.status_code, expected_status)
+        if expected_status == status.HTTP_403_FORBIDDEN:
+            mock_get_usage_data.assert_not_called()
+            mock_get_spend_data.assert_not_called()
+
     @parameterized.expand([("usage",), ("spend",)])
     @patch("ee.billing.billing_manager.BillingManager.get_spend_data")
     @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
     @patch("ee.api.billing.feature_enabled_or_false")
-    def test_admin_access_does_not_depend_on_flags(
+    def test_owner_access_with_owner_only_billing(
         self,
         endpoint: str,
         mock_flag_eval: MagicMock,
         mock_get_usage_data: MagicMock,
         mock_get_spend_data: MagicMock,
     ):
+        # owner-only-billing raises the required level to Owner; an owner still gets through.
+        self.organization_membership.level = OrganizationMembership.Level.OWNER
+        self.organization_membership.save()
+        mock_flag_eval.side_effect = lambda key, *args, **kwargs: key == OWNER_ONLY_BILLING_FLAG
         mock_get_usage_data.return_value = self.MOCK_USAGE_DATA
         mock_get_spend_data.return_value = self.MOCK_SPEND_DATA
 
         response = self.client.get(f"/api/billing/{endpoint}/")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        mock_flag_eval.assert_not_called()
 
     @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
     @patch("ee.api.billing.BillingViewset._get_teams_map")
@@ -1290,7 +1334,7 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
 
     @staticmethod
     def _member_access_flags(key: str, *args: Any, **kwargs: Any) -> bool:
-        return key == MEMBER_BILLING_USAGE_ACCESS_FLAG
+        return key == MEMBER_BILLING_USAGE_SPEND_READ_ACCESS_FLAG
 
     def _make_team_private(self, team: Team) -> None:
         AccessControl.objects.create(
@@ -1424,6 +1468,35 @@ class TestBillingUsageAndSpendAPI(APILicensedTest):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         mock_get_usage_data.assert_not_called()
+
+    @patch("ee.billing.billing_manager.BillingManager.get_usage_data")
+    @patch("ee.api.billing.feature_enabled_or_false")
+    def test_member_multi_org_does_not_leak_private_team_from_queried_org(
+        self, mock_flag_eval: MagicMock, mock_get_usage_data: MagicMock
+    ):
+        # Regression for the first-org mismatch: team scoping must follow the *queried* org's access
+        # controls, not User.teams (which derives private-project filtering from the user's first
+        # organization). Here the member also belongs to another org without the access-control
+        # feature; the queried org has it plus a private team the member cannot access. That private
+        # team must never be forwarded to, or returned from, the billing service.
+        private_team = self._setup_member_with_private_team()
+        other_org = Organization.objects.create(name="Other Org Without Access Control")
+        OrganizationMembership.objects.create(
+            user=self.user, organization=other_org, level=OrganizationMembership.Level.MEMBER
+        )
+        mock_flag_eval.side_effect = self._member_access_flags
+        mock_get_usage_data.return_value = {
+            "results": [{"data": [1, 2], "count": 2}],
+            "team_id_options": [self.team.pk, private_team.pk],
+        }
+
+        response = self.client.get("/api/billing/usage/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        passed_params = mock_get_usage_data.call_args[0][1]
+        self.assertEqual(passed_params["team_ids"], [self.team.pk])
+        self.assertEqual(passed_params["teams_map"], {self.team.pk: self.team.name})
+        self.assertEqual(response.json()["team_id_options"], [self.team.pk])
 
 
 class TestBillingPermissionDeniedForMembers(APILicensedTest):

--- a/frontend/bin/check-toolbar-graph.mjs
+++ b/frontend/bin/check-toolbar-graph.mjs
@@ -41,7 +41,7 @@ const FORBIDDEN_PACKAGES = [
 // Ratchet policy: when an edge is cut, lower the budget to lock it in; raise it only as a
 // conscious, reviewed decision in the PR that needs it. There is headroom for churn, but any
 // reintroduced leak jumps the graph back toward ~100 MiB and fails loudly.
-const TOTAL_INPUT_BYTES_BUDGET = 14_450_000
+const TOTAL_INPUT_BYTES_BUDGET = 14_436_000
 
 function fail(message) {
     console.error(`\n❌ ${message}`)

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -383,7 +383,7 @@ export const FEATURE_FLAGS = {
     MCP_ANALYTICS: 'mcp-analytics', // owner: #project-mcp-analytics
     MCP_ANALYTICS_INTENT_ROUTING: 'mcp-analytics-intent-routing', // owner: #project-mcp-analytics
     MCP_SERVERS: 'mcp-servers', // owner: #team-posthog-ai
-    MEMBER_BILLING_USAGE_ACCESS: 'member-billing-usage-access', // owner: @pawelcebula #team-billing, grants members read-only access to billing usage/spend tabs; owner-only-billing takes precedence
+    MEMBER_BILLING_USAGE_SPEND_READ_ACCESS: 'member-billing-usage-spend-read-access', // owner: @pawelcebula #team-billing, grants members read-only access to billing usage/spend tabs; owner-only-billing takes precedence
     MESSAGING_SES: 'messaging-ses', // owner #team-workflows
     METRICS: 'metrics', // owner: #team-apm (@jonmcwest, @frankh)
     NEW_TAB_PROJECT_EXPLORER: 'new-tab-project-explorer', // owner: #team-platform-ux

--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -58,7 +58,7 @@ export function Billing(): JSX.Element {
         showCreditCTAHero,
         showBillingHero,
         minimumBillingAccessLevel,
-        canOnlyViewBillingUsage,
+        canOnlyReadBillingUsageSpend,
         hasSupportAddonPlan,
     } = useValues(billingLogic)
     const { reportBillingShown } = useActions(billingLogic)
@@ -78,12 +78,12 @@ export function Billing(): JSX.Element {
         if (location.pathname === urls.organizationBilling() && featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]) {
             // View-only members can't see the Overview tab, so land them on Usage instead
             router.actions.replace(
-                urls.organizationBillingSection(canOnlyViewBillingUsage ? 'usage' : 'overview'),
+                urls.organizationBillingSection(canOnlyReadBillingUsageSpend ? 'usage' : 'overview'),
                 searchParams
             )
             return
         }
-    }, [featureFlags, location.pathname, searchParams, canOnlyViewBillingUsage])
+    }, [featureFlags, location.pathname, searchParams, canOnlyReadBillingUsageSpend])
 
     useEffect(() => {
         if (billing) {

--- a/frontend/src/scenes/billing/BillingSection.tsx
+++ b/frontend/src/scenes/billing/BillingSection.tsx
@@ -28,7 +28,7 @@ const tabs: { key: BillingSectionId; label: string }[] = [
 
 export function BillingSection(): JSX.Element {
     const { location, searchParams } = useValues(router)
-    const { canAccessBilling, canOnlyViewBillingUsage } = useValues(billingLogic)
+    const { canAccessBilling, canOnlyReadBillingUsageSpend } = useValues(billingLogic)
 
     const section = location.pathname.includes('spend')
         ? 'spend'
@@ -37,12 +37,12 @@ export function BillingSection(): JSX.Element {
           : 'overview'
 
     // View-only members have no access to the Overview tab, so send them to Usage instead.
-    // canOnlyViewBillingUsage is only true once org membership and flags are loaded, so admins never bounce.
+    // canOnlyReadBillingUsageSpend is only true once org membership and flags are loaded, so admins never bounce.
     useEffect(() => {
-        if (section === 'overview' && canOnlyViewBillingUsage) {
+        if (section === 'overview' && canOnlyReadBillingUsageSpend) {
             router.actions.replace(urls.organizationBillingSection('usage'))
         }
-    }, [section, canOnlyViewBillingUsage])
+    }, [section, canOnlyReadBillingUsageSpend])
 
     const visibleTabs = tabs.filter((tab) => tab.key !== 'overview' || canAccessBilling)
 

--- a/frontend/src/scenes/billing/BillingSpendView.tsx
+++ b/frontend/src/scenes/billing/BillingSpendView.tsx
@@ -27,9 +27,9 @@ import { BillingNoAccess } from './BillingNoAccess'
 import { billingSpendLogic } from './billingSpendLogic'
 
 export function BillingSpendView(): JSX.Element {
-    const { minimumBillingUsageAccessLevel } = useValues(billingLogic)
+    const { minimumBillingUsageSpendReadAccessLevel } = useValues(billingLogic)
     const restrictionReason = useRestrictedArea({
-        minimumAccessLevel: minimumBillingUsageAccessLevel,
+        minimumAccessLevel: minimumBillingUsageSpendReadAccessLevel,
         scope: RestrictionScope.Organization,
     })
     const logic = billingSpendLogic({ syncWithUrl: true })

--- a/frontend/src/scenes/billing/BillingUsage.tsx
+++ b/frontend/src/scenes/billing/BillingUsage.tsx
@@ -26,9 +26,9 @@ import { BillingNoAccess } from './BillingNoAccess'
 import { billingUsageLogic } from './billingUsageLogic'
 
 export function BillingUsage(): JSX.Element {
-    const { minimumBillingUsageAccessLevel } = useValues(billingLogic)
+    const { minimumBillingUsageSpendReadAccessLevel } = useValues(billingLogic)
     const restrictionReason = useRestrictedArea({
-        minimumAccessLevel: minimumBillingUsageAccessLevel,
+        minimumAccessLevel: minimumBillingUsageSpendReadAccessLevel,
         scope: RestrictionScope.Organization,
     })
     const logic = billingUsageLogic({ syncWithUrl: true })

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -10,7 +10,7 @@ import {
     buildUsageLimitApproachingMessage,
     buildUsageLimitExceededMessage,
     canAccessBilling,
-    canViewBillingUsage,
+    canReadBillingUsageSpend,
     convertAmountToUsage,
     convertLargeNumberToWords,
     convertUsageToAmount,
@@ -18,7 +18,7 @@ import {
     formatProductNames,
     formatWithDecimals,
     getMinimumBillingAccessLevel,
-    getMinimumBillingUsageAccessLevel,
+    getMinimumBillingUsageSpendReadAccessLevel,
     getProration,
     getUsageLimitConsequence,
     projectUsage,
@@ -670,22 +670,22 @@ describe('canAccessBilling', () => {
     })
 })
 
-describe('getMinimumBillingUsageAccessLevel', () => {
+describe('getMinimumBillingUsageSpendReadAccessLevel', () => {
     it.each([
         { memberAccess: false, ownerOnly: false, expected: OrganizationMembershipLevel.Admin },
         { memberAccess: true, ownerOnly: false, expected: OrganizationMembershipLevel.Member },
         { memberAccess: false, ownerOnly: true, expected: OrganizationMembershipLevel.Owner },
-        // owner-only-billing wins over member-billing-usage-access
+        // owner-only-billing wins over member-billing-usage-spend-read-access
         { memberAccess: true, ownerOnly: true, expected: OrganizationMembershipLevel.Owner },
     ])(
         'returns $expected for memberAccess=$memberAccess, ownerOnly=$ownerOnly',
         ({ memberAccess, ownerOnly, expected }) => {
-            expect(getMinimumBillingUsageAccessLevel(memberAccess, ownerOnly)).toBe(expected)
+            expect(getMinimumBillingUsageSpendReadAccessLevel(memberAccess, ownerOnly)).toBe(expected)
         }
     )
 })
 
-describe('canViewBillingUsage', () => {
+describe('canReadBillingUsageSpend', () => {
     it.each([
         { level: OrganizationMembershipLevel.Member, memberAccess: true, ownerOnly: false, expected: true },
         { level: OrganizationMembershipLevel.Member, memberAccess: true, ownerOnly: true, expected: false },
@@ -697,7 +697,7 @@ describe('canViewBillingUsage', () => {
     ])(
         'returns $expected for level=$level, memberAccess=$memberAccess, ownerOnly=$ownerOnly',
         ({ level, memberAccess, ownerOnly, expected }) => {
-            expect(canViewBillingUsage(level, memberAccess, ownerOnly)).toBe(expected)
+            expect(canReadBillingUsageSpend(level, memberAccess, ownerOnly)).toBe(expected)
         }
     )
 })

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -445,9 +445,9 @@ export function canAccessBilling(membershipLevel: number | null | undefined, own
 
 /**
  * Returns the minimum membership level required for read-only access to the billing usage/spend tabs.
- * The member-billing-usage-access feature flag lowers it to Member, but owner-only-billing takes precedence.
+ * The member-billing-usage-spend-read-access feature flag lowers it to Member, but owner-only-billing takes precedence.
  */
-export function getMinimumBillingUsageAccessLevel(
+export function getMinimumBillingUsageSpendReadAccessLevel(
     memberBillingUsageAccess: boolean,
     ownerOnlyBilling: boolean
 ): OrganizationMembershipLevel {
@@ -460,7 +460,7 @@ export function getMinimumBillingUsageAccessLevel(
 /**
  * Determines if the user can view the read-only billing usage/spend tabs based on their org membership level.
  */
-export function canViewBillingUsage(
+export function canReadBillingUsageSpend(
     membershipLevel: number | null | undefined,
     memberBillingUsageAccess: boolean,
     ownerOnlyBilling: boolean
@@ -468,7 +468,7 @@ export function canViewBillingUsage(
     if (!membershipLevel) {
         return false
     }
-    return membershipLevel >= getMinimumBillingUsageAccessLevel(memberBillingUsageAccess, ownerOnlyBilling)
+    return membershipLevel >= getMinimumBillingUsageSpendReadAccessLevel(memberBillingUsageAccess, ownerOnlyBilling)
 }
 
 /**

--- a/frontend/src/scenes/billing/billingLogic.tsx
+++ b/frontend/src/scenes/billing/billingLogic.tsx
@@ -38,9 +38,9 @@ import {
     buildUsageLimitApproachingMessage,
     buildUsageLimitExceededMessage,
     canAccessBilling as canAccessBillingUtil,
-    canViewBillingUsage as canViewBillingUsageUtil,
+    canReadBillingUsageSpend as canReadBillingUsageSpendUtil,
     getMinimumBillingAccessLevel,
-    getMinimumBillingUsageAccessLevel,
+    getMinimumBillingUsageSpendReadAccessLevel,
 } from './billing-utils'
 import { DEFAULT_ESTIMATED_MONTHLY_CREDIT_AMOUNT_USD } from './CreditCTAHero'
 
@@ -197,8 +197,8 @@ export interface billingLogicValues {
     billingPeriodUTC: BillingPeriod
     billingPlan: BillingPlan | null
     canAccessBilling: boolean
-    canOnlyViewBillingUsage: boolean
-    canViewBillingUsage: boolean
+    canOnlyReadBillingUsageSpend: boolean
+    canReadBillingUsageSpend: boolean
     computedDiscount: number | null
     creditBrackets: any[]
     creditDiscount: number
@@ -252,7 +252,7 @@ export interface billingLogicValues {
     isPurchaseCreditsModalOpen: boolean
     isUnlicensedDebug: boolean
     minimumBillingAccessLevel: OrganizationMembershipLevel
-    minimumBillingUsageAccessLevel: OrganizationMembershipLevel
+    minimumBillingUsageSpendReadAccessLevel: OrganizationMembershipLevel
     platformAddons: BillingProductV2AddonType[]
     productSpecificAlert: BillingAlertConfig | null
     products: BillingProductV2Type[]
@@ -608,12 +608,12 @@ export interface billingLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
         minimumBillingAccessLevel: (featureFlags: FeatureFlagsSet) => OrganizationMembershipLevel
         canAccessBilling: (currentOrganization: OrganizationType | null, featureFlags: FeatureFlagsSet) => boolean
-        minimumBillingUsageAccessLevel: (featureFlags: FeatureFlagsSet) => OrganizationMembershipLevel
-        canViewBillingUsage: (currentOrganization: OrganizationType | null, featureFlags: FeatureFlagsSet) => boolean
-        canOnlyViewBillingUsage: (canViewBillingUsage: boolean, canAccessBilling: boolean) => boolean
+        minimumBillingUsageSpendReadAccessLevel: (featureFlags: FeatureFlagsSet) => OrganizationMembershipLevel
+        canReadBillingUsageSpend: (currentOrganization: OrganizationType | null, featureFlags: FeatureFlagsSet) => boolean
+        canOnlyReadBillingUsageSpend: (canReadBillingUsageSpend: boolean, canAccessBilling: boolean) => boolean
         billingEntryUrl: (
             canAccessBilling: boolean,
-            canOnlyViewBillingUsage: boolean,
+            canOnlyReadBillingUsageSpend: boolean,
             featureFlags: FeatureFlagsSet
         ) => string | null
         upgradeLink: (preflight: PreflightStatus | null) => string
@@ -1056,33 +1056,33 @@ export const billingLogic = kea<billingLogicType>([
                     !!featureFlags[FEATURE_FLAGS.OWNER_ONLY_BILLING]
                 ),
         ],
-        minimumBillingUsageAccessLevel: [
+        minimumBillingUsageSpendReadAccessLevel: [
             (s) => [s.featureFlags],
             (featureFlags: FeatureFlagsSet): OrganizationMembershipLevel =>
-                getMinimumBillingUsageAccessLevel(
-                    !!featureFlags[FEATURE_FLAGS.MEMBER_BILLING_USAGE_ACCESS],
+                getMinimumBillingUsageSpendReadAccessLevel(
+                    !!featureFlags[FEATURE_FLAGS.MEMBER_BILLING_USAGE_SPEND_READ_ACCESS],
                     !!featureFlags[FEATURE_FLAGS.OWNER_ONLY_BILLING]
                 ),
         ],
-        canViewBillingUsage: [
+        canReadBillingUsageSpend: [
             (s) => [s.currentOrganization, s.featureFlags],
             (currentOrganization: OrganizationType | null, featureFlags: FeatureFlagsSet): boolean =>
-                canViewBillingUsageUtil(
+                canReadBillingUsageSpendUtil(
                     currentOrganization?.membership_level,
-                    !!featureFlags[FEATURE_FLAGS.MEMBER_BILLING_USAGE_ACCESS],
+                    !!featureFlags[FEATURE_FLAGS.MEMBER_BILLING_USAGE_SPEND_READ_ACCESS],
                     !!featureFlags[FEATURE_FLAGS.OWNER_ONLY_BILLING]
                 ),
         ],
-        canOnlyViewBillingUsage: [
-            (s) => [s.canViewBillingUsage, s.canAccessBilling],
-            (canViewBillingUsage: boolean, canAccessBilling: boolean): boolean =>
-                canViewBillingUsage && !canAccessBilling,
+        canOnlyReadBillingUsageSpend: [
+            (s) => [s.canReadBillingUsageSpend, s.canAccessBilling],
+            (canReadBillingUsageSpend: boolean, canAccessBilling: boolean): boolean =>
+                canReadBillingUsageSpend && !canAccessBilling,
         ],
         billingEntryUrl: [
-            (s) => [s.canAccessBilling, s.canOnlyViewBillingUsage, s.featureFlags],
+            (s) => [s.canAccessBilling, s.canOnlyReadBillingUsageSpend, s.featureFlags],
             (
                 canAccessBilling: boolean,
-                canOnlyViewBillingUsage: boolean,
+                canOnlyReadBillingUsageSpend: boolean,
                 featureFlags: FeatureFlagsSet
             ): string | null => {
                 const usageSpendDashboards = !!featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]
@@ -1093,7 +1093,7 @@ export const billingLogic = kea<billingLogicType>([
                 }
                 // Without the tabbed dashboards, the only billing surface is the admin-only Overview,
                 // so view-only members get no entry point
-                if (canOnlyViewBillingUsage && usageSpendDashboards) {
+                if (canOnlyReadBillingUsageSpend && usageSpendDashboards) {
                     return urls.organizationBillingSection('usage')
                 }
                 return null

--- a/frontend/src/scenes/billing/billingSpendLogic.ts
+++ b/frontend/src/scenes/billing/billingSpendLogic.ts
@@ -73,7 +73,7 @@ export interface BillingSpendLogicProps {
 export interface billingSpendLogicValues {
     billing: BillingType | null // billingLogic
     billingPeriodUTC: BillingPeriod // billingLogic
-    canViewBillingUsage: boolean // billingLogic
+    canReadBillingUsageSpend: boolean // billingLogic
     currentOrganization: OrganizationType | null // billingLogic
     isHobby: boolean // preflightLogic
     billingPeriodMarkers: BillingPeriodMarker[]
@@ -245,7 +245,7 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
     connect(() => ({
         values: [
             billingLogic,
-            ['billing', 'billingPeriodUTC', 'canViewBillingUsage', 'currentOrganization'],
+            ['billing', 'billingPeriodUTC', 'canReadBillingUsageSpend', 'currentOrganization'],
             preflightLogic,
             ['isHobby'],
         ],
@@ -272,7 +272,7 @@ export const billingSpendLogic = kea<billingSpendLogicType>([
             null as BillingSpendResponse | null,
             {
                 loadBillingSpend: async () => {
-                    if (!values.canViewBillingUsage || values.isHobby) {
+                    if (!values.canReadBillingUsageSpend || values.isHobby) {
                         return null
                     }
                     const { usage_types, team_ids, breakdowns, interval } = values.filters

--- a/frontend/src/scenes/billing/billingUsageLogic.ts
+++ b/frontend/src/scenes/billing/billingUsageLogic.ts
@@ -76,7 +76,7 @@ export interface BillingUsageLogicProps {
 export interface billingUsageLogicValues {
     billing: BillingType | null // billingLogic
     billingPeriodUTC: BillingPeriod // billingLogic
-    canViewBillingUsage: boolean // billingLogic
+    canReadBillingUsageSpend: boolean // billingLogic
     currentOrganization: OrganizationType | null // billingLogic
     isHobby: boolean // preflightLogic
     billingPeriodMarkers: BillingPeriodMarker[]
@@ -248,7 +248,7 @@ export const billingUsageLogic = kea<billingUsageLogicType>([
     connect(() => ({
         values: [
             billingLogic,
-            ['billing', 'billingPeriodUTC', 'canViewBillingUsage', 'currentOrganization'],
+            ['billing', 'billingPeriodUTC', 'canReadBillingUsageSpend', 'currentOrganization'],
             preflightLogic,
             ['isHobby'],
         ],
@@ -275,7 +275,7 @@ export const billingUsageLogic = kea<billingUsageLogicType>([
             null as BillingUsageResponse | null,
             {
                 loadBillingUsage: async () => {
-                    if (!values.canViewBillingUsage || values.isHobby) {
+                    if (!values.canReadBillingUsageSpend || values.isHobby) {
                         return null
                     }
                     const { usage_types, team_ids, breakdowns, interval } = values.filters


### PR DESCRIPTION
## Problem

Pawel reviewed [#69406](https://github.com/PostHog/posthog/pull/69406) (member read-only access to the billing Usage and Spend tabs) and approved with suggestions. This addresses all of them.

It is stacked on the #69406 branch (`posthog-code/member-billing-usage-access`) as its base, so the diff here is just the review fixes. Merge this into that branch, or cherry-pick the commit, to fold the changes into #69406.

## Changes

- **Flag rename.** `member-billing-usage-access` -> `member-billing-usage-spend-read-access`, matching the billing companion [PostHog/billing#2057](https://github.com/PostHog/billing/pull/2057) and making clear the flag also covers Spend and is read-only. Renames the flag key, the `FEATURE_FLAGS` constant, the backend permission class (`CanReadBillingUsageSpend`), the helpers and selectors (`getMinimumBillingUsageSpendReadAccessLevel`, `canReadBillingUsageSpend`, `canOnlyReadBillingUsageSpend`, `minimumBillingUsageSpendReadAccessLevel`), and the tests.
- **Permission precedence (backend).** `owner-only-billing` is now evaluated before the admin short-circuit. The permission computes a required membership level mirroring the frontend `getMinimumBillingUsageSpendReadAccessLevel` (owner-only -> Owner, else member flag -> Member, else Admin). Before this, an admin passed the PostHog usage/spend permission even under owner-only, disagreeing with the frontend and the billing service and leaning on the companion service to reject.
- **Multi-org private-project scoping (backend).** Member team visibility is scoped to the queried org via a helper mirroring `OrganizationSerializer._fetch_visible_teams`, instead of `User.teams`. `User.teams` derives private-project filtering from the user's first org, so a member in two orgs (first without the access-control feature, queried org with it plus a private project) could leak that private project to billing. This proxy is the security boundary, since billing only gets an org id plus optional team ids.
- **Toolbar graph budget.** Reverted the `TOTAL_INPUT_BYTES_BUDGET` bump in `check-toolbar-graph.mjs`, per review, to keep the check boundary-only rather than raising the byte budget as a PR gate.

## How did you test this code?

Automated checks I (Claude, via PostHog Code) actually ran in this environment:

- `ruff check` and `ruff format --check` on `ee/api/billing.py` and `ee/api/test/test_billing.py`: pass.
- `python -m py_compile` on both: pass.
- Full-repo grep sweep: zero references to any old flag or identifier name remain.

What I could not run here (this sandbox has no Postgres/ClickHouse and no frontend toolchain), still to run in CI or locally:

- The Django suite for `ee/api/test/test_billing.py::TestBillingUsageAndSpendAPI`.
- Frontend `kea-typegen`, `tsc`, and jest for `billing-utils.spec.ts`. The `*Type.ts` files are gitignored and regenerate in CI; the source renames are internally consistent (verified by grep).
- `check-toolbar-graph` after the budget revert.

Tests changed and the regression each catches:

- `test_admin_access_respects_owner_only_billing` (replaces `test_admin_access_does_not_depend_on_flags`): an admin keeping usage/spend access when `owner-only-billing` is on. The old test asserted the opposite and no longer holds after the precedence fix.
- `test_owner_access_with_owner_only_billing`: the owner branch regressing (an owner must still pass under owner-only).
- `test_member_multi_org_does_not_leak_private_team_from_queried_org`: the first-org mismatch leaking a private project from the queried org to billing for a member who belongs to multiple orgs.

Browser QA Pawel asked for (account menus, settings nav, billing redirects, Usage/Spend loaders, flag-dependent entry URLs, plus flicker and redirect-loop checks across the no-flag / member-flag / owner-only / both-flags scenarios) is the remaining manual step and has not been done here.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The billing access-control docs live on posthog.com, not in this repo.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude (PostHog Code cloud task), directed by Luke. The task was to address Pawel's four review points on #69406: the flag rename (kept aligned with billing#2057), the owner-only precedence fix, the multi-org visibility hole, and the toolbar-budget revert.

Decisions: went with a full rename including the frontend capability selectors and helpers (not just the flag string) so the names reflect "usage + spend, read-only". For the multi-org fix I mirrored `_fetch_visible_teams` using the viewset's own `user_access_control` and `user_permissions` rather than reusing the serializer method, per Pawel's suggestion. The permission now mirrors `getMinimumBillingUsageSpendReadAccessLevel` so the API, frontend, and billing service agree on precedence.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
