### PR TITLE
fix(replay-vision): stop group summaries padding opportunities

### DIFF
--- a/products/replay_vision/backend/temporal/vision_actions/synthesis.py
+++ b/products/replay_vision/backend/temporal/vision_actions/synthesis.py
@@ -63,17 +63,25 @@ _SLACK_MAX_BLOCKS = 49
 
 _SYSTEM_PROMPT = """
 You are summarizing automated observations of user session recordings into one concise group summary
-for a product team. Synthesize the recurring themes, notable patterns, and the most actionable
-opportunities — do not just list every observation.
+for a product team. Synthesize the recurring themes and notable patterns — do not just list every
+observation.
 
 Write tight Markdown: a short intro plus themed sections, letting the section count follow the data.
 When the observations show one dominant pattern, two or three sections (the pattern, meaningful
-variations or exceptions, opportunities) beat five that restate it. Do not end with a concluding
-summary, recap, or 'Summary' section — the intro already frames the report, so finish on your last
-substantive section. ~600 words is a maximum, not a target: with few themes or few observations, write
-a proportionally short report. Never pad — do not stretch thin data across extra sections, repeat the
-same finding in different words, or invent themes, motivations, or opportunities the observations do
-not contain.
+variations or exceptions) beat five that restate it. Do not end with a concluding summary, recap, or
+'Summary' section — the intro already frames the report, so finish on your last substantive section.
+~600 words is a maximum, not a target: with few themes or few observations, write a proportionally short
+report. Never pad — do not stretch thin data across extra sections, repeat the same finding in different
+words, or invent themes, motivations, or opportunities the observations do not contain.
+
+Opportunities to improve are optional, not a required section, and are not a quota. Only suggest an
+improvement when the observations show a real, recurring problem it would address — an actual error,
+failure, or friction point that appears across sessions. Do not pad the report to a fixed number of
+suggestions. A scanner watching a mostly happy path will often have few opportunities or none, and "no
+notable friction this period" is a perfectly good, useful finding — say that plainly instead of
+reaching for improvements the data does not justify. When you do suggest opportunities, cite the
+observations whose friction motivates each one; an opportunity you cannot tie to observed friction does
+not belong in the report.
 
 A header line naming the scanner, the time window, and the recording count is added automatically above
 your output — do not restate that metadata; focus on the observations' content. In particular, never state


### PR DESCRIPTION
## Problem

Replay Vision group summaries (the daily digests on the "Summaries and alerts" tab) reach for improvement suggestions. The synthesis prompt asked for "the most actionable opportunities" as a standing part of every report and listed an opportunities section as a default structure element. So even a scanner watching a mostly happy path produced roughly five "opportunities to improve" every day — noisy, repetitive, and often not grounded in any real friction. This came up alongside a citation audit that found the same reaching in fabricated friction clusters (fixed separately in #73419).

## Changes

Prompt-only change to `_SYSTEM_PROMPT` in `synthesis.py`:

- Drop "the most actionable opportunities" from the standing deliverable and drop "opportunities" from the default section list.
- Add an explicit rule: opportunities are optional and not a quota. Only suggest an improvement tied to a real, recurring problem in the observations; don't pad to a fixed count; and "no notable friction this period" is a valid, useful finding.
- Require each suggested opportunity to cite the observations whose friction motivates it (reusing the citation discipline from #73419).

No schema or code-path changes. A happy-path digest should now come out shorter, with few opportunities or none, instead of a manufactured five.

## How did you test this code?

I (Claude) ran the synthesis test suite (`test_vision_action_synthesis.py`, 44 pass), plus ruff lint + format and `hogli ci:preflight` (0 failures). The LLM is mocked in tests, so this doesn't verify the model's live behavior — the change is prompt guidance and the win shows up in real digest output. No test pins the prompt wording, so nothing regressed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Kim flagged that the daily digests are often long and always suggest ~5 improvements, which reads as reaching when the scanner is just watching a happy path. I traced it to the prompt treating opportunities as a mandatory deliverable and made them conditional on real observed friction.

This is a follow-up to the citation guardrails in #73419 (now merged). I initially tried to amend it onto that branch, but #73419 had already merged, so this is its own commit off master instead.

Tools/agent: Claude Code (Opus 4.8). Skills invoked: none beyond earlier exploration; this is a targeted prompt edit.