### PR TITLE
feat(tasks): add task pin table

### DIFF
--- a/.semgrep/rules/security/idor-team-scoped-models.yaml
+++ b/.semgrep/rules/security/idor-team-scoped-models.yaml
@@ -902,6 +902,7 @@ rules:
                               |PersonalAPIKey
                               |ScoreDefinitionVersion
                               |SignalUserAutonomyConfig
+                              |TaskPin
                               |UserPushToken
                               |WebauthnCredential
                           )$
@@ -956,6 +957,7 @@ rules:
                         |PersonalAPIKey
                         |ScoreDefinitionVersion
                         |SignalUserAutonomyConfig
+                        |TaskPin
                         |UserPushToken
                         |WebauthnCredential
                     )$

--- a/products/tasks/backend/migrations/0075_task_pin.py
+++ b/products/tasks/backend/migrations/0075_task_pin.py
@@ -1,0 +1,40 @@
+import django.utils.timezone
+import django.db.models.deletion
+from django.db import migrations, models
+
+import posthog.uuidt
+
+
+class Migration(migrations.Migration):
+    dependencies = [("tasks", "0074_task_session")]
+
+    operations = [
+        migrations.CreateModel(
+            name="TaskPin",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(default=posthog.uuidt.uuid7, editable=False, primary_key=True, serialize=False),
+                ),
+                ("pinned_at", models.DateTimeField(default=django.utils.timezone.now)),
+                (
+                    "task",
+                    models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="+", to="tasks.task"),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        db_constraint=False,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="+",
+                        to="posthog.user",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "posthog_task_pin",
+                "indexes": [models.Index(fields=["user", "-pinned_at"], name="task_pin_user_pinned_idx")],
+                "constraints": [models.UniqueConstraint(fields=("user", "task"), name="task_pin_user_task_unique")],
+            },
+        ),
+    ]

--- a/products/tasks/backend/migrations/max_migration.txt
+++ b/products/tasks/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0074_task_session
+0075_task_pin

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -1096,6 +1096,18 @@ class TaskActivity(TeamScopedRootMixin):
             )
 
 
+class TaskPin(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid7, editable=False)
+    user = models.ForeignKey("posthog.User", on_delete=models.CASCADE, related_name="+", db_constraint=False)
+    task = models.ForeignKey(Task, on_delete=models.CASCADE, related_name="+")
+    pinned_at = models.DateTimeField(default=django_timezone.now)
+
+    class Meta:
+        db_table = "posthog_task_pin"
+        constraints = [models.UniqueConstraint(fields=["user", "task"], name="task_pin_user_task_unique")]
+        indexes = [models.Index(fields=["user", "-pinned_at"], name="task_pin_user_pinned_idx")]
+
+
 @receiver(post_save, sender=Task)
 def project_task_created_activity(sender, instance: Task, created: bool, **kwargs) -> None:
     """Seed the creator's activity row. A signal rather than a facade call because tasks are


### PR DESCRIPTION
## Problem

PostHog Code needs a durable, user-scoped place to store task pins. The schema change is separated from the application code so it can deploy first.

**Why:** Pins should follow an authenticated user across devices and sessions.

## Changes

add the task pin table with team, user, and task ownership, a uniqueness constraint, and an index for newest-first user lookups

Followed by [PostHog/posthog#74595](https://github.com/PostHog/posthog/pull/74595).