### PR TITLE
chore(experiments): remove dead AA test bayesian feature flag constants

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -245,8 +245,6 @@ export const FEATURE_FLAGS = {
     WEB_ANALYTICS_REFERRER_URL_DRILLDOWN: 'web-analytics-referrer-url-drilldown', // owner: @jabahamondes #team-web-analytics
 
     // Temporary feature flags, still WIP, should be removed eventually
-    AA_TEST_BAYESIAN_LEGACY: 'aa-test-bayesian-legacy', // owner: #team-experiments
-    AA_TEST_BAYESIAN_NEW: 'aa-test-bayesian-new', // owner: #team-experiments
     ACTION_REFERENCE_COUNT: 'action-reference-count', // owner: @andyzzhao #team-product-analytics, gates bulk action reference counting on actions list
     ADVANCE_MARKETING_ANALYTICS_SETTINGS: 'advance-marketing-analytics-settings', // owner: @jabahamondes  #team-web-analytics
     AI_GATEWAY: 'ai-gateway', // owner: #team-ai-gateway, gates the AI gateway UI and llm_gateway:read on project secret API keys


### PR DESCRIPTION
## Problem

`aa-test-bayesian-new` is rolled out to 100% and its AA test is done, so the flag constant is just noise in `FEATURE_FLAGS`. Its twin `aa-test-bayesian-legacy`, added by the same AA test setup (#34815), is in the same state.

Both are dead in the codebase already. Nothing reads either one: no `featureFlags[FEATURE_FLAGS.AA_TEST_BAYESIAN_*]`, no `posthog.isFeatureEnabled`, no Python `feature_enabled`, nothing in `rust/`, `plugin-server/`, `services/`, fixtures, or tests. The declaration in `constants.tsx` was the only reference in the repo.

## Changes

Deleted the two constants from `frontend/src/lib/constants.tsx`. That's the whole diff. No branch to collapse, since the flags gated nothing.

The `// Temporary feature flags, still WIP, should be removed eventually` comment stays: it heads the whole alphabetical block below, not just these two entries.

The flags themselves are untouched in PostHog. They back AA test experiment records, so archiving or deleting them is a separate call for #team-experiments.

## How did you test this code?

No manual testing, and none is meaningful here since nothing consumed the constants.

- `rg -i 'aa.?test.?bayesian'` across the repo returns nothing after the change.
- `pnpm --filter=@posthog/frontend typescript:check` reports no error mentioning `constants.tsx` or `AA_TEST`. It does fail on pre-existing errors in this worktree from unbuilt workspace packages (`@posthog/quill-primitives`, `@posthog/hogvm`), all unrelated to this diff.
- `hogli ci:preflight --strict` passes.

No tests added. A deleted unreferenced constant has no regression to catch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Opus, via PostHog Code) did this one. I asked it to clean up `aa-test-bayesian-new`; it searched the repo, found the constant was the only reference, and confirmed against the PostHog API that both AA flags exist and are live.

Two decisions worth flagging for review. First, I told it to take the legacy twin along with the new one, since both are dead and come from the same AA setup. Second, we kept the change to code only. Deleting the flags in PostHog would touch the experiment records behind them, and that call belongs to the owning team.

No skills invoked. The task did not touch migrations, DRF, tests, or user-facing copy.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
