### PR TITLE
feat(llm-gateway): derive $ai_trace_id from traceparent for turn-level traces

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/handler.py
+++ b/services/llm-gateway/src/llm_gateway/api/handler.py
@@ -21,13 +21,9 @@ from llm_gateway.metrics.prometheus import (
 )
 from llm_gateway.observability import capture_exception
 from llm_gateway.request_context import (
-    RequestContext,
-    get_posthog_flags,
-    get_posthog_properties,
-    get_request_id,
+    rebuild_request_context,
     set_auth_user,
     set_effort,
-    set_request_context,
     set_time_to_first_token,
 )
 from llm_gateway.streaming.sse import format_sse_stream
@@ -226,14 +222,7 @@ async def handle_llm_request(
     settings = get_settings()
     start_time = time.monotonic()
 
-    set_request_context(
-        RequestContext(
-            request_id=get_request_id(),
-            product=product,
-            posthog_properties=get_posthog_properties(),
-            posthog_flags=get_posthog_flags(),
-        )
-    )
+    rebuild_request_context(product)
     set_auth_user(user)
 
     # Stash effort for the PostHog callback to stamp on the $ai_generation event (mirrors

--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -20,6 +20,7 @@ from llm_gateway.request_context import (
     get_posthog_properties,
     get_product,
     get_time_to_first_token,
+    get_traceparent_trace_id,
 )
 
 logger = structlog.get_logger(__name__)
@@ -188,9 +189,10 @@ class PostHogCallback(InstrumentedCallback):
         auth_user = get_auth_user()
         product = get_product()
 
-        # Anthropic's metadata.user_id is co-opted as a trace id by Claude Code
-        # (see _normalize_trace_id), and Claude Code sends a JSON blob there.
-        trace_id = _normalize_trace_id(metadata.get("user_id"))
+        # metadata.user_id carries Claude Code's session blob — constant for a
+        # whole task, so hashing it (_normalize_trace_id) collapses every turn
+        # into one trace. A per-turn traceparent therefore takes precedence.
+        trace_id = get_traceparent_trace_id() or _normalize_trace_id(metadata.get("user_id"))
         if auth_user is None:
             distinct_id = end_user_id or str(uuid4())
         else:
@@ -312,9 +314,7 @@ class PostHogCallback(InstrumentedCallback):
         auth_user = get_auth_user()
         product = get_product()
 
-        # Anthropic's metadata.user_id is co-opted as a trace id by Claude Code
-        # (see _normalize_trace_id), and Claude Code sends a JSON blob there.
-        trace_id = _normalize_trace_id(metadata.get("user_id"))
+        trace_id = get_traceparent_trace_id() or _normalize_trace_id(metadata.get("user_id"))
         if auth_user is None:
             distinct_id = end_user_id or str(uuid4())
         else:

--- a/services/llm-gateway/src/llm_gateway/request_context.py
+++ b/services/llm-gateway/src/llm_gateway/request_context.py
@@ -170,15 +170,11 @@ def extract_posthog_use_bedrock_fallback_from_headers(request: Request) -> bool 
 
 
 def rebuild_request_context(product: str) -> None:
-    set_request_context(
-        RequestContext(
-            request_id=get_request_id(),
-            product=product,
-            posthog_properties=get_posthog_properties(),
-            posthog_flags=get_posthog_flags(),
-            traceparent_trace_id=get_traceparent_trace_id(),
-        )
-    )
+    ctx = request_context_var.get()
+    if ctx is None:
+        set_request_context(RequestContext(request_id="", product=product))
+        return
+    set_request_context(replace(ctx, product=product))
 
 
 def apply_posthog_context_from_headers(request: Request) -> None:

--- a/services/llm-gateway/src/llm_gateway/request_context.py
+++ b/services/llm-gateway/src/llm_gateway/request_context.py
@@ -169,6 +169,18 @@ def extract_posthog_use_bedrock_fallback_from_headers(request: Request) -> bool 
     )
 
 
+def rebuild_request_context(product: str) -> None:
+    set_request_context(
+        RequestContext(
+            request_id=get_request_id(),
+            product=product,
+            posthog_properties=get_posthog_properties(),
+            posthog_flags=get_posthog_flags(),
+            traceparent_trace_id=get_traceparent_trace_id(),
+        )
+    )
+
+
 def apply_posthog_context_from_headers(request: Request) -> None:
     properties = extract_posthog_properties_from_headers(request)
     flags = extract_posthog_flags_from_headers(request)

--- a/services/llm-gateway/src/llm_gateway/request_context.py
+++ b/services/llm-gateway/src/llm_gateway/request_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from contextvars import ContextVar
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 import structlog
 
@@ -19,6 +20,7 @@ POSTHOG_PROPERTY_PREFIX = "x-posthog-property-"
 POSTHOG_FLAG_PREFIX = "x-posthog-flag-"
 POSTHOG_PROVIDER_HEADER = "x-posthog-provider"
 POSTHOG_USE_BEDROCK_FALLBACK_HEADER = "x-posthog-use-bedrock-fallback"
+TRACEPARENT_HEADER = "traceparent"
 
 _VALID_PROVIDERS = ("anthropic", "bedrock", "cloudflare")
 
@@ -29,6 +31,7 @@ class RequestContext:
     product: str = "llm_gateway"
     posthog_properties: dict[str, str] | None = None
     posthog_flags: dict[str, str] | None = None
+    traceparent_trace_id: str | None = None
 
 
 request_context_var: ContextVar[RequestContext | None] = ContextVar("request_context", default=None)
@@ -91,6 +94,34 @@ def get_posthog_flags() -> dict[str, str] | None:
     return ctx.posthog_flags if ctx else None
 
 
+def set_traceparent_trace_id(trace_id: str | None) -> None:
+    ctx = request_context_var.get()
+    if ctx is None:
+        return
+    request_context_var.set(replace(ctx, traceparent_trace_id=trace_id))
+
+
+def get_traceparent_trace_id() -> str | None:
+    ctx = request_context_var.get()
+    return ctx.traceparent_trace_id if ctx else None
+
+
+def _parse_traceparent_trace_id(value: str | None) -> str | None:
+    if not value:
+        return None
+    parts = value.split("-")
+    if len(parts) < 4:
+        return None
+    trace_id_hex = parts[1]
+    # All-zero means "no trace id" per the W3C spec, not a usable value.
+    if len(trace_id_hex) != 32 or set(trace_id_hex) == {"0"}:
+        return None
+    try:
+        return str(UUID(hex=trace_id_hex))
+    except ValueError:
+        return None
+
+
 def _extract_headers_with_prefix(request: Request, prefix: str) -> dict[str, str]:
     result: dict[str, str] = {}
     prefix_lower = prefix.lower()
@@ -146,6 +177,7 @@ def apply_posthog_context_from_headers(request: Request) -> None:
         set_posthog_properties(properties)
     if flags:
         set_posthog_flags(flags)
+    set_traceparent_trace_id(_parse_traceparent_trace_id(request.headers.get(TRACEPARENT_HEADER)))
 
 
 def set_throttle_context(runner: ThrottleRunner, context: ThrottleContext) -> None:

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -909,6 +909,114 @@ class TestPostHogCallback:
                 assert capture_call.kwargs["properties"]["$group_1"] == "https://eu.posthog.com"
                 assert capture_call.kwargs["properties"]["$ai_is_error"] is True
 
+    @pytest.mark.asyncio
+    async def test_on_success_prefers_traceparent_trace_id(
+        self, callback, standard_logging_object, mock_posthog_client
+    ):
+        kwargs = {
+            "standard_logging_object": standard_logging_object,
+            "litellm_params": {"metadata": {"user_id": '{"session_id": "blob"}'}},
+        }
+        with (
+            patch(
+                "llm_gateway.callbacks.posthog.get_traceparent_trace_id",
+                return_value="0af76519-16cd-43dd-8448-eb211c80319c",
+            ),
+            patch("llm_gateway.callbacks.posthog._capture_ai_event") as mock_capture,
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+        props = mock_capture.call_args.kwargs["properties"]
+        assert props["$ai_trace_id"] == "0af76519-16cd-43dd-8448-eb211c80319c"
+
+    @pytest.mark.asyncio
+    async def test_on_success_falls_back_to_metadata_hash_without_traceparent(
+        self, callback, standard_logging_object, mock_posthog_client
+    ):
+        blob = '{"session_id": "blob"}'
+        kwargs = {
+            "standard_logging_object": standard_logging_object,
+            "litellm_params": {"metadata": {"user_id": blob}},
+        }
+        with (
+            patch(
+                "llm_gateway.callbacks.posthog.get_traceparent_trace_id",
+                return_value=None,
+            ),
+            patch("llm_gateway.callbacks.posthog._capture_ai_event") as mock_capture,
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+        props = mock_capture.call_args.kwargs["properties"]
+        assert props["$ai_trace_id"] == _normalize_trace_id(blob)
+
+    @pytest.mark.asyncio
+    async def test_on_success_explicit_trace_id_header_wins_over_traceparent(
+        self, callback, standard_logging_object, mock_posthog_client
+    ):
+        kwargs = {
+            "standard_logging_object": standard_logging_object,
+            "litellm_params": {"metadata": {}},
+        }
+        with (
+            patch(
+                "llm_gateway.callbacks.posthog.get_traceparent_trace_id",
+                return_value="0af76519-16cd-43dd-8448-eb211c80319c",
+            ),
+            patch(
+                "llm_gateway.callbacks.posthog.get_posthog_properties",
+                return_value={"$ai_trace_id": "explicit-client-id"},
+            ),
+            patch("llm_gateway.callbacks.posthog._capture_ai_event") as mock_capture,
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+        props = mock_capture.call_args.kwargs["properties"]
+        assert props["$ai_trace_id"] == "explicit-client-id"
+
+    @pytest.mark.asyncio
+    async def test_on_success_session_id_header_passes_through(
+        self, callback, standard_logging_object, mock_posthog_client
+    ):
+        kwargs = {
+            "standard_logging_object": standard_logging_object,
+            "litellm_params": {"metadata": {}},
+        }
+        with (
+            patch(
+                "llm_gateway.callbacks.posthog.get_posthog_properties",
+                return_value={"$ai_session_id": "sess-123"},
+            ),
+            patch("llm_gateway.callbacks.posthog._capture_ai_event") as mock_capture,
+        ):
+            await callback._on_success(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+        props = mock_capture.call_args.kwargs["properties"]
+        assert props["$ai_session_id"] == "sess-123"
+
+    @pytest.mark.asyncio
+    async def test_on_failure_prefers_traceparent_trace_id(self, callback, mock_posthog_client):
+        kwargs = {
+            "standard_logging_object": {
+                "model": "claude-3-opus",
+                "custom_llm_provider": "anthropic",
+                "error_str": "boom",
+            },
+            "litellm_params": {"metadata": {"user_id": '{"session_id": "blob"}'}},
+        }
+        with (
+            patch(
+                "llm_gateway.callbacks.posthog.get_traceparent_trace_id",
+                return_value="0af76519-16cd-43dd-8448-eb211c80319c",
+            ),
+            patch("llm_gateway.callbacks.posthog._capture_ai_event") as mock_capture,
+        ):
+            await callback._on_failure(kwargs, None, 0.0, 1.0, end_user_id=None)
+
+        props = mock_capture.call_args.kwargs["properties"]
+        assert props["$ai_trace_id"] == "0af76519-16cd-43dd-8448-eb211c80319c"
+        assert props["$ai_is_error"] is True
+
 
 class TestNormalizeTraceId:
     def test_returns_fresh_uuid_when_value_is_falsy(self) -> None:

--- a/services/llm-gateway/tests/conftest.py
+++ b/services/llm-gateway/tests/conftest.py
@@ -17,8 +17,16 @@ from llm_gateway.rate_limiting.cost_throttles import (
 )
 from llm_gateway.rate_limiting.runner import ThrottleRunner
 from llm_gateway.rate_limiting.throttles import Throttle
+from llm_gateway.request_context import request_context_var
 from llm_gateway.services.plan_resolver import PlanInfo
 from llm_gateway.services.quota_resolver import QuotaResourceStatus
+
+
+@pytest.fixture(autouse=True)
+def _reset_request_context() -> Generator[None]:
+    token = request_context_var.set(None)
+    yield
+    request_context_var.reset(token)
 
 
 def _make_fake_quota_resolver() -> AsyncMock:

--- a/services/llm-gateway/tests/test_traceparent.py
+++ b/services/llm-gateway/tests/test_traceparent.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+import pytest
+
+from llm_gateway.request_context import (
+    RequestContext,
+    _parse_traceparent_trace_id,
+    apply_posthog_context_from_headers,
+    get_traceparent_trace_id,
+    set_request_context,
+)
+
+VALID_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+VALID_TRACE_UUID = "0af76519-16cd-43dd-8448-eb211c80319c"
+
+
+class TestParseTraceparentTraceId:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (VALID_TRACEPARENT, VALID_TRACE_UUID),
+            # Unknown versions are tolerated per W3C — only the trace-id field is read.
+            ("cc-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01", VALID_TRACE_UUID),
+            (None, None),
+            ("", None),
+            ("garbage", None),
+            ("00-shorttraceid-b7ad6b7169203331-01", None),
+            ("00-zzf7651916cd43dd8448eb211c80319z-b7ad6b7169203331-01", None),
+            ("00-00000000000000000000000000000000-b7ad6b7169203331-01", None),
+            ("00-0af7651916cd43dd8448eb211c80319c", None),
+        ],
+    )
+    def test_parses_or_rejects(self, value, expected):
+        assert _parse_traceparent_trace_id(value) == expected
+
+
+class TestApplyCapturesTraceparent:
+    def test_traceparent_lands_in_context(self):
+        set_request_context(RequestContext(request_id="r1"))
+        request = SimpleNamespace(headers={"traceparent": VALID_TRACEPARENT})
+        apply_posthog_context_from_headers(request)
+        assert get_traceparent_trace_id() == VALID_TRACE_UUID
+
+    def test_absent_header_leaves_none(self):
+        set_request_context(RequestContext(request_id="r2"))
+        apply_posthog_context_from_headers(SimpleNamespace(headers={}))
+        assert get_traceparent_trace_id() is None
+
+    def test_malformed_header_leaves_none(self):
+        set_request_context(RequestContext(request_id="r3"))
+        apply_posthog_context_from_headers(SimpleNamespace(headers={"traceparent": "nonsense"}))
+        assert get_traceparent_trace_id() is None

--- a/services/llm-gateway/tests/test_traceparent.py
+++ b/services/llm-gateway/tests/test_traceparent.py
@@ -56,13 +56,14 @@ class TestApplyCapturesTraceparent:
 class TestRebuildRequestContextCarriesTraceparent:
     def test_survives_the_handler_rebuild(self):
         # handler.py replaces the context mid-request; the traceparent must survive it.
-        try:
-            set_request_context(RequestContext(request_id="r4"))
-            request = SimpleNamespace(headers={"traceparent": VALID_TRACEPARENT})
-            apply_posthog_context_from_headers(request)
+        set_request_context(RequestContext(request_id="r4"))
+        request = SimpleNamespace(headers={"traceparent": VALID_TRACEPARENT})
+        apply_posthog_context_from_headers(request)
 
-            rebuild_request_context("llm_gateway")
+        rebuild_request_context("llm_gateway")
 
-            assert get_traceparent_trace_id() == VALID_TRACE_UUID
-        finally:
-            set_request_context(RequestContext(request_id="r4"))
+        assert get_traceparent_trace_id() == VALID_TRACE_UUID
+
+        rebuild_request_context("llm_gateway")
+
+        assert get_traceparent_trace_id() == VALID_TRACE_UUID

--- a/services/llm-gateway/tests/test_traceparent.py
+++ b/services/llm-gateway/tests/test_traceparent.py
@@ -7,6 +7,7 @@ from llm_gateway.request_context import (
     _parse_traceparent_trace_id,
     apply_posthog_context_from_headers,
     get_traceparent_trace_id,
+    rebuild_request_context,
     set_request_context,
 )
 
@@ -50,3 +51,18 @@ class TestApplyCapturesTraceparent:
         set_request_context(RequestContext(request_id="r3"))
         apply_posthog_context_from_headers(SimpleNamespace(headers={"traceparent": "nonsense"}))
         assert get_traceparent_trace_id() is None
+
+
+class TestRebuildRequestContextCarriesTraceparent:
+    def test_survives_the_handler_rebuild(self):
+        # handler.py replaces the context mid-request; the traceparent must survive it.
+        try:
+            set_request_context(RequestContext(request_id="r4"))
+            request = SimpleNamespace(headers={"traceparent": VALID_TRACEPARENT})
+            apply_posthog_context_from_headers(request)
+
+            rebuild_request_context("llm_gateway")
+
+            assert get_traceparent_trace_id() == VALID_TRACE_UUID
+        finally:
+            set_request_context(RequestContext(request_id="r4"))


### PR DESCRIPTION
## Problem

Every `$ai_generation` captured for PostHog Code (and other Claude-CLI products routed through this gateway) shares one `$ai_trace_id` for the entire task: the gateway hashes Anthropic's `metadata.user_id` blob, which is constant per CLI session. A multi-day task renders as a single 1,500+-generation trace in AI Observability, and `$ai_session_id` is never populated, so the AIO sessions UI shows nothing for these products.

## Changes

- `request_context.py`: parse the W3C `traceparent` header (plain string slicing, no OTel dependency) into a UUID-formatted trace id on the per-request `RequestContext`; new `rebuild_request_context()` helper built on `dataclasses.replace` so the handler's mid-request context rebuild can never drop fields.
- `callbacks/posthog.py`: `$ai_trace_id` precedence is now explicit `x-posthog-property-$ai_trace_id` header > traceparent trace-id > today's metadata hash (byte-identical fallback). Same derivation on the failure path. `$ai_span_id` untouched.
- Contract test locking in that `x-posthog-property-$ai_session_id` passes through onto captured events.
- Autouse test fixture resetting the process-global request-context `ContextVar` between tests (a leaked traceparent could otherwise fail unrelated tests under reordering).

Client counterpart (PostHog Code sends the traceparent-enabling env vars + session header) ships separately in PostHog/code; this PR is inert until clients send the headers — callers sending neither behave byte-identically to today. The Claude CLI mints a fresh traceparent trace-id per user turn (verified against CLI 2.1.197), which is exactly the trace granularity AIO wants.

## How did you test this code?

Automated only (no manual/live-gateway testing done): 18 new tests — traceparent parser matrix (malformed/all-zero/short/unknown-version), context plumbing, handler-rebuild lifecycle survival, callback precedence (success + failure paths), session-id passthrough. Regressions caught that no existing test did: the handler's context rebuild silently dropping new fields, header-derived trace id being overridden by the metadata hash, and cross-test ContextVar leakage (reproduced via explicit test reordering, now guarded by the autouse fixture). Full suite: 1416 passed, 50 skipped, 30 xfailed, 22 xpassed; ruff clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored via PostHog Code (Claude) directed by @carlos-marchal-ph. Design validated empirically first: CLI 2.1.197 run locally against a header-logging fake gateway confirmed traceparent trace-ids rotate per user turn and survive a dead OTLP endpoint. Rejected alternatives: deriving turns from request bodies (47% of coding-agent inputs are truncated at capture; trailing-user-message anchors churn mid-turn) and fabricating `$ai_session_id` from the metadata blob (would create garbage singleton sessions for blob-less products). Two review waves (plan-aware + blank-slate) caught the handler context-rebuild no-op and the test-isolation leak fixed here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*