### PR TITLE
feat(conversations): resolve assignee role name in support_tickets SQL

### DIFF
--- a/posthog/hogql/database/schema/system.py
+++ b/posthog/hogql/database/schema/system.py
@@ -1592,6 +1592,29 @@ ticket_tags_lazy_join: LazyJoin = LazyJoin(
 )
 
 
+class _TicketAssigneeRolesTable(PostgresTable, DANGEROUS_NoTeamIdCheckTable):
+    """PostgresTable variant for `ee_role`, which is organization-scoped and has no `team_id` column.
+
+    The framework's auto-injected `team_id = X` guard is skipped (the column doesn't exist); isolation
+    instead flows from the predicate, which scopes to the roles referenced by this team's ticket
+    assignments. That resolves through `system._ticket_assignments` and in turn through
+    `system.support_tickets`, whose own team_id guard the framework re-applies to the inner reference.
+    """
+
+    predicates: list[Expr] = [parse_expr("id IN (SELECT role_id FROM system._ticket_assignments)")]
+
+
+ticket_assignee_roles: _TicketAssigneeRolesTable = _TicketAssigneeRolesTable(
+    name="_ticket_assignee_roles",
+    postgres_table_name="ee_role",
+    description="Internal table (PostgreSQL `ee_role`) of roles this team's tickets are assigned to; not for direct querying — use `system.support_tickets.assignee`.",
+    fields={
+        "id": UUIDDatabaseField(name="id", description="Role UUID."),
+        "name": StringDatabaseField(name="name", description="Role name, e.g. 'Team Support'."),
+    },
+)
+
+
 ticket_assignments: _TicketScopedPostgresTable = _TicketScopedPostgresTable(
     name="_ticket_assignments",
     postgres_table_name="posthog_conversations_ticket_assignment",
@@ -1615,10 +1638,12 @@ def _ticket_assignment_select() -> ast.SelectQuery | ast.SelectSetQuery:
     return parse_select(
         """
         SELECT
-            ticket_id AS ticket_id,
-            user_id AS user_id,
-            role_id AS role_id
-        FROM system._ticket_assignments
+            ta.ticket_id AS ticket_id,
+            ta.user_id AS user_id,
+            ta.role_id AS role_id,
+            nullIf(r.name, '') AS role_name
+        FROM system._ticket_assignments AS ta
+        LEFT JOIN system._ticket_assignee_roles AS r ON r.id = assumeNotNull(ta.role_id)
         """
     )
 
@@ -1634,6 +1659,11 @@ class _TicketAssignmentTable(LazyTable):
         ),
         "role_id": UUIDDatabaseField(
             name="role_id", nullable=True, description="Role the ticket is assigned to, if assigned to a role."
+        ),
+        "role_name": StringDatabaseField(
+            name="role_name",
+            nullable=True,
+            description="Name of the role the ticket is assigned to, e.g. 'Team Support'. Null when unassigned or assigned to a user.",
         ),
     }
 
@@ -2286,6 +2316,7 @@ class SystemTables(TableNode):
         "source_sync_jobs": TableNode(name="source_sync_jobs", table=source_sync_jobs),
         "_ticket_tagged_items": TableNode(name="_ticket_tagged_items", table=ticket_tagged_items, hidden=True),
         "_ticket_assignments": TableNode(name="_ticket_assignments", table=ticket_assignments, hidden=True),
+        "_ticket_assignee_roles": TableNode(name="_ticket_assignee_roles", table=ticket_assignee_roles, hidden=True),
         "support_tickets": TableNode(name="support_tickets", table=support_tickets),
         "surveys": TableNode(name="surveys", table=surveys),
         "task_runs": TableNode(name="task_runs", table=task_runs),

--- a/posthog/hogql/database/schema/test/test_system_tables.py
+++ b/posthog/hogql/database/schema/test/test_system_tables.py
@@ -108,6 +108,8 @@ TEAM_ID_FILTER_PATTERNS = {
     # Same shape, scoped through system.support_tickets instead
     "_ticket_tagged_items": "system__support_tickets.team_id",
     "_ticket_assignments": "system__support_tickets.team_id",
+    # Roles scope one level deeper, through the assignments that reference them
+    "_ticket_assignee_roles": "system__support_tickets.team_id",
 }
 
 
@@ -146,6 +148,8 @@ class TestSystemTablesTeamScoping(BaseTest):
             "_ticket_tagged_items",
             # Hidden table backing system.support_tickets.assignee; covered by TestSystemTicketAssignmentLazyJoin.
             "_ticket_assignments",
+            # Hidden table backing the assignee role_name resolution; covered by TestSystemTicketAssignmentLazyJoin.
+            "_ticket_assignee_roles",
             # information_schema is a namespace of virtual catalog tables (tables/columns/
             # relationships/data_types) computed per-query from the caller's own Database object,
             # so it has no team_id column to isolate; behaviour is covered by TestInformationSchema.
@@ -1001,6 +1005,31 @@ class TestSystemTicketAssignmentLazyJoin(NonAtomicBaseTest):
         )
 
         assert response.results == [(None, None)]
+
+    def test_assignee_role_name_resolves_for_role_assignee(self):
+        self.role = Role.objects.create(name="Team Support", organization=self.organization)
+        ticket = _create_support_ticket(self.team, "role")
+        TicketAssignment.objects.create(ticket=ticket, role=self.role)
+
+        response = execute_hogql_query(
+            f"SELECT assignee.role_name FROM system.support_tickets WHERE id = '{ticket.id}'",
+            team=self.team,
+            user=self.user,
+        )
+
+        assert response.results[0][0] == "Team Support"
+
+    def test_assignee_role_name_null_for_user_assignee(self):
+        ticket = _create_support_ticket(self.team, "user")
+        TicketAssignment.objects.create(ticket=ticket, user=self.user)
+
+        response = execute_hogql_query(
+            f"SELECT assignee.role_name FROM system.support_tickets WHERE id = '{ticket.id}'",
+            team=self.team,
+            user=self.user,
+        )
+
+        assert response.results[0][0] is None
 
     def test_assignee_lazy_join_isolated_per_team(self):
         other_ticket = _create_support_ticket(self.other_team, "theirs")

--- a/posthog/hogql/database/test/__snapshots__/test_database.ambr
+++ b/posthog/hogql/database/test/__snapshots__/test_database.ambr
@@ -8825,7 +8825,8 @@
                   "fields": [
                       "ticket_id",
                       "user_id",
-                      "role_id"
+                      "role_id",
+                      "role_name"
                   ],
                   "hogql_value": "assignee",
                   "id": "assignee",
@@ -17715,7 +17716,8 @@
                   "fields": [
                       "ticket_id",
                       "user_id",
-                      "role_id"
+                      "role_id",
+                      "role_name"
                   ],
                   "hogql_value": "assignee",
                   "id": "assignee",


### PR DESCRIPTION
## Problem

`system.support_tickets` already exposes a ticket's `tags` and `assignee` in HogQL, where `assignee` resolves to `user_id` and `role_id`, after #74757 and #75648 merged. The one remaining gap for expressing a saved ticket view in SQL is the **role name**: a view scoped to an assignee like `Team Support` can only be matched by role UUID today, because the role name isn't resolvable. That blocks a scheduled report that counts a tag+assignee view's tickets and its next SLA breach.

This PR closes that last gap.

> [!NOTE]
> This PR was **reworked and is much smaller now**. It originally added tags + assignee to the SQL table (via a denormalization migration, later reworked to lazy joins). That functionality has since landed on master through #74757 (tags) and #75648 (assignee), which superseded most of it. The branch has been reset onto master, so this now contains only the incremental `role_name` resolution on top of that merged work.

## Changes

Adds `assignee.role_name` to the existing `support_tickets.assignee` lazy join, so a role can be matched by name:

```sql
SELECT count()
FROM system.support_tickets
WHERE status IN ('new', 'open', 'on_hold')
  AND assignee.role_name = 'Team Support'
  AND hasAny(tags.names, ['support_sme_analytics', 'support_needs_triage'])
  AND NOT has(tags.names, 'community')
```

Mechanically:

- New hidden, ticket-scoped table over `ee_role` (`_ticket_assignee_roles`). Roles are org-scoped with no `team_id`, so it's a `DANGEROUS_NoTeamIdCheckTable` scoped by predicate to the roles referenced by this team's ticket assignments. That resolves through `_ticket_assignments` and in turn through `system.support_tickets`, where the framework re-applies its `team_id` guard.
- The assignee lazy join's select `LEFT JOIN`s that table on `role_id` and returns `nullIf(r.name, '')` as `role_name` (null when unassigned or assigned to a user).

No new columns and no migration, since `ee_role` already exists.

**Query-cost note:** filtering tickets on `assignee.role_name` in a `WHERE` (like any lazy-join field) stops ClickHouse pushing the ticket table's own filters down to Postgres, so it reads across teams and filters locally. Fine for an infrequent scheduled report. If a cheaper standing-query path is wanted later, exposing a public `role_id`-joinable side table would avoid the pushdown loss.

## How did you test this code?

Added two cases to `TestSystemTicketAssignmentLazyJoin` in `posthog/hogql/database/schema/test/test_system_tables.py`:

- `test_assignee_role_name_resolves_for_role_assignee`: a role-assigned ticket resolves `assignee.role_name` to the role's name. Nothing covered role-name resolution before (the existing assignee tests only select `user_id`/`role_id`).
- `test_assignee_role_name_null_for_user_assignee`: a user-assigned ticket resolves `role_name` to null, not an empty string.

The new hidden table is registered in the team-scoping isolation checks (`TEAM_ID_FILTER_PATTERNS` + `excluded_tables`), and the `test_database` schema snapshot includes the new field.

Run locally against the dev stack, all passing:

- `hogli test posthog/hogql/database/schema/test/test_system_tables.py`: 163 passed, covering the two new cases and the team-scoping isolation checks.
- `hogli test posthog/hogql/database/test/test_database.py`: 119 passed, 16 snapshots passed.

Also checked by hand in the SQL editor against seeded local tickets, with roles `Team Support` and `Team Growth` and tickets assigned to a role, assigned to a user, and unassigned:

1. Selecting `assignee.role_id, assignee.role_name, tags.names` for every assigned ticket returns the role's name for role-assigned tickets and null for the user-assigned one.
2. The count query above returns only the tickets left after the status, tag, and role-name filters are all applied.
3. `SELECT assignee.role_name AS role_name, count() FROM system.support_tickets GROUP BY role_name` groups tickets by role name, with unassigned and user-assigned tickets falling under null.
4. `_ticket_assignee_roles` does not show up in the SQL editor's schema sidebar.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reworked via the PostHog Slack app (Claude Code). The task started as "expose tags + assignee for SQL". While it was in review, #74757 and #75648 merged that same capability, so this branch was reset onto master and narrowed to just the missing `role_name`. Chose to resolve role names through a hidden ticket-scoped `ee_role` table joined inside the existing assignee lazy join, rather than reintroduce the denormalized-column / side-table approaches from the earlier revisions, to keep the diff minimal and consistent with the merged lazy-join design. Query-cost tradeoff of lazy-join filtering is documented above as a possible follow-up.

The test commands above were run by an agent (Claude Code) on a local dev stack at this branch's head; the SQL editor checks were done by hand.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ATK5R5BL0/p1785247535800079)*
