### PR TITLE
fix(data-imports): stop shared REST client rate-limit retries minting error-tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -49,6 +49,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.bas
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.job_context import bind_job_context
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
     RESTClientNonRetryableError,
+    RESTClientRetryableError,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.predicates import (
@@ -330,7 +331,8 @@ async def _handle_import_error(
     Errors the source classifies as retryable (rate limits, transient 5xx) reach us only after
     the source's own retries are exhausted. Temporal retries the whole activity and the error is
     transient and self-recovering, so we log at ``warning`` rather than ``exception`` to keep
-    this benign, recoverable failure out of error tracking.
+    this benign, recoverable failure out of error tracking. ``RESTClientRetryableError`` gets the
+    same treatment by type, since every REST-based source hits that condition already.
 
     Everything else is logged as an exception and re-raised so Temporal retries it as usual.
     """
@@ -354,6 +356,17 @@ async def _handle_import_error(
         await handle_non_retryable_error(
             job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
         )
+
+    # RESTClientRetryableError only escapes the shared REST engine's own tenacity retry loop once
+    # that budget (rate limits, transient 5xx, connection resets/timeouts) is exhausted — the same
+    # "reaches us only after internal retries exhaust" contract as get_retryable_errors below.
+    # Honor it by type so every REST-based source gets this benign, self-recovering failure logged
+    # as a warning, rather than depending on each source separately listing "HTTP 429"/"HTTP 5xx"
+    # in get_retryable_errors.
+    if isinstance(error, RESTClientRetryableError):
+        await logger.awarning(error_msg)
+        await logger.adebug("REST client exhausted its retries - re-raising for Temporal retry")
+        raise error
 
     non_retryable_errors = source_cls.get_non_retryable_errors()
     if any(match in error_msg for match in non_retryable_errors):

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -11,6 +11,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import SimpleSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client import (
     RESTClientNonRetryableError,
+    RESTClientRetryableError,
 )
 from products.warehouse_sources.backend.temporal.data_imports.util import NonRetryableException
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities import import_data_sync as module
@@ -186,6 +187,31 @@ async def test_rest_client_non_retryable_error_routes_through_handler_without_so
     handle_mock.assert_awaited_once()
     assert handle_mock.await_args is not None
     assert handle_mock.await_args.args[5] is error
+    logger.aexception.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rest_client_retryable_error_logged_as_warning_without_source_opt_in():
+    # RESTClientRetryableError only escapes the shared REST engine's tenacity retry loop once its
+    # own attempts (rate limits, transient 5xx, connection resets/timeouts) are exhausted. It must
+    # be honored by type even when the source's get_retryable_errors doesn't list the message, so
+    # every REST-based source gets this benign, self-recovering failure logged as a warning instead
+    # of minting error-tracking noise.
+    error = RESTClientRetryableError("HTTP 429 for https://api.example.com/v3/orders/")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with mock.patch.object(module.SourceRegistry, "get_source", return_value=source):
+        with pytest.raises(RESTClientRetryableError):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    logger.awarning.assert_awaited_once()
     logger.aexception.assert_not_awaited()
 
 


### PR DESCRIPTION
## Problem

Error tracking flagged [an issue](https://us.posthog.com/project/2/error_tracking/019fa807-a196-7072-a465-a6ca868071a0) from an Eventbrite sync: `RESTClientRetryableError: HTTP 429 for https://www.eventbriteapi.com/v3/organizations/.../orders/`, raised from the shared REST source client (`rest_client.py`).

That client already retries a 429/5xx/connection-reset/timeout internally via tenacity (`_send_request`, honoring `Retry-After` with a capped exponential fallback) and only lets `RESTClientRetryableError` escape once that budget is exhausted. At that point Temporal retries the whole activity, so the failure is transient and self-recovering — exactly the kind of noise `_handle_import_error` is meant to keep out of error tracking.

`_handle_import_error` already special-cases two other shared-pipeline exception types by `isinstance` (`RESTClientNonRetryableError`, `SchemaColumnTypeChangedException`) instead of relying on each source to list a matching substring in `get_non_retryable_errors()`/`get_retryable_errors()`. `RESTClientRetryableError` had no such case, so it fell through to the generic branch and got logged as an exception — creating a tracked "bug" for every REST-based source (not just Eventbrite) whenever it hits a rate limit or transient 5xx long enough to exhaust its own retries.

## Changes

- `_handle_import_error` now treats `RESTClientRetryableError` the same way as a source-classified retryable error: logged at `warning`, not `exception`, then re-raised so Temporal retries the activity as usual.
- This covers every source built on the shared REST client, not just Eventbrite, without requiring each one to enumerate "HTTP 429"/"HTTP 5xx" in `get_retryable_errors()`.

## How did you test this code?

Added `test_rest_client_retryable_error_logged_as_warning_without_source_opt_in`, mirroring the existing `test_rest_client_non_retryable_error_routes_through_handler_without_source_opt_in` case for the sibling by-type check: asserts a `RESTClientRetryableError` is logged via `awarning` (not `aexception`) and re-raised, even when the source's own `get_retryable_errors()` doesn't list it. Catches a regression where this by-type handling is removed or narrowed, which would silently start minting error-tracking issues again for any REST-based source's exhausted rate-limit retries.

Ran the full `test_import_data_sync.py` suite (12 passed) plus `ruff check`/`ruff format --check` and a repo-wide `mypy --cache-fine-grained .` (clean) on the touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated from the linked error-tracking issue. Confirmed via the sampled `$exception` events that all three occurrences came from one Eventbrite sync hitting different schemas/sync-types within about a second, consistent with several concurrent syncs hitting the same account-level rate limit at once — a plain 429 exhausting the client's existing retry budget, not a bug in the connector or a broken backoff. Checked open PRs (`RESTClientRetryableError`, `429`, `rest_client`, `get_retryable_errors`, and the maintainer's own open PRs) for overlap; found related-but-distinct fixes (fractional `Retry-After` parsing, per-source Hubspot classification) but nothing handling this exception by type in `_handle_import_error`. Skill invoked: `/writing-tests` (kept the added test to the one regression the by-type check protects).