### PR TITLE
fix(ci): run the full suites on trunk merge-queue branches

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -1282,7 +1282,13 @@ jobs:
                   RUN_POE: ${{ needs.select-tests.outputs.run_poe }}
                   RUN_TEMPORAL: ${{ needs.select-tests.outputs.run_temporal }}
                   CORE_FILES: ${{ needs.select-tests.outputs.core_files }}
-                  IS_DRAFT: ${{ github.event.pull_request.draft }}
+                  # A trunk-merge/** PR opens as a draft but is the merge gate, and
+                  # select-tests deliberately does not run for it. Reporting it as a
+                  # draft here would turn that empty MODE into "skip" and build an
+                  # empty matrix, so the queue would merge having run no Django tests
+                  # at all. Not-draft makes the empty MODE fall through to the full
+                  # matrix, which is what the queue has to run.
+                  IS_DRAFT: ${{ github.event.pull_request.draft && !startsWith(github.head_ref, 'trunk-merge/') }}
                   FORCE_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'run-ci-backend') }}
               run: |
                   # :NOTE: Keep shard counts/group ranges in sync with historical Django matrix tuning.

--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -200,6 +200,7 @@ jobs:
             needs.sample.outputs.sampled == 'true'
             && (github.event_name != 'pull_request'
                 || github.event.pull_request.draft != true
+                || startsWith(github.head_ref, 'trunk-merge/')
                 || !contains(github.event.pull_request.labels.*.name, 'no-ci'))
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 5
@@ -562,9 +563,12 @@ jobs:
         # which build_django_matrix falls back to
         # when select-tests is skipped (empty MODE). The run-ci-backend label
         # forces the full matrices on a draft.
+        # Trunk's merge-queue branches open as draft PRs, but their run IS the
+        # merge gate, so they must never get the narrowed selection.
         if: |
             github.event_name == 'pull_request' &&
             github.event.pull_request.draft == true &&
+            !startsWith(github.head_ref, 'trunk-merge/') &&
             !contains(github.event.pull_request.labels.*.name, 'run-ci-backend') &&
             needs.changes.outputs.backend == 'true'
         runs-on: depot-ubuntu-24.04
@@ -775,7 +779,7 @@ jobs:
     turbo-tests:
         needs: [changes, turbo-discover, detect-snapshot-mode, build-product-test-matrix, get_clickhouse_versions]
         if: >-
-            !cancelled() && (github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'run-ci-backend')) && needs.turbo-discover.result == 'success' && needs.build-product-test-matrix.result == 'success' && needs.build-product-test-matrix.outputs.include != '[]' && needs.build-product-test-matrix.outputs.include != ''
+            !cancelled() && (github.event.pull_request.draft != true || startsWith(github.head_ref, 'trunk-merge/') || contains(github.event.pull_request.labels.*.name, 'run-ci-backend')) && needs.turbo-discover.result == 'success' && needs.build-product-test-matrix.result == 'success' && needs.build-product-test-matrix.outputs.include != '[]' && needs.build-product-test-matrix.outputs.include != ''
         runs-on: depot-ubuntu-24.04
         timeout-minutes: 40
         name: Product tests (${{ matrix.group }}, events schema ${{ matrix.new-events-schema && 'json' || 'legacy' }})

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2179,7 +2179,13 @@ jobs:
                   RUN_POE: ${{ needs.select-tests.outputs.run_poe }}
                   RUN_TEMPORAL: ${{ needs.select-tests.outputs.run_temporal }}
                   CORE_FILES: ${{ needs.select-tests.outputs.core_files }}
-                  IS_DRAFT: ${{ github.event.pull_request.draft }}
+                  # A trunk-merge/** PR opens as a draft but is the merge gate, and
+                  # select-tests deliberately does not run for it. Reporting it as a
+                  # draft here would turn that empty MODE into "skip" and build an
+                  # empty matrix, so the queue would merge having run no Django tests
+                  # at all. Not-draft makes the empty MODE fall through to the full
+                  # matrix, which is what the queue has to run.
+                  IS_DRAFT: ${{ github.event.pull_request.draft && !startsWith(github.head_ref, 'trunk-merge/') }}
                   FORCE_FULL: ${{ contains(github.event.pull_request.labels.*.name, 'run-ci-backend') }}
                   # The new-events-schema variants double the matrix, so they only run on
                   # PRs opted in via the test-new-events-schema label and on manual dispatch.

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -87,6 +87,7 @@ jobs:
         if: >-
             github.event_name != 'pull_request'
             || github.event.pull_request.draft != true
+            || startsWith(github.head_ref, 'trunk-merge/')
             || !contains(github.event.pull_request.labels.*.name, 'no-ci')
         name: Determine need to run backend and migration checks
         # Set job outputs to values from filter step
@@ -516,9 +517,12 @@ jobs:
         # which build_django_matrix falls back to
         # when select-tests is skipped (empty MODE). The run-ci-backend label
         # forces the full matrices on a draft.
+        # Trunk's merge-queue branches open as draft PRs, but their run IS the
+        # merge gate, so they must never get the narrowed selection.
         if: |
             github.event_name == 'pull_request' &&
             github.event.pull_request.draft == true &&
+            !startsWith(github.head_ref, 'trunk-merge/') &&
             !contains(github.event.pull_request.labels.*.name, 'run-ci-backend') &&
             needs.changes.outputs.backend == 'true'
         runs-on: ubuntu-latest
@@ -753,6 +757,7 @@ jobs:
         if: >-
             !cancelled() &&
             (github.event.pull_request.draft != true ||
+             startsWith(github.head_ref, 'trunk-merge/') ||
              contains(github.event.pull_request.labels.*.name, 'run-ci-backend')) &&
             needs.turbo-discover.result == 'success' &&
             needs.build-product-test-matrix.result == 'success' &&

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -83,7 +83,8 @@ jobs:
             github.event_name == 'push' ||
             github.event_name == 'workflow_dispatch' ||
             (github.event.pull_request.head.repo.full_name == github.repository &&
-             github.event.pull_request.draft != true)
+             (github.event.pull_request.draft != true ||
+              startsWith(github.head_ref, 'trunk-merge/')))
         name: Determine need to run E2E checks
         outputs:
             # Debounce can veto a PR run whose SHA has already been superseded (see below).

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -39,6 +39,7 @@ jobs:
         if: >-
             github.event_name != 'pull_request'
             || github.event.pull_request.draft != true
+            || startsWith(github.head_ref, 'trunk-merge/')
             || !contains(github.event.pull_request.labels.*.name, 'no-ci')
         name: Determine need to run frontend checks
         # A snapshot-only bot push (Visual Review auto-commits frontend/snapshots.yml after
@@ -181,10 +182,13 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         needs: changes
+        # Trunk's merge-queue branches open as draft PRs, but their run IS the
+        # merge gate, so they must never get the narrowed selection.
         if: |
             !cancelled() && needs.changes.outputs.frontend_code == 'true'
             && github.event_name == 'pull_request'
             && github.event.pull_request.draft == true
+            && !startsWith(github.head_ref, 'trunk-merge/')
             && !contains(github.event.pull_request.labels.*.name, 'run-ci-frontend')
         outputs:
             mode: ${{ steps.classify.outputs.mode }}

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -32,6 +32,7 @@ jobs:
         if: >-
             github.event_name != 'pull_request'
             || github.event.pull_request.draft != true
+            || startsWith(github.head_ref, 'trunk-merge/')
             || !contains(github.event.pull_request.labels.*.name, 'no-ci')
         name: Determine need to run MCP checks
         outputs:
@@ -253,7 +254,7 @@ jobs:
         # Python change, so they're the expensive half of this workflow. Build and
         # unit tests still run on drafts; the `MCP Tests Pass` aggregator treats
         # skipped as success, and the ready-for-review run is the merge gate.
-        if: needs.changes.outputs.mcp == 'true' && github.event.pull_request.draft != true
+        if: needs.changes.outputs.mcp == 'true' && (github.event.pull_request.draft != true || startsWith(github.head_ref, 'trunk-merge/'))
         env:
             DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USER }}
             DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/ci-storybook.yml
+++ b/.github/workflows/ci-storybook.yml
@@ -32,6 +32,7 @@ jobs:
         if: >-
             github.event_name != 'pull_request'
             || github.event.pull_request.draft != true
+            || startsWith(github.head_ref, 'trunk-merge/')
             || !contains(github.event.pull_request.labels.*.name, 'no-ci')
         name: Determine need to run storybook checks
         # Set job outputs to values from filter step
@@ -810,10 +811,13 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 5
         needs: [changes, build-storybook]
+        # Trunk's merge-queue branches open as draft PRs, but their run IS the
+        # merge gate, so they must never get the narrowed selection.
         if: |
             !cancelled() && needs.changes.outputs.frontend == 'true'
             && github.event_name == 'pull_request'
             && github.event.pull_request.draft == true
+            && !startsWith(github.head_ref, 'trunk-merge/')
             && !contains(github.event.pull_request.labels.*.name, 'run-ci-frontend')
         outputs:
             mode: ${{ steps.classify.outputs.mode }}

--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -22,7 +22,11 @@ permissions:
 
 jobs:
     lint-pr:
-        if: contains(fromJSON('["opened", "edited", "synchronize"]'), github.event.action)
+        # The merge queue opens its own PR per batch, titled after the branch
+        # (trunk-merge/pr-70624/<uuid>), which can never satisfy Conventional
+        # Commits. The title that matters was already validated on the PR being
+        # queued, so checking the queue's copy only fails its run.
+        if: contains(fromJSON('["opened", "edited", "synchronize"]'), github.event.action) && !startsWith(github.head_ref, 'trunk-merge/')
         uses: ./.github/workflows/pr-updated.yml
 
     turbo:


### PR DESCRIPTION
## Problem

The merge queue tests a PR on its own `trunk-merge/**` branch, and that branch opens as a draft PR. Every suite reads draft status as "narrow the tests", so the run that actually gates the merge was getting the reduced matrices.

| Suite | What the queue's run was doing |
| --- | --- |
| Django | snob-selected subset, ≤3 shards instead of the full sharding |
| Jest | narrowed `--findRelatedTests` selection |
| Storybook | narrowed visual-regression matrix |
| MCP | integration tests skipped entirely |
| E2E | **skipped entirely** — that suite drops all drafts |

E2E is the one that matters most: the queue could merge a PR without ever running it.

The draft narrowing itself is correct and worth keeping. Drafts can't merge, so cheap feedback is the right trade. The bug is that the queue's branch looks like a draft while being the opposite: it's the last thing to run before master.

Separately, the queue's PR is titled after its own branch, so the Conventional Commits title check fails on every batch. [Example run](https://github.com/PostHog/posthog/actions/runs/30398329298/job/90406738621):

```
No release type found in pull request title
"trunk-merge/pr-70624/f3dbe3c2-9d05-41e1-ae82-1e6222a6e33b"
```

## Changes

Treat a `trunk-merge/**` head as ready everywhere draft status decides scope, and skip the title check for it. Fourteen conditions across seven files, sorted by what each one actually does rather than by pattern-matching on `draft`:

| Category | Sites | Change |
| --- | --- | --- |
| Selection jobs | backend `select-tests`, frontend jest, storybook stories | `&& !startsWith(...)` so they don't run, and nothing narrows |
| Heavy matrices | backend matrices, E2E `changes`, MCP integration | `\|\| startsWith(...)` so they do run |
| `no-ci` gate | backend, frontend, mcp, storybook | exempted, so a label copied onto the queue's PR can't silence a workflow |
| PR title check | `pr-housekeeping.yml` `lint-pr` | skipped — the queue's title can never be conventional |
| Depot shadow | `.depot/workflows/ci-backend.yml` | same three backend sites mirrored |

Nothing is lost by skipping the title check: the title that matters belongs to the PR being queued and was already validated when that PR was opened or edited. The queue's PR is a throwaway that never merges through the GitHub button.

Left alone deliberately: the backend coverage comment stays off (commenting on the queue's throwaway PR is noise), and the E2E debounce only fires on `synchronize`, which the queue's branch doesn't produce.

> [!NOTE]
> Every change is additive. `github.head_ref` never starts with `trunk-merge/` on a normal PR and is empty on `push`, so behavior is identical for everything else. That also means open PRs don't need to rebase to stay green, which is the compat trap workflow edits usually hit.

All matching is on the head ref prefix, never the title, so a normal branch whose name merely mentions trunk-merge (this one, for instance) is still validated and still narrows on draft.

## How did you test this code?

I can't exercise a `trunk-merge/**` branch without a live queue run, so this is verified structurally rather than end to end:

- All seven files parse (`yaml.safe_load`), and I checked all fourteen references land at the right polarity — negated at the three selection jobs, positive at the gates and matrices. Getting one backwards would silently do the opposite of the fix.
- Ran the `startsWith` predicate against the real head ref from the failing run above plus normal branch names, confirming it skips only genuine queue branches.
- Simulated `ci-backend-shadow-drift.yml` against master: both ci-backend files are in the diff, so the parity check passes.
- `hogli lint:workflows` passes 6/6 across 105 workflows.
- `hogli ci:preflight --strict` passes.

No automated test covers this. The conditions are GitHub Actions expressions evaluated by the runner, and the only real signal is a queue run. Worth watching the first one and confirming the E2E and Django jobs actually appear on the `trunk-merge/**` branch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) made these edits at my direction. I pointed out that the queue runs on draft branches while our suites narrow on draft status, then sent it the failing title-check run.

The work was mostly in classifying the sites rather than writing the change. A blind find-and-replace on `draft` would have been wrong in both directions: the selection jobs need the condition negated so they stop running, while the matrices need it widened so they start. Reading each one also turned up the `no-ci` gate, which isn't test selection at all but would let a copied label silence an entire workflow on the queue's run.

The failing run also settled an assumption the first version of this PR flagged as unverified — that the queue surfaces as real PRs rather than bare branch pushes. The title in that log confirms it, and gives the exact head-ref format the predicate matches.

Split out of #74266 (merge-queue lanes), which is unrelated and reviews separately.

Skills invoked: `/authoring-ci-workflows`.

