### PR TITLE
fix(data-imports): reconcile decimals on delta append writes

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
@@ -605,6 +605,13 @@ class DeltaTableHelper:
                     storage_options=storage_options,
                     partition_by=PARTITION_KEY if use_partitioning else None,
                 )
+            else:
+                # An append re-casts each source column to its stored type, same as a merge. A decimal
+                # column that outgrew decimal128 arrives here as text (decimal256 renders to string),
+                # and delta-rs can't parse the scientific notation arrow emits for scale-heavy zeros
+                # (e.g. '0E-18') back into the stored decimal — an opaque DeltaError that retries
+                # forever. Align to the stored decimal types up front, exactly as the merge path does.
+                data = align_incoming_decimals_to_delta(data, delta_table.schema())
 
             await self._logger.adebug(f"write_to_deltalake: write_type = append")
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
@@ -14,7 +14,10 @@ import deltalake
 import pyarrow.compute as pc
 from parameterized import parameterized
 
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import evolve_pyarrow_schema
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
+    SchemaColumnTypeChangedException,
+    evolve_pyarrow_schema,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import PARTITION_KEY
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper import (
     DeltaTableHelper,
@@ -597,6 +600,74 @@ class TestLegacyDltTableReconciliation:
         final = result.to_pyarrow_table()
         assert final.num_rows == 3
         assert set(final.column("id").to_pylist()) == {1, 2, 3}
+
+
+class TestAppendDecimalReconciliation:
+    """Appending a decimal column that outgrew decimal128 must reconcile to the stored type.
+
+    A batch whose numeric column exceeds decimal128 is promoted to decimal256, which
+    `evolve_pyarrow_schema` renders to text for the Delta write. Arrow emits scientific
+    notation for scale-heavy zeros (e.g. '0E-18'), which delta-rs can't parse back into
+    the stored decimal — an opaque, infinitely-retrying DeltaError on the append path.
+    """
+
+    def _seed_decimal_table(self, delta_path: str) -> deltalake.DeltaTable:
+        table = pa.table(
+            {"id": pa.array([1], type=pa.int64()), "amount": pa.array([Decimal("1.5")], type=pa.decimal128(38, 10))}
+        )
+        deltalake.write_deltalake(delta_path, table)
+        return deltalake.DeltaTable(delta_path)
+
+    @pytest.mark.asyncio
+    async def test_scale_heavy_batch_is_rounded_to_stored_type(self, tmp_path: Path) -> None:
+        delta_path = str(tmp_path / "table")
+        dt = self._seed_decimal_table(delta_path)
+        helper = _make_local_helper(delta_path)
+
+        # Values fit decimal128's integer budget but carry more scale than the stored column,
+        # so they land as decimal256 and evolve renders them to text (the zero as '0E-18').
+        batch = evolve_pyarrow_schema(
+            pa.table(
+                {
+                    "id": pa.array([2, 3], type=pa.int64()),
+                    "amount": pa.array(
+                        [Decimal("0.12345678901234567890"), Decimal("0E-18")], type=pa.decimal256(76, 20)
+                    ),
+                }
+            ),
+            dt.schema(),
+        )
+        assert pa.types.is_string(batch.schema.field("amount").type)
+
+        result = await helper.write_to_deltalake(
+            data=batch, write_type="append", should_overwrite_table=False, primary_keys=None
+        )
+
+        final = result.to_pyarrow_table()
+        assert final.schema.field("amount").type == pa.decimal128(38, 10)
+        assert set(final.column("id").to_pylist()) == {1, 2, 3}
+        assert Decimal("0") in final.column("amount").to_pylist()
+
+    @pytest.mark.asyncio
+    async def test_integer_overflow_batch_raises_clean_non_retryable(self, tmp_path: Path) -> None:
+        delta_path = str(tmp_path / "table")
+        dt = self._seed_decimal_table(delta_path)
+        helper = _make_local_helper(delta_path)
+
+        batch = evolve_pyarrow_schema(
+            pa.table(
+                {
+                    "id": pa.array([2, 3], type=pa.int64()),
+                    "amount": pa.array([Decimal("1" + "0" * 35 + ".5"), Decimal("0E-18")], type=pa.decimal256(76, 18)),
+                }
+            ),
+            dt.schema(),
+        )
+
+        with pytest.raises(SchemaColumnTypeChangedException):
+            await helper.write_to_deltalake(
+                data=batch, write_type="append", should_overwrite_table=False, primary_keys=None
+            )
 
 
 class TestIncrementalBatchDeduplication:


### PR DESCRIPTION
## Problem

A data-warehouse Postgres sync (append mode, v2 pipeline) was crashing in shared pipeline code with:

```
DeltaError: Generic DeltaTable error: Arrow error: Cast error:
Cannot cast string '0E-18' to value of Decimal128(38, 10) type
```

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019fada1-cbb6-7a41-8f0c-4b8001523bf1 (surfaced on `_write_deltalake` in `delta_table_helper.py`).

The root cause is in shared code, not the Postgres connector. When a numeric column carries values that outgrow `decimal128`, the pipeline promotes the batch column to `decimal256`. delta-rs has no `decimal256`, so schema evolution renders that column to text before the write. Arrow renders scale-heavy zeros in scientific notation (`0E-18`), and delta-rs (arrow-rs) cannot parse scientific-notation strings back into the stored decimal column - even though the value is a harmless zero. The append then fails and retries forever with an opaque error.

The incremental merge path already guards against this by pre-aligning each batch's decimal columns to the stored types (`align_incoming_decimals_to_delta`). The append path never got that guard.

## Changes

Apply `align_incoming_decimals_to_delta` before an append into an existing Delta table, exactly as the merge path does. For each decimal column it parses the incoming values (including the text form) back to `Decimal` and fits them to the stored column type:

- Values that fit are rounded to the stored scale, so the write succeeds (this resolves the reported `0E-18` crash).
- A value whose integer part genuinely can't fit raises `SchemaColumnTypeChangedException`, which is already classified non-retryable and tells the user to reset and re-sync. That replaces the infinitely-retrying `DeltaError`.

> [!NOTE]
> This is scoped to the append branch of `write_to_deltalake`. It reuses existing, tested reconciliation logic - no new retry policy, no source-specific change.

## How did you test this code?

Added `TestAppendDecimalReconciliation` in `test_delta_table_helper.py`, using the existing real-local-Delta-table harness:

- `test_scale_heavy_batch_is_rounded_to_stored_type` - a batch that lands as text (including a `0E-18` zero) now writes successfully as `decimal128(38, 10)`.
- `test_integer_overflow_batch_raises_clean_non_retryable` - a genuinely oversized value now raises the clean, non-retryable `SchemaColumnTypeChangedException` instead of a `DeltaError`.

Both tests reproduce the exact production `DeltaError` when the fix is reverted, and pass with it. The regression they catch that no existing test did: decimal reconciliation on the append path (existing decimal tests only cover the merge path). Verified the mechanism end-to-end against the real `pyarrow`/`deltalake` versions in the repo.

The 4 unrelated failures in this file's `TestGetDeltaTableUnrecoverableErrors` are pre-existing and environmental (they require an object-storage endpoint not available in the sandbox).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live error-tracking webhook. I (Claude) pulled the issue's stack trace and `warehouse_sources_*` sync context via the PostHog MCP tools to scope it (Postgres, append, v2 pipeline), then reproduced the mechanism against the repo's real `pyarrow`/`deltalake` to confirm that arrow renders `decimal256` zeros as `0E-18` and that arrow-rs can't parse them back. Considered fixing the string rendering itself, but reusing the merge path's existing `align_incoming_decimals_to_delta` is the smaller, general fix and yields a clean non-retryable error for genuine overflows. Invoked the `/writing-tests` skill before adding the regression tests.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
