### PR TITLE
feat(workflows): route transactional emails to a dedicated cyclotron queue

### DIFF
--- a/nodejs/src/capabilities.ts
+++ b/nodejs/src/capabilities.ts
@@ -27,6 +27,7 @@ export const CAPABILITIES_CDP_WORKFLOWS: PluginServerCapabilities = {
     cdpCyclotronWorkerBatchResolve: true,
     cdpCyclotronWorkerHogFlow: true,
     cdpCyclotronWorkerEmail: true,
+    cdpCyclotronWorkerEmailTransactional: true,
     cdpCyclotronV2Janitor: isDevEnv(),
     cdpHogflowScheduler: isDevEnv(),
     cdpHogflowSubscriptionMatcher: isDevEnv(),
@@ -140,6 +141,10 @@ export function getPluginServerCapabilities(
         case PluginServerMode.cdp_cyclotron_worker_email_legacy_pg:
             return {
                 cdpCyclotronWorkerEmailLegacyPg: true,
+            }
+        case PluginServerMode.cdp_cyclotron_worker_email_transactional:
+            return {
+                cdpCyclotronWorkerEmailTransactional: true,
             }
         case PluginServerMode.cdp_precalculated_filters:
             return {

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -153,6 +153,7 @@ export type CdpCoreServicesConfig = Pick<
         | 'CDP_FETCH_RETRIES'
         | 'CDP_FETCH_BACKOFF_BASE_MS'
         | 'CDP_FETCH_BACKOFF_MAX_MS'
+        | 'CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED'
         | 'CDP_EMAIL_TRACKING_URL'
         | 'HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC'
         | 'HOG_FUNCTION_MONITORING_APP_METRICS_PRODUCER'
@@ -444,6 +445,7 @@ export function createCdpCoreServices(
             fetchRetries: config.CDP_FETCH_RETRIES,
             fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
             fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
+            emailTransactionalQueueEnabled: config.CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED,
         },
         { teamManager: deps.teamManager, siteUrl: config.SITE_URL },
         hogInputsService,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -92,6 +92,12 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_SES_RATE_LIMIT_CAPACITY: number
     CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS: number
 
+    // Route transactional-category emails to the dedicated 'emailtransactional'
+    // queue instead of 'email'. Only enable on deployments running against the
+    // V2 job queue AND once a worker consumes that queue — jobs routed there
+    // without a consumer sit unprocessed.
+    CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED: boolean
+
     CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: boolean
     CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: string
     CDP_FETCH_RETRIES: number
@@ -261,6 +267,8 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_SES_RATE_LIMIT_REFILL_PER_SECOND: 100,
         CDP_SES_RATE_LIMIT_CAPACITY: 50,
         CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS: 250,
+
+        CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED: false,
 
         CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: true,
         CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: '',

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email-transactional.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email-transactional.consumer.test.ts
@@ -1,0 +1,35 @@
+import { createMockJobQueue } from '~/tests/helpers/mocks/job-queue.mock'
+
+import { closeHub, createHub } from '~/common/utils/db/hub'
+import { createCdpConsumerDeps } from '~/tests/helpers/cdp'
+import { getFirstTeam, resetTestDatabase } from '~/tests/helpers/sql'
+
+import { Hub } from '../../types'
+import { CdpCyclotronWorkerEmailTransactional } from './cdp-cyclotron-worker-email-transactional.consumer'
+
+jest.setTimeout(5000)
+
+describe('CdpCyclotronWorkerEmailTransactional', () => {
+    let hub: Hub
+
+    beforeEach(async () => {
+        await resetTestDatabase()
+        hub = await createHub()
+        await getFirstTeam(hub.postgres)
+    })
+
+    afterEach(async () => {
+        jest.setTimeout(10000)
+        await closeHub(hub)
+    })
+
+    it('should set queue to emailtransactional', () => {
+        const worker = new CdpCyclotronWorkerEmailTransactional(hub, createCdpConsumerDeps(hub), createMockJobQueue())
+        expect(worker['queue']).toBe('emailtransactional')
+    })
+
+    it('should extend CdpCyclotronWorkerHogFlow', () => {
+        const worker = new CdpCyclotronWorkerEmailTransactional(hub, createCdpConsumerDeps(hub), createMockJobQueue())
+        expect(worker['name']).toBe('CdpCyclotronWorkerEmailTransactional')
+    })
+})

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email-transactional.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-email-transactional.consumer.ts
@@ -1,0 +1,14 @@
+import { PluginsServerConfig } from '~/types'
+
+import { JobQueue } from '../services/job-queue/job-queue.interface'
+import { CdpConsumerBaseDeps } from './cdp-base.consumer'
+import { CdpCyclotronWorkerHogFlow } from './cdp-cyclotron-worker-hogflow.consumer'
+
+export class CdpCyclotronWorkerEmailTransactional extends CdpCyclotronWorkerHogFlow {
+    protected override name = 'CdpCyclotronWorkerEmailTransactional'
+
+    constructor(config: PluginsServerConfig, deps: CdpConsumerBaseDeps, jobQueue: JobQueue) {
+        super(config, deps, jobQueue)
+        this.queue = 'emailtransactional'
+    }
+}

--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -550,6 +550,7 @@ export function createHogTransformerService(
             fetchRetries: config.CDP_FETCH_RETRIES,
             fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
             fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
+            emailTransactionalQueueEnabled: config.CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED,
         },
         { teamManager: deps.teamManager, siteUrl: config.SITE_URL },
         hogInputsService,

--- a/nodejs/src/cdp/services/cyclotron-v2/README.md
+++ b/nodejs/src/cdp/services/cyclotron-v2/README.md
@@ -29,6 +29,19 @@ Each dequeued job exposes an ack interface:
 - `cancel()` — mark canceled
 - `heartbeat()` — extend the lock to prevent the janitor from reclaiming the job
 
+### Fair dequeue (email queues)
+
+Queues listed in `FAIR_DEQUEUE_COUNTER_TABLES` in `manager.ts` (`email`, `emailtransactional`)
+dequeue by a precomputed `dequeue_seq` sort key instead of FIFO,
+interleaving jobs across teams so one tenant's bulk send can't starve another tenant's single email.
+Each queue has its own per-team counter table
+(`cyclotron_email_team_seq`, `cyclotron_emailtransactional_team_seq`):
+the counter encodes a team's lifetime position within that queue,
+so sharing one table would let a team's marketing volume demote its transactional sends.
+The seq is assigned on insert (`bulkCreateJobs`)
+and when a job is rescheduled into an email queue from another queue;
+retries within the same queue keep their seq and place in line.
+
 ### Janitor (standalone service)
 
 Runs on a timer interval as its own service (`PLUGIN_SERVER_MODE=cdp-cyclotron-v2-janitor`).

--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -1366,6 +1366,7 @@ describe('Cyclotron V2', () => {
 
     describe('Email fair dequeue', () => {
         const EMAIL_QUEUE = 'email'
+        const TRANSACTIONAL_QUEUE = 'emailtransactional'
 
         const readDequeueSeq = async (id: string): Promise<bigint | null> => {
             const res = await assertPool.query<{ dequeue_seq: string | null }>(
@@ -1384,9 +1385,18 @@ describe('Cyclotron V2', () => {
             return res.rows.length === 0 ? null : BigInt(res.rows[0].counter)
         }
 
+        const readTransactionalTeamCounter = async (teamId: number): Promise<bigint | null> => {
+            const res = await assertPool.query<{ counter: string }>(
+                'SELECT counter FROM cyclotron_emailtransactional_team_seq WHERE team_id = $1',
+                [teamId]
+            )
+            return res.rows.length === 0 ? null : BigInt(res.rows[0].counter)
+        }
+
         beforeEach(async () => {
-            // Wipe the per-team counter table between tests so each starts cold.
+            // Wipe the per-team counter tables between tests so each starts cold.
             await assertPool.query('DELETE FROM cyclotron_email_team_seq')
+            await assertPool.query('DELETE FROM cyclotron_emailtransactional_team_seq')
         })
 
         describe('Manager: dequeue_seq assignment', () => {
@@ -1516,6 +1526,44 @@ describe('Cyclotron V2', () => {
                 expect(seqs[2]).not.toBeNull() // email
                 // Only the email jobs bumped the team counter.
                 expect(await readTeamCounter(1)).toBe(2n)
+            })
+
+            it('assigns emailtransactional seqs from their own counter table in a mixed batch', async () => {
+                // One hogflow worker batch can route marketing and transactional
+                // emails at once, so a single bulkCreateJobs call carries both
+                // queues. Each queue must draw from its own counter table —
+                // filtering by the wrong queue name would either double-bump a
+                // counter or leave one queue's rows NULL.
+                const teamId = 7
+                const BLOCK = BigInt(16_777_216)
+                const ids = await manager.bulkCreateJobs([
+                    { teamId, queueName: EMAIL_QUEUE },
+                    { teamId, queueName: TRANSACTIONAL_QUEUE },
+                    { teamId, queueName: 'hog' },
+                ])
+
+                const seqs = await Promise.all(ids.map(readDequeueSeq))
+                expect(seqs[0]).toBe(BLOCK + BigInt(teamId)) // email: counter 1 in its table
+                expect(seqs[1]).toBe(BLOCK + BigInt(teamId)) // transactional: counter 1 in ITS table
+                expect(seqs[2]).toBeNull() // hog: no fair dequeue
+                expect(await readTeamCounter(teamId)).toBe(1n)
+                expect(await readTransactionalTeamCounter(teamId)).toBe(1n)
+            })
+
+            it("keeps a team's transactional counter independent of its email counter", async () => {
+                // The counter encodes a team's lifetime send position, so sharing
+                // the email table would make a heavy marketing sender permanently
+                // sort behind every other tenant in the transactional queue —
+                // exactly the teams the dedicated queue is meant to protect.
+                const teamId = 42
+                const BLOCK = BigInt(16_777_216)
+                await manager.bulkCreateJobs(Array.from({ length: 5 }, () => ({ teamId, queueName: EMAIL_QUEUE })))
+
+                const [transactionalId] = await manager.bulkCreateJobs([{ teamId, queueName: TRANSACTIONAL_QUEUE }])
+
+                // Fresh counter=1 in the transactional table, not 6 continued
+                // from the email history.
+                expect(await readDequeueSeq(transactionalId)).toBe(BLOCK + BigInt(teamId))
             })
         })
 
@@ -1758,6 +1806,44 @@ describe('Cyclotron V2', () => {
                 expect(await readDequeueSeq(id)).toBe(seqBefore)
                 // Counter stays at 1 — no new claim happened.
                 expect(await readTeamCounter(teamId)).toBe(1n)
+            })
+
+            it('assigns a transactional-table seq when a hogflow job is rescheduled into the emailtransactional queue', async () => {
+                // Same NULLS FIRST hazard as the hog → email case above, but for
+                // the transactional queue: if the reschedule path only handled
+                // queueName='email', re-routed transactional rows would land
+                // with NULL dequeue_seq and bypass the per-team interleave.
+                const teamId = 42
+                const jobId = await manager.createJob({ teamId, queueName: 'hog' })
+
+                const hogWorker = createWorker('hog')
+                const [job] = await dequeueOneBatch(hogWorker)
+                expect(job.id).toBe(jobId)
+                await job.reschedule({ queueName: TRANSACTIONAL_QUEUE })
+
+                expect(await readDequeueSeq(jobId)).toBe(BigInt(16_777_216) + BigInt(teamId))
+                expect(await readTransactionalTeamCounter(teamId)).toBe(1n)
+                // The email counter table is untouched by transactional routing.
+                expect(await readTeamCounter(teamId)).toBeNull()
+            })
+
+            it('fair-dequeues the emailtransactional queue by team', async () => {
+                // The worker derives fair dequeue from its queue name; if the
+                // transactional queue fell back to plain FIFO, one team's
+                // burst of "transactional" sends would starve other tenants —
+                // the cross-tenant failure mode this queue exists to prevent.
+                const teamA = 100
+                const teamB = 200
+                await manager.bulkCreateJobs([
+                    ...Array.from({ length: 5 }, () => ({ teamId: teamA, queueName: TRANSACTIONAL_QUEUE })),
+                    { teamId: teamB, queueName: TRANSACTIONAL_QUEUE },
+                ])
+
+                const worker = createWorker(TRANSACTIONAL_QUEUE, { batchMaxSize: 2 })
+                const jobs = await dequeueOneBatch(worker)
+
+                expect(jobs).toHaveLength(2)
+                expect(new Set(jobs.map((j) => j.teamId))).toEqual(new Set([teamA, teamB]))
             })
         })
     })

--- a/nodejs/src/cdp/services/cyclotron-v2/manager.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/manager.ts
@@ -16,7 +16,7 @@ import {
 } from './types'
 
 /**
- * Block size used to compute the fair-dequeue sort key for email queue jobs:
+ * Block size used to compute the fair-dequeue sort key for email-queue jobs:
  *
  *     dequeue_seq = counter * EMAIL_DEQUEUE_BLOCK_SIZE + team_id
  *
@@ -24,19 +24,43 @@ import {
  * that). Keeps headroom for ~5 × 10^11 jobs per team before the BIGINT
  * sort key overflows, which is centuries at any realistic email volume.
  *
- * Only used for queue_name='email'. Other queues leave dequeue_seq NULL.
+ * Only used for the queues in FAIR_DEQUEUE_COUNTER_TABLES. Other queues leave
+ * dequeue_seq NULL.
  */
 export const EMAIL_DEQUEUE_BLOCK_SIZE = BigInt(16_777_216)
 
 /**
- * Atomically bump the per-team email counter and return the formatted
- * `dequeue_seq` string for one new email job. Exported because the worker's
- * `reschedule()` path also needs to assign `dequeue_seq` when a hog/hogflow
- * job is re-routed into the email queue — without this, those rows land with
- * `NULL dequeue_seq` and bypass the per-team interleave (`NULLS FIRST` would
- * drain them ahead of any fair-ordered rows).
+ * Per-team counter table for each fair-dequeue queue. Each queue gets its own
+ * table because the counter encodes a team's lifetime send position within
+ * that queue: sharing one table would let a team's marketing volume push its
+ * transactional jobs permanently behind every other tenant's — exactly the
+ * teams the dedicated transactional queue is meant to protect.
  *
- * A team's *first ever* email starts at `MAX(counter) + 1` across the table
+ * Table names are interpolated into SQL as identifiers, so only add entries
+ * whose tables exist in rust/cyclotron-node-migrations.
+ *
+ * cyclotron-v2 is standalone (queue names are plain strings here), so this
+ * deliberately mirrors CYCLOTRON_EMAIL_JOB_QUEUES in cdp/types.ts rather than
+ * importing it — keep the two in sync.
+ */
+export const FAIR_DEQUEUE_COUNTER_TABLES: Record<string, string> = {
+    email: 'cyclotron_email_team_seq',
+    emailtransactional: 'cyclotron_emailtransactional_team_seq',
+}
+
+export function isFairDequeueQueue(queueName: string): boolean {
+    return queueName in FAIR_DEQUEUE_COUNTER_TABLES
+}
+
+/**
+ * Atomically bump the per-team counter for a fair-dequeue queue and return
+ * the formatted `dequeue_seq` string for one new job on it. Exported because
+ * the worker's `reschedule()` path also needs to assign `dequeue_seq` when a
+ * hog/hogflow job is re-routed into an email queue — without this, those rows
+ * land with `NULL dequeue_seq` and bypass the per-team interleave
+ * (`NULLS FIRST` would drain them ahead of any fair-ordered rows).
+ *
+ * A team's *first ever* job starts at `MAX(counter) + 1` across the table
  * (Hatchet's `p_max_assigned` pattern), so a brand-new tenant can't enqueue a
  * burst that gets free priority over established tenants' in-flight emails.
  * Continuing tenants just increment their own counter as before. `COALESCE`
@@ -45,12 +69,16 @@ export const EMAIL_DEQUEUE_BLOCK_SIZE = BigInt(16_777_216)
  * For bulk inserts of multiple email jobs at once, `bulkCreateJobs` uses its
  * own batched UPSERT for efficiency rather than calling this in a loop.
  */
-export async function assignEmailDequeueSeq(pool: Pool, teamId: number): Promise<string> {
+export async function assignEmailDequeueSeq(pool: Pool, teamId: number, queueName: string): Promise<string> {
+    const table = FAIR_DEQUEUE_COUNTER_TABLES[queueName]
+    if (!table) {
+        throw new Error(`No fair-dequeue counter table for queue '${queueName}'`)
+    }
     const result = await pool.query<{ counter: string }>(
-        `INSERT INTO cyclotron_email_team_seq (team_id, counter)
-         VALUES ($1, COALESCE((SELECT MAX(counter) FROM cyclotron_email_team_seq), 0) + 1)
+        `INSERT INTO ${table} (team_id, counter)
+         VALUES ($1, COALESCE((SELECT MAX(counter) FROM ${table}), 0) + 1)
          ON CONFLICT (team_id) DO UPDATE
-            SET counter = cyclotron_email_team_seq.counter + 1
+            SET counter = ${table}.counter + 1
          RETURNING counter`,
         [teamId]
     )
@@ -350,28 +378,47 @@ export class CyclotronV2Manager {
     /**
      * Compute the per-job `dequeue_seq` array for a batch of jobs.
      *
-     * Email-queue jobs get `counter * BLOCK_SIZE + team_id` where `counter`
-     * is the team's monotonic per-team sequence number. Sorting ascending by
-     * dequeue_seq interleaves teams: each team's first job sorts together,
-     * then each team's second job, etc.
+     * Jobs on a fair-dequeue queue get `counter * BLOCK_SIZE + team_id` where
+     * `counter` is the team's monotonic sequence number in that queue's
+     * counter table. Sorting ascending by dequeue_seq interleaves teams: each
+     * team's first job sorts together, then each team's second job, etc.
      *
-     * Non-email jobs get NULL (leaves the existing FIFO ordering untouched).
+     * Jobs on other queues get NULL (leaves the existing FIFO ordering
+     * untouched). Queues with no jobs in the batch issue no queries, so an
+     * email-only batch behaves exactly as before the transactional queue
+     * existed.
+     */
+    private async computeEmailDequeueSeqs(jobs: CyclotronV2JobInit[]): Promise<(string | null)[]> {
+        const dequeueSeqs: (string | null)[] = new Array(jobs.length).fill(null)
+        for (const [queueName, table] of Object.entries(FAIR_DEQUEUE_COUNTER_TABLES)) {
+            await this.computeSeqsForQueue(jobs, queueName, table, dequeueSeqs)
+        }
+        return dequeueSeqs
+    }
+
+    /**
+     * Fill `dequeueSeqs` for this batch's jobs on one fair-dequeue queue.
      *
      * One UPSERT for the whole batch regardless of job count — per-team
-     * counters bump by the count of email jobs from that team in this batch,
-     * and we derive each job's individual counter value in memory.
+     * counters bump by the count of this queue's jobs from that team in this
+     * batch, and we derive each job's individual counter value in memory.
      *
-     * A team's first-ever email starts at `MAX(counter) + 1` across the table
+     * A team's first-ever job starts at `MAX(counter) + 1` across the table
      * (Hatchet's `p_max_assigned` pattern), so a new tenant joining the
      * system can't enqueue a burst that gets free priority over established
      * tenants — established tenants are already at `MAX`, so a new tenant's
      * batch slots in at the same level and the round-robin interleaves them
      * by team_id from there. Continuing teams just keep incrementing.
      */
-    private async computeEmailDequeueSeqs(jobs: CyclotronV2JobInit[]): Promise<(string | null)[]> {
+    private async computeSeqsForQueue(
+        jobs: CyclotronV2JobInit[],
+        queueName: string,
+        table: string,
+        dequeueSeqs: (string | null)[]
+    ): Promise<void> {
         const indicesByTeam = new Map<number, number[]>()
         for (let i = 0; i < jobs.length; i++) {
-            if (jobs[i].queueName !== 'email') {
+            if (jobs[i].queueName !== queueName) {
                 continue
             }
             const indices = indicesByTeam.get(jobs[i].teamId)
@@ -382,9 +429,8 @@ export class CyclotronV2Manager {
             }
         }
 
-        const dequeueSeqs: (string | null)[] = new Array(jobs.length).fill(null)
         if (indicesByTeam.size === 0) {
-            return dequeueSeqs
+            return
         }
 
         const teamIds = [...indicesByTeam.keys()]
@@ -401,13 +447,13 @@ export class CyclotronV2Manager {
         // CONFLICT branch). MAX is computed once per batch via the CTE.
         const upsertResult = await this.pool.query<{ team_id: number; counter: string }>(
             `WITH max_counter AS (
-                 SELECT COALESCE(MAX(counter), 0) AS m FROM cyclotron_email_team_seq
+                 SELECT COALESCE(MAX(counter), 0) AS m FROM ${table}
              )
-             INSERT INTO cyclotron_email_team_seq (team_id, counter)
+             INSERT INTO ${table} (team_id, counter)
              SELECT team_id, increment + (SELECT m FROM max_counter)
              FROM unnest($1::int[], $2::bigint[]) AS t(team_id, increment)
              ON CONFLICT (team_id) DO UPDATE
-                SET counter = cyclotron_email_team_seq.counter
+                SET counter = ${table}.counter
                             + (EXCLUDED.counter - (SELECT m FROM max_counter))
              RETURNING team_id, counter`,
             [teamIds, increments]
@@ -419,7 +465,7 @@ export class CyclotronV2Manager {
             const newCounter = newCounters.get(teamId)
             if (newCounter === undefined) {
                 // Should never happen — every team in indicesByTeam was UPSERTed.
-                logger.error('Missing counter after UPSERT in computeEmailDequeueSeqs', { teamId })
+                logger.error('Missing counter after UPSERT in computeSeqsForQueue', { teamId, queueName })
                 continue
             }
             const startCounter = newCounter - BigInt(indices.length) + 1n
@@ -430,8 +476,6 @@ export class CyclotronV2Manager {
                 dequeueSeqs[indices[k]] = (counterForThisJob * EMAIL_DEQUEUE_BLOCK_SIZE + teamIdBigInt).toString()
             }
         }
-
-        return dequeueSeqs
     }
 
     // "In flight" = jobs still owned by the queue: parked waits/delays ('available' with a future

--- a/nodejs/src/cdp/services/cyclotron-v2/worker.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/worker.ts
@@ -4,7 +4,7 @@ import { v7 as uuidv7 } from 'uuid'
 
 import { logger } from '~/common/utils/logger'
 
-import { assignEmailDequeueSeq } from './manager'
+import { assignEmailDequeueSeq, isFairDequeueQueue } from './manager'
 import {
     CyclotronV2BulkCreateAndCheckInInput,
     CyclotronV2DequeuedJob,
@@ -221,11 +221,12 @@ export class CyclotronV2Worker {
         this.pollDelayMs = config.pollDelayMs ?? 50
         this.heartbeatTimeoutMs = config.heartbeatTimeoutMs ?? 30000
         this.includeEmptyBatches = config.includeEmptyBatches ?? false
-        // Fair (per-team round-robin) dequeue is the email queue's ordering.
-        // `dequeue_seq` is only ever assigned for email jobs (see
-        // CyclotronV2Manager), so deriving this from the queue name keeps the
-        // worker's ORDER BY in lockstep with where the sort key actually exists.
-        this.fairDequeue = config.queueName === 'email'
+        // Fair (per-team round-robin) dequeue is the email queues' ordering.
+        // `dequeue_seq` is only ever assigned for jobs on those queues (see
+        // FAIR_DEQUEUE_COUNTER_TABLES in manager.ts), so deriving this from
+        // the queue name keeps the worker's ORDER BY in lockstep with where
+        // the sort key actually exists.
+        this.fairDequeue = isFairDequeueQueue(config.queueName)
     }
 
     async connect(processBatch: (jobs: CyclotronV2DequeuedJob[]) => Promise<void>): Promise<void> {
@@ -341,14 +342,16 @@ export class CyclotronV2Worker {
      * insert time (see `CyclotronV2Manager.bulkCreateJobs` and the helper
      * `cyclotron_email_team_seq`); this method just reads them back in order.
      *
-     * Hits the partial index `idx_cyclotron_jobs_email_fair_dequeue` (only
-     * indexes email-queue rows with status='available'). NULLS FIRST drains
-     * any pre-migration legacy rows ahead of new fair-ordered ones.
+     * Hits the queue's partial fair-dequeue index — each queue in
+     * FAIR_DEQUEUE_COUNTER_TABLES has one (e.g.
+     * `idx_cyclotron_jobs_email_fair_dequeue_v2`), filtered on its queue_name
+     * and status='available'. NULLS FIRST drains any pre-migration legacy
+     * rows ahead of new fair-ordered ones.
      *
-     * Email-specific by intent — but mechanically just "ORDER BY a different
-     * column", so the SQL shape mirrors `dequeueJobs` exactly. Kept as a
-     * separate method so non-fair callers can read `dequeueJobs` end-to-end
-     * without following a conditional or an indirection.
+     * Email-queue-specific by intent — but mechanically just "ORDER BY a
+     * different column", so the SQL shape mirrors `dequeueJobs` exactly. Kept
+     * as a separate method so non-fair callers can read `dequeueJobs`
+     * end-to-end without following a conditional or an indirection.
      */
     protected async fairDequeueJobs(limit: number = this.batchMaxSize): Promise<RawJobRow[]> {
         const lockId = uuidv7()
@@ -487,17 +490,22 @@ export class CyclotronV2Worker {
                     setClauses.push(`queue_name = $${params.length}`)
                 }
 
-                // Cross-queue routing into the email queue: assign a fresh
-                // dequeue_seq so the row participates in fair ordering. Without
-                // this, hogflow → email re-routing (via job.reschedule({
-                // queueName: 'email' })) lands the row with NULL dequeue_seq,
-                // which `NULLS FIRST` drains ahead of every fair-ordered row —
-                // defeating the per-team interleave for the most common email
-                // path. Skipped when the row was already on the email queue,
-                // so existing fair-ordered rows keep their place after retry/
-                // reschedule without bumping the counter.
-                if (options?.queueName === 'email' && row.queue_name !== 'email') {
-                    const dequeueSeq = await assignEmailDequeueSeq(pool, row.team_id)
+                // Cross-queue routing into an email queue: assign a fresh
+                // dequeue_seq from the target queue's counter table so the row
+                // participates in fair ordering. Without this, hogflow → email
+                // re-routing (via job.reschedule({ queueName: 'email' })) lands
+                // the row with NULL dequeue_seq, which `NULLS FIRST` drains
+                // ahead of every fair-ordered row — defeating the per-team
+                // interleave for the most common email path. Skipped when the
+                // row was already on the target queue, so existing fair-ordered
+                // rows keep their place after retry/reschedule without bumping
+                // the counter.
+                if (
+                    options?.queueName !== undefined &&
+                    options.queueName !== row.queue_name &&
+                    isFairDequeueQueue(options.queueName)
+                ) {
+                    const dequeueSeq = await assignEmailDequeueSeq(pool, row.team_id, options.queueName)
                     params.push(dequeueSeq)
                     setClauses.push(`dequeue_seq = $${params.length}`)
                 }

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -88,6 +88,7 @@ describe('Hog Executor', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                emailTransactionalQueueEnabled: hub.CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
             hogInputsService,
@@ -2305,11 +2306,48 @@ describe('Hog Executor', () => {
 
             expect(result.invocation.id).toBe(invocation.id)
         })
+
+        it.each([
+            [true, 'transactional', 'emailtransactional'],
+            [true, 'marketing', 'email'],
+            [true, undefined, 'email'],
+            [false, 'transactional', 'email'],
+        ] as const)(
+            'with transactional queue enabled=%s and category=%s routes to the %s queue',
+            (flagEnabled, category, expectedQueue) => {
+                // Transactional sends get their own queue only when both the
+                // rollout flag and the category say so — anything else must stay
+                // on 'email', where a worker is guaranteed to be consuming.
+                ;(executor as any).config.emailTransactionalQueueEnabled = flagEnabled
+                const hogFunction = createHogFunction({
+                    name: 'Email function',
+                    metadata: category ? { message_category_type: category } : {},
+                })
+                const invocation: CyclotronJobInvocationHogFunction = {
+                    ...createExampleInvocation(hogFunction),
+                    queue: 'hogflow',
+                    queueParameters: {
+                        type: 'email',
+                        to: { email: 'user@example.com' },
+                        from: { integrationId: 1 },
+                        subject: 'Test',
+                        text: 'Hello',
+                        html: '<p>Hello</p>',
+                    },
+                }
+                invocation.state.vmState = { stack: [] } as any
+
+                const result = (executor as any).routeEmailToQueue(invocation)
+
+                expect(result.invocation.queue).toBe(expectedQueue)
+                expect(result.invocation.queueMetadata?.originQueue).toBe('hogflow')
+            }
+        )
     })
 
     describe('email queue routing', () => {
-        const createEmailInvocation = (): CyclotronJobInvocationHogFunction => {
-            const hogFunction = createHogFunction({ name: 'Email function', team_id: 123 })
+        const createEmailInvocation = (metadata?: Record<string, any>): CyclotronJobInvocationHogFunction => {
+            const hogFunction = createHogFunction({ name: 'Email function', team_id: 123, metadata })
             const invocation: CyclotronJobInvocationHogFunction = {
                 ...createExampleInvocation(hogFunction),
                 teamId: 123,
@@ -2343,6 +2381,47 @@ describe('Hog Executor', () => {
 
             expect(result.invocation.queue).not.toBe('email')
             expect(result.finished).toBe(true)
+        })
+
+        it('should send inline when already on the transactional email queue instead of re-routing', async () => {
+            // A job dequeued from 'emailtransactional' must be recognized as
+            // "already on an email queue". If the check only knew about
+            // 'email', the job would be re-routed on every dequeue and bounce
+            // between queues forever without ever sending.
+            ;(executor as any).config.emailTransactionalQueueEnabled = true
+            const invocation = createEmailInvocation({ message_category_type: 'transactional' })
+            invocation.queue = 'emailtransactional'
+
+            const result = await executor.executeWithAsyncFunctions(invocation)
+
+            expect(result.invocation.queue).toBe('emailtransactional')
+            expect(result.finished).toBe(true)
+            expect(result.metrics).not.toContainEqual(expect.objectContaining({ metric_name: 'email_queued' }))
+        })
+
+        it('should route fetches on the transactional email queue back to the origin queue', async () => {
+            // The email workers keep their lane email-only: a fetch step that
+            // resumes there is handed back to the queue it came from instead
+            // of running inline and adding arbitrary latency to email sends.
+            const hogFunction = createHogFunction({ name: 'Email function', team_id: 123 })
+            const invocation: CyclotronJobInvocationHogFunction = {
+                ...createExampleInvocation(hogFunction),
+                teamId: 123,
+                queue: 'emailtransactional',
+                queueMetadata: { originQueue: 'hogflow' },
+                queueParameters: {
+                    type: 'fetch',
+                    url: 'https://example.com/webhook',
+                    method: 'POST',
+                },
+            }
+            invocation.state.vmState = { stack: [] } as any
+
+            const result = await executor.executeWithAsyncFunctions(invocation)
+
+            expect(result.invocation.queue).toBe('hogflow')
+            expect(result.finished).toBe(false)
+            expect(jest.mocked(fetch)).not.toHaveBeenCalled()
         })
     })
 })

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -16,7 +16,9 @@ import { UUIDT } from '~/common/utils/utils'
 import { PluginsServerConfig } from '../../types'
 import { getAsyncFunctionHandler, getRegisteredAsyncFunctionNames } from '../async-function-registry'
 import '../async-functions'
+import { isEmailQueueKind } from '../types'
 import type {
+    CyclotronEmailJobQueueKind,
     CyclotronJobInvocationHogFunction,
     CyclotronJobInvocationResult,
     HogFunctionFilterGlobals,
@@ -58,6 +60,7 @@ export interface HogExecutorConfig {
     fetchRetries: number
     fetchBackoffBaseMs: number
     fetchBackoffMaxMs: number
+    emailTransactionalQueueEnabled: boolean
 }
 
 export interface HogExecutorAsyncContext {
@@ -67,7 +70,8 @@ export interface HogExecutorAsyncContext {
 
 const cdpEmailQueuedTotal = new Counter({
     name: 'cdp_email_queued_total',
-    help: 'Total emails routed to the dedicated email queue',
+    help: 'Total emails routed to a dedicated email queue',
+    labelNames: ['queue'],
 })
 
 const cdpHttpRequests = new Counter({
@@ -479,7 +483,7 @@ export class HogExecutorService {
                 // back to hogflow will be when overall execution time exceeds the
                 // budget, to avoid blocking the queue.
                 if (queueParamsType === 'fetch') {
-                    if (invocation.queue === 'email') {
+                    if (isEmailQueueKind(invocation.queue)) {
                         result = this.routeToQueue(
                             nextInvocation,
                             nextInvocation.queueMetadata?.originQueue ?? 'hogflow'
@@ -490,9 +494,9 @@ export class HogExecutorService {
                 } else if (queueParamsType === 'sendPushNotification') {
                     result = await this.pushNotificationService.executeSendPushNotification(nextInvocation)
                 } else if (queueParamsType === 'email') {
-                    // Route to the email queue only if we're not already there and the
+                    // Route to an email queue only if we're not already on one and the
                     // caller hasn't asked for inline-only execution (e.g. the test panel).
-                    const routeToEmailQueue = invocation.queue !== 'email' && !options?.sendEmailsInline
+                    const routeToEmailQueue = !isEmailQueueKind(invocation.queue) && !options?.sendEmailsInline
                     if (routeToEmailQueue) {
                         result = this.routeEmailToQueue(nextInvocation)
                     } else {
@@ -537,17 +541,24 @@ export class HogExecutorService {
     }
 
     /**
-     * Routes an email send to the dedicated email queue instead of sending inline.
-     * The email worker will pick this up, send via SES, and return the job to the
-     * original queue so the workflow can continue.
+     * Routes an email send to a dedicated email queue instead of sending inline.
+     * Transactional-category emails get their own queue (behind a rollout flag)
+     * so a bulk campaign backlog can't delay them; everything else stays on
+     * 'email'. The email worker will pick this up, send via SES, and return the
+     * job to the original queue so the workflow can continue.
      */
     private routeEmailToQueue(
         invocation: CyclotronJobInvocationHogFunction
     ): CyclotronJobInvocationResult<CyclotronJobInvocationHogFunction> {
+        const targetQueue: CyclotronEmailJobQueueKind =
+            this.config.emailTransactionalQueueEnabled &&
+            invocation.hogFunction.metadata?.message_category_type === 'transactional'
+                ? 'emailtransactional'
+                : 'email'
         const result = createInvocationResult<CyclotronJobInvocationHogFunction>(
             invocation,
             {
-                queue: 'email',
+                queue: targetQueue,
                 queueParameters: invocation.queueParameters,
                 queueMetadata: {
                     ...invocation.queueMetadata,
@@ -566,7 +577,7 @@ export class HogExecutorService {
             count: 1,
         })
 
-        cdpEmailQueuedTotal.inc()
+        cdpEmailQueuedTotal.inc({ queue: targetQueue })
 
         return result
     }

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -76,6 +76,7 @@ describe('HogFunctionHandler', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                emailTransactionalQueueEnabled: hub.CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
             hogInputsService,

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -95,6 +95,7 @@ describe('Hogflow Executor', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
+                emailTransactionalQueueEnabled: hub.CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
             hogInputsService,

--- a/nodejs/src/cdp/templates/test/test-helpers.ts
+++ b/nodejs/src/cdp/templates/test/test-helpers.ts
@@ -220,6 +220,7 @@ export class TemplateTester {
                 fetchRetries: config.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
+                emailTransactionalQueueEnabled: config.CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED,
             },
             { teamManager: this.mockTeamManager as any, siteUrl: config.SITE_URL },
             hogInputsService,

--- a/nodejs/src/cdp/types.ts
+++ b/nodejs/src/cdp/types.ts
@@ -266,8 +266,21 @@ export interface HogFunctionTiming {
 }
 
 // IMPORTANT: All queue names should be lowercase and only [A-Z0-9] characters are allowed.
-export const CYCLOTRON_INVOCATION_JOB_QUEUES = ['hog', 'hogoverflow', 'hogflow', 'email'] as const
+export const CYCLOTRON_INVOCATION_JOB_QUEUES = ['hog', 'hogoverflow', 'hogflow', 'email', 'emailtransactional'] as const
 export type CyclotronJobQueueKind = (typeof CYCLOTRON_INVOCATION_JOB_QUEUES)[number]
+
+// Queues whose worker sends emails inline. 'email' carries marketing (and
+// uncategorized) sends; 'emailtransactional' isolates transactional sends so a
+// bulk campaign backlog can't delay them.
+export const CYCLOTRON_EMAIL_JOB_QUEUES = [
+    'email',
+    'emailtransactional',
+] as const satisfies readonly CyclotronJobQueueKind[]
+export type CyclotronEmailJobQueueKind = (typeof CYCLOTRON_EMAIL_JOB_QUEUES)[number]
+
+export function isEmailQueueKind(queue: CyclotronJobQueueKind): queue is CyclotronEmailJobQueueKind {
+    return (CYCLOTRON_EMAIL_JOB_QUEUES as readonly CyclotronJobQueueKind[]).includes(queue)
+}
 
 export const CYCLOTRON_JOB_QUEUE_SOURCES = ['postgres', 'postgres-v2', 'kafka'] as const
 export type CyclotronJobQueueSource = (typeof CYCLOTRON_JOB_QUEUE_SOURCES)[number]

--- a/nodejs/src/cdp/workflows-e2e.test.ts
+++ b/nodejs/src/cdp/workflows-e2e.test.ts
@@ -21,7 +21,7 @@ import { register } from 'prom-client'
 import supertest from 'supertest'
 import express from 'ultimate-express'
 
-import { HogFlow } from '~/cdp/schema/hogflow'
+import { HogFlow, HogFlowAction } from '~/cdp/schema/hogflow'
 import { setupExpressApp } from '~/common/api/router'
 import {
     KAFKA_APP_METRICS_2,
@@ -50,6 +50,7 @@ import { createHogExecutionGlobals, insertHogFunctionTemplate, insertIntegration
 import { insertHogFlow } from './_tests/fixtures-hogflows'
 import { CdpApi } from './cdp-api'
 import { CdpCyclotronWorkerBatchResolve } from './consumers/cdp-cyclotron-worker-batch-resolve.consumer'
+import { CdpCyclotronWorkerEmailTransactional } from './consumers/cdp-cyclotron-worker-email-transactional.consumer'
 import { CdpCyclotronWorkerEmail } from './consumers/cdp-cyclotron-worker-email.consumer'
 import { CdpCyclotronWorkerHogFlow } from './consumers/cdp-cyclotron-worker-hogflow.consumer'
 import { CdpDatawarehouseEventsConsumer } from './consumers/cdp-data-warehouse-events.consumer'
@@ -2208,6 +2209,7 @@ describe('Workflows E2E (email queue)', () => {
     let eventsConsumer: CdpEventsConsumer
     let hogflowWorker: CdpCyclotronWorkerHogFlow
     let emailWorker: CdpCyclotronWorkerEmail
+    let emailTransactionalWorker: CdpCyclotronWorkerEmailTransactional
     let matcher: CdpHogflowSubscriptionMatcherConsumer | undefined
 
     let hub: Hub
@@ -2236,6 +2238,10 @@ describe('Workflows E2E (email queue)', () => {
 
         hub = await createHub()
         hub.CDP_CYCLOTRON_BATCH_DELAY_MS = 50
+        // The whole block runs with the transactional queue enabled — the
+        // deployment end-state. Existing tests use uncategorized emails, so
+        // they double as proof those still route to 'email' under the flag.
+        hub.CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED = true
 
         // `.invalid` domains are NXDOMAIN, everything else resolves as deliverable.
         const nxdomain = () => Promise.reject(Object.assign(new Error('queryMx ENOTFOUND'), { code: 'ENOTFOUND' }))
@@ -2301,6 +2307,7 @@ describe('Workflows E2E (email queue)', () => {
         const eventsProducerQueue = new CyclotronJobQueuePostgresV2(hub.CONSUMER_BATCH_SIZE, hub)
         const hogflowConsumerQueue = new CyclotronJobQueuePostgresV2(hub.CONSUMER_BATCH_SIZE, hub)
         const emailConsumerQueue = new CyclotronJobQueuePostgresV2(hub.CONSUMER_BATCH_SIZE, hub)
+        const emailTransactionalConsumerQueue = new CyclotronJobQueuePostgresV2(hub.CONSUMER_BATCH_SIZE, hub)
 
         eventsConsumer = new CdpEventsConsumer(hub, deps, {
             hogQueue: kafkaQueue,
@@ -2309,7 +2316,8 @@ describe('Workflows E2E (email queue)', () => {
         await Promise.all([kafkaQueue.startAsProducer(), eventsProducerQueue.startAsProducer()])
 
         // Hogflow worker polls jobs with queue_name='hogflow' and re-stamps email
-        // jobs to queue_name='email' so the email worker picks them up
+        // jobs to queue_name='email' (or 'emailtransactional' for
+        // transactional-category sends) so the email workers pick them up
         hogflowWorker = new CdpCyclotronWorkerHogFlow(hub, deps, hogflowConsumerQueue)
         await hogflowWorker.start()
 
@@ -2317,6 +2325,11 @@ describe('Workflows E2E (email queue)', () => {
         // and continues the workflow inline (until it hits a fetch or terminates)
         emailWorker = new CdpCyclotronWorkerEmail(hub, deps, emailConsumerQueue)
         await emailWorker.start()
+
+        // Same worker family for queue_name='emailtransactional' — the dedicated
+        // lane that keeps transactional sends behind their own backlog
+        emailTransactionalWorker = new CdpCyclotronWorkerEmailTransactional(hub, deps, emailTransactionalConsumerQueue)
+        await emailTransactionalWorker.start()
     })
 
     afterEach(async () => {
@@ -2324,6 +2337,7 @@ describe('Workflows E2E (email queue)', () => {
             eventsConsumer?.stop() ?? Promise.resolve(),
             hogflowWorker?.stop() ?? Promise.resolve(),
             emailWorker?.stop() ?? Promise.resolve(),
+            emailTransactionalWorker?.stop() ?? Promise.resolve(),
             matcher?.stop().catch(() => {}) ?? Promise.resolve(),
         ])
         await kafkaProducer.disconnect()
@@ -2430,6 +2444,80 @@ describe('Workflows E2E (email queue)', () => {
                 (j: any) => j.status === 'completed' || j.status === 'failed' || j.status === 'canceled'
             )
             expect(terminal.length).toBeGreaterThanOrEqual(1)
+        }, 10000)
+    })
+
+    it('routes a transactional-category email through the emailtransactional queue and completes', async () => {
+        // The full transactional lane: the hogflow worker re-stamps the job to
+        // 'emailtransactional' (not 'email'), the dedicated worker sends it and
+        // runs the flow to exit. If routing, the queue kind, or the worker
+        // wiring regressed, the job would either complete on 'email' (lane not
+        // isolated) or never complete (queue without a consumer).
+        const hogFlow = new FixtureHogFlowBuilder()
+            .withTeamId(team.id)
+            .withStatus('active')
+            .withExitCondition('exit_only_at_end')
+            .withWorkflow({
+                actions: {
+                    trigger: {
+                        type: 'trigger',
+                        config: { type: 'event', filters: HOG_FILTERS_EXAMPLES.no_filters.filters ?? {} },
+                    },
+                    email_1: {
+                        type: 'function_email',
+                        // Cast: the schema pins function_email's template_id to the literal
+                        // 'template-email', but this harness (like the rest of the file) uses
+                        // its own inserted template id, which resolves fine at runtime.
+                        config: {
+                            template_id: 'template-workflows-e2e-email',
+                            message_category_type: 'transactional',
+                            inputs: {
+                                email: {
+                                    value: {
+                                        to: { email: 'recipient@example.com', name: 'Recipient' },
+                                        from: { integrationId: 1, email: 'sender@posthog.com' },
+                                        subject: 'Transactional email',
+                                        text: 'Test text',
+                                        html: '<p>Test html</p>',
+                                    },
+                                },
+                            },
+                        } as HogFlowAction['config'],
+                    },
+                    exit: { type: 'exit', config: {} },
+                },
+                edges: [
+                    { from: 'trigger', to: 'email_1', type: 'continue' },
+                    { from: 'email_1', to: 'exit', type: 'continue' },
+                ],
+            })
+            .build()
+        await insertHogFlow(hub.postgres, hogFlow)
+
+        const { backgroundTask } = await eventsConsumer.processBatch([createGlobals()])
+        await backgroundTask
+
+        await waitForExpect(() => {
+            const sumCounts = (filter: (m: any) => boolean) =>
+                mockProducerObserver
+                    .getProducedKafkaMessagesForTopic(KAFKA_APP_METRICS_2)
+                    .filter(filter)
+                    .reduce((sum: number, m: any) => sum + m.value.count, 0)
+
+            expect(sumCounts((m) => m.value.metric_name === 'email_queued')).toBe(1)
+            expect(sumCounts((m) => m.value.metric_name === 'email_sent')).toBe(1)
+            expect(sumCounts((m) => m.value.metric_name === 'succeeded' && m.value.instance_id === 'exit')).toBe(1)
+        }, 15000)
+
+        // The flow finishes on the transactional worker, so the completed job
+        // row still carries the queue it was consumed from.
+        await waitForExpect(async () => {
+            const jobs = await queryCyclotronJobs()
+            const completed = jobs.filter((j: any) => j.status === 'completed')
+            expect(completed.length).toBeGreaterThanOrEqual(1)
+            expect(completed[0].queue_name).toBe('emailtransactional')
+            // Fair dequeue applies on the transactional lane from day one.
+            expect(completed[0].dequeue_seq).not.toBeNull()
         }, 10000)
     })
 

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -38,6 +38,7 @@ export enum PluginServerMode {
     cdp_cyclotron_worker_hogflow_legacy_pg = 'cdp-cyclotron-worker-hogflow-legacy-pg',
     cdp_cyclotron_worker_email = 'cdp-cyclotron-worker-email',
     cdp_cyclotron_worker_email_legacy_pg = 'cdp-cyclotron-worker-email-legacy-pg',
+    cdp_cyclotron_worker_email_transactional = 'cdp-cyclotron-worker-email-transactional',
     cdp_api = 'cdp-api',
     cdp_legacy_on_event = 'cdp-legacy-on-event',
     evaluation_scheduler = 'evaluation-scheduler',

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -26,6 +26,7 @@ import { CdpApi } from './cdp/cdp-api'
 import { CdpConsumerBaseDeps } from './cdp/consumers/cdp-base.consumer'
 import { CdpCohortMembershipConsumer } from './cdp/consumers/cdp-cohort-membership.consumer'
 import { CdpCyclotronWorkerBatchResolve } from './cdp/consumers/cdp-cyclotron-worker-batch-resolve.consumer'
+import { CdpCyclotronWorkerEmailTransactional } from './cdp/consumers/cdp-cyclotron-worker-email-transactional.consumer'
 import { CdpCyclotronWorkerEmail } from './cdp/consumers/cdp-cyclotron-worker-email.consumer'
 import { CdpCyclotronWorkerHogFlow } from './cdp/consumers/cdp-cyclotron-worker-hogflow.consumer'
 import { CdpCyclotronWorker } from './cdp/consumers/cdp-cyclotron-worker.consumer'
@@ -338,13 +339,34 @@ export class PluginServer implements NodeServer {
 
         // Boot-time guard: an email-sending deployment must carry a signing key, otherwise every send
         // would either mint an unsigned tracking link or (now that generate() fails closed) fail. Refuse
-        // to start instead of degrading silently. Both email workers below sign tracking codes.
-        const isEmailWorker = capabilities.cdpCyclotronWorkerEmail || capabilities.cdpCyclotronWorkerEmailLegacyPg
+        // to start instead of degrading silently. All email workers below sign tracking codes.
+        const isEmailWorker =
+            capabilities.cdpCyclotronWorkerEmail ||
+            capabilities.cdpCyclotronWorkerEmailLegacyPg ||
+            capabilities.cdpCyclotronWorkerEmailTransactional
         if (isEmailWorker && !hasEmailSigningKey(this.config.ENCRYPTION_SALT_KEYS)) {
             throw new Error(
                 'Email worker requires ENCRYPTION_SALT_KEYS to sign tracking codes — refusing to start. ' +
                     'Configure ENCRYPTION_SALT_KEYS so outbound emails never mint unsigned tracking links.'
             )
+        }
+
+        // Shared by the V2 email workers below: when the SES rate-limiter Valkey is
+        // configured, gate dequeue behind a Valkey-backed token bucket. Without the
+        // env var (typical for local dev outside k8s) fall back to the plain queue
+        // and dequeue is unthrottled. Both email queues draw from the same global
+        // bucket, so combined send throughput stays within the SES account limit.
+        const createSesGatedJobQueue = () => {
+            const sesValkey = createSesRateLimiterValkeyPool(this.config)
+            return sesValkey
+                ? new CyclotronJobQueueRateLimitedPostgresV2(this.config.CONSUMER_BATCH_SIZE, this.config, {
+                      limiter: new RateLimiterService(sesValkey, { name: 'ses' }),
+                      key: '@posthog/ses/global',
+                      capacity: this.config.CDP_SES_RATE_LIMIT_CAPACITY,
+                      refillPerSecond: this.config.CDP_SES_RATE_LIMIT_REFILL_PER_SECOND,
+                      throttledPollDelayMs: this.config.CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS,
+                  })
+                : new CyclotronJobQueuePostgresV2(this.config.CONSUMER_BATCH_SIZE, this.config)
         }
 
         // Transitional drain for email jobs stranded on the legacy V1 queue — the email worker
@@ -365,25 +387,30 @@ export class PluginServer implements NodeServer {
         if (capabilities.cdpCyclotronWorkerEmail) {
             serviceLoaders.push(async () => {
                 // Dedicated queue instance — see note on cdpCyclotronWorkerHogFlow above.
-                // When the SES rate-limiter Valkey is configured, use the rate-limited
-                // variant so dequeue is gated by a Valkey-backed token bucket. Without
-                // the env var (typical for local dev outside k8s) we fall back to the
-                // plain queue and dequeue is unthrottled.
                 //
-                // Fair dequeue (per-team round-robin) is intrinsic to the email queue —
+                // Fair dequeue (per-team round-robin) is intrinsic to the email queues —
                 // the worker derives it from its queue name — and applies regardless of
                 // whether rate limiting is on.
-                const sesValkey = createSesRateLimiterValkeyPool(this.config)
-                const queue = sesValkey
-                    ? new CyclotronJobQueueRateLimitedPostgresV2(this.config.CONSUMER_BATCH_SIZE, this.config, {
-                          limiter: new RateLimiterService(sesValkey, { name: 'ses' }),
-                          key: '@posthog/ses/global',
-                          capacity: this.config.CDP_SES_RATE_LIMIT_CAPACITY,
-                          refillPerSecond: this.config.CDP_SES_RATE_LIMIT_REFILL_PER_SECOND,
-                          throttledPollDelayMs: this.config.CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS,
-                      })
-                    : new CyclotronJobQueuePostgresV2(this.config.CONSUMER_BATCH_SIZE, this.config)
-                const worker = new CdpCyclotronWorkerEmail(this.config, this.withEmailValidationValkey(cdpDeps!), queue)
+                const worker = new CdpCyclotronWorkerEmail(
+                    this.config,
+                    this.withEmailValidationValkey(cdpDeps!),
+                    createSesGatedJobQueue()
+                )
+                await worker.start()
+                return worker.service
+            })
+        }
+
+        // Consumes the 'emailtransactional' queue: transactional-category sends are
+        // isolated from bulk campaign backlogs so they keep their own latency SLA.
+        // Producers only route here when CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED is set.
+        if (capabilities.cdpCyclotronWorkerEmailTransactional) {
+            serviceLoaders.push(async () => {
+                const worker = new CdpCyclotronWorkerEmailTransactional(
+                    this.config,
+                    this.withEmailValidationValkey(cdpDeps!),
+                    createSesGatedJobQueue()
+                )
                 await worker.start()
                 return worker.service
             })

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -148,6 +148,7 @@ export interface PluginServerCapabilities {
     cdpCyclotronWorkerHogFlowLegacyPg?: boolean
     cdpCyclotronWorkerEmail?: boolean
     cdpCyclotronWorkerEmailLegacyPg?: boolean
+    cdpCyclotronWorkerEmailTransactional?: boolean
     cdpPrecalculatedFilters?: boolean
     cdpCohortMembership?: boolean
     cdpApi?: boolean

--- a/rust/cyclotron-node-migrations/20260728000001_add_emailtransactional_fair_dequeue_table.sql
+++ b/rust/cyclotron-node-migrations/20260728000001_add_emailtransactional_fair_dequeue_table.sql
@@ -1,0 +1,11 @@
+-- Fair dequeue for the emailtransactional queue.
+--
+-- Same per-team monotonic counter pattern as cyclotron_email_team_seq, but a
+-- separate table: the counter encodes each team's lifetime send position, so
+-- sharing the email table would make a team with a large marketing history
+-- permanently sort behind every other tenant in the transactional queue —
+-- exactly the teams the dedicated queue is meant to protect.
+CREATE TABLE IF NOT EXISTS cyclotron_emailtransactional_team_seq (
+    team_id INT PRIMARY KEY,
+    counter BIGINT NOT NULL
+);

--- a/rust/cyclotron-node-migrations/20260728000002_add_emailtransactional_fair_dequeue_index.sql
+++ b/rust/cyclotron-node-migrations/20260728000002_add_emailtransactional_fair_dequeue_index.sql
@@ -1,0 +1,12 @@
+-- no-transaction
+--
+-- Fair-dequeue index for the emailtransactional queue, mirroring
+-- idx_cyclotron_jobs_email_fair_dequeue_v2. See
+-- 20260622000001_add_email_fair_dequeue_composite_index.sql for why
+-- `scheduled` is a key column rather than INCLUDE'd: as a non-leading key it
+-- becomes an Index Cond evaluated during the index walk instead of a
+-- heap-level Filter, and the leading `dequeue_seq NULLS FIRST` satisfies the
+-- worker's ORDER BY without a Sort node.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cyclotron_jobs_emailtransactional_fair_dequeue
+    ON cyclotron_jobs (dequeue_seq NULLS FIRST, scheduled)
+    WHERE status = 'available' AND queue_name = 'emailtransactional';


### PR DESCRIPTION
## Problem

All workflow emails, marketing and transactional alike, land on the single cyclotron `email` queue. `routeEmailToQueue` hardcodes the queue name, and the existing fair dequeue only round-robins across teams. Within one team the two categories interleave in FIFO order, so a large marketing campaign backlog delays that same team's transactional emails. The two categories need separate backlogs and delivery SLAs.

## Changes

Transactional-category emails now route to a new `emailtransactional` cyclotron queue, consumed by a dedicated worker. Marketing and uncategorized emails keep flowing through `email` unchanged.

**Before**

```mermaid
flowchart LR
    HF{{hogflow worker}} -->|every email| E[(email queue)]
    E --> EW{{email worker}}
    EW --> SES[SES, global token bucket]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class HF,EW phBlue;
    class SES phRed;
    class E phGray;
```

**After**

```mermaid
flowchart LR
    HF{{hogflow worker}} -->|marketing + uncategorized| E[(email queue)]
    HF -->|transactional, flag on| ET[(emailtransactional queue)]
    E --> EW{{email worker}}
    ET --> ETW{{transactional email worker}}
    EW --> SES[SES, shared global token bucket]
    ETW --> SES
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class HF,EW,ETW phBlue;
    class SES phRed;
    class E,ET phGray;
```

- New queue kind `emailtransactional` (queue names must be lowercase alphanumeric, hence no hyphen) plus an `isEmailQueueKind()` helper. The three routing checks in `hog-executor.service.ts` are now email-queue-set aware. The load-bearing one is the "route to an email queue only if we're not already on one" condition, without which a job on the new queue would bounce between queues forever.
- `routeEmailToQueue` picks the queue from `hogFunction.metadata.message_category_type`, gated by a new `CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED` env flag (default false) so the worker can deploy before any producer routes to it. `cdp_email_queued_total` gains a `queue` label.
- New `CdpCyclotronWorkerEmailTransactional` consumer, `PLUGIN_SERVER_MODE=cdp-cyclotron-worker-email-transactional`, wired into capabilities, the signing-key boot guard, and local dev (`CAPABILITIES_CDP_WORKFLOWS`). It shares the global SES token bucket with the existing email worker, so combined throughput stays inside the SES account limit (queue-latency isolation, deliberately not rate isolation).
- Per-team fair dequeue applies to the new queue from day one, backed by a queue-scoped counter table (`cyclotron_emailtransactional_team_seq`, two sqlx migrations). The counter encodes a team's lifetime send position, so reusing the email table would permanently sort a heavy marketing sender's transactional emails behind every other tenant, exactly the teams this queue is meant to protect. `computeEmailDequeueSeqs` and the worker reschedule path are generalized over a `FAIR_DEQUEUE_COUNTER_TABLES` map, with the email path byte-identical in behavior.

> [!NOTE]
> Rollout: merge with the flag unset, add the new deployment in the charts repo (same env footprint as the email worker, KEDA scaler on `queue="emailtransactional"`), then set `CDP_EMAIL_TRANSACTIONAL_QUEUE_ENABLED=true` on the V2 hogflow worker only. Never set it on the legacy V1 hogflow drain, which would enqueue to a V1 queue nobody consumes. Rollback is unsetting the flag; in-flight jobs on either queue finish where they are.

## How did you test this code?

Ran locally against a full stack (Postgres with all rust-migration test DBs, Redis, Kafka, maildev):

- `cyclotron-v2.test.ts`: all 126 pass, including 4 new tests. They catch: seqs drawn from the wrong counter table in mixed batches, a team's email history leaking into its transactional counter, the reschedule path leaving `NULL dequeue_seq` on the new queue (which `NULLS FIRST` would drain out of order), and the new queue silently falling back to FIFO.
- `hog-executor.service.test.ts`: full file passes with 6 new tests. A parameterized flag/category routing matrix catches routing never activating, marketing being swept into the transactional queue, and the flag being ignored. The already-on-queue test catches the infinite bounce (verified by mutation: reverting the condition makes it fail), and the fetch test catches fetches running inline on the transactional lane.
- `workflows-e2e.test.ts` email-queue block: all 14 pass, including a new end-to-end test where a transactional email transits `emailtransactional` with a `dequeue_seq`, sends, and the flow completes. The block now runs with the flag on, so the pre-existing tests double as proof that uncategorized emails still route to `email` under the flag.
- New consumer test mirrors the existing email consumer's two tests (a typo'd queue string would mean the queue is never drained).
- `tsc --noEmit` shows no new errors vs a clean checkout, and `hogli ci:preflight --fix` passes.

Not tested by me (Claude): production deployment wiring (charts repo) and real SES sends.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Added a fair-dequeue section to `nodejs/src/cdp/services/cyclotron-v2/README.md` covering the per-queue counter tables.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session) at Meikel's direction, who confirmed the two design decisions up front: fair dequeue on the new queue from day one (queue-scoped counter table rather than deferring), and a shared global SES bucket rather than a reserved transactional bucket. Skills invoked: `/writing-tests`. Notable choices: `emailtransactional` over `email-transactional` due to the queue-name character constraint in `cdp/types.ts`, a default-off producer flag to make deploy ordering safe, and no legacy-V1 or Kafka variants since the queue only exists on the Postgres-V2 backend.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
