### PR TITLE
fix(experiments): enforce per-recording access on session context endpoints

### DIFF
--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -1641,7 +1641,8 @@ class ExperimentSessionContextsResponseSerializer(serializers.Serializer):
         help_text=(
             "Per-session experiment context, in the order the session IDs were requested. Sessions whose "
             "recording metadata doesn't exist yet (still ingesting, or unknown to this project) are omitted, "
-            "as are sessions beyond the batch's recording-day budget (only the most recent days are computed). "
-            "Fetch omitted sessions individually via the single-session endpoint."
+            "as are recordings you don't have access to and sessions beyond the batch's recording-day budget "
+            "(only the most recent days are computed). Fetch omitted sessions individually via the "
+            "single-session endpoint."
         ),
     )

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -34,6 +34,7 @@ from posthog.models.activity_logging.activity_page import ActivityLogPaginatedRe
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
 from posthog.models.user import User
+from posthog.permissions import is_service_auth
 from posthog.rate_limit import (
     ClickHouseBurstRateThrottle,
     ClickHouseSustainedRateThrottle,
@@ -41,6 +42,8 @@ from posthog.rate_limit import (
     SessionContextsSustainedRateThrottle,
 )
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
+from posthog.rbac.user_access_control import UserAccessControl
+from posthog.session_recordings.models.session_recording import SessionRecording
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.experiments.models import ExperimentTimeseriesRecalculationWorkflowInputs
 from posthog.user_permissions import UserPermissions
@@ -193,6 +196,35 @@ def _slugify_feature_flag_key(name: str, *, team_id: int) -> str:
         candidate = f"{base}-{suffix}"
         suffix += 1
     return candidate
+
+
+def _accessible_session_ids(
+    request: Request, user_access_control: UserAccessControl, team: Team, session_ids: list[str]
+) -> list[str]:
+    """Drop session ids whose recording the viewer is denied at the object level.
+
+    The resource-level `session_recording` check the session-context actions run first grants
+    access to the replay product, not to every recording in it: a recording can carry its own
+    access controls, which the replay retrieve endpoint enforces via `check_object_permissions`.
+    Without this filter a viewer denied one recording could still read which experiments it saw.
+
+    Object-level controls can only target a recording that has a Postgres row, so an id without
+    one is returned as accessible. That matches replay, which serves those ids from an unsaved
+    `SessionRecording` no access control row can point at.
+    """
+    if is_service_auth(request):
+        # Mirrors AccessControlPermission.has_object_permission: service credentials authenticate
+        # as synthetic users that UserAccessControl cannot evaluate, so they are gated by API
+        # scope and project membership instead of object-level RBAC.
+        return session_ids
+
+    recordings = SessionRecording.objects.filter(team=team, session_id__in=session_ids)
+    denied_ids = {
+        recording.session_id
+        for recording in recordings
+        if not user_access_control.check_access_level_for_object(recording, required_level="viewer")
+    }
+    return [session_id for session_id in session_ids if session_id not in denied_ids]
 
 
 @extend_schema_view(
@@ -1279,6 +1311,9 @@ class EnterpriseExperimentsViewSet(
         if not self.user_access_control.check_access_level_for_resource("session_recording", required_level="viewer"):
             raise PermissionDenied("Reading session experiment context requires session replay access.")
 
+        if not _accessible_session_ids(request, self.user_access_control, self.team, [session_id]):
+            raise PermissionDenied("You don't have access to this recording.")
+
         # detail=False actions skip the automatic list-action ACL filtering, so filter here —
         # private experiments must not leak into another user's session context.
         experiments = self.user_access_control.filter_queryset_by_access_level(
@@ -1317,14 +1352,19 @@ class EnterpriseExperimentsViewSet(
         query string; the endpoint only reads. Already-computed sessions are served from (and
         cold ones written to) the same short-lived per-viewer cache the single-session endpoint
         uses, so opening any prefetched recording renders its context instantly. Sessions whose
-        recording metadata doesn't exist yet are omitted from the response, as are sessions
-        beyond the batch's recording-day budget (each distinct recording day costs its own set
-        of ClickHouse scans, so only the most recent days are computed per request).
+        recording metadata doesn't exist yet are omitted from the response, as are recordings
+        the caller can't access and sessions beyond the batch's recording-day budget (each
+        distinct recording day costs its own set of ClickHouse scans, so only the most recent
+        days are computed per request).
         """
         session_ids: list[str] = request.validated_data["session_ids"]
 
         if not self.user_access_control.check_access_level_for_resource("session_recording", required_level="viewer"):
             raise PermissionDenied("Reading session experiment context requires session replay access.")
+
+        # Denied recordings are omitted rather than rejecting the batch, matching how the response
+        # already treats a session whose recording metadata doesn't exist.
+        session_ids = _accessible_session_ids(request, self.user_access_control, self.team, session_ids)
 
         # detail=False actions skip the automatic list-action ACL filtering, so filter here —
         # private experiments must not leak into another user's session context.

--- a/products/experiments/backend/session_context.py
+++ b/products/experiments/backend/session_context.py
@@ -73,14 +73,13 @@ MAX_CANDIDATE_EXPERIMENTS = 50
 # is a backstop far above any real configuration — without it HogQL applies an implicit
 # LIMIT 100, which would silently and nondeterministically truncate legitimate rows.
 MAX_EXPOSURE_ROWS = 10_000
-# Short-lived because the context is not immutable — late-arriving events, experiment edits,
-# and access-control changes must all surface within minutes. The key includes the viewer:
-# the experiment set is filtered by per-user access control, so entries must never be shared
-# across users. That per-viewer key is also why the TTL is an acceptable ACL boundary: there
-# is no cross-user leak to begin with, the only exposure is a bounded revocation lag for a
-# viewer who legitimately had access moments before — matching how other short-TTL caches in
-# this codebase behave on permission changes. Per-endpoint ACL-version invalidation would add
-# complexity and a lookup to a path that exists to cut latency.
+# Short-lived because the context is not immutable: late-arriving events and experiment edits
+# must surface within minutes. The key includes the viewer because the experiment set is
+# filtered by per-user access control, so entries must never be shared across users.
+# The TTL is not an access-control boundary. Entries are re-filtered against the viewer's
+# current experiment access on read (see _accessible_items), and whether the viewer may open
+# the recording at all is decided per request in the view, so neither kind of revocation waits
+# for expiry. That keeps invalidation out of a path whose only job is to cut latency.
 SESSION_CONTEXT_CACHE_TTL = 10 * 60
 # Hard cap on the batch endpoint's id list. A playlist page holds 20 recordings, and every
 # extra session widens the grouped scans; anything larger should arrive as separate batches.
@@ -150,6 +149,19 @@ def _cache_key(team: Team, user: User, session_id: str) -> str:
     return f"experiment_session_context_v2_{team.pk}_{user.pk}_{session_id}"
 
 
+def _accessible_items(
+    items: list[ExperimentSessionContextItem], accessible_experiment_ids: set[int]
+) -> list[ExperimentSessionContextItem]:
+    """Re-check cached items against the viewer's current experiment access.
+
+    An entry was filtered against `experiments` when it was computed, so without this a viewer
+    whose access to an experiment is revoked would keep seeing it until the entry expires.
+    Re-checking on read makes revocation take effect immediately; a newly granted experiment
+    still waits for the entry to expire, which is the safe direction to lag in.
+    """
+    return [item for item in items if item.experiment_id in accessible_experiment_ids]
+
+
 def get_session_experiment_context(
     team: Team, session_id: str, experiments: QuerySet[Experiment], user: User
 ) -> Optional[list[ExperimentSessionContextItem]]:
@@ -168,7 +180,7 @@ def get_session_experiment_context(
     cache_key = _cache_key(team, user, session_id)
     cached = get_safe_cache(cache_key)
     if cached is not None:
-        return cached
+        return _accessible_items(cached, set(experiments.values_list("id", flat=True)))
 
     metadata = SessionReplayEvents().get_metadata(session_id, team)
     if metadata is None:
@@ -204,10 +216,14 @@ def get_session_experiment_contexts(
     unique_ids = list(dict.fromkeys(session_ids))
     results: dict[str, list[ExperimentSessionContextItem]] = {}
     cold_ids: list[str] = []
+    # Resolved once for the whole batch, and only when something is actually served from cache.
+    accessible_experiment_ids: Optional[set[int]] = None
     for session_id in unique_ids:
         cached = get_safe_cache(_cache_key(team, user, session_id))
         if cached is not None:
-            results[session_id] = cached
+            if accessible_experiment_ids is None:
+                accessible_experiment_ids = set(experiments.values_list("id", flat=True))
+            results[session_id] = _accessible_items(cached, accessible_experiment_ids)
         else:
             cold_ids.append(session_id)
 

--- a/products/experiments/backend/test/test_session_context_api.py
+++ b/products/experiments/backend/test/test_session_context_api.py
@@ -18,6 +18,7 @@ from posthog.models import PropertyDefinition, Team, User
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value, uuid7
 from posthog.rate_limit import SessionContextsBurstRateThrottle
+from posthog.session_recordings.models.session_recording import SessionRecording
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
 
 from products.access_control.backend.facade.api import upsert_property_access_control
@@ -650,6 +651,38 @@ class TestSessionExperimentContext(ClickhouseTestMixin, APILicensedTest):
         response = self._get_session_context()
         assert [result["flag_key"] for result in response.json()["results"]] == ["checkout-cta"]
 
+    def test_cached_context_drops_experiments_the_viewer_lost_access_to(self) -> None:
+        self._enable_access_controls()
+        other_user = self._create_user("other-experimenter@posthog.com")
+        self._create_recording()
+        self._create_experiment()
+        revoked_experiment = self._create_experiment(
+            key="revoked-exp", name="Revoked experiment", created_by=other_user
+        )
+        self._create_session_event(
+            properties={"$feature_flag": "checkout-cta", "$feature_flag_response": "test"},
+        )
+        self._create_session_event(
+            properties={"$feature_flag": "revoked-exp", "$feature_flag_response": "control"},
+        )
+        flush_persons_and_events()
+
+        first = self._get_session_context()
+        assert [result["flag_key"] for result in first.json()["results"]] == ["checkout-cta", "revoked-exp"]
+
+        AccessControl.objects.create(
+            team=self.team, resource="experiment", resource_id=str(revoked_experiment.pk), access_level="none"
+        )
+
+        # Both endpoints serve this session from the warm entry, so the revocation is only
+        # honored if the cached items are re-checked on read rather than at compute time.
+        with patch("products.experiments.backend.session_context._compute_session_experiment_contexts") as compute:
+            single = self._get_session_context()
+            batch = self._post_session_contexts([SESSION_ID])
+        compute.assert_not_called()
+        assert [result["flag_key"] for result in single.json()["results"]] == ["checkout-cta"]
+        assert [result["flag_key"] for result in batch.json()["results"][0]["results"]] == ["checkout-cta"]
+
     def test_repeat_request_is_served_from_cache(self) -> None:
         self._create_recording()
         self._create_experiment()
@@ -724,6 +757,25 @@ class TestSessionExperimentContext(ClickhouseTestMixin, APILicensedTest):
 
         response = self._get_session_context()
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_denies_recordings_blocked_by_object_level_access(self) -> None:
+        self._enable_access_controls()
+        self._create_recording()
+        self._create_experiment()
+        self._create_session_event(properties={"$feature_flag": "checkout-cta", "$feature_flag_response": "test"})
+        self._create_day_two_recording_with_exposure()
+        flush_persons_and_events()
+
+        blocked = SessionRecording.objects.create(team=self.team, session_id=SESSION_ID)
+        AccessControl.objects.create(
+            team=self.team, resource="session_recording", resource_id=str(blocked.id), access_level="none"
+        )
+
+        assert self._get_session_context().status_code == status.HTTP_403_FORBIDDEN
+
+        batch = self._post_session_contexts([SESSION_ID, DAY_TWO_SESSION_ID])
+        assert batch.status_code == status.HTTP_200_OK
+        assert [result["session_id"] for result in batch.json()["results"]] == [DAY_TWO_SESSION_ID]
 
     def test_requires_session_recording_read_scope(self) -> None:
         self._create_recording()

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -2357,7 +2357,7 @@ export interface ExperimentSessionContextsRequestApi {
  * Experiment/variant context for a batch of session recordings.
  */
 export interface ExperimentSessionContextsResponseApi {
-    /** Per-session experiment context, in the order the session IDs were requested. Sessions whose recording metadata doesn't exist yet (still ingesting, or unknown to this project) are omitted, as are sessions beyond the batch's recording-day budget (only the most recent days are computed). Fetch omitted sessions individually via the single-session endpoint. */
+    /** Per-session experiment context, in the order the session IDs were requested. Sessions whose recording metadata doesn't exist yet (still ingesting, or unknown to this project) are omitted, as are recordings you don't have access to and sessions beyond the batch's recording-day budget (only the most recent days are computed). Fetch omitted sessions individually via the single-session endpoint. */
     results: ExperimentSessionContextResponseApi[]
 }
 

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -1081,9 +1081,10 @@ export const getExperimentsSessionContextsCreateUrl = (projectId: string) => {
  * query string; the endpoint only reads. Already-computed sessions are served from (and
  * cold ones written to) the same short-lived per-viewer cache the single-session endpoint
  * uses, so opening any prefetched recording renders its context instantly. Sessions whose
- * recording metadata doesn't exist yet are omitted from the response, as are sessions
- * beyond the batch's recording-day budget (each distinct recording day costs its own set
- * of ClickHouse scans, so only the most recent days are computed per request).
+ * recording metadata doesn't exist yet are omitted from the response, as are recordings
+ * the caller can't access and sessions beyond the batch's recording-day budget (each
+ * distinct recording day costs its own set of ClickHouse scans, so only the most recent
+ * days are computed per request).
  */
 export const experimentsSessionContextsCreate = async (
     projectId: string,

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -1252,9 +1252,10 @@ export const ExperimentsCreateFromPromptCreateBody = /* @__PURE__ */ zod.object(
  * query string; the endpoint only reads. Already-computed sessions are served from (and
  * cold ones written to) the same short-lived per-viewer cache the single-session endpoint
  * uses, so opening any prefetched recording renders its context instantly. Sessions whose
- * recording metadata doesn't exist yet are omitted from the response, as are sessions
- * beyond the batch's recording-day budget (each distinct recording day costs its own set
- * of ClickHouse scans, so only the most recent days are computed per request).
+ * recording metadata doesn't exist yet are omitted from the response, as are recordings
+ * the caller can't access and sessions beyond the batch's recording-day budget (each
+ * distinct recording day costs its own set of ClickHouse scans, so only the most recent
+ * days are computed per request).
  */
 export const experimentsSessionContextsCreateBodySessionIdsMax = 20
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -27924,7 +27924,7 @@ export namespace Schemas {
      * Experiment/variant context for a batch of session recordings.
      */
     export interface ExperimentSessionContextsResponse {
-      /** Per-session experiment context, in the order the session IDs were requested. Sessions whose recording metadata doesn't exist yet (still ingesting, or unknown to this project) are omitted, as are sessions beyond the batch's recording-day budget (only the most recent days are computed). Fetch omitted sessions individually via the single-session endpoint. */
+      /** Per-session experiment context, in the order the session IDs were requested. Sessions whose recording metadata doesn't exist yet (still ingesting, or unknown to this project) are omitted, as are recordings you don't have access to and sessions beyond the batch's recording-day budget (only the most recent days are computed). Fetch omitted sessions individually via the single-session endpoint. */
       results: ExperimentSessionContextResponse[];
     }
 


### PR DESCRIPTION
## Problem

Both session context actions (`session_context` and the batch `session_contexts`) checked only resource level `session_recording` viewer access. That grants access to the replay product, not to every recording in it.

Replay's own retrieve endpoint does enforce per-recording access controls, through `check_object_permissions` on the `SessionRecording` it builds. So a viewer explicitly denied one recording got a 403 opening it in the player, but could still read which experiments that session saw through the experiments endpoints. This PR fixes the endpoints in #69942 and #73461 when the batch endpoint mirrored the same posture.

A second, related finding: cached context entries were filtered against the viewer's experiment access at compute time only. Revoking a viewer's access to an experiment kept surfacing it from the warm entry until the entry expired.

## Changes

**Per-recording access on both endpoints.**
A new `_accessible_session_ids` helper resolves the requested ids to `SessionRecording` rows and drops the ones the viewer is denied at the object level. It follows the existing precedent in `SessionRecordingViewSet.bulk_delete`, which filters recordings the same way.

Two behaviors are deliberate:

- Ids with no Postgres row pass through as accessible. Object level controls key on `SessionRecording.id`, and replay serves those ids from an unsaved instance no access control row can point at, so this matches replay rather than inventing a stricter rule.
- Service credentials skip the filter, mirroring `AccessControlPermission.has_object_permission`. They authenticate as synthetic users `UserAccessControl` cannot evaluate and are gated by API scope plus project membership instead.

**Revocation no longer waits for the cache TTL.**
Cached items are now re-checked against the viewer's current experiment access on read, in `_accessible_items`.
The batch resolves that id set once per request, and only when something is actually served warm, so the added cost is a single indexed query on the cache hit path.
Revocation takes effect immediately.
A newly granted experiment still waits for the entry to expire, which is the safe direction to lag in.

No invalidation was needed (entries are short-lived and behind feature flag).

The `SESSION_CONTEXT_CACHE_TTL` comment previously documented the accepted revocation lag.
It now records that the TTL is not an access control boundary.

**Docs and generated types.**
The batch action docstring and the `results` `help_text` both list what gets omitted, so denied recordings were added to each, and `hogli build:openapi` regenerated the frontend and MCP types.

Not in scope:
The recordings list endpoint does not object filter either. A blocked recording is still visible in a recordings list and only 403s when opened. That is a replay side call with a wider blast radius, and it is the larger of the two gaps.

## How did you test this code?

Automated only. I did not test this manually.

Two tests were added to `test_session_context_api.py`:

- `test_denies_recordings_blocked_by_object_level_access` catches the helper being dropped from either call site. A recording with an object level `none` row 403s on the single endpoint and is omitted from a batch that still returns the other session. No existing test created an object level control for a recording.
- `test_cached_context_drops_experiments_the_viewer_lost_access_to` catches the read path filter being removed as a perf micro optimization. It warms the cache, revokes access to one experiment, then asserts both endpoints drop it with `_compute_session_experiment_contexts` patched, which proves the answer still came from cache rather than a recompute. The nearest existing test, `test_cached_context_is_not_shared_across_users`, covers cross user isolation, not revocation for the same viewer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Opus 5) in Claude Code, directed by me.
Skills invoked: `/improving-drf-endpoints`, `/writing-code-comments`, `/writing-tests`, `/writing-user-facing-copy`.

Some things considered and rejected along the way.
Doing nothing on the experiments side was defensible for the batch, since it prefetches a recordings list that does not object filter either, but it left the single session endpoint inconsistent with replay's retrieve for the same recording.
Fixing the list centrally in replay and having experiments reuse that is the better long term shape, but it is a bigger change owned by another team, so it stays out of this PR.

On the caching side, ACL version cache keys and event driven invalidation had both been proposed and rejected before as too complex for a latency cache.
The read path re-filter is a different and much cheaper remedy: the view already builds the access filtered experiment queryset every request, and the cached items carry `experiment_id`, so closing it is a set membership test plus one indexed query.

The 403 copy reuses the phrasing already used for denials elsewhere in the codebase rather than inventing a new sentence.
