### PR TITLE
fix(demo): correct website metrics description

### DIFF
--- a/products/demo/backend/logic/dashboard_template_seeds/01_website_metrics.json
+++ b/products/demo/backend/logic/dashboard_template_seeds/01_website_metrics.json
@@ -65,7 +65,7 @@
                     "minW": 1
                 }
             },
-            "description": "Shows the number of unique users over the last 30 days."
+            "description": "Shows the number of unique users."
         },
         {
             "name": "Top Website Pages (Overall)",


### PR DESCRIPTION
## Problem

The Unique Users changed with the timerange filter, but its seeded dashboard description says that it is. As can be seen in the image, I have **last 7 days selected**, but description of widget description points to **last 30 days**
<img width="946" height="648" alt="image" src="https://github.com/user-attachments/assets/4c9f7143-22dc-4bac-885f-8752c4bc5dbb" />

## Changes

Remove the inaccurate time-period qualifier so the description matches the metric.

## How did you test this code?

- Still need to test it since this looks it could be seeded into DB at startup time. Need to do more tests

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed because this corrects copy in the dashboard template itself.

## 🤖 Agent context

Codex help doing the change.