### PR TITLE
chore(api): allow project-only flag default actions in parity test

### DIFF
--- a/posthog/api/test/test_team_project_parity.py
+++ b/posthog/api/test/test_team_project_parity.py
@@ -22,7 +22,7 @@ from posthog.api.team import TeamSerializer, TeamViewSet
 PROJECT_ONLY_SERIALIZER_FIELDS = {"product_description", "is_pending_deletion"}
 
 # Actions that legitimately exist only on the project surface (operate on the Project, not the Team).
-PROJECT_ONLY_ACTIONS = {"change_organization"}
+PROJECT_ONLY_ACTIONS = {"change_organization", "default_release_conditions", "default_evaluation_contexts"}
 
 
 def _serializer_field_names(serializer_class) -> set[str]:


### PR DESCRIPTION
## Problem

Master is red: `test_viewset_actions_are_a_superset_of_team_viewset` fails on every PR and on master itself since #73294 landed. That PR added the `default_release_conditions` and `default_evaluation_contexts` actions to the project API without registering them in the parity test's allowlist of intentionally project-only actions.

Verified locally: the test passes at the commit before #73294 and fails at it.

## Changes

Adds both actions to `PROJECT_ONLY_ACTIONS` in `posthog/api/test/test_team_project_parity.py`. They are genuinely project-level (defaults for new feature flags in a project, gated to project admins), so project-only is the intended state and this is the registration the test's own error message asks for.

## How did you test this code?

Ran the full parity test file locally on this branch: 4 passed. Also confirmed the single failing test is green at `5ebcf665afe~1` and red at `5ebcf665afe` to pin the breaking commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A, test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Found while babysitting CI on an unrelated PR: bisected the failure to #73294 by running the test at the commit and its parent. Considered adding the actions to the team viewset instead, but #73294's intent is project-scoped flag defaults, so the allowlist registration is the correct minimal fix.
