### PR TITLE
fix(workflows): stop the history tab crashing on masked actions

### DIFF
--- a/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.test.tsx
+++ b/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react'
+
+import { ActivityChange, ActivityLogItem } from 'lib/components/ActivityLog/humanizeActivity'
+
+import { ActivityScope } from '~/types'
+
+import { workflowActivityDescriber } from './workflowActivityDescriber'
+
+const getTextContent = (describer: { description: JSX.Element | string | null }): string => {
+    if (!describer.description || typeof describer.description === 'string') {
+        return (describer.description as string) || ''
+    }
+    const { container } = render(describer.description)
+    return container.textContent || ''
+}
+
+const workflowLogItem = (changes: ActivityChange[]): ActivityLogItem => ({
+    activity: 'updated',
+    created_at: '2026-07-29T10:00:00Z',
+    scope: 'HogFlow',
+    item_id: 'flow-uuid',
+    detail: { merge: null, trigger: null, changes, name: 'Welcome email' },
+})
+
+const change = (field: string, before: unknown, after: unknown): ActivityChange =>
+    ({ type: ActivityScope.HOG_FLOW, action: 'changed', field, before, after }) as ActivityChange
+
+describe('workflowActivityDescriber', () => {
+    // The backend masks `actions` because the graph can carry secret function inputs, so the log
+    // holds the string 'masked'. Mapping over that threw "itemsAfter.map is not a function" and
+    // took the whole History tab down with an error boundary.
+    it.each([
+        ['masked string', 'masked'],
+        ['object', {}],
+        ['number', 7],
+    ])('renders a plain line when an actions value is not an array (%s)', (_label, after) => {
+        const text = getTextContent(workflowActivityDescriber(workflowLogItem([change('actions', null, after)])))
+
+        expect(text).toContain('updated actions')
+    })
+
+    it('still diffs individual items when both sides really are arrays', () => {
+        const text = getTextContent(
+            workflowActivityDescriber(
+                workflowLogItem([
+                    change('actions', [{ id: 'a1', name: 'Send email' }], [{ id: 'a2', name: 'Send push' }]),
+                ])
+            )
+        )
+
+        expect(text).toContain('added action Send push')
+        expect(text).toContain('deleted action Send email')
+    })
+})

--- a/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.tsx
+++ b/products/workflows/frontend/Workflows/misc/workflowActivityDescriber.tsx
@@ -14,6 +14,16 @@ const nameOrLinkToWorkflow = (id?: string | null, name?: string | null): string 
 
 type ArrayChangeItem = { id?: string; key?: string; name?: string; label?: string }
 
+// Activity-log values are only diffable per item when they really are arrays. `actions` is masked
+// server-side (the graph can carry secret function inputs), so those entries hold the string
+// 'masked' rather than a list. Returns null for anything undiffable, so callers can fall back.
+function asItemArray(value: unknown): ArrayChangeItem[] | null {
+    if (value == null) {
+        return []
+    }
+    return Array.isArray(value) ? (value as ArrayChangeItem[]) : null
+}
+
 function processArrayChanges<T extends ArrayChangeItem>(
     itemsBefore: T[],
     itemsAfter: T[],
@@ -144,8 +154,12 @@ export function workflowActivityDescriber(logItem: ActivityLogItem, asNotificati
                     break
                 }
                 case 'actions': {
-                    const actionsBefore = (change.before as any[]) || []
-                    const actionsAfter = (change.after as any[]) || []
+                    const actionsBefore = asItemArray(change.before)
+                    const actionsAfter = asItemArray(change.after)
+                    if (!actionsBefore || !actionsAfter) {
+                        changes.push(<>updated {change.field}</>)
+                        break
+                    }
                     changes.push(
                         ...processArrayChanges(
                             actionsBefore,
@@ -158,8 +172,12 @@ export function workflowActivityDescriber(logItem: ActivityLogItem, asNotificati
                     break
                 }
                 case 'variables': {
-                    const variablesBefore = (change.before as any[]) || []
-                    const variablesAfter = (change.after as any[]) || []
+                    const variablesBefore = asItemArray(change.before)
+                    const variablesAfter = asItemArray(change.after)
+                    if (!variablesBefore || !variablesAfter) {
+                        changes.push(<>updated {change.field}</>)
+                        break
+                    }
                     changes.push(
                         ...processArrayChanges(
                             variablesBefore,


### PR DESCRIPTION
## Problem

Opening the History tab on a workflow throws and takes the whole tab down with an error boundary. Reported for a brand-new, never-sent workflow, which is the easiest way to hit it.

```
TypeError: itemsAfter.map is not a function
  at processArrayChanges → workflowActivityDescriber → humanize → humanizedActivity
```

`actions` was recently added to the activity-log mask list, because the action graph can carry secret function inputs like auth headers:

```python
"HogFlow": [
    "draft",
    "encrypted_inputs",
    "draft_encrypted_inputs",
    "actions",
],
```

So the log now stores the string `'masked'` where an array used to be. The describer was never updated and still assumed an array, behind a cast that lies about the type:

```tsx
const actionsAfter = (change.after as any[]) || []   // 'masked' is truthy, so it survives
```

`|| []` only catches null and undefined. A string sails through, and `new Map(itemsAfter.map(...))` throws. Any workflow whose first save produces an `actions` change hits it, so a new workflow reproduces immediately.

## Changes

Replaced the cast with a typed guard, applied to `actions` and `variables`:

```tsx
function asItemArray(value: unknown): ArrayChangeItem[] | null {
    if (value == null) {
        return []
    }
    return Array.isArray(value) ? (value as ArrayChangeItem[]) : null
}
```

Anything that isn't an array falls back to a plain "updated actions" line, matching how `trigger` and `edges` already read. Rows written before masking still hold real arrays, so their per-item diffs ("added action Send push") keep working.

`variables` isn't masked today, but it goes through the same code path and is one mask-list edit away from the same crash, so it gets the same guard.

Before:

![before](https://raw.githubusercontent.com/PostHog/pr-assets/aacad1d6be942d3d1a7e1af110ce56b1b0db348f/2026/07/44e08758-2a70-4cbc-90e2-2c644eec0208.png)

After:

![after](https://raw.githubusercontent.com/PostHog/pr-assets/f4633dbb856ee469318663d0195ce2bac14680e7/2026/07/3c0e5b8a-647b-4456-94fd-944259f03d5b.png)

## How did you test this code?

Reproduced it locally first. Created a workflow and saved actions into it, which produces an activity row with `field=actions before=None after='masked'`, then opened the History tab and got the same stack as the report (unminified: `processArrayChanges → workflowActivityDescriber → humanize → humanizedActivity`, matching the reported `ki → Ci → Ba → humanizedActivity`). After the fix the same page renders "updated trigger / updated edges / updated actions" with no console errors. Both screenshots above are from that local run.

Also checked the `published` activity path, which shares this code branch. There is no publish button in the UI yet (the endpoint exists but nothing calls it), and the flow is gated on the `workflows-revisions` flag, which cannot evaluate true locally because posthoganalytics is disabled in dev. So I bypassed only that flag check and let the real publish request write the activity row. It renders as "published the workflow: ... / updated billable_action_types / updated draft" with no errors. Worth noting `draft` is masked too, so it arrives as a string on the same path.

Added `workflowActivityDescriber.test.tsx`, which had no test file before. Four cases: three parameterized non-array shapes (`'masked'`, `{}`, a number) asserting a plain line is rendered, and one asserting real arrays still diff per item. I checked they earn their place by removing the guard and re-running: the three fail with the exact reported `itemsAfter.map is not a function`, while the array case still passes.

Lint and format clean on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, this is a crash fix with no change to documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I handed Claude the error text and the report that it happens on a new unsent workflow. It traced the `.map` to the describer, found the mask-list entry that changed the value's type, reproduced the crash locally against a real activity row rather than a hand-built fixture, then fixed and re-verified in the browser.

Skills invoked: `/writing-tests` before adding the test file, `/posthog-local-e2e-qa` for the local reproduction.

Decisions worth a look. The guard returns `null` for undiffable values instead of an empty array, so the caller can tell "no items" apart from "not diffable" and print the right line, rather than silently claiming nothing changed. I also considered fixing this server-side by keeping a redacted array shape instead of the `'masked'` string, but masking is deliberate and the frontend should not crash on a value shape it does not expect either way.

One adjacent thing I did not touch: `actions` and `edges` are declared `models.JSONField(default=dict)`, so a workflow with no actions stores `{}` rather than `[]`. That is not what caused this crash, but it is the same class of type confusion and the guard now covers it too.
