### PR TITLE
fix(tasks): reconstruct agent responses across polls

### DIFF
--- a/products/tasks/backend/logic/services/custom_prompt_internals.py
+++ b/products/tasks/backend/logic/services/custom_prompt_internals.py
@@ -296,6 +296,12 @@ async def poll_for_turn(
             latest_assistant_text = last_message
         # If success
         if finished and last_message:
+            if skip_lines > original_skip_lines:
+                # The final response can span poll slices. Reparse this snapshot from the
+                # turn boundary so completion returns the whole message, not its last slice.
+                _, complete_message, _, _, _ = _parse_log_content(full_log or "", original_skip_lines)
+                if complete_message is not None:
+                    last_message = complete_message
             return last_message, full_log, total_lines, printed_lines
         # Surface empty end_turn to the multi-turn session, so it can retry
         # the prompt instead of us polling until MAX_POLL_SECONDS.
@@ -303,7 +309,10 @@ async def poll_for_turn(
             # If the agent emitted text in an earlier poll of this same turn, the turn
             # is genuinely complete — end_turn just landed in a later slice.
             if latest_assistant_text is not None:
-                return latest_assistant_text, full_log, total_lines, printed_lines
+                # Reparse from the turn boundary to recover chunks that landed in earlier
+                # poll slices while still respecting tool-call message boundaries.
+                _, complete_message, _, _, _ = _parse_log_content(full_log or "", original_skip_lines)
+                return complete_message or latest_assistant_text, full_log, total_lines, printed_lines
             logger.warning(
                 "custom_prompt - poll_for_turn: empty end_turn detected (no agent_message), run=%s total_lines=%d",
                 task_run.id,
@@ -625,6 +634,10 @@ def _check_logs(task_run, skip_lines: int = 0) -> tuple[bool, str | None, str | 
     and agent messages. This avoids re-parsing the entire log on every poll cycle.
     """
     log_content = object_storage.read(task_run.log_url, missing_ok=True) or ""
+    return _parse_log_content(log_content, skip_lines)
+
+
+def _parse_log_content(log_content: str, skip_lines: int = 0) -> tuple[bool, str | None, str | None, int, bool]:
     if not log_content.strip():
         return False, None, None, 0, False
     all_lines = log_content.strip().split("\n")
@@ -657,27 +670,27 @@ def _check_logs(task_run, skip_lines: int = 0) -> tuple[bool, str | None, str | 
         if not isinstance(update, dict):
             continue
         parsed_updates.append(update)
-    # Walk backwards from the end to find the final agent response.
-    # First, skip non-agent entries (e.g. usage_update) to find the last
-    # agent message. Then collect consecutive agent messages until we hit
-    # something else — the agent sometimes splits its response across entries.
-    _AGENT_MSG_TYPES = {"agent_message", "agent_message_chunk"}
-    trailing_parts: list[str] = []
-    found_agent_msg = False
-    for update in reversed(parsed_updates):
-        is_agent_msg = update.get("sessionUpdate") in _AGENT_MSG_TYPES
-        if not found_agent_msg:
-            if is_agent_msg:
-                found_agent_msg = True
-            else:
-                continue
-        if found_agent_msg and not is_agent_msg:
+    # Ignore trailing accounting updates, then use a complete agent_message as authoritative.
+    # If the response was only streamed as chunks, join its trailing contiguous chunk block.
+    latest_text: str | None = None
+    for index in range(len(parsed_updates) - 1, -1, -1):
+        update = parsed_updates[index]
+        update_type = update.get("sessionUpdate")
+        if update_type == "agent_message":
+            latest_text = _extract_text(update)
             break
-        text = _extract_text(update)
-        if text:
-            trailing_parts.append(text)
-    trailing_parts.reverse()
-    latest_text = "".join(trailing_parts) if trailing_parts else None
+        if update_type != "agent_message_chunk":
+            continue
+        trailing_parts: list[str] = []
+        for chunk in reversed(parsed_updates[: index + 1]):
+            if chunk.get("sessionUpdate") != "agent_message_chunk":
+                break
+            text = _extract_text(chunk)
+            if text:
+                trailing_parts.append(text)
+        trailing_parts.reverse()
+        latest_text = "".join(trailing_parts) if trailing_parts else None
+        break
     # If we found end_turn but no agent message in the new lines, flag it as an empty turn.
     if agent_finished and latest_text is None:
         return False, None, log_content, total_lines, True

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -76,29 +76,25 @@ class TestPollForTurnEmptyEndTurn:
         assert exc_info.value.printed_lines >= 0
 
     @pytest.mark.asyncio
-    async def test_text_before_end_turn_across_polls_is_not_empty(self):
-        """When agent_message arrives in one poll and end_turn in the next, poll_for_turn
-        must recognize the turn as complete — not raise EmptyAgentTurnError and cause a
-        spurious retry."""
+    async def test_reassembles_chunked_response_across_polls(self):
         turn_1 = [_agent_message_line("prev"), _end_turn_line()]
-        # Current turn: prompt, then text (poll 1 sees this), then end_turn (poll 2 sees this).
-        turn_2_with_text = [_user_message_line("next"), _agent_message_line("current-turn-text")]
-        turn_2_end_turn = [_end_turn_line()]
+        turn_2_first_poll = [
+            _user_message_line("next"),
+            _agent_message_line("intermediate narration"),
+            _tool_call_line("search"),
+            _agent_message_chunk_line("final-"),
+        ]
+        turn_2_completion = [_agent_message_chunk_line("response"), _end_turn_line()]
         skip = len(turn_1)
-        # Log grows monotonically across polls — first poll has no end_turn yet,
-        # second poll appends it after the agent_message of poll 1 has already advanced
-        # the cursor past it.
         logs = [
-            "\n".join(turn_1 + turn_2_with_text),
-            "\n".join(turn_1 + turn_2_with_text + turn_2_end_turn),
+            "\n".join(turn_1 + turn_2_first_poll),
+            "\n".join(turn_1 + turn_2_first_poll + turn_2_completion),
         ]
         poll_iter = iter(logs)
 
         def next_log(*_args, **_kwargs):
             return next(poll_iter)
 
-        # Poll 1 returns (False, text, ...) — falls through to the TaskRun refresh
-        # to check for terminal status. Patch it to a running status so the loop continues.
         fake_task_run = FakeTaskRun()
         with (
             patch("posthog.storage.object_storage.read", side_effect=next_log),
@@ -107,8 +103,8 @@ class TestPollForTurnEmptyEndTurn:
             patch("products.tasks.backend.models.TaskRun.objects.get", return_value=fake_task_run),
         ):
             last_message, _, total_lines, _ = await poll_for_turn(fake_task_run, skip_lines=skip)
-        assert last_message == "current-turn-text"
-        assert total_lines == len(turn_1) + len(turn_2_with_text) + len(turn_2_end_turn)
+        assert last_message == "final-response"
+        assert total_lines == len(turn_1) + len(turn_2_first_poll) + len(turn_2_completion)
 
     @pytest.mark.asyncio
     async def test_poll_handles_s3_shrink_then_recovery_without_duplicates(self):


### PR DESCRIPTION
## Problem

Agent responses can span multiple polling windows. The poll cursor advances after each read, so the terminal poll currently returns only the final slice of a streamed response. Structured responses can therefore reach callers as incomplete JSON even though the complete response exists in the log snapshot.

```mermaid
flowchart LR
    First[Poll 1: final-] --> Cursor[Advance cursor]
    Cursor --> Terminal[Poll 2: response + end_turn]
    Terminal --> Partial[Return response]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class First phYellow;
    class Cursor phGray;
    class Terminal phBlue;
    class Partial phRed;
```

```mermaid
flowchart LR
    First[Poll 1: final-] --> Cursor[Advance cursor]
    Cursor --> Terminal[Poll 2: response + end_turn]
    Terminal --> Reparse[Reparse the same snapshot<br/>from the turn boundary]
    Reparse --> Complete[Return final-response]
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class First phYellow;
    class Cursor phGray;
    class Terminal,Reparse phBlue;
    class Complete phYellow;
```

## Changes

- Extract log parsing from the S3 read so a completed turn can be reparsed without another storage request.
- Reconstruct the response from the original turn cursor on both normal completion and the split message/end-turn path.
- Treat a finalized `agent_message` as authoritative; otherwise join only the trailing contiguous chunk block so pre-tool narration is excluded.
- Keep the fix independent of Redis and MCP gateway code.

## How did you test this code?

- Reworked the existing cross-poll regression to stream final chunks over two S3 snapshots with earlier narration separated by a tool call. It failed as `response` before the fix and passes as `final-response` afterward.
- Ran `products/tasks/backend/tests/test_check_logs.py` and `products/tasks/backend/tests/test_multi_turn_session.py`: 86 passed.
- Ruff, formatting checks, Python type checks from the commit hook, and `git diff --check` pass.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update is needed. This restores complete responses within the existing polling contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex prepared and tested this change in a private local development session; there is no shareable session link. I invoked `/writing-tests`. I kept the PR on the existing S3 polling path so it has no dependency on the MCP gateway work that exposed the timing bug.