### PR TITLE
feat(subscriptions): add complete AI report periods

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -141,6 +141,14 @@ class AIWindowConfigSerializer(serializers.Serializer):
             "* `days_ago_range` — the explicit range from start_days_ago to end_days_ago days ago"
         ),
     )
+    end_at = serializers.ChoiceField(
+        choices=Subscription.AIWindowEnd.choices,
+        default=Subscription.AIWindowEnd.NOW,
+        help_text=(
+            "Where the analysis window ends in the project's timezone. Use a complete-period option "
+            "to prevent partial days, weeks, or months from skewing comparisons."
+        ),
+    )
     start_days_ago = serializers.IntegerField(
         required=False,
         allow_null=True,

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -2988,6 +2988,7 @@ class TestAISubscriptionAPI(APILicensedTest):
             ),
             ("start_out_of_bounds", {"mode": "last_n_days", "start_days_ago": 400}, "start_days_ago"),
             ("unknown_mode", {"mode": "calendar_week"}, "mode"),
+            ("unknown_end_at", {"mode": "since_last_sent", "end_at": "end_of_time"}, "end_at"),
         ]
     )
     def test_invalid_ai_window_config_is_rejected(
@@ -3009,20 +3010,30 @@ class TestAISubscriptionAPI(APILicensedTest):
         self._mock_temporal(mock_sync)
         create_resp = self.client.post(
             f"/api/projects/{self.team.id}/subscriptions",
-            self._make_ai_payload(ai_prompt_config={"window": {"mode": "last_n_days", "start_days_ago": 14}}),
+            self._make_ai_payload(
+                ai_prompt_config={
+                    "window": {
+                        "mode": "last_n_days",
+                        "end_at": "last_complete_week",
+                        "start_days_ago": 14,
+                    }
+                }
+            ),
         )
         assert create_resp.status_code == status.HTTP_201_CREATED, create_resp.json()
         created = create_resp.json()
         assert created["ai_prompt_config"]["window"]["mode"] == "last_n_days"
+        assert created["ai_prompt_config"]["window"]["end_at"] == "last_complete_week"
         assert created["ai_prompt_config"]["window"]["start_days_ago"] == 14
 
         patch_resp = self.client.patch(
             f"/api/projects/{self.team.id}/subscriptions/{created['id']}",
-            {"ai_prompt_config": {"window": {"mode": "since_last_sent"}}},
+            {"ai_prompt_config": {"window": {"mode": "since_last_sent", "end_at": "last_complete_week"}}},
         )
         assert patch_resp.status_code == status.HTTP_200_OK, patch_resp.json()
         window = patch_resp.json()["ai_prompt_config"]["window"]
         assert window["mode"] == "since_last_sent"
+        assert window["end_at"] == "last_complete_week"
         assert window["start_days_ago"] is None
 
     def test_garbage_ai_prompt_config_still_serializes_on_read(self, mock_is_cloud, mock_flag, mock_sync):
@@ -3042,6 +3053,7 @@ class TestAISubscriptionAPI(APILicensedTest):
         assert response.status_code == status.HTTP_200_OK, response.json()
         assert response.json()["ai_prompt_config"]["window"] == {
             "mode": "since_last_sent",
+            "end_at": "now",
             "start_days_ago": None,
             "end_days_ago": None,
         }

--- a/products/exports/backend/models/subscription.py
+++ b/products/exports/backend/models/subscription.py
@@ -131,6 +131,12 @@ class Subscription(ModelActivityMixin, models.Model):
         LAST_N_DAYS = "last_n_days", "Last N days"
         DAYS_AGO_RANGE = "days_ago_range", "Between X and Y days ago"
 
+    class AIWindowEnd(models.TextChoices):
+        NOW = "now", "Now"
+        LAST_COMPLETE_DAY = "last_complete_day", "Last complete day"
+        LAST_COMPLETE_WEEK = "last_complete_week", "Last complete week"
+        LAST_COMPLETE_MONTH = "last_complete_month", "Last complete month"
+
     RRULE_FIELDS = {"frequency", "count", "interval", "start_date", "until_date", "bysetpos", "byweekday"}
 
     _FREQ_MAP: dict[str, int] = {
@@ -358,6 +364,8 @@ class Subscription(ModelActivityMixin, models.Model):
         raw = window if isinstance(window, dict) else {}
         raw_mode = raw.get("mode")
         mode = raw_mode if raw_mode in cls.AIWindowMode.values else cls.AIWindowMode.SINCE_LAST_SENT
+        raw_end_at = raw.get("end_at")
+        end_at = raw_end_at if raw_end_at in cls.AIWindowEnd.values else cls.AIWindowEnd.NOW
         start = day_bound(raw.get("start_days_ago"), 1)
         end = day_bound(raw.get("end_days_ago"), 0)
         # Mirror AIWindowConfigSerializer's per-mode normalisation, so a garbage value in a field
@@ -370,6 +378,7 @@ class Subscription(ModelActivityMixin, models.Model):
             start, end = None, None
         return {
             "mode": mode,
+            "end_at": end_at,
             "start_days_ago": start,
             "end_days_ago": end,
         }
@@ -382,6 +391,10 @@ class Subscription(ModelActivityMixin, models.Model):
     @property
     def ai_window_mode(self) -> str:
         return self._ai_window_config["mode"]
+
+    @property
+    def ai_window_end_at(self) -> str:
+        return self._ai_window_config["end_at"]
 
     @property
     def ai_window_start_days_ago(self) -> Optional[int]:

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/delivery.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/delivery.py
@@ -161,6 +161,7 @@ def _resolve_subscription_context(
         mode=subscription.ai_window_mode,
         start_days_ago=subscription.ai_window_start_days_ago,
         end_days_ago=subscription.ai_window_end_days_ago,
+        end_at=subscription.ai_window_end_at,
     )
     return team, subscription.created_by, window, subscription.ai_query_plan
 

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/spec_generator.py
@@ -164,6 +164,17 @@ def _in_tz(dt: datetime, tz: tzinfo) -> datetime:
     return (dt if dt.tzinfo is not None else dt.replace(tzinfo=UTC)).astimezone(tz)
 
 
+def _align_window_end(run_now: datetime, end_at: str) -> datetime:
+    if end_at == Subscription.AIWindowEnd.LAST_COMPLETE_DAY:
+        return run_now.replace(hour=0, minute=0, second=0, microsecond=0)
+    if end_at == Subscription.AIWindowEnd.LAST_COMPLETE_WEEK:
+        start_of_day = run_now.replace(hour=0, minute=0, second=0, microsecond=0)
+        return start_of_day - timedelta(days=start_of_day.weekday())
+    if end_at == Subscription.AIWindowEnd.LAST_COMPLETE_MONTH:
+        return run_now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    return run_now
+
+
 def compute_report_window(
     team: Team,
     last_scheduled_cutoff: Optional[datetime],
@@ -172,6 +183,7 @@ def compute_report_window(
     mode: str = Subscription.AIWindowMode.SINCE_LAST_SENT,
     start_days_ago: Optional[int] = None,
     end_days_ago: Optional[int] = None,
+    end_at: str = Subscription.AIWindowEnd.NOW,
 ) -> ReportWindow:
     """Compute the `[start, end)` analysis window for a run. Pure — callers resolve the cutoff
     and `now` and pass them in.
@@ -183,7 +195,7 @@ def compute_report_window(
     fallback, with a warning so the ignored config is diagnosable.
     """
     tz = team.timezone_info
-    run_now = _in_tz(now, tz)
+    run_now = _align_window_end(_in_tz(now, tz), end_at)
 
     if mode == Subscription.AIWindowMode.LAST_N_DAYS and start_days_ago:
         return ReportWindow(start=run_now - timedelta(days=start_days_ago), end=run_now)

--- a/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
+++ b/products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py
@@ -393,13 +393,24 @@ class TestAIWindowConfigProperties:
         sub = self._sub(config)
 
         assert sub.ai_window_mode == expected_mode
+        assert sub.ai_window_end_at == Subscription.AIWindowEnd.NOW
         assert sub.ai_window_start_days_ago is None
         assert sub.ai_window_end_days_ago is None
 
     def test_valid_config_is_read_through(self) -> None:
-        sub = self._sub({"window": {"mode": "days_ago_range", "start_days_ago": 10, "end_days_ago": 3}})
+        sub = self._sub(
+            {
+                "window": {
+                    "mode": "days_ago_range",
+                    "end_at": "last_complete_week",
+                    "start_days_ago": 10,
+                    "end_days_ago": 3,
+                }
+            }
+        )
 
         assert sub.ai_window_mode == Subscription.AIWindowMode.DAYS_AGO_RANGE
+        assert sub.ai_window_end_at == Subscription.AIWindowEnd.LAST_COMPLETE_WEEK
         assert sub.ai_window_start_days_ago == 10
         assert sub.ai_window_end_days_ago == 3
 
@@ -510,6 +521,41 @@ class TestComputeReportWindow:
 
         assert window.start == now - timedelta(days=3)
         assert window.end == now
+
+    @parameterized.expand(
+        [
+            (
+                "day",
+                Subscription.AIWindowEnd.LAST_COMPLETE_DAY,
+                datetime(2026, 7, 15, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            ),
+            (
+                "week",
+                Subscription.AIWindowEnd.LAST_COMPLETE_WEEK,
+                datetime(2026, 7, 13, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            ),
+            (
+                "month",
+                Subscription.AIWindowEnd.LAST_COMPLETE_MONTH,
+                datetime(2026, 7, 1, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            ),
+        ]
+    )
+    def test_aligns_end_to_complete_period_in_team_timezone(
+        self, _name: str, end_at: str, expected_end: datetime
+    ) -> None:
+        window = compute_report_window(
+            self._team("America/Los_Angeles"),
+            last_scheduled_cutoff=None,
+            now=datetime(2026, 7, 15, 16, 0, tzinfo=UTC),
+            window_days=7,
+            mode=Subscription.AIWindowMode.LAST_N_DAYS,
+            start_days_ago=7,
+            end_at=end_at,
+        )
+
+        assert window.end == expected_end
+        assert window.start == expected_end - timedelta(days=7)
 
     def test_days_ago_range_is_an_explicit_historical_range(self) -> None:
         now = datetime(2026, 6, 29, 16, 0, tzinfo=UTC)

--- a/products/subscriptions/frontend/components/Subscriptions/subscriptionLogic.ts
+++ b/products/subscriptions/frontend/components/Subscriptions/subscriptionLogic.ts
@@ -126,7 +126,7 @@ const NEW_SUBSCRIPTION: Partial<SubscriptionType> = {
     enabled: true,
     summary_enabled: false,
     summary_prompt_guide: '',
-    ai_prompt_config: { window: { mode: 'since_last_sent' } },
+    ai_prompt_config: { window: { mode: 'since_last_sent', end_at: 'now' } },
     send_test_now: true,
 }
 
@@ -403,6 +403,7 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
                             window: {
                                 ...subscription.ai_prompt_config?.window,
                                 mode: subscription.ai_prompt_config?.window?.mode ?? 'since_last_sent',
+                                end_at: subscription.ai_prompt_config?.window?.end_at ?? 'now',
                             },
                         },
                     }

--- a/products/subscriptions/frontend/components/Subscriptions/views/EditSubscription.tsx
+++ b/products/subscriptions/frontend/components/Subscriptions/views/EditSubscription.tsx
@@ -198,6 +198,13 @@ const AI_WINDOW_MODE_OPTIONS = [
     },
 ]
 
+const AI_WINDOW_END_OPTIONS = [
+    { value: 'now' as const, label: 'Now' },
+    { value: 'last_complete_day' as const, label: 'Last complete day' },
+    { value: 'last_complete_week' as const, label: 'Last complete week' },
+    { value: 'last_complete_month' as const, label: 'Last complete month' },
+]
+
 function AiPromptFields({
     prompt,
     windowMode,
@@ -256,6 +263,13 @@ function AiPromptFields({
                 help="The exact time range is computed in your project's timezone each time the report runs."
             >
                 <LemonSelect options={AI_WINDOW_MODE_OPTIONS} />
+            </LemonField>
+            <LemonField
+                name={['ai_prompt_config', 'window', 'end_at']}
+                label="End window at"
+                help="Use a complete period to prevent partial data from skewing comparisons."
+            >
+                <LemonSelect options={AI_WINDOW_END_OPTIONS} />
             </LemonField>
             {windowMode === 'last_n_days' && (
                 <LemonField name={['ai_prompt_config', 'window', 'start_days_ago']} label="Number of days to analyze">

--- a/products/subscriptions/frontend/generated/api.schemas.ts
+++ b/products/subscriptions/frontend/generated/api.schemas.ts
@@ -33,6 +33,21 @@ export const AIWindowConfigModeEnumApi = {
     DaysAgoRange: 'days_ago_range',
 } as const
 
+/**
+ * * `now` - Now
+ * * `last_complete_day` - Last complete day
+ * * `last_complete_week` - Last complete week
+ * * `last_complete_month` - Last complete month
+ */
+export type EndAtEnumApi = (typeof EndAtEnumApi)[keyof typeof EndAtEnumApi]
+
+export const EndAtEnumApi = {
+    Now: 'now',
+    LastCompleteDay: 'last_complete_day',
+    LastCompleteWeek: 'last_complete_week',
+    LastCompleteMonth: 'last_complete_month',
+} as const
+
 export interface AIWindowConfigApi {
     /** What the report analyzes each run:
      * * `since_last_sent` (default) — everything since the previous successful scheduled delivery (gap-free; test/manual sends don't move the anchor)
@@ -43,6 +58,13 @@ export interface AIWindowConfigApi {
      * * `last_n_days` - Last N days
      * * `days_ago_range` - Between X and Y days ago */
     mode?: AIWindowConfigModeEnumApi
+    /** Where the analysis window ends in the project's timezone. Use a complete-period option to prevent partial days, weeks, or months from skewing comparisons.
+     *
+     * * `now` - Now
+     * * `last_complete_day` - Last complete day
+     * * `last_complete_week` - Last complete week
+     * * `last_complete_month` - Last complete month */
+    end_at?: EndAtEnumApi
     /**
      * Lower bound of the analysis window, in days before the run. Required for 'last_n_days' (the N) and 'days_ago_range'; ignored for 'since_last_sent'. 1-365.
      * @minimum 1

--- a/products/subscriptions/frontend/generated/api.zod.ts
+++ b/products/subscriptions/frontend/generated/api.zod.ts
@@ -10,6 +10,7 @@
 import * as zod from 'zod'
 
 export const subscriptionsCreateBodyAiPromptConfigOneWindowOneModeDefault = `since_last_sent`
+export const subscriptionsCreateBodyAiPromptConfigOneWindowOneEndAtDefault = `now`
 export const subscriptionsCreateBodyAiPromptConfigOneWindowOneStartDaysAgoMax = 365
 
 export const subscriptionsCreateBodyAiPromptConfigOneWindowOneEndDaysAgoMin = 0
@@ -61,6 +62,15 @@ export const SubscriptionsCreateBody = /* @__PURE__ */ zod
                             .default(subscriptionsCreateBodyAiPromptConfigOneWindowOneModeDefault)
                             .describe(
                                 "What the report analyzes each run:\n\* `since_last_sent` (default) — everything since the previous successful scheduled delivery (gap-free; test\/manual sends don't move the anchor)\n\* `last_n_days` — a fixed trailing window of start_days_ago days\n\* `days_ago_range` — the explicit range from start_days_ago to end_days_ago days ago\n\n\* `since_last_sent` - Since last report\n\* `last_n_days` - Last N days\n\* `days_ago_range` - Between X and Y days ago"
+                            ),
+                        end_at: zod
+                            .enum(['now', 'last_complete_day', 'last_complete_week', 'last_complete_month'])
+                            .describe(
+                                '\* `now` - Now\n\* `last_complete_day` - Last complete day\n\* `last_complete_week` - Last complete week\n\* `last_complete_month` - Last complete month'
+                            )
+                            .default(subscriptionsCreateBodyAiPromptConfigOneWindowOneEndAtDefault)
+                            .describe(
+                                "Where the analysis window ends in the project's timezone. Use a complete-period option to prevent partial days, weeks, or months from skewing comparisons.\n\n\* `now` - Now\n\* `last_complete_day` - Last complete day\n\* `last_complete_week` - Last complete week\n\* `last_complete_month` - Last complete month"
                             ),
                         start_days_ago: zod
                             .number()
@@ -180,6 +190,7 @@ export const SubscriptionsCreateBody = /* @__PURE__ */ zod
     .describe('Standard Subscription serializer.')
 
 export const subscriptionsUpdateBodyAiPromptConfigOneWindowOneModeDefault = `since_last_sent`
+export const subscriptionsUpdateBodyAiPromptConfigOneWindowOneEndAtDefault = `now`
 export const subscriptionsUpdateBodyAiPromptConfigOneWindowOneStartDaysAgoMax = 365
 
 export const subscriptionsUpdateBodyAiPromptConfigOneWindowOneEndDaysAgoMin = 0
@@ -231,6 +242,15 @@ export const SubscriptionsUpdateBody = /* @__PURE__ */ zod
                             .default(subscriptionsUpdateBodyAiPromptConfigOneWindowOneModeDefault)
                             .describe(
                                 "What the report analyzes each run:\n\* `since_last_sent` (default) — everything since the previous successful scheduled delivery (gap-free; test\/manual sends don't move the anchor)\n\* `last_n_days` — a fixed trailing window of start_days_ago days\n\* `days_ago_range` — the explicit range from start_days_ago to end_days_ago days ago\n\n\* `since_last_sent` - Since last report\n\* `last_n_days` - Last N days\n\* `days_ago_range` - Between X and Y days ago"
+                            ),
+                        end_at: zod
+                            .enum(['now', 'last_complete_day', 'last_complete_week', 'last_complete_month'])
+                            .describe(
+                                '\* `now` - Now\n\* `last_complete_day` - Last complete day\n\* `last_complete_week` - Last complete week\n\* `last_complete_month` - Last complete month'
+                            )
+                            .default(subscriptionsUpdateBodyAiPromptConfigOneWindowOneEndAtDefault)
+                            .describe(
+                                "Where the analysis window ends in the project's timezone. Use a complete-period option to prevent partial days, weeks, or months from skewing comparisons.\n\n\* `now` - Now\n\* `last_complete_day` - Last complete day\n\* `last_complete_week` - Last complete week\n\* `last_complete_month` - Last complete month"
                             ),
                         start_days_ago: zod
                             .number()
@@ -350,6 +370,7 @@ export const SubscriptionsUpdateBody = /* @__PURE__ */ zod
     .describe('Standard Subscription serializer.')
 
 export const subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneModeDefault = `since_last_sent`
+export const subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneEndAtDefault = `now`
 export const subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneStartDaysAgoMax = 365
 
 export const subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneEndDaysAgoMin = 0
@@ -401,6 +422,15 @@ export const SubscriptionsPartialUpdateBody = /* @__PURE__ */ zod
                             .default(subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneModeDefault)
                             .describe(
                                 "What the report analyzes each run:\n\* `since_last_sent` (default) — everything since the previous successful scheduled delivery (gap-free; test\/manual sends don't move the anchor)\n\* `last_n_days` — a fixed trailing window of start_days_ago days\n\* `days_ago_range` — the explicit range from start_days_ago to end_days_ago days ago\n\n\* `since_last_sent` - Since last report\n\* `last_n_days` - Last N days\n\* `days_ago_range` - Between X and Y days ago"
+                            ),
+                        end_at: zod
+                            .enum(['now', 'last_complete_day', 'last_complete_week', 'last_complete_month'])
+                            .describe(
+                                '\* `now` - Now\n\* `last_complete_day` - Last complete day\n\* `last_complete_week` - Last complete week\n\* `last_complete_month` - Last complete month'
+                            )
+                            .default(subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneEndAtDefault)
+                            .describe(
+                                "Where the analysis window ends in the project's timezone. Use a complete-period option to prevent partial days, weeks, or months from skewing comparisons.\n\n\* `now` - Now\n\* `last_complete_day` - Last complete day\n\* `last_complete_week` - Last complete week\n\* `last_complete_month` - Last complete month"
                             ),
                         start_days_ago: zod
                             .number()

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -45,6 +45,22 @@ export namespace Schemas {
       DaysAgoRange: 'days_ago_range',
     } as const;
 
+    /**
+     * * `now` - Now
+     * * `last_complete_day` - Last complete day
+     * * `last_complete_week` - Last complete week
+     * * `last_complete_month` - Last complete month
+     */
+    export type EndAtEnum = typeof EndAtEnum[keyof typeof EndAtEnum];
+
+
+    export const EndAtEnum = {
+      Now: 'now',
+      LastCompleteDay: 'last_complete_day',
+      LastCompleteWeek: 'last_complete_week',
+      LastCompleteMonth: 'last_complete_month',
+    } as const;
+
     export interface AIWindowConfig {
       /** What the report analyzes each run:
        * * `since_last_sent` (default) — everything since the previous successful scheduled delivery (gap-free; test/manual sends don't move the anchor)
@@ -55,6 +71,13 @@ export namespace Schemas {
        * * `last_n_days` - Last N days
        * * `days_ago_range` - Between X and Y days ago */
       mode?: AIWindowConfigModeEnum;
+      /** Where the analysis window ends in the project's timezone. Use a complete-period option to prevent partial days, weeks, or months from skewing comparisons.
+       *
+       * * `now` - Now
+       * * `last_complete_day` - Last complete day
+       * * `last_complete_week` - Last complete week
+       * * `last_complete_month` - Last complete month */
+      end_at?: EndAtEnum;
       /**
          * Lower bound of the analysis window, in days before the run. Required for 'last_n_days' (the N) and 'days_ago_range'; ignored for 'since_last_sent'. 1-365.
          * @minimum 1

--- a/services/mcp/src/generated/subscriptions/api.ts
+++ b/services/mcp/src/generated/subscriptions/api.ts
@@ -45,6 +45,7 @@ export const SubscriptionsCreateParams = /* @__PURE__ */ zod.object({
 })
 
 export const subscriptionsCreateBodyAiPromptConfigOneWindowOneModeDefault = `since_last_sent`
+export const subscriptionsCreateBodyAiPromptConfigOneWindowOneEndAtDefault = `now`
 export const subscriptionsCreateBodyAiPromptConfigOneWindowOneStartDaysAgoMax = 365
 
 export const subscriptionsCreateBodyAiPromptConfigOneWindowOneEndDaysAgoMin = 0
@@ -96,6 +97,15 @@ export const SubscriptionsCreateBody = /* @__PURE__ */ zod
                             .default(subscriptionsCreateBodyAiPromptConfigOneWindowOneModeDefault)
                             .describe(
                                 "What the report analyzes each run:\n\* `since_last_sent` (default) — everything since the previous successful scheduled delivery (gap-free; test\/manual sends don't move the anchor)\n\* `last_n_days` — a fixed trailing window of start_days_ago days\n\* `days_ago_range` — the explicit range from start_days_ago to end_days_ago days ago\n\n\* `since_last_sent` - Since last report\n\* `last_n_days` - Last N days\n\* `days_ago_range` - Between X and Y days ago"
+                            ),
+                        end_at: zod
+                            .enum(['now', 'last_complete_day', 'last_complete_week', 'last_complete_month'])
+                            .describe(
+                                '\* `now` - Now\n\* `last_complete_day` - Last complete day\n\* `last_complete_week` - Last complete week\n\* `last_complete_month` - Last complete month'
+                            )
+                            .default(subscriptionsCreateBodyAiPromptConfigOneWindowOneEndAtDefault)
+                            .describe(
+                                "Where the analysis window ends in the project's timezone. Use a complete-period option to prevent partial days, weeks, or months from skewing comparisons.\n\n\* `now` - Now\n\* `last_complete_day` - Last complete day\n\* `last_complete_week` - Last complete week\n\* `last_complete_month` - Last complete month"
                             ),
                         start_days_ago: zod
                             .number()
@@ -228,6 +238,7 @@ export const SubscriptionsPartialUpdateParams = /* @__PURE__ */ zod.object({
 })
 
 export const subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneModeDefault = `since_last_sent`
+export const subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneEndAtDefault = `now`
 export const subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneStartDaysAgoMax = 365
 
 export const subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneEndDaysAgoMin = 0
@@ -279,6 +290,15 @@ export const SubscriptionsPartialUpdateBody = /* @__PURE__ */ zod
                             .default(subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneModeDefault)
                             .describe(
                                 "What the report analyzes each run:\n\* `since_last_sent` (default) — everything since the previous successful scheduled delivery (gap-free; test\/manual sends don't move the anchor)\n\* `last_n_days` — a fixed trailing window of start_days_ago days\n\* `days_ago_range` — the explicit range from start_days_ago to end_days_ago days ago\n\n\* `since_last_sent` - Since last report\n\* `last_n_days` - Last N days\n\* `days_ago_range` - Between X and Y days ago"
+                            ),
+                        end_at: zod
+                            .enum(['now', 'last_complete_day', 'last_complete_week', 'last_complete_month'])
+                            .describe(
+                                '\* `now` - Now\n\* `last_complete_day` - Last complete day\n\* `last_complete_week` - Last complete week\n\* `last_complete_month` - Last complete month'
+                            )
+                            .default(subscriptionsPartialUpdateBodyAiPromptConfigOneWindowOneEndAtDefault)
+                            .describe(
+                                "Where the analysis window ends in the project's timezone. Use a complete-period option to prevent partial days, weeks, or months from skewing comparisons.\n\n\* `now` - Now\n\* `last_complete_day` - Last complete day\n\* `last_complete_week` - Last complete week\n\* `last_complete_month` - Last complete month"
                             ),
                         start_days_ago: zod
                             .number()

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/subscriptions-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/subscriptions-create.json
@@ -8,6 +8,12 @@
                 "window": {
                     "description": "Analysis window for the report. Omitted = 'since_last_sent' (everything since the previous scheduled delivery).",
                     "properties": {
+                        "end_at": {
+                            "default": "now",
+                            "description": "Where the analysis window ends in the project's timezone. Use a complete-period option to prevent partial days, weeks, or months from skewing comparisons.\n\n* `now` - Now\n* `last_complete_day` - Last complete day\n* `last_complete_week` - Last complete week\n* `last_complete_month` - Last complete month",
+                            "enum": ["now", "last_complete_day", "last_complete_week", "last_complete_month"],
+                            "type": "string"
+                        },
                         "end_days_ago": {
                             "anyOf": [
                                 {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/subscriptions-partial-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/subscriptions-partial-update.json
@@ -7,6 +7,12 @@
                 "window": {
                     "description": "Analysis window for the report. Omitted = 'since_last_sent' (everything since the previous scheduled delivery).",
                     "properties": {
+                        "end_at": {
+                            "default": "now",
+                            "description": "Where the analysis window ends in the project's timezone. Use a complete-period option to prevent partial days, weeks, or months from skewing comparisons.\n\n* `now` - Now\n* `last_complete_day` - Last complete day\n* `last_complete_week` - Last complete week\n* `last_complete_month` - Last complete month",
+                            "enum": ["now", "last_complete_day", "last_complete_week", "last_complete_month"],
+                            "type": "string"
+                        },
                         "end_days_ago": {
                             "anyOf": [
                                 {


### PR DESCRIPTION
## Problem

AI prompt subscription windows currently end at delivery time. Reports grouped by calendar periods can therefore compare a partial day, week, or month against a complete prior period and report misleading changes.

## Changes

- Add project-timezone window boundaries for the last complete day, week, or month
- Expose the boundary setting in the prompt subscription editor and API
- Regenerate frontend and MCP API types
- Preserve `now` as the default for existing behavior

## How did you test this code?

- `bin/hogli test products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py::TestAIWindowConfigProperties products/exports/backend/temporal/subscriptions/ai_subscription/test/test_spec_generator.py::TestComputeReportWindow`
  - Covers partial-period leakage and timezone-aligned day, week, and month boundaries
- `uv run mypy --cache-fine-grained .`
- `bin/hogli ci:preflight --fix`
- `pnpm --filter=@posthog/frontend fix`
- API tests could not start because local ClickHouse was unavailable
- Frontend typecheck reached four unrelated existing errors outside the changed files

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No separate docs page covers AI prompt subscription windows. The editor and generated API schema describe the new behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change using `/improving-drf-endpoints`, `/writing-tests`, `/writing-code-comments`, and `/writing-user-facing-copy`. The implementation adds an explicit boundary choice instead of inferring complete periods from schedule timing, preserving rolling-window behavior for existing subscriptions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
