### PR TITLE
fix(data-imports): pin google search console metric types to prevent int64/double drift

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
@@ -417,10 +417,15 @@ def _row_to_dict(row: dict[str, Any], dimensions: list[str], iter_date: dt.date 
         # partition in the warehouse. The iterator already calls one day at a time, so
         # any row returned belongs to that day — inject it explicitly here.
         out["date"] = iter_date
-    out["clicks"] = row.get("clicks", 0)
-    out["impressions"] = row.get("impressions", 0)
-    out["ctr"] = row.get("ctr", 0.0)
-    out["position"] = row.get("position", 0.0)
+    # Pin each metric to its numeric type. Google serializes an exact-zero `ctr`/`position` as a
+    # JSON integer (`0`, not `0.0`), so a day where every row has zero clicks yields an all-int
+    # column that the pipeline stores as int64 — then a later day's fractional rate arrives as
+    # double and can't cast into that int64 column, failing the sync until a full reset. Coercing
+    # the rates to float (and the counts to int) keeps the stored Delta type stable across days.
+    out["clicks"] = int(row.get("clicks", 0))
+    out["impressions"] = int(row.get("impressions", 0))
+    out["ctr"] = float(row.get("ctr", 0.0))
+    out["position"] = float(row.get("position", 0.0))
     return out
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
@@ -419,7 +419,7 @@ def _row_to_dict(row: dict[str, Any], dimensions: list[str], iter_date: dt.date 
         out["date"] = iter_date
     # Pin each metric to its numeric type. Google serializes an exact-zero `ctr`/`position` as a
     # JSON integer (`0`, not `0.0`), so a day where every row has zero clicks yields an all-int
-    # column that the pipeline stores as int64 — then a later day's fractional rate arrives as
+    # column that the pipeline stores as int64. A later day's fractional rate then arrives as
     # double and can't cast into that int64 column, failing the sync until a full reset. Coercing
     # the rates to float (and the counts to int) keeps the stored Delta type stable across days.
     out["clicks"] = int(row.get("clicks", 0))

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
@@ -103,6 +103,19 @@ def test_row_to_dict_handles_missing_metrics():
     assert out["position"] == 0.0
 
 
+def test_row_to_dict_coerces_integer_serialized_rates_to_float():
+    # Google serializes an exact-zero rate as JSON `0`, which json.loads decodes to a Python int.
+    # Left as-is, an all-zero-clicks day would store `ctr`/`position` as int64 and reject a later
+    # day's fractional rate. The rates must always be floats; the counts always ints.
+    row = {"keys": ["2026-04-15"], "clicks": 3, "impressions": 20, "ctr": 0, "position": 0}
+    out = _row_to_dict(row, ["date"])
+
+    assert isinstance(out["ctr"], float)
+    assert isinstance(out["position"], float)
+    assert isinstance(out["clicks"], int)
+    assert isinstance(out["impressions"], int)
+
+
 def test_row_to_dict_injects_iter_date_when_date_not_in_dimensions():
     # `searchAppearance` schema can't include date in its API request, so the iterator
     # supplies the date externally to keep the per-day partition.


### PR DESCRIPTION
## Problem

A Google Search Console sync is failing in production with `SchemaColumnTypeChangedException` on the `ctr` and `position` columns (surfaced by [error tracking](https://us.posthog.com/project/2/error_tracking/019fad8e-9dd6-72c2-8052-9d225be0f99b)):

> Source column type changed: 'ctr' has values that no longer fit its stored type int64 (incoming data is now double). Reset and fully re-sync this table to adopt the new type.

The failing frame is in shared pipeline code (`evolve_pyarrow_schema` in `arrow_utils.py`), but the bad data shape originates in the GSC source.

`ctr` (click-through rate) and `position` (average position) are inherently fractional. Google serializes an exact-zero rate as a JSON integer (`0`, not `0.0`), which decodes to a Python `int`. On a day where every returned row has zero clicks, the whole `ctr`/`position` column arrives as `int`, so the first batch infers `int64` and the Delta table is created with the narrow type. A later day with a fractional rate arrives as `double`, delta-rs can't widen a column in place, and the cast fails deterministically. The pipeline correctly classifies this as non-retryable, so the sync stops until the table is reset.

**Why now:** this fired across several teams' GSC syncs today. It's our bug, not an upstream one — the column should never have been int64.

## Changes

Pin each metric to its numeric type in `_row_to_dict`: the rate metrics (`ctr`, `position`) to `float` and the count metrics (`clicks`, `impressions`) to `int`. The first batch then always infers `double` for the rates regardless of how Google serialized a zero, so the stored Delta type stays stable across days and the mismatch never happens.

I kept the fix at the source because shared code genuinely can't recover here: once a column is stored as int64, delta-rs cannot widen it in place, so raising and asking for a reset is the correct behavior for a genuinely-integer column. The only place with the semantic knowledge that these metrics are floating point is the source. Existing tables already stored as int64 still need a one-time reset (the error message already says so); this change stops any newly created GSC table from hitting it, and it does not break tables that already stored the rates as double.

> [!NOTE]
> This is scoped to Google Search Console. The same error class can appear for other sources on a genuine upstream schema change (e.g. a boolean field that starts returning a picklist string), where a reset really is the right answer. Those are left as-is.

## How did you test this code?

Automated only — I (Claude) can't run a live GSC sync from here.

- Added `test_row_to_dict_coerces_integer_serialized_rates_to_float`, which feeds an integer-serialized zero rate (`"ctr": 0`, `"position": 0`) through `_row_to_dict` and asserts the rates come out as `float` and the counts as `int`. This catches the regression directly: the existing `_row_to_dict` tests only use float literals (`0.1`, `4.5`), so none of them would notice an int passing straight through. If the coercion is removed, this fails.
- Ran the full `test_google_search_console.py` suite plus targeted `_row_to_dict` cases locally — all green.
- `ruff check` and `ruff format --check` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above. I (Claude) pulled the issue and representative `$exception` events over MCP, confirmed both `ctr` ("Float value 0.125000 was truncated converting to int64") and `position` ("Float value 32.375000 was truncated") fail the same way, and traced the call path from `import_data_activity_sync` → `pipeline_v2` → `evolve_pyarrow_schema`.

Decision along the way: I considered a shared-pipeline fix in `evolve_pyarrow_schema` but rejected it — an already-int64 Delta column can't be widened in place, so the exception plus reset guidance is the correct behavior for a genuinely-integer column. The only durable fix is to stop the column being created as int64, which means typing it correctly at the source.

Skills invoked: `/writing-tests` (test value gate), `/writing-code-comments`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
