### PR TITLE
chore(rate-limit): raise org invite daily cap to 200

### DIFF
--- a/posthog/api/test/test_organization_invites.py
+++ b/posthog/api/test/test_organization_invites.py
@@ -1843,7 +1843,7 @@ class TestOnboardingDelegationMigrationIndex(APIBaseTest):
 @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
 class TestOrganizationInviteRateLimits(APIBaseTest):
     # These tests exercise OrganizationInviteBurstThrottle (50/hour) and
-    # OrganizationInviteSustainedThrottle (100/day) against the live viewset.
+    # OrganizationInviteSustainedThrottle (200/day) against the live viewset.
     # Both throttles are keyed per-organization and count invites (not
     # requests), so a 20-item bulk POST consumes 20 slots.
 

--- a/posthog/rate_limit.py
+++ b/posthog/rate_limit.py
@@ -1209,7 +1209,7 @@ class OrganizationInviteBurstThrottle(_OrganizationInviteRateThrottleBase):
 
 class OrganizationInviteSustainedThrottle(_OrganizationInviteRateThrottleBase):
     scope = "organization_invite_sustained"
-    rate = "100/day"
+    rate = "200/day"
 
 
 class GitHubRepositoryRefreshThrottle(PersonalApiKeyOrUserRateThrottle):


### PR DESCRIPTION
## Problem

Large orgs onboarding their whole team hit the invite API's daily cap. The organization invite throttles count invites (not requests) and are keyed per-org, so a company inviting ~150 employees runs into the 100/day sustained limit and has to spread the work across two days. Raising the daily ceiling lets a mid-size org get everyone in on day one, while keeping abuse protection in place.

Origin: [Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1785260087674189?thread_ts=1785260087.674189&cid=C02E3BKC78F).

## Changes

- `OrganizationInviteSustainedThrottle`: `100/day` → `200/day`.
- `OrganizationInviteBurstThrottle` unchanged at `50/hour`, so bulk invite traffic is still paced within a day and can't be blasted all at once.
- Updated the doc comment in the invite rate-limit tests to reflect the new sustained cap.

## How did you test this code?

No new tests. The existing `TestOrganizationInviteRateLimits` suite patches the throttle rate (`@patch(...new="3/day")`) so it's independent of the concrete value and still exercises the throttle behavior. I did not run the suite in this environment.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from Slack: raise the per-day invite limit to 200 while keeping the hourly burst at 50. Confirmed via the code that the invite throttles count invites (not requests) and are per-org, so the daily cap was the binding constraint for a ~150-person org. Change is a one-line rate bump plus a comment fix; no viewset/serializer signatures changed.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C02E3BKC78F/p1785260087674189?thread_ts=1785260087.674189&cid=C02E3BKC78F)*
