### PR TITLE
feat(managed-migrations): raise default batch import send rate to 5000

### DIFF
--- a/products/managed_migrations/backend/admin/batch_imports.py
+++ b/products/managed_migrations/backend/admin/batch_imports.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib import admin, messages
 from django.utils.html import format_html
 
-from products.managed_migrations.backend.models.batch_imports import BatchImport
+from products.managed_migrations.backend.models.batch_imports import DEFAULT_SEND_RATE, BatchImport
 
 
 class BatchImportAdminForm(forms.ModelForm):
@@ -13,8 +13,8 @@ class BatchImportAdminForm(forms.ModelForm):
     )
     send_rate = forms.IntegerField(
         required=False,
-        help_text="Events per second to send (e.g., 1000). Leave empty to keep current value.",
-        widget=forms.NumberInput(attrs={"placeholder": "e.g., 1000"}),
+        help_text=f"Events per second to send (e.g., {DEFAULT_SEND_RATE}). Leave empty to keep current value.",
+        widget=forms.NumberInput(attrs={"placeholder": f"e.g., {DEFAULT_SEND_RATE}"}),
     )
 
     class Meta:
@@ -42,7 +42,7 @@ class BatchImportAdminForm(forms.ModelForm):
             existing_sink = instance.import_config.get("sink", {})
             sink = {
                 "type": sink_type,
-                "send_rate": send_rate if send_rate is not None else existing_sink.get("send_rate", 1000),
+                "send_rate": send_rate if send_rate is not None else existing_sink.get("send_rate", DEFAULT_SEND_RATE),
             }
             if sink_type == "kafka":
                 sink["topic"] = existing_sink.get("topic", "historical")

--- a/products/managed_migrations/backend/api/batch_imports.py
+++ b/products/managed_migrations/backend/api/batch_imports.py
@@ -27,6 +27,7 @@ from posthog.models.user import User
 
 from products.managed_migrations.backend import trial_storage
 from products.managed_migrations.backend.models.batch_imports import (
+    DEFAULT_SEND_RATE,
     BatchImport,
     BatchImportConfigBuilder,
     ContentType,
@@ -85,7 +86,7 @@ def _apply_output_sink(config_builder: BatchImportConfigBuilder, validated_data:
             record_limit=validated_data.get("trial_record_limit", TRIAL_RECORD_LIMIT_DEFAULT)
         )
     else:
-        config_builder.to_capture(send_rate=1000)
+        config_builder.to_capture(send_rate=DEFAULT_SEND_RATE)
 
 
 class BatchImportSerializer(serializers.ModelSerializer):
@@ -985,7 +986,7 @@ class BatchImportViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 return conflict
 
             import_config = deepcopy(trial.import_config)
-            import_config["sink"] = {"type": "capture", "send_rate": 1000}
+            import_config["sink"] = {"type": "capture", "send_rate": DEFAULT_SEND_RATE}
             # The worker ignores unknown config keys and never writes import_config
             # back, so this link doubles as the promotion single-use marker.
             import_config["promoted_from_trial_id"] = str(trial.id)

--- a/products/managed_migrations/backend/api/test/test_batch_imports.py
+++ b/products/managed_migrations/backend/api/test/test_batch_imports.py
@@ -16,6 +16,7 @@ from products.managed_migrations.backend import trial_storage
 from products.managed_migrations.backend.admin.batch_imports import BatchImportAdmin
 from products.managed_migrations.backend.api.batch_imports import BatchImportS3SourceCreateSerializer
 from products.managed_migrations.backend.models.batch_imports import (
+    DEFAULT_SEND_RATE,
     BatchImport,
     BatchImportConfigBuilder,
     ContentType,
@@ -695,7 +696,7 @@ class TestBatchImportAPI(APIBaseTest):
 
         # Verify sink defaults to capture
         self.assertEqual(batch_import.import_config["sink"]["type"], "capture")
-        self.assertEqual(batch_import.import_config["sink"]["send_rate"], 1000)
+        self.assertEqual(batch_import.import_config["sink"]["send_rate"], DEFAULT_SEND_RATE)
 
     def test_amplitude_migration_includes_amplitude_specific_fields(self):
         """Test that Amplitude migrations include import_events and generate_identify_events in config"""
@@ -1366,7 +1367,7 @@ class TestBatchImportTrialAPI(APIBaseTest):
         self.assertEqual(response.status_code, 201, response.json())
         promoted = BatchImport.objects.get(id=response.json()["id"])
         self.assertNotEqual(promoted.id, trial.id)
-        self.assertEqual(promoted.import_config["sink"], {"type": "capture", "send_rate": 1000})
+        self.assertEqual(promoted.import_config["sink"], {"type": "capture", "send_rate": DEFAULT_SEND_RATE})
         self.assertEqual(promoted.import_config["source"], trial.import_config["source"])
         self.assertEqual(promoted.secrets, trial.secrets)
         self.assertEqual(promoted.status, BatchImport.Status.RUNNING)

--- a/products/managed_migrations/backend/models/batch_imports.py
+++ b/products/managed_migrations/backend/models/batch_imports.py
@@ -14,6 +14,9 @@ if TYPE_CHECKING:
     from posthog.models.team import Team
 
 
+DEFAULT_SEND_RATE = 5_000
+
+
 def get_aws_external_id(team: "Team") -> str:
     region = (settings.CLOUD_DEPLOYMENT or "dev").lower()
     return f"posthog-{region}-{team.uuid}"


### PR DESCRIPTION
## Problem

New batch imports are created with a capture sink pinned to 1000 events per second. That is slower than it needs to be, so imports take longer than necessary.

## Changes

Default send rate for new imports goes from 1000 to 5000 events per second. This applies to imports created through the API and to trial runs promoted to a real import.

The value now lives in a single DEFAULT_SEND_RATE constant in the batch import model module, referenced by the API, the Django admin form (its fallback and placeholder text), and the tests. Existing imports keep whatever send rate is already stored in their config, and the admin form can still override it per import.

## How did you test this code?

Ran the existing managed migrations test suites locally, which cover the default sink config on create and on trial promotion:

- products/managed_migrations/backend/api/test/test_batch_imports.py (106 passed)
- products/managed_migrations/backend/api/test/test_support_batch_imports.py (33 passed)

Also ran mypy repo-wide, clean. No new tests, the two existing assertions on the default send rate were updated to reference the constant.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude Code (Opus 5) to bump the default. It found the two hardcoded 1000 values in the API (create and promote paths), pulled them into a shared constant rather than editing both in place, and wired the admin form fallback to the same constant so the three places cannot drift. No skills were invoked.
