### PR TITLE
fix(tasks): keep the human turn's answer in Slack, only divert post-card follow-ups

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -2977,8 +2977,8 @@ def relay_task_run_message(
 
     Returns ``(status, relay_id)`` where status is ``"accepted"`` (relay_id set), ``"skipped"``
     (run not found / terminal / no Slack mapping / empty text / streamed inline under the
-    agent-design flag / posted as a GitHub comment because it's an autonomous follow-up on an
-    already-opened PR), or ``"failed"``.
+    agent-design flag / posted as a GitHub comment because it's an autonomous follow-up after the
+    PR-opened card was already announced to Slack), or ``"failed"``.
 
     When ``text_parts`` is provided the last non-empty entry is used — it's the
     post-last-tool-use answer, and posting only that keeps the interim narration
@@ -3016,13 +3016,19 @@ def relay_task_run_message(
             logger.exception("task_run_relay_text_signal_failed", extra={"run_id": str(run.id)})
         return "skipped", None
 
-    # Once the run has opened a PR, autonomous CI/review follow-ups (the agent re-triggered by
-    # the CI loop, not by a person) belong on the PR, not trailing behind the "PR opened" card in
-    # Slack. A reply to a human's thread message carries that message's id — those stay in Slack so
-    # the conversation isn't diverted. Autonomous follow-ups have no answering message_id: comment
-    # on the PR best-effort and drop the message from Slack either way — never fall back to Slack.
+    # Once the "PR opened" card has been announced to this task's Slack thread, autonomous
+    # CI/review follow-ups (the agent re-triggered by the CI loop, not by a person) belong on the
+    # PR, not trailing behind that card in Slack. The card is the demarcation line: before it, the
+    # run is still answering the human who kicked it off — including the primary summary the agent
+    # posts right after opening the PR — so that answer must reach Slack. We key on
+    # ``slack_notified_pr_url`` (the same task-level dedupe the card itself uses) rather than the
+    # mere presence of ``output.pr_url``, which is set the moment the PR opens and so wrongly caught
+    # the human turn's own answer. A reply that carries the answering human message's id is an
+    # active conversation turn and also stays in Slack. Genuine autonomous follow-ups have no
+    # answering message_id: comment on the PR best-effort and drop the message from Slack either
+    # way — never fall back to Slack.
     pr_url = (run.output or {}).get("pr_url")
-    if pr_url and message_id is None:
+    if pr_url and message_id is None and run.task.slack_notified_pr_url == pr_url:
         _post_ci_followup_as_github_comment(run, pr_url, trimmed)
         return "skipped", None
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -5084,7 +5084,12 @@ class TestTaskRunAPI(BaseTaskAPITest):
             message_id=None,
         )
 
-    def _pr_run_with_slack_and_github(self):
+    def _pr_run_with_slack_and_github(
+        self,
+        *,
+        pr_url: str = "https://github.com/posthog/posthog/pull/1",
+        pr_card_announced: bool = True,
+    ):
         from posthog.models.integration import Integration
 
         from products.slack_app.backend.models import SlackThreadTaskMapping
@@ -5094,11 +5099,16 @@ class TestTaskRunAPI(BaseTaskAPITest):
         task.github_integration = github_integration
         task.repository = "posthog/posthog"
         task.save(update_fields=["github_integration", "repository"])
+        # The CI-follow-up diversion only kicks in once the "PR opened" card has been announced to
+        # Slack — that's the line after which agent chatter is autonomous. Default to the announced
+        # state so the follow-up tests exercise the diversion; opt out for the still-in-turn case.
+        if pr_card_announced:
+            task.mark_slack_pr_notified(pr_url)
         run = TaskRun.objects.create(
             task=task,
             team=self.team,
             status=TaskRun.Status.IN_PROGRESS,
-            output={"pr_url": "https://github.com/posthog/posthog/pull/1"},
+            output={"pr_url": pr_url},
         )
         slack_integration = Integration.objects.create(
             team=self.team, kind="slack", integration_id="T_SLACK", config={}
@@ -5140,6 +5150,28 @@ class TestTaskRunAPI(BaseTaskAPITest):
 
     @patch("products.tasks.backend.facade.api.GitHubIntegration")
     @patch("products.tasks.backend.temporal.client.execute_posthog_code_agent_relay_workflow")
+    def test_relay_message_primary_answer_before_pr_card_stays_in_slack(self, mock_execute_relay, mock_github_class):
+        # The agent opens a PR and then posts its answer to the human's request in the same turn.
+        # ``output.pr_url`` is already set, but the "PR opened" card has NOT been announced to Slack
+        # yet, so this is still the human turn — the answer must reach Slack, not the PR.
+        task, run = self._pr_run_with_slack_and_github(pr_card_announced=False)
+        mock_github = MagicMock()
+        mock_github_class.return_value = mock_github
+        mock_execute_relay.return_value = "relay-1"
+
+        response = self.client.post(
+            f"/api/projects/@current/tasks/{task.id}/runs/{run.id}/relay_message/",
+            {"text": "Removed the offending line and opened a draft PR."},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"status": "accepted", "relay_id": "relay-1"})
+        mock_github.comment_on_pull_request_from_url.assert_not_called()
+        mock_execute_relay.assert_called_once()
+
+    @patch("products.tasks.backend.facade.api.GitHubIntegration")
+    @patch("products.tasks.backend.temporal.client.execute_posthog_code_agent_relay_workflow")
     def test_relay_message_reply_to_human_after_pr_stays_in_slack(self, mock_execute_relay, mock_github_class):
         task, run = self._pr_run_with_slack_and_github()
         mock_github = MagicMock()
@@ -5163,9 +5195,7 @@ class TestTaskRunAPI(BaseTaskAPITest):
         self, mock_execute_relay, mock_github_class
     ):
         # pr_url is caller-writable; a PR outside the task's own repository must never be commented on.
-        task, run = self._pr_run_with_slack_and_github()
-        run.output = {"pr_url": "https://github.com/posthog/other-repo/pull/1"}
-        run.save(update_fields=["output"])
+        task, run = self._pr_run_with_slack_and_github(pr_url="https://github.com/posthog/other-repo/pull/1")
         mock_github = MagicMock()
         mock_github_class.return_value = mock_github
 


### PR DESCRIPTION
## Problem

Follow-up to #74247. That PR routed post-PR CI follow-ups to a GitHub comment instead of Slack, keyed on `pr_url and message_id is None`. The intent was to divert only autonomous CI/review follow-ups, but it also caught turns by users: the agent's primary answer to the human — posted in the same turn, right after the PR is opened — also has no `message_id`. So the substantive answer to the person's request landed as a GitHub comment instead of in the Slack thread where they were waiting for it.

Reported by Michael in a Slack thread, where the agent's own reply got diverted to the PR.

## Changes

Gate the diversion on the "PR opened 🚀" card actually having been announced to the task's Slack thread, using `task.slack_notified_pr_url == pr_url` — the same task-level dedupe key `_post_pr_opened_notification_once` uses. The card is the real demarcation line the original PR's description talks about ("after the PR opened card"): before it, the run is still answering the human, so the answer stays in Slack. Only follow-ups that arrive after the card — genuinely autonomous CI/review work — divert to the PR. A reply carrying the answering human message's id still stays in Slack as before.

## How did you test this code?

Updated the endpoint tests in `products/tasks/backend/tests/test_api.py`. The shared helper now marks the PR card as announced by default so the existing follow-up tests exercise the post-card diversion, and I added `test_relay_message_primary_answer_before_pr_card_stays_in_slack` — the regression this PR fixes: `output.pr_url` is set but the card hasn't been announced, so the answer must relay to Slack rather than the PR. The out-of-repo test now sets its PR through the helper so its card-announced state matches.

I (Claude, via the PostHog Slack app) could not run the DB-backed tests in this environment — no database or pytest available, same as #74247. I verified the changed files parse and pass `ruff check`. They need a run in CI or a local stack.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Michael from a Slack thread: #74247 diverted user-turn answers to GitHub, not just autonomous CI follow-ups, and he asked me to fix it.

Authored by Claude (PostHog Slack app). I traced the routing decision in `relay_task_run_message`, confirmed the `message_id is None` proxy can't tell the human turn's primary answer from an autonomous follow-up (both lack a message_id), and found `slack_notified_pr_url` — the task-level marker the "PR opened" card sets via `mark_slack_pr_notified` — as the signal that actually matches the feature's stated demarcation. Kept the `message_id`/agent-design/repo-validation behavior intact.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785268756876369?thread_ts=1785268756.876369&cid=C09G8Q32R6F)*
