### PR TITLE
fix(data-imports): raise clearly when an OAuth integration secret is still encrypted

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -64,6 +64,30 @@ from products.workflows.backend.providers import SESProvider, TwilioProvider
 logger = structlog.get_logger(__name__)
 tracer = trace.get_tracer(__name__)
 
+# Fernet tokens always start with this marker (version byte 0x80 + timestamp, base64-encoded).
+_ENCRYPTED_VALUE_PREFIX = "gAAAAA"
+
+
+class UndecryptedIntegrationSecretError(ValueError):
+    """Raised when a value read off `Integration.sensitive_config` still looks like Fernet
+    ciphertext instead of the decrypted secret.
+
+    `sensitive_config` sets `ignore_decrypt_errors=True` so integrations written before
+    encryption existed keep loading, but that same leniency means a value that fails to
+    decrypt under every configured key (a lost/rotated key, a corrupted row) comes back as
+    raw ciphertext rather than raising. Left unchecked, that ciphertext gets sent to the
+    third-party API as if it were the real credential, which rejects it as invalid — hiding
+    the actual cause behind what looks like a bad customer-supplied key.
+    """
+
+
+def _decrypted_sensitive_value(value: str | None, field_name: str) -> str | None:
+    if value is not None and value.startswith(_ENCRYPTED_VALUE_PREFIX):
+        raise UndecryptedIntegrationSecretError(
+            f"Integration.sensitive_config['{field_name}'] is still encrypted; the stored credentials could not be decrypted"
+        )
+    return value
+
 
 def _decode_jwt_payload(token: str) -> dict | None:
     """
@@ -493,11 +517,11 @@ class Integration(models.Model):
 
     @property
     def access_token(self) -> str | None:
-        return self.sensitive_config.get("access_token")
+        return _decrypted_sensitive_value(self.sensitive_config.get("access_token"), "access_token")
 
     @property
     def refresh_token(self) -> str | None:
-        return self.sensitive_config.get("refresh_token")
+        return _decrypted_sensitive_value(self.sensitive_config.get("refresh_token"), "refresh_token")
 
 
 def defer_repository_cache_fields(queryset: models.QuerySet[Integration]) -> models.QuerySet[Integration]:

--- a/posthog/models/test/test_integration_model.py
+++ b/posthog/models/test/test_integration_model.py
@@ -54,6 +54,7 @@ from posthog.models.integration import (
     SlackIntegration,
     SnowflakeIntegration,
     SnowflakeIntegrationError,
+    UndecryptedIntegrationSecretError,
     invalidate_github_repository_caches_for_installation,
     oauth_refresh_failure_reason,
     oauth_refresh_terminal_counter,
@@ -124,6 +125,21 @@ class TestIntegrationModel(BaseTest):
                     get_db_field_value("sensitive_config", integration.id)
                     == '{"id_token": null, "refresh_token": "gAAAAABlkgC8AAAAAAAAAAAAAAAAAAAAAHlWz9QOMnXDvmix-z5lNG4v0VcO9lGWejmcE_BXHXPZ1wNkb-38JupntWbshBrfFQ=="}'
                 )
+
+    @parameterized.expand([("access_token",), ("refresh_token",)])
+    def test_oauth_token_property_raises_if_still_encrypted(self, field_name: str) -> None:
+        # `sensitive_config` uses `ignore_decrypt_errors=True`, so a value that fails to decrypt
+        # under every configured key comes back as raw Fernet ciphertext instead of raising. If the
+        # `access_token`/`refresh_token` properties didn't check for that, this ciphertext would
+        # get sent straight to the third-party API as the live credential.
+        integration = Integration(team=self.team, kind="stripe", sensitive_config={field_name: "gAAAAABleftover=="})
+        with pytest.raises(UndecryptedIntegrationSecretError):
+            getattr(integration, field_name)
+
+    @parameterized.expand([("access_token",), ("refresh_token",)])
+    def test_oauth_token_property_passes_through_decrypted_value(self, field_name: str) -> None:
+        integration = Integration(team=self.team, kind="stripe", sensitive_config={field_name: "a-real-token"})
+        assert getattr(integration, field_name) == "a-real-token"
 
     def test_slack_integration_config(self):
         set_instance_setting("SLACK_APP_CLIENT_ID", None)

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -11,6 +11,7 @@ from structlog.typing import FilteringBoundLogger
 from temporalio import activity
 
 from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
+from posthog.models.integration import UndecryptedIntegrationSecretError
 from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.activity_context import current_activity_attempt
 from posthog.temporal.common.heartbeat import LivenessHeartbeater as Heartbeater
@@ -353,6 +354,16 @@ async def _handle_import_error(
     # on every retry regardless of source — classify it non-retryable by type here rather than
     # relying on each source listing the message in get_non_retryable_errors.
     if isinstance(error, SchemaColumnTypeChangedException):
+        await handle_non_retryable_error(
+            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+        )
+
+    # An OAuth `Integration.access_token`/`refresh_token` that still looks like Fernet ciphertext
+    # (a lost/rotated encryption key, a corrupted row) fails identically on every retry — the
+    # third-party API sees the same garbage credential every time. Classify by type here, shared
+    # across every OAuth-based source, rather than depending on each source's
+    # get_non_retryable_errors to recognise this message.
+    if isinstance(error, UndecryptedIntegrationSecretError):
         await handle_non_retryable_error(
             job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
         )


### PR DESCRIPTION
## Problem

Error tracking surfaced a `NonRetryableException` chained from a Stripe `AuthenticationError` during a Stripe sync ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019faaa4-91df-73e1-b7b1-8a6b4903aba1)): `Invalid API Key provided: gAAAAABq...==`. The rejected "key" starts with `gAAAAA`, the marker every Fernet-encrypted value carries — meaning the *ciphertext*, not the decrypted credential, reached Stripe's API.

Tracing the call path (`get_rows` in `stripe.py` → `_get_api_key`'s OAuth branch → `Integration.access_token`) landed on `Integration.sensitive_config`, an `EncryptedJSONField` with `ignore_decrypt_errors=True` (so integrations saved before encryption existed keep loading). That same leniency means a value that fails to decrypt under every configured key — a lost/rotated key, a corrupted row — comes back as raw ciphertext instead of raising. `access_token`/`refresh_token` handed that straight to the third-party API, which correctly rejected it, but the resulting error blamed a "bad API key" when the real cause was our own decrypt failure.

This choke point is shared by every OAuth-based warehouse source (Stripe, HubSpot, GitHub, Salesforce, and more all read `integration.access_token`/`.refresh_token`), so the fix belongs there rather than in Stripe's connector code.

## Changes

- `Integration.access_token`/`refresh_token` now raise a new `UndecryptedIntegrationSecretError` when the stored value still looks like Fernet ciphertext, instead of silently returning it.
- The data-imports activity classifies `UndecryptedIntegrationSecretError` as non-retryable **by type** (`_handle_import_error`), the same pattern already used for `RESTClientNonRetryableError`/`SchemaColumnTypeChangedException` — so this is handled uniformly across every OAuth source rather than needing each source's `get_non_retryable_errors` to recognize the message.

This doesn't change behavior for the normal (successfully decrypted) path, and doesn't touch `ignore_decrypt_errors` itself — legacy unencrypted rows still load fine, since a genuinely-unencrypted legacy value never starts with `gAAAAA`.

## How did you test this code?

- Added parameterized tests in `test_integration_model.py` covering both `access_token` and `refresh_token`: one confirms a still-encrypted value raises `UndecryptedIntegrationSecretError`, the other confirms a normal decrypted value still passes through unchanged.
- Couldn't run the Django test suite in this environment (no reachable Postgres), so I verified the guard logic directly against the real module (`django.setup()` + calling the property/helper in isolation) to confirm both the raise and pass-through paths behave as expected.
- `ruff check`/`ruff format` and `mypy` pass on the changed files (`hogli ci:preflight --fix`).

## Docs update

No user-facing behavior or API changed; no docs affected.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (PostHog Code) triaging a live error-tracking issue in the data-imports pipeline. Traced the stack trace and exception properties to identify that the "invalid API key" was actually still-encrypted ciphertext, then searched the codebase for every read site of `Integration.sensitive_config`/`access_token`/`refresh_token` to confirm this is a shared choke point across OAuth-based sources rather than Stripe-specific. Checked for existing open PRs addressing this (none found) and confirmed the fix doesn't touch the unrelated `ignore_decrypt_errors=True` migration-compatibility behavior.