### PR TITLE
fix(tasks): pack harness workspace package into local sandbox image

### DIFF
--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -261,6 +261,15 @@ class DockerSandbox(SandboxBase):
         )
 
         with tempfile.TemporaryDirectory() as tmpdir:
+            monorepo_root = os.path.dirname(os.path.dirname(agent_path))
+            shutil.copy2(
+                os.path.join(monorepo_root, "pnpm-workspace.yaml"),
+                os.path.join(tmpdir, "pnpm-workspace.yaml"),
+            )
+            shutil.copytree(
+                os.path.join(monorepo_root, "patches"),
+                os.path.join(tmpdir, "patches"),
+            )
             shutil.copytree(
                 agent_path,
                 os.path.join(tmpdir, "local-agent"),
@@ -279,6 +288,11 @@ class DockerSandbox(SandboxBase):
             shutil.copytree(
                 enricher_path,
                 os.path.join(tmpdir, "local-enricher"),
+                ignore=shutil.ignore_patterns("node_modules"),
+            )
+            shutil.copytree(
+                os.path.join(monorepo_root, "packages", "harness"),
+                os.path.join(tmpdir, "local-harness"),
                 ignore=shutil.ignore_patterns("node_modules"),
             )
 

--- a/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
+++ b/products/tasks/backend/sandbox/images/Dockerfile.sandbox-local
@@ -4,13 +4,16 @@
 
 FROM posthog-sandbox-base
 
+COPY pnpm-workspace.yaml /pnpm-workspace.yaml
+COPY patches /patches
 COPY local-shared /local-shared
 COPY local-git /local-git
 COPY local-enricher /local-enricher
+COPY local-harness /local-harness
 COPY local-agent /local-agent
 
-# Pack shared first (no workspace deps), then enricher and git (both depend on
-# shared), then agent (depends on shared, git, and enricher). Every package with
+# Pack shared first (no workspace deps), then enricher, git, and harness (all
+# depend on shared), then agent (depends on the rest). Every package with
 # a "workspace:*" dependency must have it rewritten to the packed tgz before
 # `pnpm pack`, otherwise pnpm fails with ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL.
 RUN cd /local-shared && pnpm pack && \
@@ -20,10 +23,15 @@ RUN cd /local-shared && pnpm pack && \
     cd /local-git && \
     sed -i 's/"@posthog\/shared": "workspace:\*"/"@posthog\/shared": "file:\/local-shared\/posthog-shared-1.0.0.tgz"/' package.json && \
     pnpm pack && \
+    cd /local-harness && \
+    sed -i 's/"@posthog\/shared": "workspace:\*"/"@posthog\/shared": "file:\/local-shared\/posthog-shared-1.0.0.tgz"/' package.json && \
+    pnpm pack && \
     cd /local-agent && \
     sed -i 's/"@posthog\/shared": "workspace:\*"/"@posthog\/shared": "file:\/local-shared\/posthog-shared-1.0.0.tgz"/' package.json && \
     sed -i 's/"@posthog\/git": "workspace:\*"/"@posthog\/git": "file:\/local-git\/posthog-git-1.0.0.tgz"/' package.json && \
     sed -i 's/"@posthog\/enricher": "workspace:\*"/"@posthog\/enricher": "file:\/local-enricher\/posthog-enricher-1.0.0.tgz"/' package.json && \
+    sed -i 's/"@posthog\/harness": "workspace:\*"/"@posthog\/harness": "file:\/local-harness\/posthog-harness-0.0.0-dev.tgz"/' package.json && \
     pnpm pack && \
+    rm /pnpm-workspace.yaml && \
     cd /scripts && pnpm install /local-agent/*.tgz --config.dangerouslyAllowAllBuilds=true && \
-    rm -rf /local-agent /local-shared /local-git /local-enricher
+    rm -rf /local-agent /local-shared /local-git /local-enricher /local-harness /patches


### PR DESCRIPTION
## Problem

Building the local sandbox overlay image (`Dockerfile.sandbox-local`, used when `LOCAL_POSTHOG_CODE_MONOREPO_ROOT` points at a PostHog Desktop checkout) fails now that the local agent package declares `@posthog/harness` as a `workspace:*` dependency and resolves several versions through the workspace catalog.
`pnpm pack` can't resolve the workspace protocol or `catalog:` versions without the workspace context, so local sandbox builds break with `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL`.

## Changes

- `DockerSandbox._build_local_image` now also stages the monorepo's `pnpm-workspace.yaml` (for the catalog), its `patches/` directory (for `patchedDependencies`), and `packages/harness` into the build context.
- The Dockerfile packs harness like the other local packages, rewrites the agent's `workspace:*` reference to the packed tgz, and removes the workspace file before the final `pnpm install` so that install stays a plain out-of-workspace install.

> [!NOTE]
> The harness copy is unconditional, matching how `pnpm-workspace.yaml` and `patches/` are staged. A Desktop checkout old enough to lack `packages/harness` would fail with a `FileNotFoundError` naming the path rather than the friendlier `SandboxProvisionError` used for the four long-standing packages - acceptable for a local-dev-only path, but easy to promote into `_get_local_posthog_code_packages` if reviewers prefer.

## How did you test this code?

- Verified against a current PostHog Desktop checkout that `packages/harness` exists at version `0.0.0-dev` (matching the packed tgz name), that the agent declares `@posthog/harness: workspace:*`, and that the workspace yaml defines the catalog and `patchedDependencies` this change stages.
- The full image build was exercised earlier on this machine during local built-in agent testing; I did not rebuild the image from this branch specifically.
- No automated tests: this is local-dev Docker build plumbing with no test harness around it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This fix was originally written by Codex while getting local built-in agent sandbox builds working after the harness package landed in the Desktop monorepo.
Claude Code extracted it from an unrelated feature branch's working tree into this standalone PR against master.