### PR TITLE
fix(data-imports): handle numeric-string incremental cursors on date/time fields

### DIFF
--- a/products/warehouse_sources/backend/models/external_data_schema.py
+++ b/products/warehouse_sources/backend/models/external_data_schema.py
@@ -723,6 +723,26 @@ def _parse_datetime_string(value: str) -> datetime:
         return parser.parse(stripped)
 
 
+def _coerce_incremental_datetime(value: str) -> datetime | int:
+    """Parse a DateTime/Timestamp/Date cursor string, falling back to a raw integer.
+
+    Some drivers surface a numeric cursor as a bare digit string even though the field is
+    typed as a date/time type (e.g. a ClickHouse column Arrow can't emit natively, cast to
+    String, whose current type no longer matches the incremental field's stored type).
+    dateutil's heuristics then misread the digits as a calendar year and overflow past
+    datetime's year-9999 ceiling (`ParserError`), or raise a bare `OverflowError` for longer
+    digit runs. Legitimate compact date strings like "20240115" (YYYYMMDD) parse correctly
+    above and never reach this fallback.
+    """
+    try:
+        return _parse_datetime_string(value)
+    except (parser.ParserError, OverflowError):
+        stripped = value.strip()
+        if stripped.lstrip("-").isdigit():
+            return int(stripped)
+        raise
+
+
 def process_incremental_value(value: Any | None, field_type: IncrementalFieldType | None) -> Any:
     if value is None or value == "None" or field_type is None:
         return None
@@ -743,7 +763,7 @@ def process_incremental_value(value: Any | None, field_type: IncrementalFieldTyp
         if isinstance(value, int | float) and not isinstance(value, bool):
             return value
 
-        return _parse_datetime_string(value)
+        return _coerce_incremental_datetime(value)
 
     if field_type == IncrementalFieldType.Date:
         if isinstance(value, datetime):
@@ -755,7 +775,8 @@ def process_incremental_value(value: Any | None, field_type: IncrementalFieldTyp
         if isinstance(value, int | float) and not isinstance(value, bool):
             return value
 
-        return _parse_datetime_string(value).date()
+        parsed = _coerce_incremental_datetime(value)
+        return parsed if isinstance(parsed, int) else parsed.date()
 
     if field_type == IncrementalFieldType.ObjectID:
         return str(value)

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -748,6 +748,18 @@ def test_process_incremental_value_xid_returns_value_as_is() -> None:
             IncrementalFieldType.Date,
             date(2026, 1, 5),
         ),
+        # A bare digit-string cursor on a date/time-typed field (e.g. a ClickHouse column Arrow
+        # casts to String) crashed here: dateutil misreads it as a calendar year and overflows
+        # past datetime's year-9999 ceiling. Fall back to the raw integer instead of crashing.
+        ("20662", IncrementalFieldType.Timestamp, 20662),
+        ("20662", IncrementalFieldType.DateTime, 20662),
+        ("20662", IncrementalFieldType.Date, 20662),
+        # Longer digit runs overflow C's int range and raise `OverflowError` instead of
+        # `ParserError` - same fallback must catch both.
+        ("20662123456", IncrementalFieldType.DateTime, 20662123456),
+        # A genuine compact date string (YYYYMMDD) must still parse as a real date, not fall
+        # back to the raw-integer path.
+        ("20240115", IncrementalFieldType.Date, date(2024, 1, 15)),
     ],
 )
 def test_process_incremental_value_datetime_handles_epoch_numbers(value, field_type, expected) -> None:

--- a/products/warehouse_sources/backend/tests/test_models.py
+++ b/products/warehouse_sources/backend/tests/test_models.py
@@ -9,6 +9,7 @@ from django.db.models import Model
 from django.test import SimpleTestCase
 from django.utils import timezone
 
+from dateutil import parser
 from parameterized import parameterized
 
 from posthog.models.signals import model_activity_signal
@@ -764,6 +765,15 @@ def test_process_incremental_value_xid_returns_value_as_is() -> None:
 )
 def test_process_incremental_value_datetime_handles_epoch_numbers(value, field_type, expected) -> None:
     assert process_incremental_value(value, field_type) == expected
+
+
+@pytest.mark.parametrize(
+    "field_type",
+    [IncrementalFieldType.DateTime, IncrementalFieldType.Timestamp, IncrementalFieldType.Date],
+)
+def test_process_incremental_value_datetime_reraises_unparseable_non_numeric_string(field_type) -> None:
+    with pytest.raises(parser.ParserError):
+        process_incremental_value("not-a-date-at-all", field_type)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

An error tracking issue showed a ClickHouse warehouse sync failing repeatedly with:

```
ParserError: year 20662 is out of range: 20662
```

The crash happens in shared pipeline code (`products/warehouse_sources/backend/models/external_data_schema.py`), not the ClickHouse connector itself: `process_incremental_value` hands a bare digit-string cursor value to `dateutil.parser.parse()` when the incremental field is typed `DateTime`/`Timestamp`/`Date`. A source can return a numeric cursor as a plain digit string on such a field (e.g. a column Arrow can't emit natively and casts to `String`, or a schema whose stored field type no longer matches the column). dateutil's fuzzy parsing then misreads the digits as a calendar year, which overflows past `datetime`'s year-9999 ceiling (`ParserError`) or, for longer digit runs, raises a bare `OverflowError` that wasn't caught at all. Either way the sync crashes instead of advancing.

## Changes

- Added `_coerce_incremental_datetime`: tries `dateutil` parsing first (so legitimate compact date strings like `20240115` still parse correctly), and only on `ParserError`/`OverflowError` falls back to treating a purely-numeric string as a raw integer, the same as the existing Unix-epoch-number passthrough.
- Wired this into both the `DateTime`/`Timestamp` and `Date` branches of `process_incremental_value`.

This is general shared-pipeline code, so the fix isn't ClickHouse-specific and protects any SQL-style source that can produce this same value shape.

## How did you test this code?

I'm an agent. Extended the existing parameterized test `test_process_incremental_value_datetime_handles_epoch_numbers` in `products/warehouse_sources/backend/tests/test_models.py` with cases covering: a bare digit string reproducing the exact reported crash on `Timestamp`/`DateTime`/`Date` fields, a longer digit run that hits `OverflowError` instead of `ParserError`, and a genuine `YYYYMMDD` date string to confirm the fallback doesn't shadow real dates. Ran the full parameterized test locally (`uv run pytest .../test_models.py -k test_process_incremental_value_datetime_handles_epoch_numbers`, all pass) plus `ruff check`/`ruff format` and a repo-wide `mypy` run (no issues).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - internal pipeline bug fix, no user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a production error-tracking issue. Read the stack trace to find the actual raise site (`_parse_datetime_string` in `external_data_schema.py`, not the ClickHouse connector), reproduced the exact error message locally against the installed `dateutil` version to confirm the crashing input is a bare 5-digit string, and traced how that value reaches `process_incremental_value` from `get_incremental_field_value` (per-row) and the sync-resume path in `import_data_sync.py`. Considered converting all-digit strings to int unconditionally, but rejected that because dateutil correctly parses compact `YYYYMMDD` dates - the fix only falls back after dateutil itself rejects the value as out-of-range. Ran `/writing-tests` before extending the test.

Searched open PRs (by exception type, message text, and module path) and the maintainer's own open PRs for a prior fix; found none addressing this.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*