### PR TITLE
feat(rbac): most-specific access wins for object-level access controls

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx
@@ -118,7 +118,7 @@ function AccessControlObjectUsers(): JSX.Element | null {
         addableMembers,
         accessControlMembers,
         accessControlsLoading,
-        availableLevels,
+        availableLevelsWithNone,
         canEditAccessControls,
     } = useValues(accessControlLogic)
     const { updateAccessControlMembers } = useAsyncActions(accessControlLogic)
@@ -187,7 +187,7 @@ function AccessControlObjectUsers(): JSX.Element | null {
                             size="small"
                             level={resource === 'project' ? AccessControlLevel.Admin : AccessControlLevel.Editor}
                             disabled={true}
-                            levels={availableLevels}
+                            levels={availableLevelsWithNone}
                             onChange={() => {}}
                         />
                     </div>
@@ -196,7 +196,7 @@ function AccessControlObjectUsers(): JSX.Element | null {
                         <SimplLevelComponent
                             size="small"
                             level={ac.access_level}
-                            levels={availableLevels}
+                            levels={availableLevelsWithNone}
                             onChange={(level) =>
                                 void updateAccessControlMembers([{ member: ac.organization_member as string, level }])
                             }
@@ -264,7 +264,7 @@ function AccessControlObjectRoles(): JSX.Element | null {
         accessControlsLoading,
         addableRoles,
         rolesById,
-        availableLevels,
+        availableLevelsWithNone,
         canEditAccessControls,
     } = useValues(accessControlLogic)
     const { updateAccessControlRoles } = useAsyncActions(accessControlLogic)
@@ -313,7 +313,7 @@ function AccessControlObjectRoles(): JSX.Element | null {
                         <SimplLevelComponent
                             size="small"
                             level={access_level}
-                            levels={availableLevels}
+                            levels={availableLevelsWithNone}
                             onChange={(level) => void updateAccessControlRoles([{ role, level }])}
                         />
                     </div>
@@ -392,7 +392,7 @@ function SimplLevelComponent(props: {
                     : false
                 return {
                     value: level,
-                    label: capitalizeFirstLetter(level ?? ''),
+                    label: level === 'none' ? 'No access' : capitalizeFirstLetter(level ?? ''),
                     disabledReason: isDisabled ? 'Not available for this resource type' : undefined,
                 }
             })}
@@ -439,9 +439,10 @@ function AddItemsControlsModal(props: {
         label: string
     }[]
 }): JSX.Element | null {
-    const { availableLevels, canEditAccessControls } = useValues(accessControlLogic)
+    const { availableLevels, availableLevelsWithNone, canEditAccessControls } = useValues(accessControlLogic)
     // TODO: Move this into a form logic
     const [items, setItems] = useState<string[]>([])
+    // Default to the first real grant, not "No access" — but expose "none" as a selectable deny.
     const [level, setLevel] = useState<AccessControlLevel>(availableLevels[0] ?? null)
 
     useEffect(() => {
@@ -496,7 +497,7 @@ function AddItemsControlsModal(props: {
                         disabled={!canEditAccessControls}
                     />
                 </div>
-                <SimplLevelComponent levels={availableLevels} level={level} onChange={setLevel} />
+                <SimplLevelComponent levels={availableLevelsWithNone} level={level} onChange={setLevel} />
             </div>
         </LemonModal>
     )

--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -227,9 +227,7 @@ class TestUserAccessControl(BaseUserAccessControlTest):
             resource_id=self.team.id, access_level="member", organization_member=self.organization_membership
         )
         # Enroll role_a as admin
-        ac_role = self._create_access_control(
-            resource_id=self.team.id, access_level="admin", role=self.role_a
-        )  # The highest AC
+        ac_role = self._create_access_control(resource_id=self.team.id, access_level="admin", role=self.role_a)
         # Enroll role_b as member
         ac_role_2 = self._create_access_control(resource_id=self.team.id, access_level="member", role=self.role_b)
         # Enroll self.user in both roles
@@ -248,8 +246,8 @@ class TestUserAccessControl(BaseUserAccessControlTest):
         assert ac_user in matching_acs
         assert ac_role in matching_acs
         assert ac_role_2 in matching_acs
-        # the matching one should be the highest level
-        assert self.user_access_control.access_level_for_object(self.team) == "admin"
+        # The member override is the most specific row, so it wins over the higher role grants.
+        assert self.user_access_control.access_level_for_object(self.team) == "member"
 
     def test_org_admin_always_has_access(self):
         self._create_access_control(resource_id=self.team.id, access_level="none")
@@ -585,12 +583,13 @@ class TestUserAccessControlSerializer(BaseUserAccessControlTest):
         serializer = self.Serializer(self.dashboard, context={"user_access_control": self.user_access_control})
         assert serializer.get_user_access_level(self.dashboard) == "viewer"
 
-    def test_resource_level_takes_priority(self):
-        # Both resource-level and object-level; resource-level should take priority
+    def test_object_default_takes_priority_over_resource(self):
+        # Both a resource-level default and an object-level default; the object-level row is more
+        # specific and wins, even though it grants a lower level than the resource default.
         self._create_access_control(resource="dashboard", resource_id=None, access_level="editor")
         self._create_access_control(resource="dashboard", resource_id=str(self.dashboard.id), access_level="viewer")
         serializer = self.Serializer(self.dashboard, context={"user_access_control": self.user_access_control})
-        assert serializer.get_user_access_level(self.dashboard) == "editor"
+        assert serializer.get_user_access_level(self.dashboard) == "viewer"
 
     def test_falls_back_to_object_level(self):
         # Only object-level present
@@ -848,9 +847,8 @@ class TestUserAccessControlGetUserAccessLevel(BaseUserAccessControlTest):
         access_level = self.user_access_control.get_user_access_level(self.other_dashboard)
         assert access_level == "viewer"
 
-    def test_mixed_access_controls_highest_wins(self):
-        """Test that when multiple access controls exist, highest level wins"""
-        # Create multiple access controls with different levels
+    def test_member_override_wins_over_role(self):
+        """A member override is more specific than a role grant, so it wins even when lower"""
         self._create_access_control(
             resource="dashboard",
             resource_id=str(self.other_dashboard.id),
@@ -865,7 +863,33 @@ class TestUserAccessControlGetUserAccessLevel(BaseUserAccessControlTest):
         )
 
         access_level = self.user_access_control.get_user_access_level(self.other_dashboard)
-        assert access_level == "editor"  # Higher level wins
+        assert access_level == "viewer"  # Member override wins over the higher role grant
+
+    def test_member_deny_overrides_role_grant(self):
+        """A member "none" denies the object even when a role grants access on the same object"""
+        self._create_access_control(
+            resource="dashboard",
+            resource_id=str(self.other_dashboard.id),
+            access_level="none",
+            organization_member=self.organization_membership,
+        )
+        self._create_access_control(
+            resource="dashboard",
+            resource_id=str(self.other_dashboard.id),
+            access_level="editor",
+            role=self.role_a,
+        )
+
+        assert self.user_access_control.get_user_access_level(self.other_dashboard) == "none"
+        assert self.user_access_control.check_access_level_for_object(self.other_dashboard, "viewer") is False
+
+    def test_object_default_deny_overrides_resource_grant(self):
+        """An object default of "none" makes the object private despite a resource-level grant"""
+        self._create_access_control(resource="dashboard", resource_id=None, access_level="editor")
+        self._create_access_control(resource="dashboard", resource_id=str(self.other_dashboard.id), access_level="none")
+
+        assert self.user_access_control.get_user_access_level(self.other_dashboard) == "none"
+        assert self.user_access_control.check_access_level_for_object(self.other_dashboard, "viewer") is False
 
     def test_project_level_access_for_team_objects(self):
         """Test project-level access for team objects"""
@@ -994,9 +1018,8 @@ class TestUserAccessControlSpecificAccessLevelForObject(BaseUserAccessControlTes
         access_level = self.user_access_control.specific_access_level_for_object(self.other_dashboard)
         assert access_level is None  # Global controls are ignored
 
-    def test_highest_level_wins_for_multiple_specific_controls(self):
-        """Test that highest level wins when multiple specific controls exist"""
-        # Create multiple specific access controls
+    def test_member_override_wins_over_role_for_specific_access(self):
+        """The member override is the most specific row, so it wins over a higher role grant"""
         self._create_access_control(
             resource="dashboard",
             resource_id=str(self.other_dashboard.id),
@@ -1011,27 +1034,27 @@ class TestUserAccessControlSpecificAccessLevelForObject(BaseUserAccessControlTes
         )
 
         access_level = self.user_access_control.specific_access_level_for_object(self.other_dashboard)
-        assert access_level == "editor"  # Higher level wins
+        assert access_level == "viewer"  # Member override wins over the higher role grant
 
-    def test_mixed_member_and_role_controls(self):
-        """Test that both member and role controls are considered"""
-        # Create member-specific control
+    def test_roles_are_combined_by_max_when_no_member_override(self):
+        """With no member override, role grants combine by most-permissive-wins"""
         self._create_access_control(
             resource="dashboard",
             resource_id=str(self.other_dashboard.id),
             access_level="viewer",
-            organization_member=self.organization_membership,
+            role=self.role_a,
         )
-        # Create role-specific control with higher level
         self._create_access_control(
             resource="dashboard",
             resource_id=str(self.other_dashboard.id),
             access_level="manager",
-            role=self.role_a,
+            role=self.role_b,
         )
+        RoleMembership.objects.create(user=self.user, role=self.role_b)
+        self._clear_uac_caches()
 
         access_level = self.user_access_control.specific_access_level_for_object(self.other_dashboard)
-        assert access_level == "manager"  # Role control with higher level wins
+        assert access_level == "manager"  # Highest role grant wins among roles
 
     def test_project_specific_access_control(self):
         """Test project-specific access controls"""

--- a/posthog/rbac/test/test_user_access_control_pbt.py
+++ b/posthog/rbac/test/test_user_access_control_pbt.py
@@ -382,23 +382,15 @@ def oracle_explicit_level(specs: list[RowSpec], order: list[AccessControlLevel])
     # it is lower, so a self_member "none" row beats a role_a/team_default "admin" row.
     matching = [s for s in specs if s.target in MATCHING]
 
-    object_member: list[AccessControlLevel] = [
-        s.level for s in matching if s.scope == "object" and s.target == "self_member"
+    tiers: list[list[AccessControlLevel]] = [
+        [s.level for s in matching if s.scope == "object" and s.target == "self_member"],
+        [s.level for s in matching if s.scope == "object" and s.target == "role_a"],
+        [s.level for s in matching if s.scope == "object" and s.target == "team_default"],
+        [s.level for s in matching if s.scope == "resource"],
     ]
-    if object_member:
-        return _max_level(object_member, order)
-    object_roles: list[AccessControlLevel] = [s.level for s in matching if s.scope == "object" and s.target == "role_a"]
-    if object_roles:
-        return _max_level(object_roles, order)
-    object_defaults: list[AccessControlLevel] = [
-        s.level for s in matching if s.scope == "object" and s.target == "team_default"
-    ]
-    if object_defaults:
-        return _max_level(object_defaults, order)
-
-    resource_rows: list[AccessControlLevel] = [s.level for s in matching if s.scope == "resource"]
-    if resource_rows:
-        return _max_level(resource_rows, order)
+    for tier in tiers:
+        if tier:
+            return _max_level(tier, order)
     return None
 
 
@@ -433,22 +425,14 @@ def oracle_blocked_and_allowed_object_ids(
         roles = [s.level for s in matching if s.target == "role_a"]
         defaults = [s.level for s in matching if s.target == "team_default"]
 
-        if member:
-            effective_none = all(level == NO_ACCESS_LEVEL for level in member)
-            specific_non_none = any(level != NO_ACCESS_LEVEL for level in member)
-        elif roles:
-            effective_none = all(level == NO_ACCESS_LEVEL for level in roles)
-            specific_non_none = any(level != NO_ACCESS_LEVEL for level in roles)
-        elif defaults:
-            effective_none = all(level == NO_ACCESS_LEVEL for level in defaults)
-            specific_non_none = False
-        else:
-            effective_none = False
-            specific_non_none = False
-
-        if effective_none:
+        # The most specific non-empty tier decides the object: its max is the effective level.
+        override_tier = member or roles
+        most_specific_tier = override_tier or defaults
+        if not most_specific_tier:
+            continue
+        if all(level == NO_ACCESS_LEVEL for level in most_specific_tier):
             blocked.add(resource_id)
-        if specific_non_none:
+        elif override_tier:
             allowed.add(resource_id)
     return blocked, allowed
 

--- a/posthog/rbac/test/test_user_access_control_pbt.py
+++ b/posthog/rbac/test/test_user_access_control_pbt.py
@@ -376,22 +376,29 @@ membership_levels_st = st.one_of(st.just(OrganizationMembership.Level.MEMBER), s
 
 
 def oracle_explicit_level(specs: list[RowSpec], order: list[AccessControlLevel]) -> Optional[AccessControlLevel]:
-    # Mirrors get_user_access_level(obj, explicit=True): member/role rows on the
-    # object win over resource-level rows, which win over object rows including
-    # team defaults. Note the shadowing this implies: a self_member "none" row
-    # beats a team_default "admin" row even though it is lower.
+    # Mirrors get_user_access_level(obj, explicit=True): object-level rows win as a whole over
+    # resource-level rows, and within the object they resolve by specificity -
+    # member override > max(role overrides) > object default. A more specific row wins even when
+    # it is lower, so a self_member "none" row beats a role_a/team_default "admin" row.
     matching = [s for s in specs if s.target in MATCHING]
-    specific: list[AccessControlLevel] = [
-        s.level for s in matching if s.scope == "object" and s.target != "team_default"
+
+    object_member: list[AccessControlLevel] = [
+        s.level for s in matching if s.scope == "object" and s.target == "self_member"
     ]
-    if specific:
-        return _max_level(specific, order)
+    if object_member:
+        return _max_level(object_member, order)
+    object_roles: list[AccessControlLevel] = [s.level for s in matching if s.scope == "object" and s.target == "role_a"]
+    if object_roles:
+        return _max_level(object_roles, order)
+    object_defaults: list[AccessControlLevel] = [
+        s.level for s in matching if s.scope == "object" and s.target == "team_default"
+    ]
+    if object_defaults:
+        return _max_level(object_defaults, order)
+
     resource_rows: list[AccessControlLevel] = [s.level for s in matching if s.scope == "resource"]
     if resource_rows:
         return _max_level(resource_rows, order)
-    object_rows: list[AccessControlLevel] = [s.level for s in matching if s.scope == "object"]
-    if object_rows:
-        return _max_level(object_rows, order)
     return None
 
 
@@ -414,25 +421,35 @@ def oracle_resource_access_level(resource: APIScopeObject, specs: list[RowSpec],
 def oracle_blocked_and_allowed_object_ids(
     object_specs_by_id: dict[str, list[RowSpec]],
 ) -> tuple[set[str], set[str]]:
-    # Mirrors _blocked_and_allowed_object_ids over the rows visible to self.user
-    # (only MATCHING targets survive _filter_options). Explicit (role/member) rows
-    # decide an object: any non-"none" explicit row allows it, otherwise it's blocked.
-    # With no explicit row, the object is blocked only when every default row is "none".
+    # Mirrors _blocked_and_allowed_object_ids over the rows visible to self.user (only MATCHING
+    # targets survive _filter_options). An object is blocked when its effective level
+    # (member -> max roles -> object default) is "none"; it is allowed when a member/role grant
+    # is non-"none". max(levels) == "none" iff every level in the winning tier is "none".
     blocked: set[str] = set()
     allowed: set[str] = set()
     for resource_id, specs in object_specs_by_id.items():
         matching = [s for s in specs if s.target in MATCHING]
-        if not matching:
-            continue
-        explicit = [s for s in matching if s.target != "team_default"]
-        if not explicit:
-            if all(s.level == NO_ACCESS_LEVEL for s in matching):
-                blocked.add(resource_id)
-            continue
-        if any(s.level != NO_ACCESS_LEVEL for s in explicit):
-            allowed.add(resource_id)
+        member = [s.level for s in matching if s.target == "self_member"]
+        roles = [s.level for s in matching if s.target == "role_a"]
+        defaults = [s.level for s in matching if s.target == "team_default"]
+
+        if member:
+            effective_none = all(level == NO_ACCESS_LEVEL for level in member)
+            specific_non_none = any(level != NO_ACCESS_LEVEL for level in member)
+        elif roles:
+            effective_none = all(level == NO_ACCESS_LEVEL for level in roles)
+            specific_non_none = any(level != NO_ACCESS_LEVEL for level in roles)
+        elif defaults:
+            effective_none = all(level == NO_ACCESS_LEVEL for level in defaults)
+            specific_non_none = False
         else:
+            effective_none = False
+            specific_non_none = False
+
+        if effective_none:
             blocked.add(resource_id)
+        if specific_non_none:
+            allowed.add(resource_id)
     return blocked, allowed
 
 

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -403,6 +403,40 @@ def restricted_visible_membership_ids(organization: Organization, user: User) ->
     return get_project_scoped_visible_membership_ids(organization, membership)
 
 
+def resolve_object_access_level(
+    resource: APIScopeObject,
+    access_controls: list[_AccessControl],
+) -> Optional[AccessControlLevel]:
+    """Resolve the effective access level from a pool of object-level access-control rows
+    (all scoped to a single object) using specificity precedence rather than
+    most-permissive-wins:
+
+        member override  ->  max(role overrides)  ->  object default
+
+    A more specific row wins even when it grants a *lower* level than a broader one - that is
+    what lets a member (or a role) be denied, or restricted below, an object's default level.
+    Returns None when the pool is empty.
+    """
+    if not access_controls:
+        return None
+
+    order = ordered_access_levels(resource)
+
+    def most_permissive(rows: list[_AccessControl]) -> AccessControlLevel:
+        return max(rows, key=lambda ac: order.index(ac.access_level)).access_level
+
+    member_rows = [ac for ac in access_controls if ac.organization_member_id is not None]
+    if member_rows:
+        return most_permissive(member_rows)
+
+    role_rows = [ac for ac in access_controls if ac.role_id is not None]
+    if role_rows:
+        return most_permissive(role_rows)
+
+    # Whatever remains has neither member nor role: these are the object's default rows.
+    return most_permissive(access_controls)
+
+
 def model_to_resource(model: Model) -> Optional[APIScopeObject]:
     """
     Given a model, return the resource type it represents
@@ -733,8 +767,9 @@ class UserAccessControl:
         self, obj: Model, resource: Optional[APIScopeObject] = None, explicit=False, specific_only=False
     ) -> Optional[AccessControlLevel]:
         """
-        Access levels are strings - the order of which is determined at run time.
-        We find all relevant access controls and then return the highest value
+        Resolve the user's access level for a single object from its access-control rows,
+        using specificity precedence (member -> max roles -> object default). A more specific
+        row wins even when it is lower, so a member/role can be denied below the object default.
 
         Args:
             obj: The model object to check access for
@@ -770,21 +805,20 @@ class UserAccessControl:
         filters = self._access_controls_filters_for_object(resource, str(obj.id))  # type: ignore
         access_controls = self._get_access_controls(filters)
 
-        # Filter to specific access controls if requested
+        # "Specific" resolution ignores object defaults - only member/role rows count.
         if specific_only:
             access_controls = [
                 ac for ac in access_controls if ac.role_id is not None or ac.organization_member_id is not None
             ]
-            # If we're looking for specific access controls and there are none we don't want to return the default access level
-            if not access_controls:
-                return None
 
-        # If there is no specified controls on the resource then we return the default access level
         if not access_controls:
-            return default_access_level(resource) if not explicit else None
+            # No matching object-level rows: fall back to the resource default, unless the
+            # caller only wants explicit/specific access.
+            return None if (explicit or specific_only) else default_access_level(resource)
 
-        # If there are access controls we pick the highest level the user has
-        return self._highest_access_level_from_rows(resource, access_controls)
+        # Resolve by specificity (member -> max roles -> object default) so a more specific
+        # row can restrict access below a broader one.
+        return resolve_object_access_level(resource, access_controls)
 
     def check_access_level_for_object(self, obj: Model, required_level: AccessControlLevel, explicit=False) -> bool:
         """
@@ -1104,44 +1138,33 @@ class UserAccessControl:
         """Canonical object-level decision over a pool of object access controls (rows with
         `resource_id` set), returning (blocked_ids, allowed_ids).
 
-        Explicit-wins: if a resource_id has any explicit (role/member) rule, the object is
-        allowed when any explicit rule grants non-"none", otherwise blocked. With no explicit
-        rule, the object is blocked only when every default rule is "none".
+        An object is blocked when its effective level (member -> max roles -> object default)
+        resolves to "none". It is allowed - visible even without resource-level access - when a
+        member/role override grants a non-"none" level. The two sets are mutually exclusive.
 
         Reads the `role_id` / `organization_member_id` columns rather than the `.role` /
         `.organization_member` FK accessors — equivalent result (id is None iff the relation is
         None) without firing a query per row.
         """
-        resource_id_access_levels: dict[str, list[str]] = {}
+        rows_by_resource_id: dict[str, list[_AccessControl]] = defaultdict(list)
         for access_control in access_controls:
-            resource_id_access_levels.setdefault(access_control.resource_id, []).append(access_control.access_level)
+            if access_control.resource_id is not None:
+                rows_by_resource_id[access_control.resource_id].append(access_control)
 
         blocked_resource_ids: set[str] = set()
         allowed_resource_ids: set[str] = set()
 
-        for resource_id, access_levels in resource_id_access_levels.items():
-            # Get the access controls for this specific resource_id to check role/member
-            resource_access_controls = [ac for ac in access_controls if ac.resource_id == resource_id]
+        for resource_id, rows in rows_by_resource_id.items():
+            resource = cast(APIScopeObject, rows[0].resource)
 
-            # Only consider access controls that have explicit role or member (not defaults)
-            explicit_access_controls = [
-                ac for ac in resource_access_controls if ac.role_id is not None or ac.organization_member_id is not None
-            ]
-
-            if not explicit_access_controls:
-                if all(access_level == NO_ACCESS_LEVEL for access_level in access_levels):
-                    blocked_resource_ids.add(resource_id)
-                # No explicit controls for this object - don't block it
-                continue
-
-            # Check if user has any non-"none" access to this specific object
-            has_specific_access = any(ac.access_level != NO_ACCESS_LEVEL for ac in explicit_access_controls)
-
-            if has_specific_access:
-                allowed_resource_ids.add(resource_id)
-            else:
-                # All explicit access levels are "none" - block this object
+            if resolve_object_access_level(resource, rows) == NO_ACCESS_LEVEL:
                 blocked_resource_ids.add(resource_id)
+
+            # A member/role grant lets the user see the object even without resource-level access.
+            specific_rows = [ac for ac in rows if ac.role_id is not None or ac.organization_member_id is not None]
+            specific_level = resolve_object_access_level(resource, specific_rows)
+            if specific_level is not None and specific_level != NO_ACCESS_LEVEL:
+                allowed_resource_ids.add(resource_id)
 
         return blocked_resource_ids, allowed_resource_ids
 
@@ -1220,7 +1243,15 @@ class UserAccessControl:
             .values("pk")[:1]
         )
 
-        # Subquery to check whether the user has "none" for this specific FileSystem
+        # Subquery to check whether the user has "none" for this specific FileSystem.
+        #
+        # NOTE: this is a conservative approximation of the specificity precedence that
+        # resolve_object_access_level applies elsewhere (member -> max roles -> object default):
+        # it hides the item whenever *any* matching row is "none". That can over-hide a file
+        # when a member/role grant coexists with a lower-tier "none" (e.g. member=editor but a
+        # role the user is in has "none" on the same object). It never over-exposes, so it is
+        # safe; the authoritative check is check_access_level_for_object. Tightening this to full
+        # precedence in SQL is tracked as follow-up.
         is_none_subquery = (
             AccessControl.objects.filter(
                 team_id=OuterRef("team_id"),
@@ -1304,23 +1335,19 @@ class UserAccessControl:
     def _object_access_level_from_rows(
         self, resource: APIScopeObject, object_access_controls: list[_AccessControl], explicit: bool = False
     ) -> Optional[AccessControlLevel]:
-        """Row-based object access resolution: explicit (role/member) object rows win, then
-        resource-level rows, then default object rows, then the resource default. Shared by
-        `get_user_access_level` and `bulk_object_access_levels`.
+        """Row-based object access resolution by specificity: object rows (member override ->
+        max(role overrides) -> object default) win as a whole over resource-level rows, then the
+        resource default. A more specific row wins even when it is lower, so a resolved "none" is
+        an explicit deny. Shared by `get_user_access_level` and `bulk_object_access_levels`.
         """
-        explicit_rows = [
-            ac for ac in object_access_controls if ac.role_id is not None or ac.organization_member_id is not None
-        ]
-        if explicit_rows:
-            return self._highest_access_level_from_rows(resource, explicit_rows)
+        object_level = resolve_object_access_level(resource, object_access_controls)
+        if object_level:
+            return object_level
 
         if self.has_access_levels_for_resource(resource):
             access_level_for_resource = self.access_level_for_resource(resource)
             if access_level_for_resource:
                 return access_level_for_resource
-
-        if object_access_controls:
-            return self._highest_access_level_from_rows(resource, object_access_controls)
 
         return None if explicit else default_access_level(resource)
 

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -1156,14 +1156,12 @@ class UserAccessControl:
 
         for resource_id, rows in rows_by_resource_id.items():
             resource = cast(APIScopeObject, rows[0].resource)
+            effective = resolve_object_access_level(resource, rows)
 
-            if resolve_object_access_level(resource, rows) == NO_ACCESS_LEVEL:
+            if effective == NO_ACCESS_LEVEL:
                 blocked_resource_ids.add(resource_id)
-
-            # A member/role grant lets the user see the object even without resource-level access.
-            specific_rows = [ac for ac in rows if ac.role_id is not None or ac.organization_member_id is not None]
-            specific_level = resolve_object_access_level(resource, specific_rows)
-            if specific_level is not None and specific_level != NO_ACCESS_LEVEL:
+            elif any(ac.role_id is not None or ac.organization_member_id is not None for ac in rows):
+                # A member/role grant lets the user see the object even without resource-level access.
                 allowed_resource_ids.add(resource_id)
 
         return blocked_resource_ids, allowed_resource_ids
@@ -1244,14 +1242,9 @@ class UserAccessControl:
         )
 
         # Subquery to check whether the user has "none" for this specific FileSystem.
-        #
-        # NOTE: this is a conservative approximation of the specificity precedence that
-        # resolve_object_access_level applies elsewhere (member -> max roles -> object default):
-        # it hides the item whenever *any* matching row is "none". That can over-hide a file
-        # when a member/role grant coexists with a lower-tier "none" (e.g. member=editor but a
-        # role the user is in has "none" on the same object). It never over-exposes, so it is
-        # safe; the authoritative check is check_access_level_for_object. Tightening this to full
-        # precedence in SQL is tracked as follow-up.
+        # Approximates resolve_object_access_level in SQL: any matching "none" row hides the
+        # item, so a grant in a more specific tier can be over-hidden here — but never
+        # over-exposed. The authoritative check is check_access_level_for_object.
         is_none_subquery = (
             AccessControl.objects.filter(
                 team_id=OuterRef("team_id"),


### PR DESCRIPTION
## Problem

Object access controls support the allowlist case but not the denylist case. You can grant a member or role access *above* an object's default, but you can't restrict them *below* it:

- The UI never offered "No access" for a member/role on an object, so an explicit deny couldn't be authored at all
- Even when a deny row was created via the API, resolution merged all matching rows with `max()` (most permissive wins)
- An object-level default was consulted *after* resource-level rows, so a lower object default couldn't make one object more private than its resource default.

RFC (this PR implements the object part - Cases 2 and 3): https://github.com/PostHog/requests-for-comments-public/pull/557

## Changes

**Backend** (`posthog/rbac/user_access_control.py`)

- Object access now resolves by **specificity**, not `max()`: member override → max(role overrides) → object default, and object-level rows win as a whole over resource-level rows. A more specific row wins even when it grants a *lower* level, so:
  - a member/role "none" denies the object even if another tier grants access
  - an object default "none" makes an object private despite a resource-level grant
  - an object default grant surfaces an object without per-member grants
- The rule lives in one pure reducer, `resolve_object_access_level`, shared by the object resolver, `get_user_access_level`, and the queryset blocked/allowed decision, so enforcement and filtering can't drift.

> Resource- and project-level resolution are unchanged (still most-permissive-wins) - that's the RFC's Cases 4-6, a follow-up. The FileSystem tree's SQL "none" filter keeps a conservative any-none approximation: it can over-hide when a more specific grant coexists with a broader deny, but never over-exposes; the authoritative check is `check_access_level_for_object`.

**Frontend** (`frontend/src/layout/navigation-3000/sidepanel/panels/access_control/AccessControlObject.tsx`)

- The object-level member and role pickers, and the "Add access" modal, now offer "No access", so a deny can actually be configured. The modal still defaults to the first real grant; resources with a minimum level above "none" keep it disabled.

- Storage needed no change: the API already accepted "none" for member/role rows, and a null level already means "delete the rule" as opposed to an explicit deny.

## How did you test this code?

Tests. `posthog/rbac/test/test_user_access_control.py` and `posthog/rbac/test/test_user_access_control_pbt.py` (156 tests), plus `ee/api/rbac/test/test_access_control.py` (112) and `posthog/rbac/test/test_field_access_control.py`.

- Flipped 5 existing tests that encoded the old max-wins/resource-priority semantics.
- New regression tests: a member "none" beating a coexisting role grant, and an object default "none" beating a resource-level grant - both asserted through `check_access_level_for_object`, which no existing test covered for the deny direction.
- The property-based suite's oracle was updated to the new precedence, so the DB-backed implementation is checked against a pure reference across arbitrary row configurations.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

The main design fork was what "deny" should mean when a user matches both a grant and a deny on the same object. I picked specificity precedence (member over roles, roles over default) per the RFC, over a stricter deny-wins rule - deny-wins would make it impossible to deny a role while re-granting one member. The queryset path originally resolved the reducer twice per object (all rows, then override rows only); that collapsed to a single resolution since the effective level *is* the override tier's resolution whenever override rows exist.

