### PR TITLE
feat(data-warehouse): bypass env proxy for internal-team ClickHouse direct connections

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -4,6 +4,7 @@ import re
 import ssl
 import math
 import time
+import functools
 import collections
 from collections.abc import Callable, Iterator
 from contextlib import _GeneratorContextManager
@@ -12,6 +13,7 @@ from typing import Any, Literal, Optional
 import pyarrow as pa
 import structlog
 from clickhouse_connect import get_client
+from clickhouse_connect.driver import httputil
 from clickhouse_connect.driver.client import Client as ClickHouseClient
 from clickhouse_connect.driver.exceptions import ClickHouseError, ProgrammingError
 from dlt.common.normalizers.naming.snake_case import NamingConvention
@@ -174,6 +176,19 @@ def _apply_session_settings(client: ClickHouseClient, settings: dict[str, Any]) 
             )
 
 
+@functools.cache
+def _no_env_proxy_pool_manager(verify: bool) -> Any:
+    """A shared urllib3 pool manager that never consults HTTP(S)_PROXY env vars.
+
+    clickhouse-connect only checks the proxy env vars when it builds its own
+    pool manager, so handing it one is the sanctioned per-code-path opt-out
+    from the egress proxy (see posthog/security/outbound_proxy.py for the
+    requests/httpx equivalents). Cached because clients don't own an injected
+    manager (`close()` leaves it alive), so per-call managers would leak.
+    """
+    return httputil.get_pool_manager(verify=verify)
+
+
 def _get_client(
     *,
     host: str,
@@ -185,6 +200,7 @@ def _get_client(
     verify: bool,
     query_timeout: int = DATA_QUERY_TIMEOUT_SECONDS,
     settings: Optional[dict[str, Any]] = None,
+    bypass_env_proxy: bool = False,
 ) -> ClickHouseClient:
     """Create a ClickHouse HTTP client.
 
@@ -192,6 +208,11 @@ def _get_client(
     firewall-friendly, easy to tunnel via SSH, and exposes a streaming Arrow
     reader that we use to read very large tables without buffering them in
     memory.
+
+    `bypass_env_proxy` connects directly instead of honouring the
+    HTTP(S)_PROXY env vars. Only ever set for PostHog-internal teams
+    (`is_team_allowlisted_for_internal_hosts`) — for customer-supplied config
+    the egress proxy is the SSRF backstop and must stay in the path.
     """
     attempt = 0
     while True:
@@ -209,6 +230,7 @@ def _get_client(
                 send_receive_timeout=query_timeout,
                 query_limit=0,  # we manage limits ourselves
                 compress=True,
+                pool_mgr=_no_env_proxy_pool_manager(verify) if bypass_env_proxy else None,
             )
         except (ClickHouseError, OSError, ssl.SSLError) as e:
             # OSError covers socket.gaierror, ConnectionRefusedError, TimeoutError,
@@ -308,6 +330,7 @@ def get_schemas(
     secure: bool,
     verify: bool,
     names: list[str] | None = None,
+    bypass_env_proxy: bool = False,
 ) -> dict[str, list[tuple[str, str, bool]]]:
     """Discover columns for all tables in the given database.
 
@@ -325,6 +348,7 @@ def get_schemas(
         secure=secure,
         verify=verify,
         query_timeout=METADATA_QUERY_TIMEOUT_SECONDS,
+        bypass_env_proxy=bypass_env_proxy,
     )
 
     try:
@@ -415,6 +439,7 @@ def get_clickhouse_row_count(
     secure: bool,
     verify: bool,
     names: list[str] | None = None,
+    bypass_env_proxy: bool = False,
 ) -> dict[str, int]:
     """Return total_rows per table from `system.tables`.
 
@@ -436,6 +461,7 @@ def get_clickhouse_row_count(
         secure=secure,
         verify=verify,
         query_timeout=METADATA_QUERY_TIMEOUT_SECONDS,
+        bypass_env_proxy=bypass_env_proxy,
     )
 
     try:
@@ -539,6 +565,7 @@ def get_connection_metadata(
     password: str | None,
     secure: bool,
     verify: bool,
+    bypass_env_proxy: bool = False,
 ) -> dict[str, Any]:
     """Probe the server for version metadata.
 
@@ -555,6 +582,7 @@ def get_connection_metadata(
         secure=secure,
         verify=verify,
         query_timeout=METADATA_QUERY_TIMEOUT_SECONDS,
+        bypass_env_proxy=bypass_env_proxy,
     )
 
     try:
@@ -789,6 +817,7 @@ def get_primary_keys_for_schemas(
     secure: bool,
     verify: bool,
     table_names: list[str],
+    bypass_env_proxy: bool = False,
 ) -> dict[str, list[str] | None]:
     """Detect primary keys (sorting key columns) for multiple tables.
 
@@ -810,6 +839,7 @@ def get_primary_keys_for_schemas(
             secure=secure,
             verify=verify,
             query_timeout=METADATA_QUERY_TIMEOUT_SECONDS,
+            bypass_env_proxy=bypass_env_proxy,
         )
         try:
             for table_name in table_names:
@@ -1194,6 +1224,7 @@ def clickhouse_source(
     incremental_field_type: Optional[IncrementalFieldType] = None,
     row_filters: Optional[list[ValidatedRowFilter]] = None,
     enabled_columns: Optional[list[str]] = None,
+    bypass_env_proxy: bool = False,
 ) -> SourceResponse:
     """Build a SourceResponse that pulls a single ClickHouse table.
 
@@ -1216,6 +1247,7 @@ def clickhouse_source(
             secure=secure,
             verify=verify,
             query_timeout=METADATA_QUERY_TIMEOUT_SECONDS,
+            bypass_env_proxy=bypass_env_proxy,
         )
 
         try:
@@ -1254,6 +1286,7 @@ def clickhouse_source(
                 secure=secure,
                 verify=verify,
                 names=[table_name],
+                bypass_env_proxy=bypass_env_proxy,
             )
             rows_to_sync: int | None = row_counts.get(table_name)
 
@@ -1298,6 +1331,7 @@ def clickhouse_source(
                 verify=verify,
                 query_timeout=DATA_QUERY_TIMEOUT_SECONDS,
                 settings=_query_settings(chunk_size),
+                bypass_env_proxy=bypass_env_proxy,
             )
 
             try:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -37,6 +37,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.bas
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import (
     SSHTunnelMixin,
     ValidateDatabaseHostMixin,
+    is_team_allowlisted_for_internal_hosts,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
@@ -330,6 +331,10 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
     ) -> list[SourceSchema]:
         schemas: list[SourceSchema] = []
 
+        # Internal teams may point at PostHog-internal ClickHouse hosts, which the
+        # egress proxy would refuse — connect those directly.
+        bypass_env_proxy = is_team_allowlisted_for_internal_hosts(team_id)
+
         with self.with_ssh_tunnel(config, team_id) as (host, port):
             db_schemas = get_clickhouse_schemas(
                 host=host,
@@ -340,6 +345,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                 secure=config.secure,
                 verify=config.verify,
                 names=names,
+                bypass_env_proxy=bypass_env_proxy,
             )
 
             row_counts: dict[str, int] = {}
@@ -353,6 +359,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                     secure=config.secure,
                     verify=config.verify,
                     names=names,
+                    bypass_env_proxy=bypass_env_proxy,
                 )
 
             detected_pks = get_clickhouse_primary_keys_for_schemas(
@@ -364,6 +371,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                 secure=config.secure,
                 verify=config.verify,
                 table_names=list(db_schemas.keys()),
+                bypass_env_proxy=bypass_env_proxy,
             )
 
         for table_name, columns in db_schemas.items():
@@ -458,6 +466,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
                 password=config.password,
                 secure=config.secure,
                 verify=config.verify,
+                bypass_env_proxy=is_team_allowlisted_for_internal_hosts(team_id),
             )
 
     def source_for_pipeline(self, config: ClickHouseSourceConfig, inputs: SourceInputs) -> SourceResponse:
@@ -483,6 +492,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             chunk_size_override=schema.chunk_size_override,
             row_filters=inputs.row_filters,
             enabled_columns=inputs.enabled_columns,
+            bypass_env_proxy=is_team_allowlisted_for_internal_hosts(inputs.team_id),
         )
 
     def reconcile_schema_metadata(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -1319,3 +1319,70 @@ class TestClickHouseReconcileSchemaMetadata(BaseTest):
         metadata = schema.schema_metadata
         assert metadata is not None
         assert [column["name"] for column in metadata["columns"]] == ["uuid", "timestamp"]
+
+
+class TestBypassEnvProxy:
+    """The proxy bypass for PostHog-internal direct connections.
+
+    `bypass_env_proxy=True` must hand clickhouse-connect a pool manager, which
+    stops it consulting HTTP(S)_PROXY env vars; `False` must leave the default
+    (proxy-honouring) behaviour intact.
+    """
+
+    @pytest.mark.parametrize("verify", [True, False])
+    def test_no_env_proxy_pool_manager_ignores_proxy_env(self, verify):
+        from urllib3 import PoolManager, ProxyManager
+
+        from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse.clickhouse import (
+            _no_env_proxy_pool_manager,
+        )
+
+        with patch.dict("os.environ", {"HTTPS_PROXY": "http://egress-proxy:4750"}):
+            manager = _no_env_proxy_pool_manager(verify)
+        assert isinstance(manager, PoolManager)
+        assert not isinstance(manager, ProxyManager)
+        # Cached: streaming clients must share the manager (they don't own it).
+        assert _no_env_proxy_pool_manager(verify) is manager
+
+    @pytest.mark.parametrize(
+        "bypass,expected_pool_mgr_factory",
+        [
+            (True, lambda: ch_module._no_env_proxy_pool_manager(True)),
+            (False, lambda: None),
+        ],
+    )
+    def test_get_client_forwards_pool_manager_only_when_bypassing(self, bypass, expected_pool_mgr_factory):
+        with patch.object(ch_module, "get_client") as mock_get_client:
+            _get_client(
+                host="ch.example.com",
+                port=8443,
+                database="default",
+                user="reader",
+                password="secret",
+                secure=True,
+                verify=True,
+                bypass_env_proxy=bypass,
+            )
+        assert mock_get_client.call_count == 1
+        assert mock_get_client.call_args.kwargs["pool_mgr"] is expected_pool_mgr_factory()
+
+
+class TestInternalHostTeamAllowlist:
+    @pytest.mark.parametrize(
+        "region,team_id,expected",
+        [
+            ("US", 2, True),
+            ("US", 1, False),
+            ("US", 12345, False),
+            ("EU", 1, True),
+            ("EU", 2, False),
+            ("EU", 12345, False),
+            (None, 2, False),
+            ("DEV", 2, False),
+        ],
+    )
+    def test_allowlist(self, region, team_id, expected):
+        from products.warehouse_sources.backend.temporal.data_imports.sources.common import mixins
+
+        with patch.object(mixins, "get_instance_region", return_value=region):
+            assert mixins.is_team_allowlisted_for_internal_hosts(team_id) is expected

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
@@ -27,6 +27,17 @@ _INTERNAL_IP_ERROR = (
 _DNS_FAILURE_ERROR = "Host could not be resolved"
 
 
+def is_team_allowlisted_for_internal_hosts(team_id: int) -> bool:
+    """Whether this team may point warehouse sources at PostHog-internal hosts.
+
+    Only our own internal analytics projects: team 2 in US, team 1 in EU.
+    Gates both the SSRF host check and the egress-proxy bypass for direct
+    connections to internal databases.
+    """
+    region = get_instance_region()
+    return (region == "US" and team_id == 2) or (region == "EU" and team_id == 1)
+
+
 def _is_host_safe(host: str, team_id: int) -> tuple[bool, str | None]:
     """Validate that a host is not an internal/private IP address.
 
@@ -68,7 +79,7 @@ def _is_host_safe(host: str, team_id: int) -> tuple[bool, str | None]:
         _log("allow", "e2e", None)
         return True, None
 
-    if (region == "US" and team_id == 2) or (region == "EU" and team_id == 1):
+    if is_team_allowlisted_for_internal_hosts(team_id):
         _log("allow", "team_allowlist", None)
         return True, None
 


### PR DESCRIPTION
## Problem

The ClickHouse data warehouse source speaks the HTTP(S) interface via `clickhouse-connect`, which honours the `HTTP(S)_PROXY` env vars. On cloud, all outbound traffic from the app and temporal workers goes through an egress proxy that refuses private-range destinations — correctly, since source configs are customer-supplied and the proxy is the SSRF backstop.

That same behaviour also blocks our own internal analytics projects (the teams already allowlisted in `_is_host_safe` to use internal hosts) from direct-connecting the SQL editor to internal ClickHouse.

## Changes

- Extract the existing internal-host team allowlist from `_is_host_safe` into `is_team_allowlisted_for_internal_hosts()` so the SSRF check and the proxy bypass share one gate and can't drift apart.
- `_get_client` gains `bypass_env_proxy`: when set, it injects a shared `urllib3` pool manager (via `clickhouse_connect.driver.httputil.get_pool_manager`), which stops the driver consulting proxy env vars — the per-code-path opt-out pattern from `posthog/security/outbound_proxy.py`. The manager is cached because injected managers aren't owned or closed by clients.
- The flag threads through schema discovery, row counts, connection metadata, primary-key detection, and the sync pipeline, computed from `team_id` at each entry point in `source.py`.
- Customer teams are unaffected: the flag is only ever true for the allowlisted internal teams, so the egress proxy stays in the path for all customer-supplied hosts.

## How did you test this code?

- New parameterized tests in `test_clickhouse.py`: the injected pool manager ignores proxy env vars (both `verify` values, cached instance shared), `_get_client` forwards the pool manager only when bypassing, and the region/team allowlist truth table.
- Full `test_clickhouse.py` run: 222 passed (one pre-existing DB-dependent test errors without a local Postgres; unrelated).
- Verified against the real driver that with an injected pool manager the connection dials the target host directly, and without it the same call attempts the proxy from the env var.
