### PR TITLE
feat(mcp-analytics): replace clustering tool matrix with ranked cluster rows

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6459,9 +6459,9 @@ snapshots:
     scenes-app-mcp-analytics--dashboard-with-menu-bar--light:
         hash: v1.k794b7964.0ac0bf1b02890312bdc239db7a4842f1a377468aa9c5ad67c926aecaccf510ce.V7Onp6uOX4j46-gDndut-qkT9N6LwIUCq5z4hVn-VZg
     scenes-app-mcp-analytics--intent-clustering--dark:
-        hash: v1.k794b7964.93cb428637db03234a4d0d09b51ef886d95ab801bb3e4dc6ca0f1ba3824b9fe3.JeUzojRsSPumu87KUEx7WXtojxL5GEF98Ps9CVS7WAY
+        hash: v1.k794b7964.826b206a98401ec26cf96311b2e5ecce14b9fe091af3cb1b1d6f98fcd4a62640.6BmJbXIQ7QI2eNFDI1N5x4vxm1h8NXrt3wbHrQMtHXA
     scenes-app-mcp-analytics--intent-clustering--light:
-        hash: v1.k794b7964.ef2b5829c6089a3de0ad09c44f8dbeaf2195187569a83422b32ff21712e68251.JCSWUIyzmDcXs1lun_Ym3-i7Z0YBcusaI-amLEFlXs0
+        hash: v1.k794b7964.91c4b917275ac5b48324ea171a011f11d15b9cd0aa2c89742631b0ec9a6b2934.09pdkZHfRMqYHLEdXjmgtWSamZhtMkvziQHEDD3utcY
     scenes-app-mcp-analytics--sessions--dark:
         hash: v1.k794b7964.e44b6747efcbc630753707078c16ebb36a05f9701fa89c014d8eebec1eabc4fb.i5C5Ib24E2xi_tzTLXniz3WM8UKaAFOj4aqVnMmtIiI
     scenes-app-mcp-analytics--sessions--light:
@@ -7762,6 +7762,10 @@ snapshots:
         hash: v1.k794b7964.8ebd0fb0b9db1f2cc68bcb63d890a44003403e27688a938e5cb04fbffb3b5d5e.aKxLz7jngQZcJL6b0nrArk3V-pDEoGNoPsYUiGbIYy4
     scenes-other-onboarding-shared-wizard-sync-card--local-running--light:
         hash: v1.k794b7964.644de0941a464befbdd1c1173307918762ec7bf580d08b6bb73e0170da71ab57.roPN1jIIWT47y5Xh3Gluqd744nCUVhJkfniX1oq__3M
+    scenes-other-onboarding-shared-wizard-sync-card--local-running-started-by-teammate--dark:
+        hash: v1.k794b7964.9238cd8306270044b6be400d8b253942a6ebc7639dac27e091afe3afb5900291.1tQS7yVR_gZ7fmjjzoegrw7GXmePG9-QafLgOaddLfo
+    scenes-other-onboarding-shared-wizard-sync-card--local-running-started-by-teammate--light:
+        hash: v1.k794b7964.311090aa83634a64027ca60d44a1ac93ecb22124f9144032439c364e0e513105.jEWKZmu_Lw9ugOlP0970x-jQom-SKcWM7N__q-UTgT8
     scenes-other-onboarding-shared-wizard-sync-card--local-waiting-for-input--dark:
         hash: v1.k794b7964.882a0f73b32a910ae1582ef69720f025078bc35867e04d6a03e4931999999ae1.udwLNxP_oZh1qhyS1Ce07RtoSfNpckSBGlOxC41rVp0
     scenes-other-onboarding-shared-wizard-sync-card--local-waiting-for-input--light:
@@ -7770,10 +7774,6 @@ snapshots:
         hash: v1.k794b7964.f074463c40fd8b34d0ca55c651b409fb35668ecc69fefb4e631208b3f5db1bde.zioGxlu5eKa64EXl2wzmAT4K-EC_0eK5uoUMxZIu98Y
     scenes-other-onboarding-shared-wizard-sync-card--local-waiting-for-sensitive-input--light:
         hash: v1.k794b7964.57524d53d6835dd9472c87a6aca291266fb8e8971d95ba311842386f94347fc8.sMjUBzJVzLkCThwa5LT8ntVK63w5tJ0lYltmn2pD70E
-    scenes-other-onboarding-shared-wizard-sync-card--local-running-started-by-teammate--dark:
-        hash: v1.k794b7964.9238cd8306270044b6be400d8b253942a6ebc7639dac27e091afe3afb5900291.1tQS7yVR_gZ7fmjjzoegrw7GXmePG9-QafLgOaddLfo
-    scenes-other-onboarding-shared-wizard-sync-card--local-running-started-by-teammate--light:
-        hash: v1.k794b7964.311090aa83634a64027ca60d44a1ac93ecb22124f9144032439c364e0e513105.jEWKZmu_Lw9ugOlP0970x-jQom-SKcWM7N__q-UTgT8
     scenes-other-onboarding-shared-wizard-sync-card--playground--dark:
         hash: v1.k794b7964.c69534afe39d0311b0ed3247beb145b94381706a25f2e6c7b5d3415c87564375.ViSw0_amXLmDYynCEuR_kgnY5Ncm4ULveglgIJoTIaU
     scenes-other-onboarding-shared-wizard-sync-card--playground--light:

--- a/products/mcp_analytics/frontend/clustering/MCPAnalyticsClustering.tsx
+++ b/products/mcp_analytics/frontend/clustering/MCPAnalyticsClustering.tsx
@@ -20,6 +20,7 @@ import { TZLabel } from 'lib/components/TZLabel'
 import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 
 import type { MCPIntentClusterApi, MCPIntentClusterToolEntryApi } from '../generated/api.schemas'
+import { KPI_MIN_SESSIONS } from './clusteringScorecards'
 import { ClusterJourneySankey } from './ClusterJourneySankey'
 import { ClusterSortKey, mcpClusteringLogic } from './mcpClusteringLogic'
 
@@ -60,53 +61,42 @@ function EntropyBadge({ entropy }: { entropy: number }): JSX.Element {
     )
 }
 
-function HeatmapCell({
-    entry,
-    size,
-    rowMaxCount,
-}: {
-    entry: MCPIntentClusterToolEntryApi | undefined
-    size: number
-    rowMaxCount: number
-}): JSX.Element {
-    const sizeStyle = { width: size, height: size }
-    if (!entry || entry.count === 0) {
-        return (
-            <div
-                className="rounded-[2px] bg-surface-secondary/30"
-                // eslint-disable-next-line react/forbid-dom-props
-                style={sizeStyle}
-                aria-hidden
-            />
-        )
+const TOP_TOOL_CHIPS = 3
+
+function ToolChips({ distribution }: { distribution: readonly MCPIntentClusterToolEntryApi[] }): JSX.Element {
+    if (distribution.length === 0) {
+        return <span className="text-xs text-muted">No tool calls</span>
     }
-    // Scale relative to the row's max — so the most-called tool in each
-    // cluster is fully dark and the rest grade down. A 1-call tool next to
-    // a 50-call tool still shows up clearly thanks to the 0.3 floor.
-    const intensity = rowMaxCount > 0 ? entry.count / rowMaxCount : 0
-    const opacity = Math.max(0.3, Math.min(1, intensity))
-    const hasErrors = entry.error_rate_pct > 0
+    const top = distribution.slice(0, TOP_TOOL_CHIPS)
+    const remainder = distribution.length - top.length
     return (
-        <Tooltip
-            title={
-                <div className="flex flex-col gap-0.5">
-                    <span className="font-semibold">{entry.tool}</span>
-                    <span>{entry.count.toLocaleString()} calls</span>
-                    <span>{entry.pct.toFixed(1)}% of cluster</span>
-                    {hasErrors ? <span className="text-danger">{entry.error_rate_pct.toFixed(1)}% errors</span> : null}
-                </div>
-            }
-        >
-            <div
-                className="rounded-[2px] cursor-help"
-                // eslint-disable-next-line react/forbid-dom-props
-                style={{
-                    ...sizeStyle,
-                    backgroundColor: hasErrors ? 'var(--danger)' : 'var(--accent)',
-                    opacity,
-                }}
-            />
-        </Tooltip>
+        <div className="flex flex-wrap items-center gap-1">
+            {top.map((entry) => (
+                <Tooltip
+                    key={entry.tool}
+                    title={
+                        <div className="flex flex-col gap-0.5">
+                            <span className="font-semibold">{entry.tool}</span>
+                            <span>{entry.count.toLocaleString()} calls</span>
+                            <span>{entry.pct.toFixed(1)}% of cluster</span>
+                            {entry.error_rate_pct > 0 ? (
+                                <span className="text-danger">{entry.error_rate_pct.toFixed(1)}% errors</span>
+                            ) : null}
+                        </div>
+                    }
+                >
+                    <span
+                        className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-mono bg-surface-secondary ${
+                            entry.error_rate_pct > 5 ? 'text-danger' : ''
+                        }`}
+                    >
+                        {entry.tool}
+                        <span className="text-muted tabular-nums">{Math.round(entry.pct)}%</span>
+                    </span>
+                </Tooltip>
+            ))}
+            {remainder > 0 ? <span className="text-[11px] text-muted">+{remainder} more</span> : null}
+        </div>
     )
 }
 
@@ -134,21 +124,24 @@ function Scorecards(): JSX.Element {
                         </span>
                         <span className="text-xs text-muted">({concentratedShare}%)</span>
                     </div>
-                    <span className="text-xs text-muted mt-1">Intent groups where one tool handles ≥80% of calls.</span>
+                    <span className="text-xs text-muted mt-1">
+                        Intent groups with {KPI_MIN_SESSIONS}+ sessions where one tool handles at least 80% of calls.
+                    </span>
                 </div>
                 <div className="bg-surface-primary border rounded p-3 min-h-[88px] flex flex-col">
                     <span className="text-muted text-xs font-medium uppercase">Spread routes</span>
                     <div className="flex items-baseline gap-2 mt-1">
                         <span className="text-2xl font-semibold">{spreadRoutes}</span>
-                        <span className="text-xs text-muted">of {clusters.length}</span>
+                        <span className="text-xs text-muted">of {concentratedRoutes.total}</span>
                     </div>
                     <span className="text-xs text-muted mt-1">
-                        Intent groups where no single tool covers half the calls — possible drift.
+                        Intent groups with {KPI_MIN_SESSIONS}+ sessions where no single tool covers half the calls.
+                        Possible routing drift.
                     </span>
                 </div>
                 <div className="bg-surface-primary border rounded p-3 min-h-[88px] flex flex-col">
                     <span className="text-muted text-xs font-medium uppercase">Top error route</span>
-                    {topErrorRoute && topErrorRoute.error_rate_pct > 0 ? (
+                    {topErrorRoute ? (
                         <>
                             <div className="flex items-baseline gap-2 mt-1">
                                 <span className="text-2xl font-semibold text-danger">
@@ -165,7 +158,9 @@ function Scorecards(): JSX.Element {
                             <div className="flex items-baseline gap-2 mt-1">
                                 <span className="text-2xl font-semibold text-success">0%</span>
                             </div>
-                            <span className="text-xs text-muted mt-1">No errors observed across clusters.</span>
+                            <span className="text-xs text-muted mt-1">
+                                No errors among intent groups with {KPI_MIN_SESSIONS}+ sessions.
+                            </span>
                         </>
                     )}
                 </div>
@@ -194,174 +189,190 @@ function SortHeader(): JSX.Element {
     )
 }
 
-function Heatmap(): JSX.Element {
-    const { visibleClusters, hiddenClusterCount, toolColumns, totalToolCount, selectedClusterId } =
-        useValues(mcpClusteringLogic)
+function ClusterList(): JSX.Element {
+    const { visibleClusters, hiddenClusterCount, longTail, selectedClusterId } = useValues(mcpClusteringLogic)
     const { selectCluster, showAllClusters } = useActions(mcpClusteringLogic)
 
-    if (toolColumns.length === 0) {
+    if (visibleClusters.length === 0 && !longTail) {
         return (
             <div className="bg-surface-primary border rounded p-4 text-center text-muted text-sm">
-                No tool calls observed in any cluster yet.
+                No intent clusters in this window.
             </div>
         )
     }
 
-    // Spacious mode: few tools and shortish names. Bigger cells, horizontal labels.
-    // Compact mode: many tools or long names. Github-style with rotated labels.
-    const longestName = Math.max(...toolColumns.map((t) => t.length))
-    const isSpacious = toolColumns.length <= 6 && longestName <= 14
-
-    const cellSize = isSpacious ? 22 : 14
-    const columnWidth = isSpacious ? 0 : 18 // 0 = let CSS auto-size to label width
-
-    const hiddenToolCount = totalToolCount - toolColumns.length
-
     return (
-        <div className="bg-surface-primary border rounded">
-            <div className="overflow-x-auto">
-                <table className="text-sm border-collapse" style={{ borderSpacing: 0 }}>
-                    <thead>
-                        <tr className="bg-surface-secondary text-[10px] text-muted">
-                            <th className="text-left px-3 py-2 sticky left-0 bg-surface-secondary z-10 min-w-[220px] align-bottom text-xs">
-                                Intent cluster
-                            </th>
-                            {toolColumns.map((tool) =>
-                                isSpacious ? (
-                                    <th
-                                        key={tool}
-                                        className="px-2 pb-1 pt-2 font-medium font-mono text-[11px] text-center align-bottom whitespace-nowrap"
-                                        title={tool}
-                                    >
-                                        {tool}
-                                    </th>
-                                ) : (
-                                    <th
-                                        key={tool}
-                                        className="px-0 pb-1 pt-2 font-medium align-bottom"
-                                        // eslint-disable-next-line react/forbid-dom-props
-                                        style={{ width: columnWidth, minWidth: columnWidth, maxWidth: columnWidth }}
-                                    >
-                                        <div
-                                            className="font-mono text-[10px] mx-auto whitespace-nowrap overflow-hidden text-ellipsis"
-                                            // eslint-disable-next-line react/forbid-dom-props
-                                            style={{
-                                                writingMode: 'vertical-rl',
-                                                transform: 'rotate(180deg)',
-                                                height: 96,
-                                                lineHeight: '18px',
-                                            }}
-                                            title={tool}
-                                        >
-                                            {tool}
-                                        </div>
-                                    </th>
-                                )
-                            )}
-                            <th className="px-3 py-2 text-right text-xs align-bottom">Calls</th>
-                            <th className="px-3 py-2 text-right text-xs align-bottom">Errors</th>
-                            <th className="px-3 py-2 text-left text-xs align-bottom">Routing</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {visibleClusters.map((cluster) => {
-                            const isSelected = cluster.id === selectedClusterId
-                            const byTool = new Map(cluster.tool_distribution.map((e) => [e.tool, e]))
-                            const rowMaxCount = cluster.tool_distribution.reduce(
-                                (max, entry) => Math.max(max, entry.count),
-                                0
-                            )
-                            // Sticky cells need their own background — `tr` backgrounds don't paint
-                            // through to sticky-positioned children when scrolled horizontally.
-                            const rowBg = isSelected
-                                ? 'bg-accent/10'
-                                : 'bg-surface-primary group-hover:bg-surface-secondary/60'
-                            return (
-                                <tr
-                                    key={cluster.id}
-                                    onClick={() => selectCluster(cluster.id)}
-                                    className={`group border-t border-primary cursor-pointer transition-colors ${
-                                        isSelected ? 'bg-accent/10' : 'hover:bg-surface-secondary/60'
-                                    }`}
-                                >
-                                    <td
-                                        className={`px-3 py-1.5 sticky left-0 z-10 min-w-[220px] max-w-[280px] transition-colors ${rowBg}`}
-                                    >
-                                        <div className="flex flex-col">
-                                            <span className="font-medium truncate" title={cluster.label}>
-                                                {cluster.label}
-                                            </span>
-                                            <span className="text-[10px] text-muted">
-                                                {cluster.session_count} session
-                                                {cluster.session_count === 1 ? '' : 's'} · {cluster.intent_count} intent
-                                                {cluster.intent_count === 1 ? '' : 's'}
-                                            </span>
-                                        </div>
-                                    </td>
-                                    {toolColumns.map((tool) => (
-                                        <td
-                                            key={tool}
-                                            className="p-0 align-middle"
-                                            // eslint-disable-next-line react/forbid-dom-props
-                                            style={
-                                                isSpacious
-                                                    ? undefined
-                                                    : {
-                                                          width: columnWidth,
-                                                          minWidth: columnWidth,
-                                                          maxWidth: columnWidth,
-                                                      }
-                                            }
-                                        >
-                                            <div className="flex justify-center items-center py-[2px]">
-                                                <HeatmapCell
-                                                    entry={byTool.get(tool)}
-                                                    size={cellSize}
-                                                    rowMaxCount={rowMaxCount}
-                                                />
-                                            </div>
-                                        </td>
-                                    ))}
-                                    <td className="px-3 py-1.5 text-right tabular-nums text-xs">
-                                        {cluster.call_count.toLocaleString()}
-                                    </td>
-                                    <td
-                                        className={`px-3 py-1.5 text-right tabular-nums text-xs ${
+        <div className="bg-surface-primary border rounded" data-quill>
+            <Table fullWidth>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead expand>Intent cluster</TableHead>
+                        <TableHead>Top tools</TableHead>
+                        <TableHead align="right">Calls</TableHead>
+                        <TableHead align="right">Errors</TableHead>
+                        <TableHead>Routing</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {visibleClusters.map((cluster) => {
+                        const isSelected = cluster.id === selectedClusterId
+                        return (
+                            <TableRow
+                                key={cluster.id}
+                                onClick={() => selectCluster(cluster.id)}
+                                className={`cursor-pointer transition-colors ${
+                                    isSelected ? 'bg-accent/10' : 'hover:bg-surface-secondary/60'
+                                }`}
+                            >
+                                <TableCell expand>
+                                    <div className="flex flex-col max-w-[480px]">
+                                        <span className="font-medium truncate" title={cluster.label}>
+                                            {cluster.label}
+                                        </span>
+                                        <span className="text-[10px] text-muted">
+                                            {cluster.session_count} session
+                                            {cluster.session_count === 1 ? '' : 's'} · {cluster.intent_count} intent
+                                            {cluster.intent_count === 1 ? '' : 's'}
+                                        </span>
+                                    </div>
+                                </TableCell>
+                                <TableCell>
+                                    <ToolChips distribution={cluster.tool_distribution} />
+                                </TableCell>
+                                <TableCell align="right">
+                                    <span className="tabular-nums text-xs">{cluster.call_count.toLocaleString()}</span>
+                                </TableCell>
+                                <TableCell align="right">
+                                    <span
+                                        className={`tabular-nums text-xs ${
                                             cluster.error_rate_pct > 5 ? 'text-danger font-semibold' : ''
                                         }`}
                                     >
                                         {cluster.error_rate_pct.toFixed(1)}%
-                                    </td>
-                                    <td className="px-3 py-1.5">
-                                        <EntropyBadge entropy={cluster.routing_entropy} />
-                                    </td>
-                                </tr>
-                            )
-                        })}
-                    </tbody>
-                </table>
-            </div>
-            {(hiddenClusterCount > 0 || hiddenToolCount > 0) && (
-                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-primary px-3 py-2 text-xs text-muted">
-                    {hiddenClusterCount > 0 ? (
-                        <>
-                            <span>
-                                Showing the top {visibleClusters.length} of{' '}
-                                {visibleClusters.length + hiddenClusterCount} clusters.
-                            </span>
-                            <Button size="sm" variant="outline" onClick={showAllClusters}>
-                                Show all
-                            </Button>
-                        </>
+                                    </span>
+                                </TableCell>
+                                <TableCell>
+                                    <EntropyBadge entropy={cluster.routing_entropy} />
+                                </TableCell>
+                            </TableRow>
+                        )
+                    })}
+                    {longTail ? (
+                        <TableRow>
+                            <TableCell expand>
+                                <div className="flex flex-col">
+                                    <Tooltip
+                                        title={
+                                            <div className="flex flex-col gap-1 max-w-md">
+                                                <span className="font-semibold">Sample one-off intents</span>
+                                                {longTail.sample_intents.map((intent, idx) => (
+                                                    <span key={idx} className="text-xs">
+                                                        &ldquo;{intent}&rdquo;
+                                                    </span>
+                                                ))}
+                                            </div>
+                                        }
+                                    >
+                                        <span className="font-medium text-muted cursor-help">
+                                            Long tail: {longTail.intent_count.toLocaleString()} one-off intents
+                                        </span>
+                                    </Tooltip>
+                                    <span className="text-[10px] text-muted">
+                                        {longTail.session_count.toLocaleString()} session
+                                        {longTail.session_count === 1 ? '' : 's'} that didn&apos;t group with anything
+                                        else
+                                    </span>
+                                </div>
+                            </TableCell>
+                            <TableCell>
+                                <span className="text-xs text-muted">Varied</span>
+                            </TableCell>
+                            <TableCell align="right">
+                                <span className="tabular-nums text-xs">{longTail.call_count.toLocaleString()}</span>
+                            </TableCell>
+                            <TableCell align="right">
+                                <span
+                                    className={`tabular-nums text-xs ${
+                                        longTail.error_rate_pct > 5 ? 'text-danger font-semibold' : ''
+                                    }`}
+                                >
+                                    {longTail.error_rate_pct.toFixed(1)}%
+                                </span>
+                            </TableCell>
+                            <TableCell>
+                                <span className="text-xs text-muted">n/a</span>
+                            </TableCell>
+                        </TableRow>
                     ) : null}
-                    {hiddenToolCount > 0 ? (
-                        <span>
-                            Columns show the top {toolColumns.length} of {totalToolCount} tools by call volume. Select a
-                            cluster to see its full tool breakdown.
-                        </span>
-                    ) : null}
+                </TableBody>
+            </Table>
+            {hiddenClusterCount > 0 ? (
+                <div className="flex flex-wrap items-center gap-3 border-t border-primary px-3 py-2 text-xs text-muted">
+                    <span>
+                        Showing the top {visibleClusters.length} of {visibleClusters.length + hiddenClusterCount}{' '}
+                        clusters.
+                    </span>
+                    <Button size="sm" variant="outline" onClick={showAllClusters}>
+                        Show all
+                    </Button>
                 </div>
-            )}
+            ) : null}
+        </div>
+    )
+}
+
+function RecurringIntentsSection(): JSX.Element | null {
+    const { recurring } = useValues(mcpClusteringLogic)
+    if (recurring.length === 0) {
+        return null
+    }
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex flex-col">
+                <h3 className="text-base font-semibold">Recurring automated intents</h3>
+                <span className="text-xs text-muted">
+                    The same intent text opened 3 or more sessions in this window. These are usually scheduled agents
+                    and crons, so they are listed here instead of the clusters above.
+                </span>
+            </div>
+            <div className="bg-surface-primary border rounded" data-quill>
+                <Table fullWidth>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead expand>Intent</TableHead>
+                            <TableHead align="right">Sessions</TableHead>
+                            <TableHead align="right">Calls</TableHead>
+                            <TableHead align="right">Errors</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {recurring.map((entry) => (
+                            <TableRow key={entry.intent_text}>
+                                <TableCell expand>
+                                    <span className="text-xs truncate block max-w-[560px]" title={entry.intent_text}>
+                                        {entry.intent_text}
+                                    </span>
+                                </TableCell>
+                                <TableCell align="right">
+                                    <span className="tabular-nums text-xs">{entry.session_count.toLocaleString()}</span>
+                                </TableCell>
+                                <TableCell align="right">
+                                    <span className="tabular-nums text-xs">{entry.call_count.toLocaleString()}</span>
+                                </TableCell>
+                                <TableCell align="right">
+                                    <span
+                                        className={`tabular-nums text-xs ${
+                                            entry.error_rate_pct > 5 ? 'text-danger font-semibold' : ''
+                                        }`}
+                                    >
+                                        {entry.error_rate_pct.toFixed(1)}%
+                                    </span>
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </div>
         </div>
     )
 }
@@ -594,7 +605,7 @@ export function MCPAnalyticsClustering(): JSX.Element {
             <StatusRow />
             <Scorecards />
             <SortHeader />
-            <Heatmap />
+            <ClusterList />
             {selectedCluster ? (
                 <ClusterDetail cluster={selectedCluster} />
             ) : (
@@ -602,6 +613,7 @@ export function MCPAnalyticsClustering(): JSX.Element {
                     Click a cluster row above to see its sample intents and tool breakdown.
                 </div>
             )}
+            <RecurringIntentsSection />
         </div>
     )
 }

--- a/products/mcp_analytics/frontend/clustering/clusteringScorecards.test.ts
+++ b/products/mcp_analytics/frontend/clustering/clusteringScorecards.test.ts
@@ -1,0 +1,75 @@
+import type { MCPIntentClusterApi } from '../generated/api.schemas'
+import {
+    KPI_MIN_SESSIONS,
+    computeConcentratedRoutes,
+    computeSpreadRoutes,
+    computeTopErrorRoute,
+} from './clusteringScorecards'
+
+function cluster(overrides: Partial<MCPIntentClusterApi>): MCPIntentClusterApi {
+    return {
+        id: 1,
+        label: 'a cluster',
+        intent_count: 2,
+        session_count: KPI_MIN_SESSIONS,
+        call_count: 50,
+        error_count: 0,
+        error_rate_pct: 0,
+        routing_entropy: 0.5,
+        tool_distribution: [],
+        sample_intents: [],
+        journey: null,
+        ...overrides,
+    }
+}
+
+describe('clustering scorecards', () => {
+    // Regression: KPIs used to count every cluster, so 1-session clusters
+    // (an agent doing a normal multi-step task) dominated "spread routes"
+    // and made the drift signal always alarming.
+    it('excludes clusters below the session floor from all three KPIs', () => {
+        const tiny = cluster({
+            id: 1,
+            session_count: 1,
+            error_rate_pct: 50,
+            call_count: 100,
+            tool_distribution: [
+                { tool: 'a', count: 40, pct: 40, errors: 0, error_rate_pct: 0 },
+                { tool: 'b', count: 60, pct: 60, errors: 0, error_rate_pct: 0 },
+            ],
+        })
+
+        expect(computeConcentratedRoutes([tiny])).toEqual({ focused: 0, total: 0 })
+        expect(computeSpreadRoutes([tiny])).toBe(0)
+        expect(computeTopErrorRoute([tiny])).toBeNull()
+    })
+
+    it('classifies eligible clusters by top-tool share', () => {
+        const concentrated = cluster({
+            id: 1,
+            tool_distribution: [{ tool: 'a', count: 90, pct: 90, errors: 0, error_rate_pct: 0 }],
+        })
+        const spread = cluster({
+            id: 2,
+            tool_distribution: [
+                { tool: 'a', count: 40, pct: 40, errors: 0, error_rate_pct: 0 },
+                { tool: 'b', count: 35, pct: 35, errors: 0, error_rate_pct: 0 },
+                { tool: 'c', count: 25, pct: 25, errors: 0, error_rate_pct: 0 },
+            ],
+        })
+
+        expect(computeConcentratedRoutes([concentrated, spread])).toEqual({ focused: 1, total: 2 })
+        expect(computeSpreadRoutes([concentrated, spread])).toBe(1)
+    })
+
+    it('picks the top error route by traffic-weighted error rate among eligible clusters', () => {
+        const highRateLowVolume = cluster({ id: 1, error_rate_pct: 40, call_count: 10 })
+        const lowRateHighVolume = cluster({ id: 2, error_rate_pct: 10, call_count: 1000 })
+
+        expect(computeTopErrorRoute([highRateLowVolume, lowRateHighVolume])?.id).toBe(2)
+    })
+
+    it('returns null top error route when no eligible cluster has errors', () => {
+        expect(computeTopErrorRoute([cluster({ error_rate_pct: 0 })])).toBeNull()
+    })
+})

--- a/products/mcp_analytics/frontend/clustering/clusteringScorecards.test.ts
+++ b/products/mcp_analytics/frontend/clustering/clusteringScorecards.test.ts
@@ -62,14 +62,21 @@ describe('clustering scorecards', () => {
         expect(computeSpreadRoutes([concentrated, spread])).toBe(1)
     })
 
-    it('picks the top error route by traffic-weighted error rate among eligible clusters', () => {
-        const highRateLowVolume = cluster({ id: 1, error_rate_pct: 40, call_count: 10 })
-        const lowRateHighVolume = cluster({ id: 2, error_rate_pct: 10, call_count: 1000 })
+    it('picks the top error route by error count among eligible clusters', () => {
+        const highRateLowVolume = cluster({ id: 1, call_count: 10, error_count: 4, error_rate_pct: 40 })
+        const lowRateHighVolume = cluster({ id: 2, call_count: 1000, error_count: 100, error_rate_pct: 10 })
 
         expect(computeTopErrorRoute([highRateLowVolume, lowRateHighVolume])?.id).toBe(2)
     })
 
-    it('returns null top error route when no eligible cluster has errors', () => {
-        expect(computeTopErrorRoute([cluster({ error_rate_pct: 0 })])).toBeNull()
+    // The backend rounds error_rate_pct to one decimal, so a cluster with errors
+    // below 0.05% arrives as 0.0 and must still count as an error route.
+    it.each<[string, number, boolean]>([
+        ['has no errors at all', 0, false],
+        ['has errors that round down to 0.0%', 3, true],
+    ])('surfaces a cluster that %s', (_case, errorCount, isSurfaced) => {
+        const rounded = cluster({ call_count: 10000, error_count: errorCount, error_rate_pct: 0 })
+
+        expect(computeTopErrorRoute([rounded]) !== null).toBe(isSurfaced)
     })
 })

--- a/products/mcp_analytics/frontend/clustering/clusteringScorecards.ts
+++ b/products/mcp_analytics/frontend/clustering/clusteringScorecards.ts
@@ -29,10 +29,13 @@ export function computeSpreadRoutes(clusters: readonly MCPIntentClusterApi[]): n
 }
 
 export function computeTopErrorRoute(clusters: readonly MCPIntentClusterApi[]): MCPIntentClusterApi | null {
-    const withErrors = kpiEligible(clusters).filter((c) => c.error_rate_pct > 0)
+    // error_count, not error_rate_pct: the backend rounds the rate to one
+    // decimal, so a cluster with real errors below 0.05% arrives as 0.0 and
+    // would otherwise read as error-free.
+    const withErrors = kpiEligible(clusters).filter((c) => c.error_count > 0)
     if (withErrors.length === 0) {
         return null
     }
-    // Highest traffic-weighted error count — the cluster that loses the most calls to errors.
-    return [...withErrors].sort((a, b) => b.call_count * b.error_rate_pct - a.call_count * a.error_rate_pct)[0]
+    // The cluster that loses the most calls to errors.
+    return [...withErrors].sort((a, b) => b.error_count - a.error_count)[0]
 }

--- a/products/mcp_analytics/frontend/clustering/clusteringScorecards.ts
+++ b/products/mcp_analytics/frontend/clustering/clusteringScorecards.ts
@@ -1,0 +1,38 @@
+import type { MCPIntentClusterApi } from '../generated/api.schemas'
+
+// Routing KPIs are only meaningful when the same intent theme recurs across
+// sessions — a single session touching many tools is a normal multi-step task,
+// not drift. Clusters below this floor are shown in the list but excluded
+// from the scorecard denominators.
+export const KPI_MIN_SESSIONS = 5
+
+function kpiEligible(clusters: readonly MCPIntentClusterApi[]): MCPIntentClusterApi[] {
+    return clusters.filter((c) => c.session_count >= KPI_MIN_SESSIONS)
+}
+
+export function computeConcentratedRoutes(clusters: readonly MCPIntentClusterApi[]): {
+    focused: number
+    total: number
+} {
+    const eligible = kpiEligible(clusters)
+    return {
+        focused: eligible.filter((c) => (c.tool_distribution[0]?.pct ?? 0) >= 80).length,
+        total: eligible.length,
+    }
+}
+
+export function computeSpreadRoutes(clusters: readonly MCPIntentClusterApi[]): number {
+    return kpiEligible(clusters).filter((c) => {
+        const top = c.tool_distribution[0]?.pct ?? 100
+        return c.tool_distribution.length >= 2 && top < 50
+    }).length
+}
+
+export function computeTopErrorRoute(clusters: readonly MCPIntentClusterApi[]): MCPIntentClusterApi | null {
+    const withErrors = kpiEligible(clusters).filter((c) => c.error_rate_pct > 0)
+    if (withErrors.length === 0) {
+        return null
+    }
+    // Highest traffic-weighted error count — the cluster that loses the most calls to errors.
+    return [...withErrors].sort((a, b) => b.call_count * b.error_rate_pct - a.call_count * a.error_rate_pct)[0]
+}

--- a/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.test.ts
+++ b/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.test.ts
@@ -4,7 +4,7 @@ import { initKeaTests } from '~/test/init'
 
 import { mcpAnalyticsIntentClustersRetrieve } from '../generated/api'
 import type { MCPIntentClusterApi, MCPIntentClusterSnapshotApi } from '../generated/api.schemas'
-import { MAX_HEATMAP_TOOL_COLUMNS, MAX_VISIBLE_CLUSTERS, mcpClusteringLogic } from './mcpClusteringLogic'
+import { MAX_VISIBLE_CLUSTERS, mcpClusteringLogic } from './mcpClusteringLogic'
 
 jest.mock('lib/api')
 jest.mock('../generated/api', () => ({
@@ -24,12 +24,7 @@ function cluster(id: number, overrides: Partial<MCPIntentClusterApi> = {}): MCPI
         error_count: 0,
         error_rate_pct: 0,
         routing_entropy: 0,
-        // Two tools per cluster: a high-volume one unique to the cluster and a
-        // 1-call long-tail one, so the snapshot carries 2× clusters distinct tools.
-        tool_distribution: [
-            { tool: `tool-${id}`, count: 100 - id, pct: 99, errors: 0, error_rate_pct: 0 },
-            { tool: `tail-${id}`, count: 1, pct: 1, errors: 0, error_rate_pct: 0 },
-        ],
+        tool_distribution: [{ tool: `tool-${id}`, count: 100 - id, pct: 100, errors: 0, error_rate_pct: 0 }],
         sample_intents: [`intent ${id}`],
         journey: null,
         ...overrides,
@@ -50,6 +45,8 @@ const SNAPSHOT: MCPIntentClusterSnapshotApi = {
         // only enters the visible set under the errors sort.
         cluster(i, i === HIGH_ERROR_ID ? { error_rate_pct: 50, error_count: 10 } : {})
     ),
+    long_tail: null,
+    recurring: [],
     computed_with: {
         distance_threshold: 0.2,
         embedding_model: 'test',
@@ -94,13 +91,6 @@ describe('mcpClusteringLogic', () => {
         // …but worst error rate, so it leads once sorted by errors.
         expect(logic.values.visibleClusters[0].id).toBe(HIGH_ERROR_ID)
         expect(logic.values.visibleClusters).toHaveLength(MAX_VISIBLE_CLUSTERS)
-    })
-
-    it('caps heatmap tool columns by call volume and reports the full tool count', () => {
-        expect(logic.values.toolColumns).toHaveLength(MAX_HEATMAP_TOOL_COLUMNS)
-        // Highest-volume tool leads; the 1-call long-tail tools are what get cut.
-        expect(logic.values.toolColumns[0]).toBe('tool-0')
-        expect(logic.values.totalToolCount).toBe(N_CLUSTERS * 2)
     })
 
     it('reports the true cluster count from computed_with when the snapshot is truncated', async () => {

--- a/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.ts
+++ b/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.ts
@@ -6,7 +6,13 @@ import { lemonToast } from '@posthog/lemon-ui'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { mcpAnalyticsIntentClustersRecompute, mcpAnalyticsIntentClustersRetrieve } from '../generated/api'
-import type { MCPIntentClusterApi, MCPIntentClusterSnapshotApi } from '../generated/api.schemas'
+import type {
+    MCPIntentClusterApi,
+    MCPIntentClusterLongTailApi,
+    MCPIntentClusterSnapshotApi,
+    MCPRecurringIntentApi,
+} from '../generated/api.schemas'
+import { computeConcentratedRoutes, computeSpreadRoutes, computeTopErrorRoute } from './clusteringScorecards'
 
 const EMPTY_SNAPSHOT: MCPIntentClusterSnapshotApi = {
     status: 'idle',
@@ -21,12 +27,10 @@ const EMPTY_SNAPSHOT: MCPIntentClusterSnapshotApi = {
 
 const POLL_INTERVAL_MS = 3000
 
-// The heatmap renders clusters × tools cells in one synchronous pass — a large
-// snapshot (hundreds of clusters, ~200 distinct tools) produces tens of
-// thousands of DOM nodes and freezes the tab on mount. Cap the initial render;
-// "Show all" opts into the rest.
+// A large snapshot (hundreds of clusters) renders every row in one synchronous
+// pass and freezes the tab on mount. Cap the initial render; "Show all" opts
+// into the rest.
 export const MAX_VISIBLE_CLUSTERS = 30
-export const MAX_HEATMAP_TOOL_COLUMNS = 40
 
 // The generated client types the retrieve endpoint as returning an array, but the view actually
 // returns a single object. drf-spectacular assumes ViewSet `list` actions return arrays. Normalize.
@@ -56,6 +60,8 @@ export interface mcpClusteringLogicValues {
     hasSnapshot: boolean
     hiddenClusterCount: number
     isComputing: boolean
+    longTail: MCPIntentClusterLongTailApi | null
+    recurring: readonly MCPRecurringIntentApi[]
     selectedCluster: MCPIntentClusterApi | null
     selectedClusterId: number | null
     snapshot: MCPIntentClusterSnapshotApi
@@ -63,10 +69,8 @@ export interface mcpClusteringLogicValues {
     sortKey: ClusterSortKey
     sortedClusters: MCPIntentClusterApi[]
     spreadRoutes: number
-    toolColumns: string[]
     topErrorRoute: MCPIntentClusterApi | null
     totalClusterCount: number
-    totalToolCount: number
     visibleClusters: MCPIntentClusterApi[]
 }
 
@@ -132,9 +136,9 @@ export interface mcpClusteringLogicMeta {
         sortedClusters: (clusters: readonly MCPIntentClusterApi[], sortKey: ClusterSortKey) => MCPIntentClusterApi[]
         visibleClusters: (sortedClusters: MCPIntentClusterApi[], allClustersShown: boolean) => MCPIntentClusterApi[]
         hiddenClusterCount: (sortedClusters: MCPIntentClusterApi[], visibleClusters: MCPIntentClusterApi[]) => number
-        toolColumns: (clusters: readonly MCPIntentClusterApi[]) => string[]
-        totalToolCount: (clusters: readonly MCPIntentClusterApi[]) => number
         totalClusterCount: (snapshot: MCPIntentClusterSnapshotApi) => number
+        longTail: (snapshot: MCPIntentClusterSnapshotApi) => MCPIntentClusterLongTailApi | null
+        recurring: (snapshot: MCPIntentClusterSnapshotApi) => readonly MCPRecurringIntentApi[]
         selectedCluster: (
             clusters: readonly MCPIntentClusterApi[],
             selectedClusterId: number | null
@@ -236,7 +240,7 @@ export const mcpClusteringLogic = kea<mcpClusteringLogicType>([
                 }
             },
         ],
-        // The heatmap rows: sliced after sorting so re-sorting can surface any
+        // The rendered rows: sliced after sorting so re-sorting can surface any
         // cluster into the visible set.
         visibleClusters: [
             (s) => [s.sortedClusters, s.allClustersShown],
@@ -248,34 +252,13 @@ export const mcpClusteringLogic = kea<mcpClusteringLogicType>([
             (sortedClusters: MCPIntentClusterApi[], visibleClusters: MCPIntentClusterApi[]): number =>
                 sortedClusters.length - visibleClusters.length,
         ],
-        // Tools across the whole snapshot, ordered by total calls desc — these are
-        // the heatmap columns, capped so a wide tool set can't explode the table.
-        toolColumns: [
-            (s) => [s.clusters],
-            (clusters: readonly MCPIntentClusterApi[]): string[] => {
-                const totals = new Map<string, number>()
-                for (const cluster of clusters) {
-                    for (const entry of cluster.tool_distribution) {
-                        totals.set(entry.tool, (totals.get(entry.tool) ?? 0) + entry.count)
-                    }
-                }
-                return [...totals.entries()]
-                    .sort((a, b) => b[1] - a[1])
-                    .slice(0, MAX_HEATMAP_TOOL_COLUMNS)
-                    .map(([tool]) => tool)
-            },
+        longTail: [
+            (s) => [s.snapshot],
+            (snapshot: MCPIntentClusterSnapshotApi): MCPIntentClusterLongTailApi | null => snapshot.long_tail ?? null,
         ],
-        totalToolCount: [
-            (s) => [s.clusters],
-            (clusters: readonly MCPIntentClusterApi[]): number => {
-                const tools = new Set<string>()
-                for (const cluster of clusters) {
-                    for (const entry of cluster.tool_distribution) {
-                        tools.add(entry.tool)
-                    }
-                }
-                return tools.size
-            },
+        recurring: [
+            (s) => [s.snapshot],
+            (snapshot: MCPIntentClusterSnapshotApi): readonly MCPRecurringIntentApi[] => snapshot.recurring ?? [],
         ],
         // The true number of clusters the run found — the snapshot itself only
         // carries the top MAX_SNAPSHOT_CLUSTERS by call volume, so anything
@@ -297,33 +280,20 @@ export const mcpClusteringLogic = kea<mcpClusteringLogicType>([
                 return clusters.find((c) => c.id === selectedClusterId) ?? null
             },
         ],
-        // Scorecard derivations — all from existing aggregate fields.
+        // Scorecard derivations, gated to clusters with enough sessions for the
+        // routing signal to mean anything (see clusteringScorecards.ts).
         concentratedRoutes: [
             (s) => [s.clusters],
-            (clusters: readonly MCPIntentClusterApi[]): { focused: number; total: number } => ({
-                focused: clusters.filter((c) => (c.tool_distribution[0]?.pct ?? 0) >= 80).length,
-                total: clusters.length,
-            }),
+            (clusters: readonly MCPIntentClusterApi[]): { focused: number; total: number } =>
+                computeConcentratedRoutes(clusters),
         ],
         spreadRoutes: [
             (s) => [s.clusters],
-            (clusters: readonly MCPIntentClusterApi[]): number =>
-                clusters.filter((c) => {
-                    const top = c.tool_distribution[0]?.pct ?? 100
-                    return c.tool_distribution.length >= 2 && top < 50
-                }).length,
+            (clusters: readonly MCPIntentClusterApi[]): number => computeSpreadRoutes(clusters),
         ],
         topErrorRoute: [
             (s) => [s.clusters],
-            (clusters: readonly MCPIntentClusterApi[]): MCPIntentClusterApi | null => {
-                if (clusters.length === 0) {
-                    return null
-                }
-                // Highest traffic-weighted error count — the cluster that loses the most calls to errors.
-                return [...clusters].sort(
-                    (a, b) => b.call_count * b.error_rate_pct - a.call_count * a.error_rate_pct
-                )[0]
-            },
+            (clusters: readonly MCPIntentClusterApi[]): MCPIntentClusterApi | null => computeTopErrorRoute(clusters),
         ],
         isComputing: [
             (s) => [s.snapshot],

--- a/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.ts
+++ b/products/mcp_analytics/frontend/clustering/mcpClusteringLogic.ts
@@ -136,9 +136,9 @@ export interface mcpClusteringLogicMeta {
         sortedClusters: (clusters: readonly MCPIntentClusterApi[], sortKey: ClusterSortKey) => MCPIntentClusterApi[]
         visibleClusters: (sortedClusters: MCPIntentClusterApi[], allClustersShown: boolean) => MCPIntentClusterApi[]
         hiddenClusterCount: (sortedClusters: MCPIntentClusterApi[], visibleClusters: MCPIntentClusterApi[]) => number
-        totalClusterCount: (snapshot: MCPIntentClusterSnapshotApi) => number
         longTail: (snapshot: MCPIntentClusterSnapshotApi) => MCPIntentClusterLongTailApi | null
         recurring: (snapshot: MCPIntentClusterSnapshotApi) => readonly MCPRecurringIntentApi[]
+        totalClusterCount: (snapshot: MCPIntentClusterSnapshotApi) => number
         selectedCluster: (
             clusters: readonly MCPIntentClusterApi[],
             selectedClusterId: number | null


### PR DESCRIPTION
## Problem

Stacked on #74080. The clustering page rendered a tool-by-cluster heatmap whose columns are the union of every tool any cluster touched - over 100 columns at production scale, designed for 6. The scorecards counted every cluster, so one-off sessions (an agent doing a normal multi-step task) made the "spread routes" drift KPI permanently alarming, and the "top error route" card surfaced an internal cron.

## Changes

- The heatmap is replaced by a ranked cluster table: label + session/intent counts, top-3 tool chips with share percentages (full distribution stays in the drill-in detail pane, along with the journey Sankey), calls, error rate, and the routing badge.
- The new `long_tail` aggregate from #74080 renders as a summary row with sample intents in a tooltip.
- The new `recurring` list renders as its own "Recurring automated intents" section with per-intent session/call/error columns - this is where scheduled agents and crons now show up, including their error rates.
- Routing scorecards are gated to clusters with 5+ sessions (`clusteringScorecards.ts`), with card copy stating the floor. Entropy on a single session measures "the agent did several steps", not drift; the gate keeps the KPI honest.

## How did you test this code?

- TDD: `clusteringScorecards.test.ts` written first. It catches the regression where KPIs count sub-floor clusters again (the always-alarming drift KPI), verifies concentrated/spread classification by top-tool share, and the traffic-weighted top-error pick. 4 tests pass.
- KPI derivations were extracted into pure functions so they are testable without mounting the kea logic; the logic selectors delegate to them.
- Typecheck: no errors in `products/mcp_analytics/` (the repo-wide run has pre-existing unrelated `@posthog/quill` module-resolution noise in this environment).
- Not done: a browser screenshot - I (the agent) did not boot the dev stack for this change. The E2E check is a production recompute after both PRs deploy, which should show ranked rows, a long-tail row, and the recurring section populated by the scout/cron traffic.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover this page yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude). Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/adopting-generated-api-types` conventions (all API types come from the product's generated `api.schemas.ts`).
- The kea-typegen interface blocks in `mcpClusteringLogic.ts` were updated by hand per the in-file convention (`toolColumns` removed, `longTail`/`recurring` added).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*