### PR TITLE
feat(tasks): add unread activity actions

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -5319,6 +5319,7 @@ def list_task_activity(
     limit: int = 100,
     before: datetime | None = None,
     before_id: UUID | None = None,
+    unread_only: bool = False,
 ) -> contracts.TaskActivityPageDTO:
     """The requester's feed: one row per task they are involved in, newest activity first.
 
@@ -5328,6 +5329,8 @@ def list_task_activity(
     if user_id is None:
         return contracts.TaskActivityPageDTO(results=[], unread_count=0)
     qs = _task_activity_qs(team_id, user_id)
+    if unread_only:
+        qs = qs.filter(read_at__isnull=True)
     if before is not None and before_id is not None:
         qs = qs.filter(Q(activity_at__lt=before) | Q(activity_at=before, id__lt=before_id))
     rows = list(qs.select_related("task__channel", "message__author").order_by("-activity_at", "-id")[: limit + 1])
@@ -5369,6 +5372,13 @@ def mark_task_activity_read(team_id: int, user_id: int | None, activities: Seque
         .filter(activity_versions)
         .update(read_at=django_timezone.now())
     )
+
+
+def mark_all_task_activity_read(team_id: int, user_id: int | None) -> int:
+    """Mark every unread feed row the requester can still see as read."""
+    if user_id is None:
+        return 0
+    return _task_activity_qs(team_id, user_id).filter(read_at__isnull=True).update(read_at=django_timezone.now())
 
 
 def delete_thread_message(message_id: str | UUID, task_id: str | UUID, team_id: int, user_id: int | None) -> str:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -1495,6 +1495,11 @@ class TaskActivityQuerySerializer(serializers.Serializer):
         required=False,
         help_text="Activity ID from the final row of the previous page.",
     )
+    unread_only = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Return only activity the requester has not read.",
+    )
 
     def validate(self, attrs):
         if ("before" in attrs) != ("before_id" in attrs):

--- a/products/tasks/backend/presentation/views/channels_api.py
+++ b/products/tasks/backend/presentation/views/channels_api.py
@@ -265,6 +265,7 @@ class TaskActivityViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             limit=request.validated_query_data["limit"],
             before=request.validated_query_data.get("before"),
             before_id=request.validated_query_data.get("before_id"),
+            unread_only=request.validated_query_data["unread_only"],
         )
         return Response(TaskActivityPageSerializer(activity).data)
 
@@ -288,6 +289,24 @@ class TaskActivityViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             (activity["task_id"], activity["seen_before"]) for activity in request.validated_data["activities"]
         ]
         marked_read = tasks_facade.mark_task_activity_read(self.team_id, self._user_id(), activities)
+        return Response(
+            {
+                "marked_read": marked_read,
+                "unread_count": tasks_facade.count_unread_task_activity(self.team_id, self._user_id()),
+            }
+        )
+
+    @extend_schema(
+        request=None,
+        responses={
+            200: OpenApiResponse(response=TaskActivityMarkReadResponseSerializer, description="Remaining unread total"),
+        },
+        summary="Mark all task activity read",
+        description="Clear every unread feed row the requester can currently see.",
+    )
+    @action(detail=False, methods=["post"], url_path="mark_all_read", required_scopes=["task:write"])
+    def mark_all_read(self, request, *args, **kwargs):
+        marked_read = tasks_facade.mark_all_task_activity_read(self.team_id, self._user_id())
         return Response(
             {
                 "marked_read": marked_read,

--- a/products/tasks/backend/tests/test_channels_api.py
+++ b/products/tasks/backend/tests/test_channels_api.py
@@ -566,6 +566,47 @@ class TaskActivityAPITestCase(ChannelTaskAPITestCase):
         self.assertEqual(len(page["results"]), 1)
         self.assertEqual(page["unread_count"], 3)
 
+    def test_unread_only_excludes_read_activity_before_paginating(self):
+        second = Task.objects.create(
+            team=self.team,
+            created_by=self.author,
+            channel=self.channel,
+            title="Second",
+            description="d",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        self._awaiting_input(second)
+        self._awaiting_input()
+        newest = self._row_for(self.author_client, self.task)
+        self._mark_read(
+            self.author_client,
+            [{"task_id": str(self.task.id), "seen_before": newest["activity_at"]}],
+        )
+
+        page = self.author_client.get(self._activity_url(), {"unread_only": "true", "limit": 1}).json()
+
+        self.assertEqual([row["task_id"] for row in page["results"]], [str(second.id)])
+        self.assertEqual(page["unread_count"], 1)
+        self.assertIsNone(page["next_before"])
+
+    def test_mark_all_read_clears_every_visible_unread_activity(self):
+        second = Task.objects.create(
+            team=self.team,
+            created_by=self.author,
+            channel=self.channel,
+            title="Second",
+            description="d",
+            origin_product=Task.OriginProduct.USER_CREATED,
+        )
+        self._awaiting_input()
+        self._awaiting_input(second)
+
+        response = self.author_client.post(self._activity_url() + "mark_all_read/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)
+        self.assertEqual(response.json(), {"marked_read": 2, "unread_count": 0})
+        self.assertEqual(self.author_client.get(self._activity_url()).json()["unread_count"], 0)
+
     def test_newest_activity_first_and_limit_applies(self):
         second = Task.objects.create(
             team=self.team,

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -976,6 +976,13 @@ export interface TaskActivityPageDTOApi {
     next_before_id?: string | null
 }
 
+export interface TaskActivityMarkReadResponseApi {
+    /** How many feed rows changed from unread to read. */
+    marked_read: number
+    /** The requester's remaining unread total after the update. */
+    unread_count: number
+}
+
 export interface TaskActivityReadMarkerApi {
     /** Task whose displayed activity should be marked read. */
     task_id: string
@@ -992,13 +999,6 @@ export interface TaskActivityMarkReadApi {
      * @maxItems 500
      */
     activities: TaskActivityReadMarkerApi[]
-}
-
-export interface TaskActivityMarkReadResponseApi {
-    /** How many feed rows changed from unread to read. */
-    marked_read: number
-    /** The requester's remaining unread total after the update. */
-    unread_count: number
 }
 
 /**
@@ -3703,6 +3703,10 @@ export type TaskActivityListParams = {
      * @maximum 500
      */
     limit?: number
+    /**
+     * Return only activity the requester has not read.
+     */
+    unread_only?: boolean
 }
 
 export type TaskAutomationsListParams = {

--- a/products/tasks/frontend/generated/api.ts
+++ b/products/tasks/frontend/generated/api.ts
@@ -660,6 +660,24 @@ export const taskActivityList = async (
     })
 }
 
+export const getTaskActivityMarkAllReadCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/task_activity/mark_all_read/`
+}
+
+/**
+ * Clear every unread feed row the requester can currently see.
+ * @summary Mark all task activity read
+ */
+export const taskActivityMarkAllReadCreate = async (
+    projectId: string,
+    options?: RequestInit
+): Promise<TaskActivityMarkReadResponseApi> => {
+    return apiMutator<TaskActivityMarkReadResponseApi>(getTaskActivityMarkAllReadCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+    })
+}
+
 export const getTaskActivityMarkReadCreateUrl = (projectId: string) => {
     return `/api/projects/${projectId}/task_activity/mark_read/`
 }

--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -193,6 +193,9 @@ tools:
     task-activity-list:
         operation: task_activity_list
         enabled: false
+    task-activity-mark-all-read-create:
+        operation: task_activity_mark_all_read_create
+        enabled: false
     task-activity-mark-read-create:
         operation: task_activity_mark_read_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -78734,6 +78734,10 @@ export namespace Schemas {
      * @maximum 500
      */
     limit?: number;
+    /**
+     * Return only activity the requester has not read.
+     */
+    unread_only?: boolean;
     };
 
     export type TaskAutomationsListParams = {


### PR DESCRIPTION
## Problem

The activity hover surface needs a reliable way to fetch unread rows and clear the complete unread set, including rows beyond the first feed page.

**Why:** People should be able to review and clear unread task activity without stale badge counts or partial results.

## Changes

- Add unread-only filtering before activity pagination.
- Add an atomic mark-all-read action scoped to activity the requester can see.
- Regenerate the Tasks API client types.

## How did you test this code?

- Ruff lint and format checks passed for all changed Python files.
- OpenAPI schema and Tasks client generation completed.
- Added API cases that guard unread filtering before pagination and clearing all visible unread rows.
- The Django test process was attempted, but its local services could not start because the environment lacks the phrocs prerequisite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The generated OpenAPI client documents the new filter and action. No separate product documentation currently describes this internal activity endpoint.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented this change using the repository improving-drf-endpoints, writing-tests, writing-user-facing-copy, and writing-code-comments skills. The API keeps per-row reads concurrency-safe while providing a server-side mark-all operation so clients do not need to load every page.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*