### PR TITLE
fix(data-warehouse): query synced ClickHouse source tables via S3

### DIFF
--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -750,8 +750,17 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                 connection_metadata=self.external_data_source.connection_metadata,
             )
 
-        # Engine-keyed (no is_direct_clickhouse) to satisfy the source-agnostic guard.
-        if self.external_data_source and self.external_data_source.direct_engine == "clickhouse":
+        # Requires is_direct_query (access_method == direct) so a synced ClickHouse source falls
+        # through to the S3-backed table below, the same way is_direct_postgres/mysql/etc. gate their
+        # branches. Without it every ClickHouse-typed source (synced included) becomes a direct table,
+        # which forces the direct-query path and rejects synced-table queries that have no connection.
+        # Kept engine-keyed (is_direct_query + direct_engine, not an is_direct_clickhouse property) to
+        # satisfy the source-agnostic guard.
+        if (
+            self.external_data_source
+            and self.external_data_source.is_direct_query
+            and self.external_data_source.direct_engine == "clickhouse"
+        ):
             job_inputs = self.external_data_source.job_inputs or {}
             clickhouse_database = (
                 self.options.get(DIRECT_CLICKHOUSE_DATABASE_OPTION)

--- a/products/warehouse_sources/backend/tests/test_table.py
+++ b/products/warehouse_sources/backend/tests/test_table.py
@@ -10,10 +10,13 @@ from django.test import SimpleTestCase
 from clickhouse_driver.errors import ServerException
 from parameterized import parameterized
 
+from posthog.hogql.database.direct_clickhouse_table import DirectClickHouseTable
 from posthog.hogql.database.models import DatabaseField, StringDatabaseField, UUIDDatabaseField
+from posthog.hogql.database.s3_table import DataWarehouseTable as HogQLDataWarehouseTable
 
 from posthog.exceptions import ClickHouseAtCapacity
 
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource, ExternalDataSourceType
 from products.warehouse_sources.backend.models.table import (
     DataWarehouseTable,
     get_hogql_field_for_column,
@@ -47,6 +50,36 @@ class TestDataWarehouseTableColumnOrder(BaseTest):
         table.set_columns({"z": {"clickhouse": "String"}, "a": {"clickhouse": "String"}})
 
         assert table.column_order == ["z", "a"]
+
+
+class TestHogqlDefinitionDirectGating(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("synced", ExternalDataSource.AccessMethod.WAREHOUSE, HogQLDataWarehouseTable),
+            ("direct", ExternalDataSource.AccessMethod.DIRECT, DirectClickHouseTable),
+        ]
+    )
+    def test_clickhouse_source_direct_gated_on_access_method(
+        self, _name: str, access_method: str, expected_type: type
+    ) -> None:
+        # A ClickHouse source's tables must only render as a direct table when access_method == direct.
+        # A synced (warehouse) ClickHouse source has to fall through to the S3-backed table, otherwise
+        # every connection-less query against it is forced down the direct path and rejected.
+        source = ExternalDataSource(
+            source_type=ExternalDataSourceType.CLICKHOUSE,
+            access_method=access_method,
+            job_inputs={"database": "default"},
+        )
+        table = DataWarehouseTable(
+            name="clickhouse_raffle",
+            format="DeltaS3Wrapper",
+            url_pattern="s3://bucket/team_1/raffle",
+            columns={"id": {"hogql": "StringDatabaseField", "clickhouse": "String", "valid": True}},
+            options={},
+        )
+        table.external_data_source = source
+
+        assert isinstance(table.hogql_definition(), expected_type)
 
 
 class TestSafeExposeChError:


### PR DESCRIPTION
## Problem

A synced (warehouse) ClickHouse data-warehouse source can't be queried in the SQL editor.
Any HogQL that references its tables fails with `Direct queries require selecting a connection.`, even though a synced source has no connection to select.
Hit in prod-EU (project 69647) querying `clickhouse_raffle`.

## Changes

`DataWarehouseTable.hogql_definition()` rendered every ClickHouse-typed source's tables as a `DirectSQLTable` because the ClickHouse branch gated only on `direct_engine` (which keys off `source_type`), unlike the postgres/mysql/snowflake/redshift branches that also require `access_method == direct`.
So a synced ClickHouse source's tables were forced down the direct-query path and rejected.
Added the `is_direct_query` guard so a synced ClickHouse source falls through to the normal S3-backed table; pure-direct ClickHouse sources and the dual-mode virtual-table path are unaffected.

## How did you test this code?

Added a parameterized `SimpleTestCase` (`TestHogqlDefinitionDirectGating`): a `warehouse` ClickHouse source resolves to `HogQLDataWarehouseTable`, a `direct` one to `DirectClickHouseTable`.
It catches a revert of the access-method guard; no existing test covered the engine-vs-access_method gating.
I (Claude) ran it locally, 2 passed. No manual UI testing was done by the agent.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed with Xander from a prod-EU SQL editor error. Confirmed the source config via Metabase (ClickHouse, `access_method=warehouse`, `direct_query_enabled=false`) and the failing request via a HAR (no `connectionId` sent).
Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`.
Two sibling issues surfaced in the same session are being split into their own PRs: the connection selector mislabels ClickHouse sources as "Postgres", and dual-mode ClickHouse execution 500s instead of returning a clean error.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
