### PR TITLE
fix(aio): resolve offloaded blob pointers wrapped in a data uri

### DIFF
--- a/products/ai_observability/backend/api/ai_blob.py
+++ b/products/ai_observability/backend/api/ai_blob.py
@@ -9,7 +9,13 @@ from rest_framework.request import Request
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.storage import object_storage
 
-INLINE_MIMES = {"image/png", "image/jpeg", "image/gif", "image/webp"}
+SCRIPTABLE_IMAGE_MIMES = {"image/svg+xml"}
+
+
+def _is_inline_image(content_type: str | None) -> bool:
+    if content_type is None:
+        return False
+    return content_type.startswith("image/") and content_type not in SCRIPTABLE_IMAGE_MIMES
 
 
 class AIBlobViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
@@ -26,7 +32,7 @@ class AIBlobViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
         if result is None:
             return HttpResponse(status=404)
         body, content_type = result
-        if content_type in INLINE_MIMES:
+        if _is_inline_image(content_type):
             response = HttpResponse(body, content_type=content_type)
         else:
             response = HttpResponse(body, content_type="application/octet-stream")

--- a/products/ai_observability/backend/api/test/test_ai_blob.py
+++ b/products/ai_observability/backend/api/test/test_ai_blob.py
@@ -1,6 +1,7 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from parameterized import parameterized
 from rest_framework import status
 
 HASH = "a" * 64
@@ -23,13 +24,24 @@ class TestAIBlobEndpoint(APIBaseTest):
         assert mock_read.call_args.args[0] == f"aio/{self.team.pk}/sha256/{HASH}"
         assert mock_read.call_args.kwargs["bucket"] == "ai-blobs"
 
+    @parameterized.expand(
+        [
+            ("image/heic", "image/heic", None),
+            ("image/heif", "image/heif", None),
+            ("image/avif", "image/avif", None),
+            ("image/svg+xml", "application/octet-stream", "attachment"),
+            ("application/pdf", "application/octet-stream", "attachment"),
+        ]
+    )
     @patch("products.ai_observability.backend.api.ai_blob.object_storage.read_object")
-    def test_non_allowlisted_mime_serves_as_download(self, mock_read) -> None:
-        mock_read.return_value = (b"pdf-bytes", "application/pdf")
+    def test_disposition_follows_stored_mime(
+        self, stored_mime: str, expected_content_type: str, expected_disposition: str | None, mock_read
+    ) -> None:
+        mock_read.return_value = (b"blob-bytes", stored_mime)
         response = self.client.get(self._url())
         assert response.status_code == status.HTTP_200_OK
-        assert response["Content-Type"] == "application/octet-stream"
-        assert response["Content-Disposition"].startswith("attachment")
+        assert response["Content-Type"] == expected_content_type
+        assert response.headers.get("Content-Disposition") == expected_disposition
 
     @patch("products.ai_observability.backend.api.ai_blob.object_storage.read_object")
     def test_missing_object_is_404(self, mock_read) -> None:

--- a/products/ai_observability/frontend/aiBlob.test.ts
+++ b/products/ai_observability/frontend/aiBlob.test.ts
@@ -34,6 +34,14 @@ describe('aiBlob', () => {
         expect(resolveAiBlobUrl(POINTER, null)).toBe(POINTER)
     })
 
+    it.each([
+        ['image/png', `data:image/png;base64,${POINTER}`],
+        ['application/pdf', `data:application/pdf;base64,${POINTER}`],
+    ])('resolves a pointer that a recipe wrapped in a %s data uri', (_mime, wrapped) => {
+        expect(parseAiBlobPointer(wrapped)).toMatchObject({ hash: HASH })
+        expect(resolveAiBlobUrl(wrapped, 1)).toBe(`/api/projects/1/ai_blob/v1/sha256/${HASH}`)
+    })
+
     it('resolves a pointer data field to the blob endpoint, ignoring the passed mime type', () => {
         expect(resolveDataUri(POINTER, 'image/png', 1)).toBe(`/api/projects/1/ai_blob/v1/sha256/${HASH}`)
     })

--- a/products/ai_observability/frontend/aiBlob.ts
+++ b/products/ai_observability/frontend/aiBlob.ts
@@ -9,12 +9,15 @@ export interface AiBlobPointer {
 
 const POINTER_SCHEME = 'phaiblob://'
 const POINTER_RE = /^phaiblob:\/\/(v1)\/(sha256)\/([0-9a-f]{64})(?:\?(.*))?$/
+// TODO: replace the whole URL rather than its data component, so a valid data URL can't be clobbered.
+const DATA_URI_WRAPPED_POINTER = /^data:[\w.+-]+\/[\w.+-]+;base64,(phaiblob:\/\/.*)$/
 
 export function parseAiBlobPointer(value: string): AiBlobPointer | null {
-    if (!value.startsWith(POINTER_SCHEME)) {
+    const unwrapped = DATA_URI_WRAPPED_POINTER.exec(value)?.[1] ?? value
+    if (!unwrapped.startsWith(POINTER_SCHEME)) {
         return null
     }
-    const match = POINTER_RE.exec(value)
+    const match = POINTER_RE.exec(unwrapped)
     if (!match) {
         return null
     }

--- a/products/ai_observability/frontend/messageNormalization.test.ts
+++ b/products/ai_observability/frontend/messageNormalization.test.ts
@@ -1,5 +1,6 @@
 import posthog from 'posthog-js'
 
+import { resolveAiBlobUrl } from './aiBlob'
 import { captureNormalizationFailure, normalizeMessage, normalizeMessages } from './messageNormalization'
 
 jest.mock('posthog-js', () => ({ __esModule: true, default: { capture: jest.fn() } }))
@@ -44,6 +45,39 @@ describe('messageNormalization', () => {
         it("never captures — reporting a failure is the caller's decision", () => {
             normalizeMessages({ file_path: 'src/index.ts' }, 'user')
             expect(capture).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('offloaded media', () => {
+        const HASH = 'a'.repeat(64)
+        const POINTER = `phaiblob://v1/sha256/${HASH}?mime=image%2Fpng&size=332378`
+
+        it('keeps an offloaded anthropic tool_result image resolvable through the blob endpoint', () => {
+            const { messages } = normalizeMessages(
+                {
+                    role: 'user',
+                    content: [
+                        {
+                            type: 'tool_result',
+                            tool_use_id: 'toolu_01Rg4FtbD8eH1fx2yMkQGVSz',
+                            content: [
+                                {
+                                    type: 'image',
+                                    source: { type: 'base64', media_type: 'image/png', data: POINTER },
+                                },
+                            ],
+                        },
+                    ],
+                },
+                'user'
+            )
+
+            const images = messages
+                .flatMap((message) => (Array.isArray(message.content) ? message.content : []))
+                .flatMap((part) => (typeof part === 'object' && 'image' in part ? [part.image] : []))
+
+            expect(images).toHaveLength(1)
+            expect(resolveAiBlobUrl(images[0], 1)).toBe(`/api/projects/1/ai_blob/v1/sha256/${HASH}`)
         })
     })
 


### PR DESCRIPTION
## Problem

Multimodal blob offload (#72386) replaces the base64 payload in an AI event with a `phaiblob://` pointer, and #72679 added the resolver plus the serving endpoint that turns that pointer back into a renderable URL.
Offloaded images still rendered as a broken thumbnail in the trace view.

The stored data is correct. The problem is that the resolver never gets a chance to recognize the pointer, because a normalizer recipe has already composed it into a base64 data URI

## Changes

Temporarily patch this until we figure out a solution without having to wrap and unwrap.