### PR TITLE
feat(tasks): mark wizard cloud runs in task telemetry

### DIFF
--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -240,6 +240,11 @@ class TaskProcessingContext:
             "model": self.model,
             "reasoning_effort": self.reasoning_effort,
             "initial_permission_mode": self.initial_permission_mode,
+            # Cloud setup-wizard runs are created with `origin_product=ONBOARDING`, which
+            # callers can set themselves — so it can't identify them. `wizard_config` is a
+            # protected state key only `create_wizard_cloud_run` writes, which is why the
+            # facade's own wizard-run lookups key off it too.
+            "is_wizard_run": self.wizard_config is not None,
         }
 
 

--- a/products/tasks/backend/temporal/process_task/tests/test_log_context.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_log_context.py
@@ -1,0 +1,31 @@
+from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
+
+
+def _context(state: dict | None) -> TaskProcessingContext:
+    return TaskProcessingContext(
+        task_id="task-id",
+        run_id="run-id",
+        team_id=1,
+        team_uuid="team-uuid",
+        organization_id="org-id",
+        github_integration_id=123,
+        repository="posthog/posthog",
+        distinct_id="distinct",
+        state=state,
+    )
+
+
+class TestToLogContextIsWizardRun:
+    def test_normal_run_is_not_a_wizard_run(self):
+        assert _context({"run_source": "manual"}).to_log_context()["is_wizard_run"] is False
+
+    def test_missing_state_is_not_a_wizard_run(self):
+        assert _context(None).to_log_context()["is_wizard_run"] is False
+
+    def test_empty_wizard_config_still_marks_a_wizard_run(self):
+        # `create_wizard_cloud_run` stamps `wizard_config={}` — the key's presence is the
+        # marker, so an empty dict must not read as "not a wizard run".
+        assert _context({"wizard_config": {}}).to_log_context()["is_wizard_run"] is True
+
+    def test_populated_wizard_config_marks_a_wizard_run(self):
+        assert _context({"wizard_config": {"foo": "bar"}}).to_log_context()["is_wizard_run"] is True


### PR DESCRIPTION
Adds `is_wizard_run` to task activity telemetry, derived from the protected `wizard_config` state key, so cloud setup-wizard runs are distinguishable from other `origin_product=onboarding` tasks (which callers can set themselves).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*