### PR TITLE
chore(capture): cover capture-sourced ingestion warnings downstream

### DIFF
--- a/.github/workflows/ci-nodejs.yml
+++ b/.github/workflows/ci-nodejs.yml
@@ -63,6 +63,11 @@ jobs:
                         - 'rust/replay-anonymizer/**'
                         - 'rust/replay-anonymizer-node/**'
                         - '**/crosslang/**'
+                        # The clientwarnings consumer e2e replays capture's warning envelope from
+                        # this shared fixture. Without it the rust filter below decides, and it only
+                        # admits ingestion-consumer, which does not depend on the fixture's crate, so
+                        # a capture-side envelope change would skip the test that pins the consumer.
+                        - 'rust/common/ingestion_warnings/*.json'
                         - 'posthog/clickhouse/**'
                         - 'ee/migrations/**'
                         - 'posthog/management/commands/setup_test_environment.py'

--- a/nodejs/tests/ingestion/pipelines/clientwarnings/consumer-e2e.test.ts
+++ b/nodejs/tests/ingestion/pipelines/clientwarnings/consumer-e2e.test.ts
@@ -1,5 +1,8 @@
 import { Message } from 'node-rdkafka'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 
+import { parseJSON } from '~/common/utils/json-parse'
 import { KafkaProducerRegistryComponent } from '~/ingestion/common/outputs/producer-registry'
 import {
     getDefaultKafkaDownstreamProducerEnvConfig,
@@ -55,6 +58,17 @@ jest.mock('~/common/utils/logger')
 function constComponent<T extends object>(value: T): Component<T> {
     return { start: () => Promise.resolve({ value, stop: () => Promise.resolve() }) }
 }
+
+// Envelope pin shared with rust/capture/tests/ingestion_warnings_integration.rs,
+// which asserts real capture output against it. Replaying the same artifact here
+// tests the consumer against what capture actually produces, instead of a literal
+// on this side that can drift from the producer without either test noticing.
+const CAPTURE_ENVELOPE_FIXTURE = parseJSON(
+    readFileSync(
+        path.resolve(__dirname, '../../../../../rust/common/ingestion_warnings/capture_envelope.fixture.json'),
+        'utf8'
+    )
+) as { event: string; properties: Record<string, unknown> }
 
 class ClientWarningsTestIngester implements IngesterLike {
     private stopScope?: () => Promise<void>
@@ -143,4 +157,36 @@ describe('ClientWarnings consumer E2E', () => {
             expect(warnings[0].details.message).toBe('test message')
         }, 30_000)
     })
+
+    testWithTeamIngester(
+        'resolves a capture envelope to a structured warning',
+        {},
+        async ({ ingester, team, token }) => {
+            const event = new EventBuilder(team)
+                .withEvent(CAPTURE_ENVELOPE_FIXTURE.event)
+                .withProperties(CAPTURE_ENVELOPE_FIXTURE.properties)
+                .build()
+
+            const { backgroundTask } = await ingester.handleKafkaBatch(createKafkaMessages([event], token))
+            await backgroundTask
+
+            await waitForExpect(async () => {
+                const warnings = await fetchIngestionWarnings(clickhouse, team.id)
+                expect(warnings.length).toBe(1)
+                // The structured type survives the trust allowlist rather than
+                // being downgraded to `client_ingestion_warning`, and `source`
+                // reaches the row so warnings stay attributable to capture.
+                expect(warnings[0].type).toBe('missing_event_name')
+                expect(warnings[0].source).toBe('capture')
+                expect(warnings[0].details).toMatchObject({
+                    // v2 materializes its pipeline_step column from this key.
+                    pipelineStep: 'capture_validation',
+                    count: 2,
+                    // Stamped from this side's registry, never from the envelope.
+                    category: 'event',
+                    severity: 'error',
+                })
+            }, 30_000)
+        }
+    )
 })

--- a/posthog/api/test/test_ingestion_warnings_v2.py
+++ b/posthog/api/test/test_ingestion_warnings_v2.py
@@ -107,6 +107,30 @@ class TestIngestionWarningsV2API(ClickhouseTestMixin, APIBaseTest):
 
     @parameterized.expand(
         [
+            ("missing_event_name", {"pipelineStep": "capture_validation"}, "capture_validation"),
+            ("empty_batch", {}, "unknown"),
+        ]
+    )
+    def test_samples_report_producer_and_pipeline_step(
+        self, warning_type: str, extra_details: dict, expected_step: str
+    ):
+        create_warning(
+            team_id=self.team.id,
+            type=warning_type,
+            timestamp="2026-07-07 11:30:00",
+            details={"category": "event", "severity": "error", **extra_details},
+            source="capture",
+        )
+
+        status_code, results = self._list(type=warning_type)
+
+        assert status_code == status.HTTP_200_OK
+        sample = results[0]["samples"][0]
+        assert sample["source"] == "capture"
+        assert sample["pipeline_step"] == expected_step
+
+    @parameterized.expand(
+        [
             ("category", "merge", ["cannot_merge_already_identified"]),
             ("type", "cannot_merge_already_identified", ["cannot_merge_already_identified"]),
             ("severity", "error", ["message_size_too_large"]),


### PR DESCRIPTION
## Problem

Stacked on #74287.

Capture now emits ingestion warnings, and #74287 added a Rust integration test proving capture puts the right envelope on Kafka. Nothing proved anything downstream accepts it.

That leaves the interesting failure uncovered. Capture and the Node consumer agree on an envelope shape by convention only: capture writes `$$client_ingestion_warning` with a `$$client_ingestion_warning_type` property, and the consumer's trust allowlist decides whether that type survives or gets downgraded to the generic `client_ingestion_warning`. Either side can change its idea of that shape and both sides' tests still pass. The warnings just quietly stop being attributable to capture in the product.

## Changes

Two test groups and one CI change, no production code.

**Consumer e2e** picks up the golden fixture #74287 introduced and replays it as consumer input. The Rust test asserts capture produces that artifact; this asserts the consumer resolves it into a ClickHouse row with `type = missing_event_name` (survived the allowlist rather than being downgraded), `source = capture`, and the details keys v2 materializes its `pipeline_step` column from. One artifact, pinned from both ends, so drift breaks a test instead of a dashboard.

**API tests** pin the two fields that make a warning attributable to its producer. `source` was returned by the endpoint but asserted nowhere, so dropping it from the response was a silent change. And `pipeline_step` had coverage only for rows that declare one; the `unknown` fallback for rows that don't was untested, which is the common case for producers outside the Node pipeline.

**A CI filter entry, so the consumer e2e actually runs when the fixture changes.** The `nodejs` change filter in `ci-nodejs.yml` never listed `rust/common/ingestion_warnings`, so a change to the shared fixture fell through to the `rust` filter, which only promotes to the Node jobs for `ingestion-consumer`. That crate does not depend on the fixture's crate (only `capture` and `personhog-leader` do), so the fixture-consuming test would have been skipped on precisely the change most likely to break it. This sits next to the existing `rust/replay-anonymizer/**` entries, which are there for the same shared-fixture reason.

```yaml
- 'rust/common/ingestion_warnings/*.json'
```

Scoped to `*.json` rather than `/**` so ordinary Rust work in that crate doesn't drag three Jest shards along with it.

## How did you test this code?

Automated only. I ran both suites locally:

- `pnpm --filter=@posthog/nodejs exec jest tests/ingestion/pipelines/clientwarnings/consumer-e2e.test.ts` - 2 passed
- `pytest posthog/api/test/test_ingestion_warnings_v2.py` - 14 passed
- `hogli lint:workflows` - 6/6 checks passed across 104 workflows

For the filter entry I checked the glob against the matcher that actually evaluates it, rather than assuming. `.github/actions/paths-filter` is a vendored fork of `dorny/paths-filter` that matches with `picomatch` under `{dot: true}`, so I ran the pattern through that same library and options: it matches `capture_envelope.fixture.json` and `warning_types.generated.json`, and does not match `src/lib.rs` or `Cargo.toml` in the same directory.

Regressions each group catches that nothing already did:

| Group | Regression |
|---|---|
| Consumer e2e | Capture's envelope shape and the consumer's expectation drift apart. Previously only detectable by both being wrong in production. |
| `source` assertion | The API stops returning `source`, making capture warnings indistinguishable from plugin-server ones. |
| `pipeline_step` fallback | A row with no producer-declared step returns null or empty instead of `unknown`, which is what the serializer promises. |
| CI filter entry | The consumer e2e silently stops running on fixture changes, which would make the pin above decorative on the one change it exists to catch. |

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. See the note on docs anchors below.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I drove this with Cursor (Claude). Skills invoked: `/writing-tests`, `/writing-code-comments`.

The original plan had a single e2e test spawning real capture from the Node suite. Rejected: it would have built the Rust crate inside the Node CI job. Mocking capture was also rejected, since a mock of the producer is exactly the thing that drifts. Splitting at the Kafka boundary with a shared fixture gets the same coverage at no new CI build cost, and it is the split that produced this PR and #74287.

Two planned items got dropped after checking the code, both because the work was already done or shouldn't be done:

- `WARNING_TYPE_TO_DESCRIPTION` already carries all twelve capture types.
- `WARNING_TYPE_TO_DOCS_ANCHOR` deliberately omits them, and should keep omitting them. posthog.com/docs/data/ingestion-warnings has no sections for the capture validation types, so an anchor would resolve to nothing and land the reader at the top of the page. That is what the existing fallback already does, minus the false claim that a section exists. Adding those doc sections is a posthog.com change, and the anchors should follow it, not lead it.

I also dropped a completeness test asserting every capture type has a description. Both maps have deliberate fallbacks, so such a test would impose a new requirement rather than guard an existing one. Worth a team call, not a unilateral one.

The CI filter entry was added after review flagged that the fixture path reached neither the Node change filter nor the Node test job. Reviewing it against the workflow showed the "can merge broken" framing was too strong, since a fixture-only edit still reds `ci-rust.yml` through the Rust side of the pin. The gap that does exist is the coordinated one: capture and fixture changed together and self-consistent, where the Rust test stays green and the Node test never runs. The advice to also add the fixture to the turbo task inputs I left alone, since `ci-nodejs.yml` restores no `.turbo` cache and sets no remote-cache token, so nothing in CI can serve a stale hit. Skill invoked for the workflow edit: `/authoring-ci-workflows`.

