### PR TITLE
fix(marketing-analytics): resolve default source aliases in utm audit matching

### DIFF
--- a/products/marketing_analytics/backend/services/test_utm_audit.py
+++ b/products/marketing_analytics/backend/services/test_utm_audit.py
@@ -52,7 +52,7 @@ class TestCrossReference:
 
     def test_campaign_with_source_mismatch(self):
         campaigns = [Campaign("Brand Campaign", "789", "google", 200.0, 80, 2000)]
-        utm_events = {("brand campaign", "adwords"): 30}
+        utm_events = {("brand campaign", "newsletter"): 30}
 
         results = _cross_reference(campaigns, utm_events, NO_MAPPINGS, DEFAULT_KNOWN_SOURCES)
 
@@ -61,6 +61,48 @@ class TestCrossReference:
         assert len(results[0].issues) == 1
         assert results[0].issues[0].field == "utm_source"
         assert results[0].issues[0].severity == UtmIssueSeverity.WARNING
+
+    @pytest.mark.parametrize(
+        "campaign_source,utm_source",
+        [
+            ("meta", "facebook"),
+            ("meta", "fb"),
+            ("meta", "instagram"),
+            ("google", "adwords"),
+            ("google", "google_maps"),
+        ],
+    )
+    def test_default_alias_counts_as_exact_match(self, campaign_source, utm_source):
+        campaigns = [Campaign("Spring Sale", "123", campaign_source, 100.0, 50, 1000)]
+        utm_events = {("spring sale", utm_source): 42}
+
+        results = _cross_reference(campaigns, utm_events, NO_MAPPINGS, DEFAULT_KNOWN_SOURCES)
+
+        assert len(results) == 1
+        assert results[0].has_utm_events is True
+        assert results[0].event_count == 42
+        assert len(results[0].issues) == 0
+
+    def test_custom_mapping_wins_over_default_alias(self):
+        # Team remapped 'facebook' to google, so it must not count for the meta campaign.
+        campaigns = [
+            Campaign("Spring Sale", "1", "meta", 100.0, 50, 1000),
+            Campaign("Spring Sale", "2", "google", 100.0, 50, 1000),
+        ]
+        utm_events = {("spring sale", "facebook"): 42}
+        mappings = TeamMappings(
+            source_to_integration={"facebook": "google"},
+            campaign_aliases={},
+            field_preferences={},
+        )
+
+        results = _cross_reference(campaigns, utm_events, mappings, _build_known_sources(mappings))
+
+        google = next(r for r in results if r.source_name == "google")
+        meta = next(r for r in results if r.source_name == "meta")
+        assert google.has_utm_events is True
+        assert google.event_count == 42
+        assert meta.has_utm_events is False
 
     def test_case_insensitive_matching(self):
         campaigns = [Campaign("WINTER Sale", "101", "Google", 150.0, 60, 1500)]
@@ -418,7 +460,7 @@ class TestBuildAllUtmEvents:
 
     def test_campaign_auto_source_none(self):
         campaigns = [Campaign("brand", "1", "google", 0, 0, 0)]
-        utm_events = {("brand", "adwords"): 30}
+        utm_events = {("brand", "newsletter"): 30}
 
         result = _build_all_utm_events(campaigns, utm_events, NO_MAPPINGS)
 
@@ -426,6 +468,16 @@ class TestBuildAllUtmEvents:
         assert result[0].campaign_match == "auto"
         assert result[0].source_match == "none"
         assert result[0].matched_campaign == "brand"
+
+    def test_default_alias_source_auto(self):
+        campaigns = [Campaign("brand", "1", "meta", 0, 0, 0)]
+        utm_events = {("brand", "facebook"): 30}
+
+        result = _build_all_utm_events(campaigns, utm_events, NO_MAPPINGS)
+
+        assert len(result) == 1
+        assert result[0].campaign_match == "auto"
+        assert result[0].source_match == "auto"
 
     def test_source_auto_campaign_none(self):
         campaigns = [Campaign("brand", "1", "google", 0, 0, 0)]

--- a/products/marketing_analytics/backend/services/utm_audit.py
+++ b/products/marketing_analytics/backend/services/utm_audit.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from functools import cache
 
 from django.utils import timezone
 
@@ -20,7 +21,12 @@ from products.marketing_analytics.backend.hogql_queries.constants import (
     INTEGRATION_DEFAULT_SOURCES,
     INTEGRATION_PRIMARY_SOURCE,
 )
-from products.marketing_analytics.backend.services.native_integrations import KEY_TO_NATIVE, iter_custom_source_mappings
+from products.marketing_analytics.backend.services.native_integrations import (
+    KEY_TO_NATIVE,
+    canonical_source_aliases,
+    iter_custom_source_mappings,
+    normalize,
+)
 from products.marketing_analytics.backend.services.types import (
     AlternativeSource,
     Campaign,
@@ -280,9 +286,26 @@ def _get_utm_events(team: Team, date_range: QueryDateRange, *, user: User | None
     return utm_map
 
 
+@cache
+def _default_alias_to_primary() -> dict[str, str]:
+    """Normalized default utm_source aliases ('facebook', 'adwords') -> the
+    integration's primary source name ('meta', 'google')."""
+    out: dict[str, str] = {}
+    for alias, target_key in canonical_source_aliases().items():
+        primary = INTEGRATION_PRIMARY_SOURCE.get(KEY_TO_NATIVE[target_key])
+        if primary:
+            out[alias] = str(primary).lower().strip()
+    return out
+
+
 def _resolve_source(utm_source: str, mappings: TeamMappings) -> str:
-    """Resolve a utm_source to its integration source using custom mappings."""
-    return mappings.source_to_integration.get(utm_source, utm_source)
+    """Resolve a utm_source to its integration's primary source: team custom
+    mappings first (they win, matching `build_combined_alias_map`), then the
+    platform default aliases so e.g. 'facebook' resolves to 'meta'."""
+    custom = mappings.source_to_integration.get(utm_source)
+    if custom is not None:
+        return custom
+    return _default_alias_to_primary().get(normalize(utm_source), utm_source)
 
 
 def _get_match_value(campaign: Campaign, mappings: TeamMappings) -> str:


### PR DESCRIPTION
## Problem

The UTM audit resolves a pageview's `utm_source` only through the team's `custom_source_mappings` plus a literal comparison against the integration's primary source name. The platform default aliases from `native_integrations.py` (e.g. `facebook`, `fb`, `instagram` for Meta Ads, `adwords` for Google Ads) were never consulted.

So a Meta Ads campaign whose pageviews are tagged `utm_source=facebook` reports `event_count=0` and gets flagged with a no-tagged-events issue, even though attribution health and the dashboard conversion join both resolve `facebook` to `meta` through the same alias table. The audit contradicts the dashboard it's meant to explain.

## Changes

- `_resolve_source` in `utm_audit.py` now falls back to the canonical default alias table (`canonical_source_aliases` from `native_integrations.py`, mapped to each integration's primary source) when a `utm_source` has no custom mapping. Team custom mappings still win, matching `build_combined_alias_map` semantics.
- The default-alias lookup uses `normalize()` (strips separators), while custom mappings keep their existing `.lower().strip()` keys, so custom mappings containing hyphens or underscores behave exactly as before.
- `known_sources` semantics for UNKNOWN_SOURCE vs NO_TAGGED_EVENTS are unchanged.

This affects both the per-campaign exact-match count and the source match status in the all-UTM-events list.

## How did you test this code?

Ran the full suite locally: `pytest products/marketing_analytics/backend/services/test_utm_audit.py` (71 passed).

- New parameterized test: campaigns on meta/google with events tagged `facebook`/`fb`/`instagram`/`adwords`/`google_maps` now count as exact matches and produce no issue. Catches the exact regression fixed here, which no existing test covered.
- New test: a custom mapping that remaps a default alias (`facebook` -> google) wins over the default. Guards the precedence contract if the fallback order ever flips.
- New test: the all-UTM-events list reports `source_match=auto` for a default alias. Same regression on the other output surface.
- Updated two existing tests that used `adwords` as a "mismatched" source for a Google campaign: `adwords` is a `GoogleAdsDefaultSources` value, so those tests were encoding the bug. They now use a genuinely unknown source.

No manual testing beyond the automated suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Found while generating marketing demo data: Meta campaigns tagged with the canonical `facebook` alias were flagged by the audit as not linked, contradicting the dashboard conversion join which resolved them fine. Verified the gap is an omission, not intentional: the audit predates the shared alias helpers in `native_integrations.py`, and `adwords`-as-mismatch assertions in the existing tests date from the original audit PR. Considered switching the whole audit to `build_combined_alias_map` normalization, but that would change how custom mapping keys are stored and risk breaking mappings with separators, so the fix adds the default-alias fallback only. Skills invoked: /writing-tests.