### PR TITLE
fix(fillout): avoid Unix-epoch afterDate on first incremental sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fillout/fillout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fillout/fillout.py
@@ -66,7 +66,9 @@ def _fillout_incremental_window(cursor_path: str) -> IncrementalConfig:
     return {
         "cursor_path": cursor_path,
         "start_param": "afterDate",
-        "initial_value": "1970-01-01T00:00:00Z",
+        # Not `...T00:00:00Z`: Fillout's API rejects an `afterDate` of exactly the Unix epoch
+        # with a 400 "Invalid date", so the first (pre-watermark) sync uses one second past it.
+        "initial_value": "1970-01-01T00:00:01Z",
         "convert": _format_fillout_datetime,
     }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/fillout/tests/test_fillout.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/fillout/tests/test_fillout.py
@@ -9,6 +9,7 @@ from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.fillout.fillout import (
     FilloutSubmissionsPaginator,
+    _fillout_incremental_window,
     _format_fillout_datetime,
     _validated_api_base_url,
     fillout_source,
@@ -91,6 +92,12 @@ class TestFilloutTransport:
     )
     def test_format_fillout_datetime(self, _name, value, expected) -> None:
         assert _format_fillout_datetime(value) == expected
+
+    def test_fillout_incremental_window_initial_value_is_not_unix_epoch(self) -> None:
+        # Fillout's API 400s on an `afterDate` of exactly 1970-01-01T00:00:00Z (any
+        # millisecond precision), so the pre-watermark sentinel must land elsewhere.
+        config = _fillout_incremental_window("submissionTime")
+        assert config["initial_value"] not in ("1970-01-01T00:00:00Z", "1970-01-01T00:00:00.000Z")
 
     def test_validated_api_base_url_rejects_unknown(self) -> None:
         with pytest.raises(


### PR DESCRIPTION
## Problem

Error tracking surfaced an `HTTPError: 400 Client Error: Bad Request` from a Fillout `submissions` sync, raised from the shared REST client (`_send_request` in `products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py`). The failing request's `afterDate` query param was exactly `1970-01-01T00:00:00Z`.

I confirmed against Fillout's live API (with an invalid test key, so only request-shape errors surface) that this exact value is what triggers the 400 — `1970-01-01T00:00:00Z` and `1970-01-01T00:00:00.000Z` both come back with `"Invalid date for afterDate"`, while every neighboring value (1969, 1971, one second later, etc.) parses fine and falls through to the auth-related error instead. So Fillout's API specifically rejects an `afterDate` of exactly the Unix epoch, likely from treating a zero timestamp as falsy/unset server-side.

Our Fillout connector uses `1970-01-01T00:00:00Z` as the sentinel "no watermark yet" value for the first incremental sync of a `submissions` schema (`_fillout_incremental_window` in `products/warehouse_sources/backend/temporal/data_imports/sources/fillout/fillout.py`) — so every fresh incremental `submissions` sync hit this 400 before a real watermark could ever be recorded.

## Changes

Shifts the incremental sentinel one second past the epoch (`1970-01-01T00:00:01Z`), which is still safely before any real Fillout submission but isn't the specific value Fillout's API rejects.

This is scoped to the Fillout connector — the underlying REST client and pipeline framework are shared across sources and are not at fault here, so no shared-code change was needed.

## How did you test this code?

- Reproduced the exact 400 against Fillout's live API by replaying the `afterDate` value from the error tracking issue, then confirmed the fix value is accepted (falls through to an auth error instead of the date-validation error).
- Added `test_fillout_incremental_window_initial_value_is_not_unix_epoch` to `test_fillout.py`, asserting the sentinel isn't exactly the Unix epoch in either format — this guards against a future edit reintroducing the exact value Fillout's API rejects, which no existing test caught.
- Ran the full `test_fillout.py` suite (27 tests, all passing) plus `ruff check`/`ruff format --check` on the changed files.

## Docs update

Not applicable — no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool used: Claude Code (Sonnet 5), triaging a PostHog error-tracking issue via MCP tools.
- Investigation: pulled the issue's stack trace and sampled `$exception` events (including `warehouse_sources_*` context properties) via the error-tracking MCP tools, then reproduced the failure directly against Fillout's public API to isolate the exact trigger (the literal epoch timestamp, not date formatting) before touching any code.
- Decision: fixed the connector-level sentinel value rather than the shared REST/pipeline code, since the bug is a quirk of Fillout's own date validation, not a general framework issue.