### PR TITLE
fix(data-imports): stop pagespeed insights exhausted retries minting error-tracking noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/source.py
@@ -109,6 +109,13 @@ Each analysis is a full Lighthouse run and can take several seconds. Each URL is
             "403 Client Error: Forbidden for url: https://pagespeedonline.googleapis.com": "Your API key does not have access to the PageSpeed Insights API. Enable the API for your Google Cloud project and check any key restrictions, then reconnect.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # 429/5xx are already retried internally with backoff (see google_pagespeed_insights.py's
+        # tenacity-wrapped `_fetch`); if those retries still exhaust, the failure is transient and
+        # self-recovering, so let Temporal retry the activity without surfacing it as tracked
+        # exception noise.
+        return {"PageSpeed Insights API error (retryable)"}
+
     def get_schemas(
         self,
         config: GooglePageSpeedInsightsSourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/tests/test_google_pagespeed_insights_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/tests/test_google_pagespeed_insights_source.py
@@ -101,6 +101,19 @@ class TestGooglePageSpeedInsightsSource:
 
         assert any(status in key and "pagespeedonline.googleapis.com" in key for key in errors)
 
+    @pytest.mark.parametrize(
+        "error_message",
+        [
+            "PageSpeed Insights API error (retryable): status=429",
+            "PageSpeed Insights API error (retryable): status=500",
+        ],
+    )
+    def test_retryable_errors_match_exhausted_backoff(self, error_message):
+        # `_fetch` already retries 429/5xx internally with backoff; once those attempts are
+        # exhausted, this must stay classified as retryable so it doesn't get tracked as noise.
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(pattern in error_message for pattern in retryable_errors)
+
     def test_documented_tables_render_without_credentials(self):
         # Exercises the public-docs path: a credential-free placeholder config must list every table.
         tables = self.source.get_documented_tables()


### PR DESCRIPTION
## Problem

Error tracking flagged [an issue](https://us.posthog.com/project/2/error_tracking/019fa850-98ca-73c1-97f0-8f6e4fd46293) from a Google PageSpeed Insights sync: `PageSpeedRetryableError: PageSpeed Insights API error (retryable): status=500`, raised from `google_pagespeed_insights.py`'s `_fetch`.

That function already retries 429/5xx internally via tenacity (5 attempts, exponential backoff), re-raising only once that budget is exhausted. At that point Temporal retries the whole activity, so the failure is transient and self-recovering — exactly the kind of noise `_handle_import_error` is meant to keep out of error tracking (see its docstring in `import_data_sync.py`).

The catch: `_handle_import_error` only logs at `warning` (instead of `exception`) for errors the source lists in `get_retryable_errors()`. The Google PageSpeed Insights source never implemented that method, so its exhausted-retry error fell through to the generic branch and got tracked as a bug on every transient upstream 500/429 — even though nothing is actually broken and Temporal already retries it.

Sibling sources (UptimeRobot, Notion, Twelve Data) hit the same shape and already solve it by overriding `get_retryable_errors()` with the stable prefix of their own "retryable" exception message.

## Changes

- Added `GooglePageSpeedInsightsSource.get_retryable_errors()`, matching the stable `"PageSpeed Insights API error (retryable)"` prefix used by `PageSpeedRetryableError`, mirroring the UptimeRobot/Notion pattern.

## How did you test this code?

Added `test_retryable_errors_match_exhausted_backoff`, parameterized over the 429 and 500 cases, mirroring UptimeRobot's equivalent test — asserts the source now classifies its own exhausted-retry error message as retryable. This is the regression that let a transient, already-retried 500 get tracked as a bug: without this override the message falls through `_handle_import_error`'s generic branch and gets logged as an exception instead of a warning.

Ran the full `test_google_pagespeed_insights_source.py` suite (18 passed), plus `ruff check --fix`/`ruff format --check` and a repo-wide `uv run mypy --cache-fine-grained .` (clean) on the touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated from the linked error-tracking issue: confirmed the single occurrence's stack trace terminates in `_fetch` inside this source's own code, with `$exception_handled: true` (caught and reported, not a hard crash). Traced the call path through `_handle_import_error` in `import_data_sync.py` to find why an already-retried, self-recovering error was being tracked as a bug rather than logged as a benign warning — the source was simply missing the `get_retryable_errors()` opt-in that sibling sources already use for this exact shape. Checked open PRs (`PageSpeedRetryableError`, `google_pagespeed_insights`, `pagespeed`, the maintainer's own open PRs) — found one related-but-distinct fix (#74133, `RESTClientRetryableError` handled by `isinstance` for shared REST-client sources) that doesn't cover this source's own custom exception type. Skill invoked: `/writing-tests` (kept the added test to the one regression this opt-in protects).