### PR TITLE
fix(data-imports): handle blank column names in pipeline normalization

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/arrow_utils.py
@@ -359,11 +359,21 @@ def _append_debug_column_to_pyarrows_table(table: pa.Table, load_id: int) -> pa.
     return table.append_column("_ph_debug", column)
 
 
+UNNAMED_COLUMN_FALLBACK = "unnamed_column"
+
+
 def normalize_table_column_names(table: pa.Table) -> pa.Table:
     used_names = set()
 
     for column_name in table.column_names:
-        normalized_column_name = normalize_column_name(column_name)
+        try:
+            normalized_column_name = normalize_column_name(column_name)
+        except ValueError:
+            # A source can emit a blank or whitespace-only column name — e.g. a spreadsheet with an
+            # empty header cell above a populated column. The naming convention rejects an empty
+            # identifier, so fall back to a stable placeholder rather than failing the whole sync;
+            # the dedup loop below keeps it unique against the other columns.
+            normalized_column_name = UNNAMED_COLUMN_FALLBACK
         temp_name = normalized_column_name
 
         if temp_name != column_name:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_utils.py
@@ -472,6 +472,20 @@ def test_normalize_table_column_names_prevents_collisions():
     assert normalized_table.column("another_field").to_pylist() == ["value3"]
 
 
+@pytest.mark.parametrize("blank_name", ["", " ", "   ", "\t"])
+def test_normalize_table_column_names_handles_blank_column_name(blank_name):
+    # A blank/whitespace header (e.g. an empty header cell in a spreadsheet) reaches the pipeline
+    # as an empty column name and used to crash the whole sync in the naming convention.
+    table = pa.table({blank_name: ["value1"], "real_column": ["value2"]})
+
+    normalized_table = normalize_table_column_names(table)
+
+    assert "unnamed_column" in normalized_table.column_names
+    assert "real_column" in normalized_table.column_names
+    assert normalized_table.column("unnamed_column").to_pylist() == ["value1"]
+    assert normalized_table.column("real_column").to_pylist() == ["value2"]
+
+
 def test_table_from_py_list_with_rescaling_decimal_data_loss_error():
     # Very restrictive type, and the large_decimal value is too large for the schema
     schema = pa.schema({"column": pa.decimal128(5, 1)})


### PR DESCRIPTION
## Problem

A data-warehouse import surfaced a `ValueError` in shared pipeline code, raised from `NamingConvention.normalize_identifier` (`naming_convention.py:56`).

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019fad91-603e-7472-b6b5-a077a83fde7e

The failing frame is in shared code, not a source connector. The call path is:

`import_data_activity_sync` → pipeline `run` → `_process_pa_table` → `normalize_table_column_names` (`arrow_utils.py`) → `normalize_column_name` → `NamingConvention.normalize_identifier`.

The naming convention rejects an empty identifier (`if not identifier: raise ValueError(identifier)` — note the empty exception message, which matches the captured events). A source can produce a column whose name is blank or whitespace-only — for example a spreadsheet with an empty header cell sitting above a populated column, which arrives as a column literally named `""`. `normalize_table_column_names` fed every column name through the naming convention unconditionally, so one blank column name crashed the entire sync.

## Changes

`normalize_table_column_names` now catches the empty-identifier `ValueError` and falls back to a stable `unnamed_column` placeholder. The existing dedup loop keeps that name unique against the other columns (prefixing `_` on collision), so no column is dropped and the sync proceeds.

This is fixed at the shared pipeline layer where the failure originates, so it covers the whole class of blank/whitespace column names regardless of source and applies to both pipeline v2 and v3.

Related: [#72040](https://github.com/PostHog/posthog/pull/72040) (draft) addresses the same symptom from the Google Sheets source side by renaming blank/duplicate headers before they reach the pipeline. This change is complementary — it hardens the shared normalizer itself rather than one connector.

## How did you test this code?

Added parameterized unit cases in `test_utils.py` (`test_normalize_table_column_names_handles_blank_column_name`) covering empty and whitespace-only column names, asserting the column is renamed to `unnamed_column` and its data is preserved alongside a normal column. This locks in the crash we just fixed; the existing collision test only covered non-empty names.

Ran the full `arrow_utils` test file locally: `136 passed`. `ruff check` and `ruff format --check` clean on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking issue. Read the stack trace and the shared pipeline code (`arrow_utils.py`, `naming_convention.py`, `pipeline_v2/pipeline.py`) and the Google Sheets source for reproduction context, then fixed the shared normalizer. Invoked the `/writing-tests` skill before adding the regression test. Checked open PRs (including the maintainer's) for duplicates and found #72040, which fixes the same symptom at the source layer only — this change targets the shared frame in the stack trace instead.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
