### PR TITLE
fix(loops): Override the loop email subject on Customer.io sends

### DIFF
--- a/posthog/email.py
+++ b/posthog/email.py
@@ -164,11 +164,15 @@ def get_customer_io_template_id(template_name: str) -> str:
 
 # Note: this http sender is only configure for customer.io right now and it's set up to send
 # via templates so all the configuration is done in the customer.io - i.e. no subject, body, etc.
+# `subject` is the exception: when set it overrides the template's subject line, for emails whose
+# subject interpolates user-controlled values (message_data is HTML-escaped by the sanitizer, so a
+# template-side subject would render entities like &quot; in plain text).
 def _send_via_http(
     to: list[dict[str, str]],
     campaign_key: str,
     template_name: str,
     properties: dict,
+    subject: Optional[str] = None,
 ) -> None:
     """Sends emails using Customer.io API"""
     customerio_api_key = settings.CUSTOMER_IO_API_KEY
@@ -205,6 +209,8 @@ def _send_via_http(
                     "identifiers": identifiers,
                     "message_data": properties,
                 }
+                if subject:
+                    payload["subject"] = subject
 
                 response = requests.post(
                     f"{settings.CUSTOMER_IO_API_URL}/v1/send/email", headers=headers, json=payload, timeout=30
@@ -436,6 +442,7 @@ def _send_email(
     reply_to: Optional[str] = None,
     use_http: Optional[bool] = False,
     properties: Optional[dict] = None,
+    http_subject_override: bool = False,
 ) -> None:
     """
     Sends built email message asynchronously, either through SMTP or HTTP
@@ -446,6 +453,7 @@ def _send_email(
             campaign_key=campaign_key,
             template_name=template_name,
             properties=properties or {},
+            subject=subject if http_subject_override else None,
         )
     elif is_smtp_email_service_available():
         _send_via_smtp(
@@ -471,6 +479,7 @@ class EmailMessage:
         headers: Optional[dict] = None,
         reply_to: Optional[str] = None,
         use_http: Optional[bool] = False,
+        use_http_subject_override: bool = False,
     ):
         if template_context is None:
             template_context = {}
@@ -482,6 +491,7 @@ class EmailMessage:
 
         self.campaign_key = campaign_key
         self.use_http = use_http
+        self.use_http_subject_override = use_http_subject_override
         self.to: list[dict[str, str]] = []
         self.subject = subject or ""
         self.reply_to = reply_to
@@ -527,6 +537,7 @@ class EmailMessage:
             "reply_to": self.reply_to,
             "use_http": self.use_http,
             "properties": self.properties,
+            "http_subject_override": self.use_http_subject_override,
         }
 
         if send_async:

--- a/posthog/test/test_email.py
+++ b/posthog/test/test_email.py
@@ -302,6 +302,28 @@ class TestEmail(BaseTest):
                 },
             )
 
+    @patch("posthoganalytics.capture")
+    @patch("posthog.email.requests.post")
+    def test_send_via_http_subject_override(self, mock_post, _mock_capture) -> None:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"delivery_id": "test_delivery_id", "queued_at": 1604977406}
+        mock_post.return_value = mock_response
+
+        with override_instance_config("EMAIL_HOST", "localhost"), self.settings(CUSTOMER_IO_API_KEY="test-key"):
+            message = EmailMessage(
+                campaign_key="test_campaign",
+                subject='Loop "CI failure summary" finished',
+                template_name="2fa_enabled",
+                use_http=True,
+                use_http_subject_override=True,
+            )
+            message.add_recipient("test@posthog.com", "Test User")
+            message.send(send_async=False)
+
+            payload = mock_post.call_args.kwargs["json"]
+            self.assertEqual(payload["subject"], 'Loop "CI failure summary" finished')
+
     @patch("posthog.email.requests.post")
     def test_send_via_http_handles_decimal_values(self, mock_post) -> None:
         mock_response = MagicMock()

--- a/products/tasks/backend/loop_notifications.py
+++ b/products/tasks/backend/loop_notifications.py
@@ -168,6 +168,9 @@ def _send_email(
             subject=title,
             template_context=template_context,
             use_http=True,
+            # The title embeds the loop's name, and message_data values are HTML-escaped
+            # by the sanitizer; a template-side subject would show literal &quot; entities.
+            use_http_subject_override=True,
         )
         message.add_user_recipient(loop.created_by)
         message.send(send_async=True)

--- a/products/tasks/backend/tests/test_loop_notifications.py
+++ b/products/tasks/backend/tests/test_loop_notifications.py
@@ -248,3 +248,19 @@ class TestDispatchLoopEventEmailReport(LoopNotificationsTestCase):
         mock_email_message_cls.assert_called_once()
         template_context = mock_email_message_cls.call_args.kwargs["template_context"]
         self.assertEqual(template_context["report"], expected_report)
+
+    @patch(f"{LOOP_NOTIFICATIONS_MODULE}.create_notification")
+    @patch(f"{LOOP_NOTIFICATIONS_MODULE}.is_email_available", return_value=True)
+    @patch(f"{LOOP_NOTIFICATIONS_MODULE}.EmailMessage")
+    def test_email_overrides_subject_with_plain_title(
+        self, mock_email_message_cls, _mock_email_available, _mock_create_notification
+    ):
+        loop = self.create_loop(
+            name='CI "nightly" digest', notifications={"email": {"enabled": True, "events": ["run_completed"]}}
+        )
+
+        dispatch_loop_event(loop, "run_completed", {})
+
+        kwargs = mock_email_message_cls.call_args.kwargs
+        self.assertTrue(kwargs["use_http_subject_override"])
+        self.assertEqual(kwargs["subject"], 'Loop "CI "nightly" digest" finished')


### PR DESCRIPTION
## Problem

Loop emails rendered `Loop &quot;CI failure summary&quot; finished` as the subject. `sanitize_email_properties` HTML-escapes every Customer.io `message_data` value, so any Customer.io template that interpolates trigger data into its plain-text subject line shows the entities literally. The current workaround is an entity-reversing Liquid `replace` chain in the Customer.io template, which is fragile and lives outside review.

## Changes

`_send_via_http` can now pass the Django-side subject as a send-time override on the Customer.io API call, opt-in per email via `EmailMessage(use_http_subject_override=True)`. Loop notification emails opt in, so the subject is the plain title straight from the backend and never goes through the HTML-escaping sanitizer. Default behavior for every other transactional email is unchanged.

## How did you test this code?

New test asserting the send payload carries the subject when the flag is set (the existing payload test pins that it stays absent by default), and a loop notifications test asserting the flag plus the plain-text subject for a loop name containing quotes. Full `test_email.py` and `test_loop_notifications.py` suites pass (60 tests), ruff clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

Human-driven (agent-assisted)
