### PR TITLE
chore(workflows): remove beta tag from suppression list

### DIFF
--- a/products/workflows/frontend/WorkflowsScene.tsx
+++ b/products/workflows/frontend/WorkflowsScene.tsx
@@ -2,7 +2,7 @@ import { MakeLogicType, actions, connect, kea, path, props, reducers, selectors,
 import { urlToAction } from 'kea-router'
 
 import { IconApple, IconAndroid, IconLetter, IconPlusSmall } from '@posthog/icons'
-import { LemonButton, LemonMenu, LemonMenuItems, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton, LemonMenu, LemonMenuItems } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { AccessControlAction } from 'lib/components/AccessControlAction'
@@ -234,12 +234,7 @@ export function WorkflowsScene(props: WorkflowsSceneProps = {}): JSX.Element {
             link: urls.workflows('opt-outs'),
         },
         {
-            label: (
-                <span className="inline-flex items-center gap-1.5">
-                    Suppression list
-                    <LemonTag type="completion">Beta</LemonTag>
-                </span>
-            ),
+            label: 'Suppression list',
             key: 'suppression',
             content: <SuppressionScene />,
             link: urls.workflows('suppression'),


### PR DESCRIPTION
## Problem

The suppression list tab in the workflows product was still labeled Beta. The feature is stable, so the tag should go.

## Changes

- Removed the `Beta` `LemonTag` from the "Suppression list" tab label in `WorkflowsScene`, reverting the label to a plain string.
- Dropped the now-unused `LemonTag` import from the same file.

No feature flag or env variable ever gated this tab (it renders unconditionally), so there was no flag/env cleanup left to do. The `EMAIL_SUPPRESSION_TRANSIENT_BOUNCE_THRESHOLD` env var is real operational config for the bounce logic, not a beta gate, so it was left untouched.

## How did you test this code?

I (an agent, PostHog Slack app) did not run the app or manual UI checks. Change is a static label edit plus an unused-import removal, verified by grepping that no other `LemonTag`/`Beta` reference remains in the file and that the other imports are still used.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: remove the beta tag from the workflows email suppression list and clean up any leftover feature flag / env variable gating. I searched `products/workflows` and the wider repo for suppression-related feature-flag or env gating and found none tied to the tab, so the change is limited to the label and its unused import. No repo skills were needed for this edit.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1785224874683769)*
