### PR TITLE
feat(warehouse): resolve table access through its source

### DIFF
--- a/posthog/hogql/printer/test/test_hogql_access_control.py
+++ b/posthog/hogql/printer/test/test_hogql_access_control.py
@@ -509,6 +509,43 @@ class TestWarehouseTableAccessControl(BaseTest):
             "warehouse_table", set()
         )
 
+    def test_source_denial_reaches_its_tables_but_not_self_managed(self):
+        # The gate resolves each table through RESOURCE_FALLBACK_MAP, so a rule about a source must
+        # deny the tables it syncs while leaving tables no source owns untouched. Pins the gate's
+        # resolution call: a per-table or umbrella test passes even if the gate stops consulting the
+        # source, this one doesn't.
+        from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSource
+
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_id="src",
+            connection_id="conn",
+            destination_id="dest",
+            source_type="Stripe",
+            prefix="stripe_",
+        )
+        sourced_table = DataWarehouseTable.objects.create(
+            name="stripe_customers",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=self.credential,
+            external_data_source=source,
+            url_pattern="s3://bucket/stripe/*",
+            columns={"id": "String"},
+        )
+        self._create_ac(
+            resource="external_data_source",
+            resource_id=str(source.id),
+            access_level="none",
+            member=self._membership(),
+        )
+
+        database = Database.create_for(team=self.team, user=self.user)
+
+        assert sourced_table.name in database._denied_tables
+        # allowed_table has no source, so no rule about sources may reach it.
+        assert "allowed_table" not in database._denied_tables
+
     def test_warehouse_objects_resource_none_denies_all_tables(self):
         self._create_ac(resource="warehouse_objects", access_level="none")
 

--- a/posthog/hogql_queries/access_controlled_resources.py
+++ b/posthog/hogql_queries/access_controlled_resources.py
@@ -4,6 +4,8 @@ from pydantic import BaseModel
 
 from posthog.schema import DataWarehouseNode, FunnelsDataWarehouseNode, LifecycleDataWarehouseNode
 
+from posthog.rbac.user_access_control import RESOURCE_FALLBACK_MAP
+
 if TYPE_CHECKING:
     from posthog.models import Team
 
@@ -123,17 +125,21 @@ def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str
                 # otherwise a user denied an underlying table could be served a cached view result.
                 scopes.add("warehouse_table")
 
-        # A table now resolves through the source that syncs it, so a source-level denial changes who
-        # may read a warehouse table. A cache hit skips that resolution, so the source has to partition
-        # the key as well.
-        if "warehouse_table" in scopes:
-            scopes.add("external_data_source")
-
-        return scopes
+        return _with_fallback_parents(scopes)
 
     # Structured insight queries (Trends/Funnels/Lifecycle/...) read warehouse data via a
     # DataWarehouseNode in their tree rather than by table name.
-    return {"warehouse_table", "warehouse_view", "external_data_source"} if _references_data_warehouse(query) else set()
+    return _with_fallback_parents({"warehouse_table", "warehouse_view"}) if _references_data_warehouse(query) else set()
+
+
+def _with_fallback_parents(scopes: set[str]) -> set[str]:
+    """Add the parent of every scope that resolves through one, since the parent's rules decide the
+    child's access.
+
+    Only RESOURCE_FALLBACK_MAP. RESOURCE_INHERITANCE_MAP substitutes the parent's access for the
+    child's rather than adding rules of its own, so there is nothing extra to partition on.
+    """
+    return scopes | {parent for child, parent in RESOURCE_FALLBACK_MAP.items() if child in scopes}
 
 
 def _references_data_warehouse(value) -> bool:

--- a/posthog/hogql_queries/access_controlled_resources.py
+++ b/posthog/hogql_queries/access_controlled_resources.py
@@ -123,11 +123,17 @@ def queried_access_controlled_resources(query, team: "Team") -> Optional[set[str
                 # otherwise a user denied an underlying table could be served a cached view result.
                 scopes.add("warehouse_table")
 
+        # A table now resolves through the source that syncs it, so a source-level denial changes who
+        # may read a warehouse table. A cache hit skips that resolution, so the source has to partition
+        # the key as well.
+        if "warehouse_table" in scopes:
+            scopes.add("external_data_source")
+
         return scopes
 
     # Structured insight queries (Trends/Funnels/Lifecycle/...) read warehouse data via a
     # DataWarehouseNode in their tree rather than by table name.
-    return {"warehouse_table", "warehouse_view"} if _references_data_warehouse(query) else set()
+    return {"warehouse_table", "warehouse_view", "external_data_source"} if _references_data_warehouse(query) else set()
 
 
 def _references_data_warehouse(value) -> bool:

--- a/posthog/hogql_queries/test/test_access_controlled_resources.py
+++ b/posthog/hogql_queries/test/test_access_controlled_resources.py
@@ -59,27 +59,27 @@ class TestQueriedAccessControlledResources(BaseTest):
             (
                 "information_schema_tables",
                 "select certification from system.information_schema.tables",
-                {"data_catalog", "warehouse_table", "warehouse_view"},
+                {"data_catalog", "external_data_source", "warehouse_table", "warehouse_view"},
             ),
             (
                 "information_schema_relationships",
                 "select reasoning from system.information_schema.relationships",
-                {"data_catalog", "warehouse_table", "warehouse_view"},
+                {"data_catalog", "external_data_source", "warehouse_table", "warehouse_view"},
             ),
             (
                 "information_schema_metrics",
                 "select name from system.information_schema.metrics",
-                {"data_catalog", "warehouse_table", "warehouse_view"},
+                {"data_catalog", "external_data_source", "warehouse_table", "warehouse_view"},
             ),
             (
                 "information_schema_certifications",
                 "select notes from system.information_schema.certifications",
-                {"data_catalog", "warehouse_table", "warehouse_view"},
+                {"data_catalog", "external_data_source", "warehouse_table", "warehouse_view"},
             ),
             (
                 "information_schema_relationship_proposals",
                 "select reasoning from system.information_schema.relationship_proposals",
-                {"data_catalog", "warehouse_table", "warehouse_view"},
+                {"data_catalog", "external_data_source", "warehouse_table", "warehouse_view"},
             ),
             # The plain schema tables expose no catalog-gated data, so they don't partition on it.
             ("information_schema_columns", "select * from system.information_schema.columns", set()),
@@ -104,13 +104,21 @@ class TestQueriedAccessControlledResources(BaseTest):
 
     def test_structured_query_with_data_warehouse_series(self):
         query = TrendsQuery(series=[EventsNode(event="$pageview"), self._dw_node()])
-        assert queried_access_controlled_resources(query, self.team) == {"warehouse_table", "warehouse_view"}
+        assert queried_access_controlled_resources(query, self.team) == {
+            "external_data_source",
+            "warehouse_table",
+            "warehouse_view",
+        }
 
     def test_nested_data_warehouse_node_is_detected(self):
         # The node is two levels deep (actors query -> source insight -> series), so a shallow
         # series-only check would miss it; the recursive walk must catch it (else the cache leaks).
         query = InsightActorsQuery(source=TrendsQuery(series=[self._dw_node()]))
-        assert queried_access_controlled_resources(query, self.team) == {"warehouse_table", "warehouse_view"}
+        assert queried_access_controlled_resources(query, self.team) == {
+            "external_data_source",
+            "warehouse_table",
+            "warehouse_view",
+        }
 
     def test_references_data_warehouse_covers_all_variants_and_nesting(self):
         variants = [
@@ -132,7 +140,7 @@ class TestQueriedAccessControlledResources(BaseTest):
     def test_warehouse_table_scope(self):
         self._create_warehouse_table("my_warehouse_table")
         result = queried_access_controlled_resources(HogQLQuery(query="select * from my_warehouse_table"), self.team)
-        assert result == {"warehouse_table"}
+        assert result == {"external_data_source", "warehouse_table"}
 
     def test_external_warehouse_table_matched_by_raw_name(self):
         # External tables are queryable under BOTH their raw name and the prefixed
@@ -154,7 +162,7 @@ class TestQueriedAccessControlledResources(BaseTest):
         assert get_data_warehouse_table_name(source, table.name) != table.name
 
         result = queried_access_controlled_resources(HogQLQuery(query="select * from stripe_customers"), self.team)
-        assert result == {"warehouse_table"}
+        assert result == {"external_data_source", "warehouse_table"}
 
     def test_warehouse_view_scope(self):
         DataWarehouseSavedQuery.objects.create(
@@ -163,14 +171,14 @@ class TestQueriedAccessControlledResources(BaseTest):
         result = queried_access_controlled_resources(HogQLQuery(query="select * from my_warehouse_view"), self.team)
         # warehouse_table is included too: a non-materialized view reads underlying tables, and a cache
         # hit skips that resolution, so the user's table denials must partition the key.
-        assert result == {"warehouse_view", "warehouse_table"}
+        assert result == {"warehouse_view", "warehouse_table", "external_data_source"}
 
     def test_warehouse_and_system_scopes_combined(self):
         self._create_warehouse_table("my_warehouse_table")
         result = queried_access_controlled_resources(
             HogQLQuery(query="select 1 from my_warehouse_table, system.notebooks"), self.team
         )
-        assert result == {"warehouse_table", "notebook"}
+        assert result == {"warehouse_table", "notebook", "external_data_source"}
 
     def test_catalog_fetch_loads_only_name_fields(self):
         source = ExternalDataSource.objects.create(
@@ -190,7 +198,7 @@ class TestQueriedAccessControlledResources(BaseTest):
         # longer covers what get_data_warehouse_table_name reads (rows silently defer-load per
         # row) or the default manager's externaldataschema_set prefetch leaked back in.
         with self.assertNumQueries(2):
-            assert queried_access_controlled_resources(query, self.team) == {"warehouse_table"}
+            assert queried_access_controlled_resources(query, self.team) == {"external_data_source", "warehouse_table"}
 
     def test_warehouse_table_of_another_team_not_matched(self):
         from posthog.models import Team

--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -2071,10 +2071,20 @@ class TestUserAccessControlFallbackParent(BaseUserAccessControlTest):
             name="uploads", format="Parquet", team=self.team, columns={}
         )
 
-    def _rule(self, resource, resource_id, level):
-        self._create_access_control(
-            resource=resource, resource_id=resource_id, access_level=level, organization_member=self.membership
-        )
+    def _apply(self, rules, table):
+        # The four places a rule can be written about this table. The ladder exists because these are
+        # different statements: "this source" is not "all sources", and neither is "all tables".
+        targets = {
+            "this_table": ("warehouse_table", str(table.id)),
+            "this_source": ("external_data_source", str(self.source.id)),
+            "all_tables": ("warehouse_objects", None),
+            "all_sources": ("external_data_source", None),
+        }
+        for target, level in rules.items():
+            resource, resource_id = targets[target]
+            self._create_access_control(
+                resource=resource, resource_id=resource_id, access_level=level, organization_member=self.membership
+            )
         self._clear_uac_caches()
 
     def _level(self, table):
@@ -2082,59 +2092,38 @@ class TestUserAccessControlFallbackParent(BaseUserAccessControlTest):
 
     @parameterized.expand(
         [
-            # A rule about sources reaches the tables that source syncs, at both the object and the
-            # resource layer - this is the whole point of the fallback.
-            ("source_object_denies_its_table", [("external_data_source", "SOURCE", "none")], "none"),
-            ("all_sources_denies_sourced_table", [("external_data_source", None, "none")], "none"),
-            # A rule on the table itself outranks anything the source says, in either direction.
-            (
-                "table_rule_beats_source",
-                [("external_data_source", "SOURCE", "none"), ("warehouse_table", "TABLE", "editor")],
-                "editor",
-            ),
-            (
-                "table_deny_beats_source_grant",
-                [("external_data_source", "SOURCE", "editor"), ("warehouse_table", "TABLE", "none")],
-                "none",
-            ),
-            # "All tables & views" sits above "all sources": a broad table grant is not capped by a
-            # source denial, which is what lets an editor on tables sync a schema they only view.
-            (
-                "all_tables_beats_all_sources",
-                [("external_data_source", None, "none"), ("warehouse_objects", None, "viewer")],
-                "viewer",
-            ),
-            # ...but a rule about one source is more specific than "all tables & views".
-            (
-                "source_object_beats_all_tables",
-                [("external_data_source", "SOURCE", "none"), ("warehouse_objects", None, "editor")],
-                "none",
-            ),
+            # A rule about a source reaches the tables it syncs, written either way round.
+            ("source_reaches_its_tables", {"this_source": "none"}, "none"),
+            ("all_sources_reaches_sourced_tables", {"all_sources": "none"}, "none"),
+            # The table's own rule is more specific than its source's, in both directions.
+            ("table_grant_beats_source_deny", {"this_source": "none", "this_table": "editor"}, "editor"),
+            ("table_deny_beats_source_grant", {"this_source": "editor", "this_table": "none"}, "none"),
+            # "All tables" is more specific than "all sources", so a broad table grant isn't capped
+            # by a source denial - which lets an editor on tables sync a schema they only view.
+            ("all_tables_beats_all_sources", {"all_sources": "none", "all_tables": "viewer"}, "viewer"),
+            # ...and one named source is more specific than "all tables".
+            ("one_source_beats_all_tables", {"this_source": "none", "all_tables": "editor"}, "none"),
         ]
     )
     def test_sourced_table_resolution(self, _name, rules, expected):
-        for resource, resource_id, level in rules:
-            ids = {"SOURCE": str(self.source.id), "TABLE": str(self.sourced_table.id)}
-            self._rule(resource, ids.get(resource_id, resource_id), level)
+        self._apply(rules, self.sourced_table)
 
         assert self._level(self.sourced_table) == expected
 
     @parameterized.expand(
         [
-            # A self-managed table has no source, so no rule about sources may reach it - at either
-            # layer. Without this the "all sources" rule would silently lock S3 tables and direct
-            # connections that no source has ever touched.
-            ("all_sources_denied", [("external_data_source", None, "none")], "editor"),
-            ("one_source_denied", [("external_data_source", "SOURCE", "none")], "editor"),
-            # It is still governed by the rules that do apply to it.
-            ("all_tables_denied", [("warehouse_objects", None, "none")], "none"),
-            ("own_rule", [("warehouse_table", "TABLE", "viewer")], "viewer"),
+            # A self-managed table has no source, so no rule about sources may reach it. Without this
+            # skip, restricting sources would silently lock every S3 table and direct connection that
+            # no source has ever touched.
+            ("all_sources_cannot_reach_it", {"all_sources": "none"}, "editor"),
+            ("one_source_cannot_reach_it", {"this_source": "none"}, "editor"),
+            # The rules that do apply to it still govern it - the skip isn't switching access off.
+            ("all_tables_still_governs_it", {"all_tables": "none"}, "none"),
+            ("its_own_rule_still_governs_it", {"this_table": "viewer"}, "viewer"),
         ]
     )
     def test_self_managed_table_skips_the_source(self, _name, rules, expected):
-        for resource, resource_id, level in rules:
-            ids = {"SOURCE": str(self.source.id), "TABLE": str(self.self_managed_table.id)}
-            self._rule(resource, ids.get(resource_id, resource_id), level)
+        self._apply(rules, self.self_managed_table)
 
         assert self._level(self.self_managed_table) == expected
 
@@ -2150,7 +2139,7 @@ class TestUserAccessControlFallbackParent(BaseUserAccessControlTest):
         other_table = DataWarehouseTable.objects.create(
             name="invoices", format="Parquet", team=self.team, external_data_source=other_source, columns={}
         )
-        self._rule("external_data_source", str(self.source.id), "none")
+        self._apply({"this_source": "none"}, self.sourced_table)
 
         assert self._level(self.sourced_table) == "none"
         assert self._level(other_table) == "editor"

--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -23,6 +23,7 @@ from posthog.rbac.user_access_control import (
 
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.replay_vision.backend.models.vision_action import VisionAction, VisionActionRun
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSource
 
 try:
     from ee.models.rbac.access_control import AccessControl
@@ -2046,3 +2047,110 @@ class TestBlockedResourceIdsByScope(BaseTest):
             organization_member=self.membership,
         )
         assert self._blocked() == {"10"}
+
+
+@pytest.mark.ee
+class TestUserAccessControlFallbackParent(BaseUserAccessControlTest):
+    """Resolution through RESOURCE_FALLBACK_MAP: a synced table falls back to the source that syncs it."""
+
+    def setUp(self):
+        super().setUp()
+        self.membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        self.source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id="src",
+            connection_id="conn",
+            destination_id="dest",
+            source_type="Stripe",
+            prefix="test",
+        )
+        self.sourced_table = DataWarehouseTable.objects.create(
+            name="customers", format="Parquet", team=self.team, external_data_source=self.source, columns={}
+        )
+        self.self_managed_table = DataWarehouseTable.objects.create(
+            name="uploads", format="Parquet", team=self.team, columns={}
+        )
+
+    def _rule(self, resource, resource_id, level):
+        self._create_access_control(
+            resource=resource, resource_id=resource_id, access_level=level, organization_member=self.membership
+        )
+        self._clear_uac_caches()
+
+    def _level(self, table):
+        return self.user_access_control.get_user_access_level(table)
+
+    @parameterized.expand(
+        [
+            # A rule about sources reaches the tables that source syncs, at both the object and the
+            # resource layer - this is the whole point of the fallback.
+            ("source_object_denies_its_table", [("external_data_source", "SOURCE", "none")], "none"),
+            ("all_sources_denies_sourced_table", [("external_data_source", None, "none")], "none"),
+            # A rule on the table itself outranks anything the source says, in either direction.
+            (
+                "table_rule_beats_source",
+                [("external_data_source", "SOURCE", "none"), ("warehouse_table", "TABLE", "editor")],
+                "editor",
+            ),
+            (
+                "table_deny_beats_source_grant",
+                [("external_data_source", "SOURCE", "editor"), ("warehouse_table", "TABLE", "none")],
+                "none",
+            ),
+            # "All tables & views" sits above "all sources": a broad table grant is not capped by a
+            # source denial, which is what lets an editor on tables sync a schema they only view.
+            (
+                "all_tables_beats_all_sources",
+                [("external_data_source", None, "none"), ("warehouse_objects", None, "viewer")],
+                "viewer",
+            ),
+            # ...but a rule about one source is more specific than "all tables & views".
+            (
+                "source_object_beats_all_tables",
+                [("external_data_source", "SOURCE", "none"), ("warehouse_objects", None, "editor")],
+                "none",
+            ),
+        ]
+    )
+    def test_sourced_table_resolution(self, _name, rules, expected):
+        for resource, resource_id, level in rules:
+            ids = {"SOURCE": str(self.source.id), "TABLE": str(self.sourced_table.id)}
+            self._rule(resource, ids.get(resource_id, resource_id), level)
+
+        assert self._level(self.sourced_table) == expected
+
+    @parameterized.expand(
+        [
+            # A self-managed table has no source, so no rule about sources may reach it - at either
+            # layer. Without this the "all sources" rule would silently lock S3 tables and direct
+            # connections that no source has ever touched.
+            ("all_sources_denied", [("external_data_source", None, "none")], "editor"),
+            ("one_source_denied", [("external_data_source", "SOURCE", "none")], "editor"),
+            # It is still governed by the rules that do apply to it.
+            ("all_tables_denied", [("warehouse_objects", None, "none")], "none"),
+            ("own_rule", [("warehouse_table", "TABLE", "viewer")], "viewer"),
+        ]
+    )
+    def test_self_managed_table_skips_the_source(self, _name, rules, expected):
+        for resource, resource_id, level in rules:
+            ids = {"SOURCE": str(self.source.id), "TABLE": str(self.self_managed_table.id)}
+            self._rule(resource, ids.get(resource_id, resource_id), level)
+
+        assert self._level(self.self_managed_table) == expected
+
+    def test_source_denial_does_not_leak_across_sources(self):
+        other_source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id="src2",
+            connection_id="conn2",
+            destination_id="dest2",
+            source_type="Stripe",
+            prefix="other",
+        )
+        other_table = DataWarehouseTable.objects.create(
+            name="invoices", format="Parquet", team=self.team, external_data_source=other_source, columns={}
+        )
+        self._rule("external_data_source", str(self.source.id), "none")
+
+        assert self._level(self.sourced_table) == "none"
+        assert self._level(other_table) == "editor"

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -1,12 +1,12 @@
 import json
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from functools import cached_property
+from functools import cache, cached_property
 from typing import TYPE_CHECKING, Any, Literal, Optional, cast, get_args
 
-from django.db.models import Case, CharField, Exists, F, Model, OuterRef, Q, QuerySet, Value, When
+from django.db.models import Case, CharField, Exists, F, ForeignKey, Model, OuterRef, Q, QuerySet, Value, When
 from django.db.models.functions import Cast
 
 from opentelemetry import trace
@@ -118,12 +118,22 @@ RESOURCE_INHERITANCE_MAP: dict[APIScopeObject, APIScopeObject] = {
     "vision_action": "replay_scanner",
 }
 
+# Access falls back from a child resource to a *concrete* parent - a synced table to the source
+# that syncs it. The parents in RESOURCE_INHERITANCE_MAP are abstract groupings with no rows, so
+# they stand in for the child wholesale; these have real rows, which means they take part at the
+# object layer too, and that an object with no such parent (a self-managed table has no source)
+# skips them entirely rather than inheriting anything.
+RESOURCE_FALLBACK_MAP: dict[APIScopeObject, APIScopeObject] = {
+    "warehouse_table": "external_data_source",
+}
+
 WAREHOUSE_ACCESS_SCOPES: frozenset[str] = frozenset(
     {
         "warehouse_objects",
         *(child for child, parent in RESOURCE_INHERITANCE_MAP.items() if parent == "warehouse_objects"),
     }
 )
+
 
 tracer = trace.get_tracer(__name__)
 
@@ -181,6 +191,21 @@ def ordered_access_levels(resource: APIScopeObject) -> list[AccessControlLevel]:
     if resource in ["project", "organization"]:
         return list(ACCESS_CONTROL_LEVELS_MEMBER)
     return list(ACCESS_CONTROL_LEVELS_RESOURCE)
+
+
+def _validate_resource_fallback_map() -> None:
+    """A fallback parent's level is compared on the child's scale, so both have to use the same one -
+    pairing a resource-scale child with a member-scale parent would shift every comparison by a level.
+    Run at import so a bad entry fails loudly instead of at whichever request first hits that resource.
+    """
+    for child, parent in RESOURCE_FALLBACK_MAP.items():
+        if child == parent or RESOURCE_FALLBACK_MAP.get(parent) == child:
+            raise ValueError(f"RESOURCE_FALLBACK_MAP: `{child}` -> `{parent}` is cyclic")
+        if ordered_access_levels(child) != ordered_access_levels(parent):
+            raise ValueError(f"RESOURCE_FALLBACK_MAP: `{child}` and `{parent}` use different level scales")
+
+
+_validate_resource_fallback_map()
 
 
 def default_access_level(resource: APIScopeObject) -> AccessControlLevel:
@@ -454,6 +479,35 @@ def model_to_resource(model: Model) -> Optional[APIScopeObject]:
         return None
 
     return cast(APIScopeObject, name)
+
+
+@cache
+def _fallback_parent_field(model: type[Model], parent_resource: APIScopeObject) -> Optional[str]:
+    """Attribute holding the id of `model`'s `parent_resource` foreign key, if it has one.
+
+    Found by introspection rather than a declared field map so the relationship is read off the
+    schema that already defines it. Cached because it depends only on the model class.
+    """
+    for field in model._meta.get_fields():
+        # ForeignKey covers OneToOneField too, and excludes the reverse relations get_fields() also returns.
+        if not isinstance(field, ForeignKey) or field.related_model is None:
+            continue
+        if model_to_resource(cast(Model, field.related_model)) == parent_resource:
+            return field.attname
+    return None
+
+
+def fallback_parent_object_id(obj: Model, parent_resource: APIScopeObject) -> Optional[str]:
+    """Id of the object `obj` falls back to for access, or None when it has no such parent.
+
+    None is what makes a self-managed table skip its source tiers rather than inherit from a
+    source it doesn't have - so an "all sources" rule can't reach a table no source owns.
+    """
+    field = _fallback_parent_field(type(obj), parent_resource)
+    if field is None:
+        return None
+    parent_id = getattr(obj, field, None)
+    return str(parent_id) if parent_id is not None else None
 
 
 class UserAccessControl:
@@ -1294,27 +1348,56 @@ class UserAccessControl:
         ).access_level
 
     def _object_access_level_from_rows(
-        self, resource: APIScopeObject, object_access_controls: list[_AccessControl], explicit: bool = False
+        self,
+        resource: APIScopeObject,
+        object_access_controls: list[_AccessControl],
+        explicit: bool = False,
+        fallback_parent_id: Optional[str] = None,
     ) -> Optional[AccessControlLevel]:
-        """Row-based object access resolution: explicit (role/member) object rows win, then
+        """Row-based object access resolution, most specific first: explicit (role/member) object rows,
+        then the fallback parent's object rows, then resource-level rows, then the fallback parent's
         resource-level rows, then default object rows, then the resource default. Shared by
         `get_user_access_level` and `bulk_object_access_levels`.
+
+        `fallback_parent_id` identifies the RESOURCE_FALLBACK_MAP parent this object belongs to, and is
+        None when it has none - a self-managed warehouse table has no source, so a rule written about
+        sources must not reach it. The parent's tiers straddle the object's own resource-level tier:
+        a rule on one source outranks "all tables", which in turn outranks "all sources".
         """
+        parent = RESOURCE_FALLBACK_MAP.get(resource) if fallback_parent_id else None
+
         explicit_rows = [
             ac for ac in object_access_controls if ac.role_id is not None or ac.organization_member_id is not None
         ]
         if explicit_rows:
             return self._highest_access_level_from_rows(resource, explicit_rows)
 
+        if parent:
+            parent_rows = self._get_access_controls(
+                self._access_controls_filters_for_object(parent, cast(str, fallback_parent_id))
+            )
+            if parent_rows:
+                return self._highest_access_level_from_rows(parent, parent_rows)
+
         if self.has_access_levels_for_resource(resource):
             access_level_for_resource = self.access_level_for_resource(resource)
             if access_level_for_resource:
                 return access_level_for_resource
 
+        if parent and self.has_access_levels_for_resource(parent):
+            access_level_for_parent = self.access_level_for_resource(parent)
+            if access_level_for_parent:
+                return access_level_for_parent
+
         if object_access_controls:
             return self._highest_access_level_from_rows(resource, object_access_controls)
 
         return None if explicit else default_access_level(resource)
+
+    @staticmethod
+    def _fallback_parent_id(obj: Model, resource: APIScopeObject) -> Optional[str]:
+        parent = RESOURCE_FALLBACK_MAP.get(resource)
+        return fallback_parent_object_id(obj, parent) if parent else None
 
     def get_user_access_level(self, obj: Model, explicit=False) -> Optional[AccessControlLevel]:
         resource = model_to_resource(obj)
@@ -1329,18 +1412,29 @@ class UserAccessControl:
         object_access_controls = self._get_access_controls(
             self._access_controls_filters_for_object(resource, str(obj.id))  # type: ignore
         )
-        return self._object_access_level_from_rows(resource, object_access_controls, explicit=explicit)
+        return self._object_access_level_from_rows(
+            resource,
+            object_access_controls,
+            explicit=explicit,
+            fallback_parent_id=self._fallback_parent_id(obj, resource),
+        )
 
     def bulk_object_access_levels(
         self,
         resource: APIScopeObject,
         objects: Sequence[tuple[str, Optional[int]]],
+        fallback_parent_ids: Optional[Mapping[str, Optional[str]]] = None,
     ) -> dict[str, Optional[AccessControlLevel]]:
         """Resolve the user's access level for many objects of one resource type at once.
 
         `objects` is a sequence of (object_pk_str, created_by_id) pairs. Semantics match
         `get_user_access_level`, but object rows come from the bulk preload grouped in memory,
         so no per-object queries are issued.
+
+        When `resource` has a RESOURCE_FALLBACK_MAP parent, callers should pass `fallback_parent_ids`
+        mapping each object id to its parent's id - the resolver can't read that off the database from
+        here. Omitting it resolves as though every object were parentless, which is right for objects
+        that have no parent and too permissive for those that do.
         """
         if not objects:
             return {}
@@ -1360,7 +1454,11 @@ class UserAccessControl:
                 for ac in self._get_access_controls(self._access_controls_filters_for_queryset(resource)):
                     rows_by_object_id[ac.resource_id].append(ac)
 
-            results[object_id] = self._object_access_level_from_rows(resource, rows_by_object_id.get(object_id, []))
+            results[object_id] = self._object_access_level_from_rows(
+                resource,
+                rows_by_object_id.get(object_id, []),
+                fallback_parent_id=(fallback_parent_ids or {}).get(object_id),
+            )
 
         return results
 

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -118,11 +118,8 @@ RESOURCE_INHERITANCE_MAP: dict[APIScopeObject, APIScopeObject] = {
     "vision_action": "replay_scanner",
 }
 
-# Access falls back from a child resource to a *concrete* parent - a synced table to the source
-# that syncs it. The parents in RESOURCE_INHERITANCE_MAP are abstract groupings with no rows, so
-# they stand in for the child wholesale; these have real rows, which means they take part at the
-# object layer too, and that an object with no such parent (a self-managed table has no source)
-# skips them entirely rather than inheriting anything.
+# Used to apply the more specific access when it's configured, and fall back to a parent
+# otherwise (e.g. a synced table to the source that syncs it).
 RESOURCE_FALLBACK_MAP: dict[APIScopeObject, APIScopeObject] = {
     "warehouse_table": "external_data_source",
 }
@@ -1354,15 +1351,14 @@ class UserAccessControl:
         explicit: bool = False,
         fallback_parent_id: Optional[str] = None,
     ) -> Optional[AccessControlLevel]:
-        """Row-based object access resolution, most specific first: explicit (role/member) object rows,
-        then the fallback parent's object rows, then resource-level rows, then the fallback parent's
+        """Row-based object access resolution, most specific rule first: explicit (role/member) object
+        rows, then the fallback parent's object rows, then resource-level rows, then the parent's
         resource-level rows, then default object rows, then the resource default. Shared by
         `get_user_access_level` and `bulk_object_access_levels`.
 
         `fallback_parent_id` identifies the RESOURCE_FALLBACK_MAP parent this object belongs to, and is
         None when it has none - a self-managed warehouse table has no source, so a rule written about
-        sources must not reach it. The parent's tiers straddle the object's own resource-level tier:
-        a rule on one source outranks "all tables", which in turn outranks "all sources".
+        sources must not reach it.
         """
         parent = RESOURCE_FALLBACK_MAP.get(resource) if fallback_parent_id else None
 

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -1,6 +1,6 @@
 import json
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum
 from functools import cache, cached_property
@@ -131,7 +131,6 @@ WAREHOUSE_ACCESS_SCOPES: frozenset[str] = frozenset(
     }
 )
 
-
 tracer = trace.get_tracer(__name__)
 
 
@@ -188,21 +187,6 @@ def ordered_access_levels(resource: APIScopeObject) -> list[AccessControlLevel]:
     if resource in ["project", "organization"]:
         return list(ACCESS_CONTROL_LEVELS_MEMBER)
     return list(ACCESS_CONTROL_LEVELS_RESOURCE)
-
-
-def _validate_resource_fallback_map() -> None:
-    """A fallback parent's level is compared on the child's scale, so both have to use the same one -
-    pairing a resource-scale child with a member-scale parent would shift every comparison by a level.
-    Run at import so a bad entry fails loudly instead of at whichever request first hits that resource.
-    """
-    for child, parent in RESOURCE_FALLBACK_MAP.items():
-        if child == parent or RESOURCE_FALLBACK_MAP.get(parent) == child:
-            raise ValueError(f"RESOURCE_FALLBACK_MAP: `{child}` -> `{parent}` is cyclic")
-        if ordered_access_levels(child) != ordered_access_levels(parent):
-            raise ValueError(f"RESOURCE_FALLBACK_MAP: `{child}` and `{parent}` use different level scales")
-
-
-_validate_resource_fallback_map()
 
 
 def default_access_level(resource: APIScopeObject) -> AccessControlLevel:
@@ -1419,19 +1403,19 @@ class UserAccessControl:
         self,
         resource: APIScopeObject,
         objects: Sequence[tuple[str, Optional[int]]],
-        fallback_parent_ids: Optional[Mapping[str, Optional[str]]] = None,
     ) -> dict[str, Optional[AccessControlLevel]]:
         """Resolve the user's access level for many objects of one resource type at once.
 
         `objects` is a sequence of (object_pk_str, created_by_id) pairs. Semantics match
         `get_user_access_level`, but object rows come from the bulk preload grouped in memory,
         so no per-object queries are issued.
-
-        When `resource` has a RESOURCE_FALLBACK_MAP parent, callers should pass `fallback_parent_ids`
-        mapping each object id to its parent's id - the resolver can't read that off the database from
-        here. Omitting it resolves as though every object were parentless, which is right for objects
-        that have no parent and too permissive for those that do.
         """
+        # Tables and views aren't used in search. If they need to be, load the parent ids here too, so
+        # access is checked against the source and not just the table.
+        parent = RESOURCE_FALLBACK_MAP.get(resource)
+        if parent:
+            raise NotImplementedError(f"bulk_object_access_levels cannot resolve `{resource}` through `{parent}`")
+
         if not objects:
             return {}
 
@@ -1450,11 +1434,7 @@ class UserAccessControl:
                 for ac in self._get_access_controls(self._access_controls_filters_for_queryset(resource)):
                     rows_by_object_id[ac.resource_id].append(ac)
 
-            results[object_id] = self._object_access_level_from_rows(
-                resource,
-                rows_by_object_id.get(object_id, []),
-                fallback_parent_id=(fallback_parent_ids or {}).get(object_id),
-            )
+            results[object_id] = self._object_access_level_from_rows(resource, rows_by_object_id.get(object_id, []))
 
         return results
 

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -482,7 +482,7 @@ def fallback_parent_object_id(obj: Model, parent_resource: APIScopeObject) -> Op
     """Id of the object `obj` falls back to for access, or None when it has no such parent.
 
     None is what makes a self-managed table skip its source tiers rather than inherit from a
-    source it doesn't have - so an "all sources" rule can't reach a table no source owns.
+    source it doesn't have.
     """
     field = _fallback_parent_field(type(obj), parent_resource)
     if field is None:
@@ -1339,10 +1339,6 @@ class UserAccessControl:
         rows, then the fallback parent's object rows, then resource-level rows, then the parent's
         resource-level rows, then default object rows, then the resource default. Shared by
         `get_user_access_level` and `bulk_object_access_levels`.
-
-        `fallback_parent_id` identifies the RESOURCE_FALLBACK_MAP parent this object belongs to, and is
-        None when it has none - a self-managed warehouse table has no source, so a rule written about
-        sources must not reach it.
         """
         parent = RESOURCE_FALLBACK_MAP.get(resource) if fallback_parent_id else None
 
@@ -1410,8 +1406,8 @@ class UserAccessControl:
         `get_user_access_level`, but object rows come from the bulk preload grouped in memory,
         so no per-object queries are issued.
         """
-        # Tables and views aren't used in search. If they need to be, load the parent ids here too, so
-        # access is checked against the source and not just the table.
+        # Warehouse tables aren't listed by either caller (search, the file tree). If that changes, load
+        # the parent ids here too, so access is checked against the source and not just the table.
         parent = RESOURCE_FALLBACK_MAP.get(resource)
         if parent:
             raise NotImplementedError(f"bulk_object_access_levels cannot resolve `{resource}` through `{parent}`")

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -118,8 +118,15 @@ RESOURCE_INHERITANCE_MAP: dict[APIScopeObject, APIScopeObject] = {
     "vision_action": "replay_scanner",
 }
 
-# Used to apply the more specific access when it's configured, and fall back to a parent
-# otherwise (e.g. a synced table to the source that syncs it).
+# Unlike RESOURCE_INHERITANCE_MAP above, where the child has no access of its own and just uses the
+# parent's, this checks the child's own access first and falls back to the parent.
+# For example:
+# this table (object) -> this source (object) -> all tables (resource) -> all sources (resource) -> default
+#
+# The parent's id is read off the child's foreign key to it (DataWarehouseTable.external_data_source),
+# so an entry only works when that foreign key exists. A null one means no parent, and the object
+# skips it rather than inheriting: a self-managed table has no source, so no rule about sources
+# may reach it.
 RESOURCE_FALLBACK_MAP: dict[APIScopeObject, APIScopeObject] = {
     "warehouse_table": "external_data_source",
 }


### PR DESCRIPTION
## Problem

Data warehouse access control has two separate resources: **Data warehouse sources** and **Data warehouse tables & views**. It is very easy to assume that setting sources to `No access` stops people querying that source's data. It does not. The tooltip on the setting admits it, but who reads it... 
<img width="1883" height="466" alt="image" src="https://github.com/user-attachments/assets/adde0fb3-c0f3-4977-acfb-c101deaa384a" />

The same gap shows up at the object level. Restricting one schema on a source is close to meaningless if the table it syncs stays queryable.
<img width="1577" height="638" alt="image" src="https://github.com/user-attachments/assets/8d32bb50-ab3a-4adb-ad7a-e7c0fe8c01a2" />

I think this is more expected if schemas and tables are governed by table access control, and when no table rule is configured, fall back to the source. Only for tables that came from an external source, since a self-managed table has no source to fall back to.

## Changes

**Demo:**
https://www.loom.com/share/584eae92d31d452d908412602eeb469e

**Object model**
<img width="1200" height="560" alt="image" src="https://github.com/user-attachments/assets/2380216f-04a8-4991-84cf-5d55eccd7cee" />

Adds `RESOURCE_FALLBACK_MAP`, a second resource relationship next to `RESOURCE_INHERITANCE_MAP`.

In the existing RESOURCE_INHERITANCE_MAP the child just uses the parent's access instead of its own, and only at the resource level. 

**This PR introduces a new pattern: a resource whose objects also belong to another resource.** 
Warehouse tables are the first case, but nothing about the mechanism is warehouse specific.

Object resolution gains two tiers around the existing resource tier:
<img width="984" height="452" alt="image" src="https://github.com/user-attachments/assets/a8647a05-410b-4886-8c64-b01328def8d9" />

Three notes on the diff.

`database.py` needs no change. The query gate already calls `check_access_level_for_object`, so it picks the new tiers up. The query *cache* key does change, since a cache hit would skip the gate.

The resolver change also closes the direct table API. `TableViewSet` PATCH/DELETE sits on the stock access control mixin, so a user restricted via the source now resolves to viewer there instead of the editor default. Sourced tables have no UI door to that endpoint at all - their lifecycle runs through the schema UI, gated separately in #72440 - so this was an API-only hole, and it closes here for free.

The parent's id comes from foreign key introspection rather than a declared field map, so the relationship is read off the schema that already defines it. `DataWarehouseTable.external_data_source` is the only candidate, and a self-managed table lands on `None` naturally.

## How did you test this code?

New tests and the regression each catches:

**`test_sourced_table_resolution`** (6 cases) pins the tier order. Nothing today asserts that a source rule reaches a table at all, that a table rule outranks it, or that "all tables" beats "all sources". The last one would break silently if someone reordered tiers 3 and 4 while refactoring.

**`test_self_managed_table_skips_the_source`** (4 cases) is the important one. The skip is the only behavior separating a fallback parent from an ordinary resource rule, and getting it wrong means restricting sources quietly locks every S3 table and direct connection in the project. Two positive cases confirm the table is still governed by the rules that do apply, so the test cannot pass by switching access control off.

**`test_source_denial_does_not_leak_across_sources`** guards one source's denial reaching another source's tables.

The 12 updated assertions in `test_access_controlled_resources.py` are expectation changes, not new coverage. `external_data_source` legitimately joins the queried scope set now.

## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Yes

## 🤖 Agent context


This replaces #73625, which solved the same problem with a bespoke `check_warehouse_table_access` helper wired into each enforcement site. It was branched off #72440 and depended on a method added there. This is a rebuild on master rather than a rebase. #72440 will stack on top and should shrink, since its product-local permission class largely reduces to a stock `check_access_level_for_object` call once the resolver knows the edge.

Decisions that changed along the way:

- **One map or two.** I first proposed widening `RESOURCE_INHERITANCE_MAP` to ordered tuples. Two maps won because the split tracks a real distinction: an object-less check has no object to ask whether it has a source, so it can never consult a concrete parent and should keep substituting to the umbrella exactly as it does now. It also leaves the three existing hot consumers and `WAREHOUSE_ACCESS_SCOPES` untouched, so query cache keys do not move.
- **Tuple values.** Dropped as speculative generality. One concrete parent, one plain dict, retype it if a second shows up.
- **Where the umbrella sits.** I argued for putting it last, treating "all tables and views" losing to "all sources" as correct. That was wrong. Take editor on tables and views plus viewer on sources: with the umbrella last, the source caps you at viewer and you cannot sync a schema. Syncing a schema is a statement about that table, not about the connection, so the table rule has to win.

`bulk_object_access_levels` (search, the file tree) resolves objects from ids rather than model instances, so there is nothing there to read a parent id off. Neither caller can currently pass a resource that has a fallback parent, so nothing is under-restricted today. Rather than leave that as an assumption, the method now raises if it is ever called with one. Whoever wires warehouse tables into a list surface finds out in their own tests instead of shipping a silent gap.

