### PR TITLE
fix(cdp): raise the wait_until_condition polling cap to an hour

### DIFF
--- a/nodejs/src/cdp/services/hogflows/actions/conditional_branch.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/conditional_branch.test.ts
@@ -94,11 +94,11 @@ describe('action.conditional_branch', () => {
 
         describe('wait logic', () => {
             it('should handle wait duration and schedule next check', async () => {
-                action.config.delay_duration = '2h'
+                action.config.delay_duration = '5h'
                 const result = await checkConditions(invocation, action)
                 expect(result).toEqual({
-                    // Should schedule for 10 minutes from now
-                    scheduledAt: DateTime.utc().plus({ minutes: 10 }),
+                    // Capped: schedules an hour out rather than the full five
+                    scheduledAt: DateTime.utc().plus({ hours: 1 }),
                 })
             })
 
@@ -265,11 +265,11 @@ describe('action.conditional_branch', () => {
             expect(result.nextAction).toBeUndefined()
         })
 
-        it('re-parks a wait_until_condition on the 10-minute cap (polling retained as backstop)', async () => {
-            // Polling is kept for now: a wait_until_condition re-parks on the 10-minute cap and
-            // re-checks its condition, even though the subscription matcher also wakes it early on a
-            // matching signal. A 30-minute wait therefore schedules ~10 minutes out, not ~30.
-            waitAction.config.max_wait_duration = '30m'
+        it('re-parks a wait_until_condition on the polling cap (retained as backstop)', async () => {
+            // Polling is kept for now: a wait_until_condition re-parks on the cap and re-checks its
+            // condition, even though the subscription matcher also wakes it early on a matching
+            // signal. A 90-minute wait therefore schedules an hour out, not the full 90.
+            waitAction.config.max_wait_duration = '90m'
 
             const result = await handler.execute({
                 invocation: waitInvocation,
@@ -277,7 +277,21 @@ describe('action.conditional_branch', () => {
                 result: createInvocationResult(waitInvocation),
             })
 
-            expect(result.scheduledAt).toEqual(DateTime.utc().plus({ minutes: 10 }))
+            expect(result.scheduledAt).toEqual(DateTime.utc().plus({ hours: 1 }))
+        })
+
+        it('still parks to its own deadline when that is shorter than the cap', async () => {
+            // Unchanged by the cap: short waits are governed by max_wait, so raising the cap must not
+            // stretch them. This is the guard that keeps sub-cap waits (the common shape) intact.
+            waitAction.config.max_wait_duration = '5m'
+
+            const result = await handler.execute({
+                invocation: waitInvocation,
+                action: waitAction,
+                result: createInvocationResult(waitInvocation),
+            })
+
+            expect(result.scheduledAt).toEqual(DateTime.utc().plus({ minutes: 5 }))
         })
 
         it('marks the wait as re-parked when its condition does not match', async () => {

--- a/nodejs/src/cdp/services/hogflows/actions/conditional_branch.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/conditional_branch.ts
@@ -9,7 +9,15 @@ import { findContinueAction, findNextAction, isEvaluableCondition } from '../hog
 import { ActionHandler, ActionHandlerOptions, ActionHandlerResult } from './action.interface'
 import { calculatedScheduledAt } from './delay'
 
-const DEFAULT_WAIT_DURATION_SECONDS = 10 * 60
+// How long a parked wait_until_condition may sleep before the polling backstop re-checks its
+// condition. The matcher wakes these early on a matching signal, so this only bounds how late a
+// wake can be when no signal arrives — which for a clock-based condition is the whole story.
+//
+// Kept well under a day deliberately. A wait that fires a fixed period before a stored date has an
+// actionable window the width of that period; re-checking less often than the window means the
+// re-check can land after it closed, taking a branch whose guard has since flipped. An hour leaves
+// room on the windows we see in practice while cutting re-park churn six-fold.
+const DEFAULT_WAIT_DURATION_SECONDS = 60 * 60
 
 // Increments only when the 10-minute polling re-check advances a wait_until_condition that the
 // subscription matcher did NOT wake (and not an evaluate-on-entry match). This is the decisive


### PR DESCRIPTION
## Problem

Every parked `wait_until_condition` re-parks on a 10-minute cap so the polling backstop can re-check it. For a wait with a multi-day `max_wait`, that's hundreds of dequeue/re-park cycles per run, nearly all of them for waits the subscription matcher would have woken anyway from a stream.

The cap's only real job is bounding how late a wake can be when *no* signal ever arrives. Measured over 7 days with `cdp_hogflow_wait_poll_only_advance`, which is labelled by team and flow, that is overwhelmingly one thing:

- **Clock-based conditions**, which compare against `now()` or `today()` and so produce no message to wake on. These account for **99.9%** of poll-only advances. #75453 has merged, so no new ones can be authored, and the few that exist are being migrated to a delay plus a guard.
- **Everything else**: two runs in seven days, across both regions combined. Both are person-property waits, and at least one is a run that parked with no person resolved. Not yet root-caused, and small enough that it does not justify holding anything up.

Every other parked wait is stream-woken and unaffected by the cap either way.

## Changes

Raise the cap from 10 minutes to an hour. One constant; no behavioural branch changes.

- Waits whose `max_wait` is under an hour are untouched — their own deadline still wins.
- Stream-woken waits are unaffected; the matcher wakes them on a matching signal regardless of the cap.
- Waits that genuinely need the backstop become at most an hour late instead of at most ten minutes.

## Why an hour, and not longer

A wait that fires a fixed period before a stored date has an actionable window the width of that period. Re-check less often than that window and the re-check can land after it has closed — the condition is true by then, so the run takes the **matched** branch and hits a downstream guard that has since flipped, exiting silently.

An hour keeps comfortable room under the windows we see in practice. Going to six hours, or a day, does not: an hourly-granularity reminder ("an hour before X") is a perfectly ordinary thing to build, and a cap at or above its window breaks it with no error. The saving from an hour is already 6x; the marginal churn win beyond that isn't worth spending the safety margin.

## What the churn actually looks like

Worth stating plainly, because it's the case for doing this at all. Inspecting run logs for a workflow whose waits routinely expire, a single run that rides two waits to timeout logs on the order of a thousand lines — a wake and a re-park every ten minutes for days — and learns nothing, because the condition was never going to become true. At an hour that becomes a sixth of the entries, with the same outcome.

## Why this is now a step rather than a stopgap

This started as interim margin while a larger change made the poll unnecessary. That larger change (#74423) is closed: the affected population turned out small enough that a save-time gate plus per-workflow migration reaches the same place for a fraction of the code.

So the sequence is now ~~#75453~~ (merged) → migrate the clock-based workflows → **this** → #72541, and this PR has a job of its own in it. Running a week at an hour is the evidence step before removal: once the clock-based flows are migrated, `cdp_hogflow_wait_poll_only_advance` should sit at or near zero, and a week at an hour either confirms that or names the workflow that still leans on the poll. If something does surface, it surfaces as a wake up to an hour late instead of as a silently missed one.

An earlier version of this description listed a second blocker, a wake gap for waits parked with no person anchor. That turned out to be already handled: the case it described produces a `version = 1` distinct_id repoint, which the matcher's existing merge re-key path already consumes. The residual above is what is actually left.

Still safe to merge or drop on its own — it depends on none of the others.

## How did you test this code?

- **18 unit tests** in `conditional_branch.test.ts`. Updated the cap assertions, and added one new case: a wait whose `max_wait` is shorter than the cap must still park to its own deadline. That's the guard that matters here — raising the cap must not stretch short waits, which are the common shape.
- **22 `wait_until_condition` E2E tests** against real Postgres, Kafka and Redis, across both queue backends. Includes the polling-timeout test, whose 2-second `max_wait` confirms sub-cap waits are unaffected.

11 email-queue tests in that E2E suite fail; I verified they fail identically on master without this change (local maildev is down).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Nothing to update: internal scheduling behaviour with no user-facing surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Claude Code) at my direction, split out of the #74423 investigation so it can ship or be dropped on its own.

Skill invoked: `/writing-tests` — which is why the cap assertions were updated in place rather than duplicated, and why only one new case earned its way in (the sub-cap guard; the rest of the matrix already existed).

We considered six hours and rejected it. It's safe for the wait shapes we can see today, but the audit covers what exists now rather than what someone builds next week, and six hours silently breaks any window narrower than that. An hour captures most of the churn win while leaving the failure mode much harder to hit.

Worth knowing about the metric this leans on. `cdp_hogflow_wait_poll_only_advance` only fires when the poll actually *advances* a wait, so a wait that never becomes true times out and is counted nowhere. It measures what the poll rescues, not total exposure to a missed wake. That is why the residual above is stated as two observed runs rather than as a bound, and why the week at an hour is worth running before removal rather than treating the current reading as sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

