### PR TITLE
feat(llm-gateway): send team trace id to the Go gateway

### DIFF
--- a/posthog/llm/gateway_client.py
+++ b/posthog/llm/gateway_client.py
@@ -219,22 +219,16 @@ def ai_product_headers(ai_product: str | None) -> dict[str, str] | None:
     return _ai_property_headers(ai_product=ai_product)
 
 
-# Namespace the Python LLM gateway hashes non-UUID trace identifiers under, duplicated from
-# services/llm-gateway/src/llm_gateway/callbacks/posthog.py. Both must stay equal so a team's
-# generations carry one trace id whichever gateway serves them. TestTeamTraceId pins the
-# derivation against ids observed on captured events.
+# Mirrors the namespace in services/llm-gateway/src/llm_gateway/callbacks/posthog.py. Both must
+# stay equal or a team's trace id changes with whichever gateway serves it.
 _TEAM_TRACE_ID_NAMESPACE = UUID("8d4f6b7e-6a3e-4f3a-9f3b-3b6f4d2e8a1a")
 
 
 def team_trace_id(team_id: int | None) -> str | None:
-    """Deterministic ``$ai_trace_id`` for a team's generations, or None when unattributed.
+    """Deterministic ``$ai_trace_id`` for a team, or None when unattributed.
 
-    The Python gateway derives this itself, hashing the ``metadata.user_id`` callers set to
-    ``team-<id>``. The Go gateway derives nothing: absent an ``X-PostHog-Trace-Id`` header it
-    stamps a fresh id per request, leaving every generation in a single-event trace. Sending
-    this keeps one team's generations on one trace id whichever gateway serves them.
-
-    The grouping is per team, not per pipeline run: every generation a team makes shares an id.
+    Absent an ``X-PostHog-Trace-Id`` header the Go gateway stamps a fresh id per request, leaving
+    every generation in its own trace. Grouping is per team, not per pipeline run.
     """
     if team_id is None:
         return None
@@ -242,10 +236,7 @@ def team_trace_id(team_id: int | None) -> str | None:
 
 
 def _ai_trace_headers(team_id: int | None) -> dict[str, str]:
-    """``X-PostHog-Trace-Id`` header for a team, empty when the call is unattributed.
-
-    Empty rather than None so callers can merge it into the properties header dict.
-    """
+    """``X-PostHog-Trace-Id`` header for a team; empty (not None) so callers can splat it."""
     trace_id = team_trace_id(team_id)
     return {"X-PostHog-Trace-Id": trace_id} if trace_id else {}
 
@@ -318,9 +309,8 @@ def build_async_anthropic_client(
     over to Bedrock on its own via the host breaker and reads no opt-in header. trust_env=False
     keeps the in-cluster call off the egress proxy.
 
-    An attributed call also carries ``X-PostHog-Trace-Id`` (see :func:`team_trace_id`) so the Go
-    gateway groups the team's generations under the same id the Python gateway derives. The
-    Python-gateway path derives it internally and needs no header.
+    An attributed call also carries ``X-PostHog-Trace-Id`` (see :func:`team_trace_id`); the
+    Python-gateway fallback derives the same id internally and needs no header.
     """
     gateway = resolve_ai_gateway_config()
     if gateway:

--- a/posthog/llm/gateway_client.py
+++ b/posthog/llm/gateway_client.py
@@ -1,6 +1,7 @@
 import json
 from typing import Literal
 from urllib.parse import urlparse
+from uuid import UUID, uuid5
 
 from django.conf import settings
 
@@ -218,6 +219,37 @@ def ai_product_headers(ai_product: str | None) -> dict[str, str] | None:
     return _ai_property_headers(ai_product=ai_product)
 
 
+# Namespace the Python LLM gateway hashes non-UUID trace identifiers under, duplicated from
+# services/llm-gateway/src/llm_gateway/callbacks/posthog.py. Both must stay equal so a team's
+# generations carry one trace id whichever gateway serves them. TestTeamTraceId pins the
+# derivation against ids observed on captured events.
+_TEAM_TRACE_ID_NAMESPACE = UUID("8d4f6b7e-6a3e-4f3a-9f3b-3b6f4d2e8a1a")
+
+
+def team_trace_id(team_id: int | None) -> str | None:
+    """Deterministic ``$ai_trace_id`` for a team's generations, or None when unattributed.
+
+    The Python gateway derives this itself, hashing the ``metadata.user_id`` callers set to
+    ``team-<id>``. The Go gateway derives nothing: absent an ``X-PostHog-Trace-Id`` header it
+    stamps a fresh id per request, leaving every generation in a single-event trace. Sending
+    this keeps one team's generations on one trace id whichever gateway serves them.
+
+    The grouping is per team, not per pipeline run: every generation a team makes shares an id.
+    """
+    if team_id is None:
+        return None
+    return str(uuid5(_TEAM_TRACE_ID_NAMESPACE, f"team-{team_id}"))
+
+
+def _ai_trace_headers(team_id: int | None) -> dict[str, str]:
+    """``X-PostHog-Trace-Id`` header for a team, empty when the call is unattributed.
+
+    Empty rather than None so callers can merge it into the properties header dict.
+    """
+    trace_id = team_trace_id(team_id)
+    return {"X-PostHog-Trace-Id": trace_id} if trace_id else {}
+
+
 def _anthropic_gateway_base_url(openai_base_url: str) -> str:
     """Drop the OpenAI ``/v1`` suffix so the Anthropic SDK, which appends ``/v1/messages``
     itself, hits the same gateway root the OpenAI route uses. ``resolve_ai_gateway_config``
@@ -285,18 +317,29 @@ def build_async_anthropic_client(
     ``use_bedrock_fallback`` only affects the Python-gateway fallback path; the Go gateway fails
     over to Bedrock on its own via the host breaker and reads no opt-in header. trust_env=False
     keeps the in-cluster call off the egress proxy.
+
+    An attributed call also carries ``X-PostHog-Trace-Id`` (see :func:`team_trace_id`) so the Go
+    gateway groups the team's generations under the same id the Python gateway derives. The
+    Python-gateway path derives it internally and needs no header.
     """
     gateway = resolve_ai_gateway_config()
     if gateway:
         url, api_key = gateway
+        default_headers = {
+            **(
+                _ai_property_headers(
+                    ai_product=ai_product,
+                    ai_stage=ai_stage,
+                    team_id=str(team_id) if team_id is not None else None,
+                )
+                or {}
+            ),
+            **_ai_trace_headers(team_id),
+        }
         return AsyncAnthropic(
             api_key=api_key,
             base_url=_anthropic_gateway_base_url(url),
-            default_headers=_ai_property_headers(
-                ai_product=ai_product,
-                ai_stage=ai_stage,
-                team_id=str(team_id) if team_id is not None else None,
-            ),
+            default_headers=default_headers or None,
             http_client=httpx.AsyncClient(trust_env=False),
         )
     return get_async_anthropic_gateway_client(product, team_id=team_id, use_bedrock_fallback=use_bedrock_fallback)

--- a/posthog/llm/test_gateway_client.py
+++ b/posthog/llm/test_gateway_client.py
@@ -15,10 +15,12 @@ from posthog.llm.gateway_client import (
     get_async_llm_client,
     get_llm_client,
     resolve_ai_gateway_config,
+    team_trace_id,
 )
 
 AI_GATEWAY_URL = "https://ai-gateway.example/v1"
 AI_GATEWAY_KEY = "phs_project_secret"
+TEAM_42_TRACE_ID = "30a04c7a-98b4-5119-8597-8c696e44a270"
 
 
 class TestGetLlmClient:
@@ -262,6 +264,29 @@ class TestBuildAsyncOpenAIClient:
         assert result is mock_get_async.return_value
 
 
+class TestTeamTraceId:
+    # Expected ids are not recomputed from the helper: each is a $ai_trace_id observed on events
+    # the Python gateway captured for that team, so a changed namespace or key format fails here
+    # rather than agreeing with itself.
+    @pytest.mark.parametrize(
+        "team_id,expected",
+        [
+            (2, "aba5a277-3ba6-5682-a2da-f455d39e8aff"),
+            (1589, "2e803550-d2e1-5dd7-9124-0fdd7e8c9518"),
+            (169318, "92733d55-3d1e-5062-905b-0afa3b2e2a92"),
+            (487950, "78c3f90a-d69e-5fe6-b2b2-3f22a4d7ebb1"),
+        ],
+    )
+    def test_matches_python_gateway_derivation(self, team_id: int, expected: str):
+        assert team_trace_id(team_id) == expected
+
+    def test_unattributed_call_has_no_trace_id(self):
+        assert team_trace_id(None) is None
+
+    def test_distinct_teams_do_not_share_a_trace(self):
+        assert team_trace_id(2) != team_trace_id(3)
+
+
 class TestBuildAsyncAnthropicClient:
     @override_settings(AI_GATEWAY_URL=AI_GATEWAY_URL, AI_GATEWAY_API_KEY=AI_GATEWAY_KEY)
     @patch("posthog.llm.gateway_client.httpx.AsyncClient")
@@ -281,11 +306,36 @@ class TestBuildAsyncAnthropicClient:
             default_headers={
                 "X-PostHog-Properties": json.dumps(
                     {"ai_product": "signals_grouping", "ai_stage": "match", "team_id": "42"}
-                )
+                ),
+                "X-PostHog-Trace-Id": TEAM_42_TRACE_ID,
             },
             http_client=mock_httpx.return_value,
         )
         assert result is mock_anthropic.return_value
+
+    @override_settings(AI_GATEWAY_URL=AI_GATEWAY_URL, AI_GATEWAY_API_KEY=AI_GATEWAY_KEY)
+    @patch("posthog.llm.gateway_client.httpx.AsyncClient")
+    @patch("posthog.llm.gateway_client.AsyncAnthropic")
+    def test_gateway_mode_omits_trace_header_when_team_id_unset(self, mock_anthropic, mock_httpx):
+        # Unattributed calls have no team to key the trace on, so the gateway stamps its own id.
+        build_async_anthropic_client("signals", ai_product="signals_grouping", ai_stage="match")
+
+        _, kwargs = mock_anthropic.call_args
+        assert "X-PostHog-Trace-Id" not in kwargs["default_headers"]
+
+    @override_settings(AI_GATEWAY_URL=AI_GATEWAY_URL, AI_GATEWAY_API_KEY=AI_GATEWAY_KEY)
+    @patch("posthog.llm.gateway_client.httpx.AsyncClient")
+    @patch("posthog.llm.gateway_client.AsyncAnthropic")
+    def test_gateway_mode_sends_trace_header_alongside_properties(self, mock_anthropic, mock_httpx):
+        # The trace rides its own header, so it must not displace the properties blob (which the
+        # emission path replaces per call) nor be folded into it as a reserved $-prefixed key.
+        build_async_anthropic_client("signals", team_id=42)
+
+        _, kwargs = mock_anthropic.call_args
+        assert kwargs["default_headers"] == {
+            "X-PostHog-Properties": json.dumps({"team_id": "42"}),
+            "X-PostHog-Trace-Id": TEAM_42_TRACE_ID,
+        }
 
     @override_settings(AI_GATEWAY_URL=AI_GATEWAY_URL, AI_GATEWAY_API_KEY=AI_GATEWAY_KEY)
     @patch("posthog.llm.gateway_client.httpx.AsyncClient")

--- a/posthog/llm/test_gateway_client.py
+++ b/posthog/llm/test_gateway_client.py
@@ -265,9 +265,8 @@ class TestBuildAsyncOpenAIClient:
 
 
 class TestTeamTraceId:
-    # Expected ids are not recomputed from the helper: each is a $ai_trace_id observed on events
-    # the Python gateway captured for that team, so a changed namespace or key format fails here
-    # rather than agreeing with itself.
+    # Expected ids are $ai_trace_id values observed on captured events, not recomputed from the
+    # helper: recomputing would make the test agree with itself and miss a namespace change.
     @pytest.mark.parametrize(
         "team_id,expected",
         [
@@ -317,7 +316,6 @@ class TestBuildAsyncAnthropicClient:
     @patch("posthog.llm.gateway_client.httpx.AsyncClient")
     @patch("posthog.llm.gateway_client.AsyncAnthropic")
     def test_gateway_mode_omits_trace_header_when_team_id_unset(self, mock_anthropic, mock_httpx):
-        # Unattributed calls have no team to key the trace on, so the gateway stamps its own id.
         build_async_anthropic_client("signals", ai_product="signals_grouping", ai_stage="match")
 
         _, kwargs = mock_anthropic.call_args
@@ -327,8 +325,8 @@ class TestBuildAsyncAnthropicClient:
     @patch("posthog.llm.gateway_client.httpx.AsyncClient")
     @patch("posthog.llm.gateway_client.AsyncAnthropic")
     def test_gateway_mode_sends_trace_header_alongside_properties(self, mock_anthropic, mock_httpx):
-        # The trace rides its own header, so it must not displace the properties blob (which the
-        # emission path replaces per call) nor be folded into it as a reserved $-prefixed key.
+        # The emission path replaces the properties blob per call and the gateway strips
+        # $-prefixed keys, so the trace has to ride its own header.
         build_async_anthropic_client("signals", team_id=42)
 
         _, kwargs = mock_anthropic.call_args


### PR DESCRIPTION
## Problem

Signals generations stopped grouping in LLM analytics when signals moved onto the Go ai-gateway on 21 July. Each generation now lands in its own single-event trace, and the ids don't match the ones the same teams' earlier events carry, so a team's history is split across two id schemes.

## Changes

Sends one extra request header from the Anthropic gateway client.

- `build_async_anthropic_client` attaches **`X-PostHog-Trace-Id`** on any call that carries a `team_id`.
- `team_trace_id()` derives that id the same way the Python gateway does, so both gateways produce one id per team and old and new events join.
- **No call sites change.** Grouping, safety and emission already pass `team_id`.
- Unattributed calls send nothing and keep the gateway's per-request id.

The namespace constant is copied from `services/llm-gateway`, which the Django app can't import. `TestTeamTraceId` is what stops the two drifting.

> [!NOTE]
> This groups **per team, not per pipeline run**: every generation a team makes shares one id. That is the grouping the Python gateway has always produced, so this restores continuity rather than adding run-level tracing.

## How did you test this code?

`posthog/llm/test_gateway_client.py` plus the three signals suites that exercise this client, 113 passing locally.

The derivation test pins ids taken from already-captured events rather than recomputing them from the helper, so a drifted namespace fails instead of agreeing with itself. Nothing existing tied this repo's derivation to the gateway's. I also checked both mutations go red rather than assuming coverage: dropping the header fails 2 tests, changing one hex digit of the namespace fails 6.

No manual testing. Nothing here ran against a live gateway.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Opus 5); I directed the investigation behind it. Invoked the personal `pr-descriptions` and `code-comments` skills, no repo-provided ones. Requires human review.
