### PR TITLE
chore(paths): row-by-column paths v2 prototype (do not merge)

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 
 import { LemonButton } from '@posthog/lemon-ui'
 
@@ -40,6 +41,7 @@ import { FunnelTimeToConvertTable } from 'scenes/insights/views/Funnels/FunnelTi
 import { FunnelTrendsTable } from 'scenes/insights/views/Funnels/FunnelTrendsTable'
 import { InsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable'
 import { PathsV2 } from 'scenes/paths-v2/PathsV2'
+import { PathsV2RowColumnPrototype } from 'scenes/paths-v2/prototype/PathsV2RowColumnPrototype'
 import { Paths } from 'scenes/paths/Paths'
 import { PathCanvasLabel } from 'scenes/paths/PathsLabel'
 import { RetentionContainer } from 'scenes/retention/RetentionContainer'
@@ -143,6 +145,8 @@ export function InsightVizDisplay({
 }): JSX.Element | null {
     const { insightProps, canEditInsight, isUsingPathsV1, isUsingPathsV2, isInDashboardContext } =
         useValues(insightLogic)
+    // PROTOTYPE (throwaway branch): reactive gate for the row-by-column paths explorations
+    const { searchParams: prototypeSearchParams } = useValues(router)
 
     const { activeView } = useValues(insightNavLogic(insightProps))
 
@@ -380,6 +384,10 @@ export function InsightVizDisplay({
                     />
                 )
             case InsightType.PATHS:
+                // PROTOTYPE (throwaway branch): row-by-column paths v2 explorations via ?paths_v2_proto=a|b|c
+                if (process.env.NODE_ENV !== 'production' && prototypeSearchParams.paths_v2_proto) {
+                    return <PathsV2RowColumnPrototype />
+                }
                 return isUsingPathsV2 ? <PathsV2 /> : <Paths />
             case InsightType.WEB_ANALYTICS:
                 return <WebAnalyticsInsight context={context} editMode={editMode} />

--- a/frontend/src/scenes/paths-v2/prototype/PathsV2RowColumnPrototype.tsx
+++ b/frontend/src/scenes/paths-v2/prototype/PathsV2RowColumnPrototype.tsx
@@ -1,0 +1,147 @@
+/**
+ * PROTOTYPE (throwaway branch, do not merge).
+ * Row-by-column paths v2 explorations. Mounted on any paths insight via
+ * `?paths_v2_proto=a|b|c` (see InsightVizDisplay). Consumes v1 PathsQuery results
+ * client-side; the real PathsV2Query backend is a Build-route concern.
+ */
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import { useEffect, useMemo, useState } from 'react'
+
+import { LemonSelect, LemonSwitch, LemonTag, Spinner } from '@posthog/lemon-ui'
+
+import { InsightEmptyState } from 'scenes/insights/EmptyStates'
+import { insightLogic } from 'scenes/insights/insightLogic'
+
+import { pathsDataLogic } from '../pathsDataLogic'
+import { buildRowColumnModel } from './rowColumnModel'
+import { VariantDraftSankey } from './VariantDraftSankey'
+import { VariantJourneyGrid } from './VariantJourneyGrid'
+import { VariantStepBars } from './VariantStepBars'
+
+const VARIANTS = [
+    { key: 'a', name: 'Journey grid' },
+    { key: 'b', name: 'Step bars' },
+    { key: 'c', name: 'Draft sankey' },
+]
+
+function PrototypeSwitcher({ current }: { current: string }): JSX.Element | null {
+    const { push } = useActions(router)
+    const { location, searchParams, hashParams } = useValues(router)
+
+    const currentIndex = Math.max(
+        VARIANTS.findIndex((v) => v.key === current),
+        0
+    )
+    const goTo = (index: number): void => {
+        const next = VARIANTS[(index + VARIANTS.length) % VARIANTS.length]
+        push(location.pathname, { ...searchParams, paths_v2_proto: next.key }, hashParams)
+    }
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent): void => {
+            const target = event.target as HTMLElement | null
+            if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+                return
+            }
+            if (event.key === 'ArrowLeft') {
+                goTo(currentIndex - 1)
+            } else if (event.key === 'ArrowRight') {
+                goTo(currentIndex + 1)
+            }
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => window.removeEventListener('keydown', onKeyDown)
+    })
+
+    if (process.env.NODE_ENV === 'production') {
+        return null
+    }
+
+    return (
+        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-[9999] flex items-center gap-3 rounded-full bg-black text-white px-4 py-2 shadow-lg text-sm select-none">
+            <button className="cursor-pointer" onClick={() => goTo(currentIndex - 1)}>
+                ←
+            </button>
+            <span className="font-semibold">
+                {VARIANTS[currentIndex].key.toUpperCase()} — {VARIANTS[currentIndex].name}
+            </span>
+            <button className="cursor-pointer" onClick={() => goTo(currentIndex + 1)}>
+                →
+            </button>
+        </div>
+    )
+}
+
+export function PathsV2RowColumnPrototype(): JSX.Element {
+    const { searchParams } = useValues(router)
+    const { insightProps } = useValues(insightLogic)
+    const { results, pathsFilter, insightDataLoading, theme } = useValues(pathsDataLogic(insightProps))
+
+    const [maxSteps, setMaxSteps] = useState(5)
+    const [maxRows, setMaxRows] = useState(3)
+    const [showPercentages, setShowPercentages] = useState(true)
+
+    const model = useMemo(() => buildRowColumnModel(results, maxSteps, maxRows), [results, maxSteps, maxRows])
+
+    const variant = typeof searchParams.paths_v2_proto === 'string' ? searchParams.paths_v2_proto : 'a'
+    const nodeColor = theme?.['preset-1'] || '#1d4aff'
+    const anchor = pathsFilter?.startPoint || pathsFilter?.endPoint
+
+    return (
+        <div className="h-full w-full overflow-auto p-2">
+            <div className="flex items-center gap-3 flex-wrap mb-3">
+                <LemonTag type="warning">Prototype</LemonTag>
+                <LemonTag type={anchor ? 'completion' : 'default'}>
+                    {anchor
+                        ? `Anchored to ${pathsFilter?.startPoint ? 'start' : 'end'}: ${anchor}`
+                        : 'Open paths (per-hop sittings)'}
+                </LemonTag>
+                <div className="flex items-center gap-1 text-xs">
+                    <span className="text-secondary">Max steps</span>
+                    <LemonSelect
+                        size="xsmall"
+                        value={maxSteps}
+                        onChange={(value) => value && setMaxSteps(value)}
+                        options={[3, 4, 5, 6, 7, 8, 10].map((n) => ({ value: n, label: String(n) }))}
+                    />
+                </div>
+                <div className="flex items-center gap-1 text-xs">
+                    <span className="text-secondary">Max rows per step</span>
+                    <LemonSelect
+                        size="xsmall"
+                        value={maxRows}
+                        onChange={(value) => value && setMaxRows(value)}
+                        options={[1, 2, 3, 4, 5, 8, 10].map((n) => ({ value: n, label: String(n) }))}
+                    />
+                </div>
+                <LemonSwitch label="Percentages" checked={showPercentages} onChange={setShowPercentages} size="small" />
+            </div>
+
+            {insightDataLoading ? (
+                <div className="flex items-center justify-center h-60">
+                    <Spinner className="text-2xl" />
+                </div>
+            ) : model.columns.length === 0 ? (
+                <InsightEmptyState />
+            ) : (
+                <>
+                    {variant === 'b' ? (
+                        <VariantStepBars model={model} showPercentages={showPercentages} />
+                    ) : variant === 'c' ? (
+                        <VariantDraftSankey model={model} nodeColor={nodeColor} />
+                    ) : (
+                        <VariantJourneyGrid model={model} showPercentages={showPercentages} nodeColor={nodeColor} />
+                    )}
+                    <div className="text-xs text-secondary mt-2 max-w-200">
+                        Counts are unique users per node and per connection. A user can appear in several rows of the
+                        same step, so connections into a node may add up to more than its count.
+                        {model.hiddenSteps > 0 && ` ${model.hiddenSteps} more steps in the data are not shown.`}
+                    </div>
+                </>
+            )}
+
+            <PrototypeSwitcher current={variant} />
+        </div>
+    )
+}

--- a/frontend/src/scenes/paths-v2/prototype/VariantDraftSankey.tsx
+++ b/frontend/src/scenes/paths-v2/prototype/VariantDraftSankey.tsx
@@ -1,0 +1,200 @@
+/**
+ * PROTOTYPE (throwaway branch, do not merge).
+ * Variant C "Draft sankey": stays close to draft PR #29364 and v1 — value-scaled node rects,
+ * an explicit drop-off node appended to each column, red drop-off ribbons like v1. Counts
+ * only, "other" not expandable. The baseline to react against.
+ */
+import { useMemo } from 'react'
+
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { RowColumnModel, RowNode, formatPercentage, middleEllipsis, ribbonPath, shortPathName } from './rowColumnModel'
+
+const NODE_W = 44
+const PITCH = 264
+const LABEL_H = 34
+const COLUMN_H = 460
+const TOP_PAD = 8
+
+const DROPOFF_COLOR = 'rgba(220, 53, 69, 0.55)'
+
+interface SankeyRect {
+    node: RowNode | null // null = synthetic drop-off node
+    key: string
+    label: string
+    count: number
+    x: number
+    y: number
+    height: number
+    isDropoff: boolean
+}
+
+interface SankeyRibbon {
+    key: string
+    path: string
+    isDropoff: boolean
+    title: string
+}
+
+export function VariantDraftSankey({ model, nodeColor }: { model: RowColumnModel; nodeColor: string }): JSX.Element {
+    const { rects, ribbons, chartWidth, chartHeight } = useMemo(() => {
+        const rects = new Map<string, SankeyRect>()
+
+        // drop-off node in column c collects journeys that ended at column c-1 (draft behavior)
+        const dropoffInto: number[] = model.columns.map((_, columnIndex) =>
+            columnIndex === 0 ? 0 : model.columns[columnIndex - 1].reduce((sum, node) => sum + node.dropoff, 0)
+        )
+
+        const scale = (count: number): number =>
+            Math.max(4, (count / Math.max(model.maxStepTotal, 1)) * (COLUMN_H - 5 * LABEL_H))
+
+        model.columns.forEach((column, columnIndex) => {
+            let y = TOP_PAD + LABEL_H
+            for (const node of column) {
+                const height = scale(node.count)
+                rects.set(node.key, {
+                    node,
+                    key: node.key,
+                    label: node.isOther ? `${node.name} (${node.members.length})` : shortPathName(node.name),
+                    count: node.count,
+                    x: columnIndex * PITCH,
+                    y,
+                    height,
+                    isDropoff: false,
+                })
+                y += height + LABEL_H
+            }
+            if (dropoffInto[columnIndex] > 0) {
+                const key = `${columnIndex}:$$dropoff$$`
+                rects.set(key, {
+                    node: null,
+                    key,
+                    label: 'Drop-off',
+                    count: dropoffInto[columnIndex],
+                    x: columnIndex * PITCH,
+                    y,
+                    height: scale(dropoffInto[columnIndex]),
+                    isDropoff: true,
+                })
+            }
+        })
+
+        // sankey-style ports: outgoing ribbons parcel the node height by value share
+        const outCursor = new Map<string, number>()
+        const inCursor = new Map<string, number>()
+        const takePort = (cursor: Map<string, number>, rect: SankeyRect, share: number): { y: number; t: number } => {
+            const offset = cursor.get(rect.key) ?? 0
+            const thickness = Math.max(1.5, rect.height * share)
+            cursor.set(rect.key, offset + thickness)
+            return { y: rect.y + offset, t: thickness }
+        }
+
+        const ribbons: SankeyRibbon[] = []
+        const sortedEdges = [...model.edges].sort(
+            (a, b) =>
+                (rects.get(a.from)?.y ?? 0) - (rects.get(b.from)?.y ?? 0) ||
+                (rects.get(a.to)?.y ?? 0) - (rects.get(b.to)?.y ?? 0)
+        )
+        for (const edge of sortedEdges) {
+            const from = rects.get(edge.from)
+            const to = rects.get(edge.to)
+            if (!from || !to) {
+                continue
+            }
+            const fromPort = takePort(outCursor, from, edge.value / Math.max(from.count, 1))
+            const toPort = takePort(inCursor, to, edge.value / Math.max(to.count, 1))
+            ribbons.push({
+                key: `${edge.from}→${edge.to}`,
+                path: ribbonPath(from.x + NODE_W, fromPort.y, fromPort.t, to.x, toPort.y, toPort.t),
+                isDropoff: false,
+                title: `${from.label} → ${to.label}: ${edge.value} users`,
+            })
+        }
+
+        // red drop-off ribbons: from each node's remaining height into the next column's drop-off node
+        model.columns.forEach((column, columnIndex) => {
+            const dropoffRect = rects.get(`${columnIndex + 1}:$$dropoff$$`)
+            if (!dropoffRect) {
+                return
+            }
+            for (const node of column) {
+                if (node.dropoff <= 0) {
+                    continue
+                }
+                const from = rects.get(node.key)
+                if (!from) {
+                    continue
+                }
+                const fromPort = takePort(outCursor, from, node.dropoff / Math.max(node.count, 1))
+                const toPort = takePort(inCursor, dropoffRect, node.dropoff / Math.max(dropoffRect.count, 1))
+                ribbons.push({
+                    key: `dropoff-${node.key}`,
+                    path: ribbonPath(from.x + NODE_W, fromPort.y, fromPort.t, dropoffRect.x, toPort.y, toPort.t),
+                    isDropoff: true,
+                    title: `${from.label} → drop-off: ${node.dropoff} users (${formatPercentage(
+                        node.dropoff,
+                        node.count
+                    )} of node)`,
+                })
+            }
+        })
+
+        return {
+            rects,
+            ribbons,
+            chartWidth: model.columns.length * PITCH - PITCH + NODE_W + 220,
+            chartHeight: COLUMN_H + TOP_PAD + LABEL_H,
+        }
+    }, [model])
+
+    return (
+        <div className="relative overflow-auto pb-2">
+            {/* eslint-disable-next-line react/forbid-dom-props */}
+            <div className="relative" style={{ width: chartWidth, height: chartHeight }}>
+                <svg width={chartWidth} height={chartHeight} className="absolute inset-0 pointer-events-none">
+                    {ribbons.map((ribbon) => (
+                        <path
+                            key={ribbon.key}
+                            d={ribbon.path}
+                            fill={ribbon.isDropoff ? DROPOFF_COLOR : nodeColor}
+                            opacity={ribbon.isDropoff ? 0.5 : 0.15}
+                            className="pointer-events-auto hover:opacity-60 transition-opacity"
+                        >
+                            <title>{ribbon.title}</title>
+                        </path>
+                    ))}
+                </svg>
+                {Array.from(rects.values()).map((rect) => (
+                    <div key={rect.key}>
+                        <div
+                            className="absolute text-xs leading-tight"
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{ left: rect.x, top: rect.y - LABEL_H + 4, width: 220 }}
+                        >
+                            <Tooltip title={rect.node?.name ?? rect.label}>
+                                <div className="truncate font-medium">{middleEllipsis(rect.label, 30)}</div>
+                            </Tooltip>
+                            <div className="text-secondary">{rect.count}</div>
+                        </div>
+                        <div
+                            className="absolute rounded-sm"
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{
+                                left: rect.x,
+                                top: rect.y,
+                                width: NODE_W,
+                                height: rect.height,
+                                backgroundColor: rect.isDropoff
+                                    ? 'var(--text-secondary)'
+                                    : rect.node?.isOther
+                                      ? 'var(--text-secondary)'
+                                      : nodeColor,
+                                opacity: rect.isDropoff ? 0.4 : rect.node?.isOther ? 0.6 : 1,
+                            }}
+                        />
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/paths-v2/prototype/VariantDraftSankey.tsx
+++ b/frontend/src/scenes/paths-v2/prototype/VariantDraftSankey.tsx
@@ -185,11 +185,11 @@ export function VariantDraftSankey({ model, nodeColor }: { model: RowColumnModel
                                 width: NODE_W,
                                 height: rect.height,
                                 backgroundColor: rect.isDropoff
-                                    ? 'var(--text-secondary)'
+                                    ? '#6b7280'
                                     : rect.node?.isOther
-                                      ? 'var(--text-secondary)'
+                                      ? '#9ca3af'
                                       : nodeColor,
-                                opacity: rect.isDropoff ? 0.4 : rect.node?.isOther ? 0.6 : 1,
+                                opacity: rect.isDropoff ? 0.5 : rect.node?.isOther ? 0.7 : 1,
                             }}
                         />
                     </div>

--- a/frontend/src/scenes/paths-v2/prototype/VariantJourneyGrid.tsx
+++ b/frontend/src/scenes/paths-v2/prototype/VariantJourneyGrid.tsx
@@ -1,0 +1,245 @@
+/**
+ * PROTOTYPE (throwaway branch, do not merge).
+ * Variant A "Journey grid": fixed-height node cards in step columns, curved ribbons between
+ * them, drop-offs as quiet fade-out stubs (no red), expandable "other" card per column.
+ */
+import { useMemo, useState } from 'react'
+
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { humanFriendlyDuration } from 'lib/utils/durations'
+
+import {
+    RowColumnModel,
+    RowEdge,
+    RowNode,
+    formatPercentage,
+    middleEllipsis,
+    ribbonPath,
+    shortPathName,
+} from './rowColumnModel'
+
+const CARD_W = 224
+const GAP_W = 104
+const CARD_H = 64
+const ROW_GAP = 16
+const HEADER_H = 28
+const MEMBER_ROW_H = 22
+const MAX_MEMBERS_SHOWN = 8
+const MAX_RIBBON_T = 40
+const STUB_W = 48
+
+interface CardGeometry {
+    node: RowNode
+    x: number
+    y: number
+    height: number
+}
+
+interface PortedEdge {
+    edge: RowEdge
+    thickness: number
+    fromX: number
+    fromY: number
+    toX: number
+    toY: number
+}
+
+export function VariantJourneyGrid({
+    model,
+    showPercentages,
+    nodeColor,
+}: {
+    model: RowColumnModel
+    showPercentages: boolean
+    nodeColor: string
+}): JSX.Element {
+    const [expandedColumns, setExpandedColumns] = useState<Record<number, boolean>>({})
+
+    const { cards, ports, stubs, chartWidth, chartHeight } = useMemo(() => {
+        const cards = new Map<string, CardGeometry>()
+        model.columns.forEach((column, columnIndex) => {
+            let y = HEADER_H
+            for (const node of column) {
+                const expanded = node.isOther && expandedColumns[columnIndex]
+                const height = expanded
+                    ? CARD_H + Math.min(node.members.length, MAX_MEMBERS_SHOWN) * MEMBER_ROW_H + 8
+                    : CARD_H
+                cards.set(node.key, { node, x: columnIndex * (CARD_W + GAP_W), y, height })
+                y += height + ROW_GAP
+            }
+        })
+
+        const thicknessFor = (value: number): number =>
+            Math.max(2, (value / Math.max(model.maxEdgeValue, 1)) * MAX_RIBBON_T)
+
+        // stack ports per card side, ordered by the connected card's vertical position
+        const outCursor = new Map<string, number>()
+        const inCursor = new Map<string, number>()
+        const sortedEdges = [...model.edges].sort(
+            (a, b) =>
+                (cards.get(a.from)?.y ?? 0) - (cards.get(b.from)?.y ?? 0) ||
+                (cards.get(a.to)?.y ?? 0) - (cards.get(b.to)?.y ?? 0)
+        )
+        const ports: PortedEdge[] = []
+        for (const edge of sortedEdges) {
+            const from = cards.get(edge.from)
+            const to = cards.get(edge.to)
+            if (!from || !to) {
+                continue
+            }
+            const thickness = thicknessFor(edge.value)
+            const fromY = from.y + 8 + (outCursor.get(edge.from) ?? 0)
+            const toY = to.y + 8 + (inCursor.get(edge.to) ?? 0)
+            outCursor.set(edge.from, (outCursor.get(edge.from) ?? 0) + thickness + 2)
+            inCursor.set(edge.to, (inCursor.get(edge.to) ?? 0) + thickness + 2)
+            ports.push({ edge, thickness, fromX: from.x + CARD_W, fromY, toX: to.x, toY })
+        }
+
+        // drop-off stubs continue after the outgoing ports; hidden on the last visible column
+        const lastColumn = model.columns.length - 1
+        const stubs = Array.from(cards.values())
+            .filter(({ node }) => node.dropoff > 0 && node.step < lastColumn)
+            .map(({ node, x, y }) => ({
+                node,
+                thickness: thicknessFor(node.dropoff),
+                x: x + CARD_W,
+                y: y + 8 + (outCursor.get(node.key) ?? 0),
+            }))
+
+        const chartWidth = model.columns.length * (CARD_W + GAP_W) - GAP_W + STUB_W
+        const chartHeight = Math.max(...Array.from(cards.values()).map((c) => c.y + c.height), 0) + 24
+        return { cards, ports, stubs, chartWidth, chartHeight }
+    }, [model, expandedColumns])
+
+    return (
+        <div className="relative overflow-auto pb-2">
+            {/* eslint-disable-next-line react/forbid-dom-props */}
+            <div className="relative" style={{ width: chartWidth, height: chartHeight }}>
+                <svg width={chartWidth} height={chartHeight} className="absolute inset-0 pointer-events-none">
+                    <defs>
+                        <linearGradient id="proto-dropoff-fade" x1="0" y1="0" x2="1" y2="0">
+                            <stop offset="0%" stopColor="var(--text-secondary)" stopOpacity="0.35" />
+                            <stop offset="100%" stopColor="var(--text-secondary)" stopOpacity="0" />
+                        </linearGradient>
+                    </defs>
+                    {ports.map(({ edge, thickness, fromX, fromY, toX, toY }) => {
+                        const fromNode = cards.get(edge.from)?.node
+                        return (
+                            <path
+                                key={`${edge.from}→${edge.to}`}
+                                d={ribbonPath(fromX, fromY, thickness, toX, toY, thickness)}
+                                fill={nodeColor}
+                                opacity={0.14}
+                                className="pointer-events-auto hover:opacity-40 transition-opacity"
+                            >
+                                <title>
+                                    {`${shortPathName(cards.get(edge.from)?.node.name ?? '')} → ${shortPathName(
+                                        cards.get(edge.to)?.node.name ?? ''
+                                    )}: ${edge.value} users${
+                                        fromNode ? ` (${formatPercentage(edge.value, fromNode.count)} of node)` : ''
+                                    }${edge.avgTime != null ? `, avg ${humanFriendlyDuration(edge.avgTime)}` : ''}`}
+                                </title>
+                            </path>
+                        )
+                    })}
+                    {stubs.map(({ node, thickness, x, y }) => (
+                        <path
+                            key={`stub-${node.key}`}
+                            d={`M ${x},${y} L ${x + STUB_W},${y + thickness * 0.25} L ${x + STUB_W},${
+                                y + thickness * 0.75
+                            } L ${x},${y + thickness} Z`}
+                            fill="url(#proto-dropoff-fade)"
+                            className="pointer-events-auto"
+                        >
+                            <title>{`${node.dropoff} users end their journey here (${formatPercentage(
+                                node.dropoff,
+                                node.count
+                            )} of node)`}</title>
+                        </path>
+                    ))}
+                </svg>
+
+                {model.columns.map((_, columnIndex) => (
+                    <div
+                        key={`header-${columnIndex}`}
+                        className="absolute text-xs font-semibold text-secondary"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={{ left: columnIndex * (CARD_W + GAP_W), top: 0, width: CARD_W }}
+                    >
+                        Step {columnIndex + 1}
+                    </div>
+                ))}
+
+                {Array.from(cards.values()).map(({ node, x, y, height }) => {
+                    const displayName = node.isOther ? node.name : shortPathName(node.name)
+                    const expanded = node.isOther && expandedColumns[node.step]
+                    return (
+                        <div
+                            key={node.key}
+                            className={`absolute rounded border bg-surface-primary px-2 py-1.5 ${
+                                node.isOther ? 'border-dashed cursor-pointer hover:border-primary' : ''
+                            }`}
+                            // eslint-disable-next-line react/forbid-dom-props
+                            style={{ left: x, top: y, width: CARD_W, height }}
+                            onClick={
+                                node.isOther
+                                    ? () => setExpandedColumns((prev) => ({ ...prev, [node.step]: !prev[node.step] }))
+                                    : undefined
+                            }
+                        >
+                            <Tooltip title={node.isOther ? `${node.members.length} more path items` : node.name}>
+                                <div className="text-xs font-semibold truncate">
+                                    {node.isOther
+                                        ? `${displayName} (${node.members.length} path items)${expanded ? '' : ' ▸'}`
+                                        : middleEllipsis(displayName, 32)}
+                                </div>
+                            </Tooltip>
+                            <div className="flex items-baseline gap-1.5 mt-0.5">
+                                <span className="text-sm font-semibold">{node.count}</span>
+                                {showPercentages && (
+                                    <span className="text-xs text-secondary">
+                                        {formatPercentage(node.count, model.startTotal)} of start
+                                    </span>
+                                )}
+                            </div>
+                            <div className="h-1 rounded-full bg-fill-secondary mt-1">
+                                <div
+                                    className="h-1 rounded-full"
+                                    // eslint-disable-next-line react/forbid-dom-props
+                                    style={{
+                                        width: `${Math.max(
+                                            3,
+                                            (node.count / Math.max(model.stepTotals[node.step], 1)) * 100
+                                        )}%`,
+                                        backgroundColor: node.isOther ? 'var(--text-secondary)' : nodeColor,
+                                    }}
+                                />
+                            </div>
+                            {expanded && (
+                                <div className="mt-1.5 border-t pt-1">
+                                    {node.members.slice(0, MAX_MEMBERS_SHOWN).map((member) => (
+                                        <div
+                                            key={member.name}
+                                            className="flex justify-between text-xs text-secondary leading-[22px]"
+                                        >
+                                            <span className="truncate pr-2">
+                                                {middleEllipsis(shortPathName(member.name), 26)}
+                                            </span>
+                                            <span>{member.count}</span>
+                                        </div>
+                                    ))}
+                                    {node.members.length > MAX_MEMBERS_SHOWN && (
+                                        <div className="text-xs text-secondary leading-[22px]">
+                                            and {node.members.length - MAX_MEMBERS_SHOWN} more
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/paths-v2/prototype/VariantJourneyGrid.tsx
+++ b/frontend/src/scenes/paths-v2/prototype/VariantJourneyGrid.tsx
@@ -119,8 +119,8 @@ export function VariantJourneyGrid({
                 <svg width={chartWidth} height={chartHeight} className="absolute inset-0 pointer-events-none">
                     <defs>
                         <linearGradient id="proto-dropoff-fade" x1="0" y1="0" x2="1" y2="0">
-                            <stop offset="0%" stopColor="var(--text-secondary)" stopOpacity="0.35" />
-                            <stop offset="100%" stopColor="var(--text-secondary)" stopOpacity="0" />
+                            <stop offset="0%" stopColor="#6b7280" stopOpacity="0.4" />
+                            <stop offset="100%" stopColor="#6b7280" stopOpacity="0" />
                         </linearGradient>
                     </defs>
                     {ports.map(({ edge, thickness, fromX, fromY, toX, toY }) => {
@@ -188,10 +188,18 @@ export function VariantJourneyGrid({
                                     : undefined
                             }
                         >
-                            <Tooltip title={node.isOther ? `${node.members.length} more path items` : node.name}>
+                            <Tooltip
+                                title={
+                                    node.isOther
+                                        ? `${node.members.length} more path item${node.members.length === 1 ? '' : 's'}`
+                                        : node.name
+                                }
+                            >
                                 <div className="text-xs font-semibold truncate">
                                     {node.isOther
-                                        ? `${displayName} (${node.members.length} path items)${expanded ? '' : ' ▸'}`
+                                        ? `${displayName} (${node.members.length} path item${
+                                              node.members.length === 1 ? '' : 's'
+                                          })${expanded ? '' : ' ▸'}`
                                         : middleEllipsis(displayName, 32)}
                                 </div>
                             </Tooltip>
@@ -212,7 +220,7 @@ export function VariantJourneyGrid({
                                             3,
                                             (node.count / Math.max(model.stepTotals[node.step], 1)) * 100
                                         )}%`,
-                                        backgroundColor: node.isOther ? 'var(--text-secondary)' : nodeColor,
+                                        backgroundColor: node.isOther ? '#9ca3af' : nodeColor,
                                     }}
                                 />
                             </div>

--- a/frontend/src/scenes/paths-v2/prototype/VariantStepBars.tsx
+++ b/frontend/src/scenes/paths-v2/prototype/VariantStepBars.tsx
@@ -9,8 +9,6 @@ import { useMemo, useState } from 'react'
 
 import { Tooltip } from '@posthog/lemon-ui'
 
-import { getSeriesColor } from 'lib/colors'
-
 import { RowColumnModel, RowNode, formatPercentage, middleEllipsis, shortPathName } from './rowColumnModel'
 
 const BAR_H = 420
@@ -19,15 +17,32 @@ const LABEL_W = 168
 const PITCH = BAR_W + LABEL_W + 48
 const TOP_PAD = 40
 
+// concrete hexes: CSS vars don't reliably resolve as inline SVG/background colors here
+const PALETTE = [
+    '#1d4aff',
+    '#621da6',
+    '#42827e',
+    '#ce0e74',
+    '#f14f58',
+    '#7c440e',
+    '#529a1a',
+    '#0476fb',
+    '#fe729d',
+    '#35416b',
+    '#41cbc4',
+    '#b64b02',
+]
+const OTHER_COLOR = '#9ca3af'
+
 function colorForName(name: string, isOther: boolean): string {
     if (isOther) {
-        return 'var(--text-secondary)'
+        return OTHER_COLOR
     }
     let hash = 5381
     for (let i = 0; i < name.length; i++) {
         hash = (hash * 33) ^ name.charCodeAt(i)
     }
-    return getSeriesColor(Math.abs(hash) % 15)
+    return PALETTE[Math.abs(hash) % PALETTE.length]
 }
 
 interface SegmentGeometry {
@@ -35,6 +50,7 @@ interface SegmentGeometry {
     x: number
     y: number
     height: number
+    labelY: number
 }
 
 export function VariantStepBars({
@@ -52,9 +68,13 @@ export function VariantStepBars({
             const stepTotal = Math.max(model.stepTotals[columnIndex], 1)
             const barHeight = (model.stepTotals[columnIndex] / Math.max(model.maxStepTotal, 1)) * BAR_H
             let y = TOP_PAD
+            let labelBottom = TOP_PAD - 34
             for (const node of column) {
                 const height = Math.max(3, (node.count / stepTotal) * barHeight)
-                segments.set(node.key, { node, x: columnIndex * PITCH, y, height })
+                // stack labels with a minimum pitch so thin segments don't collide
+                const labelY = Math.max(y + height / 2 - 15, labelBottom + 2)
+                labelBottom = labelY + 30
+                segments.set(node.key, { node, x: columnIndex * PITCH, y, height, labelY })
                 y += height + 2
             }
         })
@@ -140,7 +160,7 @@ export function VariantStepBars({
                                 key={`${edge.from}→${edge.to}`}
                                 d={`M ${x0},${y0} C ${xm},${y0} ${xm},${y1} ${x1},${y1}`}
                                 fill="none"
-                                stroke="var(--text-primary)"
+                                stroke="#374151"
                                 strokeWidth={Math.max(1.5, (edge.value / Math.max(model.maxEdgeValue, 1)) * 8)}
                                 opacity={0.6}
                             />
@@ -149,7 +169,7 @@ export function VariantStepBars({
                 </svg>
 
                 {/* bars */}
-                {Array.from(segments.values()).map(({ node, x, y, height }) => {
+                {Array.from(segments.values()).map(({ node, x, y, height, labelY }) => {
                     const displayName = node.isOther
                         ? `${node.name} (${node.members.length})`
                         : shortPathName(node.name)
@@ -200,13 +220,13 @@ export function VariantStepBars({
                                     onMouseLeave={() => setHoveredKey(null)}
                                 />
                             </Tooltip>
-                            {height >= 14 && (
+                            {height >= 6 && (
                                 <div
                                     className={`absolute text-xs leading-tight transition-opacity ${
                                         dimmed ? 'opacity-25' : ''
                                     }`}
                                     // eslint-disable-next-line react/forbid-dom-props
-                                    style={{ left: x + BAR_W + 8, top: y + height / 2 - 8, width: LABEL_W }}
+                                    style={{ left: x + BAR_W + 8, top: labelY, width: LABEL_W }}
                                 >
                                     <div className="truncate font-medium">{middleEllipsis(displayName, 24)}</div>
                                     <div className="text-secondary">

--- a/frontend/src/scenes/paths-v2/prototype/VariantStepBars.tsx
+++ b/frontend/src/scenes/paths-v2/prototype/VariantStepBars.tsx
@@ -1,0 +1,225 @@
+/**
+ * PROTOTYPE (throwaway branch, do not merge).
+ * Variant B "Step bars": each step is a funnel-style stacked bar, rows are segments with the
+ * same color for the same path item across steps. No permanent ribbons: hovering a segment
+ * draws its connections to the neighboring steps. Drop-off is the shrinking bar, annotated
+ * in the gap between steps.
+ */
+import { useMemo, useState } from 'react'
+
+import { Tooltip } from '@posthog/lemon-ui'
+
+import { getSeriesColor } from 'lib/colors'
+
+import { RowColumnModel, RowNode, formatPercentage, middleEllipsis, shortPathName } from './rowColumnModel'
+
+const BAR_H = 420
+const BAR_W = 64
+const LABEL_W = 168
+const PITCH = BAR_W + LABEL_W + 48
+const TOP_PAD = 40
+
+function colorForName(name: string, isOther: boolean): string {
+    if (isOther) {
+        return 'var(--text-secondary)'
+    }
+    let hash = 5381
+    for (let i = 0; i < name.length; i++) {
+        hash = (hash * 33) ^ name.charCodeAt(i)
+    }
+    return getSeriesColor(Math.abs(hash) % 15)
+}
+
+interface SegmentGeometry {
+    node: RowNode
+    x: number
+    y: number
+    height: number
+}
+
+export function VariantStepBars({
+    model,
+    showPercentages,
+}: {
+    model: RowColumnModel
+    showPercentages: boolean
+}): JSX.Element {
+    const [hoveredKey, setHoveredKey] = useState<string | null>(null)
+
+    const { segments, chartWidth, chartHeight } = useMemo(() => {
+        const segments = new Map<string, SegmentGeometry>()
+        model.columns.forEach((column, columnIndex) => {
+            const stepTotal = Math.max(model.stepTotals[columnIndex], 1)
+            const barHeight = (model.stepTotals[columnIndex] / Math.max(model.maxStepTotal, 1)) * BAR_H
+            let y = TOP_PAD
+            for (const node of column) {
+                const height = Math.max(3, (node.count / stepTotal) * barHeight)
+                segments.set(node.key, { node, x: columnIndex * PITCH, y, height })
+                y += height + 2
+            }
+        })
+        return {
+            segments,
+            chartWidth: model.columns.length * PITCH - LABEL_W / 2,
+            chartHeight: TOP_PAD + BAR_H + 32,
+        }
+    }, [model])
+
+    const hoverEdges = useMemo(() => {
+        if (!hoveredKey) {
+            return []
+        }
+        return model.edges.filter((edge) => edge.from === hoveredKey || edge.to === hoveredKey)
+    }, [model, hoveredKey])
+
+    const connectedKeys = useMemo(() => {
+        const keys = new Set<string>()
+        if (hoveredKey) {
+            keys.add(hoveredKey)
+            for (const edge of hoverEdges) {
+                keys.add(edge.from)
+                keys.add(edge.to)
+            }
+        }
+        return keys
+    }, [hoveredKey, hoverEdges])
+
+    return (
+        <div className="relative overflow-auto pb-2">
+            {/* eslint-disable-next-line react/forbid-dom-props */}
+            <div className="relative" style={{ width: chartWidth, height: chartHeight }}>
+                {/* step headers and drop-off annotations */}
+                {model.columns.map((_, columnIndex) => {
+                    const dropped =
+                        columnIndex > 0 ? model.stepTotals[columnIndex - 1] - model.stepTotals[columnIndex] : 0
+                    return (
+                        <div key={`header-${columnIndex}`}>
+                            <div
+                                className="absolute text-xs font-semibold text-secondary"
+                                // eslint-disable-next-line react/forbid-dom-props
+                                style={{ left: columnIndex * PITCH, top: 0, width: BAR_W + LABEL_W }}
+                            >
+                                Step {columnIndex + 1} · {model.stepTotals[columnIndex]}
+                                {showPercentages && columnIndex > 0 && (
+                                    <span className="font-normal">
+                                        {' '}
+                                        ({formatPercentage(model.stepTotals[columnIndex], model.startTotal)} of start)
+                                    </span>
+                                )}
+                            </div>
+                            {dropped > 0 && (
+                                <div
+                                    className="absolute text-xs text-secondary"
+                                    // eslint-disable-next-line react/forbid-dom-props
+                                    style={{ left: (columnIndex - 1) * PITCH + BAR_W + 8, top: 18, width: LABEL_W }}
+                                >
+                                    −{dropped} drop off
+                                    {showPercentages &&
+                                        ` (${formatPercentage(dropped, model.stepTotals[columnIndex - 1])})`}
+                                </div>
+                            )}
+                        </div>
+                    )
+                })}
+
+                {/* hover connections */}
+                <svg width={chartWidth} height={chartHeight} className="absolute inset-0 pointer-events-none">
+                    {hoverEdges.map((edge) => {
+                        const from = segments.get(edge.from)
+                        const to = segments.get(edge.to)
+                        if (!from || !to) {
+                            return null
+                        }
+                        const x0 = from.x + BAR_W
+                        const y0 = from.y + from.height / 2
+                        const x1 = to.x
+                        const y1 = to.y + to.height / 2
+                        const xm = (x0 + x1) / 2
+                        return (
+                            <path
+                                key={`${edge.from}→${edge.to}`}
+                                d={`M ${x0},${y0} C ${xm},${y0} ${xm},${y1} ${x1},${y1}`}
+                                fill="none"
+                                stroke="var(--text-primary)"
+                                strokeWidth={Math.max(1.5, (edge.value / Math.max(model.maxEdgeValue, 1)) * 8)}
+                                opacity={0.6}
+                            />
+                        )
+                    })}
+                </svg>
+
+                {/* bars */}
+                {Array.from(segments.values()).map(({ node, x, y, height }) => {
+                    const displayName = node.isOther
+                        ? `${node.name} (${node.members.length})`
+                        : shortPathName(node.name)
+                    const outgoing = model.edges
+                        .filter((edge) => edge.from === node.key)
+                        .sort((a, b) => b.value - a.value)
+                    const dimmed = hoveredKey !== null && !connectedKeys.has(node.key)
+                    return (
+                        <div key={node.key}>
+                            <Tooltip
+                                title={
+                                    <div className="deprecated-space-y-1">
+                                        <div className="font-semibold">{node.isOther ? displayName : node.name}</div>
+                                        <div>
+                                            {node.count} users ({formatPercentage(node.count, model.startTotal)} of
+                                            start)
+                                        </div>
+                                        {outgoing.slice(0, 5).map((edge) => (
+                                            <div key={edge.to}>
+                                                →{' '}
+                                                {middleEllipsis(
+                                                    shortPathName(segments.get(edge.to)?.node.name ?? ''),
+                                                    24
+                                                )}
+                                                : {edge.value} ({formatPercentage(edge.value, node.count)})
+                                            </div>
+                                        ))}
+                                        {node.dropoff > 0 && node.step < model.columns.length - 1 && (
+                                            <div>
+                                                ⏹ {node.dropoff} end here ({formatPercentage(node.dropoff, node.count)})
+                                            </div>
+                                        )}
+                                    </div>
+                                }
+                            >
+                                <div
+                                    className="absolute rounded-sm cursor-pointer transition-opacity"
+                                    // eslint-disable-next-line react/forbid-dom-props
+                                    style={{
+                                        left: x,
+                                        top: y,
+                                        width: BAR_W,
+                                        height,
+                                        backgroundColor: colorForName(node.name, node.isOther),
+                                        opacity: dimmed ? 0.25 : node.isOther ? 0.5 : 0.85,
+                                    }}
+                                    onMouseEnter={() => setHoveredKey(node.key)}
+                                    onMouseLeave={() => setHoveredKey(null)}
+                                />
+                            </Tooltip>
+                            {height >= 14 && (
+                                <div
+                                    className={`absolute text-xs leading-tight transition-opacity ${
+                                        dimmed ? 'opacity-25' : ''
+                                    }`}
+                                    // eslint-disable-next-line react/forbid-dom-props
+                                    style={{ left: x + BAR_W + 8, top: y + height / 2 - 8, width: LABEL_W }}
+                                >
+                                    <div className="truncate font-medium">{middleEllipsis(displayName, 24)}</div>
+                                    <div className="text-secondary">
+                                        {node.count}
+                                        {showPercentages &&
+                                            ` · ${formatPercentage(node.count, model.stepTotals[node.step])}`}
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/scenes/paths-v2/prototype/rowColumnModel.ts
+++ b/frontend/src/scenes/paths-v2/prototype/rowColumnModel.ts
@@ -1,0 +1,233 @@
+/**
+ * PROTOTYPE (throwaway branch, do not merge).
+ * Client-side transform of v1 PathsQuery links into the draft's row-by-column model
+ * (PR #29364 semantics: per-step top-N rows, "other" bucket, drop-offs) so the layout
+ * can be judged on real data without reviving the PathsV2Query backend.
+ *
+ * Counting caveat: v1 links are event-flow weights, not the v2 per-element unique-actor
+ * contract. Node counts are approximated as max(in, out); step-1 drop-offs are invisible
+ * in v1 data. Good enough to react to layout, not to numbers.
+ */
+import { PathsLink } from '~/queries/schema/schema-general'
+
+export interface RowNodeMember {
+    name: string
+    count: number
+}
+
+export interface RowNode {
+    key: string
+    step: number
+    name: string
+    count: number
+    /** users who reached this node but produced no outgoing edge (approximation, see header) */
+    dropoff: number
+    isOther: boolean
+    members: RowNodeMember[]
+}
+
+export interface RowEdge {
+    from: string
+    to: string
+    value: number
+    /** seconds, weighted average across aggregated raw edges; null when unknown */
+    avgTime: number | null
+}
+
+export interface RowColumnModel {
+    columns: RowNode[][]
+    edges: RowEdge[]
+    stepTotals: number[]
+    startTotal: number
+    maxStepTotal: number
+    maxEdgeValue: number
+    /** steps present in the data but sliced off by maxSteps */
+    hiddenSteps: number
+}
+
+const TRUNCATION_MARKER = '...'
+
+interface RawNode {
+    step: number
+    name: string
+    inValue: number
+    outValue: number
+}
+
+function parsePathName(prefixed: string): { step: number; name: string } | null {
+    const match = /^(\d+)_([\s\S]*)$/.exec(prefixed)
+    if (!match) {
+        return null
+    }
+    return { step: parseInt(match[1], 10) - 1, name: match[2] }
+}
+
+/** Strip protocol and host for URLs so column labels lead with the path. */
+export function shortPathName(name: string): string {
+    try {
+        const url = new URL(name)
+        let short = url.pathname + url.search
+        if (url.hash?.includes('/')) {
+            short += url.hash
+        }
+        return short || name
+    } catch {
+        return name
+    }
+}
+
+export function middleEllipsis(name: string, max: number): string {
+    if (name.length <= max) {
+        return name
+    }
+    const head = Math.ceil((max - 1) * 0.6)
+    const tail = max - 1 - head
+    return `${name.slice(0, head)}…${name.slice(name.length - tail)}`
+}
+
+export function buildRowColumnModel(links: PathsLink[], maxSteps: number, maxRows: number): RowColumnModel {
+    const nodeMap = new Map<string, RawNode>()
+    const rawEdges: { fromStep: number; fromName: string; toName: string; value: number; avgTime: number }[] = []
+
+    for (const link of links) {
+        const source = parsePathName(link.source)
+        const target = parsePathName(link.target)
+        if (!source || !target || target.step !== source.step + 1) {
+            continue
+        }
+        const sourceKey = `${source.step}:${source.name}`
+        const targetKey = `${target.step}:${target.name}`
+        const sourceNode = nodeMap.get(sourceKey) ?? { step: source.step, name: source.name, inValue: 0, outValue: 0 }
+        sourceNode.outValue += link.value
+        nodeMap.set(sourceKey, sourceNode)
+        const targetNode = nodeMap.get(targetKey) ?? { step: target.step, name: target.name, inValue: 0, outValue: 0 }
+        targetNode.inValue += link.value
+        nodeMap.set(targetKey, targetNode)
+        rawEdges.push({
+            fromStep: source.step,
+            fromName: source.name,
+            toName: target.name,
+            value: link.value,
+            avgTime: link.average_conversion_time,
+        })
+    }
+
+    if (nodeMap.size === 0) {
+        return {
+            columns: [],
+            edges: [],
+            stepTotals: [],
+            startTotal: 0,
+            maxStepTotal: 0,
+            maxEdgeValue: 0,
+            hiddenSteps: 0,
+        }
+    }
+
+    const availableSteps = Math.max(...Array.from(nodeMap.values()).map((n) => n.step)) + 1
+    const visibleSteps = Math.min(maxSteps, availableSteps)
+    const hiddenSteps = availableSteps - visibleSteps
+
+    // bucket each visible column into top-N rows + "other"
+    const columns: RowNode[][] = []
+    const keyByRawNode = new Map<string, string>() // `${step}:${name}` -> RowNode.key
+    for (let step = 0; step < visibleSteps; step++) {
+        const columnNodes = Array.from(nodeMap.values())
+            .filter((n) => n.step === step)
+            .map((n) => ({ ...n, count: Math.max(n.inValue, n.outValue) }))
+            .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name))
+
+        const rows = columnNodes.filter((n) => n.name !== TRUNCATION_MARKER).slice(0, maxRows)
+        const bucketed = columnNodes.filter((n) => !rows.includes(n))
+
+        const column: RowNode[] = rows.map((n) => {
+            const key = `${step}:${n.name}`
+            keyByRawNode.set(key, key)
+            return {
+                key,
+                step,
+                name: n.name,
+                count: n.count,
+                dropoff: Math.max(0, n.count - n.outValue),
+                isOther: false,
+                members: [],
+            }
+        })
+
+        if (bucketed.length > 0) {
+            const otherKey = `${step}:$$other$$`
+            for (const n of bucketed) {
+                keyByRawNode.set(`${step}:${n.name}`, otherKey)
+            }
+            column.push({
+                key: otherKey,
+                step,
+                name: 'Other',
+                count: bucketed.reduce((sum, n) => sum + n.count, 0),
+                dropoff: bucketed.reduce((sum, n) => sum + Math.max(0, n.count - n.outValue), 0),
+                isOther: true,
+                members: bucketed.map((n) => ({
+                    name: n.name === TRUNCATION_MARKER ? 'Deeper steps' : n.name,
+                    count: n.count,
+                })),
+            })
+        }
+        columns.push(column)
+    }
+
+    // aggregate raw edges onto bucketed nodes
+    const edgeMap = new Map<string, { value: number; timeWeighted: number; timeValue: number }>()
+    for (const raw of rawEdges) {
+        if (raw.fromStep + 1 >= visibleSteps) {
+            continue
+        }
+        const from = keyByRawNode.get(`${raw.fromStep}:${raw.fromName}`)
+        const to = keyByRawNode.get(`${raw.fromStep + 1}:${raw.toName}`)
+        if (!from || !to) {
+            continue
+        }
+        const key = `${from}→${to}`
+        const agg = edgeMap.get(key) ?? { value: 0, timeWeighted: 0, timeValue: 0 }
+        agg.value += raw.value
+        if (raw.avgTime != null) {
+            agg.timeWeighted += raw.avgTime * raw.value
+            agg.timeValue += raw.value
+        }
+        edgeMap.set(key, agg)
+    }
+    const edges: RowEdge[] = Array.from(edgeMap.entries()).map(([key, agg]) => {
+        const [from, to] = key.split('→')
+        return { from, to, value: agg.value, avgTime: agg.timeValue > 0 ? agg.timeWeighted / agg.timeValue : null }
+    })
+
+    const stepTotals = columns.map((column) => column.reduce((sum, node) => sum + node.count, 0))
+    return {
+        columns,
+        edges,
+        stepTotals,
+        startTotal: stepTotals[0] ?? 0,
+        maxStepTotal: Math.max(...stepTotals, 0),
+        maxEdgeValue: Math.max(...edges.map((e) => e.value), 0),
+        hiddenSteps,
+    }
+}
+
+/** Filled ribbon between two vertical port segments, for SVG overlays. */
+export function ribbonPath(x0: number, y0: number, t0: number, x1: number, y1: number, t1: number): string {
+    const xm = (x0 + x1) / 2
+    return [
+        `M ${x0},${y0}`,
+        `C ${xm},${y0} ${xm},${y1} ${x1},${y1}`,
+        `L ${x1},${y1 + t1}`,
+        `C ${xm},${y1 + t1} ${xm},${y0 + t0} ${x0},${y0 + t0}`,
+        'Z',
+    ].join(' ')
+}
+
+export function formatPercentage(part: number, whole: number): string {
+    if (whole <= 0) {
+        return '0%'
+    }
+    const pct = (part / whole) * 100
+    return `${pct < 1 && pct > 0 ? pct.toFixed(1) : Math.round(pct)}%`
+}


### PR DESCRIPTION
> [!WARNING]
> Throwaway prototype for a planning decision. Do not merge, do not review the code. It exists so the [paths v2 wayfinder map](https://app.notion.com/p/3aa89bbd191d81b9a8b8c637537269e0) ticket "Row-by-column visualization" has a living artifact and screenshots to react to.

## TL;DR (eli5)

Paths v2 wants to replace the tangled spaghetti chart with a tidy grid: a column per step, a few rows per column, everything else folded into an "other" box. Before building the real thing we made three cheap throwaway versions of that grid and screenshotted them on demo data, so we can pick what looks right and write it into the spec.

## Problem

The paths v2 draft ([#29364](https://github.com/PostHog/posthog/pull/29364)) proposed a row-by-column model (max steps × max rows per step, "other" bucket, drop-offs) but its backend doesn't compile against master. We need to judge the *layout* on real-ish data without reviving the backend: defaults, "other" bucketing, drop-off rendering, ordering, percentages.

## Changes

Client-side transform of v1 `PathsQuery` links into the row-by-column model, plus three structurally different renderers, mounted on any paths insight via `?paths_v2_proto=a|b|c` (dev builds only). A floating switcher cycles variants. Counts are approximations of the v2 contract (v1 event-flow weights, node count = max(in, out)); good enough to judge layout, not numbers.

### Variant A "journey grid" (`?paths_v2_proto=a`) — cards + ribbons, calm drop-offs

Fixed-height cards per step, curved ribbons, drop-offs as grey fade-out stubs (no red), "other" expandable in place, percentages of start on nodes.

![a-journey-grid-default](https://raw.githubusercontent.com/PostHog/pr-assets/4855cd2d4d26bb88a7d89605cef121e28206084b/2026/07/2039f26b-1938-4110-ae16-70d9116d5c83.png)

"Other" expanded in place:

![a-other-expanded](https://raw.githubusercontent.com/PostHog/pr-assets/04236ab871a93cc34965377fddacdde436e3255c/2026/07/2a64ad87-f14c-486b-add4-521de7ffb557.png)

Anchored mode (start point set) — step 1 collapses to the anchor at 100%:

![a-anchored-start](https://raw.githubusercontent.com/PostHog/pr-assets/d5049bf30e05cd7aba1abbc174b1cb57c01eab59/2026/07/5ec130ba-c878-4333-a4c7-c8bca2b729d1.png)

Density configs. 5 steps × 5 rows:

![a-rows-5](https://raw.githubusercontent.com/PostHog/pr-assets/9c671067abe4120d4524f33391a801c38e57213a/2026/07/663dfc1c-15d6-4d3f-907c-111018f7c633.png)

7 steps × 5 rows:

![a-steps-7-rows-5](https://raw.githubusercontent.com/PostHog/pr-assets/8c3ca74dffeb1b7a04cb7b6c2e8d575ad2c68ea7/2026/07/d47c1ef8-2aea-4a09-808b-8032f4355d5d.png)

5 steps × 1 row:

![a-steps-5-rows-1](https://raw.githubusercontent.com/PostHog/pr-assets/9e53ee9551636c446e459f0b82628af08a379584/2026/07/51a858f5-46e1-4aa3-b919-db2ac2e77c1a.png)

Percentages off:

![a-no-percentages](https://raw.githubusercontent.com/PostHog/pr-assets/358d09df8a5fd713908f6805fb12694cfaa2c4be/2026/07/6f7ad69f-51d0-4b82-a6c5-053484d393a6.png)

### Variant B "step bars" (`?paths_v2_proto=b`) — funnel-style stacked bars, no permanent ribbons

Same color for the same path item across steps, drop-off is the shrinking bar (annotated in the step header), connections drawn only on hover.

![b-step-bars-default](https://raw.githubusercontent.com/PostHog/pr-assets/bd8d6552fb83dacfbe86d86398518ba64f83a0a8/2026/07/2563bccf-10da-4f25-bba6-5df55b198122.png)

Hover shows a segment's connections:

![b-hover-connections](https://raw.githubusercontent.com/PostHog/pr-assets/729a096ac5d753691e5889041ffececa03f0fce0/2026/07/5e6f65f3-5295-4f73-aa55-defe7402d764.png)

### Variant C "draft sankey" (`?paths_v2_proto=c`) — the baseline to react against

Stays close to the draft PR and v1: value-scaled nodes, explicit drop-off node per column, red drop-off ribbons.

![c-draft-sankey-default](https://raw.githubusercontent.com/PostHog/pr-assets/65caa4d51d3ea01d44a17a880cd24c79e30fb8f1/2026/07/1d17eeb0-5853-4a0b-bad0-7bb849a66038.png)

## How did you test this code?

Prototype, so no tests. I ran `pnpm --filter=@posthog/frontend typescript:check` and oxlint, and captured the screenshots above from a local dev stack on generated Hedgebox demo data (200 clusters).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None, throwaway.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built by PostHog Code (Claude) working the [paths v2 wayfinder map](https://app.notion.com/p/3aa89bbd191d81b9a8b8c637537269e0). Decisions: consumed v1 query results client-side instead of reviving the draft's `PathsV2Query` backend (the autopsy ticket showed the draft tip doesn't compile and codegen drifted, and layout questions don't need exact v2 counting); gated by URL param instead of the `paths-v2` feature flag so v1/v2 behavior stays untouched. Skills used: wayfinder, prototype, run-posthog. Kea conventions intentionally skipped (component-local state) since this never merges.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
