### PR TITLE
fix(data-imports): treat a racy optimize/vacuum scan failure as transient

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -21,6 +21,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arr
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.cdp_producer import CDPProducer
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper import (
     DeltaTableHelper,
+    is_transient_delta_maintenance_error,
     is_transient_object_store_error,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.person_property_row_sink import (
@@ -704,9 +705,10 @@ async def run_pre_write_defensive_compact(
     the CDC post-load path in `common/load.py` writes the same watermark, and both merge
     via `update_sync_type_config_keys` under a row lock. Wrapped in try/except so a
     maintenance failure never blocks the actual sync; the original error path is unaffected.
-    A transient object-store error (see `is_transient_object_store_error`) is logged at
-    warning instead of captured — the next sync's maintenance pass retries it from scratch,
-    so it isn't a bug in this function, just a temporary blip talking to our own S3 bucket.
+    A transient object-store error (see `is_transient_object_store_error`) or a racy
+    concurrent-maintenance DeltaError (see `is_transient_delta_maintenance_error`) is
+    logged at warning instead of captured — the next sync's maintenance pass retries it
+    from scratch, so neither is a bug in this function.
 
     Used by both `PipelineNonDLT.run` (v2) and `PipelineV3.run` to keep the behaviour
     identical across pipelines without each having to know how to look up `partition_count`
@@ -730,8 +732,8 @@ async def run_pre_write_defensive_compact(
                 schema.id, schema.team_id, updates={"last_vacuum_version": new_version}
             )
     except Exception as e:
-        if is_transient_object_store_error(e):
-            await logger.awarning(f"Pre-write maintenance skipped: transient object-store error: {e}")
+        if is_transient_object_store_error(e) or is_transient_delta_maintenance_error(e):
+            await logger.awarning(f"Pre-write maintenance skipped: transient error: {e}")
             return
         capture_exception(e)
         await logger.aexception(f"Pre-write maintenance failed: {e}", exc_info=e)

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -5,6 +5,7 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import deltalake
 from asgiref.sync import async_to_sync
 from parameterized import parameterized
 
@@ -189,6 +190,27 @@ class TestRunPreWriteDefensiveCompact:
         # errors from delta-rs) isn't a bug in this function — it shouldn't flood error tracking the
         # way an actual maintenance bug does (see test_swallows_maintenance_failure above).
         helper = MagicMock(run_maintenance=AsyncMock(side_effect=OSError(error_message)))
+        logger = MagicMock(aexception=AsyncMock(), awarning=AsyncMock())
+
+        schema = MagicMock(partition_count=5, sync_type_config={})
+        with patch(f"{_EXTRACT_MODULE}.capture_exception") as mock_capture:
+            await run_pre_write_defensive_compact(helper, schema, MagicMock(partition_count=None), logger)
+
+        mock_capture.assert_not_called()
+        logger.awarning.assert_awaited_once()
+        logger.aexception.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_logs_transient_delta_maintenance_race_without_capturing(self):
+        # Regression: a concurrent optimize/vacuum pass on the same table (e.g. a zombie Temporal
+        # attempt racing its own retry) can have `optimize.compact` scan a file the other attempt
+        # already vacuumed away. Nothing gets committed when the scan fails, so the table isn't
+        # corrupted — this must be treated the same as the object-store blips above, not captured.
+        error = deltalake.exceptions.DeltaError(
+            "Failed to parse parquet: Optimize selected-file scan failed while scanning data: "
+            "Object at location .../part-0.parquet not found: 404 Not Found"
+        )
+        helper = MagicMock(run_maintenance=AsyncMock(side_effect=error))
         logger = MagicMock(aexception=AsyncMock(), awarning=AsyncMock())
 
         schema = MagicMock(partition_count=5, sync_type_config={})

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
@@ -78,6 +78,21 @@ def is_transient_object_store_error(error: BaseException) -> bool:
 # exactly what its "must be rerun" error message asks the caller to do.
 DELTA_MERGE_CONFLICT_RETRIES = 3
 
+# `optimize.compact` plans its rewrite against the file list at the start of its scan, then reads
+# those files. A concurrent maintenance pass on the same table (e.g. a Temporal activity attempt that
+# heartbeat-timed-out but keeps running as a zombie — see this package's README on the equivalent
+# unfenced race for repartition) can vacuum one of those files out from under the scan before it gets
+# read, which delta-rs surfaces as this DeltaError. The scan failing here means the optimize aborted
+# before committing anything — the table is left exactly as it was, just still fragmented — so this is
+# safe to skip and retry on the next maintenance pass, not a bug in our logic.
+TRANSIENT_DELTA_MAINTENANCE_ERRORS = ("Optimize selected-file scan failed",)
+
+
+def is_transient_delta_maintenance_error(error: BaseException) -> bool:
+    return isinstance(error, deltalake.exceptions.DeltaError) and any(
+        needle in str(error) for needle in TRANSIENT_DELTA_MAINTENANCE_ERRORS
+    )
+
 
 def _delta_merge_spill_kwargs() -> dict[str, int]:
     """delta-rs `merge` kwargs that let DataFusion spill to disk instead of OOMing on large merges.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
@@ -25,6 +25,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.del
     _delta_merge_spill_kwargs,
     _first_per_pk_table,
     _realign_decimal_buffers,
+    is_transient_delta_maintenance_error,
 )
 
 
@@ -1151,3 +1152,25 @@ class TestIsTableCorrupted:
             result = await helper.is_table_corrupted()
 
         assert result is expected
+
+
+class TestIsTransientDeltaMaintenanceError:
+    @parameterized.expand(
+        [
+            # A concurrent optimize/vacuum losing the race on a file scan: safe to skip and retry.
+            (
+                "optimize_scan_file_not_found",
+                deltalake.exceptions.DeltaError(
+                    "Failed to parse parquet: Optimize selected-file scan failed while scanning data: "
+                    "Object at location .../part-0.parquet not found: 404 Not Found"
+                ),
+                True,
+            ),
+            # Other DeltaErrors are real failures (e.g. a genuinely corrupt log) and must still be captured.
+            ("unrelated_delta_error", deltalake.exceptions.DeltaError("no protocol found in delta log"), False),
+            # Same message shape but not the DeltaError type delta-rs actually raises for it.
+            ("wrong_exception_type", RuntimeError("Optimize selected-file scan failed"), False),
+        ]
+    )
+    def test_matches_only_the_racy_optimize_scan_signature(self, _name: str, error: Exception, expected: bool):
+        assert is_transient_delta_maintenance_error(error) is expected


### PR DESCRIPTION
## Problem

An [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fad97-c2b1-79e3-806b-4fb052795c0c) surfaced a `DeltaError` during a Postgres sync's append write:

```
Failed to parse parquet: Parquet error: Optimize selected-file scan failed while scanning data:
Parquet error: Failed to fetch metadata for file ...: Object Store error: Object at location ...
not found: ... 404 Not Found
```

The stack trace traces through `run_pre_write_defensive_compact` (`common/extract.py`) → `DeltaTableHelper.run_maintenance` → `compact_if_fragmented` → `compact_table`, landing in delta-rs's `optimize.compact` call.

`optimize.compact` plans its rewrite against the table's file list at the start of a scan, then reads those files. If a concurrent maintenance pass on the same table (compact/vacuum can run from more than one call site across a sync, and a heartbeat-timed-out Temporal activity attempt can keep running as a "zombie" alongside its own retry — a race this package's README already documents for the equivalent repartition path) vacuums one of those files out from under the scan before it's read, delta-rs raises exactly this error.

Since the scan fails before anything commits, the table is left exactly as it was — just still fragmented — so this is safe to skip and retry on the next maintenance pass. `run_pre_write_defensive_compact` already treats maintenance failures as best-effort (the sync isn't affected either way), but this specific error was still being captured to error tracking as if it were a bug, alongside an existing, narrower classifier (`is_transient_object_store_error`) for other known-transient blips.

## Changes

- Added `is_transient_delta_maintenance_error` next to the existing `is_transient_object_store_error` in `delta_table_helper.py`, matching this specific delta-rs error signature.
- `run_pre_write_defensive_compact` now logs a warning instead of capturing when this signature is hit, the same treatment already given to transient object-store errors.

The same call chain also fans out into a couple of other pre-write/post-load maintenance call sites (`common/load.py`, `pipeline_v2/pipeline.py`), where this same race is theoretically reachable too. I left those out of this PR: [#74630](https://github.com/PostHog/posthog/pull/74630) is already open and actively editing those exact same try/except blocks for a related but distinct S3-throttling signature, so extending them here risked a needless merge conflict. Once that one lands, extending `is_transient_delta_maintenance_error` to those call sites would be a natural, low-risk follow-up.

No retry policy, timeout, or `NonRetryableErrors` classification changed — this only reclassifies an already-non-fatal exception path.

## How did you test this code?

- Added `TestIsTransientDeltaMaintenanceError` to `test_delta_table_helper.py`, parameterized over the racy scan signature, an unrelated `DeltaError`, and a non-`DeltaError` exception carrying the same message — locks in that only the specific delta-rs signature matches.
- Added `test_logs_transient_delta_maintenance_race_without_capturing` to `test_extract.py`'s `TestRunPreWriteDefensiveCompact`, mirroring the existing object-store-error case, asserting `capture_exception` is not called and a warning is logged instead.
- Ran `test_delta_table_helper.py`, `test_extract.py`, `test_load.py`, and `pipeline_v2/test_pipeline.py`: 122 passed, 4 pre-existing failures in `TestGetDeltaTableUnrecoverableErrors` (needs a live object-storage service unavailable in this sandbox; identical on unmodified `master`), several DB-backed tests erroring for the same sandbox reason.
- `ruff check` / `ruff format --check` clean on all changed files.
- Full-repo `uv run mypy --cache-fine-grained .` clean (17074 source files).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal pipeline implementation detail, no user-facing or API surface change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error-tracking issue (webhook-delivered) using Claude Code. Pulled the stack trace, exception sample, and `warehouse_sources_*` properties via the PostHog MCP tools to confirm the exact call path and that it's a v2 (non-DLT) pipeline sync. Searched open PRs for duplicates: found [#74630](https://github.com/PostHog/posthog/pull/74630) touching the same `load.py`/`pipeline_v2/pipeline.py` try/except blocks for a different error signature (S3 throttling, not this optimize/vacuum race) — scoped this PR down to the file this issue's stack trace actually implicates (`extract.py` + `delta_table_helper.py`) to avoid duplicating or conflicting with that in-flight work. Also checked [#74541](https://github.com/PostHog/posthog/pull/74541) (a different `delta_table_helper.py` bug, redundant re-fetch inside compact/vacuum) for overlap — none, since it doesn't touch the classifier or call-site error handling this PR changes. Invoked `/writing-tests` before adding coverage.