### PR TITLE
fix(code): isolate personal space context

### DIFF
--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -1088,10 +1088,10 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
 
     def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
         queryset = super().safely_get_queryset(queryset)
-        # `me` looks like a normal channel in the desktop file system, but it is
-        # the personal space. Keep each user's folder (and its CONTEXT.md)
-        # private even when project-level file-system access is otherwise shared.
-        return queryset.filter(~Q(type="folder", depth=1, path="me") | Q(created_by=self.request.user))
+        # Personal-space rows share the same path across users, so their creator
+        # is the ownership boundary even when project-level access is shared.
+        is_personal_space = Q(path="me") | Q(path__startswith="me/")
+        return queryset.filter(~is_personal_space | Q(created_by=self.request.user))
 
     def _allow_delete_without_ref(self, entry: FileSystem) -> bool:
         # Desktop canvases are `dashboard`-typed rows whose source lives in `meta`,

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -1086,8 +1086,8 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
 
     file_system_surface = "desktop"
 
-    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
-        queryset = super().safely_get_queryset(queryset)
+    def _scope_by_project(self, queryset: QuerySet) -> QuerySet:
+        queryset = super()._scope_by_project(queryset)
         # Personal-space rows share the same path across users, so their creator
         # is the ownership boundary even when project-level access is shared.
         is_personal_space = Q(path="me") | Q(path__startswith="me/")

--- a/posthog/api/file_system/file_system.py
+++ b/posthog/api/file_system/file_system.py
@@ -1086,6 +1086,13 @@ class DesktopFileSystemViewSet(FileSystemViewSet):
 
     file_system_surface = "desktop"
 
+    def safely_get_queryset(self, queryset: QuerySet) -> QuerySet:
+        queryset = super().safely_get_queryset(queryset)
+        # `me` looks like a normal channel in the desktop file system, but it is
+        # the personal space. Keep each user's folder (and its CONTEXT.md)
+        # private even when project-level file-system access is otherwise shared.
+        return queryset.filter(~Q(type="folder", depth=1, path="me") | Q(created_by=self.request.user))
+
     def _allow_delete_without_ref(self, entry: FileSystem) -> bool:
         # Desktop canvases are `dashboard`-typed rows whose source lives in `meta`,
         # not a backing Dashboard, so they legitimately have no ref. Delete the bare

--- a/posthog/api/file_system/test/test_folder_instructions.py
+++ b/posthog/api/file_system/test/test_folder_instructions.py
@@ -192,6 +192,8 @@ class TestDesktopFolderInstructionsAPI(APIBaseTest):
         self.assertNotIn(folder_id, [row["id"] for row in listing.json()["results"]])
         children = self.client.get(f"/api/projects/{self.team.id}/desktop_file_system/?parent=me")
         self.assertNotIn(str(child.id), [row["id"] for row in children.json()["results"]])
+        count = self.client.post(f"/api/projects/{self.team.id}/desktop_file_system/count_by_path?path=me")
+        self.assertNotIn(str(child.id), [row["id"] for row in count.json()["entries"]])
         self.assertEqual(
             self.client.get(f"/api/projects/{self.team.id}/desktop_file_system/{child.id}/").status_code,
             status.HTTP_404_NOT_FOUND,
@@ -204,6 +206,8 @@ class TestDesktopFolderInstructionsAPI(APIBaseTest):
 
         own_folder_id = self._create_desktop_folder("me")
         self.assertNotEqual(own_folder_id, folder_id)
+        self.client.delete(f"/api/projects/{self.team.id}/desktop_file_system/{own_folder_id}/")
+        self.assertTrue(FileSystem.objects.filter(id=child.id).exists())
 
     def test_personal_api_key_can_read_and_publish_instructions(self):
         folder_id = self._create_desktop_folder()

--- a/posthog/api/file_system/test/test_folder_instructions.py
+++ b/posthog/api/file_system/test/test_folder_instructions.py
@@ -6,7 +6,7 @@ from posthog.test.base import APIBaseTest
 from rest_framework import status
 
 from posthog.api.file_system.folder_instructions_service import FOLDER_INSTRUCTIONS_MAX_BYTES
-from posthog.models import Organization, Team
+from posthog.models import Organization, Team, User
 from posthog.models.file_system.file_system import FileSystem
 from posthog.models.file_system.folder_instructions import FileSystemFolderInstructions
 
@@ -175,7 +175,7 @@ class TestDesktopFolderInstructionsAPI(APIBaseTest):
         folder_id = self._create_desktop_folder("me")
         self.client.patch(self._instructions_url(folder_id), {"content": "private"})
 
-        other_user = self.create_organization_user("other")
+        other_user = User.objects.create_and_join(self.organization, "other@posthog.com", "testpass")
         other_user.is_staff = True
         other_user.save()
         self.client.force_login(other_user)

--- a/posthog/api/file_system/test/test_folder_instructions.py
+++ b/posthog/api/file_system/test/test_folder_instructions.py
@@ -171,6 +171,26 @@ class TestDesktopFolderInstructionsAPI(APIBaseTest):
         response = self.client.patch(self._instructions_url(str(other_folder.id)), {"content": "leak"})
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.json())
 
+    def test_me_folder_and_instructions_are_private_to_the_creator(self):
+        folder_id = self._create_desktop_folder("me")
+        self.client.patch(self._instructions_url(folder_id), {"content": "private"})
+
+        other_user = self.create_organization_user("other")
+        other_user.is_staff = True
+        other_user.save()
+        self.client.force_login(other_user)
+
+        listing = self.client.get(f"/api/projects/{self.team.id}/desktop_file_system/?type=folder")
+        self.assertNotIn(folder_id, [row["id"] for row in listing.json()["results"]])
+        self.assertEqual(self.client.get(self._instructions_url(folder_id)).status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(
+            self.client.patch(self._instructions_url(folder_id), {"content": "leak"}).status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
+
+        own_folder_id = self._create_desktop_folder("me")
+        self.assertNotEqual(own_folder_id, folder_id)
+
     def test_personal_api_key_can_read_and_publish_instructions(self):
         folder_id = self._create_desktop_folder()
         key = self.create_personal_api_key_with_scopes(["file_system:write"])

--- a/posthog/api/file_system/test/test_folder_instructions.py
+++ b/posthog/api/file_system/test/test_folder_instructions.py
@@ -174,6 +174,14 @@ class TestDesktopFolderInstructionsAPI(APIBaseTest):
     def test_me_folder_and_instructions_are_private_to_the_creator(self):
         folder_id = self._create_desktop_folder("me")
         self.client.patch(self._instructions_url(folder_id), {"content": "private"})
+        child = FileSystem.objects.create(
+            team=self.team,
+            path="me/private-canvas",
+            depth=2,
+            type="dashboard",
+            surface="desktop",
+            created_by=self.user,
+        )
 
         other_user = User.objects.create_and_join(self.organization, "other@posthog.com", "testpass")
         other_user.is_staff = True
@@ -182,6 +190,12 @@ class TestDesktopFolderInstructionsAPI(APIBaseTest):
 
         listing = self.client.get(f"/api/projects/{self.team.id}/desktop_file_system/?type=folder")
         self.assertNotIn(folder_id, [row["id"] for row in listing.json()["results"]])
+        children = self.client.get(f"/api/projects/{self.team.id}/desktop_file_system/?parent=me")
+        self.assertNotIn(str(child.id), [row["id"] for row in children.json()["results"]])
+        self.assertEqual(
+            self.client.get(f"/api/projects/{self.team.id}/desktop_file_system/{child.id}/").status_code,
+            status.HTTP_404_NOT_FOUND,
+        )
         self.assertEqual(self.client.get(self._instructions_url(folder_id)).status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(
             self.client.patch(self._instructions_url(folder_id), {"content": "leak"}).status_code,


### PR DESCRIPTION
## Problem

The desktop `me` space used the same project-scoped folder for every user, so its saved context could be read or changed by teammates. Personal spaces need a user-level ownership boundary.

## Changes

- Scope top-level desktop `me` folders to their creator.
- Cover listing, direct context reads and writes, and per-user folder provisioning.

## How did you test this code?

- `uv run ruff check posthog/api/file_system/file_system.py posthog/api/file_system/test/test_folder_instructions.py`
- `uv run ruff format --check posthog/api/file_system/file_system.py posthog/api/file_system/test/test_folder_instructions.py`
- Added an API regression test for cross-user folder and context access. The focused test could not start locally because the checkout has no PostgreSQL service (`db` is unresolved).

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation change. This restores the existing personal-space contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex traced the client and backend storage paths, then chose backend queryset scoping so existing client provisioning creates one folder per user without extra state. Invoked `/improving-drf-endpoints`, `/writing-tests`, and `/writing-code-comments`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*