### PR TITLE
fix(insights): set draft row last viewed to its edit timestamp

### DIFF
--- a/frontend/src/scenes/saved-insights/draftInsight.ts
+++ b/frontend/src/scenes/saved-insights/draftInsight.ts
@@ -65,7 +65,8 @@ export function draftInsightListItem(draft: DraftInsightQuery, currentUser: User
         updated_at: timestamp,
         last_modified_at: timestamp,
         last_modified_by: user,
-        last_viewed_at: null,
+        // The draft has no InsightViewed record, but its author saw it when they last edited it
+        last_viewed_at: timestamp,
         tags: [],
         favorited: false,
         user_access_level: AccessControlLevel.Viewer,


### PR DESCRIPTION
## TL;DR

The unsaved draft row in the insights list said "Never" under "Last viewed", even though you were editing it a minute ago. Now it shows when you last touched the draft.

## Problem

The insights list can show a local draft row for an insight you started but never saved. That draft lives only in the browser's localStorage, so it has no `InsightViewed` record on the backend, and `draftInsightListItem()` hardcoded `last_viewed_at: null`. The column rendered "Never", which reads as "untouched" for a row you just edited.

## Changes

Use the draft's stored timestamp as `last_viewed_at`. The timestamp refreshes on every edit, and the same value already feeds the "Created" and "Last modified" columns, so all three now agree.

## How did you test this code?

Existing `savedInsightsLogic` tests cover the draft row's shape and visibility. No new test: asserting this one static field mapping would be a change-detector, same as the untested `created_at`/`last_modified_at` mappings beside it. I did not test this manually in a browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task) at Thomas's request. Skills invoked: /writing-tests (decided against a new test), /writing-code-comments. Considered wiring the draft into real view tracking, but the draft has no backend row, so no `InsightViewed` record is possible; reusing the draft's edit timestamp is the honest value. Frontend typecheck/lint results follow in a PR comment once run (fresh checkout without node_modules).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
