### PR TITLE
fix(data-warehouse): fix clickhouse direct-connection metadata error

### DIFF
--- a/posthog/hogql/metadata.py
+++ b/posthog/hogql/metadata.py
@@ -73,6 +73,11 @@ def get_hogql_metadata(
             database=database,
             modifiers=query_modifiers,
             enable_select_queries=True,
+            # A resolved direct-connection source prints with its engine dialect (below), so the
+            # context must be marked direct — otherwise the ClickHouse printer's direct-table guard
+            # fires and metadata/autocomplete reports a false "can only be queried through its direct
+            # connection" error for a query that actually runs fine.
+            is_direct_query=source is not None,
             debug=query.debug or False,
             globals=query.globals,
         )

--- a/posthog/hogql/test/test_metadata.py
+++ b/posthog/hogql/test/test_metadata.py
@@ -507,6 +507,50 @@ class TestMetadata(ClickhouseTestMixin, APIBaseTest):
         self.assertTrue(metadata.isValid)
         self.assertEqual(metadata.errors, [])
 
+    def test_metadata_with_clickhouse_direct_connection_does_not_report_direct_only_error(self):
+        # Regression: ClickHouse direct sources print through the native ClickHouse printer, whose
+        # direct-table guard raises "can only be queried through its direct connection" unless the
+        # context is marked direct. The metadata path did not set is_direct_query, so it reported a
+        # false error for a query that actually runs. (Postgres/MySQL direct printers lack the guard,
+        # so this only regressed for ClickHouse.)
+        source = ExternalDataSource.objects.create(
+            source_id="ch-source",
+            connection_id="ch-connection",
+            destination_id="ch-destination",
+            team=self.team,
+            status=ExternalDataSource.Status.COMPLETED,
+            source_type=ExternalDataSourceType.CLICKHOUSE,
+            access_method=ExternalDataSource.AccessMethod.DIRECT,
+            prefix="ch",
+            job_inputs={"host": "localhost", "database": "posthog"},
+        )
+        table = DataWarehouseTable.objects.create(
+            name="events",
+            format="Parquet",
+            team=self.team,
+            external_data_source=source,
+            url_pattern="direct://clickhouse",
+            columns={
+                "uuid": {"hogql": "StringDatabaseField", "clickhouse": "String", "valid": True},
+                "team_id": {"hogql": "IntegerDatabaseField", "clickhouse": "Int64", "valid": True},
+            },
+        )
+        ExternalDataSchema.objects.create(name="events", team=self.team, source=source, table=table)
+
+        metadata = get_hogql_metadata(
+            query=HogQLMetadata(
+                kind="HogQLMetadata",
+                language=HogLanguage.HOG_QL,
+                query="SELECT * FROM events LIMIT 1",
+                response=None,
+                connectionId=str(source.id),
+            ),
+            team=self.team,
+        )
+
+        self.assertTrue(metadata.isValid)
+        self.assertEqual(metadata.errors, [])
+
     def test_metadata_with_direct_connection_allows_connection_metadata_function_in_expr(self):
         source = ExternalDataSource.objects.create(
             source_id="selected-upstream-source",


### PR DESCRIPTION
## Problem

Every query against a **ClickHouse direct-connect** source shows a red editor error — `Table "events" can only be queried through its direct connection.` — even though the query runs fine when executed.

The recently-merged `team_id`-guard fix added a guard in the native ClickHouse printer (`clickhouse.py`): a `DirectSQLTable` may only be printed when `context.is_direct_query` is set, otherwise it raises that error. Execution sets the flag (`HogQLQueryExecutor._prepare_direct_query` → `is_direct_query=True`), but the **HogQL metadata path** (which powers the editor's autocomplete/error squiggles) builds its `HogQLContext` without it — so it validates the query through the ClickHouse printer, trips the guard, and reports a false error. Postgres/MySQL direct sources don't hit this because their printers have no such guard.

## Changes

One line in `posthog/hogql/metadata.py`: mark the metadata context as direct when a connection resolved.

```python
context = HogQLContext(
    ...
    is_direct_query=source is not None,   # ← added
    ...
)
```

`source is not None` is the exact predicate already used two lines down to pick the direct dialect (`direct_dialect if source else "clickhouse"`), so metadata now prints direct tables under the same context execution uses.

## How did you test this code?

Added `test_metadata_with_clickhouse_direct_connection_does_not_report_direct_only_error` in `test_metadata.py`: builds a ClickHouse direct source + `events` table and asserts `get_hogql_metadata("SELECT * FROM events")` is valid with no errors. Before the fix it fails with the direct-only error; after, it passes. Mirrors the existing Postgres direct-connection metadata tests (Postgres didn't regress because its printer lacks the guard).

I couldn't run the DB-backed test locally (local Postgres is down), so it's left for CI. ruff + tach clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via Claude Code) traced this after Tom saw the editor flag valid ClickHouse-direct queries. It's the metadata counterpart to the execution path: both share the ClickHouse printer and its direct-table guard, but only execution was setting `is_direct_query`. There is a separate, unrelated issue where `SELECT *` on a ClickHouse direct table can fail with `UNKNOWN_IDENTIFIER` (the synced schema includes ALIAS columns a native `SELECT *` would skip) — that's a discovery-layer change and is deliberately not in this PR.
