### PR TITLE
feat(wizard): validate repository detectability before creating a cloud run

### DIFF
--- a/ee/api/agentic_provisioning/test/test_wizard_resource_actions.py
+++ b/ee/api/agentic_provisioning/test/test_wizard_resource_actions.py
@@ -14,6 +14,8 @@ from posthog.models.team.team import Team
 from posthog.models.user import OnboardingSkippedReason
 from posthog.models.user_integration import UserIntegration
 
+from products.tasks.backend.facade import api as tasks_facade
+
 from ee.api.agentic_provisioning import GITHUB_GRANT_CACHE_PREFIX, github_grants
 from ee.api.agentic_provisioning.test.base import ProvisioningTestBase
 
@@ -231,3 +233,31 @@ class TestWizardResourceActions(ProvisioningTestBase):
         assert response.status_code == 400
         assert response.json()["error"]["code"] == "github_integration_required"
         mock_create.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ("repository_inaccessible", tasks_facade.WizardRepositoryInaccessibleError),
+            ("framework_undetectable", tasks_facade.WizardFrameworkUndetectableError),
+        ]
+    )
+    @override_settings(WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID="wizard-client-id")
+    def test_wizard_runs_reports_preflight_rejections_as_input_errors(self, expected_code, facade_error):
+        # The pre-flight rejects a target the partner named, which is an input problem it can act
+        # on. Reporting it as a 500 would hide the reason and file an error-tracking issue for an
+        # expected rejection. Reachable even past the check above, which accepts any installation
+        # that can reach the repo while the run binds to one specific integration.
+        with (
+            patch.object(GitHubIntegration, "first_for_team_repository", return_value=MagicMock()),
+            patch(
+                "ee.api.agentic_provisioning.views.tasks_facade.create_wizard_cloud_run",
+                side_effect=facade_error("The pre-flight rejected octocat/hello-world."),
+            ),
+            patch("ee.api.agentic_provisioning.views.capture_exception") as mock_capture_exception,
+        ):
+            response = self._post_wizard_runs(self.team.id, {"repository": "octocat/hello-world"})
+
+        assert response.status_code == 400
+        error = response.json()["error"]
+        assert error["code"] == expected_code
+        assert error["message"] == "The pre-flight rejected octocat/hello-world."
+        mock_capture_exception.assert_not_called()

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -2040,6 +2040,22 @@ def _create_wizard_run(
             ),
             None,
         )
+    except (
+        tasks_facade.WizardRepositoryInaccessibleError,
+        tasks_facade.WizardFrameworkUndetectableError,
+    ) as e:
+        # A rejected target is an input problem the partner can act on, not a server fault: report
+        # it as a 400 under its own code, and keep it out of error tracking.
+        error_code = (
+            "repository_inaccessible"
+            if isinstance(e, tasks_facade.WizardRepositoryInaccessibleError)
+            else "framework_undetectable"
+        )
+        _capture_provisioning_event("wizard_run", "error", partner=partner, error_code=error_code, team_id=team.id)
+        return (
+            error_response(error_code, str(e), resource_id=str(team.id), status=400),
+            None,
+        )
     except Exception:
         capture_exception(additional_properties={"team_id": team.id, "step": "provisioning_wizard_run"})
         _capture_provisioning_event(

--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -58,14 +58,50 @@ OPENAI_SUPPORTED_MODELS = {"o4-mini", "gpt-5-mini", "gpt-5-nano", "gpt-5"}
 # Absolute ceiling on sandbox boots per user per day, reserved atomically right before run
 # creation. The DB-counted throttles above the view are read-then-create and can be raced by
 # parallel requests; this cache.incr cannot, so it is the hard bound a start-cancel or crash
-# loop lands on. Only requests that reach creation consume it.
+# loop lands on. Only requests that boot a sandbox consume it: a reservation whose run creation
+# then rejects is released again, so it stays a count of sandbox boots and nothing else.
 WIZARD_CLOUD_RUN_DAILY_ATTEMPT_CAP = 15
+
+# Ceiling on target pre-flights per user per day. The pre-flight spends GitHub reads from the
+# installation's shared budget before anything is created, and it deliberately costs no sandbox
+# boot, so the attempt cap above does not bound it: a caller looping on repositories that fail the
+# pre-flight would otherwise make unmetered authenticated GitHub requests. Sized well above the
+# attempt cap so it only ever binds on that looping shape, never on ordinary retrying.
+WIZARD_CLOUD_RUN_DAILY_PREFLIGHT_CAP = 40
 
 WIZARD_CLOUD_RUN_REQUESTS_TOTAL = Counter(
     "posthog_wizard_cloud_run_requests_total",
-    "Cloud-run wizard kickoff requests, by outcome (created/unavailable/invalid/permission_denied/throttled)",
+    "Cloud-run wizard kickoff requests, by outcome (created/unavailable/invalid/permission_denied/throttled/"
+    "repository_inaccessible/framework_undetectable)",
     labelnames=["outcome"],
 )
+
+# Pre-flight rejections are reported under their own outcome rather than folded into "invalid", so a
+# pre-flight that starts rejecting healthy repositories is visible without reading request logs.
+CLOUD_RUN_PREFLIGHT_OUTCOMES = frozenset({"repository_inaccessible", "framework_undetectable"})
+
+
+def _cloud_run_validation_outcome(error: exceptions.ValidationError) -> str:
+    codes = error.get_codes()
+    if isinstance(codes, list) and len(codes) == 1 and codes[0] in CLOUD_RUN_PREFLIGHT_OUTCOMES:
+        return cast(str, codes[0])
+    return "invalid"
+
+
+def _preflight_validation_error(error: Exception) -> exceptions.ValidationError:
+    """Turn a facade pre-flight rejection into a 400 carrying its own stable code.
+
+    Clients act on the code, not on the prose: each of these rejections has a specific remedy (fix
+    the repository name, grant the GitHub app access, point the wizard at another repository) that
+    a generic input-validation code would not tell them apart from.
+    """
+    code = (
+        "repository_inaccessible"
+        if isinstance(error, tasks_facade.WizardRepositoryInaccessibleError)
+        else "framework_undetectable"
+    )
+    return exceptions.ValidationError(str(error), code=code)
+
 
 # Supported Gemini models
 GEMINI_SUPPORTED_MODELS = {
@@ -466,8 +502,8 @@ class SetupWizardViewSet(viewsets.ViewSet):
         except exceptions.PermissionDenied:
             WIZARD_CLOUD_RUN_REQUESTS_TOTAL.labels(outcome="permission_denied").inc()
             raise
-        except exceptions.ValidationError:
-            WIZARD_CLOUD_RUN_REQUESTS_TOTAL.labels(outcome="invalid").inc()
+        except exceptions.ValidationError as e:
+            WIZARD_CLOUD_RUN_REQUESTS_TOTAL.labels(outcome=_cloud_run_validation_outcome(e)).inc()
             raise
         except exceptions.Throttled:
             # The atomic attempt reservation inside _cloud_run raises after check_throttles
@@ -478,23 +514,70 @@ class SetupWizardViewSet(viewsets.ViewSet):
         return response
 
     @staticmethod
-    def _reserve_cloud_run_attempt(user_id: int) -> None:
-        """Atomically consume one of the user's daily cloud-run attempts or raise Throttled.
-
-        Runs after validation and project access checks, immediately before run creation, so
-        rejected requests never consume the budget — while parallel requests cannot all slip
-        under the ceiling the way they can with the read-then-create DB throttles.
-        """
+    def _daily_reservation_key(prefix: str, user_id: int) -> str:
         window = int(time.time()) // 86400
-        key = f"wizard_cloud_run_attempts:{user_id}:{window}"
+        return f"{prefix}:{user_id}:{window}"
+
+    @classmethod
+    def _reserve_daily(cls, prefix: str, user_id: int, cap: int, detail: str) -> None:
+        """Atomically consume one unit of a per-user daily budget or raise Throttled.
+
+        cache.add + cache.incr, unlike the read-then-create DB throttles above the view, cannot be
+        raced by parallel requests, so the caps built on this are hard ceilings.
+        """
+        key = cls._daily_reservation_key(prefix, user_id)
         cache.add(key, 0, timeout=86400)
         try:
             count = cache.incr(key)
         except ValueError:
             # The key expired between add and incr; this request is the window's first.
             count = 1
-        if count > WIZARD_CLOUD_RUN_DAILY_ATTEMPT_CAP:
-            raise exceptions.Throttled(detail="You've reached today's limit for cloud setup runs. Try again tomorrow.")
+        if count > cap:
+            raise exceptions.Throttled(detail=detail)
+
+    @classmethod
+    def _release_daily(cls, prefix: str, user_id: int) -> None:
+        """Give back a reservation whose request turned out not to spend what it reserved."""
+        try:
+            cache.decr(cls._daily_reservation_key(prefix, user_id))
+        except ValueError:
+            # The window rolled over between reserving and releasing; nothing left to give back.
+            pass
+
+    @classmethod
+    def _reserve_cloud_run_attempt(cls, user_id: int) -> None:
+        """Atomically consume one of the user's daily cloud-run attempts or raise Throttled.
+
+        Runs after validation and project access checks, immediately before run creation, so
+        rejected requests never consume the budget. The target pre-flight is part of "validation"
+        here and stays above this call: a repository typo boots no sandbox, so it must not cost one
+        of the day's boots either. Run creation re-runs that pre-flight and can still reject, which
+        is what ``_release_cloud_run_attempt`` exists for.
+        """
+        cls._reserve_daily(
+            "wizard_cloud_run_attempts",
+            user_id,
+            WIZARD_CLOUD_RUN_DAILY_ATTEMPT_CAP,
+            "You've reached today's limit for cloud setup runs. Try again tomorrow.",
+        )
+
+    @classmethod
+    def _release_cloud_run_attempt(cls, user_id: int) -> None:
+        cls._release_daily("wizard_cloud_run_attempts", user_id)
+
+    @classmethod
+    def _reserve_cloud_run_preflight(cls, user_id: int) -> None:
+        """Atomically consume one of the user's daily pre-flights or raise Throttled.
+
+        Sits above the pre-flight rather than below it: the point is to bound the GitHub reads a
+        rejected request makes, and a rejected request never reaches the attempt reservation.
+        """
+        cls._reserve_daily(
+            "wizard_cloud_run_preflights",
+            user_id,
+            WIZARD_CLOUD_RUN_DAILY_PREFLIGHT_CAP,
+            "You've reached today's limit for cloud setup runs. Try again tomorrow.",
+        )
 
     def _cloud_run(self, request: Request) -> Response:
         if not bool(settings.WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID):
@@ -515,15 +598,36 @@ class SetupWizardViewSet(viewsets.ViewSet):
         if project.id not in visible_project_ids:
             raise exceptions.PermissionDenied("You don't have access to this project.")
 
-        self._reserve_cloud_run_attempt(cast(User, request.user).id)
+        user_id = cast(User, request.user).id
+
+        # Above the attempt reservation on purpose: a rejection here starts no sandbox, so it must
+        # not spend one of the day's sandbox boots. It carries its own reservation instead, which
+        # bounds the GitHub reads a request that never reaches creation can make.
+        self._reserve_cloud_run_preflight(user_id)
+        try:
+            tasks_facade.validate_wizard_cloud_run_target(
+                team=project.passthrough_team,
+                repository=repository,
+                branch=branch,
+            )
+        except (tasks_facade.WizardRepositoryInaccessibleError, tasks_facade.WizardFrameworkUndetectableError) as e:
+            raise _preflight_validation_error(e)
+
+        self._reserve_cloud_run_attempt(user_id)
 
         try:
             result = tasks_facade.create_wizard_cloud_run(
                 team=project.passthrough_team,
-                user_id=cast(User, request.user).id,
+                user_id=user_id,
                 repository=repository,
                 branch=branch,
             )
+        except (tasks_facade.WizardRepositoryInaccessibleError, tasks_facade.WizardFrameworkUndetectableError) as e:
+            # The facade re-runs the pre-flight, so GitHub answering differently between the two
+            # reads lands here rather than as a 500. It runs before the facade creates anything, so
+            # this request booted no sandbox and the attempt it reserved goes back.
+            self._release_cloud_run_attempt(user_id)
+            raise _preflight_validation_error(e)
         except ValueError as e:
             # e.g. the team/user has no GitHub integration with access to the repository.
             raise exceptions.ValidationError(str(e))

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -9,12 +9,15 @@ from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 
+from parameterized import parameterized
 from rest_framework import status
 
 from posthog.api.wizard.http import SETUP_WIZARD_CACHE_PREFIX, SETUP_WIZARD_CACHE_TIMEOUT
 from posthog.cloud_utils import get_api_host
 from posthog.models import Organization, PersonalAPIKey, User
 from posthog.models.utils import generate_random_token_personal, hash_key_value
+
+from products.tasks.backend.facade import api as tasks_facade
 
 
 class SetupWizardTests(APIBaseTest):
@@ -485,6 +488,34 @@ class SetupWizardCloudRunTests(APIBaseTest):
         assert kwargs["branch"] is None
         assert kwargs["team"].id == self.team.id
 
+    @parameterized.expand(
+        [
+            ("repository_inaccessible", tasks_facade.WizardRepositoryInaccessibleError),
+            ("framework_undetectable", tasks_facade.WizardFrameworkUndetectableError),
+        ]
+    )
+    @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
+    @patch("posthog.api.wizard.http.tasks_facade.validate_wizard_cloud_run_target")
+    def test_preflight_rejections_carry_their_own_code(self, expected_code, facade_error, mock_validate, mock_create):
+        # Clients act on the code, not the prose, so each pre-flight rejection must stay
+        # distinguishable from generic input validation. The facade re-checks the target on
+        # creation, so both call sites have to map the rejection the same way.
+        for raising in (mock_validate, mock_create):
+            mock_validate.side_effect = None
+            mock_create.side_effect = None
+            raising.side_effect = facade_error("The pre-flight rejected acme/app.")
+
+            response = self.client.post(
+                self.CLOUD_RUN_URL,
+                data={"project_id": self.team.id, "repository": "acme/app"},
+                format="json",
+            )
+
+            assert response.status_code == status.HTTP_400_BAD_REQUEST
+            body = response.json()
+            assert body["code"] == expected_code
+            assert body["detail"] == "The pre-flight rejected acme/app."
+
     @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
     def test_rejects_invalid_repository_format(self, mock_create):
         response = self.client.post(
@@ -571,6 +602,89 @@ class SetupWizardCloudRunTests(APIBaseTest):
 
         assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
         assert mock_create.call_count == 2
+
+    @patch("posthog.api.wizard.http.WIZARD_CLOUD_RUN_DAILY_ATTEMPT_CAP", 1)
+    @patch("products.tasks.backend.facade.api.recent_wizard_cloud_run_times", return_value=[])
+    @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
+    @patch("posthog.api.wizard.http.tasks_facade.validate_wizard_cloud_run_target")
+    def test_preflight_rejection_does_not_spend_an_attempt(self, mock_validate, mock_create, _mock_run_times):
+        # The reservation bounds sandbox boots, and a rejected target boots nothing. With the cap
+        # at one, a typo that consumed the budget would leave the run the user actually meant
+        # throttled out for the rest of the day.
+        mock_validate.side_effect = [tasks_facade.WizardRepositoryInaccessibleError("no such repo"), None]
+        mock_create.return_value = MagicMock(task_id="task-uuid", latest_run=MagicMock(id="run-uuid", status="queued"))
+
+        rejected = self.client.post(
+            self.CLOUD_RUN_URL,
+            data={"project_id": self.team.id, "repository": "acme/typo"},
+            format="json",
+        )
+        assert rejected.status_code == status.HTTP_400_BAD_REQUEST
+        mock_create.assert_not_called()
+
+        accepted = self.client.post(
+            self.CLOUD_RUN_URL,
+            data={"project_id": self.team.id, "repository": "acme/app"},
+            format="json",
+        )
+        assert accepted.status_code == status.HTTP_200_OK, accepted.content
+
+    @patch("posthog.api.wizard.http.WIZARD_CLOUD_RUN_DAILY_ATTEMPT_CAP", 1)
+    @patch("products.tasks.backend.facade.api.recent_wizard_cloud_run_times", return_value=[])
+    @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
+    @patch("posthog.api.wizard.http.tasks_facade.validate_wizard_cloud_run_target", return_value=None)
+    def test_creation_side_preflight_rejection_gives_the_attempt_back(
+        self, _mock_validate, mock_create, _mock_run_times
+    ):
+        # The attempt is reserved between the two pre-flights, so a target the first read accepts
+        # and the second rejects would otherwise charge a sandbox boot that never happened.
+        mock_create.side_effect = [
+            tasks_facade.WizardRepositoryInaccessibleError("no such repo"),
+            MagicMock(task_id="task-uuid", latest_run=MagicMock(id="run-uuid", status="queued")),
+        ]
+
+        rejected = self.client.post(
+            self.CLOUD_RUN_URL,
+            data={"project_id": self.team.id, "repository": "acme/app"},
+            format="json",
+        )
+        assert rejected.status_code == status.HTTP_400_BAD_REQUEST
+
+        accepted = self.client.post(
+            self.CLOUD_RUN_URL,
+            data={"project_id": self.team.id, "repository": "acme/app"},
+            format="json",
+        )
+        assert accepted.status_code == status.HTTP_200_OK, accepted.content
+
+    @patch("posthog.api.wizard.http.WIZARD_CLOUD_RUN_DAILY_PREFLIGHT_CAP", 2)
+    @patch("products.tasks.backend.facade.api.recent_wizard_cloud_run_times", return_value=[])
+    @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
+    @patch("posthog.api.wizard.http.tasks_facade.validate_wizard_cloud_run_target")
+    def test_preflight_reads_are_capped_even_though_they_spend_no_attempt(
+        self, mock_validate, mock_create, _mock_run_times
+    ):
+        # Rejected requests cost no attempt by design, so without a cap of their own a caller
+        # looping on rejected repositories would make unmetered GitHub reads.
+        mock_validate.side_effect = tasks_facade.WizardRepositoryInaccessibleError("no such repo")
+
+        for _ in range(2):
+            rejected = self.client.post(
+                self.CLOUD_RUN_URL,
+                data={"project_id": self.team.id, "repository": "acme/typo"},
+                format="json",
+            )
+            assert rejected.status_code == status.HTTP_400_BAD_REQUEST
+
+        throttled = self.client.post(
+            self.CLOUD_RUN_URL,
+            data={"project_id": self.team.id, "repository": "acme/typo"},
+            format="json",
+        )
+
+        assert throttled.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        assert mock_validate.call_count == 2
+        mock_create.assert_not_called()
 
     def tearDown(self):
         super().tearDown()

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -49,6 +49,12 @@ from products.tasks.backend.logic.services.image_builder import (
     is_custom_images_enabled,
     read_spec_from_builder_sandbox,
 )
+from products.tasks.backend.logic.wizard_preflight import (
+    WizardFrameworkUndetectableError,
+    WizardRepositoryAccess,
+    WizardRepositoryInaccessibleError,
+    preflight_wizard_repository,
+)
 from products.tasks.backend.mentions import resolve_mentioned_user_ids
 from products.tasks.backend.models import (
     Channel,
@@ -104,6 +110,8 @@ __all__ = [
     "TaskRuntime",
     "TaskRunEnvironment",
     "TaskRunStatus",
+    "WizardFrameworkUndetectableError",
+    "WizardRepositoryInaccessibleError",
     "append_task_run_log",
     "beacon_task_presence",
     "bootstrap_task_run",
@@ -209,6 +217,7 @@ __all__ = [
     "upsert_internal_sandbox_env",
     "validate_set_output",
     "validate_task_run_artifact_ids",
+    "validate_wizard_cloud_run_target",
     "warm_task_sandbox",
 ]
 
@@ -879,6 +888,36 @@ def create_and_run_task(
     )
 
 
+def validate_wizard_cloud_run_target(
+    *,
+    team,
+    repository: str,
+    branch: str | None = None,
+) -> None:
+    """Raise when pre-flight reads settle that a wizard cloud run on this target would fail.
+
+    Raises :class:`WizardRepositoryInaccessibleError` or :class:`WizardFrameworkUndetectableError`
+    only on an unambiguous answer; a pre-flight that cannot tell returns, so the run goes ahead.
+
+    Separate from ``create_wizard_cloud_run`` so a caller that meters kickoffs can turn a doomed
+    target away before it spends part of that budget on a run no sandbox will ever boot for.
+    ``create_wizard_cloud_run`` calls this itself as well, so a caller that skips it cannot start a
+    run the pre-flight would have rejected.
+    """
+    preflight = preflight_wizard_repository(team, repository, branch=branch)
+    if preflight.access is WizardRepositoryAccess.INACCESSIBLE:
+        raise WizardRepositoryInaccessibleError(
+            f"PostHog's GitHub integration can't access {repository}. Check the repository name, "
+            "or grant the PostHog GitHub app access to it, and try again."
+        )
+    if preflight.framework_detectable is False:
+        raise WizardFrameworkUndetectableError(
+            f"The wizard couldn't find a project to set up in {repository}: it has no package.json, "
+            "pyproject.toml, or other project manifest the wizard recognizes. Point it at the "
+            "repository holding your app, or run `npx @posthog/wizard` locally."
+        )
+
+
 def create_wizard_cloud_run(
     *,
     team,
@@ -900,7 +939,11 @@ def create_wizard_cloud_run(
     The PR head branch is generated here (not by the agent) so the GitHub PR webhook can bind the
     opened PR back to this run by branch + repository — wizard PRs are bot-authored, which the
     agent-side PR attribution cannot match.
+
+    Raises whatever ``validate_wizard_cloud_run_target`` raises: the run would fail inside the
+    sandbox for a reason two GitHub reads can already see.
     """
+    validate_wizard_cloud_run_target(team=team, repository=repository, branch=branch)
     head_branch = generate_wizard_head_branch()
     prompt = build_wizard_pr_agent_prompt(head_branch)
     return create_and_run_task(

--- a/products/tasks/backend/logic/wizard_preflight.py
+++ b/products/tasks/backend/logic/wizard_preflight.py
@@ -1,0 +1,205 @@
+"""Pre-flight checks run before a wizard cloud run reserves a sandbox.
+
+Two kickoff inputs decide the run's outcome before any code executes: whether the team's GitHub
+installation can reach the repository at all, and whether the repository holds any project manifest
+the wizard's framework detection keys off. Both are answerable from two GitHub reads, and both are
+otherwise only discovered inside the sandbox, minutes in, as a clone error or as the wizard aborting
+with "Could not auto-detect your framework for this project".
+
+Everything here is fail-open: a check reports a negative only on an unambiguous answer, so any
+degraded GitHub response (rate limit, timeout, truncated tree, unexpected payload) leaves the run
+exactly as it is today.
+"""
+
+import re
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+import requests
+
+from posthog.models.integration import GitHubIntegration
+from posthog.models.team import Team
+
+from products.tasks.backend.logic.services.sandbox import is_public_sandbox_repo
+from products.tasks.backend.models import resolve_team_github_integration
+
+logger = logging.getLogger(__name__)
+
+_PREFLIGHT_SOURCE = "tasks"
+_GITHUB_REQUEST_TIMEOUT_SECONDS = 5
+
+# A plain ``owner/repo`` and nothing else. The kickoff serializer only checks the two-segment shape,
+# so this is what keeps ``..``/``?``/``#`` in team-supplied input from steering the authenticated
+# reads below at a different GitHub endpoint.
+_SAFE_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+# Same containment rule for the ref, which is also interpolated into a path, with ``/`` allowed for
+# namespaced branches ("feature/x").
+_SAFE_REF_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+
+# Basenames of every project manifest the wizard identifies a framework by. Mirrors PROJECT_MANIFESTS
+# in the wizard's src/lib/detection/agentic.ts; keep the two in sync, and when in doubt add the entry
+# here, since a manifest missing from this set is what turns a healthy repository into a rejection.
+WIZARD_PROJECT_MANIFESTS = frozenset(
+    {
+        "package.json",
+        "pnpm-workspace.yaml",
+        "turbo.json",
+        "nx.json",
+        "lerna.json",
+        "requirements.txt",
+        "pyproject.toml",
+        "setup.py",
+        "Pipfile",
+        "manage.py",
+        "Gemfile",
+        "composer.json",
+        "Cargo.toml",
+        "go.mod",
+        "mix.exs",
+        "pom.xml",
+        "Package.swift",
+        "Podfile",
+        "project.yml",
+        "project.pbxproj",
+        "pubspec.yaml",
+        "build.gradle",
+        "build.gradle.kts",
+        "settings.gradle",
+        "settings.gradle.kts",
+        "libs.versions.toml",
+    }
+)
+
+# The one wizard manifest entry that is a glob rather than a fixed name.
+_WIZARD_MANIFEST_SUFFIXES = (".csproj",)
+
+
+class WizardRepositoryAccess(Enum):
+    ACCESSIBLE = "accessible"
+    INACCESSIBLE = "inaccessible"
+    UNKNOWN = "unknown"
+
+
+class WizardRepositoryInaccessibleError(Exception):
+    """The repository doesn't exist or the team's GitHub installation cannot reach it."""
+
+
+class WizardFrameworkUndetectableError(Exception):
+    """The repository holds no manifest the wizard's framework detection can work from."""
+
+
+@dataclass(frozen=True)
+class WizardRepositoryPreflight:
+    access: WizardRepositoryAccess
+    # None means "could not tell": the listing failed, came back truncated, or was never attempted.
+    # Only an explicit False may block a run.
+    framework_detectable: bool | None = None
+
+
+def preflight_wizard_repository(team: Team, repository: str, branch: str | None = None) -> WizardRepositoryPreflight:
+    """Read ``repository`` (``owner/repo``) with the team's GitHub installation.
+
+    Reads with ``resolve_team_github_integration``, the same helper ``Task._build_task`` binds a
+    run to, so the answer is reached with the credentials the run would clone with rather than with
+    some other install of the team's. ``branch`` is the ref the sandbox checks out; detectability is
+    judged on that ref's tree, and on the default branch's when no branch was requested. Never
+    raises.
+    """
+    if not _is_safe_path(repository, _SAFE_REPOSITORY_RE):
+        return WizardRepositoryPreflight(access=WizardRepositoryAccess.UNKNOWN)
+
+    if is_public_sandbox_repo(repository):
+        # The sandbox clones these unauthenticated and ``_build_task`` exempts them from needing an
+        # integration at all, so no installation's reach decides the run's fate. Reading them with
+        # one anyway would answer a question nobody asked, and a 404 would block a healthy run.
+        return WizardRepositoryPreflight(access=WizardRepositoryAccess.UNKNOWN)
+
+    try:
+        integration = resolve_team_github_integration(team)
+        if integration is None:
+            # Nothing to read with; ``_build_task`` owns this case (user integration fallback, or a
+            # hard "no GitHub integration" error).
+            return WizardRepositoryPreflight(access=WizardRepositoryAccess.UNKNOWN)
+        github = GitHubIntegration(integration, source=_PREFLIGHT_SOURCE)
+        response = _github_get(github, f"/repos/{repository}", endpoint="/repos/{owner}/{repo}")
+    except Exception:
+        logger.warning("wizard_preflight.repository_read_failed", extra={"team_id": team.id}, exc_info=True)
+        return WizardRepositoryPreflight(access=WizardRepositoryAccess.UNKNOWN)
+
+    if response.status_code == 404:
+        return WizardRepositoryPreflight(access=WizardRepositoryAccess.INACCESSIBLE)
+    if response.status_code != 200:
+        return WizardRepositoryPreflight(access=WizardRepositoryAccess.UNKNOWN)
+
+    return WizardRepositoryPreflight(
+        access=WizardRepositoryAccess.ACCESSIBLE,
+        framework_detectable=_framework_detectable(github, repository, branch or _default_branch(response)),
+    )
+
+
+def _is_safe_path(value: str, pattern: re.Pattern[str]) -> bool:
+    return bool(pattern.fullmatch(value)) and ".." not in value
+
+
+def _github_get(
+    github: GitHubIntegration,
+    path: str,
+    *,
+    endpoint: str,
+    params: dict[str, str | int] | None = None,
+) -> requests.Response:
+    return github.api_request("GET", path, endpoint=endpoint, params=params, timeout=_GITHUB_REQUEST_TIMEOUT_SECONDS)
+
+
+def _default_branch(repository_response: requests.Response) -> str | None:
+    try:
+        payload = repository_response.json()
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    default_branch = payload.get("default_branch")
+    return default_branch if isinstance(default_branch, str) and default_branch else None
+
+
+def _framework_detectable(github: GitHubIntegration, repository: str, ref: str | None) -> bool | None:
+    """Whether ``ref``'s tree holds any manifest the wizard's framework detection can work from.
+
+    The wizard globs the whole checkout for manifests, not just the root, so this matches on every
+    blob in the recursive tree. Returns None on anything that leaves the tree in doubt, a
+    ``truncated`` response included: a partial tree can hide the repository's only manifest.
+    """
+    if ref is None or not _is_safe_path(ref, _SAFE_REF_RE):
+        return None
+    try:
+        response = _github_get(
+            github,
+            f"/repos/{repository}/git/trees/{ref}",
+            endpoint="/repos/{owner}/{repo}/git/trees/{tree_sha}",
+            params={"recursive": 1},
+        )
+    except Exception:
+        logger.warning("wizard_preflight.tree_read_failed", extra={"repository": repository}, exc_info=True)
+        return None
+    if response.status_code != 200:
+        return None
+    try:
+        payload = response.json()
+    except Exception:
+        return None
+    if not isinstance(payload, dict) or payload.get("truncated") is not False:
+        return None
+    entries = payload.get("tree")
+    if not isinstance(entries, list):
+        return None
+    return any(
+        _is_wizard_manifest(entry["path"])
+        for entry in entries
+        if isinstance(entry, dict) and entry.get("type") == "blob" and isinstance(entry.get("path"), str)
+    )
+
+
+def _is_wizard_manifest(path: str) -> bool:
+    name = path.rsplit("/", 1)[-1]
+    return name in WIZARD_PROJECT_MANIFESTS or name.endswith(_WIZARD_MANIFEST_SUFFIXES)

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -60,6 +60,22 @@ def resolve_schema(schema: type[BaseModel] | dict) -> dict:
     return schema.model_json_schema()
 
 
+def resolve_team_github_integration(team: Team) -> Integration | None:
+    """The team GitHub integration a task binds to, or None when the team has no usable install.
+
+    Installs whose token refresh is permanently failing, and installs GitHub has confirmed gone,
+    are skipped: a task bound to one of those cannot clone. Callers that only predict a run's
+    outcome (the wizard pre-flight in ``logic/wizard_preflight.py``) share this so their answer is
+    reached with the same credentials the run itself would use.
+    """
+    return (
+        Integration.objects.filter(team=team, kind="github")
+        .exclude(errors=ERROR_TOKEN_REFRESH_FAILED)
+        .exclude(config__has_key=INSTALLATION_UNAVAILABLE_SINCE_CONFIG_KEY)
+        .first()
+    )
+
+
 class Channel(TeamScopedRootMixin):
     """A shared feed of tasks (rendered as "#<name>" in PostHog Desktop). Every task is
     owned by the channel it was kicked off in. Each user gets one private "personal"
@@ -532,12 +548,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
             user_github_integration_is_usable,
         )
 
-        github_integration = (
-            Integration.objects.filter(team=team, kind="github")
-            .exclude(errors=ERROR_TOKEN_REFRESH_FAILED)
-            .exclude(config__has_key=INSTALLATION_UNAVAILABLE_SINCE_CONFIG_KEY)
-            .first()
-        )
+        github_integration = resolve_team_github_integration(team)
         github_user_integration = None
         task_stub = Task(
             team=team,

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -2,7 +2,7 @@ import importlib
 from datetime import timedelta
 from typing import ClassVar
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 from django.utils import timezone as django_timezone
@@ -10,6 +10,7 @@ from django.utils import timezone as django_timezone
 from parameterized import parameterized
 
 from posthog.models import Integration, Organization, Team
+from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, GitHubIntegration
 from posthog.models.user import User
 
 from products.tasks.backend.facade import (
@@ -17,8 +18,21 @@ from products.tasks.backend.facade import (
     contracts,
     warm as warm_facade,
 )
+from products.tasks.backend.logic.wizard_preflight import WizardRepositoryAccess, WizardRepositoryPreflight
 from products.tasks.backend.models import SandboxCustomImage, SandboxEnvironment, Task, TaskRun
 from products.tasks.backend.prompts import WIZARD_HEAD_BRANCH_PLACEHOLDER, build_wizard_pr_agent_prompt
+
+_PREFLIGHT_UNKNOWN = WizardRepositoryPreflight(access=WizardRepositoryAccess.UNKNOWN)
+
+
+def _repo_response(*, status_code: int = 200, default_branch: str = "main") -> MagicMock:
+    return MagicMock(status_code=status_code, json=MagicMock(return_value={"default_branch": default_branch}))
+
+
+def _tree_response(paths: list[str], *, status_code: int = 200, truncated: bool = False) -> MagicMock:
+    payload = {"truncated": truncated, "tree": [{"type": "blob", "path": path} for path in paths]}
+    return MagicMock(status_code=status_code, json=MagicMock(return_value=payload))
+
 
 FACADE_MODULES = [
     "products.tasks.backend.facade.api",
@@ -560,8 +574,9 @@ class TestFacadeReadsAndMappers(TestCase):
         self.assertEqual(run.state["pending_dispatch"]["posthog_mcp_scopes"], "full")
         self.assertEqual(run.state["pending_dispatch"]["user_id"], self.user.id)
 
+    @patch("products.tasks.backend.facade.api.preflight_wizard_repository", return_value=_PREFLIGHT_UNKNOWN)
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
-    def test_create_wizard_cloud_run_seeds_pending_user_message(self, _mock_workflow):
+    def test_create_wizard_cloud_run_seeds_pending_user_message(self, _mock_workflow, _mock_preflight):
         Integration.objects.create(team=self.team, kind="github", config={})
         created = facade.create_wizard_cloud_run(
             team=self.team,
@@ -585,6 +600,110 @@ class TestFacadeReadsAndMappers(TestCase):
         # overlap-clone-boot launch (before run_wizard) burns the prompt on an untouched repo
         # and the run never opens a PR. Wizard runs must pin the overlap boot off.
         self.assertIs(run.state.get("overlap_clone_boot_enabled"), False)
+
+    @parameterized.expand(
+        [
+            ("manifest_in_a_subdirectory", _repo_response(), _tree_response(["apps/web/package.json"]), None),
+            (
+                "repository_not_found",
+                _repo_response(status_code=404),
+                None,
+                facade.WizardRepositoryInaccessibleError,
+            ),
+            (
+                "no_project_manifest_anywhere",
+                _repo_response(),
+                _tree_response(["README.md", "docs/index.md"]),
+                facade.WizardFrameworkUndetectableError,
+            ),
+            ("truncated_tree", _repo_response(), _tree_response(["README.md"], truncated=True), None),
+            ("tree_read_raises", _repo_response(), RuntimeError("boom"), None),
+            ("tree_read_non_200", _repo_response(), _tree_response([], status_code=500), None),
+            ("repository_read_raises", RuntimeError("boom"), None, None),
+            ("repository_read_non_200", _repo_response(status_code=500), None, None),
+        ]
+    )
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_wizard_cloud_run_preflight_only_blocks_on_unambiguous_answers(
+        self, _name, repository_read, tree_read, expected_error, _mock_workflow
+    ):
+        # The pre-flight decides whether a run gets a sandbox at all, so it may reject only on an
+        # answer that settles the question. Every degraded GitHub response has to create the run.
+        Integration.objects.create(team=self.team, kind="github", config={})
+        tasks_before = Task.objects.count()
+        runs_before = TaskRun.objects.count()
+        responses = [repository_read] if tree_read is None else [repository_read, tree_read]
+
+        with patch.object(GitHubIntegration, "api_request", side_effect=responses):
+            if expected_error is None:
+                created = facade.create_wizard_cloud_run(team=self.team, user_id=self.user.id, repository="acme-co/web")
+                self.assertTrue(TaskRun.objects.filter(task_id=created.task_id).exists())
+                return
+            with self.assertRaises(expected_error):
+                facade.create_wizard_cloud_run(team=self.team, user_id=self.user.id, repository="acme-co/web")
+
+        # A rejected kickoff must leave nothing behind: no task row, and no run holding a slot
+        # against the user's quota.
+        self.assertEqual(Task.objects.count(), tasks_before)
+        self.assertEqual(TaskRun.objects.count(), runs_before)
+
+    @parameterized.expand(
+        [
+            ("requested_branch", "develop", "develop"),
+            ("default_branch", None, "trunk"),
+        ]
+    )
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_wizard_cloud_run_preflight_reads_the_checked_out_ref(
+        self, _name, branch, expected_ref, _mock_workflow
+    ):
+        # The sandbox checks out the requested branch; judging detectability on the default branch
+        # instead would reject a run whose actual ref does hold a manifest.
+        Integration.objects.create(team=self.team, kind="github", config={})
+        with patch.object(
+            GitHubIntegration,
+            "api_request",
+            side_effect=[_repo_response(default_branch="trunk"), _tree_response(["package.json"])],
+        ) as api_request:
+            facade.create_wizard_cloud_run(
+                team=self.team, user_id=self.user.id, repository="acme-co/web", branch=branch
+            )
+
+        self.assertEqual(api_request.call_args_list[1].args[1], f"/repos/acme-co/web/git/trees/{expected_ref}")
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_wizard_cloud_run_preflight_skips_public_sandbox_repos(self, _mock_workflow):
+        # The sandbox clones these unauthenticated and the task never binds an integration for
+        # them, so reading them through the team's install answers a question the run never asks,
+        # and a 404 from that install would block a run that would have worked.
+        Integration.objects.create(team=self.team, kind="github", config={})
+
+        with patch.object(GitHubIntegration, "api_request") as api_request:
+            created = facade.create_wizard_cloud_run(
+                team=self.team, user_id=self.user.id, repository="PostHog/hedgebox"
+            )
+
+        api_request.assert_not_called()
+        self.assertTrue(TaskRun.objects.filter(task_id=created.task_id).exists())
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_wizard_cloud_run_preflight_reads_with_the_integration_the_task_binds(self, _mock_workflow):
+        # An install whose token refresh is permanently failing is skipped when the task picks its
+        # integration. The pre-flight has to skip it too: judging accessibility with credentials
+        # the run never touches is exactly how a healthy repository gets falsely rejected.
+        Integration.objects.create(team=self.team, kind="github", config={}, errors=ERROR_TOKEN_REFRESH_FAILED)
+        usable = Integration.objects.create(team=self.team, kind="github", config={})
+        read_by: list[int] = []
+
+        def api_request(github, *args, **kwargs):
+            read_by.append(github.integration.id)
+            return _repo_response() if len(read_by) == 1 else _tree_response(["package.json"])
+
+        with patch.object(GitHubIntegration, "api_request", autospec=True, side_effect=api_request):
+            created = facade.create_wizard_cloud_run(team=self.team, user_id=self.user.id, repository="acme-co/web")
+
+        self.assertEqual(set(read_by), {usable.id})
+        self.assertEqual(Task.objects.get(id=created.task_id).github_integration_id, usable.id)
 
 
 class TestRecentWizardCloudRunTimes(TestCase):


### PR DESCRIPTION
## Why

`create_wizard_cloud_run` accepts any `owner/repo` string that passes the endpoint's two-segment
format check. Two of the run's preconditions are only tested inside the sandbox, minutes after
kickoff: whether the team's GitHub installation can reach the repository at all (the clone fails with
"remote: Repository not found"), and whether the repository holds any project manifest the wizard's
framework detection keys off (the wizard exits with "Could not auto-detect your framework for this
project"). Both are answerable from two GitHub reads at kickoff, where the answer can still be turned
into an error message the caller can act on.

## What

- new `products/tasks/backend/logic/wizard_preflight.py`: reads `GET /repos/{owner}/{repo}` and, when
  that succeeds, the recursive git tree of the ref the sandbox will check out, and reports an access
  tri-state plus a tri-state `framework_detectable`. Never raises
- new `resolve_team_github_integration` in `products/tasks/backend/models.py`, extracted from
  `Task._build_task` and shared with the pre-flight, so the check and the run it predicts cannot
  drift onto different credentials. Public sandbox repos, which `_build_task` exempts from needing an
  integration at all, skip the pre-flight rather than being read through one
- `WIZARD_PROJECT_MANIFESTS` mirrors `PROJECT_MANIFESTS` in the wizard's
  `src/lib/detection/agentic.ts`, matched on the basename of every blob in the tree rather than only
  at the root, because the wizard globs the whole checkout for manifests
- new facade entry point `validate_wizard_cloud_run_target`, raising
  `WizardRepositoryInaccessibleError` / `WizardFrameworkUndetectableError` on a confirmed negative.
  `create_wizard_cloud_run` calls it, so no caller can start a run the pre-flight would reject
- `POST /api/wizard/cloud_run` calls it directly, above the daily attempt reservation, and maps each
  rejection to a 400 carrying a stable `code` (`repository_inaccessible`, `framework_undetectable`).
  The kickoff counter reports them under their own outcome label instead of folding them into
  `invalid`
- the partner provisioning endpoint maps the same two errors to 400s under the same codes, instead of
  letting them fall through to its generic 500 handler
- `WIZARD_CLOUD_RUN_DAILY_PREFLIGHT_CAP = 40`, an atomic per-user daily reservation taken immediately
  above the pre-flight and never released. The attempt cap deliberately does not charge a rejection,
  so without this a caller looping on rejected repositories would make unmetered authenticated GitHub
  reads. Sized above the attempt cap so it only binds on that shape
- `_release_cloud_run_attempt` gives the attempt back when the facade's repeated pre-flight rejects a
  target the endpoint's first read accepted. `validate_wizard_cloud_run_target` is the first statement
  of `create_wizard_cloud_run`, so a rejection there provably created nothing and booted no sandbox
- facade, endpoint, and partner-endpoint tests

## Notes for reviewers

- The blocking rule is the risk surface, so it is deliberately narrow: only a 404 on the repository
  read blocks, and only a tree read that returned 200 with `truncated: false` and zero manifest
  matches blocks. Rate limits, timeouts, non-200s, malformed payloads, truncated trees, an
  unresolvable ref, a public sandbox repo, and a team with no usable GitHub integration all create
  the run exactly as today. The parameterized facade test enumerates those cases; a change that
  starts blocking on any of them fails it.
- Adding a manifest to `WIZARD_PROJECT_MANIFESTS` is always safe; omitting one the wizard supports is
  what would reject a healthy repository, hence the pointer to the wizard file it mirrors.
- The attempt reservation is the hard ceiling on sandbox boots, so the target check sits above it: a
  repository typo boots no sandbox and now costs none of the day's budget. `create_wizard_cloud_run`
  re-checks after the reservation, which costs two more GitHub reads on the accepted path only, next
  to a sandbox that runs for up to 45 minutes. That second check can still reject, which is what the
  release path exists for, so the attempt counter stays a count of sandbox boots and nothing else.
- The two caps answer different questions and are deliberately separate: the attempt cap bounds
  sandbox boots and must not be spent by a request that boots none, the pre-flight cap bounds the
  GitHub reads a request makes before it can reach creation. Both are `cache.add` + `cache.incr`, so
  neither can be raced the way the read-then-create DB throttles can.
- Two GitHub reads on the rejected kickoff path, both with a 5s timeout, through the existing egress
  transport and the installation's shared budget.
- The repository and ref are interpolated into request paths, so both are containment-checked
  (`_is_safe_path`) before any read; the endpoint serializer only validates the two-segment shape.
- Test plan: `pytest products/tasks/backend/tests/test_facade.py products/tasks/backend/tests/test_models.py`
  (217 passed), `pytest posthog/api/wizard/test/test_http.py` (34 passed),
  `pytest ee/api/agentic_provisioning/test/test_wizard_resource_actions.py` (16 passed).

## Validating after merge

- The two new labels on `posthog_wizard_cloud_run_requests_total` are the primary signal:
  `{outcome="repository_inaccessible"}` and `{outcome="framework_undetectable"}` go from absent to
  non-zero, and `{outcome="created"}` falls by about their sum. Both regions.
- The point of the change is that those rejections used to be sandbox boots that failed minutes
  later, so `posthog_tasks_runs_in_status{status="failed",origin_product="onboarding"}` should fall
  by a comparable amount over the same window. If `created` drops but failed onboarding runs do not,
  the pre-flight is rejecting repositories that would have worked.
- The regression this can cause is exactly that false rejection. Sustained ratio of the two new
  outcomes to `created` above roughly 10%, or client `onboarding cloud run queued` no longer being
  followed by `onboarding cloud run completed` for repositories that used to work, is the line to
  investigate. `WIZARD_PROJECT_MANIFESTS` drifting behind the wizard's `PROJECT_MANIFESTS` is the
  most likely cause.
- `{outcome="throttled"}` should not rise. The pre-flight cap is 40/user/day against an attempt cap
  of 15, so throttling should keep coming from the attempt cap and the DRF run-counting throttles. A
  rise here means the pre-flight cap is binding on ordinary use and is sized wrong.
- Kickoff latency now includes two GitHub reads at a 5s timeout each. p95 of `POST
  /api/wizard/cloud_run` should move by well under a second; a jump into the 5s to 10s range means
  the reads are timing out against the installation's shared budget rather than answering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #74316
