### PR TITLE
fix(tracing): keep loading state during superseded queries

### DIFF
--- a/products/tracing/frontend/tracingDataLogic.test.ts
+++ b/products/tracing/frontend/tracingDataLogic.test.ts
@@ -9,7 +9,7 @@ import { resumeKeaLoadersErrors, silenceKeaLoadersErrors } from '~/initKea'
 import { AggregatedSpanRow } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 
-import { tracingDataLogic } from './tracingDataLogic'
+import { NEW_QUERY_STARTED_ERROR_MESSAGE, tracingDataLogic } from './tracingDataLogic'
 import { tracingFiltersLogic } from './tracingFiltersLogic'
 import type { Span } from './types'
 
@@ -317,6 +317,54 @@ describe('tracingDataLogic', () => {
             expect(sparklineSpy).toHaveBeenCalledTimes(2)
             sparklineSpy.mockRestore()
         })
+    })
+
+    describe('loading state across superseded queries', () => {
+        let toastSpy: jest.SpyInstance
+
+        beforeEach(() => {
+            silenceKeaLoadersErrors()
+            toastSpy = jest.spyOn(lemonToast, 'error').mockReturnValue(undefined as any)
+        })
+
+        afterEach(() => {
+            toastSpy.mockRestore()
+        })
+
+        it.each([
+            {
+                name: 'spans',
+                apiMethod: 'listSpans' as const,
+                start: (l: typeof logic) => l.actions.fetchSpans(),
+                fail: (l: typeof logic, error: string) => l.actions.fetchSpansFailure(error),
+                loadingValue: (l: typeof logic) => l.values.spansLoading,
+            },
+            {
+                name: 'aggregation',
+                apiMethod: 'aggregate' as const,
+                start: (l: typeof logic) => l.actions.fetchAggregation(),
+                fail: (l: typeof logic, error: string) => l.actions.fetchAggregationFailure(error),
+                loadingValue: (l: typeof logic) => l.values.aggregationLoading,
+            },
+        ])(
+            'keeps $name loading on a superseded query but clears it on a real failure',
+            ({ apiMethod, start, fail, loadingValue }) => {
+                // Newer query in flight forever, so loading stays owned by it.
+                const apiSpy = jest.spyOn(api.tracing, apiMethod).mockReturnValue(new Promise(() => {}) as any)
+                logic = mountWithSpans([])
+                start(logic)
+                expect(loadingValue(logic)).toBe(true)
+
+                // The previous request's abort must NOT drop the flag mid-flight.
+                fail(logic, NEW_QUERY_STARTED_ERROR_MESSAGE)
+                expect(loadingValue(logic)).toBe(true)
+
+                // A genuine failure still resets it.
+                fail(logic, 'boom')
+                expect(loadingValue(logic)).toBe(false)
+                apiSpy.mockRestore()
+            }
+        )
     })
 
     describe('keyed instances', () => {

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -757,10 +757,12 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
             {
                 fetchSpans: () => true,
                 fetchSpansSuccess: () => false,
-                fetchSpansFailure: () => false,
+                // A superseded query is aborted by the newer one that already re-set loading true;
+                // keep loading so the list holds its spinner instead of flashing "No spans found".
+                fetchSpansFailure: (state, { error }) => (isUserInitiatedError(error) ? state : false),
                 fetchNextPage: () => true,
                 fetchNextPageSuccess: () => false,
-                fetchNextPageFailure: () => false,
+                fetchNextPageFailure: (state, { error }) => (isUserInitiatedError(error) ? state : false),
             },
         ],
         sparklineLoading: [
@@ -792,7 +794,7 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
             {
                 fetchAggregation: () => true,
                 fetchAggregationSuccess: () => false,
-                fetchAggregationFailure: () => false,
+                fetchAggregationFailure: (state, { error }) => (isUserInitiatedError(error) ? state : false),
             },
         ],
         spanTreeLoading: [


### PR DESCRIPTION
## Problem

On `/tracing`, changing a filter (service, date range, sort, view mode) while the current query is still loading briefly flashed **"No spans found"** before the real results appeared.
It reads as "no data" when data is actually on the way.

## Changes

The span list already guarded its empty state correctly (`dataSource.length === 0 && !loading`).
The bug was that `loading` wrongly dropped to `false` mid-flight.

Starting a new query aborts the previous in-flight request.
kea-loaders turns that abort into a `*Failure` action, and the loading reducers mapped *every* failure to `false` — so the superseded request's abort cleared the loading flag the *newer, still-running* request had just set.
For the window between the abort and the new results settling, `spans === []` and `loading === false`, and the empty state rendered.

The fix guards the `spansLoading` and `aggregationLoading` failure handlers with the existing `isUserInitiatedError` helper (already used by the failure listeners to suppress error toasts on superseded queries).
A user-initiated abort now keeps loading true, while genuine failures still reset it.
This also covers the compare and operations tables, which read the same aggregation loading flag and render the same "No spans found" empty state.

```diff
- fetchSpansFailure: () => false,
+ fetchSpansFailure: (state, { error }) => (isUserInitiatedError(error) ? state : false),
```

## How did you test this code?

Added a parameterized reducer-level test in `tracingDataLogic.test.ts` covering both the spans and aggregation loaders: a superseded (aborted) failure keeps loading true, a genuine failure resets it.
This catches a revert of the guard — the exact regression that produced the flash — which no existing test covered (none asserted loading-state behavior on failure).

I (Claude) ran:

- `hogli test products/tracing/frontend/tracingDataLogic.test.ts` — 28 passed (2 new)
- `pnpm --filter=@posthog/frontend typescript:check` — clean for the edited files (the repo has unrelated pre-existing quill module-resolution errors in this worktree)
- `hogli ci:preflight --strict` — no failures

I did not perform manual browser testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Frank reported the bug and I (Claude, via PostHog Code) diagnosed and fixed it.
The investigation started at the empty-state render, which turned out to be correct — the real cause was one layer down in the loading reducers, where an aborted request's failure was indistinguishable from a real one.
I considered guarding at the component (combining a "query in flight" flag) but fixing at the reducer source is cleaner and also fixes the compare/operations tables for free.
Skills invoked: `/writing-tests` (to gate the regression test).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
