### PR TITLE
fix(data-imports): skip cloudflare zones/accounts missing a plan feature during fan-out

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/cloudflare.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/cloudflare.py
@@ -286,7 +286,8 @@ def _fanout_resource(
 
     child_endpoint = _endpoint(config, params, should_use_incremental_field)
     child_endpoint["response_actions"] = [
-        {"status_code": status, "action": "ignore"} for status in FANOUT_SKIP_STATUS_CODES
+        {"status_code": status, "action": "ignore"}
+        for status in (*FANOUT_SKIP_STATUS_CODES, *config.extra_skip_status_codes)
     ]
 
     child = _resource(endpoint, child_endpoint)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/settings.py
@@ -40,6 +40,10 @@ class CloudflareEndpointConfig:
     params: dict[str, Any] = field(default_factory=dict)
     # Query param carrying the incremental watermark, when the API filters server-side.
     incremental_param: Optional[str] = None
+    # Extra per-parent status codes to skip (in addition to FANOUT_SKIP_STATUS_CODES) —
+    # for endpoints where Cloudflare returns a non-403/404 error on a plan/feature that
+    # a specific zone or account doesn't have, rather than on missing read access.
+    extra_skip_status_codes: tuple[int, ...] = ()
 
 
 # Most Cloudflare v4 REST lists are small configuration tables with no updated-since
@@ -88,6 +92,10 @@ CLOUDFLARE_ENDPOINTS: dict[str, CloudflareEndpointConfig] = {
         path="/zones/{zone_id}/rate_limits",
         parent=ZONES_PARENT,
         parent_key="_zone_id",
+        # Cloudflare deprecated the legacy Rate Limiting Rules API in favor of the
+        # Ruleset Engine; zones without legacy rules get a 410 Gone rather than an
+        # empty list.
+        extra_skip_status_codes=(410,),
     ),
     "bot_management": CloudflareEndpointConfig(
         name="bot_management",
@@ -174,6 +182,8 @@ CLOUDFLARE_ENDPOINTS: dict[str, CloudflareEndpointConfig] = {
         path="/zones/{zone_id}/custom_certificates",
         parent=ZONES_PARENT,
         parent_key="_zone_id",
+        # Zones without custom SSL for SaaS enabled get a 400 rather than an empty list.
+        extra_skip_status_codes=(400,),
     ),
     # --- Zone-scoped client-side security ---
     "page_shield_scripts": CloudflareEndpointConfig(
@@ -227,6 +237,8 @@ CLOUDFLARE_ENDPOINTS: dict[str, CloudflareEndpointConfig] = {
         parent=ACCOUNTS_PARENT,
         parent_key="_account_id",
         pagination=SINGLE_PAGE,
+        # Accounts without billing-usage entitlement get a 400 rather than an empty list.
+        extra_skip_status_codes=(400,),
     ),
     "billable_usage": CloudflareEndpointConfig(
         name="billable_usage",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_client.py
@@ -229,6 +229,29 @@ class TestZoneFanout:
         with pytest.raises(requests.HTTPError):
             _rows(cloudflare_source("token", "dns_records", team_id=1, job_id="j"))
 
+    @pytest.mark.parametrize(
+        ("endpoint", "status_code"),
+        [("rate_limits", 410), ("custom_certificates", 400)],
+    )
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_skips_zone_missing_plan_feature_and_continues(self, MockSession, endpoint, status_code) -> None:
+        # Cloudflare returns a non-403/404 error when a zone's plan doesn't include a
+        # feature (e.g. legacy rate limiting is 410 Gone, custom certs are 400) rather
+        # than an empty list — one such zone must not abort the whole stream.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "z1"}, {"id": "z2"}], total_pages=1),
+                _error_response(status_code),
+                _response([{"id": "r2"}], total_pages=1),
+            ],
+        )
+
+        rows = _rows(cloudflare_source("token", endpoint, team_id=1, job_id="j"))
+
+        assert [(r["id"], r["_zone_id"]) for r in rows] == [("r2", "z2")]
+
     @mock.patch(CLIENT_SESSION_PATCH)
     def test_zone_without_id_is_skipped(self, MockSession) -> None:
         session = MockSession.return_value
@@ -327,6 +350,24 @@ class TestAccountFanout:
         rows = _rows(cloudflare_source("token", "kv_namespaces", team_id=1, job_id="j"))
 
         assert [(r["id"], r["_account_id"]) for r in rows] == [("n2", "a2")]
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_skips_account_missing_billing_usage_entitlement_and_continues(self, MockSession) -> None:
+        # Accounts without billing-usage entitlement get a 400 rather than an empty
+        # list — one such account must not abort the whole stream.
+        session = MockSession.return_value
+        _wire(
+            session,
+            [
+                _response([{"id": "a1"}, {"id": "a2"}], total_pages=1),
+                _error_response(400),
+                _response([{"ts": 1}], total_pages=1),
+            ],
+        )
+
+        rows = _rows(cloudflare_source("token", "billing_usage", team_id=1, job_id="j"))
+
+        assert [(r["ts"], r["_account_id"]) for r in rows] == [(1, "a2")]
 
 
 class TestSinglePageEndpoints:


### PR DESCRIPTION
## Problem

Error tracking surfaced an `HTTPError` from the Cloudflare data warehouse sync: [issue](https://us.posthog.com/project/2/error_tracking/019facd1-d097-7bc3-bc45-5c51569e42b7). Cloudflare returns a `410 Gone` for the `rate_limits` endpoint and `400 Bad Request` for `custom_certificates` and `billing_usage` when a specific zone or account doesn't have that plan feature enabled, instead of an empty list.

These are all per-zone/per-account fan-out endpoints (`_fanout_resource` in `cloudflare.py`), and the fan-out already has a mechanism for exactly this shape of failure: `FANOUT_SKIP_STATUS_CODES = (403, 404)` skips a single zone/account when the token lacks read access on it, rather than failing the whole sync. A 400/410 from a plan-gated endpoint is the same situation (this zone/account will never have the data, retrying won't help) but wasn't covered by that list, so it aborted the entire fan-out for every other zone/account instead of just skipping the one lacking the feature.

## Changes

- Added `extra_skip_status_codes` to `CloudflareEndpointConfig`, letting individual endpoints extend the set of per-parent status codes that get skipped instead of aborting the sync.
- Set it for the three affected endpoints:
  - `rate_limits`: `410` — Cloudflare deprecated the legacy Rate Limiting Rules API in favor of the Ruleset Engine.
  - `custom_certificates`: `400` — zones without custom SSL for SaaS enabled.
  - `billing_usage`: `400` — accounts without billing-usage entitlement.
- `_fanout_resource` now combines `FANOUT_SKIP_STATUS_CODES` with the endpoint's `extra_skip_status_codes` when building the child endpoint's `response_actions`.

This is scoped to just these three endpoints — every other fan-out endpoint keeps raising loudly on an unexpected 4xx, which is what we want when it's a real bug rather than a known plan/feature gap.

## How did you test this code?

Added tests in `test_cloudflare_client.py` following the existing `test_dns_records_skips_inaccessible_zone_and_continues` / `test_skips_account_the_token_cannot_read` pattern:
- `test_skips_zone_missing_plan_feature_and_continues` (parametrized over `rate_limits`/410 and `custom_certificates`/400) — one zone erroring must not abort the stream for the other zone.
- `test_skips_account_missing_billing_usage_entitlement_and_continues` — same for `billing_usage`/400.

These catch a regression where a single zone/account lacking a plan feature silently breaks the fan-out for every other zone/account of the same customer. The existing `test_dns_records_reraises_unexpected_zone_error` (400 on an endpoint without `extra_skip_status_codes`) continues to pass, confirming the fix is scoped and doesn't mask genuine bugs on other endpoints.

Ran locally:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/cloudflare/tests/test_cloudflare_client.py` — 131 passed
- `uv run ruff check` / `uv run ruff format` — clean
- `uv run mypy --cache-fine-grained .` — no issues

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — no user-facing config or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from a PostHog error-tracking issue webhook. I pulled the issue's stack trace and sampled events via the error-tracking MCP tools, traced the failure through `posthog_client.py` → `import_data_sync.py` → the REST-source pipeline into `config_setup.py`'s `response_actions_hook`, then confirmed via the raw event properties (`warehouse_sources_schema_name`) that all occurrences were `rate_limits`, `custom_certificates`, and `billing_usage` — all Cloudflare fan-out endpoints. Recognized the existing `FANOUT_SKIP_STATUS_CODES` per-parent skip mechanism in `cloudflare.py` as the established fix pattern for this class of problem and extended it per-endpoint rather than widening it globally or reaching for `get_non_retryable_errors` (which would fail the whole sync instead of just the affected zone/account). Searched open PRs for duplicates first; found none addressing this.