### PR TITLE
fix(tasks): handle loop retention database errors

### DIFF
--- a/products/tasks/backend/loop_retention.py
+++ b/products/tasks/backend/loop_retention.py
@@ -7,11 +7,13 @@ non-terminal TaskRun), and prunes old LoopFire dedup rows so that table doesn't 
 from datetime import timedelta
 from uuid import UUID
 
+from django.db import OperationalError, ProgrammingError
 from django.db.models import F, Window
 from django.db.models.functions import RowNumber
 from django.utils import timezone as django_timezone
 
 import structlog
+import psycopg.errors
 from celery import shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 
@@ -105,6 +107,14 @@ def sweep_loop_task_retention_task() -> None:
         deleted_count = sweep_loop_task_retention()
     except SoftTimeLimitExceeded:
         raise
+    except ProgrammingError as exc:
+        if isinstance(exc.__cause__, psycopg.errors.UndefinedTable | psycopg.errors.UndefinedColumn):
+            logger.debug("loop_retention.task_sweep_missing_schema", exception=exc)
+        else:
+            capture_exception(exc)
+            logger.exception("loop_retention.task_sweep_failed")
+    except OperationalError as exc:
+        logger.warning("loop_retention.task_sweep_transient_db_error", exception=exc)
     except Exception as exc:
         capture_exception(exc)
         logger.exception("loop_retention.task_sweep_failed")

--- a/products/tasks/backend/tests/test_loop_retention.py
+++ b/products/tasks/backend/tests/test_loop_retention.py
@@ -2,19 +2,27 @@ from datetime import timedelta
 
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.db import OperationalError, ProgrammingError
+from django.test import SimpleTestCase, TestCase
 from django.utils import timezone as django_timezone
 
+import psycopg.errors
 from parameterized import parameterized
 
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
 from posthog.models.user import User
 
-from products.tasks.backend.loop_retention import sweep_loop_task_retention
+from products.tasks.backend.loop_retention import sweep_loop_task_retention, sweep_loop_task_retention_task
 from products.tasks.backend.models import Loop, Task, TaskRun
 
 RETENTION_MODULE = "products.tasks.backend.loop_retention"
+
+
+def programming_error_from(cause: BaseException) -> ProgrammingError:
+    error = ProgrammingError(str(cause))
+    error.__cause__ = cause
+    return error
 
 
 class LoopRetentionTestCase(TestCase):
@@ -51,6 +59,40 @@ class LoopRetentionTestCase(TestCase):
         )
         TaskRun.objects.create(task=task, team=self.team, status=run_status, state={"loop_id": str(loop.id)})
         return task
+
+
+class TestSweepLoopTaskRetentionTask(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("missing_table", programming_error_from(psycopg.errors.UndefinedTable("missing table"))),
+            ("missing_column", programming_error_from(psycopg.errors.UndefinedColumn("missing column"))),
+            ("transient_database_failure", OperationalError("connection unavailable")),
+        ]
+    )
+    def test_expected_database_errors_are_not_reported(
+        self, _name: str, database_error: ProgrammingError | OperationalError
+    ) -> None:
+        with (
+            patch(f"{RETENTION_MODULE}.sweep_loop_task_retention", side_effect=database_error),
+            patch(f"{RETENTION_MODULE}.prune_loop_fire_records", return_value=0) as mock_prune,
+            patch(f"{RETENTION_MODULE}.capture_exception") as mock_capture,
+        ):
+            sweep_loop_task_retention_task()
+
+        mock_capture.assert_not_called()
+        mock_prune.assert_called_once_with()
+
+    def test_unexpected_programming_errors_are_reported(self) -> None:
+        database_error = programming_error_from(psycopg.errors.SyntaxError("invalid query"))
+        with (
+            patch(f"{RETENTION_MODULE}.sweep_loop_task_retention", side_effect=database_error),
+            patch(f"{RETENTION_MODULE}.prune_loop_fire_records", return_value=0) as mock_prune,
+            patch(f"{RETENTION_MODULE}.capture_exception") as mock_capture,
+        ):
+            sweep_loop_task_retention_task()
+
+        mock_capture.assert_called_once_with(database_error)
+        mock_prune.assert_called_once_with()
 
 
 class TestSweepLoopTaskRetention(LoopRetentionTestCase):


### PR DESCRIPTION
## Problem

**Why:** The loop retention janitor can run while the Tasks schema is unavailable or while the database connection is transiently unhealthy. These expected failures should skip one sweep without creating error-tracking noise.

## Changes

Catch schema-related `ProgrammingError` failures and transient `OperationalError` failures separately in the loop retention task. Both remain logged, while unexpected exceptions continue to be captured. The independent LoopFire pruning pass still runs