### PR TITLE
feat(conversations): add "Apply and set to on hold" to snooze picker

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.tsx
@@ -87,6 +87,8 @@ export interface LemonCalendarSelectProps {
     onToggleTime?: (value: boolean) => void
     /** Use 24-hour format instead of 12-hour with AM/PM */
     use24HourFormat?: boolean
+    /** Extra "Apply" variants shown in a dropdown next to the Apply button. Each receives the selected date. */
+    applyActions?: { label: string; onClick: (date: dayjs.Dayjs) => void }[]
 }
 
 export function LemonCalendarSelect({
@@ -100,6 +102,7 @@ export function LemonCalendarSelect({
     showTimeToggle,
     onToggleTime,
     use24HourFormat = false,
+    applyActions,
 }: LemonCalendarSelectProps): JSX.Element {
     const calendarRef = useRef<HTMLDivElement | null>(null)
     const [selectValue, setSelectValue] = useState<dayjs.Dayjs | null>(value ? value.startOf(granularity) : null)
@@ -232,6 +235,28 @@ export function LemonCalendarSelect({
                         disabled={!selectValue}
                         onClick={() => selectValue && onChange && onChange(selectValue)}
                         data-attr="lemon-calendar-select-apply"
+                        sideAction={
+                            applyActions?.length
+                                ? {
+                                      disabled: !selectValue,
+                                      'aria-label': 'More apply options',
+                                      dropdown: {
+                                          placement: 'bottom-end',
+                                          overlay: applyActions.map((action) => (
+                                              <LemonButton
+                                                  key={action.label}
+                                                  fullWidth
+                                                  size="small"
+                                                  disabled={!selectValue}
+                                                  onClick={() => selectValue && action.onClick(selectValue)}
+                                              >
+                                                  {action.label}
+                                              </LemonButton>
+                                          )),
+                                      },
+                                  }
+                                : undefined
+                        }
                     >
                         Apply
                     </LemonButton>
@@ -274,6 +299,13 @@ export function LemonCalendarSelectInput(props: LemonCalendarSelectInputProps): 
                         props.onChange?.(value)
                         setUncontrolledVisible(false)
                     }}
+                    applyActions={props.applyActions?.map((action) => ({
+                        ...action,
+                        onClick: (date) => {
+                            action.onClick(date)
+                            setUncontrolledVisible(false)
+                        },
+                    }))}
                     onClose={() => {
                         setUncontrolledVisible(false)
                         props.onClose?.()

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -485,6 +485,15 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                                     selectionPeriod="upcoming"
                                     clearable
                                     placeholder="Not snoozed"
+                                    applyActions={[
+                                        {
+                                            label: 'Apply and set to on hold',
+                                            onClick: (date) => {
+                                                setSnoozedUntil(date.startOf('minute').toISOString())
+                                                setStatus('on_hold')
+                                            },
+                                        },
+                                    ]}
                                     buttonProps={{
                                         size: 'small',
                                         type: 'secondary',


### PR DESCRIPTION
## Problem

When snoozing a support ticket, the only action available on the snooze date picker is "Apply", which stages the snooze date. To also move the ticket to "on hold" you have to change the Status dropdown separately. This is a common pairing, so it's worth doing in one click.

## Changes

Added a side-action dropdown to the snooze picker's "Apply" button with a second option: **Apply and set to on hold**. Choosing it stages both the snooze date and the `on_hold` status (saved with "Save changes", same as the existing Apply).

Implemented generically on the shared `LemonCalendarSelect` / `LemonCalendarSelectInput` via a new optional `applyActions` prop (`{ label, onClick(date) }[]`), rendered with the same `LemonButton` `sideAction.dropdown` pattern already used by the composer's "Send and set status" control. The input wrapper closes the popover after a secondary action fires, matching Apply's behavior. No behavior change anywhere the prop isn't passed.


https://github.com/user-attachments/assets/737f2326-a208-47a2-ac94-5e25aedff972



## How did you test this code?

I (an agent) did not run the app or manual UI testing. `node_modules` wasn't installed in this environment, so I couldn't run `typescript:check` or lint here. The change mirrors the existing `sideAction.dropdown` usage in `MessageInput.tsx` and reuses actions (`setSnoozedUntil`, `setStatus`) already wired in the scene. Please run typecheck/lint in CI and give the dropdown a quick manual check.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) at Luke's request from a Slack thread. No repo skills were required for this change. I chose to extend the shared `LemonCalendarSelect` with a generic `applyActions` prop rather than fork the component or bake snooze-specific logic into it, so the split-button stays reusable and other callers are unaffected. The secondary action stages status the same way the existing Apply stages the snooze date (persisted via "Save changes"), keeping the sidebar's save model consistent.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1785319682388109)*
