### PR TITLE
fix(postgres): mark invalid bigint incremental cursor as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -645,15 +645,18 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             # an existing column in place, so retrying won't help — the table must be reset and
             # fully re-synced to adopt the new type.
             "Source column type changed": "A column's type changed in your source database (for example an integer column was widened to bigint) and no longer fits the type we stored. We can't widen an existing column in place — please reset and fully re-sync this table to adopt the new type.",
-            # Raised by the source Postgres when the incremental query compares an integer column
-            # against a non-integer cursor value, e.g. `WHERE "id" > '1.5'`. `_build_query` renders
-            # the stored `incremental_field_last_value` as a SQL literal, so a fractional/non-integer
-            # cursor produces `InvalidTextRepresentation: invalid input syntax for type integer`.
-            # This is deterministic — every retry re-runs the identical failing query — and signals a
-            # type mismatch between the incremental field and its data. The volatile offending value
-            # (`: "1.5"`) is excluded from the match. Coercing the cursor here would change sync
-            # semantics (risk of skipped/duplicated rows), so stop and ask the user to reset.
+            # Raised by the source Postgres when the incremental query compares an integer/bigint
+            # column against a non-integer cursor value, e.g. `WHERE "id" > '1.5'` or
+            # `WHERE "id" > '2026-04-26T20:58:57.557000'`. `_build_query` renders the stored
+            # `incremental_field_last_value` as a SQL literal, so a fractional/timestamp-shaped
+            # cursor produces `InvalidTextRepresentation: invalid input syntax for type integer` (or
+            # `bigint`, depending on the column's declared width). This is deterministic — every retry
+            # re-runs the identical failing query — and signals a type mismatch between the
+            # incremental field and its data. The volatile offending value is excluded from the match.
+            # Coercing the cursor here would change sync semantics (risk of skipped/duplicated rows),
+            # so stop and ask the user to reset.
             "invalid input syntax for type integer": "PostHog tried to resume this table's incremental sync from a non-integer cursor value against an integer incremental field, which your database rejects. This usually means the incremental field's type doesn't match its data. Please reset and fully re-sync this table, or pick a different incremental field.",
+            "invalid input syntax for type bigint": "PostHog tried to resume this table's incremental sync from a non-integer cursor value against a bigint incremental field, which your database rejects. This usually means the incremental field's type doesn't match its data. Please reset and fully re-sync this table, or pick a different incremental field.",
             # Raised (ObjectNotInPrerequisiteState, SQLSTATE 55000) when a selected materialized view
             # was created `WITH NO DATA` and never refreshed — every SELECT against it fails until the
             # customer runs `REFRESH MATERIALIZED VIEW`. Deterministic and outside our control, so

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -798,6 +798,8 @@ class TestPostgresSourceNonRetryableErrors:
         [
             'invalid input syntax for type integer: "1.5"',
             'InvalidTextRepresentation: invalid input syntax for type integer: "1.5"',
+            'invalid input syntax for type bigint: "2026-04-26T20:58:57.557000"',
+            'InvalidTextRepresentation: invalid input syntax for type bigint: "2026-04-26T20:58:57.557000"',
         ],
     )
     def test_non_integer_incremental_cursor_errors_are_non_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

Error tracking surfaced a Postgres import failure: `InvalidTextRepresentation: invalid input syntax for type bigint: "<timestamp-shaped value>"`, raised from `get_rows` in `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py` while building the incremental query (`WHERE "id" > '<cursor>'`).

This happens when a table's stored incremental cursor value doesn't match its `bigint` incremental field's type. The query is deterministic, so every retry re-runs the identical failing SQL and never succeeds on its own — the sync needs a reset, not another retry attempt.

`PostgresSource.get_non_retryable_errors()` already had an entry for this exact failure shape against `integer` columns (`invalid input syntax for type integer`), but not for `bigint`, so bigint-typed incremental fields kept burning Temporal's retry budget and flooding error tracking with a self-recovering-looking but actually permanent failure.

## Changes

- Added `invalid input syntax for type bigint` to `PostgresSource.get_non_retryable_errors()` in `source.py`, mirroring the existing `integer` entry, with a message pointing the user at resetting the sync or picking a different incremental field.
- Updated the shared comment above both entries to describe the integer/bigint pair together.
- Extended the existing parametrized test (`test_non_integer_incremental_cursor_errors_are_non_retryable`) with bigint cases (raw and Temporal-wrapped) rather than adding a near-duplicate test.

## How did you test this code?

Ran the parametrized non-retryable-error test locally:

```
python -m pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py -k non_integer_incremental_cursor -q
# 4 passed
```

Also ran the full test file (`test_postgres.py`) — the 4 cases above pass; the 53 pre-existing DB-dependent tests in that file error in this sandbox for unrelated environment reasons (no live Postgres/Django DB configured), not from this change.

Ran `ruff check` and `ruff format --check` on both changed files — clean.

The added test case is the regression check: without the new dict entry, the bigint-shaped message wouldn't match any non-retryable pattern, so the test fails until the fix is applied.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification change, no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (an agent) triaged a live error-tracking issue for the Postgres data-warehouse import source, confirmed the stack trace originates in `postgres.py`'s `get_rows`, and traced it to the same root cause as an already-handled `integer`-column case in `source.py`, just for `bigint` columns. I searched open PRs (by error text, exception type, module path, and the source's usual author) and found no existing fix for this. No `/writing-tests`-flagged issues — extended the existing parametrized test instead of adding a redundant one, per that skill's guidance.