### PR TITLE
feat(engineering-analytics): per-test signal history

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -553,6 +553,7 @@ SPECTACULAR_SETTINGS = {
         "EngineeringAnalyticsPRStateEnum": "products.engineering_analytics.backend.facade.contracts.PRState",
         "QuarantineModeEnum": "products.engineering_analytics.backend.facade.contracts.QuarantineMode",
         "CITestRunnerEnum": "products.engineering_analytics.backend.facade.contracts.CITestRunner",
+        "FlakyTestClassificationEnum": "products.engineering_analytics.backend.facade.contracts.FlakyTestClassification",
         "RestrictionLevelEnum": "products.dashboards.backend.models.dashboard.Dashboard.RestrictionLevel",
         "OrganizationMembershipLevelEnum": "posthog.models.organization.OrganizationMembership.Level",
         "SetupTaskId": "posthog.models.team.setup_tasks.SetupTaskId",

--- a/products/engineering_analytics/backend/facade/api.py
+++ b/products/engineering_analytics/backend/facade/api.py
@@ -44,6 +44,7 @@ from products.engineering_analytics.backend.facade.contracts import (
     TeamCIActivity,
     TeamCIHealthList,
     TeamMergeTrend,
+    TestSignalHistory,
     WorkflowCost,
     WorkflowHealthItem,
     WorkflowJob,
@@ -340,6 +341,28 @@ def list_flaky_tests(
         date_from=date_from,
         date_to=date_to,
         min_failed_prs=min_failed_prs,
+        limit=limit,
+    )
+
+
+def get_test_signal_history(
+    *,
+    team: Team,
+    test: str,
+    runner: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    limit: int | None = None,
+    source_id: str | None = None,
+    repo: str | None = None,
+    user_access_control: "UserAccessControl | None" = None,
+) -> TestSignalHistory:
+    return logic.build_test_signal_history(
+        curated=_authorized_source(team, source_id, user_access_control, repo=repo),
+        test=test,
+        runner=runner,
+        date_from=date_from,
+        date_to=date_to,
         limit=limit,
     )
 

--- a/products/engineering_analytics/backend/facade/contracts.py
+++ b/products/engineering_analytics/backend/facade/contracts.py
@@ -598,6 +598,64 @@ class FlakyTestList:
 
 
 @dataclass(frozen=True)
+class TestSignalRun:
+    """One CI run that produced signal for a single test: what that run proved, and where it ran.
+
+    Only signal-bearing runs exist here (a failure, a quarantined failure, or a same-commit
+    recovery); ordinary passing runs are never emitted, so a list of these is a failure history and
+    never a pass/fail rate. See ``FLAKY_TEST_SIGNAL_CAVEAT``.
+    """
+
+    run_id: str
+    # None for default-branch pushes and any branch CI ran without a PR association.
+    pr_number: int | None
+    branch: str
+    failed: bool
+    # One commit both failed and passed the test in this run: a re-run attempt went green, or an
+    # in-job retry recovered it. This is the only proof that makes a test a confirmed_flake.
+    recovered: bool
+    quarantined: bool
+    signal_at: datetime
+
+
+@dataclass(frozen=True)
+class TestSignalHistory:
+    """One test's per-run signal history over a window, newest first, plus the same rollup the
+    test-health queue reports for that test.
+
+    The per-run drill-down behind ``FlakyTestItem``: the queue ranks *which* tests are worth acting
+    on, this says what one of them has done across recent runs, PRs, and branches. Both read the same
+    per-run evidence, so the counts here match the queue's for the same test and window.
+
+    ``runs`` is capped at ``limit`` with an explicit ``truncated`` flag (the ``{items, truncated,
+    limit}`` shape ``FlakyTestList`` uses). The rollup counts always cover the whole window, never
+    just the returned page, so they cannot undercount against the queue when ``truncated`` is true.
+
+    A test with no signal in the window is a legitimate empty answer rather than a 404: the counts
+    are 0, ``runs`` is empty, ``runner`` / ``classification`` / ``last_signal_at`` are null because
+    no evidence resolved them, and ``nodeid`` / ``selector`` echo the requested test. See
+    ``FLAKY_TEST_SIGNAL_CAVEAT`` for why every figure is an absolute count.
+    """
+
+    # Null when nothing matched, since the runner is only known from the matched spans.
+    runner: CITestRunner | None
+    nodeid: str
+    selector: str
+    # Null when nothing matched: with no failures recorded, 'suspected_regression' would read as a
+    # verdict on a test this window says nothing about.
+    classification: FlakyTestClassification | None
+    same_commit_recovery_run_count: int
+    failed_run_count: int
+    failed_pr_count: int
+    master_failed_run_count: int
+    quarantined_failed_run_count: int
+    last_signal_at: datetime | None
+    runs: list[TestSignalRun]
+    truncated: bool
+    limit: int
+
+
+@dataclass(frozen=True)
 class TeamCIHealthItem:
     """One owning team's rollup of the CI test surfaces it owns, with equal-length
     previous-window twins so a caller can render honest deltas.

--- a/products/engineering_analytics/backend/logic/__init__.py
+++ b/products/engineering_analytics/backend/logic/__init__.py
@@ -37,6 +37,7 @@ from products.engineering_analytics.backend.logic.sources import build_github_so
 from products.engineering_analytics.backend.logic.suite_health import (
     build_broken_tests as build_broken_tests,
     build_flaky_tests as build_flaky_tests,
+    build_test_signal_history as build_test_signal_history,
 )
 from products.engineering_analytics.backend.logic.teams import (
     build_team_ci_activity as build_team_ci_activity,

--- a/products/engineering_analytics/backend/logic/queries/test_signal_history.py
+++ b/products/engineering_analytics/backend/logic/queries/test_signal_history.py
@@ -1,0 +1,183 @@
+"""HogQL read of one test's per-run CI signal history: the drill-down behind the test-health queue.
+
+``flaky_tests.py`` aggregates the PR/run dimension away to rank *which* tests are worth acting on;
+this keeps that dimension and answers what one test has done across recent runs, PRs, and branches.
+Both embed ``_test_spans.run_evidence()``, so the grain (one row per test and CI run) and the meaning
+of a recovery are defined once and cannot drift between the queue and its drill-down.
+
+The rollup counts are window aggregates over every matched run, computed in the same pass as the
+capped page, so a truncated ``runs`` list never leaves them undercounting against the queue's figures
+for the same test and window (SPEC §5).
+
+Reads the ``posthog.trace_spans`` table on the LOGS ClickHouse cluster, not the warehouse.
+"""
+
+from datetime import datetime
+
+from posthog.hogql import ast
+
+from posthog.clickhouse.workload import Workload
+
+from products.engineering_analytics.backend.facade.contracts import (
+    CITestRunner,
+    FlakyTestClassification,
+    TestSignalHistory,
+    TestSignalRun,
+)
+from products.engineering_analytics.backend.logic.queries._curated import CuratedGitHubSource
+from products.engineering_analytics.backend.logic.queries._test_spans import (
+    run_evidence,
+    scan_placeholders,
+    selector_from_nodeid,
+)
+
+# The test match sits above run_evidence, not inside its span scan: `selector` only exists once the
+# grain rollup has picked the emitted value for the run, so matching any earlier would miss every
+# caller who pasted a selector. `OVER ()` runs after the WHERE and before ORDER BY/LIMIT, which is
+# what makes the counts window-complete while the page stays capped.
+_SELECT = """
+    SELECT
+        runner,
+        nodeid,
+        selector,
+        run_id,
+        pr_number,
+        branch,
+        failed_in_run,
+        recovered_in_run,
+        quarantined_in_run,
+        run_signal_at,
+        countIf(recovered_in_run) OVER () AS same_commit_recovery_run_count,
+        countIf(failed_in_run) OVER () AS failed_run_count,
+        uniqIf(pr_number, failed_in_run AND pr_number != '') OVER () AS failed_pr_count,
+        countIf(failed_in_run AND branch IN ('master', 'main')) OVER () AS master_failed_run_count,
+        countIf(quarantined_in_run) OVER () AS quarantined_failed_run_count,
+        max(run_signal_at) OVER () AS last_signal_at
+    FROM (__RUN_EVIDENCE__)
+    WHERE (nodeid = {test} OR selector = {test})__RUNNER_FILTER__
+    -- run_id breaks ties so two runs stamped in the same second page deterministically.
+    ORDER BY run_signal_at DESC, run_id ASC
+    LIMIT {limit_plus_one}
+"""
+
+
+def query_test_signal_history(
+    *,
+    curated: CuratedGitHubSource,
+    test: str,
+    runner: CITestRunner | None,
+    date_from: datetime,
+    date_to: datetime | None,
+    limit: int,
+) -> TestSignalHistory:
+    repository = curated.repository
+    # Fail closed: the spans are scoped to the source's repository. Without a repository identity we
+    # cannot tell one connected repo's spans from another, so return nothing rather than leak another
+    # repository's history for a same-named test.
+    if not repository:
+        return _empty_history(test=test, limit=limit)
+
+    placeholders = scan_placeholders(repository=repository, date_from=date_from, date_to=date_to)
+    placeholders["test"] = ast.Constant(value=test)
+    # +1 so a full page tells us more runs matched than returned.
+    placeholders["limit_plus_one"] = ast.Constant(value=limit + 1)
+    select = _SELECT.replace("__RUN_EVIDENCE__", run_evidence(bounded=date_to is not None))
+    if runner is not None:
+        placeholders["runner"] = ast.Constant(value=runner.value)
+        select = select.replace("__RUNNER_FILTER__", "\n        AND runner = {runner}")
+    else:
+        select = select.replace("__RUNNER_FILTER__", "")
+
+    response = curated.run(
+        select,
+        query_type="engineering_analytics.test_signal_history",
+        placeholders=placeholders,
+        # trace_spans lives on the LOGS ClickHouse cluster, not the warehouse default.
+        workload=Workload.LOGS,
+    )
+    rows = response.results or []
+    if not rows:
+        return _empty_history(test=test, limit=limit)
+
+    # The window aggregates are identical on every row, so the first row carries the whole rollup
+    # alongside the identity the match resolved to.
+    (
+        matched_runner,
+        nodeid,
+        selector,
+        *_per_run_columns,
+        same_commit_recovery_run_count,
+        failed_run_count,
+        failed_pr_count,
+        master_failed_run_count,
+        quarantined_failed_run_count,
+        last_signal_at,
+    ) = rows[0]
+    return TestSignalHistory(
+        runner=CITestRunner(matched_runner),
+        nodeid=nodeid,
+        # Prefer the emitter's exact selector; reconstruct from the nodeid for older spans, exactly as
+        # the queue does, so both surfaces hand out the same selector for the same test.
+        selector=selector or selector_from_nodeid(nodeid),
+        classification=FlakyTestClassification.from_run_evidence(
+            quarantined_failed_run_count=quarantined_failed_run_count,
+            same_commit_recovery_run_count=same_commit_recovery_run_count,
+        ),
+        same_commit_recovery_run_count=same_commit_recovery_run_count,
+        failed_run_count=failed_run_count,
+        failed_pr_count=failed_pr_count,
+        master_failed_run_count=master_failed_run_count,
+        quarantined_failed_run_count=quarantined_failed_run_count,
+        last_signal_at=last_signal_at,
+        runs=[
+            TestSignalRun(
+                run_id=run_id,
+                pr_number=_pr_number(pr_number),
+                branch=branch,
+                failed=bool(failed_in_run),
+                recovered=bool(recovered_in_run),
+                quarantined=bool(quarantined_in_run),
+                signal_at=run_signal_at,
+            )
+            for (
+                _runner,
+                _nodeid,
+                _selector,
+                run_id,
+                pr_number,
+                branch,
+                failed_in_run,
+                recovered_in_run,
+                quarantined_in_run,
+                run_signal_at,
+                *_rollup,
+            ) in rows[:limit]
+        ],
+        truncated=len(rows) > limit,
+        limit=limit,
+    )
+
+
+def _empty_history(*, test: str, limit: int) -> TestSignalHistory:
+    """No signal in the window: an unknown test is a legitimate empty answer, not a 404."""
+    return TestSignalHistory(
+        runner=None,
+        nodeid=test,
+        selector=test,
+        classification=None,
+        same_commit_recovery_run_count=0,
+        failed_run_count=0,
+        failed_pr_count=0,
+        master_failed_run_count=0,
+        quarantined_failed_run_count=0,
+        last_signal_at=None,
+        runs=[],
+        truncated=False,
+        limit=limit,
+    )
+
+
+def _pr_number(raw: str) -> int | None:
+    # Default-branch pushes carry an empty ci.pr_number stamp, and anything non-numeric is unusable
+    # as a PR key, so both read as "no PR association" rather than raising.
+    return int(raw) if raw.isdigit() else None

--- a/products/engineering_analytics/backend/logic/suite_health.py
+++ b/products/engineering_analytics/backend/logic/suite_health.py
@@ -1,14 +1,18 @@
-"""Test-health orchestration: the active test-health queue and the broken-tests panel."""
+"""Test-health orchestration: the active test-health queue, its per-test drill-down, and the
+broken-tests panel."""
 
 from products.engineering_analytics.backend.facade.contracts import (
     BROKEN_TEST_SPARKLINE_HOURS,
     BrokenTestsResult,
+    CITestRunner,
     FlakyTestList,
+    TestSignalHistory,
 )
 from products.engineering_analytics.backend.logic._shared import _parse_date, _parse_window
 from products.engineering_analytics.backend.logic.queries._curated import CuratedGitHubSource
 from products.engineering_analytics.backend.logic.queries.broken_tests import query_broken_tests
 from products.engineering_analytics.backend.logic.queries.flaky_tests import query_flaky_tests
+from products.engineering_analytics.backend.logic.queries.test_signal_history import query_test_signal_history
 
 # Test-health queue defaults: a week of signal is the triage window, a month the ceiling
 # (per-test spans are high-volume and the short Traces retention makes older data spotty anyway).
@@ -18,6 +22,10 @@ MAX_FLAKY_WINDOW_DAYS = 30
 DEFAULT_FLAKY_MIN_FAILED_PRS = 3
 _DEFAULT_FLAKY_LIMIT = 50
 _MAX_FLAKY_LIMIT = 200
+
+# The per-test drill-down pages runs rather than tests, so it carries its own default; 50
+# signal-bearing runs is already a long history for one test.
+_DEFAULT_SIGNAL_RUN_LIMIT = 50
 
 # Broken-tests panel: a fixed short window (not caller-tunable in v1, like current_branch_health).
 # Two days keeps the logs-cluster scan light while still spanning the classifier's boundaries — a
@@ -52,6 +60,49 @@ def build_flaky_tests(
         min_failed_prs=min_failed_prs,
         limit=limit,
     )
+
+
+def build_test_signal_history(
+    *,
+    curated: CuratedGitHubSource,
+    test: str,
+    runner: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+    limit: int | None = None,
+) -> TestSignalHistory:
+    normalized_test = test.strip() if test else ""
+    # A blank test would match the empty selector every span emitted before selector stamping
+    # carries, returning an unrelated pile of runs instead of one test's history.
+    if not normalized_test:
+        raise ValueError("test is required")
+    # Same window bounds as the queue this drills into, so a caller who read a test off the queue
+    # gets counts over the same span of spans.
+    parsed_from, parsed_to = _parse_window(
+        curated.team, date_from, date_to, default=_DEFAULT_FLAKY_WINDOW, max_days=MAX_FLAKY_WINDOW_DAYS
+    )
+    limit = limit if limit is not None else _DEFAULT_SIGNAL_RUN_LIMIT
+    if not 1 <= limit <= _MAX_FLAKY_LIMIT:
+        raise ValueError(f"limit must be between 1 and {_MAX_FLAKY_LIMIT}")
+    return query_test_signal_history(
+        curated=curated,
+        test=normalized_test,
+        runner=_parse_runner(runner),
+        date_from=parsed_from,
+        date_to=parsed_to,
+        limit=limit,
+    )
+
+
+def _parse_runner(value: str | None) -> CITestRunner | None:
+    """Absent/blank means both runners; anything else must be an exact enum value (ValueError → 400)."""
+    normalized = value.strip() if value else ""
+    if not normalized:
+        return None
+    try:
+        return CITestRunner(normalized)
+    except ValueError:
+        raise ValueError(f"runner must be one of: {', '.join(runner.value for runner in CITestRunner)}") from None
 
 
 def build_broken_tests(*, curated: CuratedGitHubSource) -> BrokenTestsResult:

--- a/products/engineering_analytics/backend/presentation/serializers/suite_health.py
+++ b/products/engineering_analytics/backend/presentation/serializers/suite_health.py
@@ -11,6 +11,8 @@ from products.engineering_analytics.backend.facade.contracts import (
     QuarantineFile,
     QuarantineRequest,
     QuarantineRequestResult,
+    TestSignalHistory,
+    TestSignalRun,
 )
 from products.engineering_analytics.backend.presentation.serializers._shared import RepoRefSerializer
 
@@ -75,6 +77,97 @@ class FlakyTestListSerializer(DataclassSerializer):
                 "help_text": "True when more tests qualified than the cap; `items` is the highest-ranked `limit` rows.",
             },
             "limit": {"help_text": "Maximum number of tests returned in `items`."},
+        }
+
+
+class TestSignalRunSerializer(DataclassSerializer):
+    class Meta:
+        dataclass = TestSignalRun
+        extra_kwargs = {
+            "run_id": {
+                "help_text": "The CI workflow run this signal came from. Pass it to run_failure_logs to read the "
+                "failing lines.",
+            },
+            "pr_number": {
+                "help_text": "Pull request the run belonged to, or null for default-branch pushes and any branch "
+                "CI ran without a PR association.",
+            },
+            "branch": {"help_text": "Git branch the run was for."},
+            "failed": {
+                "help_text": "The test failed or errored in this run. A run counts once however many matrix legs "
+                "it failed in.",
+            },
+            "recovered": {
+                "help_text": "One commit both failed and passed the test in this run: a 'Re-run failed jobs' "
+                "attempt went green, or an in-job pytest retry recovered it. This is the only proof that makes "
+                "the test a confirmed_flake.",
+            },
+            "quarantined": {
+                "help_text": "The test recorded a tolerated failure in this run while quarantine masked it.",
+            },
+            "signal_at": {"help_text": "When the run's most recent failure, recovery, or quarantined failure ran."},
+        }
+
+
+class TestSignalHistorySerializer(DataclassSerializer):
+    runs = TestSignalRunSerializer(
+        many=True,
+        help_text="The CI runs that produced signal for this test, newest first. Only signal-bearing runs are "
+        "here: passing runs are not emitted, so this is a failure history and never a pass rate.",
+    )
+
+    class Meta:
+        dataclass = TestSignalHistory
+        extra_kwargs = {
+            "runner": {
+                "help_text": "Test runner the matched spans came from: 'pytest' or 'jest'. Null when the test had "
+                "no signal in the window.",
+            },
+            "nodeid": {
+                "help_text": "Runner-specific stable test identity (the CI span name) the match resolved to. Echoes "
+                "the requested test when nothing matched.",
+            },
+            "selector": {
+                "help_text": "Runnable pytest or Jest selector, as the CI reporter emitted it. Echoes the requested "
+                "test when the matched spans carry no selector, or when nothing matched.",
+            },
+            "classification": {
+                "help_text": "confirmed_flake: one commit both failed and passed the test, so it is provably "
+                "nondeterministic. quarantined: a tolerated failure was recorded while it was masked. "
+                "suspected_regression: only failures were recorded, which is absence of proof, not proof that it is "
+                "a real break. Null when the test had no signal in the window.",
+            },
+            "same_commit_recovery_run_count": {
+                "help_text": "Runs where one commit both failed and passed the test: a 'Re-run failed jobs' attempt "
+                "went green on the same commit, or an in-job pytest retry (tests hand-marked "
+                "@pytest.mark.flaky(reruns=N)) recovered it. A pass in a different run is a different commit and "
+                "never counts.",
+            },
+            "failed_run_count": {
+                "help_text": "Distinct CI runs whose recorded outcome was failed or error. An absolute count, never "
+                "a rate: passing runs are not emitted, so there is no execution denominator.",
+            },
+            "failed_pr_count": {
+                "help_text": "Distinct pull requests among the failed runs. Failures on master or unattributed "
+                "branches carry no PR number and are excluded here (still in failed_run_count).",
+            },
+            "master_failed_run_count": {
+                "help_text": "Failed runs on the default branch (master/main approximation): the 'matters right now' "
+                "signal that the test is breaking the trunk, not just PR branches.",
+            },
+            "quarantined_failed_run_count": {
+                "help_text": "Runs where the test recorded a tolerated failure while quarantined: already masked in "
+                "CI, still failing.",
+            },
+            "last_signal_at": {
+                "help_text": "Most recent failure, recovery, or quarantined-failure run for this test in the window. "
+                "Null when it had no signal in the window.",
+            },
+            "truncated": {
+                "help_text": "True when more runs matched than the cap; `runs` is the newest `limit` of them. Every "
+                "count above still covers the whole window, so they never undercount against a truncated list.",
+            },
+            "limit": {"help_text": "Maximum number of runs returned in `runs`."},
         }
 
 

--- a/products/engineering_analytics/backend/presentation/views/suite_health.py
+++ b/products/engineering_analytics/backend/presentation/views/suite_health.py
@@ -10,13 +10,18 @@ from rest_framework.response import Response
 from posthog.api.mixins import TypedRequest, validated_request
 
 from products.engineering_analytics.backend.facade import api
-from products.engineering_analytics.backend.facade.contracts import FLAKY_TEST_SIGNAL_CAVEAT, QuarantineRequest
+from products.engineering_analytics.backend.facade.contracts import (
+    FLAKY_TEST_SIGNAL_CAVEAT,
+    CITestRunner,
+    QuarantineRequest,
+)
 from products.engineering_analytics.backend.presentation.serializers.suite_health import (
     BrokenTestsResultSerializer,
     FlakyTestListSerializer,
     QuarantineFileSerializer,
     QuarantineRequestResultSerializer,
     QuarantineRequestSerializer,
+    TestSignalHistorySerializer,
 )
 from products.engineering_analytics.backend.presentation.views._base import (
     _DATE_TO,
@@ -29,7 +34,7 @@ from products.engineering_analytics.backend.presentation.views._base import (
 
 
 class SuiteHealthActionsMixin(EngineeringAnalyticsViewSetBase):
-    READ_ACTIONS = ["flaky_tests", "broken_tests", "quarantine"]
+    READ_ACTIONS = ["flaky_tests", "test_signal_history", "broken_tests", "quarantine"]
     WRITE_ACTIONS = ["quarantine_request"]
 
     @extend_schema(
@@ -95,6 +100,81 @@ class SuiteHealthActionsMixin(EngineeringAnalyticsViewSetBase):
         except ValueError as exc:
             return _bad_request(exc, fallback="Invalid date, threshold, limit, or source_id")
         return Response(FlakyTestListSerializer(instance=result).data)
+
+    @extend_schema(
+        operation_id="engineering_analytics_test_signal_history",
+        parameters=[
+            OpenApiParameter(
+                name="test",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="The test to read, matched against either the nodeid or the selector the CI reporter "
+                "emitted. Paste either field from a flaky_tests row, or a literal pytest or Jest selector. Every "
+                "span carries the nodeid, so prefer it if a lookup by selector comes back empty.",
+            ),
+            OpenApiParameter(
+                name="runner",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                enum=[runner.value for runner in CITestRunner],
+                description="Optional test runner to scope to, for the rare case where a pytest and a Jest test "
+                "share an identity. Omit to read both.",
+            ),
+            OpenApiParameter(
+                name="date_from",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description="Window start: relative ('-7d', '-30d') or ISO8601. Defaults to -7d; the window "
+                "may span at most 30 days.",
+            ),
+            _DATE_TO,
+            OpenApiParameter(
+                name="limit",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                required=False,
+                description="Maximum number of runs to return (1-200). Defaults to 50.",
+            ),
+            _SOURCE_ID,
+            _REPO,
+        ],
+        responses={
+            200: TestSignalHistorySerializer,
+            400: OpenApiResponse(
+                description="Missing or blank test, or an invalid runner, date, limit, or source_id, or a window "
+                "longer than 30 days."
+            ),
+        },
+        description=(
+            "One test's signal-bearing CI runs over a window (default -7d, maximum 30 days), newest first, each with "
+            "its PR number, branch, and what the run proved: it failed, one commit both failed and passed it "
+            "(same-commit recovery), or it recorded a tolerated failure while quarantined. This is the per-test "
+            "drill-down behind flaky_tests, which ranks which tests are worth acting on; the rollup counts here match "
+            "that queue's for the same test and window, and cover the whole window even when the run list is "
+            "truncated. Pass a run's run_id to run_failure_logs for the failing lines. A test with no signal in the "
+            "window returns an empty history rather than a 404. " + FLAKY_TEST_SIGNAL_CAVEAT
+        ),
+    )
+    @action(detail=False, methods=["get"], pagination_class=None)
+    def test_signal_history(self, request: Request, **kwargs) -> Response:
+        try:
+            result = api.get_test_signal_history(
+                team=self.team,
+                test=request.query_params.get("test") or "",
+                runner=request.query_params.get("runner") or None,
+                date_from=request.query_params.get("date_from") or None,
+                date_to=request.query_params.get("date_to") or None,
+                limit=_optional_int_param(request, "limit"),
+                source_id=request.query_params.get("source_id") or None,
+                repo=request.query_params.get("repo") or None,
+                user_access_control=self.user_access_control,
+            )
+        except ValueError as exc:
+            return _bad_request(exc, fallback="Invalid test, runner, date, limit, or source_id")
+        return Response(TestSignalHistorySerializer(instance=result).data)
 
     @extend_schema(
         operation_id="engineering_analytics_broken_tests",

--- a/products/engineering_analytics/backend/tests/test_mcp.py
+++ b/products/engineering_analytics/backend/tests/test_mcp.py
@@ -8,7 +8,14 @@ _DEFINITIONS = Path(__file__).parents[4] / "services/mcp/schema/generated-tool-d
 
 class TestEngineeringAnalyticsMCPTools:
     @pytest.mark.parametrize(
-        "tool", ["pull-requests", "workflow-health", "pr-lifecycle", "engineering-analytics-flaky-tests"]
+        "tool",
+        [
+            "pull-requests",
+            "workflow-health",
+            "pr-lifecycle",
+            "engineering-analytics-flaky-tests",
+            "engineering-analytics-test-signal-history",
+        ],
     )
     def test_tool_is_generated_read_only_and_scoped(self, tool: str) -> None:
         definitions = json.loads(_DEFINITIONS.read_text())

--- a/products/engineering_analytics/backend/tests/test_test_signal_history.py
+++ b/products/engineering_analytics/backend/tests/test_test_signal_history.py
@@ -1,0 +1,263 @@
+from datetime import UTC, datetime, timedelta
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.clickhouse.client import sync_execute
+from posthog.clickhouse.traces.spans import TRACE_SPANS_DISTRIBUTED_TABLE_SQL, TRACE_SPANS_TABLE_SQL
+
+from products.engineering_analytics.backend.tests._github_fixtures import connect_github_source_without_data
+from products.warehouse_sources.backend.facade.models import ExternalDataSource
+
+T_ACROSS_PRS = "posthog/api/test/test_history/TestHistory::test_fails_across_prs"
+T_ACROSS_PRS_SELECTOR = "posthog/api/test/test_history.py::TestHistory::test_fails_across_prs"
+T_QUARANTINED = "posthog/api/test/test_masked/TestMasked::test_tolerated_failure"
+T_MATRIX_LEGS = "posthog/api/test/test_legs/TestLegs::test_fails_in_two_legs"
+T_COLLIDING = "shared/identity::test_same_name_in_both_runners"
+T_OTHER_REPO = "posthog/api/test/test_other/TestOther::test_other_repo"
+
+
+class TestTestSignalHistoryAPI(ClickhouseTestMixin, APIBaseTest):
+    # The identity match, the run grain, and the window-complete rollup all live in the HogQL query,
+    # so the regressions worth catching only surface against real seeded trace_spans rows.
+
+    CLASS_DATA_LEVEL_SETUP = True
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        connect_github_source_without_data(cls.team, prefix="history", repository="PostHog/posthog")
+        sync_execute("DROP TABLE IF EXISTS trace_spans_distributed")
+        sync_execute("DROP TABLE IF EXISTS trace_spans")
+        sync_execute(TRACE_SPANS_TABLE_SQL())
+        sync_execute(TRACE_SPANS_DISTRIBUTED_TABLE_SQL())
+
+        now = datetime.now(UTC).replace(microsecond=0)
+        recent = now - timedelta(days=1)
+        earlier = now - timedelta(days=2)
+        earliest = now - timedelta(days=3)
+        # Inside a -30d window but outside the -7d default.
+        old = now - timedelta(days=10)
+
+        rows = [
+            # One test seen on master and on two PRs, one of which recovered on a re-run attempt.
+            # Every span carries the emitted selector, so a caller can look the test up either way.
+            cls._span(1, T_ACROSS_PRS, "failed", ts=recent, run="10", branch="master"),
+            cls._span(2, T_ACROSS_PRS, "failed", ts=earlier, run="11", pr="201", branch="feat-a"),
+            cls._span(3, T_ACROSS_PRS, "failed", ts=earliest, run="12", pr="202", branch="feat-b"),
+            # The re-run attempt goes green on the same commit, later than every other signal. It is a
+            # recovery, not signal, so it must not make run 12 the newest run.
+            cls._span(4, T_ACROSS_PRS, "passed", ts=recent, run="12", attempt="2", pr="202", branch="feat-b"),
+            cls._span(5, T_ACROSS_PRS, "failed", ts=old, run="13", pr="203", branch="feat-c"),
+            # A tolerated failure while quarantine masks the test: quarantined, never a failure.
+            cls._span(6, T_QUARANTINED, "xfailed", ts=earlier, run="20", branch="master"),
+            # One run fans the test across two stable matrix jobs and both fail. One run, one failure.
+            cls._span(7, T_MATRIX_LEGS, "failed", ts=earlier, run="30", branch="master", job="FOSS:1"),
+            cls._span(8, T_MATRIX_LEGS, "failed", ts=recent, run="30", branch="master", job="EE:1"),
+            # The same identity emitted by both suites: only the runner filter can separate them.
+            cls._span(9, T_COLLIDING, "failed", ts=earlier, run="40", pr="401", branch="py"),
+            cls._span(10, T_COLLIDING, "failed", ts=earlier, run="41", pr="411", branch="js", service="ci-frontend"),
+            # Another connected repository's signal for a test this source must never answer for.
+            cls._span(11, T_OTHER_REPO, "failed", ts=earlier, run="50", repo="PostHog/posthog.com"),
+        ]
+        sync_execute(
+            "INSERT INTO trace_spans (uuid, team_id, trace_id, span_id, parent_span_id, name, kind, "
+            "timestamp, end_time, observed_timestamp, status_code, service_name, attributes_map_str, "
+            "resource_attributes) VALUES " + ",".join(rows)
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        sync_execute("DROP TABLE IF EXISTS trace_spans_distributed")
+        sync_execute("DROP TABLE IF EXISTS trace_spans")
+        sync_execute(TRACE_SPANS_TABLE_SQL())
+        sync_execute(TRACE_SPANS_DISTRIBUTED_TABLE_SQL())
+        super().tearDownClass()
+
+    @classmethod
+    def _span(
+        cls,
+        index: int,
+        name: str,
+        outcome: str,
+        *,
+        ts: datetime,
+        run: str,
+        attempt: str = "1",
+        pr: str = "",
+        branch: str = "",
+        service: str = "ci-backend",
+        repo: str = "PostHog/posthog",
+        job: str = "",
+    ) -> str:
+        # Physical attributes carry a type suffix ('test.outcome__str'); the `attributes` ALIAS column
+        # strips it. Resource attributes are stored as-is.
+        # Only T_ACROSS_PRS gets a selector that differs from its nodeid, which is what makes the
+        # two-identity lookup a real test rather than one string matching itself twice.
+        selector = T_ACROSS_PRS_SELECTOR if name == T_ACROSS_PRS else name
+        attr_pairs = [f"'test.outcome__str', '{outcome}'", f"'test.selector__str', '{selector}'"]
+        if job:
+            attr_pairs.append(f"'test.job_key__str', '{job}'")
+        attrs = f"map({', '.join(attr_pairs)})"
+        resource_pairs = [
+            f"'{key}', '{value}'"
+            for key, value in (
+                ("ci.run_id", run),
+                ("ci.run_attempt", attempt),
+                ("ci.pr_number", pr),
+                ("ci.branch", branch),
+                ("ci.repository", repo),
+            )
+            if value
+        ]
+        resource = f"map({', '.join(resource_pairs)})"
+        stamp = ts.strftime("%Y-%m-%d %H:%M:%S")
+        return (
+            f"('uuid-{index}', {cls.team.id}, 'trace-{index}', 'span-{index}', 'parent', '{name}', 1, "
+            f"'{stamp}', '{stamp}', '{stamp}', 0, '{service}', {attrs}, {resource})"
+        )
+
+    def _url(self) -> str:
+        return f"/api/projects/{self.team.id}/engineering_analytics/test_signal_history/"
+
+    def _get(self, test: str, **params: str) -> dict:
+        response = self.client.get(self._url(), {"test": test, **params})
+        assert response.status_code == status.HTTP_200_OK, response.content
+        return response.json()
+
+    def _runs(self, test: str, **params: str) -> dict[str, dict]:
+        return {run["run_id"]: run for run in self._get(test, **params)["runs"]}
+
+    @parameterized.expand([("by_nodeid", T_ACROSS_PRS), ("by_selector", T_ACROSS_PRS_SELECTOR)])
+    def test_a_test_resolves_from_either_identity(self, _name: str, test: str) -> None:
+        data = self._get(test)
+
+        # The queue hands out both fields, so either must reach the same history.
+        assert data["nodeid"] == T_ACROSS_PRS
+        assert data["selector"] == T_ACROSS_PRS_SELECTOR
+        assert data["runner"] == "pytest"
+        # Newest first, and the run whose re-run attempt passed last is still the oldest signal:
+        # a recovery pass is not signal, so it never moves a run's recency.
+        assert [run["run_id"] for run in data["runs"]] == ["10", "11", "12"]
+
+    def test_run_rows_report_where_each_run_ran_and_what_it_proved(self) -> None:
+        runs = self._runs(T_ACROSS_PRS)
+
+        # A master push carries no PR association, and 0 would read as PR #0.
+        assert runs["10"]["pr_number"] is None
+        assert (runs["10"]["branch"], runs["10"]["failed"], runs["10"]["recovered"]) == ("master", True, False)
+        assert (runs["11"]["pr_number"], runs["11"]["branch"]) == (201, "feat-a")
+        assert (runs["12"]["pr_number"], runs["12"]["failed"], runs["12"]["recovered"]) == (202, True, True)
+        assert [run["quarantined"] for run in runs.values()] == [False, False, False]
+
+        masked = self._runs(T_QUARANTINED)["20"]
+        # An xfail is a tolerated failure, not a failure.
+        assert (masked["quarantined"], masked["failed"], masked["recovered"]) == (True, False, False)
+
+    @parameterized.expand(
+        [
+            (
+                "recovered_on_a_rerun_attempt",
+                T_ACROSS_PRS,
+                "confirmed_flake",
+                {
+                    "same_commit_recovery_run_count": 1,
+                    "failed_run_count": 3,
+                    "failed_pr_count": 2,
+                    "master_failed_run_count": 1,
+                    "quarantined_failed_run_count": 0,
+                },
+            ),
+            (
+                "failing_while_masked",
+                T_QUARANTINED,
+                "quarantined",
+                {
+                    "same_commit_recovery_run_count": 0,
+                    "failed_run_count": 0,
+                    "failed_pr_count": 0,
+                    "master_failed_run_count": 0,
+                    "quarantined_failed_run_count": 1,
+                },
+            ),
+        ]
+    )
+    def test_rollup_counts_match_the_queue_definitions(
+        self, _name: str, test: str, expected_classification: str, expected_counts: dict[str, int]
+    ) -> None:
+        data = self._get(test)
+
+        assert data["classification"] == expected_classification
+        assert {key: data[key] for key in expected_counts} == expected_counts
+
+    def test_evidence_is_counted_once_per_run(self) -> None:
+        data = self._get(T_MATRIX_LEGS)
+
+        # Two failing matrix jobs of one run: one run row, one failure. Span- or job-grain counting
+        # would say 2 and double this test's apparent blast radius.
+        assert [run["run_id"] for run in data["runs"]] == ["30"]
+        assert (data["failed_run_count"], data["master_failed_run_count"]) == (1, 1)
+        # Recency is the newest failing leg, not the first one seen.
+        assert data["last_signal_at"] == data["runs"][0]["signal_at"]
+
+    def test_counts_stay_window_complete_when_the_run_list_is_truncated(self) -> None:
+        data = self._get(T_ACROSS_PRS, limit="1")
+
+        assert (len(data["runs"]), data["truncated"], data["limit"]) == (1, True, 1)
+        # The counts are a sibling aggregate of the capped list: page-scoped counts here would
+        # disagree with what the test-health queue reports for the same test and window.
+        assert (data["failed_run_count"], data["failed_pr_count"]) == (3, 2)
+        assert data["same_commit_recovery_run_count"] == 1
+
+    @parameterized.expand([("pytest", "40", "py"), ("jest", "41", "js")])
+    def test_runner_filter_separates_a_cross_runner_identity(
+        self, runner: str, expected_run: str, expected_branch: str
+    ) -> None:
+        data = self._get(T_COLLIDING, runner=runner)
+
+        assert data["runner"] == runner
+        assert [(run["run_id"], run["branch"]) for run in data["runs"]] == [(expected_run, expected_branch)]
+        assert data["failed_run_count"] == 1
+
+    def test_wider_window_includes_older_signal(self) -> None:
+        assert "13" not in self._runs(T_ACROSS_PRS)
+        assert "13" in self._runs(T_ACROSS_PRS, date_from="-30d")
+
+    def test_unknown_test_returns_an_empty_history(self) -> None:
+        data = self._get("posthog/api/test/test_nope/TestNope::test_never_ran")
+
+        # An unknown test is a legitimate empty answer, and a fabricated runner or classification
+        # would read as a verdict on a test this window says nothing about.
+        assert data["runs"] == []
+        assert (data["runner"], data["classification"], data["last_signal_at"]) == (None, None, None)
+        assert data["failed_run_count"] == 0
+        assert data["nodeid"] == "posthog/api/test/test_nope/TestNope::test_never_ran"
+
+    def test_another_repositorys_history_never_leaks(self) -> None:
+        # The spans are seeded and would qualify, but they belong to a different repository.
+        assert self._get(T_OTHER_REPO)["runs"] == []
+
+    def test_source_without_repository_fails_closed(self) -> None:
+        # Without a repository identity the spans can't be scoped, so the history must be empty
+        # rather than answer from every connected repository at once.
+        ExternalDataSource.objects.filter(team_id=self.team.id).update(job_inputs={})
+        data = self._get(T_ACROSS_PRS)
+        assert (data["runs"], data["failed_run_count"], data["truncated"]) == ([], 0, False)
+
+    @parameterized.expand(
+        [
+            ("missing_test", {}),
+            ("blank_test", {"test": "   "}),
+            ("unknown_runner", {"test": T_ACROSS_PRS, "runner": "playwright"}),
+            ("window_over_30_days", {"test": T_ACROSS_PRS, "date_from": "-45d"}),
+            ("reversed_window", {"test": T_ACROSS_PRS, "date_from": "-1d", "date_to": "-5d"}),
+            ("zero_limit", {"test": T_ACROSS_PRS, "limit": "0"}),
+            ("oversized_limit", {"test": T_ACROSS_PRS, "limit": "201"}),
+            ("non_integer_limit", {"test": T_ACROSS_PRS, "limit": "lots"}),
+        ]
+    )
+    def test_invalid_params_return_400(self, _name: str, params: dict) -> None:
+        response = self.client.get(self._url(), params)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.content

--- a/products/engineering_analytics/frontend/scenes/engineeringAnalyticsLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/engineeringAnalyticsLogic.ts
@@ -34,7 +34,7 @@ import {
 } from '../generated/api'
 import type {
     BrokenTestRowApi,
-    FlakyTestItemClassificationEnumApi,
+    FlakyTestClassificationEnumApi,
     GitHubSourceApi,
     PullRequestListItemApi,
     PushCISampleApi,
@@ -447,7 +447,7 @@ export function quarantineCountsOf(rows: QuarantineEntryRow[]): QuarantineCounts
 /** Test-health windows the UI offers; the endpoint accepts any window up to 30 days. */
 export type FlakyTestWindow = '-7d' | '-14d' | '-30d'
 export const DEFAULT_FLAKY_TEST_WINDOW: FlakyTestWindow = '-7d'
-export type FlakyTestClassification = FlakyTestItemClassificationEnumApi
+export type FlakyTestClassification = FlakyTestClassificationEnumApi
 export type TestRunner = NonNullable<QuarantineRequestApi['runner']>
 export const TEST_RUNNERS: readonly TestRunner[] = ['pytest', 'jest', 'playwright']
 

--- a/products/engineering_analytics/mcp/tools.yaml
+++ b/products/engineering_analytics/mcp/tools.yaml
@@ -217,6 +217,33 @@ tools:
     engineering-analytics-team-merge-trend:
         operation: engineering_analytics_team_merge_trend
         enabled: false
+    engineering-analytics-test-signal-history:
+        operation: engineering_analytics_test_signal_history
+        enabled: true
+        scopes:
+            - engineering_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: One test's failure history across PRs
+        description: >
+            One test's signal-bearing CI runs over a window (date_from default -7d, maximum 30 days), newest first,
+            each with its run_id, pr_number (null on master pushes), branch, and what that run proved: failed, a
+            same-commit recovery (one commit both failed and passed it, so it is provably nondeterministic), or a
+            tolerated failure recorded while quarantine masked it. This is the per-test drill-down counterpart to
+            engineering-analytics-flaky-tests, which ranks which tests are worth acting on; use it to answer "how flaky
+            is this one test, and what has it done across recent PRs". The rollup counts (failed_run_count,
+            failed_pr_count, master_failed_run_count, same_commit_recovery_run_count, quarantined_failed_run_count)
+            match what the queue reports for the same test and window, and always cover the whole window even when
+            truncated is true and runs holds only the newest limit of them. Passing runs are never emitted, so this is a
+            failure history and never a pass rate, and every count is absolute with no denominator to divide by. Pass
+            test the nodeid or the selector from a flaky-tests row, or a literal pytest or Jest selector; every span
+            carries the nodeid, so prefer it if a lookup by selector comes back empty. Add runner only to break a rare
+            pytest/Jest identity collision. A test with no signal in the window returns an empty history, not an error.
+            This data sees the main Backend pytest and Frontend Jest suites; package-specific runners are not included.
+            Pass a run's run_id to run-failure-logs for the actual failing lines.
+        feature_flag: engineering-analytics
     engineering-analytics-workflow-jobs:
         operation: engineering_analytics_workflow_jobs
         enabled: true

--- a/products/engineering_analytics/skills/diagnosing-ci-and-merge-bottlenecks/SKILL.md
+++ b/products/engineering_analytics/skills/diagnosing-ci-and-merge-bottlenecks/SKILL.md
@@ -49,6 +49,15 @@ autonomous agents (e.g. PostHog Desktop) reasoning about their own PRs.
   and Frontend Jest suites, and recovery proof only arrives when someone re-runs failed jobs (or a pytest test is hand-marked
   `@pytest.mark.flaky(reruns=N)`). Counts are absolute signal, never rates: passing runs are mostly not
   emitted, so there is no honest denominator.
+- **`engineering-analytics-test-signal-history`** — the per-test drill-down behind that queue: one test's
+  signal-bearing CI runs over the same window (`date_from` default `-7d`, max 30 days), newest first, each with
+  `run_id`, `pr_number` (`null` on master pushes), `branch`, and `failed` / `recovered` / `quarantined`. Pass
+  `test` the `nodeid` or the `selector` from a flaky-tests row. Answers "how flaky is this one test, and what has
+  it done across recent PRs": the run-by-run evidence the queue aggregates away. The rollup counts it returns
+  match the queue's for the same test and window, and stay window-complete even when `truncated` is `true`
+  (the `runs` list is then the newest `limit` of them). Passing runs are never emitted, so this is a failure
+  history, not a pass rate. A test with no signal in the window returns an empty history, not an error. Take a
+  row's `run_id` to `engineering-analytics-run-failure-logs` for the failing lines.
 
 There is no aggregate time-to-merge tool and no "counts" tool — derive those from `pull-requests` (the stuck/failing
 counts, the merge-time percentiles).
@@ -84,6 +93,7 @@ These are structural limits of today's snapshot data — state them, don't paper
 | How long are PRs taking to merge? Per author?          | `pull-requests`                     | Over merged rows (`merged_at` set, not bot, not draft), aggregate `open_to_merge_seconds` — median and p95. Group by `author.handle` for **cohort context, not a ranking** (per-developer surveillance is an explicit non-goal). Trend it by calling with two `date_from` windows.             |
 | Where is PR N stuck?                                   | `pr-lifecycle`                      | Walk the sorted events: `opened → first CI started`, the CI span (first start → last finish; one pair per workflow), `last CI finished → merged`. The largest gap is the bottleneck. A long open→merge with quick CI points at review/idle time the `partial` data can't itemize yet — say so. |
 | What is a failing test costing us? What to quarantine? | `engineering-analytics-flaky-tests` | Default window is `-7d`; rows are already ranked by blast radius (master failures, then distinct PRs hit). Report counts, never rates. For "is it flaky": only `confirmed_flake` rows are proven, and only for tests hand-marked with reruns.                                                  |
+| How flaky is _this_ test? What has it done across recent PRs? | `engineering-analytics-test-signal-history` | Pass `test` the `nodeid` or `selector`. Walk `runs` newest first: `pr_number` and `branch` say where each failure landed, `recovered` marks the same-commit proof. Report the run count, never a rate. Take a `run_id` to `engineering-analytics-run-failure-logs` for the lines.        |
 
 ## The high-value chain
 

--- a/products/engineering_analytics/skills/investigating-ci-failures/SKILL.md
+++ b/products/engineering_analytics/skills/investigating-ci-failures/SKILL.md
@@ -50,7 +50,7 @@ falls out of three columns:
 | --------------------------------------- | ------------------------------- | ---------------------------------------------------- |
 | 1 branch, any window                    | That PR's own problem           | Read its failure lines; done                         |
 | Many branches, dense burst, hits master | Trunk break (master is/was red) | Boundary query → culprit (below)                     |
-| Many branches, sporadic over days/weeks | Flaky                           | Corroborate with `engineering-analytics-flaky-tests` |
+| Many branches, sporadic over days/weeks | Flaky                           | Corroborate with `engineering-analytics-test-signal-history` |
 
 Why cross-branch means trunk: PR CI runs the PR **merged with master**, so one bad master commit
 fails every concurrently-running PR. A failure appearing on many unrelated branches in a tight
@@ -79,10 +79,18 @@ different problems sharing a test.
 
 ## Flaky → corroborate, don't guess
 
-Sporadic shape alone is suggestive, not proof. The `engineering-analytics-flaky-tests` MCP tool reads per-test CI spans
-(rerun-pass signal — a test that failed then passed on retry in the same job) and is the stronger
-signal where it has coverage. Counts only, never rates: passing runs below the emitter's duration
-threshold aren't recorded, so there is no honest denominator.
+Sporadic shape alone is suggestive, not proof. Two MCP tools read the per-test CI spans (rerun-pass
+signal — a test that failed then passed on retry in the same job) and are the stronger signal where
+they have coverage. Counts only, never rates: passing runs below the emitter's duration threshold
+aren't recorded, so there is no honest denominator.
+
+- **`engineering-analytics-test-signal-history`** — the direct answer for one named test. Pass `test`
+  the failing node id (or its selector) and read `runs` newest first: `recovered` is the same-commit
+  proof that makes it a `confirmed_flake`, `pr_number` and `branch` say where each failure landed, and
+  `master_failed_run_count` says whether it has hit trunk. An empty history means no signal in the
+  window, not that the test is fine.
+- **`engineering-analytics-flaky-tests`** — the ranked queue, for when you want the surrounding
+  context (what else is failing, and what this test costs relative to it).
 
 ## Caveats you must carry into every answer
 
@@ -116,7 +124,7 @@ threshold aren't recorded, so there is no honest denominator.
 | "What's broken across CI right now?"   | `engineering-analytics-broken-tests` MCP tool (triaged, classified)    |
 | "Why did MY PR's CI fail?"             | `engineering-analytics-ci-failure-logs` MCP tool (PR-scoped, grouped)  |
 | "Who broke master / when did X start?" | The two views, workflow above                                          |
-| "Is X flaky?"                          | Shape from `ci_failures` + the flaky-tests tool                        |
+| "Is X flaky?"                          | `engineering-analytics-test-signal-history` MCP tool (that test's runs) |
 | "What's failing on master right now?"  | `engineering-analytics-master-failures` MCP tool (grouped triage feed) |
 | "Is CI slow / expensive / PRs stuck?"  | The `diagnosing-ci-and-merge-bottlenecks` skill                        |
 | "Save this as a dashboard/insight"     | The `turning-engineering-analytics-into-insights` skill                |


### PR DESCRIPTION
## Problem

We can rank which tests are worth fixing. We can't ask what one test has actually done lately.

`posthog.trace_spans` records every failure with its run, PR, and branch, but every endpoint collapses that detail before a caller sees it.

Refs #73519.

## Changes

Adds one endpoint and MCP tool, `engineering_analytics_test_signal_history`. Give it a test, get its signal-bearing CI runs over a window (default 7 days, max 30), newest first, each with where it ran and what it proved. Backend only, mirroring the `flaky_tests` path. No UI yet.

```mermaid
flowchart TD
    SPANS[("trace_spans")]
    GRAIN["run_evidence()"]
    QUEUE["flaky_tests"]
    HIST["test_signal_history"]
    SPANS --> GRAIN
    GRAIN -->|"groups PR and run away"| QUEUE
    GRAIN -->|"keeps PR and run"| HIST
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class SPANS,QUEUE phGray;
    class GRAIN phYellow;
    class HIST phBlue;
```

Both queries embed the same `run_evidence()`, so the queue and its drill-down can't drift on what a run means.

Two things for review.

The rollup counts are `OVER ()` window aggregates, so a truncated run list still reports counts matching the queue's. Page-scoped counts would let two surfaces disagree about the same evidence, which SPEC §5 rules out.

`runner` and `classification` are nullable. With no signal in the window, `suspected_regression` would be a verdict on data that says nothing.

The `settings/web.py` and frontend lines are one forced change. A second component using `FlakyTestClassification` needs an `ENUM_NAME_OVERRIDES` entry, like `CITestRunnerEnum` already has, and that renames the generated type.

## How did you test this code?

The 21 new tests need ClickHouse and this sandbox had none, so they have never run. No Postgres either, so the generated MCP and frontend files are stale and will fail CI until it regenerates them. Lint, `tach`, and repo-wide mypy pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The endpoint catalog and tool copy live in `presentation/views.py` and `mcp/tools.yaml`, both updated here, plus the two affected skills.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in PostHog Code, working from a locked spec I handed it. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/implementing-mcp-tools`, `/writing-user-facing-copy`, `/writing-code-comments`.

Truncation was the real decision. The spec allowed page-scoped counts with a caveat, or window-complete counts, and asked for an explicit pick. Window-complete won, since two surfaces disagreeing about identical evidence is the worse failure and `OVER ()` gets it in one scan. That meant dropping the spec's suggestion to roll the counts up in Python, which can't stay complete once the page is capped.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
