### PR TITLE
feat(mcp): forward the OAuth client name on outbound PostHog API calls

### DIFF
--- a/products/notebooks/backend/analytics.py
+++ b/products/notebooks/backend/analytics.py
@@ -50,7 +50,6 @@ def capture_notebook_created(
     created_by_id: int | None = None,
     request: "Request | None" = None,
     mcp_consumer: str | None = None,
-    mcp_oauth_client: str | None = None,
     api_key_type: str | None = None,
     conversation_id: str | None = None,
     topic: str | None = None,
@@ -66,7 +65,6 @@ def capture_notebook_created(
         "creation_source": creation_source,
         **_optional_props(
             mcp_consumer=mcp_consumer,
-            mcp_oauth_client=mcp_oauth_client,
             api_key_type=api_key_type,
             conversation_id=conversation_id,
             topic=topic,
@@ -97,7 +95,6 @@ def capture_notebook_read(
     is_creator: bool,
     user_access_level: str | None = None,
     mcp_consumer: str | None = None,
-    mcp_oauth_client: str | None = None,
     api_key_type: str | None = None,
 ) -> None:
     """Emit `notebook read` for a programmatic (non-browser) notebook retrieve. Browser opens are
@@ -110,7 +107,6 @@ def capture_notebook_read(
         **_optional_props(
             user_access_level=user_access_level,
             mcp_consumer=mcp_consumer,
-            mcp_oauth_client=mcp_oauth_client,
             api_key_type=api_key_type,
         ),
     }

--- a/products/notebooks/backend/presentation/views/notebook.py
+++ b/products/notebooks/backend/presentation/views/notebook.py
@@ -111,17 +111,17 @@ def classify_request_source(request: Request) -> tuple[str, dict[str, str | None
     """Classify a notebook request as a browser action (``ui``) vs a programmatic client (``mcp``/API).
 
     Session-cookie requests are the browser; anything else (personal API key, OAuth app) is a
-    programmatic client. The PostHog MCP server forwards the client identity so PostHog Desktop can be
-    told apart from a customer's own MCP client: ``mcp_consumer`` is ``posthog-code``/``posthog-cli``
-    for first-party PostHog Desktop, and ``mcp_oauth_client`` is the OAuth app name (e.g. Claude) for
-    third-party clients. Shared by the create and read events."""
+    programmatic client. ``mcp_consumer`` is the wrapping app the PostHog MCP server forwards
+    (``posthog-code``/``posthog-cli`` for first-party PostHog Desktop), which tells it apart from a
+    customer's own MCP client. The third-party OAuth app name (e.g. Claude) rides along on every
+    request-bound event as ``mcp_oauth_client_name`` via ``get_request_analytics_properties``, so it
+    isn't repeated here. Shared by the create and read events."""
     authenticator = getattr(request, "successful_authenticator", None)
     if authenticator is None or isinstance(authenticator, SessionAuthentication):
         return NotebookCreationSource.UI, {}
     return NotebookCreationSource.MCP, {
         "api_key_type": type(authenticator).__name__,
         "mcp_consumer": request.META.get("HTTP_X_POSTHOG_MCP_CONSUMER"),
-        "mcp_oauth_client": request.META.get("HTTP_X_POSTHOG_MCP_OAUTH_CLIENT_NAME"),
     }
 
 
@@ -268,7 +268,6 @@ class NotebookSerializer(NotebookMinimalSerializer):
             visibility=notebook.visibility,
             node_count=notebook_node_count(notebook.content),
             mcp_consumer=source_props.get("mcp_consumer"),
-            mcp_oauth_client=source_props.get("mcp_oauth_client"),
             api_key_type=source_props.get("api_key_type"),
         )
 
@@ -748,7 +747,6 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
                 is_creator=instance.created_by_id == getattr(request.user, "id", None),
                 user_access_level=serializer.data.get("user_access_level"),
                 mcp_consumer=source_props.get("mcp_consumer"),
-                mcp_oauth_client=source_props.get("mcp_oauth_client"),
                 api_key_type=source_props.get("api_key_type"),
             )
 

--- a/products/notebooks/backend/test/test_analytics.py
+++ b/products/notebooks/backend/test/test_analytics.py
@@ -24,17 +24,15 @@ class _FakeKeyAuth:
 
 
 class _FakeRequest:
-    def __init__(self, authenticator, mcp_consumer=None, mcp_oauth_client=None):
+    def __init__(self, authenticator, mcp_consumer=None):
         self.successful_authenticator = authenticator
         self.META = {}
         if mcp_consumer is not None:
             self.META["HTTP_X_POSTHOG_MCP_CONSUMER"] = mcp_consumer
-        if mcp_oauth_client is not None:
-            self.META["HTTP_X_POSTHOG_MCP_OAUTH_CLIENT_NAME"] = mcp_oauth_client
 
 
-def _fake_request(authenticator, mcp_consumer=None, mcp_oauth_client=None) -> Request:
-    return cast(Request, _FakeRequest(authenticator, mcp_consumer, mcp_oauth_client))
+def _fake_request(authenticator, mcp_consumer=None) -> Request:
+    return cast(Request, _FakeRequest(authenticator, mcp_consumer))
 
 
 class TestNotebookAnalytics(BaseTest):
@@ -56,16 +54,11 @@ class TestNotebookAnalytics(BaseTest):
         self.assertEqual(extra, {})
 
     def test_classify_request_source_api_key_captures_mcp_client_identity(self):
-        # The MCP server forwards mcp_consumer (posthog-code -> PostHog Desktop) and mcp_oauth_client
-        # (the OAuth app, e.g. Claude), which is how Q4 (PostHog Desktop) is split from Q5.
-        source, extra = classify_request_source(
-            _fake_request(_FakeKeyAuth(), mcp_consumer="posthog-code", mcp_oauth_client="Claude")
-        )
+        # The MCP server forwards mcp_consumer (posthog-code -> PostHog Desktop), which is how
+        # PostHog Desktop is split from a customer's own MCP client.
+        source, extra = classify_request_source(_fake_request(_FakeKeyAuth(), mcp_consumer="posthog-code"))
         self.assertEqual(source, NotebookCreationSource.MCP)
-        self.assertEqual(
-            extra,
-            {"api_key_type": "_FakeKeyAuth", "mcp_consumer": "posthog-code", "mcp_oauth_client": "Claude"},
-        )
+        self.assertEqual(extra, {"api_key_type": "_FakeKeyAuth", "mcp_consumer": "posthog-code"})
 
     def test_classify_request_source_no_authenticator_defaults_to_ui(self):
         source, extra = classify_request_source(_fake_request(None))
@@ -111,7 +104,7 @@ class TestNotebookAnalytics(BaseTest):
         args, _ = mock_report.call_args
         self.assertEqual(args[0], self.user)
         self.assertEqual(args[1], NOTEBOOK_READ_EVENT)
-        # mcp_consumer flows through; mcp_oauth_client is unset and so dropped.
+        # mcp_consumer flows through; the None-valued optional props are dropped.
         self.assertEqual(
             args[2],
             {

--- a/services/mcp/src/hono/request-context.ts
+++ b/services/mcp/src/hono/request-context.ts
@@ -79,6 +79,13 @@ export class RequestContext {
         return this.tokenCache
     }
 
+    private async readCachedOAuthClientName(): Promise<string | undefined> {
+        if (!this.props.userHash) {
+            return undefined
+        }
+        return (await this.tokenCache.get('clientName')) || undefined
+    }
+
     private async api(): Promise<ApiClient> {
         if (!this.apiInstance) {
             const customApiBaseUrl = getCustomApiBaseUrl()
@@ -101,6 +108,11 @@ export class RequestContext {
                 mcpClientVersion: this.props.mcpClientVersion,
                 mcpProtocolVersion: this.props.mcpProtocolVersion,
                 mcpConsumer: this.props.mcpConsumer,
+                // Cached from a previous request's token introspection. On a cold cache this is
+                // still unset here, so `StateManager` also stamps it onto the live client's config
+                // the moment introspection resolves it — otherwise a token's first request would
+                // reach the API unattributed.
+                oauthClientName: await this.readCachedOAuthClientName(),
                 taskId: this.props.taskId,
             })
         }

--- a/services/mcp/src/lib/StateManager.ts
+++ b/services/mcp/src/lib/StateManager.ts
@@ -76,6 +76,10 @@ export class StateManager {
         const sanitizedClientName = sanitizeHeaderValue(client_name)
         if (sanitizedClientName) {
             await this._cache.set('clientName', sanitizedClientName)
+            // Introspection is the first point the OAuth app name is known, and the client was
+            // already built for this request — stamp it on so the rest of the request forwards
+            // `x-posthog-mcp-oauth-client-name` instead of waiting for the next cache hit.
+            this._api.config.oauthClientName = sanitizedClientName
         }
 
         return {

--- a/services/mcp/tests/hono/request-context.test.ts
+++ b/services/mcp/tests/hono/request-context.test.ts
@@ -104,6 +104,22 @@ describe('RequestContext', () => {
             expect(config.baseUrl).toBe('https://us.posthog.com')
             expect(config.publicBaseUrl).toBe('https://us.posthog.com')
         })
+
+        it.each([
+            { label: 'cached OAuth client name', cached: 'Claude', expected: 'Claude' },
+            { label: 'no cached OAuth client name', cached: undefined, expected: undefined },
+        ])('passes $label through as oauthClientName', async ({ cached, expected }) => {
+            const redis = fakeRedis()
+            if (cached) {
+                await redis.set('mcp:token:test-user:clientName', JSON.stringify(cached))
+            }
+            mockMe.mockResolvedValue({ success: true, data: { distinct_id: 'user-1' } })
+
+            const ctx = new RequestContext(redis, env, makeProps())
+            await ctx.getDistinctId()
+
+            expect(mockApiClientCtor.mock.calls[0]![0].oauthClientName).toBe(expected)
+        })
     })
 
     describe('getDistinctId', () => {

--- a/services/mcp/tests/unit/StateManager.test.ts
+++ b/services/mcp/tests/unit/StateManager.test.ts
@@ -81,6 +81,36 @@ describe('StateManager', () => {
         })
     })
 
+    describe('getApiKey', () => {
+        function oauthApi(clientName: string | null): ApiClient {
+            return {
+                config: { apiToken: 'phx_test' },
+                apiKeys: () => ({
+                    current: async () => ({ success: false, error: { message: 'not a personal key' } }),
+                }),
+                oauth: () => ({
+                    introspect: async () => ({
+                        success: true,
+                        data: { active: true, scope: 'insight:read', client_name: clientName },
+                    }),
+                }),
+            } as unknown as ApiClient
+        }
+
+        it.each([
+            { label: 'an OAuth app name', clientName: 'Claude', expected: 'Claude' },
+            { label: 'no OAuth app name', clientName: null, expected: undefined },
+        ])('stamps $label onto the live client so the same request forwards it', async ({ clientName, expected }) => {
+            const api = oauthApi(clientName)
+            stateManager = new StateManager(cache, api)
+
+            await stateManager.getApiKey()
+
+            expect(api.config.oauthClientName).toBe(expected)
+            expect(await cache.get('clientName')).toBe(expected)
+        })
+    })
+
     describe('setDefaultOrganizationAndProject', () => {
         it('should handle team-scoped API key with single team', async () => {
             const teamScopedApiKey = {


### PR DESCRIPTION
## Problem

Notebook `notebook created` / `notebook read` events can tell first-party PostHog clients apart via `mcp_consumer` (`posthog-code`, `posthog-cli`, `plugin`, `slack`), but every third-party MCP client collapses into one anonymous bucket. We can't answer "how much notebook usage comes from Claude vs Codex vs anything else."

The MCP server's API client already had an `oauthClientName` config slot that becomes the `x-posthog-mcp-oauth-client-name` header on outbound PostHog API calls. Nothing ever populated it. The name is known server-side (it's on the MCP server's own analytics events as `$mcp_oauth_client_name`), it just never made it onto the request that creates or reads the notebook. So Django's `get_mcp_properties` always saw `None` and dropped the prop.

This is not notebooks-specific. Every MCP-driven API write was landing unattributed.

## Changes

Two lines of real wiring, plus a cleanup.

**Populate `oauthClientName`.** `RequestContext.api()` now reads the cached OAuth app name from the token cache when it builds the `ApiClient`. On a cold cache that value isn't there yet, since it only lands during OAuth introspection, so `StateManager._fetchApiKey` also stamps it onto the already-built client the moment introspection resolves it. Without that second half, a token's very first request would still go out anonymous.

**Drop the duplicate notebook prop.** The Django notebook events carried their own `mcp_oauth_client`, read from the same header that `get_request_analytics_properties` already reads into `mcp_oauth_client_name` on every request-bound event. Both call sites pass `request=`, so the notebook-local copy was redundant the moment the header started arriving. Removing it leaves one property name to analyze instead of two that mean the same thing. It was always null, so nothing is lost from the event stream.

> [!NOTE]
> Attribution now flows product-wide, not just for notebooks, because it rides the shared `report_user_action` plumbing rather than per-product code.

## How did you test this code?

I (Claude) ran these locally; I did not exercise a live OAuth MCP client end to end.

- `tests/unit/StateManager.test.ts`, `tests/unit/api-client.test.ts`, `tests/hono/request-context.test.ts`, `tests/hono/request-state-resolver.test.ts` — all pass
- `products/notebooks/backend/test/{test_analytics,test_notebook_read_event,test_facade}.py` — 29 pass
- `uv run mypy --cache-fine-grained .` — clean, 16969 files
- `hogli build:openapi` — no drift
- `hogli ci:preflight --strict` — no failures

New tests, and the regression each catches:

- `StateManager > getApiKey` — the cold-cache half. Guards that introspection stamps the name onto the live client. Without it, a token's first request silently loses attribution, which is a subset of exactly the bug this PR fixes.
- `RequestContext > ApiClient construction` — the warm-cache half. Guards that a cached name reaches the `ApiClient` config at all. This is the line that was missing and produced the whole gap.

Neither path had any coverage before. `api-client.test.ts` already covers config to header, so I didn't re-test that.

To verify after deploy, third-party MCP notebook creation should break down by client instead of returning one null bucket:

```sql
SELECT properties.mcp_oauth_client_name AS client, count() AS created
FROM events
WHERE event = 'notebook created'
  AND properties.creation_source = 'mcp'
  AND properties.source = 'mcp'
  AND timestamp >= now() - INTERVAL 7 DAY
GROUP BY client ORDER BY created DESC
```

The `source = 'mcp'` filter matters. Most notebooks tagged `creation_source = 'mcp'` are actually the setup wizard (`source = 'wizard'`), so any MCP-client analysis needs to exclude it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`services/mcp/README.md` documents inbound headers a client sets, not outbound headers the server forwards, so there was nothing to update there.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this from a gap analysis I'd put together on notebook MCP attribution. Skills invoked: `/writing-tests`.

The analysis I handed over assumed the header wiring was missing entirely and recommended adding it alongside `x-posthog-mcp-consumer`. It was already there in `api/client.ts` — the config field just had no writer, which is why it looked absent from the outside.

The analysis also recommended renaming the Django prop from `mcp_oauth_client` to `mcp_oauth_client_name`. We deleted it instead. Core already emits `mcp_oauth_client_name` from the same header on every request-bound event, so renaming would have produced two identical props under one name rather than resolving the footgun. Deleting lands the same property name the verification query wants, with less code.

One thing deliberately left alone: `request-state-resolver.ts` reads `clientName` from the cache separately for `MCPClientProfile`, which looks like a dedupable second Redis read. It isn't. That read happens after `getApiKey()` resolves, so on a cold cache it sees the fresh value while the earlier `api()` read saw nothing. Sharing a memoized read would hand the resolver a stale `undefined`.

Separately, the account-note tool in customer analytics creates notebooks without emitting `notebook created` at all, so AI-generated account notes stay undercounted. Out of scope here.
