### PR TITLE
fix(pendo): paginate aggregation endpoints via filter cursor, not skip

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pendo/pendo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pendo/pendo.py
@@ -118,6 +118,13 @@ def _iter_list_endpoint(
         resumable_source_manager.save_state(PendoResumeConfig(offset=offset))
 
 
+def _escape_filter_string(value: str) -> str:
+    # Pendo's filter grammar uses JS-style string literals. `last_id` comes from a row's sort
+    # field (e.g. visitorId, which a customer's own tracking code can set to an arbitrary
+    # string), so escape backslashes and quotes before splicing it into the filter expression.
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def _iter_aggregation(
     session: requests.Session,
     base_url: str,
@@ -138,7 +145,7 @@ def _iter_aggregation(
             {"sort": [sort_field]},
         ]
         if last_id is not None:
-            pipeline.append({"filter": f'{sort_field}>"{last_id}"'})
+            pipeline.append({"filter": f'{sort_field}>"{_escape_filter_string(last_id)}"'})
         pipeline.append({"limit": AGGREGATION_PAGE_SIZE})
 
         body = {

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pendo/pendo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pendo/pendo.py
@@ -32,8 +32,11 @@ class PendoRetryableError(Exception):
 
 @dataclasses.dataclass
 class PendoResumeConfig:
-    # Number of rows already yielded for this schema; on resume we skip past them.
+    # Number of rows already yielded for a list endpoint schema; on resume we skip past them.
     offset: int = 0
+    # Sort-field value of the last row yielded for an aggregation endpoint schema. Pendo's
+    # aggregation pipeline has no skip/offset stage, so resuming re-filters for values past this.
+    last_id: Optional[str] = None
 
 
 def get_base_url(region: Optional[str]) -> str:
@@ -122,23 +125,27 @@ def _iter_aggregation(
     sort_field: str,
     logger: FilteringBoundLogger,
     resumable_source_manager: ResumableSourceManager[PendoResumeConfig],
-    start_offset: int,
+    start_after: Optional[str],
 ) -> Iterator[list[dict[str, Any]]]:
     url = f"{base_url}{AGGREGATION_PATH}"
-    offset = start_offset
+    last_id = start_after
 
     while True:
+        # Sort on a stable id and page via a `>` filter cursor: Pendo's aggregation pipeline
+        # has no skip/offset stage (a "skip" step returns a 400 "unknown step type" error).
+        pipeline: list[dict[str, Any]] = [
+            {"source": {aggregation_source: None}},
+            {"sort": [sort_field]},
+        ]
+        if last_id is not None:
+            pipeline.append({"filter": f'{sort_field}>"{last_id}"'})
+        pipeline.append({"limit": AGGREGATION_PAGE_SIZE})
+
         body = {
             "response": {"mimeType": "application/json"},
             "request": {
                 "requestId": f"posthog-{aggregation_source}",
-                "pipeline": [
-                    {"source": {aggregation_source: None}},
-                    # Sort on a stable id so skip/limit paging is deterministic across requests.
-                    {"sort": [sort_field]},
-                    {"skip": offset},
-                    {"limit": AGGREGATION_PAGE_SIZE},
-                ],
+                "pipeline": pipeline,
             },
         }
         response = _request(session, "POST", url, logger, json=body)
@@ -149,8 +156,8 @@ def _iter_aggregation(
             break
 
         yield rows
-        offset += len(rows)
-        resumable_source_manager.save_state(PendoResumeConfig(offset=offset))
+        last_id = str(rows[-1][sort_field])
+        resumable_source_manager.save_state(PendoResumeConfig(last_id=last_id))
 
         if len(rows) < AGGREGATION_PAGE_SIZE:
             break
@@ -169,13 +176,13 @@ def get_rows(
     session = make_tracked_session(headers=_get_headers(integration_key), redact_values=(integration_key,))
 
     resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    start_offset = resume.offset if resume else 0
-    if start_offset:
-        logger.debug(f"Pendo: resuming endpoint={endpoint} from offset={start_offset}")
 
     if config.is_aggregation:
         if config.aggregation_source is None:
             raise ValueError(f"Endpoint '{endpoint}' is marked as aggregation but has no aggregation_source")
+        start_after = resume.last_id if resume else None
+        if start_after is not None:
+            logger.debug(f"Pendo: resuming endpoint={endpoint} after id={start_after}")
         yield from _iter_aggregation(
             session,
             base_url,
@@ -183,11 +190,14 @@ def get_rows(
             config.primary_keys[0],
             logger,
             resumable_source_manager,
-            start_offset,
+            start_after,
         )
     else:
         if config.path is None:
             raise ValueError(f"Endpoint '{endpoint}' is not an aggregation but has no path")
+        start_offset = resume.offset if resume else 0
+        if start_offset:
+            logger.debug(f"Pendo: resuming endpoint={endpoint} from offset={start_offset}")
         yield from _iter_list_endpoint(
             session,
             base_url,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pendo/tests/test_pendo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pendo/tests/test_pendo.py
@@ -163,7 +163,9 @@ class TestGetRowsListEndpoint:
 class TestGetRowsAggregation:
     @mock.patch(f"{PENDO_PATH}.AGGREGATION_PAGE_SIZE", 2)
     @mock.patch(f"{PENDO_PATH}.make_tracked_session")
-    def test_paginates_via_skip_and_limit(self, mock_session):
+    def test_paginates_via_filter_cursor_and_limit(self, mock_session):
+        # Pendo's aggregation pipeline has no skip/offset stage (a "skip" step is rejected with
+        # a 400 "unknown step type" error), so paging must use a `>` filter cursor on the sort field.
         page1 = {"results": [{"visitorId": "1"}, {"visitorId": "2"}]}
         page2 = {"results": [{"visitorId": "3"}]}
         mock_session.return_value.request.side_effect = [_resp(page1), _resp(page2)]
@@ -181,14 +183,14 @@ class TestGetRowsAggregation:
         first_pipeline = calls[0].kwargs["json"]["request"]["pipeline"]
         assert {"source": {"visitors": None}} in first_pipeline
         assert {"sort": ["visitorId"]} in first_pipeline
-        assert {"skip": 0} in first_pipeline
         assert {"limit": 2} in first_pipeline
+        assert not any("filter" in step for step in first_pipeline)
 
         second_pipeline = calls[1].kwargs["json"]["request"]["pipeline"]
-        assert {"skip": 2} in second_pipeline
+        assert {"filter": 'visitorId>"2"'} in second_pipeline
 
-        offsets = [call.args[0].offset for call in manager.save_state.call_args_list]
-        assert offsets == [2, 3]
+        last_ids = [call.args[0].last_id for call in manager.save_state.call_args_list]
+        assert last_ids == ["2", "3"]
 
     @mock.patch(f"{PENDO_PATH}.make_tracked_session")
     def test_accounts_source_sorts_on_account_id(self, mock_session):
@@ -212,14 +214,14 @@ class TestGetRowsAggregation:
         manager.save_state.assert_not_called()
 
     @mock.patch(f"{PENDO_PATH}.make_tracked_session")
-    def test_resumes_aggregation_from_saved_offset(self, mock_session):
+    def test_resumes_aggregation_from_saved_last_id(self, mock_session):
         mock_session.return_value.request.return_value = _resp({"results": []})
-        manager = _make_manager(PendoResumeConfig(offset=10))
+        manager = _make_manager(PendoResumeConfig(last_id="9"))
 
         list(get_rows("key", "us", "visitors", mock.MagicMock(), manager))
 
         pipeline = mock_session.return_value.request.call_args.kwargs["json"]["request"]["pipeline"]
-        assert {"skip": 10} in pipeline
+        assert {"filter": 'visitorId>"9"'} in pipeline
 
 
 class TestPendoSourceResponse:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pendo/tests/test_pendo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pendo/tests/test_pendo.py
@@ -223,6 +223,18 @@ class TestGetRowsAggregation:
         pipeline = mock_session.return_value.request.call_args.kwargs["json"]["request"]["pipeline"]
         assert {"filter": 'visitorId>"9"'} in pipeline
 
+    @mock.patch(f"{PENDO_PATH}.make_tracked_session")
+    def test_escapes_quotes_in_the_filter_cursor(self, mock_session):
+        # visitorId is set by the customer's own tracking code, so a value containing a `"`
+        # must not be able to break out of the filter string literal and alter the expression.
+        mock_session.return_value.request.return_value = _resp({"results": []})
+        manager = _make_manager(PendoResumeConfig(last_id='ab"cd'))
+
+        list(get_rows("key", "us", "visitors", mock.MagicMock(), manager))
+
+        pipeline = mock_session.return_value.request.call_args.kwargs["json"]["request"]["pipeline"]
+        assert {"filter": 'visitorId>"ab\\"cd"'} in pipeline
+
 
 class TestPendoSourceResponse:
     @pytest.mark.parametrize("endpoint", list(ENDPOINTS))


### PR DESCRIPTION
## Problem

The Pendo `visitors` and `accounts` sources page through Pendo's aggregation API (`POST /api/v1/aggregation`) using a `skip` pipeline stage. Pendo's aggregation pipeline doesn't support a `skip` stage at all — every request past the first page is rejected with a 400 error ("unknown step type 'skip'"), so any sync with more rows than the page size fails outright.

Caught via an error tracking issue on `HTTPError: 400 Client Error: Bad Request for url: https://app.pendo.io/api/v1/aggregation`.

## Changes

Paginate by advancing a `>` filter cursor on the sort field between requests instead of `skip`:

```json
{"source": {"visitors": null}}, {"sort": ["visitorId"]}, {"filter": "visitorId>\"<last seen id>\""}, {"limit": 5000}
```

This mirrors the approach used by Pendo's own reference Python connector ([`singer-io/tap-pendo`](https://github.com/singer-io/tap-pendo)), which pages both its `Visitors` and `Accounts` streams the same way.

`PendoResumeConfig` gains a `last_id` field (the sort-field value of the last row yielded) used for aggregation-endpoint resume; the existing `offset` field is now scoped to the list-endpoint (`features`/`pages`/`guides`) resume path, which is unaffected.

## How did you test this code?

Updated `TestGetRowsAggregation` in `test_pendo.py`:
- `test_paginates_via_filter_cursor_and_limit` — asserts the first request has no `filter` stage, the second request's pipeline carries `{"filter": "visitorId>\"2\""}` after the first page, and resume state tracks `last_id` rather than a row count. Catches a regression back to the (broken) `skip`-based pagination.
- `test_resumes_aggregation_from_saved_last_id` — asserts a saved `last_id` produces the expected filter cursor on resume.

Ran the full `pendo` test module (44 tests) plus repo-wide `mypy` — both pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, triaging a live error-tracking issue for the Pendo warehouse source.
- Read the raw 400 response body from worker logs, which named the exact cause (`unknown step type 'skip'`), then confirmed the correct pagination approach by reading Pendo's open-source reference connector rather than guessing at undocumented API behavior.
- Skills invoked: `/writing-tests` before updating the aggregation pagination tests.