### PR TITLE
fix(file-system): expose entry creator

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -2759,6 +2759,7 @@ export interface FileSystemApi {
     /** @nullable */
     shortcut?: boolean | null
     readonly created_at: string
+    readonly created_by: UserBasicApi
     /** @nullable */
     readonly last_viewed_at: string | null
     /**
@@ -2795,6 +2796,7 @@ export interface PatchedFileSystemApi {
     /** @nullable */
     shortcut?: boolean | null
     readonly created_at?: string
+    readonly created_by?: UserBasicApi
     /** @nullable */
     readonly last_viewed_at?: string | null
     /**

--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -2759,7 +2759,7 @@ export interface FileSystemApi {
     /** @nullable */
     shortcut?: boolean | null
     readonly created_at: string
-    readonly created_by: UserBasicApi
+    readonly created_by: UserBasicApi | null
     /** @nullable */
     readonly last_viewed_at: string | null
     /**
@@ -2796,7 +2796,7 @@ export interface PatchedFileSystemApi {
     /** @nullable */
     shortcut?: boolean | null
     readonly created_at?: string
-    readonly created_by?: UserBasicApi
+    readonly created_by?: UserBasicApi | null
     /** @nullable */
     readonly last_viewed_at?: string | null
     /**

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -77,7 +77,7 @@ RECENTS_SEARCH_SCAN_LIMIT = 200
 
 class FileSystemSerializer(FileSystemAccessLevelSerializerMixin, serializers.ModelSerializer):
     last_viewed_at = serializers.DateTimeField(read_only=True, allow_null=True)
-    created_by = UserBasicSerializer(read_only=True)
+    created_by = UserBasicSerializer(read_only=True, allow_null=True)
 
     class Meta:
         model = FileSystem

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -77,6 +77,7 @@ RECENTS_SEARCH_SCAN_LIMIT = 200
 
 class FileSystemSerializer(FileSystemAccessLevelSerializerMixin, serializers.ModelSerializer):
     last_viewed_at = serializers.DateTimeField(read_only=True, allow_null=True)
+    created_by = UserBasicSerializer(read_only=True)
 
     class Meta:
         model = FileSystem
@@ -90,6 +91,7 @@ class FileSystemSerializer(FileSystemAccessLevelSerializerMixin, serializers.Mod
             "meta",
             "shortcut",
             "created_at",
+            "created_by",
             "last_viewed_at",
             "user_access_level",
         ]

--- a/posthog/api/file_system/test/test_file_system.py
+++ b/posthog/api/file_system/test/test_file_system.py
@@ -2105,9 +2105,7 @@ class TestDesktopFileSystemSurface(APIBaseTest):
         self.assertEqual(item["created_by"]["uuid"], str(self.user.uuid))
 
     def test_desktop_list_returns_null_for_deleted_creator(self):
-        FileSystem.objects.create(
-            team=self.team, path="Orphaned item", type="doc", surface="desktop", created_by=None
-        )
+        FileSystem.objects.create(team=self.team, path="Orphaned item", type="doc", surface="desktop", created_by=None)
 
         [item] = self.client.get(self.desktop_url).json()["results"]
 

--- a/posthog/api/file_system/test/test_file_system.py
+++ b/posthog/api/file_system/test/test_file_system.py
@@ -2097,6 +2097,13 @@ class TestDesktopFileSystemSurface(APIBaseTest):
         # Both the leaf and the auto-created parent folder are stamped "desktop".
         self.assertEqual(surfaces, {"desktop"})
 
+    def test_desktop_list_returns_creator(self):
+        self.client.post(self.desktop_url, {"path": "Folder/Item", "type": "doc"})
+
+        [item] = [item for item in self.client.get(self.desktop_url).json()["results"] if item["type"] == "doc"]
+
+        self.assertEqual(item["created_by"]["uuid"], str(self.user.uuid))
+
     def test_legacy_null_rows_appear_on_web_route_only(self):
         FileSystem.objects.create(team=self.team, path="Legacy", type="doc", surface=None, created_by=self.user)
 

--- a/posthog/api/file_system/test/test_file_system.py
+++ b/posthog/api/file_system/test/test_file_system.py
@@ -2104,6 +2104,15 @@ class TestDesktopFileSystemSurface(APIBaseTest):
 
         self.assertEqual(item["created_by"]["uuid"], str(self.user.uuid))
 
+    def test_desktop_list_returns_null_for_deleted_creator(self):
+        FileSystem.objects.create(
+            team=self.team, path="Orphaned item", type="doc", surface="desktop", created_by=None
+        )
+
+        [item] = self.client.get(self.desktop_url).json()["results"]
+
+        self.assertIsNone(item["created_by"])
+
     def test_legacy_null_rows_appear_on_web_route_only(self):
         FileSystem.objects.create(team=self.team, path="Legacy", type="doc", surface=None, created_by=self.user)
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -30421,6 +30421,7 @@ export namespace Schemas {
       /** @nullable */
       shortcut?: boolean | null;
       readonly created_at: string;
+      readonly created_by: UserBasic;
       /** @nullable */
       readonly last_viewed_at: string | null;
       /**
@@ -47897,6 +47898,7 @@ export namespace Schemas {
       /** @nullable */
       shortcut?: boolean | null;
       readonly created_at?: string;
+      readonly created_by?: UserBasic;
       /** @nullable */
       readonly last_viewed_at?: string | null;
       /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -30421,7 +30421,7 @@ export namespace Schemas {
       /** @nullable */
       shortcut?: boolean | null;
       readonly created_at: string;
-      readonly created_by: UserBasic;
+      readonly created_by: UserBasic | null;
       /** @nullable */
       readonly last_viewed_at: string | null;
       /**
@@ -47898,7 +47898,7 @@ export namespace Schemas {
       /** @nullable */
       shortcut?: boolean | null;
       readonly created_at?: string;
-      readonly created_by?: UserBasic;
+      readonly created_by?: UserBasic | null;
       /** @nullable */
       readonly last_viewed_at?: string | null;
       /**


### PR DESCRIPTION
## Problem

Desktop clients need the stable creator identity already stored on file-system entries to enforce personal ownership correctly.

## Changes

- Serialize the existing `created_by` relation with `UserBasicSerializer`.
- Regenerate the core API type and cover desktop list responses.

## How did you test this code?

- `uvx ruff check posthog/api/file_system/file_system.py posthog/api/file_system/test/test_file_system.py`
- `uvx ruff format --check posthog/api/file_system/file_system.py posthog/api/file_system/test/test_file_system.py`
- `OPT_OUT_CAPTURE=1 uv run --package hogli hogli build:openapi-types`
- The focused Django test was collected but could not run locally because Postgres is unavailable in this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation change needed; this exposes an existing model field in the API response.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex traced the desktop file-system contract and implemented the smallest serializer and regression-test change. No repo-provided skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*