### PR TITLE
fix(conversations): use built-in TZLabel for SLA display tooltip

### DIFF
--- a/products/conversations/frontend/components/SlaDisplay.tsx
+++ b/products/conversations/frontend/components/SlaDisplay.tsx
@@ -1,5 +1,7 @@
 import clsx from 'clsx'
 
+import { Tooltip } from '@posthog/lemon-ui'
+
 import { dayjs } from 'lib/dayjs'
 
 export function SlaDisplay({
@@ -18,20 +20,23 @@ export function SlaDisplay({
     const breached = diffMs < 0
     const atRisk = !breached && diffMs < 60 * 60 * 1000
 
+    // Use the styled lemon-ui Tooltip rather than the native `title` attribute,
+    // which the browser is slow to pop on hover and can't be styled to match.
     return (
-        <span
-            className={clsx(
-                'font-medium',
-                {
-                    'text-danger': breached,
-                    'text-warning': atRisk,
-                    'text-success': !breached && !atRisk,
-                },
-                className
-            )}
-            title={due.format('YYYY-MM-DD HH:mm:ss')}
-        >
-            {due.fromNow()}
-        </span>
+        <Tooltip title={`SLA due ${due.format('YYYY-MM-DD HH:mm:ss')}`}>
+            <span
+                className={clsx(
+                    'font-medium',
+                    {
+                        'text-danger': breached,
+                        'text-warning': atRisk,
+                        'text-success': !breached && !atRisk,
+                    },
+                    className
+                )}
+            >
+                {due.fromNow()}
+            </span>
+        </Tooltip>
     )
 }

--- a/products/conversations/frontend/components/SlaDisplay.tsx
+++ b/products/conversations/frontend/components/SlaDisplay.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx'
 
 import { TZLabel } from 'lib/components/TZLabel'
-
 import { dayjs } from 'lib/dayjs'
 
 export function SlaDisplay({

--- a/products/conversations/frontend/components/SlaDisplay.tsx
+++ b/products/conversations/frontend/components/SlaDisplay.tsx
@@ -20,8 +20,6 @@ export function SlaDisplay({
     const breached = diffMs < 0
     const atRisk = !breached && diffMs < 60 * 60 * 1000
 
-    // Use the styled lemon-ui Tooltip rather than the native `title` attribute,
-    // which the browser is slow to pop on hover and can't be styled to match.
     return (
         <Tooltip title={`SLA due ${due.format('YYYY-MM-DD HH:mm:ss')}`}>
             <span

--- a/products/conversations/frontend/components/SlaDisplay.tsx
+++ b/products/conversations/frontend/components/SlaDisplay.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 
-import { Tooltip } from '@posthog/lemon-ui'
+import { TZLabel } from 'lib/components/TZLabel'
 
 import { dayjs } from 'lib/dayjs'
 
@@ -21,20 +21,17 @@ export function SlaDisplay({
     const atRisk = !breached && diffMs < 60 * 60 * 1000
 
     return (
-        <Tooltip title={`SLA due ${due.format('YYYY-MM-DD HH:mm:ss')}`}>
-            <span
-                className={clsx(
-                    'font-medium',
-                    {
-                        'text-danger': breached,
-                        'text-warning': atRisk,
-                        'text-success': !breached && !atRisk,
-                    },
-                    className
-                )}
-            >
-                {due.fromNow()}
-            </span>
-        </Tooltip>
+        <TZLabel
+            time={due}
+            className={clsx(
+                'font-medium',
+                {
+                    'text-danger': breached,
+                    'text-warning': atRisk,
+                    'text-success': !breached && !atRisk,
+                },
+                className
+            )}
+        />
     )
 }


### PR DESCRIPTION
## Problem

The SLA countdown shown in the support tickets table and on the ticket scene revealed its absolute due date through the native browser `title` attribute. Native tooltips are slow to appear on hover (fixed browser delay) and can't be styled to match the rest of the product.

## Changes

`SlaDisplay` now renders through `TZLabel` — the built-in datetime component already used by the Created and Updated columns in this same tickets table. On hover it shows a styled popover with the SLA due time converted across device / project / UTC timezones (each copyable), instead of the plain native tooltip. The relative countdown text and the urgency color coding (danger / warning / success) carry over via `className`. Because `SlaDisplay` is the shared component behind both the tickets table SLA column and the ticket scene, both surfaces get it.

## How did you test this code?

Change is a small, self-contained swap to the existing `TZLabel` component, matching the pattern already used by the sibling date columns in `ticketColumns.tsx`. I (the agent) worked from a sparse checkout and did not run the frontend toolchain or manual UI testing in this environment. There are no existing tests for `SlaDisplay`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: replace the slow native SLA tooltip with a real one. Located the shared `SlaDisplay` component (used by the tickets table column and ticket scene). Started with the lemon-ui `Tooltip`, then switched to `TZLabel` for consistency with the Created/Updated columns in the same table — it gives a richer, timezone-aware, copyable datetime popover for free while preserving the SLA urgency coloring.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1785319942055349)*
