### PR TITLE
fix(aio): enable multimodal for PostHog Desktop

### DIFF
--- a/services/llm-gateway/pyproject.toml
+++ b/services/llm-gateway/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "prometheus-fastapi-instrumentator>=7.0.0",
     "structlog>=24.4.0",
     "httpx>=0.28.0",
-    "posthoganalytics>=3.0.0",
+    "posthoganalytics>=7.30.1",
     "cachetools>=5.5.0",
     "python-multipart>=0.0.9",
     "boto3>=1.42.65",
@@ -110,3 +110,4 @@ warn_unused_ignores = true
 [tool.uv]
 managed = true
 exclude-newer = "7 days"
+exclude-newer-package = { posthoganalytics = false }

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -419,6 +419,8 @@ class PostHogCallback(InstrumentedCallback):
             host=host,
             sync_mode=True,
             enable_local_evaluation=False,
+            _use_ai_lane=True,
+            _enable_multimodal_capture=True,
         )
         try:
             client.capture(**capture_kwargs)

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4, uuid5
 
 import structlog
 from posthoganalytics import Posthog
+from posthoganalytics.ai.utils import _capture_ai_event
 
 from llm_gateway.auth.models import resolve_distinct_id
 from llm_gateway.callbacks.base import InstrumentedCallback
@@ -423,7 +424,7 @@ class PostHogCallback(InstrumentedCallback):
             _enable_multimodal_capture=True,
         )
         try:
-            client.capture(**capture_kwargs)
+            _capture_ai_event(client, **capture_kwargs)
         except Exception as e:
             client.capture_exception(e, **capture_kwargs)
             logger.exception("posthog_capture_failed", host=host, error=str(e))

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -90,7 +90,12 @@ class TestPostHogCallback:
             await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
 
             mock_cls.assert_called_once_with(
-                "test-key", host="https://test.posthog.com", sync_mode=True, enable_local_evaluation=False
+                "test-key",
+                host="https://test.posthog.com",
+                sync_mode=True,
+                enable_local_evaluation=False,
+                _use_ai_lane=True,
+                _enable_multimodal_capture=True,
             )
             mock_client.capture.assert_called_once()
             call_kwargs = mock_client.capture.call_args.kwargs

--- a/services/llm-gateway/uv.lock
+++ b/services/llm-gateway/uv.lock
@@ -6,6 +6,9 @@ requires-python = ">=3.13"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
+[options.exclude-newer-package]
+posthoganalytics = false
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -908,7 +911,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "litellm", specifier = "==1.92.0" },
     { name = "orjson", specifier = ">=3.10.0" },
-    { name = "posthoganalytics", specifier = ">=3.0.0" },
+    { name = "posthoganalytics", specifier = ">=7.30.1" },
     { name = "prometheus-client", specifier = ">=0.21.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.0.0" },
     { name = "pydantic", specifier = ">=2.5.0" },
@@ -1190,19 +1193,17 @@ wheels = [
 
 [[package]]
 name = "posthoganalytics"
-version = "7.4.2"
+version = "7.30.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "distro" },
-    { name = "python-dateutil" },
     { name = "requests" },
-    { name = "six" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/5c/22671e2ec3e2dbf0d1c5f03266306df8c858a37993f670626e075066581c/posthoganalytics-7.4.2.tar.gz", hash = "sha256:4ca71ab40d89331552be1627e923343e8bc78b82e321c594986a83db8663ca76", size = 144644, upload-time = "2025-12-22T11:03:19.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/c5/01c59158b02c5d645bb3e351b82fc948174c05a1cd0cb21162f4d88fa28f/posthoganalytics-7.30.1.tar.gz", hash = "sha256:17ebed83ba253d5f92baba153b720642a00fdf6fee8bda95957c054c4ea98145", size = 386791, upload-time = "2026-07-27T14:19:39.927Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/19/b6e727b2a641d8e35c79bedb39c5fcfb0300711f6a5276c6c13a4efa7b85/posthoganalytics-7.4.2-py3-none-any.whl", hash = "sha256:5d909624e81dfbd9bfb72d0af34758c2542da76cfb56eed0b2e36038d67a9247", size = 167902, upload-time = "2025-12-22T11:03:17.91Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f3/a424e140dde29f3737ecd09d3f97d98a1888c05cf18cb918c9191e8f36e1/posthoganalytics-7.30.1-py3-none-any.whl", hash = "sha256:5a3517d204aebfd02c9af8e010c093f2461bce88ea1299b8cdc9419e3405112b", size = 462838, upload-time = "2026-07-27T14:19:38.143Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`services/llm-gateway` — the separate deploy unit (own `pyproject.toml`/`uv.lock`) backing `gateway.{region}.posthog.com` for `posthog_code`, `background_agents`, `posthog_ai`, `slack_app`, `conversations`, `wizard`, `review_hog`, `array`, `bedrock`, and `llm_gateway` — never joined the AI capture lane rollout in #73448/#73950. It pinned `posthoganalytics>=3.0.0` (resolved to `7.4.2`, six minors behind), and its single capture call site never set `_use_ai_lane`/`_enable_multimodal_capture`.

Bumping the SDK and setting those two flags on the constructed client turned out not to be enough on its own. The public `Posthog.capture()` method always routes to the plain analytics lane regardless of `_use_ai_lane` — the SDK only reaches the dedicated AI lane (the endpoint the S3 multimodal-blob-offload ingestion pipeline consumes from) through the internal `_capture_ai()` method, dispatched via `posthoganalytics.ai.utils._capture_ai_event()`. Every other capture site fixed by #73448/#73950 goes through the SDK's own AI-wrapper classes (`posthoganalytics.ai.openai.OpenAI`, the LangChain `CallbackHandler`, etc.), which call that dispatcher internally. `services/llm-gateway` builds its `$ai_generation` properties by hand from LiteLLM's logging object and called the plain `client.capture(...)`, bypassing it entirely — so the flags were set but nothing ever read them.

Net effect: multimodal content proxied through this gateway (e.g. a screenshot sent by a PostHog Code agent session) never reached the AI ingestion pipeline, so it never got the S3 blob offload that direct-SDK traffic already gets — it stayed as a raw, uncapped base64 blob inline in the captured event.

## Changes

- Bump `posthoganalytics` to `>=7.30.1`, with an `exclude-newer-package` override so this service's 7-day `exclude-newer` window doesn't reject a same-day release (mirrors the override on the root `pyproject.toml`).
- Set `_use_ai_lane=True` and `_enable_multimodal_capture=True` on the `Posthog(...)` client in `PostHogCallback._capture_to_destination` (`callbacks/posthog.py`).
- Swap `client.capture(**capture_kwargs)` for `_capture_ai_event(client, **capture_kwargs)` in the same method — the actual fix that gets these events routed onto the AI lane.
- Update `test_on_success_captures_event`'s constructor assertion to match.

## How did you test this code?

- `uv run pytest` (full `services/llm-gateway` suite): 1371 passed, 50 skipped, 30 xfailed, 22 xpassed.
- `uv run ruff check .` / `uv run ruff format --check .`: clean.
- Manual local end-to-end verification against a local PostHog instance, using `llm-analytics-apps/scripts/test_multimodal_passthrough.py`'s pattern as a direct-SDK baseline:
  - Direct SDK (Anthropic image call, `_enable_multimodal_capture=True`): resulting `ai_events` row carries a `phaiblob://` pointer, no inline base64 — confirms the local offload pipeline is live.
  - Same image proxied through this patched gateway, **before** the `_capture_ai_event` fix: raw base64 stayed inline (451,826 chars).
  - Same request, **after** the fix: `phaiblob://` pointer, 317 chars — matches the direct-SDK result.
- Did not exercise the gateway against a live provider in prod — no deploy from this branch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No doc references this rollout switch.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — assign @carlos-marchal-ph as DRI.

Found while auditing, with Carlos, which AI capture paths landed on the new multimodal lane after #73950. Initial fix (SDK bump + the two flags) turned out to be necessary but insufficient — local end-to-end testing via PostHog Code showed generations from the same conversation still carrying raw, unoffloaded base64 images. Traced it to `Posthog.capture()` never checking `_use_ai_lane`; only `_capture_ai_event()`/`_capture_ai()` do. Verified the gap and the fix empirically against a local PostHog instance using `llm-analytics-apps`' multimodal test scripts as a direct-SDK comparison point.