### PR TITLE
fix(tasks): reserve the run identity sandbox environment keys

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -364,6 +364,12 @@ RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS: frozenset[str] = frozenset(
         "POSTHOG_WIZARD_API_KEY",
         "POSTHOG_API_URL",
         "POSTHOG_PROJECT_ID",
+        # The run's own identity. It addresses the API the sandbox writes back through (the agent
+        # prompt POSTs living artifacts to /tasks/$POSTHOG_TASK_ID/runs/$POSTHOG_TASK_RUN_ID/) and
+        # it is what run-scoped telemetry joins on, so a sandbox environment must not supply it:
+        # the user env vars are merged AFTER these, and would otherwise win.
+        "POSTHOG_TASK_ID",
+        "POSTHOG_TASK_RUN_ID",
         "JWT_PUBLIC_KEY",
         "GITHUB_TOKEN",
         "GH_TOKEN",

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py
@@ -6,6 +6,7 @@ from products.tasks.backend.logic.services.sandbox import ExecutionResult, Sandb
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 from products.tasks.backend.temporal.process_task.activities.provision_sandbox import (
     CloneRepositoryInSandboxInput,
+    _build_environment_variables,
     clone_repository_in_sandbox,
 )
 
@@ -52,3 +53,43 @@ def test_clone_repository_uses_saved_branch_only_for_resumes(mocker, activity_en
         shallow=True,
         branch=expected_branch,
     )
+
+
+def test_build_environment_variables_keeps_the_run_identity_out_of_user_reach(mocker):
+    # The user env vars are merged after the base dict, so without the reservation a sandbox
+    # environment would simply overwrite the ids the sandbox writes back through and reports on.
+    module = "products.tasks.backend.temporal.process_task.activities.provision_sandbox"
+    mocker.patch(f"{module}.get_sandbox_api_url", return_value="https://us.posthog.com")
+    mocker.patch(f"{module}.get_sandbox_jwt_public_key", return_value="jwt-public-key")
+    mocker.patch(f"{module}.get_git_identity_env_vars", return_value={})
+    mocker.patch(f"{module}.emit_agent_log")
+
+    context = TaskProcessingContext(
+        task_id="task-id",
+        run_id="run-id",
+        team_id=1,
+        team_uuid="team-uuid",
+        organization_id="organization-id",
+        github_integration_id=123,
+        repository="posthog/posthog",
+        distinct_id="distinct-id",
+        state={"sandbox_environment_id": "sandbox-environment-id"},
+    )
+    mocker.patch.object(
+        TaskProcessingContext,
+        "get_sandbox_environment",
+        return_value=mocker.Mock(
+            name="sandbox-environment",
+            environment_variables={
+                "POSTHOG_TASK_ID": "someone-elses-task",
+                "POSTHOG_TASK_RUN_ID": "someone-elses-run",
+                "SAFE_VAR": "kept",
+            },
+        ),
+    )
+
+    environment_variables = _build_environment_variables(context, mocker.Mock(), "github-token", "access-token")
+
+    assert environment_variables["POSTHOG_TASK_ID"] == "task-id"
+    assert environment_variables["POSTHOG_TASK_RUN_ID"] == "run-id"
+    assert environment_variables["SAFE_VAR"] == "kept"


### PR DESCRIPTION
## Why

`_build_environment_variables` sets POSTHOG_TASK_ID and POSTHOG_TASK_RUN_ID on every sandbox, then merges the sandbox environment's user-supplied variables on top of them. Neither key is reserved, so a sandbox environment can overwrite the run's own identity. That identity is not decorative: the agent prompt POSTs living artifacts to `/tasks/$POSTHOG_TASK_ID/runs/$POSTHOG_TASK_RUN_ID/`, and run-scoped telemetry from processes inside the sandbox joins back on the same two values.

## What

- reserve POSTHOG_TASK_ID and POSTHOG_TASK_RUN_ID in RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS, so `filter_user_sandbox_env_vars` drops them from a sandbox environment's variables and reports them as skipped
- unit test that builds the environment with a sandbox environment claiming both keys, asserting the backend values survive and unrelated variables still apply

## Notes for reviewers

- Both keys are exported unconditionally, on agent runs as well as wizard runs, so this closes the gap for both.
- No new variable is exported. The wizard telemetry change reads these existing names precisely because they carry no POSTHOG_WIZARD_ prefix: the wizard CLI binds every POSTHOG_WIZARD_-prefixed variable to a yargs option and exits non-zero on one it has not declared, so exporting the ids under that prefix would tie a backend deploy to an npm release.
- Test plan: `pytest products/tasks/backend/temporal/process_task/activities/tests/test_provision_sandbox.py` (4 passed locally).

## Validating after merge

- The reservation only bites when a sandbox environment actually declares one of the two keys, so
  the direct signal is the existing debug line in Loki (`namespace="temporal-worker-tasks-agent"`):
  `Skipped reserved/blocked sandbox environment variable keys from '<env>': ... POSTHOG_TASK_ID ...`.
  Every occurrence after this ships is a run that previously booted with a foreign identity.
  Expected direction: rare and flat near zero, not a rising count.
- Join integrity is the outcome the reservation exists for: server events `task_run_started`,
  `task_run_completed` and `task_run_failed` (project 2) join on `properties.run_id` to whatever the
  sandbox writes back to `/tasks/$POSTHOG_TASK_ID/runs/$POSTHOG_TASK_RUN_ID/`. Runs whose
  sandbox-side writes land under a `run_id` that matches no `TaskRun` should go to zero.
- Once PostHog/wizard #991 is published, the wizard's own `task_run_id` tag on
  `setup wizard finished` must equal the run id the backend reports for that run. A cloud run where
  the two differ means the reservation is not holding.
- Regression to watch: a sandbox environment that legitimately set either key now loses it silently.
  That would show as `posthog_tasks_task_run_failed_total{origin_product}` rising for teams whose
  runs use a sandbox environment, alongside the skipped-keys line naming these two keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #74316
