### PR TITLE
fix(ci): recover jest shard identity in flat junit downloads

### DIFF
--- a/.github/scripts/report_test_timings.py
+++ b/.github/scripts/report_test_timings.py
@@ -319,20 +319,24 @@ _FLAT_JEST_JUNIT_NAME = re.compile(r"^junit-(?P<segment>.+)-(?P<chunk>\d+)\.xml$
 def flat_shard_info(info: ArtifactInfo, junit_filename: str, runner: Runner) -> ArtifactInfo:
     """Recover Jest shard identity from the JUnit filename when the download landed flat.
 
-    download-artifact extracts a single matching artifact directly into the download path with no
-    per-artifact subdirectory (selective-mode PR runs always produce exactly one Jest artifact), so
-    the directory-derived identity degrades to the download dir name. The workflow names Jest JUnit
-    files `junit-<segment>-<chunk>.xml`, which carries the same identity as the artifact name, so a
-    job key derived here matches the subdirectory layout and a re-run attempt (multi-artifact, hence
-    subdirectories) can join its recovery passes back to these failures. A flat download implies a
-    single artifact and therefore attempt 1, so `attempt` is left alone.
+    download-artifact extracts a single matching artifact directly into the download path on any
+    workflow attempt, so the artifact name cannot provide its job identity or attempt. The JUnit
+    filename supplies the Jest job identity, and the workflow context supplies the attempt. Recover
+    both so re-run filtering and recovery joins use the same identity as subdirectory downloads.
     """
     if not info.flat or runner != "jest":
         return info
     match = _FLAT_JEST_JUNIT_NAME.match(junit_filename)
     if match is None:
         return info
-    return replace(info, suite="frontend", segment=match.group("segment"), group=int(match.group("chunk")), total=None)
+    return replace(
+        info,
+        suite="frontend",
+        segment=match.group("segment"),
+        group=int(match.group("chunk")),
+        total=None,
+        attempt=current_run_attempt(),
+    )
 
 
 def parse_iso_utc(value: str) -> datetime | None:

--- a/.github/scripts/report_test_timings.py
+++ b/.github/scripts/report_test_timings.py
@@ -106,6 +106,10 @@ class ArtifactInfo:
     # Which workflow run attempt uploaded the artifact (from the `-attempt<N>` name suffix); 1
     # when unsuffixed, i.e. every artifact predating re-run-aware uploads.
     attempt: int = 1
+    # True when the JUnit files sat directly in the download root (download-artifact extracts a
+    # single matching artifact without a per-artifact subdirectory), so suite/segment/group came
+    # from the meaningless download dir name and should be recovered from the JUnit filename.
+    flat: bool = False
 
 
 @dataclass(frozen=True)
@@ -166,7 +170,10 @@ def derive_suite_segment_and_group(artifact_dir_name: str) -> tuple[str, str, in
 
 
 def collect_artifact_infos(artifacts_root: Path) -> list[ArtifactInfo]:
-    artifact_dirs = sorted(d for d in artifacts_root.iterdir() if d.is_dir()) or [artifacts_root]
+    artifact_dirs = sorted(d for d in artifacts_root.iterdir() if d.is_dir())
+    flat = not artifact_dirs
+    if flat:
+        artifact_dirs = [artifacts_root]
     parsed: list[tuple[Path, str, str, int | None, int]] = []
     for d in artifact_dirs:
         base_name, attempt = split_attempt_suffix(d.name)
@@ -184,7 +191,13 @@ def collect_artifact_infos(artifacts_root: Path) -> list[ArtifactInfo]:
 
     return [
         ArtifactInfo(
-            path=d, suite=suite, segment=segment, group=group, total=shard_totals.get((suite, segment)), attempt=attempt
+            path=d,
+            suite=suite,
+            segment=segment,
+            group=group,
+            total=shard_totals.get((suite, segment)),
+            attempt=attempt,
+            flat=flat,
         )
         for d, suite, segment, group, attempt in parsed
     ]
@@ -298,6 +311,28 @@ def product_shard_info(info: ArtifactInfo, junit_filename: str) -> ArtifactInfo:
     if not product:
         return info
     return replace(info, suite="product", segment=product, total=None)
+
+
+_FLAT_JEST_JUNIT_NAME = re.compile(r"^junit-(?P<segment>.+)-(?P<chunk>\d+)\.xml$")
+
+
+def flat_shard_info(info: ArtifactInfo, junit_filename: str, runner: Runner) -> ArtifactInfo:
+    """Recover Jest shard identity from the JUnit filename when the download landed flat.
+
+    download-artifact extracts a single matching artifact directly into the download path with no
+    per-artifact subdirectory (selective-mode PR runs always produce exactly one Jest artifact), so
+    the directory-derived identity degrades to the download dir name. The workflow names Jest JUnit
+    files `junit-<segment>-<chunk>.xml`, which carries the same identity as the artifact name, so a
+    job key derived here matches the subdirectory layout and a re-run attempt (multi-artifact, hence
+    subdirectories) can join its recovery passes back to these failures. A flat download implies a
+    single artifact and therefore attempt 1, so `attempt` is left alone.
+    """
+    if not info.flat or runner != "jest":
+        return info
+    match = _FLAT_JEST_JUNIT_NAME.match(junit_filename)
+    if match is None:
+        return info
+    return replace(info, suite="frontend", segment=match.group("segment"), group=int(match.group("chunk")), total=None)
 
 
 def parse_iso_utc(value: str) -> datetime | None:
@@ -433,7 +468,7 @@ def parse_shard(
     wall_seconds = (end - start).total_seconds()
     testcase_seconds = sum(t.duration_seconds for t in tests)
     return Shard(
-        info=product_shard_info(info, xml_path.name),
+        info=flat_shard_info(product_shard_info(info, xml_path.name), xml_path.name, runner),
         junit_filename=xml_path.name,
         start=start,
         end=end,

--- a/.github/scripts/test_report_test_timings.py
+++ b/.github/scripts/test_report_test_timings.py
@@ -249,6 +249,38 @@ def test_collect_jest_shard_marks_tolerated_failures_as_quarantined(tmp_path: Pa
     assert report_test_timings.should_emit(shard.tests[0], float("inf")) is True
 
 
+@pytest.mark.parametrize(
+    "runner,filename,recovered",
+    [
+        # download-artifact extracts a single matching artifact flat into the download root, so
+        # identity must come from the filename or the job key collapses to the download dir name
+        # and a re-run's recovery passes (subdirectory layout) can never join back to it.
+        ("jest", "junit-EE-1.xml", ("frontend", "EE", 1)),
+        # A filename without a `-<chunk>` suffix and non-jest runners keep the directory-derived
+        # fallback identity.
+        ("jest", "junit-report.xml", None),
+        ("pytest", "junit-EE-1.xml", None),
+    ],
+)
+def test_flat_download_shard_identity(
+    runner: str, filename: str, recovered: tuple[str, str, int] | None, tmp_path: Path
+) -> None:
+    _write_shard_xml(
+        tmp_path,
+        filename=filename,
+        timestamp="2026-05-04T10:00:00",
+        time="1.0",
+        body='<testcase classname="suite flaky" name="suite flaky" time="0.1" file="src/flaky.test.ts"><failure message="x"/></testcase>',
+    )
+
+    shard = report_test_timings.collect_shards(tmp_path, runner)[0]
+
+    expected = recovered or report_test_timings.derive_suite_segment_and_group(tmp_path.name)
+    assert (shard.info.suite, shard.info.segment, shard.info.group) == expected
+    if recovered:
+        assert report_test_timings.job_trace_key(shard.info) == "frontend:EE:1"
+
+
 def test_load_jest_quarantine_signals_rejects_oversized_artifacts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/.github/scripts/test_report_test_timings.py
+++ b/.github/scripts/test_report_test_timings.py
@@ -250,20 +250,25 @@ def test_collect_jest_shard_marks_tolerated_failures_as_quarantined(tmp_path: Pa
 
 
 @pytest.mark.parametrize(
-    "runner,filename,recovered",
+    "runner,filename,run_attempt,recovered,expected_attempt",
     [
         # download-artifact extracts a single matching artifact flat into the download root, so
-        # identity must come from the filename or the job key collapses to the download dir name
-        # and a re-run's recovery passes (subdirectory layout) can never join back to it.
-        ("jest", "junit-EE-1.xml", ("frontend", "EE", 1)),
+        # identity must come from the filename and current workflow attempt.
+        ("jest", "junit-EE-1.xml", 2, ("frontend", "EE", 1), 2),
         # A filename without a `-<chunk>` suffix and non-jest runners keep the directory-derived
         # fallback identity.
-        ("jest", "junit-report.xml", None),
-        ("pytest", "junit-EE-1.xml", None),
+        ("jest", "junit-report.xml", 2, None, 1),
+        ("pytest", "junit-EE-1.xml", 2, None, 1),
     ],
 )
 def test_flat_download_shard_identity(
-    runner: str, filename: str, recovered: tuple[str, str, int] | None, tmp_path: Path
+    runner: str,
+    filename: str,
+    run_attempt: int,
+    recovered: tuple[str, str, int] | None,
+    expected_attempt: int,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _write_shard_xml(
         tmp_path,
@@ -272,11 +277,13 @@ def test_flat_download_shard_identity(
         time="1.0",
         body='<testcase classname="suite flaky" name="suite flaky" time="0.1" file="src/flaky.test.ts"><failure message="x"/></testcase>',
     )
+    monkeypatch.setenv("GITHUB_RUN_ATTEMPT", str(run_attempt))
 
     shard = report_test_timings.collect_shards(tmp_path, runner)[0]
 
     expected = recovered or report_test_timings.derive_suite_segment_and_group(tmp_path.name)
     assert (shard.info.suite, shard.info.segment, shard.info.group) == expected
+    assert shard.info.attempt == expected_attempt
     if recovered:
         assert report_test_timings.job_trace_key(shard.info) == "frontend:EE:1"
 


### PR DESCRIPTION
## Problem

- When the signals job's artifact glob matches one artifact (every selective-mode run), `download-artifact` extracts it flat, so spans get `job_key junit-artifacts:junit-artifacts:None` ([example](https://github.com/PostHog/posthog/actions/runs/30283912832)) and re-run recovery joins miss.

## Changes

- Mark flat downloads; recover shard identity from the `junit-<segment>-<chunk>.xml` filename (jest only).

## How did you test this code?

- New parameterized test: recovered key equals the subdirectory layout's; non-matching filenames / pytest keep the fallback. Reporter suite 60/60.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Bug found auditing live trace spans post-merge. Skills: `/writing-tests`, `/writing-code-comments`.
