### PR TITLE
fix(frontend): make useAnimatedPresence enter transition deterministic

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5573,7 +5573,7 @@ snapshots:
     scenes-app-dashboards--show-across-viewports--narrow--dark:
         hash: v1.k794b7964.e919c4955d7113170ab00269c5f628c318afe14f26dc8aafb046b172e17f362e.YDXD84rrb2KR1I36pHMxEsGZ0sN0os_cBBdNIf89Pu8
     scenes-app-dashboards--show-across-viewports--narrow--light:
-        hash: v1.k794b7964.a46d840722e971910236d6fcd8a8f69e0b1db5ee9d472d62055b02d6569f7a99.kHEdVPNUm5DRKSlMFS12SLKf1TyChQJZKKuZ2PKvtfA
+        hash: v1.k794b7964.e6a99deaafbd0220dbe5b084e809b2c09113f273c108b48ec57b6e37720edd52.5OqJSo3vD5pzHttmCjtC1mWKKtfw54yjZbcnkl6WnOA
     scenes-app-dashboards--show-across-viewports--superwide--dark:
         hash: v1.k794b7964.9948b52cf842206c1584057a6a16b8caed7a32d95f103dbea07089a02df75a53.AuXGqOvw-P-XuzOL2Zl-BkBPb1-Q3R1949f5-IkTjZA
     scenes-app-dashboards--show-across-viewports--superwide--light:

--- a/frontend/src/lib/hooks/useAnimatedPresence.test.ts
+++ b/frontend/src/lib/hooks/useAnimatedPresence.test.ts
@@ -71,6 +71,20 @@ describe('useAnimatedPresence', () => {
         expect(result.current).toEqual({ rendered: true, shown: true })
     })
 
+    it('flips shown synchronously via a reflow when given a ref, without waiting for a frame', () => {
+        const ref = { current: document.createElement('div') }
+        const { result, rerender } = renderHook(({ isIn }) => useAnimatedPresence(isIn, 200, ref), {
+            initialProps: { isIn: false },
+        })
+        expect(result.current).toEqual({ rendered: false, shown: false })
+
+        // The layout effect forces a reflow and flips shown in the same commit —
+        // no RAF is scheduled, so the enter can't be lost to paint coalescing.
+        rerender({ isIn: true })
+        expect(result.current).toEqual({ rendered: true, shown: true })
+        expect(rafCallbacks).toHaveLength(0)
+    })
+
     it('flips shown immediately on exit and unrenders after the duration', () => {
         const { result, rerender } = renderHook(({ isIn }) => useAnimatedPresence(isIn, 200), {
             initialProps: { isIn: true },

--- a/frontend/src/lib/hooks/useAnimatedPresence.ts
+++ b/frontend/src/lib/hooks/useAnimatedPresence.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { RefObject, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 export interface AnimatedPresenceState {
     rendered: boolean
@@ -17,8 +17,19 @@ export interface AnimatedPresenceState {
  *
  * `rendered !== shown` while a transition is mid-flight, so call sites that
  * need an `aria-busy`-style signal can derive it from those two booleans.
+ *
+ * Pass `ref` (pointing at the transitioning element) when the enter animation
+ * must be reliable. Without it the flip to `shown` is deferred with rAF, which
+ * only *usually* lets the pre-transition styles paint first — under load the
+ * mount and the flip can coalesce into one paint and the enter transition is
+ * skipped. With a ref, the flip forces a synchronous reflow instead, which
+ * deterministically records the hidden state as the transition's start value.
  */
-export function useAnimatedPresence(isIn: boolean, durationMs: number): AnimatedPresenceState {
+export function useAnimatedPresence(
+    isIn: boolean,
+    durationMs: number,
+    ref?: RefObject<HTMLElement | null>
+): AnimatedPresenceState {
     const [rendered, setRendered] = useState(isIn)
     const [shown, setShown] = useState(isIn)
     const renderedRef = useRef(rendered)
@@ -27,20 +38,7 @@ export function useAnimatedPresence(isIn: boolean, durationMs: number): Animated
     useEffect(() => {
         if (isIn) {
             setRendered(true)
-            // Defer the visibility flip two frames so the browser paints the
-            // pre-transition (hidden) styles first. `setRendered` runs from a
-            // passive effect (after paint), so a single RAF fires in the same
-            // frame as the mount's paint — the browser coalesces both states
-            // into one paint and the enter transition never runs. The extra
-            // frame guarantees the hidden state paints before `shown` flips.
-            let innerRaf = 0
-            const outerRaf = window.requestAnimationFrame(() => {
-                innerRaf = window.requestAnimationFrame(() => setShown(true))
-            })
-            return () => {
-                window.cancelAnimationFrame(outerRaf)
-                window.cancelAnimationFrame(innerRaf)
-            }
+            return
         }
         if (!renderedRef.current) {
             return
@@ -49,6 +47,36 @@ export function useAnimatedPresence(isIn: boolean, durationMs: number): Animated
         const timer = window.setTimeout(() => setRendered(false), durationMs)
         return () => window.clearTimeout(timer)
     }, [isIn, durationMs])
+
+    // Flip `shown` on only once the hidden element is mounted, and make the
+    // browser commit that hidden state as the transition's start value first —
+    // otherwise the mount and the flip land in one paint and the enter
+    // transition never runs.
+    useLayoutEffect(() => {
+        if (!isIn || !rendered || shown) {
+            return
+        }
+        const node = ref?.current
+        if (node) {
+            // Force a synchronous layout so the hidden styles are the recorded
+            // start value; the flip below then animates from them. Deterministic,
+            // unlike frame-counting.
+            void node.offsetHeight
+            setShown(true)
+            return
+        }
+        // Headless fallback (no node to reflow): defer two frames so the hidden
+        // state has a chance to paint before the flip. Best-effort — pass a ref
+        // when the transition must be reliable.
+        let innerRaf = 0
+        const outerRaf = window.requestAnimationFrame(() => {
+            innerRaf = window.requestAnimationFrame(() => setShown(true))
+        })
+        return () => {
+            window.cancelAnimationFrame(outerRaf)
+            window.cancelAnimationFrame(innerRaf)
+        }
+    }, [isIn, rendered, shown, ref])
 
     return { rendered, shown }
 }

--- a/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCollapse/LemonCollapse.tsx
@@ -1,7 +1,7 @@
 import './LemonCollapse.scss'
 
 import clsx from 'clsx'
-import React, { ReactNode, useEffect, useMemo, useState } from 'react'
+import React, { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import useResizeObserver from 'use-resize-observer'
 
 import { IconCollapse, IconExpand } from '@posthog/icons'
@@ -131,7 +131,8 @@ function LemonCollapsePanel({
     onHeaderClick,
 }: LemonCollapsePanelProps): JSX.Element {
     const { height: contentHeight, ref: contentRef } = useResizeObserver({ box: 'border-box' })
-    const { rendered, shown } = useAnimatedPresence(isExpanded, 200)
+    const bodyRef = useRef<HTMLDivElement>(null)
+    const { rendered, shown } = useAnimatedPresence(isExpanded, 200, bodyRef)
 
     const { headerChildren, headerProps } = useMemo((): HeaderDefinition => {
         if (header && typeof header === 'object' && 'children' in header) {
@@ -174,6 +175,7 @@ function LemonCollapsePanel({
 
             {rendered && (
                 <div
+                    ref={bodyRef}
                     className="LemonCollapsePanel__body"
                     // eslint-disable-next-line react/forbid-dom-props
                     style={{ height: shown ? contentHeight : 0 }}


### PR DESCRIPTION
## Problem

The expand (enter) animation on `LemonCollapse` is non-deterministic. Sometimes it slides open, sometimes it jumps straight to the open state with no transition. #73960 lowered the odds by deferring the flip an extra frame, but it did not actually fix the race.

A CSS `height` transition only runs if the browser commits the hidden (`height: 0`) state as the transition's start value before `height` flips to the target. `useAnimatedPresence` is headless (it owns no DOM node), so it can only approximate that by deferring the flip with `requestAnimationFrame`. rAF gives no guarantee that a paint or style flush lands between two callbacks, so under load the mount and the flip coalesce into one paint and the transition is skipped. `LemonCollapse` compounds it by transitioning to a pixel height that `ResizeObserver` measures asynchronously, a second unordered async signal racing the flip.

## Changes

- `useAnimatedPresence` takes an optional `ref` to the transitioning element. On enter, when the ref is set, it reads `offsetHeight` to force a synchronous reflow, which records the hidden state as the transition's start value, then flips `shown` in the same layout pass. Deterministic, no frame-counting.
- Call sites that pass no ref keep the rAF fallback, so the four other consumers are untouched.
- `LemonCollapse` passes a `bodyRef` into the panel body, opting into the reflow path.

Forcing the reflow also makes the `ResizeObserver` timing irrelevant. Whichever order `contentHeight` and the flip arrive in, `0` is always the established start value.

## How did you test this code?

- Jest: 11/11 in `useAnimatedPresence.test.ts`, including a new test asserting the ref path flips `shown` synchronously with zero frames scheduled. That's the regression guard for the flake.
- Manual: expanded and collapsed the Exposures panel repeatedly in local dev, and the enter animation now runs every time.
- I could not run the full frontend typecheck or build from a light worktree.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #73960, which shipped a best-effort double-rAF and still flaked in practice. I diagnosed the root cause as paint coalescing in a headless hook and switched the enter path to a forced reflow, the same technique framework transition libraries use. Skills invoked: /writing-tests.
