### PR TITLE
fix(marketing-analytics): apply organic fallback to warehouse conversion goals

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
@@ -2114,6 +2114,21 @@ class ConversionGoalProcessor:
             ],
         )
 
+    def _apply_organic_default(self, expr: ast.Expr, default_value: str) -> ast.Call:
+        """Fall back to the organic default when the value is NULL or empty, matching the
+        events attribution path so all goal kinds classify unattributed conversions alike."""
+        return ast.Call(
+            name="if",
+            args=[
+                ast.Call(
+                    name="notEmpty",
+                    args=[ast.Call(name="coalesce", args=[expr, ast.Constant(value="")])],
+                ),
+                expr,
+                ast.Constant(value=default_value),
+            ],
+        )
+
     def _resolve_direct_field_expr(self, field: TrackedField, table: str) -> ast.Expr:
         """Resolve a tracked field to an AST expression for direct queries (no attribution pipeline)."""
         if self.goal.kind in ["EventsNode", "ActionsNode"]:
@@ -2200,11 +2215,9 @@ class ConversionGoalProcessor:
         where_conditions.extend(additional_conditions)
 
         # Campaign expression with organic default
-        campaign_expr = ast.Call(
-            name="coalesce", args=[utm_campaign_expr, ast.Constant(value=self.config.organic_campaign)]
-        )
+        campaign_expr = self._apply_organic_default(utm_campaign_expr, self.config.organic_campaign)
         source_expr = self._normalize_source_field(
-            ast.Call(name="coalesce", args=[utm_source_expr, ast.Constant(value=self.config.organic_source)])
+            self._apply_organic_default(utm_source_expr, self.config.organic_source)
         )
 
         # Build field expressions for all tracked fields

--- a/products/marketing_analytics/backend/hogql_queries/test/external/warehouse_conversions_empty_utm.csv
+++ b/products/marketing_analytics/backend/hogql_queries/test/external/warehouse_conversions_empty_utm.csv
@@ -1,0 +1,3 @@
+user_id,event_timestamp,campaign_name,source_name,revenue
+dw_user_1,2023-01-10 10:00:00,,,100
+dw_user_2,2023-01-12 11:00:00,summer_sale,google,250

--- a/products/marketing_analytics/backend/hogql_queries/test_conversion_goal_processor.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_conversion_goal_processor.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from freezegun import freeze_time
 from posthog.test.base import BaseTest, ClickhouseTestMixin, _create_event, _create_person, events_cache_tests
@@ -29,6 +31,7 @@ from products.marketing_analytics.backend.hogql_queries.conversion_goal_processo
     add_conversion_goal_property_filters,
 )
 from products.marketing_analytics.backend.hogql_queries.marketing_analytics_config import MarketingAnalyticsConfig
+from products.warehouse_sources.backend.facade.testing import create_data_warehouse_table_from_csv
 
 
 def _create_action(**kwargs):
@@ -252,6 +255,59 @@ class TestConversionGoalProcessor(ClickhouseTestMixin, BaseTest):
 
         assert processor.get_table_name() == "warehouse_table"
         assert processor.get_date_field() == "event_timestamp"
+
+    def test_data_warehouse_node_empty_utm_falls_back_to_organic(self):
+        csv_path = Path(__file__).parent / "test/external/warehouse_conversions_empty_utm.csv"
+        table, _source, _credential, _df, cleanup_fn = create_data_warehouse_table_from_csv(
+            csv_path,
+            "conversions_empty_utm",
+            {
+                "user_id": "String",
+                "event_timestamp": "DateTime",
+                "campaign_name": "String",
+                "source_name": "String",
+                "revenue": "Int64",
+            },
+            "test_storage_bucket-posthog.marketing_analytics.empty_utm",
+            self.team,
+        )
+        self.addCleanup(cleanup_fn)
+
+        goal = ConversionGoalFilter3(
+            kind="DataWarehouseNode",
+            id=table.name,
+            table_name=table.name,
+            conversion_goal_id="warehouse_empty_utm",
+            conversion_goal_name="Warehouse Empty UTM",
+            math=BaseMathType.TOTAL,
+            distinct_id_field="user_id",
+            id_field="user_id",
+            timestamp_field="event_timestamp",
+            schema_map={
+                "utm_campaign_name": "campaign_name",
+                "utm_source_name": "source_name",
+                "distinct_id_field": "user_id",
+                "timestamp_field": "event_timestamp",
+            },
+        )
+        processor = ConversionGoalProcessor(goal=goal, index=0, team=self.team, config=self.config)
+
+        additional_conditions: list[ast.Expr] = [
+            ast.CompareOperation(
+                left=ast.Field(chain=["event_timestamp"]),
+                op=ast.CompareOperationOp.GtEq,
+                right=ast.Call(name="toDate", args=[ast.Constant(value="2023-01-01")]),
+            ),
+        ]
+        cte_query = processor.generate_cte_query(additional_conditions)
+        response = execute_hogql_query(query=cte_query, team=self.team)
+
+        # Schema: [0]=match_key, [1]=campaign, [2]=id, [3]=source, [4]=conversion
+        results = {row[1]: (row[3], row[4]) for row in response.results}
+        assert results == {
+            "organic": ("organic", 1),
+            "summer_sale": ("google", 1),
+        }, f"Empty utm columns must fall back to organic like event goals do, got {response.results}"
 
     # ================================================================
     # 3. MATH TYPE TESTS - TOTAL, DAU, SUM, etc.


### PR DESCRIPTION
## Problem

Marketing analytics conversion goals handle unattributed conversions (no UTM data) inconsistently depending on the goal kind:

- Events/actions goals run through the attribution pipeline, where conversions with no attributable UTM fall back to campaign `organic` / source `organic` via an empty-string-aware check (`notEmpty`).
- Data warehouse goals run through the direct query path, where the fallback is `coalesce(utm_field, 'organic')`. That only catches NULL. Warehouse UTM columns are typically non-nullable strings, so empty values flow through as `''`.

Visible symptoms with the same underlying users:

- At the channel drill-down, warehouse-goal conversions get classified into different channel buckets than event-goal conversions, because `''`/`''` and `organic`/`organic` classify differently.
- The non-integrated conversions table shows rows with blank campaign and blank source cells.

## Changes

- `_generate_direct_query` now applies an empty-or-NULL aware organic fallback (`_apply_organic_default`) to the UTM campaign and source expressions, matching what the attribution path already does in `_build_final_aggregation_query`.
- No behavior change for values that are present, and NULLs still fall back the same as before. The only change is that empty strings now also fall back to `organic`.

## How did you test this code?

- Added `test_data_warehouse_node_empty_utm_falls_back_to_organic`: builds a warehouse table from CSV with one row of empty UTM columns and one row with real UTM values, runs the processor end to end, and asserts the empty row surfaces as `organic`/`organic` while the populated row passes through. This catches a regression no existing test does (existing organic-fallback tests only cover events goals through the attribution path); verified it fails without the fix.
- Ran the full `test_conversion_goal_processor.py`, `test_conversion_goal_processor_refactor.py`, `test_marketing_analytics_table_query_runner.py`, and `test_conversion_goals_aggregator.py` suites locally, all green, snapshots unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, this is a bug fix aligning behavior with what the docs already describe for organic attribution.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code. Skills invoked: /writing-tests.
- Root cause found by comparing the two query paths in `conversion_goal_processor.py`: warehouse goals always take `_generate_direct_query`, whose fallback was NULL-only `coalesce`, while events goals use `notEmpty`-based defaults in the final aggregation. The fix reuses the same empty-aware semantics in the direct path instead of patching each UI surface.
- Possible follow-up (out of scope here): auditing whether channel classification of `organic`/`organic` itself is consistent across every drill-down surface. This PR only fixes the goal-kind inconsistency.
