### PR TITLE
fix(data-imports): cap honoured Retry-After to avoid sleep overflow

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/tests/test_transport.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/tests/test_transport.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock
+
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http.transport import (
+    DEFAULT_RETRY,
+    BoundedRetry,
+)
+
+
+def _response_with_retry_after(value: str) -> MagicMock:
+    response = MagicMock()
+    response.headers = {"Retry-After": value}
+    return response
+
+
+class TestBoundedRetry:
+    @parameterized.expand(
+        [
+            # An absurd Retry-After used to reach time.sleep uncapped and raise
+            # OverflowError ("timestamp too large to convert to C PyTime_t").
+            ("huge_integer", "100000000000"),
+            ("above_cap", "600"),
+        ]
+    )
+    def test_retry_after_is_capped(self, _name: str, header_value: str) -> None:
+        retry = BoundedRetry(total=3)
+        assert retry.get_retry_after(_response_with_retry_after(header_value)) == BoundedRetry.DEFAULT_BACKOFF_MAX
+
+    def test_retry_after_below_cap_is_untouched(self) -> None:
+        retry = BoundedRetry(total=3)
+        assert retry.get_retry_after(_response_with_retry_after("5")) == 5
+
+    def test_no_retry_after_header_returns_none(self) -> None:
+        retry = BoundedRetry(total=3)
+        response = MagicMock()
+        response.headers = {}
+        assert retry.get_retry_after(response) is None
+
+    def test_default_retry_is_bounded_and_survives_clone(self) -> None:
+        # urllib3 rebuilds the Retry via `new()` on each attempt; the cap must survive.
+        assert isinstance(DEFAULT_RETRY, BoundedRetry)
+        assert isinstance(DEFAULT_RETRY.new(), BoundedRetry)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/transport.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/http/transport.py
@@ -25,7 +25,25 @@ from urllib3.util.retry import Retry
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.http.observer import record_request
 
-DEFAULT_RETRY = Retry(
+
+class BoundedRetry(Retry):
+    """`Retry` that caps the honoured `Retry-After` sleep.
+
+    A server can send a `Retry-After` far larger than any sane wait — an absurd
+    integer or a date decades out. urllib3 passes it straight to `time.sleep`,
+    which raises `OverflowError` once it exceeds what a C `PyTime_t` can hold,
+    killing the sync. Bounding it to the backoff ceiling keeps a hostile value
+    from overflowing (and from parking a worker for hours).
+    """
+
+    def get_retry_after(self, response: Any) -> float | None:
+        retry_after = super().get_retry_after(response)
+        if retry_after is None:
+            return None
+        return min(retry_after, self.DEFAULT_BACKOFF_MAX)
+
+
+DEFAULT_RETRY = BoundedRetry(
     total=3,
     backoff_factor=0.5,
     status_forcelist=(429, 500, 502, 503, 504),


### PR DESCRIPTION
## Problem

A data-warehouse import crashed with `OverflowError: timestamp too large to convert to C PyTime_t`, surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019fa7b2-98a2-74f1-9df8-56b9f2b31745)). The failing frame is in shared pipeline code, not the source connector.

Root cause: on a retryable status (429/5xx) the upstream server returned a `Retry-After` header with an absurd value (a huge integer, or an HTTP-date far in the future). urllib3's `Retry.sleep_for_retry` reads that value and hands it straight to `time.sleep`. Once the value exceeds what a C `PyTime_t` can hold, `time.sleep` raises `OverflowError` and kills the sync. Even short of overflow, honoring an arbitrary server-supplied wait could park a worker for hours.

The relevant stack (innermost frames):

```
rest_client._send_request -> requests Session.send
  -> TrackedHTTPAdapter.send (common/http/transport.py)
    -> urllib3 connectionpool.urlopen
      -> Retry.sleep -> Retry.sleep_for_retry -> time.sleep(retry_after)  # OverflowError
```

## Changes

`DEFAULT_RETRY` in the shared tracked transport (`common/http/transport.py`) now uses a small `BoundedRetry` subclass that caps the honored `Retry-After` at urllib3's backoff ceiling (`DEFAULT_BACKOFF_MAX`, 120s). This lives in the shared transport used by the common REST client, so every REST-based source is covered, not just the one that tripped it.

This is deliberately not added to `NonRetryableErrors`. The retries themselves are healthy; the bug was in how long we were told to wait between them. A bounded wait keeps legitimate rate-limit backoff working while making an absurd value harmless.

> [!NOTE]
> Capping means we may retry slightly sooner than a server that genuinely asked for a longer wait. With `total=3` retries on a background import this is fine, and it matches the ceiling urllib3 already applies to its own exponential backoff.

## How did you test this code?

Automated tests I (Claude) actually ran, all passing:

- `test_transport.py` — new regression tests at the transport layer:
  - an oversized `Retry-After` (the value that reproduces the `OverflowError`) and an above-cap value are both clamped to the backoff ceiling
  - a below-cap value passes through untouched, and a missing header returns `None`
  - `DEFAULT_RETRY` is a `BoundedRetry` and stays one across `Retry.new()` (urllib3 rebuilds the policy on each attempt, so the cap must survive the clone)

I also confirmed end-to-end that the adapter mounted by `make_tracked_session` is a `BoundedRetry` and clamps an oversized header to 120, and reproduced the original `OverflowError` from a raw oversized `time.sleep` before the fix. `ruff` and a targeted `mypy` run on the changed module are clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue in the data-warehouse import pipeline. I traced the stack from the import activity into urllib3's retry sleep, confirmed the shared transport (not the Dub connector) owns the retry policy, and reproduced the overflow locally. I considered marking the error non-retryable but rejected it: the retries are fine, the wait duration was the bug, so bounding the honored `Retry-After` in shared code is the general fix. Regression tests sit at the same layer as the fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
