### PR TITLE
fix(ingestion): allow $ai_* prefixed events in the ai pipeline

### DIFF
--- a/nodejs/src/ingestion/common/steps/allow-events.test.ts
+++ b/nodejs/src/ingestion/common/steps/allow-events.test.ts
@@ -63,4 +63,17 @@ describe('createAllowEventsStep', () => {
 
         expect(result).toEqual(allowed ? ok(input) : dlq('event_not_in_allowlist'))
     })
+
+    test.each([
+        ['$$heatmap', true],
+        ['$ai_tag', true],
+        ['$pageview', false],
+    ])('names and prefixes combine as OR: %s allowed=%s', async (eventName, allowed) => {
+        const combinedStep = createAllowEventsStep({ eventNames: ['$$heatmap'], eventPrefixes: ['$ai_'] })
+        const input = makeInput(eventName)
+
+        const result = await combinedStep(input)
+
+        expect(result).toEqual(allowed ? ok(input) : dlq('event_not_in_allowlist'))
+    })
 })

--- a/nodejs/src/ingestion/common/steps/allow-events.test.ts
+++ b/nodejs/src/ingestion/common/steps/allow-events.test.ts
@@ -15,7 +15,7 @@ function makeInput(eventName: string | undefined) {
 }
 
 describe('createAllowEventsStep', () => {
-    const step = createAllowEventsStep(['$$client_ingestion_warning'])
+    const step = createAllowEventsStep({ eventNames: ['$$client_ingestion_warning'] })
 
     it('passes through events whose name is in the allow list', async () => {
         const input = makeInput('$$client_ingestion_warning')
@@ -41,11 +41,26 @@ describe('createAllowEventsStep', () => {
         expect(result).toEqual(ok(input))
     })
 
-    it('DLQs every named event when the allow list is empty', async () => {
-        const emptyStep = createAllowEventsStep([])
+    it('DLQs every named event when nothing is allowed', async () => {
+        const emptyStep = createAllowEventsStep({})
 
         const result = await emptyStep(makeInput('$pageview'))
 
         expect(result).toEqual(dlq('event_not_in_allowlist'))
+    })
+
+    test.each([
+        ['$ai_generation', true],
+        ['$ai_tag', true],
+        ['$ai_', true],
+        ['$aiproduct_event', false],
+        ['$pageview', false],
+    ])('eventPrefixes matches by prefix: %s allowed=%s', async (eventName, allowed) => {
+        const prefixStep = createAllowEventsStep({ eventPrefixes: ['$ai_'] })
+        const input = makeInput(eventName)
+
+        const result = await prefixStep(input)
+
+        expect(result).toEqual(allowed ? ok(input) : dlq('event_not_in_allowlist'))
     })
 })

--- a/nodejs/src/ingestion/common/steps/allow-events.ts
+++ b/nodejs/src/ingestion/common/steps/allow-events.ts
@@ -2,21 +2,29 @@ import { dlq, ok } from '~/ingestion/framework/results'
 import { ProcessingStep } from '~/ingestion/framework/steps'
 import { EventHeaders } from '~/types'
 
+export interface AllowedEvents {
+    /** Exact event names to allow. */
+    eventNames?: readonly string[]
+    /** Event name prefixes to allow (e.g. `$ai_`). */
+    eventPrefixes?: readonly string[]
+}
+
 /**
- * DLQs any event whose header `event` name is not in the allow list.
- * Reads from the parsed Kafka headers so it can run before message-body
- * parsing — use in a consumer's pipeline to enforce that only its
- * target event type(s) flow through. Anything else is misrouted and
- * goes to the DLQ for investigation. Events with no `event` header
- * pass through (no name to match against).
+ * DLQs any event whose header `event` name is not allowed, either by
+ * exact name or by prefix. Reads from the parsed Kafka headers so it
+ * can run before message-body parsing — use in a consumer's pipeline
+ * to enforce that only its target event type(s) flow through. Anything
+ * else is misrouted and goes to the DLQ for investigation. Events with
+ * no `event` header pass through (no name to match against).
  */
 export function createAllowEventsStep<T extends { headers: EventHeaders }>(
-    allowed: readonly string[]
+    allowed: AllowedEvents
 ): ProcessingStep<T, T> {
-    const allowedSet = new Set(allowed)
+    const allowedNames = new Set(allowed.eventNames ?? [])
+    const allowedPrefixes = allowed.eventPrefixes ?? []
     return function allowEventsStep(input) {
         const name = input.headers.event
-        if (name === undefined || allowedSet.has(name)) {
+        if (name === undefined || allowedNames.has(name) || allowedPrefixes.some((prefix) => name.startsWith(prefix))) {
             return Promise.resolve(ok(input))
         }
         return Promise.resolve(dlq('event_not_in_allowlist'))

--- a/nodejs/src/ingestion/common/steps/deny-events.test.ts
+++ b/nodejs/src/ingestion/common/steps/deny-events.test.ts
@@ -67,4 +67,17 @@ describe('createDenyEventsStep', () => {
 
         expect(result).toEqual(denied ? dlq('event_in_denylist') : ok(input))
     })
+
+    test.each([
+        ['$exception', true],
+        ['$ai_generation', true],
+        ['$pageview', false],
+    ])('names and prefixes combine as OR: %s denied=%s', async (eventName, denied) => {
+        const combinedStep = createDenyEventsStep({ eventNames: ['$exception'], eventPrefixes: ['$ai_'] })
+        const input = makeInput(eventName)
+
+        const result = await combinedStep(input)
+
+        expect(result).toEqual(denied ? dlq('event_in_denylist') : ok(input))
+    })
 })

--- a/nodejs/src/ingestion/common/steps/deny-events.test.ts
+++ b/nodejs/src/ingestion/common/steps/deny-events.test.ts
@@ -15,7 +15,7 @@ function makeInput(eventName: string | undefined) {
 }
 
 describe('createDenyEventsStep', () => {
-    const step = createDenyEventsStep(['$exception', '$$client_ingestion_warning'])
+    const step = createDenyEventsStep({ eventNames: ['$exception', '$$client_ingestion_warning'] })
 
     it('DLQs events whose name is in the deny list', async () => {
         const result = await step(makeInput('$exception'))
@@ -45,12 +45,26 @@ describe('createDenyEventsStep', () => {
         expect(result).toEqual(ok(input))
     })
 
-    it('passes through everything when the deny list is empty', async () => {
-        const emptyStep = createDenyEventsStep([])
+    it('passes through everything when nothing is denied', async () => {
+        const emptyStep = createDenyEventsStep({})
         const input = makeInput('$exception')
 
         const result = await emptyStep(input)
 
         expect(result).toEqual(ok(input))
+    })
+
+    test.each([
+        ['$ai_generation', true],
+        ['$ai_', true],
+        ['$aiproduct_event', false],
+        ['$pageview', false],
+    ])('eventPrefixes denies by prefix: %s denied=%s', async (eventName, denied) => {
+        const prefixStep = createDenyEventsStep({ eventPrefixes: ['$ai_'] })
+        const input = makeInput(eventName)
+
+        const result = await prefixStep(input)
+
+        expect(result).toEqual(denied ? dlq('event_in_denylist') : ok(input))
     })
 })

--- a/nodejs/src/ingestion/common/steps/deny-events.ts
+++ b/nodejs/src/ingestion/common/steps/deny-events.ts
@@ -2,21 +2,27 @@ import { dlq, ok } from '~/ingestion/framework/results'
 import { ProcessingStep } from '~/ingestion/framework/steps'
 import { EventHeaders } from '~/types'
 
+export interface DeniedEvents {
+    /** Exact event names to deny. */
+    eventNames?: readonly string[]
+    /** Event name prefixes to deny (e.g. `$ai_`). */
+    eventPrefixes?: readonly string[]
+}
+
 /**
- * DLQs any event whose header `event` name is in the deny list. Reads
- * from the parsed Kafka headers so it can run before message-body
- * parsing — use in a consumer's pipeline to block specific event types
- * that belong in a different consumer. Anything matching the list is
- * misrouted and goes to the DLQ for investigation. Events with no
+ * DLQs any event whose header `event` name is denied, either by exact
+ * name or by prefix. Reads from the parsed Kafka headers so it can run
+ * before message-body parsing — use in a consumer's pipeline to block
+ * event types that belong in a different consumer. Anything matching
+ * is misrouted and goes to the DLQ for investigation. Events with no
  * `event` header pass through (no name to match against).
  */
-export function createDenyEventsStep<T extends { headers: EventHeaders }>(
-    denied: readonly string[]
-): ProcessingStep<T, T> {
-    const deniedSet = new Set(denied)
+export function createDenyEventsStep<T extends { headers: EventHeaders }>(denied: DeniedEvents): ProcessingStep<T, T> {
+    const deniedNames = new Set(denied.eventNames ?? [])
+    const deniedPrefixes = denied.eventPrefixes ?? []
     return function denyEventsStep(input) {
         const name = input.headers.event
-        if (name !== undefined && deniedSet.has(name)) {
+        if (name !== undefined && (deniedNames.has(name) || deniedPrefixes.some((prefix) => name.startsWith(prefix)))) {
             return Promise.resolve(dlq('event_in_denylist'))
         }
         return Promise.resolve(ok(input))

--- a/nodejs/src/ingestion/pipelines/ai/pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/ai/pipeline.ts
@@ -46,7 +46,6 @@ import { createReadOnlyProcessGroupsStep } from '~/ingestion/common/steps/event-
 import { createSplitAiEventsStep } from '~/ingestion/common/steps/event-processing/split-ai-events-step'
 import { createStripPersonUpdatePropertiesStep } from '~/ingestion/common/steps/event-processing/strip-person-update-properties-step'
 import { createRecordIngestionLagStep } from '~/ingestion/common/steps/record-ingestion-lag'
-import { AI_EVENT_TYPES } from '~/ingestion/common/subpipelines/ai-event-types'
 import { IngestionOverflowMode } from '~/ingestion/config'
 import { TopHogWrapper, sum, sumOk, sumResult } from '~/ingestion/framework/extensions/tophog'
 import { isDropResult } from '~/ingestion/framework/results'
@@ -146,8 +145,11 @@ export function createAiIngestionPipeline<
         })
             .beforeBatch((b) => b.pipe(createEventFiltersBatchAppMetricsBeforeBatchStep(outputs)))
             // Header-only steps: allow only AI events, apply token restrictions.
+            // Prefix match rather than the canonical AI_EVENT_TYPES set: internal
+            // meta-events ($ai_tag, $ai_generation_summary, ...) share the lane
+            // without the ai_events double-write, which stays gated on the set.
             .parseHeaders()
-            .pipe(createAllowEventsStep([...AI_EVENT_TYPES]))
+            .pipe(createAllowEventsStep({ eventPrefixes: ['$ai_'] }))
             .pipe(
                 createApplyEventRestrictionsStep(eventIngestionRestrictionManager, {
                     overflowMode,

--- a/nodejs/src/ingestion/pipelines/analytics/joined-ingestion-pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/analytics/joined-ingestion-pipeline.ts
@@ -206,7 +206,7 @@ export function createJoinedIngestionPipeline<
             // Header-only steps: token-level deny list and restrictions. Cheap; runs
             // per-event before we touch the body.
             .parseHeaders()
-            .pipe(createDenyEventsStep(['$exception', '$$client_ingestion_warning', '$$heatmap']))
+            .pipe(createDenyEventsStep({ eventNames: ['$exception', '$$client_ingestion_warning', '$$heatmap'] }))
             .pipe(
                 createApplyEventRestrictionsStep(eventIngestionRestrictionManager, {
                     overflowMode,

--- a/nodejs/src/ingestion/pipelines/clientwarnings/pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/clientwarnings/pipeline.ts
@@ -56,7 +56,7 @@ export function createClientWarningsPipeline<
     })
         .beforeBatch((b) => b.pipe(createEventFiltersBatchAppMetricsBeforeBatchStep(outputs)))
         .parseHeaders()
-        .pipe(createAllowEventsStep(['$$client_ingestion_warning']))
+        .pipe(createAllowEventsStep({ eventNames: ['$$client_ingestion_warning'] }))
         .pipe(createApplyBasicEventRestrictionsStep(eventIngestionRestrictionManager))
         .parseMessage()
         .resolveTeam()

--- a/nodejs/src/ingestion/pipelines/heatmaps/pipeline.ts
+++ b/nodejs/src/ingestion/pipelines/heatmaps/pipeline.ts
@@ -72,7 +72,7 @@ export function createHeatmapsPipeline<TInput extends HeatmapsPipelineInput, TCo
         })
             .beforeBatch((b) => b.pipe(createEventFiltersBatchAppMetricsBeforeBatchStep(outputs)))
             .parseHeaders()
-            .pipe(createAllowEventsStep(['$$heatmap']))
+            .pipe(createAllowEventsStep({ eventNames: ['$$heatmap'] }))
             .pipe(createApplyBasicEventRestrictionsStep(eventIngestionRestrictionManager))
             .parseMessage()
             .resolveTeam()


### PR DESCRIPTION
## Problem

The standalone AI ingestion pipeline's allow step admits only the seven canonical AI event types, so internal AI meta-events (`$ai_tag`, `$ai_generation_summary`, `$ai_trace_summary`, `$ai_evaluation_report`) that get routed onto the AI topic are DLQ'd with `event_not_in_allowlist`.
These events are emitted server-side via `capture_internal` and are regular `events`-table events, but they share the `$ai_` namespace and can legitimately arrive on the AI lane.

## Changes

- `createAllowEventsStep` and `createDenyEventsStep` now take `{ eventNames?, eventPrefixes? }` instead of a flat list of exact names.
- The AI pipeline allows by prefix (`$ai_`) instead of the exact `AI_EVENT_TYPES` set.
- The clientwarnings, heatmaps, and analytics pipelines keep exact-name matching via `eventNames`.

Downstream behavior is unchanged for meta-events: `createSplitAiEventsStep` and `createProcessAiEventStep` still gate on `AI_EVENT_TYPES`, so only canonical AI events get trace normalization and the `ai_events` double-write. Meta-events just flow to the `events` output instead of the DLQ.

The deny step gains prefix support for symmetry — when capture-side AI routing switches over, the analytics pipeline can deny the whole `$ai_` namespace with the same shape.

> [!NOTE]
> The AI lane is read-only for persons, so meta-events processed there have person-update properties stripped, unlike the analytics lane.

## How did you test this code?

Extended `allow-events.test.ts` and `deny-events.test.ts` with parameterized prefix cases (`$ai_tag` allowed, `$aiproduct_event` and `$pageview` unaffected) — catches a regression where prefix matching is removed and `$ai_` meta-events start DLQing again; no existing test covered prefix matching.
Also ran the clientwarnings, heatmaps, and analytics pipeline suites to cover the signature change at their call sites.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: /writing-tests.
Decisions: started from a DLQ investigation that traced `event_not_in_allowlist` on the AI lane to `$ai_`-namespaced meta-events; chose prefix-allowing in the consumer over widening the canonical `AI_EVENT_TYPES` set (that would change `ai_events` double-write semantics) and over encoding prefixes as `'$ai_*'` magic strings in the existing list argument (rejected in review as hacky in favor of an explicit options object). The deny-step alignment was requested as a follow-up for API symmetry.
