### PR TITLE
fix(conversations): mark failed ai triage runs complete

### DIFF
--- a/products/conversations/backend/api/tests/test_tickets.py
+++ b/products/conversations/backend/api/tests/test_tickets.py
@@ -320,6 +320,21 @@ class TestTicketAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["count"], 1)
 
+    def test_filter_by_failed_ai_triage(self, mock_on_commit):
+        self.ticket.ai_triage = {"status": "done", "result": "failed"}
+        self.ticket.save(update_fields=["ai_triage"])
+        Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.WIDGET,
+            widget_session_id="other-session",
+            distinct_id="other-user",
+            ai_triage={"status": "done", "result": "persisted"},
+        )
+
+        ticket_ids = self._list_ids(ai_triage_result="failed")
+
+        self.assertEqual(ticket_ids, {str(self.ticket.id)})
+
     def test_filter_by_multiple_statuses(self, mock_on_commit):
         """Test filtering tickets by multiple statuses (comma-separated)."""
         self.ticket.status = Status.NEW

--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -564,6 +564,7 @@ class TicketViewSet(TaggedItemViewSetMixin, TeamAndOrgViewSetMixin, viewsets.Mod
                 "skipped_unactionable",
                 "blocked_unsafe",
                 "blocked_unsafe_reply",
+                "failed",
                 "in_progress",
             }
             results = {r.strip() for r in ai_triage_result_param.split(",") if r.strip() in valid_results}

--- a/products/conversations/backend/temporal/pipeline.py
+++ b/products/conversations/backend/temporal/pipeline.py
@@ -63,10 +63,11 @@ class SupportReplyWorkflow:
 
     Triage lifecycle (`ai_triage.status`), recorded via `_record_triage`:
       - in_progress: run started, context built, draft loop not yet terminal.
-      - done: a terminal branch set `outcome`; recorded in `finally`. An empty
-        `outcome` (unexpected crash) is never marked done.
+      - done: the run ended and a terminal outcome was recorded in `finally`.
 
     Terminal outcomes (`ai_triage.result`), exactly one per finished run:
+      - failed: the workflow stopped on an unexpected error; Temporal retains
+        the underlying failure for diagnosis.
       - blocked_unsafe: input safety gate rejected the incoming ticket
         (prompt-injection / exfiltration) before any LLM draft work.
       - skipped_unactionable: classifier judged the ticket has no answerable
@@ -424,9 +425,11 @@ class SupportReplyWorkflow:
                 "missing": best_missing,
             }
             return "escalated_no_reply"
+        except Exception:
+            # Keep the workflow failed in Temporal while closing its persisted lifecycle.
+            outcome = {"result": "failed"}
+            raise
         finally:
-            # `outcome` is only set on the workflow's own terminal branches; on an unexpected
-            # crash it stays empty, so we never mark a failed run as "done".
             if outcome:
                 await _record_triage(
                     {

--- a/products/conversations/backend/temporal/tests/test_pipeline.py
+++ b/products/conversations/backend/temporal/tests/test_pipeline.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from parameterized import parameterized
+from temporalio.client import WorkflowFailureError
 
 from posthog.models import Organization, Team
 
@@ -1549,6 +1550,76 @@ class TestRecordTriageActivity:
             assert last_call_patch["status"] == "done"
             assert last_call_patch["result"] == expected_result
             assert "finished_at" in last_call_patch
+
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_records_failed_triage_when_draft_activity_fails(self):
+        from temporalio.testing import WorkflowEnvironment
+        from temporalio.worker import Worker
+
+        failure_message = "sensitive draft failure"
+        with (
+            patch(
+                f"{BUILD_CONTEXT_MODULE}._build_context_sync",
+                return_value=BuildContextOutput(ticket_context="help", ticket_title="Help"),
+            ),
+            patch(
+                f"{SAFETY_FILTER_MODULE}._safety_filter",
+                new_callable=AsyncMock,
+                return_value=SafetyFilterOutput(safe=True),
+            ),
+            patch(
+                f"{CLASSIFY_MODULE}._classify",
+                new_callable=AsyncMock,
+                return_value=ClassifyOutput(ticket_type="how_to", needs_diagnostics=False, seed_queries=[]),
+            ),
+            patch(
+                f"{REFINE_QUERIES_MODULE}._refine_queries",
+                new_callable=AsyncMock,
+                return_value=RefineQueriesOutput(queries=["q"]),
+            ),
+            patch(f"{RETRIEVE_MODULE}._retrieve_sync", return_value=RetrieveOutput(chunk_ids=[])),
+            patch(
+                f"{DRAFT_MODULE}._draft_async",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError(failure_message),
+            ),
+            patch(f"{RECORD_TRIAGE_MODULE}._record_triage_sync") as mock_record_triage,
+        ):
+            async with await WorkflowEnvironment.start_time_skipping() as env:
+                async with Worker(
+                    env.client,
+                    task_queue="test-queue",
+                    workflows=[SupportReplyWorkflow],
+                    activities=[
+                        support_build_context_activity,
+                        support_safety_filter_activity,
+                        support_classify_activity,
+                        support_refine_queries_activity,
+                        support_retrieve_activity,
+                        support_draft_activity,
+                        support_record_triage_activity,
+                    ],
+                ):
+                    with pytest.raises(WorkflowFailureError):
+                        await env.client.execute_workflow(
+                            SupportReplyWorkflow.run,
+                            SupportReplyInput(team_id=1, ticket_id="deadbeef-0000-0000-0000-000000000001"),
+                            id="test-triage-draft-failure",
+                            task_queue="test-queue",
+                        )
+
+        first_call_patch = mock_record_triage.call_args_list[0][0][2]
+        assert first_call_patch["status"] == "in_progress"
+
+        last_call_patch = mock_record_triage.call_args_list[-1][0][2]
+        assert last_call_patch["status"] == "done"
+        assert last_call_patch["result"] == "failed"
+        assert "finished_at" in last_call_patch
+        assert "ai_trace_id" in last_call_patch
+        assert "workflow_id" in last_call_patch
+        assert "run_id" in last_call_patch
+        assert failure_message not in repr(last_call_patch)
 
     @pytest.mark.django_db
     @pytest.mark.asyncio

--- a/products/conversations/frontend/types.ts
+++ b/products/conversations/frontend/types.ts
@@ -58,6 +58,7 @@ export type AITriageResult =
     | 'skipped_unactionable'
     | 'blocked_unsafe'
     | 'blocked_unsafe_reply'
+    | 'failed'
 
 export interface AITriage {
     schema_version?: number
@@ -297,6 +298,7 @@ export const aiTriageResultLabel: Record<AITriageResult, string> = {
     skipped_unactionable: 'Skipped',
     blocked_unsafe: 'Blocked unsafe ticket',
     blocked_unsafe_reply: 'Blocked unsafe reply',
+    failed: 'Failed',
 }
 
 export const aiTriageProcessingLabel = 'Processing'
@@ -319,6 +321,7 @@ export function aiTriageResultTagType(result: AITriageResult): AITriageTagType {
             return 'warning'
         case 'blocked_unsafe':
         case 'blocked_unsafe_reply':
+        case 'failed':
             return 'danger'
         case 'skipped_unactionable':
             return 'default'


### PR DESCRIPTION
## Problem

An unexpected support workflow failure after AI triage starts leaves `ai_triage.status` as `in_progress`. Temporal has already failed the execution, but the ticket list continues to show “Processing” indefinitely.

```mermaid
flowchart LR
    Start[AI triage starts] --> Running[status: in_progress]
    Running --> Failure{Unexpected failure}
    Failure --> Stale[status remains in_progress]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Start phYellow;
    class Running phBlue;
    class Failure phRed;
    class Stale phGray;
```

```mermaid
flowchart LR
    Start[AI triage starts] --> Running[status: in_progress]
    Running --> Failure{Unexpected failure}
    Failure --> Persist[status: done<br/>result: failed]
    Persist --> Temporal[Temporal execution remains failed]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class Start phYellow;
    class Running phBlue;
    class Failure phRed;
    class Persist phBlue;
    class Temporal phGray;
```

## Changes

- Record `status="done"` and `result="failed"` when an unexpected workflow exception occurs, then re-raise so Temporal retains the failure.
- Keep exception text out of the ticket’s public triage metadata. Existing workflow and run IDs remain the diagnostic link.
- Show “Failed” in the AI status column and expose it through the existing ticket filter.

No screenshot is included because this reuses the existing AI status tag and only adds a new terminal label.

## How did you test this code?

- Added a Temporal workflow regression for an exhausted draft activity failure. It catches the stale `in_progress` state and verifies that the workflow still raises without persisting exception text.
- Added an API regression proving `ai_triage_result=failed` filters tickets instead of being ignored by the allowlist.
- Ran the full six-case `TestRecordTriageActivity` class, focused API test, Ruff checks, frontend lint/format, commit hooks, and `hogli ci:preflight --fix`.
- The repository-wide TypeScript check is currently blocked by unrelated missing workspace modules; it reported no errors in the conversations files changed here.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update is needed. This corrects persisted lifecycle state and reuses the existing ticket status UI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex prepared and tested this change in a private local development session; there is no shareable session link. I invoked `/writing-tests` and `/improving-drf-endpoints`. I chose a terminal `failed` result under the existing `done` lifecycle status so the UI stops processing while Temporal remains the source of the underlying failure. Exception text is deliberately not copied into ticket metadata.