### PR TITLE
fix(ci): drop bash arithmetic ternary that breaks semgrep parsing

### DIFF
--- a/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
+++ b/.github/scripts/verify-playwright-new-tests-and-snapshots.sh
@@ -108,7 +108,13 @@ while IFS= read -r test_file; do
     # Can't analyze (no detectable tests, or no changed lines) → re-run the whole file.
     if ((total_file_tests == 0)) || ((${#changed_lines[@]} == 0)); then
         targets+=("$pw_file")
-        num_targeted_tests=$((num_targeted_tests + (total_file_tests > 0 ? total_file_tests : 1)))
+        # No arithmetic ternary here: it's valid bash, but semgrep's bash parser
+        # can't handle it and aborts the whole security scan on this file.
+        if ((total_file_tests > 0)); then
+            num_targeted_tests=$((num_targeted_tests + total_file_tests))
+        else
+            num_targeted_tests=$((num_targeted_tests + 1))
+        fi
         continue
     fi
 


### PR DESCRIPTION
## Problem

The `semgrep` check is currently failing on every PR that triggers a python scan:

```
.github/scripts/verify-playwright-new-tests-and-snapshots.sh:111
Syntax error: `(` was unexpected  →  semgrep exits 3
```

The script uses a bash **arithmetic ternary** (`$((a + (b > 0 ? b : 1)))`). That's valid bash and has been on master since June — but the semgrep jobs pull **live registry rule packs** (`p/python`, `p/owasp-top-ten`, `p/security-audit`, `p/trailofbits`; only the image is pinned, not the rules), and a registry-side update started applying bash-language rules to the full-repo scan. Semgrep's bash grammar can't parse the ternary, so the whole scan aborts — no repo change triggered it, which is why every open PR went red simultaneously.

## Changes

Rewrite the ternary as a plain `if`, with a comment so it doesn't get refactored back. The computed value is identical. This is the only arithmetic ternary in any `.sh` file in the repo, so this unblocks the check fleet-wide.

An alternative (or belt-and-braces follow-up) would be pinning the registry rule packs the way the image is pinned, so registry drift can't fail CI again — left out of this PR to keep it minimal.

## How did you test this code?

- `bash -n` passes on the modified script; the rewritten branch computes the same value as the ternary.
- Repo-wide grep confirms no other `$(( … ? … : … ))` in any shell script.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Claude Code) diagnosed this while babysitting an unrelated PR whose semgrep check went red along with every other open PR's: annotations pointed at the parse error, the ternary predates the failures by six weeks, the pinned semgrep image is unchanged, and the rule packs are live registry references — leaving registry drift as the trigger. Also reported via `hogli devex:feedback` before the root cause was found.
