### PR TITLE
fix(data-warehouse): exclude alias columns from clickhouse discovery

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -361,11 +361,18 @@ def get_schemas(
             params["names"] = tuple(names)
             names_filter = "AND table IN %(names)s"
 
+        # Skip ALIAS and EPHEMERAL columns. A native `SELECT *` never touches them, but our
+        # `SELECT *` expands to an explicit column list — so an ALIAS whose defining expression no
+        # longer resolves on the server (a dropped/renamed underlying column, or one the connecting
+        # user can't read) fails the whole query with UNKNOWN_IDENTIFIER (code 47), and EPHEMERAL
+        # columns aren't selectable at all. Ordinary, DEFAULT and MATERIALIZED columns hold real,
+        # selectable data and are kept.
         result = client.query(
             f"""
             SELECT table, name, type
             FROM system.columns
             WHERE database = %(database)s {names_filter}
+              AND default_kind NOT IN ('ALIAS', 'EPHEMERAL')
             ORDER BY table ASC, position ASC
             """,
             parameters=params,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -952,6 +952,27 @@ class TestGetSchemas:
         assert events_cols["id"] == ("UInt64", False)
         assert events_cols["name"] == ("Nullable(String)", True)
 
+    def test_discovery_query_excludes_alias_and_ephemeral_columns(self):
+        # A native `SELECT *` skips ALIAS/EPHEMERAL columns, but our `SELECT *` expands to an
+        # explicit column list — an included ALIAS whose expression can't resolve breaks the whole
+        # query with UNKNOWN_IDENTIFIER (code 47). The filter must stay in the discovery query.
+        from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse import clickhouse as ch_module
+
+        mock_client = self._make_mock_client([("events", "id", "UInt64")])
+        with patch.object(ch_module, "_get_client", return_value=mock_client):
+            ch_module.get_schemas(
+                host="localhost",
+                port=8443,
+                database="default",
+                user="default",
+                password="",
+                secure=True,
+                verify=True,
+            )
+
+        queries = [str(call.args[0]) for call in mock_client.query.call_args_list]
+        assert any("default_kind NOT IN ('ALIAS', 'EPHEMERAL')" in q for q in queries)
+
     def test_excludes_materialized_view_inner_tables(self):
         from products.warehouse_sources.backend.temporal.data_imports.sources.clickhouse import clickhouse as ch_module
 


### PR DESCRIPTION
## Problem

`SELECT *` against a ClickHouse direct-connect table fails with `ClickHouse error code 47` (`UNKNOWN_IDENTIFIER`), while `SELECT <ordinary_column>` works.

ClickHouse schema discovery (`get_schemas`) reads `system.columns` with no `default_kind` filter, so it pulls in **ALIAS** columns alongside ordinary ones. A native `SELECT *` silently skips ALIAS (and MATERIALIZED/EPHEMERAL) columns, but PostHog's `SELECT *` expands to the explicit discovered column list — forcing selection of every alias. An ALIAS is stored only as an expression; if that expression references an identifier that no longer resolves on the server (a dropped/renamed underlying column, or one the connecting user can't read), the whole projection fails with code 47. `SELECT uuid` works because `uuid` is an ordinary column with nothing to resolve.

## Changes

Filter the discovery query to skip non-plainly-selectable columns:

```sql
AND default_kind NOT IN ('ALIAS', 'EPHEMERAL')
```

- **ALIAS** — computed expressions; excluded by a native `SELECT *`, and the code-47 culprit.
- **EPHEMERAL** — not selectable at all, and hold no stored data.
- **Ordinary / DEFAULT / MATERIALIZED** are kept — they hold real, selectable data. (We deliberately keep MATERIALIZED rather than fully mirroring a native `SELECT *`, so materialized data columns aren't silently dropped from the schema.)

> [!NOTE]
> This changes what future schema discovery returns. Existing direct-ClickHouse tables keep their already-synced column list (including aliases) until the source's schemas are refreshed — hitting **Refresh schemas** re-runs discovery and rebuilds the table's columns without the aliases. No data reload is needed; direct sources rebuild the table definition in place.

## How did you test this code?

Added `test_discovery_query_excludes_alias_and_ephemeral_columns` to the existing mocked `get_schemas` suite — asserts the discovery query carries the `default_kind NOT IN ('ALIAS', 'EPHEMERAL')` filter (the filtering is server-side SQL, so the meaningful guard is that the clause is present; catches the regression of someone dropping it). **Ran it locally — passes.**

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I (Claude, via Claude Code) found this after Tom's ClickHouse-direct `SELECT *` failed with code 47 while `SELECT uuid` worked, pointing straight at one non-resolving column in the projection. Tom chose the alias-only scope (over also excluding MATERIALIZED, which would mirror native `SELECT *` but drop real data columns). Skill invoked: `/writing-tests` for the test decision. Companion to the metadata-guard fix in a separate PR; both stem from ClickHouse direct support not being fully threaded through every layer.
