### PR TITLE
fix(mixpanel): surface an actionable error for a 400 at validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/mixpanel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/mixpanel.py
@@ -199,8 +199,17 @@ def validate_credentials(
             "plan that includes the data export API, and the account must be in good standing. Check your "
             "Mixpanel plan and billing, then try again.",
         )
+    if response.status_code == 400:
+        return (
+            False,
+            "Mixpanel rejected the request (400). This usually means the project ID isn't valid for the "
+            "selected region. Check your project ID and region, then try again.",
+        )
 
-    return False, f"Mixpanel returned an unexpected status ({response.status_code}) while validating credentials."
+    return (
+        False,
+        "Could not validate your Mixpanel credentials. Check the region, username, secret, and project ID, then try again.",
+    )
 
 
 def _check_response(response: requests.Response, url: str, logger: FilteringBoundLogger) -> requests.Response:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/test_mixpanel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mixpanel/test_mixpanel.py
@@ -255,6 +255,7 @@ class TestValidateCredentials:
             ("unauthorized", 401, None, False),
             ("forbidden_at_create", 403, None, True),
             ("forbidden_with_schema", 403, "export", False),
+            ("bad_request", 400, None, False),
             ("unexpected", 500, None, False),
         ]
     )
@@ -268,6 +269,15 @@ class TestValidateCredentials:
             assert error is None
         else:
             assert error is not None
+
+    def test_bad_request_points_at_the_project_id(self) -> None:
+        # A 400 used to fall through and surface the raw status code, which is not actionable.
+        session = MagicMock()
+        session.post.return_value = FakeResponse(status_code=400)
+        with patch.object(mp, "make_tracked_session", return_value=session):
+            ok, error = validate_credentials("us", "user", "secret", "123")
+        assert ok is False
+        assert error is not None and "project ID" in error
 
     def test_network_error_returns_failure(self) -> None:
         session = MagicMock()


### PR DESCRIPTION
## Problem

When someone connects a Mixpanel source, we validate their credentials with a cheap probe against the cohorts list endpoint. We map 200/401/403/402 to specific outcomes, but any other status fell through to a message that just echoed the raw HTTP status code. Yesterday that surfaced to users as a bare "returned an unexpected status (400)", which tells them nothing about what to fix.

A 400 on that probe almost always means the project ID isn't valid for the selected region.

**Why:** These validation errors are the first thing a user sees in the new-source wizard, and a raw status code is a dead end. This came out of a triage of failed source-creation attempts.

## Changes

- Handle a 400 explicitly at validation with copy that points at the project ID and region.
- Replace the raw-status-code fallthrough with a generic but actionable message.

## How did you test this code?

Extended `TestValidateCredentials` in `test_mixpanel.py`:
- Added a `bad_request` (400) case to the status-mapping parameterization.
- Added `test_bad_request_points_at_the_project_id`, which locks in that a 400 returns actionable copy naming the project ID instead of the raw status. This catches a regression back to the old fallthrough leak.

Ran the suite locally: `TestValidateCredentials` passes (9 tests).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (PostHog Code) as part of a triage of failed data-warehouse source-creation attempts. Invoked the `/writing-tests` and `/writing-user-facing-copy` skills while shaping the test and the error copy. I could not manually exercise the wizard; only the automated test above was run.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
