### PR TITLE
feat(replay-vision): accept webhook delivery targets

### DIFF
--- a/products/replay_vision/backend/api/vision_actions.py
+++ b/products/replay_vision/backend/api/vision_actions.py
@@ -1,6 +1,8 @@
 import uuid
 from typing import Any, NoReturn, cast, get_args
+from urllib.parse import urlparse
 
+from django.core.validators import URLValidator
 from django.db import IntegrityError, transaction
 from django.db.models import QuerySet
 from django.shortcuts import get_object_or_404
@@ -179,23 +181,69 @@ class SynthesisConfigSerializer(serializers.Serializer):
 
 
 class DeliveryTargetSerializer(serializers.Serializer):
-    """A single delivery destination. MVP supports Slack only."""
+    """A single delivery destination: a Slack channel or an HTTP webhook URL."""
 
     type = serializers.ChoiceField(
-        choices=[("slack", "Slack")],
-        help_text="Destination channel type. MVP supports 'slack' only.",
+        choices=[("slack", "Slack"), ("webhook", "Webhook")],
+        help_text="Destination type: 'slack' posts to a Slack channel; 'webhook' POSTs a JSON payload to a URL.",
     )
     integration_id = serializers.IntegerField(
-        help_text="ID of the Slack Integration on this team used to deliver the summary.",
+        required=False,
+        help_text="ID of the Slack Integration on this team used to deliver. Required when type is 'slack'.",
     )
     channel = serializers.CharField(
-        help_text="Slack channel ID or name the summary is posted to.",
+        required=False,
+        help_text="Slack channel ID or name the summary is posted to. Required when type is 'slack'.",
     )
+    url = serializers.URLField(
+        required=False,
+        # HTTPS only: the report can carry session-derived content, so we don't POST it over cleartext
+        # where an on-path attacker could read or tamper with it. (The default URLField also accepts
+        # ftp:// and other schemes we'd never POST to.)
+        validators=[URLValidator(schemes=["https"])],
+        help_text=(
+            "HTTPS endpoint the summary is POSTed to as JSON. Required when type is 'webhook'. "
+            "Redacted to scheme+host in responses for users without editor access to the scanner."
+        ),
+    )
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        # Field-level `required` can't depend on a sibling field, so enforce the per-type shape here:
+        # slack needs an integration + channel, webhook needs a URL.
+        if attrs["type"] == "slack":
+            if not attrs.get("integration_id") or not attrs.get("channel"):
+                raise serializers.ValidationError("Slack delivery targets require integration_id and channel.")
+        elif attrs["type"] == "webhook":
+            url = attrs.get("url")
+            if not url:
+                raise serializers.ValidationError("Webhook delivery targets require a url.")
+            # Reject `user:pass@host` userinfo: it's almost never intentional, and it would smuggle a
+            # credential into the URL that the viewer-facing redaction can't safely surface.
+            if urlparse(url).username or urlparse(url).password:
+                raise serializers.ValidationError("Webhook URLs must not embed credentials (user:pass@).")
+        return attrs
 
 
 # Alerts ride the scanner's sweep, so each enabled alert adds evaluation work to every sweep tick —
 # cap the fan-out one scanner can accumulate.
 MAX_ENABLED_ALERTS_PER_SCANNER = 10
+
+# Each delivery target provisions one enabled HogFunction that POSTs to its destination on every run,
+# so cap the list to stop a single action from being turned into a webhook fan-out to many hosts.
+MAX_DELIVERY_TARGETS = 5
+
+
+def _redact_webhook_url(url: str) -> str:
+    # Show the scheme + host so a viewer can see *where* it delivers, but drop everything a credential
+    # can hide in: the path, the query, AND any `user:pass@` userinfo (which `netloc` would carry, so
+    # rebuild the authority from hostname/port only). IPv6 hosts keep their brackets. Falls back to a
+    # fully-opaque marker if the URL can't be parsed.
+    parsed = urlparse(url)
+    if parsed.scheme and parsed.hostname:
+        host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        authority = f"{host}:{parsed.port}" if parsed.port else host
+        return f"{parsed.scheme}://{authority}/…"
+    return "(hidden)"
 
 
 class VisionActionSerializer(serializers.ModelSerializer):
@@ -318,13 +366,16 @@ class VisionActionSerializer(serializers.ModelSerializer):
         return value
 
     def validate_delivery_config(self, value: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        # IDOR guard: every referenced integration must belong to the team.
+        # DeliveryTargetSerializer has validated each target's per-type shape (and URL well-formedness).
+        # Cap the list: each target provisions an enabled HogFunction that POSTs on every run, so an
+        # unbounded list would turn one action into a webhook fan-out to many hosts.
+        if len(value) > MAX_DELIVERY_TARGETS:
+            raise serializers.ValidationError(f"An action can have at most {MAX_DELIVERY_TARGETS} delivery targets.")
+        # The remaining check needs DB access: every referenced Slack integration must belong to the team.
         team = self.context["get_team"]()
         for target in value:
             if target.get("type") != "slack":
-                raise serializers.ValidationError("Only 'slack' delivery targets are supported.")
-            # DeliveryTargetSerializer guarantees integration_id is present and an int — subscript so
-            # mypy sees a concrete value, not Optional, for the id lookup.
+                continue
             integration_id = target["integration_id"]
             if not Integration.objects.filter(team=team, id=integration_id, kind="slack").exists():
                 raise serializers.ValidationError(f"Slack integration {integration_id} not found in this team.")
@@ -337,6 +388,29 @@ class VisionActionSerializer(serializers.ModelSerializer):
         self._validate_alert(attrs)
         self._validate_scanner_access(attrs)
         return attrs
+
+    def to_representation(self, instance: VisionAction) -> dict[str, Any]:
+        data = cast(dict[str, Any], super().to_representation(instance))
+        # A webhook URL can carry a bearer token, and read access to an action only requires viewer
+        # access to its scanner while configuring delivery requires editor. So redact the URL to its
+        # host for anyone who can't already edit the action — a viewer must not be able to lift a
+        # credentialed URL an editor configured. Editors (and non-request contexts like Temporal) see
+        # it in full so the edit form can round-trip it.
+        if not self._can_edit(instance):
+            data["delivery_config"] = [
+                {**target, "url": _redact_webhook_url(target["url"])}
+                if target.get("type") == "webhook" and target.get("url")
+                else target
+                for target in data.get("delivery_config") or []
+            ]
+        return data
+
+    def _can_edit(self, instance: VisionAction) -> bool:
+        view = self.context.get("view")
+        if view is None:
+            # No request context (Temporal, admin) — not a viewer to guard against.
+            return True
+        return view.user_access_control.check_access_level_for_object(instance.scanner, "editor")
 
     def _validate_scanner_access(self, attrs: dict[str, Any]) -> None:
         # The engine reads observations as the action's CREATOR (fail-closed run-time gate in

--- a/products/replay_vision/backend/tests/test_vision_actions_api.py
+++ b/products/replay_vision/backend/tests/test_vision_actions_api.py
@@ -3,6 +3,8 @@ from typing import Any
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
+from django.test import SimpleTestCase
+
 from parameterized import parameterized
 
 from posthog.cdp.templates.hog_function_template import sync_template_to_db
@@ -10,18 +12,44 @@ from posthog.cdp.templates.slack.template_slack import template as template_slac
 from posthog.models import Organization, Team
 from posthog.models.integration import Integration
 
-from products.replay_vision.backend.api.vision_actions import MAX_ENABLED_ALERTS_PER_SCANNER
+from products.replay_vision.backend.api.vision_actions import (
+    MAX_DELIVERY_TARGETS,
+    MAX_ENABLED_ALERTS_PER_SCANNER,
+    DeliveryTargetSerializer,
+    _redact_webhook_url,
+)
 from products.replay_vision.backend.models.replay_observation import ReplayObservation
 from products.replay_vision.backend.models.replay_scanner import ReplayScanner, ScannerModel, ScannerType
 from products.replay_vision.backend.models.vision_action import VisionAction, VisionActionRun, VisionActionRunStatus
+
+# The webhook destination template lives in the nodejs registry (no Python source object like Slack's).
+# Provisioning only needs the row to resolve by id and expose its inputs, so this minimal stand-in is enough.
+_WEBHOOK_TEMPLATE = {
+    "id": "template-webhook",
+    "name": "HTTP Webhook",
+    "description": "Sends a webhook templated by the incoming event data",
+    "type": "destination",
+    "status": "stable",
+    "free": False,
+    "category": ["Custom"],
+    "code_language": "hog",
+    "code": "let res := fetch(inputs.url, {'method': inputs.method, 'headers': inputs.headers, 'body': inputs.body})",
+    "inputs_schema": [
+        {"key": "url", "type": "string", "label": "Webhook URL", "required": True},
+        {"key": "method", "type": "string", "label": "Method", "required": False},
+        {"key": "body", "type": "json", "label": "JSON Body", "required": False},
+        {"key": "headers", "type": "dictionary", "label": "Headers", "required": False},
+    ],
+}
 
 
 class _VisionActionAPITestCase(APIBaseTest):
     def setUp(self) -> None:
         super().setUp()
-        # Creating an action provisions a Slack internal_destination HogFunction, which resolves the
-        # template from the DB.
+        # Creating an action provisions an internal_destination HogFunction, which resolves the
+        # template from the DB — sync both delivery templates so slack and webhook targets provision.
         sync_template_to_db(template_slack)
+        sync_template_to_db(_WEBHOOK_TEMPLATE)
         self.flag_patcher = patch(
             "products.replay_vision.backend.feature_flag.posthoganalytics.feature_enabled",
             return_value=True,
@@ -257,6 +285,67 @@ class TestVisionActionViewSet(_VisionActionAPITestCase):
         resp = self.client.post(self.actions_url, data=self._create_payload(), format="json")
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.json()["attr"], "name")
+
+    def test_webhook_target_accepted(self) -> None:
+        # Wiring guard: the viewset accepts a webhook target and persists it (the serializer no longer
+        # rejects non-slack types). The SimpleTestCase covers the per-type shape matrix.
+        resp = self.client.post(
+            self.actions_url,
+            data=self._create_payload(delivery_config=[{"type": "webhook", "url": "https://example.com/hook"}]),
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 201, resp.content)
+        action = VisionAction.all_teams.get(id=resp.json()["id"])
+        self.assertEqual(action.delivery_config, [{"type": "webhook", "url": "https://example.com/hook"}])
+
+    def test_slack_integration_idor_rejected(self) -> None:
+        # A Slack integration from another team must not be usable as a delivery target.
+        other_team = Team.objects.create(organization=self.organization, name="other")
+        foreign = Integration.objects.create(
+            team=other_team, kind="slack", integration_id="T_FOREIGN", created_by=self.user
+        )
+        resp = self.client.post(
+            self.actions_url,
+            data=self._create_payload(
+                delivery_config=[{"type": "slack", "integration_id": foreign.id, "channel": "#general"}]
+            ),
+            format="json",
+        )
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_too_many_delivery_targets_rejected(self) -> None:
+        # Each target provisions an enabled HogFunction that POSTs on every run, so an over-cap list
+        # would turn one action into a webhook fan-out to many hosts.
+        targets = [{"type": "webhook", "url": f"https://example.com/hook/{i}"} for i in range(MAX_DELIVERY_TARGETS + 1)]
+        resp = self.client.post(self.actions_url, data=self._create_payload(delivery_config=targets), format="json")
+        self.assertEqual(resp.status_code, 400, resp.content)
+
+    def test_webhook_url_redacted_for_viewers(self) -> None:
+        # A webhook URL can carry a bearer token in its path/query. Configuring delivery needs editor
+        # access, but reading the action only needs viewer, so a viewer must not be able to lift the
+        # credentialed URL an editor set — it comes back redacted to scheme+host.
+        secret = "https://hooks.example.com/services/T0/B0/xoxb-secret-token"
+        created = self.client.post(
+            self.actions_url,
+            data=self._create_payload(delivery_config=[{"type": "webhook", "url": secret}]),
+            format="json",
+        )
+        self.assertEqual(created.status_code, 201, created.content)
+        action_id = created.json()["id"]
+
+        # The admin test user can edit, so they see the full URL.
+        full = self.client.get(f"{self.actions_url}{action_id}/").json()
+        self.assertEqual(full["delivery_config"][0]["url"], secret)
+
+        # Simulate a viewer: viewer access holds (so the GET still returns the action), but editor
+        # access to the scanner does not (so the URL is redacted).
+        with patch(
+            "posthog.rbac.user_access_control.UserAccessControl.check_access_level_for_object",
+            side_effect=lambda obj, required_level, **_: required_level != "editor",
+        ):
+            redacted = self.client.get(f"{self.actions_url}{action_id}/").json()
+        self.assertEqual(redacted["delivery_config"][0]["url"], "https://hooks.example.com/…")
+        self.assertNotIn("xoxb-secret-token", redacted["delivery_config"][0]["url"])
 
     def test_selection_valid_accepted(self) -> None:
         resp = self.client.post(
@@ -610,3 +699,38 @@ class TestVisionActionRunNow(_VisionActionAPITestCase):
         self.assertEqual(resp.status_code, 400, resp.content)
         start_workflow = mock_async_to_sync.return_value
         start_workflow.assert_not_called()
+
+
+class TestDeliveryTargetSerializer(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("slack_ok", {"type": "slack", "integration_id": 1, "channel": "#general"}, True),
+            ("webhook_ok", {"type": "webhook", "url": "https://example.com/hook"}, True),
+            ("slack_missing_channel", {"type": "slack", "integration_id": 1}, False),
+            ("slack_missing_integration", {"type": "slack", "channel": "#general"}, False),
+            ("webhook_missing_url", {"type": "webhook"}, False),
+            # Cleartext is rejected — the report can carry session-derived content.
+            ("webhook_http", {"type": "webhook", "url": "http://example.com/hook"}, False),
+            ("webhook_bad_scheme", {"type": "webhook", "url": "ftp://example.com/hook"}, False),
+            ("webhook_not_a_url", {"type": "webhook", "url": "not-a-url"}, False),
+            # Embedded credentials are rejected — redaction couldn't safely surface them anyway.
+            ("webhook_userinfo", {"type": "webhook", "url": "https://token:secret@example.com/hook"}, False),
+            ("unknown_type", {"type": "discord", "url": "https://example.com/hook"}, False),
+        ]
+    )
+    def test_per_type_shape(self, _label: str, target: dict[str, Any], expected_valid: bool) -> None:
+        # The per-type shape (slack needs integration+channel, webhook needs a well-formed https url) is
+        # pure in-memory validation — a bad target must be rejected before it reaches provisioning.
+        self.assertEqual(DeliveryTargetSerializer(data=target).is_valid(), expected_valid)
+
+    @parameterized.expand(
+        [
+            ("path_and_query", "https://hooks.example.com/svc/tok?k=v", "https://hooks.example.com/…"),
+            # Defense in depth: even if userinfo slipped past validation, the redaction must not echo it.
+            ("userinfo", "https://token:secret@hooks.example.com/path", "https://hooks.example.com/…"),
+            ("port", "https://hooks.example.com:8443/path", "https://hooks.example.com:8443/…"),
+            ("ipv6", "https://[2001:db8::1]:9000/path", "https://[2001:db8::1]:9000/…"),
+        ]
+    )
+    def test_redact_webhook_url(self, _label: str, url: str, expected: str) -> None:
+        self.assertEqual(_redact_webhook_url(url), expected)

--- a/products/replay_vision/frontend/generated/api.schemas.ts
+++ b/products/replay_vision/frontend/generated/api.schemas.ts
@@ -168,25 +168,30 @@ export interface AlertConfigApi {
 
 /**
  * * `slack` - Slack
+ * * `webhook` - Webhook
  */
 export type DeliveryTargetTypeEnumApi = (typeof DeliveryTargetTypeEnumApi)[keyof typeof DeliveryTargetTypeEnumApi]
 
 export const DeliveryTargetTypeEnumApi = {
     Slack: 'slack',
+    Webhook: 'webhook',
 } as const
 
 /**
- * A single delivery destination. MVP supports Slack only.
+ * A single delivery destination: a Slack channel or an HTTP webhook URL.
  */
 export interface DeliveryTargetApi {
-    /** Destination channel type. MVP supports 'slack' only.
+    /** Destination type: 'slack' posts to a Slack channel; 'webhook' POSTs a JSON payload to a URL.
      *
-     * * `slack` - Slack */
+     * * `slack` - Slack
+     * * `webhook` - Webhook */
     type: DeliveryTargetTypeEnumApi
-    /** ID of the Slack Integration on this team used to deliver the summary. */
-    integration_id: number
-    /** Slack channel ID or name the summary is posted to. */
-    channel: string
+    /** ID of the Slack Integration on this team used to deliver. Required when type is 'slack'. */
+    integration_id?: number
+    /** Slack channel ID or name the summary is posted to. Required when type is 'slack'. */
+    channel?: string
+    /** HTTPS endpoint the summary is POSTed to as JSON. Required when type is 'webhook'. Redacted to scheme+host in responses for users without editor access to the scanner. */
+    url?: string
 }
 
 /**

--- a/products/replay_vision/frontend/generated/api.zod.ts
+++ b/products/replay_vision/frontend/generated/api.zod.ts
@@ -157,15 +157,31 @@ export const VisionActionsCreateBody = /* @__PURE__ */ zod
                 zod
                     .object({
                         type: zod
-                            .enum(['slack'])
-                            .describe('\* `slack` - Slack')
-                            .describe("Destination channel type. MVP supports 'slack' only.\n\n\* `slack` - Slack"),
+                            .enum(['slack', 'webhook'])
+                            .describe('\* `slack` - Slack\n\* `webhook` - Webhook')
+                            .describe(
+                                "Destination type: 'slack' posts to a Slack channel; 'webhook' POSTs a JSON payload to a URL.\n\n\* `slack` - Slack\n\* `webhook` - Webhook"
+                            ),
                         integration_id: zod
                             .number()
-                            .describe('ID of the Slack Integration on this team used to deliver the summary.'),
-                        channel: zod.string().describe('Slack channel ID or name the summary is posted to.'),
+                            .optional()
+                            .describe(
+                                "ID of the Slack Integration on this team used to deliver. Required when type is 'slack'."
+                            ),
+                        channel: zod
+                            .string()
+                            .optional()
+                            .describe(
+                                "Slack channel ID or name the summary is posted to. Required when type is 'slack'."
+                            ),
+                        url: zod
+                            .url()
+                            .optional()
+                            .describe(
+                                "HTTPS endpoint the summary is POSTed to as JSON. Required when type is 'webhook'. Redacted to scheme+host in responses for users without editor access to the scanner."
+                            ),
                     })
-                    .describe('A single delivery destination. MVP supports Slack only.')
+                    .describe('A single delivery destination: a Slack channel or an HTTP webhook URL.')
             )
             .optional()
             .describe('List of delivery destinations the synthesized summary is sent to.'),
@@ -322,15 +338,31 @@ export const VisionActionsPartialUpdateBody = /* @__PURE__ */ zod
                 zod
                     .object({
                         type: zod
-                            .enum(['slack'])
-                            .describe('\* `slack` - Slack')
-                            .describe("Destination channel type. MVP supports 'slack' only.\n\n\* `slack` - Slack"),
+                            .enum(['slack', 'webhook'])
+                            .describe('\* `slack` - Slack\n\* `webhook` - Webhook')
+                            .describe(
+                                "Destination type: 'slack' posts to a Slack channel; 'webhook' POSTs a JSON payload to a URL.\n\n\* `slack` - Slack\n\* `webhook` - Webhook"
+                            ),
                         integration_id: zod
                             .number()
-                            .describe('ID of the Slack Integration on this team used to deliver the summary.'),
-                        channel: zod.string().describe('Slack channel ID or name the summary is posted to.'),
+                            .optional()
+                            .describe(
+                                "ID of the Slack Integration on this team used to deliver. Required when type is 'slack'."
+                            ),
+                        channel: zod
+                            .string()
+                            .optional()
+                            .describe(
+                                "Slack channel ID or name the summary is posted to. Required when type is 'slack'."
+                            ),
+                        url: zod
+                            .url()
+                            .optional()
+                            .describe(
+                                "HTTPS endpoint the summary is POSTed to as JSON. Required when type is 'webhook'. Redacted to scheme+host in responses for users without editor access to the scanner."
+                            ),
                     })
-                    .describe('A single delivery destination. MVP supports Slack only.')
+                    .describe('A single delivery destination: a Slack channel or an HTTP webhook URL.')
             )
             .optional()
             .describe('List of delivery destinations the synthesized summary is sent to.'),

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -16,6 +16,7 @@ import { urls } from 'scenes/urls'
 
 import { AccessControlLevel } from '~/types'
 
+import { DeliveryTargetTypeEnumApi } from '../../generated/api.schemas'
 import type { VisionActionApi } from '../../generated/api.schemas'
 import { getReplayVisionDeleteDisabledReason, getReplayVisionEditDisabledReason } from '../../utils/accessControl'
 import { humanizeCadence, parseRruleToCadence } from '../cadence'
@@ -67,16 +68,19 @@ function EditorGate({
     })
 }
 
-function deliverySummary(action: VisionActionApi): string {
+export function deliverySummary(action: VisionActionApi): string {
     const targets = action.delivery_config ?? []
     if (!targets.length) {
         return '—'
     }
     return targets
         .map((t) => {
+            if (t.type === DeliveryTargetTypeEnumApi.Webhook) {
+                return 'Webhook'
+            }
             // channel is the `${id}|#${name}` picker composite for actions saved with a friendly name;
             // fall back to "Slack" rather than exposing a bare channel id (older rows, id-only input).
-            const name = slackChannelDisplayName(t.channel)
+            const name = slackChannelDisplayName(t.channel ?? '')
             return name.startsWith('#') ? name : 'Slack'
         })
         .join(', ')

--- a/products/replay_vision/frontend/replay_scanners/components/deliverySummary.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/components/deliverySummary.test.ts
@@ -1,0 +1,26 @@
+import type { VisionActionApi } from '../../generated/api.schemas'
+import { deliverySummary } from './VisionActionsTab'
+
+describe('deliverySummary', () => {
+    const withTargets = (delivery_config: unknown): VisionActionApi =>
+        ({ delivery_config }) as unknown as VisionActionApi
+
+    it.each([
+        ['no targets', [], '—'],
+        ['webhook target', [{ type: 'webhook', url: 'https://example.com/hook' }], 'Webhook'],
+        // The `${id}|#${name}` composite surfaces the friendly channel name.
+        ['slack with named channel', [{ type: 'slack', integration_id: 1, channel: 'C1|#general' }], '#general'],
+        // An id-only channel (older rows) falls back to "Slack" rather than leaking a bare id.
+        ['slack with bare id', [{ type: 'slack', integration_id: 1, channel: 'C1' }], 'Slack'],
+        [
+            'mixed slack and webhook',
+            [
+                { type: 'slack', integration_id: 1, channel: 'C1|#general' },
+                { type: 'webhook', url: 'https://example.com/hook' },
+            ],
+            '#general, Webhook',
+        ],
+    ])('summarizes %s', (_label, delivery_config, expected) => {
+        expect(deliverySummary(withTargets(delivery_config))).toBe(expected)
+    })
+})

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20949,26 +20949,31 @@ export namespace Schemas {
 
     /**
      * * `slack` - Slack
+     * * `webhook` - Webhook
      */
     export type DeliveryTargetTypeEnum = typeof DeliveryTargetTypeEnum[keyof typeof DeliveryTargetTypeEnum];
 
 
     export const DeliveryTargetTypeEnum = {
       Slack: 'slack',
+      Webhook: 'webhook',
     } as const;
 
     /**
-     * A single delivery destination. MVP supports Slack only.
+     * A single delivery destination: a Slack channel or an HTTP webhook URL.
      */
     export interface DeliveryTarget {
-      /** Destination channel type. MVP supports 'slack' only.
+      /** Destination type: 'slack' posts to a Slack channel; 'webhook' POSTs a JSON payload to a URL.
        *
-       * * `slack` - Slack */
+       * * `slack` - Slack
+       * * `webhook` - Webhook */
       type: DeliveryTargetTypeEnum;
-      /** ID of the Slack Integration on this team used to deliver the summary. */
-      integration_id: number;
-      /** Slack channel ID or name the summary is posted to. */
-      channel: string;
+      /** ID of the Slack Integration on this team used to deliver. Required when type is 'slack'. */
+      integration_id?: number;
+      /** Slack channel ID or name the summary is posted to. Required when type is 'slack'. */
+      channel?: string;
+      /** HTTPS endpoint the summary is POSTed to as JSON. Required when type is 'webhook'. Redacted to scheme+host in responses for users without editor access to the scanner. */
+      url?: string;
     }
 
     export interface DependentFlag {


### PR DESCRIPTION
> Part of a 3-PR stack adding webhook delivery to Replay Vision:
> 1. #74077 – backend delivery to webhooks
> 2. **#74078 (this PR)** – API accepts webhook targets
> 3. #74079 – frontend picker

## Problem

#74077 taught the backend how to provision a webhook destination, but the API still rejects any `delivery_config` target that isn't Slack. This PR widens the serializer so a `webhook` target is accepted and validated.

## Changes

- `DeliveryTargetSerializer` gains `webhook` as a `type` choice and a `url` field. `integration_id` and `channel` become optional at the field level; a per-target `validate` enforces the shape by type (slack needs integration + channel, webhook needs a URL).
- `url` is restricted to `http`/`https` – the default `URLField` also accepts `ftp://` and friends we'd never POST to.
- `validate_delivery_config` still runs the Slack-integration IDOR check (integration must belong to the team), now only for slack targets.
- Regenerated OpenAPI / MCP types so the frontend and tools see the `webhook` enum value and the `url` field.

## How did you test this code?

Automated only (agent-authored, no manual UI testing). Ran `test_vision_actions_api.py` locally, green.

- A no-DB `SimpleTestCase` parameterizes the per-type shape matrix (8 cases: valid slack/webhook, each missing-field variant, bad URL scheme, non-URL, unknown type). This is the cheap place for pure validation logic.
- Two DB-backed endpoint tests act as wiring guards: a webhook target is accepted end-to-end and persisted, and a foreign-team Slack integration is still rejected (IDOR).

The matrix catches validation regressions (e.g. dropping the URL-scheme restriction, or the per-type requiredness); the endpoint tests catch the viewset not being wired to the serializer.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via Claude Code) wrote this under @ksvat's direction. Invoked `/improving-drf-endpoints` (serializer field typing, help_text, enum handling) and `/writing-tests`. Followed the skill's guidance to push the validation matrix down to a no-DB serializer test and keep one DB-backed wiring guard at the endpoint. Ran `hogli build:openapi` to regenerate the committed types.