### PR TITLE
fix(flags): tolerate non-dict request body in flag update

### DIFF
--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -5141,6 +5141,31 @@ class TestExperimentCRUD(_HoistFlagConfigClientMixin, APILicensedTest):
         self.assertEqual(launch_response.status_code, status.HTTP_200_OK)
         self.assertEqual(launch_response.json()["status"], "running")
 
+    def test_launch_experiment_endpoint_with_list_body(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "List Body Endpoint",
+                "feature_flag_key": "list-body-endpoint-flag",
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        experiment_id = response.json()["id"]
+
+        # The endpoint declares no request body, so a JSON array must not reach the flag serializer
+        # as a non-dict `request.data`.
+        launch_response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/launch/",
+            [],
+            format="json",
+        )
+        self.assertEqual(launch_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(launch_response.json()["status"], "running")
+
+        flag = FeatureFlag.objects.get(key="list-body-endpoint-flag", team=self.team)
+        self.assertTrue(flag.active)
+
     def test_archive_experiment_endpoint(self):
         response = self.client.post(
             f"/api/projects/{self.team.id}/experiments/",

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -1857,9 +1857,11 @@ class FeatureFlagSerializer(
     @approval_gate(["feature_flag.enable", "feature_flag.disable", "feature_flag.update"])
     def update(self, instance: FeatureFlag, validated_data: dict, *args: Any, **kwargs: Any) -> FeatureFlag:
         request = self.context["request"]
-        # This is a workaround to ensure update works when called from a scheduled task.
-        if request and not hasattr(request, "data"):
-            request.data = {}
+        # Service-layer callers may carry no body, and an endpoint that declares no request schema
+        # can hand us a non-dict one (e.g. a JSON array posted to /experiments/:id/launch/).
+        request_data = getattr(request, "data", None) if request else None
+        if not isinstance(request_data, dict):
+            request_data = {}
 
         validated_data["last_modified_by"] = request.user
         # Prevent DRF from attempting to set reverse FK relation directly
@@ -2001,7 +2003,7 @@ class FeatureFlagSerializer(
                 k: v for k, v in previous_filters.items() if k not in ("holdout_groups", "super_groups")
             }
 
-        version = request.data.get("version", -1)
+        version = request_data.get("version", -1)
 
         try:
             with transaction.atomic():
@@ -2013,7 +2015,7 @@ class FeatureFlagSerializer(
 
                 # NOW check for conflicts after all transformations
                 if version != -1 and version != locked_version:
-                    original_flag = request.data.get("original_flag", {})
+                    original_flag = request_data.get("original_flag", {})
                     conflicting_changes = self._get_conflicting_changes(
                         locked_instance,
                         validated_data,

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -2015,7 +2015,11 @@ class FeatureFlagSerializer(
 
                 # NOW check for conflicts after all transformations
                 if version != -1 and version != locked_version:
-                    original_flag = request_data.get("original_flag", {})
+                    # Not a serializer field, so the client controls its type; the conflict helpers
+                    # index into it by field name and would raise on a list or string.
+                    original_flag = request_data.get("original_flag")
+                    if not isinstance(original_flag, dict):
+                        original_flag = {}
                     conflicting_changes = self._get_conflicting_changes(
                         locked_instance,
                         validated_data,

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -2892,6 +2892,34 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         conflicts = serializer._get_conflicting_changes(feature_flag, validated_data, original_flag)
         self.assertEqual(conflicts, ["name", "filters"])
 
+    @parameterized.expand(
+        [
+            ("list", ["active"]),
+            ("string", "active"),
+            ("number", 1),
+        ]
+    )
+    @patch("products.feature_flags.backend.api.feature_flag.report_user_action")
+    def test_updating_feature_flag_with_non_dict_original_flag(
+        self, _name, original_flag, mock_report_user_action
+    ) -> None:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/feature_flags/",
+            data={"name": "original name", "key": "a-flag-with-a-bad-original-flag"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        flag_id = response.json()["id"]
+
+        # A stale version enters the conflict branch, where original_flag is indexed by field name.
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{flag_id}",
+            data={"active": False, "version": 999, "original_flag": original_flag},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(FeatureFlag.objects.get(id=flag_id).active)
+
     @patch("products.feature_flags.backend.api.feature_flag.report_user_action")
     def test_updating_feature_flag_treats_null_version_as_zero(self, mock_report_user_action):
         with freeze_time("2021-08-25T22:09:14.252Z") as frozen_datetime:


### PR DESCRIPTION
## Problem

`POST /api/projects/:id/experiments/:id/launch/` returns a 500 in production:

```
AttributeError: 'list' object has no attribute 'get'
  products/feature_flags/backend/api/feature_flag.py:2004  version = request.data.get("version", -1)
```

The launch action declares no request body (`@extend_schema(request=None)`) and validates nothing, so whatever the client posted is parsed by DRF and handed straight down: view → `ExperimentService.launch_experiment` → `set_flag_active` → `update_flag` → `FeatureFlagSerializer.update`. If the body is a JSON array, `request.data` is a list and `update()` blows up reading `version` off it.

The existing workaround in `update()` only covered a missing `.data` attribute (service layer shims), not a wrong type. It also can't be extended by assignment, since DRF's `Request.data` is a read only property.

## Changes

`update()` now reads the body through a type checked local instead of assuming a dict:

```python
request_data = getattr(request, "data", None) if request else None
if not isinstance(request_data, dict):
    request_data = {}
```

Both body reads in the method (`version`, `original_flag`) use it. `update()` is the one choke point every facade write goes through (`update_flag`, `set_flag_active`, `archive_flag`, `unarchive_flag`, `ship_variant`), so this covers all callers rather than just the launch path.

I did not add body validation to the launch endpoint or a shared "safe request data" helper. One guard at the choke point is enough today, and either is easy to add if a second non-dict path shows up.

## How did you test this code?

Automated only, no manual testing.

- Added `test_launch_experiment_endpoint_with_list_body` in `products/experiments/backend/test/test_presentation_api.py`. It posts a JSON array body to the launch endpoint and asserts a 200 plus the flag going active. Regression it catches: a non-dict `request.data` reaching `FeatureFlagSerializer.update`, which no existing test exercised (every other experiment action validates its body with a serializer first, so they all pass a dict). Confirmed it fails with the 500 when the source fix is stashed and passes with it.
- `hogli test products/experiments/backend/test/test_presentation_api.py -k launch_experiment_endpoint` (4 passed)
- `ruff check` and `ruff format --check` on both files

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code) wrote this from the production error stack trace. Skills invoked: `/writing-tests` before adding the test.

The first instinct was to validate the body in the experiments launch action, but tracing the callers showed every facade write funnels through `FeatureFlagSerializer.update`, and `launch` is just the one action that happens to have no body validation. Guarding at the serializer is the smaller diff and fixes the sibling paths too. Extending the existing `hasattr` guard in place was ruled out because `Request.data` has no setter on a real HTTP request.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
