### PR TITLE
fix(data-modeling): let CTEs shadow view names in cycle detection

### DIFF
--- a/products/data_modeling/backend/models/modeling.py
+++ b/products/data_modeling/backend/models/modeling.py
@@ -223,7 +223,14 @@ class BoundedResolver(Resolver):
     def visit_join_expr(self, node: ast.JoinExpr):
         """Override to add cycle detection and depth limiting for view tables."""
         # CTEs are handled entirely by the parent class, but for views we track visited for cycle detection
-        if isinstance(node.table, ast.Field) and self.database is not None:
+        if (
+            isinstance(node.table, ast.Field)
+            and self.database is not None
+            # CTEs shadow database tables (the parent checks self.ctes before any table lookup),
+            # so a name bound in the current WITH scope is never a view reference; without this
+            # skip, a view whose body defines a same-named CTE reads as a cycle with itself
+            and self.ctes.get(".".join(str(n) for n in node.table.chain)) is None
+        ):
             try:
                 database_table = self.database.get_table([str(n) for n in node.table.chain])
             except QueryError:

--- a/products/data_warehouse/backend/models/test/test_modeling.py
+++ b/products/data_warehouse/backend/models/test/test_modeling.py
@@ -673,6 +673,23 @@ class TestBoundedResolver(BaseTest):
 
         assert get_parents_from_model_query(self.team, "nested_union", body) == {"events"}
 
+    @parameterized.expand(
+        [
+            # `WITH x AS (...) SELECT FROM x` saved as view `x`: the CTE shadows the view's
+            # own name, so this is not a self-cycle.
+            ("own_name", "reservations_all"),
+            # A CTE shadowing a different existing view must win over inlining that view.
+            ("other_view_name", "some_other_view"),
+        ]
+    )
+    def test_cte_shadowing_a_view_name_resolves_to_the_cte(self, _name, shadowed_name):
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team, name=shadowed_name, query={"query": "select id from persons"}
+        )
+        body = f"with {shadowed_name} as (select event from events) select * from {shadowed_name}"
+
+        assert get_parents_from_model_query(self.team, "reservations_all", body) == {"events"}
+
     def test_depth_limit_raises_when_chain_too_deep(self):
         self._make_chain(length=4)  # v0 → v1 → v2 → v3
 


### PR DESCRIPTION
## Problem

A saved query whose body opens with a CTE named after the view itself, the common `WITH x AS (...) SELECT * FROM x` idiom saved as view `x`, fails every DAG sync with `ResolutionCycleError: Circular dependency detected in view 'x'`. There is no cycle. The base resolver's contract is that a CTE shadows any database table of the same name (https://github.com/PostHog/posthog/blob/master/posthog/hogql/resolver.py#L1260 checks `self.ctes` before any table lookup), but `BoundedResolver.visit_join_expr` runs its saved-query cycle guard on the raw database lookup before delegating to the parent, so the shadowed name is treated as a self-reference.

Surfaced on a real customer view during a DAG consolidation, where the failed sync blocked the merge.

## Changes

One condition in `BoundedResolver.visit_join_expr`. Skip the whole saved-query branch (cycle check, depth accounting, pending-view bookkeeping) when the field's chain is bound to a CTE in the current scope, using the identical `self.ctes.get(".".join(chain))` lookup the parent performs. Control then falls through to `super().visit_join_expr`, which resolves the CTE.

Timing is safe by construction. The parent registers a select's WITH CTEs (and hoists a union's leading WITH) into `self.ctes` before visiting FROM, and this check reads the same dict the parent consults at lookup time, so the two can never disagree. Recursive CTEs pre-register a placeholder before their body resolves, so `FROM x` inside `WITH RECURSIVE x` also skips the guard, and a non-recursive `WITH x AS (SELECT FROM x)` where `x` is a view still expands and cycle-checks the view inside the CTE body, matching parent behavior. Real cycles between views still raise.

## How did you test this code?

Red-first: the new parameterized test `test_cte_shadowing_a_view_name_resolves_to_the_cte` failed on the `own_name` row with the exact production error before the fix. The regression it catches that no existing test did: CTE-over-view shadowing in the bounded resolver, both for the view's own name (the false cycle) and for a different existing view (the `{persons}` body on the decoy view makes a wrong inline observable as wrong parents).

- `pytest products/data_warehouse/backend/models/test/test_modeling.py` — 52 passed, including the real-cycle tests (`test_bounded_resolver_errors_inherit_query_error`, `test_soft_mode_cycle_still_raises`) still raising
- `pytest products/data_modeling/backend/test/test_saved_query_dag_sync.py` — 29 passed, including `test_sync_raises_on_cycle`
- ruff check and format clean, `hogli ci:preflight --fix` 0 failures

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session. Root-caused by comparing the guard's lookup order against the base resolver's CTE precedence, red test written first, fix implemented by a subagent against that test. Contained to `products/data_modeling/backend/models/modeling.py` deliberately, no HogQL files touched, same containment as the earlier bounded-resolver fixes (#73176, #73483). Skills invoked: /writing-tests.
