### PR TITLE
fix(insights): strip whitespace from trends formula before parsing

### DIFF
--- a/posthog/hogql_queries/utils/formula_ast.py
+++ b/posthog/hogql_queries/utils/formula_ast.py
@@ -25,7 +25,7 @@ class FormulaAST:
             map = {}
             for index, value in enumerate(consts):
                 map[chr(ord("`") + index + 1)] = value
-            result = self._evaluate(node.lower(), map)
+            result = self._evaluate(node.strip().lower(), map)
             res.append(result)
         return res
 

--- a/posthog/hogql_queries/utils/test/test_formula_ast.py
+++ b/posthog/hogql_queries/utils/test/test_formula_ast.py
@@ -1,3 +1,5 @@
+from parameterized import parameterized
+
 from posthog.test.base import APIBaseTest
 
 from posthog.hogql_queries.utils.formula_ast import FormulaAST
@@ -67,3 +69,19 @@ class TestFormulaAST(APIBaseTest):
         formula = self._get_formula_ast()
         response = formula.call("+A")
         self.assertListEqual([1, 2, 3, 4], response)
+
+    @parameterized.expand(
+        [
+            ("leading_space", " A/B*100"),
+            ("trailing_space", "A/B*100 "),
+            ("both", "  A/B*100  "),
+            ("leading_newline", "\nA/B*100"),
+            ("tab", "\tA/B*100"),
+        ]
+    )
+    def test_whitespace_padded_formula(self, _name: str, formula_str: str):
+        # A stray leading space used to reach ast.parse and raise IndentationError,
+        # failing the whole insight/dashboard query.
+        formula = self._get_formula_ast()
+        response = formula.call(formula_str)
+        self.assertListEqual([100, 100, 100, 100], response)

--- a/posthog/hogql_queries/utils/test/test_formula_ast.py
+++ b/posthog/hogql_queries/utils/test/test_formula_ast.py
@@ -1,6 +1,6 @@
-from parameterized import parameterized
-
 from posthog.test.base import APIBaseTest
+
+from parameterized import parameterized
 
 from posthog.hogql_queries.utils.formula_ast import FormulaAST
 


### PR DESCRIPTION
## Problem

Whitespace around a trends formula can raise an `IndentationError`, breaking the insight and any dashboard using it.

## Changes

- Strip leading and trailing whitespace before parsing formulas
- Apply the fix server-side so existing saved insights work without edits

## How did you test this code?

- Added parameterized coverage for leading and trailing spaces, tabs, and newlines
- Full test suite not run locally; CI will verify it

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude traced the parsing failure and implemented the fix. The `/writing-tests` skill guided the regression coverage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C045L1VEG87/p1785266832566809?thread_ts=1785266832.566809&cid=C045L1VEG87)*