### PR TITLE
fix(cdp): match microsoft ads conversions on email or phone without a click id

### DIFF
--- a/nodejs/src/cdp/templates/_destinations/microsoft_ads/microsoft.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/microsoft_ads/microsoft.template.test.ts
@@ -82,16 +82,27 @@ describe('microsoft template', () => {
             `"Error from capi.uet.microsoft.com (status 401): {'error': {'code': 'Unauthorized', 'message': 'You are not authorized to access this resource.'}}"`
         )
     })
-    it('skips when microsoftClickId is missing', async () => {
+    it('sends the conversion without a click id when email is present', async () => {
         const response = await tester.invokeMapping(
             'Conversion',
             { tagId: '12345678', apiToken: 'api-token', eventName: 'purchase' },
             createAdDestinationPayload({ person: { properties: { msclkid: null } } })
         )
+        expect(response.error).toBeUndefined()
+        expect(JSON.parse(response.invocation.queueParameters!.body as string).data[0].userData).toEqual({
+            em: '3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3',
+        })
+    })
+    it('skips when no identifier is available', async () => {
+        const response = await tester.invokeMapping(
+            'Conversion',
+            { tagId: '12345678', apiToken: 'api-token', eventName: 'purchase' },
+            createAdDestinationPayload({ person: { properties: { msclkid: null, email: null } } })
+        )
         expect(response.logs.filter((log) => log.level === 'info').map((log) => log.message)).toMatchInlineSnapshot(
             `
             [
-              "Empty \`microsoftClickId\`. Skipping...",
+              "No \`microsoftClickId\`, \`email\` or \`phone\` to identify the user with. Skipping...",
             ]
         `
         )

--- a/nodejs/src/cdp/templates/_destinations/microsoft_ads/microsoft.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/microsoft_ads/microsoft.template.test.ts
@@ -29,7 +29,7 @@ describe('microsoft template', () => {
         expect(response.finished).toEqual(false)
         expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
             {
-              "body": "{"data":[{"eventType":"custom","eventName":"purchase","eventTime":1735689600,"userData":{"msclkid":"microsoft-id","em":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3"},"eventId":"event-id","customData":{"value":100,"currency":"USD"}}]}",
+              "body": "{"data":[{"eventType":"custom","eventName":"purchase","eventTime":1735689600,"userData":{"msclkid":"microsoft-id","em":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3","ph":"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8"},"eventId":"event-id","customData":{"value":100,"currency":"USD"}}]}",
               "headers": {
                 "Authorization": "Bearer api-token",
                 "Content-Type": "application/json",
@@ -53,7 +53,7 @@ describe('microsoft template', () => {
         expect(response.finished).toEqual(false)
         expect(response.invocation.queueParameters).toMatchInlineSnapshot(`
             {
-              "body": "{"data":[{"eventType":"custom","eventName":"purchase","eventTime":1735689600,"userData":{"msclkid":"microsoft-id","em":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3"},"eventId":"event-id"}]}",
+              "body": "{"data":[{"eventType":"custom","eventName":"purchase","eventTime":1735689600,"userData":{"msclkid":"microsoft-id","em":"3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3","ph":"422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8"},"eventId":"event-id"}]}",
               "headers": {
                 "Authorization": "Bearer api-token",
                 "Content-Type": "application/json",
@@ -84,23 +84,34 @@ describe('microsoft template', () => {
             `"Error from capi.uet.microsoft.com (status 401): {'error': {'code': 'Unauthorized', 'message': 'You are not authorized to access this resource.'}}"`
         )
     })
-    it('sends the conversion without a click id when email is present', async () => {
+    // Any one identifier is enough for Microsoft to attribute, so none of them may gate the send
+    it.each([
+        ['click id', { email: null, phone: null }, { msclkid: 'microsoft-id' }],
+        [
+            'email',
+            { msclkid: null, phone: null },
+            { em: '3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3' },
+        ],
+        [
+            'phone',
+            { msclkid: null, email: null },
+            { ph: '422ce82c6fc1724ac878042f7d055653ab5e983d186e616826a72d4384b68af8' },
+        ],
+    ])('sends the conversion when only %s is available', async (_, personProperties, expectedUserData) => {
         const response = await tester.invokeMapping(
             'Conversion',
             { tagId: '12345678', apiToken: 'api-token', eventName: 'purchase' },
-            createAdDestinationPayload({ person: { properties: { msclkid: null } } })
+            createAdDestinationPayload({ person: { properties: personProperties } })
         )
         expect(response.error).toBeUndefined()
         const body = parseJSON((response.invocation.queueParameters as { body: string }).body)
-        expect(body.data[0].userData).toEqual({
-            em: '3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3',
-        })
+        expect(body.data[0].userData).toEqual(expectedUserData)
     })
     it('skips when no identifier is available', async () => {
         const response = await tester.invokeMapping(
             'Conversion',
             { tagId: '12345678', apiToken: 'api-token', eventName: 'purchase' },
-            createAdDestinationPayload({ person: { properties: { msclkid: null, email: null } } })
+            createAdDestinationPayload({ person: { properties: { msclkid: null, email: null, phone: null } } })
         )
         expect(response.logs.filter((log) => log.level === 'info').map((log) => log.message)).toMatchInlineSnapshot(
             `

--- a/nodejs/src/cdp/templates/_destinations/microsoft_ads/microsoft.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/microsoft_ads/microsoft.template.test.ts
@@ -1,5 +1,7 @@
 import { DateTime, Settings } from 'luxon'
 
+import { parseJSON } from '~/common/utils/json-parse'
+
 import { TemplateTester, createAdDestinationPayload } from '../../test/test-helpers'
 import { template } from './microsoft.template'
 
@@ -89,7 +91,8 @@ describe('microsoft template', () => {
             createAdDestinationPayload({ person: { properties: { msclkid: null } } })
         )
         expect(response.error).toBeUndefined()
-        expect(JSON.parse(response.invocation.queueParameters!.body as string).data[0].userData).toEqual({
+        const body = parseJSON((response.invocation.queueParameters as { body: string }).body)
+        expect(body.data[0].userData).toEqual({
             em: '3d4eee8538a4bbbe2ef7912f90ee494c1280f74dd7fd81232e58deb9cb9997e3',
         })
     })

--- a/nodejs/src/cdp/templates/_destinations/microsoft_ads/microsoft.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/microsoft_ads/microsoft.template.ts
@@ -19,10 +19,10 @@ const build_inputs = (): HogFunctionInputSchemaType[] => {
             type: 'string',
             label: 'Microsoft Click ID (msclkid)',
             description:
-                'The Microsoft click ID (msclkid) associated with this conversion. Required for click attribution.',
+                'The Microsoft click ID (msclkid) associated with this conversion. It gives the most accurate click attribution, but conversions can also match on hashed email or phone when no click ID is available.',
             default: '{person.properties.msclkid ?? person.properties.$initial_msclkid}',
             secret: false,
-            required: true,
+            required: false,
         },
         {
             key: 'eventTime',
@@ -95,19 +95,20 @@ export const template: HogFunctionTemplate = {
     category: ['Advertisement'],
     code_language: 'hog',
     code: `
-if (empty(inputs.microsoftClickId)) {
-    print('Empty \`microsoftClickId\`. Skipping...')
-    return
-}
-
-let userData := {
-    'msclkid': inputs.microsoftClickId
+let userData := {}
+if (not empty(inputs.microsoftClickId)) {
+    userData.msclkid := inputs.microsoftClickId
 }
 if (not empty(inputs.email)) {
     userData.em := sha256Hex(lower(trim(inputs.email)))
 }
 if (not empty(inputs.phone)) {
     userData.ph := sha256Hex(lower(trim(inputs.phone)))
+}
+// Microsoft can only attribute a conversion if it carries at least one identifier
+if (length(keys(userData)) == 0) {
+    print('No \`microsoftClickId\`, \`email\` or \`phone\` to identify the user with. Skipping...')
+    return
 }
 
 let conversion := {

--- a/nodejs/src/cdp/templates/_destinations/microsoft_ads/microsoft.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/microsoft_ads/microsoft.template.ts
@@ -77,7 +77,7 @@ const build_inputs = (): HogFunctionInputSchemaType[] => {
             label: 'Phone number',
             description:
                 'Phone number for enhanced conversions. Sent SHA-256 hashed; leave blank to omit. Normalize to E.164 format (e.g. +14255551234) for best match rates.',
-            default: '',
+            default: '{person.properties.phone}',
             secret: false,
             required: false,
         },


### PR DESCRIPTION
## Problem

A customer testing the new Microsoft Ads destination noticed the template bails out of any event that has no `msclkid`, and asked whether that's right given the API can also match on email.

They're correct. In [Microsoft's UET Conversions API schema](https://learn.microsoft.com/en-us/advertising/guides/uet-conversion-api-integration?view=bingads-13), `msclkid` is not a required field, and the docs explicitly recommend sending hashed email (`em`) and phone (`ph`) for enhanced conversions so measurement survives third-party cookie loss. Hard-gating on the click ID drops every conversion from a user who arrived without one, or whose click ID we never captured, even when we have a perfectly good identifier to send.

## Changes

The click ID is now optional. The template builds `userData` from whatever it has and only skips the event when none of `msclkid`, `email`, or `phone` are available, which is the point where Microsoft genuinely can't attribute anything. This matches how the Snapchat destination already handles its identifier set.

```diff
-if (empty(inputs.microsoftClickId)) {
-    print('Empty `microsoftClickId`. Skipping...')
-    return
-}
-
-let userData := {
-    'msclkid': inputs.microsoftClickId
+let userData := {}
+if (not empty(inputs.microsoftClickId)) {
+    userData.msclkid := inputs.microsoftClickId
 }
```

The `microsoftClickId` input drops `required: true` and its description now says it gives the best attribution rather than that it's mandatory.

Review also turned up that the `phone` input defaulted to an empty string while `email` defaulted to `{person.properties.email}`, so the phone match path was unreachable without hand-wiring the field. It now defaults to `{person.properties.phone}`, matching the snapchat and tiktok destinations.

> [!NOTE]
> Behavior change for anyone already running this destination: events that were previously skipped will now send if the person has an email or phone. That's the intent, but it means conversion volume in Microsoft Advertising will go up after this ships.

## How did you test this code?

Automated only, I didn't exercise this against a live UET tag.

Claude updated `microsoft.template.test.ts` and ran it (5 passed). Two cases changed:

- A parameterized case replaces the old `skips when microsoftClickId is missing`, asserting we still fire when only the click id, only the email, or only the phone is present. That's the direct regression guard for this fix, and each identifier gets its own branch rather than email standing in for all three.
- `skips when no identifier is available` covers the remaining skip path, so a future refactor can't quietly drop the guard entirely and start posting unattributable events.

I also checked our hashing against the worked examples in Microsoft's CAPI docs: both the email and phone hashes match, including keeping the leading `+` on E.164 numbers, so that needed no change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed, the destination's user-facing copy is the input description which is updated here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus) did the change. I pointed it at the customer's question and it verified the claim against Microsoft's published CAPI schema before touching anything, rather than taking the report at face value. Worth confirming that reading in review.

It considered widening the payload further while in here, `externalId`, `clientIpAddress`, and `clientUserAgent` are all supported and would help match rates, but left them out to keep this scoped to the reported bug. Skills invoked: `/writing-user-facing-copy` for the input description, `/writing-tests` for the test changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

