### PR TITLE
feat(provisioning): move partner capabilities into a provisioning_config column

### DIFF
--- a/ee/api/agentic_provisioning/accounts.py
+++ b/ee/api/agentic_provisioning/accounts.py
@@ -39,9 +39,7 @@ from ee.api.agentic_provisioning.wizard import (
 def partner_label(partner: OAuthApplication | None) -> str:
     """How a partner is named to a user, in the org it provisions and on the consent screen.
 
-    The app's own name, which is what the user already saw when they authorized it. There used
-    to be a separate admin-set label that took precedence; a second name for the same partner
-    only ever meant the two could disagree.
+    The app's own name, which is what the user already saw when they authorized it.
     """
     if partner is None or not partner.name:
         return "Partner"
@@ -337,6 +335,17 @@ def process_wizard_block(*, partner: OAuthApplication, user: User, team: Team, w
     {"error": {code, message}} for the partner to branch on and retry granularly.
     """
     try:
+        # create_wizard_run refuses an ungranted partner anyway, but checking before the grant
+        # is linked keeps a refused request from consuming a single-use grant the partner
+        # would then have to mint again.
+        if not partner.provisioning.can_start_wizard_runs:
+            return {
+                "error": {
+                    "code": "forbidden",
+                    "message": "Starting wizard runs is not enabled for this partner",
+                }
+            }
+
         grant_id = wizard_config.get("grant_id")
         installation_id = wizard_config.get("installation_id")
         repository = wizard_config.get("repository")

--- a/ee/api/agentic_provisioning/accounts.py
+++ b/ee/api/agentic_provisioning/accounts.py
@@ -37,13 +37,15 @@ from ee.api.agentic_provisioning.wizard import (
 
 
 def partner_label(partner: OAuthApplication | None) -> str:
-    if partner is None:
+    """How a partner is named to a user, in the org it provisions and on the consent screen.
+
+    The app's own name, which is what the user already saw when they authorized it. There used
+    to be a separate admin-set label that took precedence; a second name for the same partner
+    only ever meant the two could disagree.
+    """
+    if partner is None or not partner.name:
         return "Partner"
-    if partner.provisioning_partner_type:
-        return partner.provisioning_partner_type.capitalize()
-    if partner.name:
-        return partner.name
-    return "Partner"
+    return partner.name
 
 
 def get_callback_url(app: OAuthApplication | None) -> str | None:
@@ -135,7 +137,7 @@ def handle_existing_user(
     Consent also picks the project (see agentic_authorize), so nothing the partner sends can
     select a team for an account it did not create.
     """
-    if partner.provisioning_skip_existing_user_consent:
+    if partner.provisioning.skip_existing_user_consent:
         capture_provisioning_event(
             "account_request",
             "silent_blocked_existing_user",

--- a/ee/api/agentic_provisioning/analytics.py
+++ b/ee/api/agentic_provisioning/analytics.py
@@ -26,8 +26,6 @@ def capture_provisioning_event(
     if partner is not None:
         properties.setdefault("partner_id", str(partner.id))
         properties.setdefault("client_name", partner.name)
-        if partner.provisioning_partner_type:
-            properties.setdefault("partner_type", partner.provisioning_partner_type)
     posthoganalytics.capture(
         f"agentic_provisioning {event_type}",
         distinct_id=distinct_id,
@@ -45,7 +43,7 @@ def capture_auth_event(app: OAuthApplication, outcome: str, **extra: object) -> 
         distinct_id=_anonymous_distinct_id(),
         properties={
             "outcome": outcome,
-            "partner_type": app.provisioning_partner_type,
+            "client_name": app.name,
             "client_type": app.client_type,
             "app_id": str(app.id),
             **extra,

--- a/ee/api/agentic_provisioning/authentication.py
+++ b/ee/api/agentic_provisioning/authentication.py
@@ -71,8 +71,7 @@ class ProvisioningAuthentication(BaseAuthentication):
 
     Partners are OAuthApplications with ``is_provisioning_partner`` set. The OAuthApplication
     handles standard OAuth (tokens, scopes, consent) and also stores provisioning config:
-    feature flags (provisioning_can_create_accounts, provisioning_can_provision_resources)
-    and rate limits.
+    capabilities and rate limits (see OAuthApplication.provisioning).
 
     How a partner proves itself follows from its registered ``token_endpoint_auth_method``
     (RFC 7591), not from what a given request happens to carry: ``private_key_jwt`` partners
@@ -164,7 +163,7 @@ class ProvisioningAuthentication(BaseAuthentication):
         except OAuthApplication.DoesNotExist:
             return None
 
-        if not app.is_provisioning_partner or not app.provisioning_active:
+        if not app.is_provisioning_partner or not app.provisioning.active:
             return None
 
         if app.is_cimd_client:
@@ -219,9 +218,9 @@ class ProvisioningBearerAuthentication(BaseAuthentication):
         if app is None or not app.is_provisioning_partner:
             raise ProvisioningError("unauthorized", "Authentication failed", status=401)
 
-        if not app.provisioning_active:
+        if not app.provisioning.active:
             raise ProvisioningError("unauthorized", "Partner is deactivated", status=401)
-        if not app.provisioning_can_provision_resources:
+        if not app.provisioning.can_provision_resources:
             raise ProvisioningError("forbidden", "Resource provisioning not enabled for this partner", status=403)
 
         return access_token.user, access_token
@@ -230,9 +229,9 @@ class ProvisioningBearerAuthentication(BaseAuthentication):
         return "Bearer"
 
 
-def authenticate_confidential_partner(request: Request) -> OAuthApplication:
-    """Identify a provisioning partner, requiring proof-bearing auth and an admin-registered
-    partner identity.
+def authenticate_confidential_partner(request: Request, *, capability: str) -> OAuthApplication:
+    """Identify a provisioning partner, requiring proof-bearing auth and an explicitly granted
+    capability.
 
     Only confidential partners carry proof that the caller controls the partner. Public
     partners are identified solely by a ``client_id`` anyone can send, so they never qualify
@@ -242,13 +241,8 @@ def authenticate_confidential_partner(request: Request) -> OAuthApplication:
     Authenticating is necessary but not sufficient. A CIMD client self-registers by publishing
     a metadata document, and one that declares ``private_key_jwt`` becomes a confidential
     client whose assertions it can sign with its own published key, so it would clear a
-    confidential-only gate without any PostHog involvement.
-
-    CIMD auto-registration is the only path that sets ``is_provisioning_partner`` without an
-    admin, so it is the only one that needs a second signal, and the signal is an admin-set
-    ``provisioning_partner_type``. Deliberately not required of non-CIMD partners: those exist
-    only because someone created them in the admin, and demanding a partner type of them would
-    lock out an already-configured partner whose type field was simply left blank.
+    confidential-only gate without any PostHog involvement. ``capability`` names the
+    ``provisioning`` flag an admin has to grant on top, which self-registration never sets.
 
     Raises :class:`ProvisioningError` when no qualifying partner is identified.
     """
@@ -264,8 +258,8 @@ def authenticate_confidential_partner(request: Request) -> OAuthApplication:
         raise ProvisioningError("unauthorized", CLIENT_NOT_REGISTERED_MESSAGE, status=401)
     if not partner.requires_client_authentication:
         raise ProvisioningError("forbidden", "This endpoint requires a confidential partner", status=403)
-    if partner.is_cimd_client and not partner.provisioning_partner_type:
-        raise ProvisioningError("forbidden", "This endpoint requires a registered provisioning partner", status=403)
+    if not getattr(partner.provisioning, capability):
+        raise ProvisioningError("forbidden", "This endpoint is not enabled for this partner", status=403)
     return partner
 
 
@@ -273,10 +267,19 @@ class ConfidentialPartnerAuthentication(BaseAuthentication):
     """DRF form of :func:`authenticate_confidential_partner`, so confidential
     endpoints declare it in ``authentication_classes`` and can't ship without
     it. The partner rides ``request.auth``; these endpoints act for the partner,
-    not an end user, so the user stays anonymous."""
+    not an end user, so the user stays anonymous.
+
+    Subclassed per capability rather than parameterized, because DRF instantiates
+    authentication classes with no arguments."""
+
+    capability: str
 
     def authenticate(self, request: Request) -> tuple[AnonymousUser, OAuthApplication]:
-        return AnonymousUser(), authenticate_confidential_partner(request)
+        return AnonymousUser(), authenticate_confidential_partner(request, capability=self.capability)
 
     def authenticate_header(self, request: Request) -> str:
         return "Basic"
+
+
+class GitHubGrantsAuthentication(ConfidentialPartnerAuthentication):
+    capability = "can_use_github_grants"

--- a/ee/api/agentic_provisioning/credentials.py
+++ b/ee/api/agentic_provisioning/credentials.py
@@ -59,7 +59,7 @@ def maybe_create_provisioned_pat(
 ) -> str | None:
     """Create a Personal API Key for a provisioned user and return the raw key value.
 
-    Gated by ``app.provisioning_issues_personal_api_key``: off by default, so most
+    Gated by ``app.provisioning.issues_personal_api_key``: off by default, so most
     apps never receive a provisioned PAT (the OAuth token is the credential).
     Returns ``None`` when the gate is off, and the caller omits ``personal_api_key``
     from the response entirely.
@@ -80,7 +80,7 @@ def maybe_create_provisioned_pat(
     ``label_prefix`` should be pre-validated by ``validate_label_prefix``; pass
     ``None`` (or any falsy value) to label the key with just the team name.
     """
-    if not app or not app.provisioning_issues_personal_api_key:
+    if not app or not app.provisioning.issues_personal_api_key:
         return None
     if not app.ceiling_scopes:
         capture_provisioning_event("pat_mint", "skipped_unseeded_ceiling", partner=app, team_id=team.id)

--- a/ee/api/agentic_provisioning/test/base.py
+++ b/ee/api/agentic_provisioning/test/base.py
@@ -35,6 +35,28 @@ TEST_PARTNER_SCOPES = [
 ]
 
 
+# A partner granted everything, so a test narrows to the one capability it is about rather
+# than restating the other eight. `provisioning_config(can_start_wizard_runs=False)` reads as
+# the thing under test; a literal dict at each call site does not.
+TEST_PARTNER_PROVISIONING: dict[str, bool] = {
+    "active": True,
+    "can_create_accounts": True,
+    "can_provision_resources": True,
+    "can_use_github_grants": True,
+    "can_start_wizard_runs": True,
+    "can_issue_deep_links": True,
+    # Stands in for the one grandfathered app that still mints a provisioned PAT.
+    "issues_personal_api_key": True,
+}
+
+
+def provisioning_config(**overrides) -> dict:
+    """The stored form of the test partner's config. Goes into ``_provisioning_config``."""
+    from posthog.models.oauth_provisioning import ProvisioningConfig
+
+    return ProvisioningConfig(**{**TEST_PARTNER_PROVISIONING, **overrides}).model_dump(mode="json")
+
+
 class ProvisioningTestBase(APIBaseTest):
     def setUp(self):
         super().setUp()
@@ -55,13 +77,7 @@ class ProvisioningTestBase(APIBaseTest):
                 "algorithm": "RS256",
                 "scopes": TEST_PARTNER_SCOPES,
                 "is_provisioning_partner": True,
-                "provisioning_partner_type": "test_partner",
-                "provisioning_active": True,
-                "provisioning_can_create_accounts": True,
-                "provisioning_can_provision_resources": True,
-                "provisioning_can_issue_deep_links": True,
-                # Stands in for the one grandfathered app that still mints a provisioned PAT.
-                "provisioning_issues_personal_api_key": True,
+                "_provisioning_config": provisioning_config(),
             },
         )
         return app

--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -16,7 +16,7 @@ from posthog.models.user import User
 
 from ee.api.agentic_provisioning.analytics import capture_provisioning_event
 from ee.api.agentic_provisioning.constants import AUTH_CODE_CACHE_PREFIX, PENDING_AUTH_CACHE_PREFIX
-from ee.api.agentic_provisioning.test.base import ProvisioningTestBase
+from ee.api.agentic_provisioning.test.base import ProvisioningTestBase, provisioning_config
 
 ACCOUNT_REQUESTS_URL = "/api/agentic/provisioning/account_requests"
 VALID_CODE_CHALLENGE = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
@@ -79,8 +79,7 @@ class TestAccountRequests(ProvisioningTestBase):
     def test_existing_user_requires_consent_even_for_skip_consent_partner(self):
         # No partner may silently link a pre-existing account. A verified client secret proves
         # the partner controls itself, never that it controls this email.
-        self.partner.provisioning_skip_existing_user_consent = True
-        self.partner.save(update_fields=["provisioning_skip_existing_user_consent"])
+        self.partner.update_provisioning(skip_existing_user_consent=True)
 
         payload = self._account_request_payload(email=self.user.email, code_challenge=VALID_CODE_CHALLENGE)
         res = self._post_account_request(payload)
@@ -191,10 +190,9 @@ class TestPKCEPartnerExistingUserConsent(ProvisioningTestBase):
             algorithm="RS256",
             is_first_party=True,
             is_provisioning_partner=True,
-            provisioning_partner_type="test_partner",
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
-            provisioning_can_provision_resources=True,
+            _provisioning_config=provisioning_config(
+                active=True, can_create_accounts=True, can_provision_resources=True
+            ),
         )
 
     def _post_as_pkce_partner(self, data: dict):
@@ -300,7 +298,7 @@ class TestPKCEPartnerExistingUserConsent(ProvisioningTestBase):
         # A public PKCE caller is identified only by a client_id anyone can send, so even with
         # skip_existing_user_consent it must not silently mint for an existing account — it has
         # no proof it controls the partner or the account.
-        self.pkce_partner.provisioning_skip_existing_user_consent = True
+        self.pkce_partner.update_provisioning(skip_existing_user_consent=True)
         self.pkce_partner.save()
         User.objects.create_and_join(
             organization=self.organization, email="existing@example.com", password="testpass", first_name="Existing"
@@ -348,7 +346,6 @@ class TestCaptureProvisioningEvent(ProvisioningTestBase):
             authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
             redirect_uris="https://partner.example.com/callback",
             algorithm="RS256",
-            provisioning_partner_type=partner_type,
         )
 
     @parameterized.expand(

--- a/ee/api/agentic_provisioning/test/test_account_requests.py
+++ b/ee/api/agentic_provisioning/test/test_account_requests.py
@@ -107,7 +107,7 @@ class TestAccountRequests(ProvisioningTestBase):
     @parameterized.expand(
         [
             ("with_name", {"region": "US", "organization_name": "Acme Corp"}, "Acme Corp"),
-            ("without_name", {"region": "US"}, "Test_partner (orgname@example.com)"),
+            ("without_name", {"region": "US"}, "Test Provisioning Partner (orgname@example.com)"),
         ]
     )
     def test_new_user_organization_name(self, _name, config, expected_org_name):
@@ -337,9 +337,9 @@ class TestPKCEPartnerExistingUserConsent(ProvisioningTestBase):
 
 
 class TestCaptureProvisioningEvent(ProvisioningTestBase):
-    def _make_partner(self, partner_type: str = "test_partner") -> OAuthApplication:
+    def _make_partner(self) -> OAuthApplication:
         return OAuthApplication.objects.create(
-            client_id=f"attribution-test-{partner_type or 'untyped'}",
+            client_id="attribution-test",
             name="Attribution Test Client",
             client_secret="",
             client_type=OAuthApplication.CLIENT_PUBLIC,
@@ -348,16 +348,10 @@ class TestCaptureProvisioningEvent(ProvisioningTestBase):
             algorithm="RS256",
         )
 
-    @parameterized.expand(
-        [
-            ("typed_partner", "test_partner", True, "test_partner"),
-            ("untyped_partner", "", True, None),
-            ("no_partner", None, False, None),
-        ]
-    )
+    @parameterized.expand([("with_partner", True), ("no_partner", False)])
     @patch("ee.api.agentic_provisioning.analytics.posthoganalytics.capture")
-    def test_partner_attribution(self, _name, partner_type, expects_client, expected_partner_type, mock_capture):
-        partner = None if partner_type is None else self._make_partner(partner_type=partner_type)
+    def test_partner_attribution(self, _name, expects_client, mock_capture):
+        partner = self._make_partner() if expects_client else None
         capture_provisioning_event("account_request", "new_user", partner=partner, team_id=42)
 
         props = mock_capture.call_args.kwargs["properties"]
@@ -368,7 +362,3 @@ class TestCaptureProvisioningEvent(ProvisioningTestBase):
         else:
             assert "client_name" not in props
             assert "partner_id" not in props
-        if expected_partner_type is None:
-            assert "partner_type" not in props
-        else:
-            assert props["partner_type"] == expected_partner_type

--- a/ee/api/agentic_provisioning/test/test_authorize.py
+++ b/ee/api/agentic_provisioning/test/test_authorize.py
@@ -11,7 +11,12 @@ from posthog.models.oauth import OAuthApplication
 from posthog.models.user import User
 
 from ee.api.agentic_provisioning.constants import AUTH_CODE_CACHE_PREFIX, PENDING_AUTH_CACHE_PREFIX
-from ee.api.agentic_provisioning.test.base import TEST_PARTNER_CLIENT_SECRET, TEST_PARTNER_SCOPES, ProvisioningTestBase
+from ee.api.agentic_provisioning.test.base import (
+    TEST_PARTNER_CLIENT_SECRET,
+    TEST_PARTNER_SCOPES,
+    ProvisioningTestBase,
+    provisioning_config,
+)
 
 PARTNER_CALLBACK = "https://partner.example.com/callback"
 
@@ -45,9 +50,7 @@ class AuthorizeTestBase(ProvisioningTestBase):
             is_first_party=True,
             scopes=TEST_PARTNER_SCOPES,
             is_provisioning_partner=True,
-            provisioning_partner_type="test_partner",
-            provisioning_active=True,
-            provisioning_skip_existing_user_consent=True,
+            _provisioning_config=provisioning_config(active=True, skip_existing_user_consent=True),
         )
 
 
@@ -235,8 +238,7 @@ class TestAgenticAuthorizeConfirm(AgenticAuthorizeMultiOrgBase):
             redirect_uris=PARTNER_CALLBACK,
             algorithm="RS256",
             is_provisioning_partner=True,
-            provisioning_partner_type="test_partner",
-            provisioning_active=True,
+            _provisioning_config=provisioning_config(active=True),
         )
         self._set_pending_auth("state_attr", self.user.email, partner=partner)
         res = self._confirm("state_attr", self.team.id)

--- a/ee/api/agentic_provisioning/test/test_client_registration.py
+++ b/ee/api/agentic_provisioning/test/test_client_registration.py
@@ -94,7 +94,14 @@ class TestClientRegistration(ProvisioningTestBase):
             "algorithm": "RS256",
             "scopes": TEST_PARTNER_SCOPES,
             "is_provisioning_partner": True,
-            "_provisioning_config": provisioning_config(active=True, can_create_accounts=True),
+            # The default here is a client that registered itself: it does ordinary
+            # provisioning, and holds none of the capabilities an admin has to grant.
+            "_provisioning_config": provisioning_config(
+                active=True,
+                can_create_accounts=True,
+                can_use_github_grants=False,
+                can_start_wizard_runs=False,
+            ),
         }
         return OAuthApplication.objects.create(**{**defaults, **overrides})
 

--- a/ee/api/agentic_provisioning/test/test_client_registration.py
+++ b/ee/api/agentic_provisioning/test/test_client_registration.py
@@ -15,7 +15,7 @@ from posthog.api.oauth.cimd import CIMDFetchError
 from posthog.api.oauth.client_assertion import CLIENT_ASSERTION_TYPE_JWT_BEARER, ClientAssertionError
 from posthog.models.oauth import OAuthApplication
 
-from ee.api.agentic_provisioning.test.base import TEST_PARTNER_SCOPES, ProvisioningTestBase
+from ee.api.agentic_provisioning.test.base import TEST_PARTNER_SCOPES, ProvisioningTestBase, provisioning_config
 
 REGISTRATION_URL = "/api/agentic/provisioning/client_registration"
 ACCOUNT_REQUESTS_URL = "/api/agentic/provisioning/account_requests"
@@ -94,8 +94,7 @@ class TestClientRegistration(ProvisioningTestBase):
             "algorithm": "RS256",
             "scopes": TEST_PARTNER_SCOPES,
             "is_provisioning_partner": True,
-            "provisioning_active": True,
-            "provisioning_can_create_accounts": True,
+            "_provisioning_config": provisioning_config(active=True, can_create_accounts=True),
         }
         return OAuthApplication.objects.create(**{**defaults, **overrides})
 
@@ -143,7 +142,7 @@ class TestClientRegistration(ProvisioningTestBase):
         assert KID in checks["jwks"]["detail"]
 
     def test_partner_registered_by_an_admin_can_use_github_grants(self):
-        self._make_partner(provisioning_partner_type="wizard")
+        self._make_partner(_provisioning_config=provisioning_config(can_use_github_grants=True))
 
         res = self._register({"client_id": CIMD_URL})
 
@@ -167,27 +166,27 @@ class TestClientRegistration(ProvisioningTestBase):
         # A CIMD app registered through the ordinary OAuth flow carries no provisioning
         # config. Opting it in used to happen implicitly on the auth path; it is now this
         # endpoint's job, and without it such a client could never reach any endpoint here.
-        self._make_partner(is_provisioning_partner=False, provisioning_active=False)
+        self._make_partner(is_provisioning_partner=False, _provisioning_config=provisioning_config(active=False))
 
         res = self._register({"client_id": CIMD_URL})
 
         assert res.status_code == 200, res.json()
         app = OAuthApplication.objects.get(cimd_metadata_url=CIMD_URL)
         assert app.is_provisioning_partner
-        assert app.provisioning_active
+        assert app.provisioning.active
 
     def test_deactivated_partner_is_not_reactivated_by_re_registering(self):
         # Only a client that is not yet a partner gets the defaults applied. Registering again
         # must not undo an admin turning a partner off, which would make the endpoint a way for
         # a partner to reinstate itself.
-        self._make_partner(provisioning_active=False)
+        self._make_partner(_provisioning_config=provisioning_config(active=False))
 
         res = self._register({"client_id": CIMD_URL})
 
         assert res.status_code == 400, res.json()
         assert res.json()["error"]["code"] == "registration_failed"
         app = OAuthApplication.objects.get(cimd_metadata_url=CIMD_URL)
-        assert app.provisioning_active is False
+        assert app.provisioning.active is False
 
     def test_unreachable_jwks_is_reported_as_a_failed_check(self):
         self._make_partner()

--- a/ee/api/agentic_provisioning/test/test_deep_links.py
+++ b/ee/api/agentic_provisioning/test/test_deep_links.py
@@ -57,8 +57,7 @@ class TestDeepLinks(ProvisioningTestBase):
 
     def test_deep_link_denied_when_partner_not_allowed(self):
         token = self._get_bearer_token()
-        self.partner.provisioning_can_issue_deep_links = False
-        self.partner.save(update_fields=["provisioning_can_issue_deep_links"])
+        self.partner.update_provisioning(can_issue_deep_links=False)
         res = self._post_with_bearer(
             "/api/agentic/provisioning/deep_links",
             data={"purpose": "dashboard"},

--- a/ee/api/agentic_provisioning/test/test_e2e_flow.py
+++ b/ee/api/agentic_provisioning/test/test_e2e_flow.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from posthog.models.oauth import OAuthApplication
 from posthog.models.user import User
 
-from ee.api.agentic_provisioning.test.base import ProvisioningTestBase
+from ee.api.agentic_provisioning.test.base import ProvisioningTestBase, provisioning_config
 
 TOKEN_URL = "/api/agentic/oauth/token"
 
@@ -132,10 +132,9 @@ class TestE2EProvisioningFlow(ProvisioningTestBase):
             is_first_party=True,
             scopes=["query:read"],
             is_provisioning_partner=True,
-            provisioning_partner_type="test_partner",
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
-            provisioning_can_provision_resources=True,
+            _provisioning_config=provisioning_config(
+                active=True, can_create_accounts=True, can_provision_resources=True
+            ),
         )
 
         existing_user = User.objects.create_and_join(

--- a/ee/api/agentic_provisioning/test/test_github_grants.py
+++ b/ee/api/agentic_provisioning/test/test_github_grants.py
@@ -10,7 +10,7 @@ from posthog.models.oauth import OAuthApplication
 
 from ee.api.agentic_provisioning import github_grants
 from ee.api.agentic_provisioning.constants import GITHUB_GRANT_CACHE_PREFIX
-from ee.api.agentic_provisioning.test.base import TEST_PARTNER_CLIENT_SECRET, ProvisioningTestBase
+from ee.api.agentic_provisioning.test.base import TEST_PARTNER_CLIENT_SECRET, ProvisioningTestBase, provisioning_config
 
 ACCESS_TOKEN = "gho_secret_user_token"
 
@@ -149,8 +149,7 @@ class TestGitHubGrants(ProvisioningTestBase):
             redirect_uris="https://pkce.example.com",
             algorithm="RS256",
             is_provisioning_partner=True,
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
+            _provisioning_config=provisioning_config(active=True, can_create_accounts=True),
         )
         response = self.client.post(
             "/api/agentic/provisioning/github/grants",
@@ -199,14 +198,14 @@ class TestGitHubGrants(ProvisioningTestBase):
         assert response.status_code == 401
 
     def test_create_grant_requires_account_creation_permission(self):
-        self.partner.provisioning_can_create_accounts = False
+        self.partner.update_provisioning(can_create_accounts=False)
         self.partner.save()
         response = self._post_grants({"code": "gh_code"})
         assert response.status_code == 403
         assert response.json()["error"]["code"] == "forbidden"
 
     def test_create_grant_partner_rate_limited(self):
-        self.partner.provisioning_rate_limit_github_grants = 1
+        self.partner.update_provisioning_rate_limits(github_grants=1)
         self.partner.save()
         first = self._create_grant_via_api()
         assert first.status_code == 200
@@ -215,8 +214,8 @@ class TestGitHubGrants(ProvisioningTestBase):
         assert second["Retry-After"]
 
     def test_capability_refusal_does_not_spend_grant_budget(self):
-        self.partner.provisioning_rate_limit_github_grants = 1
-        self.partner.provisioning_can_create_accounts = False
+        self.partner.update_provisioning(can_create_accounts=False)
+        self.partner.update_provisioning_rate_limits(github_grants=1)
         self.partner.save()
 
         for _ in range(3):
@@ -224,7 +223,7 @@ class TestGitHubGrants(ProvisioningTestBase):
             assert refused.status_code == 403
             assert refused.json()["error"]["code"] == "forbidden"
 
-        self.partner.provisioning_can_create_accounts = True
+        self.partner.update_provisioning(can_create_accounts=True)
         self.partner.save()
         assert self._create_grant_via_api().status_code == 200
 
@@ -259,7 +258,7 @@ class TestGitHubGrants(ProvisioningTestBase):
         assert response.json()["error"]["code"] == "grant_not_found"
 
     def _create_other_partner(
-        self, *, partner_type: str = "other_test_partner", is_cimd_client: bool = False
+        self, *, can_use_github_grants: bool = True, is_cimd_client: bool = False
     ) -> OAuthApplication:
         return OAuthApplication.objects.create(
             name="Other Partner",
@@ -271,9 +270,9 @@ class TestGitHubGrants(ProvisioningTestBase):
             redirect_uris="https://other.example.com",
             algorithm="RS256",
             is_provisioning_partner=True,
-            provisioning_partner_type=partner_type,
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
+            _provisioning_config=provisioning_config(
+                active=True, can_create_accounts=True, can_use_github_grants=can_use_github_grants
+            ),
         )
 
     def test_repositories_grant_of_other_partner_returns_404(self):
@@ -322,12 +321,12 @@ class TestGitHubGrants(ProvisioningTestBase):
         assert foreign.status_code == 404
         assert owner.status_code == 200
 
-    def test_repositories_rejects_a_self_registered_cimd_partner(self):
+    def test_repositories_rejects_a_partner_without_the_capability(self):
         # A CIMD client self-registers by publishing a metadata document and becomes confidential
-        # by declaring private_key_jwt, so authenticating cannot be the only gate here. An
-        # admin-set provisioning_partner_type is what separates one PostHog vouched for.
+        # by declaring private_key_jwt, so authenticating cannot be the only gate here. The
+        # capability is granted by an admin, and self-registration never grants it.
         grant = github_grants.create_grant(self.partner, AUTHORIZATION, "octocat@example.com")
-        unvouched = self._create_other_partner(partner_type="", is_cimd_client=True)
+        unvouched = self._create_other_partner(can_use_github_grants=False, is_cimd_client=True)
         response = self._get_api(
             f"/api/agentic/provisioning/github/grants/{grant.grant_id}/repositories",
             HTTP_AUTHORIZATION=self._basic_auth_header(unvouched),
@@ -335,12 +334,11 @@ class TestGitHubGrants(ProvisioningTestBase):
         assert response.status_code == 403
         assert response.json()["error"]["code"] == "forbidden"
 
-    def test_repositories_allows_a_non_cimd_partner_with_no_partner_type(self):
-        # Only CIMD auto-registration can make a partner without an admin, so a non-CIMD app is
-        # vouched for by the fact that it exists. Requiring a partner type of it too would lock
-        # out an already-configured partner whose type field was left blank.
+    def test_repositories_allows_a_partner_granted_the_capability(self):
+        # The other half of the gate: the capability is what admits a partner, whether or not it
+        # is a CIMD client.
         grant = github_grants.create_grant(self.partner, AUTHORIZATION, "octocat@example.com")
-        admin_registered = self._create_other_partner(partner_type="")
+        admin_registered = self._create_other_partner(can_use_github_grants=True)
 
         def fake_github_request(method, request_url, **kwargs):
             if request_url.endswith("/user/installations"):

--- a/ee/api/agentic_provisioning/test/test_oauth_token.py
+++ b/ee/api/agentic_provisioning/test/test_oauth_token.py
@@ -12,7 +12,7 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
 
 from ee.api.agentic_provisioning.constants import AUTH_CODE_CACHE_PREFIX
-from ee.api.agentic_provisioning.test.base import TEST_PARTNER_SCOPES, ProvisioningTestBase
+from ee.api.agentic_provisioning.test.base import TEST_PARTNER_SCOPES, ProvisioningTestBase, provisioning_config
 from ee.models.rbac.access_control import AccessControl
 
 TOKEN_URL = "/api/agentic/oauth/token"
@@ -181,8 +181,7 @@ class TestOAuthTokenExchange(ProvisioningTestBase):
             algorithm="RS256",
             scopes=TEST_PARTNER_SCOPES,
             is_provisioning_partner=True,
-            provisioning_partner_type="test_partner",
-            provisioning_active=True,
+            _provisioning_config=provisioning_config(active=True),
         )
         code, verifier = self._mint_auth_code(partner=pkce_partner)
 

--- a/ee/api/agentic_provisioning/test/test_partner_rate_limits.py
+++ b/ee/api/agentic_provisioning/test/test_partner_rate_limits.py
@@ -8,10 +8,11 @@ from parameterized import parameterized
 from rest_framework.test import APIClient
 
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication, OAuthRefreshToken
+from posthog.models.oauth_provisioning import ProvisioningRateLimits
 
 from ee.api.agentic_provisioning.constants import AUTH_CODE_CACHE_PREFIX, PARTNER_RATE_LIMIT_DEFAULTS
 from ee.api.agentic_provisioning.exceptions import ProvisioningError
-from ee.api.agentic_provisioning.test.base import TEST_PARTNER_CLIENT_SECRET, ProvisioningTestBase
+from ee.api.agentic_provisioning.test.base import TEST_PARTNER_CLIENT_SECRET, ProvisioningTestBase, provisioning_config
 from ee.api.agentic_provisioning.throttling import enforce_partner_rate_limit
 
 PARTNER_CLIENT_ID = "partner_rate_limit_test"
@@ -34,10 +35,9 @@ class TestPartnerRateLimits(ProvisioningTestBase):
             algorithm="RS256",
             is_first_party=True,
             is_provisioning_partner=True,
-            provisioning_partner_type="test_partner",
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
-            provisioning_can_provision_resources=True,
+            _provisioning_config=provisioning_config(
+                active=True, can_create_accounts=True, can_provision_resources=True
+            ),
         )
 
     def tearDown(self):
@@ -57,7 +57,7 @@ class TestPartnerRateLimits(ProvisioningTestBase):
         ]
     )
     def test_default_limit_applies_when_field_is_null(self, endpoint):
-        assert getattr(self.partner_app, f"provisioning_rate_limit_{endpoint}") is None
+        assert getattr(self.partner_app.provisioning.rate_limits, endpoint) is None
         expected_limit = PARTNER_RATE_LIMIT_DEFAULTS[endpoint]
 
         for _ in range(expected_limit):
@@ -68,8 +68,7 @@ class TestPartnerRateLimits(ProvisioningTestBase):
         assert ctx.exception.status == 429
 
     def test_custom_override_respected(self):
-        self.partner_app.provisioning_rate_limit_account_requests = 3
-        self.partner_app.save(update_fields=["provisioning_rate_limit_account_requests"])
+        self.partner_app.update_provisioning_rate_limits(account_requests=3)
 
         for _ in range(3):
             enforce_partner_rate_limit(self.partner_app, "account_requests")
@@ -80,22 +79,13 @@ class TestPartnerRateLimits(ProvisioningTestBase):
         assert ctx.exception.retry_after is not None
 
     def test_zero_override_disables_limiting(self):
-        self.partner_app.provisioning_rate_limit_account_requests = 0
-        self.partner_app.save(update_fields=["provisioning_rate_limit_account_requests"])
+        self.partner_app.update_provisioning_rate_limits(account_requests=0)
 
         for _ in range(100):
             enforce_partner_rate_limit(self.partner_app, "account_requests")
 
     def test_separate_buckets_per_endpoint(self):
-        self.partner_app.provisioning_rate_limit_account_requests = 2
-        self.partner_app.provisioning_rate_limit_resource_creates = 2
-        self.partner_app.save(
-            update_fields=[
-                "provisioning_rate_limit_account_requests",
-                "provisioning_rate_limit_resource_creates",
-            ]
-        )
-
+        self.partner_app.update_provisioning_rate_limits(account_requests=2, resource_creates=2)
         for _ in range(2):
             enforce_partner_rate_limit(self.partner_app, "account_requests")
 
@@ -113,13 +103,12 @@ class TestPartnerRateLimits(ProvisioningTestBase):
             redirect_uris="https://other.example.com/callback",
             algorithm="RS256",
             is_provisioning_partner=True,
-            provisioning_partner_type="other",
-            provisioning_active=True,
-            provisioning_rate_limit_account_requests=2,
+            _provisioning_config=provisioning_config(
+                active=True, rate_limits=ProvisioningRateLimits(account_requests=2)
+            ),
         )
 
-        self.partner_app.provisioning_rate_limit_account_requests = 2
-        self.partner_app.save(update_fields=["provisioning_rate_limit_account_requests"])
+        self.partner_app.update_provisioning_rate_limits(account_requests=2)
 
         for _ in range(2):
             enforce_partner_rate_limit(self.partner_app, "account_requests")
@@ -131,8 +120,7 @@ class TestPartnerRateLimits(ProvisioningTestBase):
     # --- Integration: token exchange rate limiting ---
 
     def test_token_exchange_auth_code_rate_limited(self):
-        self.partner_app.provisioning_rate_limit_token_exchanges = 1
-        self.partner_app.save(update_fields=["provisioning_rate_limit_token_exchanges"])
+        self.partner_app.update_provisioning_rate_limits(token_exchanges=1)
 
         # First exchange succeeds
         self._get_partner_bearer_token()
@@ -159,8 +147,7 @@ class TestPartnerRateLimits(ProvisioningTestBase):
         assert cache.get(f"{AUTH_CODE_CACHE_PREFIX}{code}") is None
 
     def test_token_exchange_refresh_rate_limited(self):
-        self.partner_app.provisioning_rate_limit_token_exchanges = 1
-        self.partner_app.save(update_fields=["provisioning_rate_limit_token_exchanges"])
+        self.partner_app.update_provisioning_rate_limits(token_exchanges=1)
 
         # Create access + refresh token for the partner
         access_token = OAuthAccessToken.objects.create(
@@ -228,8 +215,7 @@ class TestPartnerRateLimits(ProvisioningTestBase):
     # --- Integration: resource creation rate limiting ---
 
     def test_resource_create_rate_limited(self):
-        self.partner_app.provisioning_rate_limit_resource_creates = 1
-        self.partner_app.save(update_fields=["provisioning_rate_limit_resource_creates"])
+        self.partner_app.update_provisioning_rate_limits(resource_creates=1)
 
         token = self._get_partner_bearer_token()
 

--- a/ee/api/agentic_provisioning/test/test_private_key_jwt_partner.py
+++ b/ee/api/agentic_provisioning/test/test_private_key_jwt_partner.py
@@ -12,7 +12,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from posthog.api.oauth.client_assertion import CLIENT_ASSERTION_TYPE_JWT_BEARER
 from posthog.models.oauth import OAuthAccessToken, OAuthApplication
 
-from ee.api.agentic_provisioning.test.base import TEST_PARTNER_SCOPES, ProvisioningTestBase
+from ee.api.agentic_provisioning.test.base import TEST_PARTNER_SCOPES, ProvisioningTestBase, provisioning_config
 
 ACCOUNT_REQUESTS_URL = "/api/agentic/provisioning/account_requests"
 TOKEN_URL = "/api/agentic/oauth/token"
@@ -53,10 +53,9 @@ class TestPrivateKeyJwtPartner(ProvisioningTestBase):
             algorithm="RS256",
             scopes=TEST_PARTNER_SCOPES,
             is_provisioning_partner=True,
-            provisioning_partner_type="test_partner",
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
-            provisioning_can_provision_resources=True,
+            _provisioning_config=provisioning_config(
+                active=True, can_create_accounts=True, can_provision_resources=True
+            ),
         )
 
     def _assertion(self, **overrides) -> str:

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -241,7 +241,7 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
 
     # --- Org naming ---
 
-    def test_wizard_org_named_with_partner_type(self):
+    def test_org_named_after_the_partner_app(self):
         _, challenge = self._pkce_pair()
         email = "org-name-test@example.com"
 
@@ -251,7 +251,7 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
         membership = user.organization_memberships.first()
         assert membership is not None
         org = membership.organization
-        assert org.name == f"Wizard ({email})"
+        assert org.name == f"PostHog Wizard ({email})"
 
     # --- PAT scopes ---
 

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -14,11 +14,12 @@ from posthog.api.oauth.cimd import (
     fetch_and_upsert_cimd_application,
 )
 from posthog.models.oauth import OAuthApplication
+from posthog.models.oauth_provisioning import ProvisioningRateLimits
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.user import User
 
 from ee.api.agentic_provisioning.authentication import ProvisioningAuthentication
-from ee.api.agentic_provisioning.test.base import TEST_PARTNER_CLIENT_SECRET, ProvisioningTestBase
+from ee.api.agentic_provisioning.test.base import TEST_PARTNER_CLIENT_SECRET, ProvisioningTestBase, provisioning_config
 
 WIZARD_CLIENT_ID = "test-wizard-client"
 
@@ -38,10 +39,9 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
             algorithm="RS256",
             is_first_party=True,
             is_provisioning_partner=True,
-            provisioning_partner_type="wizard",
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
-            provisioning_can_provision_resources=True,
+            _provisioning_config=provisioning_config(
+                active=True, can_create_accounts=True, can_provision_resources=True
+            ),
         )
 
     def _wizard_account_request(self, request_id: str, email: str, challenge: str):
@@ -131,8 +131,7 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
         assert res.json()["error"]["code"] == "unauthorized"
 
     def test_inactive_client_secret_partner_rejected(self):
-        self.partner.provisioning_active = False
-        self.partner.save(update_fields=["provisioning_active"])
+        self.partner.update_provisioning(active=False)
 
         res = self._post_with_client_secret(
             "/api/agentic/provisioning/account_requests",
@@ -161,10 +160,9 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
             redirect_uris="https://legacy.example.com/callback",
             algorithm="RS256",
             is_provisioning_partner=False,
-            provisioning_partner_type="stripe",
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
-            provisioning_can_provision_resources=True,
+            _provisioning_config=provisioning_config(
+                active=True, can_create_accounts=True, can_provision_resources=True
+            ),
         )
 
         res = self._post_api(
@@ -226,9 +224,7 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
             redirect_uris="https://localhost",
             algorithm="RS256",
             is_provisioning_partner=True,
-            provisioning_partner_type="disabled",
-            provisioning_active=True,
-            provisioning_can_create_accounts=False,
+            _provisioning_config=provisioning_config(active=True, can_create_accounts=False),
         )
 
         res = self._post_api(
@@ -277,8 +273,7 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
     # --- is_active kill switch ---
 
     def test_inactive_pkce_partner_rejected(self):
-        self.wizard_app.provisioning_active = False
-        self.wizard_app.save(update_fields=["provisioning_active"])
+        self.wizard_app.update_provisioning(active=False)
 
         _, challenge = self._pkce_pair()
         res = self._wizard_account_request("req_inactive_pkce", "inactive-pkce@example.com", challenge)
@@ -289,8 +284,7 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
     def test_partner_without_can_provision_resources_rejected(self):
         token = self._get_bearer_token()
 
-        self.partner.provisioning_can_provision_resources = False
-        self.partner.save(update_fields=["provisioning_can_provision_resources"])
+        self.partner.update_provisioning(can_provision_resources=False)
 
         res = self._post_with_bearer("/api/agentic/provisioning/resources", {}, token=token)
         assert res.status_code == 403
@@ -310,10 +304,9 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
             is_cimd_client=True,
             cimd_metadata_url=cimd_url,
             is_provisioning_partner=True,
-            provisioning_partner_type="wizard",
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
-            provisioning_can_provision_resources=True,
+            _provisioning_config=provisioning_config(
+                active=True, can_create_accounts=True, can_provision_resources=True
+            ),
         )
 
         _, challenge = self._pkce_pair()
@@ -343,9 +336,7 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
             is_cimd_client=True,
             cimd_metadata_url=cimd_url,
             is_provisioning_partner=True,
-            provisioning_partner_type="wizard",
-            provisioning_active=False,
-            provisioning_can_create_accounts=True,
+            _provisioning_config=provisioning_config(active=False, can_create_accounts=True),
         )
 
         _, challenge = self._pkce_pair()
@@ -382,10 +373,9 @@ class TestProvisioningAuthentication(ProvisioningTestBase):
             is_cimd_client=True,
             cimd_metadata_url=cimd_url,
             is_provisioning_partner=True,
-            provisioning_partner_type="wizard",
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
-            provisioning_can_provision_resources=True,
+            _provisioning_config=provisioning_config(
+                active=True, can_create_accounts=True, can_provision_resources=True
+            ),
         )
         self.addCleanup(real_cache.delete, _cache_key(cimd_url))
         # _identify_pkce_partner warms the blocklist cache with a 1-year TTL; clear it too.
@@ -468,9 +458,9 @@ class TestCimdProvisioningRegistration(ProvisioningTestBase):
         app = self._register()
         assert app.is_cimd_client
         assert app.is_provisioning_partner
-        assert app.provisioning_active
-        assert app.provisioning_can_create_accounts
-        assert app.provisioning_can_provision_resources
+        assert app.provisioning.active
+        assert app.provisioning.can_create_accounts
+        assert app.provisioning.can_provision_resources
 
         _, challenge = self._pkce_pair()
         res = self.client.post(
@@ -534,10 +524,12 @@ class TestCimdProvisioningRegistration(ProvisioningTestBase):
             is_cimd_client=True,
             cimd_metadata_url=CIMD_PROV_URL,
             is_provisioning_partner=True,
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
-            provisioning_can_provision_resources=True,
-            provisioning_rate_limit_account_requests=10,
+            _provisioning_config=provisioning_config(
+                active=True,
+                can_create_accounts=True,
+                can_provision_resources=True,
+                rate_limits=ProvisioningRateLimits(account_requests=10),
+            ),
         )
 
         _, challenge = self._pkce_pair()
@@ -558,8 +550,7 @@ class TestCimdProvisioningRegistration(ProvisioningTestBase):
         assert post_account_request("ratelimit-1@example.com").status_code == 200
 
         partner = OAuthApplication.objects.get(cimd_metadata_url=CIMD_PROV_URL)
-        partner.provisioning_rate_limit_account_requests = 2
-        partner.save(update_fields=["provisioning_rate_limit_account_requests"])
+        partner.update_provisioning_rate_limits(account_requests=2)
 
         assert post_account_request("ratelimit-2@example.com").status_code == 200
         res = post_account_request("ratelimit-3@example.com")
@@ -644,9 +635,9 @@ class TestCimdProvisioningRegistration(ProvisioningTestBase):
                 is_cimd_client=True,
                 cimd_metadata_url=url,
                 is_provisioning_partner=True,
-                provisioning_active=True,
-                provisioning_can_create_accounts=True,
-                provisioning_can_provision_resources=True,
+                _provisioning_config=provisioning_config(
+                    active=True, can_create_accounts=True, can_provision_resources=True
+                ),
             )
 
         url = f"https://{base_domain}/path-0/metadata.json"
@@ -675,9 +666,9 @@ class TestCimdProvisioningRegistration(ProvisioningTestBase):
             is_cimd_client=True,
             cimd_metadata_url=CIMD_PROV_URL,
             is_provisioning_partner=True,
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
-            provisioning_can_provision_resources=True,
+            _provisioning_config=provisioning_config(
+                active=True, can_create_accounts=True, can_provision_resources=True
+            ),
         )
 
         email = "cimd-org-name@example.com"
@@ -731,9 +722,9 @@ class TestCimdProvisioningRegistration(ProvisioningTestBase):
             is_cimd_client=True,
             cimd_metadata_url=CIMD_PROV_URL,
             is_provisioning_partner=True,
-            provisioning_active=True,
-            provisioning_can_create_accounts=True,
-            provisioning_can_provision_resources=True,
+            _provisioning_config=provisioning_config(
+                active=True, can_create_accounts=True, can_provision_resources=True
+            ),
         )
         block_cimd_url(CIMD_PROV_URL)
 

--- a/ee/api/agentic_provisioning/test/test_resources.py
+++ b/ee/api/agentic_provisioning/test/test_resources.py
@@ -7,7 +7,7 @@ from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.team.team import Team
 
 from ee.api.agentic_provisioning.credentials import maybe_create_provisioned_pat
-from ee.api.agentic_provisioning.test.base import ProvisioningTestBase
+from ee.api.agentic_provisioning.test.base import ProvisioningTestBase, provisioning_config
 
 
 class TestProvisioningResources(ProvisioningTestBase):
@@ -25,8 +25,7 @@ class TestProvisioningResources(ProvisioningTestBase):
         assert "host" in data["complete"]["access_configuration"]
 
     def test_create_resource_rate_limited_uses_status_envelope(self):
-        self.partner.provisioning_rate_limit_resource_creates = 1
-        self.partner.save(update_fields=["provisioning_rate_limit_resource_creates"])
+        self.partner.update_provisioning_rate_limits(resource_creates=1)
         token = self._get_bearer_token()
 
         assert self._post_with_bearer("/api/agentic/provisioning/resources", token=token).status_code == 200
@@ -164,8 +163,7 @@ class TestProvisioningResources(ProvisioningTestBase):
     def test_create_resource_omits_pat_when_app_gate_off(self):
         token = self._get_bearer_token()
         app = self.partner
-        app.provisioning_issues_personal_api_key = False
-        app.save(update_fields=["provisioning_issues_personal_api_key"])
+        app.update_provisioning(issues_personal_api_key=False)
         before = PersonalAPIKey.objects.filter(user=self.user).count()
         res = self._post_with_bearer(
             "/api/agentic/provisioning/resources",
@@ -186,7 +184,7 @@ class TestProvisioningResources(ProvisioningTestBase):
             redirect_uris="https://localhost",
             algorithm="RS256",
             scopes=["insight:read"],
-            provisioning_issues_personal_api_key=gate_on,
+            _provisioning_config=provisioning_config(issues_personal_api_key=gate_on),
         )
         result = maybe_create_provisioned_pat(self.user, self.team, app, "insight:read")
         if gate_on:
@@ -498,7 +496,6 @@ class TestProvisioningResources(ProvisioningTestBase):
             authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
             redirect_uris="https://localhost",
             algorithm="RS256",
-            provisioning_partner_type="other_partner",
         )
         other_partner_team = Team.objects.create_with_data(
             initiating_user=self.user,
@@ -689,7 +686,6 @@ class TestProvisioningResourceRemove(ProvisioningTestBase):
             authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
             redirect_uris="https://localhost",
             algorithm="RS256",
-            provisioning_partner_type="other_partner",
         )
         TeamProvisioningConfig.objects.update_or_create(
             team=self.team, defaults={"application": other_partner, "stripe_project_id": "proj_other_owner"}

--- a/ee/api/agentic_provisioning/test/test_rotate_credentials.py
+++ b/ee/api/agentic_provisioning/test/test_rotate_credentials.py
@@ -75,8 +75,7 @@ class TestProvisioningRotateCredentials(ProvisioningTestBase):
     def test_rotate_omits_pat_when_app_gate_off(self):
         token = self._get_bearer_token()
         app = self.partner
-        app.provisioning_issues_personal_api_key = False
-        app.save(update_fields=["provisioning_issues_personal_api_key"])
+        app.update_provisioning(issues_personal_api_key=False)
         res = self._post_with_bearer(
             f"/api/agentic/provisioning/resources/{self.team.id}/rotate_credentials",
             token=token,

--- a/ee/api/agentic_provisioning/test/test_scope_hydration.py
+++ b/ee/api/agentic_provisioning/test/test_scope_hydration.py
@@ -69,7 +69,6 @@ class TestPartnerTokenScopeHydration(ProvisioningTestBase):
             authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
             redirect_uris="https://localhost",
             algorithm="RS256",
-            provisioning_partner_type="other_partner",
         )
         other_partner_team = self._provision_team(other_partner, "Other partner team", "proj_other")
 

--- a/ee/api/agentic_provisioning/test/test_wizard_resource_actions.py
+++ b/ee/api/agentic_provisioning/test/test_wizard_resource_actions.py
@@ -153,6 +153,20 @@ class TestWizardResourceActions(ProvisioningTestBase):
         assert response.status_code == 403
         assert response.json()["error"]["code"] == "forbidden"
 
+    @override_settings(WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID="wizard-client-id")
+    def test_wizard_runs_rejects_a_partner_without_the_capability(self):
+        # Holding a bearer token for an active partner used to be enough to start a coding-agent
+        # run in a customer's repository. It now takes its own grant, which self-registration
+        # never gives out.
+        self.partner.update_provisioning(can_start_wizard_runs=False)
+
+        with patch("ee.api.agentic_provisioning.wizard.tasks_facade.create_wizard_cloud_run") as mock_create:
+            response = self._post_wizard_runs(self.team.id, {"repository": "octocat/hello-world"})
+
+        assert response.status_code == 403
+        assert response.json()["error"]["code"] == "forbidden"
+        mock_create.assert_not_called()
+
     @override_settings(WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID="")
     def test_wizard_runs_unavailable_without_oauth_client_id(self):
         response = self._post_wizard_runs(self.team.id, {"repository": "octocat/hello-world"})

--- a/ee/api/agentic_provisioning/test/test_wizard_resource_actions.py
+++ b/ee/api/agentic_provisioning/test/test_wizard_resource_actions.py
@@ -155,9 +155,8 @@ class TestWizardResourceActions(ProvisioningTestBase):
 
     @override_settings(WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID="wizard-client-id")
     def test_wizard_runs_rejects_a_partner_without_the_capability(self):
-        # Holding a bearer token for an active partner used to be enough to start a coding-agent
-        # run in a customer's repository. It now takes its own grant, which self-registration
-        # never gives out.
+        # Starting a coding-agent run in a customer's repository takes its own grant, which
+        # self-registration never gives out - a bearer token for an active partner is not enough.
         self.partner.update_provisioning(can_start_wizard_runs=False)
 
         with patch("ee.api.agentic_provisioning.wizard.tasks_facade.create_wizard_cloud_run") as mock_create:

--- a/ee/api/agentic_provisioning/throttling.py
+++ b/ee/api/agentic_provisioning/throttling.py
@@ -94,7 +94,7 @@ def _count_partner_request(partner: OAuthApplication, endpoint: str) -> tuple[in
     if endpoint not in PARTNER_RATE_LIMIT_DEFAULTS:
         raise ValueError(f"Unknown rate limit endpoint: {endpoint}")
 
-    override = getattr(partner, f"provisioning_rate_limit_{endpoint}", None)
+    override = getattr(partner.provisioning.rate_limits, endpoint, None)
     limit = override if override is not None else PARTNER_RATE_LIMIT_DEFAULTS[endpoint]
 
     if limit <= 0:
@@ -177,11 +177,11 @@ class ResourceCreatesThrottle(PartnerRateThrottle):
     error_message = "Rate limit exceeded for this partner. Try again later."
 
     def get_partner(self, request: Request) -> OAuthApplication | None:
+        # Plain OAuth apps whose tokens reach this endpoint are not partners and carry no
+        # partner quota. Keyed on is_provisioning_partner rather than any capability flag, so
+        # revoking a capability narrows what a partner may do without also un-throttling it.
         partner = super().get_partner(request)
-        # provisioning_partner_type is the stable partner marker; apps without
-        # it (plain OAuth apps whose tokens reach this endpoint) are not
-        # subject to partner quotas.
-        if partner is None or not partner.provisioning_partner_type:
+        if partner is None or not partner.is_provisioning_partner:
             return None
         return partner
 

--- a/ee/api/agentic_provisioning/throttling.py
+++ b/ee/api/agentic_provisioning/throttling.py
@@ -178,10 +178,11 @@ class ResourceCreatesThrottle(PartnerRateThrottle):
 
     def get_partner(self, request: Request) -> OAuthApplication | None:
         # Plain OAuth apps whose tokens reach this endpoint are not partners and carry no
-        # partner quota. Keyed on is_provisioning_partner rather than any capability flag, so
-        # revoking a capability narrows what a partner may do without also un-throttling it.
+        # partner quota. Keyed on carrying provisioning config rather than on a capability or
+        # on is_provisioning_partner, so neither revoking a capability nor disabling the
+        # partner outright also un-throttles its outstanding tokens.
         partner = super().get_partner(request)
-        if partner is None or not partner.is_provisioning_partner:
+        if partner is None or not partner.carries_provisioning_config:
             return None
         return partner
 

--- a/ee/api/agentic_provisioning/views/account_requests.py
+++ b/ee/api/agentic_provisioning/views/account_requests.py
@@ -64,7 +64,7 @@ class AccountRequestsView(ProvisioningAPIView):
             scopes = sorted(effective_ceiling(partner.ceiling_scopes))
         configuration = data["configuration"]
 
-        if not partner.provisioning_can_create_accounts:
+        if not partner.provisioning.can_create_accounts:
             capture_provisioning_event("account_request", "error", error_code="account_creation_disabled")
             raise ProvisioningError("forbidden", "Account creation is not enabled for this partner", status=403)
 

--- a/ee/api/agentic_provisioning/views/authorize.py
+++ b/ee/api/agentic_provisioning/views/authorize.py
@@ -90,13 +90,13 @@ def agentic_authorize(request: Any) -> HttpResponseBase:
     is_trusted_partner = False
     partner_app = resolve_pending_partner(partner_id)
     if partner_app is not None:
-        if not partner_app.provisioning_active:
+        if not partner_app.provisioning.active:
             cache.delete(pending_key)
             capture_provisioning_event("authorize", "partner_deactivated")
             return HttpResponseRedirect(f"{settings.SITE_URL}?error=partner_deactivated")
         # Fail closed: a partner-identified pending state missing the flag (e.g. created by an
         # older pod mid-deploy) must still require consent, never silently auto-approve.
-        is_trusted_partner = partner_app.provisioning_skip_existing_user_consent and not pending.get(
+        is_trusted_partner = partner_app.provisioning.skip_existing_user_consent and not pending.get(
             "consent_required", True
         )
 
@@ -193,7 +193,7 @@ class AuthorizeConfirmView(APIView):
 
         confirm_partner_id = pending.get("partner_id", "")
         confirm_partner: OAuthApplication | None = resolve_pending_partner(confirm_partner_id)
-        if confirm_partner is not None and not confirm_partner.provisioning_active:
+        if confirm_partner is not None and not confirm_partner.provisioning.active:
             cache.delete(pending_key)
             capture_provisioning_event("authorize_confirm", "partner_deactivated", partner=confirm_partner)
             return Response({"error": "partner_deactivated"}, status=403)

--- a/ee/api/agentic_provisioning/views/base.py
+++ b/ee/api/agentic_provisioning/views/base.py
@@ -21,10 +21,7 @@ from rest_framework.views import APIView
 from posthog.models.oauth import OAuthAccessToken
 from posthog.models.team.team import Team
 
-from ee.api.agentic_provisioning.authentication import (
-    ConfidentialPartnerAuthentication,
-    ProvisioningBearerAuthentication,
-)
+from ee.api.agentic_provisioning.authentication import GitHubGrantsAuthentication, ProvisioningBearerAuthentication
 from ee.api.agentic_provisioning.exceptions import Envelope, ProvisioningError, render_provisioning_error
 from ee.api.agentic_provisioning.region_proxy import RegionProxyMixin
 from ee.api.agentic_provisioning.serializers import first_error_message
@@ -65,7 +62,7 @@ class ProvisioningAPIView(RegionProxyMixin, APIView):
             raise TypeError(
                 f"{cls.__name__} declares no authentication_classes. Provisioning endpoints are "
                 "partner-facing, so set authentication_classes (for example to "
-                "ConfidentialPartnerAuthentication) or, if it must authenticate inside the "
+                "GitHubGrantsAuthentication) or, if it must authenticate inside the "
                 "handler, set authenticates_in_handler = True."
             )
 
@@ -119,23 +116,41 @@ class ProvisioningAPIView(RegionProxyMixin, APIView):
         return serializer.validated_data
 
 
-class ConfidentialPartnerAPIView(ProvisioningAPIView):
-    """Base for confidential-partner endpoints (GitHub grants).
+class GitHubGrantsAPIView(ProvisioningAPIView):
+    """Base for the GitHub grant endpoints.
 
     The partner rides ``request.auth``, having proven itself with either a signed
     ``private_key_jwt`` assertion or a verified client secret. A public partner is identified
-    only by a client_id anyone can send, so it never reaches these endpoints.
+    only by a client_id anyone can send, so it never reaches these endpoints, and a confidential
+    one still needs ``can_use_github_grants`` granted.
     """
 
-    authentication_classes = [ConfidentialPartnerAuthentication]
+    authentication_classes = [GitHubGrantsAuthentication]
 
 
 class BearerResourceAPIView(ProvisioningAPIView):
-    """Base for the bearer-authenticated resource endpoints (status envelope)."""
+    """Base for the bearer-authenticated resource endpoints (status envelope).
+
+    An endpoint that does more than ordinary resource provisioning calls
+    :meth:`require_capability` in its handler.
+    """
 
     error_envelope = "status"
     region_proxy_strategy = "bearer_lookup"
     authentication_classes = [ProvisioningBearerAuthentication]
+
+    def require_capability(self, access_token: OAuthAccessToken, capability: str, resource_id: str = "") -> None:
+        """Refuse an endpoint the partner has not been granted.
+
+        ``ProvisioningBearerAuthentication`` only establishes that the token belongs to an
+        active partner allowed to provision resources at all, so anything beyond that is
+        checked here rather than being implied by holding a token.
+        """
+        app = access_token.application
+        if app is None or not getattr(app.provisioning, capability):
+            raise ProvisioningError(
+                "forbidden", "This endpoint is not enabled for this partner", resource_id=resource_id, status=403
+            )
 
     def parse_resource_team_id(self, resource_id: str, access_token: OAuthAccessToken) -> int:
         try:

--- a/ee/api/agentic_provisioning/views/base.py
+++ b/ee/api/agentic_provisioning/views/base.py
@@ -129,28 +129,11 @@ class GitHubGrantsAPIView(ProvisioningAPIView):
 
 
 class BearerResourceAPIView(ProvisioningAPIView):
-    """Base for the bearer-authenticated resource endpoints (status envelope).
-
-    An endpoint that does more than ordinary resource provisioning calls
-    :meth:`require_capability` in its handler.
-    """
+    """Base for the bearer-authenticated resource endpoints (status envelope)."""
 
     error_envelope = "status"
     region_proxy_strategy = "bearer_lookup"
     authentication_classes = [ProvisioningBearerAuthentication]
-
-    def require_capability(self, access_token: OAuthAccessToken, capability: str, resource_id: str = "") -> None:
-        """Refuse an endpoint the partner has not been granted.
-
-        ``ProvisioningBearerAuthentication`` only establishes that the token belongs to an
-        active partner allowed to provision resources at all, so anything beyond that is
-        checked here rather than being implied by holding a token.
-        """
-        app = access_token.application
-        if app is None or not getattr(app.provisioning, capability):
-            raise ProvisioningError(
-                "forbidden", "This endpoint is not enabled for this partner", resource_id=resource_id, status=403
-            )
 
     def parse_resource_team_id(self, resource_id: str, access_token: OAuthAccessToken) -> int:
         try:

--- a/ee/api/agentic_provisioning/views/client_registration.py
+++ b/ee/api/agentic_provisioning/views/client_registration.py
@@ -79,21 +79,22 @@ class ClientRegistrationView(ProvisioningAPIView):
                 "jwks_uri": app.jwks_uri,
                 "scopes": app.ceiling_scopes,
                 "provisioning": {
-                    "active": app.provisioning_active,
-                    "can_create_accounts": app.provisioning_can_create_accounts,
-                    "can_provision_resources": app.provisioning_can_provision_resources,
+                    "active": app.provisioning.active,
+                    "can_create_accounts": app.provisioning.can_create_accounts,
+                    "can_provision_resources": app.provisioning.can_provision_resources,
                 },
                 # Spelled out because "why can't I call github/grants" is the question this
-                # endpoint exists to answer, and the rule (a confidential client that PostHog
-                # registered as a partner) is not something a partner can infer from its own
-                # metadata document.
+                # endpoint exists to answer, and the rule (a confidential client PostHog granted
+                # the capability to) is not something a partner can infer from its own metadata
+                # document.
                 "capabilities": {
-                    "account_requests": app.provisioning_active and app.provisioning_can_create_accounts,
+                    "account_requests": app.provisioning.active and app.provisioning.can_create_accounts,
                     "github_grants": (
                         app.requires_client_authentication
-                        and not (app.is_cimd_client and not app.provisioning_partner_type)
-                        and app.provisioning_can_create_accounts
+                        and app.provisioning.can_use_github_grants
+                        and app.provisioning.can_create_accounts
                     ),
+                    "wizard_runs": app.provisioning.active and app.provisioning.can_start_wizard_runs,
                 },
                 "checks": checks,
             }
@@ -145,7 +146,7 @@ class ClientRegistrationView(ProvisioningAPIView):
         if not app.is_provisioning_partner:
             _record(checks, "provisioning_enabled", False, "This client is not enabled for agentic provisioning")
             return None
-        if not app.provisioning_active:
+        if not app.provisioning.active:
             _record(checks, "provisioning_enabled", False, "Provisioning is deactivated for this client")
             return None
         _record(checks, "provisioning_enabled", True, "Active")

--- a/ee/api/agentic_provisioning/views/deep_links.py
+++ b/ee/api/agentic_provisioning/views/deep_links.py
@@ -57,7 +57,7 @@ class DeepLinksView(BearerResourceAPIView):
     def post(self, request: Request) -> Response:
         access_token = cast(OAuthAccessToken, request.auth)
 
-        if not access_token.application.provisioning_can_issue_deep_links:
+        if not access_token.application.provisioning.can_issue_deep_links:
             capture_provisioning_event("deep_link_created", "not_enabled", partner=access_token.application)
             raise ProvisioningError(
                 "deep_links_not_enabled",

--- a/ee/api/agentic_provisioning/views/github_grants.py
+++ b/ee/api/agentic_provisioning/views/github_grants.py
@@ -5,7 +5,7 @@ only ever sees an opaque grant_id. No region proxy: grants are region-local
 
 Grant creation enforces its partner quota inline rather than through
 ``partner_throttle_classes``, so the capability check runs first: a partner
-without ``provisioning_can_create_accounts`` is refused for free instead of
+without ``can_create_accounts`` is refused for free instead of
 burning its hourly grant budget on requests it can never complete.
 """
 
@@ -25,14 +25,14 @@ from ee.api.agentic_provisioning.analytics import capture_provisioning_event
 from ee.api.agentic_provisioning.exceptions import ProvisioningError
 from ee.api.agentic_provisioning.serializers import GitHubGrantCreateSerializer
 from ee.api.agentic_provisioning.throttling import GrantPollThrottle, enforce_partner_rate_limit
-from ee.api.agentic_provisioning.views.base import ConfidentialPartnerAPIView
+from ee.api.agentic_provisioning.views.base import GitHubGrantsAPIView
 
 
-class GitHubGrantsCreateView(ConfidentialPartnerAPIView):
+class GitHubGrantsCreateView(GitHubGrantsAPIView):
     def post(self, request: Request) -> Response:
         partner = cast(OAuthApplication, request.auth)
 
-        if not partner.provisioning_can_create_accounts:
+        if not partner.provisioning.can_create_accounts:
             capture_provisioning_event("github_grant", "error", partner=partner, error_code="account_creation_disabled")
             raise ProvisioningError("forbidden", "Account creation is not enabled for this partner", status=403)
 
@@ -77,7 +77,7 @@ class GitHubGrantsCreateView(ConfidentialPartnerAPIView):
         )
 
 
-class GitHubGrantRepositoriesView(ConfidentialPartnerAPIView):
+class GitHubGrantRepositoriesView(GitHubGrantsAPIView):
     # Keyed per calling partner and grant id, so polls against an id the caller does
     # not own can only exhaust the caller's own budget.
     partner_throttle_classes = [GrantPollThrottle]

--- a/ee/api/agentic_provisioning/views/oauth_token.py
+++ b/ee/api/agentic_provisioning/views/oauth_token.py
@@ -370,10 +370,7 @@ class OAuthTokenView(ProvisioningAPIView):
                 )
             new_scope = " ".join(narrowed_scopes)
 
-            # provisioning_partner_type is a stable marker set at partner registration;
-            # checking it instead of is_provisioning_partner prevents a bypass when an admin
-            # clears that flag to disable a partner without revoking its tokens.
-            if oauth_app and oauth_app.provisioning_partner_type:
+            if oauth_app and oauth_app.is_provisioning_partner:
                 enforce_partner_rate_limit(oauth_app, "token_exchanges")
 
             old_access = old_refresh.access_token

--- a/ee/api/agentic_provisioning/views/oauth_token.py
+++ b/ee/api/agentic_provisioning/views/oauth_token.py
@@ -370,7 +370,9 @@ class OAuthTokenView(ProvisioningAPIView):
                 )
             new_scope = " ".join(narrowed_scopes)
 
-            if oauth_app and oauth_app.is_provisioning_partner:
+            # Not is_provisioning_partner: an admin clearing that flag to disable a partner
+            # leaves its outstanding refresh tokens working, and they must stay throttled.
+            if oauth_app and oauth_app.carries_provisioning_config:
                 enforce_partner_rate_limit(oauth_app, "token_exchanges")
 
             old_access = old_refresh.access_token

--- a/ee/api/agentic_provisioning/views/resources.py
+++ b/ee/api/agentic_provisioning/views/resources.py
@@ -248,12 +248,18 @@ class GitHubIntegrationView(BearerResourceAPIView):
 
 class WizardRunsView(BearerResourceAPIView):
     """Kick off a cloud wizard run against a repository the team's GitHub
-    integration can reach."""
+    integration can reach.
+
+    Starting a coding-agent run inside a customer's repository reaches a long way past
+    provisioning a project, so it needs its own grant rather than following from a partner
+    being allowed to provision resources at all.
+    """
 
     def post(self, request: Request, resource_id: str) -> Response:
         user = cast(User, request.user)
         access_token = cast(OAuthAccessToken, request.auth)
 
+        self.require_capability(access_token, "can_start_wizard_runs", resource_id=resource_id)
         team = self.get_scoped_team(resource_id, access_token)
 
         data = self.validated_body(

--- a/ee/api/agentic_provisioning/views/resources.py
+++ b/ee/api/agentic_provisioning/views/resources.py
@@ -252,14 +252,14 @@ class WizardRunsView(BearerResourceAPIView):
 
     Starting a coding-agent run inside a customer's repository reaches a long way past
     provisioning a project, so it needs its own grant rather than following from a partner
-    being allowed to provision resources at all.
+    being allowed to provision resources at all. ``create_wizard_run`` enforces that, for
+    this endpoint and the account-request wizard block alike.
     """
 
     def post(self, request: Request, resource_id: str) -> Response:
         user = cast(User, request.user)
         access_token = cast(OAuthAccessToken, request.auth)
 
-        self.require_capability(access_token, "can_start_wizard_runs", resource_id=resource_id)
         team = self.get_scoped_team(resource_id, access_token)
 
         data = self.validated_body(

--- a/ee/api/agentic_provisioning/wizard.py
+++ b/ee/api/agentic_provisioning/wizard.py
@@ -128,6 +128,18 @@ def create_wizard_run(
 ) -> dict[str, str]:
     """Gate + throttle + create a cloud wizard run. Returns the run payload;
     raises :class:`ProvisioningError` on failure."""
+    # Checked here rather than in each caller: the resource endpoint and the account-request
+    # wizard block both land on this function, so this is the one place a new caller cannot
+    # forget. Before the rate limits, so a partner without the grant can't spend its quota.
+    if not partner.provisioning.can_start_wizard_runs:
+        capture_provisioning_event("wizard_run", "error", partner=partner, error_code="forbidden")
+        raise ProvisioningError(
+            "forbidden",
+            "Starting wizard runs is not enabled for this partner",
+            resource_id=str(team.id),
+            status=403,
+        )
+
     if not bool(settings.WIZARD_CLOUD_RUN_OAUTH_CLIENT_ID):
         capture_provisioning_event("wizard_run", "error", partner=partner, error_code="wizard_unavailable")
         raise ProvisioningError(

--- a/posthog/admin/admins/oauth_admin.py
+++ b/posthog/admin/admins/oauth_admin.py
@@ -52,8 +52,6 @@ class OAuthApplicationForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        for name, field in _provisioning_form_fields().items():
-            self.fields[name] = field
         self._load_provisioning_initial()
 
         # Set algorithm constraints
@@ -119,6 +117,13 @@ class OAuthApplicationForm(forms.ModelForm):
             instance.save()
             self.save_m2m()
         return instance
+
+
+# Declared on the class rather than added per instance, so admin's fieldset validation and
+# modelform_factory can see them. Fields added in __init__ exist too late for either.
+for _field_name, _form_field in _provisioning_form_fields().items():
+    OAuthApplicationForm.declared_fields[_field_name] = _form_field
+    OAuthApplicationForm.base_fields[_field_name] = _form_field
 
 
 class ProvisioningCapabilityFilter(admin.SimpleListFilter):

--- a/posthog/admin/admins/oauth_admin.py
+++ b/posthog/admin/admins/oauth_admin.py
@@ -148,6 +148,7 @@ class ProvisioningCapabilityFilter(admin.SimpleListFilter):
         capability = self.value()
         if not capability or capability not in ProvisioningConfig.model_fields:
             return queryset
+        # nosemgrep: orm-field-injection -- capability is allowlisted above, and the JSONField prefix keeps any __ as a JSON key lookup
         return queryset.filter(**{f"_provisioning_config__{capability}": True})
 
 

--- a/posthog/admin/admins/oauth_admin.py
+++ b/posthog/admin/admins/oauth_admin.py
@@ -14,15 +14,47 @@ from oauth2_provider.generators import generate_client_id, generate_client_secre
 from oauth2_provider.models import AbstractApplication
 
 from posthog.models.oauth import OAuthApplication, revoke_application_sessions
+from posthog.models.oauth_provisioning import ProvisioningConfig, ProvisioningRateLimits
+
+# The provisioning config is one JSONB column, but an operator should still get the checkboxes
+# they had when it was a column each: a raw JSON textarea turns a mistyped capability key into
+# something that silently reads back as "not granted" while looking granted on screen.
+# Derived from the pydantic schema so a capability added there shows up here automatically.
+PROVISIONING_FIELD_PREFIX = "provisioning_"
+PROVISIONING_RATE_LIMIT_PREFIX = "provisioning_rate_limit_"
+
+
+def _provisioning_form_fields() -> dict[str, forms.Field]:
+    """One form field per capability, plus one per rate-limit override."""
+    fields: dict[str, forms.Field] = {}
+    for name, info in ProvisioningConfig.model_fields.items():
+        if name in ("rate_limits", "rate_limit_source"):
+            continue
+        fields[f"{PROVISIONING_FIELD_PREFIX}{name}"] = forms.BooleanField(
+            required=False, label=name.replace("_", " "), help_text=info.description or ""
+        )
+    for name in ProvisioningRateLimits.model_fields:
+        fields[f"{PROVISIONING_RATE_LIMIT_PREFIX}{name}"] = forms.IntegerField(
+            required=False, min_value=0, label=f"rate limit {name.replace('_', ' ')} (per hour)"
+        )
+    return fields
+
+
+PROVISIONING_FORM_FIELD_NAMES = tuple(_provisioning_form_fields())
 
 
 class OAuthApplicationForm(forms.ModelForm):
     class Meta:
         model = OAuthApplication
-        fields = "__all__"
+        # The JSONB column is edited through the generated fields below, never as raw JSON.
+        exclude = ("_provisioning_config",)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        for name, field in _provisioning_form_fields().items():
+            self.fields[name] = field
+        self._load_provisioning_initial()
 
         # Set algorithm constraints
         if "algorithm" in self.fields:
@@ -51,6 +83,68 @@ class OAuthApplicationForm(forms.ModelForm):
             if "client_type" in self.fields:
                 self.fields["client_type"].initial = AbstractApplication.CLIENT_CONFIDENTIAL
 
+    def _load_provisioning_initial(self) -> None:
+        config = self.instance.provisioning if self.instance.pk else ProvisioningConfig()
+        for name in ProvisioningConfig.model_fields:
+            if name in ("rate_limits", "rate_limit_source"):
+                continue
+            self.fields[f"{PROVISIONING_FIELD_PREFIX}{name}"].initial = getattr(config, name)
+        for name in ProvisioningRateLimits.model_fields:
+            self.fields[f"{PROVISIONING_RATE_LIMIT_PREFIX}{name}"].initial = getattr(config.rate_limits, name)
+
+    def save(self, commit: bool = True):
+        instance = super().save(commit=False)
+
+        previous = instance.provisioning
+        capabilities = {
+            name: self.cleaned_data[f"{PROVISIONING_FIELD_PREFIX}{name}"]
+            for name in ProvisioningConfig.model_fields
+            if name not in ("rate_limits", "rate_limit_source")
+        }
+        rate_limits = ProvisioningRateLimits(
+            **{
+                name: self.cleaned_data[f"{PROVISIONING_RATE_LIMIT_PREFIX}{name}"]
+                for name in ProvisioningRateLimits.model_fields
+            }
+        )
+        # An operator typing a limit here outranks the verified/unverified defaults, so record
+        # that. Without it the next CIMD metadata refresh re-tiers the app and overwrites them.
+        source = previous.rate_limit_source
+        if rate_limits.account_requests != previous.rate_limits.account_requests:
+            source = "admin"
+
+        instance.provisioning = ProvisioningConfig(**capabilities, rate_limits=rate_limits, rate_limit_source=source)
+
+        if commit:
+            instance.save()
+            self.save_m2m()
+        return instance
+
+
+class ProvisioningCapabilityFilter(admin.SimpleListFilter):
+    """Filter partners by a granted capability.
+
+    The capabilities live inside a JSONB column, so the per-column checkbox filters the admin
+    used to offer are gone. One filter over every capability replaces them, and it stays in
+    step with the schema rather than needing an entry added per capability.
+    """
+
+    title = "provisioning capability"
+    parameter_name = "provisioning_capability"
+
+    def lookups(self, request, model_admin):
+        return [
+            (name, name.replace("_", " "))
+            for name in ProvisioningConfig.model_fields
+            if name not in ("rate_limits", "rate_limit_source")
+        ]
+
+    def queryset(self, request, queryset):
+        capability = self.value()
+        if not capability or capability not in ProvisioningConfig.model_fields:
+            return queryset
+        return queryset.filter(**{f"_provisioning_config__{capability}": True})
+
 
 # Registered manually in `posthog/admin/__init__.py::register_all_admin()`
 # after `admin.site.unregister(OAuthApplication)` clears the default that
@@ -75,9 +169,8 @@ class OAuthApplicationAdmin(admin.ModelAdmin):  # nosemgrep: admin-modeladmin-ne
         "is_cimd_client",
         "is_first_party",
         "auth_brand",
-        "provisioning_active",
         "is_provisioning_partner",
-        "provisioning_partner_type",
+        ProvisioningCapabilityFilter,
     )
     search_fields = ("name", "client_id", "cimd_metadata_url", "user__email", "organization__name")
     autocomplete_fields = ("user", "organization")
@@ -170,19 +263,7 @@ class OAuthApplicationAdmin(admin.ModelAdmin):  # nosemgrep: admin-modeladmin-ne
 
     def get_fieldsets(self, request, obj=None):
         if obj:
-            provisioning_fields = [
-                "is_provisioning_partner",
-                "provisioning_partner_type",
-                "provisioning_active",
-                "provisioning_skip_existing_user_consent",
-                "provisioning_can_issue_deep_links",
-                "provisioning_issues_personal_api_key",
-                "provisioning_can_create_accounts",
-                "provisioning_can_provision_resources",
-                "provisioning_rate_limit_account_requests",
-                "provisioning_rate_limit_token_exchanges",
-                "provisioning_rate_limit_resource_creates",
-            ]
+            provisioning_fields = ["is_provisioning_partner", *PROVISIONING_FORM_FIELD_NAMES]
 
             return (
                 (None, {"fields": ("id", "name", "client_id", "client_type", "auth_brand", "logo_uri")}),
@@ -205,12 +286,14 @@ class OAuthApplicationAdmin(admin.ModelAdmin):  # nosemgrep: admin-modeladmin-ne
                     "Provisioning",
                     {
                         "description": (
-                            "Provisioning settings for agentic partners. How a partner authenticates follows "
-                            "from the fields above: a confidential client with a jwks_uri signs an assertion "
-                            "with its own key (preferred), a confidential client without one presents a client "
-                            "secret, and a public client is identified by client_id and relies on PKCE. Only "
-                            "confidential partners may use the GitHub grant endpoints. Use the 'Generate a new "
-                            "client secret' action to issue a secret."
+                            "Provisioning settings for partners. Every capability is off unless you "
+                            "grant it here, including for a partner that registered itself. How a partner "
+                            "authenticates follows from the fields above: a confidential client with a "
+                            "jwks_uri signs an assertion with its own key (preferred), a confidential client "
+                            "without one presents a client secret, and a public client is identified by "
+                            "client_id and relies on PKCE. The GitHub grant endpoints additionally require a "
+                            "confidential client. Use the 'Generate a new client secret' action to issue a "
+                            "secret. Leave a rate limit blank to use the endpoint's default."
                         ),
                         "fields": tuple(provisioning_fields),
                     },

--- a/posthog/admin/admins/oauth_admin.py
+++ b/posthog/admin/admins/oauth_admin.py
@@ -107,8 +107,10 @@ class OAuthApplicationForm(forms.ModelForm):
         )
         # An operator typing a limit here outranks the verified/unverified defaults, so record
         # that. Without it the next CIMD metadata refresh re-tiers the app and overwrites them.
+        # Keyed on the field actually changing in this form rather than on the stored value, so
+        # saving an unrelated field doesn't pin a limit a CIMD refresh set since the form loaded.
         source = previous.rate_limit_source
-        if rate_limits.account_requests != previous.rate_limits.account_requests:
+        if f"{PROVISIONING_RATE_LIMIT_PREFIX}account_requests" in self.changed_data:
             source = "admin"
 
         instance.provisioning = ProvisioningConfig(**capabilities, rate_limits=rate_limits, rate_limit_source=source)

--- a/posthog/admin/test_oauth_admin.py
+++ b/posthog/admin/test_oauth_admin.py
@@ -20,10 +20,63 @@ class TestOAuthApplicationAdmin(BaseTest):
         super().setUp()
         self.admin = OAuthApplicationAdmin(OAuthApplication, AdminSite())
 
-    def test_list_filter_includes_provisioning_fields(self):
-        assert "provisioning_active" in self.admin.list_filter
-        assert "is_provisioning_partner" in self.admin.list_filter
-        assert "provisioning_partner_type" in self.admin.list_filter
+    def _provisioning_form(self, app: OAuthApplication, **fields):
+        form_class = self.admin.get_form(RequestFactory().get("/"), app, change=True)
+        data = {
+            "name": app.name,
+            "client_id": app.client_id,
+            "client_type": app.client_type,
+            "authorization_grant_type": app.authorization_grant_type,
+            "redirect_uris": app.redirect_uris,
+            "algorithm": app.algorithm,
+            **fields,
+        }
+        return form_class(data=data, instance=app)
+
+    def test_admin_grants_a_capability_into_the_config(self):
+        # Granting a capability is the admin's whole job here, and it writes into a JSONB blob
+        # rather than a column, so a form that silently dropped it would look like it worked.
+        app = OAuthApplication.objects.create(
+            name="Capability App",
+            client_id="capability_client_id",
+            client_secret="secret",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            algorithm="RS256",
+        )
+        assert app.provisioning.can_use_github_grants is False
+
+        form = self._provisioning_form(app, provisioning_can_use_github_grants="on")
+        assert form.is_valid(), form.errors
+        form.save()
+
+        app.refresh_from_db()
+        granted = app.provisioning
+        assert granted.can_use_github_grants is True
+        # Unticked boxes stay off rather than picking up a default.
+        assert granted.can_start_wizard_runs is False
+
+    def test_admin_rate_limit_override_outranks_the_verified_default(self):
+        # A CIMD refresh re-tiers the account-request limit unless the source says an admin set
+        # it, so an override typed here has to record that or the next refresh overwrites it.
+        app = OAuthApplication.objects.create(
+            name="Rate Limit App",
+            client_id="rate_limit_client_id",
+            client_secret="secret",
+            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="https://example.com/callback",
+            algorithm="RS256",
+        )
+
+        form = self._provisioning_form(app, provisioning_rate_limit_account_requests="250")
+        assert form.is_valid(), form.errors
+        form.save()
+
+        app.refresh_from_db()
+        assert app.provisioning.rate_limits.account_requests == 250
+        assert app.provisioning.rate_limit_source == "admin"
 
     @parameterized.expand(
         [

--- a/posthog/admin/test_oauth_admin.py
+++ b/posthog/admin/test_oauth_admin.py
@@ -26,6 +26,7 @@ class TestOAuthApplicationAdmin(BaseTest):
             "name": app.name,
             "client_id": app.client_id,
             "client_type": app.client_type,
+            "auth_brand": app.auth_brand,
             "authorization_grant_type": app.authorization_grant_type,
             "redirect_uris": app.redirect_uris,
             "algorithm": app.algorithm,

--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -11,7 +11,7 @@ import re
 import json
 import time
 import hashlib
-from typing import TypedDict, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 from urllib.parse import urlparse
 
 from django.core.cache import cache
@@ -41,6 +41,9 @@ from posthog.security.pinned_requests import PinnedIPAdapter, select_pinned_ip
 from posthog.security.url_validation import is_url_allowed, validate_url_and_pin_ips
 
 from .client_name import sanitize_client_name, validate_client_name
+
+if TYPE_CHECKING:
+    from posthog.models.oauth_provisioning import ProvisioningConfig
 
 logger = structlog.get_logger(__name__)
 
@@ -623,24 +626,26 @@ def _update_cimd_application(app: OAuthApplication, metadata: CIMDMetadataDocume
         # legacy rows with no source recorded (source="") stay put. Legacy
         # rows are treated conservatively as admin to avoid clobbering values
         # that pre-date this field.
-        if app.is_provisioning_partner and app.provisioning_rate_limit_account_requests_source in (
-            "default_unverified",
-            "default_verified",
-        ):
+        config = app.provisioning
+        if app.is_provisioning_partner and config.rate_limit_source in ("default_unverified", "default_verified"):
             became_verified = old_org_id is None and new_org_id is not None
             became_unverified = old_org_id is not None and new_org_id is None
-            if became_verified:
-                app.provisioning_rate_limit_account_requests = CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT
-                app.provisioning_rate_limit_account_requests_source = "default_verified"
-                update_fields.extend(
-                    ["provisioning_rate_limit_account_requests", "provisioning_rate_limit_account_requests_source"]
+            if became_verified or became_unverified:
+                app.provisioning = config.model_copy(
+                    update={
+                        "rate_limits": config.rate_limits.model_copy(
+                            update={
+                                "account_requests": (
+                                    CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT
+                                    if became_verified
+                                    else CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT
+                                )
+                            }
+                        ),
+                        "rate_limit_source": "default_verified" if became_verified else "default_unverified",
+                    }
                 )
-            elif became_unverified:
-                app.provisioning_rate_limit_account_requests = CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT
-                app.provisioning_rate_limit_account_requests_source = "default_unverified"
-                update_fields.extend(
-                    ["provisioning_rate_limit_account_requests", "provisioning_rate_limit_account_requests_source"]
-                )
+                update_fields.append("_provisioning_config")
 
     try:
         app.full_clean()
@@ -817,45 +822,59 @@ def get_application_by_client_id(client_id: str) -> OAuthApplication:
 # traceable to a real PostHog organization.
 CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT = 10  # per hour, anonymous CIMD
 CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT = 100  # per hour, verified CIMD
-CIMD_PROVISIONING_DEFAULTS: dict[str, bool | int | str] = {
-    # Nothing here touches client authentication: that is derived from the client's own
-    # metadata document by _resolve_client_authentication, so a CIMD partner is public or
-    # private_key_jwt according to what it publishes.
-    "is_provisioning_partner": True,
-    "provisioning_active": True,
-    "provisioning_can_create_accounts": True,
-    "provisioning_can_provision_resources": True,
-    "provisioning_rate_limit_account_requests": CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
-}
 
 
-def _cimd_provisioning_defaults_for(app: OAuthApplication) -> dict:
-    """Return the provisioning default profile to apply to this CIMD app on
-    first-time registration. Verified apps (linked to a PostHog org) get the
-    higher account-request rate limit."""
-    defaults = dict(CIMD_PROVISIONING_DEFAULTS)
-    if app.organization_id is not None:
-        defaults["provisioning_rate_limit_account_requests"] = CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT
-        defaults["provisioning_rate_limit_account_requests_source"] = "default_verified"
-    else:
-        defaults["provisioning_rate_limit_account_requests_source"] = "default_unverified"
-    return defaults
+def _cimd_provisioning_defaults_for(app: OAuthApplication) -> "ProvisioningConfig":
+    """The config a CIMD app gets when it registers itself, layered over whatever it already has.
+
+    Nothing here touches client authentication: that is derived from the client's own metadata
+    document by _resolve_client_authentication, so a CIMD partner is public or private_key_jwt
+    according to what it publishes.
+
+    Deliberately narrow. Creating accounts and provisioning resources is the whole point of
+    self-serve registration, so those are turned on; no other capability is, because a partner
+    that vouched for itself by publishing a document is not the same as one PostHog decided to
+    trust. GitHub grants, wizard runs, deep links and skipped consent are granted by an admin or
+    not at all.
+
+    Layered rather than replacing the config wholesale, so an admin who granted a capability
+    before the app first registered does not have it silently dropped here. For the ordinary
+    case - a brand new self-registered client - the existing config is empty and the two are
+    the same thing.
+    """
+    config = app.provisioning
+    changes: dict[str, object] = {"active": True, "can_create_accounts": True, "can_provision_resources": True}
+
+    # Verified partners (those who presented a valid `posthog_verification_token`) get a higher
+    # account-request limit, since abuse is traceable to a real PostHog organization. An admin
+    # override already recorded on the app outranks both tiers.
+    if config.rate_limit_source != "admin":
+        verified = app.organization_id is not None
+        changes["rate_limits"] = config.rate_limits.model_copy(
+            update={
+                "account_requests": (
+                    CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT
+                    if verified
+                    else CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT
+                )
+            }
+        )
+        changes["rate_limit_source"] = "default_verified" if verified else "default_unverified"
+
+    return config.model_copy(update=changes)
 
 
 def apply_provisioning_defaults(app: OAuthApplication) -> OAuthApplication:
-    """Apply provisioning defaults to a CIMD app and persist them.
+    """Opt a CIMD app into provisioning with the self-serve defaults, and persist them.
 
-    Computes the correct defaults (verified vs anonymous rate limit) based on
-    the app's organization linkage, sets the fields, and saves. Respects
-    `provisioning_disabled` as a kill switch - returns the app untouched
-    rather than re-enabling a partner an admin has explicitly disabled."""
-    if app.provisioning_disabled:
+    Respects the `disabled` kill switch - returns the app untouched rather than re-enabling a
+    partner an admin has explicitly disabled."""
+    if app.provisioning.disabled:
         return app
     became_partner = not app.is_provisioning_partner
-    defaults = _cimd_provisioning_defaults_for(app)
-    for field, value in defaults.items():
-        setattr(app, field, value)
-    app.save(update_fields=list(defaults.keys()))
+    app.is_provisioning_partner = True
+    app.provisioning = _cimd_provisioning_defaults_for(app)
+    app.save(update_fields=["is_provisioning_partner", "_provisioning_config"])
 
     # A partner appearing without an admin creating it is the event worth watching for abuse,
     # so it fires on the transition only - re-running the defaults over an existing partner is
@@ -868,7 +887,7 @@ def apply_provisioning_defaults(app: OAuthApplication) -> OAuthApplication:
                 "cimd_url": app.cimd_metadata_url,
                 "client_name": app.name,
                 "app_id": str(app.pk),
-                "account_requests_rate_limit": app.provisioning_rate_limit_account_requests,
+                "account_requests_rate_limit": app.provisioning.rate_limits.account_requests,
                 "is_verified": app.organization_id is not None,
                 "organization_id": str(app.organization_id) if app.organization_id else None,
             },

--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
-from django.db import IntegrityError
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 import requests
@@ -568,6 +568,39 @@ def _touch_verification_token(token: CIMDVerificationToken) -> None:
     CIMDVerificationToken.objects.filter(pk=token.pk).update(last_used_at=timezone.now())
 
 
+def _retier_account_requests_limit(app: OAuthApplication, *, verified: bool) -> None:
+    """Move a partner's account-request limit onto the verified or unverified default tier.
+
+    Only our own default tiers move. An explicit admin override (source="admin") stays put, and
+    so does a legacy row with no source recorded, treated conservatively as admin so a value
+    that pre-dates the field is not clobbered.
+
+    Locks and re-reads before deciding, because the caller's copy of the app was loaded before a
+    network fetch of the metadata document. That window is wide enough for an admin to have
+    revoked a capability in it, and merging into a stale blob would write the revoked value back.
+    """
+    with transaction.atomic():
+        current = OAuthApplication.objects.select_for_update().get(pk=app.pk)
+        config = current.provisioning
+        if not current.is_provisioning_partner or config.rate_limit_source not in (
+            "default_unverified",
+            "default_verified",
+        ):
+            return
+        app.update_provisioning(
+            rate_limits=config.rate_limits.model_copy(
+                update={
+                    "account_requests": (
+                        CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT
+                        if verified
+                        else CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT
+                    )
+                }
+            ),
+            rate_limit_source="default_verified" if verified else "default_unverified",
+        )
+
+
 def _update_cimd_application(app: OAuthApplication, metadata: CIMDMetadataDocument) -> OAuthApplication:
     """
     Update an existing OAuthApplication from refreshed CIMD metadata.
@@ -620,32 +653,6 @@ def _update_cimd_application(app: OAuthApplication, metadata: CIMDMetadataDocume
     if old_org_id != new_org_id:
         app.organization = new_org
         update_fields.append("organization")
-        # When verification status flips on an already-provisioning app, keep
-        # the rate-limit tier in sync. Only bump when the source is one of our
-        # default tiers — explicit admin overrides (source="admin") and
-        # legacy rows with no source recorded (source="") stay put. Legacy
-        # rows are treated conservatively as admin to avoid clobbering values
-        # that pre-date this field.
-        config = app.provisioning
-        if app.is_provisioning_partner and config.rate_limit_source in ("default_unverified", "default_verified"):
-            became_verified = old_org_id is None and new_org_id is not None
-            became_unverified = old_org_id is not None and new_org_id is None
-            if became_verified or became_unverified:
-                app.provisioning = config.model_copy(
-                    update={
-                        "rate_limits": config.rate_limits.model_copy(
-                            update={
-                                "account_requests": (
-                                    CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT
-                                    if became_verified
-                                    else CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT
-                                )
-                            }
-                        ),
-                        "rate_limit_source": "default_verified" if became_verified else "default_unverified",
-                    }
-                )
-                update_fields.append("_provisioning_config")
 
     try:
         app.full_clean()
@@ -658,6 +665,13 @@ def _update_cimd_application(app: OAuthApplication, metadata: CIMDMetadataDocume
     else:
         if verification is not None:
             _touch_verification_token(verification)
+        # Keep the rate-limit tier in step with verification status. Written after the main save
+        # and through its own locked merge, rather than as another field on it, because the whole
+        # provisioning blob has to be rewritten to change one key inside it.
+        if old_org_id is None and new_org_id is not None:
+            _retier_account_requests_limit(app, verified=True)
+        elif old_org_id is not None and new_org_id is None:
+            _retier_account_requests_limit(app, verified=False)
         # Emit a distinct event on org re-linking so a metadata compromise
         # flipping A→B (or A→None, None→A) is visible in analytics, not
         # just buried in the generic refresh event.
@@ -868,13 +882,22 @@ def apply_provisioning_defaults(app: OAuthApplication) -> OAuthApplication:
     """Opt a CIMD app into provisioning with the self-serve defaults, and persist them.
 
     Respects the `disabled` kill switch - returns the app untouched rather than re-enabling a
-    partner an admin has explicitly disabled."""
-    if app.provisioning.disabled:
-        return app
-    became_partner = not app.is_provisioning_partner
-    app.is_provisioning_partner = True
-    app.provisioning = _cimd_provisioning_defaults_for(app)
-    app.save(update_fields=["is_provisioning_partner", "_provisioning_config"])
+    partner an admin has explicitly disabled.
+
+    Locks and re-reads the config first. Registration runs after a network fetch of the metadata
+    document, so the caller's copy of the app can be seconds or minutes old, and layering the
+    defaults over that copy would write back a capability - or a cleared kill switch - that an
+    admin revoked while the fetch was in flight.
+    """
+    with transaction.atomic():
+        current = OAuthApplication.objects.select_for_update().get(pk=app.pk)
+        app._provisioning_config = current._provisioning_config
+        if app.provisioning.disabled:
+            return app
+        became_partner = not current.is_provisioning_partner
+        app.is_provisioning_partner = True
+        app.provisioning = _cimd_provisioning_defaults_for(app)
+        app.save(update_fields=["is_provisioning_partner", "_provisioning_config"])
 
     # A partner appearing without an admin creating it is the event worth watching for abuse,
     # so it fires on the transition only - re-running the defaults over an existing partner is

--- a/posthog/api/oauth/test_cimd.py
+++ b/posthog/api/oauth/test_cimd.py
@@ -590,11 +590,11 @@ class TestApplyProvisioningDefaults(APIBaseTest):
         app = apply_provisioning_defaults(existing)
 
         self.assertTrue(app.is_provisioning_partner)
-        self.assertTrue(app.provisioning_active)
-        self.assertTrue(app.provisioning_can_create_accounts)
-        self.assertTrue(app.provisioning_can_provision_resources)
+        self.assertTrue(app.provisioning.active)
+        self.assertTrue(app.provisioning.can_create_accounts)
+        self.assertTrue(app.provisioning.can_provision_resources)
         self.assertEqual(
-            app.provisioning_rate_limit_account_requests,
+            app.provisioning.rate_limits.account_requests,
             CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
         )
 
@@ -618,8 +618,7 @@ class TestApplyProvisioningDefaults(APIBaseTest):
         mock_get.return_value = _mock_response(_make_metadata(), headers={})
         existing = fetch_and_upsert_cimd_application(VALID_CIMD_URL)
         assert existing is not None
-        existing.provisioning_disabled = True
-        existing.save(update_fields=["provisioning_disabled"])
+        existing.update_provisioning(disabled=True)
         mock_capture.reset_mock()
 
         app = apply_provisioning_defaults(existing)
@@ -679,7 +678,7 @@ class TestCIMDVerificationToken(APIBaseTest):
         assert app is not None
         self.assertEqual(app.organization_id, self.organization.id)
         self.assertEqual(
-            app.provisioning_rate_limit_account_requests,
+            app.provisioning.rate_limits.account_requests,
             CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT,
         )
 
@@ -692,7 +691,7 @@ class TestCIMDVerificationToken(APIBaseTest):
         assert app is not None
         self.assertIsNone(app.organization_id)
         self.assertEqual(
-            app.provisioning_rate_limit_account_requests,
+            app.provisioning.rate_limits.account_requests,
             CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
         )
 
@@ -750,7 +749,7 @@ class TestCIMDVerificationToken(APIBaseTest):
         app = OAuthApplication.objects.get(cimd_metadata_url=VALID_CIMD_URL)
         self.assertIsNone(app.organization_id)
         self.assertEqual(
-            app.provisioning_rate_limit_account_requests,
+            app.provisioning.rate_limits.account_requests,
             CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
         )
 
@@ -764,7 +763,7 @@ class TestCIMDVerificationToken(APIBaseTest):
         assert refreshed is not None
         self.assertEqual(refreshed.organization_id, self.organization.id)
         self.assertEqual(
-            refreshed.provisioning_rate_limit_account_requests,
+            refreshed.provisioning.rate_limits.account_requests,
             CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT,
         )
 
@@ -778,7 +777,7 @@ class TestCIMDVerificationToken(APIBaseTest):
         app = OAuthApplication.objects.get(cimd_metadata_url=VALID_CIMD_URL)
         self.assertEqual(app.organization_id, self.organization.id)
         self.assertEqual(
-            app.provisioning_rate_limit_account_requests,
+            app.provisioning.rate_limits.account_requests,
             CIMD_PROVISIONING_ACCOUNT_REQUESTS_VERIFIED_RATE_LIMIT,
         )
 
@@ -789,7 +788,7 @@ class TestCIMDVerificationToken(APIBaseTest):
         assert refreshed is not None
         self.assertIsNone(refreshed.organization_id)
         self.assertEqual(
-            refreshed.provisioning_rate_limit_account_requests,
+            refreshed.provisioning.rate_limits.account_requests,
             CIMD_PROVISIONING_ACCOUNT_REQUESTS_DEFAULT_RATE_LIMIT,
         )
 
@@ -798,15 +797,8 @@ class TestCIMDVerificationToken(APIBaseTest):
         mock_get.return_value = _mock_response(_make_metadata(), headers={})
         _register_provisioning_partner()
         app = OAuthApplication.objects.get(cimd_metadata_url=VALID_CIMD_URL)
-        app.provisioning_rate_limit_account_requests = 250
-        app.provisioning_rate_limit_account_requests_source = "admin"
-        app.save(
-            update_fields=[
-                "provisioning_rate_limit_account_requests",
-                "provisioning_rate_limit_account_requests_source",
-            ]
-        )
-
+        app.update_provisioning(rate_limit_source="admin")
+        app.update_provisioning_rate_limits(account_requests=250)
         _, plaintext = create_cimd_verification_token(
             organization=self.organization, label="Post-admin-override", created_by=self.user
         )
@@ -816,8 +808,8 @@ class TestCIMDVerificationToken(APIBaseTest):
 
         assert refreshed is not None
         self.assertEqual(refreshed.organization_id, self.organization.id)
-        self.assertEqual(refreshed.provisioning_rate_limit_account_requests, 250)
-        self.assertEqual(refreshed.provisioning_rate_limit_account_requests_source, "admin")
+        self.assertEqual(refreshed.provisioning.rate_limits.account_requests, 250)
+        self.assertEqual(refreshed.provisioning.rate_limit_source, "admin")
 
 
 class TestAuthorizationServerMetadata(APIBaseTest):

--- a/posthog/api/oauth/test_cimd.py
+++ b/posthog/api/oauth/test_cimd.py
@@ -618,7 +618,9 @@ class TestApplyProvisioningDefaults(APIBaseTest):
         mock_get.return_value = _mock_response(_make_metadata(), headers={})
         existing = fetch_and_upsert_cimd_application(VALID_CIMD_URL)
         assert existing is not None
-        existing.update_provisioning(disabled=True)
+        # Disabled through a separate row read, so `existing` still holds the pre-revocation
+        # copy - the state a registration is in when its metadata fetch overlaps an admin edit.
+        OAuthApplication.objects.get(pk=existing.pk).update_provisioning(disabled=True)
         mock_capture.reset_mock()
 
         app = apply_provisioning_defaults(existing)
@@ -627,6 +629,22 @@ class TestApplyProvisioningDefaults(APIBaseTest):
         app.refresh_from_db()
         self.assertFalse(app.is_provisioning_partner)
         self.assertNotIn("cimd_provisioning_partner_registered", _captured_events(mock_capture))
+
+    @patch("posthog.api.oauth.cimd.requests.Session.get")
+    def test_registration_does_not_restore_a_capability_revoked_mid_fetch(self, mock_get, _url_mock):
+        mock_get.return_value = _mock_response(_make_metadata(), headers={})
+        existing = fetch_and_upsert_cimd_application(VALID_CIMD_URL)
+        assert existing is not None
+        existing.update_provisioning(can_use_github_grants=True)
+        OAuthApplication.objects.get(pk=existing.pk).update_provisioning(can_use_github_grants=False)
+
+        app = apply_provisioning_defaults(existing)
+
+        self.assertFalse(app.provisioning.can_use_github_grants)
+        app.refresh_from_db()
+        self.assertFalse(app.provisioning.can_use_github_grants)
+        # The self-serve defaults still land - only the admin's revocation survives on top.
+        self.assertTrue(app.provisioning.can_create_accounts)
 
 
 @patch("posthog.security.url_validation.resolve_host_ips", return_value={ip_address("93.184.216.34")})

--- a/posthog/api/oauth/test_client_assertion.py
+++ b/posthog/api/oauth/test_client_assertion.py
@@ -70,7 +70,6 @@ class TestClientAssertion(BaseTest):
             redirect_uris="https://partner.example.com/callback",
             algorithm="RS256",
             is_provisioning_partner=True,
-            provisioning_active=True,
         )
 
     def _claims(self, **overrides) -> dict:

--- a/posthog/management/commands/backfill_agentic_provisioning_scope.py
+++ b/posthog/management/commands/backfill_agentic_provisioning_scope.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--application-id",
             type=str,
-            help="Limit to a single OAuthApplication id. Defaults to every application with provisioning_partner_type set.",
+            help="Limit to a single OAuthApplication id. Defaults to every provisioning partner.",
         )
         parser.add_argument(
             "--dry-run",
@@ -39,7 +39,7 @@ class Command(BaseCommand):
         application_id = options.get("application_id")
         dry_run: bool = options["dry_run"]
 
-        application_qs = OAuthApplication.objects.exclude(provisioning_partner_type="")
+        application_qs = OAuthApplication.objects.filter(is_provisioning_partner=True)
         if application_id:
             application_qs = application_qs.filter(id=application_id)
 

--- a/posthog/migrations/1273_oauth_provisioning_config.py
+++ b/posthog/migrations/1273_oauth_provisioning_config.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """Add provisioning_config, the JSONB column that replaces the per-capability columns.
+
+    Schema only. The backfill lands in 1274, the Postgres defaults the retired columns need in
+    1275, and the model-state removal in 1276, because a data migration or a RunSQL sharing a
+    file with schema changes holds its locks for the whole file. Additive and defaulted, so this
+    half is safe on its own and leaves the previous release untouched.
+    """
+
+    dependencies = [("posthog", "1272_user_ui_configuration")]
+
+    operations = [
+        migrations.AddField(
+            model_name="oauthapplication",
+            name="_provisioning_config",
+            field=models.JSONField(
+                blank=True,
+                db_column="provisioning_config",
+                db_default={},
+                default=dict,
+                help_text=(
+                    "Provisioning capabilities and per-endpoint rate limits. Every "
+                    "capability is off unless explicitly granted."
+                ),
+            ),
+        ),
+    ]

--- a/posthog/migrations/1274_backfill_oauth_provisioning_config.py
+++ b/posthog/migrations/1274_backfill_oauth_provisioning_config.py
@@ -1,0 +1,87 @@
+from django.db import migrations
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+BATCH_SIZE = 500
+
+
+def backfill_provisioning_config(apps, schema_editor):
+    OAuthApplication = apps.get_model("posthog", "OAuthApplication")
+
+    # Only rows that carry provisioning state. Every other app keeps the empty-object default,
+    # which reads back as a partner that may do nothing.
+    candidates = OAuthApplication.objects.exclude(
+        is_provisioning_partner=False,
+        provisioning_partner_type="",
+        provisioning_active=False,
+    ).order_by("pk")
+
+    updated = []
+    for app in candidates.iterator(chunk_size=BATCH_SIZE):
+        # provisioning_partner_type was doing double duty as the marker for a partner PostHog
+        # vouched for, and it is the only signal available here for who keeps the two elevated
+        # capabilities. A self-registered CIMD partner never had one set, so it does not get
+        # them - which is the restriction this change exists to introduce.
+        vouched_for = bool(app.provisioning_partner_type)
+
+        app._provisioning_config = {
+            "active": app.provisioning_active,
+            "disabled": app.provisioning_disabled,
+            "can_create_accounts": app.provisioning_can_create_accounts,
+            "can_provision_resources": app.provisioning_can_provision_resources,
+            # Previously gated on `is_cimd_client and not provisioning_partner_type`, so a
+            # non-CIMD partner passed on being admin-created alone. Both collapse to the same
+            # rule now, and this preserves who can call the endpoints today.
+            "can_use_github_grants": vouched_for or not app.is_cimd_client,
+            # Previously ungated: any active partner with can_provision_resources could start a
+            # cloud wizard run, self-registered CIMD partners included. Narrowed to vouched-for
+            # partners here.
+            "can_start_wizard_runs": vouched_for and app.provisioning_can_provision_resources,
+            "can_issue_deep_links": app.provisioning_can_issue_deep_links,
+            "skip_existing_user_consent": app.provisioning_skip_existing_user_consent,
+            "issues_personal_api_key": app.provisioning_issues_personal_api_key,
+            "rate_limits": {
+                "account_requests": app.provisioning_rate_limit_account_requests,
+                "token_exchanges": app.provisioning_rate_limit_token_exchanges,
+                "resource_creates": app.provisioning_rate_limit_resource_creates,
+                "github_grants": app.provisioning_rate_limit_github_grants,
+                "wizard_runs": app.provisioning_rate_limit_wizard_runs,
+            },
+            "rate_limit_source": app.provisioning_rate_limit_account_requests_source,
+        }
+        updated.append(app)
+        if len(updated) >= BATCH_SIZE:
+            OAuthApplication.objects.bulk_update(updated, ["_provisioning_config"])
+            updated = []
+    if updated:
+        OAuthApplication.objects.bulk_update(updated, ["_provisioning_config"])
+
+    # An active partner that loses wizard runs here is the intended outcome, but it is a
+    # capability being taken away from a live integration, so name the rows in the deploy log
+    # rather than letting them find out by 403.
+    lost_wizard_runs = list(
+        candidates.filter(
+            provisioning_active=True,
+            provisioning_can_provision_resources=True,
+            provisioning_partner_type="",
+        ).values_list("id", flat=True)
+    )
+    if lost_wizard_runs:
+        logger.warning("provisioning_partners_lost_wizard_runs", application_ids=lost_wizard_runs)
+
+
+class Migration(migrations.Migration):
+    """Backfill provisioning_config from the per-capability columns.
+
+    Alone in its own migration: a RunPython sharing a file with schema changes holds locks for
+    the whole file. It has to run while those columns are still in the model state, which is why
+    it sits before 1276 rather than after.
+    """
+
+    dependencies = [("posthog", "1273_oauth_provisioning_config")]
+
+    operations = [
+        migrations.RunPython(backfill_provisioning_config, migrations.RunPython.noop, elidable=True),
+    ]

--- a/posthog/migrations/1274_backfill_oauth_provisioning_config.py
+++ b/posthog/migrations/1274_backfill_oauth_provisioning_config.py
@@ -31,13 +31,13 @@ def backfill_provisioning_config(apps, schema_editor):
             "disabled": app.provisioning_disabled,
             "can_create_accounts": app.provisioning_can_create_accounts,
             "can_provision_resources": app.provisioning_can_provision_resources,
-            # Previously gated on `is_cimd_client and not provisioning_partner_type`, so a
-            # non-CIMD partner passed on being admin-created alone. Both collapse to the same
-            # rule now, and this preserves who can call the endpoints today.
+            # The old gate was `is_cimd_client and not provisioning_partner_type`, so a non-CIMD
+            # partner passed on being admin-created alone. Both collapse to one capability, and
+            # this mapping preserves exactly who can call the endpoints.
             "can_use_github_grants": vouched_for or not app.is_cimd_client,
-            # Previously ungated: any active partner with can_provision_resources could start a
-            # cloud wizard run, self-registered CIMD partners included. Narrowed to vouched-for
-            # partners here.
+            # The wizard endpoints carried no gate of their own, so any active partner with
+            # can_provision_resources could start a cloud run, self-registered CIMD partners
+            # included. Narrowed to vouched-for partners here.
             "can_start_wizard_runs": vouched_for and app.provisioning_can_provision_resources,
             "can_issue_deep_links": app.provisioning_can_issue_deep_links,
             "skip_existing_user_consent": app.provisioning_skip_existing_user_consent,

--- a/posthog/migrations/1274_backfill_oauth_provisioning_config.py
+++ b/posthog/migrations/1274_backfill_oauth_provisioning_config.py
@@ -17,20 +17,15 @@ def backfill_provisioning_config(apps, schema_editor):
     # transaction outside the migration's.
     db_alias = schema_editor.connection.alias
 
-    # Only rows that carry provisioning state. Every other app keeps the empty-object default,
-    # which reads back as a partner that may do nothing.
-    candidates = (
-        OAuthApplication.objects.using(db_alias)
-        .exclude(
-            is_provisioning_partner=False,
-            provisioning_partner_type="",
-            provisioning_active=False,
-        )
-        .order_by("pk")
-    )
+    # Every row, deliberately unfiltered. Provisioning state is spread over fourteen columns and
+    # several were set by migrations keyed on things unrelated to whether an app looks like a
+    # partner today, so any filter cheap enough to write here skips rows that carry state. A row
+    # with no state maps to a config that grants nothing, which is what the column's `{}` default
+    # already reads as, so writing it everywhere costs a batched update and loses nothing.
+    candidates = OAuthApplication.objects.using(db_alias).order_by("pk")
 
-    # Collected while iterating because no index covers the filter, so a second pass would mean a
-    # second sequential scan of the whole table.
+    # Collected while iterating rather than in a second query, which would mean a second pass over
+    # the table.
     lost_wizard_runs = []
     updated = []
     for app in candidates.iterator(chunk_size=BATCH_SIZE):
@@ -40,15 +35,29 @@ def backfill_provisioning_config(apps, schema_editor):
         # them - which is the restriction this change exists to introduce.
         vouched_for = bool(app.provisioning_partner_type)
 
+        # Two of the capabilities below read permissively on a row nobody ever configured:
+        # provisioning_can_provision_resources was added with `default=True`, and the old
+        # github-grants gate passed anything non-CIMD. Both endpoint families already require
+        # is_provisioning_partner before they consult the capability (authentication.py, in
+        # `_resolve_partner` and `ProvisioningBearerAuthentication`), so requiring it here too
+        # changes no request's outcome - it keeps the backfill from writing a granted-looking
+        # value onto every ordinary OAuth app in the table, which would read as a grant in the
+        # admin and become load-bearing the day a gate stopped checking the flag.
+        is_partner = app.is_provisioning_partner
+
         app._provisioning_config = {
             "active": app.provisioning_active,
+            # Never conditioned on is_provisioning_partner: clearing that flag is part of how an
+            # admin kills a partner, and the kill switch has to outlive it or the next CIMD
+            # registration re-grants the partner its defaults.
             "disabled": app.provisioning_disabled,
             "can_create_accounts": app.provisioning_can_create_accounts,
-            "can_provision_resources": app.provisioning_can_provision_resources,
+            "can_provision_resources": is_partner and app.provisioning_can_provision_resources,
             # The old gate was `is_cimd_client and not provisioning_partner_type`, so a non-CIMD
-            # partner passed on being admin-created alone. Both collapse to one capability, and
-            # this mapping preserves exactly who can call the endpoints.
-            "can_use_github_grants": vouched_for or not app.is_cimd_client,
+            # partner passed on being admin-created alone. Both collapse to one capability, and a
+            # partner type still carries the grant on its own - 1268 only flagged pkce and bearer
+            # apps, so a vouched-for partner on another auth method must not lose it here.
+            "can_use_github_grants": vouched_for or (is_partner and not app.is_cimd_client),
             # The wizard endpoints carried no gate of their own, so any active partner with
             # can_provision_resources could start a cloud run, self-registered CIMD partners
             # included. Narrowed to vouched-for partners here.

--- a/posthog/migrations/1274_backfill_oauth_provisioning_config.py
+++ b/posthog/migrations/1274_backfill_oauth_provisioning_config.py
@@ -10,14 +10,28 @@ BATCH_SIZE = 500
 def backfill_provisioning_config(apps, schema_editor):
     OAuthApplication = apps.get_model("posthog", "OAuthApplication")
 
+    # Pinned to the alias `migrate` is running on rather than letting the router pick. bin/migrate
+    # uses `default_direct`, which bypasses PgBouncer and therefore has server-side cursors
+    # enabled; the router would send this to `default`, where DISABLE_SERVER_SIDE_CURSORS makes
+    # .iterator() buffer the whole result set client-side and puts the writes in their own
+    # transaction outside the migration's.
+    db_alias = schema_editor.connection.alias
+
     # Only rows that carry provisioning state. Every other app keeps the empty-object default,
     # which reads back as a partner that may do nothing.
-    candidates = OAuthApplication.objects.exclude(
-        is_provisioning_partner=False,
-        provisioning_partner_type="",
-        provisioning_active=False,
-    ).order_by("pk")
+    candidates = (
+        OAuthApplication.objects.using(db_alias)
+        .exclude(
+            is_provisioning_partner=False,
+            provisioning_partner_type="",
+            provisioning_active=False,
+        )
+        .order_by("pk")
+    )
 
+    # Collected while iterating because no index covers the filter, so a second pass would mean a
+    # second sequential scan of the whole table.
+    lost_wizard_runs = []
     updated = []
     for app in candidates.iterator(chunk_size=BATCH_SIZE):
         # provisioning_partner_type was doing double duty as the marker for a partner PostHog
@@ -51,23 +65,20 @@ def backfill_provisioning_config(apps, schema_editor):
             },
             "rate_limit_source": app.provisioning_rate_limit_account_requests_source,
         }
+        # Could start a cloud run before this migration and cannot after it.
+        if app.provisioning_active and app.provisioning_can_provision_resources and not vouched_for:
+            lost_wizard_runs.append(str(app.id))
+
         updated.append(app)
         if len(updated) >= BATCH_SIZE:
-            OAuthApplication.objects.bulk_update(updated, ["_provisioning_config"])
+            OAuthApplication.objects.using(db_alias).bulk_update(updated, ["_provisioning_config"])
             updated = []
     if updated:
-        OAuthApplication.objects.bulk_update(updated, ["_provisioning_config"])
+        OAuthApplication.objects.using(db_alias).bulk_update(updated, ["_provisioning_config"])
 
     # An active partner that loses wizard runs here is the intended outcome, but it is a
     # capability being taken away from a live integration, so name the rows in the deploy log
     # rather than letting them find out by 403.
-    lost_wizard_runs = list(
-        candidates.filter(
-            provisioning_active=True,
-            provisioning_can_provision_resources=True,
-            provisioning_partner_type="",
-        ).values_list("id", flat=True)
-    )
     if lost_wizard_runs:
         logger.warning("provisioning_partners_lost_wizard_runs", application_ids=lost_wizard_runs)
 

--- a/posthog/migrations/1275_default_legacy_provisioning_columns.py
+++ b/posthog/migrations/1275_default_legacy_provisioning_columns.py
@@ -1,0 +1,44 @@
+from django.db import migrations
+
+# Every retired column that is NOT NULL. Their Django ``default=`` was only ever applied in
+# Python, so once the model stops listing them every INSERT would violate the constraint.
+# Defaults rather than dropping NOT NULL, so rows written by new code still read back exactly as
+# the previous release expects while both are live.
+BOOLEAN_COLUMNS = [
+    "provisioning_active",
+    "provisioning_can_create_accounts",
+    "provisioning_can_issue_deep_links",
+    "provisioning_can_provision_resources",
+    "provisioning_disabled",
+    "provisioning_skip_existing_user_consent",
+]
+TEXT_COLUMNS = [
+    "provisioning_partner_type",
+    "provisioning_rate_limit_account_requests_source",
+]
+
+# provisioning_issues_personal_api_key already has a Postgres default (it was added with
+# db_default), and the five rate-limit columns are nullable, so neither needs anything here.
+
+
+def _set_default(column: str, literal: str) -> migrations.RunSQL:
+    return migrations.RunSQL(
+        sql=f"""ALTER TABLE "posthog_oauthapplication" ALTER COLUMN "{column}" SET DEFAULT {literal};""",
+        reverse_sql=f"""ALTER TABLE "posthog_oauthapplication" ALTER COLUMN "{column}" DROP DEFAULT;""",
+    )
+
+
+class Migration(migrations.Migration):
+    """Give Postgres defaults for the provisioning columns 1276 drops from the model state.
+
+    Alone in its own migration: RunSQL sharing a file with other operations holds its lock for
+    the whole file. These are catalog-only ALTERs on a small table, so they are cheap, but they
+    still take a brief ACCESS EXCLUSIVE lock each.
+    """
+
+    dependencies = [("posthog", "1274_backfill_oauth_provisioning_config")]
+
+    operations = [
+        *[_set_default(column, "false") for column in BOOLEAN_COLUMNS],
+        *[_set_default(column, "''") for column in TEXT_COLUMNS],
+    ]

--- a/posthog/migrations/1275_default_legacy_provisioning_columns.py
+++ b/posthog/migrations/1275_default_legacy_provisioning_columns.py
@@ -20,25 +20,30 @@ TEXT_COLUMNS = [
 # provisioning_issues_personal_api_key already has a Postgres default (it was added with
 # db_default), and the five rate-limit columns are nullable, so neither needs anything here.
 
+COLUMN_DEFAULTS = [(column, "false") for column in BOOLEAN_COLUMNS] + [(column, "''") for column in TEXT_COLUMNS]
 
-def _set_default(column: str, literal: str) -> migrations.RunSQL:
-    return migrations.RunSQL(
-        sql=f"""ALTER TABLE "posthog_oauthapplication" ALTER COLUMN "{column}" SET DEFAULT {literal};""",
-        reverse_sql=f"""ALTER TABLE "posthog_oauthapplication" ALTER COLUMN "{column}" DROP DEFAULT;""",
-    )
+SET_DEFAULTS_SQL = 'ALTER TABLE "posthog_oauthapplication" ' + ", ".join(
+    f'ALTER COLUMN "{column}" SET DEFAULT {literal}' for column, literal in COLUMN_DEFAULTS
+)
+DROP_DEFAULTS_SQL = 'ALTER TABLE "posthog_oauthapplication" ' + ", ".join(
+    f'ALTER COLUMN "{column}" DROP DEFAULT' for column, _ in COLUMN_DEFAULTS
+)
 
 
 class Migration(migrations.Migration):
     """Give Postgres defaults for the provisioning columns 1276 drops from the model state.
 
+    One ALTER carrying every SET DEFAULT clause rather than one statement per column. These are
+    catalog-only changes, but each still needs a brief ACCESS EXCLUSIVE lock, so batching takes
+    that lock once instead of eight times - and keeps the file to a single operation, which is
+    what the migration risk analyzer asks of one that would otherwise mix several.
+
     Alone in its own migration: RunSQL sharing a file with other operations holds its lock for
-    the whole file. These are catalog-only ALTERs on a small table, so they are cheap, but they
-    still take a brief ACCESS EXCLUSIVE lock each.
+    the whole file.
     """
 
     dependencies = [("posthog", "1274_backfill_oauth_provisioning_config")]
 
     operations = [
-        *[_set_default(column, "false") for column in BOOLEAN_COLUMNS],
-        *[_set_default(column, "''") for column in TEXT_COLUMNS],
+        migrations.RunSQL(sql=SET_DEFAULTS_SQL, reverse_sql=DROP_DEFAULTS_SQL),
     ]

--- a/posthog/migrations/1276_untrack_legacy_provisioning_columns.py
+++ b/posthog/migrations/1276_untrack_legacy_provisioning_columns.py
@@ -1,0 +1,41 @@
+from django.db import migrations
+
+RETIRED_COLUMNS = [
+    "provisioning_active",
+    "provisioning_can_create_accounts",
+    "provisioning_can_issue_deep_links",
+    "provisioning_can_provision_resources",
+    "provisioning_disabled",
+    "provisioning_issues_personal_api_key",
+    "provisioning_partner_type",
+    "provisioning_rate_limit_account_requests",
+    "provisioning_rate_limit_account_requests_source",
+    "provisioning_rate_limit_github_grants",
+    "provisioning_rate_limit_resource_creates",
+    "provisioning_rate_limit_token_exchanges",
+    "provisioning_rate_limit_wizard_runs",
+    "provisioning_skip_existing_user_consent",
+]
+
+
+class Migration(migrations.Migration):
+    """Stop tracking the per-capability provisioning columns in Django state.
+
+    Runs after 1275 so Postgres already has defaults for the NOT NULL ones by the time the model
+    stops listing them, and after 1274 so the backfill still had them in state to read from.
+
+    State-only: the columns stay in Postgres so a rollback to the previous release still finds
+    them, and so no read of a dropped column can 500 during the deploy window. Drop them for
+    real in a later release, once no deployed code references them.
+    """
+
+    dependencies = [("posthog", "1275_default_legacy_provisioning_columns")]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(model_name="oauthapplication", name=column) for column in RETIRED_COLUMNS
+            ],
+            database_operations=[],
+        ),
+    ]

--- a/posthog/migrations/max_migration.txt
+++ b/posthog/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-1272_user_ui_configuration
+1276_untrack_legacy_provisioning_columns

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -336,6 +336,9 @@ field_name_overrides: dict[AuditableScope, dict[str, str]] = {
         "run_interval_minutes": "run interval (minutes)",
         "emit": "emit findings",
     },
+    "OAuthApplication": {
+        "_provisioning_config": "provisioning config",
+    },
     "OrganizationDomain": {
         "jit_provisioning_enabled": "just-in-time provisioning",
         "sso_enforcement": "SSO enforcement",

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -246,16 +246,39 @@ class OAuthApplication(ModelActivityMixin, AbstractApplication):  # type: ignore
         """Apply a partial change to the config and persist it.
 
         The blob is one column, so a read-modify-write is the only way to set a single key
-        without clobbering its neighbours. Centralized here so no caller has to remember that,
-        and so ``update_fields`` stays correct.
+        without clobbering its neighbours. That makes concurrent writers a lost-update
+        problem - an admin granting a capability while a CIMD refresh re-tiers a rate limit
+        would otherwise have one silently overwrite the other - so the row is locked and
+        re-read inside the transaction rather than trusting the copy in memory.
         """
-        self.provisioning = self.provisioning.model_copy(update=changes)
-        self.save(update_fields=["_provisioning_config"])
+        with transaction.atomic():
+            current = OAuthApplication.objects.select_for_update().get(pk=self.pk)
+            self._provisioning_config = current._provisioning_config
+            self.provisioning = self.provisioning.model_copy(update=changes)
+            self.save(update_fields=["_provisioning_config"])
         return self.provisioning
 
     def update_provisioning_rate_limits(self, **changes: object) -> "ProvisioningConfig":
-        """Apply a partial change to the nested rate limits and persist it."""
-        return self.update_provisioning(rate_limits=self.provisioning.rate_limits.model_copy(update=changes))
+        """Apply a partial change to the nested rate limits and persist it.
+
+        Nested under the same lock as any other partial change, so the read of the current
+        limits can't be stale by the time it is written back.
+        """
+        with transaction.atomic():
+            current = OAuthApplication.objects.select_for_update().get(pk=self.pk)
+            self._provisioning_config = current._provisioning_config
+            return self.update_provisioning(rate_limits=self.provisioning.rate_limits.model_copy(update=changes))
+
+    @property
+    def carries_provisioning_config(self) -> bool:
+        """Whether this app has ever been configured for provisioning, whatever
+        ``is_provisioning_partner`` says now.
+
+        Partner quotas key on this rather than the flag, so an admin who disables a partner
+        without revoking its outstanding tokens doesn't also exempt those tokens from the
+        rate limits.
+        """
+        return bool(self._provisioning_config)
 
     # Client authentication is registration state on purpose. A client_id is public, so
     # inferring the method from what a request happens to present would let anyone act as a

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -29,6 +29,10 @@ from posthog.models.utils import UUIDT, generate_random_token, hash_key_value, m
 if TYPE_CHECKING:
     from posthog.models import Organization, User
 
+    # This model loads at django.setup() in every process; the pydantic schema is
+    # runtime-imported in the accessors that materialize it.
+    from posthog.models.oauth_provisioning import ProvisioningConfig
+
 
 class OAuthApplicationAccessLevel(enum.Enum):
     ALL = "all"
@@ -210,73 +214,48 @@ class OAuthApplication(ModelActivityMixin, AbstractApplication):  # type: ignore
             "follows from client_type, so there is no separate provisioning auth method."
         ),
     )
-    provisioning_partner_type: models.CharField = models.CharField(
-        max_length=50,
+    # Mangled so the `provisioning` property below can own the readable name. Every capability
+    # and quota lives in here; see posthog/models/oauth_provisioning.py for the shape. Empty
+    # object means "a partner that may do nothing yet", which is the intended starting point.
+    _provisioning_config: models.JSONField = models.JSONField(
+        default=dict,
+        db_default={},
         blank=True,
-        default="",
-        help_text="Partner identifier: stripe, wizard, etc. Empty for non-provisioning apps.",
-    )
-    provisioning_active: models.BooleanField = models.BooleanField(
-        default=False, help_text="Must be explicitly enabled for provisioning access"
-    )
-    provisioning_can_create_accounts: models.BooleanField = models.BooleanField(
-        default=False, help_text="Can this app create PostHog accounts on behalf of users"
-    )
-    provisioning_can_provision_resources: models.BooleanField = models.BooleanField(
-        default=True, help_text="Can this app provision projects and API keys"
-    )
-    provisioning_issues_personal_api_key: models.BooleanField = models.BooleanField(
-        default=False,
-        db_default=False,
+        db_column="provisioning_config",
         help_text=(
-            "Whether provisioning mints a Personal API Key for this app. Off by default; "
-            "only grandfathered apps (the legacy Stripe app) still issue one, capped at the app's scopes."
+            "Provisioning capabilities and per-endpoint rate limits. Every capability is off unless explicitly granted."
         ),
     )
-    provisioning_rate_limit_account_requests: models.IntegerField = models.IntegerField(
-        null=True, blank=True, help_text="Override default rate limit for account_requests (per hour)"
-    )
-    provisioning_rate_limit_account_requests_source: models.CharField = models.CharField(
-        max_length=24,
-        blank=True,
-        default="",
-        choices=[
-            ("default_unverified", "default_unverified"),
-            ("default_verified", "default_verified"),
-            ("admin", "admin"),
-        ],
-        help_text=(
-            "Records who set provisioning_rate_limit_account_requests so verification flips don't "
-            "overwrite an explicit admin override."
-        ),
-    )
-    provisioning_rate_limit_token_exchanges: models.IntegerField = models.IntegerField(
-        null=True, blank=True, help_text="Override default rate limit for token exchanges (per hour)"
-    )
-    provisioning_rate_limit_resource_creates: models.IntegerField = models.IntegerField(
-        null=True, blank=True, help_text="Override default rate limit for resource creates (per hour)"
-    )
-    provisioning_rate_limit_github_grants: models.IntegerField = models.IntegerField(
-        null=True, blank=True, help_text="Override default rate limit for GitHub grant creation (per hour)"
-    )
-    provisioning_rate_limit_wizard_runs: models.IntegerField = models.IntegerField(
-        null=True, blank=True, help_text="Override default rate limit for wizard cloud run creation (per hour)"
-    )
-    provisioning_disabled: models.BooleanField = models.BooleanField(
-        default=False,
-        help_text=(
-            "Kill switch for misbehaving partners. When true, apply_provisioning_defaults will not "
-            "re-enable the app on subsequent CIMD requests."
-        ),
-    )
-    provisioning_skip_existing_user_consent: models.BooleanField = models.BooleanField(
-        default=False,
-        help_text="Skip user consent when linking existing accounts. Only enable for fully trusted partners.",
-    )
-    provisioning_can_issue_deep_links: models.BooleanField = models.BooleanField(
-        default=False,
-        help_text="Allow this app to issue deep links that mint full web sessions. Only enable for fully trusted partners.",
-    )
+
+    @property
+    def provisioning(self) -> "ProvisioningConfig":
+        """The parsed provisioning config. Absent keys read as their default, so a partner is
+        never accidentally granted a capability the stored blob never mentioned."""
+        from posthog.models.oauth_provisioning import ProvisioningConfig  # noqa: PLC0415
+
+        return ProvisioningConfig.model_validate(self._provisioning_config or {})
+
+    @provisioning.setter
+    def provisioning(self, value: "ProvisioningConfig | dict") -> None:
+        from posthog.models.oauth_provisioning import ProvisioningConfig  # noqa: PLC0415
+
+        config = value if isinstance(value, ProvisioningConfig) else ProvisioningConfig.model_validate(value)
+        self._provisioning_config = config.model_dump(mode="json")
+
+    def update_provisioning(self, **changes: object) -> "ProvisioningConfig":
+        """Apply a partial change to the config and persist it.
+
+        The blob is one column, so a read-modify-write is the only way to set a single key
+        without clobbering its neighbours. Centralized here so no caller has to remember that,
+        and so ``update_fields`` stays correct.
+        """
+        self.provisioning = self.provisioning.model_copy(update=changes)
+        self.save(update_fields=["_provisioning_config"])
+        return self.provisioning
+
+    def update_provisioning_rate_limits(self, **changes: object) -> "ProvisioningConfig":
+        """Apply a partial change to the nested rate limits and persist it."""
+        return self.update_provisioning(rate_limits=self.provisioning.rate_limits.model_copy(update=changes))
 
     # Client authentication is registration state on purpose. A client_id is public, so
     # inferring the method from what a request happens to present would let anyone act as a

--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -277,8 +277,15 @@ class OAuthApplication(ModelActivityMixin, AbstractApplication):  # type: ignore
         Partner quotas key on this rather than the flag, so an admin who disables a partner
         without revoking its outstanding tokens doesn't also exempt those tokens from the
         rate limits.
+
+        "Grants or records something" rather than "the column is non-empty": the backfill writes
+        a config to every row, ordinary OAuth apps included, so a non-empty blob says nothing
+        about whether an app was ever a partner. A config equal to the all-default one carries no
+        grant, no deactivation and no quota, which is exactly the app that owes no partner quota.
         """
-        return bool(self._provisioning_config)
+        from posthog.models.oauth_provisioning import ProvisioningConfig  # noqa: PLC0415
+
+        return self.is_provisioning_partner or self.provisioning != ProvisioningConfig()
 
     # Client authentication is registration state on purpose. A client_id is public, so
     # inferring the method from what a request happens to present would let anyone act as a

--- a/posthog/models/oauth_provisioning.py
+++ b/posthog/models/oauth_provisioning.py
@@ -1,0 +1,77 @@
+"""Storage shape for ``OAuthApplication.provisioning_config``.
+
+A provisioning partner's capabilities and quotas live in one JSONB column rather than
+a column each. The column is internal storage, not a public DTO: nothing in the API surface
+serializes it directly, so it is free to change shape here without a schema migration.
+
+Every capability defaults to False. A partner is granted what it may do explicitly, so a key
+that has never been written reads as "not allowed" rather than inheriting whatever default the
+column happened to be created with. That is what makes adding a capability safe: existing rows
+do not silently acquire it.
+
+``extra="ignore"`` rather than ``forbid`` so a row written by a newer release still loads on an
+older one mid-deploy. Unknown keys are rejected where an operator can act on the message
+instead - see the admin form - because silently dropping a mistyped capability key would read
+to an operator as a capability that was granted.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Records who set the account-request rate limit, so a verification flip doesn't overwrite an
+# explicit admin override. Empty for rows that pre-date the field.
+RateLimitSource = Literal["", "default_unverified", "default_verified", "admin"]
+
+
+class ProvisioningRateLimits(BaseModel):
+    """Per-endpoint hourly overrides. None means "use the endpoint's default"."""
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    account_requests: int | None = None
+    token_exchanges: int | None = None
+    resource_creates: int | None = None
+    github_grants: int | None = None
+    wizard_runs: int | None = None
+
+
+class ProvisioningConfig(BaseModel):
+    """What a provisioning partner may do, and how often.
+
+    Whether an app is a partner at all stays on ``OAuthApplication.is_provisioning_partner``:
+    that is identity rather than capability, and it is the column admin and querysets filter on.
+
+    Frozen, because ``OAuthApplication.provisioning`` parses the column afresh on every read:
+    ``app.provisioning.active = True`` would otherwise mutate a throwaway object and persist
+    nothing, which for a capability check fails open and looks like it worked. Change it with
+    ``app.update_provisioning(active=True)`` instead.
+    """
+
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    active: bool = False
+    # Kill switch for a misbehaving partner. Checked separately from `active` so re-running the
+    # self-serve defaults cannot turn a partner an admin switched off back on.
+    disabled: bool = False
+
+    can_create_accounts: bool = False
+    can_provision_resources: bool = False
+    # Exchanging GitHub OAuth codes and starting cloud wizard runs both act well beyond ordinary
+    # provisioning, so neither follows from being a partner - each is granted on its own.
+    can_use_github_grants: bool = False
+    can_start_wizard_runs: bool = False
+
+    # Only for partners trusted enough that the blast radius of the app being compromised is
+    # understood: a deep link mints a full web session, and skipping consent links an existing
+    # account without the user agreeing to it.
+    can_issue_deep_links: bool = False
+    skip_existing_user_consent: bool = False
+
+    # Grandfathered: only the legacy Stripe app still mints a Personal API Key.
+    issues_personal_api_key: bool = False
+
+    rate_limits: ProvisioningRateLimits = Field(default_factory=ProvisioningRateLimits)
+    rate_limit_source: RateLimitSource = ""

--- a/posthog/models/test/test_oauth.py
+++ b/posthog/models/test/test_oauth.py
@@ -4,7 +4,7 @@ from freezegun import freeze_time
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.test import TestCase, override_settings
+from django.test import SimpleTestCase, TestCase, override_settings
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -18,6 +18,7 @@ from posthog.models.oauth import (
     revoke_application_sessions,
     revoke_oauth_session,
 )
+from posthog.models.oauth_provisioning import ProvisioningConfig
 
 
 class TestOAuthModels(TestCase):
@@ -549,3 +550,33 @@ class TestOAuthModels(TestCase):
         other_app.refresh_from_db()
         self.assertEqual(app.sessions_revoked_at, timezone.now())
         self.assertIsNone(other_app.sessions_revoked_at)
+
+
+class TestCarriesProvisioningConfig(SimpleTestCase):
+    @parameterized.expand(
+        [
+            # The backfill writes a config to every row, so an ordinary OAuth app ends up with a
+            # populated blob. Owing a partner quota has to key on what the config says, or every
+            # OAuth app's refresh starts consuming the partner token-exchange bucket.
+            ("all_default_config", {"is_provisioning_partner": False, "config": ProvisioningConfig()}, False),
+            ("partner_flag", {"is_provisioning_partner": True, "config": ProvisioningConfig()}, True),
+            # An admin disabling a partner clears the flag, and its outstanding tokens must stay
+            # throttled rather than being exempted by the same action.
+            (
+                "disabled_partner",
+                {"is_provisioning_partner": False, "config": ProvisioningConfig(disabled=True)},
+                True,
+            ),
+            (
+                "quota_recorded",
+                {"is_provisioning_partner": False, "config": ProvisioningConfig(rate_limit_source="admin")},
+                True,
+            ),
+        ]
+    )
+    def test_carries_provisioning_config(self, _name: str, fields: dict, expected: bool) -> None:
+        app = OAuthApplication(
+            is_provisioning_partner=fields["is_provisioning_partner"],
+            _provisioning_config=fields["config"].model_dump(mode="json"),
+        )
+        assert app.carries_provisioning_config is expected

--- a/posthog/test/activity_logging/test_oauth_application_activity_logging.py
+++ b/posthog/test/activity_logging/test_oauth_application_activity_logging.py
@@ -137,8 +137,7 @@ class TestOAuthApplicationActivityLogging(BaseTest):
         application = self._create_application(scopes=["insight:read"])
         self._scope_logs(application).delete()
 
-        application.provisioning_active = True
-        application.save(update_fields=["provisioning_active"])
+        application.update_provisioning(active=True)
 
         self.assertEqual(self._scope_logs(application).count(), 0)
 

--- a/posthog/test/test_migration_1274.py
+++ b/posthog/test/test_migration_1274.py
@@ -1,0 +1,97 @@
+from typing import Any
+
+import pytest
+from posthog.test.base import TestMigrations
+
+from parameterized import parameterized
+
+pytestmark = pytest.mark.skip("old migrations slow overall test run down")
+
+
+class BackfillProvisioningConfigMigrationTest(TestMigrations):
+    migrate_from = "1273_oauth_provisioning_config"
+    migrate_to = "1274_backfill_oauth_provisioning_config"
+
+    CLASS_DATA_LEVEL_SETUP = False
+
+    def setUpBeforeMigration(self, apps: Any) -> None:
+        OAuthApplication = apps.get_model("posthog", "OAuthApplication")
+        self.OAuthApplication = OAuthApplication
+
+        # A partner PostHog vouched for, carrying a partner type and a custom quota.
+        self.vouched = self._create_app(
+            "vouched",
+            is_provisioning_partner=True,
+            provisioning_partner_type="wizard",
+            provisioning_active=True,
+            provisioning_can_create_accounts=True,
+            provisioning_can_provision_resources=True,
+            provisioning_can_issue_deep_links=True,
+            provisioning_rate_limit_account_requests=250,
+            provisioning_rate_limit_account_requests_source="admin",
+        )
+        # A CIMD client that registered itself: partner, but nobody vouched for it.
+        self.self_registered = self._create_app(
+            "self_registered",
+            is_cimd_client=True,
+            cimd_metadata_url="https://selfreg.example.com/.well-known/oauth-client-metadata.json",
+            is_provisioning_partner=True,
+            provisioning_active=True,
+            provisioning_can_create_accounts=True,
+            provisioning_can_provision_resources=True,
+        )
+        # An admin-created partner whose type field was simply left blank.
+        self.blank_type = self._create_app(
+            "blank_type",
+            is_provisioning_partner=True,
+            provisioning_active=True,
+            provisioning_can_provision_resources=True,
+        )
+        # An ordinary OAuth app that has nothing to do with provisioning.
+        self.plain = self._create_app("plain")
+
+    def _create_app(self, slug: str, **fields: Any):
+        return self.OAuthApplication.objects.create(
+            name=f"App {slug}",
+            client_id=f"client-{slug}",
+            client_secret="",
+            client_type="confidential",
+            authorization_grant_type="authorization-code",
+            redirect_uris="https://example.com/callback",
+            algorithm="RS256",
+            **fields,
+        )
+
+    @parameterized.expand(
+        [
+            # A partner type was the old github-grants gate, so it carries over as the grant.
+            ("vouched", "can_use_github_grants", True),
+            # Wizard runs were ungated before; a vouched-for partner keeps them.
+            ("vouched", "can_start_wizard_runs", True),
+            ("vouched", "can_issue_deep_links", True),
+            # Self-registration never vouched for anything, so both elevated capabilities go.
+            ("self_registered", "can_use_github_grants", False),
+            ("self_registered", "can_start_wizard_runs", False),
+            # Still allowed to do the ordinary provisioning it was already doing.
+            ("self_registered", "can_create_accounts", True),
+            ("self_registered", "active", True),
+            # Non-CIMD apps only exist because an admin made them, which is what the old gate
+            # treated as vouched-for. Preserved so a blank type doesn't lock one out.
+            ("blank_type", "can_use_github_grants", True),
+            # Wizard runs had no such carve-out, and no partner type means no grant.
+            ("blank_type", "can_start_wizard_runs", False),
+        ]
+    )
+    def test_capability_backfill(self, app_attr: str, key: str, expected: bool) -> None:
+        app = self.OAuthApplication.objects.get(pk=getattr(self, app_attr).pk)
+        assert app.provisioning_config[key] is expected
+
+    def test_rate_limits_and_source_carry_over(self) -> None:
+        config = self.OAuthApplication.objects.get(pk=self.vouched.pk).provisioning_config
+        assert config["rate_limits"]["account_requests"] == 250
+        assert config["rate_limit_source"] == "admin"
+
+    def test_non_partner_app_is_left_empty(self) -> None:
+        # Backfilling every row would hand an ordinary OAuth app a config it should never have,
+        # and the empty object is what makes "never granted" the default.
+        assert self.OAuthApplication.objects.get(pk=self.plain.pk).provisioning_config == {}

--- a/posthog/test/test_migration_1274.py
+++ b/posthog/test/test_migration_1274.py
@@ -5,6 +5,8 @@ from posthog.test.base import TestMigrations
 
 from parameterized import parameterized
 
+from posthog.models.oauth_provisioning import ProvisioningConfig
+
 pytestmark = pytest.mark.skip("old migrations slow overall test run down")
 
 
@@ -47,6 +49,21 @@ class BackfillProvisioningConfigMigrationTest(TestMigrations):
             provisioning_active=True,
             provisioning_can_provision_resources=True,
         )
+        # A self-registered partner an admin killed: flag cleared, kill switch set, deactivated.
+        # None of that shows up in the three columns that used to select rows for this backfill.
+        self.killed = self._create_app(
+            "killed",
+            is_cimd_client=True,
+            cimd_metadata_url="https://killed.example.com/.well-known/oauth-client-metadata.json",
+            provisioning_disabled=True,
+        )
+        # Capabilities that older migrations granted keyed on provisioning_auth_method and
+        # client_id, on a row that 1268 did not make a partner.
+        self.legacy = self._create_app(
+            "legacy",
+            provisioning_can_issue_deep_links=True,
+            provisioning_issues_personal_api_key=True,
+        )
         # An ordinary OAuth app that has nothing to do with provisioning.
         self.plain = self._create_app("plain")
 
@@ -80,6 +97,21 @@ class BackfillProvisioningConfigMigrationTest(TestMigrations):
             ("blank_type", "can_use_github_grants", True),
             # Wizard runs had no such carve-out, and no partner type means no grant.
             ("blank_type", "can_start_wizard_runs", False),
+            # The kill switch is the one capability whose default fails open, so a row that
+            # carries it has to be backfilled however unconfigured it otherwise looks - or the
+            # next CIMD registration re-grants the partner everything.
+            ("killed", "disabled", True),
+            # These two fail closed instead, so losing them silently breaks a live integration.
+            ("legacy", "can_issue_deep_links", True),
+            ("legacy", "issues_personal_api_key", True),
+            # Ordinary OAuth apps are the bulk of the table and never a provisioning partner, so
+            # an unfiltered backfill must not hand them either capability that reads permissively
+            # off an unconfigured row - the old gate let anything non-CIMD through, and
+            # provisioning_can_provision_resources was added with default=True.
+            ("plain", "can_use_github_grants", False),
+            ("plain", "can_provision_resources", False),
+            # And the partners that do hold it have to keep it.
+            ("vouched", "can_provision_resources", True),
         ]
     )
     def test_capability_backfill(self, app_attr: str, key: str, expected: bool) -> None:
@@ -91,7 +123,8 @@ class BackfillProvisioningConfigMigrationTest(TestMigrations):
         assert config["rate_limits"]["account_requests"] == 250
         assert config["rate_limit_source"] == "admin"
 
-    def test_non_partner_app_is_left_empty(self) -> None:
-        # Backfilling every row would hand an ordinary OAuth app a config it should never have,
-        # and the empty object is what makes "never granted" the default.
-        assert self.OAuthApplication.objects.get(pk=self.plain.pk)._provisioning_config == {}
+    def test_non_partner_app_grants_nothing(self) -> None:
+        # Every row is backfilled, so what keeps an ordinary OAuth app harmless is the mapping
+        # rather than being skipped: its config has to mean the same as the column's {} default.
+        config = self.OAuthApplication.objects.get(pk=self.plain.pk)._provisioning_config
+        assert ProvisioningConfig.model_validate(config) == ProvisioningConfig()

--- a/posthog/test/test_migration_1274.py
+++ b/posthog/test/test_migration_1274.py
@@ -84,14 +84,14 @@ class BackfillProvisioningConfigMigrationTest(TestMigrations):
     )
     def test_capability_backfill(self, app_attr: str, key: str, expected: bool) -> None:
         app = self.OAuthApplication.objects.get(pk=getattr(self, app_attr).pk)
-        assert app.provisioning_config[key] is expected
+        assert app._provisioning_config[key] is expected
 
     def test_rate_limits_and_source_carry_over(self) -> None:
-        config = self.OAuthApplication.objects.get(pk=self.vouched.pk).provisioning_config
+        config = self.OAuthApplication.objects.get(pk=self.vouched.pk)._provisioning_config
         assert config["rate_limits"]["account_requests"] == 250
         assert config["rate_limit_source"] == "admin"
 
     def test_non_partner_app_is_left_empty(self) -> None:
         # Backfilling every row would hand an ordinary OAuth app a config it should never have,
         # and the empty object is what makes "never granted" the default.
-        assert self.OAuthApplication.objects.get(pk=self.plain.pk).provisioning_config == {}
+        assert self.OAuthApplication.objects.get(pk=self.plain.pk)._provisioning_config == {}


### PR DESCRIPTION
## Problem

Provisioning partner capabilities were spread across a dozen boolean and integer columns on `OAuthApplication`, and one of them — `provisioning_partner_type`, a free-text `CharField` with no choices — had quietly become load-bearing for security. It was doing seven jobs at once:

| Where | What it did |
|---|---|
| `authentication.py` | **The GitHub grants gate** (`is_cimd_client and not provisioning_partner_type` → 403) |
| `client_registration.py` | Mirrored that gate in the reported capabilities |
| `oauth_token.py` | Whether the token-exchange quota applies on refresh |
| `throttling.py` | Whether the resource-create quota applies |
| `analytics.py` | A `partner_type` dimension on every event |
| `accounts.py` | A user-visible label, capitalized to name the provisioned org |
| `backfill_agentic_provisioning_scope` | Which apps the command walks |

So the security gate was "is this string non-empty". An admin who set it to get a nicer org name silently granted GitHub grants. And uses 3 and 4 pull the opposite way from use 1: blank means *less* trusted for the gate but *unthrottled* for quotas, which is live today — every self-registered CIMD partner has no partner type, so `ResourceCreatesThrottle` returns `None` and they create resources with no partner quota.

Wizard runs had no gate at all. `WizardRunsView` is a `BearerResourceAPIView`, so it only required an active partner with `can_provision_resources` — which the CIMD self-serve defaults turn on. Any partner that got a user through consent could start a coding-agent run in that customer's repository.

## Changes

`provisioning_partner_type` is gone. Every capability and quota now lives in one `provisioning_config` JSONB column, backed by a pydantic schema in `posthog/models/oauth_provisioning.py`, following the `db_column` + property-accessor pattern already used by `TeamRevenueAnalyticsConfig` and `visual_review`'s `DiffMetadata`.

```python
app.provisioning.can_use_github_grants   # read
app.update_provisioning(active=True)     # write
```

**Every capability defaults to false.** A key that has never been written reads as "not allowed", which is what makes adding a capability safe: existing rows don't silently acquire it.

Two new gates replace the overloaded one:

- `can_use_github_grants` — checked by `GitHubGrantsAuthentication`, uniformly, with no CIMD special case
- `can_start_wizard_runs` — checked in `WizardRunsView`, which had nothing before

`is_provisioning_partner` stays a real column. It answers "is this app a partner at all" rather than "what may it do", it's the natural admin filter, and migration `1267` on the parent PR only just added it.

The config is **frozen**. `app.provisioning` re-parses the column on every read, so `app.provisioning.active = True` would mutate a throwaway object and persist nothing — for a capability check that fails *open* while looking like it worked. Frozen turns that into a loud error. This caught several real bugs while migrating the test suite.

### Admin

Capabilities render as checkboxes and rate limits as integer fields, generated from the pydantic schema so a new capability appears automatically. Not a raw JSON textarea: a mistyped key there reads back as "not granted" while looking granted on screen, which is the wrong failure mode for a security control. Typing a rate limit also stamps `rate_limit_source = "admin"`, so the next CIMD metadata refresh can't overwrite it. The per-column checkbox filters collapse into one `ProvisioningCapabilityFilter`.

### Migrations

Four, mirroring the `1267`–`1270` sequence already on the parent branch, since a `RunPython` or `RunSQL` sharing a file with schema changes holds its locks for the whole file:

1. `1273` — add the column (`ADD COLUMN ... DEFAULT '{}'::jsonb NOT NULL`)
2. `1274` — backfill from the old columns
3. `1275` — `SET DEFAULT` on each retired NOT NULL column, so inserts keep working once the model stops listing them
4. `1276` — state-only `RemoveField`

The backfill walks **every row**, unfiltered. An earlier version selected only rows that looked like partners, but `exclude(a=False, b="", c=False)` is one negated conjunction, so it skipped rows where all three were at their defaults rather than rows carrying no state - which is exactly the shape of a killed partner (flag cleared, deactivated, `provisioning_disabled=True`). Those rows kept the `{}` default, and `disabled` is the one field whose default fails open, so the kill switch was lost and the next CIMD registration re-granted the partner. The same skip dropped `can_issue_deep_links`, `skip_existing_user_consent`, `issues_personal_api_key` and the rate-limit overrides that `1120`, `1123` and `1212` set keyed on unrelated columns. Thanks to @MattBro for catching it.

Two capabilities read permissively off a row nobody configured - `provisioning_can_provision_resources` was added with `default=True`, and the old github-grants gate passed anything non-CIMD - so both also require `is_provisioning_partner` in the mapping. Both endpoint families already require that flag before consulting the capability, so no request changes outcome; it only stops the backfill writing a granted-looking value onto every ordinary OAuth app. `disabled` is deliberately not conditioned on the flag, since clearing it is half of how a partner gets killed.

Because every row now carries a config, `carries_provisioning_config` can no longer mean "the blob is non-empty" - it asks whether the config grants or records anything, so ordinary OAuth apps still owe no partner token-exchange quota.

The columns stay in Postgres, so a rollback still finds them and no read of a dropped column can 500 mid-deploy. Dropping them for real is a later release.

The two representations are not synced during the deploy window: old pods still read the legacy columns. Every direction of that split fails closed - a partner that self-registers or is granted a capability on a new pod looks unconfigured to an old one, so the old one denies - except revocation, which a not-yet-replaced pod can miss and a rollback would lose. Accepted rather than dual-written for one release: revoking a misbehaving partner in earnest means revoking its sessions and blocking its metadata URL, neither of which is version-split, and both of which take effect on every pod immediately.

> [!WARNING]
> **The backfill takes wizard runs away from self-registered partners.** `can_start_wizard_runs` backfills to `partner_type != ""`. Since wizard runs were previously ungated, any partner relying on them without a partner type set will start getting 403. That's the point of the change, but it's the thing to check before this ships: the migration logs the affected application ids as `provisioning_partners_lost_wizard_runs`.
>
> `can_use_github_grants` preserves today's rule exactly — `partner_type` set, or non-CIMD.

Self-serve CIMD registration grants only `active`, `can_create_accounts` and `can_provision_resources`. GitHub grants, wizard runs, deep links and skipped consent are admin-granted or not at all. The defaults layer over any existing config rather than replacing it, so a capability an admin granted before first registration isn't dropped.

## How did you test this code?

Automated, run locally by me (Claude):

- `uv run mypy --cache-fine-grained .` — clean across 17,051 files. It caught a real narrowing bug in one of the new admin tests.
- `hogli ci:preflight --fix` — 0 failures
- `makemigrations --check` — no state drift; `sqlmigrate` inspected for all four migrations; all four applied against a dev database

The suites have since run locally: `pytest ee/api/agentic_provisioning/` (328 passed) and `pytest posthog/api/oauth/test_cimd.py posthog/admin/test_oauth_admin.py` (117 passed). Backend CI was green on the previous head. I have not run `posthog/test/activity_logging/` locally, so CI covers that one.

New tests, and the regression each catches that nothing existing did:

- `test_migration_1274.py` — the backfill mapping, parameterized over vouched / self-registered / blank-type / killed / legacy / plain apps. A mis-mapped capability either strands a live partner on 403 or over-grants one, and it's a one-shot data migration. Carries the repo's standard `pytest.mark.skip` for migration tests, so it does not run in CI; 17 passed locally with the skip lifted.
- `carries_provisioning_config` in `posthog/models/test/test_oauth.py` — a populated-but-all-default config must not count as partner state. Without it, an ordinary OAuth app's refresh would consume the partner token-exchange quota, and nothing else in the suite notices because tests never run the backfill.
- `test_wizard_runs_rejects_a_partner_without_the_capability` — the new gate. Without it, dropping the `require_capability` call silently restores today's unrestricted behavior.
- `test_registration_does_not_restore_a_capability_revoked_mid_fetch` — the locked read-modify-write on the CIMD registration path. Grants a capability, revokes it through a separate row read so the caller's copy is stale, then re-registers. Without the lock the stale copy writes the revoked capability back, which is a capability check that fails open. `test_disabled_partner_is_not_re_enabled` now revokes the same way, so it covers the kill switch on a stale copy too.
- Two admin form tests — that granting a capability persists into the JSONB, and that a rate-limit override records `source="admin"`. The form assembles the blob by hand, so a bug there means an admin action that appears to work and does nothing.

Rewritten rather than added: `test_repositories_rejects_a_self_registered_cimd_partner` and its non-CIMD counterpart encoded the old CIMD-vs-non-CIMD split, which the uniform gate replaces. They now assert on the capability.

I did not manually exercise the admin UI in a browser, or verify against production data which partners currently rely on wizard runs. The latter is the open question on the wizard-runs cutover above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs cover these internal partner capabilities.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this, directed by me. Skills invoked: `/django-migrations` (the four-phase split, `SeparateDatabaseAndState`, and the `SET DEFAULT`-before-untrack step all come from it) and `/writing-tests` (which is why the rewritten GitHub-grants tests are rewrites rather than additions, and why the backfill test is parameterized instead of nine near-identical cases).

Decisions worth surfacing for review:

- **Scope.** I considered moving only the capability booleans and leaving the five rate-limit ints as columns. Moving everything won: the namespace stops sprawling, and adding a capability no longer means a migration. Cheap because only one ORM filter existed on any of these fields, and it was on the column being deleted.
- **Frozen config.** Added after a scripted rewrite of the test suite turned `x.provisioning_active = False` into `x.provisioning.active = False` — a silent no-op, because the property returns a fresh object. Freezing makes that class of bug impossible rather than relying on reviewers to spot it.
- **`extra="ignore"`** on the schema, not `forbid`, so a row written by a newer release still loads on an older one mid-deploy. Unknown-key rejection lives in the admin form instead, where an operator can act on the message.
- **Generated admin fields** rather than a JSON textarea, for the fail-open reason above.



