### PR TITLE
fix(dashboards): rank auto breakdown colors by series size

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardBreakdownColors.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardBreakdownColors.test.ts
@@ -273,10 +273,39 @@ describe('dashboardBreakdownColors', () => {
 
             expect(extractBreakdownValuesByTile(tiles)).toEqual([
                 [
-                    { breakdownValue: 'Chrome', breakdownType: 'event' },
-                    { breakdownValue: 'Firefox', breakdownType: 'event' },
+                    { breakdownValue: 'Chrome', breakdownType: 'event', magnitude: 0 },
+                    { breakdownValue: 'Firefox', breakdownType: 'event', magnitude: 0 },
                 ],
-                [{ breakdownValue: 'Chrome', breakdownType: 'event' }],
+                [{ breakdownValue: 'Chrome', breakdownType: 'event', magnitude: 0 }],
+            ])
+        })
+
+        it('sizes values from their rows, preferring aggregated_value and keeping the largest across duplicates', () => {
+            const tiles = [
+                trendsTile([
+                    { action: { order: 0 }, breakdown_value: ['Chrome'], count: 120 },
+                    { action: { order: 1 }, breakdown_value: ['Chrome'], count: 80 },
+                    { action: { order: 0 }, breakdown_value: ['Firefox'], aggregated_value: 5, count: 999 },
+                ]),
+                // retention rows carry the cohort size as the first interval's count
+                createTestTile({
+                    result: [{ breakdown_value: 'Chrome', values: [{ count: 40 }, { count: 10 }] }],
+                    query: {
+                        kind: NodeKind.InsightVizNode,
+                        source: {
+                            kind: NodeKind.RetentionQuery,
+                            breakdownFilter: { breakdown: '$browser', breakdown_type: 'event' },
+                        },
+                    } as InsightVizNode<InsightQueryNode>,
+                }),
+            ]
+
+            expect(extractBreakdownValuesByTile(tiles)).toEqual([
+                [
+                    { breakdownValue: 'Chrome', breakdownType: 'event', magnitude: 120 },
+                    { breakdownValue: 'Firefox', breakdownType: 'event', magnitude: 5 },
+                ],
+                [{ breakdownValue: 'Chrome', breakdownType: 'event', magnitude: 40 }],
             ])
         })
     })
@@ -295,6 +324,14 @@ describe('dashboardBreakdownColors', () => {
             breakdownValue: string,
             colorToken: BreakdownColorConfig['colorToken']
         ): BreakdownColorConfig => ({ breakdownValue, breakdownType: 'event', colorToken, source: 'auto' })
+        const sized = (
+            breakdownValue: string,
+            magnitude: number
+        ): { breakdownValue: string; breakdownType: 'event'; magnitude: number } => ({
+            breakdownValue,
+            breakdownType: 'event',
+            magnitude,
+        })
 
         it('assigns only values that appear on two or more tiles', () => {
             const result = applyAutoBreakdownColors([[value('Chrome'), value('Firefox')], [value('Chrome')]], [])
@@ -305,7 +342,7 @@ describe('dashboardBreakdownColors', () => {
             ])
         })
 
-        it('fills free slots in sorted order and appends after existing configs', () => {
+        it('fills free slots in value order when sizes tie, appending after existing configs', () => {
             const existing: BreakdownColorConfig[] = [
                 { breakdownValue: 'Chrome', breakdownType: 'event', colorToken: 'preset-3', source: 'manual' },
             ]
@@ -317,6 +354,46 @@ describe('dashboardBreakdownColors', () => {
                 { breakdownValue: 'Alibaba', breakdownType: 'event', colorToken: 'preset-1', source: 'auto' },
                 { breakdownValue: 'Google', breakdownType: 'event', colorToken: 'preset-2', source: 'auto' },
             ])
+        })
+
+        it('ranks shared values by series size, largest first, like one merged insight', () => {
+            const result = applyAutoBreakdownColors(
+                [
+                    [sized('Zebra', 100), sized('Apple', 5)],
+                    [sized('Zebra', 100), sized('Apple', 5)],
+                ],
+                []
+            )
+
+            // value order would put Apple first; size order matches the insights' own coloring
+            expect(result).toEqual([autoConfig('Zebra', 'preset-1'), autoConfig('Apple', 'preset-2')])
+        })
+
+        it('ranks by the highest size across tiles, not the first seen', () => {
+            const result = applyAutoBreakdownColors(
+                [
+                    [sized('Zeta', 10), sized('Alpha', 50)],
+                    [sized('Zeta', 200), sized('Alpha', 50)],
+                ],
+                []
+            )
+
+            expect(result).toEqual([autoConfig('Zeta', 'preset-1'), autoConfig('Alpha', 'preset-2')])
+        })
+
+        it('moves the smaller series when two persisted auto entries collide', () => {
+            const existing: BreakdownColorConfig[] = [autoConfig('Zeta', 'preset-1'), autoConfig('Alpha', 'preset-1')]
+
+            const result = applyAutoBreakdownColors(
+                [
+                    [sized('Zeta', 100), sized('Alpha', 5)],
+                    [sized('Zeta', 100), sized('Alpha', 5)],
+                ],
+                existing
+            )
+
+            // the larger series is the more recognizable one, so it keeps its color
+            expect(result).toEqual([autoConfig('Zeta', 'preset-1'), autoConfig('Alpha', 'preset-2')])
         })
 
         it('returns non-colliding configs unchanged, by reference, in their original order', () => {
@@ -468,22 +545,25 @@ describe('dashboardBreakdownColors', () => {
             expect(tokens.size).toBe(0)
         })
 
-        it('fills the slots the tile overrides do not use, in position order', () => {
+        it('keeps non-colliding series on their position colors and moves only the displaced one', () => {
             const tokens = computeTileFallbackTokens(
                 [
-                    { position: 0, overrideToken: null },
-                    { position: 1, overrideToken: 'preset-1' },
+                    { position: 0, overrideToken: 'preset-4' },
+                    { position: 1, overrideToken: null },
                     { position: 2, overrideToken: null },
-                    { position: 3, overrideToken: 'preset-4' },
+                    { position: 3, overrideToken: null },
                     { position: 4, overrideToken: null },
                 ],
                 15
             )
 
+            // the override occupies slot 3, so only the position-3 series moves, to the lowest
+            // slot the tile leaves unused; everyone else keeps their standalone insight color
             expect(tokens).toEqual(
                 new Map([
-                    [0, 'preset-2'],
+                    [1, 'preset-2'],
                     [2, 'preset-3'],
+                    [3, 'preset-1'],
                     [4, 'preset-5'],
                 ])
             )

--- a/frontend/src/scenes/dashboard/dashboardBreakdownColors.ts
+++ b/frontend/src/scenes/dashboard/dashboardBreakdownColors.ts
@@ -23,6 +23,13 @@ export type BreakdownColorConfig = {
 
 export type BreakdownValueAndType = Pick<BreakdownColorConfig, 'breakdownValue' | 'breakdownType'>
 
+/** A breakdown value as it appears on one tile, sized for auto-assignment ranking. */
+export type TileBreakdownValue = BreakdownValueAndType & {
+    /** Best-effort series size on the tile (aggregated value, else range total), so assignment
+     * can rank values the way a single insight orders its series. Missing means unranked. */
+    magnitude?: number
+}
+
 /** Label of the synthetic baseline row funnel insights contribute to the colors table. */
 export const FUNNEL_BASELINE_BREAKDOWN_LABEL = 'Baseline'
 
@@ -88,13 +95,25 @@ export function mergeBreakdownColorConfigs(...configLists: BreakdownColorConfig[
     return merged
 }
 
-function extractTileBreakdownValues(tile: DashboardTile<QueryBasedInsightModel>): BreakdownValueAndType[] {
+/** Reads the size of one result row across insight kinds: trends rows carry aggregated_value
+ * (total-value displays) or count (range total), retention rows carry the cohort size as the
+ * first interval's count. */
+function extractResultMagnitude(result: any): number {
+    for (const candidate of [result?.aggregated_value, result?.count, result?.values?.[0]?.count]) {
+        if (typeof candidate === 'number' && Number.isFinite(candidate)) {
+            return candidate
+        }
+    }
+    return 0
+}
+
+function extractTileBreakdownValues(tile: DashboardTile<QueryBasedInsightModel>): TileBreakdownValue[] {
     if (!isInsightVizNode(tile.insight?.query)) {
         return []
     }
 
     const querySource = tile.insight?.query.source
-    let breakdownValues: (BreakdownValueAndType | null)[] = []
+    let breakdownValues: (TileBreakdownValue | null)[] = []
     if (isFunnelsQuery(querySource)) {
         const funnelVizType = querySource.funnelsFilter?.funnelVizType
         const isStepsViz = funnelVizType === undefined || funnelVizType === FunnelVizType.Steps
@@ -115,15 +134,21 @@ function extractTileBreakdownValues(tile: DashboardTile<QueryBasedInsightModel>)
         tile.insight?.result?.forEach((result: any) => {
             const key = getFunnelDatasetKey(result)
             const breakdownValue = normalizeBreakdownValue(JSON.parse(key)['breakdown_value'])
-            breakdownValues.push(breakdownValue == null ? null : { breakdownValue, breakdownType })
+            breakdownValues.push(
+                breakdownValue == null
+                    ? null
+                    : { breakdownValue, breakdownType, magnitude: extractResultMagnitude(result) }
+            )
         })
     } else if (isTrendsQuery(querySource)) {
         const breakdownType = querySource.breakdownFilter?.breakdown_type || 'event'
         breakdownValues =
-            tile.insight?.result?.map((result: any): BreakdownValueAndType | null => {
+            tile.insight?.result?.map((result: any): TileBreakdownValue | null => {
                 const key = getTrendDatasetKey(result)
                 const breakdownValue = normalizeBreakdownValue(JSON.parse(key)['breakdown_value'])
-                return breakdownValue == null ? null : { breakdownValue, breakdownType }
+                return breakdownValue == null
+                    ? null
+                    : { breakdownValue, breakdownType, magnitude: extractResultMagnitude(result) }
             }) || []
     } else if (isRetentionQuery(querySource) && hasBreakdownFilter(querySource.breakdownFilter)) {
         const breakdownType = querySource.breakdownFilter.breakdown_type || 'event'
@@ -131,16 +156,24 @@ function extractTileBreakdownValues(tile: DashboardTile<QueryBasedInsightModel>)
         // like trends/funnels have, because retention has no resultCustomizations whose
         // persisted keys the extraction would need to stay in sync with.
         breakdownValues =
-            tile.insight?.result?.map((result: any): BreakdownValueAndType | null => {
+            tile.insight?.result?.map((result: any): TileBreakdownValue | null => {
                 const breakdownValue = normalizeBreakdownValue(result.breakdown_value)
-                return breakdownValue == null ? null : { breakdownValue, breakdownType }
+                return breakdownValue == null
+                    ? null
+                    : { breakdownValue, breakdownType, magnitude: extractResultMagnitude(result) }
             }) || []
     }
 
     return breakdownValues
-        .filter((value): value is BreakdownValueAndType => value != null)
-        .reduce<BreakdownValueAndType[]>((acc, curr) => {
-            if (!acc.some((x) => x.breakdownValue === curr.breakdownValue && x.breakdownType === curr.breakdownType)) {
+        .filter((value): value is TileBreakdownValue => value != null)
+        .reduce<TileBreakdownValue[]>((acc, curr) => {
+            const existing = acc.find(
+                (x) => x.breakdownValue === curr.breakdownValue && x.breakdownType === curr.breakdownType
+            )
+            if (existing) {
+                // A value repeats across series or retention cohorts; its largest row is its size.
+                existing.magnitude = Math.max(existing.magnitude ?? 0, curr.magnitude ?? 0)
+            } else {
                 acc.push(curr)
             }
             return acc
@@ -152,7 +185,7 @@ function extractTileBreakdownValues(tile: DashboardTile<QueryBasedInsightModel>)
  * colors may collide, and how many tiles share a value decides whether it gets one at all. */
 export function extractBreakdownValuesByTile(
     insightTiles: DashboardTile<QueryBasedInsightModel>[] | null
-): BreakdownValueAndType[][] {
+): TileBreakdownValue[][] {
     if (insightTiles == null) {
         return []
     }
@@ -165,6 +198,7 @@ export function extractBreakdownValues(
 ): BreakdownValueAndType[] {
     return extractBreakdownValuesByTile(insightTiles)
         .flat()
+        .map(({ breakdownValue, breakdownType }): BreakdownValueAndType => ({ breakdownValue, breakdownType }))
         .reduce<BreakdownValueAndType[]>((acc, curr) => {
             if (!acc.some((x) => x.breakdownValue === curr.breakdownValue && x.breakdownType === curr.breakdownType)) {
                 acc.push(curr)
@@ -239,19 +273,22 @@ export function buildSharedBreakdownValueLookup(
  *
  * Stability comes from persistence, not from the algorithm: manual pins never move, and
  * persisted auto entries keep their slots unless two of them meet on one tile with the same
- * slot (a new tile landed, or the entry predates collision-aware assignment). Uncovered
- * shared values and collision-displaced auto entries are then assigned in deterministic
- * order: the lowest globally-unused slot while slots last, then a slot the value's own
- * tiles don't show yet, then the slot least used on those tiles. A duplicate color on two
- * different charts is invisible; on one chart it isn't, so exhaustion prefers cross-tile
- * reuse over within-tile reuse.
+ * slot (a new tile landed, or the entry predates collision-aware assignment); of such a
+ * pair, the smaller series moves, since the larger one is the more recognizable of the two.
+ * Uncovered shared values and displaced entries are then assigned as if their series formed
+ * one insight merged across every tile: ranked by size, largest first, because insights hand
+ * out position colors in size order, which keeps dashboard colors close to what each insight
+ * shows on its own. Ties fall back to a locale-independent value order. Each value takes the
+ * lowest globally-unused slot while slots last, then a slot its own tiles don't show yet,
+ * then the slot least used on those tiles: a duplicate color on two different charts is
+ * invisible, on one chart it isn't.
  *
  * Returns the full config list: existing entries in their original order (re-slotted ones
  * replaced in place, so an unchanged dashboard round-trips deep-equal for the save diff),
  * with new assignments appended.
  */
 export function applyAutoBreakdownColors(
-    tileBreakdownValues: BreakdownValueAndType[][],
+    tileBreakdownValues: TileBreakdownValue[][],
     existingConfigs: BreakdownColorConfig[],
     paletteSize: number = dataColorVars.length
 ): BreakdownColorConfig[] {
@@ -259,20 +296,27 @@ export function applyAutoBreakdownColors(
         return [...existingConfigs]
     }
 
-    const valueTiles = new Map<string, { value: BreakdownValueAndType; tiles: number[] }>()
+    const valueTiles = new Map<string, { value: BreakdownValueAndType; tiles: number[]; magnitude: number }>()
     tileBreakdownValues.forEach((values, tileIndex) => {
         for (const value of values) {
             const key = breakdownValueTileKey(value)
             const entry = valueTiles.get(key)
             if (entry) {
                 entry.tiles.push(tileIndex)
+                // The highest value across tiles ranks the series, mirroring how the value
+                // would place in a single insight containing its biggest series.
+                entry.magnitude = Math.max(entry.magnitude, value.magnitude ?? 0)
             } else {
-                valueTiles.set(key, { value, tiles: [tileIndex] })
+                valueTiles.set(key, { value, tiles: [tileIndex], magnitude: value.magnitude ?? 0 })
             }
         }
     })
     const tilesOf = (value: BreakdownValueAndType): number[] =>
         valueTiles.get(breakdownValueTileKey(value))?.tiles ?? []
+    const magnitudeOf = (value: BreakdownValueAndType): number =>
+        valueTiles.get(breakdownValueTileKey(value))?.magnitude ?? 0
+    const compareAssignmentRank = (a: BreakdownValueAndType, b: BreakdownValueAndType): number =>
+        magnitudeOf(b) - magnitudeOf(a) || compareAssignmentOrder(a, b)
 
     // Per-tile slot usage drives collision checks; global usage keeps distinct values on
     // distinct colors while free slots last.
@@ -299,10 +343,10 @@ export function applyAutoBreakdownColors(
         }
     }
 
-    // Walking persisted auto entries in assignment order means that of a colliding pair,
-    // the later-sorted value is the one that moves.
+    // Walking persisted auto entries in rank order means that of a colliding pair, the
+    // smaller series (or the later-sorted one, on ties) is the one that moves.
     const displaced: BreakdownValueAndType[] = []
-    for (const config of [...autoConfigs].sort(compareAssignmentOrder)) {
+    for (const config of [...autoConfigs].sort(compareAssignmentRank)) {
         const slot = presetTokenToSlot(config.colorToken, paletteSize)!
         const tiles = tilesOf(config)
         const collidesWithinTile = tiles.some((tile) => (tileSlotCounts[tile].get(slot) ?? 0) > 0)
@@ -324,7 +368,7 @@ export function applyAutoBreakdownColors(
 
     const allSlots = Array.from({ length: paletteSize }, (_, slot) => slot)
     const assignments = new Map<string, BreakdownColorConfig>()
-    for (const candidate of [...uncovered, ...displaced].sort(compareAssignmentOrder)) {
+    for (const candidate of [...uncovered, ...displaced].sort(compareAssignmentRank)) {
         const tiles = tilesOf(candidate)
         const usedOnOwnTiles = (slot: number): number =>
             tiles.reduce((sum, tile) => sum + (tileSlotCounts[tile].get(slot) ?? 0), 0)
@@ -363,13 +407,14 @@ export type TileFallbackSeries = {
 
 /** Position-based fallback tokens for the series of one tile that have no value override.
  *
- * Without dashboard colors, series get `preset-(position + 1)`: consecutive palette slots,
- * which are designed to look distinct next to each other. Value overrides break that
- * sequence, since they occupy slots scattered across the whole dashboard, so a
- * position-colored neighbor can land on the same slot as an override on the same chart.
- * Instead, non-overridden series fill the slots the tile's overrides do not use, in
- * position order, cycling through those free slots once they run out (a duplicate among
- * far-apart positions beats duplicating an override's color).
+ * Without dashboard colors, series get `preset-(position + 1)`. Value overrides occupy slots
+ * scattered across the whole dashboard, so a position-colored neighbor can land on the same
+ * slot as an override shown on the same chart. Non-overridden series therefore keep their own
+ * position slot whenever no override on this tile uses it, so the tile deviates from the
+ * standalone insight as little as possible; only the colliding series move, to the lowest
+ * slots the tile leaves unused. Once those run out, displaced series cycle through the
+ * non-override slots (a duplicate among far-apart positions beats duplicating an override's
+ * color).
  *
  * Returns an empty map when the tile has no overrides, so override-free tiles keep plain
  * position colors and render exactly as a standalone insight, and when overrides cover the
@@ -401,8 +446,24 @@ export function computeTileFallbackTokens(
     const positions = [...new Set(series.map((s) => s.position))]
         .filter((position) => !overriddenPositions.has(position))
         .sort((a, b) => a - b)
-    positions.forEach((position, index) => {
-        fallbackTokens.set(position, slotToPresetToken(freeSlots[index % freeSlots.length]))
+
+    const keptSlots = new Set<number>()
+    const displacedPositions: number[] = []
+    for (const position of positions) {
+        const naturalSlot = position % paletteSize
+        if (!usedSlots.has(naturalSlot) && !keptSlots.has(naturalSlot)) {
+            keptSlots.add(naturalSlot)
+            fallbackTokens.set(position, slotToPresetToken(naturalSlot))
+        } else {
+            displacedPositions.push(position)
+        }
+    }
+    // With every non-override slot kept by another series, a displaced series duplicating a
+    // kept slot still beats duplicating an override's color.
+    const remainingFree = freeSlots.filter((slot) => !keptSlots.has(slot))
+    const displacedPool = remainingFree.length > 0 ? remainingFree : freeSlots
+    displacedPositions.forEach((position, index) => {
+        fallbackTokens.set(position, slotToPresetToken(displacedPool[index % displacedPool.length]))
     })
     return fallbackTokens
 }


### PR DESCRIPTION
## TL;DR

Stacked on #74067. Dashboard auto colors were handed out in alphabetical order, so a chart on a dashboard could look nothing like the same insight opened standalone. Now colors are assigned as if all charts were one big insight: the biggest series gets the first color, the next biggest the second, and so on. Series without a dashboard color simply keep the color they'd have standalone. A dashboard now deviates from its insights only where two series on one chart would otherwise clash.

## Problem

Insights hand out position colors in series-size order. The auto assignment from #74067 ranked shared values alphabetically instead, and its tile completion compacted non-override series into whatever slots the overrides left free. Both reshuffle a tile's colors relative to the standalone insight even when nothing conflicts, which was the jarring part of the report in [the originating Slack thread](https://posthog.slack.com/archives/C0368RPHLQH/p1785145521830129): clicking from the dashboard into the insight changed the colors.

## Changes

- `applyAutoBreakdownColors` ranks uncovered shared values (and collision-displaced entries) by series size, largest first, as one insight merged across every tile would. Ties fall back to the previous locale-independent value order, so unsized values behave exactly as before. Of two colliding persisted auto entries, the smaller series now moves, since the larger one is the more recognizable.
- `extractBreakdownValuesByTile` sizes each value from its result rows (`aggregated_value`, else `count`, else retention's first-interval count), keeping the largest across duplicate rows and tiles.
- `computeTileFallbackTokens` keeps non-override series on their own position slots and moves only series whose slot an override occupies, to the lowest slots the tile leaves unused; overflow cycling is unchanged.

Persisted colors still never re-derive, so saved dashboards don't churn. On unsaved dashboards the ranking follows the data, so it can shift between visits if series sizes reorder; saving pins it, same as before.

## How did you test this code?

Automated only, run locally by the agent (no browser run):

- 4 new cases in `dashboardBreakdownColors.test.ts`: size ranking beats value order (fails under the old alphabetical sort), ranking by the highest size across tiles (fails under first-seen), the smaller persisted entry moving on collision (fails under the old walk order), and magnitude extraction incl. `aggregated_value` precedence and dedupe-max (catches the extraction wiring silently degrading to unranked).
- Rebuilt one completion test around a fixture that distinguishes keep-natural from the old compaction (override on slot 3: compaction shifted every series down one, keep-natural moves only the colliding series). The old fixture produced identical output under both algorithms, so it couldn't catch a regression here.
- All other existing cases pass unchanged, which pins the tie fallback and the persistence/collision invariants from #74067: 124 tests across the dashboard suites, 315 across trends/funnels/retention/modal. Lint, format, and `typescript:check` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code) directed by @thmsobrmlr. Skills invoked: `/writing-tests`, `/writing-code-comments`. Key decision: rank-by-size ("one merged insight") over the initially planned per-tile position preference. Ranking is collision-free by construction and matches how insights already order series; per-tile preference needed conflict resolution between values wanting the same slot and was sensitive to greedy order. Sizes are a ranking heuristic only: a wrong or missing magnitude can only produce a suboptimal order, never a wrong or colliding color. Out of scope, noted for later: values whose insights carry their own saved result customization still lose that custom color to the dashboard-wide one, because customizations aren't visible to extraction.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*