### PR TITLE
feat(ai): surface stored property descriptions on read_taxonomy paths

### DIFF
--- a/ee/hogai/chat_agent/query_planner/test/test_toolkit.py
+++ b/ee/hogai/chat_agent/query_planner/test/test_toolkit.py
@@ -5,7 +5,11 @@ from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, BaseTest, ClickhouseTestMixin, _create_event, _create_person
 from unittest.mock import patch
 
-from posthog.schema import CachedActorsPropertyTaxonomyQueryResponse, CachedEventTaxonomyQueryResponse
+from posthog.schema import (
+    CachedActorsPropertyTaxonomyQueryResponse,
+    CachedEventTaxonomyQueryResponse,
+    EventTaxonomyItem,
+)
 
 from posthog.models.group.util import create_group
 from posthog.models.group_type_mapping import invalidate_group_types_cache
@@ -15,6 +19,7 @@ from products.actions.backend.models.action import Action
 from products.event_definitions.backend.models.property_definition import PropertyDefinition, PropertyType
 
 from ee.hogai.chat_agent.query_planner.toolkit import TaxonomyAgentToolkit, final_answer
+from ee.models.property_definition import EnterprisePropertyDefinition
 
 
 class DummyToolkit(TaxonomyAgentToolkit):
@@ -116,6 +121,36 @@ class TestTaxonomyAgentToolkit(ClickhouseTestMixin, APIBaseTest):
         result = toolkit.retrieve_entity_properties("person")
         self.assertIn("$virt_initial_channel_type", result)
         self.assertIn("$virt_revenue", result)
+
+    def test_retrieve_entity_properties_surfaces_stored_descriptions(self):
+        # Guards the sync (read_taxonomy) person and group paths passing stored descriptions through —
+        # the async chat-agent toolkit paths are covered in ee/hogai/chat_agent/taxonomy tests.
+        EnterprisePropertyDefinition.objects.create(
+            team=self.team,
+            type=PropertyDefinition.Type.PERSON,
+            name="plan_tier",
+            property_type="String",
+            description="Subscription tier\nof the account",
+        )
+        toolkit = DummyToolkit(self.team, self.user)
+        result = toolkit.retrieve_entity_properties("person")
+        self.assertIn("- plan_tier – Subscription tier of the account", result)
+
+        create_group_type_mapping_without_created_at(
+            team=self.team, project_id=self.team.project_id, group_type_index=0, group_type="organization"
+        )
+        invalidate_group_types_cache(self.team.project_id)
+        EnterprisePropertyDefinition.objects.create(
+            team=self.team,
+            type=PropertyDefinition.Type.GROUP,
+            group_type_index=0,
+            name="employee_count",
+            property_type="Numeric",
+            description="Head count reported by the account",
+        )
+        toolkit = DummyToolkit(self.team, self.user)
+        result = toolkit.retrieve_entity_properties("organization")
+        self.assertIn("- employee_count – Head count reported by the account", result)
 
     def test_retrieve_entity_property_values(self):
         toolkit = DummyToolkit(self.team, self.user)
@@ -410,6 +445,32 @@ class TestTaxonomyAgentToolkit(ClickhouseTestMixin, APIBaseTest):
 
         result = toolkit.retrieve_event_or_action_properties(incorrect_action_id)
         self.assertEqual(result, "No actions exist in the project.")
+
+    @patch.object(DummyToolkit, "_retrieve_event_or_action_taxonomy")
+    def test_retrieve_event_properties_surfaces_stored_descriptions(self, mock_retrieve):
+        # Guards the sync (read_taxonomy) event path passing stored descriptions through.
+        EnterprisePropertyDefinition.objects.create(
+            team=self.team,
+            type=PropertyDefinition.Type.EVENT,
+            name="mixer_session_id",
+            property_type="String",
+            description="ID of the live\nmixing session",
+        )
+        now = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_retrieve.return_value = (
+            CachedEventTaxonomyQueryResponse(
+                cache_key="stored-description",
+                is_cached=True,
+                last_refresh=now,
+                next_allowed_client_refresh=now,
+                results=[EventTaxonomyItem(property="mixer_session_id", sample_values=[], sample_count=0)],
+                timezone="UTC",
+            ),
+            "event event1",
+        )
+        toolkit = DummyToolkit(self.team, self.user)
+        result = toolkit.retrieve_event_or_action_properties("event1")
+        self.assertIn("- mixer_session_id – ID of the live mixing session", result)
 
     def test_enrich_props_with_descriptions(self):
         toolkit = DummyToolkit(self.team, self.user)

--- a/ee/hogai/chat_agent/query_planner/toolkit.py
+++ b/ee/hogai/chat_agent/query_planner/toolkit.py
@@ -20,6 +20,7 @@ from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import Actor
 from posthog.hogql_queries.ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Team, User
+from posthog.settings import EE_AVAILABLE
 from posthog.taxonomy.property_access import restricted_property_names
 from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP, CoreFilterDefinition
 
@@ -45,6 +46,7 @@ from ee.hogai.chat_agent.taxonomy.virtual_properties import (
     virtual_group_for_entity,
     virtual_property_no_values_message,
 )
+from ee.hogai.utils.helpers import sanitize_event_description
 from ee.hogai.utils.prompt import format_prompt_string
 
 MaxSupportedQueryKind = Literal["trends", "funnel", "retention", "sql"]
@@ -161,8 +163,47 @@ class TaxonomyAgentToolkit:
 
         return "\n".join(output_parts)
 
-    def _enrich_props_with_descriptions(self, entity: str, props: Iterable[tuple[str, str | None]]):
-        return enrich_props_with_descriptions(entity, props)
+    def _enrich_props_with_descriptions(
+        self,
+        entity: str,
+        props: Iterable[tuple[str, str | None]],
+        stored_descriptions: dict[str, str] | None = None,
+    ):
+        return enrich_props_with_descriptions(entity, props, stored_descriptions)
+
+    def _get_stored_property_descriptions(
+        self,
+        property_type: PropertyDefinition.Type,
+        names: list[str],
+        group_type_index: int | None = None,
+    ) -> dict[str, str]:
+        """Map property name -> sanitized user-authored description from the team's property definitions.
+
+        Sync twin of `TaxonomyAgentToolkit._get_stored_property_descriptions` in
+        `ee/hogai/chat_agent/taxonomy/toolkit.py`. Only the enterprise `PropertyDefinition` model
+        carries a `description` field, so this is a no-op on non-EE builds. Descriptions never
+        influence which properties are surfaced — the list is discovered elsewhere. Runs a single
+        batched query.
+        """
+        if not EE_AVAILABLE or not names:
+            return {}
+
+        from ee.models.property_definition import (
+            EnterprisePropertyDefinition,  # noqa: PLC0415 — EE-only model, keep off the OSS import path
+        )
+
+        qs = (
+            EnterprisePropertyDefinition.objects.filter(team=self._team, type=property_type, name__in=names)
+            .exclude(description__isnull=True)
+            .exclude(description="")
+        )
+        if group_type_index is not None:
+            qs = qs.filter(group_type_index=group_type_index)
+        return {
+            name: sanitize_event_description(description)
+            for name, description in qs.values_list("name", "description")
+            if description
+        }
 
     def retrieve_entity_properties(self, entity: str, max_properties: int = 500) -> str:
         """
@@ -184,7 +225,10 @@ class TaxonomyAgentToolkit:
             stored_props += list_virtual_properties(
                 "person_properties", exclude={name for name, _ in stored_props} | restricted
             )
-            props = self._enrich_props_with_descriptions("person", stored_props)
+            stored_descriptions = self._get_stored_property_descriptions(
+                PropertyDefinition.Type.PERSON, [name for name, _ in stored_props]
+            )
+            props = self._enrich_props_with_descriptions("person", stored_props, stored_descriptions)
         elif entity == "session":
             # Session properties are not in the DB.
             props = self._enrich_props_with_descriptions(
@@ -209,7 +253,12 @@ class TaxonomyAgentToolkit:
                 if p[0] not in restricted
             ]
             stored_props += list_virtual_properties("groups", exclude={name for name, _ in stored_props} | restricted)
-            props = self._enrich_props_with_descriptions(entity, stored_props)
+            stored_descriptions = self._get_stored_property_descriptions(
+                PropertyDefinition.Type.GROUP,
+                [name for name, _ in stored_props],
+                group_type_index=group_type_index,
+            )
+            props = self._enrich_props_with_descriptions(entity, stored_props, stored_descriptions)
 
         if not props:
             return f"Properties do not exist in the taxonomy for the entity {entity}."
@@ -276,9 +325,14 @@ class TaxonomyAgentToolkit:
         if not props:
             return f"Properties do not exist in the taxonomy for the {verbose_name}."
 
+        stored_descriptions = self._get_stored_property_descriptions(
+            PropertyDefinition.Type.EVENT, [name for name, _ in props]
+        )
         return format_prompt_string(
             PROPERTIES_EXAMPLE_PROMPT,
-            result=self._generate_properties_output(self._enrich_props_with_descriptions("event", props)),
+            result=self._generate_properties_output(
+                self._enrich_props_with_descriptions("event", props, stored_descriptions)
+            ),
         )
 
     def _format_property_values(


### PR DESCRIPTION
## Problem

#73360 lets the chat agent's taxonomy toolkit read user-authored property descriptions, but the `read_taxonomy` tool is powered by a second toolkit (`ee/hogai/chat_agent/query_planner/toolkit.py`) that still drops them.
Agents consuming the taxonomy through MCP see property names without the descriptions teams wrote in Data Management - the same gap #72685 closed for event descriptions on this path.

Refs #62925

## Changes

Stacked on #73360: the base branch is that PR's branch, so merging this folds the change into the parent and it ships as one unit.

- Adds a sync `_get_stored_property_descriptions` to the query planner toolkit, mirroring the async one the parent PR added: EE-gated (no-op on OSS builds), one batched query, descriptions run through `sanitize_event_description`, and the core taxonomy still wins so a stored description can't override a built-in one.
- Wires it into the person, group (scoped by `group_type_index`), and event/action property paths. Session properties stay core-only since they have no stored definitions.

Kept as a sync twin rather than a shared helper because the two toolkits already follow a deliberate sync/async split (`_restricted_property_names`, `_enrich_props_with_descriptions`), and this keeps the stack free of edits to the parent PR's files.

## How did you test this code?

Two tests in `ee/hogai/chat_agent/query_planner/test/test_toolkit.py`, each catching the regression this PR fixes - the sync toolkit paths not passing stored descriptions through. The parent PR's tests only cover the async chat-agent toolkit, so nothing existing catches this:

- `test_retrieve_entity_properties_surfaces_stored_descriptions` - person and group paths surface a stored description on the formatted output, with a newline collapsed to show sanitization.
- `test_retrieve_event_properties_surfaces_stored_descriptions` - event path, with the ClickHouse taxonomy query mocked per the file's existing pattern.

This environment has no Postgres/ClickHouse/docker, so the suite runs in CI. Verified locally: ruff check and format pass, and both changed modules import cleanly under Django with the new signatures.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Claude) during a review of #73360. The review found that the parent PR covers the chat agent's taxonomy toolkit but not the query planner toolkit behind the `read_taxonomy` MCP tool, and the reviewer asked for a stacked PR closing that gap. Skills invoked: `/writing-tests`. Main decision: mirror the parent's helper as a sync private method instead of consolidating into one shared function, matching the existing sync/async toolkit pattern and avoiding churn on the parent branch while it's under review.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
