### PR TITLE
fix(warehouse): retry a 401 that lands mid-pagination

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -321,11 +321,19 @@ class RESTClient:
                 paginator.set_resume_state(initial_paginator_state)
             paginator.init_request(request)
 
+        # Flipped once any request in this walk has come back authenticated, which changes how a
+        # later 401 is read — see the 401 branch in ``_send_request``.
+        auth_established = False
+
         while True:
             try:
-                response, body = self._send_request(request, hooks, body_check=malformed_check)
+                response, body = self._send_request(
+                    request, hooks, body_check=malformed_check, auth_established=auth_established
+                )
             except IgnoreResponseException:
                 break
+
+            auth_established = True
 
             data = self._extract_response(
                 body, data_selector, required=data_selector_required, empty_body_ok=data_selector_empty_ok
@@ -350,7 +358,11 @@ class RESTClient:
         reraise=True,
     )
     def _send_request(
-        self, request: Request, hooks: Hooks, body_check: Optional[Callable[[Any], None]] = None
+        self,
+        request: Request,
+        hooks: Hooks,
+        body_check: Optional[Callable[[Any], None]] = None,
+        auth_established: bool = False,
     ) -> tuple[Response, Any]:
         prepared = self.session.prepare_request(request)
         # Fail loud on a pagination/resume URL that points off the expected host before the
@@ -407,6 +419,20 @@ class RESTClient:
                 self._redact(f"HTTP {response.status_code} for {_safe_url(response.url)}"),
                 retry_after=_parse_retry_after(response),
             )
+
+        # A 401 on the first request of a walk is a genuine credential problem, so it stays
+        # fail-fast below. A 401 *after* the same credential has already been accepted is a
+        # different animal: the API's auth tier rejected one request mid-stream. Aborting there
+        # throws away a long paginated export, and for sources that classify "401 Client Error" as
+        # non-retryable it also pauses the schema and tells the user to check a token that
+        # demonstrably works. Retry instead. The message is taken verbatim from `raise_for_status`
+        # so that a credential genuinely revoked mid-run still matches that classification once
+        # the retries are exhausted, rather than degrading into an unrecognized error.
+        if response.status_code == 401 and auth_established:
+            try:
+                response.raise_for_status()
+            except HTTPError as e:
+                raise RESTClientRetryableError(self._redact(str(e))) from None
 
         response_hooks = hooks.get("response", [])
         if response_hooks:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -321,8 +321,7 @@ class RESTClient:
                 paginator.set_resume_state(initial_paginator_state)
             paginator.init_request(request)
 
-        # Flipped once any request in this walk has come back authenticated, which changes how a
-        # later 401 is read — see the 401 branch in ``_send_request``.
+        # Set once a request in this walk has succeeded; changes how a later 401 is read.
         auth_established = False
 
         while True:
@@ -420,18 +419,15 @@ class RESTClient:
                 retry_after=_parse_retry_after(response),
             )
 
-        # A 401 on the first request of a walk is a genuine credential problem, so it stays
-        # fail-fast below. A 401 *after* the same credential has already been accepted is a
-        # different animal: the API's auth tier rejected one request mid-stream. Aborting there
-        # throws away a long paginated export, and for sources that classify "401 Client Error" as
-        # non-retryable it also pauses the schema and tells the user to check a token that
-        # demonstrably works. Retry instead. The message is taken verbatim from `raise_for_status`
-        # so that a credential genuinely revoked mid-run still matches that classification once
-        # the retries are exhausted, rather than degrading into an unrecognized error.
+        # A 401 before anything has authenticated is a bad credential, and stays fail-fast below.
+        # A 401 after the same credential was accepted is the auth tier rejecting one request
+        # mid-stream, where aborting throws away a long paginated export.
         if response.status_code == 401 and auth_established:
             try:
                 response.raise_for_status()
             except HTTPError as e:
+                # Keep raise_for_status's wording — once retries are spent, the schema pause and
+                # friendly message in `update_external_data_job_model` select on it by substring.
                 raise RESTClientRetryableError(self._redact(str(e))) from None
 
         response_hooks = hooks.get("response", [])

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -6,7 +6,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from requests import Response
-from requests.exceptions import ChunkedEncodingError, ProxyError, ReadTimeout
+from requests.exceptions import ChunkedEncodingError, HTTPError, ProxyError, ReadTimeout
 
 from posthog.temporal.common.errors import NonReportableError
 
@@ -68,6 +68,26 @@ def _make_non_json_response(content: bytes, status_code: int = 200) -> Response:
     resp.headers["Content-Type"] = "application/json"
     resp.url = "https://api.example.com/items"
     return resp
+
+
+def _make_unauthorized_response() -> Response:
+    resp = _make_response({"error": "Couldn't authenticate you"}, status_code=401)
+    resp.reason = "Unauthorized"
+    resp.url = "https://api.example.com/items"
+    return resp
+
+
+class _TwoPagePaginator(BasePaginator):
+    def __init__(self) -> None:
+        super().__init__()
+        self._page = 0
+
+    def update_state(self, response, data=None) -> None:
+        self._page += 1
+        self._has_next_page = self._page < 2
+
+    def update_request(self, request) -> None:
+        pass
 
 
 class TestRESTClient:
@@ -357,6 +377,64 @@ class TestRESTClient:
             list(client.paginate(path="/items", paginator=SinglePagePaginator()))
 
         assert mock_session.send.call_count == 5
+
+    @patch("tenacity.nap.time.sleep")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+    )
+    def test_first_request_401_fails_fast(self, MockSession, mock_sleep) -> None:
+        # Nothing has authenticated yet, so a 401 really is a bad credential — surface it
+        # immediately instead of burning the retry budget on a deterministic rejection.
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.send.return_value = _make_unauthorized_response()
+
+        client = RESTClient(base_url="https://api.example.com")
+        with pytest.raises(HTTPError, match="401 Client Error"):
+            list(client.paginate(path="/items", paginator=SinglePagePaginator()))
+
+        assert mock_session.send.call_count == 1
+
+    @patch("tenacity.nap.time.sleep")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+    )
+    def test_401_after_an_authenticated_page_is_retried(self, MockSession, mock_sleep) -> None:
+        # The same credential was accepted for page 1, so a 401 on page 2 is a transient rejection
+        # from the API's auth tier. Retrying it keeps a long paginated export alive.
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.send.side_effect = [
+            _make_response([{"id": 1}]),
+            _make_unauthorized_response(),
+            _make_response([{"id": 2}]),
+        ]
+
+        client = RESTClient(base_url="https://api.example.com")
+        pages = list(client.paginate(path="/items", paginator=_TwoPagePaginator()))
+
+        assert pages == [[{"id": 1}], [{"id": 2}]]
+        assert mock_session.send.call_count == 3
+
+    @patch("tenacity.nap.time.sleep")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+    )
+    def test_persistent_401_mid_walk_keeps_the_client_error_wording(self, MockSession, mock_sleep) -> None:
+        # A credential revoked mid-run exhausts the retries, and sources classify that case by
+        # matching on "401 Client Error" — so the reraised message has to keep the wording.
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.send.side_effect = [_make_response([{"id": 1}]), *[_make_unauthorized_response()] * 8]
+
+        client = RESTClient(base_url="https://api.example.com")
+        with pytest.raises(RESTClientRetryableError, match="401 Client Error"):
+            list(client.paginate(path="/items", paginator=_TwoPagePaginator()))
+
+        assert mock_session.send.call_count == 6
 
     @pytest.mark.parametrize(
         "content",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -120,20 +120,8 @@ class TestRESTClient:
         ]
         mock_session.send.side_effect = responses
 
-        class TwoPagePaginator(BasePaginator):
-            def __init__(self):
-                super().__init__()
-                self._page = 0
-
-            def update_state(self, response, data=None):
-                self._page += 1
-                self._has_next_page = self._page < 2
-
-            def update_request(self, request):
-                pass
-
         client = RESTClient(base_url="https://api.example.com")
-        pages = list(client.paginate(path="/items", paginator=TwoPagePaginator()))
+        pages = list(client.paginate(path="/items", paginator=_TwoPagePaginator()))
 
         assert len(pages) == 2
         assert pages[0] == [{"id": 1}]
@@ -383,8 +371,7 @@ class TestRESTClient:
         "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
     )
     def test_first_request_401_fails_fast(self, MockSession, mock_sleep) -> None:
-        # Nothing has authenticated yet, so a 401 really is a bad credential — surface it
-        # immediately instead of burning the retry budget on a deterministic rejection.
+        # Nothing has authenticated yet, so the 401 is a bad credential, not a blip.
         mock_session = MockSession.return_value
         mock_session.headers = {}
         mock_session.prepare_request.return_value = MagicMock()
@@ -401,8 +388,7 @@ class TestRESTClient:
         "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
     )
     def test_401_after_an_authenticated_page_is_retried(self, MockSession, mock_sleep) -> None:
-        # The same credential was accepted for page 1, so a 401 on page 2 is a transient rejection
-        # from the API's auth tier. Retrying it keeps a long paginated export alive.
+        # Page 1 authenticated, so the page-2 401 is retried rather than failing the walk.
         mock_session = MockSession.return_value
         mock_session.headers = {}
         mock_session.prepare_request.return_value = MagicMock()
@@ -423,8 +409,7 @@ class TestRESTClient:
         "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
     )
     def test_persistent_401_mid_walk_keeps_the_client_error_wording(self, MockSession, mock_sleep) -> None:
-        # A credential revoked mid-run exhausts the retries, and sources classify that case by
-        # matching on "401 Client Error" — so the reraised message has to keep the wording.
+        # Schema pausing selects on this wording by substring, so exhausting retries must keep it.
         mock_session = MockSession.return_value
         mock_session.headers = {}
         mock_session.prepare_request.return_value = MagicMock()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
@@ -204,9 +204,7 @@ class TestZendeskIncrementalEndpointPaginator:
         assert req.params == {}
 
     def test_raises_when_next_page_does_not_advance(self) -> None:
-        # ticket_events has no cursor export to fall back on, so a timestamp shared by more records
-        # than one page holds would otherwise re-fetch the same page against a 10 req/min endpoint
-        # forever.
+        # A repeated next_page is the time-based export stalling; it must raise, not loop forever.
         p = ZendeskIncrementalEndpointPaginator()
         stalled = {"end_of_stream": False, "next_page": "https://x.zendesk.com/next?start_time=1718485289"}
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/tests/test_zendesk.py
@@ -203,6 +203,18 @@ class TestZendeskIncrementalEndpointPaginator:
         # next_page is a full URL carrying its own query string, so existing params are cleared.
         assert req.params == {}
 
+    def test_raises_when_next_page_does_not_advance(self) -> None:
+        # ticket_events has no cursor export to fall back on, so a timestamp shared by more records
+        # than one page holds would otherwise re-fetch the same page against a 10 req/min endpoint
+        # forever.
+        p = ZendeskIncrementalEndpointPaginator()
+        stalled = {"end_of_stream": False, "next_page": "https://x.zendesk.com/next?start_time=1718485289"}
+
+        p.update_state(_make_response(stalled))
+
+        with pytest.raises(ValueError, match="same next_page twice"):
+            p.update_state(_make_response(stalled))
+
     @pytest.mark.parametrize(
         "body",
         [

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/zendesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/zendesk.py
@@ -335,11 +335,9 @@ class ZendeskIncrementalEndpointPaginator(BasePaginator):
         if not next_page:
             raise ValueError("Zendesk incremental export returned end_of_stream=False without a next_page")
 
-        # The time-based export advances by setting the next `start_time` to the page's `end_time`,
-        # so when more than `per_page` records share that timestamp the link stops moving and
-        # pagination re-fetches the same page forever. `tickets` and `users` escape this via the
-        # cursor export; `ticket_events` and `ticket_metric_events` have no cursor variant, so the
-        # stall has to be detected here rather than spinning against a rate-limited endpoint.
+        # No cursor export exists for these endpoints (see the `tickets` resource above), so a
+        # timestamp shared by more records than one page holds pins `start_time` and re-fetches
+        # the same page forever.
         if next_page == current_page:
             raise ValueError(
                 "Zendesk incremental export returned the same next_page twice: pagination is stalled on a "

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/zendesk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zendesk/zendesk.py
@@ -307,9 +307,14 @@ class ZendeskCursorIncrementalPaginator(BasePaginator):
 
 
 class ZendeskIncrementalEndpointPaginator(BasePaginator):
+    def __init__(self) -> None:
+        super().__init__()
+        self._next_page: Optional[str] = None
+
     def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
         res = response.json()
 
+        current_page = self._next_page
         self._next_page = None
 
         if not res:
@@ -329,6 +334,17 @@ class ZendeskIncrementalEndpointPaginator(BasePaginator):
         next_page = res.get("next_page")
         if not next_page:
             raise ValueError("Zendesk incremental export returned end_of_stream=False without a next_page")
+
+        # The time-based export advances by setting the next `start_time` to the page's `end_time`,
+        # so when more than `per_page` records share that timestamp the link stops moving and
+        # pagination re-fetches the same page forever. `tickets` and `users` escape this via the
+        # cursor export; `ticket_events` and `ticket_metric_events` have no cursor variant, so the
+        # stall has to be detected here rather than spinning against a rate-limited endpoint.
+        if next_page == current_page:
+            raise ValueError(
+                "Zendesk incremental export returned the same next_page twice: pagination is stalled on a "
+                "timestamp shared by more records than one page can hold"
+            )
 
         self._next_page = next_page
         self._has_next_page = True


### PR DESCRIPTION
## Problem

A Zendesk `ticket_events` backfill died with `401 Unauthorized` on a URL that Zendesk itself had handed us as its `next_page` link.
The same credential had already authenticated every page before it, so this was not a bad token.
We treated it as one anyway.

Two things go wrong:

1. `RESTClient` only retries 429 and 5xx, so a single 401 aborts the entire page walk.
2. `ZendeskSource` classifies `401 Client Error` as non-retryable, which pauses the schema and tells the user to check an API token that demonstrably works.

Every other Zendesk auth failure I looked at has the opposite shape: `start_time=0` on the first request, with every schema on the source failing together.
Those are real credential problems and should keep failing fast.

Separately, `ticket_events` and `ticket_metric_events` have no cursor export, so they are stuck on the time-based incremental export.
That is the one `tickets` already moved off, because pagination stalls when more records share a timestamp than fit on a page.
`ZendeskCursorIncrementalPaginator` guards against a non-advancing cursor. The time-based paginator had no equivalent, and would spin forever against a 10 req/min endpoint.

## Changes

- `RESTClient` tracks whether any request in a `paginate()` walk has come back authenticated. A 401 before that still fails fast. A 401 after it is retried on the existing bounded backoff.
- The reraised message is taken verbatim from `raise_for_status`, so a credential genuinely revoked mid-run still matches each source's `get_non_retryable_errors()` wording once retries are exhausted. That path is unchanged apart from a few bounded retries first.
- `ZendeskIncrementalEndpointPaginator` raises when Zendesk returns the same `next_page` twice.

The first two apply to every REST-based source, not just Zendesk.

> [!NOTE]
> First-request 401s are untouched, so connect-time credential validation and the "check your token" pause both behave exactly as before.

## How did you test this code?

Automated only. I (Claude) could not run a live Zendesk sync from this environment.

New tests, and the regression each one catches:

- `RESTClient`, first-request 401 fails fast without retrying. Guards the boundary this PR introduces, so a bad token never starts costing five retries per attempt.
- `RESTClient`, 401 after an authenticated page is retried and the walk completes. This is the reported bug.
- `RESTClient`, persistent mid-walk 401 exhausts retries and still carries the `401 Client Error` wording. Sources classify revoked credentials by matching that string, so losing it would silently stop pausing schemas for real auth failures.
- Zendesk paginator, a repeated `next_page` raises instead of looping.

Also ran every existing source test file that touches `RESTClient` or `make_tracked_session` (19,840 tests) to confirm nothing depended on the old fail-fast-on-401 behavior, plus `ruff check`, `ruff format`, and repo-wide `uv run mypy --cache-fine-grained .`. All clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed. This is internal sync-engine behavior, no API, config, or user-facing workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus) wrote this after I asked it to work out why a customer's Zendesk sync was 401ing partway through.
The giveaway was in the URL: it ended in `.json` and carried a non-zero `start_time`, neither of which our configured request path produces, so it could only have come from a Zendesk `next_page` link.
That pinned it as a mid-walk failure rather than a credential problem, which is the whole basis for the fix.

The design fork was retry-once versus classify-by-position.
We went with position in the walk, because it keeps genuine credential failures failing fast and fixes the transient case for every REST source at once, rather than patching Zendesk's error dict and leaving the same trap set for the other sources.
Preserving `raise_for_status`'s exact wording on the exhausted path is deliberate and slightly subtle: source classification is substring matching on that text, so rewording it would quietly break schema pausing for real revocations.

Two things this PR does not do.
It does not explain why Zendesk 401s mid-stream. Zendesk documents rate limiting as 429 and 401 as static misconfiguration, so the trigger is unconfirmed. This makes us resilient to it rather than diagnosing it.
It also leaves `ZendeskIncrementalEndpointPaginator` without `get_resume_state`, so an activity retry still re-walks from the last committed watermark instead of the failed page. Worth doing, bigger change, kept out of here.

No repo skills were invoked while producing this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
