### PR TITLE
fix(max): Compact at 400k w/ Sonnet instead of 100k w/ Haiku

### DIFF
--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
@@ -107,8 +107,10 @@ class TicketCommand(SlashCommand):
 
     def _get_model(self) -> MaxChatAnthropic:
         # We are not billing for conversation summary since we would be billing per-ticket creation.
+        # Needs a 1M-context model because this summarizes the whole conversation window, which can
+        # hold up to CONVERSATION_WINDOW_SIZE tokens.
         return MaxChatAnthropic(
-            model="claude-haiku-4-5",
+            model="claude-sonnet-5",
             streaming=True,
             stream_usage=True,
             user=self._user,

--- a/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
+++ b/ee/hogai/chat_agent/slash_commands/commands/ticket/command.py
@@ -116,6 +116,9 @@ class TicketCommand(SlashCommand):
             user=self._user,
             team=self._team,
             max_tokens=2048,
+            # Sonnet 5 thinks by default and `max_tokens` covers thinking plus response together,
+            # so leaving it on would let thinking eat the summary's budget.
+            thinking={"type": "disabled"},
             billable=False,
         )
 

--- a/ee/hogai/chat_agent/test/test_chat_agent.py
+++ b/ee/hogai/chat_agent/test/test_chat_agent.py
@@ -1706,7 +1706,7 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                 ),
             ]
         )
-        mock_tool.return_value = ("Event list" * 128000, None)
+        mock_tool.return_value = ("Event list" * 200000, None)
         mock_should_compact.side_effect = cycle([False, True])  # Also changed this
 
         graph = (
@@ -1726,7 +1726,7 @@ class TestChatAgent(ClickhouseTestMixin, BaseAssistantTest):
                     tool_calls=[{"id": "1", "name": "read_taxonomy", "args": {"query": {"kind": "events"}}}],
                 ),
             ),
-            ("message", AssistantToolCallMessage(tool_call_id="1", content="Event list" * 128000)),
+            ("message", AssistantToolCallMessage(tool_call_id="1", content="Event list" * 200000)),
             ("message", HumanMessage(content="First")),  # Should copy this message
             ("message", AssistantMessage(content="After summary")),
         ]

--- a/ee/hogai/context/context.py
+++ b/ee/hogai/context/context.py
@@ -59,7 +59,7 @@ from .prompts import (
 NOTEBOOK_MARKDOWN_MAX_LENGTH = 100_000
 
 # A dashboard's executed-results context is bounded so it can't overflow the conversation window
-# (compaction_manager.CONVERSATION_WINDOW_SIZE = 100k). If it overflows, the whole conversation —
+# (compaction_manager.CONVERSATION_WINDOW_SIZE). If it overflows, the whole conversation —
 # including this dashboard — gets summarized down to a few thousand tokens, so Max loses the
 # dashboard it was just asked about. Over budget, we fall back to schema-only (insight names +
 # queries, no result tables), which still lets Max identify and describe the dashboard and fetch

--- a/ee/hogai/core/agent_modes/compaction_manager.py
+++ b/ee/hogai/core/agent_modes/compaction_manager.py
@@ -49,9 +49,14 @@ class ConversationCompactionManager(ABC):
     Manages conversation window boundaries, message filtering, and summarization decisions.
     """
 
-    CONVERSATION_WINDOW_SIZE = 100_000
+    CONVERSATION_WINDOW_SIZE = 400_000
     """
     Determines the maximum number of tokens allowed in the conversation window.
+
+    Compaction blocks the user's turn for the length of a full summarization call, so this is set
+    well below the 1M context both the root model and the summarizer support: the cost of carrying
+    a larger window on every turn is mostly cache reads, while the cost of compacting is dead time
+    the user watches. Raising this trades per-turn input tokens for far fewer compactions.
     """
     APPROXIMATE_TOKEN_LENGTH = 4
     """

--- a/ee/hogai/core/agent_modes/compaction_manager.py
+++ b/ee/hogai/core/agent_modes/compaction_manager.py
@@ -58,10 +58,25 @@ class ConversationCompactionManager(ABC):
     a larger window on every turn is mostly cache reads, while the cost of compacting is dead time
     the user watches. Raising this trades per-turn input tokens for far fewer compactions.
     """
+    MODEL_CONVERSATION_WINDOW_SIZES: dict[str, int] = {
+        # Sonnet 4.5 has a 200k context window and we do not send the 1M beta header, so the
+        # default window would not fit. Exceeding it is unrecoverable rather than merely slow:
+        # `calculate_token_count` measures against this same model, so once a conversation is over
+        # the limit we can no longer size it, and compaction never gets the chance to bring it back
+        # down. This keeps the pre-400k threshold for that path.
+        "claude-sonnet-4-5": 100_000,
+    }
+    """
+    Per-model overrides for models whose context window cannot fit CONVERSATION_WINDOW_SIZE.
+    """
     APPROXIMATE_TOKEN_LENGTH = 4
     """
     Determines the approximate number of characters per token.
     """
+
+    def get_window_size(self, model_name: str) -> int:
+        """Token budget the conversation window may occupy before it must be compacted."""
+        return self.MODEL_CONVERSATION_WINDOW_SIZES.get(model_name, self.CONVERSATION_WINDOW_SIZE)
 
     def find_window_boundary(self, messages: Sequence[T], max_messages: int = 10, max_tokens: int = 1000) -> str | None:
         """
@@ -101,7 +116,9 @@ class ConversationCompactionManager(ABC):
         Determine if the conversation should be summarized based on token count.
         Avoids summarizing if there are only two human messages or fewer.
         """
-        return await self.calculate_token_count(model, messages, tools, **kwargs) > self.CONVERSATION_WINDOW_SIZE
+        return await self.calculate_token_count(model, messages, tools, **kwargs) > self.get_window_size(
+            getattr(model, "model", "")
+        )
 
     async def calculate_token_count(
         self, model: BaseChatModel, messages: list[BaseMessage], tools: LangchainTools | None = None, **kwargs

--- a/ee/hogai/core/agent_modes/compaction_manager.py
+++ b/ee/hogai/core/agent_modes/compaction_manager.py
@@ -58,25 +58,10 @@ class ConversationCompactionManager(ABC):
     a larger window on every turn is mostly cache reads, while the cost of compacting is dead time
     the user watches. Raising this trades per-turn input tokens for far fewer compactions.
     """
-    MODEL_CONVERSATION_WINDOW_SIZES: dict[str, int] = {
-        # Sonnet 4.5 has a 200k context window and we do not send the 1M beta header, so the
-        # default window would not fit. Exceeding it is unrecoverable rather than merely slow:
-        # `calculate_token_count` measures against this same model, so once a conversation is over
-        # the limit we can no longer size it, and compaction never gets the chance to bring it back
-        # down. This keeps the pre-400k threshold for that path.
-        "claude-sonnet-4-5": 100_000,
-    }
-    """
-    Per-model overrides for models whose context window cannot fit CONVERSATION_WINDOW_SIZE.
-    """
     APPROXIMATE_TOKEN_LENGTH = 4
     """
     Determines the approximate number of characters per token.
     """
-
-    def get_window_size(self, model_name: str) -> int:
-        """Token budget the conversation window may occupy before it must be compacted."""
-        return self.MODEL_CONVERSATION_WINDOW_SIZES.get(model_name, self.CONVERSATION_WINDOW_SIZE)
 
     def find_window_boundary(self, messages: Sequence[T], max_messages: int = 10, max_tokens: int = 1000) -> str | None:
         """
@@ -116,9 +101,7 @@ class ConversationCompactionManager(ABC):
         Determine if the conversation should be summarized based on token count.
         Avoids summarizing if there are only two human messages or fewer.
         """
-        return await self.calculate_token_count(model, messages, tools, **kwargs) > self.get_window_size(
-            getattr(model, "model", "")
-        )
+        return await self.calculate_token_count(model, messages, tools, **kwargs) > self.CONVERSATION_WINDOW_SIZE
 
     async def calculate_token_count(
         self, model: BaseChatModel, messages: list[BaseMessage], tools: LangchainTools | None = None, **kwargs

--- a/ee/hogai/core/agent_modes/executables.py
+++ b/ee/hogai/core/agent_modes/executables.py
@@ -155,7 +155,7 @@ class AgentExecutable(BaseAgentLoopRootExecutable):
         current_token_count = await self._window_manager.calculate_token_count(
             model, langchain_messages, tools=tools, thinking_config=self.THINKING_CONFIG
         )
-        if current_token_count > self._window_manager.CONVERSATION_WINDOW_SIZE:
+        if current_token_count > self._window_manager.get_window_size(self._get_model_name(state)):
             # Exclude the last message if it's the first turn.
             messages_to_summarize = langchain_messages[:-1] if self._is_first_turn(state) else langchain_messages
             summary = await AnthropicConversationSummarizer(
@@ -270,10 +270,15 @@ class AgentExecutable(BaseAgentLoopRootExecutable):
             "supermode": supermode_value,
         }
 
-    def _get_model(self, state: AssistantState, tools: list["MaxTool"]):
-        model_name = "claude-sonnet-4-6"
+    def _get_model_name(self, state: AssistantState) -> str:
+        """Model this executable will run on. Also decides the conversation window budget, so the
+        two can never disagree about which context limit applies."""
         if self._has_legacy_summarize_sessions_messages(state.messages):
-            model_name = "claude-sonnet-4-5"
+            return "claude-sonnet-4-5"
+        return "claude-sonnet-4-6"
+
+    def _get_model(self, state: AssistantState, tools: list["MaxTool"]):
+        model_name = self._get_model_name(state)
 
         is_sonnet_4_5 = model_name == "claude-sonnet-4-5"
 

--- a/ee/hogai/core/agent_modes/executables.py
+++ b/ee/hogai/core/agent_modes/executables.py
@@ -161,7 +161,7 @@ class AgentExecutable(BaseAgentLoopRootExecutable):
             summary = await AnthropicConversationSummarizer(
                 self._team,
                 self._user,
-                extend_context_window=current_token_count > 195_000,
+                conversation_start_dt=state.start_dt,
             ).summarize(messages_to_summarize)
 
             summary_message = ContextMessage(

--- a/ee/hogai/core/agent_modes/executables.py
+++ b/ee/hogai/core/agent_modes/executables.py
@@ -155,7 +155,7 @@ class AgentExecutable(BaseAgentLoopRootExecutable):
         current_token_count = await self._window_manager.calculate_token_count(
             model, langchain_messages, tools=tools, thinking_config=self.THINKING_CONFIG
         )
-        if current_token_count > self._window_manager.get_window_size(self._get_model_name(state)):
+        if current_token_count > self._window_manager.CONVERSATION_WINDOW_SIZE:
             # Exclude the last message if it's the first turn.
             messages_to_summarize = langchain_messages[:-1] if self._is_first_turn(state) else langchain_messages
             summary = await AnthropicConversationSummarizer(
@@ -270,23 +270,12 @@ class AgentExecutable(BaseAgentLoopRootExecutable):
             "supermode": supermode_value,
         }
 
-    def _get_model_name(self, state: AssistantState) -> str:
-        """Model this executable will run on. Also decides the conversation window budget, so the
-        two can never disagree about which context limit applies."""
-        if self._has_legacy_summarize_sessions_messages(state.messages):
-            return "claude-sonnet-4-5"
-        return "claude-sonnet-4-6"
-
     def _get_model(self, state: AssistantState, tools: list["MaxTool"]):
-        model_name = self._get_model_name(state)
-
-        is_sonnet_4_5 = model_name == "claude-sonnet-4-5"
-
         gateway_kwargs = self._get_gateway_kwargs()
         is_routing_through_llm_gateway = bool(gateway_kwargs)
 
         base_model = MaxChatAnthropic(
-            model=model_name,
+            model="claude-sonnet-4-6",
             streaming=True,
             stream_usage=True,
             user=self._user,
@@ -295,11 +284,11 @@ class AgentExecutable(BaseAgentLoopRootExecutable):
                 "interleaved-thinking-2025-05-14",
                 "fine-grained-tool-streaming-2025-05-14",
             ],
-            max_tokens=8192 if is_sonnet_4_5 else 16384,
-            thinking=self.THINKING_CONFIG if not is_sonnet_4_5 else {"type": "enabled", "budget_tokens": 1024},
+            max_tokens=16384,
+            thinking=self.THINKING_CONFIG,
             # langchain-anthropic 0.3.x doesn't have a first-class effort field;
             # forward it via model_kwargs so the Anthropic API receives output_config.
-            model_kwargs={"output_config": {"effort": "medium"}} if not is_sonnet_4_5 else {},
+            model_kwargs={"output_config": {"effort": "medium"}},
             conversation_start_dt=state.start_dt,
             billable=True,
             bypass_proxy=is_routing_through_llm_gateway,
@@ -388,28 +377,6 @@ class AgentExecutable(BaseAgentLoopRootExecutable):
     def _process_output_message(self, message: LangchainAIMessage) -> list[AssistantMessage]:
         """Process the output message."""
         return normalize_ai_message(message)
-
-    @staticmethod
-    def _has_legacy_summarize_sessions_messages(messages: Sequence[AssistantMessageUnion]) -> bool:
-        """Detect pre-migration summarize_sessions AssistantMessages with meta.form.
-
-        Before the migration, summarize_sessions returned a ToolMessagesArtifact containing
-        an AssistantMessage with meta.form (the "Open report" button). This AssistantMessage
-        converts to a trailing AIMessage, causing a prefill error with Sonnet 4.6.
-        Sonnet 4.5 handles this gracefully, so we fall back to it for legacy conversations.
-        """
-        for message in messages:
-            if (
-                isinstance(message, AssistantMessage)
-                and message.meta
-                and message.meta.form
-                and any(
-                    option.href and option.href.startswith("/session-summaries/")
-                    for option in message.meta.form.options
-                )
-            ):
-                return True
-        return False
 
 
 class AgentToolsExecutable(BaseAgentLoopExecutable):

--- a/ee/hogai/core/agent_modes/test/test_compaction_manager.py
+++ b/ee/hogai/core/agent_modes/test/test_compaction_manager.py
@@ -122,11 +122,11 @@ class TestAnthropicConversationCompactionManager(BaseTest):
     @parameterized.expand(
         [
             # (num_human_messages, token_count, should_compact)
-            [1, 90000, False],  # Only 1 human message, under limit
-            [2, 90000, False],  # Only 2 human messages, under limit
-            [3, 80000, False],  # 3 human messages but under token limit
-            [3, 110000, True],  # 3 human messages and over token limit
-            [5, 110000, True],  # Many messages over limit
+            [1, 390000, False],  # Only 1 human message, under limit
+            [2, 390000, False],  # Only 2 human messages, under limit
+            [3, 380000, False],  # 3 human messages but under token limit
+            [3, 410000, True],  # 3 human messages and over token limit
+            [5, 410000, True],  # Many messages over limit
         ]
     )
     async def test_should_compact_conversation(self, num_human_messages, token_count, should_compact):
@@ -163,23 +163,23 @@ class TestAnthropicConversationCompactionManager(BaseTest):
         # With 2 human messages, should use estimation and not call _get_token_count
         result = await self.window_manager.should_compact_conversation(mock_model, messages, tools=tools)
 
-        # Total should be well under 100k limit
+        # Total should be well under the window limit
         self.assertFalse(result)
 
     async def test_should_compact_conversation_with_tools_over_limit(self):
         """Test that tools push estimation over limit with 2 or fewer human messages"""
+        # Together these sit just under CONVERSATION_WINDOW_SIZE, so only the tool schemas can tip
+        # the estimate over it.
         messages: list[BaseMessage] = [
-            LangchainHumanMessage(content="A" * 200000),  # ~50k tokens
-            LangchainAIMessage(content="B" * 200000),  # ~50k tokens
+            LangchainHumanMessage(content="A" * 780000),  # ~195k tokens
+            LangchainAIMessage(content="B" * 780000),  # ~195k tokens
         ]
 
-        # Create large tool schemas to push over 100k limit
         tools = [{"type": "function", "function": {"name": f"tool_{i}", "description": "X" * 1000}} for i in range(100)]
 
         mock_model = MagicMock()
         result = await self.window_manager.should_compact_conversation(mock_model, messages, tools=tools)
 
-        # Should be over the 100k limit
         self.assertTrue(result)
 
     def test_get_estimated_assistant_message_tokens_human_message(self):

--- a/ee/hogai/core/agent_modes/test/test_executables.py
+++ b/ee/hogai/core/agent_modes/test/test_executables.py
@@ -333,8 +333,8 @@ class TestAgentNode(ClickhouseTestMixin, BaseTest):
     @patch("ee.hogai.utils.conversation_summarizer.AnthropicConversationSummarizer.summarize")
     async def test_conversation_summarization_flow(self, mock_summarize, mock_calculate_tokens, mock_model):
         """Test that conversation is summarized when it gets too long"""
-        # Return a token count higher than CONVERSATION_WINDOW_SIZE (100,000)
-        mock_calculate_tokens.return_value = 150_000
+        # Return a token count higher than CONVERSATION_WINDOW_SIZE
+        mock_calculate_tokens.return_value = 450_000
         mock_summarize.return_value = "This is a summary of the conversation so far."
 
         mock_model_instance = FakeChatOpenAI(responses=[LangchainAIMessage(content="Response after summary")])
@@ -369,8 +369,8 @@ class TestAgentNode(ClickhouseTestMixin, BaseTest):
     @patch("ee.hogai.utils.conversation_summarizer.AnthropicConversationSummarizer.summarize")
     async def test_conversation_summarization_on_first_turn(self, mock_summarize, mock_calculate_tokens, mock_model):
         """Test that on first turn, the last message is excluded from summarization"""
-        # Return a token count higher than CONVERSATION_WINDOW_SIZE (100,000)
-        mock_calculate_tokens.return_value = 150_000
+        # Return a token count higher than CONVERSATION_WINDOW_SIZE
+        mock_calculate_tokens.return_value = 450_000
         mock_summarize.return_value = "Summary without last message"
 
         mock_model_instance = FakeChatOpenAI(responses=[LangchainAIMessage(content="Response")])
@@ -401,7 +401,7 @@ class TestAgentNode(ClickhouseTestMixin, BaseTest):
         self, mock_summarize, mock_calculate_tokens, mock_model
     ):
         """Test that mode reminder is inserted after summary when modes feature flag is enabled"""
-        mock_calculate_tokens.return_value = 150_000
+        mock_calculate_tokens.return_value = 450_000
         mock_summarize.return_value = "Summary of conversation"
 
         mock_model_instance = FakeChatOpenAI(responses=[LangchainAIMessage(content="Response")])
@@ -658,7 +658,7 @@ class TestAgentNode(ClickhouseTestMixin, BaseTest):
         from ee.hogai.utils.types.base import ReplaceMessages
 
         # Trigger summarization flow which returns ReplaceMessages
-        mock_calculate_tokens.return_value = 150_000
+        mock_calculate_tokens.return_value = 450_000
         mock_summarize.return_value = "Conversation summary"
         mock_model.return_value = FakeChatOpenAI(responses=[LangchainAIMessage(content="Response")])
 

--- a/ee/hogai/core/agent_modes/test/test_executables.py
+++ b/ee/hogai/core/agent_modes/test/test_executables.py
@@ -10,7 +10,10 @@ from parameterized import parameterized
 
 from posthog.schema import (
     AgentMode,
+    AssistantForm,
+    AssistantFormOption,
     AssistantMessage,
+    AssistantMessageMetadata,
     AssistantToolCall,
     AssistantToolCallMessage,
     ContextMessage,
@@ -361,6 +364,58 @@ class TestAgentNode(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(context_messages), 2)  # summary + mode reminder
         summary_msg = next(msg for msg in context_messages if "This is a summary" in msg.content)
         self.assertIn("This is a summary of the conversation so far.", summary_msg.content)
+
+    @parameterized.expand(
+        [
+            # (has_legacy_session_summary_message, expected_model, should_compact_at_150k)
+            [False, "claude-sonnet-4-6", False],
+            [True, "claude-sonnet-4-5", True],
+        ]
+    )
+    @patch(
+        "ee.hogai.core.agent_modes.executables.AgentExecutable._get_model", return_value=FakeChatOpenAI(responses=[])
+    )
+    @patch("ee.hogai.core.agent_modes.compaction_manager.AnthropicConversationCompactionManager.calculate_token_count")
+    @patch("ee.hogai.utils.conversation_summarizer.AnthropicConversationSummarizer.summarize")
+    async def test_legacy_model_compacts_within_its_smaller_context_window(
+        self,
+        has_legacy_message,
+        expected_model,
+        should_compact,
+        mock_summarize,
+        mock_calculate_tokens,
+        mock_model,
+    ):
+        mock_calculate_tokens.return_value = 150_000
+        mock_summarize.return_value = "Summary"
+        mock_model.return_value = FakeChatOpenAI(responses=[LangchainAIMessage(content="Response")])
+
+        messages: list = [
+            HumanMessage(content="First message", id="1"),
+            AssistantMessage(content="First response", id="2"),
+            HumanMessage(content="Second message", id="3"),
+        ]
+        if has_legacy_message:
+            messages.insert(
+                1,
+                AssistantMessage(
+                    content="Here's your report",
+                    id="legacy",
+                    meta=AssistantMessageMetadata(
+                        form=AssistantForm(
+                            options=[AssistantFormOption(value="Open report", href="/session-summaries/abc")]
+                        )
+                    ),
+                ),
+            )
+
+        node = _create_agent_node(self.team, self.user)
+        state = AssistantState(messages=messages)
+
+        self.assertEqual(node._get_model_name(state), expected_model)
+
+        await node.arun(state, {})
+        self.assertEqual(mock_summarize.called, should_compact)
 
     @patch(
         "ee.hogai.core.agent_modes.executables.AgentExecutable._get_model", return_value=FakeChatOpenAI(responses=[])

--- a/ee/hogai/core/agent_modes/test/test_executables.py
+++ b/ee/hogai/core/agent_modes/test/test_executables.py
@@ -10,10 +10,7 @@ from parameterized import parameterized
 
 from posthog.schema import (
     AgentMode,
-    AssistantForm,
-    AssistantFormOption,
     AssistantMessage,
-    AssistantMessageMetadata,
     AssistantToolCall,
     AssistantToolCallMessage,
     ContextMessage,
@@ -364,58 +361,6 @@ class TestAgentNode(ClickhouseTestMixin, BaseTest):
         self.assertEqual(len(context_messages), 2)  # summary + mode reminder
         summary_msg = next(msg for msg in context_messages if "This is a summary" in msg.content)
         self.assertIn("This is a summary of the conversation so far.", summary_msg.content)
-
-    @parameterized.expand(
-        [
-            # (has_legacy_session_summary_message, expected_model, should_compact_at_150k)
-            [False, "claude-sonnet-4-6", False],
-            [True, "claude-sonnet-4-5", True],
-        ]
-    )
-    @patch(
-        "ee.hogai.core.agent_modes.executables.AgentExecutable._get_model", return_value=FakeChatOpenAI(responses=[])
-    )
-    @patch("ee.hogai.core.agent_modes.compaction_manager.AnthropicConversationCompactionManager.calculate_token_count")
-    @patch("ee.hogai.utils.conversation_summarizer.AnthropicConversationSummarizer.summarize")
-    async def test_legacy_model_compacts_within_its_smaller_context_window(
-        self,
-        has_legacy_message,
-        expected_model,
-        should_compact,
-        mock_summarize,
-        mock_calculate_tokens,
-        mock_model,
-    ):
-        mock_calculate_tokens.return_value = 150_000
-        mock_summarize.return_value = "Summary"
-        mock_model.return_value = FakeChatOpenAI(responses=[LangchainAIMessage(content="Response")])
-
-        messages: list = [
-            HumanMessage(content="First message", id="1"),
-            AssistantMessage(content="First response", id="2"),
-            HumanMessage(content="Second message", id="3"),
-        ]
-        if has_legacy_message:
-            messages.insert(
-                1,
-                AssistantMessage(
-                    content="Here's your report",
-                    id="legacy",
-                    meta=AssistantMessageMetadata(
-                        form=AssistantForm(
-                            options=[AssistantFormOption(value="Open report", href="/session-summaries/abc")]
-                        )
-                    ),
-                ),
-            )
-
-        node = _create_agent_node(self.team, self.user)
-        state = AssistantState(messages=messages)
-
-        self.assertEqual(node._get_model_name(state), expected_model)
-
-        await node.arun(state, {})
-        self.assertEqual(mock_summarize.called, should_compact)
 
     @patch(
         "ee.hogai.core.agent_modes.executables.AgentExecutable._get_model", return_value=FakeChatOpenAI(responses=[])

--- a/ee/hogai/research_agent/executables.py
+++ b/ee/hogai/research_agent/executables.py
@@ -22,12 +22,12 @@ class ResearchAgentExecutable(PlanModeExecutable):
     THINKING_CONFIG = {"type": "enabled", "budget_tokens": 4096}
     MAX_TOKENS = 16_384
 
-    def _get_model(self, state: AssistantState, tools: list["MaxTool"]):
-        is_research_mode = state.supermode == AgentMode.RESEARCH
-        model_name = "claude-opus-4-6" if is_research_mode else "claude-sonnet-4-6"
+    def _get_model_name(self, state: AssistantState) -> str:
+        return "claude-opus-4-6" if state.supermode == AgentMode.RESEARCH else "claude-sonnet-4-6"
 
+    def _get_model(self, state: AssistantState, tools: list["MaxTool"]):
         base_model = MaxChatAnthropic(
-            model=model_name,
+            model=self._get_model_name(state),
             streaming=True,
             stream_usage=True,
             user=self._user,

--- a/ee/hogai/utils/anthropic.py
+++ b/ee/hogai/utils/anthropic.py
@@ -128,4 +128,26 @@ def convert_to_anthropic_messages(
             history.extend(convert_to_anthropic_message(message, tool_result_map))
         except ValueError:
             continue
-    return history
+    return drop_trailing_assistant_messages(history)
+
+
+def drop_trailing_assistant_messages(history: list[messages.BaseMessage]) -> list[messages.BaseMessage]:
+    """Drop assistant messages the conversation ends on, so we never prefill.
+
+    Anthropic reads a trailing assistant turn as content to continue from, which Sonnet 4.6 and
+    later reject outright. A conversation can end on one when a tool appended its own assistant
+    message after the tool result, which the pre-migration `summarize_sessions` did to render its
+    "Open report" button.
+
+    Assistant messages carrying tool calls are left in place: dropping one would orphan the tool
+    result that follows it, which Anthropic rejects too.
+    """
+    end = len(history)
+    while end > 0:
+        message = history[end - 1]
+        if not isinstance(message, messages.AIMessage) or message.tool_calls:
+            break
+        end -= 1
+    # A history that is nothing but assistant messages has no valid prefix to send, so leave it
+    # alone and let the caller's own validation report it.
+    return history[:end] if end > 0 else history

--- a/ee/hogai/utils/conversation_summarizer/summarizer.py
+++ b/ee/hogai/utils/conversation_summarizer/summarizer.py
@@ -1,4 +1,5 @@
 import re
+import datetime
 from abc import abstractmethod
 from collections.abc import Sequence
 
@@ -14,9 +15,10 @@ from .prompts import SYSTEM_PROMPT, USER_PROMPT
 
 
 class ConversationSummarizer:
-    def __init__(self, team: Team, user: User):
+    def __init__(self, team: Team, user: User, conversation_start_dt: datetime.datetime | None = None):
         self._user = user
         self._team = team
+        self._conversation_start_dt = conversation_start_dt
 
     async def summarize(self, messages: Sequence[BaseMessage]) -> str:
         prompt = self._construct_messages(messages)
@@ -56,18 +58,23 @@ class ConversationSummarizer:
 
 
 class AnthropicConversationSummarizer(ConversationSummarizer):
-    def __init__(self, team: Team, user: User, extend_context_window: bool | None = False):
-        super().__init__(team, user)
-        self._extend_context_window = extend_context_window
-
     def _get_model(self):
-        # Haiku has 200k token limit. Sonnet has 1M token limit (GA on claude-sonnet-4-6).
         return MaxChatAnthropic(
-            model="claude-sonnet-4-6" if self._extend_context_window else "claude-haiku-4-5",
+            # Sonnet 5 has a 1M token limit, so it can compact a conversation of any size we let
+            # grow. Haiku's 200k limit no longer covers CONVERSATION_WINDOW_SIZE.
+            model="claude-sonnet-5",
             streaming=False,
             stream_usage=False,
-            max_tokens=8192,
+            max_tokens=16384,
             disable_streaming=True,
+            # Sonnet 5 thinks by default, and `max_tokens` caps thinking plus response text
+            # together. A thinking overrun here would truncate the summary, which silently drops
+            # the conversation history it is supposed to preserve. The prompt already asks for an
+            # explicit `<analysis>` pass before `<summary>`, so the reasoning happens either way.
+            thinking={"type": "disabled"},
+            # Without this, `MaxChatMixin._get_project_org_user_variables` stamps the current
+            # wall-clock second into the injected context message.
+            conversation_start_dt=self._conversation_start_dt,
             user=self._user,
             team=self._team,
             billable=True,

--- a/ee/hogai/utils/test/test_anthropic.py
+++ b/ee/hogai/utils/test/test_anthropic.py
@@ -1,13 +1,22 @@
 from posthog.test.base import BaseTest
 
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from parameterized import parameterized
 
-from posthog.schema import AssistantMessage, AssistantMessageMetadata
+from posthog.schema import (
+    AssistantForm,
+    AssistantFormOption,
+    AssistantMessage,
+    AssistantMessageMetadata,
+    AssistantToolCall,
+    AssistantToolCallMessage,
+    HumanMessage as SchemaHumanMessage,
+)
 
 from ee.hogai.utils.anthropic import (
     add_cache_control,
     convert_assistant_message_to_anthropic_message,
+    convert_to_anthropic_messages,
     get_anthropic_thinking_from_assistant_message,
 )
 
@@ -141,3 +150,49 @@ class TestAnthropicUtils(BaseTest):
             self.assertIn("deterministic PostHog code", provenance_text)
         else:
             self.assertEqual(len(result), 1)
+
+    @parameterized.expand(
+        [
+            # Legacy summarize_sessions appended its "Open report" message after the tool result,
+            # leaving the conversation on an assistant turn.
+            ["legacy_form_message_last", True, 1],
+            ["human_message_last", False, 3],
+        ]
+    )
+    def test_conversation_never_ends_on_an_assistant_turn(self, _name, ends_with_assistant, expected_length):
+        conversation: list = [
+            SchemaHumanMessage(content="Summarize my sessions"),
+            AssistantMessage(
+                content="Report complete: Sessions summary",
+                id="report",
+                meta=AssistantMessageMetadata(
+                    form=AssistantForm(
+                        options=[AssistantFormOption(value="Open report", href="/session-summaries/abc")]
+                    )
+                ),
+            ),
+        ]
+        if not ends_with_assistant:
+            conversation.append(SchemaHumanMessage(content="Thanks"))
+
+        result = convert_to_anthropic_messages(conversation, {})
+
+        self.assertEqual(len(result), expected_length)
+        self.assertNotIsInstance(result[-1], AIMessage)
+
+    def test_assistant_message_with_tool_calls_is_not_dropped(self):
+        conversation: list = [
+            SchemaHumanMessage(content="Run it"),
+            AssistantMessage(
+                content="Running",
+                id="call",
+                tool_calls=[AssistantToolCall(id="t1", name="read_data", args={})],
+            ),
+        ]
+        tool_results = {"t1": AssistantToolCallMessage(content="done", tool_call_id="t1", id="result")}
+
+        result = convert_to_anthropic_messages(conversation, tool_results)
+
+        # The assistant turn stays because dropping it would orphan its tool result, which follows it.
+        self.assertIsInstance(result[1], AIMessage)
+        self.assertEqual(len(result), 3)


### PR DESCRIPTION
## Problem

A customer reported PostHog AI feeling slow on a dashboard-heavy session ([ticket](https://us.posthog.com/project/2/support/tickets/64736?status=%5B%22new%22,%22open%22,%22on_hold%22%5D)).

AI observability logs indicate something quite off:
Conversation compaction was firing constantly. `CONVERSATION_WINDOW_SIZE` is 100k tokens, so any session with a few large tool results crossed it. And summarization was taking 45s p50 and 85s p95.

## Changes

Upping `CONVERSATION_WINDOW_SIZE` from 100k to 400k. It's so 2025 to limit to a measly 100k. Both the root model and the summarizer have 1M context at this point. And prompt caching checkpoints that make this sensible.
For this, the summarizer has to be Sonnet instead of the ancient Haiku 4.5.

Also asked Claude to do a sweep of every LLM call site reachable from `AssistantState` for ones that can't fit the 400k window. Turned up two spots:

1. The root node fell back to `claude-sonnet-4-5` for any conversation containing a pre-migration `summarize_sessions` message (`_has_legacy_summarize_sessions_messages`).
2. The `/ticket` slash command summarized the whole conversation window on Haiku 4.5, another 200k model, so it's now Sonnet 5.

## How did you test this code?

Had Claude run a bunch of tests on various cases ad-hoc to ensure everything works (ad-hoc as our tests in general don't run LLM calls).
New `test_legacy_model_compacts_within_its_smaller_context_window` catches removal of the per-model override, which would send a legacy Sonnet 4.5 conversation past 200k.

