### PR TITLE
feat(data-warehouse): promote Brevo source to beta

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/source.py
@@ -67,7 +67,7 @@ class BrevoSource(ResumableSource[BrevoSourceConfig, BrevoResumeConfig]):
             category=DataWarehouseSourceCategory.MARKETING___EMAIL,
             keywords=["sendinblue"],
             label="Brevo",
-            releaseStatus=ReleaseStatus.ALPHA,
+            releaseStatus=ReleaseStatus.BETA,
             caption="""Enter your Brevo API key to automatically pull your Brevo (formerly Sendinblue) data into the PostHog Data warehouse.
 
 You can create an API key in your [Brevo account settings](https://app.brevo.com/settings/keys/api).""",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/tests/test_brevo_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/brevo/tests/test_brevo_source.py
@@ -47,7 +47,7 @@ class TestBrevoSource:
         config = BrevoSource().get_source_config
         assert config.label == "Brevo"
         assert config.unreleasedSource is None
-        assert config.releaseStatus == "alpha"
+        assert config.releaseStatus == "beta"
         assert config.iconPath == "/static/services/brevo.png"
 
     def test_source_config_has_api_key_password_field(self) -> None:


### PR DESCRIPTION
## Problem

The Brevo (formerly Sendinblue) data-warehouse source has been running as alpha. Over the last 7-day window it has cleared our promotion bar, so the alpha label undersells how ready it is.

## Changes

Promote the Brevo source's `releaseStatus` from `alpha` to `beta` - the value the `/api/public_source_configs/` endpoint surfaces for the connector. Metrics backing the promotion (7-day window):

- In active use by 31 teams (threshold: at least 30)
- Import error rate of 0.0% (threshold: under 5.0%)

Status-label change only. No connector behavior, schemas, or sync logic changed. Gating is untouched - the source was already visible (`unreleasedSource` is unset), so `releaseStatus` is a soft label with no extra flag to remove.

## How did you test this code?

Updated the existing source-config assertion to expect `beta` and ran it:
`products/warehouse_sources/backend/temporal/data_imports/sources/brevo/tests/test_brevo_source.py::TestBrevoSource::test_source_config_basics` passes. `ruff check` is clean on the source.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) made this change on Tom's direction. Invoked the `/implementing-warehouse-sources` skill to confirm the convention: `releaseStatus` uses the `ReleaseStatus` enum and moves alpha → beta once a source is past its rough edges. Located the single source of truth in `brevo/source.py`, flipped the enum, and updated the one test that pinned the old value. Checked open PRs (including the maintainer's own) for an existing Brevo promotion first - none found.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
