### PR TITLE
fix(data-imports): classify ActiveCampaign 402 as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/source.py
@@ -86,6 +86,9 @@ You can find both in your ActiveCampaign account under **Settings > Developer**.
             "401 Client Error": "Invalid ActiveCampaign credentials. Please check your API URL and key and reconnect.",
             "403 Client Error": "Access forbidden. Please check that your ActiveCampaign API key is valid and reconnect.",
             "Unauthorized for url": "Invalid ActiveCampaign credentials. Please check your API URL and key and reconnect.",
+            # Each account's API host is a customer-specific subdomain (e.g. https://acme.api-us1.com),
+            # so match on the stable error prefix rather than a fixed host.
+            "402 Client Error: Payment Required": "Your ActiveCampaign account doesn't have an active plan, or its payment failed. Check your ActiveCampaign billing, then resync.",
             # `active_campaign_source` raises this when the configured api_url fails our URL
             # validation — an unresolvable host (wrong account name), a private/internal host,
             # or a bad scheme. All are user-config problems retrying can't fix. Match the stable

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/tests/test_active_campaign_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/active_campaign/tests/test_active_campaign_source.py
@@ -75,7 +75,13 @@ class TestActiveCampaignSource:
 
     @pytest.mark.parametrize(
         "expected_key",
-        ["401 Client Error", "403 Client Error", "Unauthorized for url", "ActiveCampaign API URL is not allowed"],
+        [
+            "401 Client Error",
+            "403 Client Error",
+            "Unauthorized for url",
+            "ActiveCampaign API URL is not allowed",
+            "402 Client Error: Payment Required",
+        ],
     )
     def test_non_retryable_errors(self, expected_key: str) -> None:
         assert expected_key in self.source.get_non_retryable_errors()


### PR DESCRIPTION
## Problem

An ActiveCampaign sync surfaced repeated `HTTPError: 402 Client Error: Payment Required` events in error tracking. ActiveCampaign returns 402 when an account's plan or payment is inactive, a permanent upstream condition that retrying can never fix. The stack trace pointed at the shared REST engine (`rest_client.py`), but that's just the code path every REST-based source shares, not the bug's origin: `ActiveCampaignSource.get_non_retryable_errors()` didn't list this message, so the error fell through the generic path and got retried by Temporal on every attempt while spamming error tracking.

## Changes

Add a `"402 Client Error: Payment Required"` entry to `ActiveCampaignSource.get_non_retryable_errors()`, matching the pattern already used by several other sources (Shopify, Instantly, AppFollow, StockData, RSS, DataForSEO) that classify their own 402 responses the same way. The match is on the stable error prefix rather than a fixed host, since each ActiveCampaign account's API host is a customer-specific subdomain.

## How did you test this code?

Extended the existing parametrized `test_non_retryable_errors` test with the new `"402 Client Error: Payment Required"` case, covering the regression that a 402 wasn't previously classified as non-retryable. Ran the full `test_active_campaign_source.py` suite (17 passed), `ruff check --fix` / `ruff format`, and `mypy` on the changed file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - no documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated a live PostHog error-tracking issue (HTTPError 402 during an ActiveCampaign sync) via the PostHog MCP error-tracking tools, traced the stack to the shared REST client, and confirmed via SQL that the same exception fingerprint also fires for an unrelated Mux 400 error, since error-tracking groups by code location, not message. That ruled out a shared-code bug and pointed at the source-level non-retryable-error classification instead. A grep across the pipeline found the established, source-specific convention for classifying 402s (already used by ~8 other sources), and applied the same pattern to ActiveCampaign, which was missing it.

No skills were invoked beyond the mandatory `/writing-tests` and `/writing-user-facing-copy` checks for the added test case and the new customer-facing error message.