### PR TITLE
fix(cymbal): bound metric labels and cut hot-path log noise

### DIFF
--- a/rust/cymbal/src/core/metric_consts.rs
+++ b/rust/cymbal/src/core/metric_consts.rs
@@ -106,7 +106,6 @@ pub const SPIKE_INCREMENT_ISSUE_BUCKETS_TIME: &str = "cymbal_spike_increment_iss
 pub const SPIKE_INCREMENT_TEAM_BUCKETS_TIME: &str = "cymbal_spike_increment_team_buckets_time";
 pub const SPIKE_GET_SPIKING_ISSUES_TIME: &str = "cymbal_spike_get_spiking_issues_time";
 pub const SPIKE_ACQUIRE_LOCKS_TIME: &str = "cymbal_spike_acquire_locks_time";
-pub const SPIKE_EMIT_EVENTS_TIME: &str = "cymbal_spike_emit_events_time";
 pub const SPIKE_ISSUES_CHECKED: &str = "cymbal_spike_issues_checked";
 pub const SPIKE_ISSUES_SPIKING: &str = "cymbal_spike_issues_spiking";
 pub const SPIKE_ISSUES_BLOCKED_BY_COOLDOWN: &str = "cymbal_spike_issues_blocked_by_cooldown";

--- a/rust/cymbal/src/core/symbolication/symbol/mod.rs
+++ b/rust/cymbal/src/core/symbolication/symbol/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     metric_consts::JAVA_EXCEPTION_REMAP_FAILED,
     symbolication::symbol_store::{chunk_id::OrChunkId, proguard::ProguardRef},
 };
-use tracing::warn;
+use tracing::debug;
 pub mod local;
 pub mod records;
 
@@ -82,12 +82,13 @@ pub trait SymbolResolver: Send + Sync + 'static {
                 exception.exception_type = new_type
             }
             Err(ResolveError::ResolutionError(frame_error)) => {
-                warn!(
-                    "Failed to resolve Java exception module and type: {}",
-                    frame_error
+                debug!(
+                    team_id,
+                    reason = frame_error.metric_reason(),
+                    error = %frame_error,
+                    "failed to resolve Java exception module and type"
                 );
-                // Handle resolution error
-                metrics::counter!(JAVA_EXCEPTION_REMAP_FAILED, "reason" => frame_error.to_string())
+                metrics::counter!(JAVA_EXCEPTION_REMAP_FAILED, "reason" => frame_error.metric_reason())
                     .increment(1)
             }
             Err(ResolveError::UnhandledError(err)) => {

--- a/rust/cymbal/src/core/symbolication/symbol_store/chunk_id.rs
+++ b/rust/cymbal/src/core/symbolication/symbol_store/chunk_id.rs
@@ -141,7 +141,7 @@ where
             }
             SymbolSetLoadResult::MissingStoragePtr(set_ref) => {
                 // It's never valid to have no failure reason and no storage pointer - if we hit this case, just panic
-                error!("No storage pointer found for chunk id {}", set_ref);
+                error!(team_id, "No storage pointer found for chunk id {}", set_ref);
                 panic!("No storage pointer found for chunk id {set_ref}");
             }
             SymbolSetLoadResult::MissingBlob(mut record) => {

--- a/rust/cymbal/src/core/symbolication/symbol_store/saving.rs
+++ b/rust/cymbal/src/core/symbolication/symbol_store/saving.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Duration, Utc};
 use moka::future::{Cache, CacheBuilder};
 use sha2::{Digest, Sha512};
 use sqlx::PgPool;
-use tracing::{error, info, warn};
+use tracing::{debug, error, warn};
 use uuid::Uuid;
 
 use crate::{
@@ -130,7 +130,7 @@ impl<F> Saving<F> {
         set_ref: String,
         data: Bytes,
     ) -> Result<String, UnhandledError> {
-        info!("Saving symbol set data for {}", set_ref);
+        debug!(team_id, set_ref = %set_ref, "saving symbol set data");
         let start = common_metrics::timing_guard(SAVE_SYMBOL_SET, &[]).label("data", "true");
         // Generate a new opaque key, prepending our prefix.
         let key = self.add_prefix(Uuid::now_v7().to_string());
@@ -159,14 +159,18 @@ impl<F> Saving<F> {
             .invalidate(&Self::negative_cache_key(team_id, &record.set_ref))
             .await;
         if !wrote_new_data {
-            warn!(
-                "Not overwriting existing symbol set data for {} after dynamic fetch",
-                record.set_ref
+            // Expected race: a concurrent fetch or upload for the same ref won; not a fault.
+            debug!(
+                team_id,
+                set_ref = %record.set_ref,
+                "not overwriting existing symbol set data after dynamic fetch"
             );
             if let Err(err) = self.s3_client.delete(&self.bucket, &key).await {
                 warn!(
+                    team_id,
                     "Failed to clean up unused symbol set data at {} after skipped DB update: {:?}",
-                    key, err
+                    key,
+                    err
                 );
             }
             start.label("outcome", "skipped_existing_data").fin();
@@ -183,9 +187,11 @@ impl<F> Saving<F> {
             v.max(0) as u64
         });
 
-        info!(
-            "Deleted {} stack frames for symbol set {}",
-            deleted, record.id
+        debug!(
+            team_id,
+            symbol_set_id = %record.id,
+            deleted,
+            "deleted stack frames for re-saved symbol set"
         );
         metrics::counter!(FRAME_RESOLUTION_RESULTS_DELETED).increment(deleted);
 
@@ -201,7 +207,7 @@ impl<F> Saving<F> {
         set_ref: String,
         reason: &FrameError,
     ) -> Result<(), UnhandledError> {
-        info!("Saving symbol set error for {}", set_ref);
+        debug!(team_id, set_ref = %set_ref, "saving symbol set error");
         let start = common_metrics::timing_guard(SAVE_SYMBOL_SET, &[]).label("data", "false");
         let failure_reason = serde_json::to_string(&reason)?;
         let mut record = SymbolSetRecord {
@@ -294,7 +300,7 @@ where
                 return Err(error);
             }
 
-            info!("Fetching symbol set data for {}", lookup_ref);
+            debug!(team_id, lookup_ref = %lookup_ref, "fetching symbol set data");
             let Some(mut record) = SymbolSetRecord::load(&self.pool, team_id, lookup_ref).await?
             else {
                 continue;
@@ -305,12 +311,16 @@ where
             }
 
             if let Some(storage_ptr) = record.storage_ptr.clone() {
-                info!("Found s3 saved symbol set data for {}", lookup_ref);
+                debug!(team_id, lookup_ref = %lookup_ref, "found s3 saved symbol set data");
                 record.set_last_used(&self.pool).await?;
                 let data = match self.s3_client.get(&self.bucket, &storage_ptr).await {
                     Ok(Some(data)) => data,
                     Ok(None) => {
-                        warn!("Storage pointer points to a record that doesn't exist");
+                        warn!(
+                            team_id,
+                            lookup_ref = %lookup_ref,
+                            "Storage pointer points to a record that doesn't exist"
+                        );
                         record.delete(&self.pool).await?;
                         return Err(FrameError::MissingChunkIdData(lookup_ref.clone()).into());
                     }
@@ -330,14 +340,17 @@ where
                 .last_used
                 .is_some_and(|l| Utc::now() - l < chrono::Duration::days(1))
             {
-                info!("Found recent symbol set error for {}", lookup_ref);
+                debug!(team_id, lookup_ref = %lookup_ref, "found recent symbol set error");
                 // We tried less than a day ago to get the set data, and failed, so bail out
                 // with the stored error. We unwrap here because we should never store a "no set"
                 // row without also storing the error, and if we do, we want to panic, but we
                 // also want to log an error
                 metrics::counter!(SAVED_SYMBOL_SET_ERROR_RETURNED).increment(1);
                 let Some(failure_reason) = record.failure_reason.clone() else {
-                    error!("Found a record with no data and no error: {:?}", record);
+                    error!(
+                        team_id,
+                        "Found a record with no data and no error: {:?}", record
+                    );
                     panic!("Found a record with no data and no error");
                 };
                 // Cache this known-recent failure so subsequent lookups for the same ref skip
@@ -356,7 +369,7 @@ where
                 return Err(ResolveError::ResolutionError(error));
             }
 
-            info!("Found stale symbol set error for {}", lookup_ref);
+            debug!(team_id, lookup_ref = %lookup_ref, "found stale symbol set error");
             // We last tried to get the symbol set more than a day ago, so we should try again
             metrics::counter!(SYMBOL_SET_FETCH_RETRY).increment(1);
         }
@@ -366,7 +379,7 @@ where
         match self.inner.fetch(team_id, r).await {
             // NOTE: We don't save the data here, because we want to save it only after parsing
             Ok(data) => {
-                info!("Inner fetched symbol set data");
+                debug!(team_id, "inner fetched symbol set data");
                 Ok(Saveable {
                     data,
                     storage_ptr: None,
@@ -417,7 +430,7 @@ where
 
         match self.inner.parse(bytes).await {
             Ok(s) => {
-                info!("Parsed symbol set data");
+                debug!(team_id, "parsed symbol set data");
                 if let (Some(bytes_to_save), Some(save_ref)) = (bytes_to_save, &save_ref) {
                     self.save_data(team_id, save_ref.clone(), bytes_to_save)
                         .await?;
@@ -425,7 +438,7 @@ where
                 Ok(s)
             }
             Err(ResolveError::ResolutionError(e)) => {
-                info!("Failed to parse symbol set data");
+                debug!(team_id, "failed to parse symbol set data");
                 if storage_ptr.is_none() {
                     if let Some(save_ref) = save_ref {
                         // Save fresh parse failures to prevent refetching for a day, but never

--- a/rust/cymbal/src/core/symbolication/symbol_store/sourcemap.rs
+++ b/rust/cymbal/src/core/symbolication/symbol_store/sourcemap.rs
@@ -8,7 +8,7 @@ use posthog_symbol_data::{read_symbol_data_with_byte_count, write_symbol_data, S
 use reqwest::Url;
 use sqlx::PgPool;
 use symbolic::sourcemapcache::{SourceMapCache, SourceMapCacheWriter};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{
     core::config::ResolverConfig,
@@ -312,7 +312,7 @@ async fn find_sourcemap_url(
     start: Url,
     max_response_bytes: usize,
 ) -> Result<JsSourcePeek, ResolveError> {
-    info!("Fetching script source from {}", start);
+    debug!("Fetching script source from {}", start);
 
     // If this request fails, we cannot resolve the frame, and hand this error to the frames
     // failure-case handling.
@@ -341,7 +341,7 @@ async fn find_sourcemap_url(
     let chunk_id_from_body = extract_chunk_id_from_body(&body);
 
     if let Some(header_url) = header_url {
-        info!("Found sourcemap header: {:?}", header_url);
+        debug!("Found sourcemap header: {:?}", header_url);
         metrics::counter!(SOURCEMAP_HEADER_FOUND).increment(1);
 
         // If the header was set but is unusable, that's a js-specific resolution error - one we can try to handle,

--- a/rust/cymbal/src/core/types/frames/mod.rs
+++ b/rust/cymbal/src/core/types/frames/mod.rs
@@ -34,14 +34,10 @@ pub(crate) fn record_frame_resolution_failure(
     err: &dyn std::fmt::Display,
 ) {
     metrics::counter!(FRAME_NOT_RESOLVED, "lang" => lang, "reason" => reason).increment(1);
-    match reason {
-        "network_error" | "invalid_data" | "symbol_not_found" => {
-            tracing::warn!(lang = lang, reason = reason, error = %err, "frame resolution failed");
-        }
-        _ => {
-            tracing::debug!(lang = lang, reason = reason, error = %err, "frame resolution failed");
-        }
-    }
+    // Debug, not warn: these are almost always customer misconfiguration (a release shipped
+    // without sourcemaps, an expired CDN URL), and they fire once per unresolved frame — a
+    // single bad release would warn-storm the logs. The counter above carries the signal.
+    tracing::debug!(lang = lang, reason = reason, error = %err, "frame resolution failed");
 }
 
 pub mod releases;

--- a/rust/cymbal/src/core/types/langs/apple.rs
+++ b/rust/cymbal/src/core/types/langs/apple.rs
@@ -94,43 +94,24 @@ impl RawAppleFrame {
     where
         C: SymbolCatalog<OrChunkId<AppleRef>, ParsedNativeSymbols>,
     {
-        tracing::debug!(
-            "[apple-debug] resolve() called: instruction_addr={:?}, module={:?}, function={:?}, debug_images_count={}",
-            self.instruction_addr, self.module, self.function, debug_images.len()
-        );
-
         match self
             .resolve_impl(team_id, catalog, debug_images, context_lines)
             .await
         {
-            Ok(frames) => {
-                tracing::debug!(
-                    "[apple-debug] resolve() SUCCESS: {} frame(s), first resolved_name={:?}",
-                    frames.len(),
-                    frames.first().and_then(|f| f.resolved_name.as_deref())
-                );
-                Ok(frames)
-            }
+            Ok(frames) => Ok(frames),
             Err(ResolveError::ResolutionError(FrameError::Apple(e))) => {
-                tracing::debug!("[apple-debug] resolve() Apple error: {:?}", e);
                 Ok(vec![self.handle_resolution_error(e)])
             }
-            Err(ResolveError::ResolutionError(FrameError::MissingChunkIdData(chunk_id))) => {
-                tracing::debug!("[apple-debug] resolve() MissingChunkIdData: {}", chunk_id);
-                Ok(vec![self.handle_resolution_error(AppleError::MissingDsym(
-                    chunk_id,
-                ))])
-            }
+            Err(ResolveError::ResolutionError(FrameError::MissingChunkIdData(chunk_id))) => Ok(
+                vec![self.handle_resolution_error(AppleError::MissingDsym(chunk_id))],
+            ),
             Err(ResolveError::ResolutionError(e)) => {
-                tracing::warn!("Unexpected Apple symbol resolution error: {:?}", e);
+                tracing::warn!(team_id, "Unexpected Apple symbol resolution error: {:?}", e);
                 Ok(vec![self.handle_resolution_error(AppleError::ParseError(
                     e.to_string(),
                 ))])
             }
-            Err(ResolveError::UnhandledError(e)) => {
-                tracing::error!("[apple-debug] resolve() unhandled error: {:?}", e);
-                Err(e)
-            }
+            Err(ResolveError::UnhandledError(e)) => Err(e),
         }
     }
 
@@ -153,19 +134,10 @@ impl RawAppleFrame {
 
         let instruction_addr =
             native::parse_hex_address(instruction_addr).map_err(AppleError::from)?;
-        tracing::debug!(
-            "[apple-debug] resolve_impl: parsed instruction_addr=0x{:x}",
-            instruction_addr
-        );
 
         let debug_image =
             native::find_debug_image(instruction_addr, self.image_addr.as_deref(), debug_images)
                 .map_err(AppleError::from)?;
-        tracing::debug!(
-            "[apple-debug] resolve_impl: matched debug_image debug_id={}, image_addr={}",
-            debug_image.debug_id,
-            debug_image.image_addr
-        );
 
         let relative_addr = native::calculate_relative_addr(instruction_addr, debug_image)
             .map_err(AppleError::from)?;
@@ -175,29 +147,15 @@ impl RawAppleFrame {
         // This is safe for top (crash-site) frames too: addr-1 still falls within the
         // same function body, so the function and line resolve correctly.
         let lookup_addr = relative_addr.saturating_sub(1);
-        tracing::debug!(
-            "[apple-debug] resolve_impl: relative_addr=0x{:x}, lookup_addr=0x{:x}",
-            relative_addr,
-            lookup_addr
-        );
 
-        tracing::debug!(
-            "[apple-debug] resolve_impl: looking up symbols for chunk_id={}",
-            debug_image.debug_id
-        );
         let symbols: Arc<ParsedNativeSymbols> = catalog
             .lookup(team_id, OrChunkId::chunk_id(debug_image.debug_id.clone()))
             .await?;
-        tracing::debug!("[apple-debug] resolve_impl: symbols loaded successfully");
 
         let symbol_infos = symbols.lookup(lookup_addr).map_err(AppleError::from)?;
         if symbol_infos.is_empty() {
             return Err(AppleError::SymbolNotFound(lookup_addr).into());
         }
-        tracing::debug!(
-            "[apple-debug] resolve_impl: found {} logical frame(s) (including inlined)",
-            symbol_infos.len()
-        );
 
         // Build one resolved Frame per logical layer.
         //

--- a/rust/cymbal/src/core/types/langs/hermes.rs
+++ b/rust/cymbal/src/core/types/langs/hermes.rs
@@ -59,7 +59,11 @@ impl RawHermesFrame {
                 Ok(self.handle_resolution_error(HermesError::NoSourcemapUploaded(chunk_id)))
             }
             Err(ResolveError::ResolutionError(e)) => {
-                tracing::warn!("Unexpected Hermes symbol resolution error: {:?}", e);
+                tracing::warn!(
+                    team_id,
+                    "Unexpected Hermes symbol resolution error: {:?}",
+                    e
+                );
                 Ok(self.handle_resolution_error(HermesError::InvalidMap(e.to_string())))
             }
             Err(ResolveError::UnhandledError(e)) => Err(e),

--- a/rust/cymbal/src/core/types/langs/java.rs
+++ b/rust/cymbal/src/core/types/langs/java.rs
@@ -70,7 +70,10 @@ impl RawJavaFrame {
                 vec![self.handle_resolution_error(ProguardError::MissingMap(chunk_id))],
             ),
             Err(ResolveError::ResolutionError(e)) => {
-                warn!("Unexpected Proguard symbol resolution error: {:?}", e);
+                warn!(
+                    team_id,
+                    "Unexpected Proguard symbol resolution error: {:?}", e
+                );
                 Ok(vec![
                     self.handle_resolution_error(ProguardError::InvalidMapping)
                 ])

--- a/rust/cymbal/src/core/types/langs/js.rs
+++ b/rust/cymbal/src/core/types/langs/js.rs
@@ -60,7 +60,7 @@ impl RawJSFrame {
                 Ok(self.handle_resolution_error(JsResolveErr::NoSourcemapUploaded(chunk_id)))
             }
             Err(ResolveError::ResolutionError(e)) => {
-                warn!("Unexpected JS symbol resolution error: {:?}", e);
+                warn!(team_id, "Unexpected JS symbol resolution error: {:?}", e);
                 Ok(self.handle_resolution_error(JsResolveErr::InvalidSourceMap(e.to_string())))
             }
             Err(ResolveError::UnhandledError(e)) => Err(e),

--- a/rust/cymbal/src/core/types/langs/native.rs
+++ b/rust/cymbal/src/core/types/langs/native.rs
@@ -205,7 +205,11 @@ impl RawNativeFrame {
                 vec![self.handle_resolution_error(NativeError::MissingSymbolSet(chunk_id))],
             ),
             Err(ResolveError::ResolutionError(e)) => {
-                tracing::warn!("Unexpected native symbol resolution error: {:?}", e);
+                tracing::warn!(
+                    team_id,
+                    "Unexpected native symbol resolution error: {:?}",
+                    e
+                );
                 Ok(vec![self.handle_resolution_error(NativeError::ParseError(
                     e.to_string(),
                 ))])

--- a/rust/cymbal/src/core/types/langs/node.rs
+++ b/rust/cymbal/src/core/types/langs/node.rs
@@ -61,7 +61,10 @@ impl RawNodeFrame {
                 Ok((self, JsResolveErr::NoSourcemapUploaded(chunk_id)).into())
             }
             Err(ResolveError::ResolutionError(e)) => {
-                warn!("Unexpected Node.js symbol resolution error: {:?}", e);
+                warn!(
+                    team_id,
+                    "Unexpected Node.js symbol resolution error: {:?}", e
+                );
                 Ok((self, JsResolveErr::InvalidSourceMap(e.to_string())).into())
             }
             Err(ResolveError::UnhandledError(e)) => Err(e),

--- a/rust/cymbal/src/modes/processing/stages/linking/issue.rs
+++ b/rust/cymbal/src/modes/processing/stages/linking/issue.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use common_types::format::parse_datetime_assuming_utc;
 use sqlx::{Acquire, PgConnection};
-use tracing::warn;
+use tracing::debug;
 use uuid::Uuid;
 
 use crate::{
@@ -42,8 +42,9 @@ impl IssueLinker {
             .map(str::to_string)
             .unwrap_or_else(|| input.exception_list()[0].exception_message.clone());
 
+        // Debug: a bad client timestamp is SDK/user data quality, handled by falling back.
         let event_timestamp = parse_datetime_assuming_utc(input.timestamp()).unwrap_or_else(|e| {
-            warn!(
+            debug!(
                 event = input.uuid().to_string(),
                 "Failed to get event timestamp, using current time, error: {:?}", e
             );
@@ -195,7 +196,7 @@ async fn load_and_maybe_reopen(
     // Reopened — mirror the side effects from `resolve_issue`'s fast-path reopen branch.
     let event_timestamp =
         parse_datetime_assuming_utc(event_properties.timestamp()).unwrap_or_else(|e| {
-            warn!(
+            debug!(
                 event = event_properties.uuid().to_string(),
                 "Failed to get event timestamp, using current time, error: {:?}", e
             );

--- a/rust/cymbal/src/modes/processing/stages/resolution/remote/mux.rs
+++ b/rust/cymbal/src/modes/processing/stages/resolution/remote/mux.rs
@@ -22,7 +22,7 @@ use tokio::task::JoinHandle;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Channel;
 use tonic::{Code, Request, Status};
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::metric_consts::{
     REMOTE_RESOLUTION_ENDPOINT_ADMISSION_REJECTIONS, REMOTE_RESOLUTION_ENDPOINT_MUX_IN_FLIGHT,
@@ -37,6 +37,9 @@ pub struct ResolveMux {
 
 struct ResolveMuxInner {
     addr: SocketAddr,
+    // Pre-built metric label for this endpoint — cloned into metric macros
+    // (an atomic refcount bump) instead of allocating a String per emission.
+    endpoint_label: Arc<str>,
     outbound: mpsc::Sender<ResolveItem>,
     waiters: Mutex<HashMap<u64, Waiter>>,
     task: Mutex<Option<JoinHandle<()>>>,
@@ -129,6 +132,7 @@ impl ResolveMux {
         let (outbound, inbound) = mpsc::channel(queue_capacity.max(1));
         let inner = Arc::new(ResolveMuxInner {
             addr,
+            endpoint_label: Arc::from(addr.to_string()),
             outbound,
             waiters: Mutex::new(HashMap::new()),
             task: Mutex::new(None),
@@ -252,7 +256,9 @@ impl ResolveMuxInner {
             waiter
         };
         let Some(waiter) = waiter else {
-            warn!(
+            // The caller usually gave up (deadline/cancel) before the outcome landed, so this
+            // scales with client-side timeouts under load — too hot for warn.
+            debug!(
                 endpoint = %self.addr,
                 stream_id = outcome.id,
                 "remote resolution outcome had no waiter"
@@ -286,7 +292,7 @@ impl ResolveMuxInner {
     fn record_waiter_count(&self, count: usize) {
         metrics::gauge!(
             REMOTE_RESOLUTION_ENDPOINT_MUX_IN_FLIGHT,
-            "endpoint" => self.addr.to_string(),
+            "endpoint" => self.endpoint_label.clone(),
         )
         .set(count as f64);
     }
@@ -294,7 +300,7 @@ impl ResolveMuxInner {
     fn record_admission_rejection(&self, reason: &'static str) {
         metrics::counter!(
             REMOTE_RESOLUTION_ENDPOINT_ADMISSION_REJECTIONS,
-            "endpoint" => self.addr.to_string(),
+            "endpoint" => self.endpoint_label.clone(),
             "reason" => reason,
         )
         .increment(1);

--- a/rust/cymbal/src/modes/processing/stages/resolution/remote/resolver/retry.rs
+++ b/rust/cymbal/src/modes/processing/stages/resolution/remote/resolver/retry.rs
@@ -7,7 +7,11 @@ use std::time::{Duration, Instant};
 
 use rand::Rng;
 use tokio::sync::OwnedSemaphorePermit;
-use tracing::warn;
+// Per-item retry/overload/reroute logs are debug, not warn: they fire O(items × attempts)
+// exactly when the resolution pool is already overloaded, and the
+// `cymbal_remote_resolution_requests_total` outcomes carry the same signal. Endpoint-level
+// state changes (stream broke, endpoint ejected) stay at warn in the pool/mux.
+use tracing::{debug, warn};
 
 use cymbal_proto::cymbal::resolution::v1::{resolve_outcome, ErrorKind, ResolveOutcome};
 use tonic::Status;
@@ -92,7 +96,7 @@ pub(super) async fn resolve_work_item(
                     "reason" => err.reason_tag(),
                 )
                 .increment(1);
-                warn!(
+                debug!(
                     endpoint = %endpoint,
                     token = work_item.token,
                     attempt,
@@ -160,7 +164,7 @@ pub(super) async fn resolve_work_item(
                 metrics::counter!(REMOTE_RESOLUTION_REQUESTS, "outcome" => "overloaded_item")
                     .increment(1);
                 metrics::counter!(REMOTE_RESOLUTION_OVERLOAD_ESCALATIONS).increment(1);
-                warn!(
+                debug!(
                     endpoint = %endpoint,
                     token = work_item.token,
                     attempt,
@@ -181,7 +185,7 @@ pub(super) async fn resolve_work_item(
             } => {
                 metrics::counter!(REMOTE_RESOLUTION_REQUESTS, "outcome" => "retryable_item")
                     .increment(1);
-                warn!(
+                debug!(
                     endpoint = %endpoint,
                     token = work_item.token,
                     attempt,

--- a/rust/cymbal/src/modes/resolution/README.md
+++ b/rust/cymbal/src/modes/resolution/README.md
@@ -199,9 +199,11 @@ These metric names are exported by the cymbal client unless noted. Definitions l
 Client-side warnings on the cymbal pods:
 
 - `remote resolution dns refresh failed` — DNS refresh task swallowed an error and will retry next tick.
-- `remote resolution transport-level retry` — caller-side transport retry classification, tagged with a bounded reason.
-- `remote resolution returned item overload` — an overloaded result was escalated into a per-item reroute.
+- `remote resolution stream failed to open` / `stream broke` / `stream ended` — the per-endpoint mux stream died; every in-flight item on it is failed over.
+- `temporarily ejected overloaded remote resolution endpoint` — an endpoint was pulled from routing on an overload signal.
 - `remote resolution outcome id did not match submitted item` — the mux ignored an outcome for another id.
+
+Per-item retry/overload/reroute logs (`transport-level retry`, `returned item overload`, `returned item retry`, `outcome had no waiter`) are emitted at debug — they fire O(items × attempts) under overload, so watch the `cymbal_remote_resolution_requests_total{outcome}` counters instead, and enable `RUST_LOG=cymbal=debug` only for targeted investigation.
 
 Logs intentionally do not include raw routing keys as metric labels. Routing keys can contain symbol-set references, so cymbal uses bounded counters/histograms and endpoint labels only where the endpoint set is bounded by discovery.
 


### PR DESCRIPTION
## Problem

A review of cymbal's Prometheus metrics and logs (all three run modes, cross-referenced against the alert specs, KEDA triggers, and Grafana dashboards that consume them) surfaced a few high-priority issues:

- `cymbal_java_exception_remap_failed` uses a Display-formatted error message as its `reason` label, so it can mint a new time series per distinct error text.
- The resolve mux allocates a fresh `String` for its `endpoint` label on every gauge update, against the repo's `Arc<str>` metrics convention.
- Several logs fire per frame, per item-retry, or per cache miss at warn/info. A customer shipping a release without sourcemaps warn-storms once per unresolved frame, and the remote-resolution retry path logs O(items × attempts) warns exactly when the resolution pool is already overloaded.
- Symbol-store logs take `team_id` as a parameter but never log it, including the errors emitted right before two panics, so crash triage loses team attribution.
- `cymbal_spike_emit_events_time` is defined but never emitted, and the Apple resolver still carries a block of leftover `[apple-debug]` instrumentation.

None of the demoted or removed logs back an alert, and none of the touched metrics change name, so dashboards and alert rules are unaffected (the java remap metric's `reason` values change, but it has no dashboard or alert consumer).

## Changes

- Bound the java remap `reason` label to the existing `metric_reason()` enum, and log the failure at debug with `team_id`.
- Pre-build the per-endpoint `Arc<str>` label once per mux; delete the dead spike-timer constant.
- Demote to debug: per-frame resolution failures (the `FRAME_NOT_RESOLVED` counter carries the signal), per-item remote-resolution retry/overload/reroute logs (the `cymbal_remote_resolution_requests_total` outcomes carry it; endpoint-level stream/ejection warns stay), symbol-set fetch/save narration on the cache-miss path, and event-timestamp fallbacks for malformed client timestamps.
- Add `team_id` to the symbol-store logs, the pre-panic errors, and the six per-language "unexpected resolution error" catch-all warns.
- Remove the `[apple-debug]` leftovers and update the resolution README's "logs to look for" section to match the new levels.

## How did you test this code?

`cargo check -p cymbal` and `cargo clippy -p cymbal --tests` pass; the only clippy warnings are pre-existing in untouched files. No behavior changes beyond log levels/fields and metric label values, so no new tests. I was not able to run the sqlx-backed test suite in this environment (no local Postgres).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `rust/cymbal/src/modes/resolution/README.md` (logs-to-look-for section) in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code session). The session ran a full inventory of cymbal's metric emission sites and log call sites, checked consumers (alert specs, KEDA scalers, and the grafana-dashboards repo) to confirm which metrics are load-bearing, and then applied only the changes that need no coordination with dashboards or alert rules. Larger consolidations flagged by the review (nested stage-timer histograms, cache hit/miss counter pairs, duplicate `/process` HTTP metrics) were deliberately left out of this wave because they require lockstep dashboard/alert updates.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*