### PR TITLE
fix(warehouse): bypass egress proxy for tunneled ClickHouse connections

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -226,20 +226,33 @@ class _NoRedirectPoolManager(PoolManager):
 
 
 @functools.cache
-def _no_env_proxy_pool_manager(verify: bool) -> Any:
+def _no_env_proxy_pool_manager(verify: bool, server_hostname: str | None = None) -> Any:
     """A shared urllib3 pool manager that never consults HTTP(S)_PROXY env vars.
 
     clickhouse-connect only checks the proxy env vars when it builds its own
     pool manager, so handing it one is the sanctioned per-code-path opt-out
     from the egress proxy (see posthog/security/outbound_proxy.py for the
     requests/httpx equivalents). Cached because clients don't own an injected
-    manager (`close()` leaves it alive), so per-call managers would leak.
+    manager (`close()` leaves it alive), so per-call managers would leak; the
+    cache is bounded by the set of distinct tunneled HTTPS hostnames a worker
+    sees, which is small.
+
+    `server_hostname` keeps TLS verification honest through an SSH tunnel: we dial the
+    tunnel's loopback bind, but SNI and hostname validation must run against the database's
+    own hostname or the certificate can never match. Mirrors what clickhouse-connect does
+    with `server_host_name` when it builds its own manager — a branch it skips entirely
+    when handed a `pool_mgr`.
 
     Built from clickhouse-connect's own options factory so the TCP keepalive tuning and
     certificate handling match a direct connection, then recorded where the library tracks
     its own managers so connection expiry and interpreter-exit cleanup cover this one too.
     """
-    manager = _NoRedirectPoolManager(**httputil.get_pool_manager_options(verify=verify))
+    options = httputil.get_pool_manager_options(verify=verify)
+    if server_hostname:
+        if verify:
+            options["assert_hostname"] = server_hostname
+        options["server_hostname"] = server_hostname
+    manager = _NoRedirectPoolManager(**options)
     httputil.all_managers[manager] = int(time.time())
     return manager
 
@@ -256,6 +269,7 @@ def _get_client(
     query_timeout: int = DATA_QUERY_TIMEOUT_SECONDS,
     settings: Optional[dict[str, Any]] = None,
     bypass_env_proxy: BypassEnvProxy = None,
+    server_hostname: str | None = None,
 ) -> ClickHouseClient:
     """Create a ClickHouse HTTP client.
 
@@ -273,9 +287,18 @@ def _get_client(
     in the path, so the tunnel claim is checked against the address here: the
     flag and the host travel to this point independently, and a caller pairing
     "tunnel_loopback" with a non-loopback host has lost that pairing.
+
+    `server_hostname` (tunnel only) is the database's own hostname, so TLS SNI
+    and certificate hostname validation run against it rather than against the
+    loopback address we dial — disabling verification is not the supported way
+    to make HTTPS work through a tunnel.
     """
     if bypass_env_proxy == "tunnel_loopback":
         _require_loopback(host)
+    pool_mgr = None
+    if bypass_env_proxy:
+        tunnel_tls_hostname = server_hostname if bypass_env_proxy == "tunnel_loopback" and secure else None
+        pool_mgr = _no_env_proxy_pool_manager(verify, tunnel_tls_hostname)
     attempt = 0
     while True:
         try:
@@ -292,7 +315,7 @@ def _get_client(
                 send_receive_timeout=query_timeout,
                 query_limit=0,  # we manage limits ourselves
                 compress=True,
-                pool_mgr=_no_env_proxy_pool_manager(verify) if bypass_env_proxy else None,
+                pool_mgr=pool_mgr,
             )
         except (ClickHouseError, OSError, ssl.SSLError) as e:
             # OSError covers socket.gaierror, ConnectionRefusedError, TimeoutError,
@@ -398,6 +421,7 @@ def get_schemas(
     verify: bool,
     names: list[str] | None = None,
     bypass_env_proxy: BypassEnvProxy = None,
+    server_hostname: str | None = None,
 ) -> dict[str, list[tuple[str, str, bool]]]:
     """Discover columns for all tables in the given database.
 
@@ -416,6 +440,7 @@ def get_schemas(
         verify=verify,
         query_timeout=METADATA_QUERY_TIMEOUT_SECONDS,
         bypass_env_proxy=bypass_env_proxy,
+        server_hostname=server_hostname,
     )
 
     try:
@@ -514,6 +539,7 @@ def get_clickhouse_row_count(
     verify: bool,
     names: list[str] | None = None,
     bypass_env_proxy: BypassEnvProxy = None,
+    server_hostname: str | None = None,
 ) -> dict[str, int]:
     """Return total_rows per table from `system.tables`.
 
@@ -536,6 +562,7 @@ def get_clickhouse_row_count(
         verify=verify,
         query_timeout=METADATA_QUERY_TIMEOUT_SECONDS,
         bypass_env_proxy=bypass_env_proxy,
+        server_hostname=server_hostname,
     )
 
     try:
@@ -640,6 +667,7 @@ def get_connection_metadata(
     secure: bool,
     verify: bool,
     bypass_env_proxy: BypassEnvProxy = None,
+    server_hostname: str | None = None,
 ) -> dict[str, Any]:
     """Probe the server for version metadata.
 
@@ -657,6 +685,7 @@ def get_connection_metadata(
         verify=verify,
         query_timeout=METADATA_QUERY_TIMEOUT_SECONDS,
         bypass_env_proxy=bypass_env_proxy,
+        server_hostname=server_hostname,
     )
 
     try:
@@ -892,6 +921,7 @@ def get_primary_keys_for_schemas(
     verify: bool,
     table_names: list[str],
     bypass_env_proxy: BypassEnvProxy = None,
+    server_hostname: str | None = None,
 ) -> dict[str, list[str] | None]:
     """Detect primary keys (sorting key columns) for multiple tables.
 
@@ -914,6 +944,7 @@ def get_primary_keys_for_schemas(
             verify=verify,
             query_timeout=METADATA_QUERY_TIMEOUT_SECONDS,
             bypass_env_proxy=bypass_env_proxy,
+            server_hostname=server_hostname,
         )
         try:
             for table_name in table_names:
@@ -1317,6 +1348,7 @@ def clickhouse_source(
     row_filters: Optional[list[ValidatedRowFilter]] = None,
     enabled_columns: Optional[list[str]] = None,
     bypass_env_proxy: BypassEnvProxy = None,
+    server_hostname: str | None = None,
 ) -> SourceResponse:
     """Build a SourceResponse that pulls a single ClickHouse table.
 
@@ -1340,6 +1372,7 @@ def clickhouse_source(
             verify=verify,
             query_timeout=METADATA_QUERY_TIMEOUT_SECONDS,
             bypass_env_proxy=bypass_env_proxy,
+            server_hostname=server_hostname,
         )
 
         try:
@@ -1379,6 +1412,7 @@ def clickhouse_source(
                 verify=verify,
                 names=[table_name],
                 bypass_env_proxy=bypass_env_proxy,
+                server_hostname=server_hostname,
             )
             rows_to_sync: int | None = row_counts.get(table_name)
 
@@ -1425,6 +1459,7 @@ def clickhouse_source(
                 query_timeout=DATA_QUERY_TIMEOUT_SECONDS,
                 settings=_query_settings(chunk_size),
                 bypass_env_proxy=bypass_env_proxy,
+                server_hostname=server_hostname,
             )
 
             try:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -18,6 +18,8 @@ from clickhouse_connect.driver.client import Client as ClickHouseClient
 from clickhouse_connect.driver.exceptions import ClickHouseError, ProgrammingError
 from dlt.common.normalizers.naming.snake_case import NamingConvention
 from structlog.types import FilteringBoundLogger
+from urllib3 import PoolManager
+from urllib3.response import HTTPResponse
 
 from posthog.exceptions_capture import capture_exception
 
@@ -194,6 +196,29 @@ def _apply_session_settings(client: ClickHouseClient, settings: dict[str, Any]) 
             )
 
 
+class _NoRedirectPoolManager(PoolManager):
+    """A urllib3 manager that refuses to follow redirects.
+
+    Only proxy-bypassing connections use this manager. urllib3 follows a cross-host redirect
+    on the same manager, so without this the host we connect to could answer with a redirect
+    to an arbitrary address and we would fetch it directly from the worker, which is the
+    reachability the egress proxy exists to deny. A ClickHouse HTTP endpoint has no reason to
+    redirect us, so refusing costs nothing: the 3xx response goes back to clickhouse-connect,
+    which reports it as a connection error.
+
+    Enforced by overriding `urlopen` rather than through the pool's `retries` option because
+    clickhouse-connect passes its own `retries` on every request, which would take precedence
+    over a pool-level default.
+    """
+
+    # The urllib3 1.26 stub types `urlopen` with the generic `RequestMethods` parameters and
+    # omits `redirect`, even though it is the real third parameter of `PoolManager.urlopen`.
+    # Declaring the stub's parameters instead would forward `encode_multipart` down to
+    # `HTTPConnectionPool.urlopen`, which rejects it, so match the runtime signature.
+    def urlopen(self, method: str, url: str, redirect: bool = True, **kw: Any) -> HTTPResponse:  # type: ignore[override]
+        return super().urlopen(method, url, redirect=False, **kw)
+
+
 @functools.cache
 def _no_env_proxy_pool_manager(verify: bool) -> Any:
     """A shared urllib3 pool manager that never consults HTTP(S)_PROXY env vars.
@@ -203,8 +228,14 @@ def _no_env_proxy_pool_manager(verify: bool) -> Any:
     from the egress proxy (see posthog/security/outbound_proxy.py for the
     requests/httpx equivalents). Cached because clients don't own an injected
     manager (`close()` leaves it alive), so per-call managers would leak.
+
+    Built from clickhouse-connect's own options factory so the TCP keepalive tuning and
+    certificate handling match a direct connection, then recorded where the library tracks
+    its own managers so connection expiry and interpreter-exit cleanup cover this one too.
     """
-    return httputil.get_pool_manager(verify=verify)
+    manager = _NoRedirectPoolManager(**httputil.get_pool_manager_options(verify=verify))
+    httputil.all_managers[manager] = int(time.time())
+    return manager
 
 
 def _get_client(
@@ -229,8 +260,12 @@ def _get_client(
 
     `bypass_env_proxy` connects directly instead of honouring the
     HTTP(S)_PROXY env vars. Only ever set for PostHog-internal teams
-    (`is_team_allowlisted_for_internal_hosts`) — for customer-supplied config
-    the egress proxy is the SSRF backstop and must stay in the path.
+    (`is_team_allowlisted_for_internal_hosts`) or for an address that came out
+    of our own SSH tunnel — the proxy blocks the tunnel's loopback bind, and no
+    request would reach the forwarded port. For a customer-supplied host the
+    egress proxy is the SSRF backstop and must stay in the path, so callers
+    take the tunnel flag from the helper that produced the address rather than
+    inferring it from the host looking like loopback.
     """
     attempt = 0
     while True:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -264,8 +264,8 @@ def _get_client(
     of our own SSH tunnel — the proxy blocks the tunnel's loopback bind, and no
     request would reach the forwarded port. For a customer-supplied host the
     egress proxy is the SSRF backstop and must stay in the path, so callers
-    take the tunnel flag from the helper that produced the address rather than
-    inferring it from the host looking like loopback.
+    derive the tunnel case from the same predicate the tunnel branch itself
+    uses rather than inferring it from the host looking like loopback.
     """
     attempt = 0
     while True:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -4,7 +4,7 @@ import re
 import ssl
 import math
 import time
-import functools
+import threading
 import collections
 from collections.abc import Callable, Iterator
 from contextlib import _GeneratorContextManager
@@ -225,7 +225,15 @@ class _NoRedirectPoolManager(PoolManager):
         return super().urlopen(method, url, redirect=False, **kw)
 
 
-@functools.cache
+# Bounds the manager cache below. `server_hostname` is user-controlled (the source's
+# configured host), so an unbounded cache would let repeated credential validations with
+# distinct hostnames retain a manager each for the life of the worker. Far above the number
+# of distinct tunneled HTTPS hostnames a worker legitimately serves concurrently.
+_POOL_MANAGER_CACHE_MAX = 32
+_pool_managers: collections.OrderedDict[tuple[bool, str | None], Any] = collections.OrderedDict()
+_pool_managers_lock = threading.Lock()
+
+
 def _no_env_proxy_pool_manager(verify: bool, server_hostname: str | None = None) -> Any:
     """A shared urllib3 pool manager that never consults HTTP(S)_PROXY env vars.
 
@@ -233,9 +241,7 @@ def _no_env_proxy_pool_manager(verify: bool, server_hostname: str | None = None)
     pool manager, so handing it one is the sanctioned per-code-path opt-out
     from the egress proxy (see posthog/security/outbound_proxy.py for the
     requests/httpx equivalents). Cached because clients don't own an injected
-    manager (`close()` leaves it alive), so per-call managers would leak; the
-    cache is bounded by the set of distinct tunneled HTTPS hostnames a worker
-    sees, which is small.
+    manager (`close()` leaves it alive), so per-call managers would leak.
 
     `server_hostname` keeps TLS verification honest through an SSH tunnel: we dial the
     tunnel's loopback bind, but SNI and hostname validation must run against the database's
@@ -243,18 +249,36 @@ def _no_env_proxy_pool_manager(verify: bool, server_hostname: str | None = None)
     with `server_host_name` when it builds its own manager — a branch it skips entirely
     when handed a `pool_mgr`.
 
+    LRU-bounded: eviction closes the manager's pools and removes it from the library's
+    process-global registry, the two places that would otherwise retain it forever. An
+    evicted manager still held by a live client keeps working — urllib3 rebuilds pools on
+    demand — it just stops being shared or expiry-swept.
+
     Built from clickhouse-connect's own options factory so the TCP keepalive tuning and
     certificate handling match a direct connection, then recorded where the library tracks
     its own managers so connection expiry and interpreter-exit cleanup cover this one too.
     """
-    options = httputil.get_pool_manager_options(verify=verify)
-    if server_hostname:
-        if verify:
-            options["assert_hostname"] = server_hostname
-        options["server_hostname"] = server_hostname
-    manager = _NoRedirectPoolManager(**options)
-    httputil.all_managers[manager] = int(time.time())
-    return manager
+    key = (verify, server_hostname)
+    with _pool_managers_lock:
+        manager = _pool_managers.get(key)
+        if manager is not None:
+            _pool_managers.move_to_end(key)
+            return manager
+
+        options = httputil.get_pool_manager_options(verify=verify)
+        if server_hostname:
+            if verify:
+                options["assert_hostname"] = server_hostname
+            options["server_hostname"] = server_hostname
+        manager = _NoRedirectPoolManager(**options)
+        httputil.all_managers[manager] = int(time.time())
+        _pool_managers[key] = manager
+
+        while len(_pool_managers) > _POOL_MANAGER_CACHE_MAX:
+            _, evicted = _pool_managers.popitem(last=False)
+            httputil.all_managers.pop(evicted, None)
+            evicted.clear()
+        return manager
 
 
 def _get_client(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -31,6 +31,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.par
     DEFAULT_PARTITION_TARGET_SIZE_IN_BYTES,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.helpers import incremental_type_to_initial_value
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import _require_loopback
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql import (
     Column,
     Table,
@@ -45,6 +46,11 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
 from products.warehouse_sources.backend.types import IncrementalFieldType, PartitionSettings
+
+# Why a connection is allowed to skip the egress proxy, or None to stay proxied. A reason
+# rather than a bool so `_get_client` — where every call site converges — can check the
+# claim against the address it was given instead of trusting the caller's pairing.
+BypassEnvProxy = Literal["tunnel_loopback", "internal_team"] | None
 
 # ClickHouse default ports
 CLICKHOUSE_HTTP_PORT = 8123
@@ -249,7 +255,7 @@ def _get_client(
     verify: bool,
     query_timeout: int = DATA_QUERY_TIMEOUT_SECONDS,
     settings: Optional[dict[str, Any]] = None,
-    bypass_env_proxy: bool = False,
+    bypass_env_proxy: BypassEnvProxy = None,
 ) -> ClickHouseClient:
     """Create a ClickHouse HTTP client.
 
@@ -258,15 +264,18 @@ def _get_client(
     reader that we use to read very large tables without buffering them in
     memory.
 
-    `bypass_env_proxy` connects directly instead of honouring the
-    HTTP(S)_PROXY env vars. Only ever set for PostHog-internal teams
-    (`is_team_allowlisted_for_internal_hosts`) or for an address that came out
-    of our own SSH tunnel — the proxy blocks the tunnel's loopback bind, and no
-    request would reach the forwarded port. For a customer-supplied host the
-    egress proxy is the SSRF backstop and must stay in the path, so callers
-    derive the tunnel case from the same predicate the tunnel branch itself
-    uses rather than inferring it from the host looking like loopback.
+    `bypass_env_proxy` names why the connection may skip the HTTP(S)_PROXY env
+    vars: "internal_team" for PostHog-internal teams
+    (`is_team_allowlisted_for_internal_hosts`), "tunnel_loopback" for an
+    address that came out of our own SSH tunnel — the proxy blocks the tunnel's
+    loopback bind, and no request would reach the forwarded port. For a
+    customer-supplied host the egress proxy is the SSRF backstop and must stay
+    in the path, so the tunnel claim is checked against the address here: the
+    flag and the host travel to this point independently, and a caller pairing
+    "tunnel_loopback" with a non-loopback host has lost that pairing.
     """
+    if bypass_env_proxy == "tunnel_loopback":
+        _require_loopback(host)
     attempt = 0
     while True:
         try:
@@ -388,7 +397,7 @@ def get_schemas(
     secure: bool,
     verify: bool,
     names: list[str] | None = None,
-    bypass_env_proxy: bool = False,
+    bypass_env_proxy: BypassEnvProxy = None,
 ) -> dict[str, list[tuple[str, str, bool]]]:
     """Discover columns for all tables in the given database.
 
@@ -504,7 +513,7 @@ def get_clickhouse_row_count(
     secure: bool,
     verify: bool,
     names: list[str] | None = None,
-    bypass_env_proxy: bool = False,
+    bypass_env_proxy: BypassEnvProxy = None,
 ) -> dict[str, int]:
     """Return total_rows per table from `system.tables`.
 
@@ -630,7 +639,7 @@ def get_connection_metadata(
     password: str | None,
     secure: bool,
     verify: bool,
-    bypass_env_proxy: bool = False,
+    bypass_env_proxy: BypassEnvProxy = None,
 ) -> dict[str, Any]:
     """Probe the server for version metadata.
 
@@ -882,7 +891,7 @@ def get_primary_keys_for_schemas(
     secure: bool,
     verify: bool,
     table_names: list[str],
-    bypass_env_proxy: bool = False,
+    bypass_env_proxy: BypassEnvProxy = None,
 ) -> dict[str, list[str] | None]:
     """Detect primary keys (sorting key columns) for multiple tables.
 
@@ -1307,7 +1316,7 @@ def clickhouse_source(
     incremental_field_type: Optional[IncrementalFieldType] = None,
     row_filters: Optional[list[ValidatedRowFilter]] = None,
     enabled_columns: Optional[list[str]] = None,
-    bypass_env_proxy: bool = False,
+    bypass_env_proxy: BypassEnvProxy = None,
 ) -> SourceResponse:
     """Build a SourceResponse that pulls a single ClickHouse table.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -69,6 +69,13 @@ _TEMPORARILY_UNAVAILABLE = (
     "ClickHouse is temporarily busy or unavailable and didn't accept the connection. Wait a moment and try again."
 )
 
+# Connections that skip the egress proxy don't follow redirects, so a redirecting endpoint
+# comes back as a 3xx response code instead of a request to wherever it pointed.
+_REDIRECTED = (
+    "We reached your ClickHouse host but it redirected us, and redirects aren't followed. Point the source at the "
+    "ClickHouse HTTP interface directly rather than at a proxy or load balancer in front of it."
+)
+
 # Error message → user-friendly translation. Matched as a substring of the
 # exception string. Patterns are lowercase-matched.
 ClickHouseErrors: dict[str, str] = {
@@ -82,6 +89,10 @@ ClickHouseErrors: dict[str, str] = {
     "name or service not known": "Could not resolve the ClickHouse host",
     "connection refused": "Could not connect to ClickHouse on the given host/port",
     "connection timed out": "Connection to ClickHouse timed out. Does your database have our IP addresses allow-listed?",
+    # Must stay above the generic "ssl" entry, which would otherwise match first and send the
+    # user to the wrong toggle. Expected over an SSH tunnel: we connect to the tunnel's local
+    # address, which a certificate issued for the database's own hostname doesn't cover.
+    "hostname mismatch": "The server's TLS certificate doesn't cover the address we connect to. Set 'Verify SSL certificate?' to No, or use a host the certificate covers.",
     "ssl": "TLS/SSL handshake failed. If your server does not use TLS, disable the HTTPS toggle.",
     # The host answered but isn't serving the ClickHouse HTTP interface on this
     # host/port (wrong port, a proxy, or a native-protocol port). Same wording
@@ -90,6 +101,10 @@ ClickHouseErrors: dict[str, str] = {
     # `_get_client` raises this when the host answers 2xx with a body that isn't a
     # ClickHouse response (a proxy/LB page, or a different service on the host/port).
     "did not return a valid clickhouse response": NOT_A_CLICKHOUSE_HTTP_RESPONSE,
+    "returned response code 301": _REDIRECTED,
+    "returned response code 302": _REDIRECTED,
+    "returned response code 307": _REDIRECTED,
+    "returned response code 308": _REDIRECTED,
     "returned response code 429": _TEMPORARILY_UNAVAILABLE,
     "returned response code 502": _TEMPORARILY_UNAVAILABLE,
     "returned response code 503": _TEMPORARILY_UNAVAILABLE,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -110,6 +110,20 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.CLICKHOUSE
 
+    def _bypass_env_proxy(self, config: ClickHouseSourceConfig, team_id: int) -> bool:
+        """Whether this connection must skip the egress proxy.
+
+        Two cases, both of which the proxy would refuse. Internal teams may point a source at a
+        PostHog-internal host. And a tunneled connection is made to the tunnel's own loopback
+        bind address, which the proxy blocks by design — clickhouse-connect honours HTTP_PROXY
+        for every host including loopback, so the request would never reach the forwarded port
+        and the tunnel would open no channel to the customer's ClickHouse.
+
+        ClickHouse is the only tunnel-capable source this bites: the other database drivers use
+        raw TCP sockets and ignore the proxy env vars entirely.
+        """
+        return self.ssh_tunnel_enabled(config) or is_team_allowlisted_for_internal_hosts(team_id)
+
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
@@ -330,7 +344,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                 verify=config.verify,
                 query_timeout=query_timeout,
                 settings=settings,
-                bypass_env_proxy=is_team_allowlisted_for_internal_hosts(team_id),
+                bypass_env_proxy=self._bypass_env_proxy(config, team_id),
             )
             try:
                 yield client
@@ -348,9 +362,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
     ) -> list[SourceSchema]:
         schemas: list[SourceSchema] = []
 
-        # Internal teams may point at PostHog-internal ClickHouse hosts, which the
-        # egress proxy would refuse — connect those directly.
-        bypass_env_proxy = is_team_allowlisted_for_internal_hosts(team_id)
+        bypass_env_proxy = self._bypass_env_proxy(config, team_id)
 
         with self.with_ssh_tunnel(config, team_id) as (host, port):
             db_schemas = get_clickhouse_schemas(
@@ -483,7 +495,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                 password=config.password,
                 secure=config.secure,
                 verify=config.verify,
-                bypass_env_proxy=is_team_allowlisted_for_internal_hosts(team_id),
+                bypass_env_proxy=self._bypass_env_proxy(config, team_id),
             )
 
     def source_for_pipeline(self, config: ClickHouseSourceConfig, inputs: SourceInputs) -> SourceResponse:
@@ -509,7 +521,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             chunk_size_override=schema.chunk_size_override,
             row_filters=inputs.row_filters,
             enabled_columns=inputs.enabled_columns,
-            bypass_env_proxy=is_team_allowlisted_for_internal_hosts(inputs.team_id),
+            bypass_env_proxy=self._bypass_env_proxy(config, inputs.team_id),
         )
 
     def reconcile_schema_metadata(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -91,9 +91,11 @@ ClickHouseErrors: dict[str, str] = {
     "connection refused": "Could not connect to ClickHouse on the given host/port",
     "connection timed out": "Connection to ClickHouse timed out. Does your database have our IP addresses allow-listed?",
     # Must stay above the generic "ssl" entry, which would otherwise match first and send the
-    # user to the wrong toggle. Expected over an SSH tunnel: we connect to the tunnel's local
-    # address, which a certificate issued for the database's own hostname doesn't cover.
-    "hostname mismatch": "The server's TLS certificate doesn't cover the address we connect to. Set 'Verify SSL certificate?' to No, or use a host the certificate covers.",
+    # user to the wrong toggle. Verification runs against the configured ClickHouse host even
+    # over an SSH tunnel (server_hostname), so a mismatch is real: the certificate doesn't
+    # cover the host the user configured. Deliberately does not suggest turning verification
+    # off — that would train users into a MITM-able setup.
+    "hostname mismatch": "The server's TLS certificate doesn't cover the ClickHouse host configured for this source. Use a host name the certificate covers.",
     "ssl": "TLS/SSL handshake failed. If your server does not use TLS, disable the HTTPS toggle.",
     # The host answered but isn't serving the ClickHouse HTTP interface on this
     # host/port (wrong port, a proxy, or a native-protocol port). Same wording
@@ -367,6 +369,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                 query_timeout=query_timeout,
                 settings=settings,
                 bypass_env_proxy=self._bypass_env_proxy(config, team_id),
+                server_hostname=config.host,
             )
             try:
                 yield client
@@ -397,6 +400,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                 verify=config.verify,
                 names=names,
                 bypass_env_proxy=bypass_env_proxy,
+                server_hostname=config.host,
             )
 
             row_counts: dict[str, int] = {}
@@ -411,6 +415,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                     verify=config.verify,
                     names=names,
                     bypass_env_proxy=bypass_env_proxy,
+                    server_hostname=config.host,
                 )
 
             detected_pks = get_clickhouse_primary_keys_for_schemas(
@@ -423,6 +428,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                 verify=config.verify,
                 table_names=list(db_schemas.keys()),
                 bypass_env_proxy=bypass_env_proxy,
+                server_hostname=config.host,
             )
 
         for table_name, columns in db_schemas.items():
@@ -518,6 +524,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                 secure=config.secure,
                 verify=config.verify,
                 bypass_env_proxy=self._bypass_env_proxy(config, team_id),
+                server_hostname=config.host,
             )
 
     def source_for_pipeline(self, config: ClickHouseSourceConfig, inputs: SourceInputs) -> SourceResponse:
@@ -544,6 +551,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             row_filters=inputs.row_filters,
             enabled_columns=inputs.enabled_columns,
             bypass_env_proxy=self._bypass_env_proxy(config, inputs.team_id),
+            server_hostname=config.host,
         )
 
     def reconcile_schema_metadata(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -22,6 +22,7 @@ from posthog.exceptions_capture import capture_exception
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse.clickhouse import (
     NOT_A_CLICKHOUSE_HTTP_RESPONSE,
+    BypassEnvProxy,
     ClickHouseConnectionError,
     _get_client,
     clickhouse_source,
@@ -125,20 +126,25 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.CLICKHOUSE
 
-    def _bypass_env_proxy(self, config: ClickHouseSourceConfig, team_id: int) -> bool:
-        """Whether this connection must skip the egress proxy.
+    def _bypass_env_proxy(self, config: ClickHouseSourceConfig, team_id: int) -> BypassEnvProxy:
+        """Why this connection may skip the egress proxy, or None to stay proxied.
 
         Two cases, both of which the proxy would refuse. Internal teams may point a source at a
         PostHog-internal host. And a tunneled connection is made to the tunnel's own loopback
-        bind address (enforced by `_require_loopback` in the tunnel helpers), which the proxy
-        blocks by design — clickhouse-connect honours HTTP_PROXY for every host including
-        loopback, so the request would never reach the forwarded port and the tunnel would
-        open no channel to the customer's ClickHouse.
+        bind address, which the proxy blocks by design — clickhouse-connect honours HTTP_PROXY
+        for every host including loopback, so the request would never reach the forwarded port
+        and the tunnel would open no channel to the customer's ClickHouse. The tunnel claim is
+        checked twice downstream: the tunnel helpers refuse to yield a non-loopback bind, and
+        `_get_client` refuses a non-loopback host claiming "tunnel_loopback".
 
         ClickHouse is the only tunnel-capable source this bites: the other database drivers use
         raw TCP sockets and ignore the proxy env vars entirely.
         """
-        return self.ssh_tunnel_enabled(config) or is_team_allowlisted_for_internal_hosts(team_id)
+        if self.ssh_tunnel_enabled(config):
+            return "tunnel_loopback"
+        if is_team_allowlisted_for_internal_hosts(team_id):
+            return "internal_team"
+        return None
 
     @property
     def get_source_config(self) -> SourceConfig:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -130,9 +130,10 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
 
         Two cases, both of which the proxy would refuse. Internal teams may point a source at a
         PostHog-internal host. And a tunneled connection is made to the tunnel's own loopback
-        bind address, which the proxy blocks by design — clickhouse-connect honours HTTP_PROXY
-        for every host including loopback, so the request would never reach the forwarded port
-        and the tunnel would open no channel to the customer's ClickHouse.
+        bind address (enforced by `_require_loopback` in the tunnel helpers), which the proxy
+        blocks by design — clickhouse-connect honours HTTP_PROXY for every host including
+        loopback, so the request would never reach the forwarded port and the tunnel would
+        open no channel to the customer's ClickHouse.
 
         ClickHouse is the only tunnel-capable source this bites: the other database drivers use
         raw TCP sockets and ignore the proxy env vars entirely.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -36,6 +36,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse
     get_primary_keys_for_schemas,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse.source import (
+    _REDIRECTED,
     _TEMPORARILY_UNAVAILABLE,
     GENERIC_CONNECTION_ERROR,
     ClickHouseSource,
@@ -958,6 +959,24 @@ class TestTranslateError:
         msg = f"HTTPDriver for https://host:8443 returned response code {code}"
         assert ClickHouseSource._translate_error(msg) == _TEMPORARILY_UNAVAILABLE
 
+    @pytest.mark.parametrize("code", ["301", "302", "307", "308"])
+    def test_redirect_responses_name_the_redirect(self, code):
+        # Proxy-bypassing connections don't follow redirects, so the 3xx reaches the user.
+        msg = f"HTTPDriver for https://host:8443 returned response code {code}"
+        assert ClickHouseSource._translate_error(msg) == _REDIRECTED
+
+    def test_certificate_hostname_mismatch_points_at_the_verify_toggle(self):
+        # Expected when tunneling: the certificate covers the database's own hostname, not
+        # the tunnel's local address. Matching the generic "ssl" entry first would tell the
+        # user to disable HTTPS, which is the wrong toggle.
+        msg = (
+            "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, "
+            "certificate is not valid for '127.0.0.1'"
+        )
+        translated = ClickHouseSource._translate_error(msg)
+        assert translated is not None
+        assert "Verify SSL certificate?" in translated
+
 
 class TestGetSchemas:
     """Tests `get_schemas` with a fully mocked ClickHouse client."""
@@ -1537,8 +1556,8 @@ class TestGetClientEgressProxyRouting:
                     with pytest.raises(ClickHouseConnectionError):
                         _connect_to(port=bound_port, bypass_env_proxy=bypass)
 
-        assert bool(bound_requests) is bypass
-        assert bool(proxy_requests) is not bypass
+        assert bool(bound_requests) == bypass
+        assert bool(proxy_requests) == (not bypass)
 
     def test_redirect_away_from_the_target_is_not_followed(self) -> None:
         # A bypassing connection skips the egress proxy, so following a redirect would let the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -1,4 +1,8 @@
-from collections.abc import AsyncIterable
+import os
+import socket
+import threading
+from collections.abc import AsyncIterable, Iterator
+from contextlib import contextmanager
 
 import pytest
 from posthog.test.base import BaseTest
@@ -6,6 +10,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pyarrow as pa
 from clickhouse_connect.driver.exceptions import ClickHouseError, OperationalError, ProgrammingError
+from parameterized import parameterized
 
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
@@ -1465,21 +1470,111 @@ class TestInternalHostTeamAllowlist:
             assert mixins.is_team_allowlisted_for_internal_hosts(team_id) is expected
 
 
+_FORBIDDEN_RESPONSE = b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+
+
+@contextmanager
+def _recording_server(response: bytes = _FORBIDDEN_RESPONSE) -> Iterator[tuple[int, list[str]]]:
+    server = socket.create_server(("127.0.0.1", 0))
+    server.settimeout(0.1)
+    requests: list[str] = []
+    stop = threading.Event()
+
+    def serve() -> None:
+        while not stop.is_set():
+            try:
+                conn, _ = server.accept()
+            except (TimeoutError, OSError):
+                continue
+            with conn:
+                requests.append(conn.recv(8192).decode("latin-1").split("\r\n")[0])
+                conn.sendall(response)
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    try:
+        yield server.getsockname()[1], requests
+    finally:
+        stop.set()
+        thread.join(timeout=5)
+        server.close()
+
+
+def _connect_to(*, port: int, bypass_env_proxy: bool) -> None:
+    _get_client(
+        host="127.0.0.1",
+        port=port,
+        database="default",
+        user="default",
+        password=None,
+        secure=False,
+        verify=True,
+        bypass_env_proxy=bypass_env_proxy,
+    )
+
+
+class TestGetClientEgressProxyRouting:
+    """Where the connection actually goes, which is what decides whether a tunnel works.
+
+    PostHog's runtime points HTTP_PROXY at the Smokescreen egress proxy, and Smokescreen blocks
+    loopback. Routing a tunneled connection through it means the request never reaches the SSH
+    tunnel's local forwarded port, so the tunnel opens no channel to the customer's ClickHouse
+    and the source fails with a generic connection error. The stub servers answer with a
+    deterministic 403 rather than dropping the connection so that `_get_client` raises on the
+    first attempt instead of entering its transient-retry backoff.
+    """
+
+    @parameterized.expand([("bypassing", True), ("proxied", False)])
+    def test_only_a_proxied_connection_goes_through_the_egress_proxy(self, _name: str, bypass: bool) -> None:
+        with _recording_server() as (proxy_port, proxy_requests):
+            with _recording_server() as (bound_port, bound_requests):
+                proxy_url = f"http://127.0.0.1:{proxy_port}"
+                env = {"HTTP_PROXY": proxy_url, "http_proxy": proxy_url}
+                with patch.dict(os.environ, env):
+                    os.environ.pop("NO_PROXY", None)
+                    os.environ.pop("no_proxy", None)
+
+                    with pytest.raises(ClickHouseConnectionError):
+                        _connect_to(port=bound_port, bypass_env_proxy=bypass)
+
+        assert bool(bound_requests) is bypass
+        assert bool(proxy_requests) is not bypass
+
+    def test_redirect_away_from_the_target_is_not_followed(self) -> None:
+        # A bypassing connection skips the egress proxy, so following a redirect would let the
+        # host we reached send us to an address the proxy would have denied.
+        with _recording_server() as (elsewhere_port, elsewhere_requests):
+            redirect = (
+                f"HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{elsewhere_port}/\r\n"
+                "Content-Length: 0\r\nConnection: close\r\n\r\n"
+            ).encode()
+            with _recording_server(response=redirect) as (bound_port, bound_requests):
+                with pytest.raises(ClickHouseConnectionError):
+                    _connect_to(port=bound_port, bypass_env_proxy=True)
+
+        assert bound_requests
+        assert elsewhere_requests == []
+
+
 class TestDirectQueryClientBypassEnvProxy:
     """`direct_query_client` backs the HogQL direct-SQL adapter, and unlike every other
     `_get_client` call site on `ClickHouseSource` it once omitted `bypass_env_proxy` entirely —
     an allowlisted internal team's direct query silently routed through the egress proxy and
     failed to reach the PostHog-internal host it was pointed at.
+
+    A tunneled connection must bypass for a different reason: the address is our own loopback
+    bind, which the proxy blocks, so a customer team with a tunnel never reached its ClickHouse.
     """
 
     @pytest.mark.parametrize(
-        "region,team_id,expected_bypass",
+        "region,team_id,tunneled,expected_bypass",
         [
-            ("US", 2, True),
-            ("US", 12345, False),
+            ("US", 2, False, True),
+            ("US", 12345, False, False),
+            ("US", 12345, True, True),
         ],
     )
-    def test_forwards_bypass_env_proxy_from_team_allowlist(self, region, team_id, expected_bypass):
+    def test_forwards_bypass_env_proxy_from_team_allowlist(self, region, team_id, tunneled, expected_bypass):
         from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse import source as source_module
         from products.warehouse_sources.backend.temporal.data_imports.sources.common import mixins
 
@@ -1490,6 +1585,7 @@ class TestDirectQueryClientBypassEnvProxy:
         config.password = None
         config.secure = True
         config.verify = True
+        config.ssh_tunnel = MagicMock(enabled=True) if tunneled else None
 
         with patch.object(mixins, "get_instance_region", return_value=region):
             with patch.object(source, "with_ssh_tunnel") as mock_with_ssh_tunnel:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -965,17 +965,19 @@ class TestTranslateError:
         msg = f"HTTPDriver for https://host:8443 returned response code {code}"
         assert ClickHouseSource._translate_error(msg) == _REDIRECTED
 
-    def test_certificate_hostname_mismatch_points_at_the_verify_toggle(self):
-        # Expected when tunneling: the certificate covers the database's own hostname, not
-        # the tunnel's local address. Matching the generic "ssl" entry first would tell the
-        # user to disable HTTPS, which is the wrong toggle.
+    def test_certificate_hostname_mismatch_names_the_certificate_not_the_toggles(self):
+        # Verification runs against the configured host even over a tunnel, so a mismatch is
+        # a real certificate problem. Matching the generic "ssl" entry first would tell the
+        # user to disable HTTPS, and the message must not suggest turning verification off.
         msg = (
             "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, "
             "certificate is not valid for '127.0.0.1'"
         )
         translated = ClickHouseSource._translate_error(msg)
         assert translated is not None
-        assert "Verify SSL certificate?" in translated
+        assert "certificate" in translated
+        assert "HTTPS" not in translated
+        assert "Verify SSL" not in translated
 
 
 class TestGetSchemas:
@@ -1448,7 +1450,7 @@ class TestBypassEnvProxy:
     @pytest.mark.parametrize(
         "bypass,expected_pool_mgr_factory",
         [
-            ("internal_team", lambda: ch_module._no_env_proxy_pool_manager(True)),
+            ("internal_team", lambda: ch_module._no_env_proxy_pool_manager(True, None)),
             (None, lambda: None),
         ],
     )
@@ -1575,6 +1577,30 @@ class TestGetClientEgressProxyRouting:
         assert bound_requests
         assert elsewhere_requests == []
 
+    def test_tunneled_https_verifies_against_the_database_hostname(self) -> None:
+        # We dial the tunnel's loopback bind, so SNI and hostname validation must run against
+        # the database's own hostname or a valid certificate can never match — and the
+        # workaround users would reach for is disabling verification, which invites MITM
+        # between the SSH server and ClickHouse.
+        with patch.object(ch_module, "get_client") as mock_get_client:
+            _get_client(
+                host="127.0.0.1",
+                port=8443,
+                database="default",
+                user="default",
+                password=None,
+                secure=True,
+                verify=True,
+                bypass_env_proxy="tunnel_loopback",
+                server_hostname="clickhouse.internal",
+            )
+        manager = mock_get_client.call_args.kwargs["pool_mgr"]
+        pool = manager.connection_from_host("127.0.0.1", 8443, scheme="https")
+        assert pool.assert_hostname == "clickhouse.internal"
+        assert pool.conn_kw["server_hostname"] == "clickhouse.internal"
+        # Plain-HTTP tunnels must not share the hostname-pinned manager.
+        assert manager is not ch_module._no_env_proxy_pool_manager(True, None)
+
     def test_tunnel_claim_with_non_loopback_host_is_refused(self) -> None:
         # The flag and the host reach `_get_client` independently; a caller pairing the
         # tunnel claim with a host that didn't come from a tunnel must fail loudly, before
@@ -1618,6 +1644,7 @@ class TestDirectQueryClientBypassEnvProxy:
 
         source = ClickHouseSource()
         config = MagicMock()
+        config.host = "db.example.com"
         config.database = "default"
         config.user = "default"
         config.password = None
@@ -1633,3 +1660,6 @@ class TestDirectQueryClientBypassEnvProxy:
                         pass
 
         assert mock_get_client.call_args.kwargs["bypass_env_proxy"] == expected_bypass
+        # The configured host always rides along; `_get_client` only applies it to TLS when
+        # the bypass reason is the tunnel.
+        assert mock_get_client.call_args.kwargs["server_hostname"] == "db.example.com"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -1469,6 +1469,21 @@ class TestBypassEnvProxy:
         assert mock_get_client.call_count == 1
         assert mock_get_client.call_args.kwargs["pool_mgr"] is expected_pool_mgr_factory()
 
+    def test_eviction_releases_the_manager_everywhere_it_is_retained(self):
+        # The cache key contains the user-controlled hostname, so it must be bounded — and a
+        # bounded cache only helps if eviction also drops the manager from clickhouse-connect's
+        # process-global registry, the other place that would retain it for the worker's life.
+        from clickhouse_connect.driver.httputil import all_managers
+
+        with patch.object(ch_module, "_POOL_MANAGER_CACHE_MAX", 2):
+            first = ch_module._no_env_proxy_pool_manager(True, "evict-me.example")
+            assert first in all_managers
+            for n in range(2):
+                ch_module._no_env_proxy_pool_manager(True, f"filler-{n}.example")
+
+        assert first not in all_managers
+        assert ch_module._no_env_proxy_pool_manager(True, "evict-me.example") is not first
+
 
 class TestInternalHostTeamAllowlist:
     @pytest.mark.parametrize(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -1448,8 +1448,8 @@ class TestBypassEnvProxy:
     @pytest.mark.parametrize(
         "bypass,expected_pool_mgr_factory",
         [
-            (True, lambda: ch_module._no_env_proxy_pool_manager(True)),
-            (False, lambda: None),
+            ("internal_team", lambda: ch_module._no_env_proxy_pool_manager(True)),
+            (None, lambda: None),
         ],
     )
     def test_get_client_forwards_pool_manager_only_when_bypassing(self, bypass, expected_pool_mgr_factory):
@@ -1519,7 +1519,7 @@ def _recording_server(response: bytes = _FORBIDDEN_RESPONSE) -> Iterator[tuple[i
         server.close()
 
 
-def _connect_to(*, port: int, bypass_env_proxy: bool) -> None:
+def _connect_to(*, port: int, bypass_env_proxy: "ch_module.BypassEnvProxy") -> None:
     _get_client(
         host="127.0.0.1",
         port=port,
@@ -1543,8 +1543,8 @@ class TestGetClientEgressProxyRouting:
     first attempt instead of entering its transient-retry backoff.
     """
 
-    @parameterized.expand([("bypassing", True), ("proxied", False)])
-    def test_only_a_proxied_connection_goes_through_the_egress_proxy(self, _name: str, bypass: bool) -> None:
+    @parameterized.expand([("tunneled", "tunnel_loopback"), ("internal", "internal_team"), ("proxied", None)])
+    def test_only_a_proxied_connection_goes_through_the_egress_proxy(self, _name: str, reason) -> None:
         with _recording_server() as (proxy_port, proxy_requests):
             with _recording_server() as (bound_port, bound_requests):
                 proxy_url = f"http://127.0.0.1:{proxy_port}"
@@ -1554,10 +1554,11 @@ class TestGetClientEgressProxyRouting:
                     os.environ.pop("no_proxy", None)
 
                     with pytest.raises(ClickHouseConnectionError):
-                        _connect_to(port=bound_port, bypass_env_proxy=bypass)
+                        _connect_to(port=bound_port, bypass_env_proxy=reason)
 
-        assert bool(bound_requests) == bypass
-        assert bool(proxy_requests) == (not bypass)
+        bypassed = reason is not None
+        assert bool(bound_requests) == bypassed
+        assert bool(proxy_requests) == (not bypassed)
 
     def test_redirect_away_from_the_target_is_not_followed(self) -> None:
         # A bypassing connection skips the egress proxy, so following a redirect would let the
@@ -1569,10 +1570,28 @@ class TestGetClientEgressProxyRouting:
             ).encode()
             with _recording_server(response=redirect) as (bound_port, bound_requests):
                 with pytest.raises(ClickHouseConnectionError):
-                    _connect_to(port=bound_port, bypass_env_proxy=True)
+                    _connect_to(port=bound_port, bypass_env_proxy="tunnel_loopback")
 
         assert bound_requests
         assert elsewhere_requests == []
+
+    def test_tunnel_claim_with_non_loopback_host_is_refused(self) -> None:
+        # The flag and the host reach `_get_client` independently; a caller pairing the
+        # tunnel claim with a host that didn't come from a tunnel must fail loudly, before
+        # any connection is attempted with the proxy-bypassing manager.
+        with patch.object(ch_module, "get_client") as mock_get_client:
+            with pytest.raises(Exception, match="non-loopback"):
+                _get_client(
+                    host="ch.example.com",
+                    port=8443,
+                    database="default",
+                    user="default",
+                    password=None,
+                    secure=True,
+                    verify=True,
+                    bypass_env_proxy="tunnel_loopback",
+                )
+        mock_get_client.assert_not_called()
 
 
 class TestDirectQueryClientBypassEnvProxy:
@@ -1588,9 +1607,9 @@ class TestDirectQueryClientBypassEnvProxy:
     @pytest.mark.parametrize(
         "region,team_id,tunneled,expected_bypass",
         [
-            ("US", 2, False, True),
-            ("US", 12345, False, False),
-            ("US", 12345, True, True),
+            ("US", 2, False, "internal_team"),
+            ("US", 12345, False, None),
+            ("US", 12345, True, "tunnel_loopback"),
         ],
     )
     def test_forwards_bypass_env_proxy_from_team_allowlist(self, region, team_id, tunneled, expected_bypass):
@@ -1613,4 +1632,4 @@ class TestDirectQueryClientBypassEnvProxy:
                     with source.direct_query_client(config, team_id, query_timeout=60):
                         pass
 
-        assert mock_get_client.call_args.kwargs["bypass_env_proxy"] is expected_bypass
+        assert mock_get_client.call_args.kwargs["bypass_env_proxy"] == expected_bypass

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
@@ -241,6 +241,16 @@ class SSHTunnelMixin:
     ) -> Callable[[], _GeneratorContextManager[tuple[str, int]]]:
         return make_ssh_tunnel_factory(config, team_id)
 
+    def ssh_tunnel_enabled(self, config) -> bool:
+        """Whether the tunnel helpers above will tunnel rather than connect directly.
+
+        For callers that need to know which branch was taken, because the `(host, port)` they
+        receive means something different in each case: a tunnel yields our own local bind
+        address, while a direct connection yields the user's configured host. Shares
+        `_enabled_ssh_tunnel` with the branch itself so the two cannot drift apart.
+        """
+        return _enabled_ssh_tunnel(config) is not None
+
     def ssh_tunnel_is_valid(self, config, team_id: int) -> tuple[bool, str | None]:
         if hasattr(config, "ssh_tunnel") and config.ssh_tunnel and config.ssh_tunnel.enabled:
             if config.ssh_tunnel.host:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
@@ -1,5 +1,6 @@
 import time
 import socket
+import ipaddress
 from collections.abc import Callable, Generator
 from contextlib import _GeneratorContextManager, contextmanager
 from typing import Any
@@ -183,6 +184,25 @@ def _logged_connection(config, team_id: int | None) -> Generator[None]:
         raise
 
 
+def _require_loopback(host: str) -> str:
+    """Refuse to treat a non-loopback address as a tunnel bind.
+
+    ClickHouse skips the egress proxy for tunneled connections on the strength of the tunnel
+    branch only ever yielding its own loopback bind address (`SSHTunnel.get_tunnel` pins
+    `local_bind_address` to 127.0.0.1). That invariant lives in a different file from the
+    bypass, so enforce it where the address is produced: if a future change makes this branch
+    yield anything else — a fallback to the configured host, a non-loopback bind — the proxy
+    bypass would silently extend to it, and this raises instead.
+    """
+    try:
+        is_loopback = ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        is_loopback = False
+    if not is_loopback:
+        raise Exception(f"SSH tunnel bound to non-loopback address {host!r}; refusing to use it")
+    return host
+
+
 @contextmanager
 def open_ssh_tunnel(config, team_id: int | None = None) -> Generator[tuple[str, int]]:
     """Yield `(host, port)` for a database connection, going through an SSH tunnel if configured."""
@@ -195,7 +215,7 @@ def open_ssh_tunnel(config, team_id: int | None = None) -> Generator[tuple[str, 
                 if tunnel is None:
                     raise Exception("Can't open tunnel to SSH server")
 
-                yield tunnel.local_bind_host, tunnel.local_bind_port
+                yield _require_loopback(tunnel.local_bind_host), tunnel.local_bind_port
         else:
             yield config.host, config.port
 
@@ -218,7 +238,7 @@ def make_ssh_tunnel_factory(
                 with ssh_tunnel.get_tunnel(config.host, config.port) as tunnel:
                     if tunnel is None:
                         raise Exception("Can't open tunnel to SSH server")
-                    yield tunnel.local_bind_host, tunnel.local_bind_port
+                    yield _require_loopback(tunnel.local_bind_host), tunnel.local_bind_port
 
         return with_ssh_func
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
@@ -317,6 +317,22 @@ class TestConnectionOpenLogging(SimpleTestCase):
         assert all(call.kwargs["team_id"] == 42 for call in mock_logger.info.call_args_list)
 
 
+class TestTunnelYieldsLoopbackOnly(SimpleTestCase):
+    # ClickHouse bypasses the egress proxy for tunneled connections on the strength of the
+    # tunnel branch only ever yielding its own loopback bind. A tunnel bound anywhere else
+    # must be refused, not silently handed to a proxy-bypassing client.
+    @parameterized.expand([("open_ssh_tunnel", None), ("factory", None)])
+    def test_non_loopback_bind_is_refused(self, entrypoint: str, _unused: None):
+        config = FakeConfig(ssh_tunnel=FakeSSHTunnelConfig(enabled=True, host="0.tcp.ngrok.example"))
+        with patch(f"{_MIXINS_MODULE}.SSHTunnel") as mock_ssh, patch(f"{_MIXINS_MODULE}.logger"):
+            tunnel = mock_ssh.from_config.return_value.get_tunnel.return_value.__enter__.return_value
+            tunnel.local_bind_host, tunnel.local_bind_port = "10.0.0.5", 55555
+            cm = open_ssh_tunnel(config) if entrypoint == "open_ssh_tunnel" else make_ssh_tunnel_factory(config)()
+            with pytest.raises(Exception, match="non-loopback"):
+                with cm:
+                    pass
+
+
 class TestOAuthMixinIntegrationFetchResilience(SimpleTestCase):
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

Setting up a ClickHouse data warehouse source over an SSH tunnel always failed with a generic "could not connect to ClickHouse" error. The reporter's `sshd` logs showed our client authenticating successfully and then closing the connection under a second later, without ever opening a `direct-tcpip` channel. The port forward was never requested, so their ClickHouse was never contacted. They reproduced it with a fully unrestricted SSH user, ruling out anything on their side.

ClickHouse is the only tunnel-capable source whose driver speaks HTTP. `clickhouse-connect` runs over urllib3 and resolves `HTTP_PROXY` per host with no loopback exemption (`check_env_proxy` only skips hosts listed in `NO_PROXY`), so the tunneled request went to the Smokescreen egress proxy, which blocks loopback by design. It never reached the tunnel's local forwarded port, the tunnel opened no channel, and the idle SSH connection was torn down. Postgres, MySQL, MSSQL and Redshift are unaffected — their drivers use raw TCP sockets and ignore the proxy env vars.

This hit the sync path too, not just the connection test, since both build their client the same way.

```mermaid
flowchart LR
  W{{Data import worker}} -->|"http://127.0.0.1:ephemeral"| P[Smokescreen egress proxy]
  P -->|loopback refused| F[Generic connect error]
  T[SSH tunnel local bind] -.->|never reached| C[(Customer ClickHouse)]
  classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
  classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
  classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
  class W phBlue;
  class P,F phRed;
  class T,C phGray;
```

## Changes

Master already has the opt-out this needs: `bypass_env_proxy` hands `clickhouse-connect` a pool manager, which makes it skip its own proxy wiring. Until now it was only ever set for teams allowlisted for PostHog-internal hosts (#74205, #74270). A tunneled address needs the same treatment for a different reason, so `ClickHouseSource._bypass_env_proxy` now returns true for either case, and the four call sites (connection test and schema discovery, connection metadata, direct HogQL queries, streaming sync reads) go through it.

Two things worth flagging for review:

- **The tunnel provenance is threaded through explicitly, not sniffed from the host string.** `SSHTunnelMixin.ssh_tunnel_enabled` shares its predicate with the tunnel branch itself, so the flag can't drift from the path actually taken. Matching on "host looks like loopback" would have been smaller, but it also bypasses the proxy for a *user-supplied* loopback host, and there the proxy is the control stopping a source from reaching the worker's own services.
- **The shared pool manager now refuses redirects.** urllib3 follows a cross-host redirect on the same manager, so a proxy-bypassing manager would let the host we reached send us to an address the proxy exists to deny. This applies to the internal-host bypass as well, which has the same exposure — a ClickHouse HTTP endpoint has no reason to redirect us, so a 3xx now comes back as a connection error.

Two error translations come with it, both for failures this change makes reachable. A tunneled server on HTTPS with certificate verification on now fails on hostname verification instead of at the proxy, because the certificate covers the database's own hostname and we connect to the tunnel's local address; that matched the generic `"ssl"` entry and told the user to turn off the HTTPS toggle, which is the wrong one. And a bypassing connection that gets a 3xx now surfaces the redirect rather than falling through to "check that the host and port are correct".

> [!NOTE]
> Direct (non-tunneled) connections for non-allowlisted teams are untouched and still go through Smokescreen for egress control. This stays a per-code-path opt-out, not a `NO_PROXY` entry.

### Tunneled HTTPS verifies against the database hostname

A tunneled HTTPS connection dials the tunnel's loopback bind, so SNI and certificate hostname validation would run against `127.0.0.1` and a valid certificate could never match — pushing users toward disabling verification, which invites MITM between the SSH server and ClickHouse. The proxy-bypassing pool manager now pins `server_hostname`/`assert_hostname` to the configured ClickHouse host (mirroring clickhouse-connect's own `server_host_name` handling, which it skips entirely when handed a `pool_mgr` — `httpclient.py:104`), with the manager cache keyed on `(verify, hostname)`. Because the hostname is user-controlled, that cache is LRU-bounded, and eviction closes the manager and removes it from clickhouse-connect's process-global registry. The hostname-mismatch error message no longer suggests turning verification off.

## How did you test this code?

`TestGetClientEgressProxyRouting` stands up two loopback stub servers, points `HTTP_PROXY` at one and the client at the other, and asserts which one receives the request — no existing test covered where the connection is routed, only which kwarg was passed. Its second case asserts a redirect off the target is not followed. `TestDirectQueryClientBypassEnvProxy` gains a tunneled non-allowlisted case, which is exactly the reported scenario. The four call sites now share one helper, so they aren't tested individually.

`TestTranslateError` gains cases for the two new translations; the certificate one guards the ordering trap, since the generic `"ssl"` entry would otherwise match first and give the wrong advice.

I verified both guards fail when mutated: dropping the tunnel term from `_bypass_env_proxy` fails the tunneled case, and restoring urllib3's redirect following fails the redirect case. The stub servers answer with a deterministic 403 so `_get_client` raises on the first attempt instead of entering its retry backoff; the suite needs no ClickHouse and runs in ~11s.

Automated checks run locally:

- `pytest .../clickhouse/test_clickhouse.py .../common/test_mixins.py` — 293 passed.
- `uv run mypy --cache-fine-grained .` repo-wide — clean across 17,395 files, which also confirms no call site was missed.
- `ruff check` / `ruff format --check`, and `hogli ci:preflight --strict`.

I could not reproduce the original failure end to end: that needs an SSH bastion, a ClickHouse serving plain HTTP, and a Smokescreen-like proxy that blocks loopback. **Before merging, someone should confirm the diagnosis against production**, which is cheap: `_logged_connection` in the shared mixins already emits `data_imports.connection_error` with the underlying error string on this path, so a failing tunneled ClickHouse source should show the proxy error there. (I couldn't run that query myself — the `logs` table exceeds the 46 GiB read cap on any window wide enough to catch it.)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing surface changed, so nothing to update. The behavior is internal request routing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude in PostHog Code, directed by me.

This PR was opened on 2026-07-27, closed unmerged, and is now reopened rebased onto master. The original version added its own proxy-less pool manager and threaded a separate `via_tunnel` argument through every ClickHouse helper. Master has since grown `bypass_env_proxy` and `_no_env_proxy_pool_manager` for the internal-host case, so the change is now a much smaller one that reuses them: the plumbing already exists, and only the condition that sets the flag and the manager's redirect handling change. The no-redirect manager and the explicit-provenance argument are carried over from the original review.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`.

Reviewed against my own checklist by a second agent with no context on writing it. Its findings drove the two error translations, the "known gap" section above, and two wording fixes. It also independently re-derived the diagnosis from the installed `clickhouse-connect` and `sshtunnel` sources, which is the part of this PR I could not confirm in production.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
