### PR TITLE
fix(replay): show V2 trigger groups in recording settings panel

### DIFF
--- a/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewGrid.tsx
+++ b/frontend/src/scenes/session-recordings/player/sidebar/PlayerSidebarOverviewGrid.tsx
@@ -29,6 +29,7 @@ const SNAPSHOT_SCOPE: string[] = [
     'session_recording_event_trigger_config',
     'session_recording_retention_period',
     'session_recording_trigger_match_type_config',
+    'session_recording_trigger_groups',
     'session_replay_config',
     'recording_domains',
 ]


### PR DESCRIPTION
## Problem

When you open a session recording, the sidebar has a **Settings at the time of the recording** panel. It only listed the legacy (V1) recording-config fields: sample rate, minimum duration, linked flag, URL/event triggers.

For a project that uses **V2 trigger groups**, those legacy fields are dormant. Sampling and minimum duration are set per group, so the panel would show, for example, a 30s minimum duration and a null sample rate that were not what actually governed the recording. When debugging why a recording behaved a certain way, that is actively misleading. In a recent debugging session it sent us down the wrong path, and we only found the real config by digging through the Team activity log by hand.

## Changes

- Add `session_recording_trigger_groups` to the panel's `SNAPSHOT_SCOPE` in `PlayerSidebarOverviewGrid.tsx`. The panel is driven by `settings_as_of`, so the group config (per-group `matchType`, `sampleRate`, `minDurationMs`, conditions) renders **reconstructed to the recording's capture time**, not the current values.
- No backend change. `settings_as_of` already returns the field (it is in `TEAM_CONFIG_FIELDS`), and the shared `SettingsSnapshot` already renders JSON values.

Net diff is a single line. This is a visibility fix, not a behavior change: it does not touch how recordings are captured or kept, it just surfaces the config that actually applied so the panel stops contradicting the V2 setup.

I didn't attach a screenshot: reproducing a recording from a V2-trigger-groups project locally is non-trivial, so I couldn't capture the panel in the real state. The output is the existing generic `SettingsSnapshot` rendering one extra field.

## How did you test this code?

- `pnpm --filter=@posthog/frontend fix` (Oxlint + Oxfmt) passed.
- Frontend typecheck: the changed file is clean, zero errors under `frontend/src`. The repo-wide `typescript:check` in this worktree surfaces pre-existing `@posthog/quill-primitives` / `lib/ui/quill` module-resolution errors in unrelated `products/*` folders (the quill package isn't built here); none come from this change.
- I (PostHog Code) did **not** manually exercise the panel against a live V2 recording, for the reproducibility reason above. No test was added: the change is a single scope-array entry rendered by the existing generic `SettingsSnapshot`, so a test would assert framework plumbing rather than a realistic regression.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not doc-worthy (internal debugging panel). Added `skip-inkeep-docs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). I directed the work; PostHog Code (Claude) did the investigation and the edit.

This came out of debugging why a ~15s recording existed on a project whose minimum duration reads as 30s. The cause was that the project runs V2 trigger groups, where sampling and minimum duration live per group, while the recording's settings panel only showed the dormant legacy fields. That mismatch is what this PR fixes.

- Exploration was done with a few read-only Explore agents over the replay config builder (`remote_config.py`), the `settings_as_of` endpoint, and the player panel components.
- Decisions: I first added an info banner that appeared when trigger groups were present, to explicitly flag that the legacy rows might not apply. Dropped it on review as over-the-top: once the trigger-groups config is visible in the panel it speaks for itself, and a persistent banner on every V2 recording is noise. The final change is just the one scope entry.
- Follow-ups intentionally out of scope: (1) whether posthog-js should fall back to the top-level minimum duration when a matched V2 group has no `minDurationMs` (lives in the posthog-js repo); (2) taxonomy drift, where the SDK emits `v2_trigger_groups` for the `remote trigger matching config` property but `taxonomy.py` only documents `all` / `any`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
