### PR TITLE
feat(surveys): warn that backend events can't trigger surveys

### DIFF
--- a/frontend/src/scenes/surveys/SurveyEventTrigger.tsx
+++ b/frontend/src/scenes/surveys/SurveyEventTrigger.tsx
@@ -3,7 +3,7 @@ import { PropertyMatchType } from 'posthog-js'
 import { useMemo } from 'react'
 
 import { IconX } from '@posthog/icons'
-import { LemonCard, LemonCheckbox, LemonCollapse } from '@posthog/lemon-ui'
+import { LemonBanner, LemonCard, LemonCheckbox, LemonCollapse, Link } from '@posthog/lemon-ui'
 
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -254,14 +254,25 @@ function SurveyEventSelector({
 
 export function SurveyEventTrigger(): JSX.Element {
     return (
-        <SurveyEventSelector
-            conditionField="events"
-            label="User sends events"
-            info="Triggers fire when the event is captured in the current user session via a PostHog SDK. Property filtering requires posthog-js 1.268+ or posthog-react-native 4.15+."
-            emptyTitle="No events selected"
-            emptyDescription="Pick events that should trigger this survey."
-            showRepeatedActivation
-        />
+        <div className="space-y-2">
+            <LemonBanner type="info" dismissKey="survey-event-trigger-client-side-only">
+                Events must be captured in the user's browser or app by a PostHog SDK to trigger a survey. Events sent
+                from your backend (for example posthog-node, Python, or a server-side integration) can't trigger
+                surveys, since eligibility is evaluated on the client.{' '}
+                <Link to="https://posthog.com/docs/surveys/troubleshooting" target="_blank">
+                    Learn more
+                </Link>
+                .
+            </LemonBanner>
+            <SurveyEventSelector
+                conditionField="events"
+                label="User sends events"
+                info="Triggers fire when the event is captured in the current user session via a PostHog SDK. Property filtering requires posthog-js 1.268+ or posthog-react-native 4.15+."
+                emptyTitle="No events selected"
+                emptyDescription="Pick events that should trigger this survey."
+                showRepeatedActivation
+            />
+        </div>
     )
 }
 


### PR DESCRIPTION
## Problem

We regularly see survey support tickets where a customer sets up an event trigger (say a `Subscribe` event) and the survey never shows. The root cause is almost always that the triggering event is sent from the backend (posthog-node, Python, a server-side integration) rather than captured in the user's browser or app. Survey eligibility is evaluated entirely client-side by the SDK, so it never observes a backend event.

Today this limitation lives only in a single line of the [troubleshooting docs](https://posthog.com/docs/surveys/troubleshooting). Nothing in the survey editor itself hints at it, so people wire up a backend event, see nothing, and open a ticket.

Refs #25433

## Changes

Added a dismissable info banner to the event trigger section of the survey editor. It explains that events must be captured client-side by a PostHog SDK, that backend events can't trigger surveys, and links to the troubleshooting docs.

The banner renders wherever the "User sends events" trigger appears (both the new activation-triggers layout behind `SURVEYS_ACTIONS` and the legacy one), and is dismissable via `dismissKey` so it doesn't nag repeat users.

## How did you test this code?

I (Claude, via the PostHog Slack app) wasn't able to run the frontend toolchain — this was authored in a fresh shallow clone with no `node_modules`, so I did not run jest, oxlint, or the TypeScript checker. Changes are limited to one presentational component:

- Verified `LemonBanner` and `Link` are both exported from `@posthog/lemon-ui` and commonly co-imported elsewhere.
- The existing `SurveyEventTrigger.test.tsx` queries by text/testid, so wrapping the selector in a container `div` and adding the banner shouldn't affect it, but this should be confirmed in CI.

Please let CI run the jest + lint + typecheck gates before marking ready for review.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) at the request of a PostHog team member investigating a surveys support ticket where a customer's `Subscribe` event was fired from posthog-node and the survey never displayed. Invoked the `debugging-surveys` skill to confirm the eligibility pipeline is client-side only.

Decision: put the note in-product rather than docs-only, since the docs line is easily missed at the moment someone is configuring the trigger. Kept it as a dismissable `LemonBanner` (info) rather than always-on helper text so it educates without permanently taking space. A companion docs expansion in PostHog/posthog.com could follow.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1785263806973219)*
