### PR TITLE
fix(onboarding): recover the run card when the stream delivers no state

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5573,7 +5573,7 @@ snapshots:
     scenes-app-dashboards--show-across-viewports--narrow--dark:
         hash: v1.k794b7964.e919c4955d7113170ab00269c5f628c318afe14f26dc8aafb046b172e17f362e.YDXD84rrb2KR1I36pHMxEsGZ0sN0os_cBBdNIf89Pu8
     scenes-app-dashboards--show-across-viewports--narrow--light:
-        hash: v1.k794b7964.2a88f06991ca4c13ad27ee62db8eaa037c542301e28c24934eedc1bbb78cb338.3Ne0cm6_2xQiGE1wGcRzmw0QBd3QrEYkELz3PCg9J48
+        hash: v1.k794b7964.a46d840722e971910236d6fcd8a8f69e0b1db5ee9d472d62055b02d6569f7a99.kHEdVPNUm5DRKSlMFS12SLKf1TyChQJZKKuZ2PKvtfA
     scenes-app-dashboards--show-across-viewports--superwide--dark:
         hash: v1.k794b7964.9948b52cf842206c1584057a6a16b8caed7a32d95f103dbea07089a02df75a53.AuXGqOvw-P-XuzOL2Zl-BkBPb1-Q3R1949f5-IkTjZA
     scenes-app-dashboards--show-across-viewports--superwide--light:
@@ -7646,6 +7646,10 @@ snapshots:
         hash: v1.k794b7964.9b570a49e8ac8dfc934d386c081f7fae1d4282de06afae86bd7c5a36a7754948.dlJN-Winmieb8CReOxRv0AHUwAkrSYEIX0uT6oFBiMA
     scenes-other-onboarding-shared-installation-progress--floating-dismissible--light:
         hash: v1.k794b7964.e8d02d56edcf2e5ab2998c7407b12d1eef019d6dfe4e468a1299ed6c16ba3882.XkNbvIk-X1rTmnRo8guX8oFQyzVvdjqHxQEDNOLlRK8
+    scenes-other-onboarding-shared-installation-progress--lost-contact--dark:
+        hash: v1.k794b7964.0c823488913bc658132cbacd34dbfa099c952d4285be11f466c1faab2aa176de.2Yn_3R4IZA1r64pwys8AM3xEDicPJSw9gJ0vxCVWwVM
+    scenes-other-onboarding-shared-installation-progress--lost-contact--light:
+        hash: v1.k794b7964.0bfdd92c602253db00b1204978e4e14b4e1562e484f1610f2595465c470eeb8c.mAtv6ApOmQhhgbyFrqf9ye1xKLKGMLGD6C-ORG2AVYQ
     scenes-other-onboarding-shared-installation-progress--playground--dark:
         hash: v1.k794b7964.73dd3b1ca302d1d915814fb1c93516188ee3a6c010a9deedc21aba892b0c4eaa.TED9G6l7yoWOiiXzoG27nGeTlcy4E02tWrI0-iEqOBM
     scenes-other-onboarding-shared-installation-progress--playground--light:

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.stories.tsx
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/InstallationProgressView.stories.tsx
@@ -192,6 +192,20 @@ export const FailedWizard: Story = {
     },
 }
 
+// A run whose stream never delivered any state: no pipeline steps to show, only the recovery CTAs.
+export const LostContact: Story = {
+    args: {
+        progress: progress({
+            phase: 'error',
+            steps: [],
+            error: {
+                title: 'Setup lost contact',
+                detail: 'We stopped hearing back from this run. Run the wizard yourself, or dismiss it and start over.',
+            },
+        }),
+    },
+}
+
 export const FailedNoDetail: Story = {
     args: {
         progress: progress({

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/installationProgressLogic.test.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/installationProgressLogic.test.ts
@@ -94,6 +94,15 @@ describe('installationProgressLogic merge', () => {
             expect(cloudProgress(taskState({ status: 'in_progress' }), [], 'open', null, true).phase).toBe('running')
         })
 
+        it('surfaces a run that never delivered any state as an error, not an eternal idle spinner', () => {
+            // `idle` renders a spinner with no recovery controls, so a stream that stayed silent has
+            // to resolve to the error phase (which carries the retry CTAs and the dismiss control).
+            const result = cloudProgress(null, [], 'open', null, true)
+            expect(result.phase).toBe('error')
+            expect(result.error?.title).toBe('Setup lost contact')
+            expect(result.isCurrent).toBe(true)
+        })
+
         it.each([
             ['pending', 'pending'],
             ['in_progress', 'in_progress'],

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/installationProgressLogic.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/installationProgressLogic.ts
@@ -148,7 +148,17 @@ export function cloudProgress(
 ): InstallationProgress {
     let phase: InstallationPhase
     let stalledError: { title: string; detail: string | null } | null = null
-    if (!taskRunState) {
+    if (!taskRunState && isStalled) {
+        // The stream never delivered any run state (deleted or access-revoked run, a stream that
+        // stayed silent past taskRunStreamLogic's no-state window). `idle` renders as a spinner with
+        // no way out, so surface the dead end: the error phase carries the retry CTAs and the
+        // dismiss control.
+        phase = 'error'
+        stalledError = {
+            title: 'Setup lost contact',
+            detail: 'We stopped hearing back from this run. Run the wizard yourself, or dismiss it and start over.',
+        }
+    } else if (!taskRunState) {
         phase = taskConnectionStatus === 'connecting' ? 'connecting' : 'idle'
     } else if (taskRunState.status === 'queued' && isStalled) {
         // The run never left the queue (see taskRunStreamLogic's stall timer) — nothing is actually

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/taskRunStreamLogic.test.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/taskRunStreamLogic.test.ts
@@ -3,6 +3,7 @@ import { installMockEventSource, MockEventSource } from 'lib/wizard-sync/eventSo
 
 import { expectLogic } from 'kea-test-utils'
 
+import { ApiError } from 'lib/api-error'
 import {
     DEFAULT_POLLING_INTERVAL_SECS,
     jitteredIntervalMs,
@@ -17,13 +18,15 @@ import { projectLogic } from 'scenes/projectLogic'
 
 import { initKeaTests } from '~/test/init'
 
-import { tasksActiveWizardRunRetrieve } from 'products/tasks/frontend/generated/api'
+import { tasksActiveWizardRunRetrieve, tasksRunsRetrieve } from 'products/tasks/frontend/generated/api'
 import type { TaskRunDetailDTOApi } from 'products/tasks/frontend/generated/api.schemas'
 
 import { activeCloudRunLogic } from './activeCloudRunLogic'
 import {
     cloudRunCompletionReport,
     mergeProgressStep,
+    NO_STATE_STALL_MS,
+    parseStreamErrorMessage,
     parseTaskRunStreamMessage,
     TaskRunProgressStep,
     taskRunDetailToStreamState,
@@ -40,6 +43,7 @@ jest.mock('products/tasks/frontend/generated/api', () => ({
 }))
 
 const mockActiveWizardRun = tasksActiveWizardRunRetrieve as jest.Mock
+const mockRunRetrieve = tasksRunsRetrieve as jest.Mock
 
 function step(overrides: Partial<TaskRunProgressStep> = {}): TaskRunProgressStep {
     return {
@@ -290,6 +294,19 @@ describe('taskRunStreamLogic helpers', () => {
         })
     })
 
+    describe('parseStreamErrorMessage', () => {
+        // The browser dispatches transport failures under the same `error` name, so a payload that
+        // does not carry a message must not be mistaken for the server giving up on the stream.
+        it.each([
+            ['the server error payload', '{"error": "Stream not available"}', 'Stream not available'],
+            ['a payload without an error field', '{"type": "task_run_state"}', null],
+            ['a non-string error field', '{"error": 42}', null],
+            ['invalid JSON', 'not json', null],
+        ])('reads %s', (_name, rawData, expected) => {
+            expect(parseStreamErrorMessage(rawData)).toBe(expected)
+        })
+    })
+
     describe('taskRunPrUrl', () => {
         it('prefers the terminal output url over the pr progress step', () => {
             const state = runState({ output: { pr_url: 'https://x/pull/2' } })
@@ -413,6 +430,7 @@ describe('taskRunStreamLogic transport', () => {
             status: 'in_progress',
             started_at: RUN_STARTED_AT,
         })
+        mockRunRetrieve.mockReset()
         restoreEventSource = installMockEventSource()
         logic = taskRunStreamLogic({ taskId: 'task-1', runId: 'run-1' })
         logic.mount()
@@ -493,5 +511,97 @@ describe('taskRunStreamLogic transport', () => {
         mounted = false
         jest.advanceTimersByTime(SSE_RECONNECT_MAX_MS)
         expect(MockEventSource.instances).toHaveLength(1)
+    })
+
+    // The run-detail fallback resolves outside kea, so its dispatches land a few microtasks after
+    // the event that triggered it.
+    const flushFallback = async (): Promise<void> => {
+        for (let i = 0; i < 5; i++) {
+            await Promise.resolve()
+        }
+    }
+
+    const runDetail = (overrides: Record<string, unknown> = {}): TaskRunDetailDTOApi =>
+        ({
+            id: 'run-1',
+            status: 'in_progress',
+            stage: null,
+            output: null,
+            branch: null,
+            error_message: null,
+            updated_at: '2026-01-01T00:05:00Z',
+            completed_at: null,
+            ...overrides,
+        }) as unknown as TaskRunDetailDTOApi
+
+    it('settles a finished run from its detail when the server has no stream to serve', async () => {
+        mockRunRetrieve.mockResolvedValue(
+            runDetail({ status: 'completed', completed_at: '2026-01-01T00:06:00Z', output: { pr_url: 'https://x/1' } })
+        )
+        logic.actions.connect()
+        MockEventSource.last().emitOpen()
+        await expectLogic(logic).toDispatchActions(['connectionOpened'])
+
+        // A named `error` event carries a payload; a transport failure does not. Only the former
+        // means the server gave up waiting for the run's stream key.
+        MockEventSource.last().emitNamed('error', '{"error": "Stream not available"}')
+        await flushFallback()
+
+        expect(mockRunRetrieve).toHaveBeenCalledWith(String(MOCK_TEAM_ID), 'task-1', 'run-1')
+        expect(logic.values.taskRunState).toMatchObject({ status: 'completed' })
+        expect(logic.values.isComplete).toBe(true)
+        // Nothing more will ever be published for a finished run, so no retry is scheduled either.
+        jest.advanceTimersByTime(SSE_RECONNECT_MAX_MS)
+        expect(MockEventSource.instances).toHaveLength(1)
+    })
+
+    it('reconnects when the stream is unavailable but the run is still live', async () => {
+        mockRunRetrieve.mockResolvedValue(runDetail({ status: 'in_progress' }))
+        logic.actions.connect()
+        MockEventSource.last().emitNamed('error', '{"error": "Stream not available"}')
+        await flushFallback()
+
+        expect(logic.values.taskRunState).toMatchObject({ status: 'in_progress' })
+        jest.advanceTimersByTime(PAST_FIRST_RECONNECT_MS)
+        expect(MockEventSource.instances).toHaveLength(2)
+    })
+
+    it('marks the stream dead when the run detail is gone for good', async () => {
+        mockRunRetrieve.mockRejectedValue(new ApiError('not found', 404))
+        logic.actions.connect()
+        MockEventSource.last().emitNamed('error', '{"error": "Stream not available"}')
+        await flushFallback()
+
+        expect(logic.values.isStalled).toBe(true)
+        // A deleted or access-revoked run is not worth retrying.
+        jest.advanceTimersByTime(SSE_RECONNECT_MAX_MS)
+        expect(MockEventSource.instances).toHaveLength(1)
+    })
+
+    it('reports a stall when the stream delivers no state at all', async () => {
+        logic.actions.connect()
+        MockEventSource.last().emitOpen()
+        await expectLogic(logic).toDispatchActions(['connectionOpened'])
+
+        jest.advanceTimersByTime(NO_STATE_STALL_MS)
+        expect(logic.values.isStalled).toBe(true)
+    })
+
+    it('keeps the no-state stall through a scheduled reconnect', async () => {
+        // The regression: a reconnect clears isStalled, and a per-connect timer would be re-armed
+        // for another full window (or, armed once per lifetime, never re-armed at all), putting the
+        // surfaces back on the eternal spinner with no way out.
+        logic.actions.connect()
+        MockEventSource.last().emitOpen()
+        jest.advanceTimersByTime(NO_STATE_STALL_MS)
+        expect(logic.values.isStalled).toBe(true)
+
+        mockRunRetrieve.mockRejectedValue(new Error('network hiccup'))
+        MockEventSource.last().emitNamed('error', '{"error": "Stream not available"}')
+        await flushFallback()
+        jest.advanceTimersByTime(PAST_FIRST_RECONNECT_MS)
+
+        expect(MockEventSource.instances).toHaveLength(2)
+        expect(logic.values.isStalled).toBe(true)
     })
 })

--- a/frontend/src/scenes/onboarding/shared/wizard-sync/taskRunStreamLogic.ts
+++ b/frontend/src/scenes/onboarding/shared/wizard-sync/taskRunStreamLogic.ts
@@ -1,10 +1,10 @@
 import { MakeLogicType, actions, connect, kea, key, listeners, path, props, reducers } from 'kea'
 
-import { sseReconnectDelayMs } from 'lib/wizard-sync/pollLoop'
+import { isPermanentPollError, sseReconnectDelayMs } from 'lib/wizard-sync/pollLoop'
 import { logSyncDebug } from 'lib/wizard-sync/wizardSyncDebugLogic'
 import { projectLogic } from 'scenes/projectLogic'
 
-import { getTasksRunsStreamRetrieveUrl } from 'products/tasks/frontend/generated/api'
+import { getTasksRunsStreamRetrieveUrl, tasksRunsRetrieve } from 'products/tasks/frontend/generated/api'
 import type { TaskRunDetailDTOApi } from 'products/tasks/frontend/generated/api.schemas'
 
 import { onboardingEventUsageLogic } from '../../onboardingEventUsageLogic'
@@ -17,8 +17,28 @@ export type TaskRunConnectionStatus = 'idle' | 'connecting' | 'open' | 'closed' 
 // seconds; minutes of silence means the pipeline isn't running at all.
 export const QUEUED_STALL_MS = 2 * 60 * 1000
 
-// Project the REST run snapshot onto the same shape the SSE `task_run_state` events carry, so polling and
-// streaming feed `taskRunStateUpdated` identically and the rest of the logic stays mode-agnostic.
+// How long the stream may stay connected without delivering ANY run state before we give up. A
+// deleted or access-revoked run, a stream key that never materializes, or a transport stuck in a
+// reconnect loop would otherwise leave surfaces spinning on `idle` indefinitely. Longer than the
+// server's own wait for a missing stream key, so a slow-to-start run gets one full server-side
+// wait plus reconnect slack. The first state event disarms it.
+export const NO_STATE_STALL_MS = 4 * 60 * 1000
+
+// Payload of the stream's named `error` events (e.g. {"error": "Stream not available"} once the
+// server gives up waiting for the run's stream key). Returns the message, or null when the data is
+// not such a payload.
+export function parseStreamErrorMessage(rawData: string): string | null {
+    try {
+        const payload = JSON.parse(rawData) as { error?: unknown }
+        return typeof payload.error === 'string' ? payload.error : null
+    } catch {
+        return null
+    }
+}
+
+// Project the REST run snapshot onto the same shape the SSE `task_run_state` events carry, so the
+// stream and the run-detail fallback feed `taskRunStateUpdated` identically and the rest of the
+// logic stays transport-agnostic.
 export function taskRunDetailToStreamState(dto: TaskRunDetailDTOApi): TaskRunStreamState {
     return {
         status: dto.status,
@@ -252,7 +272,9 @@ export type taskRunStreamLogicType = MakeLogicType<
  * `stream-end` closes the stream; rotation (`end`) and transient drops are handled by EventSource's
  * native reconnect (it replays the `Last-Event-ID` cursor the server stamps on every event). Fatal
  * closes (readyState CLOSED, e.g. any non-200 on a (re)connect) never retry natively, so the logic
- * schedules its own backed-off reconnect, per the posthog/api/streaming.py consumer contract.
+ * schedules its own backed-off reconnect, per the posthog/api/streaming.py consumer contract. A named
+ * `error` event means the server has no stream to serve, so the run is settled from its REST detail
+ * instead; a stream that stays silent past NO_STATE_STALL_MS is reported stalled.
  *
  * When the `onboarding-wizard-sync-mode` flag resolves to `polling` (GROW-118), the EventSource is
  * replaced by an interval that re-fetches the run's REST snapshot and feeds it through the same
@@ -339,9 +361,10 @@ export const taskRunStreamLogic = kea<taskRunStreamLogicType>([
                 connectionErrored: (_, { error }) => error,
             },
         ],
-        // The run has sat in `queued` past the stall window — the backend never picked it up (e.g.
-        // no Temporal worker is running). Surfaces render this as a failure instead of an eternal
-        // spinner. Cleared as soon as the run reports any non-queued state.
+        // The run is stuck: either it sat in `queued` past the stall window (the backend never picked
+        // it up, e.g. no Temporal worker is running) or the stream stayed silent past
+        // NO_STATE_STALL_MS without ever delivering state. Surfaces render this as a failure instead
+        // of an eternal spinner. Cleared as soon as the run reports any non-queued state.
         isStalled: [
             false,
             {
@@ -368,6 +391,8 @@ export const taskRunStreamLogic = kea<taskRunStreamLogicType>([
                     ...report,
                 })
             }
+            // State arrived, so this run is not the "nothing ever came back" case whatever its status.
+            cache.disposables.dispose('no-state-stall')
             // Arm a stall timer while the run reports `queued`; any other status disarms it. The timer
             // rides disposables so unmount (and tab-hide) tears it down with everything else.
             if (state.status !== 'queued') {
@@ -386,6 +411,10 @@ export const taskRunStreamLogic = kea<taskRunStreamLogicType>([
             // A connect (manual or scheduled) supersedes any pending reconnect timer, so the two can
             // never race a second stream open.
             cache.disposables.dispose('task-run-reconnect')
+            // Whether this is a scheduled retry of a failed cycle or a fresh attempt (mount, or a
+            // surface asking to reconnect). Only the latter earns a new no-state window below.
+            const resumingCycle = cache.reconnectScheduled === true
+            cache.reconnectScheduled = false
             // No run to stream — the Installation layer connects this source even in local mode (where
             // there's no TaskRun), so stay idle rather than opening a stream to a non-existent run.
             if (!props.runId) {
@@ -458,37 +487,123 @@ export const taskRunStreamLogic = kea<taskRunStreamLogicType>([
                     actions.streamCompleted()
                     cache.disposables.dispose('task-run-sync')
                 })
-                eventSource.onerror = (): void => {
+                const scheduleReconnect = (reason: string): void => {
+                    // The run-detail fallback can resolve after an unmount, which tears the manager down.
+                    if (!cache.disposables) {
+                        return
+                    }
+                    const attempt = ((cache.sseReconnectAttempt as number | undefined) ?? 0) + 1
+                    cache.sseReconnectAttempt = attempt
+                    const delayMs = sseReconnectDelayMs(attempt)
+                    const suffix = `reconnecting in ~${Math.round(delayMs / 1000)}s`
+                    logSyncDebug(debugSource, 'error', `${reason}, ${suffix}`)
+                    actions.connectionErrored(`${reason}, ${suffix}`)
+                    // The timer rides disposables so an unmount tears it down, and a hidden tab
+                    // pauses it instead of reconnecting in the background.
+                    cache.disposables.add(() => {
+                        const timer = window.setTimeout(() => {
+                            // Marks the connect as a continuation of this failed cycle, not a fresh
+                            // attempt: the no-state deadline below must not move with every retry.
+                            cache.reconnectScheduled = true
+                            actions.connect()
+                        }, delayMs)
+                        return () => window.clearTimeout(timer)
+                    }, 'task-run-reconnect')
+                }
+
+                // One recovery per opened stream: the server may emit its error event more than once
+                // before the close lands, and the run detail only needs fetching once.
+                let recovering = false
+                const recoverFromStreamError = (reason: string): void => {
+                    if (recovering) {
+                        return
+                    }
+                    recovering = true
+                    // The server closes cleanly right after this event, which the browser would answer
+                    // by reconnecting into the same wait indefinitely. Drop the transport and settle the
+                    // run from its REST snapshot instead.
+                    cache.disposables.dispose('task-run-sync')
+                    void (async () => {
+                        try {
+                            const detail = await tasksRunsRetrieve(String(projectId), props.taskId, props.runId)
+                            const state = taskRunDetailToStreamState(detail)
+                            logSyncDebug(debugSource, 'event', `run detail → ${state.status} (stream unavailable)`)
+                            actions.taskRunStateUpdated(state)
+                            if (isTerminalStatus(state.status)) {
+                                // Nothing further will ever be published for a finished run.
+                                actions.streamCompleted()
+                                return
+                            }
+                            scheduleReconnect(reason)
+                        } catch (err) {
+                            if (isPermanentPollError(err)) {
+                                // Deleted run, or access revoked: the stream is dead for good, so stop
+                                // retrying and let the surfaces offer retry/dismiss.
+                                logSyncDebug(debugSource, 'error', `run detail unavailable: ${String(err)}`)
+                                actions.runStalled()
+                                actions.connectionErrored(reason)
+                                return
+                            }
+                            scheduleReconnect(reason)
+                        }
+                    })()
+                }
+
+                // Both the server's named `error` event and the browser's transport failures dispatch
+                // under the name `error`; only the former is a MessageEvent carrying a payload, so
+                // `data` is what tells them apart.
+                eventSource.addEventListener('error', (event: Event): void => {
+                    const rawData = (event as MessageEvent<unknown>).data
+                    if (typeof rawData === 'string') {
+                        recoverFromStreamError(parseStreamErrorMessage(rawData) ?? 'Stream unavailable')
+                        return
+                    }
                     // CLOSED → browser gave up (any non-200 on a (re)connect lands here and it will
                     // never retry on its own), so schedule our own reconnect with backoff; anything
                     // else → it's already retrying (rides the Last-Event-ID cursor), so just surface
                     // "reconnecting".
                     if (eventSource.readyState === EventSource.CLOSED) {
-                        const attempt = ((cache.sseReconnectAttempt as number | undefined) ?? 0) + 1
-                        cache.sseReconnectAttempt = attempt
-                        const delayMs = sseReconnectDelayMs(attempt)
-                        logSyncDebug(
-                            debugSource,
-                            'error',
-                            `SSE closed, reconnecting in ~${Math.round(delayMs / 1000)}s`
-                        )
-                        actions.connectionErrored(
-                            `EventSource connection closed, reconnecting in ~${Math.round(delayMs / 1000)}s`
-                        )
-                        // The timer rides disposables so an unmount tears it down, and a hidden tab
-                        // pauses it instead of reconnecting in the background.
-                        cache.disposables.add(() => {
-                            const timer = window.setTimeout(() => actions.connect(), delayMs)
-                            return () => window.clearTimeout(timer)
-                        }, 'task-run-reconnect')
+                        scheduleReconnect('EventSource connection closed')
                     } else {
                         logSyncDebug(debugSource, 'error', 'SSE transport error, reconnecting')
                         actions.connectionErrored('EventSource transport error, reconnecting')
                     }
-                }
+                })
 
                 return () => eventSource.close()
             }, 'task-run-sync')
+
+            // Give up if the stream never delivers ANY run state (see NO_STATE_STALL_MS). The
+            // deadline is absolute, not a fresh window per connect: a transport stuck in a reconnect
+            // loop retries faster than the window is long, so a per-connect timer would be pushed
+            // back forever and never trip. A fresh attempt does get a fresh window, since it is a
+            // real chance for the run to report. The first state event disarms the whole thing.
+            if (!values.taskRunState) {
+                if (!resumingCycle || cache.noStateDeadline === undefined) {
+                    cache.noStateDeadline = Date.now() + NO_STATE_STALL_MS
+                }
+                const remainingMs = (cache.noStateDeadline as number) - Date.now()
+                if (remainingMs <= 0) {
+                    // Past the deadline with nothing to show for it, and the reducer cleared
+                    // `isStalled` on the way into this listener. Re-report it now: waiting on a timer
+                    // that has already expired would drop the surfaces back to an eternal spinner.
+                    actions.runStalled()
+                } else {
+                    cache.disposables.add(() => {
+                        const timer = window.setTimeout(() => {
+                            cache.disposables.dispose('no-state-stall')
+                            if (values.taskRunState) {
+                                return
+                            }
+                            // Nothing is coming. Drop any pending reconnect too: the retry loop is
+                            // not what is going to fix this, and the surfaces now offer their own.
+                            cache.disposables.dispose('task-run-reconnect')
+                            actions.runStalled()
+                        }, remainingMs)
+                        return () => window.clearTimeout(timer)
+                    }, 'no-state-stall')
+                }
+            }
         },
         disconnect: () => {
             // Tolerant of an empty/absent runId: local mode builds this logic with runId ''.
@@ -496,6 +611,9 @@ export const taskRunStreamLogic = kea<taskRunStreamLogicType>([
             cache.disposables.dispose('task-run-sync')
             cache.disposables.dispose('task-run-reconnect')
             cache.disposables.dispose('queued-stall')
+            cache.disposables.dispose('no-state-stall')
+            // The next connect is a new attempt, not a continuation of the cycle torn down here.
+            cache.reconnectScheduled = false
         },
     })),
 ])


### PR DESCRIPTION
## Problem

The task-run SSE endpoint emits a NAMED `error` event (a MessageEvent carrying `{"error": "Stream not available"}`) once it gives up waiting for a run's Redis stream key, then closes cleanly. `taskRunStreamLogic` never listened for that event, and a clean close is exactly what a native EventSource answers by reconnecting, so the client re-entered the same server-side wait forever while `cloudProgress` held the surfaces on the `idle` phase. `idle` renders a spinner with no recovery controls, and its only other exit was a state event that, by construction, was never coming. `taskRunDetailToStreamState` already existed to project the REST run snapshot onto the stream's state shape but had no caller.

## Changes

- `taskRunStreamLogic` listens for `error` with `addEventListener` and branches on `event.data`: a payload means the server has no stream to serve, no payload means a browser transport failure (the existing CLOSED and backoff handling, now factored into `scheduleReconnect`).
- On a server error payload the logic drops the EventSource (so the browser cannot reconnect into the same wait), fetches the run once through `tasksRunsRetrieve`, and feeds it through `taskRunDetailToStreamState`: a terminal status settles the stream via `streamCompleted`, a live run schedules a backed-off reconnect, and a permanent fetch error (401/403/404/410, per `isPermanentPollError`) marks the stream dead with `runStalled`.
- New `NO_STATE_STALL_MS` (4 minutes, longer than the server's own wait for a missing stream key) fixes an absolute deadline the first time the stream connects with nothing to show. A scheduled retry keeps that deadline instead of restarting it, so a transport looping faster than the window cannot push it back forever, and a connect made after the deadline passed reports the stall straight away rather than clearing it. The first state event disarms the whole thing.
- `cloudProgress` maps "no run state plus stalled" to the `error` phase with a `Setup lost contact` title, which is the phase that already carries the retry CTAs and the dismiss control.
- `parseStreamErrorMessage` parses the named event's payload, returning null for anything that is not a `{error: string}` body.

> [!NOTE]
> `isStalled` is now set by two independent conditions. The queued-stall path is unchanged. The no-state path can only fire while `taskRunState` is null, and `cloudProgress` checks that case first. A terminal state arriving through the fallback does not fire the funnel's completion event: `cloudRunCompletionReport` requires an observed non-terminal to terminal transition, and the backend already reports runs that finish unobserved.

## How did you test this code?

No manual testing. I am an agent and could not exercise this in a browser, so everything below is automated and was run locally:

- `jest src/scenes/onboarding/shared/wizard-sync` (7 suites, 174 tests)

What the new tests catch that nothing did before:

- `parseStreamErrorMessage` cases: a transport failure being mistaken for the server's named event, which would fire the REST fallback on every reconnect.
- run-detail fallback cases: a server error payload that does not settle a finished run, does not retry a live one, or retries a run that is gone for good.
- `reports a stall when the stream delivers no state at all`: the eternal spinner this PR removes.
- `keeps the no-state stall through a scheduled reconnect`: a reconnect clearing `isStalled` with nothing left to re-arm, which puts the spinner back with no error CTAs and no dismiss.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact. Recovery behavior inside an existing surface.

## 🤖 Agent context


I (actually Claude Code, Opus 5) wrote this. No repo skills were invoked.

Decisions worth knowing: the named `error` event and the browser's transport failures both dispatch under the name `error`, so the branch is on `typeof event.data === 'string'` rather than on two separate handlers, and the old `onerror` assignment had to go for `addEventListener` to see both. The no-state timer went through two designs before this one. Armed once per logic lifetime it could never be re-armed after firing, and re-armed per connect it could be pushed back forever by a retry loop that is faster than the window. An absolute deadline, refreshed only by a fresh connect attempt, is what satisfies both. The run-detail fallback resolves outside kea, so `scheduleReconnect` returns early when the disposables manager is already gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Validating after merge

This mostly turns an invisible dead end into a visible one. It does not change how many runs finish, so the server-side run counters are the control, not the signal.

- `posthog_tasks_task_run_stream_connections_closed_total{origin_product="onboarding",outcome="unavailable"}` is the exact server event this PR now handles. Its ratio to `posthog_tasks_task_run_stream_connections_opened_total{origin_product="onboarding"}` should fall: each `unavailable` close used to be answered by an immediate native reconnect into the same wait, and is now answered by one REST fetch plus at most one backed-off reconnect.
- `wizard sync run dismissed` (project 2) with `mode="cloud"` and `phase="error"` should appear for a class of runs that could not produce it before, because the surface held `phase="idle"` with no dismiss control. Direction: up from roughly zero.
- The falsifier for that same event is `elapsed_seconds`. `NO_STATE_STALL_MS` is 4 minutes, so dismissals at `phase="error"` with `elapsed_seconds` under 240 mean the no-state deadline is firing on healthy runs and the recovery CTAs are being offered while the stream is still working.
- Control: `posthog_tasks_runs_in_status{origin_product="onboarding"}` and `posthog_tasks_oldest_open_run_age_seconds{origin_product="onboarding"}` should be flat. Nothing here cancels or completes a run, it only lets the client stop waiting on one, so movement there points at something other than this change.
- Server-side `task_run_started` with no `task_run_completed`, `task_run_failed` or `task_run_cancelled` on the same `properties.run_id` is the population this PR is for. That population should not shrink; what should change is that its clients reach a terminal surface instead of a spinner.

Fixes #74316
