### PR TITLE
fix(ai): use stored property description when core entry lacks one

### DIFF
--- a/ee/hogai/chat_agent/taxonomy/format.py
+++ b/ee/hogai/chat_agent/taxonomy/format.py
@@ -90,10 +90,11 @@ def enrich_props_with_descriptions(
 ):
     """Attach a description to each property.
 
-    The built-in core taxonomy wins. For custom properties it has never heard of, fall back to the
-    user-authored description stored on the property definition (passed in already sanitized). This
-    only enriches properties the caller already discovered via ClickHouse — it never sources the
-    property list itself from Postgres.
+    A non-empty core-taxonomy description wins, so a stored description can never override (or
+    spoof) a built-in one. Where core has none (custom properties, or label-only core entries such
+    as the web-vitals values), fall back to the user-authored description stored on the property
+    definition (passed in already sanitized). This only enriches properties the caller already
+    discovered via ClickHouse; it never sources the property list itself from Postgres.
     """
     enriched_props = []
     mapping = {
@@ -110,7 +111,5 @@ def enrich_props_with_descriptions(
             if entity_definition.get("system") or entity_definition.get("ignored_in_assistant"):
                 continue
             description = entity_definition.get("description_llm") or entity_definition.get("description")
-        else:
-            description = stored_descriptions.get(prop_name)
-        enriched_props.append((prop_name, prop_type, description))
+        enriched_props.append((prop_name, prop_type, description or stored_descriptions.get(prop_name)))
     return enriched_props

--- a/ee/hogai/chat_agent/taxonomy/test/test_toolkit.py
+++ b/ee/hogai/chat_agent/taxonomy/test/test_toolkit.py
@@ -48,15 +48,21 @@ class TestTaxonomyAgentToolkit(BaseTest):
         self.assertEqual(browser_prop[1], "String")
         self.assertIsNotNone(browser_prop[2])
 
-    def test_enrich_props_uses_stored_description_only_for_custom_props(self):
-        # Custom properties fall back to the user-authored description; core taxonomy still wins so a
-        # stored description can never override (or spoof) a built-in one.
-        props = [("$browser", "String"), ("custom_prop", "Numeric")]
-        stored = {"custom_prop": "Revenue in cents", "$browser": "should be ignored"}
+    def test_enrich_props_stored_description_precedence(self):
+        # The stored description fills in for custom properties and for core entries that have no
+        # description of their own (label-only, like $web_vitals_FCP_value); a core description
+        # still wins so a stored one can never override (or spoof) a built-in.
+        props = [("$browser", "String"), ("custom_prop", "Numeric"), ("$web_vitals_FCP_value", "Numeric")]
+        stored = {
+            "$browser": "should be ignored",
+            "custom_prop": "Revenue in cents",
+            "$web_vitals_FCP_value": "First contentful paint, in milliseconds",
+        }
         enriched = self.toolkit._enrich_props_with_descriptions("event", props, stored)
         by_name = {name: description for name, _, description in enriched}
 
         self.assertEqual(by_name["custom_prop"], "Revenue in cents")
+        self.assertEqual(by_name["$web_vitals_FCP_value"], "First contentful paint, in milliseconds")
         self.assertNotEqual(by_name["$browser"], "should be ignored")
 
     @parameterized.expand(


### PR DESCRIPTION
## Problem

#73360 (and #74289 for the query_planner path) let Max fall back to the user-authored property description for properties the core taxonomy doesn't know. But the fallback only fired when a property was entirely absent from `CORE_FILTER_DEFINITIONS_BY_GROUP`. Some core entries are label-only: the web-vitals value properties (`$web_vitals_FCP_value` and friends) have a `label` but no `description`, and are neither `system` nor `ignored_in_assistant`. For those, core "won" with nothing, so a description a customer wrote in Data Management never reached Max.

Refs #62925

## Changes

In the shared `enrich_props_with_descriptions`, fall back to the stored description whenever the resolved core description is empty, instead of only when the property is absent from the core taxonomy entirely. The invariants that matter are unchanged: a non-empty core description still wins (a stored description can't override or spoof a built-in one), and `system` / `ignored_in_assistant` properties are still skipped outright, so a stored description can't resurrect them.

Both toolkits that pass stored descriptions share this helper (the chat_agent taxonomy toolkit from #73360, and the query_planner toolkit once #74289 lands), so both paths pick up the fix. Callers that pass no stored descriptions are unchanged.

## How did you test this code?

Extended the precedence test (renamed to `test_enrich_props_stored_description_precedence`, since its old name locked the old behavior) with a `$web_vitals_FCP_value` case. It catches the regression no existing test did: reverting the fallback silently drops customer descriptions on label-only core entries, which is exactly the gap fixed here. The existing assertions (custom property picks up stored description, `$browser` can't be overridden) are preserved.

The agent could not run the Django-backed suite in this environment (no dev stack; `hogli` unavailable). Verified instead: executed the changed function directly against the real `CORE_FILTER_DEFINITIONS_BY_GROUP`, covering core-with-description winning over a spoof attempt, custom property → stored, label-only core → stored, a system property staying hidden despite a stored entry, label-only with nothing stored staying empty, and no-stored-descriptions callers unchanged. `ruff check` and `ruff format --check` pass and both files byte-compile.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code from a code-review finding on #73360, confirmed against the taxonomy source: the event and person property groups each contain 16 label-only entries, several of which are ordinary annotatable properties. Skills invoked: `/writing-tests`, `/writing-code-comments`. Decisions: extended the existing precedence test rather than adding a new test function, and folded the fallback into the append expression instead of keeping a separate `else` branch, since both branches now share the same fallback.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
