### PR TITLE
feat(tasks): wizard cloud-run support for sentry migration

### DIFF
--- a/posthog/api/wizard/http.py
+++ b/posthog/api/wizard/http.py
@@ -61,6 +61,10 @@ OPENAI_SUPPORTED_MODELS = {"o4-mini", "gpt-5-mini", "gpt-5-nano", "gpt-5"}
 # loop lands on. Only requests that reach creation consume it.
 WIZARD_CLOUD_RUN_DAILY_ATTEMPT_CAP = 15
 
+# Gates the sentry_migration use case server-side; the serializer alone would let anyone
+# start migration runs before the feature launches.
+SENTRY_MIGRATION_FEATURE_FLAG = "error-tracking-sentry-migration"
+
 WIZARD_CLOUD_RUN_REQUESTS_TOTAL = Counter(
     "posthog_wizard_cloud_run_requests_total",
     "Cloud-run wizard kickoff requests, by outcome (created/unavailable/invalid/permission_denied/throttled)",
@@ -121,6 +125,14 @@ class SetupWizardCloudRunSerializer(serializers.Serializer):
         required=False,
         allow_blank=True,
         help_text="Base branch the wizard's pull request should target. Defaults to the repository's default branch.",
+    )
+    use_case = serializers.ChoiceField(
+        choices=["setup", "sentry_migration"],
+        default="setup",
+        help_text=(
+            "What the wizard run should do: 'setup' integrates PostHog into the repository, 'sentry_migration' "
+            "migrates the repository's existing Sentry setup to PostHog error tracking."
+        ),
     )
 
     def validate_repository(self, value: str) -> str:
@@ -505,6 +517,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
         project_id = serializer.validated_data["project_id"]
         repository = serializer.validated_data["repository"]
         branch = serializer.validated_data.get("branch") or None
+        use_case = serializer.validated_data["use_case"]
 
         visible_project_ids = UserPermissions(cast(User, request.user)).project_ids_visible_for_user
         try:
@@ -515,6 +528,16 @@ class SetupWizardViewSet(viewsets.ViewSet):
         if project.id not in visible_project_ids:
             raise exceptions.PermissionDenied("You don't have access to this project.")
 
+        if use_case == "sentry_migration" and not posthoganalytics.feature_enabled(
+            SENTRY_MIGRATION_FEATURE_FLAG,
+            str(cast(User, request.user).distinct_id),
+            groups={"organization": str(project.organization_id), "project": str(project.id)},
+            group_properties={"organization": {"id": str(project.organization_id)}},
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        ):
+            raise exceptions.ValidationError("Migrating from Sentry is not available for this project yet.")
+
         self._reserve_cloud_run_attempt(cast(User, request.user).id)
 
         try:
@@ -523,6 +546,7 @@ class SetupWizardViewSet(viewsets.ViewSet):
                 user_id=cast(User, request.user).id,
                 repository=repository,
                 branch=branch,
+                use_case=use_case,
             )
         except ValueError as e:
             # e.g. the team/user has no GitHub integration with access to the repository.

--- a/posthog/api/wizard/test/test_http.py
+++ b/posthog/api/wizard/test/test_http.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 from rest_framework import status
 
-from posthog.api.wizard.http import SETUP_WIZARD_CACHE_PREFIX, SETUP_WIZARD_CACHE_TIMEOUT
+from posthog.api.wizard.http import SENTRY_MIGRATION_FEATURE_FLAG, SETUP_WIZARD_CACHE_PREFIX, SETUP_WIZARD_CACHE_TIMEOUT
 from posthog.cloud_utils import get_api_host
 from posthog.models import Organization, PersonalAPIKey, User
 from posthog.models.utils import generate_random_token_personal, hash_key_value
@@ -484,6 +484,34 @@ class SetupWizardCloudRunTests(APIBaseTest):
         assert kwargs["user_id"] == self.user.id
         assert kwargs["branch"] is None
         assert kwargs["team"].id == self.team.id
+        assert kwargs["use_case"] == "setup"
+
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=False)
+    @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
+    def test_sentry_migration_rejected_when_flag_off(self, mock_create, mock_flag):
+        response = self.client.post(
+            self.CLOUD_RUN_URL,
+            data={"project_id": self.team.id, "repository": "acme/app", "use_case": "sentry_migration"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_create.assert_not_called()
+        assert mock_flag.call_args.args[0] == SENTRY_MIGRATION_FEATURE_FLAG
+
+    @patch("posthog.api.wizard.http.posthoganalytics.feature_enabled", return_value=True)
+    @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
+    def test_sentry_migration_passes_use_case_when_flag_on(self, mock_create, _mock_flag):
+        mock_create.return_value = MagicMock(task_id="task-uuid", latest_run=MagicMock(id="run-uuid", status="queued"))
+
+        response = self.client.post(
+            self.CLOUD_RUN_URL,
+            data={"project_id": self.team.id, "repository": "acme/app", "use_case": "sentry_migration"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.content
+        assert mock_create.call_args.kwargs["use_case"] == "sentry_migration"
 
     @patch("posthog.api.wizard.http.tasks_facade.create_wizard_cloud_run")
     def test_rejects_invalid_repository_format(self, mock_create):

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -65,7 +65,12 @@ from products.tasks.backend.models import (
     TaskThreadMessage,
     TaskThreadMessageMention,
 )
-from products.tasks.backend.prompts import build_wizard_pr_agent_prompt, generate_wizard_head_branch
+from products.tasks.backend.prompts import (
+    WIZARD_SENTRY_MIGRATION_HEAD_BRANCH_PREFIX,
+    WIZARD_SENTRY_MIGRATION_PR_AGENT_PROMPT,
+    build_wizard_pr_agent_prompt,
+    generate_wizard_head_branch,
+)
 from products.tasks.backend.visibility import task_control_q, task_run_visibility_q, task_visibility_q
 
 from . import contracts
@@ -885,6 +890,7 @@ def create_wizard_cloud_run(
     user_id: int,
     repository: str,
     branch: str | None = None,
+    use_case: Literal["setup", "sentry_migration"] = "setup",
 ) -> contracts.CreatedTaskDTO:
     """Create + run a cloud setup-wizard task.
 
@@ -894,6 +900,10 @@ def create_wizard_cloud_run(
     token (see ``create_wizard_oauth_access_token``), independent of the agent's sandbox token, so
     the agent runs with read-only PostHog scopes.``wizard_config`` marks the run so the workflow runs the wizard pre-agent step.
 
+    ``use_case`` selects what the wizard does: ``"setup"`` integrates PostHog, ``"sentry_migration"``
+    runs the wizard's ``sentry`` subcommand to migrate the repo's Sentry setup to PostHog error
+    tracking (the subcommand is allowlisted in the ``run_wizard`` activity).
+
     ``user_id`` is the person going through onboarding; it becomes the task's ``created_by`` so the
     run is explicitly attributed to them.
 
@@ -901,19 +911,29 @@ def create_wizard_cloud_run(
     opened PR back to this run by branch + repository — wizard PRs are bot-authored, which the
     agent-side PR attribution cannot match.
     """
-    head_branch = generate_wizard_head_branch()
-    prompt = build_wizard_pr_agent_prompt(head_branch)
+    if use_case == "sentry_migration":
+        head_branch = generate_wizard_head_branch(prefix=WIZARD_SENTRY_MIGRATION_HEAD_BRANCH_PREFIX)
+        prompt = build_wizard_pr_agent_prompt(head_branch, template=WIZARD_SENTRY_MIGRATION_PR_AGENT_PROMPT)
+        title = "Migrate from Sentry"
+        origin_product = Task.OriginProduct.ERROR_TRACKING
+        wizard_config: dict = {"subcommand": "sentry"}
+    else:
+        head_branch = generate_wizard_head_branch()
+        prompt = build_wizard_pr_agent_prompt(head_branch)
+        title = "Set up PostHog"
+        origin_product = Task.OriginProduct.ONBOARDING
+        wizard_config = {}
     return create_and_run_task(
         team=team,
-        title="Set up PostHog",
+        title=title,
         description=prompt,
-        origin_product=Task.OriginProduct.ONBOARDING,
+        origin_product=origin_product,
         user_id=user_id,
         repository=repository,
         create_pr=True,
         mode="background",
         branch=branch,
-        wizard_config={},
+        wizard_config=wizard_config,
         wizard_head_branch=head_branch,
         posthog_mcp_scopes="read_only",
         # The agent server boots idle; this is the message that actually kicks it off once ready

--- a/products/tasks/backend/prompts.py
+++ b/products/tasks/backend/prompts.py
@@ -13,11 +13,20 @@ WIZARD_HEAD_BRANCH_PLACEHOLDER = "<wizard-head-branch>"
 
 WIZARD_HEAD_BRANCH_PREFIX = "posthog/instrumentation-"
 
+WIZARD_SENTRY_MIGRATION_HEAD_BRANCH_PREFIX = "posthog/sentry-migration-"
 
-def generate_wizard_head_branch() -> str:
+# Every prefix a wizard cloud run may generate a head branch under; the GitHub PR webhook uses
+# this to recognize wizard head branches and bind the PR back to the run (see webhooks.find_task_run).
+WIZARD_HEAD_BRANCH_PREFIXES: tuple[str, ...] = (
+    WIZARD_HEAD_BRANCH_PREFIX,
+    WIZARD_SENTRY_MIGRATION_HEAD_BRANCH_PREFIX,
+)
+
+
+def generate_wizard_head_branch(prefix: str = WIZARD_HEAD_BRANCH_PREFIX) -> str:
     """A unique PR head branch for a wizard run; the random suffix is here to prevent
     collisions with existing branches in the user's repo."""
-    return f"{WIZARD_HEAD_BRANCH_PREFIX}{secrets.token_hex(3)}"
+    return f"{prefix}{secrets.token_hex(3)}"
 
 
 WIZARD_PR_AGENT_PROMPT = rf"""
@@ -307,11 +316,190 @@ unrelated to the integration and documented in a PR comment.
 """
 
 
-def build_wizard_pr_agent_prompt(head_branch: str) -> str:
+WIZARD_SENTRY_MIGRATION_PR_AGENT_PROMPT = rf"""
+# Context
+
+PostHog's wizard has already run its Sentry migration in this repository and migrated the existing
+Sentry error monitoring setup to PostHog error tracking. The working tree contains its uncommitted
+changes: modified source files, an updated package manifest, installed dependencies. It may also
+contain a `posthog-setup-report.md` summary, a `.posthog-events.json` plan, and some skills
+definitions under a harness skills folder such as `.claude/skills/*` or `.agents/skills/*`.
+
+The wizard's full console output is saved to `/tmp/wizard-cloud-run/wizard-output.log` (outside the
+repository, so it can never be committed). Read it whenever you need to understand what the wizard
+actually did - which files it touched, what it migrated or skipped, any warnings it printed, or why
+something in the working tree looks the way it does.
+
+# Your role
+
+You are NOT here to migrate from Sentry yourself or write any product/instrumentation code. Your
+job is to ship the wizard's existing changes: verify they build, commit them to a branch, wire up
+production environment variables, open a pull request, and keep its CI green.
+
+Rules that apply to every step:
+
+- Do not add, remove, edit, or "improve" the migration the wizard produced.
+- Do not remove Sentry code the wizard chose to keep, and do not migrate anything it skipped.
+- Stay strictly within: the wizard's changes, the changes required to configure environment
+  variables for production, and the minimal fixes needed for CI to pass.
+- Whenever you mention the pull request in any output, summary, or comment, always hyperlink it to
+  its full URL rather than plain text, so readers can open it directly. For example:
+  `Opened [#42123](https://github.com/org/repo/pull/42123) with the Sentry migration.`
+
+# Workflow
+
+Work through the steps below IN ORDER. Each step ends with a checkpoint: run the checkpoint
+commands and confirm the expected result before starting the next step. If a checkpoint fails, fix
+the problem and re-run the checkpoint - do not move on with a failing checkpoint.
+
+## Step 1 - Verify the project builds
+
+Using the repo's EXISTING scripts (check `package.json` scripts or the equivalent for the repo's
+language), verify the project still builds, type-checks, and lints. If a change the wizard made
+breaks any of these, make the MINIMAL fix required to compile - do not redesign or refactor.
+
+**Checkpoint:** the repo's build, type-check, and lint commands all exit 0. For example:
+
+```bash
+npm run build && npm run typecheck && npm run lint
+# every command exits 0 before you continue
+```
+
+Skip whichever of these the repo genuinely does not have a script for; never invent new scripts.
+Also, remember the scripts above are for example purposes only. You should use the scripts that
+are actually in the repository.
+
+## Step 2 - Commit the wizard's changes to a new branch
+
+1. Create a branch named exactly `{WIZARD_HEAD_BRANCH_PLACEHOLDER}`. This name was
+   pre-generated for this run and PostHog uses it to link the pull request back to the
+   migration progress — do NOT choose a different branch name.
+2. Look at `git log` to learn this repository's commit message convention.
+3. Commit the wizard's changes in that style; the message should resemble the concept of
+   "Migrate from Sentry to PostHog error tracking". For example, in a repo using conventional
+   commits:
+
+   ```text
+   feat: migrate from Sentry to PostHog error tracking
+   ```
+
+4. Do NOT commit `posthog-setup-report.md` or `.posthog-events.json` - they are local reference
+   only. Leave them untracked or exclude them from staging.
+5. Do NOT commit any of the skills included under a harness skills folder like `.claude/skills/*`
+   or `.agents/skills/*` (any `.<harness>/skills/` path). Leave them untracked or exclude them
+   from staging.
+
+**Checkpoint:** the commit exists on `{WIZARD_HEAD_BRANCH_PLACEHOLDER}` and contains none of the
+forbidden files. Run the two checks separately so you can see exactly which kind leaked if either
+fails:
+
+```bash
+git rev-parse --abbrev-ref HEAD          # prints: {WIZARD_HEAD_BRANCH_PLACEHOLDER}
+git show --stat HEAD                      # lists the wizard's files
+
+# 1. Reference files (local-only summaries/plans/logs):
+git show --stat HEAD | grep -E 'posthog-setup-report|posthog-events|wizard-output' && echo "FAIL: reference files committed" || echo "OK: no reference files"
+
+# 2. Harness skills folders (.claude/skills/, .agents/skills/, any .<harness>/skills/):
+git show --stat HEAD | grep -E '\.[^/]+/skills/' && echo "FAIL: skills files committed" || echo "OK: no skills files"
+
+# expected: both print OK (the grep finding nothing is the pass case). If either FAILs, unstage
+# those paths, amend the commit, and re-run this checkpoint.
+```
+
+## Step 3 - Configure environment variables for production
+
+1. Identify how the codebase is deployed to production.
+2. If you can automatically configure the required PostHog environment variables in a file that
+   will be read in production, do so, and commit that change to the same branch as a SEPARATE
+   commit. This includes any changes to `.env`, `wrangler.jsonc`, `docker-compose.yml`,
+   or any other file that is used to configure the production environment.
+3. If you can't configure them automatically, do not commit anything in this step - instead write
+   down in your notes which variables are needed and what values they must be set to,
+   for use in the PR description in Step 4.
+4. Do NOT delete Sentry environment variables (like the DSN) from production config unless the
+   wizard already removed every use of them from the code; if it did, note the variables that are
+   now safe to remove in the PR description instead of removing them yourself.
+5. You should know the project API token from the PostHog MCP server context. If you don't have
+   it, run the `projects-get` MCP tool to fetch it.
+
+**Checkpoint:** exactly one of the following is true:
+
+- `git log --oneline -2` shows a separate env-var commit on top of the migration commit, or
+- you have a written note of every required variable name and value, ready for the PR description.
+
+## Step 4 - Open the pull request
+
+Title the pull request "Migrate from Sentry to PostHog error tracking".
+
+Write the PR description FROM the contents of `posthog-setup-report.md` (or, if it does not exist,
+from the wizard output log):
+
+- If `.github/pull_request_template.md` exists, use it as a starting point.
+- Summarize what the wizard migrated: the Sentry SDK usage it replaced, the PostHog error tracking
+  setup it added, and every file it changed - name them, never write "various files".
+- List anything the wizard deliberately kept or skipped, so reviewers know what still runs
+  through Sentry.
+- Add a short "How to verify" section: trigger a test error in the app, then open the project's
+  PostHog error tracking [Issues page](https://app.posthog.com/error_tracking) and confirm the
+  error appears.
+- Add a section explaining the environment variables situation, based on the Step 3 outcome:
+  - If you configured them automatically: explain that PostHog error tracking will work as soon as
+    the code is deployed to production.
+  - If you could not configure them automatically: name the deployment platform you detected and
+    list every required variable with its exact value in a table, then explain where to set them.
+    If the project is in Javascript, assume the reader is non-technical and carefully walk through
+    every variable and value, explicitly explaining what environment variables are for; for any
+    other language, assume the reader is technical and familiar with environment variables. If the
+    platform has a local CLI for setting env vars (Vercel, Netlify, Heroku, Fly.io, ...), add a
+    subsection with the exact commands - double-check the CLI syntax first, since many commands
+    (including `vercel env add`) take the target environment as a positional argument and read the
+    value from stdin.
+
+In all cases: use the REAL variable names the wizard's code reads and the REAL token from Step 3 -
+never placeholder names, and never guess the platform. If you genuinely cannot tell how the app is
+deployed, say so explicitly and list the variables with their values anyway.
+
+**Checkpoint:** the PR exists and you have its URL:
+
+```bash
+gh pr view --json url -q .url
+# returns the PR URL - use this exact URL for every later mention of the PR
+```
+
+## Step 5 - Keep CI green
+
+1. Wait for the PR's required checks to finish. Poll deterministically instead of guessing:
+
+   ```bash
+   gh pr checks --watch
+   ```
+
+2. If a required check fails BECAUSE OF the migration (build / type / lint), read its logs and
+   make the minimal fix, then push and watch again.
+3. If CI is red for reasons unrelated to the migration, do not fix it - note it in a PR comment
+   instead.
+
+While keeping CI green, never:
+
+- modify unrelated code,
+- add, remove, or upgrade dependencies beyond what a failing required check requires,
+- touch `.github/workflows/**`, `CODEOWNERS`, or branch-protection config.
+
+**Checkpoint:** `gh pr checks` shows every required check passing, or every remaining failure is
+unrelated to the migration and documented in a PR comment.
+
+# Working style
+
+{SHELL_EFFICIENCY_INSTRUCTION}
+"""
+
+
+def build_wizard_pr_agent_prompt(head_branch: str, *, template: str = WIZARD_PR_AGENT_PROMPT) -> str:
     """The wizard PR agent prompt with the run's server-generated head branch baked in.
 
     The branch must be known before the agent runs so the GitHub PR webhook can bind the
     opened PR back to the TaskRun (see webhooks.find_task_run); letting the agent invent
     the name made that binding impossible.
     """
-    return WIZARD_PR_AGENT_PROMPT.replace(WIZARD_HEAD_BRANCH_PLACEHOLDER, head_branch)
+    return template.replace(WIZARD_HEAD_BRANCH_PLACEHOLDER, head_branch)

--- a/products/tasks/backend/temporal/process_task/activities/run_wizard.py
+++ b/products/tasks/backend/temporal/process_task/activities/run_wizard.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from django.conf import settings
 
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 from posthog.temporal.common.utils import asyncify
 from posthog.utils import get_instance_region
@@ -18,6 +19,10 @@ logger = logging.getLogger(__name__)
 
 # Published npm package, pinned to @latest so cloud runs exercise the same build users install.
 WIZARD_PACKAGE = "@posthog/wizard@latest"
+
+# Subcommands the wizard may be asked to run via wizard_config; anything else fails the run
+# rather than executing an arbitrary wizard mode in the sandbox.
+_ALLOWED_WIZARD_SUBCOMMANDS = {"sentry"}
 
 # Large repos can take ~45 min to integrate (observed p99.9 of real runs). The Temporal activity's
 # start_to_close_timeout (see workflow._run_wizard_if_configured) must stay above this so the
@@ -64,7 +69,15 @@ def _format_wizard_output(result: ExecutionResult) -> str:
     return "\n".join(sections) + "\n"
 
 
-def _build_wizard_command(repo_path: str, project_id: int) -> str:
+def _build_wizard_command(repo_path: str, project_id: int, subcommand: str | None = None) -> str:
+    # wizard_config comes from run state; validating here keeps every caller behind the allowlist.
+    # non_retryable: retrying would run the same unknown subcommand again.
+    if subcommand is not None and subcommand not in _ALLOWED_WIZARD_SUBCOMMANDS:
+        raise ApplicationError(
+            f"Unknown wizard subcommand {subcommand!r}; allowed: {sorted(_ALLOWED_WIZARD_SUBCOMMANDS)}",
+            non_retryable=True,
+        )
+
     # The wizard reads its access token from the POSTHOG_WIZARD_API_KEY env var injected into the
     # sandbox (see provision_sandbox), so the token never appears on the command line.
     # --headless-DONOTUSE-EXPERIMENTAL runs the published wizard non-interactively.
@@ -74,6 +87,12 @@ def _build_wizard_command(repo_path: str, project_id: int) -> str:
         # detect, with partial output preserved. -k 30 escalates to SIGKILL 30s after SIGTERM.
         f"timeout -k 30 {WIZARD_RUN_TIMEOUT_SECONDS}",
         f"npx --yes {WIZARD_PACKAGE}",
+    ]
+
+    if subcommand is not None:
+        parts.append(shlex.quote(subcommand))
+
+    parts += [
         "--headless-DONOTUSE-EXPERIMENTAL",
         "--install-dir .",
         f"--region {shlex.quote(_wizard_region())}",
@@ -114,7 +133,7 @@ def run_wizard(input: RunWizardInput) -> None:
 
         emit_agent_log(ctx.run_id, "info", "Running the PostHog setup wizard")
         sandbox = Sandbox.get_by_id(input.sandbox_id)
-        command = _build_wizard_command(repo_path, ctx.team_id)
+        command = _build_wizard_command(repo_path, ctx.team_id, subcommand=(ctx.wizard_config or {}).get("subcommand"))
 
         result = sandbox.execute(command, timeout_seconds=_SANDBOX_EXEC_TIMEOUT_SECONDS)
 

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_run_wizard.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_run_wizard.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from django.test import SimpleTestCase, override_settings
 
 from parameterized import parameterized
+from temporalio.exceptions import ApplicationError
 
 from products.tasks.backend.logic.services.sandbox import ExecutionResult
 from products.tasks.backend.temporal.process_task.activities.run_wizard import (
@@ -32,6 +33,27 @@ class TestBuildWizardCommand(SimpleTestCase):
         assert WIZARD_PACKAGE in command
         assert "--install-dir ." in command
         assert "--project-id 123" in command
+
+    def test_subcommand_is_inserted_between_package_and_flags(self) -> None:
+        # The sentry migration runs `npx @posthog/wizard sentry <flags>`; inserting the subcommand
+        # after the flags (or dropping it) would run the default setup wizard instead.
+        base = _build_wizard_command("/tmp/workspace/repos/acme/app", 123)
+        with_subcommand = _build_wizard_command("/tmp/workspace/repos/acme/app", 123, subcommand="sentry")
+
+        assert f"npx --yes {WIZARD_PACKAGE} sentry --headless-DONOTUSE-EXPERIMENTAL" in with_subcommand
+        # No subcommand leaves the command byte-identical to before the parameter existed.
+        assert f"npx --yes {WIZARD_PACKAGE} --headless-DONOTUSE-EXPERIMENTAL" in base
+        assert with_subcommand.replace(" sentry ", " ", 1) == base
+
+    @parameterized.expand([("self-driving",), ("",)])
+    def test_unknown_subcommand_raises_non_retryable(self, subcommand: str) -> None:
+        # wizard_config comes from run state; an unrecognized subcommand must fail the run
+        # permanently instead of executing an arbitrary wizard mode in the sandbox.
+        with self.assertRaises(ApplicationError) as ctx:
+            _build_wizard_command("/tmp/workspace/repos/acme/app", 123, subcommand=subcommand)
+
+        assert ctx.exception.non_retryable is True
+        assert repr(subcommand) in str(ctx.exception)
 
     @parameterized.expand([(True,), (False,)])
     def test_base_url_pins_local_instance_only_in_debug(self, debug: bool) -> None:

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -585,6 +585,31 @@ class TestFacadeReadsAndMappers(TestCase):
         # overlap-clone-boot launch (before run_wizard) burns the prompt on an untouched repo
         # and the run never opens a PR. Wizard runs must pin the overlap boot off.
         self.assertIs(run.state.get("overlap_clone_boot_enabled"), False)
+        # No subcommand for the default use case — a leaked one would run the wrong wizard.
+        self.assertEqual(run.state.get("wizard_config"), {})
+
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_wizard_cloud_run_sentry_migration_variant(self, _mock_workflow):
+        Integration.objects.create(team=self.team, kind="github", config={})
+        created = facade.create_wizard_cloud_run(
+            team=self.team,
+            user_id=self.user.id,
+            repository="acme-co/web",
+            use_case="sentry_migration",
+        )
+        task = Task.objects.get(id=created.task_id)
+        self.assertEqual(task.origin_product, Task.OriginProduct.ERROR_TRACKING)
+        self.assertEqual(task.title, "Migrate from Sentry")
+        run = TaskRun.objects.get(task_id=created.task_id)
+        # run_wizard reads this to invoke `npx @posthog/wizard sentry` (the subcommand is
+        # allowlisted there); losing it silently runs the default setup wizard instead.
+        self.assertEqual(run.state.get("wizard_config"), {"subcommand": "sentry"})
+        head_branch = run.state.get("wizard_head_branch")
+        assert head_branch is not None
+        self.assertRegex(head_branch, r"^posthog/sentry-migration-[0-9a-f]{6}$")
+        self.assertIn(f"`{head_branch}`", run.state["pending_user_message"])
+        self.assertNotIn(WIZARD_HEAD_BRANCH_PLACEHOLDER, run.state["pending_user_message"])
+        self.assertIn("Migrate from Sentry to PostHog error tracking", run.state["pending_user_message"])
 
 
 class TestRecentWizardCloudRunTimes(TestCase):

--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -1055,7 +1055,15 @@ class TestFindTaskRun(TestCase):
         )
         self.assertEqual(result, branch_run)
 
-    def test_finds_wizard_run_by_state_head_branch(self):
+    @parameterized.expand(
+        [
+            ("setup", "posthog/instrumentation-ab12cd"),
+            # Sentry migration runs use their own prefix; the prefix gate in find_task_run
+            # must recognize it or their PRs never bind back to the run.
+            ("sentry_migration", "posthog/sentry-migration-ab12cd"),
+        ]
+    )
+    def test_finds_wizard_run_by_state_head_branch(self, _name, head_branch):
         # Wizard cloud runs never have the PR head branch in TaskRun.branch (that column is
         # the checkout base); the server-generated head branch lives in run state. Dropping
         # this match leg silently unbinds every wizard PR from its run again.
@@ -1064,12 +1072,12 @@ class TestFindTaskRun(TestCase):
             team=self.team,
             status=TaskRun.Status.IN_PROGRESS,
             branch="main",
-            state={"wizard_head_branch": "posthog/instrumentation-ab12cd"},
+            state={"wizard_head_branch": head_branch},
         )
-        result = find_task_run(branch="posthog/instrumentation-ab12cd", repository="posthog/posthog")
+        result = find_task_run(branch=head_branch, repository="posthog/posthog")
         self.assertEqual(result, wizard_run)
         # Same branch name from a foreign repository must not be attributed to this run.
-        self.assertIsNone(find_task_run(branch="posthog/instrumentation-ab12cd", repository="acme/other"))
+        self.assertIsNone(find_task_run(branch=head_branch, repository="acme/other"))
         # The run's `branch` column holds the checkout base, so a same-repo PR whose head
         # ref equals it must not claim the wizard run through the plain branch leg.
         self.assertIsNone(find_task_run(branch="main", repository="posthog/posthog"))

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -18,7 +18,7 @@ from products.signals.backend.models import InvalidStatusTransition, SignalRepor
 from products.tasks.backend.facade.api import post_pr_created_thread_update, signal_workflow_completion
 from products.tasks.backend.facade.cancellation import cancel_task_run
 from products.tasks.backend.models import TaskRun
-from products.tasks.backend.prompts import WIZARD_HEAD_BRANCH_PREFIX
+from products.tasks.backend.prompts import WIZARD_HEAD_BRANCH_PREFIXES
 
 logger = structlog.get_logger(__name__)
 
@@ -82,7 +82,7 @@ def find_task_run(
         # The prefix check keeps this leg off the hot path for ordinary PR webhooks, and
         # terminal runs are excluded so a reopened branch can't fire events on a dead run
         # (post-merge events for bound runs resolve via the pr_url leg above).
-        if branch.startswith(WIZARD_HEAD_BRANCH_PREFIX):
+        if branch.startswith(WIZARD_HEAD_BRANCH_PREFIXES):
             task_run = (
                 TaskRun.objects.filter(
                     state__wizard_head_branch=branch,


### PR DESCRIPTION
## Problem

The wizard cloud-run flow ("open a PR for me") can only run the default PostHog setup. The Sentry migration flow needs it to run the wizard's upcoming `sentry` subcommand, which replaces the Sentry SDK with PostHog error tracking, and to open PRs that read as a migration rather than an install.

## Changes

Monorepo plumbing only; the `sentry` subcommand itself ships in the @posthog/wizard repo:

- `run_wizard` activity: allowlisted optional subcommand (`_ALLOWED_WIZARD_SUBCOMMANDS = {"sentry"}`) inserted into the npx command; unknown values raise non-retryable instead of running the wrong wizard
- `prompts.py`: a Sentry-migration PR agent prompt (same sentinel and checkpoint mechanics; PR copy says "Migrate from Sentry to PostHog error tracking") and a `posthog/sentry-migration-` head-branch prefix
- `create_wizard_cloud_run` facade: `use_case: Literal["setup", "sentry_migration"] = "setup"`; the sentry case sets origin `ERROR_TRACKING`, title, `wizard_config={"subcommand": "sentry"}`, prompt and prefix; the setup path emits byte-identical kwargs
- wizard `cloud_run` API: optional `use_case` field, gated server-side behind the `error-tracking-sentry-migration` flag, checked before the attempt-cap reservation so rejected requests don't burn quota

> [!NOTE]
> Also fixes a latent bug this feature would have hit: the PR webhook's run binding only matched branches starting with the instrumentation prefix, so sentry-migration PRs would never bind back to their task run. `find_task_run` now matches a prefix tuple.

## How did you test this code?

Automated, run locally against current master (166 passed):

- run_wizard: subcommand inserted between package and flags, no-subcommand command byte-identical, unknown/empty subcommand raises non-retryably
- facade: sentry variant sets origin/title/config/prefix/prompt; default path unchanged
- wizard API: `use_case` defaults to setup, flag-off sentry_migration rejected with the facade never called, flag-on passes through
- webhooks: run binding parameterized over both branch prefixes

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None; behavior is flag-gated and the user-facing surface lands with the error tracking scene PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Claude Code) with me directing, as part of the Sentry migration series. Skills invoked: /improving-drf-endpoints, /writing-tests. The allowlist check lives inside `_build_wizard_command` as the single choke point for every caller rather than in the activity body.
