### PR TITLE
feat(tasks): tag task_run_started with origin_product

### DIFF
--- a/products/tasks/backend/temporal/process_task/tests/test_workflow.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_workflow.py
@@ -77,6 +77,7 @@ def _build_context(
     environment: str | None = None,
     use_modal_vm_sandbox: bool = False,
     custom_image_name: str | None = None,
+    origin_product: str | None = None,
 ) -> TaskProcessingContext:
     return TaskProcessingContext(
         task_id="task-id",
@@ -87,6 +88,7 @@ def _build_context(
         github_integration_id=github_integration_id,
         repository=repository,
         distinct_id="distinct-id",
+        origin_product=origin_product,
         environment=environment,
         create_pr=True,
         state=state or {},
@@ -892,6 +894,31 @@ class TestProcessTaskWorkflowUnit:
         assert result.sandbox_id == "sandbox-123"
         read_sandbox_logs_mock.assert_awaited_once_with("sandbox-123")
         cleanup_sandbox_mock.assert_awaited_once_with("sandbox-123", complete_stream=True)
+
+    async def test_task_run_started_and_failed_carry_the_same_origin_product(self, monkeypatch):
+        workflow = ProcessTaskWorkflow()
+        track_workflow_event_mock = AsyncMock()
+
+        monkeypatch.setattr(
+            workflow,
+            "_get_task_processing_context",
+            AsyncMock(return_value=_build_context(github_integration_id=123, origin_product="onboarding")),
+        )
+        monkeypatch.setattr(workflow, "_update_task_run_status", AsyncMock())
+        monkeypatch.setattr(workflow, "_track_workflow_event", track_workflow_event_mock)
+        monkeypatch.setattr(workflow, "_post_slack_update", AsyncMock())
+        monkeypatch.setattr(workflow, "_read_sandbox_logs", AsyncMock())
+        monkeypatch.setattr(workflow, "_cleanup_sandbox", AsyncMock())
+        monkeypatch.setattr(workflow, "_emit_progress", AsyncMock())
+        monkeypatch.setattr(
+            workflow, "_get_sandbox_for_repository", AsyncMock(side_effect=RuntimeError("clone failed"))
+        )
+
+        await workflow.run(ProcessTaskInput(run_id="run-id"))
+
+        tracked = {call.args[0]: call.args[1] for call in track_workflow_event_mock.await_args_list}
+        assert tracked["task_run_started"]["origin_product"] == "onboarding"
+        assert tracked["task_run_failed"]["origin_product"] == "onboarding"
 
     async def test_run_refuses_local_environment_run_without_touching_it(self, monkeypatch):
         # If a local (desktop-driven) run is ever cloud-dispatched again (e.g. the reconciler's

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -1012,6 +1012,7 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 "task_id": self.context.task_id,
                 "repository": self.context.repository,
                 "team_id": self.context.team_id,
+                "origin_product": self.context.origin_product,
             },
         )
 


### PR DESCRIPTION
## Why

`task_run_failed` carries `origin_product` from the workflow context, but `task_run_started` (fired
right after the IN_PROGRESS transition) does not. The two events therefore cannot be joined on the
same dimension, so any per-origin start/failure pairing has to fall back on a separate lookup of the
task row. The value is already resolved on `TaskProcessingContext` at workflow start, so the started
event can carry it directly.

## What

- add `origin_product` to the `task_run_started` property bag in `ProcessTaskWorkflow._provision_and_start_agent`, sourced from `self.context.origin_product` exactly as the failure path does
- add an `origin_product` keyword to the `_build_context` test helper
- unit test asserting both `task_run_started` and `task_run_failed` report the same origin

## Notes for reviewers

- No Temporal patch gate. Per `.claude/rules/temporal-workflow-versioning.md`, activity input
  dataclasses are safe to edit; this only adds a key to the `properties` dict inside the existing
  `TrackWorkflowEventInput`, and adds no command to the workflow's sequence, so replaying histories
  see an unchanged command list.
- `origin_product` is `str | None` on the context, so runs without an origin send an explicit null
  rather than omitting the key, matching `task_run_failed`.
- Test plan: pytest products/tasks/backend/temporal/process_task/tests/test_workflow.py -k "origin_product or provisioning_fails" (2 passed locally).

## Validating after merge

- This changes no run behavior; it only makes an existing dimension observable at start time. What
  proves it works is the property's presence, not a shift in any run outcome.
- Signal: the server event `task_run_started` (project 2) carries `properties.origin_product`. Within
  one deploy the share of `task_run_started` events emitted by `ProcessTaskWorkflow` that carry the
  key should go from 0% to 100%, with the value `onboarding` for wizard cloud runs and null for runs
  whose task has no origin.
- The pairing this exists for: for a given `properties.run_id`, `task_run_started` and
  `task_run_failed` must report the same `origin_product`. Any `run_id` where the two disagree is a
  defect in how the context is resolved, not in the events.
- Known gap, so the overall share stays under 100%: `execute_sandbox/workflow.py` emits its own
  `task_run_started` without this key. Scope the check to runs that also produce a `task_run_failed`
  or `task_run_completed` from `ProcessTaskWorkflow` before reading the number as short.
- Regression: `origin_product` null on `task_run_started` while the same run's `task_run_failed`
  reports a non-null value. Nothing else about the run changes, so there is no other failure mode to
  watch for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #74316
