### PR TITLE
fix(marketing-analytics): strip infinity sentinel from csv exports

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -12,11 +12,14 @@ from posthog.schema import (
     ConversionGoalFilter2,
     ConversionGoalFilter3,
     DateRange,
+    InfinityValue,
     MarketingAnalyticsConstants,
     MarketingAnalyticsDrillDownLevel,
+    MarketingAnalyticsItem,
 )
 
 from posthog.hogql import ast
+from posthog.hogql.constants import LimitContext
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.database.database import Database
 from posthog.hogql.database.schema.channel_type import ChannelTypeExprs, create_channel_type_expr
@@ -68,6 +71,23 @@ COMPARE_PERIOD_PREVIOUS = "previous"
 COSTS_PRECOMPUTE_TTL_SECONDS = {"0d": 6 * 60 * 60, "1d": 24 * 60 * 60, "default": 7 * 24 * 60 * 60}
 
 
+_INFINITY_SENTINELS = {float(InfinityValue.NUMBER_999999), float(InfinityValue.NUMBER__999999)}
+
+
+def strip_infinity_sentinels(response: AnalyticsQueryResponseProtocol) -> None:
+    """Blank the "infinite change" sentinel (±999999) so tabular exports, which render cells raw, don't show it as a real percentage."""
+    results = getattr(response, "results", None)
+    if isinstance(results, dict):
+        cells = list(results.values())
+    elif isinstance(results, list):
+        cells = [cell for row in results for cell in (row if isinstance(row, list) else [row])]
+    else:
+        return
+    for cell in cells:
+        if isinstance(cell, MarketingAnalyticsItem) and cell.changeFromPreviousPct in _INFINITY_SENTINELS:
+            cell.changeFromPreviousPct = None
+
+
 def _session_start_day(expr: ast.Expr) -> ast.Expr:
     """Truncate to the day, via a function the sessions timestamp pushdown recognizes.
 
@@ -102,6 +122,8 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         start = time.perf_counter()
         try:
             response = self._calculate()
+            if self.limit_context == LimitContext.EXPORT:
+                strip_infinity_sentinels(response)
             self._capture_query_event("marketing analytics query performed", start)
             return response
         except Exception as e:

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_base_query_runner.py
@@ -1,0 +1,49 @@
+from parameterized import parameterized
+
+from posthog.schema import (
+    InfinityValue,
+    MarketingAnalyticsAggregatedQueryResponse,
+    MarketingAnalyticsItem,
+    MarketingAnalyticsTableQueryResponse,
+    WebAnalyticsItemKind,
+)
+
+from products.marketing_analytics.backend.hogql_queries.marketing_analytics_base_query_runner import (
+    strip_infinity_sentinels,
+)
+
+
+def _item(change_pct: float | None) -> MarketingAnalyticsItem:
+    return MarketingAnalyticsItem(
+        key="Cost",
+        kind=WebAnalyticsItemKind.CURRENCY,
+        value=100.0,
+        previous=0.0,
+        changeFromPreviousPct=change_pct,
+        hasComparison=True,
+    )
+
+
+class TestStripInfinitySentinels:
+    @parameterized.expand(
+        [
+            (float(InfinityValue.NUMBER_999999), None),
+            (float(InfinityValue.NUMBER__999999), None),
+            (42.0, 42.0),
+            (0.0, 0.0),
+            (None, None),
+        ]
+    )
+    def test_table_response_cells(self, change_pct: float | None, expected: float | None) -> None:
+        response = MarketingAnalyticsTableQueryResponse(results=[[_item(change_pct), _item(7.0)]])
+        strip_infinity_sentinels(response)
+        assert response.results[0][0].changeFromPreviousPct == expected
+        assert response.results[0][1].changeFromPreviousPct == 7.0
+
+    def test_aggregated_response_dict_results(self) -> None:
+        response = MarketingAnalyticsAggregatedQueryResponse(
+            results={"cost": _item(float(InfinityValue.NUMBER_999999)), "clicks": _item(12.0)}
+        )
+        strip_infinity_sentinels(response)
+        assert response.results["cost"].changeFromPreviousPct is None
+        assert response.results["clicks"].changeFromPreviousPct == 12.0


### PR DESCRIPTION
## Problem

Marketing analytics table cells carry a `changeFromPreviousPct` that uses `InfinityValue` sentinels (±999999) to mean "changed from 0". The UI knows the convention and renders a dash with an explanatory tooltip, but the CSV/XLSX exporter flattens the cell objects raw, so exported columns like `Demos booked.changeFromPreviousPct` show a literal 999999, which reads as a real 999999% change.

## Changes

When a marketing analytics query runs with `LimitContext.EXPORT` (the server-side CSV/XLSX export path), the sentinel is now blanked to null before the response is flattened, so the exported cell is empty instead of 999999.

The stripping lives in `MarketingAnalyticsBaseQueryRunner.calculate`, so it covers the table, aggregated, and non-integrated-conversions runners in one place. The UI contract is untouched, since regular queries never use the export limit context, and export queries always recalculate and are never written to the query cache. The generic exporter stays marketing-agnostic.

## How did you test this code?

Ran the new unit tests plus repo-wide mypy and ruff. The bug itself was found by exporting the marketing analytics table with demo data and seeing 0-to-N changes exported as literal 999999.

Added `test_marketing_analytics_base_query_runner.py` with parameterized cases for `strip_infinity_sentinels` over both response shapes (table's list-of-lists and aggregated's dict). It catches the regression where the sentinel mapping is broken or dropped and exports again contain 999999; no existing test exercises export-context sanitization. The tests are DB-free and run in under a second.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and implemented with Claude Code. I asked it to find where the export flattens `MarketingAnalyticsItem` cells and pick the least invasive fix. It considered special-casing the generic exporter (`products/exports/backend/tasks/csv_exporter.py`) but rejected that to keep the exporter product-agnostic, and instead gated the fix on `LimitContext.EXPORT` inside the marketing analytics base runner, after confirming export queries bypass the shared query cache so cached UI responses can't be affected. Skills invoked: /writing-tests.
