### PR TITLE
fix(aio): convert structured-output ValidationError to parse error

### DIFF
--- a/products/ai_observability/backend/llm/providers/openai.py
+++ b/products/ai_observability/backend/llm/providers/openai.py
@@ -174,10 +174,9 @@ class OpenAIAdapter:
                     if "response_format" in str(e).lower() or "json_schema" in str(e).lower():
                         return self._complete_with_json_fallback(client, request, messages, analytics)
                     raise
-                except ValidationError as e:
-                    # json_schema enforces JSON shape only, so cross-field pydantic validators and
-                    # truncated output still fail parsing here. Surface as a parse error (like the
-                    # JSON-fallback path) so callers skip the item instead of crashing.
+                except (ValidationError, openai.LengthFinishReasonError) as e:
+                    # json_schema does not enforce cross-field validators, while the SDK raises a separate
+                    # exception for length-limited output. Normalize both so callers skip invalid output.
                     raise StructuredOutputParseError(f"Failed to parse structured output: {e}") from e
             else:
                 create_response = client.chat.completions.create(

--- a/products/ai_observability/backend/llm/providers/openai.py
+++ b/products/ai_observability/backend/llm/providers/openai.py
@@ -16,7 +16,7 @@ from posthoganalytics.ai.openai import (
     AzureOpenAI as WrappedAzureOpenAI,
     OpenAI,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from products.ai_observability.backend.llm.errors import (
     AuthenticationError,
@@ -174,6 +174,11 @@ class OpenAIAdapter:
                     if "response_format" in str(e).lower() or "json_schema" in str(e).lower():
                         return self._complete_with_json_fallback(client, request, messages, analytics)
                     raise
+                except ValidationError as e:
+                    # json_schema enforces JSON shape only, so cross-field pydantic validators and
+                    # truncated output still fail parsing here. Surface as a parse error (like the
+                    # JSON-fallback path) so callers skip the item instead of crashing.
+                    raise StructuredOutputParseError(f"Failed to parse structured output: {e}") from e
             else:
                 create_response = client.chat.completions.create(
                     model=request.model,

--- a/products/ai_observability/backend/llm/providers/test/test_openai_adapter.py
+++ b/products/ai_observability/backend/llm/providers/test/test_openai_adapter.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -124,18 +126,11 @@ class _VerdictWithNA(BaseModel):
         return self
 
 
-def _truncated_json_error() -> ValidationError:
-    # Mirrors a truncated structured-output response the SDK fails to parse.
-    try:
-        _Verdict.model_validate_json('{"')
-    except ValidationError as e:
-        return e
-    raise AssertionError("expected ValidationError")
+def _length_finish_reason_error() -> openai.LengthFinishReasonError:
+    return openai.LengthFinishReasonError(completion=MagicMock(usage=None))
 
 
 def _cross_field_error() -> ValidationError:
-    # Mirrors the model returning applicable=true with a null verdict — valid JSON shape,
-    # rejected by the cross-field validator.
     try:
         _VerdictWithNA.model_validate({"applicable": True, "verdict": None})
     except ValidationError as e:
@@ -209,11 +204,13 @@ class TestOpenAIAdapterErrorMapping:
 
     @parameterized.expand(
         [
-            ("truncated_json", _truncated_json_error),
+            ("length_finish_reason", _length_finish_reason_error),
             ("cross_field_validator", _cross_field_error),
         ]
     )
-    def test_structured_output_validation_error_maps_to_parse_error(self, _name, make_error):
+    def test_structured_output_parse_errors_map_to_parse_error(
+        self, _name: str, make_error: Callable[[], Exception]
+    ) -> None:
         adapter = OpenAIAdapter()
         mock_client = MagicMock()
         mock_client.beta.chat.completions.parse.side_effect = make_error()

--- a/products/ai_observability/backend/llm/providers/test/test_openai_adapter.py
+++ b/products/ai_observability/backend/llm/providers/test/test_openai_adapter.py
@@ -8,9 +8,13 @@ from posthoganalytics.ai.openai import (
     AzureOpenAI as WrappedAzureOpenAI,
     OpenAI as WrappedOpenAI,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError, model_validator
 
-from products.ai_observability.backend.llm.errors import ContextWindowExceededError, QuotaExceededError
+from products.ai_observability.backend.llm.errors import (
+    ContextWindowExceededError,
+    QuotaExceededError,
+    StructuredOutputParseError,
+)
 from products.ai_observability.backend.llm.providers.openai import OpenAIAdapter, OpenAIConfig
 from products.ai_observability.backend.llm.types import AnalyticsContext, CompletionRequest
 
@@ -109,6 +113,36 @@ class _Verdict(BaseModel):
     verdict: bool
 
 
+class _VerdictWithNA(BaseModel):
+    applicable: bool
+    verdict: bool | None = None
+
+    @model_validator(mode="after")
+    def _check(self) -> "_VerdictWithNA":
+        if self.applicable and self.verdict is None:
+            raise ValueError("verdict is required when applicable is true")
+        return self
+
+
+def _truncated_json_error() -> ValidationError:
+    # Mirrors a truncated structured-output response the SDK fails to parse.
+    try:
+        _Verdict.model_validate_json('{"')
+    except ValidationError as e:
+        return e
+    raise AssertionError("expected ValidationError")
+
+
+def _cross_field_error() -> ValidationError:
+    # Mirrors the model returning applicable=true with a null verdict — valid JSON shape,
+    # rejected by the cross-field validator.
+    try:
+        _VerdictWithNA.model_validate({"applicable": True, "verdict": None})
+    except ValidationError as e:
+        return e
+    raise AssertionError("expected ValidationError")
+
+
 class TestOpenAIAdapterErrorMapping:
     @pytest.fixture
     def request_no_structured_output(self) -> CompletionRequest:
@@ -171,4 +205,26 @@ class TestOpenAIAdapterErrorMapping:
 
         with patch("products.ai_observability.backend.llm.providers.openai.openai.OpenAI", return_value=mock_client):
             with pytest.raises(ContextWindowExceededError):
+                adapter.complete(request, api_key="sk-test", analytics=AnalyticsContext(capture=False))
+
+    @parameterized.expand(
+        [
+            ("truncated_json", _truncated_json_error),
+            ("cross_field_validator", _cross_field_error),
+        ]
+    )
+    def test_structured_output_validation_error_maps_to_parse_error(self, _name, make_error):
+        adapter = OpenAIAdapter()
+        mock_client = MagicMock()
+        mock_client.beta.chat.completions.parse.side_effect = make_error()
+        request = CompletionRequest(
+            model="gpt-5-mini",
+            system="s",
+            messages=[{"role": "user", "content": "x"}],
+            provider="openai",
+            response_format=_Verdict,
+        )
+
+        with patch("products.ai_observability.backend.llm.providers.openai.openai.OpenAI", return_value=mock_client):
+            with pytest.raises(StructuredOutputParseError):
                 adapter.complete(request, api_key="sk-test", analytics=AnalyticsContext(capture=False))


### PR DESCRIPTION
## Problem

Several AI observability evaluation runs fail because the native structured-output parser can raise exceptions that the adapter does not normalize. One observed failure is a backend-side `pydantic.ValidationError` from `products/ai_observability/backend/llm/providers/openai.py` when the judge model returns a boolean-with-NA result of `applicable=true` with a null verdict. That output is valid against the `json_schema` because the verdict is `bool | null`, but the model's cross-field validator rejects it.

Length-limited output is a second failure mode. When OpenAI marks a response with `finish_reason=length`, the SDK raises `LengthFinishReasonError` before Pydantic parses the content.

OpenAI's `json_schema` strict mode enforces the JSON shape, but not Python-side cross-field validators. Unlike the JSON fallback path, which wraps parse failures in `StructuredOutputParseError`, the native path allowed these exceptions to escape. `call_llm_judge` then reached its generic handler and retried the evaluation activity instead of skipping the item.

## Changes

Wrap `ValidationError` and `LengthFinishReasonError` from the native structured-output path in the same `StructuredOutputParseError` used by the JSON fallback path. The LLM judge already handles that error as non-retryable, so invalid judge output skips the item instead of failing the run.

## Why

Surfaced while reviewing the AI observability team's MCP tool quality. This is a distinct, active backend failure on the evaluation path, so it is worth fixing separately.

## How did you test this code?

- Added a parameterized test to `test_openai_adapter.py` covering a cross-field `ValidationError` and the SDK's `LengthFinishReasonError`. Both must become `StructuredOutputParseError`.
- Ran `TestOpenAIAdapterErrorMapping`: 6 tests passed.
- Ran `bin/hogli ci:preflight --fix`: no failures.

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. While producing a ranked report of the AI observability team's most pressing MCP tool issues, error tracking surfaced an active backend `ValidationError` on the evaluation judge path. Root-caused to the native structured-output path not normalizing Pydantic validation failures or the SDK's length-finish exception like the JSON fallback path does.

Skills invoked: `/writing-tests` (test value gate). Considered loosening the `BooleanWithNAEvalResult` validator or coercing a verdict, but rejected that because inventing a verdict would corrupt evaluation results. Treating malformed output as a skip follows the existing convention. This is a Temporal activity implementation change, not a workflow command change, so it is safe for in-flight executions.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1785257807494179)*
