### PR TITLE
fix(google_ads): fail clearly when API version is missing from installed SDK

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -1,6 +1,8 @@
 import time
 import typing
+import pkgutil
 import datetime as dt
+import importlib.util
 import collections.abc
 
 from django.conf import settings
@@ -219,6 +221,37 @@ def google_ads_client(config: GoogleAdsSourceConfigUnion, team_id: int) -> Googl
     return client
 
 
+def _installed_google_ads_api_versions() -> list[str]:
+    """Version subpackages (`vNN`) bundled in the installed google-ads SDK."""
+    package = importlib.import_module("google.ads.googleads")
+    return sorted(
+        name for _, name, _ in pkgutil.iter_modules(package.__path__) if name.startswith("v") and name[1:].isdigit()
+    )
+
+
+def _get_versioned_service(
+    client: GoogleAdsClient,
+    name: str,
+    *,
+    version: str,
+    interceptors: list | None = None,
+) -> typing.Any:
+    """Fetch a versioned Google Ads service, failing clearly on an unavailable API version.
+
+    ``client.get_service`` raises an opaque ``ValueError`` ("Specified service ... does not exist
+    in Google Ads API <v>", chaining a ``ModuleNotFoundError``) when the requested version's
+    package isn't bundled in the installed google-ads SDK — e.g. a source resolving to a version
+    the SDK no longer ships. Surface the version mismatch itself so it's diagnosable rather than
+    reading as a missing-service bug.
+    """
+    if importlib.util.find_spec(f"google.ads.googleads.{version}") is None:
+        available = ", ".join(_installed_google_ads_api_versions()) or "none"
+        raise ValueError(
+            f"Google Ads API {version} is not available in the installed google-ads SDK (available: {available})."
+        )
+    return client.get_service(name, version=version, interceptors=interceptors)
+
+
 class GoogleAdsColumn(Column):
     """Represents a column of a Google Ads resource."""
 
@@ -408,8 +441,8 @@ def get_schemas(config: GoogleAdsSourceConfigUnion, team_id: int, api_version: s
     Only selectable fields are, well, selected.
     """
     client = google_ads_client(config, team_id)
-    gaf_service = client.get_service(
-        "GoogleAdsFieldService", version=api_version, interceptors=tracked_interceptors(GOOGLE_ADS_HOST)
+    gaf_service = _get_versioned_service(
+        client, "GoogleAdsFieldService", version=api_version, interceptors=tracked_interceptors(GOOGLE_ADS_HOST)
     )
     fields_query = _search_fields_with_transient_retry(
         gaf_service, "select name, data_type, is_repeated, type_url where selectable = true"
@@ -544,8 +577,8 @@ def google_ads_source(
 
     def get_rows() -> collections.abc.Iterator[pa.Table]:
         client = google_ads_client(config, team_id)
-        service: GoogleAdsServiceClient = client.get_service(
-            "GoogleAdsService", version=api_version, interceptors=tracked_interceptors(GOOGLE_ADS_HOST)
+        service: GoogleAdsServiceClient = _get_versioned_service(
+            client, "GoogleAdsService", version=api_version, interceptors=tracked_interceptors(GOOGLE_ADS_HOST)
         )
         customer_id = clean_customer_id(config.customer_id)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -38,6 +38,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.google_ads
     GoogleAdsColumn,
     GoogleAdsTable,
     _get_integration,
+    _get_versioned_service,
     _is_rejected_page_token_error,
     _is_stale_page_token_error,
     _is_transient_client_init_error,
@@ -376,6 +377,22 @@ class TestGrpcReceiveLimit:
 
         keys = [key for key, _ in google_ads_client_module._GRPC_CHANNEL_OPTIONS]
         assert keys.count("grpc.max_receive_message_length") == 1
+
+
+class TestGetVersionedService:
+    def test_unavailable_api_version_raises_clear_error(self):
+        # A resolved version the installed SDK can't serve (stale pin, version skew) otherwise
+        # surfaces as the SDK's opaque "Specified service ... does not exist" ValueError.
+        client = mock.MagicMock()
+        with pytest.raises(ValueError, match="not available in the installed google-ads SDK"):
+            _get_versioned_service(client, "GoogleAdsFieldService", version="v999")
+        client.get_service.assert_not_called()
+
+    def test_available_api_version_delegates_to_get_service(self):
+        client = mock.MagicMock()
+        service = _get_versioned_service(client, "GoogleAdsFieldService", version="v23")
+        client.get_service.assert_called_once_with("GoogleAdsFieldService", version="v23", interceptors=None)
+        assert service is client.get_service.return_value
 
 
 class TestValidateCredentials:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -39,6 +39,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.google_ads
     GoogleAdsTable,
     _get_integration,
     _get_versioned_service,
+    _installed_google_ads_api_versions,
     _is_rejected_page_token_error,
     _is_stale_page_token_error,
     _is_transient_client_init_error,
@@ -389,9 +390,12 @@ class TestGetVersionedService:
         client.get_service.assert_not_called()
 
     def test_available_api_version_delegates_to_get_service(self):
+        # Derive the version from the SDK actually installed rather than hardcoding one, so this
+        # exercises the real find_spec lookup without assuming a particular version ships.
+        version = _installed_google_ads_api_versions()[0]
         client = mock.MagicMock()
-        service = _get_versioned_service(client, "GoogleAdsFieldService", version="v23")
-        client.get_service.assert_called_once_with("GoogleAdsFieldService", version="v23", interceptors=None)
+        service = _get_versioned_service(client, "GoogleAdsFieldService", version=version)
+        client.get_service.assert_called_once_with("GoogleAdsFieldService", version=version, interceptors=None)
         assert service is client.get_service.return_value
 
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ValueError` from the Google Ads warehouse source:

> Specified service GoogleAdsFieldService" does not exist in Google Ads API v25.

with a chained `ModuleNotFoundError: No module named 'google.ads.googleads.v25'`. It fires in the import pipeline ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019faa05-81ec-7861-a5b2-12d137b18ee4)).

The message reads like a missing-service bug, but the real cause is version skew: `client.get_service(name, version=...)` was called with a Google Ads API version whose package isn't bundled in the running google-ads SDK. The SDK catches its own internal `ModuleNotFoundError` and re-raises this opaque `ValueError`, which is hard to triage and points at the wrong thing.

The version reaching `get_service` comes from the source's resolved API version pin (falling back to `default_version`). A source resolving to any version the installed SDK can't serve, for example a stale pin to a dropped version or a dependency that lags the code, hits the same crash.

## Changes

Both the schema-discovery path (`GoogleAdsFieldService`) and the sync path (`GoogleAdsService`) now go through a small `_get_versioned_service` guard. It checks whether the requested version's package is importable in the installed SDK and, if not, raises a clear error naming the requested version and the versions the SDK actually ships:

> Google Ads API v25 is not available in the installed google-ads SDK (available: v21, v22, v23, v24).

If the version is available, it delegates to `get_service` unchanged, so healthy syncs are unaffected.

I deliberately did not remap the version to a different one. The source framework honors a source's version pin verbatim precisely to avoid silently moving a customer onto a different API version, so the right move here is to fail with a diagnosable error rather than swap versions behind the customer's back. This is not a credentials or user-config problem, so it stays out of `get_non_retryable_errors` and remains retryable, since a corrected SDK or pin clears it.

## How did you test this code?

Automated only (I'm an agent, no manual sync run):

- New `TestGetVersionedService` unit tests: an unavailable version (`v999`) raises the clear error and never calls `get_service`; an available version (`v23`) delegates through with the expected args. Regression guard: without the version check, an unserviceable version would again produce the SDK's opaque "Specified service ... does not exist" error instead of the actionable one.
- Ran the full `test_google_ads_source.py` suite (163 passed) plus `ruff check`/`ruff format` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Confirmed the failure originates in this source's `get_service` calls, reproduced the exact error shape locally by requesting a version absent from the installed SDK, and confirmed no open PR already covers it.

Skills invoked: `/writing-tests`. Considered adding the message to `get_non_retryable_errors` but rejected it: this is a version/deploy-skew bug on our side, not a user/upstream credential error, so disabling the customer's source would be wrong. Kept the fix scoped to the `get_service` boundary rather than touching the per-version proto imports.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
