### PR TITLE
feat(data-catalog): create a metric from a saved insight

### DIFF
--- a/frontend/src/scenes/insights/InsightModals.tsx
+++ b/frontend/src/scenes/insights/InsightModals.tsx
@@ -4,7 +4,9 @@ import { router } from 'kea-router'
 import { AddToDashboardModal } from 'lib/components/AddToDashboard/AddToDashboardModal'
 import { SharingModal } from 'lib/components/Sharing/SharingModal'
 import { TerraformExportModal } from 'lib/components/TerraformExporter/TerraformExportModal'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { NewDashboardModal } from 'scenes/dashboard/NewDashboardModal'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -17,6 +19,7 @@ import { InsightLogicProps, InsightShortId, ItemMode } from '~/types'
 import { areAlertsSupportedForInsight } from 'products/alerts/frontend/logic/insightAlertsLogic'
 import { EditAlertModal } from 'products/alerts/frontend/views/EditAlertModal'
 import { ManageAlertsModal } from 'products/alerts/frontend/views/ManageAlertsModal'
+import { MetricFromInsightModal } from 'products/data_catalog/frontend/components/MetricFromInsightModal'
 import { EndpointFromInsightModal } from 'products/endpoints/frontend/EndpointFromInsightModal'
 import { SubscriptionsModal } from 'products/subscriptions/frontend/components/Subscriptions/SubscriptionsModal'
 
@@ -35,6 +38,7 @@ export function InsightModals({ insightLogicProps }: { insightLogicProps: Insigh
                     <InsightAlertsModals insightLogicProps={insightLogicProps} />
                     <NewDashboardModal />
                     <InsightEndpointModalWrapper insightLogicProps={insightLogicProps} />
+                    <InsightMetricModalWrapper insightLogicProps={insightLogicProps} />
                 </>
             )}
 
@@ -172,6 +176,26 @@ function InsightEndpointModalWrapper({ insightLogicProps }: { insightLogicProps:
         <EndpointFromInsightModal
             insightQuery={insightQuery as unknown as HogQLQuery | EndpointQueryNode}
             insightShortId={insight.short_id}
+        />
+    )
+}
+
+function InsightMetricModalWrapper({
+    insightLogicProps,
+}: {
+    insightLogicProps: InsightLogicProps
+}): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { insight } = useValues(insightLogic(insightLogicProps))
+
+    if (!featureFlags[FEATURE_FLAGS.PRODUCT_DATA_CATALOG]) {
+        return null
+    }
+
+    return (
+        <MetricFromInsightModal
+            insightShortId={insight.short_id}
+            insightName={insight.name || insight.derived_name || undefined}
         />
     )
 }

--- a/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
@@ -193,7 +193,7 @@ export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: 
             ) : null}
 
             {featureFlags[FEATURE_FLAGS.PRODUCT_DATA_CATALOG] ? (
-                <CreateMetricFromInsightButton isSavedInsight={isSavedInsight} />
+                <CreateMetricFromInsightButton isSavedInsight={isSavedInsight} insightShortId={insight?.short_id} />
             ) : null}
 
             {canEditInSqlEditor && (
@@ -225,8 +225,21 @@ export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: 
     )
 }
 
-function CreateMetricFromInsightButton({ isSavedInsight }: { isSavedInsight: boolean }): JSX.Element {
+function CreateMetricFromInsightButton({
+    isSavedInsight,
+    insightShortId,
+}: {
+    isSavedInsight: boolean
+    insightShortId?: string
+}): JSX.Element | null {
     const { openMetricFromInsightModal } = useActions(metricsLogic)
+    const { allMetrics } = useValues(metricsLogic)
+
+    // A metric already snapshots this insight, so don't offer to create a duplicate.
+    if (insightShortId && allMetrics.some((metric) => metric.source_insight_short_id === insightShortId)) {
+        return null
+    }
+
     return (
         <ButtonPrimitive
             onClick={openMetricFromInsightModal}

--- a/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightPanelActions.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 
-import { IconCode2, IconCopy, IconEndpoints, IconPencil, IconPeople } from '@posthog/icons'
+import { IconCode2, IconCopy, IconEndpoints, IconGraph, IconPencil, IconPeople } from '@posthog/icons'
 
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
 import { SceneAddToDashboardButton } from 'lib/components/Scenes/InsightOrDashboard/SceneAddToDashboardButton'
@@ -34,6 +34,7 @@ import {
     QueryBasedInsightModel,
 } from '~/types'
 
+import { metricsLogic } from 'products/data_catalog/frontend/metricsLogic'
 import { endpointLogic } from 'products/endpoints/frontend/endpointLogic'
 
 import { insightModalsLogic } from '../insightModalsLogic'
@@ -191,6 +192,10 @@ export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: 
                 </ButtonPrimitive>
             ) : null}
 
+            {featureFlags[FEATURE_FLAGS.PRODUCT_DATA_CATALOG] ? (
+                <CreateMetricFromInsightButton isSavedInsight={isSavedInsight} />
+            ) : null}
+
             {canEditInSqlEditor && (
                 <Link
                     to={urls.sqlEditor({ query: hogQL ?? undefined })}
@@ -217,5 +222,21 @@ export function InsightPanelActions({ insightLogicProps }: { insightLogicProps: 
 
             {isSavedInsight && <SceneMetalyticsSummaryButton dataAttrKey={RESOURCE_TYPE} />}
         </ScenePanelActionsSection>
+    )
+}
+
+function CreateMetricFromInsightButton({ isSavedInsight }: { isSavedInsight: boolean }): JSX.Element {
+    const { openMetricFromInsightModal } = useActions(metricsLogic)
+    return (
+        <ButtonPrimitive
+            onClick={openMetricFromInsightModal}
+            menuItem
+            disabledReasons={{
+                'You must save the insight first before creating a metric from it': !isSavedInsight,
+            }}
+        >
+            <IconGraph />
+            Create metric
+        </ButtonPrimitive>
     )
 }

--- a/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
@@ -204,7 +204,7 @@ function InsightSceneMenuBarInner({ insightLogicProps }: { insightLogicProps: In
                                         Endpoint
                                     </SceneMenuBarItem>
                                 )}
-                                {showCreateMetric && <CreateMetricMenuBarItem />}
+                                {showCreateMetric && <CreateMetricMenuBarItem insightShortId={insight?.short_id} />}
                                 {showCohort && (
                                     <SceneMenuBarItem
                                         opensFloatingUi
@@ -426,8 +426,15 @@ function InsightSceneMenuBarInner({ insightLogicProps }: { insightLogicProps: In
     )
 }
 
-function CreateMetricMenuBarItem(): JSX.Element {
+function CreateMetricMenuBarItem({ insightShortId }: { insightShortId?: string }): JSX.Element | null {
     const { openMetricFromInsightModal } = useActions(metricsLogic)
+    const { allMetrics } = useValues(metricsLogic)
+
+    // A metric already snapshots this insight, so don't offer to create a duplicate.
+    if (insightShortId && allMetrics.some((metric) => metric.source_insight_short_id === insightShortId)) {
+        return null
+    }
+
     return (
         <SceneMenuBarItem
             opensFloatingUi

--- a/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
+++ b/frontend/src/scenes/insights/SidePanel/InsightSceneMenuBar.tsx
@@ -7,6 +7,7 @@ import {
     IconCopy,
     IconDownload,
     IconEndpoints,
+    IconGraph,
     IconPencil,
     IconPeople,
     IconPlusSmall,
@@ -60,6 +61,7 @@ import {
     SidePanelTab,
 } from '~/types'
 
+import { metricsLogic } from 'products/data_catalog/frontend/metricsLogic'
 import { endpointLogic } from 'products/endpoints/frontend/endpointLogic'
 import { urlForSubscriptions } from 'products/subscriptions/frontend/components/Subscriptions/utils'
 
@@ -148,9 +150,11 @@ function InsightSceneMenuBarInner({ insightLogicProps }: { insightLogicProps: In
         featureFlags[FEATURE_FLAGS.ENDPOINTS] &&
         isSavedInsight &&
         !getAccessControlDisabledReason(AccessControlResourceType.Endpoint, AccessControlLevel.Editor)
+    const showCreateMetric = !!featureFlags[FEATURE_FLAGS.PRODUCT_DATA_CATALOG] && isSavedInsight
     const showAddToNotebook = isSavedInsight
     const showCreateMenu =
         showCreateEndpoint ||
+        showCreateMetric ||
         showCohort ||
         isSavedInsight /* add-to-dashboard, add-to-notebook, subscribe, alerts, share */
     const showMetadataMenu = true // tags + activity always shown
@@ -200,6 +204,7 @@ function InsightSceneMenuBarInner({ insightLogicProps }: { insightLogicProps: In
                                         Endpoint
                                     </SceneMenuBarItem>
                                 )}
+                                {showCreateMetric && <CreateMetricMenuBarItem />}
                                 {showCohort && (
                                     <SceneMenuBarItem
                                         opensFloatingUi
@@ -418,5 +423,19 @@ function InsightSceneMenuBarInner({ insightLogicProps }: { insightLogicProps: In
                 </SceneMenuBarMenu>
             )}
         </SceneMenuBar>
+    )
+}
+
+function CreateMetricMenuBarItem(): JSX.Element {
+    const { openMetricFromInsightModal } = useActions(metricsLogic)
+    return (
+        <SceneMenuBarItem
+            opensFloatingUi
+            onClick={openMetricFromInsightModal}
+            data-attr={`${RESOURCE_TYPE}-menubar-create-metric`}
+        >
+            <IconGraph />
+            Metric
+        </SceneMenuBarItem>
     )
 }

--- a/products/data_catalog/frontend/components/MetricFromInsightModal.tsx
+++ b/products/data_catalog/frontend/components/MetricFromInsightModal.tsx
@@ -1,0 +1,138 @@
+import { useActions, useValues } from 'kea'
+import { useMemo, useState } from 'react'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { LemonInput } from 'lib/lemon-ui/LemonInput'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+import { LemonTable } from 'lib/lemon-ui/LemonTable'
+import { Link } from 'lib/lemon-ui/Link'
+import { slugify } from 'lib/utils/strings'
+import { urls } from 'scenes/urls'
+
+import { validateMetricName } from '../common'
+import { metricsLogic } from '../metricsLogic'
+
+export interface MetricFromInsightModalProps {
+    insightShortId?: string
+    insightName?: string
+}
+
+export function MetricFromInsightModal({ insightShortId, insightName }: MetricFromInsightModalProps): JSX.Element {
+    const { metricFromInsightModalOpen, isCreatingMetric, allMetrics } = useValues(metricsLogic)
+    const { createMetricFromInsight, closeMetricFromInsightModal } = useActions(metricsLogic)
+
+    const [name, setName] = useState('')
+    const [displayName, setDisplayName] = useState('')
+    const [description, setDescription] = useState('')
+
+    const prefilledName = useMemo(() => slugify(insightName || '').replace(/-/g, '_'), [insightName])
+    const effectiveName = name || prefilledName
+    const nameError = validateMetricName(effectiveName)
+
+    const metricsFromThisInsight = insightShortId
+        ? allMetrics.filter((metric) => metric.source_insight_short_id === insightShortId)
+        : []
+
+    const submitDisabledReason = !insightShortId
+        ? 'Save the insight first'
+        : nameError
+          ? nameError
+          : !description.trim()
+            ? 'Add a description'
+            : undefined
+
+    const handleClose = (): void => {
+        setName('')
+        setDisplayName('')
+        setDescription('')
+        closeMetricFromInsightModal()
+    }
+
+    const handleSubmit = (): void => {
+        if (submitDisabledReason || !insightShortId) {
+            return
+        }
+        createMetricFromInsight({
+            name: effectiveName,
+            display_name: displayName.trim(),
+            description: description.trim(),
+            source_insight_short_id: insightShortId,
+        })
+    }
+
+    return (
+        <LemonModal
+            isOpen={metricFromInsightModalOpen}
+            onClose={handleClose}
+            width={560}
+            title="Create metric from insight"
+        >
+            <LemonModal.Content>
+                <div className="flex flex-col gap-4">
+                    {metricsFromThisInsight.length > 0 && (
+                        <div className="flex flex-col gap-1">
+                            <span className="text-secondary">Metrics already created from this insight</span>
+                            <LemonTable
+                                dataSource={metricsFromThisInsight}
+                                columns={[
+                                    {
+                                        title: 'Name',
+                                        key: 'name',
+                                        render: (_, metric) => (
+                                            <Link to={urls.dataCatalogMetric(metric.name)}>
+                                                {metric.display_name || metric.name}
+                                            </Link>
+                                        ),
+                                    },
+                                ]}
+                                size="small"
+                                embedded
+                            />
+                        </div>
+                    )}
+
+                    <LemonField.Pure
+                        label="Name"
+                        error={effectiveName ? nameError : undefined}
+                        info="A unique identifier for the metric, like monthly_active_users."
+                    >
+                        <LemonInput
+                            value={effectiveName}
+                            onChange={setName}
+                            placeholder="monthly_active_users"
+                            autoFocus
+                        />
+                    </LemonField.Pure>
+
+                    <LemonField.Pure label="Display name">
+                        <LemonInput value={displayName} onChange={setDisplayName} placeholder="Monthly active users" />
+                    </LemonField.Pure>
+
+                    <LemonField.Pure label="Description">
+                        <LemonInput
+                            value={description}
+                            onChange={setDescription}
+                            placeholder="What this metric measures and how to read it"
+                        />
+                    </LemonField.Pure>
+                </div>
+            </LemonModal.Content>
+
+            <LemonModal.Footer>
+                <LemonButton type="secondary" onClick={handleClose} disabled={isCreatingMetric}>
+                    Cancel
+                </LemonButton>
+                <LemonButton
+                    type="primary"
+                    onClick={handleSubmit}
+                    loading={isCreatingMetric}
+                    disabledReason={submitDisabledReason}
+                    data-attr="data-catalog-create-metric-from-insight-submit"
+                >
+                    Create metric
+                </LemonButton>
+            </LemonModal.Footer>
+        </LemonModal>
+    )
+}

--- a/products/data_catalog/frontend/metricsLogic.test.ts
+++ b/products/data_catalog/frontend/metricsLogic.test.ts
@@ -139,4 +139,25 @@ describe('metricsLogic', () => {
 
         expect(logic.values.allMetrics).toHaveLength(0)
     })
+
+    it('creates a metric from an insight with the short id and no definition', async () => {
+        ;(dataCatalogMetricsCreate as jest.Mock).mockResolvedValue(
+            buildMetric({ id: 'metric-3', name: 'from_insight', source_insight_short_id: 'abc123' })
+        )
+
+        logic.actions.openMetricFromInsightModal()
+        logic.actions.createMetricFromInsight({
+            name: 'from_insight',
+            display_name: '',
+            description: 'Snapshotted from an insight',
+            source_insight_short_id: 'abc123',
+        })
+        await expectLogic(logic).toFinishAllListeners()
+
+        const body = (dataCatalogMetricsCreate as jest.Mock).mock.calls.at(-1)?.[1]
+        expect(body.source_insight_short_id).toEqual('abc123')
+        expect(body.definition).toBeUndefined()
+        expect(logic.values.metricFromInsightModalOpen).toEqual(false)
+        expect(logic.values.allMetrics.map((metric) => metric.name)).toContain('from_insight')
+    })
 })

--- a/products/data_catalog/frontend/metricsLogic.tsx
+++ b/products/data_catalog/frontend/metricsLogic.tsx
@@ -55,6 +55,13 @@ export interface SavedInsightOption {
     label: string
 }
 
+export interface MetricFromInsightRequest {
+    name: string
+    display_name: string
+    description: string
+    source_insight_short_id: string
+}
+
 const MARKDOWN_DEFINITION_KIND = 'MarkdownDefinition'
 
 function projectId(): string {
@@ -77,6 +84,7 @@ export interface metricsLogicValues {
     filters: MetricsFilters
     insightSearch: string
     isCreatingMetric: boolean
+    metricFromInsightModalOpen: boolean
     metrics: DataCatalogMetricApi[]
     newMetricForm: NewMetricForm
     newMetricModalOpen: boolean
@@ -90,11 +98,17 @@ export interface metricsLogicActions {
     approveMetric: (name: string) => {
         name: string
     }
+    closeMetricFromInsightModal: () => {
+        value: true
+    }
     closeNewMetricModal: () => {
         value: true
     }
     createMetric: () => {
         value: true
+    }
+    createMetricFromInsight: (request: MetricFromInsightRequest) => {
+        request: MetricFromInsightRequest
     }
     deleteMetric: (name: string) => {
         name: string
@@ -140,6 +154,9 @@ export interface metricsLogicActions {
         payload?: {
             value: true
         }
+    }
+    openMetricFromInsightModal: () => {
+        value: true
     }
     openNewMetricModal: () => {
         value: true
@@ -202,6 +219,9 @@ export const metricsLogic = kea<metricsLogicType>([
         refreshMetricFromInsight: (name: string) => ({ name }),
         deleteMetric: (name: string) => ({ name }),
         setActionInFlight: (name: string, inFlight: boolean) => ({ name, inFlight }),
+        openMetricFromInsightModal: true,
+        closeMetricFromInsightModal: true,
+        createMetricFromInsight: (request: MetricFromInsightRequest) => ({ request }),
     }),
     loaders(({ values }) => ({
         allMetrics: [
@@ -262,6 +282,13 @@ export const metricsLogic = kea<metricsLogicType>([
             false,
             {
                 setCreatingMetric: (_, { creating }) => creating,
+            },
+        ],
+        metricFromInsightModalOpen: [
+            false,
+            {
+                openMetricFromInsightModal: () => true,
+                closeMetricFromInsightModal: () => false,
             },
         ],
         actionsInFlight: [
@@ -338,6 +365,32 @@ export const metricsLogic = kea<metricsLogicType>([
                 lemonToast.error(
                     apiErrorDetail(error) || 'Could not create the metric. Check the fields and try again.'
                 )
+            } finally {
+                actions.setCreatingMetric(false)
+            }
+        },
+        createMetricFromInsight: async ({ request }) => {
+            if (values.isCreatingMetric) {
+                return
+            }
+            actions.setCreatingMetric(true)
+            try {
+                const created = await dataCatalogMetricsCreate(projectId(), {
+                    name: request.name,
+                    display_name: request.display_name || undefined,
+                    description: request.description,
+                    source_insight_short_id: request.source_insight_short_id,
+                })
+                actions.loadMetricsSuccess([created, ...values.allMetrics])
+                actions.closeMetricFromInsightModal()
+                lemonToast.success('Metric created from insight', {
+                    button: {
+                        label: 'View metric',
+                        action: () => router.actions.push(urls.dataCatalogMetric(created.name)),
+                    },
+                })
+            } catch (error) {
+                lemonToast.error(apiErrorDetail(error) || 'Could not create the metric from this insight. Try again.')
             } finally {
                 actions.setCreatingMetric(false)
             }


### PR DESCRIPTION
## Problem

The catalog can snapshot an insight's query into a governed metric, but only through the API or an agent. This PR adds that action to the insight scene, so someone looking at an insight can turn it into a catalog metric in one step. It mirrors the existing create-endpoint-from-insight flow.

Because the success toast links to the metric detail scene, this PR stacks on #73977 (the detail scene) rather than the metrics PR. The plan listed PR4 on top of the metrics PR, but the U4 dependency it also names makes the detail stack the correct base.

## Changes

Adds a "Metric" create action in two places on the insight scene, gated on `FEATURE_FLAGS.PRODUCT_DATA_CATALOG` and a saved insight:

- The insight side panel (`InsightPanelActions`) and the scene menu bar (`InsightSceneMenuBar`) each get a "Create metric" / "Metric" entry. Both are wrapped so the metrics logic mounts only when the flag is on, rather than for every insight viewer.
- `InsightModals` mounts the new `MetricFromInsightModal` (flag-gated). The modal prefills the metric name from the insight, lists metrics already created from this insight, and on submit calls the generated create endpoint with `source_insight_short_id` and no definition, so the server snapshots the insight's query. The success toast links to the new metric's detail scene.

The double-submission guard and the create call live in `metricsLogic`; the modal owns only its transient form fields.

## Screenshots

**Create a metric from a saved insight**

![Create metric from insight](https://raw.githubusercontent.com/PostHog/pr-assets/b325a88313ffe4f1227e283e588842c904f5e065/2026/07/4cde1511-1472-4e48-8be2-3485b50eed57.png)

## How did you test this code?

- Added a case to `metricsLogic.test.ts`: creating from an insight calls the generated create with `source_insight_short_id` and no `definition`, closes the modal, and appends the metric. The double-submit guard is the same `isCreatingMetric` path already covered by the create test.
- Frontend typecheck clean across the touched `data_catalog` and insight files; lint and format pass; all 8 `data_catalog` logic tests green on this branch.

I (Claude) could not run manual browser QA. The author or reviewer can verify that from a saved insight, Create then Metric produces a metric whose detail shows the snapshotted query, and that editing the insight's query afterward makes the metric show drifted.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs page covers the catalog UI yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thiago directed this from the data catalog UI plan; I (Claude) implemented it. Final PR of the stack, on top of #73977.

Skills invoked: `/adopting-generated-api-types`, `/writing-user-facing-copy`, `/writing-tests`, `/writing-code-comments`.

Decisions worth flagging:

- Stacked on the detail-scene PR, not the metrics PR, so `urls.dataCatalogMetric` exists for the success-toast link. Noted above.
- Each insight-scene entry point renders through a small flag-scoped subcomponent so `metricsLogic` (which fetches all metrics on mount) only mounts when the catalog flag is on, not for every insight viewer.
- The modal keeps its form fields in local component state since they are transient; the create call and its guard stay in the logic.

