### PR TITLE
fix(data-imports): stop reporting transient S3 blips as compaction failures

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
@@ -294,6 +294,9 @@ async def run_post_load_operations(
     from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import (
         finalize_desc_sort_incremental_value,
     )
+    from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper import (  # noqa: PLC0415 — keeps the heavy deltalake dep off this module's top-level import path
+        is_transient_object_store_error,
+    )
     from products.warehouse_sources.backend.temporal.data_imports.pipelines.helpers import build_table_name
     from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_sync import (
         register_cdc_companion_table,
@@ -346,16 +349,24 @@ async def run_post_load_operations(
                         schema.id, schema.team_id, updates={watermark_key: new_version}
                     )
         except Exception as e:
-            capture_exception(e)
-            logger.exception(f"Delta maintenance failed: {e}", exc_info=e)
+            if is_transient_object_store_error(e):
+                # A rate-limited or connectivity blip talking to our own S3 bucket isn't a bug - the
+                # next tick's maintenance pass retries the same idempotent cleanup.
+                logger.warning(f"Delta maintenance skipped: transient object-store error: {e}")
+            else:
+                capture_exception(e)
+                logger.exception(f"Delta maintenance failed: {e}", exc_info=e)
     else:
         logger.debug("Triggering compaction and vacuuming on delta table")
         try:
             with POST_LOAD_DURATION_SECONDS.labels(operation="compact").time():
                 await delta_table_helper.compact_table()
         except Exception as e:
-            capture_exception(e)
-            logger.exception(f"Compaction failed: {e}", exc_info=e)
+            if is_transient_object_store_error(e):
+                logger.warning(f"Compaction skipped: transient object-store error: {e}")
+            else:
+                capture_exception(e)
+                logger.exception(f"Compaction failed: {e}", exc_info=e)
 
     if is_cdc_companion:
         # Look up the existing companion table's queryable_folder (not the main schema.table).

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
@@ -174,18 +174,47 @@ class TestRunPostLoadDeltaMaintenance:
         else:
             update_config.assert_not_called()
 
+    @parameterized.expand(
+        [
+            # A genuine maintenance bug must still be captured for visibility.
+            ("genuine_bug", RuntimeError("maintenance blew up"), True),
+            # A transient S3 rate-limit/connectivity blip is already non-fatal here (the next
+            # tick's maintenance retries the same idempotent cleanup) and must not be promoted
+            # into a fresh error-tracking issue — the regression this guards.
+            ("transient_s3_slowdown", OSError("Generic S3 error: Please reduce your request rate."), False),
+        ]
+    )
     @pytest.mark.asyncio
-    async def test_maintenance_failure_does_not_fail_post_load(self):
-        # A maintenance hiccup (S3 flake) must not fail the final batch — the rest of post-load
+    async def test_maintenance_failure_handling(self, _name: str, error: Exception, expect_capture: bool):
+        # A maintenance hiccup must not fail the final batch — the rest of post-load
         # (queryable folder prep, table registration) still has to run or the job wedges.
         schema = _make_schema(is_cdc=True)
         helper = _make_helper()
-        helper.run_maintenance = AsyncMock(side_effect=RuntimeError("maintenance blew up"))
+        helper.run_maintenance = AsyncMock(side_effect=error)
 
         with patch(f"{_LOAD_MODULE}.capture_exception") as mock_capture:
             _, prepare_s3 = await _run_post_load(schema, helper, cdc_write_mode="incremental")
 
-        mock_capture.assert_called_once()
+        assert mock_capture.called is expect_capture
+        prepare_s3.assert_awaited_once()
+
+    @parameterized.expand(
+        [
+            ("genuine_bug", RuntimeError("compaction blew up"), True),
+            ("transient_s3_slowdown", OSError("Generic S3 error: Please reduce your request rate."), False),
+        ]
+    )
+    @pytest.mark.asyncio
+    async def test_compact_failure_handling(self, _name: str, error: Exception, expect_capture: bool):
+        # Same non-fatal handling as maintenance, for the non-CDC unconditional compact_table path.
+        schema = _make_schema(is_cdc=False)
+        helper = _make_helper()
+        helper.compact_table = AsyncMock(side_effect=error)
+
+        with patch(f"{_LOAD_MODULE}.capture_exception") as mock_capture:
+            _, prepare_s3 = await _run_post_load(schema, helper)
+
+        assert mock_capture.called is expect_capture
         prepare_s3.assert_awaited_once()
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/pipeline.py
@@ -54,7 +54,10 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arr
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.async_iterate import async_iterate
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.batcher import Batcher
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.cdp_producer import CDPProducer
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper import DeltaTableHelper
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper import (
+    DeltaTableHelper,
+    is_transient_object_store_error,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.hogql_schema import HogQLSchema
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.partitioning import setup_partitioning
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.person_property_row_sink import (
@@ -454,8 +457,13 @@ class PipelineNonDLT(Generic[ResumableData]):
         try:
             await self._delta_table_helper.compact_table()
         except Exception as e:
-            capture_exception(e)
-            await self._logger.aexception(f"Compaction failed: {e}", exc_info=e)
+            if is_transient_object_store_error(e):
+                # A rate-limited or connectivity blip compacting/vacuuming our own S3 bucket isn't a
+                # bug - the next sync's post-run compaction retries the same idempotent cleanup.
+                await self._logger.awarning(f"Compaction skipped: transient object-store error: {e}")
+            else:
+                capture_exception(e)
+                await self._logger.aexception(f"Compaction failed: {e}", exc_info=e)
 
         file_uris = await self._delta_table_helper.get_file_uris()
         await self._logger.adebug(f"Preparing S3 files - total parquet files: {len(file_uris)}")

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/test/test_pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v2/test/test_pipeline.py
@@ -1,11 +1,17 @@
+import uuid
 from typing import cast
 
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.cdp_producer import CDPProducer
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v2.pipeline import PipelineNonDLT
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
+
+_PIPELINE_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v2.pipeline"
 
 
 @pytest.mark.asyncio
@@ -38,3 +44,66 @@ async def test_run_cleanup_failure_does_not_mask_import_error(monkeypatch):
         await pipeline.run()
 
     pipeline._logger.aexception.assert_awaited_once_with("Failed to clean up delta table helper")
+
+
+def _make_pipeline_for_post_run_operations() -> PipelineNonDLT:
+    pipeline = PipelineNonDLT.__new__(PipelineNonDLT)
+    pipeline._logger = AsyncMock()
+    pipeline._delta_table_helper = AsyncMock()
+    pipeline._delta_table_helper.get_delta_table.return_value = MagicMock()
+    pipeline._delta_table_helper.get_file_uris.return_value = []
+    pipeline._job = MagicMock(id=uuid.uuid4(), team_id=1)
+    pipeline._table = None
+    pipeline._resource_name = "orders"
+    pipeline._schema = MagicMock()
+    pipeline._schema.initial_sync_complete = True
+    # Non-CDC skips the CDC-companion-seeding block, so only validate_schema_and_update_table
+    # (mocked below) needs to be reachable.
+    pipeline._schema.sync_type = ExternalDataSchema.SyncType.INCREMENTAL
+    pipeline._schema.cdc_table_mode = "consolidated"
+    pipeline._source = MagicMock()
+    pipeline._resource = MagicMock()
+    pipeline._internal_schema = MagicMock()
+    pipeline._last_incremental_field_value = None
+    return pipeline
+
+
+def _fake_database_sync_to_async_pool(fn):
+    async def _inner(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return _inner
+
+
+class TestPostRunOperationsCompactionErrorHandling:
+    # Regression: `_post_run_operations` used to call `capture_exception` for every compaction
+    # failure, including transient S3 rate-limit/connectivity blips that are already non-fatal
+    # (the sync completes regardless) — flooding error tracking with noise. A genuine compaction
+    # bug must still be captured.
+    @parameterized.expand(
+        [
+            ("transient_s3_slowdown", OSError("Generic S3 error: Please reduce your request rate."), False),
+            ("genuine_bug", OSError("Access Denied: not authorized"), True),
+        ]
+    )
+    @pytest.mark.asyncio
+    async def test_compaction_error_handling(self, _name: str, error: Exception, expect_capture: bool):
+        pipeline = _make_pipeline_for_post_run_operations()
+        cast(AsyncMock, pipeline._delta_table_helper.compact_table).side_effect = error
+
+        with (
+            patch(f"{_PIPELINE_MODULE}.capture_exception") as mock_capture,
+            patch(f"{_PIPELINE_MODULE}.database_sync_to_async_pool", _fake_database_sync_to_async_pool),
+            patch(f"{_PIPELINE_MODULE}.prepare_s3_files_for_querying", AsyncMock(return_value="orders__query_1")),
+            patch(f"{_PIPELINE_MODULE}.update_last_synced_at", AsyncMock()),
+            patch(f"{_PIPELINE_MODULE}.notify_revenue_analytics_that_sync_has_completed", AsyncMock()),
+            patch(f"{_PIPELINE_MODULE}.finalize_desc_sort_incremental_value", AsyncMock()),
+            patch(f"{_PIPELINE_MODULE}.validate_schema_and_update_table", AsyncMock()),
+        ):
+            await pipeline._post_run_operations(row_count=10)
+
+        assert mock_capture.called is expect_capture
+        if expect_capture:
+            cast(AsyncMock, pipeline._logger.aexception).assert_awaited_once()
+        else:
+            cast(AsyncMock, pipeline._logger.awarning).assert_awaited_once()


### PR DESCRIPTION
## Problem

An [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fad8f-204e-7e41-b170-22731c6334cf) surfaced an `OSError: Generic S3 error ... 503 Service Unavailable ... SlowDown ... Please reduce your request rate`, raised from `DeltaTableHelper.vacuum_table()` (via `compact_table()`), called from `_post_run_operations()` at the end of every v2-pipeline sync. The same fingerprint fires across many unrelated source types and schemas within the same short window, which points at S3 throttling a burst of concurrent post-sync vacuum/compact operations against the shared data-warehouse bucket, not a bug tied to any one source.

Tracing the call site: `_post_run_operations` already wraps `compact_table()` in a bare `try/except Exception: capture_exception(e)` — so the sync itself is unaffected either way, this is purely error-tracking noise. The pipeline layer already has a classifier for exactly this failure mode, `is_transient_object_store_error()` in `delta_table_helper.py`, and the pre-write maintenance path (`common/extract.py`'s `run_pre_write_defensive_compact`) already uses it to log a warning instead of capturing. The post-run path in `pipeline_v2/pipeline.py`, and the equivalent post-load paths in `common/load.py` (CDC maintenance and non-CDC compact), never picked it up, so the exact same transient S3 blip is treated inconsistently depending on which call site hits it.

## Changes

- `pipeline_v2/pipeline.py`'s `_post_run_operations`: check `is_transient_object_store_error(e)` before capturing a `compact_table()` failure; log a warning instead when it's a recognized transient S3 blip.
- `common/load.py`'s `run_post_load_operations`: same treatment for both the CDC `run_maintenance()` branch and the non-CDC `compact_table()` branch.

No retry policy, timeout, or `NonRetryableErrors` classification changed — this only makes an already-non-fatal exception path consistent with the classifier the pipeline already has, at the two call sites that were missing it.

## How did you test this code?

- Extended `pipeline_v2/test/test_pipeline.py` with a parameterized `test_compaction_error_handling` (transient S3 blip → warning, no capture; genuine `OSError` → captured) — the exact regression this PR fixes.
- Extended `common/test/test_load.py`'s `TestRunPostLoadDeltaMaintenance` similarly for both the CDC maintenance path and the non-CDC compact path.
- Ran the full `test_pipeline.py` (pipeline_v2), `test_load.py` (common), and `test_delta_table_helper.py` (core) suites: 82 passed, 4 pre-existing failures in `TestGetDeltaTableUnrecoverableErrors` that need a live object-storage service unavailable in this sandbox — confirmed identical on unmodified `master`.
- `ruff check` / `ruff format --check` clean on all 4 changed files.
- Full-repo `uv run mypy --cache-fine-grained .` clean (17074 source files).

## Docs update

N/A — internal pipeline implementation detail, no user-facing or API surface change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error-tracking issue (webhook-delivered) using Claude Code. Pulled the stack trace, exception samples, and `warehouse_sources_*` properties via the PostHog MCP tools to confirm the failure is cross-source (Postgres, MySQL, GoogleAds, GitHub) and lives entirely in shared pipeline code. Searched open PRs for duplicates: found [#69306](https://github.com/PostHog/posthog/pull/69306) addressing the same root cause with a similar design, but it targets `pipelines/pipeline/delta_table_helper.py`, a path removed by a since-refactor (now `pipelines/core/`), so it can't land as-is; also checked [#74541](https://github.com/PostHog/posthog/pull/74541) (a different bug in the same file) for overlap — none. Invoked `/writing-tests` before adding test coverage.