### PR TITLE
feat(mcp-analytics): split recurring automated intents out of clustering

### DIFF
--- a/posthog/temporal/mcp_analytics/intent_clustering/activities.py
+++ b/posthog/temporal/mcp_analytics/intent_clustering/activities.py
@@ -26,6 +26,7 @@ import asyncio
 from django.db import transaction
 from django.utils import timezone
 
+import numpy as np
 import structlog
 from temporalio import activity
 
@@ -109,13 +110,25 @@ async def compute_intent_clusters_activity(inputs: IntentClusteringWorkflowInput
             snapshot = await _mark_computing(team, user)
 
             try:
+                # Recurring texts are reported as their own ranked list and kept
+                # out of the semantic corpus so automation can't dominate the
+                # clusters (the top production clusters were all scout/cron
+                # boilerplate before this split).
+                recurring = await database_sync_to_async(intent_clustering.fetch_recurring_intents)(
+                    team, lookback_days=inputs.lookback_days
+                )
+                activity.heartbeat("fetched recurring intents")
+
                 records, intent_by_session = await database_sync_to_async(intent_clustering.fetch_intent_corpus)(
-                    team, lookback_days=inputs.lookback_days, top_n=inputs.top_n
+                    team,
+                    lookback_days=inputs.lookback_days,
+                    top_n=inputs.top_n,
+                    exclude_texts={r.intent_text for r in recurring},
                 )
                 activity.heartbeat("fetched corpus")
 
                 if not records:
-                    await database_sync_to_async(_save_empty_blob)(snapshot)
+                    await database_sync_to_async(_save_empty_blob)(snapshot, recurring)
                     logger.info(
                         "mcpa.intent_clustering.no_intents_found",
                         team_id=inputs.team_id,
@@ -158,6 +171,7 @@ async def compute_intent_clusters_activity(inputs: IntentClusteringWorkflowInput
                     labels,
                     embeddings,
                     journeys_by_cluster=journeys_by_cluster,
+                    recurring=recurring,
                 )
                 await _persist_clusters(snapshot, clusters_blob)
 
@@ -184,21 +198,23 @@ async def compute_intent_clusters_activity(inputs: IntentClusteringWorkflowInput
                 raise
 
 
-def _save_empty_blob(snapshot: MCPIntentClusterSnapshot) -> None:
+def _save_empty_blob(
+    snapshot: MCPIntentClusterSnapshot, recurring: list[intent_clustering.RecurringIntent] | None = None
+) -> None:
     """Synchronous helper to write an empty snapshot when the corpus is empty.
+
+    Recurring intents still persist — a team whose traffic is entirely
+    automated has no semantic corpus but a very real recurring list.
 
     Lives outside the async activity body so ``database_sync_to_async`` can
     wrap it without re-entrancy from inside an async context.
     """
-    snapshot.clusters = {
-        "clusters": [],
-        "computed_with": {
-            "distance_threshold": intent_clustering.DEFAULT_DISTANCE_THRESHOLD,
-            "embedding_model": intent_clustering.EMBEDDING_MODEL,
-            "n_intents": 0,
-            "n_clusters": 0,
-        },
-    }
+    snapshot.clusters = intent_clustering.build_snapshot(
+        [],
+        np.array([], dtype=np.int64),
+        np.zeros((0, 0), dtype=np.float32),
+        recurring=recurring,
+    )
     snapshot.status = MCPIntentClusterSnapshot.Status.IDLE
     snapshot.error_message = ""
     snapshot.last_computed_at = timezone.now()

--- a/posthog/temporal/mcp_analytics/intent_clustering/activities.py
+++ b/posthog/temporal/mcp_analytics/intent_clustering/activities.py
@@ -114,8 +114,12 @@ async def compute_intent_clusters_activity(inputs: IntentClusteringWorkflowInput
                 # out of the semantic corpus so automation can't dominate the
                 # clusters (the top production clusters were all scout/cron
                 # boilerplate before this split).
+                # Fetched wider than the display cap: every recurring text has to reach
+                # exclude_texts below, and the blob truncates to the display cap itself.
                 recurring = await database_sync_to_async(intent_clustering.fetch_recurring_intents)(
-                    team, lookback_days=inputs.lookback_days
+                    team,
+                    lookback_days=inputs.lookback_days,
+                    limit=intent_clustering.MAX_RECURRING_EXCLUSIONS,
                 )
                 activity.heartbeat("fetched recurring intents")
 

--- a/products/mcp_analytics/backend/facade/contracts.py
+++ b/products/mcp_analytics/backend/facade/contracts.py
@@ -136,6 +136,25 @@ class IntentCluster:
 
 
 @dataclass(frozen=True)
+class IntentClusterLongTail:
+    intent_count: int
+    session_count: int
+    call_count: int
+    error_count: int
+    error_rate_pct: float
+    sample_intents: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class RecurringIntentEntry:
+    intent_text: str
+    session_count: int
+    call_count: int
+    error_count: int
+    error_rate_pct: float
+
+
+@dataclass(frozen=True)
 class IntentClusterSnapshotMeta:
     distance_threshold: float
     embedding_model: str
@@ -150,6 +169,8 @@ class IntentClusterSnapshot:
     last_computed_at: datetime | None
     last_computed_by_email: str
     clusters: list[IntentCluster] = field(default_factory=list)
+    long_tail: IntentClusterLongTail | None = None
+    recurring: list[RecurringIntentEntry] = field(default_factory=list)
     computed_with: IntentClusterSnapshotMeta | None = None
 
 

--- a/products/mcp_analytics/backend/intent_clustering.py
+++ b/products/mcp_analytics/backend/intent_clustering.py
@@ -70,6 +70,12 @@ MAX_LONG_TAIL_SAMPLES = 10
 RECURRING_MIN_SESSIONS = 3
 MAX_RECURRING_INTENTS = 50
 
+# The same list both renders and feeds fetch_intent_corpus(exclude_texts=...), and those
+# want different bounds: 50 rows is a readable table, but a team with more than 50
+# recurring texts would leak the tail straight back into the semantic corpus. Fetch the
+# exclusion set this much wider and let the blob truncate to the display cap.
+MAX_RECURRING_EXCLUSIONS = 500
+
 # Placeholder previously written by the (now-removed) summariser job for sessions with no
 # recordable tool-call intents. Still filtered out of the corpus so it doesn't form a
 # meaningless pseudo-cluster of "empty" sessions.
@@ -244,6 +250,13 @@ def fetch_intent_corpus(
             continue
         intent_by_session[session_id] = text
 
+    # A session whose opening intent recurs is automation no matter how the summary
+    # overlay later describes it, so settle exclusion against the event text before the
+    # overlay replaces it — matching only on the final text lets those sessions back in.
+    recurring_sessions = (
+        {sid for sid, text in intent_by_session.items() if text in exclude_texts} if exclude_texts else set()
+    )
+
     # Overlay LLM-generated session summaries, and include summarised sessions
     # the event sample missed (e.g. generated for a session whose events sit
     # just outside the sampled set).
@@ -258,7 +271,11 @@ def fetch_intent_corpus(
         intent_by_session[session_id] = text
 
     if exclude_texts:
-        intent_by_session = {sid: text for sid, text in intent_by_session.items() if text not in exclude_texts}
+        intent_by_session = {
+            sid: text
+            for sid, text in intent_by_session.items()
+            if sid not in recurring_sessions and text not in exclude_texts
+        }
 
     if not intent_by_session:
         return [], {}
@@ -815,7 +832,7 @@ def _serialize_recurring(recurring: list[RecurringIntent] | None) -> list[dict[s
             "error_count": r.error_count,
             "error_rate_pct": round(100.0 * r.error_count / r.call_count, 1) if r.call_count else 0.0,
         }
-        for r in recurring or []
+        for r in (recurring or [])[:MAX_RECURRING_INTENTS]
     ]
 
 

--- a/products/mcp_analytics/backend/intent_clustering.py
+++ b/products/mcp_analytics/backend/intent_clustering.py
@@ -50,8 +50,25 @@ EMBEDDING_MODEL = "text-embedding-3-small-1536"
 EMBEDDING_PREFIX = "User intent: "
 DEFAULT_LOOKBACK_DAYS = 7
 DEFAULT_TOP_N_INTENTS = 500
-DEFAULT_DISTANCE_THRESHOLD = 0.2
+# Cosine distance at which agglomerative merging stops. 0.2 produced >90%
+# singleton clusters on production diversity (same-topic paraphrases of
+# free-text intents typically sit at 0.25-0.45 distance on this embedding
+# model); 0.4 merges paraphrases while keeping distinct topics apart.
+DEFAULT_DISTANCE_THRESHOLD = 0.4
 MAX_SAMPLE_INTENTS_PER_CLUSTER = 3
+
+# Clusters below this member count collapse into the long-tail bucket instead
+# of rendering as rows — a page of singleton "clusters" is just a session list.
+MIN_CLUSTER_INTENTS = 2
+MAX_LONG_TAIL_SAMPLES = 10
+
+# An intent text repeated verbatim across this many sessions in the window is
+# automated traffic (scouts, crons, scheduled agents) — humans virtually never
+# type the same free-text twice, let alone across sessions. Detected
+# behaviourally rather than by client/identity properties because automation
+# runs under the same consumers and distinct_ids as interactive use.
+RECURRING_MIN_SESSIONS = 3
+MAX_RECURRING_INTENTS = 50
 
 # Placeholder previously written by the (now-removed) summariser job for sessions with no
 # recordable tool-call intents. Still filtered out of the corpus so it doesn't form a
@@ -81,6 +98,16 @@ class IntentRecord:
     session_count: int = 0
     tool_counts: dict[str, int] = field(default_factory=dict)
     error_counts: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RecurringIntent:
+    """An intent text repeated verbatim across many sessions — automated traffic."""
+
+    intent_text: str
+    session_count: int
+    call_count: int
+    error_count: int
 
 
 # Intent corpus -----------------------------------------------------------
@@ -173,6 +200,7 @@ def fetch_intent_corpus(
     team: Team,
     lookback_days: int = DEFAULT_LOOKBACK_DAYS,
     top_n: int = DEFAULT_TOP_N_INTENTS,
+    exclude_texts: set[str] | None = None,
 ) -> tuple[list[IntentRecord], dict[str, str]]:
     """Return ``(records, intent_by_session)`` for clustering.
 
@@ -185,6 +213,9 @@ def fetch_intent_corpus(
 
     ``intent_by_session`` is exposed so callers can later join session-level
     data (e.g. journey aggregation) back to the cluster a session belongs to.
+
+    ``exclude_texts`` drops sessions whose representative text matches — used
+    to keep recurring automated intents out of the semantic corpus.
 
     ``lookback_days`` bounds both stores to the same window: event queries
     filter by timestamp, and session intent rows are filtered by ``created_at``
@@ -225,6 +256,9 @@ def fetch_intent_corpus(
         if not session_id or not text or text == NO_INTENT_RECORDED_FALLBACK:
             continue
         intent_by_session[session_id] = text
+
+    if exclude_texts:
+        intent_by_session = {sid: text for sid, text in intent_by_session.items() if text not in exclude_texts}
 
     if not intent_by_session:
         return [], {}
@@ -282,6 +316,93 @@ def fetch_intent_corpus(
 
     records.sort(key=lambda r: r.frequency, reverse=True)
     return records[:top_n], intent_by_session
+
+
+# Recurring intents --------------------------------------------------------
+
+# First intent per session over the FULL window (no corpus sampling), rolled up
+# by exact text. argMinIf keeps the per-session call/error counts over all tool
+# calls while the first-intent pick only considers intent-bearing rows.
+_RECURRING_INTENTS_SQL = """
+SELECT
+    first_intent,
+    count() AS n_sessions,
+    sum(calls) AS call_count,
+    sum(errors) AS error_count
+FROM (
+    SELECT
+        $session_id AS session_id,
+        argMinIf(
+            toString(properties.$mcp_intent),
+            timestamp,
+            coalesce(toString(properties.$mcp_intent), '') != ''
+        ) AS first_intent,
+        count() AS calls,
+        countIf(toString(properties.$mcp_is_error) IN ('true', '1')) AS errors
+    FROM events
+    WHERE event = {event}
+        AND timestamp >= now() - INTERVAL {lookback_days} DAY
+        AND $session_id != ''
+    GROUP BY session_id
+    HAVING first_intent != ''
+)
+GROUP BY first_intent
+HAVING n_sessions >= {min_sessions}
+ORDER BY n_sessions DESC
+LIMIT {max_recurring}
+"""
+
+
+def fetch_recurring_intents(
+    team: Team,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    min_sessions: int = RECURRING_MIN_SESSIONS,
+    limit: int = MAX_RECURRING_INTENTS,
+) -> list[RecurringIntent]:
+    """Return intent texts that open ``min_sessions``-plus sessions in the window.
+
+    These are scheduled agents, crons, and scout runs: they repeat the same
+    opening intent verbatim every run, where interactive intents are almost
+    always unique. Callers surface them as their own ranked list and pass the
+    texts to ``fetch_intent_corpus(exclude_texts=...)`` so they don't dominate
+    the semantic clusters.
+    """
+    query = parse_select(
+        _RECURRING_INTENTS_SQL,
+        placeholders={
+            "event": ast.Constant(value=MCP_TOOL_CALL_EVENT),
+            "lookback_days": ast.Constant(value=lookback_days),
+            "min_sessions": ast.Constant(value=min_sessions),
+            "max_recurring": ast.Constant(value=limit),
+        },
+    )
+    with tags_context(product=Product.MCP, feature=Feature.QUERY, team_id=team.id):
+        response = execute_hogql_query(query=query, team=team)
+
+    # Clip to the corpus text bound so exclusion matching in
+    # fetch_intent_corpus compares like with like; merge any rows the clip
+    # collapses together.
+    merged: dict[str, dict[str, int]] = {}
+    for row in response.results or []:
+        text = str(row[0] or "").strip()[:MAX_INTENT_TEXT_LENGTH]
+        if not text or text == NO_INTENT_RECORDED_FALLBACK:
+            continue
+        bucket = merged.setdefault(text, {"sessions": 0, "calls": 0, "errors": 0})
+        bucket["sessions"] += int(row[1] or 0)
+        bucket["calls"] += int(row[2] or 0)
+        bucket["errors"] += int(row[3] or 0)
+
+    out = [
+        RecurringIntent(
+            intent_text=text,
+            session_count=data["sessions"],
+            call_count=data["calls"],
+            error_count=data["errors"],
+        )
+        for text, data in merged.items()
+    ]
+    out.sort(key=lambda r: r.session_count, reverse=True)
+    return out
 
 
 # Journeys ----------------------------------------------------------------
@@ -570,6 +691,8 @@ def build_snapshot(
     embeddings: np.ndarray,
     distance_threshold: float = DEFAULT_DISTANCE_THRESHOLD,
     journeys_by_cluster: dict[int, dict[str, Any]] | None = None,
+    recurring: list[RecurringIntent] | None = None,
+    min_cluster_intents: int = MIN_CLUSTER_INTENTS,
 ) -> dict[str, Any]:
     """Aggregate clusters into the JSONB snapshot shape persisted in Postgres.
 
@@ -578,9 +701,13 @@ def build_snapshot(
 
     ``journeys_by_cluster`` is the output of ``aggregate_journeys_per_cluster``
     keyed by cluster id. Optional; clusters without an entry get a null journey.
+
+    Clusters with fewer than ``min_cluster_intents`` members collapse into one
+    ``long_tail`` aggregate; ``recurring`` entries (from
+    ``fetch_recurring_intents``) are serialised alongside the clusters.
     """
     if len(records) == 0:
-        return _empty_snapshot(distance_threshold, n_intents=0)
+        return _empty_snapshot(distance_threshold, n_intents=0, recurring=recurring)
     assert len(records) == len(labels) == len(embeddings), (
         f"records ({len(records)}), labels ({len(labels)}), and embeddings ({len(embeddings)}) must be the same length"
     )
@@ -633,32 +760,77 @@ def build_snapshot(
             }
         )
 
+    # Collapse sub-threshold clusters into one long-tail aggregate — rendering
+    # them as rows turns the page into a session list.
+    kept = [c for c in clusters if c["intent_count"] >= min_cluster_intents]
+    tail = [c for c in clusters if c["intent_count"] < min_cluster_intents]
+    long_tail: dict[str, Any] | None = None
+    if tail:
+        tail_calls = sum(c["call_count"] for c in tail)
+        tail_errors = sum(c["error_count"] for c in tail)
+        tail_samples = [
+            intent
+            for cluster in sorted(tail, key=lambda c: c["call_count"], reverse=True)
+            for intent in cluster["sample_intents"]
+        ]
+        long_tail = {
+            "intent_count": sum(c["intent_count"] for c in tail),
+            "session_count": sum(c["session_count"] for c in tail),
+            "call_count": tail_calls,
+            "error_count": tail_errors,
+            "error_rate_pct": round(100.0 * tail_errors / tail_calls, 1) if tail_calls else 0.0,
+            "sample_intents": tail_samples[:MAX_LONG_TAIL_SAMPLES],
+        }
+
     # Sort clusters by call volume desc so the UI shows the most impactful first.
-    clusters.sort(key=lambda c: c["call_count"], reverse=True)
+    kept.sort(key=lambda c: c["call_count"], reverse=True)
 
     # Persist only the highest-volume clusters; ``n_clusters`` keeps the full
-    # count so the UI can say how many the run actually found.
-    n_clusters_total = len(clusters)
-    del clusters[MAX_SNAPSHOT_CLUSTERS:]
+    # count so the UI can say how many the run actually found. The cap applies to
+    # `kept` because that is what ships — sub-threshold clusters are already
+    # aggregated into `long_tail` rather than counted as rows.
+    n_clusters_total = len(kept)
+    del kept[MAX_SNAPSHOT_CLUSTERS:]
 
     return {
-        "clusters": clusters,
+        "clusters": kept,
+        "long_tail": long_tail,
+        "recurring": _serialize_recurring(recurring),
         "computed_with": {
             "distance_threshold": distance_threshold,
             "embedding_model": EMBEDDING_MODEL,
             "n_intents": len(records),
             "n_clusters": n_clusters_total,
+            "n_long_tail_intents": long_tail["intent_count"] if long_tail else 0,
         },
     }
 
 
-def _empty_snapshot(distance_threshold: float, n_intents: int) -> dict[str, Any]:
+def _serialize_recurring(recurring: list[RecurringIntent] | None) -> list[dict[str, Any]]:
+    return [
+        {
+            "intent_text": r.intent_text,
+            "session_count": r.session_count,
+            "call_count": r.call_count,
+            "error_count": r.error_count,
+            "error_rate_pct": round(100.0 * r.error_count / r.call_count, 1) if r.call_count else 0.0,
+        }
+        for r in recurring or []
+    ]
+
+
+def _empty_snapshot(
+    distance_threshold: float, n_intents: int, recurring: list[RecurringIntent] | None = None
+) -> dict[str, Any]:
     return {
         "clusters": [],
+        "long_tail": None,
+        "recurring": _serialize_recurring(recurring),
         "computed_with": {
             "distance_threshold": distance_threshold,
             "embedding_model": EMBEDDING_MODEL,
             "n_intents": n_intents,
             "n_clusters": 0,
+            "n_long_tail_intents": 0,
         },
     }

--- a/products/mcp_analytics/backend/logic.py
+++ b/products/mcp_analytics/backend/logic.py
@@ -680,6 +680,8 @@ def get_intent_cluster_snapshot(team: Team) -> contracts.IntentClusterSnapshot:
 
     blob = snapshot.clusters or {}
     clusters_raw = blob.get("clusters", []) if isinstance(blob, dict) else []
+    long_tail_raw = blob.get("long_tail") if isinstance(blob, dict) else None
+    recurring_raw = blob.get("recurring", []) if isinstance(blob, dict) else []
     meta_raw = blob.get("computed_with") if isinstance(blob, dict) else None
 
     # Snapshots persisted before build_snapshot capped its output can hold
@@ -698,6 +700,8 @@ def get_intent_cluster_snapshot(team: Team) -> contracts.IntentClusterSnapshot:
         last_computed_at=snapshot.last_computed_at,
         last_computed_by_email=snapshot.last_computed_by.email if snapshot.last_computed_by else "",
         clusters=[_to_cluster_dto(item) for item in clusters_raw if isinstance(item, dict)],
+        long_tail=_to_long_tail_dto(long_tail_raw) if isinstance(long_tail_raw, dict) else None,
+        recurring=[_to_recurring_dto(item) for item in recurring_raw if isinstance(item, dict)],
         computed_with=_to_meta_dto(meta_raw) if isinstance(meta_raw, dict) else None,
     )
 
@@ -742,6 +746,27 @@ def _to_journey_dto(journey: dict[str, Any]) -> contracts.IntentClusterJourney:
         paths=[_to_journey_path_dto(p) for p in journey.get("paths", []) if isinstance(p, dict)],
         total_sessions=int(journey.get("total_sessions", 0)),
         leak=(_to_journey_path_dto(journey["leak"]) if isinstance(journey.get("leak"), dict) else None),
+    )
+
+
+def _to_long_tail_dto(item: dict[str, Any]) -> contracts.IntentClusterLongTail:
+    return contracts.IntentClusterLongTail(
+        intent_count=int(item.get("intent_count", 0)),
+        session_count=int(item.get("session_count", 0)),
+        call_count=int(item.get("call_count", 0)),
+        error_count=int(item.get("error_count", 0)),
+        error_rate_pct=float(item.get("error_rate_pct", 0.0)),
+        sample_intents=[str(s) for s in item.get("sample_intents", []) if isinstance(s, str)],
+    )
+
+
+def _to_recurring_dto(item: dict[str, Any]) -> contracts.RecurringIntentEntry:
+    return contracts.RecurringIntentEntry(
+        intent_text=str(item.get("intent_text", "")),
+        session_count=int(item.get("session_count", 0)),
+        call_count=int(item.get("call_count", 0)),
+        error_count=int(item.get("error_count", 0)),
+        error_rate_pct=float(item.get("error_rate_pct", 0.0)),
     )
 
 

--- a/products/mcp_analytics/backend/presentation/serializers.py
+++ b/products/mcp_analytics/backend/presentation/serializers.py
@@ -493,6 +493,41 @@ class MCPIntentClusterSerializer(serializers.Serializer):
     )
 
 
+class MCPIntentClusterLongTailSerializer(serializers.Serializer):
+    intent_count = serializers.IntegerField(
+        read_only=True, help_text="Number of intents that clustered below the minimum cluster size."
+    )
+    session_count = serializers.IntegerField(
+        read_only=True, help_text="Number of sessions represented by the long-tail intents."
+    )
+    call_count = serializers.IntegerField(read_only=True, help_text="Total tool calls across all long-tail intents.")
+    error_count = serializers.IntegerField(
+        read_only=True, help_text="Total error responses across all long-tail intents."
+    )
+    error_rate_pct = serializers.FloatField(
+        read_only=True, help_text="Aggregate error rate across long-tail tool calls, 0–100."
+    )
+    sample_intents = serializers.ListField(
+        child=serializers.CharField(),
+        read_only=True,
+        help_text="Up to ten representative long-tail intent strings, ordered by call volume desc.",
+    )
+
+
+class MCPRecurringIntentSerializer(serializers.Serializer):
+    intent_text = serializers.CharField(
+        read_only=True, help_text="The exact intent text repeated verbatim across sessions."
+    )
+    session_count = serializers.IntegerField(
+        read_only=True, help_text="Number of sessions in the window that opened with this intent."
+    )
+    call_count = serializers.IntegerField(read_only=True, help_text="Total tool calls across those sessions.")
+    error_count = serializers.IntegerField(read_only=True, help_text="Total error responses across those sessions.")
+    error_rate_pct = serializers.FloatField(
+        read_only=True, help_text="Aggregate error rate across those sessions' tool calls, 0–100."
+    )
+
+
 class MCPIntentClusterSnapshotMetaSerializer(serializers.Serializer):
     distance_threshold = serializers.FloatField(
         read_only=True, help_text="Cosine distance threshold used by the clustering algorithm."
@@ -521,7 +556,28 @@ class MCPIntentClusterSnapshotSerializer(serializers.Serializer):
         allow_blank=True,
         help_text="Email of the user who triggered the latest recompute, empty for system-triggered runs.",
     )
-    clusters = MCPIntentClusterSerializer(many=True, read_only=True, help_text="All clusters in the snapshot.")
+    clusters = MCPIntentClusterSerializer(
+        many=True,
+        read_only=True,
+        help_text="Clusters that met the minimum member count, sorted by call volume desc.",
+    )
+    long_tail = MCPIntentClusterLongTailSerializer(
+        read_only=True,
+        allow_null=True,
+        help_text=(
+            "Aggregate of intents whose clusters fell below the minimum member count. "
+            "Null when every cluster met the minimum."
+        ),
+    )
+    recurring = MCPRecurringIntentSerializer(
+        many=True,
+        read_only=True,
+        help_text=(
+            "Intent texts repeated verbatim across many sessions — automated traffic "
+            "(scheduled agents, crons, scout runs) excluded from the semantic clusters, "
+            "ranked by session count desc."
+        ),
+    )
     computed_with = MCPIntentClusterSnapshotMetaSerializer(
         read_only=True,
         allow_null=True,

--- a/products/mcp_analytics/backend/tests/test_intent_clustering.py
+++ b/products/mcp_analytics/backend/tests/test_intent_clustering.py
@@ -31,6 +31,7 @@ from products.mcp_analytics.backend.intent_clustering import (
     MAX_INTENT_TEXT_LENGTH,
     NO_INTENT_RECORDED_FALLBACK,
     IntentRecord,
+    RecurringIntent,
     _content_hash,
     _decode_embedding,
     _encode_embedding,
@@ -40,6 +41,7 @@ from products.mcp_analytics.backend.intent_clustering import (
     cluster_embeddings,
     embed_intents_async,
     fetch_intent_corpus,
+    fetch_recurring_intents,
     fetch_session_journeys,
 )
 from products.mcp_analytics.backend.models import MCPIntentEmbeddingCache, MCPSession
@@ -199,10 +201,79 @@ class TestBuildSnapshot:
         labels = np.array([0, 1], dtype=np.int64)
         embeddings = np.array([_unit([1.0, 0.0]), _unit([0.0, 1.0])], dtype=np.float32)
 
-        snapshot = build_snapshot(records, labels, embeddings)
+        snapshot = build_snapshot(records, labels, embeddings, min_cluster_intents=1)
 
         assert snapshot["clusters"][0]["label"] == "popular intent"
         assert snapshot["clusters"][1]["label"] == "rare intent"
+
+    def test_singleton_clusters_collapse_into_long_tail(self) -> None:
+        records = [
+            IntentRecord(
+                intent_text="check flag rollout",
+                frequency=8,
+                session_count=2,
+                tool_counts={"feature_flag_get": 8},
+            ),
+            IntentRecord(
+                intent_text="look up flag status",
+                frequency=4,
+                session_count=1,
+                tool_counts={"feature_flag_get": 4},
+            ),
+            IntentRecord(
+                intent_text="one-off question",
+                frequency=3,
+                session_count=1,
+                tool_counts={"query_run": 3},
+                error_counts={"query_run": 1},
+            ),
+        ]
+        labels = np.array([0, 0, 1], dtype=np.int64)
+        embeddings = np.array([_unit([1.0, 0.1]), _unit([1.0, 0.0]), _unit([0.0, 1.0])], dtype=np.float32)
+
+        snapshot = build_snapshot(records, labels, embeddings)
+
+        assert [c["label"] for c in snapshot["clusters"]] == ["check flag rollout"]
+        long_tail = snapshot["long_tail"]
+        assert long_tail["intent_count"] == 1
+        assert long_tail["session_count"] == 1
+        assert long_tail["call_count"] == 3
+        assert long_tail["error_count"] == 1
+        assert long_tail["error_rate_pct"] == pytest.approx(33.3, abs=0.1)
+        assert long_tail["sample_intents"] == ["one-off question"]
+        assert snapshot["computed_with"]["n_clusters"] == 1
+        assert snapshot["computed_with"]["n_long_tail_intents"] == 1
+
+    def test_no_long_tail_when_all_clusters_meet_min_size(self) -> None:
+        records = [
+            IntentRecord(intent_text="a", frequency=2, session_count=1, tool_counts={"tool_a": 2}),
+            IntentRecord(intent_text="b", frequency=1, session_count=1, tool_counts={"tool_a": 1}),
+        ]
+        labels = np.array([0, 0], dtype=np.int64)
+        embeddings = np.array([_unit([1.0, 0.1]), _unit([1.0, 0.0])], dtype=np.float32)
+
+        snapshot = build_snapshot(records, labels, embeddings)
+
+        assert snapshot["long_tail"] is None
+
+    def test_recurring_entries_are_embedded_in_blob(self) -> None:
+        recurring = [
+            RecurringIntent(intent_text="daily demo check", session_count=61, call_count=610, error_count=300),
+        ]
+
+        snapshot = build_snapshot(
+            [], np.array([], dtype=np.int64), np.zeros((0, 4), dtype=np.float32), recurring=recurring
+        )
+
+        assert snapshot["recurring"] == [
+            {
+                "intent_text": "daily demo check",
+                "session_count": 61,
+                "call_count": 610,
+                "error_count": 300,
+                "error_rate_pct": 49.2,
+            }
+        ]
 
     def test_sample_intents_capped_and_sorted_by_frequency(self) -> None:
         records = [
@@ -245,20 +316,25 @@ class TestBuildSnapshot:
         # A degenerate run (tight threshold, diverse corpus) can label almost every
         # intent as its own cluster; without the cap the persisted blob and the
         # unpaginated API response grow unbounded.
+        # Two intents per cluster so every cluster clears MIN_CLUSTER_INTENTS and stays a
+        # row — a singleton-per-cluster corpus is absorbed by the long-tail aggregate
+        # instead, which is a different guard.
         n_total = MAX_SNAPSHOT_CLUSTERS + 5
         records = [
-            IntentRecord(intent_text=f"intent_{i}", frequency=i + 1, tool_counts={"tool_a": i + 1})
+            IntentRecord(intent_text=f"intent_{i}_{half}", frequency=i + 1, tool_counts={"tool_a": i + 1})
             for i in range(n_total)
+            for half in range(2)
         ]
-        labels = np.arange(n_total, dtype=np.int64)
-        embeddings = np.array([_unit([1.0, float(i + 1)]) for i in range(n_total)], dtype=np.float32)
+        labels = np.repeat(np.arange(n_total, dtype=np.int64), 2)
+        embeddings = np.array([_unit([1.0, float(i + 1)]) for i in range(n_total) for _ in range(2)], dtype=np.float32)
 
         snapshot = build_snapshot(records, labels, embeddings)
 
         assert len(snapshot["clusters"]) == MAX_SNAPSHOT_CLUSTERS
         assert snapshot["computed_with"]["n_clusters"] == n_total
-        # The highest-volume clusters are the ones kept (call counts 1..n_total; the 5 smallest drop).
-        assert min(cluster["call_count"] for cluster in snapshot["clusters"]) == 6
+        assert snapshot["long_tail"] is None
+        # Each cluster's call_count is 2*(i+1); the 5 smallest drop, so the floor is 2*6.
+        assert min(cluster["call_count"] for cluster in snapshot["clusters"]) == 12
 
 
 # fetch_intent_corpus -----------------------------------------------------
@@ -366,6 +442,17 @@ class TestFetchIntentCorpus(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixi
         records, _ = fetch_intent_corpus(self.team, lookback_days=lookback_days)
 
         assert [r.intent_text for r in records] == expected_intents
+
+    def test_exclude_texts_drops_matching_sessions_from_corpus(self) -> None:
+        self._seed_tool_call("cron-1", "execute-sql", intent="recurring bot intent")
+        self._seed_tool_call("cron-2", "execute-sql", intent="recurring bot intent")
+        self._seed_tool_call("human-1", "query-trends", intent="unique human question")
+        flush_persons_and_events()
+
+        records, intent_by_session = fetch_intent_corpus(self.team, exclude_texts={"recurring bot intent"})
+
+        assert {r.intent_text for r in records} == {"unique human question"}
+        assert set(intent_by_session) == {"human-1"}
 
     def test_builds_corpus_from_event_intents_without_session_rows(self) -> None:
         # Two intents in one session: the chronologically first one represents it.
@@ -475,6 +562,65 @@ class TestFetchIntentCorpus(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixi
 
         journeys = fetch_session_journeys(self.team, list(intent_by_session.keys()))
         assert len(journeys) == n_sessions
+
+
+# fetch_recurring_intents --------------------------------------------------
+
+
+class TestFetchRecurringIntents(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixin, BaseTest):
+    def _seed_tool_call(
+        self,
+        session_id: str,
+        tool_name: str,
+        is_error: bool = False,
+        intent: str | None = None,
+    ) -> None:
+        properties: dict[str, Any] = {
+            "$session_id": session_id,
+            "$mcp_tool_name": tool_name,
+            "$mcp_is_error": is_error,
+        }
+        if intent is not None:
+            properties["$mcp_intent"] = intent
+        _create_event(
+            event_uuid=uuid.uuid4(),
+            event="$mcp_tool_call",
+            team=self.team,
+            distinct_id="seed",
+            timestamp=datetime.now(tz=UTC) - timedelta(hours=1),
+            properties=properties,
+        )
+
+    def test_repeated_first_intent_aggregates_sessions_calls_and_errors(self) -> None:
+        # Three cron sessions opening with the same intent; later calls in the
+        # session carry no intent but must still count toward call volume.
+        for i in range(3):
+            self._seed_tool_call(f"cron-{i}", "execute-sql", intent="daily demo check", is_error=(i == 0))
+            self._seed_tool_call(f"cron-{i}", "read-data-schema")
+        self._seed_tool_call("human-1", "query-trends", intent="one-off question")
+        flush_persons_and_events()
+
+        out = fetch_recurring_intents(self.team, min_sessions=3)
+
+        assert [r.intent_text for r in out] == ["daily demo check"]
+        assert out[0].session_count == 3
+        assert out[0].call_count == 6
+        assert out[0].error_count == 1
+
+    @parameterized.expand(
+        [
+            ("below_threshold_excluded", 3, []),
+            ("at_threshold_included", 2, ["twice repeated"]),
+        ]
+    )
+    def test_min_sessions_threshold(self, _name: str, min_sessions: int, expected: list[str]) -> None:
+        for i in range(2):
+            self._seed_tool_call(f"s-{i}", "execute-sql", intent="twice repeated")
+        flush_persons_and_events()
+
+        out = fetch_recurring_intents(self.team, min_sessions=min_sessions)
+
+        assert [r.intent_text for r in out] == expected
 
 
 # Embedding helpers -----------------------------------------------------

--- a/products/mcp_analytics/backend/tests/test_intent_clustering.py
+++ b/products/mcp_analytics/backend/tests/test_intent_clustering.py
@@ -29,6 +29,7 @@ from products.mcp_analytics.backend.intent_clustering import (
     DEFAULT_DISTANCE_THRESHOLD,
     EMBEDDING_MODEL,
     MAX_INTENT_TEXT_LENGTH,
+    MAX_RECURRING_INTENTS,
     NO_INTENT_RECORDED_FALLBACK,
     IntentRecord,
     RecurringIntent,
@@ -275,6 +276,21 @@ class TestBuildSnapshot:
             }
         ]
 
+    def test_recurring_entries_are_capped_for_display(self) -> None:
+        # The exclusion set is fetched wider than the display cap, so the blob has to
+        # truncate or the whole exclusion list ships to the client.
+        recurring = [
+            RecurringIntent(intent_text=f"bot intent {i}", session_count=3, call_count=3, error_count=0)
+            for i in range(MAX_RECURRING_INTENTS + 25)
+        ]
+
+        snapshot = build_snapshot(
+            [], np.array([], dtype=np.int64), np.zeros((0, 4), dtype=np.float32), recurring=recurring
+        )
+
+        assert len(snapshot["recurring"]) == MAX_RECURRING_INTENTS
+        assert snapshot["recurring"][0]["intent_text"] == "bot intent 0"
+
     def test_sample_intents_capped_and_sorted_by_frequency(self) -> None:
         records = [
             IntentRecord(intent_text=f"intent_{i}", frequency=10 - i, tool_counts={"tool_a": 10 - i}) for i in range(5)
@@ -453,6 +469,21 @@ class TestFetchIntentCorpus(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixi
 
         assert {r.intent_text for r in records} == {"unique human question"}
         assert set(intent_by_session) == {"human-1"}
+
+    def test_exclude_texts_drops_recurring_sessions_that_also_have_an_llm_summary(self) -> None:
+        # The summary overlay replaces a session's event intent, so matching only on the
+        # final text lets an automated session back into the semantic corpus under its
+        # summary — exactly what the recurring split exists to prevent.
+        self._seed_tool_call("cron-1", "execute-sql", intent="recurring bot intent")
+        self._seed_tool_call("cron-2", "execute-sql", intent="recurring bot intent")
+        self._seed_tool_call("human-1", "query-trends", intent="unique human question")
+        flush_persons_and_events()
+        self._seed_session("cron-1", "Summarised nightly rollup run")
+
+        records, intent_by_session = fetch_intent_corpus(self.team, exclude_texts={"recurring bot intent"})
+
+        assert set(intent_by_session) == {"human-1"}
+        assert {r.intent_text for r in records} == {"unique human question"}
 
     def test_builds_corpus_from_event_intents_without_session_rows(self) -> None:
         # Two intents in one session: the chronologically first one represents it.

--- a/products/mcp_analytics/backend/tests/test_logic.py
+++ b/products/mcp_analytics/backend/tests/test_logic.py
@@ -122,6 +122,51 @@ class TestGetIntentClusterSnapshot(_MCPAnalyticsTeamScopedTestMixin, APIBaseTest
         assert cluster.tool_distribution[0].error_rate_pct == 8.3
         assert snapshot.computed_with is not None
         assert snapshot.computed_with.n_clusters == 1
+        # Blobs written before the long-tail/recurring split must still map.
+        assert snapshot.long_tail is None
+        assert snapshot.recurring == []
+
+    def test_maps_long_tail_and_recurring_blob_keys(self) -> None:
+        MCPIntentClusterSnapshot.objects.create(
+            team=self.team,
+            status=MCPIntentClusterSnapshot.Status.IDLE,
+            last_computed_at=timezone.now(),
+            clusters={
+                "clusters": [],
+                "long_tail": {
+                    "intent_count": 42,
+                    "session_count": 44,
+                    "call_count": 610,
+                    "error_count": 12,
+                    "error_rate_pct": 2.0,
+                    "sample_intents": ["one-off question"],
+                },
+                "recurring": [
+                    {
+                        "intent_text": "daily demo check",
+                        "session_count": 61,
+                        "call_count": 610,
+                        "error_count": 300,
+                        "error_rate_pct": 49.2,
+                    }
+                ],
+                "computed_with": {
+                    "distance_threshold": 0.4,
+                    "embedding_model": "text-embedding-3-small-1536",
+                    "n_intents": 43,
+                    "n_clusters": 0,
+                },
+            },
+        )
+
+        snapshot = logic.get_intent_cluster_snapshot(self.team)
+
+        assert snapshot.long_tail is not None
+        assert snapshot.long_tail.intent_count == 42
+        assert snapshot.long_tail.sample_intents == ["one-off question"]
+        assert len(snapshot.recurring) == 1
+        assert snapshot.recurring[0].intent_text == "daily demo check"
+        assert snapshot.recurring[0].error_rate_pct == 49.2
 
     def test_caps_clusters_from_an_oversized_stored_blob(self) -> None:
         # Snapshots persisted before the build-side cap can hold hundreds of

--- a/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.test.ts
+++ b/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.test.ts
@@ -50,6 +50,8 @@ const SNAPSHOT: MCPIntentClusterSnapshotApi = {
         // only enters the visible set under the errors sort.
         cluster(i, i === HIGH_ERROR_ID ? { error_rate_pct: 50, error_count: 10 } : {})
     ),
+    long_tail: null,
+    recurring: [],
     computed_with: {
         distance_threshold: 0.2,
         embedding_model: 'test',

--- a/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.ts
+++ b/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.ts
@@ -14,6 +14,8 @@ const EMPTY_SNAPSHOT: MCPIntentClusterSnapshotApi = {
     last_computed_at: null,
     last_computed_by_email: '',
     clusters: [],
+    long_tail: null,
+    recurring: [],
     computed_with: null,
 }
 

--- a/products/mcp_analytics/frontend/generated/api.schemas.ts
+++ b/products/mcp_analytics/frontend/generated/api.schemas.ts
@@ -225,6 +225,34 @@ export interface MCPIntentClusterApi {
     readonly journey: MCPIntentClusterJourneyApi | null
 }
 
+export interface MCPIntentClusterLongTailApi {
+    /** Number of intents that clustered below the minimum cluster size. */
+    readonly intent_count: number
+    /** Number of sessions represented by the long-tail intents. */
+    readonly session_count: number
+    /** Total tool calls across all long-tail intents. */
+    readonly call_count: number
+    /** Total error responses across all long-tail intents. */
+    readonly error_count: number
+    /** Aggregate error rate across long-tail tool calls, 0–100. */
+    readonly error_rate_pct: number
+    /** Up to ten representative long-tail intent strings, ordered by call volume desc. */
+    readonly sample_intents: readonly string[]
+}
+
+export interface MCPRecurringIntentApi {
+    /** The exact intent text repeated verbatim across sessions. */
+    readonly intent_text: string
+    /** Number of sessions in the window that opened with this intent. */
+    readonly session_count: number
+    /** Total tool calls across those sessions. */
+    readonly call_count: number
+    /** Total error responses across those sessions. */
+    readonly error_count: number
+    /** Aggregate error rate across those sessions' tool calls, 0–100. */
+    readonly error_rate_pct: number
+}
+
 export interface MCPIntentClusterSnapshotMetaApi {
     /** Cosine distance threshold used by the clustering algorithm. */
     readonly distance_threshold: number
@@ -252,8 +280,12 @@ export interface MCPIntentClusterSnapshotApi {
     readonly last_computed_at: string | null
     /** Email of the user who triggered the latest recompute, empty for system-triggered runs. */
     readonly last_computed_by_email: string
-    /** All clusters in the snapshot. */
+    /** Clusters that met the minimum member count, sorted by call volume desc. */
     readonly clusters: readonly MCPIntentClusterApi[]
+    /** Aggregate of intents whose clusters fell below the minimum member count. Null when every cluster met the minimum. */
+    readonly long_tail: MCPIntentClusterLongTailApi | null
+    /** Intent texts repeated verbatim across many sessions — automated traffic (scheduled agents, crons, scout runs) excluded from the semantic clusters, ranked by session count desc. */
+    readonly recurring: readonly MCPRecurringIntentApi[]
     /** Settings used to produce the snapshot. Null when no snapshot has been computed yet. */
     readonly computed_with: MCPIntentClusterSnapshotMetaApi | null
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -39327,6 +39327,21 @@ export namespace Schemas {
       readonly journey: MCPIntentClusterJourney | null;
     }
 
+    export interface MCPIntentClusterLongTail {
+      /** Number of intents that clustered below the minimum cluster size. */
+      readonly intent_count: number;
+      /** Number of sessions represented by the long-tail intents. */
+      readonly session_count: number;
+      /** Total tool calls across all long-tail intents. */
+      readonly call_count: number;
+      /** Total error responses across all long-tail intents. */
+      readonly error_count: number;
+      /** Aggregate error rate across long-tail tool calls, 0–100. */
+      readonly error_rate_pct: number;
+      /** Up to ten representative long-tail intent strings, ordered by call volume desc. */
+      readonly sample_intents: readonly string[];
+    }
+
     /**
      * * `idle` - Idle
      * * `computing` - Computing
@@ -39340,6 +39355,19 @@ export namespace Schemas {
       Computing: 'computing',
       Error: 'error',
     } as const;
+
+    export interface MCPRecurringIntent {
+      /** The exact intent text repeated verbatim across sessions. */
+      readonly intent_text: string;
+      /** Number of sessions in the window that opened with this intent. */
+      readonly session_count: number;
+      /** Total tool calls across those sessions. */
+      readonly call_count: number;
+      /** Total error responses across those sessions. */
+      readonly error_count: number;
+      /** Aggregate error rate across those sessions' tool calls, 0–100. */
+      readonly error_rate_pct: number;
+    }
 
     export interface MCPIntentClusterSnapshotMeta {
       /** Cosine distance threshold used by the clustering algorithm. */
@@ -39368,8 +39396,12 @@ export namespace Schemas {
       readonly last_computed_at: string | null;
       /** Email of the user who triggered the latest recompute, empty for system-triggered runs. */
       readonly last_computed_by_email: string;
-      /** All clusters in the snapshot. */
+      /** Clusters that met the minimum member count, sorted by call volume desc. */
       readonly clusters: readonly MCPIntentCluster[];
+      /** Aggregate of intents whose clusters fell below the minimum member count. Null when every cluster met the minimum. */
+      readonly long_tail: MCPIntentClusterLongTail | null;
+      /** Intent texts repeated verbatim across many sessions — automated traffic (scheduled agents, crons, scout runs) excluded from the semantic clusters, ranked by session count desc. */
+      readonly recurring: readonly MCPRecurringIntent[];
       /** Settings used to produce the snapshot. Null when no snapshot has been computed yet. */
       readonly computed_with: MCPIntentClusterSnapshotMeta | null;
     }


### PR DESCRIPTION
## Problem

The intent clustering page became unreadable at production scale. The last recompute produced 355 clusters from 500 intents, with 92% of clusters being a single intent - the page reads as a session list, not clusters. Worse, every top cluster and the top-error KPI were internal automation: scheduled scouts and crons repeat the same intent text verbatim every run, so they dominate any volume ranking, while human intents are almost all unique.

## Changes

Base PR of a two-PR stack (frontend follows).

- New `fetch_recurring_intents`: intent texts that open 3+ sessions in the window, with session/call/error rollups from the full window (not the sampled corpus). Detection is behavioral rather than by client or identity properties, because automation runs under the same consumers and distinct_ids as interactive use (verified against production data: identity-based splits leak in both directions, while a repetition split cleanly separates 172 recurring texts covering ~24K sessions from ~247K unique-intent sessions).
- Recurring texts are excluded from the semantic corpus (`fetch_intent_corpus(exclude_texts=...)`) and serialized into the snapshot blob as their own ranked `recurring` list.
- Clusters below 2 members collapse into one `long_tail` aggregate (counts, error rate, sample intents) instead of rendering as rows.
- `DEFAULT_DISTANCE_THRESHOLD` retuned 0.2 to 0.4: 0.2 produced >90% singletons on free-text diversity. The long-tail bucket makes residual mis-tuning cosmetic rather than page-breaking, and `computed_with` still records the threshold per snapshot.
- Contracts, DTO mapping, and serializers for the two new snapshot fields; old blobs without the keys map to `long_tail=null` / `recurring=[]` (covered by test).

All changes are inside the Temporal activity body and pure functions - no workflow command changes, so no determinism/versioning concerns.

## How did you test this code?

- TDD: new tests written first and watched fail (`fetch_recurring_intents` did not exist; long-tail keys absent), then green.
- New coverage and the regression each piece catches:
  - `TestFetchRecurringIntents`: aggregation across sessions including intent-less follow-up calls, and the min-sessions threshold (parameterized) - a SQL/aggregation bug here silently refills the clusters with automation.
  - `test_exclude_texts_drops_matching_sessions_from_corpus` - exclusion not applied means scout noise returns.
  - `test_singleton_clusters_collapse_into_long_tail` / `test_no_long_tail_when_all_clusters_meet_min_size` / `test_recurring_entries_are_embedded_in_blob` - blob shape the frontend depends on.
  - `test_maps_long_tail_and_recurring_blob_keys` plus legacy-blob assertions - production currently has an old-format blob; a mapping crash would take down the endpoint.
- Full `products/mcp_analytics/backend/tests/` + `posthog/temporal/mcp_analytics/`: 142 passed locally.
- `hogli build:openapi` regenerated types; `hogli ci:preflight --fix` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs under `docs/` describe the clustering pipeline internals.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Skills invoked: `/writing-tests`, `/improving-drf-endpoints`, `/writing-user-facing-copy`.
- The recurring-detection design was validated against live production data first: consumer/client properties and distinct_ids both fail to separate scout runs from human desktop sessions (same identities do both), while exact-text repetition separates them cleanly. The repetition threshold (3+ sessions) and the shape of the distribution (86% of sessions have a globally unique first intent) come from that investigation.
- Considered identity/property-based filtering and rejected it as fragile; considered keeping the 0.2 threshold and rejected it after measuring 92% singletons on the live corpus.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*