### PR TITLE
fix(replay-vision): honor observation naming conventions in titles

### DIFF
--- a/products/replay_vision/backend/temporal/scanners/prompts/summarizer_summary_step.jinja
+++ b/products/replay_vision/backend/temporal/scanners/prompts/summarizer_summary_step.jinja
@@ -3,6 +3,6 @@
 Additional context from the team operating the product being recorded:
 {{ user_prompt }}{% endif %}
 
-`title` is a short, plain-text headline, up to 120 characters (citations go in `summary`, not the title). `summary` should be {{ length_guidance }}.
+`title` is a short, plain-text headline, up to 120 characters (citations go in `summary`, not the title).{% if user_prompt %} If the context above specifies a naming convention or format for observations, `title` must follow it exactly (an observation's name is its title).{% endif %} `summary` should be {{ length_guidance }}.
 
 {{ cite_in('summary') }}

--- a/products/replay_vision/backend/temporal/scanners/summarizer.py
+++ b/products/replay_vision/backend/temporal/scanners/summarizer.py
@@ -27,7 +27,13 @@ _LENGTH_GUIDANCE: dict[SummaryLength, str] = {
 class SummarizerSummaryResponse(BaseModel, frozen=True):
     """First turn: the title + body summary. Field order is load-bearing — `confidence` last, after the content."""
 
-    title: str = Field(max_length=120, description="Short title for the session (~80 chars). Plain text, no quotes.")
+    title: str = Field(
+        max_length=120,
+        description=(
+            "Short title for the session (~80 chars). Plain text, no quotes. If the team's context specifies "
+            "a naming convention or format for observations, the title must follow it exactly."
+        ),
+    )
     summary: str = Field(description="Body text whose length follows the scanner's configured length.")
     confidence: float = confidence_field()
 

--- a/products/replay_vision/backend/tests/test_scanners.py
+++ b/products/replay_vision/backend/tests/test_scanners.py
@@ -587,6 +587,12 @@ class TestSummarizerScannerSteps:
         # Facets are best-effort: a failed facet turn must not lose the summary it follows.
         assert steps[1].required is False
 
+    def test_summary_step_makes_title_follow_operator_naming_convention(self) -> None:
+        scanner = scanner_from_db(
+            _build_replay_scanner(scanner_type=ScannerType.SUMMARIZER, scanner_config={"prompt": "p"})
+        )
+        assert "naming convention" in scanner.core_steps()[0].instruction
+
     def test_summary_step_opts_into_citations_facets_step_forbids_them(self) -> None:
         scanner = scanner_from_db(
             _build_replay_scanner(scanner_type=ScannerType.SUMMARIZER, scanner_config={"prompt": "p"})


### PR DESCRIPTION
## Problem

A summarizer scanner's prompt can ask for a naming convention for its observations (for example "Name each observation: `<user>` from `<organization>` `<likely intent>`"), but the generated titles don't consistently follow it.

Two things push the model away from the convention:

- The summary step template frames the operator's prompt as background context, then issues its own generic title instruction ("a short, plain-text headline"), which tends to win.
- The structured output schema description for `title` ("Short title for the session (~80 chars)") steers the same generic shape right at generation time.

Origin: [Slack thread](https://posthog.slack.com/archives/C0B7TE4R8GH/p1785260023733099).

## Changes

- `summarizer_summary_step.jinja`: the title instruction now explicitly defers to any naming convention or format the operator's context specifies, and bridges the terminology the operator uses ("an observation's name is its title").
- `SummarizerSummaryResponse.title` field description: states the same precedence rule at the schema level, since that description is what the model sees while filling the field.

Prompt-level only, no API or data changes, fully backwards compatible.

## How did you test this code?

- Added `test_summary_step_makes_title_follow_operator_naming_convention` to `test_scanners.py`. It catches a template refactor that drops the convention-precedence sentence from the rendered summary step, which would silently lose operator control over titles again. No existing test asserted anything about the title instruction.
- Ran `products/replay_vision/backend/tests/test_scanners.py` (86 passed) and `test_prompt_evaluation.py` (46 passed) locally.
- I did not manually re-run a scanner against a live session, so adherence improvement is expected from the prompt change but not yet observed on fresh observations.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs describe the summarizer title behavior, so nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. The `/writing-tests` skill was invoked before adding the test.

Decisions: reproduced the failure mode from a dogfood summarizer scanner whose own feedback themes flagged titles missing the requested fields, and traced it to the template's generic title instruction outranking the operator's convention.
Considered exposing model temperature as scanner config for more consistent outputs, but that is a larger API surface and doesn't fix the instruction-precedence problem, so this PR keeps it prompt-level. Temperature config can be a follow-up if adherence is still inconsistent.
