### PR TITLE
fix(data-imports): keep exhausted REST retries out of error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -30,7 +30,14 @@ from .utils import resolve_request_url
 logger = logging.getLogger(__name__)
 
 
-class RESTClientRetryableError(Exception):
+class RESTClientRetryableError(NonReportableError):
+    """A transient failure (429/5xx, connection reset/timeout, malformed/truncated body) that
+    tenacity reissues up to the client's attempt cap. Once that budget is exhausted it escapes to
+    the activity and Temporal's own activity retry takes over — the upstream blip is expected to
+    clear, not a PostHog defect. Subclasses NonReportableError, like ``RESTClientNonRetryableError``,
+    so the activity interceptor keeps it out of error tracking instead of minting an issue per blip.
+    """
+
     def __init__(self, message: str, retry_after: Optional[float] = None) -> None:
         super().__init__(message)
         self.retry_after = retry_after

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -353,10 +353,14 @@ class TestRESTClient:
         mock_session.send.return_value = error
 
         client = RESTClient(base_url="https://api.example.com")
-        with pytest.raises(RESTClientRetryableError):
+        with pytest.raises(RESTClientRetryableError) as ctx:
             list(client.paginate(path="/items", paginator=SinglePagePaginator()))
 
         assert mock_session.send.call_count == 5
+        # An upstream blip surviving every tenacity attempt is expected to clear on Temporal's own
+        # activity retry, not a PostHog defect, so it must carry the non-reportable marker the
+        # activity interceptor uses to keep it out of error tracking.
+        assert isinstance(ctx.value, NonReportableError)
 
     @pytest.mark.parametrize(
         "content",


### PR DESCRIPTION
## Problem

An error-tracking issue fired for a data warehouse import sync: `RESTClientRetryableError: HTTP 524 for https://api.cal.com/v2/bookings` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019fada5-7437-7261-8d38-3923413706b6)). HTTP 524 is Cloudflare's "origin didn't respond in time" timeout - a transient upstream blip, not a bug.

The shared REST engine already retries this internally (tenacity, 5 attempts with backoff) before giving up, and `import_data_sync.py`'s `_handle_import_error` already classifies `RESTClientRetryableError` as "benign, self-recovering" and logs it at `warning` instead of `exception` specifically so it wouldn't show up as error-tracking noise. That intent doesn't hold: the Temporal activity interceptor that decides whether to call `capture_exception` (`posthog/temporal/common/posthog_client.py`) only skips reporting for exceptions that subclass `NonReportableError` - the application log level has no effect on it. So every exhausted-retry transient error from any REST-based source (429s, 5xx, connection resets/timeouts) still mints a fresh error-tracking issue, once its retry budget runs out, on every occurrence.

`RESTClientNonRetryableError` (the sibling "retrying can never help" error) already solves this correctly by subclassing `NonReportableError`. `RESTClientRetryableError` didn't.

## Changes

- `RESTClientRetryableError` now subclasses `NonReportableError`, the same pattern `RESTClientNonRetryableError` already uses, so the activity interceptor actually keeps it out of error tracking once it escapes the REST client's own retry loop.
- Temporal's own activity-level retry is unaffected - this only changes whether the escaped exception is reported, not whether (or how many times) the sync retries.

## How did you test this code?

- Extended `test_send_request_raises_retryable_after_persistent_transient_error` in `test_rest_client.py` to assert the raised `RESTClientRetryableError` is also a `NonReportableError`, mirroring the existing assertion for `RESTClientNonRetryableError` in `test_non_json_response_body_is_non_retryable`.
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py` - 34 passed.
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py` - 12 passed (unaffected, confirms `_handle_import_error`'s type-based `RESTClientRetryableError` branch still behaves as before).
- `uv run mypy --cache-fine-grained .` - no issues in 17074 source files.
- `uv run ruff check` / `ruff format --check` on changed files - clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - internal error-tracking classification, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triggered by an error-tracking webhook for the issue linked above. I (Claude) triaged the stack trace, traced the exception path from the Cal.com sync's REST call up through the shared pipeline and Temporal activity interceptor, and found the retry-vs-report classification gap.
- Checked existing open PRs for overlap first: [#74388](https://github.com/PostHog/posthog/pull/74388) fixes the same underlying gap (log level doesn't suppress `capture_exception`) for a different error class (transient S3/object-store errors), confirming this is an established pattern rather than a novel fix - it doesn't touch `RESTClientRetryableError` or this file, so no duplicate.
- No skills invoked; this was a direct code read + targeted fix following the existing `RESTClientNonRetryableError` precedent in the same file.