### PR TITLE
fix(ci): pin sharding plan so re-runs re-execute earlier failures

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -58,13 +58,13 @@
 # - Test durations restored from Depot Cache (posthog-test-durations- prefix), refreshed by
 #   .depot/workflows/ci-backend-update-test-timing.yml, so shard counts match GitHub Actions.
 #   Committed .test_durations is the fallback.
-# - Sharding-plan pinning for re-runs: canonical snapshots the durations files as a
-#   run-scoped artifact in turbo-discover (plus a per-segment durations restore feeding it)
-#   and re-run attempts restore that snapshot, so a re-run shard re-collects exactly the
-#   tests that failed in attempt 1 instead of resharding from a newer daily cache. The
-#   shadow strips artifact uploads (above) and is a non-blocking timing trial whose signal
-#   is attempt-1 runs, so it keeps plain floating cache restores; changes confined to that
-#   pinning need no depot bump.
+# - Sharding-plan pinning: canonical snapshots the durations files as a run-scoped
+#   artifact in turbo-discover (plus a per-segment durations restore feeding it) and every
+#   test job applies that snapshot, so all shards of all attempts plan from identical
+#   timing data and a re-run shard re-collects the tests it failed with instead of
+#   resharding from a fresher cache entry. The shadow strips artifact uploads (above) and
+#   is a non-blocking timing trial, so it keeps plain floating cache restores; changes
+#   confined to that pinning need no depot bump.
 # - master (push) runs only check-migrations to prime the shared schema cache; the
 #   test matrices are skipped on master (canonical runs them). PRs and dispatches
 #   run the full graph — that is where the apples-to-apples comparison happens

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -59,12 +59,9 @@
 #   .depot/workflows/ci-backend-update-test-timing.yml, so shard counts match GitHub Actions.
 #   Committed .test_durations is the fallback.
 # - Sharding-plan pinning: canonical snapshots the durations files as a run-scoped
-#   artifact in turbo-discover (plus a per-segment durations restore feeding it) and every
-#   test job applies that snapshot, so all shards of all attempts plan from identical
-#   timing data and a re-run shard re-collects the tests it failed with instead of
-#   resharding from a fresher cache entry. The shadow strips artifact uploads (above) and
-#   is a non-blocking timing trial, so it keeps plain floating cache restores; changes
-#   confined to that pinning need no depot bump.
+#   artifact and every test job applies it, so re-runs shard like attempt 1. The shadow
+#   strips artifact uploads (above), so it keeps floating restores; no depot bump needed
+#   for changes confined to that pinning.
 # - master (push) runs only check-migrations to prime the shared schema cache; the
 #   test matrices are skipped on master (canonical runs them). PRs and dispatches
 #   run the full graph — that is where the apples-to-apples comparison happens

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -58,6 +58,13 @@
 # - Test durations restored from Depot Cache (posthog-test-durations- prefix), refreshed by
 #   .depot/workflows/ci-backend-update-test-timing.yml, so shard counts match GitHub Actions.
 #   Committed .test_durations is the fallback.
+# - Sharding-plan pinning for re-runs: canonical snapshots the durations files as a
+#   run-scoped artifact in turbo-discover (plus a per-segment durations restore feeding it)
+#   and re-run attempts restore that snapshot, so a re-run shard re-collects exactly the
+#   tests that failed in attempt 1 instead of resharding from a newer daily cache. The
+#   shadow strips artifact uploads (above) and is a non-blocking timing trial whose signal
+#   is attempt-1 runs, so it keeps plain floating cache restores; changes confined to that
+#   pinning need no depot bump.
 # - master (push) runs only check-migrations to prime the shared schema cache; the
 #   test matrices are skipped on master (canonical runs them). PRs and dispatches
 #   run the full graph — that is where the apples-to-apples comparison happens

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -449,6 +449,41 @@ jobs:
                   restore-keys: |
                       posthog-test-durations-
 
+            - name: Restore per-segment test durations from cache
+              # Restored here as well as in the Django job so the sharding-plan snapshot
+              # below covers the per-segment plan files the Core/Temporal shards read.
+              uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+              with:
+                  path: |
+                      .test_durations.core
+                      .test_durations.temporal
+                  key: posthog-segment-durations-${{ github.run_id }}
+                  restore-keys: |
+                      posthog-segment-durations-
+
+            - name: Snapshot the sharding plan for re-run attempts
+              # The durations caches float to the newest daily entry, so a re-run days
+              # later shards from different timing data than attempt 1. Under "re-run
+              # failed jobs" only the failed shards re-execute, which means a reshard can
+              # move a test that failed in attempt 1 onto a shard that is not re-run: the
+              # test is then never re-executed, every job goes green, and the gate passes
+              # a still-broken PR. Snapshotting the plan inputs as a run-scoped artifact
+              # lets re-run attempts restore attempt 1's exact plan, so a re-run shard
+              # re-collects exactly the tests it failed with.
+              if: github.run_attempt == '1'
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              with:
+                  name: test-durations-plan
+                  path: |
+                      .test_durations
+                      .test_durations.core
+                      .test_durations.temporal
+                  include-hidden-files: true
+                  # The committed .test_durations always exists; the per-segment files are
+                  # cache-only and may legitimately be absent.
+                  if-no-files-found: warn
+                  retention-days: 14
+
             - name: Discover products to test
               id: discover
               env:
@@ -874,6 +909,26 @@ jobs:
                   key: posthog-test-durations-${{ github.run_id }}
                   restore-keys: |
                       posthog-test-durations-
+
+            - name: Download attempt 1's sharding plan on re-runs
+              # Same re-run pinning as the Django job: a sharded product must re-collect
+              # the same tests on a re-run, else a test that failed in attempt 1 can move
+              # to a shard that is not re-run and never be re-executed while the gate goes
+              # green. Falls back to the floating cache when the snapshot is missing.
+              id: pinned-plan
+              if: github.run_attempt != '1'
+              continue-on-error: true
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  name: test-durations-plan
+                  path: /tmp/test-durations-plan
+
+            - name: Apply the pinned sharding plan
+              if: steps.pinned-plan.outcome == 'success'
+              shell: bash
+              run: |
+                  cp /tmp/test-durations-plan/.test_durations .test_durations
+                  echo "Sharding plan pinned to attempt 1's snapshot"
 
             - name: Run product tests
               id: run-product-tests
@@ -2639,6 +2694,37 @@ jobs:
                   key: posthog-segment-durations-${{ github.run_id }}
                   restore-keys: |
                       posthog-segment-durations-
+
+            - name: Download attempt 1's sharding plan on re-runs
+              # The cache restores above float to the newest daily entry, which on a
+              # re-run days later can differ from what attempt 1 sharded with. Under
+              # "re-run failed jobs" only the failed shards re-execute, so a reshard can
+              # move a test that failed in attempt 1 onto a shard that is not re-run,
+              # and the failure is never re-executed yet the gate goes green. Pinning
+              # every attempt of a run to the plan snapshotted by turbo-discover makes a
+              # re-run shard re-collect exactly the tests it failed with.
+              # continue-on-error because a missing snapshot (turbo-discover failed, or
+              # the artifact expired) falls back to the floating caches above.
+              id: pinned-plan
+              if: github.run_attempt != '1'
+              continue-on-error: true
+              uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+              with:
+                  name: test-durations-plan
+                  path: /tmp/test-durations-plan
+
+            - name: Apply the pinned sharding plan
+              if: steps.pinned-plan.outcome == 'success'
+              shell: bash
+              run: |
+                  # Delete before copying so a per-segment file the snapshot lacks cannot
+                  # survive from the newer floating cache and diverge from the pinned union.
+                  rm -f .test_durations.core .test_durations.temporal
+                  cp /tmp/test-durations-plan/.test_durations .test_durations
+                  for f in .test_durations.core .test_durations.temporal; do
+                      if [ -f "/tmp/test-durations-plan/$f" ]; then cp "/tmp/test-durations-plan/$f" "$f"; fi
+                  done
+                  echo "Sharding plan pinned to attempt 1's snapshot"
 
             - name: Determine if --snapshot-update should be on
               # UPDATE mode: human commits - update snapshots

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -918,10 +918,9 @@ jobs:
                       posthog-test-durations-
 
             - name: Download the run's sharding plan snapshot
-              # Same pinning as the Django job: every shard of every attempt must plan
-              # from the same timing data, else a test that failed earlier can move to a
-              # shard that is not re-run and never be re-executed while the gate goes
-              # green. Falls back to the floating cache when the snapshot is missing.
+              # Same pinning as the Django job, for products sharded with pytest-split
+              # (full rationale on turbo-discover's "Snapshot the sharding plan" step).
+              # Falls back to the floating cache when the snapshot is missing.
               id: pinned-plan
               continue-on-error: true
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -2711,16 +2710,13 @@ jobs:
                       posthog-segment-durations-
 
             - name: Download the run's sharding plan snapshot
-              # The cache restores above float to the newest entry (refreshed every six
-              # hours), so shards restoring at different times, and re-run attempts days
-              # apart, can otherwise plan from different timing data. Under "re-run failed
-              # jobs" only the failed shards re-execute, so such a reshard can move a test
-              # that failed earlier onto a shard that is not re-run, and the failure is
-              # never re-executed yet the gate goes green. Applying the snapshot taken by
-              # turbo-discover makes every shard of every attempt plan from identical
-              # timing data, so a re-run shard re-collects the tests it failed with.
-              # continue-on-error because a missing snapshot (turbo-discover failed, or
-              # the artifact expired) falls back to the floating caches above.
+              # Apply the plan snapshotted by turbo-discover so every shard of every
+              # attempt plans from identical timing data; the floating restores above can
+              # otherwise diverge between jobs and attempts, letting a partial re-run
+              # skip a test that failed earlier (full rationale on the "Snapshot the
+              # sharding plan" step). continue-on-error because a missing snapshot
+              # (turbo-discover failed, or the artifact expired) falls back to the
+              # floating caches above.
               id: pinned-plan
               continue-on-error: true
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -450,8 +450,7 @@ jobs:
                       posthog-test-durations-
 
             - name: Restore per-segment test durations from cache
-              # Restored here as well as in the Django job so the sharding-plan snapshot
-              # below covers the per-segment plan files the Core/Temporal shards read.
+              # Also restored here so the snapshot below covers the per-segment plan files.
               uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
               with:
                   path: |
@@ -462,19 +461,12 @@ jobs:
                       posthog-segment-durations-
 
             - name: Snapshot the sharding plan for this run
-              # The durations caches float to the newest entry (the timing-update workflow
-              # refreshes them every six hours), so two jobs restoring minutes apart, or a
-              # re-run days later, can shard from different timing data. Under "re-run
-              # failed jobs" only the failed shards re-execute, which means a reshard can
-              # move a test that failed earlier onto a shard that is not re-run: the test
-              # is then never re-executed, every job goes green, and the gate passes a
-              # still-broken PR. Snapshotting the plan inputs once per run lets every test
-              # job in every attempt plan from identical timing data, so a re-run shard
-              # re-collects the tests it failed with. overwrite covers "re-run all jobs",
-              # where this job re-executes and re-snapshots; a failed-jobs re-run keeps
-              # the last full attempt's snapshot because this job is not re-run.
-              # continue-on-error because consumers fall back to the floating caches, so
-              # a failed upload must not take down the run's root job.
+              # The timing caches float to their newest entry, so a re-run can shard
+              # differently from attempt 1 and, under "re-run failed jobs", a failing
+              # test can move to a shard that never re-runs while the gate goes green.
+              # Every test job applies this snapshot instead, so all attempts shard
+              # identically. Best-effort (consumers fall back to the floating caches);
+              # overwrite lets a "re-run all jobs" attempt re-snapshot.
               continue-on-error: true
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
@@ -485,10 +477,9 @@ jobs:
                       .test_durations.temporal
                   include-hidden-files: true
                   overwrite: true
-                  # The committed .test_durations always exists; the per-segment files are
-                  # cache-only and may legitimately be absent.
+                  # The per-segment files are cache-only and may legitimately be absent.
                   if-no-files-found: warn
-                  # Covers GitHub's 30-day re-run window so a late re-run still pins.
+                  # GitHub allows re-runs for 30 days.
                   retention-days: 30
 
             - name: Discover products to test
@@ -918,9 +909,7 @@ jobs:
                       posthog-test-durations-
 
             - name: Download the run's sharding plan snapshot
-              # Same pinning as the Django job, for products sharded with pytest-split
-              # (full rationale on turbo-discover's "Snapshot the sharding plan" step).
-              # Falls back to the floating cache when the snapshot is missing.
+              # Same pinning as the Django job; falls back to the floating cache.
               id: pinned-plan
               continue-on-error: true
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -2710,13 +2699,8 @@ jobs:
                       posthog-segment-durations-
 
             - name: Download the run's sharding plan snapshot
-              # Apply the plan snapshotted by turbo-discover so every shard of every
-              # attempt plans from identical timing data; the floating restores above can
-              # otherwise diverge between jobs and attempts, letting a partial re-run
-              # skip a test that failed earlier (full rationale on the "Snapshot the
-              # sharding plan" step). continue-on-error because a missing snapshot
-              # (turbo-discover failed, or the artifact expired) falls back to the
-              # floating caches above.
+              # Pin every attempt to the plan turbo-discover snapshotted (rationale on
+              # that step); a missing snapshot falls back to the floating caches above.
               id: pinned-plan
               continue-on-error: true
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -2732,8 +2716,7 @@ jobs:
                       echo "::warning::Sharding-plan snapshot is incomplete, keeping the floating cache restores"
                       exit 0
                   fi
-                  # Delete before copying so a per-segment file the snapshot lacks cannot
-                  # survive from a newer floating cache and diverge from the pinned union.
+                  # rm first so segment files the snapshot lacks don't survive the floating restore
                   rm -f .test_durations.core .test_durations.temporal
                   cp /tmp/test-durations-plan/.test_durations .test_durations
                   for f in .test_durations.core .test_durations.temporal; do
@@ -2742,9 +2725,6 @@ jobs:
                   echo "Sharding plan pinned to this run's snapshot"
 
             - name: Warn when a re-run reshards unpinned
-              # On attempt 1 the floating caches are the status quo, but a re-run without
-              # the snapshot loses the re-execution guarantee, which is worth surfacing
-              # on the run summary rather than only in a collapsed step log.
               if: github.run_attempt != '1' && steps.pinned-plan.outcome != 'success'
               shell: bash
               run: echo "::warning::Sharding-plan snapshot unavailable, this re-run reshards from the floating timing caches and may not re-execute tests that failed in earlier attempts"

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -461,16 +461,21 @@ jobs:
                   restore-keys: |
                       posthog-segment-durations-
 
-            - name: Snapshot the sharding plan for re-run attempts
-              # The durations caches float to the newest daily entry, so a re-run days
-              # later shards from different timing data than attempt 1. Under "re-run
+            - name: Snapshot the sharding plan for this run
+              # The durations caches float to the newest entry (the timing-update workflow
+              # refreshes them every six hours), so two jobs restoring minutes apart, or a
+              # re-run days later, can shard from different timing data. Under "re-run
               # failed jobs" only the failed shards re-execute, which means a reshard can
-              # move a test that failed in attempt 1 onto a shard that is not re-run: the
-              # test is then never re-executed, every job goes green, and the gate passes
-              # a still-broken PR. Snapshotting the plan inputs as a run-scoped artifact
-              # lets re-run attempts restore attempt 1's exact plan, so a re-run shard
-              # re-collects exactly the tests it failed with.
-              if: github.run_attempt == '1'
+              # move a test that failed earlier onto a shard that is not re-run: the test
+              # is then never re-executed, every job goes green, and the gate passes a
+              # still-broken PR. Snapshotting the plan inputs once per run lets every test
+              # job in every attempt plan from identical timing data, so a re-run shard
+              # re-collects the tests it failed with. overwrite covers "re-run all jobs",
+              # where this job re-executes and re-snapshots; a failed-jobs re-run keeps
+              # the last full attempt's snapshot because this job is not re-run.
+              # continue-on-error because consumers fall back to the floating caches, so
+              # a failed upload must not take down the run's root job.
+              continue-on-error: true
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
               with:
                   name: test-durations-plan
@@ -479,10 +484,12 @@ jobs:
                       .test_durations.core
                       .test_durations.temporal
                   include-hidden-files: true
+                  overwrite: true
                   # The committed .test_durations always exists; the per-segment files are
                   # cache-only and may legitimately be absent.
                   if-no-files-found: warn
-                  retention-days: 14
+                  # Covers GitHub's 30-day re-run window so a late re-run still pins.
+                  retention-days: 30
 
             - name: Discover products to test
               id: discover
@@ -910,13 +917,12 @@ jobs:
                   restore-keys: |
                       posthog-test-durations-
 
-            - name: Download attempt 1's sharding plan on re-runs
-              # Same re-run pinning as the Django job: a sharded product must re-collect
-              # the same tests on a re-run, else a test that failed in attempt 1 can move
-              # to a shard that is not re-run and never be re-executed while the gate goes
+            - name: Download the run's sharding plan snapshot
+              # Same pinning as the Django job: every shard of every attempt must plan
+              # from the same timing data, else a test that failed earlier can move to a
+              # shard that is not re-run and never be re-executed while the gate goes
               # green. Falls back to the floating cache when the snapshot is missing.
               id: pinned-plan
-              if: github.run_attempt != '1'
               continue-on-error: true
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
               with:
@@ -927,8 +933,17 @@ jobs:
               if: steps.pinned-plan.outcome == 'success'
               shell: bash
               run: |
+                  if [ ! -f /tmp/test-durations-plan/.test_durations ]; then
+                      echo "::warning::Sharding-plan snapshot is incomplete, keeping the floating cache restore"
+                      exit 0
+                  fi
                   cp /tmp/test-durations-plan/.test_durations .test_durations
-                  echo "Sharding plan pinned to attempt 1's snapshot"
+                  echo "Sharding plan pinned to this run's snapshot"
+
+            - name: Warn when a re-run reshards unpinned
+              if: github.run_attempt != '1' && steps.pinned-plan.outcome != 'success'
+              shell: bash
+              run: echo "::warning::Sharding-plan snapshot unavailable, this re-run reshards from the floating timing cache and may not re-execute tests that failed in earlier attempts"
 
             - name: Run product tests
               id: run-product-tests
@@ -2695,18 +2710,18 @@ jobs:
                   restore-keys: |
                       posthog-segment-durations-
 
-            - name: Download attempt 1's sharding plan on re-runs
-              # The cache restores above float to the newest daily entry, which on a
-              # re-run days later can differ from what attempt 1 sharded with. Under
-              # "re-run failed jobs" only the failed shards re-execute, so a reshard can
-              # move a test that failed in attempt 1 onto a shard that is not re-run,
-              # and the failure is never re-executed yet the gate goes green. Pinning
-              # every attempt of a run to the plan snapshotted by turbo-discover makes a
-              # re-run shard re-collect exactly the tests it failed with.
+            - name: Download the run's sharding plan snapshot
+              # The cache restores above float to the newest entry (refreshed every six
+              # hours), so shards restoring at different times, and re-run attempts days
+              # apart, can otherwise plan from different timing data. Under "re-run failed
+              # jobs" only the failed shards re-execute, so such a reshard can move a test
+              # that failed earlier onto a shard that is not re-run, and the failure is
+              # never re-executed yet the gate goes green. Applying the snapshot taken by
+              # turbo-discover makes every shard of every attempt plan from identical
+              # timing data, so a re-run shard re-collects the tests it failed with.
               # continue-on-error because a missing snapshot (turbo-discover failed, or
               # the artifact expired) falls back to the floating caches above.
               id: pinned-plan
-              if: github.run_attempt != '1'
               continue-on-error: true
               uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
               with:
@@ -2717,14 +2732,26 @@ jobs:
               if: steps.pinned-plan.outcome == 'success'
               shell: bash
               run: |
+                  if [ ! -f /tmp/test-durations-plan/.test_durations ]; then
+                      echo "::warning::Sharding-plan snapshot is incomplete, keeping the floating cache restores"
+                      exit 0
+                  fi
                   # Delete before copying so a per-segment file the snapshot lacks cannot
-                  # survive from the newer floating cache and diverge from the pinned union.
+                  # survive from a newer floating cache and diverge from the pinned union.
                   rm -f .test_durations.core .test_durations.temporal
                   cp /tmp/test-durations-plan/.test_durations .test_durations
                   for f in .test_durations.core .test_durations.temporal; do
                       if [ -f "/tmp/test-durations-plan/$f" ]; then cp "/tmp/test-durations-plan/$f" "$f"; fi
                   done
-                  echo "Sharding plan pinned to attempt 1's snapshot"
+                  echo "Sharding plan pinned to this run's snapshot"
+
+            - name: Warn when a re-run reshards unpinned
+              # On attempt 1 the floating caches are the status quo, but a re-run without
+              # the snapshot loses the re-execution guarantee, which is worth surfacing
+              # on the run summary rather than only in a collapsed step log.
+              if: github.run_attempt != '1' && steps.pinned-plan.outcome != 'success'
+              shell: bash
+              run: echo "::warning::Sharding-plan snapshot unavailable, this re-run reshards from the floating timing caches and may not re-execute tests that failed in earlier attempts"
 
             - name: Determine if --snapshot-update should be on
               # UPDATE mode: human commits - update snapshots


### PR DESCRIPTION
## Problem

- Backend CI shards tests with pytest-split from timing caches that always float to the newest entry (refreshed every 6 hours).
- A re-run days later reshards the suite. With "re-run failed jobs", only failed shards re-execute, so a deterministically failing test can move onto a shard that never re-runs.
- Everything goes green and the broken PR merges. This is how #73294 landed a red parity test on master (fixed hours later in #74058).
- #74210 detects this after the fact by cross-checking JUnit across attempts. This PR removes the cause instead.

## Changes

- `turbo-discover` uploads a run-scoped snapshot of the plan inputs (`.test_durations`, `.test_durations.core`, `.test_durations.temporal`). Best-effort, `overwrite: true` so a full re-run re-snapshots.
- Django and product test jobs apply that snapshot on **every** attempt: all shards of all attempts plan from identical timing data, so a re-run shard re-collects exactly the tests it failed with.
- Missing/expired snapshot falls back to today's floating-cache behavior. A re-run that falls back emits a `::warning::` on the run summary.
- Depot shadow: header exemption only (it strips artifact uploads).

## How did you test this code?

- `bin/hogli lint:workflows` and `hogli ci:preflight --fix` pass; YAML validated (actionlint unavailable in the environment).
- Re-runs can't be exercised locally; every failure path degrades to current behavior.
- A 6-reviewer adversarial review ran on the first revision; both confirmed findings (unguarded upload in the gate-required `turbo-discover` job, attempt 1 not pinned) are fixed in the second commit.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed. CI-internal; rationale lives in the workflow comments.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with PostHog Code (Claude Code). Incident verified from the actual CI runs: attempt 1 restored timing cache `…07-24T190135Z` and shard 6/19 failed the parity test; the re-run three days later restored `…07-27T190146Z`, resharded, and no shard re-executed it.
- Chose plan pinning over #74210's post-hoc JUnit verification: smaller, fixes the root cause.
- Run-scoped artifact instead of a run-keyed cache entry because cache entries can be LRU-evicted within multi-day re-run windows.
- Skills invoked: /authoring-ci-workflows, /writing-code-comments. Reviewed via a 6-agent qa-team pass plus 5 targeted lenses.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
