### PR TITLE
fix(aio): declare order_by on the prompt list query serializer

### DIFF
--- a/posthog/api/llm_prompt.py
+++ b/posthog/api/llm_prompt.py
@@ -15,6 +15,7 @@ from rest_framework.serializers import BaseSerializer
 
 from posthog.api.capture import capture_internal
 from posthog.api.llm_prompt_serializers import (
+    ALLOWED_LIST_ORDERINGS,
     LLMPromptDuplicateSerializer,
     LLMPromptFetchQuerySerializer,
     LLMPromptGetByNameQuerySerializer,
@@ -72,24 +73,6 @@ from products.ai_observability.backend.models.llm_prompt import LLMPrompt, LLMPr
 
 PROMPT_FETCHED_EVENT = "$llm_prompt_fetched"
 PROMPT_FETCHED_EVENT_SOURCE = "llm_prompt_management"
-ALLOWED_LIST_ORDERINGS = {
-    "name": "name",
-    "-name": "-name",
-    "created_at": "created_at",
-    "-created_at": "-created_at",
-    "updated_at": "updated_at",
-    "-updated_at": "-updated_at",
-    "version": "version",
-    "-version": "-version",
-    "latest_version": "latest_version",
-    "-latest_version": "-latest_version",
-    "version_count": "version_count",
-    "-version_count": "-version_count",
-    "first_version_created_at": "first_version_created_at",
-    "-first_version_created_at": "-first_version_created_at",
-    "prompt_size_bytes": "prompt_size_bytes",
-    "-prompt_size_bytes": "-prompt_size_bytes",
-}
 
 
 @extend_schema(extensions={"x-product": "llm_analytics"})
@@ -226,7 +209,7 @@ class LLMPromptViewSet(
         if created_by_id:
             queryset = queryset.filter(created_by_id=created_by_id)
 
-        order_by = request.query_params.get("order_by", "-created_at")
+        order_by = params.get("order_by", "-created_at")
         queryset = queryset.order_by(ALLOWED_LIST_ORDERINGS.get(order_by, "-created_at"), "-id")
         return queryset
 

--- a/posthog/api/llm_prompt_serializers.py
+++ b/posthog/api/llm_prompt_serializers.py
@@ -83,6 +83,27 @@ def validate_prompt_label_name_value(value: str) -> str:
     return value
 
 
+# Maps accepted order_by values to queryset ordering fields. Lives here so the list
+# query serializer can declare the choices; the viewset imports it for the lookup.
+ALLOWED_LIST_ORDERINGS = {
+    "name": "name",
+    "-name": "-name",
+    "created_at": "created_at",
+    "-created_at": "-created_at",
+    "updated_at": "updated_at",
+    "-updated_at": "-updated_at",
+    "version": "version",
+    "-version": "-version",
+    "latest_version": "latest_version",
+    "-latest_version": "-latest_version",
+    "version_count": "version_count",
+    "-version_count": "-version_count",
+    "first_version_created_at": "first_version_created_at",
+    "-first_version_created_at": "-first_version_created_at",
+    "prompt_size_bytes": "prompt_size_bytes",
+    "-prompt_size_bytes": "-prompt_size_bytes",
+}
+
 CONTENT_MODE_CHOICES = ["full", "preview", "none"]
 CONTENT_MODE_HELP = (
     "Controls how much prompt content is included in the response. "
@@ -136,6 +157,12 @@ class LLMPromptListQuerySerializer(serializers.Serializer):
     created_by_id = serializers.IntegerField(
         required=False,
         help_text="Filter prompts by the ID of the user who created them.",
+    )
+    order_by = serializers.ChoiceField(
+        choices=list(ALLOWED_LIST_ORDERINGS),
+        required=False,
+        default="-created_at",
+        help_text="Field to sort the prompt list by. Prefix with '-' for descending order.",
     )
     content = serializers.ChoiceField(
         choices=CONTENT_MODE_CHOICES,

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -16,6 +16,7 @@ from posthog.api.llm_prompt import LLMPromptViewSet
 from posthog.api.llm_prompt_serializers import (
     MAX_PROMPT_PAYLOAD_BYTES,
     LLMPromptDuplicateSerializer,
+    LLMPromptListQuerySerializer,
     validate_prompt_label_name_value,
 )
 from posthog.api.services.llm_prompt import MAX_PROMPT_VERSION
@@ -1034,6 +1035,15 @@ class TestLLMPromptDuplicateSerializerValidationNoDB(SimpleTestCase):
     def test_accepts_valid_new_name(self) -> None:
         serializer = LLMPromptDuplicateSerializer(data={"new_name": "a-valid_name1"})
         assert serializer.is_valid(), serializer.errors
+
+
+class TestLLMPromptListQuerySerializerValidationNoDB(SimpleTestCase):
+    def test_rejects_unknown_order_by(self) -> None:
+        # order_by used to be read from raw query params with a silent fallback; the serializer
+        # now owns the contract, so an unknown value must fail validation (and 400 at the endpoint).
+        serializer = LLMPromptListQuerySerializer(data={"order_by": "prompt"})
+        assert not serializer.is_valid()
+        assert "order_by" in serializer.errors
 
 
 class TestLLMPromptLabelsAPI(APIBaseTest):

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -3017,6 +3017,28 @@ export type LlmPromptsListParams = {
      */
     offset?: number
     /**
+     * Field to sort the prompt list by. Prefix with '-' for descending order.
+     *
+     * * `name` - name
+     * * `-name` - -name
+     * * `created_at` - created_at
+     * * `-created_at` - -created_at
+     * * `updated_at` - updated_at
+     * * `-updated_at` - -updated_at
+     * * `version` - version
+     * * `-version` - -version
+     * * `latest_version` - latest_version
+     * * `-latest_version` - -latest_version
+     * * `version_count` - version_count
+     * * `-version_count` - -version_count
+     * * `first_version_created_at` - first_version_created_at
+     * * `-first_version_created_at` - -first_version_created_at
+     * * `prompt_size_bytes` - prompt_size_bytes
+     * * `-prompt_size_bytes` - -prompt_size_bytes
+     * @minLength 1
+     */
+    order_by?: string
+    /**
      * Optional substring filter applied to prompt names and prompt content.
      */
     search?: string

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -76589,6 +76589,28 @@ export namespace Schemas {
      */
     offset?: number;
     /**
+     * Field to sort the prompt list by. Prefix with '-' for descending order.
+     *
+     * * `name` - name
+     * * `-name` - -name
+     * * `created_at` - created_at
+     * * `-created_at` - -created_at
+     * * `updated_at` - updated_at
+     * * `-updated_at` - -updated_at
+     * * `version` - version
+     * * `-version` - -version
+     * * `latest_version` - latest_version
+     * * `-latest_version` - -latest_version
+     * * `version_count` - version_count
+     * * `-version_count` - -version_count
+     * * `first_version_created_at` - first_version_created_at
+     * * `-first_version_created_at` - -first_version_created_at
+     * * `prompt_size_bytes` - prompt_size_bytes
+     * * `-prompt_size_bytes` - -prompt_size_bytes
+     * @minLength 1
+     */
+    order_by?: string;
+    /**
      * Optional substring filter applied to prompt names and prompt content.
      */
     search?: string;

--- a/services/mcp/src/generated/ai_observability/api.ts
+++ b/services/mcp/src/generated/ai_observability/api.ts
@@ -1657,6 +1657,7 @@ export const LlmPromptsListParams = /* @__PURE__ */ zod.object({
 })
 
 export const llmPromptsListQueryContentDefault = `full`
+export const llmPromptsListQueryOrderByDefault = `-created_at`
 
 export const LlmPromptsListQueryParams = /* @__PURE__ */ zod.object({
     content: zod
@@ -1668,6 +1669,13 @@ export const LlmPromptsListQueryParams = /* @__PURE__ */ zod.object({
     created_by_id: zod.number().optional().describe('Filter prompts by the ID of the user who created them.'),
     limit: zod.number().optional().describe('Number of results to return per page.'),
     offset: zod.number().optional().describe('The initial index from which to return the results.'),
+    order_by: zod
+        .string()
+        .min(1)
+        .default(llmPromptsListQueryOrderByDefault)
+        .describe(
+            "Field to sort the prompt list by. Prefix with '-' for descending order.\n\n\* `name` - name\n\* `-name` - -name\n\* `created_at` - created_at\n\* `-created_at` - -created_at\n\* `updated_at` - updated_at\n\* `-updated_at` - -updated_at\n\* `version` - version\n\* `-version` - -version\n\* `latest_version` - latest_version\n\* `-latest_version` - -latest_version\n\* `version_count` - version_count\n\* `-version_count` - -version_count\n\* `first_version_created_at` - first_version_created_at\n\* `-first_version_created_at` - -first_version_created_at\n\* `prompt_size_bytes` - prompt_size_bytes\n\* `-prompt_size_bytes` - -prompt_size_bytes"
+        ),
     search: zod.string().optional().describe('Optional substring filter applied to prompt names and prompt content.'),
 })
 


### PR DESCRIPTION
## Problem

The prompt list endpoint supports `order_by` (16 orderings), but `LLMPromptListQuerySerializer` never declared it. The viewset read it from raw query params with a silent fallback, so the generated `LlmPromptsListParams` type and the MCP tool schema omitted the parameter entirely. Flagged as a follow-up in #73470.

## Changes

- Add `order_by` as a `ChoiceField` on the list query serializer, defaulting to `-created_at`.
- Move `ALLOWED_LIST_ORDERINGS` from the viewset into the serializers module so the field can use it as choices; the viewset now reads the validated value.
- Regenerated types: `LlmPromptsListParams` and the MCP `llma-prompt-list` tool schema now document the parameter and its accepted values.

> [!NOTE]
> Small behavior change: an unknown `order_by` value now returns a 400 instead of being silently ignored and falling back to `-created_at`. The app only ever sends valid values.

## How did you test this code?

New `SimpleTestCase` asserting an unknown `order_by` fails validation. This locks in the 400 contract, which no existing test covered because the old code ignored bad values. The existing endpoint test (`test_list_can_order_by_prompt_size_bytes`) guards the valid-value wiring. All 13 list/ordering tests in `test_llm_prompt.py` pass; ruff and mypy clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, the parameter docs are generated from the serializer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code made this change in a worktree, invoking /improving-drf-endpoints and /writing-tests. The constant moved to the serializers module rather than importing it from the viewset, since the viewset already imports the serializers module and the reverse would be circular.
