### PR TITLE
chore(ci): avoid arithmetic ternary semgrep cannot parse

### DIFF
--- a/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
+++ b/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
@@ -108,7 +108,11 @@ while IFS= read -r test_file; do
     # Can't analyze (no detectable tests, or no changed lines) → re-run the whole file.
     if ((total_file_tests == 0)) || ((${#changed_lines[@]} == 0)); then
         targets+=("$pw_file")
-        num_targeted_tests=$((num_targeted_tests + (total_file_tests > 0 ? total_file_tests : 1)))
+        if ((total_file_tests > 0)); then
+            num_targeted_tests=$((num_targeted_tests + total_file_tests))
+        else
+            num_targeted_tests=$((num_targeted_tests + 1))
+        fi
         continue
     fi
 

--- a/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
+++ b/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
@@ -160,7 +160,8 @@ fi
 # signal), skip verification entirely. ~40 serial test-runs (~5 min) fits the slack left after
 # the main suite.
 MAX_TOTAL_TEST_RUNS=40
-if ((num_targeted_tests * REPEAT_COUNT > MAX_TOTAL_TEST_RUNS)); then
+total_test_runs=$((num_targeted_tests * REPEAT_COUNT))
+if ((total_test_runs > MAX_TOTAL_TEST_RUNS)); then
     echo "Skipping flake verification: $num_targeted_tests targeted test(s) × --repeat-each=$REPEAT_COUNT exceeds the ~${MAX_TOTAL_TEST_RUNS}-run time budget (broad change or a shared-scope edit in a large spec)"
     exit 0
 fi


### PR DESCRIPTION
## Problem

The semgrep job is failing on every open PR right now, including ones that only touch markdown. The job dies here:

```
Error: Syntax error at line .github/scripts/verify-playwright-new-tests-and-snapshots.sh:111:
 `(` was unexpected
Error: Process completed with exit code 1.
```

Semgrep's bash parser can't handle two constructs in that script. Bash itself has no problem with either, `bash -n` passes clean, and the lines have been in the tree since #64056 landed on June 17. So the trigger is on the reporting side, in `PostHog/.github`, which now treats a parse error as a hard failure rather than a warning. That repo is outside this one, so this PR just removes the things it trips on.

## Changes

Two behavior-preserving rewrites.

**1. Parenthesized ternary inside arithmetic expansion (line 111)**

```diff
-        num_targeted_tests=$((num_targeted_tests + (total_file_tests > 0 ? total_file_tests : 1)))
+        if ((total_file_tests > 0)); then
+            num_targeted_tests=$((num_targeted_tests + total_file_tests))
+        else
+            num_targeted_tests=$((num_targeted_tests + 1))
+        fi
```

I went with if/else rather than the tighter `((total_file_tests == 0)) && total_file_tests=1` because the script runs under `set -euo pipefail`, where a `((...))` test that evaluates false returns 1 and would abort the script.

**2. Multiplication inside a bare arithmetic command (line 163)**

```diff
 MAX_TOTAL_TEST_RUNS=40
-if ((num_targeted_tests * REPEAT_COUNT > MAX_TOTAL_TEST_RUNS)); then
+total_test_runs=$((num_targeted_tests * REPEAT_COUNT))
+if ((total_test_runs > MAX_TOTAL_TEST_RUNS)); then
```

The second one only surfaced after the first was fixed, since the parser stops at the first error per file. Running semgrep locally pinned down the actual boundary:

| Form | Parses |
| --- | --- |
| `total=$((a * b))` | yes |
| `if ((a * b > c))` | no |
| `$((x + (y > 0 ? y : 1)))` | no |

So `*` is fine inside `$(( ))` and breaks inside a bare `(( ))`. Hoisting the product into a variable is enough.

## How did you test this code?

I reproduced the CI failure locally with semgrep 1.171.0 and confirmed the fix there before pushing.

- Before: semgrep reports the syntax error at 163 and parses ~99.5% of the file.
- After: no syntax errors, ~100.0% of lines parsed.
- `bash -n` passes on the script.
- The two arithmetic forms are equivalent for `total_file_tests` of 0, 1, and 5.

Caveat: CI runs semgrep 1.163.0, not 1.171.0. The error reproduces identically on both, but it is not a bit-identical check. The semgrep check on this PR is the real confirmation, and it passes.

No unit tests here. This is a CI helper script with no test harness, and the change is a pure syntax rewrite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I hit this on an unrelated markdown-only PR and asked Claude to work out whether it was mine. It wasn't. Several PRs opened the same day were failing semgrep identically, and the script commit predates the failures by six weeks, which points at the org-side reporting script rather than anything in this repo. The full-repo scan flagged only this one file, so this should be the last of it.

The first attempt fixed only line 111, on the strength of a grep for similar constructs, and CI immediately came back with a second error at 163. Lesson applied: Claude installed semgrep locally rather than guessing at the parser a second time, which is also how the `$(( ))` versus `(( ))` distinction above got pinned down instead of assumed.

We considered just waiting it out, on the theory that whoever changed `PostHog/.github` would revert it. Decided against that since the fix here is a behavioral no-op and unblocks the repo either way.

Tools: Claude Code (Opus 5). No repo skills invoked.
