### PR TITLE
feat(experiments): add admin tools for experiment metric recalculations

### DIFF
--- a/products/experiments/backend/admin/__init__.py
+++ b/products/experiments/backend/admin/__init__.py
@@ -1,3 +1,7 @@
 # Importing these submodules fires their `@admin.register` decorators when
 # `autodiscover_modules("admin")` imports this package.
-from products.experiments.backend.admin import experiment_admin, experiment_saved_metric_admin  # noqa: F401
+from products.experiments.backend.admin import (  # noqa: F401
+    experiment_admin,
+    experiment_saved_metric_admin,
+    recalculation_admin,
+)

--- a/products/experiments/backend/admin/recalculation_admin.py
+++ b/products/experiments/backend/admin/recalculation_admin.py
@@ -1,0 +1,200 @@
+from django.conf import settings
+from django.contrib import admin, messages
+from django.db.models import QuerySet
+from django.http import HttpRequest, HttpResponseRedirect
+from django.urls import path, reverse
+from django.utils import timezone
+from django.utils.html import format_html
+
+from products.experiments.backend.models.experiment import ExperimentMetricsRecalculation
+from products.experiments.backend.recalculation import (
+    cancel_recalculation_workflow,
+    request_recalculation,
+    start_metrics_recalculation_workflow,
+)
+
+_TERMINAL_STATUSES = {
+    ExperimentMetricsRecalculation.Status.COMPLETED,
+    ExperimentMetricsRecalculation.Status.FAILED,
+}
+
+
+def temporal_workflow_url(recalculation_id: str) -> str:
+    """Link to the recalc's Temporal Cloud workflow. Uses the runtime namespace (e.g. posthog-prod-us.usz2o),
+    so it resolves per region without hardcoding a slug."""
+    return (
+        f"https://cloud.temporal.io/namespaces/{settings.TEMPORAL_NAMESPACE}"
+        f"/workflows/experiment-metrics-recalculation-{recalculation_id}"
+    )
+
+
+@admin.register(ExperimentMetricsRecalculation)
+class ExperimentMetricsRecalculationAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "experiment_link",
+        "team_id",
+        "status",
+        "trigger",
+        "total_metrics",
+        "created_at",
+        "started_at",
+        "completed_at",
+        "temporal_link",
+    )
+    list_filter = ("status", "trigger")
+    search_fields = ("id", "experiment__id", "team__id")
+    ordering = ("-created_at",)
+    # Operators drive state through the action buttons below, not field-by-field edits, so every field is
+    # read-only. This is a pure admin-layer setting — no model or migration change.
+    readonly_fields = (
+        "id",
+        "team",
+        "experiment",
+        "status",
+        "trigger",
+        "total_metrics",
+        "metric_uuids",
+        "metric_errors",
+        "metric_retries",
+        "query_to",
+        "created_at",
+        "started_at",
+        "completed_at",
+        "created_by",
+        "temporal_link",
+    )
+    # First page shows the latest 10; older runs stay reachable via pagination.
+    list_per_page = 10
+    change_form_template = "admin/experiments/experimentmetricsrecalculation/change_form.html"
+
+    def get_queryset(self, request: HttpRequest) -> QuerySet[ExperimentMetricsRecalculation]:
+        # `objects` is the fail-closed TeamScopedManager, which raises TeamScopeError without an ambient team
+        # scope — and admin runs outside request/team scope, so the default manager would 500 every changelist
+        # and detail render (and get_object, which reads through here). This admin is staff-only and manages
+        # runs across all teams, so read cross-team through `unscoped()`, the prescribed escape hatch.
+        return ExperimentMetricsRecalculation.objects.unscoped()
+
+    @admin.display(description="Experiment")
+    def experiment_link(self, obj: ExperimentMetricsRecalculation) -> str:
+        url = reverse("admin:experiments_experiment_change", args=[obj.experiment_id])
+        return format_html('<a href="{}">{}</a>', url, obj.experiment_id)
+
+    @admin.display(description="Temporal workflow")
+    def temporal_link(self, obj: ExperimentMetricsRecalculation) -> str:
+        return format_html(
+            '<a href="{}" target="_blank" rel="noopener">open in Temporal</a>', temporal_workflow_url(str(obj.id))
+        )
+
+    def has_add_permission(self, request) -> bool:
+        # New runs are created through the "Start new recalculation" button (which also dispatches the
+        # workflow), never via the bare admin add form that would leave an orphaned pending row.
+        return False
+
+    def change_view(self, request, object_id, form_url="", extra_context=None):
+        extra_context = extra_context or {}
+        obj = self.get_object(request, object_id)
+        if obj is not None:
+            is_terminal = obj.status in _TERMINAL_STATUSES
+            extra_context["can_mark_terminal"] = not is_terminal
+            extra_context["mark_failed_url"] = reverse("admin:experiments_recalculation_mark_failed", args=[obj.pk])
+            extra_context["mark_completed_url"] = reverse(
+                "admin:experiments_recalculation_mark_completed", args=[obj.pk]
+            )
+            extra_context["start_recalculation_url"] = reverse("admin:experiments_recalculation_start", args=[obj.pk])
+        return super().change_view(request, object_id, form_url, extra_context)
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "<path:object_id>/mark-failed/",
+                self.admin_site.admin_view(self.mark_failed_view),
+                name="experiments_recalculation_mark_failed",
+            ),
+            path(
+                "<path:object_id>/mark-completed/",
+                self.admin_site.admin_view(self.mark_completed_view),
+                name="experiments_recalculation_mark_completed",
+            ),
+            path(
+                "<path:object_id>/start/",
+                self.admin_site.admin_view(self.start_recalculation_view),
+                name="experiments_recalculation_start",
+            ),
+        ]
+        return custom + urls
+
+    def _mark_terminal(self, request, object_id, status: str):
+        obj = self.get_object(request, object_id)
+        if obj is None:
+            return HttpResponseRedirect(reverse("admin:experiments_experimentmetricsrecalculation_changelist"))
+
+        change_url = reverse("admin:experiments_experimentmetricsrecalculation_change", args=[obj.pk])
+        if request.method != "POST":
+            return HttpResponseRedirect(change_url)
+
+        # First-write-wins guard: only stamp a terminal status on a run that hasn't already finalized, so this
+        # never clobbers a run the workflow completed a moment earlier. Mirrors the activity's completed_at guard.
+        # for_team scopes the fail-closed write to the row's own team (admin runs outside request/team scope).
+        updated = (
+            ExperimentMetricsRecalculation.objects.for_team(obj.team_id)
+            .filter(id=obj.pk, completed_at__isnull=True)
+            .update(status=status, completed_at=timezone.now())
+        )
+        if not updated:
+            messages.error(request, "This recalculation is already terminal; nothing to change.")
+            return HttpResponseRedirect(change_url)
+
+        # Cancelling the workflow after force-failing keeps a still-running run from burning ClickHouse quota
+        # alongside a status that now says it's done. Best-effort: a finished/never-started run just no-ops.
+        if status == ExperimentMetricsRecalculation.Status.FAILED:
+            cancel_recalculation_workflow(str(obj.pk))
+
+        obj.refresh_from_db()
+        self.log_change(request, obj, f"Manually marked {status} from admin.")
+        messages.success(request, f"Recalculation marked {status}.")
+        return HttpResponseRedirect(change_url)
+
+    def mark_failed_view(self, request, object_id):
+        return self._mark_terminal(request, object_id, ExperimentMetricsRecalculation.Status.FAILED)
+
+    def mark_completed_view(self, request, object_id):
+        return self._mark_terminal(request, object_id, ExperimentMetricsRecalculation.Status.COMPLETED)
+
+    def start_recalculation_view(self, request, object_id):
+        obj = self.get_object(request, object_id)
+        if obj is None:
+            return HttpResponseRedirect(reverse("admin:experiments_experimentmetricsrecalculation_changelist"))
+
+        change_url = reverse("admin:experiments_experimentmetricsrecalculation_change", args=[obj.pk])
+        if request.method != "POST":
+            return HttpResponseRedirect(change_url)
+
+        experiment = obj.experiment
+        try:
+            result = request_recalculation(experiment, request.user, trigger="manual")
+        except Exception as e:
+            messages.error(request, f"Could not create recalculation: {e}")
+            return HttpResponseRedirect(change_url)
+
+        if result.get("is_existing"):
+            messages.info(request, "An active recalculation already exists for this experiment; reused it.")
+            return HttpResponseRedirect(change_url)
+
+        recalculation_id = str(result["id"])
+        try:
+            start_metrics_recalculation_workflow(recalculation_id, str(experiment.team.organization_id))
+        except Exception as e:
+            # Roll the fresh row back to FAILED so a workflow that never started isn't left pending forever.
+            ExperimentMetricsRecalculation.objects.for_team(experiment.team_id).filter(id=recalculation_id).update(
+                status=ExperimentMetricsRecalculation.Status.FAILED
+            )
+            messages.error(request, f"Created the row but failed to start the workflow (marked failed): {e}")
+            return HttpResponseRedirect(change_url)
+
+        new_change_url = reverse("admin:experiments_experimentmetricsrecalculation_change", args=[recalculation_id])
+        messages.success(
+            request, format_html('Started new recalculation <a href="{}">{}</a>.', new_change_url, recalculation_id)
+        )
+        return HttpResponseRedirect(new_change_url)

--- a/products/experiments/backend/admin/recalculation_admin.py
+++ b/products/experiments/backend/admin/recalculation_admin.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib import admin, messages
+from django.core.exceptions import PermissionDenied
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponseRedirect
 from django.urls import path, reverse
@@ -95,8 +96,11 @@ class ExperimentMetricsRecalculationAdmin(admin.ModelAdmin):
         extra_context = extra_context or {}
         obj = self.get_object(request, object_id)
         if obj is not None:
+            # Hide the action buttons from a view-only staff user; the endpoints reject them too.
+            can_manage = self.has_change_permission(request, obj)
             is_terminal = obj.status in _TERMINAL_STATUSES
-            extra_context["can_mark_terminal"] = not is_terminal
+            extra_context["can_mark_terminal"] = can_manage and not is_terminal
+            extra_context["can_start_recalculation"] = can_manage
             extra_context["mark_failed_url"] = reverse("admin:experiments_recalculation_mark_failed", args=[obj.pk])
             extra_context["mark_completed_url"] = reverse(
                 "admin:experiments_recalculation_mark_completed", args=[obj.pk]
@@ -129,6 +133,10 @@ class ExperimentMetricsRecalculationAdmin(admin.ModelAdmin):
         obj = self.get_object(request, object_id)
         if obj is None:
             return HttpResponseRedirect(reverse("admin:experiments_experimentmetricsrecalculation_changelist"))
+
+        # admin_view only enforces is_staff; a view-only staff user must not be able to mutate the row.
+        if not self.has_change_permission(request, obj):
+            raise PermissionDenied
 
         change_url = reverse("admin:experiments_experimentmetricsrecalculation_change", args=[obj.pk])
         if request.method != "POST":
@@ -166,6 +174,9 @@ class ExperimentMetricsRecalculationAdmin(admin.ModelAdmin):
         obj = self.get_object(request, object_id)
         if obj is None:
             return HttpResponseRedirect(reverse("admin:experiments_experimentmetricsrecalculation_changelist"))
+
+        if not self.has_change_permission(request, obj):
+            raise PermissionDenied
 
         change_url = reverse("admin:experiments_experimentmetricsrecalculation_change", args=[obj.pk])
         if request.method != "POST":

--- a/products/experiments/backend/admin/recalculation_admin.py
+++ b/products/experiments/backend/admin/recalculation_admin.py
@@ -154,10 +154,7 @@ class ExperimentMetricsRecalculationAdmin(admin.ModelAdmin):
             messages.error(request, "This recalculation is already terminal; nothing to change.")
             return HttpResponseRedirect(change_url)
 
-        # Cancelling the workflow after force-failing keeps a still-running run from burning ClickHouse quota
-        # alongside a status that now says it's done. Best-effort: a finished/never-started run just no-ops.
-        if status == ExperimentMetricsRecalculation.Status.FAILED:
-            cancel_recalculation_workflow(str(obj.pk))
+        cancel_recalculation_workflow(str(obj.pk))
 
         obj.refresh_from_db()
         self.log_change(request, obj, f"Manually marked {status} from admin.")

--- a/products/experiments/backend/recalculation.py
+++ b/products/experiments/backend/recalculation.py
@@ -13,6 +13,7 @@ import asyncio
 from datetime import timedelta
 from uuid import UUID
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 from django.utils import timezone
@@ -37,6 +38,7 @@ from products.experiments.backend.models.experiment import (
     ExperimentMetricsRecalculation,
 )
 from products.experiments.backend.result_serialization import strip_step_sessions
+from products.experiments.backend.temporal.models import ExperimentMetricsRecalculationWorkflowInputs
 from products.experiments.backend.temporal.recalc_fingerprint import compute_recalc_fingerprint
 from products.experiments.backend.temporal.recalculation_logic import discover_experiment_metrics, find_metric_dict
 
@@ -203,6 +205,29 @@ def build_job_payload(
         if live_progress is not None:
             payload.update(live_progress)
     return payload
+
+
+def cancel_recalculation_workflow(recalculation_id: str) -> None:
+    """Best-effort cancel of a single recalc's Temporal workflow. Swallows failures (already-finished or
+    never-started runs) so callers can pair it with a status write without the cancel masking that write."""
+    _cancel_superseded_workflows([recalculation_id])
+
+
+def start_metrics_recalculation_workflow(recalculation_id: str, organization_id: str) -> None:
+    """Dispatch the recalculation Temporal workflow for an already-created pending row. Mirrors the API's
+    start path (task queue + org-scoped fairness key) so the admin and the viewset stay in step."""
+    temporal = sync_connect()
+    asyncio.run(
+        temporal.start_workflow(
+            "experiment-metrics-recalculation-workflow",
+            ExperimentMetricsRecalculationWorkflowInputs(
+                recalculation_id=recalculation_id,
+                fairness_key=organization_id,
+            ),
+            id=f"experiment-metrics-recalculation-{recalculation_id}",
+            task_queue=settings.EXPERIMENTS_RECALCULATION_TASK_QUEUE,
+        )
+    )
 
 
 def _cancel_superseded_workflows(recalculation_ids: list[str]) -> None:

--- a/products/experiments/backend/templates/admin/experiments/experimentmetricsrecalculation/change_form.html
+++ b/products/experiments/backend/templates/admin/experiments/experimentmetricsrecalculation/change_form.html
@@ -4,7 +4,7 @@
 {% block after_field_sets %}
     {{ block.super }}
 
-    {% if original %}
+    {% if original and can_start_recalculation %}
     <fieldset style="margin: 20px 0; padding: 16px; border: 1px solid #ccc; border-radius: 4px;">
         <h2>Recalculation actions</h2>
         <div style="margin-top: 12px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">

--- a/products/experiments/backend/templates/admin/experiments/experimentmetricsrecalculation/change_form.html
+++ b/products/experiments/backend/templates/admin/experiments/experimentmetricsrecalculation/change_form.html
@@ -1,0 +1,21 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block after_field_sets %}
+    {{ block.super }}
+
+    {% if original %}
+    <fieldset style="margin: 20px 0; padding: 16px; border: 1px solid #ccc; border-radius: 4px;">
+        <h2>Recalculation actions</h2>
+        <div style="margin-top: 12px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
+            {% if can_mark_terminal %}
+                <button type="submit" formaction="{{ mark_failed_url }}" formmethod="post" formnovalidate class="button" style="padding: 8px 14px; background: #ba2121;">Mark as failed (and cancel workflow)</button>
+                <button type="submit" formaction="{{ mark_completed_url }}" formmethod="post" formnovalidate class="button" style="padding: 8px 14px;">Mark as completed</button>
+            {% else %}
+                <p style="color: #666; margin: 4px 0;">This recalculation is already terminal.</p>
+            {% endif %}
+            <button type="submit" formaction="{{ start_recalculation_url }}" formmethod="post" formnovalidate class="button" style="padding: 8px 14px; background: #417690;">Start new recalculation</button>
+        </div>
+    </fieldset>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

When an experiment metric recalculation gets stuck (a workflow that fails after starting, or a run wedged in progress), there's no way to inspect or unstick it. An operator has to wait out the 30-minute staleness TTL or edit the row by hand, and there's no quick link into the run's Temporal workflow to see what happened.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

This PR adds a Django admin for `ExperimentMetricsRecalculation` to inspect recent runs and drive them to a terminal state manually.

### Recalculation admin

A `ModelAdmin` listing the latest runs (10 per page, newest first) with the experiment, team, status, trigger, timestamps, and a per-row link into the run's Temporal Cloud workflow. Every field is read-only; operators drive state through action buttons on the detail page rather than editing fields. The changelist reads cross-team through `unscoped()` because the admin runs outside request/team scope and `ExperimentMetricsRecalculation` is a fail-closed team-scoped model.

Three buttons on the detail page:

- Mark as failed, which force-fails the row and best-effort cancels its Temporal workflow so a zombie run stops burning ClickHouse quota.
- Mark as completed, which stamps the run terminal.
- Start new recalculation, which creates a run and dispatches the workflow, honoring the same idempotency guard as the API so it reuses an active run instead of stacking a second.

Terminal writes use `for_team(obj.team_id)` and are first-write-wins on `completed_at`, so a manual mark can't clobber a run the workflow just finalized.

- `products/experiments/backend/admin/__init__.py`
- `products/experiments/backend/admin/recalculation_admin.py`
- `products/experiments/backend/templates/admin/experiments/experimentmetricsrecalculation/change_form.html`

### Reusable workflow helpers

Extracted `start_metrics_recalculation_workflow` and `cancel_recalculation_workflow` into `recalculation.py` so the admin dispatches and cancels workflows through the same path as the API viewset instead of duplicating the Temporal wiring. `cancel_recalculation_workflow` wraps the existing `_cancel_superseded_workflows` for the single-run case.

- `products/experiments/backend/recalculation.py`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

```bash
uv run mypy --cache-fine-grained products/experiments/backend/admin/recalculation_admin.py products/experiments/backend/recalculation.py
```

![cat-type-small](https://github.com/user-attachments/assets/22e6a72d-85d0-4065-9c6c-d177456de8dd)

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

Model: Opus 4.8
Manually refactored: **yes**

Skills used:

- /django-migrations (local)
- /writing-tests (local)
- /writing-pull-requests (local)

Relevant decisions:

- The changelist and `get_object` read through `unscoped()`, while the mark-failed/completed writes use `for_team(obj.team_id)`, because `ExperimentMetricsRecalculation` is fail-closed (`TeamScopedRootMixin`) and the admin runs with no ambient team scope; the default manager would raise `TeamScopeError` on every render.
- Mark-as-failed pairs the status write with a best-effort `cancel_recalculation_workflow`, so force-failing a run also stops the still-running workflow rather than leaving it to burn ClickHouse quota next to a row that says it's done.
- Terminal writes are first-write-wins on `completed_at`, mirroring the workflow's finalize guard, so a manual mark and a concurrent workflow finalize can't clobber each other.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?