### PR TITLE
fix(review-hog): serve code review at /code-review not /code_review

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -191,7 +191,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/replay-vision/:id/triggers': ['ReplayVisionScannerEditor', 'replayVisionScannerTriggers'],
     '/replay-vision/:id/self-driving': ['ReplayVisionScannerEditor', 'replayVisionScannerSelfDriving'],
     '/replay-vision/:id': ['ReplayVisionScanner', 'replayVision'],
-    '/code_review': ['CodeReview', 'codeReview'],
+    '/code-review': ['CodeReview', 'codeReview'],
     '/session-summaries': ['SessionGroupSummariesTable', 'sessionGroupSummariesTable'],
     '/session-summaries/:sessionGroupId': ['SessionGroupSummary', 'sessionGroupSummary'],
     '/skills': ['Skills', 'skills'],
@@ -1304,7 +1304,7 @@ export const productUrls = {
     replayVisionActionNew: (scannerId: string, mode?: 'group_summary' | 'alert'): string =>
         `/replay-vision/${scannerId}/actions/new${mode === 'alert' ? '?mode=alert' : ''}`,
     replayVisionActionEdit: (actionId: string): string => `/replay-vision/actions/${actionId}/edit`,
-    codeReview: (): string => '/code_review',
+    codeReview: (): string => '/code-review',
     sessionSummaries: (): string => '/session-summaries',
     sessionSummary: (sessionGroupId: string): string => `/session-summaries/${sessionGroupId}`,
     skills: (): string => '/skills',

--- a/frontend/src/scenes/sceneLogic.test.tsx
+++ b/frontend/src/scenes/sceneLogic.test.tsx
@@ -81,13 +81,15 @@ describe('sceneLogic', () => {
         expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.featureFlag('123'))
     })
 
-    it('redirects the old /code_review path to /code-review, preserving the ?review= deep link', async () => {
-        router.actions.push('/code_review', { review: 'r-9' })
+    it('redirects the old /code_review path to /code-review, preserving the ?review= deep link and hash', async () => {
+        router.actions.push('/code_review', { review: 'r-9' }, { panel: 'max:inspect' })
         await expectLogic(logic).delay(1)
         expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.codeReview())
         // ?review=<report id> is a permanent public contract baked into GitHub PR comments — the
-        // redirect must carry it across so those links keep opening the right report.
+        // redirect must carry it across so those links keep opening the right report. The hash
+        // carries global side-panel state, so it has to survive the redirect too.
         expect(router.values.searchParams.review).toEqual('r-9')
+        expect(router.values.hashParams.panel).toEqual('max:inspect')
     })
 
     it('persists the loaded scenes', async () => {

--- a/frontend/src/scenes/sceneLogic.test.tsx
+++ b/frontend/src/scenes/sceneLogic.test.tsx
@@ -81,6 +81,15 @@ describe('sceneLogic', () => {
         expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.featureFlag('123'))
     })
 
+    it('redirects the old /code_review path to /code-review, preserving the ?review= deep link', async () => {
+        router.actions.push('/code_review', { review: 'r-9' })
+        await expectLogic(logic).delay(1)
+        expect(removeProjectIdIfPresent(router.values.location.pathname)).toEqual(urls.codeReview())
+        // ?review=<report id> is a permanent public contract baked into GitHub PR comments — the
+        // redirect must carry it across so those links keep opening the right report.
+        expect(router.values.searchParams.review).toEqual('r-9')
+    })
+
     it('persists the loaded scenes', async () => {
         const expectedAnnotation = partial({
             component: expect.any(Function),

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -658,6 +658,9 @@ export const redirects: Record<
     '/annotations/:id': ({ id }) => urls.annotation(id),
     '/batch_exports/:id': ({ id }) => urls.batchExport(id),
     '/batch_exports': urls.destinations(),
+    // The scene lives at /code-review (hyphen); catch the old underscore variant, keeping the
+    // ?review= / ?reviews_scope= deep links that PR status comments bake in
+    '/code_review': (_params, searchParams) => combineUrl(urls.codeReview(), searchParams).url,
     '/comments': () => urls.comments(),
     '/dashboards': urls.dashboards(),
     '/data-management': urls.eventDefinitions(),

--- a/frontend/src/scenes/scenes.ts
+++ b/frontend/src/scenes/scenes.ts
@@ -660,7 +660,7 @@ export const redirects: Record<
     '/batch_exports': urls.destinations(),
     // The scene lives at /code-review (hyphen); catch the old underscore variant, keeping the
     // ?review= / ?reviews_scope= deep links that PR status comments bake in
-    '/code_review': (_params, searchParams) => combineUrl(urls.codeReview(), searchParams).url,
+    '/code_review': (_params, searchParams, hashParams) => combineUrl(urls.codeReview(), searchParams, hashParams).url,
     '/comments': () => urls.comments(),
     '/dashboards': urls.dashboards(),
     '/data-management': urls.eventDefinitions(),

--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -217,7 +217,7 @@ pr_metadata.head_branch` is threaded (as explicit kwargs, alongside `team_id` / 
     (`reviewer/status_comment.py`) is posted at kickoff, edited with stage progress, and rewritten with the
     outcome: the full found counts, what was published, and — when the urgency threshold held findings back —
     whose threshold it was (the author's / the requester's / the default, from `resolved_from`) plus a
-    "View them in PostHog" deep link to the exact report (`/project/<team>/code_review?review=<report id>`,
+    "View them in PostHog" deep link to the exact report (`/project/<team>/code-review?review=<report id>`,
     a **permanent public contract** — the frontend URL sync and `report_deep_link` must keep agreeing on it).
 
 ---
@@ -482,7 +482,7 @@ caller. See [DECISIONS.md](./DECISIONS.md) for each trigger's auth / scope / ide
 viewer is the **acting user OR the PR's author** — `author_login` compared case-insensitively against the
 viewer's linked GitHub login (`User.get_github_login()`, the reverse of the author→user mapping the reviewer
 runs under; no linked login → acting-user match only). `scope=everyone` is the whole project; `retrieve` is
-project-wide so any listed review opens. A specific report is linkable at `/code_review?review=<report id>`
+project-wide so any listed review opens. A specific report is linkable at `/code-review?review=<report id>`
 (mirrored to/from the drawer by `reviewHogSettingsLogic`'s URL sync; the status comment's held-back link
 targets it, so the param is a permanent contract). The drawer buckets a review's findings into published vs
 below-threshold by the detail's stored `run_urgency_threshold` — the viewer's current setting is only the

--- a/products/review_hog/backend/reviewer/status_comment.py
+++ b/products/review_hog/backend/reviewer/status_comment.py
@@ -118,7 +118,7 @@ def report_deep_link(team_id: int, report_id: str) -> str:
     re-edited); the frontend's Code review URL sync accepts exactly this param, so the two must keep
     agreeing. Auth-gated like any app link — the same posture as posting Slack links publicly.
     """
-    return f"{settings.SITE_URL}/project/{team_id}/code_review?review={report_id}"
+    return f"{settings.SITE_URL}/project/{team_id}/code-review?review={report_id}"
 
 
 def _plural(count: int, noun: str) -> str:

--- a/products/review_hog/backend/tests/test_status_comment.py
+++ b/products/review_hog/backend/tests/test_status_comment.py
@@ -145,11 +145,11 @@ class TestRenderFinalBody:
             threshold=IssuePriority.SHOULD_FIX,
             review_url=None,
             resolved_from=resolved_from,
-            report_url="https://ph.test/project/1/code_review?review=rid",
+            report_url="https://ph.test/project/1/code-review?review=rid",
         )
         assert f"2 findings stayed below {expected}" in body, body
         # Held-back findings are otherwise invisible to the author — the comment must not dead-end.
-        assert "[View them in PostHog](https://ph.test/project/1/code_review?review=rid)" in body
+        assert "[View them in PostHog](https://ph.test/project/1/code-review?review=rid)" in body
 
     @patch(f"{_MODULE}.random.choice", return_value=("https://example.test/dog.png", "A happy dog"))
     def test_uses_the_randomly_selected_clean_review_media(self, mock_choice: MagicMock) -> None:
@@ -360,7 +360,7 @@ class TestFinalizeStatusComment(BaseTest):
         assert '2 findings stayed below the author\'s "Should fix" urgency threshold' in body
         # The held-back link into the app. `?review=<report id>` is a permanent public contract
         # (baked into GitHub comments) — the frontend's URL sync accepts exactly this param.
-        assert f"/project/{self.team.id}/code_review?review={report_id})" in body
+        assert f"/project/{self.team.id}/code-review?review={report_id})" in body
 
     def test_failed_edit_rewrites_the_comment_as_failed(
         self, mock_request: MagicMock, mock_integration: MagicMock

--- a/products/review_hog/manifest.tsx
+++ b/products/review_hog/manifest.tsx
@@ -16,10 +16,10 @@ export const manifest: ProductManifest = {
         },
     },
     routes: {
-        '/code_review': ['CodeReview', 'codeReview'],
+        '/code-review': ['CodeReview', 'codeReview'],
     },
     urls: {
-        codeReview: (): string => '/code_review',
+        codeReview: (): string => '/code-review',
     },
     treeItemsProducts: [
         {

--- a/products/review_hog/mcp/tools.yaml
+++ b/products/review_hog/mcp/tools.yaml
@@ -6,7 +6,7 @@
 # All other fields (title, description, enrich_url, etc.) are yours to configure.
 category: ReviewHog
 feature: review_hog
-url_prefix: /code_review
+url_prefix: /code-review
 ui_apps: {}
 tools:
     review-hog-blind-spots-list:

--- a/services/mcp/src/tools/generated/review_hog.ts
+++ b/services/mcp/src/tools/generated/review_hog.ts
@@ -43,7 +43,7 @@ const reviewHogReviewsList = (): ToolBase<
                 scope: params.scope,
             },
         })
-        return await withPostHogUrl(context, result, '/code_review')
+        return await withPostHogUrl(context, result, '/code-review')
     },
 })
 


### PR DESCRIPTION
## Problem

`/code_review` was the odd one out. Nearly every route in the app is kebab-case (`data-management`, `error-tracking`, `feature-flags`…), and the underscore stuck out enough to get flagged. Raised in a Slack thread — the maintainer was fine with the rename.

## Changes

Rename the Code review scene route from `/code_review` to `/code-review` (manifest + regenerated `products.tsx`).

Add a redirect from the old `/code_review` path that forwards query params. The `?review=` / `?reviews_scope=` params are a permanent public contract baked into GitHub PR status comments, so the redirect carries them across and those links keep opening the right report. This mirrors the existing `/feature-flags` → `/feature_flags` redirect precedent (though in the opposite direction).

Also updated the backend deep-link builder, the MCP tool `url_prefix` and its generated output, and the architecture doc. The `DECISIONS.md` log keeps the historical `/code_review` mentions since it records decisions as they were made.

> [!NOTE]
> Old `/code_review` links (including those already sitting in GitHub PR comments) redirect to `/code-review` with their `?review=` intact, so nothing breaks.

## How did you test this code?

Added a redirect test in `sceneLogic.test.tsx` asserting `/code_review?review=r-9` lands on `/code-review` with the `review` param preserved — catches the regression where the permanent PR-comment deep links break or silently drop the param. Updated the backend `test_status_comment.py` assertions to the new path.

I (Claude, via the PostHog Slack app) could not run the JS/Python suites in this environment — no `node_modules`/toolchain. `products.tsx` and the generated MCP file were hand-edited to match their generators; CI preflight regenerates and verifies consistency.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Andy Maguire from a Slack thread that pointed out the underscore inconsistency. I checked `urls.ts` first and confirmed hyphens are the dominant convention (~9% of paths use underscores, mostly legacy `/instance/*` admin routes), then made the change.

Key decision: keep a redirect rather than a clean rename, because the `?review=` deep link is documented in-code as a permanent public contract embedded in GitHub PR comments — a bare rename would 404 those. The redirect forwards all incoming search params via `combineUrl` so both `review` and `reviews_scope` survive. Left `iconType: 'code_review'` and the signals `code_review` artefact type untouched — those are enum/icon identifiers, not URLs.

No repo skills were invocable in this environment; applied the test value-gate manually.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785242874571769?thread_ts=1785242874.571769&cid=C09SK2PAGKF)*
