### PR TITLE
fix(llm-analytics): apply OTel attribute fallbacks when the primary value is a 'none' placeholder

### DIFF
--- a/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.test.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.test.ts
@@ -161,6 +161,35 @@ describe('mapOtelAttributes', () => {
         expect(event.properties!['gen_ai.response.model']).toBeUndefined()
     })
 
+    it.each([
+        ['gen_ai.system', '$ai_provider', 'gen_ai.provider.name'],
+        ['gen_ai.request.model', '$ai_model', 'gen_ai.response.model'],
+    ])("uses %s as fallback for %s when primary %s is the literal 'none' placeholder", (fallbackKey, phKey, primaryKey) => {
+        // Micrometer-based instrumentations (e.g. Spring AI) emit the literal string 'none' for
+        // unavailable attributes — notably the response model on Amazon Bedrock Converse, which
+        // does not echo the model id in the response.
+        const event = createEvent('$ai_generation', { [primaryKey]: 'none', [fallbackKey]: 'fallback' })
+        mapOtelAttributes(event)
+        expect(event.properties![phKey]).toBe('fallback')
+        expect(event.properties![fallbackKey]).toBeUndefined()
+        expect(event.properties![primaryKey]).toBeUndefined()
+    })
+
+    it('falls back to gen_ai.request.model when gen_ai.response.model is null', () => {
+        const event = createEvent('$ai_generation', {
+            'gen_ai.request.model': 'eu.anthropic.claude-opus-4-8',
+            'gen_ai.response.model': null,
+        })
+        mapOtelAttributes(event)
+        expect(event.properties!.$ai_model).toBe('eu.anthropic.claude-opus-4-8')
+    })
+
+    it("keeps the 'none' placeholder when no fallback value exists", () => {
+        const event = createEvent('$ai_generation', { 'gen_ai.response.model': 'none' })
+        mapOtelAttributes(event)
+        expect(event.properties!.$ai_model).toBe('none')
+    })
+
     it.each(['telemetry.sdk.language', 'gen_ai.operation.name', 'posthog.ai.debug'])(
         'strips %s from properties',
         (key) => {

--- a/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.ts
+++ b/nodejs/src/ingestion/pipelines/ai/otel/attribute-mapping.ts
@@ -28,6 +28,16 @@ const FALLBACK_ATTRIBUTE_MAP: Record<string, string> = {
     'gen_ai.usage.completion_tokens': '$ai_output_tokens',
 }
 
+// Micrometer-based instrumentations (e.g. Spring AI) emit the literal string 'none' for attributes
+// whose value is unavailable — notably gen_ai.response.model on providers that don't echo the model
+// id in the response (Amazon Bedrock Converse). Treat that placeholder like an absent value so the
+// fallback attributes can apply.
+const MICROMETER_NONE_PLACEHOLDER = 'none'
+
+function isAbsent(value: unknown): boolean {
+    return value === undefined || value === null || value === MICROMETER_NONE_PLACEHOLDER
+}
+
 const STRIP_ATTRIBUTES = new Set([
     'telemetry.sdk.language',
     'gen_ai.operation.name',
@@ -101,7 +111,7 @@ export function mapOtelAttributes(event: PluginEvent): void {
     }
 
     for (const [otelKey, phKey] of Object.entries(FALLBACK_ATTRIBUTE_MAP)) {
-        if (event.properties[otelKey] !== undefined && event.properties[phKey] === undefined) {
+        if (!isAbsent(event.properties[otelKey]) && isAbsent(event.properties[phKey])) {
             event.properties[phKey] = event.properties[otelKey]
         }
         delete event.properties[otelKey]


### PR DESCRIPTION
## Problem

Spring AI (and other Micrometer-based instrumentations) emit the **literal string `'none'`** for observation attributes whose value is unavailable — Micrometer's `KeyValue.NONE_VALUE` placeholder, used to keep metric dimension sets stable. The most common case: `gen_ai.response.model` on **Amazon Bedrock Converse**, which does not echo the model id in its responses.

When such a span reaches the OTLP AI ingestion endpoint, `mapOtelAttributes` copies `'none'` into `$ai_model`, which makes it *defined* — so the existing `gen_ai.request.model → $ai_model` fallback (which checks `=== undefined`) never applies. Result: every generation from Spring AI + Bedrock lands with `$ai_model: "none"` and **no cost attribution**, even though the request model id is present on the span and PostHog's pricing recognizes it (verified: a span with `gen_ai.response.model = eu.anthropic.claude-opus-4-8` prices correctly).

This is not workable around with a transformation either: transformations run before `mapOtelAttributes`, whose primary assignment overwrites anything a transformation sets, and Hog cannot make a key strictly `undefined` (`null` still passes the `!== undefined` check).

## Reproduction

Send OTLP/HTTP to `/i/v0/ai/otel`:

```json
{"name": "chat eu.anthropic.claude-opus-4-8", "attributes": [
  {"key": "gen_ai.request.model",  "value": {"stringValue": "eu.anthropic.claude-opus-4-8"}},
  {"key": "gen_ai.response.model", "value": {"stringValue": "none"}},
  {"key": "gen_ai.usage.input_tokens",  "value": {"stringValue": "1000"}},
  {"key": "gen_ai.usage.output_tokens", "value": {"stringValue": "100"}}
]}
```

Actual: `$ai_model = "none"`, no `$ai_total_cost_usd`.
Expected: `$ai_model = "eu.anthropic.claude-opus-4-8"`, cost computed.

## Fix

Treat `'none'` and `null` as absent in the fallback pass of `mapOtelAttributes`, so `gen_ai.request.model` (and `gen_ai.system`) can apply. A real response model still always wins; when no fallback exists, the `'none'` value is kept as before.

## Tests

Added cases to `attribute-mapping.test.ts`: fallback applies over a `'none'` primary (model + provider), over a `null` primary, and the placeholder is preserved when no fallback value exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)