### PR TITLE
fix(conversations): use TZLabel for snoozed-until clock in status column

### DIFF
--- a/products/conversations/frontend/scenes/tickets/ticketColumns.tsx
+++ b/products/conversations/frontend/scenes/tickets/ticketColumns.tsx
@@ -134,9 +134,11 @@ const TICKET_COLUMNS: Record<TicketColumnKey, TicketColumnDefinition> = {
                         {ticket.status === 'on_hold' ? 'On hold' : ticket.status}
                     </LemonTag>
                     {ticket.snoozed_until && (
-                        <span title={`Snoozed until ${new Date(ticket.snoozed_until).toLocaleString()}`}>
-                            <IconClock className="text-muted-alt text-base" />
-                        </span>
+                        <Tooltip title={`Snoozed until ${new Date(ticket.snoozed_until).toLocaleString()}`}>
+                            <span className="flex items-center">
+                                <IconClock className="text-muted-alt text-base" />
+                            </span>
+                        </Tooltip>
                     )}
                 </span>
             ),

--- a/products/conversations/frontend/scenes/tickets/ticketColumns.tsx
+++ b/products/conversations/frontend/scenes/tickets/ticketColumns.tsx
@@ -134,11 +134,11 @@ const TICKET_COLUMNS: Record<TicketColumnKey, TicketColumnDefinition> = {
                         {ticket.status === 'on_hold' ? 'On hold' : ticket.status}
                     </LemonTag>
                     {ticket.snoozed_until && (
-                        <Tooltip title={`Snoozed until ${new Date(ticket.snoozed_until).toLocaleString()}`}>
+                        <TZLabel time={ticket.snoozed_until} title="Snoozed until" showSeconds>
                             <span className="flex items-center">
                                 <IconClock className="text-muted-alt text-base" />
                             </span>
-                        </Tooltip>
+                        </TZLabel>
                     )}
                 </span>
             ),


### PR DESCRIPTION
## Problem

The snoozed-until clock icon in the tickets table status column revealed its snooze time through the native browser `title` attribute. Native tooltips are slow to appear on hover (fixed browser delay) and can't be styled, and the time was shown as a flat local-time string with no timezone context.

## Changes

Wrap the clock icon in `TZLabel` (using it as the trigger via `children`), the built-in datetime component already used elsewhere in this product. Hovering the clock now shows a styled popover with the snooze time converted across device / project / UTC (each copyable), under a "Snoozed until" header — the same timezone-aware treatment the SLA display gets in #74588.

<img width="846" height="498" alt="CleanShot 2026-07-29 at 12 01 23@2x" src="https://github.com/user-attachments/assets/acd59408-89fb-4841-9a23-0cf0b664ac2c" />


## How did you test this code?

Verified locally — hovering the clock icon opens the timezone-aware popover as expected (see screenshot above). Ran `oxfmt` on the file.

Implementation note: passing a custom `children` trigger to `TZLabel` has no precedent elsewhere in the repo (every other use lets it render its own time text), and in that path `TZLabel` does not forward its ref to the child — but the `LemonDropdown` hover wrapper attaches the trigger fine, confirmed by the local check above.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #74588, from the same Slack thread. First replaced the native `title` with a lemon-ui `Tooltip`, then — on request — switched to `TZLabel` so the snooze time is displayed timezone-aware, consistent with the SLA display. `TZLabel` accepts a `title` prop that labels the popover header, and a `children` prop used here to keep the clock icon as the hover trigger.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1785319942055349)*
