### PR TITLE
fix(web-analytics): fit the warm run pod request onto dagster nodes

### DIFF
--- a/products/web_analytics/dags/README.md
+++ b/products/web_analytics/dags/README.md
@@ -17,19 +17,22 @@ compilation is CPU-bound Python, so parallelism comes from shard processes, not
 threads; threads inside a shard overlap the IO-bound parts (ClickHouse reads
 and inserts, cache lookups). Sharding is by `team_id % shards`, which keeps
 every potential duplicate `(team, cache_key)` inside one shard so per-shard
-dedupe needs no coordination. The run pod requests CPU/memory to match the
-shard count via the `dagster-k8s/config` tag on the job.
+dedupe needs no coordination. The run pod requests 6 CPUs / 12Gi via the
+`dagster-k8s/config` tag on the job — the ceiling the 8-core dagster nodes can
+actually schedule (~7.9 allocatable), so the default 8 shards deliberately
+oversubscribe CPU slightly; that's fine because shards idle during their
+IO-bound stretches. Don't size shards one-to-one with cores.
 
 ## Live-tunable settings (instance settings, no redeploy)
 
-| Setting                                       | Default | Meaning                                                                                                                        |
-| --------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `WEB_ANALYTICS_WARMING_SHARDS`                | 8       | Shard subprocesses per run (clamp 1-16). Bounds real CPU parallelism; keep the job's `dagster-k8s/config` CPU request in step. |
-| `WEB_ANALYTICS_WARMING_SHARD_THREADS`         | 6       | Worker threads inside each shard (clamp 1-64). Total ClickHouse-side concurrency ≈ shards × this.                              |
-| `WEB_ANALYTICS_WARMING_DAYS`                  | 14      | query_log lookback for demand selection.                                                                                       |
-| `WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT`       | 2       | Per-shape demand floor for selection.                                                                                          |
-| `WEB_ANALYTICS_WARMING_MAX_SHAPES`            | 400000  | Fleet-wide selection cap.                                                                                                      |
-| `WEB_ANALYTICS_WARMING_SELECTION_TTL_SECONDS` | 21600   | Selection cache TTL (the expensive fleet scan re-runs on this cadence).                                                        |
+| Setting                                       | Default | Meaning                                                                                                                                                            |
+| --------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `WEB_ANALYTICS_WARMING_SHARDS`                | 8       | Shard subprocesses per run (clamp 1-16). Real CPU parallelism is capped by the pod's 6-CPU request (the node-schedulable ceiling), so shards beyond ~8 add little. |
+| `WEB_ANALYTICS_WARMING_SHARD_THREADS`         | 6       | Worker threads inside each shard (clamp 1-64). Total ClickHouse-side concurrency ≈ shards × this.                                                                  |
+| `WEB_ANALYTICS_WARMING_DAYS`                  | 14      | query_log lookback for demand selection.                                                                                                                           |
+| `WEB_ANALYTICS_WARMING_MIN_QUERY_COUNT`       | 2       | Per-shape demand floor for selection.                                                                                                                              |
+| `WEB_ANALYTICS_WARMING_MAX_SHAPES`            | 400000  | Fleet-wide selection cap.                                                                                                                                          |
+| `WEB_ANALYTICS_WARMING_SELECTION_TTL_SECONDS` | 21600   | Selection cache TTL (the expensive fleet scan re-runs on this cadence).                                                                                            |
 
 Settings are read at run start; changes apply to the next run.
 

--- a/products/web_analytics/dags/cache_warming.py
+++ b/products/web_analytics/dags/cache_warming.py
@@ -941,11 +941,12 @@ def report_warming_plan_op(context: dagster.OpExecutionContext, queries: list[di
         # The agent default is 2 CPUs / 8Gi (charts: argocd/dagster/values). The
         # sharded pass runs one subprocess per shard, each compiling HogQL on its
         # own core, so the run pod needs CPU for the shards and memory for that
-        # many Django interpreters.
+        # many Django interpreters. Capped at 6 CPUs: the dagster nodepool runs
+        # 8-core nodes with ~7.9 allocatable, so an 8-CPU request never schedules.
         "dagster-k8s/config": {
             "container_config": {
                 "resources": {
-                    "requests": {"cpu": "8000m", "memory": "12Gi"},
+                    "requests": {"cpu": "6000m", "memory": "12Gi"},
                     "limits": {"memory": "12Gi"},
                 }
             }


### PR DESCRIPTION
## Problem

#74471's `dagster-k8s/config` tag requests 8 CPUs for the sharded warm run pod — but the dagster run nodes are 8-core with **~7.91 CPU allocatable** (kubelet reservation + daemonsets), so the request can never be satisfied and the run sits `Pending` indefinitely (verified via kube-state-metrics: `kube_pod_status_scheduled{condition="false"}` for run `66a6691c`, no Karpenter provisioning triggered).

## Changes

Request **6 CPUs** instead — fits today's nodes with headroom while still giving the 8 shard subprocesses six real cores (~6× compile parallelism vs the single-GIL baseline).

Open follow-up (not this PR): the Karpenter dagster pool allows up to 32xlarge instances yet didn't provision for the 8-CPU pod — worth a `kubectl describe` on the pending pod to understand the constraint mismatch before considering any charts change.

## How did you test this code?

- One-line resource-tag change; no behavior change in the op code. Existing suite (62 tests) unaffected — the tag isn't exercised by tests.
- Node capacity verified against prod kube-state-metrics (allocatable 7.91 CPU / 32Gi on current dagster run nodes).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Claude Code) diagnosed the pending pod via VictoriaMetrics kube-state-metrics after the first sharded run stuck in "Starting", and sized the corrected request against actual node allocatable.
