### PR TITLE
fix(tasks): read direct-ingest event stream when polling for turns

### DIFF
--- a/products/tasks/backend/logic/services/custom_prompt_internals.py
+++ b/products/tasks/backend/logic/services/custom_prompt_internals.py
@@ -18,7 +18,9 @@ from posthog.storage import object_storage
 from posthog.storage.object_storage import ObjectStorageError
 from posthog.temporal.oauth import PosthogMcpScopes
 
+from products.tasks.backend.logic.stream.redis_stream import DATA_KEY, get_task_run_stream_key
 from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.redis import get_tasks_stream_redis_sync, run_uses_dedicated_stream
 
 if TYPE_CHECKING:
     from temporalio.client import WorkflowHandle
@@ -30,7 +32,7 @@ logger = logging.getLogger(__name__)
 # Type for an optional output callback (e.g. management command's self.stdout.write)
 OutputFn = Callable[[str], object] | None
 
-# Sandbox logs polling from S3
+# Sandbox event polling
 POLL_INTERVAL_SECONDS = 10
 MAX_POLL_SECONDS = 30 * 60  # default per-turn budget; callers with longer turns pass max_poll_seconds
 MAX_CONSECUTIVE_STORAGE_ERRORS = 3
@@ -222,7 +224,7 @@ async def poll_for_turn(
     workflow_handle: WorkflowHandle | None = None,
     max_poll_seconds: int | None = None,
 ) -> tuple[str, str | None, int, int]:
-    """Poll S3 logs until the agent finishes a turn.
+    """Poll sandbox events until the agent finishes a turn.
 
     `max_poll_seconds` overrides the default poll budget for callers whose activity
     timeout is shorter than `MAX_POLL_SECONDS` — the dropped-finalization salvage only
@@ -285,7 +287,7 @@ async def poll_for_turn(
         # Warn once per minute of silence (not every poll) so stalls surface without flooding logs.
         if stale_seconds >= 60 and stale_seconds % 60 < POLL_INTERVAL_SECONDS:
             logger.warning(
-                "custom_prompt - poll_for_turn: no new S3 log lines for %ds, run=%s, total_lines=%d",
+                "custom_prompt - poll_for_turn: no new event lines for %ds, run=%s, total_lines=%d",
                 stale_seconds,
                 task_run.id,
                 total_lines,
@@ -630,10 +632,10 @@ def _stream_new_lines(
 
 def _check_logs(task_run, skip_lines: int = 0) -> tuple[bool, str | None, str | None, int, bool]:
     """
-    Parse S3 logs. When skip_lines > 0, only lines after that offset are inspected for end_turn
+    Parse sandbox events. When skip_lines > 0, only lines after that offset are inspected for end_turn
     and agent messages. This avoids re-parsing the entire log on every poll cycle.
     """
-    log_content = object_storage.read(task_run.log_url, missing_ok=True) or ""
+    log_content = _read_log_content(task_run)
     return _parse_log_content(log_content, skip_lines)
 
 
@@ -661,7 +663,9 @@ def _parse_log_content(log_content: str, skip_lines: int = 0) -> tuple[bool, str
         if not isinstance(notification, dict):
             continue
         result = notification.get("result")
-        if isinstance(result, dict) and result.get("stopReason") == "end_turn":
+        if (isinstance(result, dict) and result.get("stopReason") == "end_turn") or notification.get(
+            "method"
+        ) == "_posthog/turn_complete":
             agent_finished = True
         if notification.get("method") != "session/update":
             continue
@@ -695,6 +699,28 @@ def _parse_log_content(log_content: str, skip_lines: int = 0) -> tuple[bool, str
     if agent_finished and latest_text is None:
         return False, None, log_content, total_lines, True
     return agent_finished, latest_text, log_content, total_lines, False
+
+
+def _read_log_content(task_run: TaskRun) -> str:
+    state = task_run.state if isinstance(getattr(task_run, "state", None), dict) else {}
+    use_event_stream = bool(state.get("sandbox_event_ingest_enabled")) or bool(
+        settings.DEBUG and settings.TASKS_AGENT_PROXY_INGEST_URL
+    )
+    if not use_event_stream:
+        return object_storage.read(task_run.log_url, missing_ok=True) or ""
+
+    redis_client = get_tasks_stream_redis_sync(run_uses_dedicated_stream(state))
+    stream_entries = redis_client.xrange(get_task_run_stream_key(str(task_run.id)))
+    lines: list[str] = []
+    for _, fields in stream_entries:
+        raw = fields.get(DATA_KEY)
+        if raw is None:
+            raw = fields.get(DATA_KEY.decode())
+        if isinstance(raw, bytes):
+            lines.append(raw.decode("utf-8"))
+        elif isinstance(raw, str):
+            lines.append(raw)
+    return "\n".join(lines)
 
 
 def _is_failed_progress(notification: dict) -> bool:

--- a/products/tasks/backend/tests/test_multi_turn_session.py
+++ b/products/tasks/backend/tests/test_multi_turn_session.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.db import OperationalError
+from django.test import override_settings
 
 from asgiref.sync import sync_to_async
 from parameterized import parameterized
@@ -50,6 +51,41 @@ class _Resp(BaseModel):
 
 
 class TestPollForTurnEmptyEndTurn:
+    @pytest.mark.asyncio
+    @override_settings(DEBUG=True, TASKS_AGENT_PROXY_INGEST_URL="http://localhost:8003")
+    async def test_reads_direct_event_ingest_stream(self):
+        fake_task_run = FakeTaskRun()
+        fake_task_run.state = {"sandbox_event_ingest_enabled": False}
+        lines = [
+            _agent_message_line("gateway-response"),
+            json.dumps(
+                {
+                    "type": "notification",
+                    "notification": {
+                        "method": "_posthog/turn_complete",
+                        "params": {"stopReason": "end_turn"},
+                    },
+                }
+            ),
+        ]
+        stream_entries = [
+            (f"{index}-0".encode(), {b"data": line.encode()}) for index, line in enumerate(lines, start=1)
+        ]
+
+        with (
+            patch("asyncio.sleep", new=AsyncMock()),
+            patch(
+                "products.tasks.backend.logic.services.custom_prompt_internals.get_tasks_stream_redis_sync"
+            ) as get_redis,
+            patch("posthog.storage.object_storage.read") as read_object_storage,
+        ):
+            get_redis.return_value.xrange.return_value = stream_entries
+            last_message, _, total_lines, _ = await poll_for_turn(fake_task_run)
+
+        assert last_message == "gateway-response"
+        assert total_lines == len(lines)
+        read_object_storage.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_raises_empty_agent_turn_error_with_offsets(self):
         """poll_for_turn must translate the _check_logs empty-end_turn flag into a


### PR DESCRIPTION
## Problem

When sandbox event ingest is enabled for a built-in agent run (Scouts, support agent), the sandbox publishes its events to the agent-proxy Redis stream instead of writing S3 logs.
`poll_for_turn` only ever read the S3 log object, so it never saw the final message or the turn completion and hung for the full poll budget (up to 30 minutes) before failing the run.
This surfaced while smoke-testing built-in agent runs locally with direct ingest pointed at the agent-proxy.

Stacked on #74344 (it builds on the `_parse_log_content` split introduced there).

## Changes

- `_check_logs` now reads through a new `_read_log_content` helper: when the run's state has `sandbox_event_ingest_enabled` (or local dev opts in via `DEBUG` + `TASKS_AGENT_PROXY_INGEST_URL`), it reads the run's Redis stream via the existing tasks stream helpers; otherwise it reads S3 exactly as before.
- Turn completion now also recognizes the proxy's synthetic `_posthog/turn_complete` notification alongside the existing `stopReason == "end_turn"` result.
- Comment and docstring wording updated from "S3 logs" to "sandbox events" where the code is now source-agnostic.

## How did you test this code?

- Ran `products/tasks/backend/tests/test_multi_turn_session.py` locally (79 passed), including the new `test_reads_direct_event_ingest_stream`.
- The new test catches a regression no existing test did: with direct ingest enabled, `poll_for_turn` must return the agent's final message from the Redis stream and never touch S3 - previously it hung for the entire poll budget.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This fix was originally written by Codex while debugging local built-in agent runs that hung despite the agent finishing its turn.
Claude Code later extracted it from an unrelated feature branch's working tree into this standalone PR, porting it onto #74344's branch since it depends on the `_parse_log_content` refactor there.
Skills invoked: /writing-tests.
Repo-wide mypy was not run locally (small, fully annotated diff); CI covers it.