### PR TITLE
chore(retention): flag data churn in compare recheck [do not merge]

### DIFF
--- a/posthog/management/commands/compare_retention_correctness.py
+++ b/posthog/management/commands/compare_retention_correctness.py
@@ -296,6 +296,14 @@ def _check_one(insight: Insight, url: str, freeze: bool, recheck: bool) -> Row:
                 f"{len(diff.cell_diffs)} {stable}cell diff(s), "
                 f"rows legacy={diff.row_count_legacy} dwh={diff.row_count_dwh}"
             )
+            if rechecked and diff.cell_diffs:
+                # Value-identical cells reproduce exactly (deterministic difference); moved values
+                # mean the data changed under the queries in both passes (merge/late-ingest churn).
+                identical = sum(1 for c in diff.cell_diffs if c.values_stable)
+                if identical:
+                    detail += f", {identical}/{len(diff.cell_diffs)} value-identical (deterministic)"
+                else:
+                    detail += ", all values moved between passes (churn, not deterministic)"
             if recheck and not rechecked:
                 detail += " (recheck errored — stability unverified)"
         return Row(insight.id, insight.short_id, insight.team_id, url, diff.status, detail)

--- a/posthog/management/commands/compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/compare_retention_legacy_vs_dwh.py
@@ -111,6 +111,11 @@ class CellDiff:
     dwh: float
     abs_diff: float
     rel_diff: Optional[float]  # None when legacy == 0
+    # Recheck verdict: True = the second pass returned the exact same legacy/dwh values
+    # (a deterministic difference), False = the cell differed again but with moved values
+    # (the data churned under the queries — merges/late ingest, not a systematic gap),
+    # None = no recheck information (single pass).
+    values_stable: Optional[bool] = None
 
 
 @dataclasses.dataclass
@@ -524,9 +529,18 @@ def intersect_stable_mismatch(first: CorrectnessDiff, second: CorrectnessDiff) -
     mismatch (reproduces) from live-ingest noise that happened to land outside the trailing window on
     the first pass (does not reproduce). Every MISMATCH signal is intersected, since live ingest can
     perturb breakdown ranking and row coverage as well as raw cell counts.
+
+    Kept cells are annotated with ``values_stable``: a deterministic query difference returns the
+    exact same legacy/dwh values in both passes, while continuously-churning data (person merges,
+    late ingest into historical buckets) keeps the same busy cells differing with MOVED values.
+    Key-only matching cannot tell those apart; the annotation can.
     """
-    second_keys = {_cell_key(c) for c in second.cell_diffs}
-    stable_cells = [c for c in first.cell_diffs if _cell_key(c) in second_keys]
+    second_by_key = {_cell_key(c): c for c in second.cell_diffs}
+    stable_cells = [
+        dataclasses.replace(c, values_stable=(c.legacy == twin.legacy and c.dwh == twin.dwh))
+        for c in first.cell_diffs
+        if (twin := second_by_key.get(_cell_key(c))) is not None
+    ]
 
     second_only_legacy = set(second.breakdown_only_legacy)
     second_only_dwh = set(second.breakdown_only_dwh)
@@ -1223,16 +1237,25 @@ def _render_trailing_drift(
 
 
 def _render_cell_diff_table(out: Callable[[str], None], cell_diffs: list[CellDiff], max_rows: int) -> None:
-    out("| Breakdown | Cohort | Period | Field | Legacy | DWH | Δabs | Δrel |")
-    out("| --- | --- | --- | --- | --- | --- | --- | --- |")
+    # The values column only exists when a recheck ran: "identical" = same values both passes
+    # (deterministic difference), "moved" = differed both passes with different values (data churn).
+    has_stability = any(diff.values_stable is not None for diff in cell_diffs)
+    stability_header = " Values |" if has_stability else ""
+    out(f"| Breakdown | Cohort | Period | Field | Legacy | DWH | Δabs | Δrel |{stability_header}")
+    out(f"| --- | --- | --- | --- | --- | --- | --- | --- |{' --- |' if has_stability else ''}")
     for diff in cell_diffs[:max_rows]:
         rel = "n/a" if diff.rel_diff is None else f"{diff.rel_diff * 100:+.1f}%"
+        stability_cell = ""
+        if has_stability:
+            stability_cell = (
+                f" {'identical' if diff.values_stable else 'moved' if diff.values_stable is not None else 'n/a'} |"
+            )
         out(
             f"| {_fmt_breakdown(diff.breakdown_value)} | {diff.row_label} | {diff.value_label} | "
-            f"{diff.field} | {diff.legacy:g} | {diff.dwh:g} | {diff.abs_diff:g} | {rel} |"
+            f"{diff.field} | {diff.legacy:g} | {diff.dwh:g} | {diff.abs_diff:g} | {rel} |{stability_cell}"
         )
     if len(cell_diffs) > max_rows:
-        out(f"| … | | | | | | +{len(cell_diffs) - max_rows} more | |")
+        out(f"| … | | | | | | +{len(cell_diffs) - max_rows} more | |{' |' if has_stability else ''}")
     out("")
 
 

--- a/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
+++ b/posthog/management/commands/test/test_compare_retention_legacy_vs_dwh.py
@@ -318,6 +318,17 @@ class TestIntersectStableMismatch(TestCase):
         self.assertEqual(result.status, "MISMATCH")
         self.assertEqual(len(result.cell_diffs), 1)
         self.assertEqual(result.cell_diffs[0].value_label, "Day 1")
+        self.assertIs(result.cell_diffs[0].values_stable, True)
+
+    def test_moved_values_kept_but_marked_unstable(self):
+        # Same cell differs in both passes but with different values: data churned under the
+        # queries (merges / late ingest), so it must not be reported as a deterministic difference.
+        first = diff_retention_results(_simple_series([100, 50]), _simple_series([100, 40]))
+        second = diff_retention_results(_simple_series([100, 52]), _simple_series([100, 45]))
+        result = intersect_stable_mismatch(first, second)
+        self.assertEqual(result.status, "MISMATCH")
+        self.assertEqual(len(result.cell_diffs), 1)
+        self.assertIs(result.cell_diffs[0].values_stable, False)
 
     def test_reproduced_row_count_mismatch_kept(self):
         first = diff_retention_results(_simple_series([10]), [])


### PR DESCRIPTION
## TL;DR (eli5)

When we run the same retention insight twice with two different query implementations and the numbers differ, there are two possible reasons: the queries really disagree (a bug), or the data changed while we were looking (people got merged, late events arrived). Until now the tool couldn't tell these apart. Now it checks: if the numbers are exactly the same on a second look, it's a bug. If the numbers moved, it's the data.

Stacked on #64819 (the commands only exist on that branch), same [do not merge] status.

## Problem

The prod sweep flagged two insights as MISMATCH (team 15506, both monthly first-time retention with different start/return events):

```
[3046/10000] MISMATCH Y6DH6tPi (team 15506) — 2 stable cell diff(s), rows legacy=13 dwh=13
[3226/10000] MISMATCH 00a7uYNz (team 15506) — 1 stable cell diff(s), rows legacy=4 dwh=4
```

Local investigation found no parity gap: all four query shapes (legacy two-arm, legacy single-scan, DWH single-scan, DWH union) return identical results on synthetic data for both insight shapes, including under `SAMPLE 0.25` and with person-override (PoE v2) data. The remaining suspect is live data churn: person merges and late ingest move historical monthly buckets between the two sequential variant runs.

The recheck couldn't discriminate. `intersect_stable_mismatch` matched recheck cells by key only, so a cell that differed in both passes with *different values* (the churn signature) still counted as a stable mismatch. A deterministic query bug reproduces *identical* values.

## Changes

- `CellDiff` gains `values_stable`: `True` = second pass returned the exact same legacy/dwh values (deterministic difference), `False` = the cell differed again but values moved (churn), `None` = no recheck ran.
- `compare_retention_correctness` mismatch lines now end with `2/2 value-identical (deterministic)` or `all values moved between passes (churn, not deterministic)`.
- The full report's cell diff table gains a `Values` column (`identical` / `moved`), only when a recheck ran.

Rerunning the sweep (or just `--insight-id 1798742 --insight-id 1818123`) with this change answers churn-vs-bug directly.

## How did you test this code?

I'm an agent (Claude Code). Automated checks only:

- Extended `test_reproduced_mismatch_kept` to assert the kept cell is marked `values_stable=True` (catches the annotation being dropped), and added `test_moved_values_kept_but_marked_unstable` (catches moved-value cells being marked deterministic). No existing test covered value-level recheck semantics.
- Full unit suites for both commands: 76 passed.
- `ruff check` and `ruff format` clean.

Not run end-to-end against prod ClickHouse; the two flagged insights should be re-checked on a prod pod with this change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change, internal validation tooling.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude), directed by the assignee, while investigating the two sweep mismatches above. Skills invoked: /writing-tests.

Decisions:

- Ruled out a deterministic query gap locally first: generated all four builder shapes for the two prod insight configs and ran an empirical parity probe (400 synthetic actors, multi-distinct-id persons, months scattered around the window). Also force-ran the seven tests excluded from the legacy-vs-variant comparison harness; all pass, so the exclusion list predates the parity fixes and is stale (possible separate cleanup on master).
- Kept moved-value cells in the mismatch verdict rather than dropping them: churn plus a real bug can coexist, so the annotation reports rather than filters.
- Originally pushed to #64819 directly; moved to this stacked PR so the base branch stays at the state its sweep ran from.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*