### PR TITLE
feat(feature-flags): migrate early access opt-ins on flag key rename

### DIFF
--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -2063,6 +2063,10 @@ class FeatureFlagSerializer(
 
         if old_key != instance.key:
             _update_feature_flag_dashboard(instance, old_key)
+            if instance.has_feature_enrollment:
+                from products.feature_flags.backend.tasks import migrate_feature_enrollment_on_key_change
+
+                migrate_feature_enrollment_on_key_change.delay(instance.team_id, old_key, instance.key)
 
         report_user_action(
             request.user,

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -2066,7 +2066,7 @@ class FeatureFlagSerializer(
             if instance.has_feature_enrollment:
                 from products.feature_flags.backend.tasks import migrate_feature_enrollment_on_key_change
 
-                migrate_feature_enrollment_on_key_change.delay(instance.team_id, old_key, instance.key)
+                migrate_feature_enrollment_on_key_change.delay(instance.team_id, old_key, instance.id)
 
         report_user_action(
             request.user,

--- a/products/feature_flags/backend/tasks.py
+++ b/products/feature_flags/backend/tasks.py
@@ -9,6 +9,11 @@ import structlog
 from celery import shared_task
 from prometheus_client import Gauge
 
+from posthog.hogql import ast
+from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS, LimitContext
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.api.capture import capture_internal
 from posthog.models.team import Team
 from posthog.scoping_audit import skip_team_scope_audit
 from posthog.storage.hypercache_manager import HYPERCACHE_SIGNAL_UPDATE_COUNTER
@@ -104,6 +109,71 @@ def update_team_service_flags_cache(team_id: int) -> None:
     HYPERCACHE_SIGNAL_UPDATE_COUNTER.labels(
         namespace="feature_flags", cache_name="flags", operation="update", result="success" if success else "failure"
     ).inc()
+
+
+@shared_task(
+    ignore_result=True,
+    queue=CeleryQueue.FEATURE_FLAGS.value,
+    max_retries=3,
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+)
+@skip_team_scope_audit
+def migrate_feature_enrollment_on_key_change(team_id: int, old_key: str, new_key: str) -> None:
+    """
+    Copy `$feature_enrollment/<old_key>` person properties to the new key after a flag
+    key rename, so existing early access opt-ins (and explicit opt-outs) keep applying —
+    evaluation derives the enrollment property name from the flag's current key.
+    Persons who already have a value under the new key are left untouched, and the old
+    property is kept so renaming back stays lossless. Safe to retry: re-sending a $set
+    a person already received is a no-op.
+    """
+    try:
+        team = Team.objects.get(id=team_id)
+    except Team.DoesNotExist:
+        logger.exception("Team does not exist for enrollment migration", team_id=team_id)
+        return
+
+    # Property access (rather than JSONExtractString) lets the HogQL printer use
+    # materialized person-property columns when available.
+    response = execute_hogql_query(
+        """
+        SELECT
+            argMax(pdi.distinct_id, created_at) AS distinct_id,
+            properties[{old_prop}] AS enrollment_value
+        FROM persons
+        WHERE properties[{old_prop}] IN ('true', 'false')
+        AND properties[{new_prop}] IS NULL
+        GROUP BY id, enrollment_value
+        LIMIT {limit}
+        """,
+        placeholders={
+            "old_prop": ast.Constant(value=f"$feature_enrollment/{old_key}"),
+            "new_prop": ast.Constant(value=f"$feature_enrollment/{new_key}"),
+            "limit": ast.Constant(value=MAX_SELECT_RETURNED_ROWS),
+        },
+        team=team,
+        limit_context=LimitContext.QUERY_ASYNC,
+    )
+
+    if len(response.results) >= MAX_SELECT_RETURNED_ROWS:
+        logger.warning(
+            "Feature enrollment migration hit the row cap; not all enrollments migrated",
+            team_id=team_id,
+            old_key=old_key,
+            new_key=new_key,
+        )
+
+    new_prop = f"$feature_enrollment/{new_key}"
+    for distinct_id, enrollment_value in response.results:
+        capture_internal(
+            token=team.api_token,
+            event_name="$set",
+            event_source="feature_flag_enrollment_key_migration",
+            distinct_id=distinct_id,
+            properties={"$set": {new_prop: enrollment_value == "true"}},
+            process_person_profile=True,
+        ).raise_for_status()
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.FEATURE_FLAGS.value)

--- a/products/feature_flags/backend/tasks.py
+++ b/products/feature_flags/backend/tasks.py
@@ -13,7 +13,7 @@ from posthog.hogql import ast
 from posthog.hogql.constants import MAX_SELECT_RETURNED_ROWS, LimitContext
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.api.capture import capture_internal
+from posthog.api.capture import capture_batch_internal
 from posthog.models.team import Team
 from posthog.scoping_audit import skip_team_scope_audit
 from posthog.storage.hypercache_manager import HYPERCACHE_SIGNAL_UPDATE_COUNTER
@@ -41,6 +41,8 @@ logger = structlog.get_logger(__name__)
 # Matches the task's hard time_limit so a crashed run's lock expires before the next
 # 5-minute schedule.
 LOCAL_EVAL_CANARY_LOCK_TIMEOUT_SECONDS = 90
+
+ENROLLMENT_MIGRATION_PAGE_SIZE = MAX_SELECT_RETURNED_ROWS
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.FEATURE_FLAGS.value)
@@ -113,20 +115,23 @@ def update_team_service_flags_cache(team_id: int) -> None:
 
 @shared_task(
     ignore_result=True,
-    queue=CeleryQueue.FEATURE_FLAGS.value,
+    queue=CeleryQueue.FEATURE_FLAGS_LONG_RUNNING.value,
     max_retries=3,
     autoretry_for=(Exception,),
     retry_backoff=True,
 )
 @skip_team_scope_audit
-def migrate_feature_enrollment_on_key_change(team_id: int, old_key: str, new_key: str) -> None:
+def migrate_feature_enrollment_on_key_change(team_id: int, old_key: str, flag_id: int) -> None:
     """
-    Copy `$feature_enrollment/<old_key>` person properties to the new key after a flag
-    key rename, so existing early access opt-ins (and explicit opt-outs) keep applying —
-    evaluation derives the enrollment property name from the flag's current key.
-    Persons who already have a value under the new key are left untouched, and the old
-    property is kept so renaming back stays lossless. Safe to retry: re-sending a $set
-    a person already received is a no-op.
+    Copy `$feature_enrollment/<old_key>` person properties to the flag's key after a rename,
+    so existing early access opt-ins (and explicit opt-outs) keep applying — evaluation
+    derives the enrollment property name from the flag's current key.
+
+    The destination is the flag's key as of execution, not as of the rename, so a chain of
+    renames converges on the final key instead of stranding people on an intermediate one.
+    Writes use `$set_once`, so a person who makes a fresh choice under the new key during the
+    migration can't be clobbered, and retries are harmless. The old property is kept so
+    renaming back stays lossless. Enrollees are paged through by person id.
     """
     try:
         team = Team.objects.get(id=team_id)
@@ -134,46 +139,70 @@ def migrate_feature_enrollment_on_key_change(team_id: int, old_key: str, new_key
         logger.exception("Team does not exist for enrollment migration", team_id=team_id)
         return
 
-    # Property access (rather than JSONExtractString) lets the HogQL printer use
-    # materialized person-property columns when available.
-    response = execute_hogql_query(
-        """
-        SELECT
-            argMax(pdi.distinct_id, created_at) AS distinct_id,
-            properties[{old_prop}] AS enrollment_value
-        FROM persons
-        WHERE properties[{old_prop}] IN ('true', 'false')
-        AND properties[{new_prop}] IS NULL
-        GROUP BY id, enrollment_value
-        LIMIT {limit}
-        """,
-        placeholders={
-            "old_prop": ast.Constant(value=f"$feature_enrollment/{old_key}"),
-            "new_prop": ast.Constant(value=f"$feature_enrollment/{new_key}"),
-            "limit": ast.Constant(value=MAX_SELECT_RETURNED_ROWS),
-        },
-        team=team,
-        limit_context=LimitContext.QUERY_ASYNC,
-    )
+    flag = FeatureFlag.objects.filter(team_id=team_id, id=flag_id, deleted=False).first()
+    if flag is None:
+        return
 
-    if len(response.results) >= MAX_SELECT_RETURNED_ROWS:
-        logger.warning(
-            "Feature enrollment migration hit the row cap; not all enrollments migrated",
-            team_id=team_id,
-            old_key=old_key,
-            new_key=new_key,
-        )
+    new_key = flag.key
+    if new_key == old_key:
+        return
 
     new_prop = f"$feature_enrollment/{new_key}"
-    for distinct_id, enrollment_value in response.results:
-        capture_internal(
-            token=team.api_token,
-            event_name="$set",
-            event_source="feature_flag_enrollment_key_migration",
-            distinct_id=distinct_id,
-            properties={"$set": {new_prop: enrollment_value == "true"}},
-            process_person_profile=True,
-        ).raise_for_status()
+    cursor = ""
+
+    while True:
+        # Property access (rather than JSONExtractString) lets the HogQL printer use
+        # materialized person-property columns when available.
+        response = execute_hogql_query(
+            """
+            SELECT
+                toString(id) AS person_id,
+                argMax(pdi.distinct_id, created_at) AS distinct_id,
+                properties[{old_prop}] AS enrollment_value
+            FROM persons
+            WHERE properties[{old_prop}] IN ('true', 'false')
+            AND properties[{new_prop}] IS NULL
+            AND toString(id) > {cursor}
+            GROUP BY id, enrollment_value
+            ORDER BY person_id
+            LIMIT {limit}
+            """,
+            placeholders={
+                "old_prop": ast.Constant(value=f"$feature_enrollment/{old_key}"),
+                "new_prop": ast.Constant(value=new_prop),
+                "cursor": ast.Constant(value=cursor),
+                "limit": ast.Constant(value=ENROLLMENT_MIGRATION_PAGE_SIZE),
+            },
+            team=team,
+            limit_context=LimitContext.QUERY_ASYNC,
+        )
+
+        if not response.results:
+            return
+
+        # A person whose distinct ids all moved to another person in a merge joins to nothing
+        # and comes back blank; capture rejects the whole batch over one such event.
+        events = [
+            {
+                "event": "$set",
+                "distinct_id": distinct_id,
+                "properties": {"$set_once": {new_prop: enrollment_value == "true"}},
+            }
+            for _person_id, distinct_id, enrollment_value in response.results
+            if distinct_id
+        ]
+        if events:
+            capture_batch_internal(
+                events=events,
+                token=team.api_token,
+                event_source="feature_flag_enrollment_key_migration",
+                process_person_profile=True,
+            ).raise_for_status()
+
+        if len(response.results) < ENROLLMENT_MIGRATION_PAGE_SIZE:
+            return
+
+        cursor = response.results[-1][0]
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.FEATURE_FLAGS.value)

--- a/products/feature_flags/backend/test/test_migrate_feature_enrollment.py
+++ b/products/feature_flags/backend/test/test_migrate_feature_enrollment.py
@@ -1,0 +1,95 @@
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, call, patch
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.test.persons import create_person
+
+from products.feature_flags.backend.models.feature_flag import FeatureFlag
+from products.feature_flags.backend.tasks import migrate_feature_enrollment_on_key_change
+
+ENROLLMENT_FILTERS = {
+    "feature_enrollment": True,
+    "groups": [{"properties": [], "rollout_percentage": 100}],
+}
+
+
+class TestMigrateFeatureEnrollmentOnKeyChange(APIBaseTest):
+    @patch("products.feature_flags.backend.tasks.capture_internal")
+    def test_copies_enrollment_values_without_clobbering(self, mock_capture: MagicMock) -> None:
+        create_person(
+            team=self.team,
+            distinct_ids=["opted-in"],
+            properties={"$feature_enrollment/old-key": True},
+        )
+        create_person(
+            team=self.team,
+            distinct_ids=["opted-out"],
+            properties={"$feature_enrollment/old-key": False},
+        )
+        create_person(
+            team=self.team,
+            distinct_ids=["already-migrated"],
+            properties={"$feature_enrollment/old-key": True, "$feature_enrollment/new-key": False},
+        )
+        create_person(team=self.team, distinct_ids=["unrelated"], properties={})
+
+        migrate_feature_enrollment_on_key_change(self.team.id, "old-key", "new-key")
+
+        assert mock_capture.call_count == 2
+        mock_capture.assert_has_calls(
+            [
+                call(
+                    token=self.team.api_token,
+                    event_name="$set",
+                    event_source="feature_flag_enrollment_key_migration",
+                    distinct_id="opted-in",
+                    properties={"$set": {"$feature_enrollment/new-key": True}},
+                    process_person_profile=True,
+                ),
+                call(
+                    token=self.team.api_token,
+                    event_name="$set",
+                    event_source="feature_flag_enrollment_key_migration",
+                    distinct_id="opted-out",
+                    properties={"$set": {"$feature_enrollment/new-key": False}},
+                    process_person_profile=True,
+                ),
+            ],
+            any_order=True,
+        )
+
+    @patch("products.feature_flags.backend.tasks.migrate_feature_enrollment_on_key_change.delay")
+    def test_key_rename_of_enrollment_flag_enqueues_migration(self, mock_delay: MagicMock) -> None:
+        flag = FeatureFlag.objects.create(
+            team=self.team, key="old-key", created_by=self.user, filters=ENROLLMENT_FILTERS
+        )
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{flag.id}/",
+            {"key": "new-key"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_delay.assert_called_once_with(self.team.id, "old-key", "new-key")
+
+    @parameterized.expand(
+        [
+            ("no_enrollment", {"groups": [{"properties": [], "rollout_percentage": 100}]}, {"key": "new-key"}),
+            ("no_key_change", ENROLLMENT_FILTERS, {"name": "renamed display name"}),
+        ]
+    )
+    @patch("products.feature_flags.backend.tasks.migrate_feature_enrollment_on_key_change.delay")
+    def test_no_migration_when_not_an_enrollment_key_rename(
+        self, _name: str, filters: dict, patch_body: dict, mock_delay: MagicMock
+    ) -> None:
+        flag = FeatureFlag.objects.create(team=self.team, key="old-key", created_by=self.user, filters=filters)
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/feature_flags/{flag.id}/",
+            patch_body,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_delay.assert_not_called()

--- a/products/feature_flags/backend/test/test_migrate_feature_enrollment.py
+++ b/products/feature_flags/backend/test/test_migrate_feature_enrollment.py
@@ -1,5 +1,5 @@
 from posthog.test.base import APIBaseTest
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 from parameterized import parameterized
 from rest_framework import status
@@ -15,50 +15,107 @@ ENROLLMENT_FILTERS = {
 }
 
 
-class TestMigrateFeatureEnrollmentOnKeyChange(APIBaseTest):
-    @patch("products.feature_flags.backend.tasks.capture_internal")
-    def test_copies_enrollment_values_without_clobbering(self, mock_capture: MagicMock) -> None:
-        create_person(
-            team=self.team,
-            distinct_ids=["opted-in"],
-            properties={"$feature_enrollment/old-key": True},
-        )
-        create_person(
-            team=self.team,
-            distinct_ids=["opted-out"],
-            properties={"$feature_enrollment/old-key": False},
-        )
-        create_person(
-            team=self.team,
-            distinct_ids=["already-migrated"],
-            properties={"$feature_enrollment/old-key": True, "$feature_enrollment/new-key": False},
-        )
-        create_person(team=self.team, distinct_ids=["unrelated"], properties={})
+# Person rows land in ClickHouse, which isn't rolled back between tests, so each test
+# below uses its own enrollment key and distinct ids to stay order-independent.
+def _sent_enrollments(mock_capture: MagicMock) -> dict[str, dict]:
+    return {
+        event["distinct_id"]: event["properties"]
+        for call in mock_capture.call_args_list
+        for event in call.kwargs["events"]
+    }
 
-        migrate_feature_enrollment_on_key_change(self.team.id, "old-key", "new-key")
+
+class TestMigrateFeatureEnrollmentOnKeyChange(APIBaseTest):
+    @patch("products.feature_flags.backend.tasks.capture_batch_internal")
+    def test_copies_enrollment_values_without_clobbering(self, mock_capture: MagicMock) -> None:
+        flag = FeatureFlag.objects.create(
+            team=self.team, key="new-key", created_by=self.user, filters=ENROLLMENT_FILTERS
+        )
+        create_person(
+            team=self.team,
+            distinct_ids=["copy-opted-in"],
+            properties={"$feature_enrollment/copy-key": True},
+        )
+        create_person(
+            team=self.team,
+            distinct_ids=["copy-opted-out"],
+            properties={"$feature_enrollment/copy-key": False},
+        )
+        create_person(
+            team=self.team,
+            distinct_ids=["copy-already-migrated"],
+            properties={"$feature_enrollment/copy-key": True, "$feature_enrollment/new-key": False},
+        )
+        create_person(team=self.team, distinct_ids=["copy-unrelated"], properties={})
+
+        migrate_feature_enrollment_on_key_change(self.team.id, "copy-key", flag.id)
+
+        assert mock_capture.call_count == 1
+        assert _sent_enrollments(mock_capture) == {
+            "copy-opted-in": {"$set_once": {"$feature_enrollment/new-key": True}},
+            "copy-opted-out": {"$set_once": {"$feature_enrollment/new-key": False}},
+        }
+        kwargs = mock_capture.call_args.kwargs
+        assert kwargs["token"] == self.team.api_token
+        assert kwargs["event_source"] == "feature_flag_enrollment_key_migration"
+        assert kwargs["process_person_profile"] is True
+
+    @patch("products.feature_flags.backend.tasks.capture_batch_internal")
+    def test_writes_to_the_flags_current_key_after_a_chained_rename(self, mock_capture: MagicMock) -> None:
+        flag = FeatureFlag.objects.create(
+            team=self.team, key="newest-key", created_by=self.user, filters=ENROLLMENT_FILTERS
+        )
+        create_person(
+            team=self.team,
+            distinct_ids=["chained-opted-in"],
+            properties={"$feature_enrollment/chained-key": True},
+        )
+
+        migrate_feature_enrollment_on_key_change(self.team.id, "chained-key", flag.id)
+
+        assert _sent_enrollments(mock_capture) == {
+            "chained-opted-in": {"$set_once": {"$feature_enrollment/newest-key": True}}
+        }
+
+    @patch("products.feature_flags.backend.tasks.capture_batch_internal")
+    def test_no_migration_when_flag_is_gone(self, mock_capture: MagicMock) -> None:
+        flag = FeatureFlag.objects.create(
+            team=self.team, key="new-key", created_by=self.user, filters=ENROLLMENT_FILTERS, deleted=True
+        )
+        create_person(
+            team=self.team,
+            distinct_ids=["deleted-flag-opted-in"],
+            properties={"$feature_enrollment/deleted-flag-key": True},
+        )
+
+        migrate_feature_enrollment_on_key_change(self.team.id, "deleted-flag-key", flag.id)
+
+        mock_capture.assert_not_called()
+
+    @patch("products.feature_flags.backend.tasks.ENROLLMENT_MIGRATION_PAGE_SIZE", 1)
+    @patch("products.feature_flags.backend.tasks.capture_batch_internal")
+    def test_pages_through_enrollees(self, mock_capture: MagicMock) -> None:
+        flag = FeatureFlag.objects.create(
+            team=self.team, key="new-key", created_by=self.user, filters=ENROLLMENT_FILTERS
+        )
+        create_person(
+            team=self.team,
+            distinct_ids=["paged-first"],
+            properties={"$feature_enrollment/paged-key": True},
+        )
+        create_person(
+            team=self.team,
+            distinct_ids=["paged-second"],
+            properties={"$feature_enrollment/paged-key": True},
+        )
+
+        migrate_feature_enrollment_on_key_change(self.team.id, "paged-key", flag.id)
 
         assert mock_capture.call_count == 2
-        mock_capture.assert_has_calls(
-            [
-                call(
-                    token=self.team.api_token,
-                    event_name="$set",
-                    event_source="feature_flag_enrollment_key_migration",
-                    distinct_id="opted-in",
-                    properties={"$set": {"$feature_enrollment/new-key": True}},
-                    process_person_profile=True,
-                ),
-                call(
-                    token=self.team.api_token,
-                    event_name="$set",
-                    event_source="feature_flag_enrollment_key_migration",
-                    distinct_id="opted-out",
-                    properties={"$set": {"$feature_enrollment/new-key": False}},
-                    process_person_profile=True,
-                ),
-            ],
-            any_order=True,
-        )
+        assert _sent_enrollments(mock_capture) == {
+            "paged-first": {"$set_once": {"$feature_enrollment/new-key": True}},
+            "paged-second": {"$set_once": {"$feature_enrollment/new-key": True}},
+        }
 
     @patch("products.feature_flags.backend.tasks.migrate_feature_enrollment_on_key_change.delay")
     def test_key_rename_of_enrollment_flag_enqueues_migration(self, mock_delay: MagicMock) -> None:
@@ -72,7 +129,7 @@ class TestMigrateFeatureEnrollmentOnKeyChange(APIBaseTest):
         )
 
         assert response.status_code == status.HTTP_200_OK
-        mock_delay.assert_called_once_with(self.team.id, "old-key", "new-key")
+        mock_delay.assert_called_once_with(self.team.id, "old-key", flag.id)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

Early access opt-in state is stored per person as a `$feature_enrollment/<flag_key>` person property, and flag evaluation derives that property name from the flag's **current** key.
Renaming a flag that backs an early access feature therefore silently orphans every existing opt-in: the flag starts consulting `$feature_enrollment/<new_key>` while enrolled users still carry the old property, so they all drop out of the beta with no signal to anyone.
The rename branch already carries over the flag's usage dashboard; enrollment was the missing half.

## Changes

- On a key rename of a flag with `feature_enrollment` set, the serializer's existing rename branch now enqueues a new `migrate_feature_enrollment_on_key_change` Celery task (on the long-running feature-flags queue, since it does blocking capture calls).
- The task pages through persons holding `$feature_enrollment/<old_key>` (keyset-paginated HogQL by person id, same query pattern as the early-access stage-change task) and captures `$set` events via `capture_batch_internal`, with these semantics:
  - the destination property comes from the flag's key **at execution time** (the task receives the flag id), so a chain of quick renames converges on the final key instead of stranding people on an intermediate one
  - writes use `$set_once`, so a person who makes a fresh choice under the new key while the migration is in flight is never clobbered - and task retries are harmless by construction
  - the stored value is copied, so explicit opt-outs (`false`) survive the rename too
  - persons who already have a value under the new key are skipped, which also covers renaming back to a key with history
  - persons whose distinct ids were all merged away are skipped instead of failing the page
  - the old property is left in place, so renaming back is lossless

> [!NOTE]
> The migration flows through the regular ingestion pipeline (`$set` events), so restored opt-ins appear once ingestion catches up, not instantaneously at rename time. Re-running is a no-op for already-migrated persons.

## How did you test this code?

- `pytest products/feature_flags/backend/test/test_migrate_feature_enrollment.py` (4 passed):
  - one ClickHouse-backed task test covering copy, opt-out preservation, and no-clobber in a single pass over four persons - catches wrong value semantics that would re-lose or corrupt enrollments
  - one trigger test asserting a key rename of an enrollment flag enqueues the task with the right args - catches the original regression (rename silently dropping every opt-in), which no existing test covered
  - one parameterized negative pair (non-enrollment flag rename, enrollment flag update without key change) - guards against migrating on every flag save
- Verified end to end against the local dev stack: created an early access feature via the API (which sets `feature_enrollment` on its flag), renamed the flag key via `PATCH`, and confirmed the task was dispatched to the `feature_flags` queue with the right args and that its `$set` events reached capture and landed in Kafka with the correct payloads - the opted-in person got `true` and the opted-out person kept `false` under the new property key
- Existing key-change update tests in `test_feature_flag.py` still pass
- Repo-wide `mypy --cache-fine-grained .` clean, ruff clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs describe flag rename behavior; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code; skills invoked: `/writing-tests`, `/improving-drf-endpoints`.
Decisions along the way:

- Used `capture_internal` with the team's token (tenant ingestion, works for any team/region/self-hosted) rather than this module's `posthoganalytics`-based capture helper, which targets PostHog's own telemetry project and is only correct for the one team it is gated to.
- Chose copy-on-rename over freezing the enrollment property name on the flag: SDKs write `$feature_enrollment/<current key>` client-side from the key they receive, so a frozen server-side read key would diverge from what every new opt-in writes.
- The old property is intentionally not deleted, and persons with an existing value under the new key are intentionally skipped, to keep rename/rename-back sequences lossless.


