### PR TITLE
fix(data-viz): route SQL charts by resolved series type

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.test.ts
@@ -38,4 +38,24 @@ describe('sqlChartComponentFor', () => {
     ])('routes mixed bar + line series on %s to SqlComboGraph', (_name, visualizationType) => {
         expect(sqlChartComponentFor({ ...baseProps(visualizationType), yData: mixedYData }).name).toBe('SqlComboGraph')
     })
+
+    it('routes an all-bar line chart to SqlBarGraph', () => {
+        const allBars = [
+            ySeries('a', { display: { displayType: 'bar' } }),
+            ySeries('b', { display: { displayType: 'bar' } }),
+        ]
+        expect(sqlChartComponentFor({ ...baseProps(ChartDisplayType.ActionsLineGraph), yData: allBars }).name).toBe(
+            'SqlBarGraph'
+        )
+    })
+
+    it("routes a percent stack whose line shares the bars' axis to SqlBarGraph", () => {
+        expect(
+            sqlChartComponentFor({
+                ...baseProps(ChartDisplayType.ActionsStackedBar),
+                yData: mixedYData,
+                chartSettings: { stackBars100: true },
+            }).name
+        ).toBe('SqlBarGraph')
+    })
 })

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlChart.tsx
@@ -6,7 +6,7 @@ import { AxisBreakdownSeries } from '../seriesBreakdownLogic'
 import { SqlBarGraph } from './SqlBarGraph'
 import { SqlComboGraph } from './SqlComboGraph'
 import { SqlLineGraph } from './SqlLineGraph'
-import { canRenderSqlBarGraph, canRenderSqlComboGraph } from './sqlLineGraphAdapter'
+import { sqlChartKind } from './sqlLineGraphAdapter'
 
 export type SqlChartProps = {
     xData: AxisSeries<string> | null
@@ -27,13 +27,14 @@ export type SqlChartProps = {
  * series, bar for bar-only, line/area otherwise. (Pie has its own wrapper — see PieChart.)
  */
 export function sqlChartComponentFor(props: SqlChartProps): (props: SqlChartProps) => JSX.Element {
-    if (canRenderSqlComboGraph(props)) {
-        return SqlComboGraph
+    switch (sqlChartKind(props)) {
+        case 'combo':
+            return SqlComboGraph
+        case 'bar':
+            return SqlBarGraph
+        case 'line':
+            return SqlLineGraph
     }
-    if (canRenderSqlBarGraph(props)) {
-        return SqlBarGraph
-    }
-    return SqlLineGraph
 }
 
 /** Entry point for rendering a non-pie SQL (DataVisualization) chart: dispatches line, area, bar,

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -180,6 +180,26 @@ describe('sqlLineGraphAdapter', () => {
                 )
             ).toBe('bar')
         })
+
+        // Regression: TimeSeriesBarChart percent-stacks every series it's given regardless of
+        // series.type, so degrading to bar here would force the right-axis line into the same [0, 1]
+        // stack as the left-axis bar/line pair and render it as a constant 100% bar.
+        it("picks combo for percent-stacked bars when a line shares the bars' axis and another line is on the right axis", () => {
+            const yData = [
+                ySeries('a', [1], { display: { displayType: 'bar' } }),
+                ySeries('b', [2], { display: { displayType: 'line' } }),
+                ySeries('c', [3], { display: { displayType: 'line', yAxisPosition: 'right' } }),
+            ]
+            expect(
+                sqlChartKind(
+                    baseProps({
+                        visualizationType: ChartDisplayType.ActionsStackedBar,
+                        yData,
+                        chartSettings: { stackBars100: true },
+                    })
+                )
+            ).toBe('combo')
+        })
     })
 
     describe('seriesDisplayType', () => {

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -25,9 +25,6 @@ import {
     buildSeries,
     buildSqlTooltipConfig,
     buildTrendLineConfigs,
-    canRenderSqlBarGraph,
-    canRenderSqlComboGraph,
-    canRenderSqlLineGraph,
     capYSeriesData,
     comboBarLayoutForDisplay,
     exceedsMaxSeries,
@@ -35,6 +32,7 @@ import {
     hasAxisTickFormatting,
     hasMixedSeriesTypes,
     seriesDisplayType,
+    sqlChartKind,
 } from './sqlLineGraphAdapter'
 
 const numericColumn = (name: string, dataIndex: number): AxisSeries<number | null>['column'] => ({
@@ -65,70 +63,122 @@ const baseProps = (overrides: Partial<SqlChartProps>): SqlChartProps => ({
 })
 
 describe('sqlLineGraphAdapter', () => {
-    describe('canRenderSqlLineGraph', () => {
-        it.each([
-            ['line graph', ChartDisplayType.ActionsLineGraph, true],
-            ['area graph', ChartDisplayType.ActionsAreaGraph, true],
-            ['bar graph', ChartDisplayType.ActionsBar, false],
-            ['stacked bar graph', ChartDisplayType.ActionsStackedBar, false],
-        ])('returns %s support correctly for %s', (_name, visualizationType, expected) => {
-            expect(canRenderSqlLineGraph(baseProps({ visualizationType }))).toBe(expected)
-        })
+    describe('sqlChartKind', () => {
+        // Explicit line + bar so the mix holds regardless of the base chart type's auto resolution.
+        const mixed = [
+            ySeries('a', [1], { display: { displayType: 'line' } }),
+            ySeries('b', [2], { display: { displayType: 'bar' } }),
+        ]
 
-        it('falls back when any series renders as a bar', () => {
-            const yData = [ySeries('a', [1]), ySeries('b', [2], { display: { displayType: 'bar' } })]
-            expect(canRenderSqlLineGraph(baseProps({ yData }))).toBe(false)
+        it.each([
+            ['line graph', ChartDisplayType.ActionsLineGraph, 'line'],
+            ['area graph', ChartDisplayType.ActionsAreaGraph, 'line'],
+            ['bar graph', ChartDisplayType.ActionsBar, 'bar'],
+            ['stacked bar graph', ChartDisplayType.ActionsStackedBar, 'bar'],
+            // Pie never reaches dispatch — PieChart wraps it separately.
+            ['pie graph', ChartDisplayType.ActionsPie, 'line'],
+        ])('follows the chart type for a %s with no series', (_name, visualizationType, expected) => {
+            expect(sqlChartKind(baseProps({ visualizationType }))).toBe(expected)
         })
 
         it.each([
             ['line graph', ChartDisplayType.ActionsLineGraph],
             ['area graph', ChartDisplayType.ActionsAreaGraph],
-        ])('renders trend-line series natively rather than falling back for a %s', (_name, visualizationType) => {
-            const yData = [ySeries('a', [1], { display: { trendLine: true } })]
-            expect(canRenderSqlLineGraph(baseProps({ visualizationType, yData }))).toBe(true)
+            ['bar graph', ChartDisplayType.ActionsBar],
+            ['stacked bar graph', ChartDisplayType.ActionsStackedBar],
+        ])('picks combo for mixed series on a %s', (_name, visualizationType) => {
+            expect(sqlChartKind(baseProps({ visualizationType, yData: mixed }))).toBe('combo')
         })
 
-        it('renders right y-axis series natively rather than falling back', () => {
-            const yData = [ySeries('a', [1]), ySeries('b', [2], { display: { yAxisPosition: 'right' } })]
-            expect(canRenderSqlLineGraph(baseProps({ yData }))).toBe(true)
-        })
-    })
-
-    describe('canRenderSqlBarGraph', () => {
-        it.each([
-            ['line graph', ChartDisplayType.ActionsLineGraph, false],
-            ['area graph', ChartDisplayType.ActionsAreaGraph, false],
-            ['bar graph', ChartDisplayType.ActionsBar, true],
-            ['stacked bar graph', ChartDisplayType.ActionsStackedBar, true],
-        ])('returns %s support correctly for %s', (_name, visualizationType, expected) => {
-            expect(canRenderSqlBarGraph(baseProps({ visualizationType }))).toBe(expected)
+        it('does not pick combo for an unsupported chart type', () => {
+            expect(sqlChartKind(baseProps({ visualizationType: ChartDisplayType.ActionsPie, yData: mixed }))).toBe(
+                'line'
+            )
         })
 
         it.each([
             ['line', 'line' as const],
             ['area', 'area' as const],
-        ])('falls back when any series overrides display to %s (mixed combo chart)', (_name, displayType) => {
-            const yData = [ySeries('a', [1]), ySeries('b', [2], { display: { displayType } })]
-            expect(canRenderSqlBarGraph(baseProps({ visualizationType: ChartDisplayType.ActionsBar, yData }))).toBe(
-                false
-            )
+        ])('picks line when every column on a bar graph is overridden to %s', (_name, displayType) => {
+            const yData = [
+                ySeries('a', [1], { display: { displayType } }),
+                ySeries('b', [2], { display: { displayType } }),
+            ]
+            expect(sqlChartKind(baseProps({ visualizationType: ChartDisplayType.ActionsBar, yData }))).toBe('line')
         })
 
-        // Trend lines render natively via TrendLineOverlay — no fallback needed.
+        // Regression: the per-column setting is more specific than the chart-level type, so an
+        // all-bar line chart must draw bars. It used to fall through to the line renderer, which
+        // ignores per-series type and drew them as lines.
+        it.each([
+            ['line graph', ChartDisplayType.ActionsLineGraph],
+            ['area graph', ChartDisplayType.ActionsAreaGraph],
+        ])('picks bar when every column on a %s is overridden to bar', (_name, visualizationType) => {
+            const yData = [
+                ySeries('a', [1], { display: { displayType: 'bar' } }),
+                ySeries('b', [2], { display: { displayType: 'bar' } }),
+            ]
+            expect(sqlChartKind(baseProps({ visualizationType, yData }))).toBe('bar')
+        })
+
+        // Trend lines and right-axis series render natively on every path — they never change the kind.
         it.each([
             ['a plain series', [ySeries('a', [1], { display: { trendLine: true } })]],
             ['a breakdown series', [breakdownSeries('chrome', [1], { display: { trendLine: true } })]],
-        ])('renders natively when %s has a trend line', (_name, yData) => {
-            expect(canRenderSqlBarGraph(baseProps({ visualizationType: ChartDisplayType.ActionsBar, yData }))).toBe(
-                true
-            )
+        ])('keeps the bar kind when %s has a trend line', (_name, yData) => {
+            expect(sqlChartKind(baseProps({ visualizationType: ChartDisplayType.ActionsBar, yData }))).toBe('bar')
         })
 
-        it('renders natively when any series targets the right y-axis', () => {
+        it('keeps the bar kind when a series targets the right y-axis', () => {
             const yData = [ySeries('a', [1], { display: { yAxisPosition: 'right' } })]
-            expect(canRenderSqlBarGraph(baseProps({ visualizationType: ChartDisplayType.ActionsBar, yData }))).toBe(
-                true
-            )
+            expect(sqlChartKind(baseProps({ visualizationType: ChartDisplayType.ActionsBar, yData }))).toBe('bar')
+        })
+
+        it('keeps the line kind for trend-line and right-axis series on a line graph', () => {
+            const yData = [
+                ySeries('a', [1], { display: { trendLine: true } }),
+                ySeries('b', [2], { display: { yAxisPosition: 'right' } }),
+            ]
+            expect(sqlChartKind(baseProps({ yData }))).toBe('line')
+        })
+
+        it('picks combo when a series has a trend line alongside the mix', () => {
+            const yData = [
+                ySeries('a', [1], { display: { displayType: 'bar' } }),
+                ySeries('b', [2], { display: { displayType: 'line', trendLine: true } }),
+            ]
+            expect(sqlChartKind(baseProps({ visualizationType: ChartDisplayType.ActionsBar, yData }))).toBe('combo')
+        })
+
+        it('picks combo for percent-stacked bars when the line is on the right axis', () => {
+            const yData = [
+                ySeries('a', [1], { display: { displayType: 'line', yAxisPosition: 'right' } }),
+                ySeries('b', [2], { display: { displayType: 'bar' } }),
+            ]
+            expect(
+                sqlChartKind(
+                    baseProps({
+                        visualizationType: ChartDisplayType.ActionsStackedBar,
+                        yData,
+                        chartSettings: { stackBars100: true },
+                    })
+                )
+            ).toBe('combo')
+        })
+
+        // Regression: the bars' axis clamps to [0, 1] in percent mode, so a line on that same axis
+        // can't be reconciled with it. Degrade to a plain percent stack — this used to fall through
+        // to the line renderer, which dropped the stacking entirely.
+        it("picks bar for percent-stacked bars when a line shares the bars' axis", () => {
+            expect(
+                sqlChartKind(
+                    baseProps({
+                        visualizationType: ChartDisplayType.ActionsStackedBar,
+                        yData: mixed,
+                        chartSettings: { stackBars100: true },
+                    })
+                )
+            ).toBe('bar')
         })
     })
 
@@ -187,76 +237,6 @@ describe('sqlLineGraphAdapter', () => {
             ],
         ])('detects %s', (_name, visualizationType, yData, expected) => {
             expect(hasMixedSeriesTypes(yData, visualizationType)).toBe(expected)
-        })
-    })
-
-    describe('canRenderSqlComboGraph', () => {
-        // Explicit line + bar so the mix holds regardless of the base chart type's auto resolution.
-        const mixed = [
-            ySeries('a', [1], { display: { displayType: 'line' } }),
-            ySeries('b', [2], { display: { displayType: 'bar' } }),
-        ]
-
-        it.each([
-            ['line graph', ChartDisplayType.ActionsLineGraph],
-            ['area graph', ChartDisplayType.ActionsAreaGraph],
-            ['bar graph', ChartDisplayType.ActionsBar],
-            ['stacked bar graph', ChartDisplayType.ActionsStackedBar],
-        ])('renders mixed series on a %s', (_name, visualizationType) => {
-            expect(canRenderSqlComboGraph(baseProps({ visualizationType, yData: mixed }))).toBe(true)
-        })
-
-        it('does not render when series are all one type', () => {
-            const yData = [ySeries('a', [1]), ySeries('b', [2])]
-            expect(canRenderSqlComboGraph(baseProps({ visualizationType: ChartDisplayType.ActionsBar, yData }))).toBe(
-                false
-            )
-        })
-
-        it('does not claim an unsupported chart type', () => {
-            expect(
-                canRenderSqlComboGraph(baseProps({ visualizationType: ChartDisplayType.ActionsPie, yData: mixed }))
-            ).toBe(false)
-        })
-
-        it('renders natively when any series has a trend line (TrendLineOverlay handles it)', () => {
-            const yData = [
-                ySeries('a', [1], { display: { displayType: 'bar' } }),
-                ySeries('b', [2], { display: { displayType: 'line', trendLine: true } }),
-            ]
-            expect(canRenderSqlComboGraph(baseProps({ visualizationType: ChartDisplayType.ActionsBar, yData }))).toBe(
-                true
-            )
-        })
-
-        it('renders natively for percent-stacked bars when the line is on the right axis', () => {
-            const yData = [
-                ySeries('a', [1], { display: { displayType: 'line', yAxisPosition: 'right' } }),
-                ySeries('b', [2], { display: { displayType: 'bar' } }),
-            ]
-            expect(
-                canRenderSqlComboGraph(
-                    baseProps({
-                        visualizationType: ChartDisplayType.ActionsStackedBar,
-                        yData,
-                        chartSettings: { stackBars100: true },
-                    })
-                )
-            ).toBe(true)
-        })
-
-        it("falls back for percent-stacked bars when a line shares the bars' axis", () => {
-            // The bars' axis clamps to [0, 1] in percent mode — a line on the same (default/left)
-            // axis has no way to plot its raw values there, so the combo path is unavailable.
-            expect(
-                canRenderSqlComboGraph(
-                    baseProps({
-                        visualizationType: ChartDisplayType.ActionsStackedBar,
-                        yData: mixed,
-                        chartSettings: { stackBars100: true },
-                    })
-                )
-            ).toBe(false)
         })
     })
 

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -64,10 +64,7 @@ export function seriesDisplayType(
 
 /** True when the series resolve to a mix of bar and line/area — the case neither the line-only nor
  *  the bar-only quill path can render, so it routes to {@link SqlComboGraph}. */
-export function hasMixedSeriesTypes(
-    yData: NonNullable<SqlChartProps['yData']>,
-    visualizationType: ChartDisplayType
-): boolean {
+export function hasMixedSeriesTypes(yData: SqlLineYSeries[], visualizationType: ChartDisplayType): boolean {
     let hasBar = false
     let hasLineLike = false
     for (const series of yData) {
@@ -104,75 +101,54 @@ export function buildTrendLineConfigs(ySeriesData: SqlLineYSeries[] | null | und
     }, [])
 }
 
-/**
- * Plain line/area charts — including goal lines, trend lines, and right y-axis series — render here.
- * Series that mix a bar with a line/area route to {@link canRenderSqlComboGraph}; other mixes fall
- * back to the legacy chart.js path.
- */
-export function canRenderSqlLineGraph(props: SqlChartProps): boolean {
-    const { visualizationType, yData } = props
+export type SqlChartKind = 'line' | 'bar' | 'combo'
 
-    if (
-        visualizationType !== ChartDisplayType.ActionsLineGraph &&
-        visualizationType !== ChartDisplayType.ActionsAreaGraph
-    ) {
-        return false
-    }
-    if (yData?.some((series) => series.settings?.display?.displayType === 'bar')) {
-        return false
-    }
-    return true
-}
-
-export function canRenderSqlBarGraph(props: SqlChartProps): boolean {
-    const { visualizationType, yData } = props
-
-    if (visualizationType !== ChartDisplayType.ActionsBar && visualizationType !== ChartDisplayType.ActionsStackedBar) {
-        return false
-    }
-    if (
-        yData?.some((series) => {
-            const displayType = series.settings?.display?.displayType
-            return displayType === 'line' || displayType === 'area'
-        })
-    ) {
-        return false
-    }
-    return true
+/** The slice of chart props renderer dispatch reads — `SqlChartProps` and Customer analytics'
+ *  `BillingChartProps` both satisfy it. */
+export interface SqlChartKindProps {
+    visualizationType: ChartDisplayType
+    yData: SqlLineYSeries[] | null | undefined
+    chartSettings: ChartSettings
 }
 
 /**
- * Mixed bar + line/area series render on quill's {@link TimeSeriesComboChart}. Percent-stacked
- * bars are supported as long as every line/area series is routed to the right axis — one sharing
- * the bars' axis can't be reconciled with the bars' [0, 1] percent scale, so that case falls back.
+ * The single source of truth for which quill renderer draws a SQL insight. Resolves the per-series
+ * display types once (`auto` inherits the chart-level type) and picks from there, so the answer
+ * follows the series rather than the chart-level type alone: a line chart whose every column is set
+ * to Bar draws bars.
  */
-export function canRenderSqlComboGraph(props: SqlChartProps): boolean {
-    const { visualizationType, yData, chartSettings } = props
+export function sqlChartKind({ visualizationType, yData, chartSettings }: SqlChartKindProps): SqlChartKind {
+    const isBarBase =
+        visualizationType === ChartDisplayType.ActionsBar || visualizationType === ChartDisplayType.ActionsStackedBar
+    const isLineBase =
+        visualizationType === ChartDisplayType.ActionsLineGraph ||
+        visualizationType === ChartDisplayType.ActionsAreaGraph
 
-    if (
-        visualizationType !== ChartDisplayType.ActionsLineGraph &&
-        visualizationType !== ChartDisplayType.ActionsAreaGraph &&
-        visualizationType !== ChartDisplayType.ActionsBar &&
-        visualizationType !== ChartDisplayType.ActionsStackedBar
-    ) {
-        return false
+    // Pie and friends never reach dispatch — PieChart wraps them separately.
+    if (!isBarBase && !isLineBase) {
+        return 'line'
     }
-    if (!yData || !hasMixedSeriesTypes(yData, visualizationType)) {
-        return false
+    if (!yData?.length) {
+        return isBarBase ? 'bar' : 'line'
     }
-    // Percent-stacked bars clamp their axis to [0, 1] — a line/area series sharing that same axis
-    // would plot its raw values off-scale with no way to reconcile the two domains. Only allow a
-    // percent-stack combo when every non-bar series is routed to the right axis instead.
-    if (
-        visualizationType === ChartDisplayType.ActionsStackedBar &&
-        chartSettings.stackBars100 &&
-        yData.some(
-            (series) => seriesDisplayType(visualizationType, series.settings) !== 'bar' && !isRightAxisSeries(series)
-        )
-    ) {
-        return false
+
+    if (hasMixedSeriesTypes(yData, visualizationType)) {
+        // Percent-stacked bars clamp their axis to [0, 1] — a line/area series sharing that same
+        // axis would plot its raw values off-scale with no way to reconcile the two domains. Keep
+        // the percent stack and draw those series as bars; a right-axis series has its own scale
+        // and is safe to combo.
+        const sharesPercentAxis =
+            visualizationType === ChartDisplayType.ActionsStackedBar &&
+            chartSettings.stackBars100 &&
+            yData.some(
+                (series) =>
+                    seriesDisplayType(visualizationType, series.settings) !== 'bar' && !isRightAxisSeries(series)
+            )
+        return sharesPercentAxis ? 'bar' : 'combo'
     }
-    return true
+
+    // Not mixed, so every series resolved the same way — the first one speaks for all of them.
+    return seriesDisplayType(visualizationType, yData[0].settings) === 'bar' ? 'bar' : 'line'
 }
 
 export function barLayoutForDisplay(

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -105,11 +105,7 @@ export type SqlChartKind = 'line' | 'bar' | 'combo'
 
 /** The slice of chart props renderer dispatch reads — `SqlChartProps` and Customer analytics'
  *  `BillingChartProps` both satisfy it. */
-export interface SqlChartKindProps {
-    visualizationType: ChartDisplayType
-    yData: SqlLineYSeries[] | null | undefined
-    chartSettings: ChartSettings
-}
+export type SqlChartKindProps = Pick<SqlChartProps, 'visualizationType' | 'yData' | 'chartSettings'>
 
 /**
  * The single source of truth for which quill renderer draws a SQL insight. Resolves the per-series
@@ -135,15 +131,21 @@ export function sqlChartKind({ visualizationType, yData, chartSettings }: SqlCha
     if (hasMixedSeriesTypes(yData, visualizationType)) {
         // Percent-stacked bars clamp their axis to [0, 1] — a line/area series sharing that same
         // axis would plot its raw values off-scale with no way to reconcile the two domains. Keep
-        // the percent stack and draw those series as bars; a right-axis series has its own scale
-        // and is safe to combo.
+        // the percent stack and draw those series as bars — but only when every non-bar series is on
+        // the left axis: `TimeSeriesBarChart` has no notion of `series.type` and percent-stacks every
+        // series it's given, so a right-axis non-bar series would still get force-stacked into a
+        // constant 100% bar. A right-axis non-bar series has its own scale and is safe to combo.
+        const hasNonBarOnLeftAxis = yData.some(
+            (series) => seriesDisplayType(visualizationType, series.settings) !== 'bar' && !isRightAxisSeries(series)
+        )
+        const hasNonBarOnRightAxis = yData.some(
+            (series) => seriesDisplayType(visualizationType, series.settings) !== 'bar' && isRightAxisSeries(series)
+        )
         const sharesPercentAxis =
             visualizationType === ChartDisplayType.ActionsStackedBar &&
             chartSettings.stackBars100 &&
-            yData.some(
-                (series) =>
-                    seriesDisplayType(visualizationType, series.settings) !== 'bar' && !isRightAxisSeries(series)
-            )
+            hasNonBarOnLeftAxis &&
+            !hasNonBarOnRightAxis
         return sharesPercentAxis ? 'bar' : 'combo'
     }
 

--- a/products/customer_analytics/frontend/components/Accounts/AccountBillingChart.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountBillingChart.tsx
@@ -26,8 +26,7 @@ import {
     buildComboChartConfig,
     buildLineChartConfig,
     buildSeries,
-    canRenderSqlBarGraph,
-    canRenderSqlComboGraph,
+    sqlChartKind,
 } from '~/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter'
 import { AxisSeries, dataVisualizationLogic } from '~/queries/nodes/DataVisualization/dataVisualizationLogic'
 import {
@@ -120,13 +119,14 @@ function BillingChartByKind({
     chartProps: BillingChartProps
     hiddenKeys: string[]
 }): JSX.Element | null {
-    if (canRenderSqlComboGraph(chartProps)) {
-        return <BillingComboChart chartProps={chartProps} hiddenKeys={hiddenKeys} />
+    switch (sqlChartKind(chartProps)) {
+        case 'combo':
+            return <BillingComboChart chartProps={chartProps} hiddenKeys={hiddenKeys} />
+        case 'bar':
+            return <BillingBarChart chartProps={chartProps} hiddenKeys={hiddenKeys} />
+        case 'line':
+            return <BillingLineChart chartProps={chartProps} hiddenKeys={hiddenKeys} />
     }
-    if (canRenderSqlBarGraph(chartProps)) {
-        return <BillingBarChart chartProps={chartProps} hiddenKeys={hiddenKeys} />
-    }
-    return <BillingLineChart chartProps={chartProps} hiddenKeys={hiddenKeys} />
 }
 
 // One subcomponent per chart kind because useBillingChartModel's config type follows the builder it's given.


### PR DESCRIPTION
## Problem

The SQL chart renderer was picked by an ordered chain of three `canRenderSql*Graph` predicates ending in an unconditional fallthrough:

```ts
if (canRenderSqlComboGraph(props)) { return SqlComboGraph }
if (canRenderSqlBarGraph(props))   { return SqlBarGraph }
return SqlLineGraph   // ← unconditional
```

The predicates are *named* as capability checks ("can this renderer handle these props?") but *used* as dispatch. Those two contracts are incompatible, and the gap between them hid two real mis-renders:

**1. `canRenderSqlLineGraph` had no production caller.** Exported, documented, four tests — zero callers. Both dispatch sites end with an unconditional `return SqlLineGraph`, so its "no" was never consulted. Consequence: a line/area chart whose **every** column is set to Display type = Bar (reachable from the per-column picker in `SeriesTab`) fell through to the line renderer. `buildSeries` stamps `type: 'bar'` on each series, but `TimeSeriesLineChart` ignores per-series type — so the bars drew as lines.

**2. Percent stack + a line on the bars' own axis rendered as plain lines.** `canRenderSqlComboGraph` *deliberately* declines here (the `[0,1]` percent axis can't be reconciled with raw line values) expecting a fallback; `canRenderSqlBarGraph` also declines (a line series is present). The chart landed on the line renderer, dropping the percent stacking entirely.

The docstrings said these cases "fall back to the legacy chart.js path" — that path was deleted in c41720586bd, so the comments were stale and the deliberate bail-out had nowhere safe to land.

## Fix

Replace all three predicates with one total function:

```ts
export type SqlChartKind = 'line' | 'bar' | 'combo'
export function sqlChartKind(props: SqlChartKindProps): SqlChartKind
```

It resolves the per-series display types once (`auto` inherits the chart-level type) and picks from there, so the answer follows the series rather than the chart-level type alone. Both dispatch sites — `SqlChart` and Customer analytics' `AccountBillingChart`, previously the same three branches hand-synced in two files — now `switch` on it. Ordering stops being implicit and the branches are exhaustive by type.

Behaviour changes, both fixes:
- all-bar line/area chart → `SqlBarGraph` (was `SqlLineGraph`)
- percent stack whose line/area shares the bars' axis → `SqlBarGraph`, keeping the stack (was `SqlLineGraph`, losing it)

Everything else routes exactly as before, including the empty-series case (follows the chart type) and percent stacks whose line is on the *right* axis (still combo — it has its own scale).

`SqlChartKindProps` names the three fields dispatch actually reads instead of taking all of `SqlChartProps`, which is what let `AccountBillingChart` quietly pass a structurally different props object.

## Testing

- `sqlLineGraphAdapter.test.ts`: the three predicate suites are folded into one `sqlChartKind` suite; every existing case is preserved and re-expressed, plus two regression cases with comments explaining the old behaviour.
- `SqlChart.test.ts`: two new routing assertions covering both bugs end-to-end.
- 147 tests pass across the two changed suites; 282 across all 10 chart suites.
- `tsgo --noEmit`: no errors in the changed files.
- `oxlint` clean, `oxfmt --check` clean.

I verified both bugs on the pre-fix code by temporarily asserting the old routing, before writing the fix.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*