### PR TITLE
chore(meta_ads): count Graph API errors by subcode and recovery taken

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -18,6 +18,7 @@ from requests.exceptions import (
 )
 
 from posthog.models.integration import ERROR_TOKEN_REFRESH_FAILED, Integration, MetaAdsIntegration
+from posthog.temporal.common.errors import NonReportableError
 
 from products.warehouse_sources.backend.temporal.data_imports.naming_convention import NamingConvention
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
@@ -32,6 +33,18 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.int
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs.metaads import (
     MetaAdsSourceConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.metrics import (
+    DISPOSITION_AUTH,
+    DISPOSITION_RATE_LIMIT,
+    DISPOSITION_SHRINK,
+    DISPOSITION_SHRINK_EXHAUSTED,
+    DISPOSITION_TRANSIENT_EXHAUSTED,
+    DISPOSITION_UNCLASSIFIED,
+    FALLBACK_CHUNK_DAYS,
+    FALLBACK_PAGE_LIMIT,
+    record_adaptive_fallback,
+    record_api_error,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.schemas import RESOURCE_SCHEMAS
 from products.warehouse_sources.backend.types import IncrementalFieldType
@@ -455,6 +468,25 @@ def _is_rate_limit_error(response: Response) -> bool:
     return _meta_error_code(response) in META_RATE_LIMIT_ERROR_CODES
 
 
+def _error_disposition(response: Response) -> str:
+    """Which recovery path the connector took for this failure.
+
+    Ordered to match ``_raise_meta_api_error`` below, so the label always
+    describes what actually happened rather than what could have. Reaching here
+    with a transient error means ``_get_with_transient_retry`` already spent its
+    attempts on it without the error clearing.
+    """
+    if _is_permanent_auth_error(response):
+        return DISPOSITION_AUTH
+    if _is_rate_limit_error(response):
+        return DISPOSITION_RATE_LIMIT
+    if _should_shrink_request(response):
+        return DISPOSITION_SHRINK
+    if _is_transient_error(response):
+        return DISPOSITION_TRANSIENT_EXHAUSTED
+    return DISPOSITION_UNCLASSIFIED
+
+
 def _raise_meta_api_error(response: Response) -> typing.NoReturn:
     """Raise a descriptive exception for a non-200 Meta API response.
 
@@ -462,17 +494,28 @@ def _raise_meta_api_error(response: Response) -> typing.NoReturn:
     that ``MetaAdsSource.get_non_retryable_errors`` matches on, so the job fails
     fast instead of burning retries. A momentary backend blip (see
     ``_is_transient_error``) that has already exhausted its in-process retries is
-    tagged so ``MetaAdsSource.get_retryable_errors`` can keep the self-recovering
-    failure out of error tracking once Temporal retries the activity, excluding
-    anything the shrink ladders can still act on, which ends at
-    ``_raise_shrink_exhausted_error`` instead. The raw response is appended for
-    debugging.
+    raised as ``MetaAdsRetryableError``, excluding anything the shrink ladders
+    can still act on, which ends at ``_raise_shrink_exhausted_error`` instead.
+    The raw response is appended for debugging.
     Everything else raises the raw response and stays retryable.
     """
+    error = _meta_error_body(response)
+    disposition = _error_disposition(response)
+    record_api_error(_meta_error_code(response), error.get("error_subcode"), disposition)
+    logger.warning(
+        "meta_ads_api_error",
+        status_code=response.status_code,
+        code=error.get("code"),
+        subcode=error.get("error_subcode"),
+        disposition=disposition,
+        # The only identifier that survives into Meta's own logs.
+        fbtrace_id=error.get("fbtrace_id"),
+    )
+
     if _is_permanent_auth_error(response):
         raise Exception(f"{META_AUTH_ERROR_MESSAGE} (Meta API response: {response.status_code} - {response.text})")
     if _is_transient_error(response) and not _should_shrink_request(response):
-        raise Exception(f"Meta API request failed (retryable): {response.status_code} - {response.text}")
+        raise MetaAdsRetryableError(f"Meta API request failed (retryable): {response.status_code} - {response.text}")
     raise Exception(f"Meta API request failed: {response.status_code} - {response.text}")
 
 
@@ -485,7 +528,28 @@ def _raise_shrink_exhausted_error(response: Response) -> typing.NoReturn:
     matches on the message, so the job stops and tells the user what to change
     rather than retrying against the schedule forever.
     """
+    error = _meta_error_body(response)
+    record_api_error(_meta_error_code(response), error.get("error_subcode"), DISPOSITION_SHRINK_EXHAUSTED)
+    logger.warning(
+        "meta_ads_shrink_exhausted",
+        status_code=response.status_code,
+        code=error.get("code"),
+        subcode=error.get("error_subcode"),
+        fbtrace_id=error.get("fbtrace_id"),
+    )
     raise Exception(f"{SHRINK_EXHAUSTED_ERROR_MESSAGE} (Meta API response: {response.status_code} - {response.text})")
+
+
+class MetaAdsRetryableError(NonReportableError):
+    """A Meta failure Temporal should retry and error tracking should ignore.
+
+    Subclassing ``NonReportableError`` is what keeps a self-recovering blip out
+    of error tracking: the activity interceptor in
+    posthog/temporal/common/posthog_client.py skips capture for this type, and
+    re-raising the exception unchanged (as import_data_sync does for anything
+    matching ``get_retryable_errors``) would otherwise carry it straight into
+    ``capture_exception``.
+    """
 
 
 class MetaAdsAuthError(Exception):
@@ -616,6 +680,7 @@ def _iter_simple_pagination(
             if _should_shrink_request(response):
                 smaller = _next_smaller_limit(current_limit)
                 if smaller is not None:
+                    record_adaptive_fallback(FALLBACK_PAGE_LIMIT, current_limit, smaller)
                     current_limit = smaller
                     response = _issue()
                     continue
@@ -742,13 +807,16 @@ def _iter_time_range_pagination(
                     if chunk_size_days in TIME_RANGE_CHUNK_SIZES:
                         current_index = TIME_RANGE_CHUNK_SIZES.index(chunk_size_days)
                         if current_index < len(TIME_RANGE_CHUNK_SIZES) - 1:
-                            chunk_size_days = TIME_RANGE_CHUNK_SIZES[current_index + 1]
+                            smaller_chunk = TIME_RANGE_CHUNK_SIZES[current_index + 1]
+                            record_adaptive_fallback(FALLBACK_CHUNK_DAYS, chunk_size_days, smaller_chunk)
+                            chunk_size_days = smaller_chunk
                             continue
                     # The date range is already a single day, so the page size
                     # is the only dimension left. Re-issuing the same chunk at a
                     # smaller limit is safe: nothing has been yielded yet.
                     smaller_limit = _next_smaller_limit(current_limit)
                     if smaller_limit is not None:
+                        record_adaptive_fallback(FALLBACK_PAGE_LIMIT, current_limit, smaller_limit)
                         current_limit = smaller_limit
                         continue
                     _raise_shrink_exhausted_error(response)
@@ -763,6 +831,7 @@ def _iter_time_range_pagination(
                 if _should_shrink_request(response) and last_paging_url is not None:
                     smaller = _next_smaller_limit(current_limit)
                     if smaller is not None:
+                        record_adaptive_fallback(FALLBACK_PAGE_LIMIT, current_limit, smaller)
                         current_limit = smaller
                         retry_url = _override_limit(last_paging_url, current_limit)
                         response = _fetch_paging_url(retry_url, access_token)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -228,6 +228,15 @@ def get_schemas() -> dict[str, MetaAdsSchema]:
 # https://developers.facebook.com/docs/marketing-api/insights/error-codes
 META_TIMEOUT_ERROR_SUBCODES = {1504018, 1504038}
 
+# Subcode 1504044 ("Unknown Error Occurred") is documented alongside the timeouts
+# above, with the same remedy: ask for less data. It arrives as `code: 2` with
+# `message: "Service temporarily unavailable"`, so without this set it reads as a
+# momentary blip and only ever gets retried unchanged. Kept separate from the
+# timeouts because it really can be one, and is worth a few unchanged retries
+# before we start shrinking.
+# https://developers.facebook.com/docs/marketing-api/insights/error-codes
+META_HEAVY_QUERY_ERROR_SUBCODES = {1504044}
+
 # Chunk sizes for adaptive time-range pagination (in days)
 # Start with 30-day chunks, fall back to smaller chunks on timeout
 TIME_RANGE_CHUNK_SIZES = [30, 7, 1]
@@ -278,7 +287,13 @@ def _next_smaller_limit(current: int) -> int | None:
 
 
 def _is_timeout_error(response: Response) -> bool:
-    """Check if the response is a Meta API timeout error that can be resolved with smaller date ranges."""
+    """Check if the response is a Meta API timeout error that can be resolved with smaller date ranges.
+
+    Deliberately narrower than ``_should_shrink_request``: these subcodes are
+    unambiguous, so ``_get_with_transient_retry`` hands them straight to the
+    shrink ladders instead of spending retries on a request Meta has already
+    told us is too big.
+    """
     try:
         error = response.json().get("error", {})
 
@@ -291,6 +306,19 @@ def _is_timeout_error(response: Response) -> bool:
         return error.get("code") == 1 and "reduce the amount of data" in message
     except (ValueError, KeyError, AttributeError):
         return False
+
+
+def _should_shrink_request(response: Response) -> bool:
+    """Return True for failures a smaller date range or page size can resolve.
+
+    Covers the unambiguous timeouts plus the heavy-query subcodes, which reach
+    here only after ``_get_with_transient_retry`` has spent its unchanged
+    retries on them without the error clearing. A failure that survives those is
+    not the momentary blip Meta's error body claims.
+    """
+    if _is_timeout_error(response):
+        return True
+    return _meta_error_body(response).get("error_subcode") in META_HEAVY_QUERY_ERROR_SUBCODES
 
 
 # Meta's error-code reference documents code 1 ("API Unknown" — an unexplained backend hiccup
@@ -391,14 +419,23 @@ META_RATE_LIMIT_ERROR_MESSAGE = (
     "Meta is rate limiting requests for this connection. Please wait a few minutes and try again."
 )
 
+# Matched by `MetaAdsSource.get_non_retryable_errors`, so it has to stay in sync
+# with the key there.
+SHRINK_EXHAUSTED_ERROR_MESSAGE = "Meta could not return this data even at the smallest request size"
 
-def _meta_error_code(response: Response) -> int | None:
-    """The numeric ``error.code`` of a Meta error body, or None if it carries no parseable one."""
+
+def _meta_error_body(response: Response) -> dict:
+    """The ``error`` object of a Meta error response, or an empty dict if it carries none."""
     try:
         error = response.json().get("error", {})
     except (ValueError, AttributeError):
-        return None
-    code = error.get("code")
+        return {}
+    return error if isinstance(error, dict) else {}
+
+
+def _meta_error_code(response: Response) -> int | None:
+    """The numeric ``error.code`` of a Meta error body, or None if it carries no parseable one."""
+    code = _meta_error_body(response).get("code")
     return code if isinstance(code, int) else None
 
 
@@ -426,16 +463,29 @@ def _raise_meta_api_error(response: Response) -> typing.NoReturn:
     fast instead of burning retries. A momentary backend blip (see
     ``_is_transient_error``) that has already exhausted its in-process retries is
     tagged so ``MetaAdsSource.get_retryable_errors`` can keep the self-recovering
-    failure out of error tracking once Temporal retries the activity — excluding
-    the too-much-data timeout, which has its own non-retryable classification since
-    plain retries never resolve it. The raw response is appended for debugging.
+    failure out of error tracking once Temporal retries the activity, excluding
+    anything the shrink ladders can still act on, which ends at
+    ``_raise_shrink_exhausted_error`` instead. The raw response is appended for
+    debugging.
     Everything else raises the raw response and stays retryable.
     """
     if _is_permanent_auth_error(response):
         raise Exception(f"{META_AUTH_ERROR_MESSAGE} (Meta API response: {response.status_code} - {response.text})")
-    if _is_transient_error(response) and not _is_timeout_error(response):
+    if _is_transient_error(response) and not _should_shrink_request(response):
         raise Exception(f"Meta API request failed (retryable): {response.status_code} - {response.text}")
     raise Exception(f"Meta API request failed: {response.status_code} - {response.text}")
+
+
+def _raise_shrink_exhausted_error(response: Response) -> typing.NoReturn:
+    """Raise once both shrink ladders have bottomed out and Meta still refuses.
+
+    Terminal on purpose: the date range is down to a single day and the page
+    size to its smallest rung, so the next Temporal retry would re-issue exactly
+    the request that just failed. ``MetaAdsSource.get_non_retryable_errors``
+    matches on the message, so the job stops and tells the user what to change
+    rather than retrying against the schedule forever.
+    """
+    raise Exception(f"{SHRINK_EXHAUSTED_ERROR_MESSAGE} (Meta API response: {response.status_code} - {response.text})")
 
 
 class MetaAdsAuthError(Exception):
@@ -563,12 +613,13 @@ def _iter_simple_pagination(
             # Too-much-data: shrink the page limit and retry the same request.
             # Re-issuing the same URL/cursor at a smaller limit is safe — no
             # already-yielded rows are re-emitted.
-            if _is_timeout_error(response):
+            if _should_shrink_request(response):
                 smaller = _next_smaller_limit(current_limit)
                 if smaller is not None:
                     current_limit = smaller
                     response = _issue()
                     continue
+                _raise_shrink_exhausted_error(response)
             _raise_meta_api_error(response)
 
         try:
@@ -687,11 +738,20 @@ def _iter_time_range_pagination(
 
             if response.status_code != 200:
                 # Fallback only happens on the initial chunk request (before any data is yielded).
-                if _is_timeout_error(response) and chunk_size_days in TIME_RANGE_CHUNK_SIZES:
-                    current_index = TIME_RANGE_CHUNK_SIZES.index(chunk_size_days)
-                    if current_index < len(TIME_RANGE_CHUNK_SIZES) - 1:
-                        chunk_size_days = TIME_RANGE_CHUNK_SIZES[current_index + 1]
+                if _should_shrink_request(response):
+                    if chunk_size_days in TIME_RANGE_CHUNK_SIZES:
+                        current_index = TIME_RANGE_CHUNK_SIZES.index(chunk_size_days)
+                        if current_index < len(TIME_RANGE_CHUNK_SIZES) - 1:
+                            chunk_size_days = TIME_RANGE_CHUNK_SIZES[current_index + 1]
+                            continue
+                    # The date range is already a single day, so the page size
+                    # is the only dimension left. Re-issuing the same chunk at a
+                    # smaller limit is safe: nothing has been yielded yet.
+                    smaller_limit = _next_smaller_limit(current_limit)
+                    if smaller_limit is not None:
+                        current_limit = smaller_limit
                         continue
+                    _raise_shrink_exhausted_error(response)
                 _raise_meta_api_error(response)
 
         malformed_json_attempts = 0
@@ -700,13 +760,14 @@ def _iter_time_range_pagination(
                 # Mid-chunk timeout: retry the same cursor URL with a smaller
                 # ``limit``. Re-issuing earlier pages (i.e. shrinking the
                 # chunk) is not safe here — we've already yielded them.
-                if _is_timeout_error(response) and last_paging_url is not None:
+                if _should_shrink_request(response) and last_paging_url is not None:
                     smaller = _next_smaller_limit(current_limit)
                     if smaller is not None:
                         current_limit = smaller
                         retry_url = _override_limit(last_paging_url, current_limit)
                         response = _fetch_paging_url(retry_url, access_token)
                         continue
+                    _raise_shrink_exhausted_error(response)
                 _raise_meta_api_error(response)
 
             try:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/metrics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/metrics.py
@@ -1,0 +1,84 @@
+"""Meta Ads connector metrics.
+
+Each metric is emitted twice from one ``record_*`` helper: a Prometheus
+instrument (auto-scraped by the worker's combined metrics server, feeds Grafana)
+and an OTLP twin with the same name and attributes pushed into the PostHog
+Metrics product via posthog/otel_metrics.py (no-op unless
+OTEL_METRICS_EXPORT_URL/TOKEN are configured). Recording is swallowed by the
+factory so telemetry can never fail a sync.
+"""
+
+from prometheus_client import Counter
+
+from posthog.otel_metrics import OtelInstrumentFactory
+
+_otel = OtelInstrumentFactory("meta-ads")
+
+# Meta's `error.code` values the connector explicitly classifies. Anything else
+# is bucketed by `_code_label` so a Meta-side change cannot grow the label set
+# without bound.
+# https://developers.facebook.com/docs/graph-api/guides/error-handling
+_KNOWN_ERROR_CODES = frozenset({1, 2, 4, 10, 17, 32, 100, 102, 190, 613, 3018})
+
+# Insights-endpoint subcodes from Meta's error table, plus 99 ("unknown") which
+# their generic Graph API errors carry. Same bucketing rationale as the codes
+# above.
+# https://developers.facebook.com/docs/marketing-api/insights/error-codes
+_KNOWN_ERROR_SUBCODES = frozenset(
+    {99, 459, 460, 1504018, 1504022, 1504033, 1504038, 1504039, 1504041, 1504042, 1504043, 1504044, 1504045, 3191001}
+)
+
+# What recovery the connector attempted for a failure that reached its terminal
+# raise. `transient_retry_exhausted` is the misclassification signal: an error we
+# treat as a momentary blip that survives every unchanged retry is, by
+# definition, not momentary. `unclassified` means no recovery path matched.
+DISPOSITION_AUTH = "auth"
+DISPOSITION_RATE_LIMIT = "rate_limit"
+DISPOSITION_SHRINK = "shrink"
+DISPOSITION_SHRINK_EXHAUSTED = "shrink_exhausted"
+DISPOSITION_TRANSIENT_EXHAUSTED = "transient_retry_exhausted"
+DISPOSITION_UNCLASSIFIED = "unclassified"
+
+FALLBACK_CHUNK_DAYS = "chunk_days"
+FALLBACK_PAGE_LIMIT = "page_limit"
+
+META_ADS_API_ERRORS = Counter(
+    "meta_ads_api_errors_total",
+    "Graph API failures at their terminal raise, by Meta error code and the recovery the connector attempted",
+    ["code", "subcode", "disposition"],
+)
+
+META_ADS_ADAPTIVE_FALLBACK = Counter(
+    "meta_ads_adaptive_fallback_total",
+    "Rungs taken on the adaptive fallback ladders that shrink an over-heavy insights request",
+    ["dimension", "from_size", "to_size"],
+)
+
+
+def _code_label(code: int | None) -> str:
+    if code is None:
+        return "none"
+    if code in _KNOWN_ERROR_CODES:
+        return str(code)
+    # Collapse the 200-299 permission range rather than emit a series per code.
+    if 200 <= code < 300:
+        return "permission_2xx"
+    return "other"
+
+
+def _subcode_label(subcode: object) -> str:
+    if isinstance(subcode, int) and subcode in _KNOWN_ERROR_SUBCODES:
+        return str(subcode)
+    return "none" if subcode is None else "other"
+
+
+def record_api_error(code: int | None, subcode: object, disposition: str) -> None:
+    labels = {"code": _code_label(code), "subcode": _subcode_label(subcode), "disposition": disposition}
+    META_ADS_API_ERRORS.labels(**labels).inc()
+    _otel.record_counter_twin(META_ADS_API_ERRORS, 1, labels)
+
+
+def record_adaptive_fallback(dimension: str, from_size: int, to_size: int) -> None:
+    labels = {"dimension": dimension, "from_size": str(from_size), "to_size": str(to_size)}
+    META_ADS_ADAPTIVE_FALLBACK.labels(**labels).inc()
+    _otel.record_counter_twin(META_ADS_ADAPTIVE_FALLBACK, 1, labels)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/source.py
@@ -42,6 +42,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.meta_ads import (
     META_AUTH_ERROR_MESSAGE,
+    SHRINK_EXHAUSTED_ERROR_MESSAGE,
     MetaAdsAuthError,
     MetaAdsRateLimitError,
     MetaAdsResumeConfig,
@@ -132,6 +133,14 @@ class MetaAdsSource(ResumableSource[MetaAdsSourceConfig, MetaAdsResumeConfig], O
             # both paths shrink the per-page limit 500 → 100 → 50); if it still escapes after those
             # fallbacks are exhausted, retrying the whole job won't help.
             "Please reduce the amount of data you're asking for": None,
+            # Raised by `meta_ads._raise_shrink_exhausted_error` once both ladders
+            # have bottomed out. The next attempt would re-issue the identical
+            # single-day, smallest-page request that just failed, so the only thing
+            # left is for the user to narrow the sync window.
+            SHRINK_EXHAUSTED_ERROR_MESSAGE: (
+                "Meta couldn't return this data even at the smallest request size. Lower the sync "
+                "history for insights in your Meta Ads source settings, then run the sync again."
+            ),
         }
 
     def get_retryable_errors(self) -> set[str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -29,6 +29,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.m
     META_AUTH_ERROR_MESSAGE,
     META_TRANSIENT_ERROR_MAX_ATTEMPTS,
     PAGE_LIMIT_FALLBACK_SIZES,
+    SHRINK_EXHAUSTED_ERROR_MESSAGE,
     MetaAdsAuthError,
     MetaAdsResumeConfig,
     _earliest_supported_since,
@@ -309,7 +310,8 @@ class TestSimplePaginationLimitFallback:
             "products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.meta_ads.make_tracked_session"
         ) as mock_get:
             mock_get.return_value.get.side_effect = responses
-            with pytest.raises(Exception, match="Meta API request failed: 500"):
+            # Terminal: the next attempt would re-issue the same request.
+            with pytest.raises(Exception, match=SHRINK_EXHAUSTED_ERROR_MESSAGE):
                 list(_iter_simple_pagination(self.INITIAL_URL, self.PARAMS, None, manager))
 
         # One attempt per rung, then it gives up.
@@ -783,6 +785,70 @@ class TestTimeRangePagination:
         tr = json.loads(mock_get.return_value.get.call_args_list[1].kwargs["params"]["time_range"])
         assert tr == {"since": "2026-03-01", "until": "2026-03-07"}
 
+    def test_heavy_query_subcode_retries_unchanged_then_shrinks_chunk(self, monkeypatch) -> None:
+        monkeypatch.setattr(meta_ads_module, "_backoff_sleep", lambda attempt: None)
+        manager = _build_manager()
+        # Production shape: labeled code 2, so it retries unchanged before shrinking.
+        heavy_body = {
+            "error": {
+                "message": "Service temporarily unavailable",
+                "type": "OAuthException",
+                "is_transient": False,
+                "code": 2,
+                "error_subcode": 1504044,
+            }
+        }
+        responses = [_mock_response(400, heavy_body) for _ in range(META_TRANSIENT_ERROR_MAX_ATTEMPTS)] + [
+            _mock_response(200, {"data": [{"ad_id": str(i)}], "paging": {}}) for i in range(1, 6)
+        ]
+
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.meta_ads.make_tracked_session"
+        ) as mock_get:
+            mock_get.return_value.get.side_effect = responses
+            batches = list(
+                _iter_time_range_pagination(
+                    self.URL,
+                    self.PARAMS,
+                    {"since": "2026-03-01", "until": "2026-03-30"},
+                    None,
+                    manager,
+                )
+            )
+
+        assert [b[0]["ad_id"] for b in batches] == ["1", "2", "3", "4", "5"]
+        calls = mock_get.return_value.get.call_args_list
+        for call in calls[:META_TRANSIENT_ERROR_MAX_ATTEMPTS]:
+            assert json.loads(call.kwargs["params"]["time_range"]) == {"since": "2026-03-01", "until": "2026-03-30"}
+        assert json.loads(calls[META_TRANSIENT_ERROR_MAX_ATTEMPTS].kwargs["params"]["time_range"]) == {
+            "since": "2026-03-01",
+            "until": "2026-03-07",
+        }
+
+    def test_exhausting_both_ladders_on_initial_chunk_raises_non_retryable(self) -> None:
+        manager = _build_manager()
+        timeout_body = {"error": {"error_subcode": 1504018, "message": "timeout"}}
+        # Three chunk rungs, then two page-limit rungs once the chunk hits one day.
+        responses = [_mock_response(500, timeout_body) for _ in range(5)]
+
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.meta_ads.make_tracked_session"
+        ) as mock_get:
+            mock_get.return_value.get.side_effect = responses
+            with pytest.raises(Exception, match=SHRINK_EXHAUSTED_ERROR_MESSAGE):
+                list(
+                    _iter_time_range_pagination(
+                        self.URL,
+                        self.PARAMS,
+                        {"since": "2026-03-01", "until": "2026-03-30"},
+                        None,
+                        manager,
+                    )
+                )
+
+        limits = [call.kwargs["params"]["limit"] for call in mock_get.return_value.get.call_args_list]
+        assert limits == [500, 500, 500, 100, 50]
+
 
 class TestOverrideLimit:
     @pytest.mark.parametrize(
@@ -975,7 +1041,7 @@ class TestMidChunkLimitFallback:
             )
             # Drain the first batch (which succeeds), then expect the failure.
             assert next(gen) == [{"ad_id": "1"}]
-            with pytest.raises(Exception, match="Meta API request failed: 500"):
+            with pytest.raises(Exception, match=SHRINK_EXHAUSTED_ERROR_MESSAGE):
                 list(gen)
 
     def test_non_timeout_mid_chunk_error_does_not_retry(self) -> None:
@@ -1184,6 +1250,10 @@ class TestNonRetryableErrors:
             # 500 when Meta's backend refuses to service the query even after adaptive
             # chunking has shrunk the window to its smallest size.
             'Meta API request failed: 500 - {"error":{"code":1,"message":"Please reduce the amount of data you\'re asking for, then retry your request"}}',
+            # Both shrink ladders bottomed out, so the next attempt would re-issue
+            # the identical single-day, smallest-page request that just failed.
+            f"{SHRINK_EXHAUSTED_ERROR_MESSAGE} (Meta API response: 400 - "
+            '{"error":{"message":"Service temporarily unavailable","code":2,"error_subcode":1504044}})',
             # code 190 / subcode 459 — account checkpoint, the user must log in to Facebook.
             f"{META_AUTH_ERROR_MESSAGE} (Meta API response: 400 - "
             '{"error":{"message":"You cannot access the app till you log in to www.facebook.com and follow the '

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -13,6 +13,8 @@ from requests.exceptions import (
     JSONDecodeError as RequestsJSONDecodeError,
 )
 
+from posthog.temporal.common.errors import NonReportableError
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.integration_accounts import (
     IntegrationAccountListingError,
 )
@@ -33,6 +35,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.m
     MetaAdsAuthError,
     MetaAdsResumeConfig,
     _earliest_supported_since,
+    _error_disposition,
     _fetch_integration_row,
     _is_permanent_auth_error,
     _is_transient_error,
@@ -45,6 +48,13 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.m
     get_integration,
     list_ad_accounts,
     meta_ads_source,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.metrics import (
+    DISPOSITION_AUTH,
+    DISPOSITION_RATE_LIMIT,
+    DISPOSITION_SHRINK,
+    DISPOSITION_TRANSIENT_EXHAUSTED,
+    DISPOSITION_UNCLASSIFIED,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.source import MetaAdsSource
 from products.warehouse_sources.backend.types import IncrementalFieldType
@@ -1308,6 +1318,9 @@ class TestRetryableErrors:
         with pytest.raises(Exception) as exc_info:
             _raise_meta_api_error(_mock_response(500, body))
         assert any(pattern in str(exc_info.value) for pattern in patterns)
+        # import_data_sync re-raises this unchanged, so the NonReportableError
+        # subclass is what keeps the activity interceptor from reporting it.
+        assert isinstance(exc_info.value, NonReportableError)
 
     def test_too_much_data_timeout_does_not_match_retryable_pattern(self) -> None:
         # The too-much-data timeout keeps its own non-retryable classification (adaptive chunking
@@ -1323,6 +1336,26 @@ class TestRetryableErrors:
         with pytest.raises(Exception) as exc_info:
             _raise_meta_api_error(_mock_response(500, body))
         assert not any(pattern in str(exc_info.value) for pattern in patterns)
+
+
+class TestErrorDisposition:
+    @pytest.mark.parametrize(
+        "body,expected",
+        [
+            ({"error": {"code": 190, "error_subcode": 460}}, DISPOSITION_AUTH),
+            ({"error": {"code": 200}}, DISPOSITION_AUTH),
+            ({"error": {"code": 4, "error_subcode": 1504022}}, DISPOSITION_RATE_LIMIT),
+            ({"error": {"code": 2, "error_subcode": 1504038}}, DISPOSITION_SHRINK),
+            # Meta labels this code 2, but `_should_shrink_request` claims it.
+            ({"error": {"code": 2, "error_subcode": 1504044}}, DISPOSITION_SHRINK),
+            ({"error": {"code": 1, "error_subcode": 99}}, DISPOSITION_TRANSIENT_EXHAUSTED),
+            ({"error": {"code": 3018}}, DISPOSITION_UNCLASSIFIED),
+            ({"error": {}}, DISPOSITION_UNCLASSIFIED),
+        ],
+    )
+    def test_disposition_matches_recovery_path(self, body: dict, expected: str) -> None:
+        # Ordering is load-bearing: the label names the recovery that actually ran.
+        assert _error_disposition(_mock_response(400, body)) == expected
 
 
 @freeze_time("2026-06-16")


### PR DESCRIPTION
## Problem
The Meta Ads connector emits no metrics, so a failure that retries forever without adapting looks identical to one that adapted and recovered. That is why the bug fixed in #74286 sat unnoticed.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
- `meta_ads_api_errors_total`, by Meta error code, subcode, and which recovery we actually attempted. `transient_retry_exhausted` is the one to alert on: an error we treat as a blip that survives every unchanged retry is misclassified by definition
- `meta_ads_adaptive_fallback_total`, so we can tell whether the shrink ladders engage at all
- One log line carrying Meta's `fbtrace_id`, the only id that survives into their logs when we need to ask them about a request
- `MetaAdsRetryableError` now subclasses `NonReportableError`, which is what #73142 actually needed. Swapping the log call wasn't enough, since `import_data_sync` re-raises unchanged and the activity interceptor only skips capture for that type

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Tests only. Can't confirm the metrics reach the Metrics product locally, the OTel factory no-ops without `OTEL_METRICS_EXPORT_URL` and `_TOKEN`. Added cases for the disposition ordering, and an isinstance assertion so a revert of the `NonReportableError` change can't pass while every message-based assertion still does.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Opus 5 in Claude Code. Skills: `/instrumenting-first-party-metrics` (settled the prom plus OTel twin pattern and the label cardinality rules), `/writing-tests`, `/writing-code-comments`.

Deliberately no `endpoint` label. An earlier cut had one, plus a latency histogram and a separate retry-outcome counter, and was about twice this size. Threading `endpoint` down to the request helpers meant six signature changes and every direct call site in the tests, for a dimension already on the job record. The two counters here are what actually catch the failure mode.
