### PR TITLE
chore(ci): parameterize flaky report runners

### DIFF
--- a/.github/scripts/weekly-flaky-report.mjs
+++ b/.github/scripts/weekly-flaky-report.mjs
@@ -35,7 +35,7 @@ const GITHUB_REF_NAME = process.env.GITHUB_REF_NAME || 'master'
 const TOP_N = 10
 const CANDIDATE_POOL = 40
 const CLUSTER_MIN_TESTS = 5
-const REPORT_RUNNER = 'pytest'
+const REPORT_RUNNERS = ['pytest']
 const PARKED_NAMES_SHOWN = 5
 
 // The endpoint's quarantine signal only covers `.test_quarantine.json`, where the pytest adapter
@@ -96,17 +96,17 @@ function endpointUrl(action, params = {}) {
 
 const AUTH_HEADERS = { Authorization: `Bearer ${API_KEY}` }
 
-function flakyTestsUrl() {
+function flakyTestsUrl(runner) {
     return endpointUrl('flaky_tests', {
         date_from: '-7d',
         limit: 100,
         repo: GITHUB_REPOSITORY,
-        runner: REPORT_RUNNER,
+        runner,
     })
 }
 
-function fetchFlakyTests() {
-    return withRetry(() => request(flakyTestsUrl(), { headers: AUTH_HEADERS }, 'flaky_tests'))
+function fetchFlakyTests(runner) {
+    return withRetry(() => request(flakyTestsUrl(runner), { headers: AUTH_HEADERS }, 'flaky_tests'))
 }
 
 // `values` bind through HogQL's {placeholder} syntax, escaped server-side — never
@@ -136,8 +136,17 @@ function isMasterBurst(item) {
     )
 }
 
-function selectReportCandidates(items) {
-    return items.filter((item) => item.runner === REPORT_RUNNER && !isMasterBurst(item)).slice(0, CANDIDATE_POOL)
+function selectReportCandidates(items, runner) {
+    return items.filter((item) => item.runner === runner && !isMasterBurst(item)).slice(0, CANDIDATE_POOL)
+}
+
+async function fetchCandidatePools(runners, fetchTests = fetchFlakyTests) {
+    return Promise.all(
+        runners.map(async (runner) => {
+            const result = await fetchTests(runner)
+            return { runner, candidates: selectReportCandidates(result.items || [], runner) }
+        })
+    )
 }
 
 // Product suites run from their product dir, so a selector path may be repo- or
@@ -288,7 +297,7 @@ const TRUNK_QUARANTINED_QUERY = `
 
 // Uploads off, a missing table, or a query error all degrade to a report without Trunk state,
 // never to a failed run or an empty table.
-async function fetchTrunkQuarantined(runHogql = hogql, enabled = TRUNK_UPLOADS_ON) {
+async function fetchTrunkQuarantined(runner, runHogql = hogql, enabled = TRUNK_UPLOADS_ON) {
     const none = () => null
     if (!enabled) {
         return none
@@ -296,7 +305,7 @@ async function fetchTrunkQuarantined(runHogql = hogql, enabled = TRUNK_UPLOADS_O
     let rows = []
     try {
         const result = await runHogql(TRUNK_QUARANTINED_QUERY.replace('__TRUNK_TABLE__', TRUNK_TABLE), {
-            runner: REPORT_RUNNER,
+            runner,
         })
         rows = result.results || []
     } catch (err) {
@@ -333,8 +342,8 @@ function partitionParked(items, trunkFor, masksCi = TRUNK_MASKS_CI) {
 // Parking has to happen before clustering: a cluster's selector is a bare file path, which can
 // never match a Trunk node id, so collapsing first buries quarantined tests in a row that then
 // ranks as if CI still failed on them.
-function buildQueue(items, trunkFor, masksCi = TRUNK_MASKS_CI) {
-    const { queue, parked } = partitionParked(selectReportCandidates(items), trunkFor, masksCi)
+function buildQueue(candidates, trunkFor, masksCi = TRUNK_MASKS_CI) {
+    const { queue, parked } = partitionParked(candidates, trunkFor, masksCi)
     return { queue: collapseClusters(queue), parked }
 }
 
@@ -498,9 +507,9 @@ async function main() {
         return
     }
     const now = new Date()
-    const result = await fetchFlakyTests()
-    const trunkFor = await fetchTrunkQuarantined()
-    const { queue, parked } = buildQueue(result.items || [], trunkFor)
+    const [{ runner, candidates }] = await fetchCandidatePools(REPORT_RUNNERS)
+    const trunkFor = await fetchTrunkQuarantined(runner)
+    const { queue, parked } = buildQueue(candidates, trunkFor)
     const extrasFor = await enrich(queue.filter((item) => !item.cluster_size))
     // Rescued runs first (the strongest per-test signal), clusters and the rest by volume.
     const flaky = queue
@@ -539,8 +548,10 @@ export {
     buildQueue,
     CLUSTER_MIN_TESTS,
     enrich,
+    fetchCandidatePools,
     fetchTrunkQuarantined,
     flakyTestsUrl,
+    REPORT_RUNNERS,
     selectReportCandidates,
     tableRows,
 }

--- a/.github/scripts/weekly-flaky-report.test.mjs
+++ b/.github/scripts/weekly-flaky-report.test.mjs
@@ -6,19 +6,24 @@ import {
     buildQueue,
     CLUSTER_MIN_TESTS,
     enrich,
+    fetchCandidatePools,
     fetchTrunkQuarantined,
     flakyTestsUrl,
+    REPORT_RUNNERS,
     selectReportCandidates,
     tableRows,
 } from './weekly-flaky-report.mjs'
 
 describe('weekly flaky report', () => {
-    it('requests pytest candidates for the current repository before the endpoint limit', () => {
-        const url = flakyTestsUrl()
+    it('builds runner-specific endpoint URLs before the endpoint limit', () => {
+        const pytestUrl = flakyTestsUrl('pytest')
+        const jestUrl = flakyTestsUrl('jest')
 
-        assert.equal(url.searchParams.get('runner'), 'pytest')
-        assert.equal(url.searchParams.get('repo'), 'PostHog/posthog')
-        assert.equal(url.searchParams.get('limit'), '100')
+        assert.deepEqual(REPORT_RUNNERS, ['pytest'])
+        assert.equal(pytestUrl.searchParams.get('runner'), 'pytest')
+        assert.equal(jestUrl.searchParams.get('runner'), 'jest')
+        assert.equal(jestUrl.searchParams.get('repo'), 'PostHog/posthog')
+        assert.equal(jestUrl.searchParams.get('limit'), '100')
     })
 
     it('builds a Slack table with supported cells and structured links', () => {
@@ -85,14 +90,14 @@ describe('weekly flaky report', () => {
         })
     })
 
-    it('keeps proved pytest flakes and excludes Jest and unproved master bursts', () => {
+    it('selects proved flakes for the requested runner', () => {
         const common = {
             failed_run_count: 4,
             failed_pr_count: 1,
             master_failed_run_count: 3,
             quarantined_failed_run_count: 0,
         }
-        const candidates = selectReportCandidates([
+        const items = [
             { ...common, runner: 'pytest', selector: 'test_proved.py::test_proved', classification: 'confirmed_flake' },
             {
                 ...common,
@@ -101,11 +106,37 @@ describe('weekly flaky report', () => {
                 classification: 'suspected_regression',
             },
             { ...common, runner: 'jest', selector: 'test_report.ts', classification: 'confirmed_flake' },
-        ])
+        ]
 
         assert.deepEqual(
-            candidates.map((candidate) => candidate.selector),
+            selectReportCandidates(items, 'pytest').map((candidate) => candidate.selector),
             ['test_proved.py::test_proved']
+        )
+        assert.deepEqual(
+            selectReportCandidates(items, 'jest').map((candidate) => candidate.selector),
+            ['test_report.ts']
+        )
+    })
+
+    it('fetches each runner into its own candidate pool', async () => {
+        const requestedRunners = []
+        const pools = await fetchCandidatePools(['pytest', 'jest'], async (runner) => {
+            requestedRunners.push(runner)
+            return {
+                items: [
+                    { runner, selector: `${runner}.test`, classification: 'confirmed_flake' },
+                    { runner: runner === 'pytest' ? 'jest' : 'pytest', selector: 'other.test' },
+                ],
+            }
+        })
+
+        assert.deepEqual(requestedRunners, ['pytest', 'jest'])
+        assert.deepEqual(
+            pools.map(({ runner, candidates }) => [runner, candidates.map((candidate) => candidate.selector)]),
+            [
+                ['pytest', ['pytest.test']],
+                ['jest', ['jest.test']],
+            ]
         )
     })
 
@@ -143,7 +174,7 @@ describe('weekly flaky report', () => {
         ]
 
         for (const { label, enabled, runHogql } of cases) {
-            const trunkFor = await fetchTrunkQuarantined(runHogql, enabled)
+            const trunkFor = await fetchTrunkQuarantined('pytest', runHogql, enabled)
 
             assert.equal(trunkFor(item), null, label)
         }
@@ -151,12 +182,12 @@ describe('weekly flaky report', () => {
 
     it('matches Trunk rows to a product suite reported product-relative', async () => {
         const trunkFor = await fetchTrunkQuarantined(
+            'pytest',
             async () => ({
                 results: [
                     [
                         'products/example/backend/tests/test_migration.py::MigrationTest::test_backfill',
                         '2026-07-29T09:14:22.000Z',
-                        'AUTO_QUARANTINE',
                     ],
                 ],
             }),


### PR DESCRIPTION
## Problem

- The weekly flaky report hardcoded pytest across request construction and candidate selection, blocking runner extensions.

## Changes

- Pass an explicit runner through URLs and candidate filtering.
- Keep the configured runner list pytest-only.
- Fetch each configured runner into an isolated candidate pool.

## How did you test this code?

- Node test: 10 passing cases guard server-side runner filtering, explicit selection, and isolated pools, run under both a bare shell and a CI-like environment.
- Rebased onto the merged Trunk work: `selectReportCandidates` no longer collapses clusters (parking has to run first), and the Trunk lookup takes the runner.
- Oxfmt check passed.
- `hogli ci:preflight --fix` completed without failures.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- No documentation change because observable behavior remains pytest-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Codex used `/wt`, `/writing-tests`, `/writing-code-comments`, `/hogli`, `/running-ci-preflight`, `/code-review`, and `/simplify`.
- The refactor is limited to seams required by the Jest follow-up.
