### PR TITLE
feat(devex): derive a product capability spec for posthog.com

### DIFF
--- a/.github/scripts/diff-product-capabilities.py
+++ b/.github/scripts/diff-product-capabilities.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201 allow print statements
+"""Report surfaces that regressed between two capability spec builds.
+
+A surface flipping to `unavailable` usually means a real product regression — a deleted
+mcp/tools.yaml, a removed onboarding flow — rather than an intended change. Nothing else
+would notice, because the spec regenerates happily either way.
+
+Advisory only: prints GitHub Actions warnings and always exits 0. Publishing a correct
+spec must never be blocked by the contents of that spec.
+"""
+
+from __future__ import annotations
+
+import sys
+import json
+from pathlib import Path
+
+# `unknown` is not a regression: it means a derivation was deferred or a world opened,
+# not that a product lost a capability.
+REGRESSED_TO = "unavailable"
+REGRESSED_FROM = {"available", "preview"}
+
+
+def _load(path: Path) -> tuple[set[str], dict[tuple[str, str, str], str]]:
+    """Returns (product names, verdicts).
+
+    Product names are read from the product list rather than inferred from the verdict
+    keys: a product carrying no surfaces contributes no keys, and inferring names from
+    keys would make it invisible to the added/removed comparison.
+    """
+    spec = json.loads(path.read_text())
+    products = spec.get("products", [])
+    names = {product["product"] for product in products}
+    verdicts = {
+        (product["product"], group, key): fact["availability"]
+        for product in products
+        for group in ("surfaces", "data_sources")
+        for key, fact in product.get(group, {}).items()
+    }
+    return names, verdicts
+
+
+def main(previous_path: str, current_path: str) -> int:
+    previous_names, previous = _load(Path(previous_path))
+    current_names, current = _load(Path(current_path))
+
+    regressions = sorted(
+        (product, group, key, was)
+        for (product, group, key), was in previous.items()
+        if was in REGRESSED_FROM and current.get((product, group, key)) == REGRESSED_TO
+    )
+
+    for product, group, key, was in regressions:
+        print(f"::warning::{product}: {group}.{key} went {was} -> {REGRESSED_TO}")
+
+    added = sorted(current_names - previous_names)
+    removed = sorted(previous_names - current_names)
+    if added:
+        print(f"New products: {', '.join(added)}")
+    if removed:
+        print(f"::warning::Products no longer in the spec: {', '.join(removed)}")
+    if not regressions and not removed:
+        print("No capability regressions.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: diff-product-capabilities.py <previous.json> <current.json>", file=sys.stderr)
+        raise SystemExit(2)
+    raise SystemExit(main(sys.argv[1], sys.argv[2]))

--- a/.github/workflows/publish-product-capabilities.yml
+++ b/.github/workflows/publish-product-capabilities.yml
@@ -1,0 +1,158 @@
+name: Publish product capability spec
+
+# Master-only by design. The artifact is derived from the repo and consumed by
+# posthog.com; nothing in this repo reads it, so there is nothing for a PR to drift
+# against. Keeping `pull_request` off means ordinary product PRs pay nothing for it — no
+# extra required check, no merge latency, and no additional per-PR workflow dispatch.
+#
+# The PR-side guard rails live elsewhere: `hogli product:lint --all` (already running in
+# ci-backend.yml) validates that every product's capability inputs parse.
+on:
+    push:
+        branches:
+            - master
+        paths:
+            - 'products/*/product.yaml'
+            - 'products/*/mcp/tools.yaml'
+            - 'products/*/skills/**'
+            - 'products/signals/skills/**'
+            - 'products/product-aliases.json'
+            - 'docs/onboarding/**'
+            - 'cli/src/**'
+            - 'posthog/cdp/templates/slack/**'
+            - 'products/signals/backend/enums.py'
+            - 'tools/hogli-commands/hogli_commands/product/capabilities/**'
+            - '.github/workflows/publish-product-capabilities.yml'
+    # Lets us cut a fresh artifact without waiting for a qualifying commit.
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.sha }}
+    cancel-in-progress: false
+
+jobs:
+    current-master:
+        name: Check current master
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        if: github.repository_owner == 'PostHog'
+        outputs:
+            is-current: ${{ steps.current-master.outputs.is_current }}
+        permissions:
+            contents: read
+        steps:
+            # Two pushes landing close together would otherwise race to publish, and the
+            # loser would overwrite `-latest` with an older build.
+            - name: Check current master
+              id: current-master
+              env:
+                  GIT_SHA: ${{ github.sha }}
+                  REPOSITORY: ${{ github.repository }}
+              run: |
+                  REMOTE_MASTER=$(git ls-remote "https://github.com/${REPOSITORY}.git" refs/heads/master || true)
+                  CURRENT_MASTER=$(printf '%s\n' "$REMOTE_MASTER" | awk '{print $1}')
+                  if [ "$CURRENT_MASTER" = "$GIT_SHA" ]; then
+                      echo "is_current=true" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "is_current=false" >> "$GITHUB_OUTPUT"
+                      echo "Skipping capability spec release for stale master SHA $GIT_SHA"
+                  fi
+
+    publish:
+        name: Publish capability spec
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        needs: current-master
+        if: github.repository_owner == 'PostHog' && needs.current-master.outputs.is-current == 'true'
+        permissions:
+            contents: write
+        steps:
+            # Depth 1 is enough: `git rev-parse HEAD` (which stamps commit_sha) and the
+            # `git ls-remote --tags` version lookup both work without local history.
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+            # No Docker, Postgres, Rust or Django: the derivation reads YAML, markdown
+            # frontmatter and directory listings only. Keep it that way — this job exists
+            # to be cheap.
+            - name: Set up Python
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+              with:
+                  python-version-file: 'pyproject.toml'
+                  token: ${{ github.token }}
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+              with:
+                  version: '0.11.28' # pinned: unpinned setup-uv calls GH API on every job, exhausts rate limit
+                  enable-cache: true
+                  cache-dependency-glob: uv.lock
+                  save-cache: false
+
+            - name: Install python dependencies
+              run: UV_PROJECT_ENVIRONMENT=$pythonLocation uv sync --frozen --dev
+
+            - name: Validate derivation sources
+              run: ./bin/hogli lint:product-capabilities
+
+            - name: Run capability spec tests
+              run: pytest tools/hogli-commands/hogli_commands/tests/test_product_capabilities.py -q
+
+            - name: Build capability spec
+              run: ./bin/hogli build:product-capabilities --release
+
+            # A surface flipping to `unavailable` is usually a real product regression
+            # (a deleted tools.yaml, a removed onboarding flow) rather than an intended
+            # change. Informational only — publishing must not block on it.
+            - name: Report availability regressions
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  if gh release download product-capabilities-latest \
+                      --pattern product-capabilities.json --output /tmp/previous.json 2>/dev/null; then
+                      python .github/scripts/diff-product-capabilities.py \
+                          /tmp/previous.json dist/product-capabilities.json || true
+                  else
+                      echo "No previous release to compare against."
+                  fi
+
+            - name: Determine next version
+              id: version
+              run: |
+                  REMOTE_TAGS=$(git ls-remote --tags --refs origin 'refs/tags/product-capabilities-v*')
+                  LATEST_TAG=$(printf '%s\n' "$REMOTE_TAGS" | awk '{print $2}' | sed 's#refs/tags/##' | grep -E '^product-capabilities-v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
+                  if [ -z "$LATEST_TAG" ]; then LATEST_TAG="product-capabilities-v0.0.0"; fi
+                  MINOR=$(echo "${LATEST_TAG#product-capabilities-v}" | cut -d. -f2)
+                  echo "tag=product-capabilities-v0.$((MINOR + 1)).0" >> "$GITHUB_OUTPUT"
+
+            - name: Create versioned release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  RELEASE_TAG: ${{ steps.version.outputs.tag }}
+              run: |
+                  gh release create "$RELEASE_TAG" \
+                      dist/product-capabilities.json \
+                      --title "Product capability spec $RELEASE_TAG" \
+                      --notes "Build from ${{ github.sha }}" \
+                      --target "${{ github.sha }}" \
+                      --latest=false
+
+            # Consumers that do not want to resolve a version pin fetch this instead:
+            #   .../releases/download/product-capabilities-latest/product-capabilities.json
+            - name: Update latest release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+                  RELEASE_TAG: ${{ steps.version.outputs.tag }}
+              run: |
+                  if gh release view product-capabilities-latest >/dev/null 2>&1; then
+                      gh release upload product-capabilities-latest \
+                          dist/product-capabilities.json --clobber
+                      gh release edit product-capabilities-latest \
+                          --notes "Latest build — same as $RELEASE_TAG"
+                  else
+                      gh release create product-capabilities-latest \
+                          dist/product-capabilities.json \
+                          --title "Product capability spec (Latest)" \
+                          --notes "Latest build — same as $RELEASE_TAG" \
+                          --target "${{ github.sha }}" \
+                          --latest=false
+                  fi

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,8 @@ frontend/.cache/
 frontend/@posthog/apps-common/dist/
 frontend/dist/
 frontend/dist-report/
+# Repo-root build artifacts published to GitHub Releases (product-capabilities.json)
+/dist/
 frontend/eager-graph-report*.json
 frontend/pnpm-error.log
 frontend/public/Matter*.woff*

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -566,6 +566,10 @@ build:
         cmd: python products/posthog_ai/scripts/build_skills.py
         description: Build agent skills from products/*/skills/ into dist/skills/ and
             dist/skills.zip
+    build:product-capabilities:
+        click: hogli_commands.product.capabilities.build:cmd_build
+        description: Derive the product capability spec (surfaces and data sources per
+            product) into dist/product-capabilities.json
     init:skill:
         cmd: python products/posthog_ai/scripts/build_skills.py --init
         description: Scaffold a new agent skill directory with SKILL.md boilerplate
@@ -820,6 +824,9 @@ quality:
     lint:skills:
         cmd: python products/posthog_ai/scripts/build_skills.py --lint
         description: Validate agent skill sources (syntax, frontmatter, depth constraints)
+    lint:product-capabilities:
+        click: hogli_commands.product.capabilities.build:cmd_lint
+        description: Validate product capability derivation sources without writing output
     lint:python:fix:
         cmd: ./bin/ruff.sh check --fix
         description: Fix Python code quality issues

--- a/products/product-aliases.json
+++ b/products/product-aliases.json
@@ -1,0 +1,7 @@
+{
+    "$comment": "Historical names that map to a product directory, for tooling that joins an external token (an OpenAPI x-product value, a scout scope, an agent-mode filename) back to products/<dir>. Read by services/mcp/scripts/scaffold-yaml.ts and the product capability generator. Keys are aliases, values are real directory names under products/.",
+    "aliases": {
+        "llm_analytics": "ai_observability",
+        "session_replay": "replay"
+    }
+}

--- a/services/mcp/scripts/scaffold-yaml.ts
+++ b/services/mcp/scripts/scaffold-yaml.ts
@@ -30,9 +30,14 @@ const PRODUCTS_DIR = path.resolve(REPO_ROOT, 'products')
 const OPENAPI_PATH = path.resolve(REPO_ROOT, 'frontend/tmp/openapi.json')
 const DEFINITIONS_DIR = path.resolve(MCP_ROOT, 'definitions')
 
-const productAliases: Record<string, string> = {
-    llm_analytics: 'ai_observability',
-}
+// Shared with the product capability generator, which performs the same alias-aware
+// join from an external token back to a products/<dir>. Kept in one file so the two
+// cannot drift apart.
+const productAliases: Record<string, string> = (
+    JSON.parse(fs.readFileSync(path.resolve(PRODUCTS_DIR, 'product-aliases.json'), 'utf-8')) as {
+        aliases: Record<string, string>
+    }
+).aliases
 
 // ------------------------------------------------------------------
 // Types

--- a/tools/hogli-commands/hogli_commands/product/capabilities/__init__.py
+++ b/tools/hogli-commands/hogli_commands/product/capabilities/__init__.py
@@ -1,0 +1,8 @@
+"""Derived product capability spec.
+
+Computes, for every product, which surfaces it is usable from (web, MCP, Max AI,
+self-driving, CLI, API, Slack, alerts) and which data sources feed it. Every fact is
+derived from files that already exist in the repo — nothing here is hand-authored.
+
+The output is published as a versioned JSON artifact for posthog.com to consume.
+"""

--- a/tools/hogli-commands/hogli_commands/product/capabilities/build.py
+++ b/tools/hogli-commands/hogli_commands/product/capabilities/build.py
@@ -1,0 +1,199 @@
+"""Build the derived product capability spec.
+
+Orchestrates the per-surface derivation sources, enforces the invariants that keep the
+output honest, and serializes the result.
+
+Surfaces not yet derived emit `unknown` with a reason rather than being omitted — a
+consumer must be able to tell "we know this is false" from "we haven't computed it".
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import click
+
+from ..paths import PRODUCTS_DIR, REPO_ROOT
+from .context import DerivationContext
+from .join import assert_no_ambiguous_joins
+from .models import PROSE_KEYS, CapabilitySpec, ProductCapability, SurfaceFact, UnattributedFacts, unknown
+from .sources import mcp, onboarding, platform, scouts
+
+SPEC_VERSION = "0.1.0"
+
+DEFAULT_OUTPUT = REPO_ROOT / "dist" / "product-capabilities.json"
+
+# Surfaces with no derivation yet. Each names the specific thing that would close it, so
+# the gap is actionable rather than just an absence.
+DEFERRED_SURFACES: dict[str, str] = {
+    "web": "not yet derived — requires productManifestFacts.json from frontend/build-products.mjs",
+    "max_ai": "not yet derived — requires AST over products/*/backend/max_tools.py",
+    "api": "not yet derived — requires OpenAPI x-product attribution",
+    "slack": "not yet derived — requires AST over posthog/urls.py slack routes",
+    "alerts": "not yet derived — requires import-graph analysis of products.alerts.backend",
+    "cli": "cli/ carries no product attribution",
+}
+
+DEFERRED_DATA_SOURCES: dict[str, str] = {
+    "events": "requires setupProbe in manifest.tsx, which only one product declares today",
+    "max_context": "not yet derived — requires scanning ee/hogai/context/",
+}
+
+SURFACE_KEYS = ["web", "mcp", "max_ai", "self_driving", "api", "slack", "alerts", "cli"]
+DATA_SOURCE_KEYS = ["onboarding_sdks", "events", "max_context"]
+
+
+def _product_dirs() -> set[str]:
+    """Products in the same sense `hogli product:lint` uses: a directory with __init__.py."""
+    return {d.name for d in PRODUCTS_DIR.iterdir() if d.is_dir() and (d / "__init__.py").exists()}
+
+
+def _assert_complete(source_name: str, facts: dict[str, SurfaceFact], product_dirs: set[str]) -> None:
+    """A source must answer for every product. Silence is not a verdict."""
+    missing = product_dirs - facts.keys()
+    extra = facts.keys() - product_dirs
+    if missing or extra:
+        raise ValueError(
+            f"source `{source_name}` returned an incomplete product set — "
+            f"missing={sorted(missing)} unexpected={sorted(extra)}"
+        )
+
+
+def _assert_no_prose(payload: str) -> None:
+    """The artifact states facts; posthog.com writes the words."""
+    found: set[str] = set()
+
+    def walk(node: object) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key in PROSE_KEYS:
+                    found.add(key)
+                walk(value)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(json.loads(payload))
+    if found:
+        raise ValueError(f"capability spec contains prose keys {sorted(found)} — it must carry facts only")
+
+
+def build_spec(*, release: bool = False) -> CapabilitySpec:
+    product_dirs = _product_dirs()
+    ctx = DerivationContext(repo_root=REPO_ROOT, products_dir=PRODUCTS_DIR, product_dirs=product_dirs)
+
+    derived_surfaces = {"mcp": mcp.derive(ctx), "self_driving": scouts.derive(ctx)}
+    derived_data_sources = {"onboarding_sdks": onboarding.derive(ctx)}
+
+    for name, facts in {**derived_surfaces, **derived_data_sources}.items():
+        _assert_complete(name, facts, product_dirs)
+
+    orphan_scopes = scouts.unattributed_scopes(ctx)
+    assert_no_ambiguous_joins(sorted(product_dirs) + orphan_scopes, product_dirs, ctx.aliases)
+
+    from ..product_yaml import load_product_yaml
+
+    products: list[ProductCapability] = []
+    for name in sorted(product_dirs):
+        meta = load_product_yaml(name)
+        products.append(
+            ProductCapability(
+                product=name,
+                name=meta.get("name") or name,
+                owners=list(meta.get("owners") or []),
+                surfaces={
+                    key: derived_surfaces[key][name] if key in derived_surfaces else unknown(DEFERRED_SURFACES[key])
+                    for key in SURFACE_KEYS
+                },
+                data_sources={
+                    key: derived_data_sources[key][name]
+                    if key in derived_data_sources
+                    else unknown(DEFERRED_DATA_SOURCES[key])
+                    for key in DATA_SOURCE_KEYS
+                },
+            )
+        )
+
+    spec = CapabilitySpec(
+        spec_version=SPEC_VERSION,
+        products=products,
+        platform=platform.derive(ctx),
+        unattributed=UnattributedFacts(scout_scopes=orphan_scopes),
+    )
+
+    if release:
+        spec.generated_at = datetime.now(UTC).isoformat()
+        spec.commit_sha = _current_commit()
+
+    return spec
+
+
+def _current_commit() -> str | None:
+    try:
+        result = subprocess.run(["git", "rev-parse", "HEAD"], cwd=REPO_ROOT, capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def serialize(spec: CapabilitySpec) -> str:
+    payload = spec.model_dump_json(by_alias=True, indent=4, exclude_none=False)
+    _assert_no_prose(payload)
+    return payload + "\n"
+
+
+def _summarize(spec: CapabilitySpec) -> str:
+    counts: dict[str, dict[str, int]] = {}
+    for product in spec.products:
+        for key, fact in {**product.surfaces, **product.data_sources}.items():
+            counts.setdefault(key, {}).setdefault(fact.availability, 0)
+            counts[key][fact.availability] += 1
+
+    lines = [f"{len(spec.products)} products", ""]
+    for key in SURFACE_KEYS + DATA_SOURCE_KEYS:
+        breakdown = ", ".join(f"{v} {k}" for k, v in sorted(counts.get(key, {}).items()))
+        lines.append(f"  {key:18} {breakdown}")
+    if spec.unattributed.scout_scopes:
+        lines += [
+            "",
+            f"  unattributed scout scopes ({len(spec.unattributed.scout_scopes)}): "
+            + ", ".join(spec.unattributed.scout_scopes),
+        ]
+    return "\n".join(lines)
+
+
+@click.command(name="build:product-capabilities")
+@click.option("--release", is_flag=True, help="Stamp generated_at + commit_sha and write to dist/.")
+@click.option("--product", "product_name", default=None, help="Dump a single product to stdout, write nothing.")
+@click.option("--output", type=click.Path(path_type=Path), default=None, help="Override the output path.")
+def cmd_build(release: bool, product_name: str | None, output: Path | None) -> None:
+    """Derive the product capability spec from the repo."""
+    spec = build_spec(release=release)
+
+    if product_name:
+        match = next((p for p in spec.products if p.product == product_name), None)
+        if match is None:
+            raise click.ClickException(f"unknown product `{product_name}`")
+        click.echo(match.model_dump_json(by_alias=True, indent=4))
+        return
+
+    destination = output or DEFAULT_OUTPUT
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(serialize(spec))
+    click.echo(_summarize(spec))
+    click.echo(f"\nwrote {destination.relative_to(REPO_ROOT)}")
+
+
+@click.command(name="lint:product-capabilities")
+def cmd_lint() -> None:
+    """Validate every capability derivation source without writing anything."""
+    try:
+        spec = build_spec()
+        serialize(spec)
+    except Exception as exc:
+        raise click.ClickException(f"capability spec derivation failed: {exc}") from exc
+    click.echo(_summarize(spec))
+    click.echo("\ncapability sources OK")

--- a/tools/hogli-commands/hogli_commands/product/capabilities/context.py
+++ b/tools/hogli-commands/hogli_commands/product/capabilities/context.py
@@ -1,0 +1,29 @@
+"""Shared inputs handed to every derivation source."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import cached_property
+from pathlib import Path
+
+from .join import Join, join_to_product, load_aliases
+
+
+@dataclass
+class DerivationContext:
+    repo_root: Path
+    products_dir: Path
+    # Product directory names, in the same sense `hogli product:lint` uses: a directory
+    # under products/ with an __init__.py. Sources must return a fact for each of these.
+    product_dirs: set[str]
+
+    @cached_property
+    def aliases(self) -> dict[str, str]:
+        return load_aliases(self.products_dir)
+
+    def join(self, token: str) -> Join:
+        return join_to_product(token, self.product_dirs, self.aliases)
+
+    def rel(self, path: Path) -> str:
+        """Repo-relative path string, for the `from` provenance list."""
+        return str(path.relative_to(self.repo_root))

--- a/tools/hogli-commands/hogli_commands/product/capabilities/join.py
+++ b/tools/hogli-commands/hogli_commands/product/capabilities/join.py
@@ -1,0 +1,112 @@
+"""Joining external tokens back to a product directory.
+
+Several derivation sources name a product with a token that is not exactly a directory
+name: a scout's `metadata.scope`, an agent-mode filename, an `ee/hogai/context/` module.
+This module holds the single mechanical join used by all of them, so no source invents
+its own matching rules.
+
+The join is deliberately dumb. It normalizes case and separators, consults the shared
+alias file, and tries one round of de-pluralization. It never guesses beyond that: a
+token that does not resolve is reported as unattributed rather than assigned to the
+nearest-looking product.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from .models import MatchKind
+
+# Aliases live at the repo level (not inside this package) because they are a fact about
+# product directory naming, shared with services/mcp/scripts/scaffold-yaml.ts.
+_ALIASES_FILENAME = "product-aliases.json"
+
+
+@dataclass(frozen=True)
+class Join:
+    product: str | None
+    match: MatchKind
+
+
+NO_JOIN = Join(None, "none")
+
+
+def normalize_token(token: str) -> str:
+    """kebab/space -> snake, lowercased. Purely mechanical, no semantics."""
+    return token.strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def load_aliases(products_dir: Path) -> dict[str, str]:
+    """Load the shared alias map. Missing file is fatal: silently running with no
+    aliases would produce wrong `unattributed` output that looks plausible."""
+    path = products_dir / _ALIASES_FILENAME
+    data = json.loads(path.read_text())
+    aliases = data.get("aliases")
+    if not isinstance(aliases, dict):
+        raise ValueError(f"{path} must contain an `aliases` object")
+    return {normalize_token(k): normalize_token(v) for k, v in aliases.items()}
+
+
+def _depluralize(token: str) -> str | None:
+    """Strip exactly one trailing `s`. Resolves the singular/plural mismatch between
+    `ee/hogai/context/survey/` and `products/surveys/`."""
+    return token[:-1] if token.endswith("s") and len(token) > 1 else None
+
+
+def join_to_product(token: str, product_dirs: set[str], aliases: dict[str, str]) -> Join:
+    """Resolve an external token to a product directory, recording how confident we are.
+
+    Callers should surface `match` in their facts so a consumer can discount a join that
+    relied on normalization rather than an exact name.
+    """
+    normalized = normalize_token(token)
+
+    # Aliases are consulted before exact matches, deliberately. An alias exists precisely
+    # to redirect a token away from the directory it appears to name — `llm_analytics`
+    # resolves to `ai_observability` even though `products/llm_analytics` still exists,
+    # because that directory is a vestigial shell. Checking exact first would make every
+    # such alias dead config and silently attribute facts to the wrong product.
+    aliased = aliases.get(normalized)
+    if aliased and aliased in product_dirs:
+        return Join(aliased, "alias")
+
+    if normalized in product_dirs:
+        return Join(normalized, "exact")
+
+    singular = _depluralize(normalized)
+    if singular and singular in product_dirs:
+        return Join(singular, "normalized")
+
+    plural = f"{normalized}s"
+    if plural in product_dirs:
+        return Join(plural, "normalized")
+
+    return NO_JOIN
+
+
+def assert_no_ambiguous_joins(tokens: list[str], product_dirs: set[str], aliases: dict[str, str]) -> None:
+    """Fail loudly if de-pluralization is doing more work than it can justify.
+
+    `_depluralize` is a heuristic wearing an algorithm's clothes. It is safe while at
+    most one token per product relies on it — the moment two distinct tokens both *fuzzy*
+    resolve to the same product, we can no longer tell which one the repo meant, and
+    picking either silently attributes facts on a coin flip.
+
+    Exact and alias matches are authoritative and never counted here: a token that
+    matches a directory outright is not a guess.
+    """
+    fuzzy_targets: dict[str, list[str]] = {}
+    for token in tokens:
+        join = join_to_product(token, product_dirs, aliases)
+        if join.product and join.match == "normalized":
+            fuzzy_targets.setdefault(join.product, []).append(token)
+
+    collisions = {product: sorted(toks) for product, toks in fuzzy_targets.items() if len(toks) > 1}
+    if collisions:
+        raise ValueError(
+            "ambiguous product joins — de-pluralization maps multiple distinct tokens onto "
+            f"the same product: {collisions}. Resolve with an explicit entry in "
+            "products/product-aliases.json."
+        )

--- a/tools/hogli-commands/hogli_commands/product/capabilities/models.py
+++ b/tools/hogli-commands/hogli_commands/product/capabilities/models.py
@@ -1,0 +1,109 @@
+"""Pydantic models for the derived product capability spec.
+
+The validators here are the enforcement mechanism for the spec's core promise: every
+claim is traceable to a file, and anything we cannot compute says so out loud rather
+than defaulting to false.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# `unavailable` is a stronger claim than `unknown`: it means we enumerated every place
+# this surface could be registered and none named this product. Only closed-world
+# derivations may emit it. Anything else is `unknown`.
+Availability = Literal["available", "preview", "unavailable", "unknown"]
+
+MatchKind = Literal["exact", "normalized", "alias", "none"]
+
+AVAILABILITY_VALUES: list[Availability] = ["available", "preview", "unavailable", "unknown"]
+
+# Keys that would make this a content artifact rather than a facts artifact. posthog.com
+# writes all prose; the repo only states what is true. Asserted over the serialized output.
+PROSE_KEYS = frozenset({"description", "summary", "title", "tagline", "docs_url", "copy"})
+
+FactValue = int | str | bool | list[str] | None
+
+
+class SurfaceFact(BaseModel):
+    """One product's verdict on one surface (or data source)."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    availability: Availability
+    facts: dict[str, FactValue] = Field(default_factory=dict)
+    # Repo-relative paths a reviewer can open to re-derive the verdict. Deliberately no
+    # line numbers — they churn without changing meaning.
+    from_: list[str] = Field(default_factory=list, alias="from")
+    unknown_reason: str | None = None
+
+    @model_validator(mode="after")
+    def _honesty(self) -> SurfaceFact:
+        if self.availability == "unknown":
+            if not self.unknown_reason:
+                raise ValueError("an `unknown` verdict must explain itself via unknown_reason")
+        else:
+            if not self.from_:
+                raise ValueError(f"a `{self.availability}` verdict must cite at least one source file")
+            if self.unknown_reason:
+                raise ValueError("unknown_reason is only meaningful on an `unknown` verdict")
+        return self
+
+
+def unknown(reason: str) -> SurfaceFact:
+    """The honest answer when a fact cannot be computed."""
+    return SurfaceFact(availability="unknown", unknown_reason=reason)
+
+
+class ProductCapability(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    name: str
+    owners: list[str]
+    surfaces: dict[str, SurfaceFact]
+    data_sources: dict[str, SurfaceFact]
+
+
+class PlatformFacts(BaseModel):
+    """Facts that are genuinely global. A per-product value for these would be invented.
+
+    The Slack CDP destination template, for instance, carries no product attribution at
+    all — it is available to every project.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    slack_cdp_outbound_destination: bool
+    warehouse_signal_sources: list[str] = Field(default_factory=list)
+    cli_command_groups: list[str] = Field(default_factory=list)
+
+
+class UnattributedFacts(BaseModel):
+    """The honesty valve: things we found but could not join to a product directory.
+
+    Emitted verbatim rather than dropped or guessed at, so a consumer can see the gap
+    and decide what to do about it.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    scout_scopes: list[str] = Field(default_factory=list)
+    agent_modes: list[str] = Field(default_factory=list)
+    max_context_modules: list[str] = Field(default_factory=list)
+
+
+class CapabilitySpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    spec_version: str
+    # Populated only by `--release`. posthog.com uses this to detect a stopped publish;
+    # without that check a broken generator serves stale data indefinitely.
+    generated_at: str | None = None
+    commit_sha: str | None = None
+    availability_values: list[Availability] = Field(default_factory=lambda: list(AVAILABILITY_VALUES))
+    products: list[ProductCapability]
+    platform: PlatformFacts
+    unattributed: UnattributedFacts

--- a/tools/hogli-commands/hogli_commands/product/capabilities/sources/__init__.py
+++ b/tools/hogli-commands/hogli_commands/product/capabilities/sources/__init__.py
@@ -1,0 +1,7 @@
+"""Per-surface derivation modules.
+
+Every module exposes ``derive(ctx) -> dict[str, SurfaceFact]`` keyed by product directory
+name, and must return an entry for *every* product in ``ctx.product_dirs``. Omitting a
+product is a bug: a consumer cannot distinguish a missing key from a negative answer.
+``unknown(reason)`` is how a source says "I don't know".
+"""

--- a/tools/hogli-commands/hogli_commands/product/capabilities/sources/mcp.py
+++ b/tools/hogli-commands/hogli_commands/product/capabilities/sources/mcp.py
@@ -1,0 +1,81 @@
+"""MCP surface: which products expose tools to agents over MCP.
+
+Closed world. A product's MCP tools live at ``products/<X>/mcp/tools.yaml`` and nowhere
+else, so absence is provable and this source may emit `unavailable`.
+
+Attribution is by *path*, not by the file's ``feature:`` field. `feature` is a display
+key that is not guaranteed to equal the directory name, so trusting it would let a
+product's tools be attributed to a different product.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from ..context import DerivationContext
+from ..models import SurfaceFact
+
+_TOOLS_RELPATH = ("mcp", "tools.yaml")
+
+
+def _flag_gated(entry: dict) -> bool:
+    return bool(entry.get("feature_flag"))
+
+
+def derive(ctx: DerivationContext) -> dict[str, SurfaceFact]:
+    results: dict[str, SurfaceFact] = {}
+
+    for product in sorted(ctx.product_dirs):
+        path = ctx.products_dir.joinpath(product, *_TOOLS_RELPATH)
+        if not path.exists():
+            results[product] = SurfaceFact(
+                availability="unavailable",
+                facts={"enabled_tool_count": 0},
+                **{"from": [f"products/{product}/"]},
+            )
+            continue
+
+        rel = ctx.rel(path)
+        config = yaml.safe_load(path.read_text()) or {}
+        tools = config.get("tools") or {}
+        wrappers = config.get("wrappers") or {}
+        ui_apps = config.get("ui_apps") or {}
+
+        enabled = {name: e for name, e in tools.items() if isinstance(e, dict) and e.get("enabled")}
+        enabled_wrappers = {name: e for name, e in wrappers.items() if isinstance(e, dict) and e.get("enabled")}
+        all_enabled = {**enabled, **enabled_wrappers}
+
+        if not all_enabled:
+            # Scaffolded but nothing shipped. The file exists only because scaffold-yaml
+            # discovered API operations, which is not the same as an available surface.
+            results[product] = SurfaceFact(
+                availability="unavailable",
+                facts={"enabled_tool_count": 0, "total_operation_count": len(tools)},
+                **{"from": [rel]},
+            )
+            continue
+
+        scopes = sorted({s for e in all_enabled.values() for s in (e.get("scopes") or [])})
+        annotations = [e.get("annotations") or {} for e in all_enabled.values()]
+
+        # `preview` means the surface exists but nobody can reach it without a flag.
+        # If even one tool is ungated the surface is genuinely available.
+        availability = "preview" if all(_flag_gated(e) for e in all_enabled.values()) else "available"
+
+        results[product] = SurfaceFact(
+            availability=availability,
+            facts={
+                "enabled_tool_count": len(all_enabled),
+                "total_operation_count": len(tools),
+                "tool_names": sorted(all_enabled),
+                "wrapper_names": sorted(enabled_wrappers),
+                "ui_app_names": sorted(ui_apps),
+                "scopes": scopes,
+                "read_only_tool_count": sum(1 for a in annotations if a.get("readOnly")),
+                "destructive_tool_count": sum(1 for a in annotations if a.get("destructive")),
+                "url_prefix": config.get("url_prefix"),
+            },
+            **{"from": [rel]},
+        )
+
+    return results

--- a/tools/hogli-commands/hogli_commands/product/capabilities/sources/onboarding.py
+++ b/tools/hogli-commands/hogli_commands/product/capabilities/sources/onboarding.py
@@ -1,0 +1,85 @@
+"""Data source: which SDKs and platforms a product documents an install flow for.
+
+In-app onboarding content lives at ``docs/onboarding/<kebab-product>/``, one TSX file per
+SDK. "No directory means no onboarding flow" is only a valid inference while *every*
+onboarding directory maps to a product — otherwise a product's flow could be sitting in a
+directory we failed to join, and `unavailable` would be a false negative.
+
+So this source closes its own world: if any directory fails to join, products without one
+get `unknown`; once every directory resolves, they get a provable `unavailable`.
+
+This is the only data-source fact derivable today. The richer one — which events feed a
+product — depends on `setupProbe` in manifest.tsx, which exactly one product declares.
+"""
+
+from __future__ import annotations
+
+from ..context import DerivationContext
+from ..models import SurfaceFact
+
+_ONBOARDING_RELDIR = "docs/onboarding"
+
+# Shared plumbing, not SDKs.
+_NON_SDK_STEMS = frozenset({"index", "steps", "library-docs", "package", "tsconfig"})
+
+
+def _scan(ctx: DerivationContext) -> tuple[dict[str, tuple[str, list[str]]], list[str]]:
+    """Returns (product -> (relpath, sdks), unjoined directory names)."""
+    onboarding_root = ctx.repo_root / _ONBOARDING_RELDIR
+    by_product: dict[str, tuple[str, list[str]]] = {}
+    unjoined: list[str] = []
+
+    if not onboarding_root.is_dir():
+        return by_product, unjoined
+
+    # Directories are kebab-case (`ai-observability`) while product dirs are snake_case,
+    # hence the join rather than a direct lookup.
+    for entry in sorted(onboarding_root.iterdir()):
+        if not entry.is_dir():
+            continue
+        join = ctx.join(entry.name)
+        if join.product is None:
+            unjoined.append(entry.name)
+            continue
+        sdks = sorted({f.stem for f in entry.iterdir() if f.suffix in {".tsx", ".ts"} and f.stem not in _NON_SDK_STEMS})
+        by_product[join.product] = (f"{_ONBOARDING_RELDIR}/{entry.name}/", sdks)
+
+    return by_product, unjoined
+
+
+def unattributed_dirs(ctx: DerivationContext) -> list[str]:
+    return sorted(_scan(ctx)[1])
+
+
+def derive(ctx: DerivationContext) -> dict[str, SurfaceFact]:
+    by_product, unjoined = _scan(ctx)
+    world_is_open = bool(unjoined)
+
+    results: dict[str, SurfaceFact] = {}
+    for product in sorted(ctx.product_dirs):
+        found = by_product.get(product)
+
+        if found is None:
+            if world_is_open:
+                results[product] = SurfaceFact(
+                    availability="unknown",
+                    unknown_reason=(
+                        f"onboarding attribution is incomplete — {len(unjoined)} directory(ies) under "
+                        f"{_ONBOARDING_RELDIR}/ name no product, so absence of a flow is not provable"
+                    ),
+                )
+            else:
+                results[product] = SurfaceFact(
+                    availability="unavailable",
+                    facts={"count": 0},
+                    **{"from": [f"{_ONBOARDING_RELDIR}/"]},
+                )
+            continue
+
+        rel, sdks = found
+        results[product] = SurfaceFact(
+            availability="available" if sdks else "unavailable",
+            facts={"sdks": sdks, "count": len(sdks)},
+            **{"from": [rel]},
+        )
+    return results

--- a/tools/hogli-commands/hogli_commands/product/capabilities/sources/platform.py
+++ b/tools/hogli-commands/hogli_commands/product/capabilities/sources/platform.py
@@ -1,0 +1,53 @@
+"""Facts that are global rather than per-product.
+
+Some capabilities genuinely have no product attribution. The Slack CDP destination
+template is available to every project and names no product; the CLI ships command groups
+with no product mapping at all. Emitting a per-product boolean for either would be
+fabricating attribution the repo does not have, so they are reported once, here.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ..context import DerivationContext
+from ..models import PlatformFacts
+
+_SLACK_TEMPLATE = "posthog/cdp/templates/slack/template_slack.py"
+_SIGNALS_ENUMS = "products/signals/backend/enums.py"
+_CLI_SRC = "cli/src"
+
+_ENUM_MEMBER_RE = re.compile(r'^\s+[A-Z0-9_]+\s*=\s*"([a-z0-9_]+)"', re.MULTILINE)
+
+
+def _warehouse_signal_sources(ctx: DerivationContext) -> list[str]:
+    """SignalSourceProduct values that are NOT product directories.
+
+    These are the third-party systems (Sentry, Zendesk, Snyk, …) that feed the Signals
+    inbox. They are a data-source registry, not a product list, which is why they belong
+    at the platform level rather than being joined onto products.
+    """
+    path = ctx.repo_root / _SIGNALS_ENUMS
+    if not path.exists():
+        return []
+    text = path.read_text()
+    block = re.search(r"class SignalSourceProduct\(StrEnum\):(.*?)(?=\nclass )", text, re.DOTALL)
+    if not block:
+        return []
+    values = _ENUM_MEMBER_RE.findall(block.group(1))
+    return sorted({v for v in values if ctx.join(v).product is None})
+
+
+def _cli_command_groups(ctx: DerivationContext) -> list[str]:
+    src = ctx.repo_root / _CLI_SRC
+    if not src.is_dir():
+        return []
+    return sorted(d.name for d in src.iterdir() if d.is_dir())
+
+
+def derive(ctx: DerivationContext) -> PlatformFacts:
+    return PlatformFacts(
+        slack_cdp_outbound_destination=(ctx.repo_root / _SLACK_TEMPLATE).exists(),
+        warehouse_signal_sources=_warehouse_signal_sources(ctx),
+        cli_command_groups=_cli_command_groups(ctx),
+    )

--- a/tools/hogli-commands/hogli_commands/product/capabilities/sources/scouts.py
+++ b/tools/hogli-commands/hogli_commands/product/capabilities/sources/scouts.py
@@ -1,0 +1,113 @@
+"""Self-driving surface: which products a Signals scout watches, and which ship skills.
+
+**Open world today.** Scouts declare the product they cover via `metadata.scope` in their
+SKILL.md frontmatter, but eleven scopes (`apm`, `web_vitals`, `csp_violations`, …) do not
+name any product directory. `apm` almost certainly covers `products/tracing` — but the
+repo does not say so, and inferring it would be a guess. While any scope is unattributed,
+absence of a scout is not evidence of absence, so products with no scout get `unknown`
+rather than `unavailable`.
+
+The world closes itself: once every scope resolves, this source starts emitting
+`unavailable`, with no rule change needed.
+"""
+
+from __future__ import annotations
+
+import re
+
+import yaml
+
+from ..context import DerivationContext
+from ..models import SurfaceFact
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+_SCOUT_GLOB_DIR = "products/signals/skills"
+_SCOUT_PREFIX = "signals-scout-"
+
+
+def _frontmatter(text: str) -> dict:
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+    parsed = yaml.safe_load(match.group(1))
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _scout_scopes(ctx: DerivationContext) -> list[tuple[str, str, str | None]]:
+    """(scout_name, relpath, scope) for every canonical scout, scope may be None."""
+    root = ctx.repo_root / _SCOUT_GLOB_DIR
+    if not root.is_dir():
+        return []
+
+    found: list[tuple[str, str, str | None]] = []
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir() or not entry.name.startswith(_SCOUT_PREFIX):
+            continue
+        skill = entry / "SKILL.md"
+        if not skill.exists():
+            continue
+        metadata = _frontmatter(skill.read_text()).get("metadata") or {}
+        scope = metadata.get("scope") if isinstance(metadata, dict) else None
+        found.append((entry.name, ctx.rel(skill), scope if isinstance(scope, str) else None))
+    return found
+
+
+def unattributed_scopes(ctx: DerivationContext) -> list[str]:
+    """Scout scopes that name no product directory. Surfaced verbatim at the top level."""
+    return sorted({scope for _name, _rel, scope in _scout_scopes(ctx) if scope and ctx.join(scope).product is None})
+
+
+def derive(ctx: DerivationContext) -> dict[str, SurfaceFact]:
+    scouts = _scout_scopes(ctx)
+    world_is_open = bool(unattributed_scopes(ctx))
+
+    by_product: dict[str, list[tuple[str, str, str]]] = {}
+    for name, rel, scope in scouts:
+        if not scope:
+            continue
+        join = ctx.join(scope)
+        if join.product is None:
+            continue
+        by_product.setdefault(join.product, []).append((name, rel, join.match))
+
+    results: dict[str, SurfaceFact] = {}
+    for product in sorted(ctx.product_dirs):
+        scout_entries = by_product.get(product, [])
+        skills_dir = ctx.products_dir / product / "skills"
+        skill_names = (
+            sorted(d.name for d in skills_dir.iterdir() if d.is_dir() and (d / "SKILL.md").exists())
+            if skills_dir.is_dir()
+            else []
+        )
+
+        sources = [rel for _n, rel, _m in scout_entries]
+        if skill_names:
+            sources.append(f"products/{product}/skills/")
+
+        if scout_entries or skill_names:
+            results[product] = SurfaceFact(
+                availability="available",
+                facts={
+                    "scouts": sorted(n for n, _r, _m in scout_entries),
+                    "scout_match": sorted({m for _n, _r, m in scout_entries}),
+                    "skills": skill_names,
+                },
+                **{"from": sources},
+            )
+        elif world_is_open:
+            results[product] = SurfaceFact(
+                availability="unknown",
+                unknown_reason=(
+                    "scout attribution is incomplete — some scout scopes name no product "
+                    "directory, so the absence of a scout does not prove the absence of coverage"
+                ),
+            )
+        else:
+            results[product] = SurfaceFact(
+                availability="unavailable",
+                facts={"scouts": [], "skills": []},
+                **{"from": [f"{_SCOUT_GLOB_DIR}/", f"products/{product}/"]},
+            )
+
+    return results

--- a/tools/hogli-commands/hogli_commands/product/checks.py
+++ b/tools/hogli-commands/hogli_commands/product/checks.py
@@ -1047,6 +1047,117 @@ class OrphanedTestFilesCheck(ProductCheck):
         return result
 
 
+class CapabilitySourcesCheck(ProductCheck):
+    """Validates that this product's capability-spec inputs parse.
+
+    The capability spec is derived from files products already own (mcp/tools.yaml,
+    skill frontmatter). A malformed one does not break the product, so nothing else
+    catches it — it just quietly drops the product's facts out of the published spec.
+    """
+
+    label = "capability spec sources"
+
+    def run(self, ctx: CheckContext) -> CheckResult:
+        import yaml
+
+        result = CheckResult()
+
+        tools_yaml = ctx.product_dir / "mcp" / "tools.yaml"
+        if tools_yaml.exists():
+            try:
+                parsed = yaml.safe_load(tools_yaml.read_text())
+            except yaml.YAMLError as exc:
+                result.issues.append(f"mcp/tools.yaml does not parse: {exc}")
+                result.file = f"products/{ctx.name}/mcp/tools.yaml"
+            else:
+                if not isinstance(parsed, dict):
+                    result.issues.append("mcp/tools.yaml must be a YAML mapping")
+                    result.file = f"products/{ctx.name}/mcp/tools.yaml"
+
+        skills_dir = ctx.product_dir / "skills"
+        if skills_dir.is_dir():
+            for skill in sorted(skills_dir.iterdir()):
+                skill_md = skill / "SKILL.md"
+                if not skill.is_dir() or not skill_md.exists():
+                    continue
+                match = re.match(r"^---\s*\n(.*?)\n---\s*\n", skill_md.read_text(), re.DOTALL)
+                if not match:
+                    result.issues.append(f"skills/{skill.name}/SKILL.md has no YAML frontmatter")
+                    result.file = f"products/{ctx.name}/skills/{skill.name}/SKILL.md"
+                    continue
+                try:
+                    yaml.safe_load(match.group(1))
+                except yaml.YAMLError as exc:
+                    result.issues.append(f"skills/{skill.name}/SKILL.md frontmatter does not parse: {exc}")
+                    result.file = f"products/{ctx.name}/skills/{skill.name}/SKILL.md"
+
+        result.lines.append("✓ ok" if not result.issues else f"✗ {len(result.issues)} issue(s)")
+        return result
+
+
+class ScoutScopeAttributionCheck(ProductCheck):
+    """A Signals scout's `metadata.scope` must name a real product directory.
+
+    Scope is how the capability spec attributes self-driving coverage to a product. A
+    scope naming a directory that does not exist is a stale reference: the scout keeps
+    running, but its product silently shows no coverage. Scopes that name no directory at
+    all are a separate, known gap (tracked as `unattributed.scout_scopes`) and are not
+    flagged here — only ones that look like a rename that was half-applied.
+    """
+
+    label = "scout scope attribution"
+
+    def run(self, ctx: CheckContext) -> CheckResult:
+        import yaml
+
+        skills_dir = ctx.product_dir / "skills"
+        scouts = (
+            [d for d in sorted(skills_dir.iterdir()) if d.is_dir() and d.name.startswith("signals-scout-")]
+            if skills_dir.is_dir()
+            else []
+        )
+        if not scouts:
+            return CheckResult(skip=True)
+
+        from .paths import PRODUCTS_DIR
+
+        product_dirs = {d.name for d in PRODUCTS_DIR.iterdir() if d.is_dir() and (d / "__init__.py").exists()}
+        aliases_path = PRODUCTS_DIR / "product-aliases.json"
+        aliases = json.loads(aliases_path.read_text()).get("aliases", {}) if aliases_path.exists() else {}
+
+        result = CheckResult()
+        for scout in scouts:
+            skill_md = scout / "SKILL.md"
+            if not skill_md.exists():
+                continue
+            match = re.match(r"^---\s*\n(.*?)\n---\s*\n", skill_md.read_text(), re.DOTALL)
+            if not match:
+                continue
+            try:
+                frontmatter = yaml.safe_load(match.group(1)) or {}
+            except yaml.YAMLError:
+                continue  # CapabilitySourcesCheck reports the parse failure
+            metadata = frontmatter.get("metadata") if isinstance(frontmatter, dict) else None
+            scope = metadata.get("scope") if isinstance(metadata, dict) else None
+            if not isinstance(scope, str) or not scope:
+                continue
+            resolved = aliases.get(scope, scope)
+            if resolved in product_dirs:
+                continue
+            # Only flag a scope that looks like it *meant* a directory — i.e. one whose
+            # alias target is missing. A scope with no directory anywhere is the known
+            # open-world gap, not a broken reference.
+            if scope in aliases:
+                result.issues.append(
+                    f"skills/{scout.name}: metadata.scope '{scope}' aliases to '{resolved}', "
+                    "which is not a product directory"
+                )
+                result.file = f"products/{ctx.name}/skills/{scout.name}/SKILL.md"
+
+        result.lines.append("✓ ok" if not result.issues else f"✗ {len(result.issues)} stale scope(s)")
+        return result
+
+
 CHECKS: list[ProductCheck] = [
     ProductYamlCheck(),
     RequiredRootFilesCheck(),
@@ -1056,4 +1167,6 @@ CHECKS: list[ProductCheck] = [
     TachCheck(),
     IsolationChainCheck(),
     OrphanedTestFilesCheck(),
+    CapabilitySourcesCheck(),
+    ScoutScopeAttributionCheck(),
 ]

--- a/tools/hogli-commands/hogli_commands/tests/test_product_capabilities.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_product_capabilities.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hogli_commands.product.capabilities import build as cap_build
+from hogli_commands.product.capabilities.context import DerivationContext
+from hogli_commands.product.capabilities.join import assert_no_ambiguous_joins, join_to_product, normalize_token
+from hogli_commands.product.capabilities.models import PROSE_KEYS, SurfaceFact
+from hogli_commands.product.capabilities.sources import (
+    mcp as mcp_source,
+    onboarding as onboarding_source,
+    scouts as scouts_source,
+)
+from pydantic import ValidationError
+
+
+@pytest.fixture(scope="module")
+def spec() -> cap_build.CapabilitySpec:
+    return cap_build.build_spec()
+
+
+@pytest.fixture(scope="module")
+def by_product(spec: cap_build.CapabilitySpec) -> dict[str, object]:
+    return {p.product: p for p in spec.products}
+
+
+def _fact(product, dotted: str) -> object:
+    group, key, attr = dotted.split(".", 2)
+    fact = getattr(product, group)[key]
+    return getattr(fact, attr) if attr in {"availability", "unknown_reason"} else fact.facts.get(attr)
+
+
+# The manual product mapping this spec replaces, encoded as assertions — one entry per
+# *derivation rule*, not per product. More products would exercise the same code paths
+# with different data: churn without coverage. Negatives and `unknown`s are asserted
+# deliberately, since a golden set of only `available` checks would still pass if a bug
+# made everything available.
+GOLDEN: dict[str, dict[str, object]] = {
+    "error_tracking": {
+        # The all-positive baseline: if a bug made a whole source return empty, this is
+        # the first thing to go red.
+        "surfaces.mcp.availability": "available",
+        "surfaces.self_driving.availability": "available",
+        "data_sources.onboarding_sdks.availability": "available",
+        # A deferred surface must stay `unknown`, never silently become a negative.
+        "surfaces.cli.availability": "unknown",
+    },
+    "replay": {
+        # Reached only through the `session_replay` alias. If alias resolution regresses
+        # to preferring an exact directory match, this product silently loses its scout
+        # and its onboarding flow — the exact bug this ordering was written to prevent.
+        "surfaces.self_driving.availability": "available",
+        "data_sources.onboarding_sdks.availability": "available",
+    },
+    "llm_analytics": {
+        # The other half of that alias: a vestigial shell that must read as empty rather
+        # than absorbing the real AI observability product's facts.
+        "surfaces.mcp.availability": "unavailable",
+        "data_sources.onboarding_sdks.availability": "unavailable",
+    },
+    # Every enabled tool sits behind the `mcp-analytics` flag, so the surface exists but
+    # nobody can reach it without opting in. Guards the preview rule specifically.
+    "mcp_analytics": {"surfaces.mcp.availability": "preview"},
+}
+
+
+@pytest.mark.parametrize("product_name", sorted(GOLDEN))
+def test_golden_set(by_product: dict, product_name: str) -> None:
+    product = by_product[product_name]
+    for dotted, expected in GOLDEN[product_name].items():
+        assert _fact(product, dotted) == expected, f"{product_name}.{dotted}"
+
+
+def test_mcp_facts_are_populated_not_just_counted(by_product: dict) -> None:
+    # An availability verdict alone would still pass if `facts` came back empty, leaving
+    # consumers with a surface they cannot describe. Assert the payload is really there
+    # without pinning individual tool names, which get renamed legitimately.
+    facts = by_product["error_tracking"].surfaces["mcp"].facts
+    assert facts["enabled_tool_count"] == len(facts["tool_names"]) > 0
+    assert all(isinstance(name, str) for name in facts["tool_names"])
+    assert any(scope.startswith("error_tracking:") for scope in facts["scopes"])
+
+
+def test_every_product_appears_once_with_full_key_set(spec: cap_build.CapabilitySpec) -> None:
+    names = [p.product for p in spec.products]
+    assert len(names) == len(set(names))
+    for product in spec.products:
+        # A missing key is indistinguishable from a negative answer to a consumer.
+        assert list(product.surfaces) == cap_build.SURFACE_KEYS
+        assert list(product.data_sources) == cap_build.DATA_SOURCE_KEYS
+
+
+def test_output_carries_no_prose(spec: cap_build.CapabilitySpec) -> None:
+    payload = json.loads(cap_build.serialize(spec))
+
+    def walk(node: object) -> set[str]:
+        if isinstance(node, dict):
+            return {k for k in node if k in PROSE_KEYS} | {f for v in node.values() for f in walk(v)}
+        if isinstance(node, list):
+            return {f for item in node for f in walk(item)}
+        return set()
+
+    assert walk(payload) == set()
+
+
+def test_release_stamps_only_when_asked(spec: cap_build.CapabilitySpec) -> None:
+    assert spec.generated_at is None and spec.commit_sha is None
+    released = cap_build.build_spec(release=True)
+    assert released.generated_at is not None
+
+
+def test_unattributed_scout_scopes_do_not_grow_silently(spec: cap_build.CapabilitySpec) -> None:
+    # Each orphan keeps 56 products on `unknown` for self_driving. Growth should be a
+    # conscious decision, so pin the count and force an explicit bump.
+    assert len(spec.unattributed.scout_scopes) <= 11, f"new unattributed scout scopes: {spec.unattributed.scout_scopes}"
+
+
+def test_self_driving_is_unknown_not_unavailable_while_scopes_are_orphaned(
+    spec: cap_build.CapabilitySpec, by_product: dict
+) -> None:
+    if not spec.unattributed.scout_scopes:
+        pytest.skip("scout attribution is complete; the world is closed")
+    verdicts = {p.surfaces["self_driving"].availability for p in spec.products}
+    assert "unavailable" not in verdicts
+
+
+# --- honesty contract -------------------------------------------------------------
+
+
+def test_verdict_requires_a_source_file() -> None:
+    with pytest.raises(ValidationError):
+        SurfaceFact(availability="available", **{"from": []})
+
+
+def test_unknown_requires_a_reason() -> None:
+    with pytest.raises(ValidationError):
+        SurfaceFact(availability="unknown")
+
+
+def test_unknown_reason_is_rejected_on_a_known_verdict() -> None:
+    with pytest.raises(ValidationError):
+        SurfaceFact(availability="unavailable", unknown_reason="why", **{"from": ["a"]})
+
+
+# --- join -------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "token,expected",
+    [("Error-Tracking", "error_tracking"), ("web analytics", "web_analytics"), ("MCP_Analytics", "mcp_analytics")],
+)
+def test_normalize_token(token: str, expected: str) -> None:
+    assert normalize_token(token) == expected
+
+
+def test_alias_beats_an_exact_directory_match() -> None:
+    # products/llm_analytics exists but is vestigial; the alias must win or the real
+    # product silently loses its scout.
+    dirs = {"llm_analytics", "ai_observability"}
+    join = join_to_product("llm_analytics", dirs, {"llm_analytics": "ai_observability"})
+    assert (join.product, join.match) == ("ai_observability", "alias")
+
+
+@pytest.mark.parametrize("token,expected", [("survey", "surveys"), ("feature_flag", "feature_flags")])
+def test_depluralization(token: str, expected: str) -> None:
+    join = join_to_product(token, {expected}, {})
+    assert (join.product, join.match) == (expected, "normalized")
+
+
+def test_unjoinable_token_reports_none() -> None:
+    assert join_to_product("apm", {"error_tracking"}, {}).product is None
+
+
+def test_ambiguous_joins_raise() -> None:
+    # Both tokens reach `surveys` only by de-pluralization, so neither is authoritative.
+    with pytest.raises(ValueError, match="ambiguous product joins"):
+        assert_no_ambiguous_joins(["survey", "surveyss"], {"surveys"}, {})
+
+
+def test_exact_match_alongside_a_fuzzy_one_is_not_ambiguous() -> None:
+    # `surveys` matches the directory outright, so it is authoritative and `survey`
+    # resolving to the same product is agreement, not a collision.
+    assert_no_ambiguous_joins(["survey", "surveys"], {"surveys"}, {})
+
+
+# --- source units -----------------------------------------------------------------
+
+
+def _ctx(tmp_path: Path, products: set[str]) -> DerivationContext:
+    products_dir = tmp_path / "products"
+    for name in products:
+        (products_dir / name).mkdir(parents=True, exist_ok=True)
+    (products_dir / "product-aliases.json").write_text(json.dumps({"aliases": {}}))
+    return DerivationContext(repo_root=tmp_path, products_dir=products_dir, product_dirs=products)
+
+
+def test_mcp_all_tools_disabled_is_unavailable(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, {"alpha"})
+    tools = ctx.products_dir / "alpha" / "mcp"
+    tools.mkdir(parents=True)
+    (tools / "tools.yaml").write_text("tools:\n  a-tool:\n    enabled: false\n")
+    fact = mcp_source.derive(ctx)["alpha"]
+    assert fact.availability == "unavailable"
+    assert fact.facts["total_operation_count"] == 1
+
+
+def test_mcp_all_enabled_tools_flag_gated_is_preview(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, {"alpha"})
+    tools = ctx.products_dir / "alpha" / "mcp"
+    tools.mkdir(parents=True)
+    (tools / "tools.yaml").write_text("tools:\n  a-tool:\n    enabled: true\n    feature_flag: beta-thing\n")
+    assert mcp_source.derive(ctx)["alpha"].availability == "preview"
+
+
+def test_mcp_returns_a_fact_for_every_product(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, {"alpha", "beta"})
+    assert set(mcp_source.derive(ctx)) == {"alpha", "beta"}
+
+
+def test_scout_missing_metadata_block_is_tolerated(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, {"alpha"})
+    scout = tmp_path / "products" / "signals" / "skills" / "signals-scout-thing"
+    scout.mkdir(parents=True)
+    (scout / "SKILL.md").write_text("---\nname: signals-scout-thing\ndescription: x\n---\n\nbody\n")
+    assert scouts_source.unattributed_scopes(ctx) == []
+    assert scouts_source.derive(ctx)["alpha"].availability in {"unknown", "unavailable"}
+
+
+def test_onboarding_opens_the_world_when_a_directory_does_not_join(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, {"alpha"})
+    orphan = tmp_path / "docs" / "onboarding" / "not-a-product"
+    orphan.mkdir(parents=True)
+    (orphan / "web.tsx").write_text("")
+    fact = onboarding_source.derive(ctx)["alpha"]
+    assert fact.availability == "unknown"
+    assert onboarding_source.unattributed_dirs(ctx) == ["not-a-product"]
+
+
+def test_onboarding_closed_world_proves_absence(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path, {"alpha", "beta"})
+    flow = tmp_path / "docs" / "onboarding" / "alpha"
+    flow.mkdir(parents=True)
+    (flow / "web.tsx").write_text("")
+    (flow / "index.ts").write_text("")
+    results = onboarding_source.derive(ctx)
+    assert results["alpha"].availability == "available"
+    assert results["alpha"].facts["sdks"] == ["web"]
+    assert results["beta"].availability == "unavailable"


### PR DESCRIPTION
## Problem

posthog.com wants to show, per product, which surfaces it works with (web, MCP, Max AI, self-driving, CLI, API, Slack, alerts) and which data sources feed it. There is no machine-readable source for any of that today, so the website would have to hand-maintain a parallel copy that silently goes stale.

We had an accurate mapping of this. It lived in a chat transcript. Nothing recomputed it and nothing failed when reality diverged.

## Changes

A generator that derives the spec instead of anyone writing it down. Every fact is computed from files that already exist and are already CI-enforced. Nothing is hand-authored.

The output is `dist/product-capabilities.json`, published to a GitHub release on master. posthog.com fetches it at build time and renders it however it likes. The repo owns what is true, the website owns every word.

**The part that makes it trustworthy.** Where a fact cannot be computed, the output says `unknown` with a machine-readable reason rather than guessing. Three Pydantic validators enforce that structurally, so it cannot rot into optimism:

1. A non-`unknown` verdict must cite at least one source file.
2. An `unknown` must explain itself.
3. `unavailable` is only emitted for closed-world derivations, where we can enumerate every place a surface could be registered.

Rule 3 is the important one. "We checked everywhere and it is not there" and "we cannot tell" are different claims, and collapsing them is how a spec starts lying. Sources that cannot prove absence open their own world and downgrade to `unknown`, then close it again automatically once attribution is complete. No rule change needed.

**What v0.1 actually derives**, across all 71 products:

| Surface | Verdict source | Result |
| --- | --- | --- |
| `mcp` | `products/*/mcp/tools.yaml` | 30 available, 13 preview, 28 unavailable |
| `self_driving` | scout `metadata.scope` + `products/*/skills/` | 35 available, 36 unknown |
| `onboarding_sdks` | `docs/onboarding/<product>/` | 9 available, 62 unavailable |

Everything else emits `unknown` naming the specific thing that would close it (for example `web` needs a new output from `build-products.mjs`, `events` needs `setupProbe`, which exactly one manifest declares today).

> [!NOTE]
> That is deliberately about 60% of the matrix unknown on day one. It is the cost of not guessing, and I think it is the right trade: a spec the website can trust for the part it covers beats one it has to second-guess entirely. Every unknown is enumerated with its fix.

**Costs nothing on the PR path.** The artifact is never committed, so there is no drift check and no regenerate step for contributors. I measured 9.8% of commits (39 of 400) touch a derivation source, and under the first draft of this design each of those would have had to regenerate and commit a JSON file they did not care about. Not worth it to buy PR-diff visibility. Two cheap checks ride the existing `hogli product:lint --all` instead, and publishing is a master-only workflow with no `pull_request` trigger.

Two aliasing fixes worth flagging, both cases where the obvious join is wrong:

- `productAliases` moves out of `scaffold-yaml.ts` into `products/product-aliases.json` so the MCP scaffolder and this generator cannot drift. Aliases now resolve **before** exact directory matches, because `products/llm_analytics` is a vestigial shell that would otherwise shadow the real `ai_observability` product and steal its scout.
- Added `session_replay -> replay` for the same reason. `products/session_replay` is two files with no `product.yaml`; the real product is `products/replay`. Without the alias, Replay reports no scout and no onboarding flow, which is a false negative rather than an honest unknown.

> [!WARNING]
> posthog.com must fail or warn its own build when `generated_at` goes stale (roughly 7 days). This is load-bearing, not a nice-to-have. The failure mode that kills this system is silent: someone restructures a source file, a derivation stops matching, the build stays green, and the website serves wrong data for weeks. Nobody watches a green dashboard. Consumer-side staleness detection is what surfaces that automatically.

## How did you test this code?

Automated, all run by me (Claude):

- `pytest tools/hogli-commands/hogli_commands/tests/test_product_capabilities.py` plus the neighbouring `test_checks.py`, 229 passing.
- `hogli product:lint --all`, 69 products pass, runtime unchanged within noise at about 1.9s.
- `hogli lint:workflows`, all 6 checks across 106 workflows.
- `hogli ci:preflight`, 0 failures. Ruff lint and format clean.
- Rebased onto current master (214 commits) and re-ran everything. `self_driving` moved 34 to 35 available on the new base, which is the generator correctly picking up coverage that landed in the meantime.

What the tests catch, since the template asks:

- **Golden set**: the manual mapping this replaces, one case per derivation rule rather than per product. Adding more products would be the same code paths with different data. It asserts negatives and `unknown`s, not just positives, because a golden set of only `available` checks still passes if a bug makes everything available. The `replay` case specifically guards alias-before-exact ordering, which is a bug I actually shipped mid-implementation and this caught.
- **Invariants**: no prose keys in the output, and every product present exactly once with the complete surface key set. A missing key is indistinguishable from a negative answer to a consumer.
- **Honesty contract**: the three validators reject their bad inputs.
- **Source units**: synthetic `tmp_path` trees for the edge cases that will actually break, including all-tools-disabled, flag-gated-only, missing scout frontmatter, and open versus closed world.

I could not run `pnpm --filter=@posthog/mcp typecheck` on the `scaffold-yaml.ts` change because `node_modules` is not installed in my environment. I verified the changed expression evaluates correctly under plain `node` and that `PRODUCTS_DIR` is declared before use, but a reviewer should let CI confirm the typecheck.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code) wrote this. It started from a request to encode an ad-hoc product surface mapping somewhere posthog.com could reference, and the design decisions fell out of two questions Sarah pushed back with: whether this needs human maintenance, and what CI actually costs.

Both changed the design. The first draft committed the JSON and drift-checked it. Measuring the trigger rate (9.8% of commits) against what that buys (PR-diff visibility) made it clear the tax was not worth it, so the committed file and the drift check are gone and the whole PR path is now two checks inside a job that already runs. The ownership question pushed the safeguards from "assign a team" toward consumer-side staleness detection plus tripwires that turn silent-wrong into loud-wrong, since no assigned owner watches a passing build.

Skills invoked: `/writing-tests` (which trimmed the golden set from 12 products to 4 rules and removed a test pinning a renameable tool name) and `/authoring-ci-workflows` (which caught a `fetch-depth: 0` I did not need and would have failed the linter).

One thing left open on purpose. `self_driving` stays `unknown` for 36 products because 11 scout scopes (`apm`, `web_vitals`, `csp_violations` and friends) name no product directory. `apm` almost certainly means `products/tracing`, but the repo does not say so and inferring it would be exactly the guessing this design refuses. Closing it means adding `metadata.product:` to 26 scout files, which is attribution rather than prose, the same role `x-product` plays for API operations. That is a real decision with a real cost and it belongs to a human, so I left it rather than quietly resolving it. A test pins the orphan count so it cannot grow unnoticed.
