### PR TITLE
feat(dashboards): support explicit "no breakdown" filter override

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.test.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.test.tsx
@@ -217,6 +217,31 @@ describe('InsightDetails', () => {
             expect(result.interval).toEqual(expected.interval)
         })
 
+        it.each([
+            {
+                label: 'empty tile breakdown filter (explicit "no breakdown") beats a dashboard breakdown',
+                filtersOverride: { breakdown_filter: { breakdown: '$browser', breakdown_type: 'event' } },
+                tileFiltersOverride: { breakdown_filter: {} },
+                expected: { breakdownFilter: {}, source: 'tile' },
+            },
+            {
+                label: 'empty dashboard breakdown filter is reported as a dashboard override',
+                filtersOverride: { breakdown_filter: {} },
+                tileFiltersOverride: undefined,
+                expected: { breakdownFilter: {}, source: 'dashboard' },
+            },
+            {
+                label: 'absent breakdown filters mean no breakdown override',
+                filtersOverride: { properties: [countryUS] },
+                tileFiltersOverride: undefined,
+                expected: null,
+            },
+        ])('$label', ({ filtersOverride, tileFiltersOverride, expected }) => {
+            const result = getEffectiveFilterOverrides(undefined, filtersOverride as any, tileFiltersOverride as any)
+
+            expect(result.breakdown).toEqual(expected)
+        })
+
         it('resolves scalar overrides from the backend context layers, ignoring raw props', () => {
             const result = getEffectiveFilterOverrides(
                 { dashboard: { filterTestAccounts: true, interval: 'week' }, tile: null } as any,

--- a/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightDetails.tsx
@@ -538,6 +538,14 @@ export function InsightBreakdownSummary({ query }: { query: InsightQueryNode | H
     return <BreakdownSummary breakdownFilter={query.breakdownFilter} />
 }
 
+function BreakdownRemovedSummary({ source }: { source: OverrideSource }): JSX.Element {
+    return (
+        <InsightDetailSectionDisplay icon={<IconSort />} label="Breakdown by">
+            <OverrideNote source={source}>breakdown removed</OverrideNote>
+        </InsightDetailSectionDisplay>
+    )
+}
+
 export function BreakdownSummary({
     breakdownFilter,
     override,
@@ -774,6 +782,9 @@ export const InsightDetails = React.memo(
                                 breakdownFilter={overrideBreakdownFilter}
                                 override={{ source: overrideBreakdown.source }}
                             />
+                        ) : overrideBreakdown ? (
+                            // Set-but-empty override: the layer explicitly removed the breakdown.
+                            <BreakdownRemovedSummary source={overrideBreakdown.source} />
                         ) : (
                             <InsightBreakdownSummary query={query.source} />
                         )}

--- a/frontend/src/queries/utils.ts
+++ b/frontend/src/queries/utils.ts
@@ -1006,6 +1006,12 @@ export function hasBreakdownFilter(
     return hasSingleBreakdown(breakdownFilter) || hasMultiBreakdown(breakdownFilter)
 }
 
+/** A set-but-empty breakdown filter is the explicit "no breakdown" override in dashboard and tile
+ * filters, as opposed to null/absent, which inherits the lower layer's breakdown. */
+export function isEmptyBreakdownFilter(breakdownFilter?: BreakdownFilter | null): boolean {
+    return breakdownFilter != null && !hasBreakdownFilter(breakdownFilter)
+}
+
 export function isValidQueryForExperiment(query: Node): boolean {
     if (!isNodeWithSource(query) || !isFunnelsQuery(query.source)) {
         return false

--- a/frontend/src/scenes/dashboard/DashboardEditBarAdvancedFilters.tsx
+++ b/frontend/src/scenes/dashboard/DashboardEditBarAdvancedFilters.tsx
@@ -12,6 +12,7 @@ import { dashboardLogic } from 'scenes/dashboard/dashboardLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
+import { hasBreakdownFilter, isEmptyBreakdownFilter } from '~/queries/utils'
 import { DashboardMode, DashboardPlacement } from '~/types'
 
 type TestAccountFilterChoice = 'inherit' | 'filter-out' | 'include'
@@ -26,6 +27,14 @@ const CHOICE_HINTS: Record<TestAccountFilterChoice, string> = {
     inherit: 'Each insight keeps its own "Filter out internal and test users" setting.',
     'filter-out': 'Internal and test users are filtered out of every insight on this dashboard.',
     include: 'Internal and test users are included in every insight on this dashboard.',
+}
+
+type BreakdownOverrideChoice = 'inherit' | 'custom' | 'none'
+
+const BREAKDOWN_CHOICE_HINTS: Record<BreakdownOverrideChoice, string> = {
+    inherit: 'Each insight keeps its own breakdown.',
+    custom: "The breakdown picked in the edit bar replaces every insight's breakdown.",
+    none: 'Breakdowns are removed from every insight on this dashboard.',
 }
 
 /**
@@ -43,7 +52,7 @@ export function DashboardEditBarAdvancedFilters(): JSX.Element {
         effectiveBreakdownColors,
         dataColorThemeId,
     } = useValues(dashboardLogic)
-    const { setFilterTestAccounts, setDashboardMode } = useActions(dashboardLogic)
+    const { setFilterTestAccounts, setBreakdownFilter, setDashboardMode } = useActions(dashboardLogic)
     const { showInsightColorsModal } = useActions(dashboardInsightColorsModalLogic)
     const { currentTeam } = useValues(teamLogic)
     const hasDashboardColors = useFeatureFlag('PRODUCT_ANALYTICS_DASHBOARD_COLORS')
@@ -53,13 +62,23 @@ export function DashboardEditBarAdvancedFilters(): JSX.Element {
     const choice: TestAccountFilterChoice =
         filterTestAccounts === null ? 'inherit' : filterTestAccounts ? 'filter-out' : 'include'
     const hasTestAccountFilters = (currentTeam?.test_account_filters || []).length > 0
+    const breakdownChoice: BreakdownOverrideChoice = hasBreakdownFilter(effectiveEditBarFilters.breakdown_filter)
+        ? 'custom'
+        : isEmptyBreakdownFilter(effectiveEditBarFilters.breakdown_filter)
+          ? 'none'
+          : 'inherit'
     // Only the full dashboard scene mounts DashboardInsightColorsModal, so elsewhere the button would no-op.
     const showColors =
         hasDashboardColors && canEditDashboard && !!dashboard && placement === DashboardPlacement.Dashboard
     // Auto-assigned colors aren't an override — only pinned values and a picked theme are.
     const hasColorOverrides =
         effectiveBreakdownColors.some((config) => config.source !== 'auto') || dataColorThemeId != null
-    const overrideCount = (choice === 'inherit' ? 0 : 1) + (showColors && hasColorOverrides ? 1 : 0)
+    // A custom breakdown is already visible in the edit bar itself, so only the otherwise
+    // invisible "no breakdown" state counts toward the badge.
+    const overrideCount =
+        (choice === 'inherit' ? 0 : 1) +
+        (breakdownChoice === 'none' ? 1 : 0) +
+        (showColors && hasColorOverrides ? 1 : 0)
 
     return (
         <Popover
@@ -122,6 +141,49 @@ export function DashboardEditBarAdvancedFilters(): JSX.Element {
                         ]}
                     />
                     <p className="mb-0 text-xs text-secondary">{CHOICE_HINTS[choice]}</p>
+                    <LemonDivider className="my-0" />
+                    <LemonLabel info="Remove the breakdown from every insight on this dashboard, or let each insight keep its own. Picking a breakdown in the edit bar replaces every insight's breakdown instead.">
+                        Breakdown
+                    </LemonLabel>
+                    <LemonSegmentedButton<BreakdownOverrideChoice>
+                        fullWidth
+                        size="small"
+                        value={breakdownChoice}
+                        onChange={(next) => {
+                            if (next === 'custom') {
+                                return
+                            }
+                            if (dashboardMode !== DashboardMode.Edit) {
+                                setDashboardMode(DashboardMode.Edit, DashboardEventSource.DashboardFilters)
+                            }
+                            setBreakdownFilter(next === 'none' ? {} : null)
+                        }}
+                        options={[
+                            {
+                                value: 'inherit',
+                                label: 'Inherit',
+                                tooltip: 'Each insight keeps its own breakdown',
+                                'data-attr': 'dashboard-breakdown-override-inherit',
+                            },
+                            {
+                                value: 'custom',
+                                label: 'Custom',
+                                tooltip: 'Set with the breakdown button in the edit bar',
+                                disabledReason:
+                                    breakdownChoice === 'custom'
+                                        ? undefined
+                                        : 'Pick a breakdown with the breakdown button in the edit bar',
+                                'data-attr': 'dashboard-breakdown-override-custom',
+                            },
+                            {
+                                value: 'none',
+                                label: 'No breakdown',
+                                tooltip: 'Remove the breakdown from every insight on this dashboard',
+                                'data-attr': 'dashboard-breakdown-override-none',
+                            },
+                        ]}
+                    />
+                    <p className="mb-0 text-xs text-secondary">{BREAKDOWN_CHOICE_HINTS[breakdownChoice]}</p>
                     {showColors && (
                         <>
                             <LemonDivider className="my-0" />

--- a/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
+++ b/frontend/src/scenes/dashboard/TileFiltersOverride.tsx
@@ -15,7 +15,12 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { groupsModel } from '~/models/groupsModel'
 import { BreakdownFilter, NodeKind } from '~/queries/schema/schema-general'
-import { isInsightQueryWithBreakdown, isInsightQueryWithSeries, isInsightVizNode } from '~/queries/utils'
+import {
+    isEmptyBreakdownFilter,
+    isInsightQueryWithBreakdown,
+    isInsightQueryWithSeries,
+    isInsightVizNode,
+} from '~/queries/utils'
 import type { DashboardTile, InsightLogicProps, IntervalType, QueryBasedInsightModel } from '~/types'
 
 import { tileLogic } from './tileLogic'
@@ -162,6 +167,23 @@ export function TileFiltersOverride({ tile }: { tile: DashboardTile<QueryBasedIn
                             size="small"
                         />
                     </BindLogic>
+                    <div className="mt-2">
+                        <LemonSwitch
+                            checked={isEmptyBreakdownFilter(overrides.breakdown_filter)}
+                            onChange={(checked) => setBreakdown(checked ? {} : null)}
+                            label="No breakdown"
+                            bordered
+                            fullWidth
+                            disabledReason={
+                                supportsBreakdown ? undefined : "This insight type doesn't support a breakdown override"
+                            }
+                            data-attr="tile-override-no-breakdown"
+                        />
+                        <p className="text-xs text-muted mt-1 mb-0">
+                            Remove the breakdown from this tile, even if the dashboard or the insight has one. Adding a
+                            breakdown above turns this off.
+                        </p>
+                    </div>
                 </div>
             </div>
         </div>

--- a/frontend/src/scenes/insights/utils.tsx
+++ b/frontend/src/scenes/insights/utils.tsx
@@ -40,6 +40,7 @@ import {
 } from '~/queries/schema/schema-general'
 import {
     containsHogQLQuery,
+    hasBreakdownFilter,
     isDataTableNode,
     isAnyDataWarehouseNode,
     isEventsNode,
@@ -866,7 +867,9 @@ export const hasUnsupportedBreakdownForDataWarehouseTrends = (
 ): boolean => {
     const breakdownFilter = filtersOverride?.breakdown_filter
 
-    if (!breakdownFilter) {
+    // Matches the backend's has_breakdown_filter gate: a set-but-empty breakdown filter is the
+    // explicit "no breakdown" override, which data warehouse series do support.
+    if (!hasBreakdownFilter(breakdownFilter)) {
         return false
     }
 

--- a/posthog/hogql_queries/apply_dashboard_filters.py
+++ b/posthog/hogql_queries/apply_dashboard_filters.py
@@ -100,7 +100,10 @@ def merge_filters_by_priority(base_filters: dict | None, override_filters: dict 
     """Merge two filter layers, with `override_filters` taking priority over `base_filters`.
 
     The override wins per field. Scalars (breakdown, interval, test-account filtering) are replaced
-    outright when the override sets them. Property filters stack (AND-combine) by default, since two
+    outright when the override sets them. For the breakdown that includes the set-but-empty form:
+    `breakdown_filter: {}` is an explicit "no breakdown" override that replaces the base layer's
+    breakdown (and ultimately the insight's own), while a null/absent `breakdown_filter` inherits.
+    Property filters stack (AND-combine) by default, since two
     filters on the same key can still describe a valid set (e.g. `utm_source = google` and
     `utm_source is set`). A base property is dropped only when an override property provably contradicts
     it — ANDing them could never match — in which case the override wins. The date range is treated as

--- a/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_dashboard_filters.py
@@ -452,6 +452,19 @@ class TestTrendsDashboardFilters(BaseTest):
         )
         assert query_runner.query.trendsFilter is None
 
+    def test_empty_dashboard_breakdown_filter_removes_breakdown(self):
+        query_runner = self._create_query_runner(
+            "2020-01-09",
+            "2020-01-20",
+            IntervalType.DAY,
+            None,
+            breakdown=BreakdownFilter(breakdown="abc", breakdown_limit=5),
+        )
+
+        query_runner.apply_dashboard_filters(DashboardFilter(breakdown_filter=BreakdownFilter()))
+
+        assert query_runner.query.breakdownFilter is None
+
     def test_compare_is_removed_for_all_time_range(self):
         query_runner = self._create_query_runner(
             "2024-07-07",

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -114,7 +114,11 @@ from posthog.errors import QueryErrorCategory, classify_query_error, clickhouse_
 from posthog.event_usage import AnalyticsProps, groups, report_user_or_team_action
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.access_controlled_resources import queried_access_controlled_resources
-from posthog.hogql_queries.insights.utils.breakdowns import has_multi_breakdown, has_single_breakdown
+from posthog.hogql_queries.insights.utils.breakdowns import (
+    has_breakdown_filter,
+    has_multi_breakdown,
+    has_single_breakdown,
+)
 from posthog.hogql_queries.insights.utils.entities import has_data_warehouse_node
 from posthog.hogql_queries.insights.utils.properties import has_any_property_filters
 from posthog.hogql_queries.query_failure_handling import (
@@ -2486,9 +2490,16 @@ class QueryRunner(ABC, Generic[Q, R, CR]):
             if dashboard_filter.explicitDate is not None:
                 date_range.explicitDate = dashboard_filter.explicitDate
 
-        if dashboard_filter.breakdown_filter and not should_ignore_dashboard_breakdown:
+        if dashboard_filter.breakdown_filter is not None and not should_ignore_dashboard_breakdown:
             if hasattr(self.query, "breakdownFilter"):  # redundant, but required for mypy
-                self.query.breakdownFilter = dashboard_filter.breakdown_filter
+                # A set-but-empty breakdown filter (no breakdown/breakdowns) is the explicit
+                # "no breakdown" override; normalize it to None so downstream code never sees
+                # a truthy empty BreakdownFilter on the query.
+                self.query.breakdownFilter = (
+                    dashboard_filter.breakdown_filter
+                    if has_breakdown_filter(dashboard_filter.breakdown_filter)
+                    else None
+                )
 
         # Interval and test-account overrides apply only to query types that carry the field.
         # Types without it (retention, paths) are silently skipped rather than mutated.

--- a/posthog/hogql_queries/test/test_merge_filters_by_priority.py
+++ b/posthog/hogql_queries/test/test_merge_filters_by_priority.py
@@ -42,6 +42,35 @@ class TestMergeFiltersByPriority(SimpleTestCase):
         assert merged["filterTestAccounts"] is True
         assert merged["breakdown_filter"] == {"breakdown": "$browser", "breakdown_type": "event"}
 
+    def test_empty_tile_breakdown_filter_overrides_dashboard_breakdown(self):
+        dashboard_breakdown = {"breakdown": "$browser", "breakdown_type": "event"}
+
+        merged = merge_filters_by_priority(
+            {"breakdown_filter": dashboard_breakdown},
+            {"breakdown_filter": {}},
+        )
+        resolved_layers = resolve_filter_layers_by_priority(
+            {"breakdown_filter": dashboard_breakdown},
+            {"breakdown_filter": {}},
+        )
+
+        assert merged == {"breakdown_filter": {}}
+        assert resolved_layers == {
+            "dashboard": {},
+            "tile": {"breakdown_filter": {}},
+            "overridden_dashboard": {"breakdown_filter": dashboard_breakdown},
+        }
+
+    def test_null_tile_breakdown_filter_inherits_dashboard_breakdown(self):
+        dashboard_breakdown = {"breakdown": "$browser", "breakdown_type": "event"}
+
+        merged = merge_filters_by_priority(
+            {"breakdown_filter": dashboard_breakdown},
+            {"breakdown_filter": None},
+        )
+
+        assert merged == {"breakdown_filter": dashboard_breakdown}
+
     def test_properties_on_different_keys_are_and_combined_dashboard_first(self):
         dashboard_prop = {"key": "$country", "value": "US", "type": "event"}
         tile_prop = {"key": "$browser", "value": "Chrome", "type": "event"}


### PR DESCRIPTION
## TL;DR

Dashboards and tiles can override the breakdown insights use. Until now that override could only *replace* a breakdown with another one. This PR adds a third option: override with *no breakdown at all*. An empty `breakdown_filter` (`{}`) now explicitly means "remove the breakdown", while a missing/null one keeps meaning "inherit".

## Problem

The breakdown override on dashboards is two-state: unset (each insight keeps its own breakdown) or set (replace every breakdown). There is no way to say "no breakdown here", neither dashboard-wide nor per tile. On the backend, a set-but-empty `breakdown_filter` object happened to clear the breakdown, but only by accident of pydantic model truthiness, and the frontend collapsed that state into "inherit" so it could not be expressed or displayed in the UI.

## Changes

Representation: `breakdown_filter: {}` = explicit "no breakdown" override; `null`/absent = inherit; populated = replace. Works the same on dashboard filters and tile `filters_overrides`, since both flow through the same merge and apply code.

Backend:
- `QueryRunner.apply_dashboard_filters` now handles the set-but-empty breakdown filter explicitly and normalizes the applied query's `breakdownFilter` to `None`, so downstream code never sees a truthy empty `BreakdownFilter`.
- Documented the tri-state contract in `merge_filters_by_priority` (the merge already passed `{}` through correctly).

Frontend:
- Tile filters override modal: a "No breakdown" switch below the breakdown picker.
- Dashboard edit bar, advanced options popover: a breakdown tri-state (Inherit / Custom / No breakdown), mirroring the test account filtering control; the "no breakdown" state counts toward the popover's override badge.
- Insight details: shows "breakdown removed" with the layer tag (dashboard/tile) instead of silently showing nothing.
- New `isEmptyBreakdownFilter` helper next to `hasBreakdownFilter`.

## How did you test this code?

- `posthog/hogql_queries/test/test_merge_filters_by_priority.py` (ran locally, 40 passed): two new tests locking the tri-state at the merge layer. Regression caught: a truthiness/`in`-style check would make a tile's `{}` lose to the dashboard's breakdown (or make `null` clear it); no existing test covered breakdown merging with empty/null values.
- `test_trends_dashboard_filters.py`: new test asserting an empty dashboard `breakdown_filter` removes the insight's breakdown (`breakdownFilter is None`). Regression caught: gating the apply on `has_breakdown_filter` would silently re-enable insight breakdowns under a "no breakdown" override. Not runnable in this environment (needs Postgres); please rely on CI.
- `InsightDetails.test.tsx`: breakdown cases for `getEffectiveFilterOverrides` (pure function) locking that `{}` is reported as an override with the right source and absent means no override. Not runnable here (no node_modules); please rely on CI.
- Not manually tested in a browser; the two new UI controls (tile switch, edit bar segmented control) follow the existing controls next to them.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Skills invoked: /writing-user-facing-copy, /writing-tests, /writing-code-comments.
- Chose the set-but-empty `{}` representation over a new schema field because the whole backend chain (merge, resolve layers, `DashboardFilter` parsing, apply) already round-trips it and treats it as "no breakdown"; this PR formalizes that instead of adding a second way to express the same thing. No schema changes, so no OpenAPI/schema codegen needed.
- Kept the picker-emptied state collapsing to `null` (inherit) in both UIs; only the explicit controls produce `{}`, so removing breakdown tags behaves as before.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*