### PR TITLE
feat(tasks): expose task run create and start as MCP tools

### DIFF
--- a/products/tasks/mcp/tools.yaml
+++ b/products/tasks/mcp/tools.yaml
@@ -379,7 +379,26 @@ tools:
         enabled: false
     tasks-runs-create:
         operation: tasks_runs_create
-        enabled: false
+        enabled: true
+        scopes:
+            - task:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create task run
+        description: >
+            Create a run for an existing task without starting it. Launching a task takes two steps: create the run
+            here, then call tasks-runs-start-create to start it. Pass `environment: cloud` for a remote sandbox run or
+            `environment: local` for a desktop session; cloud runs also need a runtime selection (`runtime_adapter` and
+            `model`). Creating a cloud run is gated on team usage and returns 429 when the team is over its posthog_code
+            limit. Returns the created run.
+        feature_flag: tasks
+        response:
+            exclude:
+                - log_url
+                - state.sandbox_connect_token
+                - state.sandbox_url
     tasks-runs-list:
         operation: tasks_runs_list
         enabled: true
@@ -473,7 +492,24 @@ tools:
         enabled: false
     tasks-runs-start-create:
         operation: tasks_runs_start_create
-        enabled: false
+        enabled: true
+        scopes:
+            - task:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Start task run
+        description: >
+            Start an existing queued or not_started cloud run. This is the second step after tasks-runs-create. Only
+            cloud runs can be started here. Starting a cloud run consumes team usage and returns 429 when the team is
+            over its posthog_code limit. Returns the task with its updated latest run.
+        feature_flag: tasks
+        response:
+            exclude:
+                - latest_run.log_url
+                - latest_run.state.sandbox_connect_token
+                - latest_run.state.sandbox_url
     tasks-runs-stream-retrieve:
         operation: tasks_runs_stream_retrieve
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -8837,6 +8837,21 @@
         },
         "feature_flag": "tasks"
     },
+    "tasks-runs-create": {
+        "description": "Create a run for an existing task without starting it. Launching a task takes two steps: create the run here, then call tasks-runs-start-create to start it. Pass `environment: cloud` for a remote sandbox run or `environment: local` for a desktop session; cloud runs also need a runtime selection (`runtime_adapter` and `model`). Creating a cloud run is gated on team usage and returns 429 when the team is over its posthog_code limit. Returns the created run.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Create task run",
+        "title": "Create task run",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
     "tasks-runs-list": {
         "description": "List all runs for a specific task. Returns lightweight run metadata only — call tasks-runs-retrieve for full run detail including state, output, and artifacts.",
         "category": "Tasks",
@@ -8879,6 +8894,21 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        },
+        "feature_flag": "tasks"
+    },
+    "tasks-runs-start-create": {
+        "description": "Start an existing queued or not_started cloud run. This is the second step after tasks-runs-create. Only cloud runs can be started here. Starting a cloud run consumes team usage and returns 429 when the team is over its posthog_code limit. Returns the task with its updated latest run.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Start task run",
+        "title": "Start task run",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
         },
         "feature_flag": "tasks"
     },

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -9416,6 +9416,21 @@
         },
         "feature_flag": "tasks"
     },
+    "tasks-runs-create": {
+        "description": "Create a run for an existing task without starting it. Launching a task takes two steps: create the run here, then call tasks-runs-start-create to start it. Pass `environment: cloud` for a remote sandbox run or `environment: local` for a desktop session; cloud runs also need a runtime selection (`runtime_adapter` and `model`). Creating a cloud run is gated on team usage and returns 429 when the team is over its posthog_code limit. Returns the created run.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Create task run",
+        "title": "Create task run",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "tasks"
+    },
     "tasks-runs-list": {
         "description": "List all runs for a specific task. Returns lightweight run metadata only — call tasks-runs-retrieve for full run detail including state, output, and artifacts.",
         "category": "Tasks",
@@ -9458,6 +9473,21 @@
             "idempotentHint": true,
             "openWorldHint": true,
             "readOnlyHint": true
+        },
+        "feature_flag": "tasks"
+    },
+    "tasks-runs-start-create": {
+        "description": "Start an existing queued or not_started cloud run. This is the second step after tasks-runs-create. Only cloud runs can be started here. Starting a cloud run consumes team usage and returns 429 when the team is over its posthog_code limit. Returns the task with its updated latest run.",
+        "category": "Tasks",
+        "feature": "tasks",
+        "summary": "Start task run",
+        "title": "Start task run",
+        "required_scopes": ["task:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
         },
         "feature_flag": "tasks"
     },

--- a/services/mcp/src/generated/tasks/api.ts
+++ b/services/mcp/src/generated/tasks/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 14 enabled ops
+ * PostHog API - MCP 16 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -1016,6 +1016,169 @@ export const TasksRunsListQueryParams = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * Create a new run for a specific task without starting execution.
+ * @summary Create task run
+ */
+export const TasksRunsCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+    task_id: zod.string(),
+})
+
+export const tasksRunsCreateBodyImportedMcpServersItemNameMax = 64
+
+export const tasksRunsCreateBodyImportedMcpServersItemUrlMax = 2048
+
+export const tasksRunsCreateBodyImportedMcpServersItemHeadersItemNameMax = 256
+
+export const tasksRunsCreateBodyImportedMcpServersItemHeadersItemValueMax = 4096
+
+export const tasksRunsCreateBodyRelayedMcpServersItemNameMax = 64
+
+export const tasksRunsCreateBodyEnvironmentDefault = `local`
+export const tasksRunsCreateBodyModeDefault = `background`
+export const tasksRunsCreateBodyBranchMax = 255
+
+export const TasksRunsCreateBody = /* @__PURE__ */ zod
+    .object({
+        imported_mcp_servers: zod
+            .array(
+                zod
+                    .object({
+                        type: zod.enum(['http', 'sse']).describe('\* `http` - http\n\* `sse` - sse'),
+                        name: zod.string().max(tasksRunsCreateBodyImportedMcpServersItemNameMax),
+                        url: zod.url().max(tasksRunsCreateBodyImportedMcpServersItemUrlMax),
+                        headers: zod
+                            .array(
+                                zod.object({
+                                    name: zod.string().max(tasksRunsCreateBodyImportedMcpServersItemHeadersItemNameMax),
+                                    value: zod
+                                        .string()
+                                        .max(tasksRunsCreateBodyImportedMcpServersItemHeadersItemValueMax),
+                                })
+                            )
+                            .optional(),
+                    })
+                    .describe("One client-imported MCP server, in the agent server's --mcpServers entry shape.")
+            )
+            .nullish()
+            .describe(
+                'Local url-based MCP servers from the creating client (PostHog Desktop) to make available inside the cloud sandbox. Header values are treated as credentials: stored encrypted and never returned by the API.'
+            ),
+        relayed_mcp_servers: zod
+            .array(
+                zod
+                    .object({
+                        name: zod.string().max(tasksRunsCreateBodyRelayedMcpServersItemNameMax),
+                    })
+                    .describe('One desktop-only MCP server relayed into the run — a name only, never configuration.')
+            )
+            .nullish()
+            .describe(
+                'Names of desktop-only MCP servers the creating client (PostHog Desktop) relays into the cloud sandbox over the durable event\/command channel. Names only — the server configuration (command, env, URL, headers) never crosses the wire.'
+            ),
+        environment: zod
+            .enum(['local', 'cloud'])
+            .describe('\* `local` - local\n\* `cloud` - cloud')
+            .default(tasksRunsCreateBodyEnvironmentDefault)
+            .describe(
+                "Execution environment for the new run. Use 'cloud' for remote sandbox runs and 'local' for desktop sessions.\n\n\* `local` - local\n\* `cloud` - cloud"
+            ),
+        mode: zod
+            .enum(['interactive', 'background'])
+            .describe('\* `interactive` - interactive\n\* `background` - background')
+            .default(tasksRunsCreateBodyModeDefault)
+            .describe(
+                "Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs\n\n\* `interactive` - interactive\n\* `background` - background"
+            ),
+        branch: zod
+            .string()
+            .max(tasksRunsCreateBodyBranchMax)
+            .nullish()
+            .describe('Git branch to checkout in the sandbox'),
+        sandbox_environment_id: zod
+            .string()
+            .optional()
+            .describe('Optional sandbox environment to apply for this cloud run.'),
+        custom_image_id: zod
+            .string()
+            .optional()
+            .describe(
+                "Optional custom base image for this cloud run's sandbox (Modal VM runtime only); takes precedence over the environment's image."
+            ),
+        pr_authorship_mode: zod
+            .enum(['user', 'bot'])
+            .describe('\* `user` - user\n\* `bot` - bot')
+            .optional()
+            .describe(
+                'Whether pull requests for this run should be authored by the user or the bot.\n\n\* `user` - user\n\* `bot` - bot'
+            ),
+        auto_publish: zod
+            .boolean()
+            .nullish()
+            .describe(
+                'When true, the cloud run agent pushes its work and opens a draft pull request on completion without waiting for an explicit ask.'
+            ),
+        run_source: zod
+            .enum(['manual', 'signal_report'])
+            .describe('\* `manual` - manual\n\* `signal_report` - signal_report')
+            .optional()
+            .describe(
+                'High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.\n\n\* `manual` - manual\n\* `signal_report` - signal_report'
+            ),
+        signal_report_id: zod
+            .string()
+            .optional()
+            .describe('Optional signal report identifier when this run was started from Inbox.'),
+        runtime_adapter: zod
+            .enum(['claude', 'codex'])
+            .describe('\* `claude` - claude\n\* `codex` - codex')
+            .optional()
+            .describe(
+                "Agent runtime adapter to launch for this run. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime.\n\n\* `claude` - claude\n\* `codex` - codex"
+            ),
+        model: zod.string().optional().describe('LLM model identifier to run in the selected runtime.'),
+        reasoning_effort: zod
+            .enum(['low', 'medium', 'high', 'xhigh', 'max', 'ultracode'])
+            .describe(
+                '\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max\n\* `ultracode` - ultracode'
+            )
+            .optional()
+            .describe(
+                'Reasoning effort to request for models that expose an effort control.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max\n\* `ultracode` - ultracode'
+            ),
+        context_window: zod
+            .enum(['200k', '1m'])
+            .describe('\* `200k` - 200k\n\* `1m` - 1m')
+            .optional()
+            .describe('Context window size for models that support the 1M window.\n\n\* `200k` - 200k\n\* `1m` - 1m'),
+        fast_mode: zod.boolean().nullish().describe('Enable fast mode for models that support it.'),
+        github_user_token: zod
+            .string()
+            .optional()
+            .describe('Ephemeral GitHub user token from PostHog Desktop for user-authored cloud pull requests.'),
+        initial_permission_mode: zod
+            .enum(['default', 'acceptEdits', 'plan', 'bypassPermissions', 'auto', 'read-only', 'full-access'])
+            .describe(
+                '\* `default` - default\n\* `acceptEdits` - acceptEdits\n\* `plan` - plan\n\* `bypassPermissions` - bypassPermissions\n\* `auto` - auto\n\* `read-only` - read-only\n\* `full-access` - full-access'
+            )
+            .optional()
+            .describe(
+                "Initial permission mode for the agent session. Claude runtimes accept PostHog permission presets like 'plan'. Codex runtimes accept native Codex modes like 'plan', 'auto', and 'read-only'.\n\n\* `default` - default\n\* `acceptEdits` - acceptEdits\n\* `plan` - plan\n\* `bypassPermissions` - bypassPermissions\n\* `auto` - auto\n\* `read-only` - read-only\n\* `full-access` - full-access"
+            ),
+        rtk_enabled: zod
+            .boolean()
+            .nullish()
+            .describe(
+                'Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out.'
+            ),
+    })
+    .describe('Request body for creating a task run without starting execution yet.')
+
+/**
  * Retrieve a single run for a specific task.
  * @summary Get task run
  */
@@ -1064,4 +1227,33 @@ export const TasksRunsSessionLogsRetrieveQueryParams = /* @__PURE__ */ zod.objec
         .min(tasksRunsSessionLogsRetrieveQueryOffsetMin)
         .default(tasksRunsSessionLogsRetrieveQueryOffsetDefault)
         .describe('Zero-based offset into the filtered log entries'),
+})
+
+/**
+ * Start an existing cloud run after any initial run-scoped attachments have been uploaded.
+ * @summary Start task run
+ */
+export const TasksRunsStartCreateParams = /* @__PURE__ */ zod.object({
+    id: zod.string(),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+    task_id: zod.string(),
+})
+
+export const tasksRunsStartCreateBodyPendingUserArtifactIdsItemMax = 128
+
+export const TasksRunsStartCreateBody = /* @__PURE__ */ zod.object({
+    pending_user_message: zod
+        .string()
+        .optional()
+        .describe('Initial or follow-up user message to include in the run prompt.'),
+    pending_user_artifact_ids: zod
+        .array(zod.string().max(tasksRunsStartCreateBodyPendingUserArtifactIdsItemMax))
+        .optional()
+        .describe(
+            'Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox.'
+        ),
 })

--- a/services/mcp/src/tools/generated/tasks.ts
+++ b/services/mcp/src/tools/generated/tasks.ts
@@ -17,11 +17,15 @@ import {
     TasksCreateBody,
     TasksListQueryParams,
     TasksRetrieveParams,
+    TasksRunsCreateBody,
+    TasksRunsCreateParams,
     TasksRunsListParams,
     TasksRunsListQueryParams,
     TasksRunsRetrieveParams,
     TasksRunsSessionLogsRetrieveParams,
     TasksRunsSessionLogsRetrieveQueryParams,
+    TasksRunsStartCreateBody,
+    TasksRunsStartCreateParams,
 } from '@/generated/tasks/api'
 import { getConfirmedActionRuntime } from '@/tools/confirmed-action-registry'
 import {
@@ -467,6 +471,85 @@ const tasksRetrieve = (): ToolBase<typeof TasksRetrieveSchema, WithPostHogUrl<Sc
     },
 })
 
+const TasksRunsCreateSchema = TasksRunsCreateParams.omit({ project_id: true }).extend(TasksRunsCreateBody.shape)
+
+const tasksRunsCreate = (): ToolBase<typeof TasksRunsCreateSchema, Schemas.TaskRunDetailDTO> => ({
+    name: 'tasks-runs-create',
+    schema: TasksRunsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof TasksRunsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.imported_mcp_servers !== undefined) {
+            body['imported_mcp_servers'] = params.imported_mcp_servers
+        }
+        if (params.relayed_mcp_servers !== undefined) {
+            body['relayed_mcp_servers'] = params.relayed_mcp_servers
+        }
+        if (params.environment !== undefined) {
+            body['environment'] = params.environment
+        }
+        if (params.mode !== undefined) {
+            body['mode'] = params.mode
+        }
+        if (params.branch !== undefined) {
+            body['branch'] = params.branch
+        }
+        if (params.sandbox_environment_id !== undefined) {
+            body['sandbox_environment_id'] = params.sandbox_environment_id
+        }
+        if (params.custom_image_id !== undefined) {
+            body['custom_image_id'] = params.custom_image_id
+        }
+        if (params.pr_authorship_mode !== undefined) {
+            body['pr_authorship_mode'] = params.pr_authorship_mode
+        }
+        if (params.auto_publish !== undefined) {
+            body['auto_publish'] = params.auto_publish
+        }
+        if (params.run_source !== undefined) {
+            body['run_source'] = params.run_source
+        }
+        if (params.signal_report_id !== undefined) {
+            body['signal_report_id'] = params.signal_report_id
+        }
+        if (params.runtime_adapter !== undefined) {
+            body['runtime_adapter'] = params.runtime_adapter
+        }
+        if (params.model !== undefined) {
+            body['model'] = params.model
+        }
+        if (params.reasoning_effort !== undefined) {
+            body['reasoning_effort'] = params.reasoning_effort
+        }
+        if (params.context_window !== undefined) {
+            body['context_window'] = params.context_window
+        }
+        if (params.fast_mode !== undefined) {
+            body['fast_mode'] = params.fast_mode
+        }
+        if (params.github_user_token !== undefined) {
+            body['github_user_token'] = params.github_user_token
+        }
+        if (params.initial_permission_mode !== undefined) {
+            body['initial_permission_mode'] = params.initial_permission_mode
+        }
+        if (params.rtk_enabled !== undefined) {
+            body['rtk_enabled'] = params.rtk_enabled
+        }
+        const result = await context.api.request<Schemas.TaskRunDetailDTO>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/${encodeURIComponent(String(params.task_id))}/runs/`,
+            body,
+        })
+        const filtered = omitResponseFields(result, [
+            'log_url',
+            'state.sandbox_connect_token',
+            'state.sandbox_url',
+        ]) as typeof result
+        return filtered
+    },
+})
+
 const TasksRunsListSchema = TasksRunsListParams.omit({ project_id: true }).extend(TasksRunsListQueryParams.shape)
 
 const tasksRunsList = (): ToolBase<
@@ -556,6 +639,36 @@ const tasksRunsSessionLogsRetrieve = (): ToolBase<typeof TasksRunsSessionLogsRet
     },
 })
 
+const TasksRunsStartCreateSchema = TasksRunsStartCreateParams.omit({ project_id: true }).extend(
+    TasksRunsStartCreateBody.shape
+)
+
+const tasksRunsStartCreate = (): ToolBase<typeof TasksRunsStartCreateSchema, Schemas.TaskDetailDTO> => ({
+    name: 'tasks-runs-start-create',
+    schema: TasksRunsStartCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof TasksRunsStartCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.pending_user_message !== undefined) {
+            body['pending_user_message'] = params.pending_user_message
+        }
+        if (params.pending_user_artifact_ids !== undefined) {
+            body['pending_user_artifact_ids'] = params.pending_user_artifact_ids
+        }
+        const result = await context.api.request<Schemas.TaskDetailDTO>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/tasks/${encodeURIComponent(String(params.task_id))}/runs/${encodeURIComponent(String(params.id))}/start/`,
+            body,
+        })
+        const filtered = omitResponseFields(result, [
+            'latest_run.log_url',
+            'latest_run.state.sandbox_connect_token',
+            'latest_run.state.sandbox_url',
+        ]) as typeof result
+        return filtered
+    },
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'loops-create-prepare': loopsCreatePrepare,
     'loops-create-execute': loopsCreateExecute,
@@ -569,7 +682,9 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'tasks-create': tasksCreate,
     'tasks-list': tasksList,
     'tasks-retrieve': tasksRetrieve,
+    'tasks-runs-create': tasksRunsCreate,
     'tasks-runs-list': tasksRunsList,
     'tasks-runs-retrieve': tasksRunsRetrieve,
     'tasks-runs-session-logs-retrieve': tasksRunsSessionLogsRetrieve,
+    'tasks-runs-start-create': tasksRunsStartCreate,
 }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-runs-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-runs-create.json
@@ -1,0 +1,188 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "auto_publish": {
+            "anyOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "When true, the cloud run agent pushes its work and opens a draft pull request on completion without waiting for an explicit ask."
+        },
+        "branch": {
+            "anyOf": [
+                {
+                    "maxLength": 255,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Git branch to checkout in the sandbox"
+        },
+        "context_window": {
+            "description": "Context window size for models that support the 1M window.\n\n* `200k` - 200k\n* `1m` - 1m",
+            "enum": ["200k", "1m"],
+            "type": "string"
+        },
+        "custom_image_id": {
+            "description": "Optional custom base image for this cloud run's sandbox (Modal VM runtime only); takes precedence over the environment's image.",
+            "type": "string"
+        },
+        "environment": {
+            "default": "local",
+            "description": "Execution environment for the new run. Use 'cloud' for remote sandbox runs and 'local' for desktop sessions.\n\n* `local` - local\n* `cloud` - cloud",
+            "enum": ["local", "cloud"],
+            "type": "string"
+        },
+        "fast_mode": {
+            "anyOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Enable fast mode for models that support it."
+        },
+        "github_user_token": {
+            "description": "Ephemeral GitHub user token from PostHog Desktop for user-authored cloud pull requests.",
+            "type": "string"
+        },
+        "imported_mcp_servers": {
+            "anyOf": [
+                {
+                    "items": {
+                        "description": "One client-imported MCP server, in the agent server's --mcpServers entry shape.",
+                        "properties": {
+                            "headers": {
+                                "items": {
+                                    "properties": {
+                                        "name": {
+                                            "maxLength": 256,
+                                            "type": "string"
+                                        },
+                                        "value": {
+                                            "maxLength": 4096,
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": ["name", "value"],
+                                    "type": "object"
+                                },
+                                "type": "array"
+                            },
+                            "name": {
+                                "maxLength": 64,
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "* `http` - http\n* `sse` - sse",
+                                "enum": ["http", "sse"],
+                                "type": "string"
+                            },
+                            "url": {
+                                "format": "uri",
+                                "maxLength": 2048,
+                                "type": "string"
+                            }
+                        },
+                        "required": ["type", "name", "url"],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Local url-based MCP servers from the creating client (PostHog Desktop) to make available inside the cloud sandbox. Header values are treated as credentials: stored encrypted and never returned by the API."
+        },
+        "initial_permission_mode": {
+            "description": "Initial permission mode for the agent session. Claude runtimes accept PostHog permission presets like 'plan'. Codex runtimes accept native Codex modes like 'plan', 'auto', and 'read-only'.\n\n* `default` - default\n* `acceptEdits` - acceptEdits\n* `plan` - plan\n* `bypassPermissions` - bypassPermissions\n* `auto` - auto\n* `read-only` - read-only\n* `full-access` - full-access",
+            "enum": ["default", "acceptEdits", "plan", "bypassPermissions", "auto", "read-only", "full-access"],
+            "type": "string"
+        },
+        "mode": {
+            "default": "background",
+            "description": "Execution mode: 'interactive' for user-connected runs, 'background' for autonomous runs\n\n* `interactive` - interactive\n* `background` - background",
+            "enum": ["interactive", "background"],
+            "type": "string"
+        },
+        "model": {
+            "description": "LLM model identifier to run in the selected runtime.",
+            "type": "string"
+        },
+        "pr_authorship_mode": {
+            "description": "Whether pull requests for this run should be authored by the user or the bot.\n\n* `user` - user\n* `bot` - bot",
+            "enum": ["user", "bot"],
+            "type": "string"
+        },
+        "reasoning_effort": {
+            "description": "Reasoning effort to request for models that expose an effort control.\n\n* `low` - low\n* `medium` - medium\n* `high` - high\n* `xhigh` - xhigh\n* `max` - max\n* `ultracode` - ultracode",
+            "enum": ["low", "medium", "high", "xhigh", "max", "ultracode"],
+            "type": "string"
+        },
+        "relayed_mcp_servers": {
+            "anyOf": [
+                {
+                    "items": {
+                        "description": "One desktop-only MCP server relayed into the run — a name only, never configuration.",
+                        "properties": {
+                            "name": {
+                                "maxLength": 64,
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name"],
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Names of desktop-only MCP servers the creating client (PostHog Desktop) relays into the cloud sandbox over the durable event/command channel. Names only — the server configuration (command, env, URL, headers) never crosses the wire."
+        },
+        "rtk_enabled": {
+            "anyOf": [
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Whether rtk command-output compression is enabled for this run. Omitted or null follows the server-side default (enabled); false opts this run out."
+        },
+        "run_source": {
+            "description": "High-level source that triggered this run, used to distinguish manual and signal-based cloud runs.\n\n* `manual` - manual\n* `signal_report` - signal_report",
+            "enum": ["manual", "signal_report"],
+            "type": "string"
+        },
+        "runtime_adapter": {
+            "description": "Agent runtime adapter to launch for this run. Use 'claude' for the Claude runtime or 'codex' for the Codex runtime.\n\n* `claude` - claude\n* `codex` - codex",
+            "enum": ["claude", "codex"],
+            "type": "string"
+        },
+        "sandbox_environment_id": {
+            "description": "Optional sandbox environment to apply for this cloud run.",
+            "type": "string"
+        },
+        "signal_report_id": {
+            "description": "Optional signal report identifier when this run was started from Inbox.",
+            "type": "string"
+        },
+        "task_id": {
+            "type": "string"
+        }
+    },
+    "required": ["task_id"],
+    "type": "object"
+}

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-runs-start-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/tasks-runs-start-create.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "pending_user_artifact_ids": {
+            "description": "Identifiers for run artifacts that should be attached to the next user message delivered to the sandbox.",
+            "items": {
+                "maxLength": 128,
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "pending_user_message": {
+            "description": "Initial or follow-up user message to include in the run prompt.",
+            "type": "string"
+        },
+        "task_id": {
+            "type": "string"
+        }
+    },
+    "required": ["id", "task_id"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

`tasks-create` only writes the Task row. There was no MCP tool to create or start a TaskRun, so an agent that created a task couldn't actually run it — someone had to open the task in the app to launch it. This closes that gap so a launch can happen end to end over MCP.

## Changes

Enable two already-scaffolded tools in `products/tasks/mcp/tools.yaml` and regenerate the committed MCP artifacts:

- `tasks-runs-create` (`tasks_runs_create`) — bootstraps the run row without starting it.
- `tasks-runs-start-create` (`tasks_runs_start_create`) — starts an existing queued or not_started cloud run.

Both are gated on `task:write` and the `tasks` feature flag, with `readOnly: false`, `destructive: false`, `idempotent: false`. Descriptions spell out the two-step ordering (create a run, then start it) and note that starting a cloud run consumes team usage and returns 429 when the team is over its `posthog_code` limit.

Responses omit sandbox connection credentials (`state.sandbox_connect_token`, `state.sandbox_url`) and the presigned `log_url`, matching the neighbouring `tasks-runs-retrieve` / `tasks-retrieve` tools.

No backend changes were needed: `TaskRunViewSet.create` and the `start` action already carry full `@validated_request` annotations with request and response serializers, so their generated schemas are non-empty and correctly typed.

## How did you test this code?

Automated only — I (Claude) ran these locally:

- `pnpm --filter=@posthog/mcp run lint-tool-names` — passes (both names within the 52-char kebab-case limit).
- `pnpm --filter=@posthog/mcp exec vitest run tests/unit/tool-name-validation.test.ts tests/unit/generate-tools.test.ts tests/unit/tool-filtering.test.ts` — 937 passed.
- `pnpm --filter=@posthog/mcp run fix` (Oxlint + Oxfmt) — clean.
- Verified the two operations resolve to non-empty request schemas in the generated OpenAPI spec, and that the generated handlers POST to the correct nested run paths and omit the sensitive fields.

`typecheck` currently fails only on pre-existing `Cannot find module '@posthog/quill' / 'react'` errors in `src/ui-apps/*` (missing workspace packages in this environment); none touch the tasks generated files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude) enabled and documented the two tools, then regenerated the committed artifacts. Skills invoked: `/implementing-mcp-tools`, and I read `services/mcp/CONTRIBUTING.md`. I confirmed no backend serializer changes were required by inspecting `TaskRunBootstrapCreateRequestSerializer` and `TaskRunStartRequestSerializer` (both already fully typed with `help_text`) and checking the generated OpenAPI component schemas are non-empty. Scopes were deliberately kept to `task:write` only.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
