### PR TITLE
chore(ci): build and publish the streamlit sandbox image

### DIFF
--- a/.github/workflows/cd-sandbox-base-image.yml
+++ b/.github/workflows/cd-sandbox-base-image.yml
@@ -169,7 +169,7 @@ jobs:
                 contains(github.event.pull_request.labels.*.name, 'build-tasks-sandbox-image')
             )
         runs-on: depot-ubuntu-24.04
-        timeout-minutes: 10
+        timeout-minutes: 15
         permissions:
             id-token: write # allow issuing OIDC tokens for this workflow run
             contents: read # allow at least reading the repo contents, add other permissions if necessary
@@ -265,6 +265,17 @@ jobs:
                   platforms: linux/arm64,linux/amd64
                   build-args: |
                       BASE_IMAGE=ghcr.io/posthog/posthog-sandbox-base:${{ github.sha }}
+
+            - name: Build and push container image (streamlit)
+              id: build-streamlit
+              uses: depot/build-push-action@5f3b3c2e5a00f0093de47f657aeaefcedff27d18 # v1.17.0
+              with:
+                  context: . # use local checkout (includes downloaded artifact)
+                  file: ./products/tasks/backend/sandbox/images/Dockerfile.sandbox-streamlit
+                  buildx-fallback: false # the fallback is so slow it's better to just fail
+                  push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
+                  tags: ${{ github.ref == 'refs/heads/master' && format('ghcr.io/posthog/posthog-sandbox-streamlit:master,ghcr.io/posthog/posthog-sandbox-streamlit:{0}', github.sha) || format('ghcr.io/posthog/posthog-sandbox-streamlit:{0}', github.sha) }}
+                  platforms: linux/arm64,linux/amd64
 
     # Single required status check for branch protection. Add future sandbox
     # image jobs to `needs` here rather than reconfiguring GitHub.


### PR DESCRIPTION
## Problem

Starting a Streamlit app fails with `SandboxProvisionError: Failed to create sandbox` before Modal is ever reached.
The sandbox provisioner resolves `ghcr.io/posthog/posthog-sandbox-streamlit:master` to an immutable digest and fails closed when it can't (`modal_sandbox.py` refuses the mutable `:master` tag because Modal caches images by reference indefinitely).
That resolution can never succeed: `Dockerfile.sandbox-streamlit` was merged, but the sandbox image CD workflow only builds `sandbox-base`, `sandbox-notebook`, `sandbox-pi`, and `sandbox-vm` — the streamlit image has never been published to GHCR.

## Changes

- Add a `Build and push container image (streamlit)` step to `cd-sandbox-base-image.yml`, mirroring the existing steps. The image is standalone (pinned `python:3.11-slim` base, no build args, no skills artifact), so no `build-args` are passed.
- Bump the build job `timeout-minutes` from 10 to 15 to account for the fifth sequential multi-arch build.

No changes needed to the paths filter (`products/tasks/backend/sandbox/images/**` already covers the Dockerfile) or to the `sandbox_base_image_check` aggregation job (same job, new step).

> [!NOTE]
> After the first publish, the `posthog-sandbox-streamlit` GHCR package must be flipped to public in the org package settings — digest resolution uses an anonymous pull token, same as the other sandbox images. That's a manual one-time step this PR can't do.

## How did you test this code?

- `bin/hogli lint:workflows` and `hogli ci:preflight` pass (workflow-lint triggered, 0 failures).
- This PR itself triggers the workflow (the workflow file is in its own paths filter), so the streamlit image build runs on this PR — that's the real test that the Dockerfile builds in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — internal CI wiring only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, directed by @sakce. Skills invoked: /authoring-ci-workflows.
Diagnosis path: app start failures traced through worker logs to the digest-resolution failure, then confirmed the GHCR package doesn't exist (GitHub API 404, anonymous manifest request 403) and that no workflow references the streamlit Dockerfile.
Kept the step consistent with the notebook step (push gated on `pull_request || CD_DEPLOY_ENABLED`) rather than the vm step's unconditional `push: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UjktdjziWVMYbBxa6tsqg
