### PR TITLE
fix(conversations): strip commonmark escapes from outbound plain text

### DIFF
--- a/products/conversations/backend/api/tests/test_events.py
+++ b/products/conversations/backend/api/tests/test_events.py
@@ -304,6 +304,15 @@ class TestConversationEvents(BaseTest):
         assert len(call_kwargs["properties"]["message_content"]) == 1000
 
     @patch("products.conversations.backend.events.capture_internal")
+    def test_message_content_drops_commonmark_escapes(self, mock_capture):
+        # Workflow email templates render this property as plain text, so the escapes the
+        # editor adds when serializing to markdown would reach the customer verbatim.
+        capture_message_sent(self.ticket, "msg-id", "No worries\\! Docs are here\\.", author=self.user)
+
+        call_kwargs = mock_capture.call_args.kwargs
+        assert call_kwargs["properties"]["message_content"] == "No worries! Docs are here."
+
+    @patch("products.conversations.backend.events.capture_internal")
     def test_event_uses_ticket_team_token_not_other_team(self, mock_capture):
         """Verify events route to the ticket's team, not any other team."""
         from posthog.models import Organization, Team

--- a/products/conversations/backend/api/tests/test_formatting.py
+++ b/products/conversations/backend/api/tests/test_formatting.py
@@ -149,6 +149,36 @@ class TestSlackFormatting(SimpleTestCase):
 
         assert slack_text == expected
 
+    @parameterized.expand(
+        [
+            ("broadcast", "<!channel> ping", "&lt;!channel&gt; ping"),
+            ("user_mention", "hi <@U123ABC>", "hi &lt;@U123ABC&gt;"),
+            ("fake_link", "see <http://evil|click>", "see &lt;http://evil|click&gt;"),
+        ]
+    )
+    def test_outbound_text_fallback_neutralizes_slack_control_chars(self, _name: str, text: str, expected: str) -> None:
+        # Dropping CommonMark escapes must not re-arm Slack control syntax typed as plain
+        # text, or a user could make the bot broadcast to a channel or inject a link.
+        rich_content = {
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": text}]}],
+        }
+
+        slack_text, _ = rich_content_to_slack_payload(rich_content, "")
+
+        assert slack_text == expected
+
+    def test_outbound_code_block_preserves_literal_backslashes(self) -> None:
+        # Code bypasses markdown escaping, so the unescape pass must leave its backslashes alone.
+        rich_content = {
+            "type": "doc",
+            "content": [{"type": "codeBlock", "content": [{"type": "text", "text": r"C:\Projects\*"}]}],
+        }
+
+        slack_text, _ = rich_content_to_slack_payload(rich_content, "")
+
+        assert slack_text == "```\nC:\\Projects\\*\n```"
+
     def test_rich_content_roundtrip_preserves_line_breaks_and_paragraphs(self) -> None:
         rich_content = {
             "type": "doc",

--- a/products/conversations/backend/api/tests/test_formatting.py
+++ b/products/conversations/backend/api/tests/test_formatting.py
@@ -132,6 +132,23 @@ class TestSlackFormatting(SimpleTestCase):
         assert first_link["url"] == "https://posthog.com"
         assert first_link["style"] == {"bold": True, "italic": True, "underline": True}
 
+    @parameterized.expand(
+        [
+            ("exclamation", "Hello world!", "Hello world!"),
+            ("period_and_hyphen", "v2.0 is out - grab it.", "v2.0 is out - grab it."),
+            ("parens_and_hash", "See item (3) #done", "See item (3) #done"),
+        ]
+    )
+    def test_outbound_text_fallback_drops_commonmark_escapes(self, _name: str, text: str, expected: str) -> None:
+        rich_content = {
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": text}]}],
+        }
+
+        slack_text, _ = rich_content_to_slack_payload(rich_content, "")
+
+        assert slack_text == expected
+
     def test_rich_content_roundtrip_preserves_line_breaks_and_paragraphs(self) -> None:
         rich_content = {
             "type": "doc",

--- a/products/conversations/backend/api/tests/test_formatting.py
+++ b/products/conversations/backend/api/tests/test_formatting.py
@@ -169,6 +169,66 @@ class TestSlackFormatting(SimpleTestCase):
 
         assert slack_text == expected
 
+    @parameterized.expand(
+        [
+            ("bold", [{"type": "bold"}], "*Hi*"),
+            ("italic", [{"type": "italic"}], "_Hi_"),
+            ("bold_italic", [{"type": "bold"}, {"type": "italic"}], "*_Hi_*"),
+        ]
+    )
+    def test_outbound_emphasis_maps_to_mrkdwn(self, _name: str, marks: list[dict], expected: str) -> None:
+        # The bold rewrite emits mrkdwn `*x*`, which the italic rewrite consumes if bold
+        # is written in place — every bold word then reaches Slack in italics.
+        rich_content = {
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Hi", "marks": marks}]}],
+        }
+
+        slack_text, _ = rich_content_to_slack_payload(rich_content, "")
+
+        assert slack_text == expected
+
+    @parameterized.expand(
+        [
+            ("asterisks", "*not bold*", "*not bold*"),
+            ("underscores", "_not italic_", "_not italic_"),
+            ("backtick", "a ` b", "a ` b"),
+        ]
+    )
+    def test_outbound_text_fallback_keeps_escaped_characters_literal(
+        self, _name: str, text: str, expected: str
+    ) -> None:
+        # Serialization escapes these, so the mrkdwn rewrites must not read them as syntax
+        # and turn a literal "*not bold*" into italics on its way to the fallback.
+        rich_content = {
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": text}]}],
+        }
+
+        slack_text, _ = rich_content_to_slack_payload(rich_content, "")
+
+        assert slack_text == expected
+
+    def test_outbound_escaped_backtick_does_not_capture_following_code_span(self) -> None:
+        # An escaped backtick must not pair with a real code span's opener, or the span
+        # loses its protection and the stray backtick leaks into the fallback.
+        rich_content = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "text", "text": "a ` b <@U1> "},
+                        {"type": "text", "text": "x", "marks": [{"type": "code"}]},
+                    ],
+                }
+            ],
+        }
+
+        slack_text, _ = rich_content_to_slack_payload(rich_content, "")
+
+        assert slack_text == "a ` b &lt;@U1&gt; `x`"
+
     def test_outbound_code_block_preserves_literal_backslashes(self) -> None:
         # Code bypasses markdown escaping, so the unescape pass must leave its backslashes alone.
         rich_content = {
@@ -526,6 +586,24 @@ class TestEmailFormatting(SimpleTestCase):
         txt_body, _ = rich_content_to_email_payload(rich_content, "")
 
         assert txt_body == "**Read **[the docs](https://posthog.com/docs)"
+
+    def test_escaped_backtick_does_not_capture_following_code_span(self) -> None:
+        rich_content = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "text", "text": "a ` b "},
+                        {"type": "text", "text": "x", "marks": [{"type": "code"}]},
+                    ],
+                }
+            ],
+        }
+
+        txt_body, _ = rich_content_to_email_payload(rich_content, "")
+
+        assert txt_body == "a ` b `x`"
 
     def test_code_keeps_literal_backslashes(self) -> None:
         rich_content = {

--- a/products/conversations/backend/api/tests/test_formatting.py
+++ b/products/conversations/backend/api/tests/test_formatting.py
@@ -7,6 +7,7 @@ from products.conversations.backend.formatting import (
     _slack_unicode_to_char,
     extract_images_from_rich_content,
     extract_slack_user_ids,
+    rich_content_to_email_payload,
     rich_content_to_slack_payload,
     slack_to_content_and_rich_content,
 )
@@ -482,3 +483,72 @@ class TestSlackFormatting(SimpleTestCase):
         content, rich_content = slack_to_content_and_rich_content("", blocks)
         assert "<@UXYZ999>" in content
         assert rich_content is not None
+
+
+class TestEmailFormatting(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("exclamation", "No worries!", "No worries!"),
+            ("period_and_hyphen", "Docs for migrate-to-cloud are here.", "Docs for migrate-to-cloud are here."),
+            ("parens_and_hash", "See item (3) #done", "See item (3) #done"),
+        ]
+    )
+    def test_text_part_drops_commonmark_escapes(self, _name: str, text: str, expected: str) -> None:
+        rich_content = {
+            "type": "doc",
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": text}]}],
+        }
+
+        txt_body, _ = rich_content_to_email_payload(rich_content, "")
+
+        assert txt_body == expected
+
+    def test_text_part_keeps_markdown_syntax(self) -> None:
+        # Only the escapes go — mail clients render the text part verbatim, but the markers
+        # are what a reader falling back to plain text has to work with.
+        rich_content = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "text", "text": "Read ", "marks": [{"type": "bold"}]},
+                        {
+                            "type": "text",
+                            "text": "the docs",
+                            "marks": [{"type": "link", "attrs": {"href": "https://posthog.com/docs"}}],
+                        },
+                    ],
+                }
+            ],
+        }
+
+        txt_body, _ = rich_content_to_email_payload(rich_content, "")
+
+        assert txt_body == "**Read **[the docs](https://posthog.com/docs)"
+
+    def test_code_keeps_literal_backslashes(self) -> None:
+        rich_content = {
+            "type": "doc",
+            "content": [{"type": "codeBlock", "content": [{"type": "text", "text": r"C:\Projects\*"}]}],
+        }
+
+        txt_body, _ = rich_content_to_email_payload(rich_content, "")
+
+        assert txt_body == "```\nC:\\Projects\\*\n```"
+
+    def test_fallback_content_renders_without_escapes_in_both_parts(self) -> None:
+        # Messages without rich content (Slack, imports) carry markdown in `content`, so the
+        # escapes reached the HTML part too — not just the text part.
+        txt_body, html_body = rich_content_to_email_payload(None, "Hey there\\! Ping me \\- anytime\\.")
+
+        assert txt_body == "Hey there! Ping me - anytime."
+        assert "<p>Hey there! Ping me - anytime.</p>" in html_body
+        assert "\\" not in html_body
+
+    def test_fallback_content_escapes_html_and_keeps_paragraphs(self) -> None:
+        txt_body, html_body = rich_content_to_email_payload(None, "First <b>line</b>\nsame para\n\nSecond para")
+
+        assert txt_body == "First <b>line</b>\nsame para\n\nSecond para"
+        assert "<p>First &lt;b&gt;line&lt;/b&gt;<br>same para</p>" in html_body
+        assert "<p>Second para</p>" in html_body

--- a/products/conversations/backend/api/tests/test_signals.py
+++ b/products/conversations/backend/api/tests/test_signals.py
@@ -61,6 +61,13 @@ class TestTicketMessageSignals(BaseTest):
         assert self.ticket.updated_at == comment.created_at
         assert self.ticket.unread_customer_count == 0  # Customer messages don't increment this
 
+    def test_message_preview_drops_commonmark_escapes(self, mock_on_commit):
+        # The preview is read as plain text by the widget and by outbound notifications.
+        self._create_team_message("On it\\! Migration docs are here\\.")
+
+        self.ticket.refresh_from_db()
+        assert self.ticket.last_message_text == "On it! Migration docs are here."
+
     def test_team_message_updates_stats_and_unread(self, mock_on_commit):
         comment = self._create_team_message("Response from team")
 

--- a/products/conversations/backend/events.py
+++ b/products/conversations/backend/events.py
@@ -27,6 +27,7 @@ from posthog.personhog_client.caller_tag import personhog_caller_tag
 from posthog.settings import SITE_URL
 
 from products.conversations.backend.cache import get_cached_resolved_groups, set_cached_resolved_groups
+from products.conversations.backend.formatting import strip_markdown_escapes
 from products.conversations.backend.models import Ticket, TicketAssignment
 from products.conversations.backend.models.constants import Channel, OrganizationIdSource
 
@@ -532,7 +533,7 @@ def capture_message_sent(
     """Team member sent a message on a ticket."""
     properties = _get_ticket_base_properties(ticket)
     properties["message_id"] = message_id
-    properties["message_content"] = (message_content or "")[:1000]
+    properties["message_content"] = strip_markdown_escapes(message_content or "")[:1000]
     properties["author_type"] = "team"
     properties.update(_get_actor_properties(author, "user"))
     properties.update(_get_customer_properties(ticket, include_distinct_id=True))
@@ -553,7 +554,7 @@ def capture_message_received(ticket: Ticket, message_id: str, message_content: s
     """Customer sent a message on a ticket."""
     properties = _get_ticket_base_properties(ticket)
     properties["message_id"] = message_id
-    properties["message_content"] = (message_content or "")[:1000]
+    properties["message_content"] = strip_markdown_escapes(message_content or "")[:1000]
     properties["author_type"] = "customer"
     properties.update(_get_customer_properties(ticket))
     properties.update(_get_assignment_properties(ticket))

--- a/products/conversations/backend/formatting.py
+++ b/products/conversations/backend/formatting.py
@@ -28,6 +28,9 @@ _RE_SINGLE_NEWLINE = re.compile(r"(?<!\n)\n(?!\n)")
 _RE_MD_ESCAPE = re.compile(r"([\\`*_{}\[\]()#+\-.!|])")
 _RE_MD_UNESCAPE = re.compile(r"\\([\\`*_{}\[\]()#+\-.!|])")
 _RE_ALT_ESCAPE = re.compile(r"([\\\]])")
+# Fenced blocks (```...```) or simple inline spans (`code`). Their contents are literal
+# and must skip mrkdwn rewriting and backslash unescaping.
+_RE_CODE_SEGMENT = re.compile(r"```[\s\S]*?```|`[^`\n]*`")
 _RE_SLACK_EMOJI = re.compile(r":([a-z0-9_+\-]+):")
 
 
@@ -159,12 +162,29 @@ def strip_slack_user_mentions(text: str) -> str:
     return _RE_SLACK_USER_MENTION.sub("", text)
 
 
+def _escape_slack_control_chars(text: str) -> str:
+    """Neutralize Slack's control characters so user text can't inject mentions/links/broadcasts."""
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
 def content_to_slack_mrkdwn(content: str) -> str:
     """Convert markdown comment content to Slack mrkdwn text."""
     if not content:
         return ""
 
-    text = content
+    # Pull code out first: its contents are literal, so they must not be rewritten as
+    # mrkdwn, have escapes stripped, or have their `<`/`>`/`&` treated as user injection.
+    code_segments: list[str] = []
+
+    def capture_code(match: re.Match) -> str:
+        code_segments.append(match.group(0))
+        return f"\x00CODE{len(code_segments) - 1}\x00"
+
+    text = _RE_CODE_SEGMENT.sub(capture_code, content)
+
+    # Escape control chars in user text before the conversions below emit their own trusted
+    # `<...>` link tokens — otherwise a literal `<!channel>` would become an active broadcast.
+    text = _escape_slack_control_chars(text)
 
     text = _RE_MD_IMAGE.sub(r"<\2|\1>", text)
 
@@ -186,6 +206,9 @@ def content_to_slack_mrkdwn(content: str) -> str:
     # backslash escapes left over from serialization — Slack mrkdwn doesn't use them and
     # would otherwise show them literally (e.g. "world\!").
     text = _RE_MD_UNESCAPE.sub(r"\1", text)
+
+    for index, value in enumerate(code_segments):
+        text = text.replace(f"\x00CODE{index}\x00", _escape_slack_control_chars(value))
 
     def resolve_mention(match: re.Match) -> str:
         uuid_str = match.group(1)

--- a/products/conversations/backend/formatting.py
+++ b/products/conversations/backend/formatting.py
@@ -26,6 +26,7 @@ _RE_MD_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _RE_MD_MENTION = re.compile(r"@member:([a-f0-9-]+)")
 _RE_SINGLE_NEWLINE = re.compile(r"(?<!\n)\n(?!\n)")
 _RE_MD_ESCAPE = re.compile(r"([\\`*_{}\[\]()#+\-.!|])")
+_RE_MD_UNESCAPE = re.compile(r"\\([\\`*_{}\[\]()#+\-.!|])")
 _RE_ALT_ESCAPE = re.compile(r"([\\\]])")
 _RE_SLACK_EMOJI = re.compile(r":([a-z0-9_+\-]+):")
 
@@ -180,6 +181,11 @@ def content_to_slack_mrkdwn(content: str) -> str:
 
     for index, value in enumerate(bold_italic_matches):
         text = text.replace(f"\x00BI{index}\x00", f"*_{value}_*")
+
+    # Markdown syntax has been rewritten to Slack mrkdwn above, so drop the CommonMark
+    # backslash escapes left over from serialization — Slack mrkdwn doesn't use them and
+    # would otherwise show them literally (e.g. "world\!").
+    text = _RE_MD_UNESCAPE.sub(r"\1", text)
 
     def resolve_mention(match: re.Match) -> str:
         uuid_str = match.group(1)

--- a/products/conversations/backend/formatting.py
+++ b/products/conversations/backend/formatting.py
@@ -167,6 +167,28 @@ def _escape_slack_control_chars(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
+def strip_markdown_escapes(text: str) -> str:
+    """
+    Drop the CommonMark backslash escapes that serialization adds.
+
+    Use this for destinations that don't read CommonMark — plain-text email bodies,
+    message previews — where "world\\!" must render as "world!". Code spans and code
+    blocks keep their contents literal, so they are left alone.
+    """
+    if not text:
+        return ""
+
+    chunks: list[str] = []
+    position = 0
+    for code_segment in _RE_CODE_SEGMENT.finditer(text):
+        chunks.append(_RE_MD_UNESCAPE.sub(r"\1", text[position : code_segment.start()]))
+        chunks.append(code_segment.group(0))
+        position = code_segment.end()
+    chunks.append(_RE_MD_UNESCAPE.sub(r"\1", text[position:]))
+
+    return "".join(chunks)
+
+
 def content_to_slack_mrkdwn(content: str) -> str:
     """Convert markdown comment content to Slack mrkdwn text."""
     if not content:
@@ -679,6 +701,26 @@ def _serialize_inline_nodes_to_html(nodes: list[JSON]) -> str:
     return "".join(chunks)
 
 
+def _wrap_email_html(body: str) -> str:
+    return f"""<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; line-height: 1.5; color: #333;">
+{body}
+</body>
+</html>"""
+
+
+def _plain_text_to_email_html(text: str) -> str:
+    """Wrap plain text in email HTML — blank lines start a paragraph, single newlines break a line."""
+    paragraphs = [paragraph for paragraph in re.split(r"\n{2,}", text) if paragraph.strip()]
+    blocks = [
+        "<p>{}</p>".format("<br>".join(_escape_html(line) for line in paragraph.split("\n")))
+        for paragraph in paragraphs
+    ]
+    return _wrap_email_html("\n".join(blocks) or "<p></p>")
+
+
 def rich_content_to_html(rich_content: JSON | None) -> str:
     """Serialize PostHog rich content JSON to email-safe HTML."""
     if not rich_content or rich_content.get("type") != "doc":
@@ -722,14 +764,7 @@ def rich_content_to_html(rich_content: JSON | None) -> str:
             if src:
                 blocks.append(f'<p><img src="{_escape_html(src)}" alt="{_escape_html(alt)}"></p>')
 
-    body = "\n".join(blocks)
-    return f"""<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"></head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 14px; line-height: 1.5; color: #333;">
-{body}
-</body>
-</html>"""
+    return _wrap_email_html("\n".join(blocks))
 
 
 def rich_content_to_slack_payload(
@@ -750,3 +785,22 @@ def rich_content_to_slack_payload(
             return content_to_slack_mrkdwn(source_content), blocks
 
     return content_to_slack_mrkdwn(fallback_content), None
+
+
+def rich_content_to_email_payload(rich_content: JSON | None, fallback_content: str) -> tuple[str, str]:
+    """
+    Convert outbound app message to email body fields.
+
+    Returns:
+    - text (the text/plain part — markdown without the CommonMark escapes, which mail
+      clients show verbatim; images are dropped because a bare URL reads as noise)
+    - html (the text/html alternative)
+    """
+    if rich_content:
+        html_body = rich_content_to_html(rich_content)
+        if html_body:
+            markdown_text = rich_content_to_markdown(rich_content, include_images=False)
+            return strip_markdown_escapes(markdown_text or fallback_content), html_body
+
+    text_body = strip_markdown_escapes(fallback_content)
+    return text_body, _plain_text_to_email_html(text_body)

--- a/products/conversations/backend/formatting.py
+++ b/products/conversations/backend/formatting.py
@@ -26,11 +26,12 @@ _RE_MD_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _RE_MD_MENTION = re.compile(r"@member:([a-f0-9-]+)")
 _RE_SINGLE_NEWLINE = re.compile(r"(?<!\n)\n(?!\n)")
 _RE_MD_ESCAPE = re.compile(r"([\\`*_{}\[\]()#+\-.!|])")
-_RE_MD_UNESCAPE = re.compile(r"\\([\\`*_{}\[\]()#+\-.!|])")
 _RE_ALT_ESCAPE = re.compile(r"([\\\]])")
-# Fenced blocks (```...```) or simple inline spans (`code`). Their contents are literal
-# and must skip mrkdwn rewriting and backslash unescaping.
-_RE_CODE_SEGMENT = re.compile(r"```[\s\S]*?```|`[^`\n]*`")
+# A backslash escape left by serialization, a fenced block (```...```), or an inline span
+# (`code`). Both need lifting out before any rewriting: escapes because the char they hide
+# must not be read as syntax, code because its contents are literal. Escapes are matched
+# first so an escaped backtick can't pair with a real code span's opening backtick.
+_RE_MD_ESCAPE_OR_CODE = re.compile(r"\\([\\`*_{}\[\]()#+\-.!|])|```[\s\S]*?```|`[^`\n]*`")
 _RE_SLACK_EMOJI = re.compile(r":([a-z0-9_+\-]+):")
 
 
@@ -178,15 +179,7 @@ def strip_markdown_escapes(text: str) -> str:
     if not text:
         return ""
 
-    chunks: list[str] = []
-    position = 0
-    for code_segment in _RE_CODE_SEGMENT.finditer(text):
-        chunks.append(_RE_MD_UNESCAPE.sub(r"\1", text[position : code_segment.start()]))
-        chunks.append(code_segment.group(0))
-        position = code_segment.end()
-    chunks.append(_RE_MD_UNESCAPE.sub(r"\1", text[position:]))
-
-    return "".join(chunks)
+    return _RE_MD_ESCAPE_OR_CODE.sub(lambda match: match.group(1) if match.group(1) else match.group(0), text)
 
 
 def content_to_slack_mrkdwn(content: str) -> str:
@@ -194,15 +187,22 @@ def content_to_slack_mrkdwn(content: str) -> str:
     if not content:
         return ""
 
-    # Pull code out first: its contents are literal, so they must not be rewritten as
-    # mrkdwn, have escapes stripped, or have their `<`/`>`/`&` treated as user injection.
+    # Pull escaped characters and code out first. An escaped character is one the author
+    # typed literally, so it must not be read as mrkdwn syntax by the rewrites below.
+    # Code contents are literal too, and must additionally keep their `<`/`>`/`&` out of
+    # the injection check.
     code_segments: list[str] = []
+    escaped_chars: list[str] = []
 
-    def capture_code(match: re.Match) -> str:
+    def capture_escape_or_code(match: re.Match) -> str:
+        escaped_char = match.group(1)
+        if escaped_char:
+            escaped_chars.append(escaped_char)
+            return f"\x00ESC{len(escaped_chars) - 1}\x00"
         code_segments.append(match.group(0))
         return f"\x00CODE{len(code_segments) - 1}\x00"
 
-    text = _RE_CODE_SEGMENT.sub(capture_code, content)
+    text = _RE_MD_ESCAPE_OR_CODE.sub(capture_escape_or_code, content)
 
     # Escape control chars in user text before the conversions below emit their own trusted
     # `<...>` link tokens — otherwise a literal `<!channel>` would become an active broadcast.
@@ -217,20 +217,34 @@ def content_to_slack_mrkdwn(content: str) -> str:
         return f"\x00BI{len(bold_italic_matches) - 1}\x00"
 
     text = _RE_MD_BOLD_ITALIC.sub(capture_bold_italic, text)
-    text = _RE_MD_BOLD.sub(r"*\1*", text)
+
+    # Bold is stashed rather than rewritten in place: mrkdwn bold is `*x*`, which the
+    # italic rewrite below would otherwise consume and turn back into `_x_`.
+    bold_matches: list[str] = []
+
+    def capture_bold(match: re.Match) -> str:
+        bold_matches.append(match.group(1))
+        return f"\x00BOLD{len(bold_matches) - 1}\x00"
+
+    text = _RE_MD_BOLD.sub(capture_bold, text)
     text = _RE_MD_ITALIC.sub(r"_\1_", text)
     text = _RE_MD_LINK.sub(r"<\2|\1>", text)
+
+    for index, value in enumerate(bold_matches):
+        text = text.replace(f"\x00BOLD{index}\x00", f"*{value}*")
 
     for index, value in enumerate(bold_italic_matches):
         text = text.replace(f"\x00BI{index}\x00", f"*_{value}_*")
 
-    # Markdown syntax has been rewritten to Slack mrkdwn above, so drop the CommonMark
-    # backslash escapes left over from serialization — Slack mrkdwn doesn't use them and
-    # would otherwise show them literally (e.g. "world\!").
-    text = _RE_MD_UNESCAPE.sub(r"\1", text)
-
     for index, value in enumerate(code_segments):
         text = text.replace(f"\x00CODE{index}\x00", _escape_slack_control_chars(value))
+
+    # Put the escaped characters back as themselves, now that the rewrites can no longer
+    # read them as syntax — Slack mrkdwn has no backslash escaping and would show a
+    # leftover "world\!" literally. Restored before mentions so an `@member:` UUID that
+    # was escaped mid-token is whole again by the time the mention regex runs.
+    for index, value in enumerate(escaped_chars):
+        text = text.replace(f"\x00ESC{index}\x00", value)
 
     def resolve_mention(match: re.Match) -> str:
         uuid_str = match.group(1)

--- a/products/conversations/backend/signals.py
+++ b/products/conversations/backend/signals.py
@@ -17,6 +17,7 @@ from posthog.models.instance_setting import get_instance_setting
 
 from .cache import invalidate_messages_cache, invalidate_tickets_cache
 from .events import capture_message_received, capture_message_sent, capture_ticket_created
+from .formatting import strip_markdown_escapes
 from .models import EmailOutboxMessage, Ticket
 from .models.constants import Channel
 from .tasks import (
@@ -137,7 +138,7 @@ def update_ticket_on_message(sender, instance: Comment, created: bool, **kwargs)
         update_fields = {
             "message_count": F("message_count") + 1,
             "last_message_at": created_at,
-            "last_message_text": (content or "")[:500],  # Truncate to 500 chars
+            "last_message_text": strip_markdown_escapes(content or "")[:500],  # Truncate to 500 chars
             "updated_at": created_at,
         }
 
@@ -267,7 +268,7 @@ def handle_comment_soft_delete(sender, instance: Comment, **kwargs):
             if last_comment:
                 Ticket.objects.filter(id=item_id, team_id=team_id).update(
                     last_message_at=last_comment.created_at,
-                    last_message_text=(last_comment.content or "")[:500],
+                    last_message_text=strip_markdown_escapes(last_comment.content or "")[:500],
                 )
             else:
                 Ticket.objects.filter(id=item_id, team_id=team_id).update(

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -1,6 +1,5 @@
 """Celery tasks for the conversations product."""
 
-import html as html_mod
 import json
 from datetime import datetime, timedelta
 from email.utils import formataddr
@@ -34,7 +33,7 @@ from products.conversations.backend.cache import NUDGE_DISMISS_TTL, suppress_nud
 from products.conversations.backend.events import capture_ticket_status_changed
 from products.conversations.backend.formatting import (
     extract_images_from_rich_content,
-    rich_content_to_html,
+    rich_content_to_email_payload,
     rich_content_to_markdown,
     rich_content_to_slack_payload,
 )
@@ -768,12 +767,7 @@ def _process_outbox_row(outbox: EmailOutboxMessage) -> None:
         if all_ids:
             headers["References"] = " ".join(all_ids)
 
-    if comment.rich_content:
-        html_body = rich_content_to_html(comment.rich_content)
-        txt_body = rich_content_to_markdown(comment.rich_content, include_images=False)
-    else:
-        txt_body = comment.content or ""
-        html_body = f"<p>{html_mod.escape(comment.content or '')}</p>"
+    txt_body, html_body = rich_content_to_email_payload(comment.rich_content, comment.content or "")
 
     subject = ticket.email_subject or "Your support request"
     is_reply = latest_mapping is not None


### PR DESCRIPTION
## Problem

The rich editor → Slack conversion was over-escaping the message text fallback, so Slack messages showed stray backslashes before ordinary punctuation (`\!`, `\.`, `\-`, `\#`, `\(`, etc.). The same escapes reach customers by email: the `text/plain` part of outbound support replies, and the message previews that notification templates render as plain text.

## Changes

Rich content is serialized to markdown via `_escape_markdown`, which backslash-escapes every CommonMark special char. Slack mrkdwn, plain-text email parts, and notification previews don't read CommonMark, so the escapes leaked through verbatim.

- Slack: un-escape at the end of `content_to_slack_mrkdwn`, after the mrkdwn rewrites run. Code and Slack control chars stay protected.
- Email: added `rich_content_to_email_payload`, the counterpart of `rich_content_to_slack_payload`. It returns the `text/plain` part without the escapes plus the `text/html` alternative, and messages without rich content now render through the same HTML shell instead of one bare escaped paragraph.
- Previews: the `message_content` event property and the denormalized ticket message preview are read as plain text downstream, so they drop the escapes too. Existing rows and events keep what they were written with.

Escapes are stripped through one shared helper that leaves code spans and code blocks literal. Markdown syntax itself (`**bold**`, `[label](url)`) is untouched in the plain-text part — only the escapes go.

## How did you test this code?

Added email payload cases to `test_formatting.py` (text part loses the escapes, code keeps its backslashes, the fallback path is clean in both parts and still HTML-escapes), plus one preview case each in `test_signals.py` and `test_events.py` for the two surfaces notification templates read. Locally: `test_formatting.py`, `test_signals.py`, `test_events.py`, `test_email_endpoints.py`, `test_tickets.py`, `test_mailgun.py`, `test_slack_image_sync.py` all pass, and repo-wide `mypy` is clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack support thread, then extended after the same effect showed up in an outbound email. Confirmed in project data that the escapes are present on the great majority of recent outbound message events, which is what the plain-text notification template renders. Root-caused the double-transform (escape-then-render without un-escape) in `products/conversations/backend/formatting.py`. Chose to un-escape at the destination boundaries rather than skip escaping upfront, which the intermediate markdown step still relies on for Slack blocks, GitHub comments, and round-tripping.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1785258020763879?thread_ts=1785258020.763879&cid=C08S2L0S5MZ)*
