### PR TITLE
fix(experiments): allow conversion window field to clear

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricConversionWindowFilter.tsx
@@ -74,7 +74,8 @@ export function ExperimentMetricConversionWindowFilter({
                             fullWidth={false}
                             min={intervalBounds[0]}
                             max={intervalBounds[1]}
-                            value={metric.conversion_window || 1}
+                            // NaN renders as empty and keeps the input controlled; undefined would not
+                            value={metric.conversion_window ?? NaN}
                             onChange={(value) => {
                                 handleSetMetric({ ...metric, conversion_window: value || undefined })
                             }}


### PR DESCRIPTION
## Problem

Closes #67942

The **Conversion window limit** number input in experiment metrics snapped back to `1` the moment you cleared it. Setting a value like `5` meant typing `15` and backspacing the `1`.

`value={metric.conversion_window || 1}` was the cause. Clearing the field stores `undefined`, and `undefined || 1` renders as `1`.

## Changes

```diff
-                            value={metric.conversion_window || 1}
+                            // NaN renders as empty and keeps the input controlled; undefined would not
+                            value={metric.conversion_window ?? NaN}
```

Passing `undefined` straight through would fix the snapping but flip the element from controlled to uncontrolled, since that is what a cleared number input resolves to. `LemonInput` already maps `NaN` to an empty string for `type="number"`, so `NaN` gets an empty field and keeps React in control. `min`/`max` from `TIME_INTERVAL_BOUNDS` still bound whatever gets committed.

This supersedes #68827 by @okxint, which carried the same fix but could not go through the merge queue without verified commits. Same change, rebased onto master as one signed commit, with @okxint credited as co-author.

## How did you test this code?

I ran `pnpm --filter=@posthog/frontend fix` and the frontend typecheck; no new errors from this file. No manual browser check and no new automated test - the change is a render-value expression, and the empty-render behavior it relies on is the documented contract of `LemonInput`'s existing `NaN` branch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude (PostHog Code) to land @okxint's PR. Greptile had flagged a real follow-on problem on that PR: dropping the `|| 1` fallback fixes the snapping but hands `undefined` to the input on clear, which is the controlled-to-uncontrolled switch. Claude traced `LemonInput` and found it already normalizes `NaN` to `''` for number inputs, so the smaller fix was to feed it `NaN` rather than to change `LemonInput`.

Rejected: teaching `LemonInput` to treat `undefined` as `''` for `type="number"`. That would also fix the same latent bug in `FunnelConversionWindowFilter`, but it touches 171 number-input call sites, about 27 of which pass no `value` today and would flip from uncontrolled to controlled. Not worth attaching to a one-line fix.

No skills invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
