### PR TITLE
fix(semantic-layer): bypass warehouse access control when sampling rows

### DIFF
--- a/products/data_modeling/backend/logic/enrich_view_semantics.py
+++ b/products/data_modeling/backend/logic/enrich_view_semantics.py
@@ -155,16 +155,15 @@ def _get_row_sample(saved_query: DataWarehouseSavedQuery) -> list[dict[str, str]
     Only call this for materialized views — running the raw view query for an unmaterialized view is
     unbounded cost. `saved_query.name` is validated to a strict identifier, so it's safe to interpolate.
     """
-    from posthog.api.services.query import process_query_dict  # noqa: PLC0415 — heavy HogQL/query stack
-    from posthog.clickhouse.query_tagging import Feature, Product, tags_context  # noqa: PLC0415
-    from posthog.hogql_queries.query_runner import ExecutionMode  # noqa: PLC0415
+    from posthog.hogql.query import execute_hogql_query  # noqa: PLC0415 — heavy HogQL/query stack
 
-    query = {"kind": "HogQLQuery", "query": f"SELECT * FROM {saved_query.name} LIMIT {ROW_SAMPLE_LIMIT}"}
+    from posthog.clickhouse.query_tagging import Feature, Product, tags_context  # noqa: PLC0415
+
+    query = f"SELECT * FROM {saved_query.name} LIMIT {ROW_SAMPLE_LIMIT}"
     try:
         with tags_context(product=Product.WAREHOUSE, feature=Feature.DATA_MODELING):
-            response = process_query_dict(
-                saved_query.team, query, execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS
-            )
+            # Safe to bypass: it only samples a view the team owns, to generate column descriptions.
+            response = execute_hogql_query(query, team=saved_query.team, bypass_warehouse_access_control=True)
     except Exception as e:
         capture_exception(e)
         return []


### PR DESCRIPTION
## Problem

Semantic enrichment generates column descriptions for a data-modeling view. To do that it samples a few rows from the materialized view in `_get_row_sample`.

That sample runs in a background Temporal activity with no user. Warehouse access control fails closed in a userless context (`_is_warehouse_table_denied` treats a missing `UserAccessControl` as deny-all), so resolving the view raises `TableAccessDeniedError`, the best-effort handler swallows it, and the sample comes back empty.

So for any team under the `hogql-warehouse-access-control` rollout, enrichment quietly degrades to the definition-only pass and generates descriptions without real row data. 

There is a second-order effect worth knowing about. `compute_enrichment_hash` includes a `sample_bit` that flips once a view is first materialized, which is what triggers the one-time upgrade to descriptions informed by real rows. If that upgrade pass runs while the sample is empty, the view keeps its weaker descriptions until its definition or column set changes.

## Changes

`_get_row_sample` now calls `execute_hogql_query` with `bypass_warehouse_access_control=True` instead of `process_query_dict`.

`process_query_dict` has no bypass knob. Adding one would widen a core query API for a single background caller, so I went the other way: `execute_hogql_query` already exposes the flag, and it is what the rest of the data modeling pipeline uses. Both `run_workflow.py` and `materialize_view.py` build their database with the same bypass for the same reason.

> [!NOTE]
> This does not weaken access control for anything a user runs. It only affects the background enrichment activity, which has no user to check against in the first place. The bypass is scoped to sampling a view the team already owns, and those rows only ever reach the enrichment prompt.

## How did you test this code?

Automated tests only, via CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No.

## 🤖 Agent context

Found while monitoring the `hogql-warehouse-access-control` rollout. These denials showed up in error tracking as their own class, separate from the cache-warming and export paths, and it was the one class expected to grow in proportion to the rollout percentage rather than staying flat.