### PR TITLE
fix(ai): wire property descriptions into query_planner taxonomy toolkit

### DIFF
--- a/ee/hogai/chat_agent/query_planner/test/test_toolkit.py
+++ b/ee/hogai/chat_agent/query_planner/test/test_toolkit.py
@@ -420,6 +420,26 @@ class TestTaxonomyAgentToolkit(ClickhouseTestMixin, APIBaseTest):
         self.assertEqual(type, "String")
         self.assertIsNotNone(description)
 
+    def test_retrieve_entity_properties_surfaces_stored_descriptions(self):
+        # Regression guard for the read_taxonomy path: a user-authored description on a custom
+        # property must reach the LLM. The shared helper was wired for stored descriptions in
+        # #73360, but this (query_planner) toolkit — the one read_taxonomy actually constructs —
+        # was left calling it without them, so descriptions never surfaced in production.
+        from ee.models.property_definition import EnterprisePropertyDefinition
+
+        EnterprisePropertyDefinition.objects.create(
+            team=self.team,
+            type=PropertyDefinition.Type.PERSON,
+            name="plan_tier",
+            property_type="String",
+            description="Subscription tier\nof the account",
+        )
+        toolkit = DummyToolkit(self.team, self.user)
+        result = toolkit.retrieve_entity_properties("person")
+
+        # Sanitization collapses the newline so a description can't break out of its line.
+        self.assertIn("- plan_tier – Subscription tier of the account", result)
+
     def test_generate_properties_output_replaces_newlines_in_descriptions(self):
         toolkit = DummyToolkit(self.team, self.user)
         props: list[tuple[str, str | None, str | None]] = [

--- a/ee/hogai/chat_agent/query_planner/toolkit.py
+++ b/ee/hogai/chat_agent/query_planner/toolkit.py
@@ -20,6 +20,7 @@ from posthog.hogql_queries.ai.actors_property_taxonomy_query_runner import Actor
 from posthog.hogql_queries.ai.event_taxonomy_query_runner import EventTaxonomyQueryRunner
 from posthog.hogql_queries.query_runner import ExecutionMode
 from posthog.models import Team, User
+from posthog.settings import EE_AVAILABLE
 from posthog.taxonomy.property_access import restricted_property_names
 from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP, CoreFilterDefinition
 
@@ -45,6 +46,7 @@ from ee.hogai.chat_agent.taxonomy.virtual_properties import (
     virtual_group_for_entity,
     virtual_property_no_values_message,
 )
+from ee.hogai.utils.helpers import sanitize_event_description
 from ee.hogai.utils.prompt import format_prompt_string
 
 MaxSupportedQueryKind = Literal["trends", "funnel", "retention", "sql"]
@@ -161,8 +163,46 @@ class TaxonomyAgentToolkit:
 
         return "\n".join(output_parts)
 
-    def _enrich_props_with_descriptions(self, entity: str, props: Iterable[tuple[str, str | None]]):
-        return enrich_props_with_descriptions(entity, props)
+    def _enrich_props_with_descriptions(
+        self,
+        entity: str,
+        props: Iterable[tuple[str, str | None]],
+        stored_descriptions: dict[str, str] | None = None,
+    ):
+        return enrich_props_with_descriptions(entity, props, stored_descriptions)
+
+    def _get_stored_property_descriptions(
+        self,
+        property_type: PropertyDefinition.Type,
+        names: list[str],
+        group_type_index: int | None = None,
+    ) -> dict[str, str]:
+        """Map property name -> sanitized user-authored description from the team's property definitions.
+
+        Only the enterprise `PropertyDefinition` model carries a `description` field, so this is a
+        no-op on non-EE builds. Descriptions live only in Postgres and never influence which
+        properties are surfaced — the list still comes from ClickHouse / stored definitions. Runs a
+        single batched query.
+        """
+        if not EE_AVAILABLE or not names:
+            return {}
+
+        from ee.models.property_definition import (
+            EnterprisePropertyDefinition,  # noqa: PLC0415 — EE-only model, keep off the OSS import path
+        )
+
+        qs = (
+            EnterprisePropertyDefinition.objects.filter(team=self._team, type=property_type, name__in=names)
+            .exclude(description__isnull=True)
+            .exclude(description="")
+        )
+        if group_type_index is not None:
+            qs = qs.filter(group_type_index=group_type_index)
+        return {
+            name: sanitize_event_description(description)
+            for name, description in qs.values_list("name", "description")
+            if description
+        }
 
     def retrieve_entity_properties(self, entity: str, max_properties: int = 500) -> str:
         """
@@ -184,7 +224,10 @@ class TaxonomyAgentToolkit:
             stored_props += list_virtual_properties(
                 "person_properties", exclude={name for name, _ in stored_props} | restricted
             )
-            props = self._enrich_props_with_descriptions("person", stored_props)
+            stored_descriptions = self._get_stored_property_descriptions(
+                PropertyDefinition.Type.PERSON, [name for name, _ in stored_props]
+            )
+            props = self._enrich_props_with_descriptions("person", stored_props, stored_descriptions)
         elif entity == "session":
             # Session properties are not in the DB.
             props = self._enrich_props_with_descriptions(
@@ -209,7 +252,12 @@ class TaxonomyAgentToolkit:
                 if p[0] not in restricted
             ]
             stored_props += list_virtual_properties("groups", exclude={name for name, _ in stored_props} | restricted)
-            props = self._enrich_props_with_descriptions(entity, stored_props)
+            stored_descriptions = self._get_stored_property_descriptions(
+                PropertyDefinition.Type.GROUP,
+                [name for name, _ in stored_props],
+                group_type_index=group_type_index,
+            )
+            props = self._enrich_props_with_descriptions(entity, stored_props, stored_descriptions)
 
         if not props:
             return f"Properties do not exist in the taxonomy for the entity {entity}."
@@ -276,9 +324,14 @@ class TaxonomyAgentToolkit:
         if not props:
             return f"Properties do not exist in the taxonomy for the {verbose_name}."
 
+        stored_descriptions = self._get_stored_property_descriptions(
+            PropertyDefinition.Type.EVENT, [name for name, _ in props]
+        )
         return format_prompt_string(
             PROPERTIES_EXAMPLE_PROMPT,
-            result=self._generate_properties_output(self._enrich_props_with_descriptions("event", props)),
+            result=self._generate_properties_output(
+                self._enrich_props_with_descriptions("event", props, stored_descriptions)
+            ),
         )
 
     def _format_property_values(


### PR DESCRIPTION
## Problem

#73360 shipped and deployed, but Max still couldn't read user-authored property descriptions. A trace confirmed why: Max's `read_taxonomy` tool constructs the `TaxonomyAgentToolkit` in `ee/hogai/chat_agent/query_planner/toolkit.py`, but #73360 only wired the *other* toolkit (`ee/hogai/chat_agent/taxonomy/toolkit.py`).

The shared helper `enrich_props_with_descriptions` was taught to accept `stored_descriptions` (defaulting to `None`), but this toolkit kept calling it without them, and never queried `EnterprisePropertyDefinition` at all. So in the path Max actually uses, descriptions were silently dropped.

Refs #73360

## Changes

Wire the query_planner toolkit the same way #73360 wired its sibling:

- Add `_get_stored_property_descriptions` (EE-gated no-op on OSS, sanitized via `sanitize_event_description`, single batched query, scoped by `group_type_index` for groups).
- Pass `stored_descriptions` into `_enrich_props_with_descriptions` on the event, person, and group paths. Core taxonomy still wins, so a stored description can't override or spoof a built-in one.

The property *list* still comes from ClickHouse / stored definitions exactly as before. This only attaches a Postgres-stored description to properties already surfaced. No new read path.

## How did you test this code?

Added `test_retrieve_entity_properties_surfaces_stored_descriptions` in the query_planner toolkit tests — it creates a custom person property with a multi-line description and asserts it surfaces on `retrieve_entity_properties("person")` output with the newline collapsed. This is the regression that no existing test caught: the helper was covered, but nothing exercised *this* toolkit end to end, which is exactly how the production gap slipped through.

I (Claude, the PostHog Slack app) could not run the Django suite in this environment (no dev stack). Verified: both files byte-compile, and `ruff check` / `ruff format --check` pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app, directed by Sufi from a Slack thread after a deployed trace showed #73360 hadn't fixed the behavior. I diagnosed it by reading the failing trace (it called `read_taxonomy` three times) and following the tool to its toolkit, which was the untouched one. Chose to mirror #73360's approach exactly rather than refactor the two toolkits into one shared path — that consolidation is worth doing but is out of scope for a fix.

I also checked whether #73360 needs a rollback: it does not. Its `format.py` change is backward compatible (the new arg defaults to `None`), and its toolkit change is live and correct in the `web_analytics` / `replay` max-tool paths that use that toolkit. The gap was missing coverage, not a regression.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BALLBBKAB/p1784830865575919)*
