### PR TITLE
fix(zoho_crm): hide the raw OAuth error code on a failed validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/source.py
@@ -34,6 +34,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.zoho_crm.s
     SHOULD_SYNC_DEFAULT,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.zoho_crm.zoho_crm import (
+    REFRESH_TOKEN_REJECTED_MESSAGE,
     ZohoCRMResumeConfig,
     validate_credentials as validate_zoho_crm_credentials,
     zoho_crm_source,
@@ -54,7 +55,7 @@ class ZohoCRMSource(ResumableSource[ZohoCRMSourceConfig, ZohoCRMResumeConfig]):
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         return {
-            "Zoho CRM token refresh failed": "Zoho CRM rejected your refresh token. Generate a new one for your self client and reconnect.",
+            "Zoho CRM token refresh failed": REFRESH_TOKEN_REJECTED_MESSAGE,
             "400 Client Error: Bad Request for url: https://accounts.zoho": "Zoho CRM rejected your OAuth credentials. Check that the client ID, client secret, and refresh token all belong to the same self client.",
             "401 Client Error: Unauthorized for url": "Your Zoho CRM access token is invalid or expired. Reconnect the source to issue a new one.",
             "403 Client Error: Forbidden for url": "Your Zoho CRM token is missing a scope for this module. Re-authorize with the ZohoCRM.modules.ALL and ZohoCRM.settings.fields.READ scopes.",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/tests/test_zoho_crm.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/tests/test_zoho_crm.py
@@ -13,6 +13,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.zoho_crm.z
     MAX_FIELDS_PER_REQUEST,
     MAX_PAGE,
     PAGE_SIZE,
+    REFRESH_TOKEN_REJECTED_MESSAGE,
     ZohoCRMAuthError,
     ZohoCRMClient,
     ZohoCRMResumeConfig,
@@ -433,13 +434,16 @@ class TestValidateCredentials:
         assert error is not None and "mars" in error
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
-    def test_refresh_token_rejection_surfaces_the_reason(self, make_session: mock.MagicMock) -> None:
+    def test_refresh_token_rejection_gives_actionable_copy(self, make_session: mock.MagicMock) -> None:
+        # The raw Zoho OAuth error code (here "invalid_client") is not actionable, so validation
+        # must return the friendly reconnect message instead of leaking the code.
         make_session.return_value = _session([], post_responses=[_response(200, {"error": "invalid_client"})])
 
         is_valid, error = validate_credentials("us", "cid", "secret", "refresh")
 
         assert is_valid is False
-        assert error is not None and "invalid_client" in error
+        assert error == REFRESH_TOKEN_REJECTED_MESSAGE
+        assert "invalid_client" not in (error or "")
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_http_failure_is_not_valid(self, make_session: mock.MagicMock) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/tests/test_zoho_crm_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/tests/test_zoho_crm_source.py
@@ -15,6 +15,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.zoho_crm.s
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.zoho_crm.source import ZohoCRMSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.zoho_crm.zoho_crm import (
+    REFRESH_TOKEN_REJECTED_MESSAGE,
     ZOHO_REGIONS,
     ZohoCRMResumeConfig,
 )
@@ -168,7 +169,7 @@ class TestZohoCRMSource:
     @pytest.mark.parametrize(
         "probe_result, expected",
         [
-            ((False, "Zoho CRM token refresh failed: invalid_client"), "Zoho CRM token refresh failed: invalid_client"),
+            ((False, REFRESH_TOKEN_REJECTED_MESSAGE), REFRESH_TOKEN_REJECTED_MESSAGE),
             ((False, None), "Invalid Zoho CRM credentials"),
         ],
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/zoho_crm.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/zoho_crm/zoho_crm.py
@@ -42,6 +42,12 @@ MAX_PAGE = 2000 // PAGE_SIZE
 MAX_FIELDS_PER_REQUEST = 50
 REQUEST_TIMEOUT_SECONDS = 60
 
+# Shown when the refresh-token exchange is rejected. The raw Zoho `error` code (e.g. `invalid_code`)
+# is kept on the exception for logs but never surfaced to users, who can't act on it.
+REFRESH_TOKEN_REJECTED_MESSAGE = (
+    "Zoho CRM rejected your refresh token. Generate a new one for your self client and reconnect."
+)
+
 
 class ZohoCRMAuthError(Exception):
     pass
@@ -321,8 +327,8 @@ def validate_credentials(
 
     try:
         client.get(f"/crm/{api_version}/settings/modules")
-    except ZohoCRMAuthError as e:
-        return False, str(e)
+    except ZohoCRMAuthError:
+        return False, REFRESH_TOKEN_REJECTED_MESSAGE
     except Exception:
         return False, None
     return True, None


### PR DESCRIPTION
## Problem

When you connect a Zoho CRM source, we validate by exchanging your refresh token for an access token. If Zoho rejects the exchange, it answers with an `error` code in the body. We were passing that raw code straight through to the user, so the new-source wizard showed a message ending in a bare Zoho OAuth error code. That gives the user nothing to act on.

The sync path already maps this failure to friendly copy telling the user to generate a new refresh token and reconnect. Validation just wasn't using it.

**Why:** These validation errors are the first thing a user sees in the new-source wizard. Surfacing a raw OAuth code is a dead end. This came out of a triage of failed source-creation attempts.

## Changes

- `validate_credentials` now returns the friendly reconnect message instead of the raw exception text.
- Extracted the copy into one shared constant (`REFRESH_TOKEN_REJECTED_MESSAGE`) so validation and the non-retryable-error map can't drift.
- The raw Zoho error code stays on the exception, so logs and error tracking keep the detail.

## How did you test this code?

- Updated `test_refresh_token_rejection_gives_actionable_copy` to assert the friendly message is returned and the raw OAuth code is not leaked. This is the regression that would reappear if someone reverted to `str(e)`.
- Updated the source-layer passthrough fixture to use the shared constant (a raw code can no longer be produced there).
- Ran the full `zoho_crm/tests/` suite locally: 106 passed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (PostHog Code) as part of a triage of failed data-warehouse source-creation attempts. Invoked the `/writing-tests` and `/writing-user-facing-copy` skills. I could not manually exercise the wizard; only the automated tests above were run.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
