### PR TITLE
fix(engineering-analytics): paginate unbounded tables

### DIFF
--- a/products/engineering_analytics/frontend/scenes/PullRequestDetailScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/PullRequestDetailScene.tsx
@@ -606,6 +606,8 @@ function PrWorkflowsTable({
     ]
     return (
         <LemonTable
+            // Namespaces the page search param so paging can't move other tables sharing this URL.
+            id="pr-workflows"
             dataSource={orderedRows}
             columns={columns}
             size="small"
@@ -630,6 +632,7 @@ function PrWorkflowsTable({
                     />
                 ),
             }}
+            pagination={{ pageSize: 10 }}
             emptyState="No CI runs match."
             nouns={['workflow', 'workflows']}
         />

--- a/products/engineering_analytics/frontend/scenes/RepoOverviewScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/RepoOverviewScene.tsx
@@ -118,6 +118,8 @@ function MasterFailuresSection(): JSX.Element {
         <Section id="now" title={`Failing on ${currentDefaultBranch}`} note="Last 24 hours">
             <LemonCard hoverEffect={false} className="overflow-hidden p-0">
                 <LemonTable<MasterFailureGroupApi>
+                    // Namespaces the page/order search params so paging can't move other tables sharing this URL.
+                    id="master-failures"
                     dataSource={masterFailures}
                     loading={masterFailuresLoading}
                     embedded
@@ -218,6 +220,7 @@ function MasterFailuresSection(): JSX.Element {
                             ),
                         },
                     ]}
+                    pagination={{ pageSize: 10 }}
                     emptyState={`Nothing failing on ${currentDefaultBranch} in the last 24 hours.`}
                     nouns={['failure group', 'failure groups']}
                 />


### PR DESCRIPTION
## Problem

- The failing-on-master table on the engineering analytics overview had no pagination, so it rendered every failure group. The product's other tables paginate.

## Changes

- Paginate failing-on-master and the PR-detail workflows table at 10 rows.
- Give each a `LemonTable` `id`, which namespaces its page/order search params. Without one, every paginated table shares a bare `page`.

## How did you test this code?

- Product jest suite: 128 pass. Product typecheck clean. No manual browser testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code. Skills invoked: `/code-review`, `/simplify`.
- First pass paginated four tables. Review caught that two sit inside `expandedRowRender` and would have shared the outer table's `page` param, so paging nested jobs would jump the outer runs table and unmount the open row.
- Left those two unpaginated rather than synthesize per-instance ids. `FunnelCorrelationTable` is the repo's only nested paginated table.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
