### PR TITLE
fix(replay): convert legacy filters when applying a saved filter

### DIFF
--- a/frontend/src/scenes/session-recordings/filters/SavedFilters.tsx
+++ b/frontend/src/scenes/session-recordings/filters/SavedFilters.tsx
@@ -32,6 +32,7 @@ import {
 import { sessionRecordingSavedFiltersLogic } from '../filters/sessionRecordingSavedFiltersLogic'
 import { playlistFiltersLogic } from '../playlist/playlistFiltersLogic'
 import { stripSessionIds } from '../playlist/playlistUtils'
+import { asUniversalFilters } from '../playlist/sessionRecordingsPlaylistLogic'
 import { SavedFiltersEmptyState, SavedFiltersLoadingState } from './SavedFiltersStates'
 
 export function isPlaylistRecordingsCounts(x: unknown): x is PlaylistRecordingsCounts {
@@ -153,11 +154,16 @@ export function SavedFilters({
                     <>
                         <div
                             onClick={() => {
-                                if (filter && filter.filters) {
-                                    setFilters(stripSessionIds(filter.filters))
-                                    setActiveFilterTab('filters')
-                                    setAppliedSavedFilter(filter)
+                                if (!filter) {
+                                    return
                                 }
+                                const universalFilters = asUniversalFilters(filter.filters)
+                                if (!universalFilters) {
+                                    return
+                                }
+                                setFilters(stripSessionIds(universalFilters))
+                                setActiveFilterTab('filters')
+                                setAppliedSavedFilter(filter)
                             }}
                             className="cursor-pointer text-current hover:text-accent"
                         >

--- a/frontend/src/scenes/session-recordings/filters/sessionRecordingSavedFiltersLogic.ts
+++ b/frontend/src/scenes/session-recordings/filters/sessionRecordingSavedFiltersLogic.ts
@@ -17,6 +17,7 @@ import {
 } from '~/types'
 
 import { deletePlaylist, stripSessionIds } from '../playlist/playlistUtils'
+import { asUniversalFilters } from '../playlist/sessionRecordingsPlaylistLogic'
 
 export const PLAYLISTS_PER_PAGE = 30
 
@@ -269,7 +270,9 @@ export const sessionRecordingSavedFiltersLogic = kea<sessionRecordingSavedFilter
             if (savedFilterId) {
                 const savedFilter = await api.recordings.getPlaylist(savedFilterId)
                 if (savedFilter) {
-                    router.actions.push(urls.replay(ReplayTabs.Home, stripSessionIds(savedFilter.filters)))
+                    router.actions.push(
+                        urls.replay(ReplayTabs.Home, stripSessionIds(asUniversalFilters(savedFilter.filters)))
+                    )
                     actions.setAppliedSavedFilter(savedFilter)
                 }
             }

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistScene.tsx
@@ -36,9 +36,8 @@ import {
     ScenePanelInfoSection,
 } from '~/layout/scenes/SceneLayout'
 
-import { isUniversalFilters } from '../utils'
 import { SessionRecordingsPlaylist } from './SessionRecordingsPlaylist'
-import { convertLegacyFiltersToUniversalFilters } from './sessionRecordingsPlaylistLogic'
+import { asUniversalFilters } from './sessionRecordingsPlaylistLogic'
 import {
     SessionRecordingsPlaylistLogicProps,
     sessionRecordingsPlaylistSceneLogic,
@@ -230,11 +229,7 @@ export function SessionRecordingsPlaylistScene(): JSX.Element {
                 <SessionRecordingsPlaylist
                     logicKey={playlist.short_id}
                     // backwards compatibility for legacy filters
-                    filters={
-                        playlist.filters && isUniversalFilters(playlist.filters)
-                            ? playlist.filters
-                            : convertLegacyFiltersToUniversalFilters({}, playlist.filters)
-                    }
+                    filters={asUniversalFilters(playlist.filters)}
                     onFiltersChange={setFilters}
                     onPinnedChange={onPinnedChange}
                     pinnedRecordings={pinnedRecordings ?? []}

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -26,6 +26,7 @@ import { playlistFiltersLogic } from './playlistFiltersLogic'
 import {
     DEFAULT_RECORDING_FILTERS,
     DEFAULT_RECORDING_FILTERS_ORDER_BY,
+    asUniversalFilters,
     convertLegacyFiltersToUniversalFilters,
     convertUniversalFiltersToRecordingsQuery,
     getDefaultFilters,
@@ -1194,6 +1195,29 @@ describe('sessionRecordingsPlaylistLogic', () => {
                 properties: [],
                 session_ids: ['session-1', 'session-2', 'session-3'],
             })
+        })
+    })
+
+    describe('asUniversalFilters', () => {
+        // A playlist saved before universal filters stores only `events`. Left unconverted it has no
+        // filter_group, so the query converter finds nothing to filter on and the list returns
+        // everything while the UI shows no criteria.
+        it('carries a legacy saved filter through to the recordings query', () => {
+            const legacy = { events: [{ id: '$rageclick', type: 'events', order: 0 }] }
+
+            const query = convertUniversalFiltersToRecordingsQuery(asUniversalFilters(legacy as any)!)
+
+            expect(query.events).toEqual([expect.objectContaining({ id: '$rageclick', type: 'events' })])
+        })
+
+        it('leaves filters that are already universal untouched', () => {
+            const universal = getDefaultFilters()
+
+            expect(asUniversalFilters(universal)).toBe(universal)
+        })
+
+        it('returns undefined when there are no stored filters', () => {
+            expect(asUniversalFilters(undefined)).toBeUndefined()
         })
     })
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -73,7 +73,7 @@ import {
     isValidRecordingOrder,
 } from '../filters/recordingsQueryConversions'
 import { playerSettingsLogic } from '../player/playerSettingsLogic'
-import { filtersFromUniversalFilterGroups } from '../utils'
+import { filtersFromUniversalFilterGroups, isUniversalFilters } from '../utils'
 import { playlistFiltersLogic } from './playlistFiltersLogic'
 
 // Re-exported for back-compat with existing import sites; the implementations now live in the leaf
@@ -339,6 +339,20 @@ export function isValidRecordingFilters(filters: Partial<RecordingUniversalFilte
     }
 
     return true
+}
+
+/**
+ * Saved playlists persisted before universal filters store the legacy shape, which has no
+ * `filter_group` for the filter UI to render or for the query converter to read. Anything loading
+ * stored filters has to come through here, or a legacy playlist silently applies no filters at all.
+ */
+export function asUniversalFilters(
+    filters: RecordingUniversalFilters | LegacyRecordingFilters | undefined | null
+): RecordingUniversalFilters | undefined {
+    if (!filters) {
+        return undefined
+    }
+    return isUniversalFilters(filters) ? filters : convertLegacyFiltersToUniversalFilters({}, filters)
 }
 
 export function convertLegacyFiltersToUniversalFilters(


### PR DESCRIPTION
## Problem

Applying a saved filter from the saved filters list passed its stored filters straight into the universal filter state. A playlist saved before universal filters stores the legacy shape (`{"events": [...]}`) with no `filter_group`, and both the filter UI and the query converter read `filter_group`, so:

- the filter chips rendered nothing, and
- `convertUniversalFiltersToRecordingsQuery` found nothing to filter on, so the list returned every recording

That is both halves of #36380 from one cause. The reporter guessed the criteria were hidden because the event didn't exist in their project yet; the actual trigger is the age of the saved playlist. Their account predates universal filters, so its auto-created default filters are all stored in the legacy shape.

Closes #36380

## Changes

One helper, `asUniversalFilters`, that converts a stored filter set only when it isn't already universal. The three places that load stored playlist filters now share it:

| Where | Before |
|---|---|
| `SavedFilters.tsx` (applying from the list) | passed stored filters through unconverted |
| `sessionRecordingSavedFiltersLogic.ts` (`?savedFilterId=` deep link) | passed stored filters through unconverted |
| `SessionRecordingsPlaylistScene.tsx` | converted correctly, inline |

The scene had the right logic all along, which is why opening a legacy playlist on its own page worked while applying the same filter from the list did not. Collapsing all three onto one helper is what stops a fourth call site from getting it wrong again.

## How did you test this code?

Three cases in `sessionRecordingsPlaylistLogic.test.ts`. The one that matters asserts the whole chain: the exact legacy shape from the issue, through `asUniversalFilters`, into `convertUniversalFiltersToRecordingsQuery`, and checks `$rageclick` actually lands in `query.events`. That's the observable thing that was broken, rather than the intermediate filter object.

I verified it catches the bug rather than just passing: with the helper stubbed back to a pass-through (the old behavior) that test fails, and it passes with the helper in place.

Also ran locally:

- `frontend/src/scenes/session-recordings/playlist/` and `filters/` — 9 suites, 170 tests, all passing
- `pnpm --filter=@posthog/frontend typescript:check` — clean

Worth knowing what I ruled out first. I probed the backend directly, filtering recordings for an event no session has, and it correctly returned nothing. So the "shows all replays" symptom was never a query bug, which is what pointed at the filters never arriving in the first place.

I did not verify this in a browser. Reproducing it needs a playlist stored in the legacy shape, which new projects don't produce.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) did this while working the open `feature/replay` backlog. Skills invoked: `/superpowers:systematic-debugging`, `/writing-tests`, `/writing-code-comments`.

My first hypothesis was the display path: that `EntityFilterInfo` rendered a blank chip when an event was missing from the project's definitions, which is what the issue suggests. Reading it killed that idea, since `getDisplayNameFromEntityFilter` already falls back to the raw `id` and then to the core-filter label. Following the stored JSON shape from the issue instead led to the converter gap, which had the advantage of explaining the second symptom too rather than just the first.
