### PR TITLE
fix(cli): strip Windows verbatim paths before spawning node api

### DIFF
--- a/cli/.sampo/changesets/windows-api-verbatim-path.md
+++ b/cli/.sampo/changesets/windows-api-verbatim-path.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Fixed `posthog-cli api` commands crashing on Windows when loading the bundled Node.js script.

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2093,6 +2093,7 @@ dependencies = [
  "colored",
  "crossterm 0.28.1",
  "dirs",
+ "dunce",
  "globset",
  "inquire",
  "libc",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5.31", features = ["derive", "env"] }
 dirs = "6.0.0"
+dunce = "1.0.5"
 inquire = "0.7.5"
 chrono = "0.4.42"
 posthog-symbol-data = "0.5.0"

--- a/cli/src/api_proxy.rs
+++ b/cli/src/api_proxy.rs
@@ -107,8 +107,12 @@ impl ApiProxyError {
     }
 }
 
+// This module canonicalizes through `dunce` because `std::fs::canonicalize`
+// returns `\\?\`-prefixed verbatim paths on Windows, and Node cannot load a
+// main script from such a path (it exits with `EISDIR: illegal operation on a
+// directory, lstat 'C:'` before any script code runs).
 fn canonicalize_file(path: &Path) -> Option<PathBuf> {
-    let resolved = path.canonicalize().ok()?;
+    let resolved = dunce::canonicalize(path).ok()?;
     if resolved.is_file() {
         Some(resolved)
     } else {
@@ -152,8 +156,7 @@ fn materialize_embedded_script(
         .map_err(|source| materialize_failed(MaterializeStep::CreateDir, source))?;
     fs::write(&path, bundle)
         .map_err(|source| materialize_failed(MaterializeStep::Write, source))?;
-    let resolved = path
-        .canonicalize()
+    let resolved = dunce::canonicalize(&path)
         .map_err(|source| materialize_failed(MaterializeStep::Canonicalize, source))?;
     if !resolved.is_file() {
         return Err(materialize_failed(
@@ -212,11 +215,10 @@ fn find_script() -> Result<PathBuf, ApiProxyError> {
         }
         let path = PathBuf::from(path);
         let resolved =
-            path.canonicalize()
-                .map_err(|source| ApiProxyError::ConfiguredPathMissing {
-                    path: path.display().to_string(),
-                    source,
-                })?;
+            dunce::canonicalize(&path).map_err(|source| ApiProxyError::ConfiguredPathMissing {
+                path: path.display().to_string(),
+                source,
+            })?;
         if !resolved.is_file() {
             return Err(ApiProxyError::ConfiguredPathNotAFile {
                 path: resolved.display().to_string(),
@@ -386,14 +388,19 @@ mod tests {
 
         assert_eq!(
             resolved,
-            temp_dir
-                .path()
-                .join("api-cli")
-                .join(env!("CARGO_PKG_VERSION"))
-                .join(API_CLI_BUNDLE)
-                .canonicalize()
-                .expect("canonicalize materialized bundle")
+            dunce::canonicalize(
+                temp_dir
+                    .path()
+                    .join("api-cli")
+                    .join(env!("CARGO_PKG_VERSION"))
+                    .join(API_CLI_BUNDLE),
+            )
+            .expect("canonicalize materialized bundle")
         );
+        // Node rejects verbatim paths as a main script, so the resolved path
+        // must stay in legacy `C:\...` form on Windows.
+        #[cfg(windows)]
+        assert!(!resolved.to_string_lossy().starts_with(r"\\?\"));
         assert_eq!(
             fs::read(resolved).expect("read materialized bundle"),
             b"embedded bundle"
@@ -453,7 +460,7 @@ mod tests {
 
         assert_eq!(
             resolved,
-            legacy_bundle.canonicalize().expect("canonicalize legacy")
+            dunce::canonicalize(&legacy_bundle).expect("canonicalize legacy")
         );
     }
 
@@ -488,8 +495,7 @@ mod tests {
 
         assert_eq!(
             resolved,
-            embedded_bundle_path(&install_dir)
-                .canonicalize()
+            dunce::canonicalize(embedded_bundle_path(&install_dir))
                 .expect("canonicalize embedded bundle")
         );
         assert_eq!(


### PR DESCRIPTION
## Problem

`posthog-cli api` crashes instantly on Windows:

```
Error: EISDIR: illegal operation on a directory, lstat 'C:'
```

Every `api` subcommand is unusable, and the `@posthog/wizard cli add` flow breaks with it.

The Rust side resolves the bundled Node script with `Path::canonicalize`, which on Windows returns a verbatim path like `\\?\C:\Users\...\posthog-api-cli.mjs`. Node cannot load a main script given in that form: its module loader misparses the `\\?\` prefix and crashes before any script code runs.

Closes #73389

## Changes

- Canonicalize through `dunce::canonicalize` in `cli/src/api_proxy.rs` (`canonicalize_file`, `materialize_embedded_script`, and the `POSTHOG_API_CLI_PATH` branch of `find_script`). `dunce` strips the verbatim prefix when the path fits the legacy `C:\...` form and is a no-op on non-Windows.
- `dunce` was already a transitive dependency, so this only promotes it to a direct one (no new crates in the lockfile).
- Updated test expectations to canonicalize the same way, and added a Windows-only assertion that the materialized bundle path stays in legacy form.

Same approach as the existing drafts #73708 and #73416.

## How did you test this code?

Verified on the same setup as the issue (Windows 11 build 26200, Node 24.18, posthog-cli 0.9.1):

- Reproduced the bug exactly: `node "\\?\C:\...\posthog-api-cli.mjs" tools` fails with `EISDIR: ... lstat 'C:'`, which is what the shipped binary invokes today.
- Built this branch locally on Windows (rustc 1.91.1, the CI-pinned toolchain) with the API CLI bundle embedded. The built `posthog-cli.exe api tools` prints the tool list and exits 0, where the shipped 0.9.1 binary crashes. Also verified fresh materialization: after deleting `~\.posthog\api-cli`, the built binary recreates the bundle and runs fine.
- `cargo test` on Windows: all 10 `api_proxy` tests pass, including the new Windows-only assertion. One pre-existing unrelated failure (`dsym::source_bundle::tests::symlinked_source_files_are_refused`) because Windows requires Developer Mode or admin rights to create symlinks; it fails on master too on this machine.
- rustfmt round-trip of the edited file is byte-identical.

The new Windows-only assertion catches a revert to `Path::canonicalize` (the resolved path would regain the `\\?\` prefix). CI runs CLI tests on Linux only, so that assertion guards Windows dev machines rather than CI. `hogli ci:preflight` could not run on this machine (no Python/venv).
## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior changes besides the crash going away; no docs touched.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code (Fable 5). I hit the crash locally and directed the investigation; Claude traced the failure to `Path::canonicalize` producing verbatim paths that Node 24 cannot load, made the change, and ran the manual verification described above. Repo skills consulted: writing-tests, writing-code-comments. The existing drafts #73708 and #73416 reached the same conclusion independently.