### PR TITLE
feat(llm-gateway): add free onboarding product for wizard cloud runs

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -94,6 +94,13 @@ CODE_INVITE_NOT_REDEEMABLE = "not_redeemable"
 
 WIZARD_PR_READY_EMAIL_FEATURE_FLAG = "wizard-cloud-run-pr-ready-email-enabled"
 
+# Runtime posture for a setup-wizard cloud run, applied in create_wizard_cloud_run. The model is
+# pinned because these runs route to the unbilled `onboarding` gateway product, which allowlists a
+# narrow model set; the string form avoids pulling the temporal RuntimeAdapter enum onto this path.
+WIZARD_CLOUD_RUN_RUNTIME_ADAPTER = "claude"
+WIZARD_CLOUD_RUN_MODEL = "claude-sonnet-5"
+WIZARD_CLOUD_RUN_AI_STAGE = "wizard_pr_agent"
+
 __all__ = [
     "CODE_INVITE_INVALID_CODE",
     "CODE_INVITE_NOT_REDEEMABLE",
@@ -900,6 +907,10 @@ def create_wizard_cloud_run(
     The PR head branch is generated here (not by the agent) so the GitHub PR webhook can bind the
     opened PR back to this run by branch + repository — wizard PRs are bot-authored, which the
     agent-side PR attribution cannot match.
+
+    The model is pinned rather than left to the agent's default because these runs bill to nobody:
+    they route to the unbilled ``onboarding`` gateway product, whose model allowlist is narrow, and
+    PostHog absorbs the cost. Keep the pin inside that allowlist or the run fails at the gateway.
     """
     head_branch = generate_wizard_head_branch()
     prompt = build_wizard_pr_agent_prompt(head_branch)
@@ -916,6 +927,9 @@ def create_wizard_cloud_run(
         wizard_config={},
         wizard_head_branch=head_branch,
         posthog_mcp_scopes="read_only",
+        runtime_adapter=WIZARD_CLOUD_RUN_RUNTIME_ADAPTER,
+        model=WIZARD_CLOUD_RUN_MODEL,
+        ai_stage=WIZARD_CLOUD_RUN_AI_STAGE,
         # The agent server boots idle; this is the message that actually kicks it off once ready
         # (delivered by forward_pending_user_message). Without it the run stalls after "Started agent".
         pending_user_message=prompt,

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -1783,6 +1783,16 @@ _PROTECTED_RUN_STATE_KEYS = frozenset(
         "loop_trigger_id",
         "trigger_context",
         "config_snapshot",
+        # The run's model posture, chosen at creation by the server-owned caller and read back out
+        # of state when the run dispatches. It decides what the run costs, and for a run routed to
+        # an unbilled gateway product (create_wizard_cloud_run pins claude-sonnet-5 for the
+        # `onboarding` product) it is the only thing keeping the run off the more expensive models
+        # that product still allowlists. Every writer is server-side, so nothing legitimate PATCHes
+        # these.
+        "runtime_adapter",
+        "provider",
+        "model",
+        "reasoning_effort",
     }
 )
 

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -608,6 +608,11 @@ class TaskWriteSerializer(serializers.Serializer):
             # would route the task's run logs into PostHog's internal Logs project
             # (run_log_mirror) and inherit scout visibility semantics.
             raise serializers.ValidationError("origin_product 'signals_scout' is reserved for signals scout runs")
+        if value == tasks_facade.TaskOriginProduct.ONBOARDING:
+            # This origin routes the run's LLM traffic to the unbilled `onboarding` gateway
+            # product, so a forged one would be free model access. Only create_wizard_cloud_run
+            # sets it, behind its own rate limits and daily cap.
+            raise serializers.ValidationError("origin_product 'onboarding' is reserved for setup wizard cloud runs")
         return value
 
     def validate_repository(self, value):

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -4484,6 +4484,10 @@ class TestTaskRunAPI(BaseTaskAPITest):
                     "pending_dispatch",
                     "pending_external_followups",
                     "pending_external_followups_generation",
+                    "runtime_adapter",
+                    "provider",
+                    "model",
+                    "reasoning_effort",
                     "scratch",
                 ],
             },
@@ -4503,6 +4507,13 @@ class TestTaskRunAPI(BaseTaskAPITest):
         assert run.state["pending_dispatch"] == {"workflow_id_prefix": "review-real", "create_pr": True}
         assert run.state["pending_external_followups"] == pending_external_followups
         assert run.state["pending_external_followups_generation"] == 7
+        # Dropping the model posture is as good as repointing it: the processing context reads these
+        # back with .get(), so an absent key silently falls back to the runtime's default rather than
+        # the pin the server chose.
+        assert run.state["runtime_adapter"] == "claude"  # protected key survives removal
+        assert run.state["provider"] == "anthropic"  # protected key survives removal
+        assert run.state["model"] == "claude-sonnet-5"  # protected key survives removal
+        assert run.state["reasoning_effort"] == "low"  # protected key survives removal
         assert "scratch" not in run.state  # non-protected key removed
 
     @patch("products.tasks.backend.facade.api.signal_workflow_completion")

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -4386,6 +4386,10 @@ class TestTaskRunAPI(BaseTaskAPITest):
                 "pending_dispatch": {"workflow_id_prefix": "review-real", "create_pr": True},
                 "pending_external_followups": pending_external_followups,
                 "pending_external_followups_generation": 7,
+                "runtime_adapter": "claude",
+                "provider": "anthropic",
+                "model": "claude-sonnet-5",
+                "reasoning_effort": "low",
             },
         )
 
@@ -4395,7 +4399,8 @@ class TestTaskRunAPI(BaseTaskAPITest):
         # (which would mint a write-scoped wizard token into the sandbox), change rollout
         # decisions, change Modal resume snapshot metadata, repoint the run at another
         # team's Temporal workflow, or steer an orphan re-dispatch (workflow ID prefix / MCP
-        # scopes) via pending_dispatch. Non-protected keys still merge.
+        # scopes) via pending_dispatch, or repoint the run at a costlier model (which for a run
+        # routed to an unbilled gateway product is free spend). Non-protected keys still merge.
         response = self.client.patch(
             f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/",
             {
@@ -4425,6 +4430,10 @@ class TestTaskRunAPI(BaseTaskAPITest):
                         }
                     ],
                     "pending_external_followups_generation": 999,
+                    "runtime_adapter": "codex",
+                    "provider": "openai",
+                    "model": "claude-opus-4-8",
+                    "reasoning_effort": "high",
                     "scratch": "ok",
                 }
             },
@@ -4451,6 +4460,10 @@ class TestTaskRunAPI(BaseTaskAPITest):
         assert run.state["pending_dispatch"] == {"workflow_id_prefix": "review-real", "create_pr": True}
         assert run.state["pending_external_followups"] == pending_external_followups
         assert run.state["pending_external_followups_generation"] == 7
+        assert run.state["runtime_adapter"] == "claude"
+        assert run.state["provider"] == "anthropic"
+        assert run.state["model"] == "claude-sonnet-5"
+        assert run.state["reasoning_effort"] == "low"
         assert run.state["scratch"] == "ok"  # non-protected keys still merge
 
         # Nor can a caller remove a protected key to force a fallback or unguarded path.

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1267,6 +1267,7 @@ class TestTaskAPI(BaseTaskAPITest):
         [
             ("image_builder",),
             ("experiments",),
+            ("onboarding",),
         ]
     )
     def test_create_task_rejects_internal_origin(self, origin: str):

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -586,6 +586,23 @@ class TestFacadeReadsAndMappers(TestCase):
         # and the run never opens a PR. Wizard runs must pin the overlap boot off.
         self.assertIs(run.state.get("overlap_clone_boot_enabled"), False)
 
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_wizard_cloud_run_pins_its_model(self, _mock_workflow):
+        Integration.objects.create(team=self.team, kind="github", config={})
+        created = facade.create_wizard_cloud_run(
+            team=self.team,
+            user_id=self.user.id,
+            repository="acme-co/web",
+        )
+        run = TaskRun.objects.get(task_id=created.task_id)
+        # Wizard runs route to the unbilled `onboarding` gateway product, which allowlists only
+        # these models. Dropping the pin puts the run back on the agent-server's premium default,
+        # which that product rejects, so every wizard cloud run would 403 at the gateway. Changing
+        # the pin means changing the allowlist in services/llm-gateway too.
+        self.assertEqual(run.state.get("runtime_adapter"), "claude")
+        self.assertEqual(run.state.get("model"), "claude-sonnet-5")
+        self.assertEqual(run.state.get("ai_stage"), "wizard_pr_agent")
+
 
 class TestRecentWizardCloudRunTimes(TestCase):
     organization: ClassVar[Organization]

--- a/services/llm-gateway/README.md
+++ b/services/llm-gateway/README.md
@@ -234,6 +234,7 @@ OAuth access is permitted only for products with an explicit `allowed_applicatio
 | `ci`                 | API key only    | All                        | CI / e2e test runs              |
 | `posthog_code`       | OAuth only      | Restricted set             | Desktop coding agent            |
 | `background_agents`  | OAuth only      | Restricted set             | Cloud background agents         |
+| `onboarding`         | OAuth only      | claude-sonnet-5            | Unbilled setup wizard cloud run |
 | `wizard`             | API key + OAuth | All                        | Max AI assistant                |
 | `django`             | API key only    | All                        | Server-side Django calls        |
 | `growth`             | API key only    | All                        | Growth team                     |
@@ -334,5 +335,6 @@ response = client.chat.completions.create(
 ```
 
 `ai_product` and `$ai_billable` are derived from the product config (`products/config.py`):
-the route sets `ai_product` from the `product` arg, and `$ai_billable` from that product's
-`billable` flag. Set `billable=True` on the product config to bill its generations.
+the route sets `ai_product` from the `product` arg, and `$ai_billable` from whether that
+product has a `credit_bucket`. Set `credit_bucket` on the product config to bill its
+generations into that bucket; leave it `None` to keep them unbilled.

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -62,6 +62,18 @@ DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
         sustained_limit_usd=10000.0,
         sustained_window_seconds=2592000,
     ),
+    # Deliberately far below DEFAULT_USER_COST_LIMIT, which is what this product would fall back to.
+    # The route's server-credential marker proves a token was minted server-side, not that it belongs
+    # to a wizard run, so any sandbox token satisfies it (INTERNAL_SCOPES in posthog/temporal/oauth.py
+    # grants the marker to every task run). A setup wizard pass costs cents, so a per-user ceiling this
+    # low leaves real onboarding untouched while keeping the unbilled bucket a rounding error if the
+    # marker is ever the only thing standing in the way.
+    "onboarding": UserCostLimit(
+        burst_limit_usd=20.0,
+        burst_window_seconds=86400,
+        sustained_limit_usd=50.0,
+        sustained_window_seconds=2592000,
+    ),
 }
 
 FREE_PLAN_COST_LIMIT = UserCostLimit(

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -30,6 +30,7 @@ DEFAULT_PRODUCT_COST_LIMITS: dict[str, "ProductCostLimit"] = {
     "wizard": ProductCostLimit(limit_usd=10000.0, window_seconds=86400),
     "posthog_code": ProductCostLimit(limit_usd=5000.0, window_seconds=3600),
     "background_agents": ProductCostLimit(limit_usd=1000.0, window_seconds=3600),
+    "onboarding": ProductCostLimit(limit_usd=1000.0, window_seconds=3600),
     "django": ProductCostLimit(limit_usd=5000.0, window_seconds=86400),
     "custom_image_scans": ProductCostLimit(limit_usd=1000.0, window_seconds=86400),
     "signals": ProductCostLimit(limit_usd=25000.0, window_seconds=86400),

--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -62,16 +62,17 @@ DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
         sustained_limit_usd=10000.0,
         sustained_window_seconds=2592000,
     ),
-    # Deliberately far below DEFAULT_USER_COST_LIMIT, which is what this product would fall back to.
-    # The route's server-credential marker proves a token was minted server-side, not that it belongs
-    # to a wizard run, so any sandbox token satisfies it (INTERNAL_SCOPES in posthog/temporal/oauth.py
-    # grants the marker to every task run). A setup wizard pass costs cents, so a per-user ceiling this
-    # low leaves real onboarding untouched while keeping the unbilled bucket a rounding error if the
-    # marker is ever the only thing standing in the way.
+    # Nobody is billed for onboarding (credit_bucket=None), so this bounds blast radius rather than
+    # spend: the route's server-credential marker proves a token was minted server-side, not that it
+    # belongs to a wizard run, and INTERNAL_SCOPES in posthog/temporal/oauth.py grants that marker to
+    # every task run. Sized to stay clear of real onboarding rather than to be tight, since cutting a
+    # user off mid-setup is worse than the unbilled spend: half of DEFAULT_USER_COST_LIMIT, and well
+    # under the comparable agentic product (background_agents, $500/week burst). Staff bypass this
+    # entirely via is_usage_unlimited, so internal runs are never capped by it.
     "onboarding": UserCostLimit(
-        burst_limit_usd=20.0,
+        burst_limit_usd=50.0,
         burst_window_seconds=86400,
-        sustained_limit_usd=50.0,
+        sustained_limit_usd=500.0,
         sustained_window_seconds=2592000,
     ),
 }

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -88,6 +88,18 @@ _POSTHOG_CODE_AGENT_MODELS: Final[frozenset[str]] = frozenset(
     }
 )
 
+# Products whose requires_server_credential applies right away rather than waiting for
+# posthog_code_model_gate_enabled. The flag exists so products that already shipped accepting plain
+# Code OAuth tokens keep working until the Code billing cutover. A product that never had such a
+# permissive period has nothing to stay compatible with, and leaving it flag-gated would ship an
+# unbilled route open to any Code OAuth token for as long as the flag is off.
+UNCONDITIONAL_SERVER_CREDENTIAL_PRODUCTS: Final[frozenset[str]] = frozenset(
+    {
+        "custom_image_scans",
+        "onboarding",
+    }
+)
+
 PRODUCTS: Final[dict[str, ProductConfig]] = {
     "llm_gateway": ProductConfig(
         allowed_application_ids=None,
@@ -431,13 +443,14 @@ def check_product_access(
     # and route around the posthog_code free-tier model gate. Require the internal marker that
     # only server-minted tokens carry. OAuth-only: personal API keys reach the gateway with an
     # explicit, feature-gated llm_gateway:read scope (a `*` PAK is rejected at auth), so the
-    # shared server-side gateway key still works here. Gated behind the same flag as the
-    # free-tier gate so it stays inert until the Code billing cutover.
+    # shared server-side gateway key still works here. Products that shipped before this check
+    # existed stay behind the free-tier flag so they keep working until the Code billing cutover;
+    # the rest enforce it now, per UNCONDITIONAL_SERVER_CREDENTIAL_PRODUCTS.
     if (
         config.requires_server_credential
         and is_oauth
         and INTERNAL_RUN_SCOPE not in (scopes or [])
-        and (settings.posthog_code_model_gate_enabled or resolved_product == "custom_image_scans")
+        and (settings.posthog_code_model_gate_enabled or resolved_product in UNCONDITIONAL_SERVER_CREDENTIAL_PRODUCTS)
     ):
         return False, f"Product '{product}' requires a server-minted credential"
 

--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -139,6 +139,19 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         credit_bucket=None,
         requires_server_credential=True,
     ),
+    # The setup wizard's cloud run (Task.OriginProduct.ONBOARDING). Unbilled like
+    # background_agents, and this one runs before the user has decided to buy anything.
+    # Two gates keep the free route shut: Django refuses `onboarding` as a caller-supplied
+    # task origin, and the agent-server only routes here for a run carrying the protected
+    # `wizard_config` state key. Models stay narrow because a free bucket shouldn't reach
+    # the whole fleet; claude-opus-4-8 is only the SDK's fallback for the pinned sonnet.
+    "onboarding": ProductConfig(
+        allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID, POSTHOG_CODE_DEV_APP_ID}),
+        allowed_models=frozenset({"claude-sonnet-5", "claude-opus-4-8"}) | BEDROCK_MODELS,
+        allow_api_keys=False,
+        credit_bucket=None,
+        requires_server_credential=True,
+    ),
     "slack_app": ProductConfig(
         allowed_application_ids=frozenset({POSTHOG_CODE_US_APP_ID, POSTHOG_CODE_EU_APP_ID, POSTHOG_CODE_DEV_APP_ID}),
         allowed_models=_POSTHOG_CODE_AGENT_MODELS | BEDROCK_MODELS,

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -552,9 +552,9 @@ class TestCheckFreeTierModelAccess:
 
 class TestServerCredentialRequirement:
     """The internal products that share the PostHog Desktop OAuth app (background_agents, signals,
-    slack_app, conversations) must accept only server-minted tokens — those carrying the internal
-    `internal_run:read` marker. Otherwise a user's own Desktop OAuth token could route around the
-    posthog_code free-tier gate through these products to premium models."""
+    slack_app, conversations, onboarding) must accept only server-minted tokens — those carrying the
+    internal `internal_run:read` marker. Otherwise a user's own Desktop OAuth token could route around
+    the posthog_code free-tier gate through these products to premium models."""
 
     _MARKER_SCOPES = ["llm_gateway:read", "task:write", "internal_run:read"]
 
@@ -567,7 +567,7 @@ class TestServerCredentialRequirement:
         yield
         get_settings.cache_clear()
 
-    @pytest.mark.parametrize("product", ["background_agents", "signals", "slack_app", "conversations"])
+    @pytest.mark.parametrize("product", ["background_agents", "signals", "slack_app", "conversations", "onboarding"])
     def test_oauth_without_marker_is_rejected(self, product: str):
         # a desktop Code token (wildcard scope, no internal marker); claude-sonnet-5 is in every
         # sibling's model list, so the rejection is unambiguously the missing server credential
@@ -577,7 +577,7 @@ class TestServerCredentialRequirement:
         assert allowed is False
         assert error is not None and "server-minted" in error
 
-    @pytest.mark.parametrize("product", ["background_agents", "signals", "slack_app", "conversations"])
+    @pytest.mark.parametrize("product", ["background_agents", "signals", "slack_app", "conversations", "onboarding"])
     def test_oauth_with_marker_is_allowed(self, product: str):
         allowed, error = check_product_access(
             product, "oauth_access_token", POSTHOG_CODE_US_APP_ID, "claude-sonnet-5", scopes=self._MARKER_SCOPES

--- a/services/llm-gateway/tests/test_product_config.py
+++ b/services/llm-gateway/tests/test_product_config.py
@@ -16,6 +16,7 @@ from llm_gateway.products.config import (
     PRODUCTS,
     TWIG_EU_APP_ID,
     TWIG_US_APP_ID,
+    UNCONDITIONAL_SERVER_CREDENTIAL_PRODUCTS,
     WIZARD_EU_APP_ID,
     WIZARD_US_APP_ID,
     check_free_tier_model_access,
@@ -613,6 +614,33 @@ class TestServerCredentialRequirement:
         assert allowed is True
         assert error is None
 
+    # The rest of this class runs with the gate forced on, which is the state in which the
+    # requirement was already known to hold. These cover the default state, where the products that
+    # never shipped without the check have to enforce it anyway. Spelled out rather than derived
+    # from UNCONDITIONAL_SERVER_CREDENTIAL_PRODUCTS: parameterizing over the set under test would
+    # make dropping a product from it delete its own coverage instead of failing.
+    @pytest.mark.parametrize("product", ["custom_image_scans", "onboarding"])
+    def test_gate_disabled_still_refuses_unconditional_products(self, product: str, monkeypatch: pytest.MonkeyPatch):
+        from llm_gateway.config import get_settings
+
+        monkeypatch.delenv("LLM_GATEWAY_POSTHOG_CODE_MODEL_GATE_ENABLED", raising=False)
+        get_settings.cache_clear()
+        allowed, error = check_product_access(product, "oauth_access_token", POSTHOG_CODE_US_APP_ID, None, scopes=["*"])
+        assert allowed is False
+        assert error is not None and "server-minted" in error
+
+    @pytest.mark.parametrize("product", ["custom_image_scans", "onboarding"])
+    def test_gate_disabled_still_admits_server_minted_tokens(self, product: str, monkeypatch: pytest.MonkeyPatch):
+        from llm_gateway.config import get_settings
+
+        monkeypatch.delenv("LLM_GATEWAY_POSTHOG_CODE_MODEL_GATE_ENABLED", raising=False)
+        get_settings.cache_clear()
+        allowed, error = check_product_access(
+            product, "oauth_access_token", POSTHOG_CODE_US_APP_ID, None, scopes=self._MARKER_SCOPES
+        )
+        assert allowed is True
+        assert error is None
+
 
 _CODE_APP_IDS = frozenset({POSTHOG_CODE_DEV_APP_ID, POSTHOG_CODE_EU_APP_ID, POSTHOG_CODE_US_APP_ID})
 _CODE_APP_PRODUCTS = [
@@ -634,6 +662,12 @@ class TestServerCredentialConfigInvariant:
             "credential, so a user's own Desktop OAuth token could reach it and route around the "
             "posthog_code free-tier model gate"
         )
+
+    def test_unconditional_products_are_the_ones_enforcing_without_the_flag(self):
+        # Pairs with the two flag-off tests above, which name their products literally. If a
+        # product is added here without flag-off coverage, or removed from here while still
+        # expected to enforce, exactly one of the two sides fails.
+        assert UNCONDITIONAL_SERVER_CREDENTIAL_PRODUCTS == frozenset({"custom_image_scans", "onboarding"})
 
     def test_posthog_code_is_the_only_code_app_product_open_to_user_tokens(self):
         # desktop users hold marker-less Code tokens; requiring the marker on the


### PR DESCRIPTION
## Problem

Setup wizard cloud runs (the "run the wizard in the cloud" path from onboarding) create a task with `origin_product = "onboarding"`.
The agent-server has no mapping for that origin, so it falls through to the `posthog_code` default and every generation the run makes bills into `CreditBucket.POSTHOG_CODE_CREDITS`.

Two things wrong with that. We charge a customer's PostHog Code credits for onboarding, which is our acquisition spend and happens before they have decided to buy anything. And wizard traffic is indistinguishable from real Code tasks in `$ai_generation`, so we cannot see what onboarding actually costs.

`ai_product` cannot be fixed with a header. The gateway re-asserts it from the route in `_apply_owned_event_properties` precisely so callers cannot spoof it. The route is the only lever, which means a new product.

## Changes

A new `onboarding` gateway product, unbilled (`credit_bucket=None`), with an explicit cost ceiling so the spend gauge actually gets published for it.

Wizard cloud runs now pin `claude-sonnet-5` instead of inheriting the agent-server's `claude-opus-4-8` default, and stamp `ai_stage="wizard_pr_agent"` so the PR agent's generations stay separable inside the product. The pin is what makes the narrow model allowlist workable.

A free product needs a closed door, and `origin_product` is caller-settable: any `task:write` holder can POST a task claiming any origin except the three we already reject. So the task API now refuses `onboarding` too, the same way it refuses `image_builder` and `experiments`. Without that, this PR would ship a free LLM endpoint.

That guard is one of two. The other lives in the agent-server: it only routes to the free product when the run also carries the `wizard_config` state key, which only the server-side wizard flow stamps and which the run PATCH allowlist drops. A task that merely claims the origin stays on `posthog_code`.

Also fixed one adjacent lie in the gateway README, which still documented a `billable=True` flag that was replaced by `credit_bucket`.

> [!IMPORTANT]
> This PR is the first half. The agent-server half is PostHog/code#3855, and it must land **after** this one.
> The gateway deploys from its own path-triggered pipeline, so until `onboarding` exists in `PRODUCTS` there, any request to that path segment gets a 400 from `validate_product`. Landing this first is inert, since nothing requests the slug until the agent change ships and the sandbox base image rebuilds.

> [!NOTE]
> Model allowlist includes `claude-opus-4-8` on purpose. The Claude SDK sets it as `fallbackModel` for refusal and overload rescue whenever it is not the primary, so a 403 there would fail the run instead of rescuing it. Bedrock ids are in for the same reason, matching `posthog_code` and `background_agents`.

## How did you test this code?

I (well, Claude) ran these locally, all green:

- `services/llm-gateway` full suite, 1375 passed. The new product is picked up automatically by the derived `TestServerCredentialConfigInvariant`, which is what forces `requires_server_credential=True` on anything sharing the Code OAuth app.
- `products/tasks/backend/tests/test_api.py` plus `posthog/api/wizard/`, 660 passed.
- `products/tasks/backend/tests/test_facade.py`, 31 passed.

New test coverage and the regression each one catches:

| Test | Catches |
| --- | --- |
| `onboarding` case added to `test_create_task_rejects_internal_origin` | Someone drops the API guard and the free route becomes forgeable by any `task:write` caller. This is the security-relevant one. |
| `test_create_wizard_cloud_run_pins_its_model` | The model pin gets dropped, runs go back to the premium default, and every wizard cloud run then 403s at the gateway because that model is not in the product's allowlist. |
| `onboarding` added to the two `TestServerCredentialRequirement` lists | The server-credential marker stops being enforced for this product. Those lists are hand-enumerated, so a new product is not covered without it. |

Not tested by me: the end to end run against a real sandbox. That needs both halves deployed plus a sandbox image rebuild, so it has to happen after the agent PR lands. What I would check then is that the run's `$ai_generation` events carry `ai_product = "onboarding"`, `$ai_billable = false`, `ai_stage = "wizard_pr_agent"`, and sonnet-5 as the model.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `services/llm-gateway/README.md` in this PR: added the product to the registered products table and corrected the `billable` reference to `credit_bucket`. No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code, driven by me. Invoked `/writing-tests` before adding tests.

The interesting decision was how hard to lock the free route. The first proposal was a dedicated internal OAuth scope minted only for wizard runs and required by the product, mirroring `signal_scout_internal`. I rejected it as too much machinery for the payoff. What we went with instead is the two-factor gate described above, which reuses markers that already exist and are already protected.

Worth knowing while reviewing: the gateway's own `requires_server_credential` flag is set here for consistency and to satisfy the config invariant test, but it is not carrying the weight. It is OAuth-only, it is inert unless `posthog_code_model_gate_enabled` is on, and every sandbox token already carries `internal_run:read` anyway, so it cannot tell a wizard run from any other task run. The API guard and the `wizard_config` check are what actually close the door.

One related finding I deliberately left out of scope. `Task.internal` is settable on create and mutable on PATCH, and `isInternal` maps to `background_agents`, which is also unbilled. That looks like the same shape of hole, already open. It may be covered by `requires_server_credential` depending on what `LLM_GATEWAY_POSTHOG_CODE_MODEL_GATE_ENABLED` is set to in production, which I could not verify from here. Worth a look, separately.
