### PR TITLE
fix(customer-analytics): label active users chart lines distinctly

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5573,7 +5573,7 @@ snapshots:
     scenes-app-dashboards--show-across-viewports--medium--dark:
         hash: v1.k794b7964.700cde8e1a4cc8c902b217300de8c5bbca2c3d1d4c727f0533fc664679bc22d3.bd-grjT3BisGzyb6iVrYefXx4uBqpaFrcjl3ZM-eEII
     scenes-app-dashboards--show-across-viewports--medium--light:
-        hash: v1.k794b7964.a234c28bcd64c498f325a8d7afbb3e5733e43aab3b07a7cae6b98af69603d1e6.xUojuNjkLX7GERozP3JglULFZ8NLXOqQ0ZPKmRBMaZQ
+        hash: v1.k794b7964.2e865350cfdb9ec6f0ac5387df2f4b0fb67d3a7605b7bf7dd4ddae901f510128.A-k_xdWvVTsFK3zbzXsYP-TjPTPx4Peb8QW2oBUXdTk
     scenes-app-dashboards--show-across-viewports--narrow--dark:
         hash: v1.k794b7964.e919c4955d7113170ab00269c5f628c318afe14f26dc8aafb046b172e17f362e.YDXD84rrb2KR1I36pHMxEsGZ0sN0os_cBBdNIf89Pu8
     scenes-app-dashboards--show-across-viewports--narrow--light:

--- a/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
+++ b/products/customer_analytics/frontend/customerAnalyticsSceneLogic.ts
@@ -567,7 +567,13 @@ export const customerAnalyticsSceneLogic = kea<customerAnalyticsSceneLogicType>(
                             source: {
                                 kind: NodeKind.TrendsQuery,
                                 tags: CUSTOMER_ANALYTICS_DEFAULT_QUERY_TAGS,
-                                series: [dauSeries, wauSeries, mauSeries],
+                                // Label each line distinctly here rather than on the shared
+                                // selectors, which are reused by other single-metric charts.
+                                series: [
+                                    { ...dauSeries, custom_name: 'Daily active' },
+                                    { ...wauSeries, custom_name: 'Weekly active' },
+                                    { ...mauSeries, custom_name: 'Monthly active' },
+                                ],
                                 interval: 'day',
                                 dateRange: {
                                     date_from: dateRange.date_from,


### PR DESCRIPTION
## Problem

In Customer analytics (B2C and B2B), the "Active users (daily/weekly/monthly)" chart drew three lines that were all labelled "Activity". There was no way to tell which line was daily, weekly, or monthly, so hovering a point gave you a number with no idea which cadence it belonged to.

The cause: the DAU, WAU and MAU series are all built by spreading the same shared `activityEvent` (which carries `custom_name: 'Activity'`) and only changing the `math` type. None of them set a distinguishing name, so all three inherited "Activity".

## Changes

Set a distinct `custom_name` on each of the three series — "Daily active", "Weekly active", "Monthly active" — at the chart's use-site in `activeUsersInsights`, rather than on the shared `dauSeries` / `wauSeries` / `mauSeries` selectors.

Doing it at the use-site matters: those selectors are reused by other single-metric charts (e.g. the lifecycle "highly engaged" chart and the WAU/MAU stat cards), so baking a "Daily" label into the shared selector would have leaked the wrong label onto unrelated charts. The labels stay cadence-only ("Daily active" rather than "Daily active users") because for B2B these series count accounts/organizations, not users.

## How did you test this code?

Read-through and reasoning only. I (the PostHog Slack app agent) could not run the app or capture screenshots in this environment, and the frontend type checker couldn't run because `node_modules` isn't installed in the fresh clone. The change is type-safe by inspection: `custom_name?: string` is a valid field on `EntityNode`, and the three series are narrowed to non-null by the guard directly above (`if (!dauSeries || !wauSeries || !mauSeries) return []`) before the spread.

No tests or story snapshots asserted on the old labels, so none needed updating.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Ben Lea (ben.l@posthog.com) reported the bug from a Slack thread and directed the fix.

Investigated and authored by the PostHog Slack app (Claude). I traced the chart from its title back to `customerAnalyticsSceneLogic.ts`, confirmed the shared-`activityEvent` root cause, and ran the repo's `qa-team` multi-agent review over the diff. That review caught two things I folded in: my first attempt set `custom_name` on the shared selectors, which the reviewers flagged would leak the label onto the lifecycle chart that also consumes `dauSeries`, so I moved the labelling to the use-site; and it converged on "Daily active / Weekly active / Monthly active" over bare "Daily / Weekly / Monthly" as clearer in a standalone tooltip while staying correct for B2B account-based metrics.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A2AHK6CN8/p1785286682342379)*
