### PR TITLE
fix(data-warehouse): keep synced clickhouse sources on s3-backed tables

### DIFF
--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -750,8 +750,15 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                 connection_metadata=self.external_data_source.connection_metadata,
             )
 
-        # Engine-keyed (no is_direct_clickhouse) to satisfy the source-agnostic guard.
-        if self.external_data_source and self.external_data_source.direct_engine == "clickhouse":
+        # Engine-keyed (no is_direct_clickhouse) to satisfy the source-agnostic guard. The
+        # is_direct_query check is load-bearing: direct_engine ignores access_method, and a synced
+        # source's tables must stay S3-backed — as a direct table, every ordinary query against
+        # them fails (the printer's team_id guard doesn't skip DirectSQLTable).
+        if (
+            self.external_data_source
+            and self.external_data_source.is_direct_query
+            and self.external_data_source.direct_engine == "clickhouse"
+        ):
             job_inputs = self.external_data_source.job_inputs or {}
             clickhouse_database = (
                 self.options.get(DIRECT_CLICKHOUSE_DATABASE_OPTION)

--- a/products/warehouse_sources/backend/tests/test_table.py
+++ b/products/warehouse_sources/backend/tests/test_table.py
@@ -10,15 +10,55 @@ from django.test import SimpleTestCase
 from clickhouse_driver.errors import ServerException
 from parameterized import parameterized
 
+from posthog.hogql.database.direct_clickhouse_table import DirectClickHouseTable
 from posthog.hogql.database.models import DatabaseField, StringDatabaseField, UUIDDatabaseField
+from posthog.hogql.database.s3_table import DataWarehouseTable as HogQLDataWarehouseTable
 
 from posthog.exceptions import ClickHouseAtCapacity
 
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.table import (
     DataWarehouseTable,
     get_hogql_field_for_column,
     run_chdb_query,
 )
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+class TestHogQLDefinitionDirectDispatch(BaseTest):
+    @parameterized.expand(
+        [
+            ("synced_clickhouse", ExternalDataSourceType.CLICKHOUSE, "warehouse", HogQLDataWarehouseTable),
+            ("synced_clickhouse_cloud", ExternalDataSourceType.CLICKHOUSECLOUD, "warehouse", HogQLDataWarehouseTable),
+            ("direct_clickhouse", ExternalDataSourceType.CLICKHOUSE, "direct", DirectClickHouseTable),
+        ]
+    )
+    def test_clickhouse_table_class_respects_access_method(
+        self,
+        _name: str,
+        source_type: str,
+        access_method: str,
+        expected_class: type,
+    ) -> None:
+        # A synced ClickHouse source's tables must stay S3-backed: a DirectSQLTable is
+        # excluded from the printer's team_id-guard skip list, so resolving a synced table
+        # as direct makes every ordinary query against it fail.
+        source = ExternalDataSource(
+            team=self.team,
+            source_type=source_type,
+            access_method=access_method,
+            job_inputs={"database": "analytics"},
+        )
+        table = DataWarehouseTable(
+            name="external_events",
+            format="Parquet",
+            team=self.team,
+            url_pattern="s3://bucket/team_1/external_events",
+            external_data_source=source,
+            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "valid": True}},
+        )
+
+        assert type(table.hogql_definition()) is expected_class
 
 
 class TestDataWarehouseTableColumnOrder(BaseTest):


### PR DESCRIPTION
## Problem

#72906 added direct-query support for ClickHouse sources. Its dispatch branch in `DataWarehouseTable.hogql_definition` keys on `direct_engine == "clickhouse"` alone. `direct_engine` maps from `source_type` and deliberately ignores `access_method` (its docstring says so), so the branch also fires for regular **synced** ClickHouse and ClickhouseCloud sources.

That flips every synced table of those sources from the S3-backed `DataWarehouseTable` to `DirectClickHouseTable`. A `DirectSQLTable` is not in the ClickHouse printer's `team_id`-guard skip list (`_ensure_team_id_where_clause` only skips `DataWarehouseTable`/`SavedQuery`), so the printer injects a `team_id = N` filter and `Table.get_field("team_id")` raises a plain `Exception`:

```
Exception: Field "team_id" not found on table DirectClickHouseTable
```

Nothing on the query path handles it, so every HogQL query touching such a table (endpoint runs, insights, SQL editor, materializations) returns an unhandled 500. This is the regression behind the endpoint execution system-error-rate alert firing since 2026-07-27 ~13:00 UTC.

Every other engine's branch gates on `is_direct_postgres`/`is_direct_mysql`/etc., which all require `access_method == DIRECT`. The ClickHouse branch skipped that gate.

## Changes

- Gate the `DirectClickHouseTable` branch on `external_data_source.is_direct_query`, matching the other engines while staying engine-keyed (no source-type branching).
- Synced (warehouse-mode) ClickHouse/ClickhouseCloud tables resolve to the S3-backed table again; direct-mode sources keep resolving to `DirectClickHouseTable`.

## How did you test this code?

Red-first test: `TestHogQLDefinitionDirectDispatch` (parameterized) asserts synced ClickHouse and ClickhouseCloud sources resolve to the S3-backed table. Both cases failed with `DirectClickHouseTable` before the fix. A third case pins that direct-mode sources still get `DirectClickHouseTable`. No existing test covered `hogql_definition` dispatch by access method, which is how #72906 shipped.

Ran (all green):

- `products/warehouse_sources/backend/tests/test_table.py` (11 passed)
- `posthog/hogql/direct_sql/test/test_clickhouse_adapter.py`, `posthog/hogql/direct_sql/test/test_registry_and_capability.py`, `products/warehouse_sources/backend/tests/test_models.py`, `products/data_warehouse/backend/test/test_direct_query_engines.py` (197 passed)

No manual testing against a live ClickHouse source. I (or, actually Claude) verified the class dispatch at the unit level only.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, directed by the assignee. Root-caused from the prod alert by grouping captured `$exception` events on the endpoint run path (13.5k+ hits of the `team_id` error starting exactly at the deploy of #72906), then tracing `hogql_definition` dispatch and the printer's team-guard skip list. Skills invoked: `/quick-fix-pr`, `/writing-tests`. Considered reverting #72906 instead; chose the one-condition gate since it preserves the direct-query feature and the tests from that PR still pass.
