### PR TITLE
fix(llm-analytics): price gemini reasoning tokens for models/-prefixed names

### DIFF
--- a/nodejs/src/ingestion/pipelines/ai/costs/output-costs.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/output-costs.test.ts
@@ -180,6 +180,18 @@ describe('calculateOutputCost()', () => {
                 expectedCost: 0.0036,
                 description: 'includes reasoning tokens for gemini-3.1-pro-preview',
             },
+            {
+                // The Gemini SDK reports models as `models/<name>`; the provider
+                // prefix must be stripped before the anchored reasoning regex,
+                // otherwise reasoning tokens are silently priced at zero.
+                modelName: 'models/gemini-3-flash-preview',
+                modelRow: gemini3FlashModel,
+                outputTokens: 2,
+                reasoningTokens: 77,
+                // (2 + 77) * 3e-6 = 0.000237
+                expectedCost: 0.000237,
+                description: 'includes reasoning tokens for models/-prefixed gemini-3-flash-preview',
+            },
         ])('$description', ({ modelName, modelRow, outputTokens, reasoningTokens, expectedCost }) => {
             const event = createAIEvent({
                 $ai_provider: 'google',

--- a/nodejs/src/ingestion/pipelines/ai/costs/output-costs.ts
+++ b/nodejs/src/ingestion/pipelines/ai/costs/output-costs.ts
@@ -9,7 +9,16 @@ import { ResolvedModelCost } from './providers/types'
 const REASONING_COST_MODELS = [/^gemini-2\.5-/, /^gemini-3(\.\d+)?-/]
 
 export const mustAddReasoningCost = (model: string): boolean => {
-    return REASONING_COST_MODELS.some((candidate) => candidate.test(model.toLowerCase()))
+    const lowerCaseModel = model.toLowerCase()
+    // Strip any provider/path prefix (e.g. the Gemini API's `models/` resource
+    // prefix, or a `google/` provider prefix) before matching. The patterns are
+    // start-anchored, so `models/gemini-3-flash-preview` would otherwise never
+    // match and its (billed) reasoning tokens would be priced at zero. This
+    // mirrors how findCostFromModel resolves the price for the same string.
+    const bareModel = lowerCaseModel.includes('/')
+        ? (lowerCaseModel.split('/').pop() ?? lowerCaseModel)
+        : lowerCaseModel
+    return REASONING_COST_MODELS.some((candidate) => candidate.test(bareModel))
 }
 
 const warnMissingModalityRate = (event: PluginEvent, cost: ResolvedModelCost, modality: 'audio' | 'image'): void => {


### PR DESCRIPTION
## Problem

For Gemini, the LLM-analytics cost pipeline prices base output tokens correctly but silently prices reasoning (thinking) tokens at zero whenever the model string carries a provider/path prefix.

The reasoning-cost gate is start-anchored on the bare name:

```ts
const REASONING_COST_MODELS = [/^gemini-2\.5-/, /^gemini-3(\.\d+)?-/]
mustAddReasoningCost(event.properties['$ai_model'])
```

But the Gemini SDK reports models as `models/gemini-3-flash-preview` (and some routes as `google/gemini-...`). The price *lookup* already strips that prefix (`findCostFromModel` → `getModelMatchVariants` does `split('/').pop()`), so base output tokens are billed right. The reasoning check runs on the raw string, so `models/gemini-3-flash-preview` fails the anchor and its reasoning tokens are dropped from the cost. The result is internally inconsistent: bare `gemini-3-flash-preview` gets reasoning priced, `models/gemini-3-flash-preview` does not, for identical semantics.

The gap is large in practice. Gemini thinking tokens are billed by Google at the completion rate and, for these models, dwarf the visible completion tokens, so a big slice of real spend never lands in `$ai_total_cost_usd`.

> [!NOTE]
> This is the counter-position to #71065, which argues reasoning is already inside `candidates_token_count` and pricing it double-counts. A billing reconciliation says otherwise: in aggregate, reasoning tokens on these models run several times *higher* than reported output tokens, so `candidates_token_count` cannot already contain them. They are additive, exactly as Google bills them. Refs #71065.

## Changes

Strip any provider/path prefix before the reasoning-cost regex, mirroring how the price lookup normalizes the same string. `models/gemini-3-flash-preview` and `google/gemini-2.5-pro` now correctly get reasoning tokens folded into the output cost. Gemini 2.0 and non-Gemini models are unaffected.

## How did you test this code?

Added a regression case in `output-costs.test.ts` for a `models/`-prefixed Gemini 3 model in the existing reasoning-token table (no existing case covered a prefixed model, which is exactly why the gap shipped). I (the agent) was not able to run the repo's jest suite in this environment, so I verified the matcher in isolation against real production model strings and controls: every `models/`- and `google/`-prefixed Gemini 2.5/3 name now matches, while `models/gemini-2.0-flash`, `gpt-4o`, and `claude-sonnet-4` correctly do not.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Radu directed this from a Slack thread investigating why LLM-analytics cost was reconciling ~40% low against cloud billing for a Gemini-heavy workload. Diagnosis: `$ai_reasoning_tokens` is captured correctly by the SDK on nearly every generation, but the cost pipeline's reasoning gate never matched the `models/`-prefixed model strings those events carry, so the tokens were priced at zero. I (the PostHog Slack app, running Claude) traced the mapping through `output-costs.ts` and `cost-model-matching.ts`, confirmed against production event data that reasoning tokens are additive (not already in output), and scoped the fix to prefix-normalization to stay consistent with the existing price lookup.

The separate Gemini cache-write instrumentation gap (`$ai_cache_creation_input_tokens` is never populated for Gemini) is real but out of scope here and will be a follow-up in posthog-python.


---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ABFBDLQ92/p1785167583106289)*
