### PR TITLE
chore(admin): clarify person_properties deletion caption

### DIFF
--- a/posthog/admin/admins/data_deletion_request_admin.py
+++ b/posthog/admin/admins/data_deletion_request_admin.py
@@ -202,7 +202,7 @@ class DataDeletionRequestForm(forms.ModelForm):
     person_properties = ArrayTextareaField(
         required=False,
         help_text="One property name per line. You can also paste a JSON array. "
-        "Properties to remove from events.person_properties. This does NOT delete the properties from the person itself, only from the person_properties stored on events. "
+        "Properties to remove from events.person.properties. This does NOT delete the properties from the person itself, only from the person.properties stored on events. "
         "Required for property removal requests when properties is empty.",
     )
     hogql_predicate = forms.CharField(

--- a/posthog/admin/admins/data_deletion_request_admin.py
+++ b/posthog/admin/admins/data_deletion_request_admin.py
@@ -202,7 +202,8 @@ class DataDeletionRequestForm(forms.ModelForm):
     person_properties = ArrayTextareaField(
         required=False,
         help_text="One property name per line. You can also paste a JSON array. "
-        "Properties to remove from events.person_properties. Required for property removal requests when properties is empty.",
+        "Properties to remove from events.person_properties. This does NOT delete the properties from the person itself, only from the person_properties stored on events. "
+        "Required for property removal requests when properties is empty.",
     )
     hogql_predicate = forms.CharField(
         required=False,


### PR DESCRIPTION
## Problem

In the data deletion request admin, the `person_properties` field caption didn't make clear that removing properties there only scrubs them from the `person_properties` stored on events — it does not delete those properties from the person itself. This caused confusion about what the request actually does.

## Changes

Updated the `person_properties` help text to explicitly state that it does NOT delete properties from the person, only from the `person_properties` stored on events.

## How did you test this code?

Copy-only change to an admin form `help_text` string; no automated tests run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread where the caption was ambiguous about whether the person's own properties are affected. Change is a single `help_text` edit in `posthog/admin/admins/data_deletion_request_admin.py`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1785255283031469?thread_ts=1785255283.031469&cid=C075D3C5HST)*
