### PR TITLE
fix(data-warehouse): label ClickHouse connections in the SQL editor selector

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/connectionSelectorLogic.ts
+++ b/frontend/src/scenes/data-warehouse/editor/connectionSelectorLogic.ts
@@ -5,6 +5,7 @@ import { ApiConfig } from 'lib/api'
 import { urls } from 'scenes/urls'
 
 import IconPostHog from 'public/posthog-icon.svg'
+import IconClickHouse from 'public/services/clickhouse.svg'
 import IconDuckDB from 'public/services/duckdb.svg'
 import IconMySQL from 'public/services/mysql.png'
 import IconPostgres from 'public/services/postgres.png'
@@ -40,7 +41,7 @@ export interface ConnectionSelectOptionGroup {
     options: ConnectionSelectOption[]
 }
 
-type ConnectionEngine = 'duckdb' | 'postgres' | 'mysql' | 'snowflake' | 'redshift'
+type ConnectionEngine = 'duckdb' | 'postgres' | 'mysql' | 'snowflake' | 'redshift' | 'clickhouse'
 
 const ENGINE_LABELS: Record<ConnectionEngine, string> = {
     duckdb: 'DuckDB',
@@ -48,6 +49,7 @@ const ENGINE_LABELS: Record<ConnectionEngine, string> = {
     mysql: 'MySQL',
     snowflake: 'Snowflake',
     redshift: 'Redshift',
+    clickhouse: 'ClickHouse',
 }
 
 const ENGINE_ICONS: Record<ConnectionEngine, string> = {
@@ -56,6 +58,7 @@ const ENGINE_ICONS: Record<ConnectionEngine, string> = {
     mysql: IconMySQL,
     snowflake: IconSnowflake,
     redshift: IconRedshift,
+    clickhouse: IconClickHouse,
 }
 
 function getConnectionEngine(
@@ -65,7 +68,8 @@ function getConnectionEngine(
         source.engine === 'duckdb' ||
         source.engine === 'mysql' ||
         source.engine === 'snowflake' ||
-        source.engine === 'redshift'
+        source.engine === 'redshift' ||
+        source.engine === 'clickhouse'
     ) {
         return source.engine
     }


### PR DESCRIPTION
## Problem

In the SQL editor's connection selector, a ClickHouse data-warehouse source shows as "Postgres" with the Postgres icon.
The engine label/icon map had no `clickhouse` entry, so `getConnectionEngine` fell through to its `'postgres'` default.

## Changes

Added `clickhouse` to the `ConnectionEngine` union, the `ENGINE_LABELS` and `ENGINE_ICONS` maps, and the engine detection in `getConnectionEngine`, using the existing `public/services/clickhouse.svg` asset.
A ClickHouse source now renders as "ClickHouse" (or "ClickHouse · synced" for a warehouse source).

## How did you test this code?

No new automated test: the maps are `Record<ConnectionEngine, ...>`, so a missing engine entry is a TypeScript compile error rather than a runtime bug, which is a stronger guard than a unit test would be.
The agent did not capture a screenshot (no running app in this session).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out from a prod-EU SQL editor investigation with Xander. This is the cosmetic sibling of the backend fix in #74196 (synced ClickHouse tables were also wrongly treated as direct).
Skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
