### PR TITLE
fix(data-imports): avoid lazy schema fetch in table statistics activity

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/compute_table_statistics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/compute_table_statistics.py
@@ -211,6 +211,9 @@ def compute_table_statistics_sync(team_id: int, schema_id: uuid.UUID) -> dict[st
     if job is None:
         emit_completed("skipped", reason="no_job")
         return {"status": "skipped", "reason": "no_job"}
+    # Reuse the already-loaded, select_related schema instead of letting job.folder_path() lazily
+    # fetch job.schema on a pooled connection a transaction pooler may have dropped in the meantime.
+    job.schema = schema
 
     resource_name = schema.resolved_s3_folder_name or schema.name
     delta_table_helper = DeltaTableHelper(resource_name=resource_name, job=job, logger=log)

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_compute_table_statistics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_compute_table_statistics.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 import pyarrow as pa
@@ -211,8 +213,9 @@ class TestComputeTableStatisticsSync:
         ):
             compute_table_statistics_sync(team.id, schema.id)
 
-        with self.assertNumQueries(0):
+        with CaptureQueriesContext(connection) as ctx:
             captured["job"].folder_path()
+        assert len(ctx.captured_queries) == 0
 
     def test_runs_without_ai_data_processing_consent(self) -> None:
         # Statistics never leave our infra, so — unlike enrichment — they must NOT be gated on AI consent.

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_compute_table_statistics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_compute_table_statistics.py
@@ -192,6 +192,28 @@ class TestComputeTableStatisticsSync:
         assert stat.computed_for_delta_version == 12
         assert stat.column_type == "Int64"
 
+    def test_job_reuses_prefetched_schema_to_avoid_lazy_query(self) -> None:
+        # job is fetched without select_related("schema"), so job.folder_path() (which reads
+        # job.schema.source.source_type) would otherwise fire a lazy SELECT on a pooled connection a
+        # transaction pooler may have dropped mid-run, raising a transient OperationalError.
+        team = self._team()
+        schema, table, _ = self._schema_table_job(team)
+        add_actions = pa.table({"num_records": [1], "null_count.amount": [0], "min.amount": [1], "max.amount": [1]})
+        captured: dict = {}
+
+        def _capture_helper(*, resource_name, job, logger):
+            captured["job"] = job
+            return self._mock_delta(add_actions)
+
+        with (
+            patch.object(comp, "statistics_enabled", return_value=True),
+            patch(DELTA_HELPER_PATH, side_effect=_capture_helper),
+        ):
+            compute_table_statistics_sync(team.id, schema.id)
+
+        with self.assertNumQueries(0):
+            captured["job"].folder_path()
+
     def test_runs_without_ai_data_processing_consent(self) -> None:
         # Statistics never leave our infra, so — unlike enrichment — they must NOT be gated on AI consent.
         # Guards against someone copy-pasting enrichment's consent gate into this path.


### PR DESCRIPTION
## Problem

Error tracking surfaced a transient `OperationalError` ("connection ... closed the connection unexpectedly") from the warehouse table-statistics activity: [issue](https://us.posthog.com/project/2/error_tracking/019faa52-1e37-7410-bea2-3f14efa25578).

The stack trace shows `compute_table_statistics_sync` fetching an `ExternalDataJob` without `select_related("schema")`. When `DeltaTableHelper` later calls `job.folder_path()`, that lazily resolves `job.schema` with a brand-new DB query — on a connection a transaction pooler (PgBouncer, port 6543 in the trace) may have already recycled or dropped, since this runs well after the activity's earlier queries. The error itself is a transient infra blip and stays retryable; the actual defect is the avoidable lazy fetch that exposes that failure mode.

This is a different call path than the similar-looking open [#71934](https://github.com/PostHog/posthog/pull/71934), which fixes a lazy `schema.source` read in the `import_data_sync.py` loader — that PR doesn't touch `compute_table_statistics.py`, so this one is not a duplicate.

## Changes

`compute_table_statistics_sync` already loads `schema` (with `select_related("source", "table")`) moments before fetching `job` for the same `schema_id`. Assign it onto `job` directly (`job.schema = schema`) so `job.folder_path()` reads the cached, already-loaded object instead of triggering a lazy relation load.

## How did you test this code?

Added `test_job_reuses_prefetched_schema_to_avoid_lazy_query` to `test_compute_table_statistics.py` — captures the `job` passed into `DeltaTableHelper` and asserts `job.folder_path()` costs zero queries; fails without the fix (the lazy fetch it guards against).

Ran locally (this sandbox has no Postgres, so only the DB-independent suite ran here — the new test needs the DB and runs in CI):

- `TestAggregateAddActionStats` and `TestComputeTableStatisticsWorkflow` (14 tests, no DB): pass
- `ruff check` / `ruff format --check` on both changed files: pass
- `mypy` on the changed activity file: pass

## Docs update

Not applicable — internal pipeline reliability fix, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from the error tracking issue linked above. Traced the stack trace through `compute_table_statistics_activity` → `compute_table_statistics_sync` → `DeltaTableHelper.get_delta_table` → `job.folder_path()` → the lazy `job.schema` FK access. Checked open PRs and `NonRetryableErrors` definitions first to rule out both a duplicate fix and an already-classified exclusion; confirmed the shared `NonRetryableErrors` layers only cover customer-source connection errors, not PostHog's own control-plane DB, and that PR #71934 fixes a sibling-but-different lazy-load site. Invoked `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*