### PR TITLE
fix(ci): avoid bash constructs semgrep's parser can't handle

### DIFF
--- a/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
+++ b/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
@@ -108,7 +108,11 @@ while IFS= read -r test_file; do
     # Can't analyze (no detectable tests, or no changed lines) → re-run the whole file.
     if ((total_file_tests == 0)) || ((${#changed_lines[@]} == 0)); then
         targets+=("$pw_file")
-        num_targeted_tests=$((num_targeted_tests + (total_file_tests > 0 ? total_file_tests : 1)))
+        if ((total_file_tests > 0)); then
+            num_targeted_tests=$((num_targeted_tests + total_file_tests))
+        else
+            num_targeted_tests=$((num_targeted_tests + 1))
+        fi
         continue
     fi
 
@@ -156,7 +160,8 @@ fi
 # signal), skip verification entirely. ~40 serial test-runs (~5 min) fits the slack left after
 # the main suite.
 MAX_TOTAL_TEST_RUNS=40
-if ((num_targeted_tests * REPEAT_COUNT > MAX_TOTAL_TEST_RUNS)); then
+total_test_runs=$((num_targeted_tests * REPEAT_COUNT))
+if ((total_test_runs > MAX_TOTAL_TEST_RUNS)); then
     echo "Skipping flake verification: $num_targeted_tests targeted test(s) × --repeat-each=$REPEAT_COUNT exceeds the ~${MAX_TOTAL_TEST_RUNS}-run time budget (broad change or a shared-scope edit in a large spec)"
     exit 0
 fi


### PR DESCRIPTION
## Problem

CI was flagging a Semgrep `PartialParsing` warning on `.github/scripts/verify-playwright-new-tests-and-snapshots.sh`, reported as a syntax error: `` `(` was unexpected `` at line 111.

This isn't just a benign warning in our own `ci-security.yaml` jobs (those exit 0 on `PartialParsing` alone) — the hosted `semgrep` check actually fails the build on it, regardless of what the PR touches. Example: it failed on #74245, an unrelated PR that only changed `products/endpoints/package.json` — [failed `semgrep` job](https://github.com/PostHog/posthog/actions/runs/30370471518/job/90321899368).

## Changes

Semgrep's bash grammar can't parse two constructs that are otherwise valid bash:

- A ternary (`cond ? a : b`) nested inside `$(( ))` arithmetic expansion (line 111).
- A `*` multiplication used directly inside a bare `((...))` conditional test (line 159 as it was before this change) — multiplication inside `$(( ))` alone parses fine, it's specifically `*` inside `((...))` that trips the parser.

Rewrote both into equivalent forms: the ternary became an `if`/`else` assignment, and the multiplication is now precomputed into a variable via `$(( ))` before the `((...))` comparison. No behavior change.

## How did you test this code?

- `bash -n` on the full script to confirm it's still valid bash.
- Reproduced the exact failure locally with `uvx semgrep --lang bash --pattern 'x' <script> --verbose`, which reported `PartialParsing` on the same two lines and ~98% parsed. After the fix, the same command reports 100% parsed with no `PartialParsing` exceptions.
- Wrote small isolated repro scripts for each construct (ternary-in-`$(( ))`, `*` inside `((...))`) to confirm which exact pattern Semgrep chokes on, rather than guessing from the error text.
- Ran a small standalone script exercising both rewritten branches (`total_file_tests` 0 and non-zero, and the multiply/compare) to confirm the new logic produces the same results as the original ternary/multiplication.
- Did not run the full CI Playwright flake-verification job itself (that requires a real PR diff with changed Playwright spec files) — verification was limited to the parsing/logic checks above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Hugues hit this Semgrep `PartialParsing` error on CI and asked me (Claude Code) to fix it. I reproduced the parser failure locally with `semgrep --lang bash` rather than guessing from the error message, isolated it to two distinct bash constructs the grammar can't handle, and rewrote both to behavior-equivalent forms. Verified with `bash -n`, local Semgrep re-runs, and small logic-equivalence scripts.
