### PR TITLE
fix(tasks): register Kimi without effort levels

### DIFF
--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -20,15 +20,23 @@ from products.tasks.backend.temporal.process_task.utils import (
     get_git_identity_env_vars,
     get_github_credential_source,
     get_imported_mcp_server_configs,
+    get_models_for_runtime_adapter,
     get_relayed_mcp_server_names,
     get_sandbox_github_token,
     get_sandbox_ph_mcp_configs,
+    get_supported_reasoning_efforts,
     get_task_run_actor_user,
     get_task_run_credential_user,
     get_user_mcp_server_configs,
     is_caller_token_run,
     loop_mcp_installation_allowlist,
 )
+
+
+class TestRuntimeModelCapabilities(SimpleTestCase):
+    def test_kimi_is_known_without_selectable_reasoning_effort(self) -> None:
+        assert "moonshotai/kimi-k3" in get_models_for_runtime_adapter("claude")
+        assert get_supported_reasoning_efforts("claude", "moonshotai/kimi-k3") == ()
 
 
 class TestRunStateSnapshotPaths(TestCase):

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -111,6 +111,7 @@ CLAUDE_REASONING_EFFORTS_BY_MODEL: dict[str, tuple[ReasoningEffort, ...]] = {
         ReasoningEffort.HIGH,
         ReasoningEffort.MAX,
     ),
+    "moonshotai/kimi-k3": (),
     "claude-opus-4-5": (
         ReasoningEffort.LOW,
         ReasoningEffort.MEDIUM,


### PR DESCRIPTION
## Problem

Kimi K3 is available to tasks but is absent from the canonical Claude-adapter model registry because it supports no selectable effort values.

**Why:** Model discovery and effort validation should describe the same capability contract used by PostHog Code.

## Changes

Register Kimi K3 with an empty effort tuple, making it a known task model while continuing to reject every explicit effort value.