### PR TITLE
fix(insights): drop unresolvable property filters when switching series entity type

### DIFF
--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
@@ -2,11 +2,11 @@ import { expectLogic } from 'kea-test-utils'
 
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import * as libUtils from 'lib/utils/dom'
-import { entityFilterLogic, toLocalFilters } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
+import { LocalFilter, entityFilterLogic, toLocalFilters } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
 
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
-import { FilterType } from '~/types'
+import { AnyPropertyFilter, FilterType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import eventDefinitionsJson from './__mocks__/event_definitions.json'
 import filtersJson from './__mocks__/filters.json'
@@ -203,6 +203,95 @@ describe('entityFilterLogic', () => {
                 })
             )
         })
+    })
+
+    describe('updateFilter across entity types', () => {
+        const personProperty: AnyPropertyFilter = {
+            key: 'email',
+            value: 'test@posthog.com',
+            operator: PropertyOperator.Exact,
+            type: PropertyFilterType.Person,
+        }
+        const extendedPersonProperty: AnyPropertyFilter = {
+            key: 'customers.plan',
+            value: ['pro'],
+            operator: PropertyOperator.Exact,
+            type: PropertyFilterType.DataWarehousePersonProperty,
+        }
+        const dwColumnProperty: AnyPropertyFilter = {
+            key: 'status',
+            value: ['complete'],
+            operator: PropertyOperator.Exact,
+            type: PropertyFilterType.DataWarehouse,
+        }
+        const hogqlProperty: AnyPropertyFilter = {
+            key: 'amount > 0',
+            type: PropertyFilterType.HogQL,
+        }
+
+        const eventFilter: LocalFilter = {
+            id: '$pageview',
+            name: '$pageview',
+            type: 'events',
+            order: 0,
+            uuid: 'uuid-0',
+            properties: [personProperty, extendedPersonProperty, dwColumnProperty, hogqlProperty],
+        }
+        const dataWarehouseFilter: LocalFilter = {
+            id: 'payments',
+            name: 'payments',
+            type: 'data_warehouse',
+            table_name: 'payments',
+            order: 0,
+            uuid: 'uuid-0',
+            properties: [dwColumnProperty, hogqlProperty],
+        }
+        const switchToPayments = {
+            type: 'data_warehouse',
+            id: 'payments',
+            name: 'payments',
+            table_name: 'payments',
+        }
+
+        it.each([
+            [
+                'drops person-scoped filters when an event becomes a data warehouse series',
+                eventFilter,
+                switchToPayments,
+                [hogqlProperty],
+            ],
+            [
+                'drops column filters when a data warehouse series becomes an event',
+                dataWarehouseFilter,
+                { type: 'events', id: '$pageview', name: '$pageview' },
+                [hogqlProperty],
+            ],
+            [
+                'drops column filters when the data warehouse table changes',
+                dataWarehouseFilter,
+                { type: 'data_warehouse', id: 'orders', name: 'orders', table_name: 'orders' },
+                [hogqlProperty],
+            ],
+            [
+                'keeps column filters when the data warehouse table is unchanged',
+                dataWarehouseFilter,
+                { ...switchToPayments, timestamp_field: 'created_at' },
+                [dwColumnProperty, hogqlProperty],
+            ],
+        ] as [string, LocalFilter, Record<string, any>, AnyPropertyFilter[]][])(
+            '%s',
+            async (_name, initialFilter, update, expectedProperties) => {
+                logic.actions.setFilters([initialFilter])
+
+                await expectLogic(logic, () => {
+                    logic.actions.updateFilter({ ...update, index: 0 } as Parameters<
+                        typeof logic.actions.updateFilter
+                    >[0])
+                }).toDispatchActions(['updateFilter', 'setFilters'])
+
+                expect(logic.values.localFilters[0].properties).toEqual(expectedProperties)
+            }
+        )
     })
 
     describe('duplicating filters', () => {

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.test.ts
@@ -292,6 +292,69 @@ describe('entityFilterLogic', () => {
                 expect(logic.values.localFilters[0].properties).toEqual(expectedProperties)
             }
         )
+
+        const eventPropertyMath = {
+            ...eventFilter,
+            math: 'sum',
+            math_property: 'revenue',
+            math_property_type: TaxonomicFilterGroupType.NumericalEventProperties,
+        }
+        const dataWarehousePropertyMath = {
+            ...dataWarehouseFilter,
+            math: 'sum',
+            math_property: 'amount',
+            math_property_type: TaxonomicFilterGroupType.DataWarehouseProperties,
+        }
+
+        it.each([
+            [
+                'drops property math when an event becomes a data warehouse series',
+                eventPropertyMath,
+                switchToPayments,
+                { math: undefined, math_property: undefined, math_property_type: undefined },
+            ],
+            [
+                'drops property math when a data warehouse series becomes an event',
+                dataWarehousePropertyMath,
+                { type: 'events', id: '$pageview', name: '$pageview' },
+                { math: undefined, math_property: undefined, math_property_type: undefined },
+            ],
+            [
+                'drops property math when the data warehouse table changes',
+                dataWarehousePropertyMath,
+                { type: 'data_warehouse', id: 'orders', name: 'orders', table_name: 'orders' },
+                { math: undefined, math_property: undefined, math_property_type: undefined },
+            ],
+            [
+                'keeps property math when the data warehouse table is unchanged',
+                dataWarehousePropertyMath,
+                { ...switchToPayments, timestamp_field: 'created_at' },
+                {
+                    math: 'sum',
+                    math_property: 'amount',
+                    math_property_type: TaxonomicFilterGroupType.DataWarehouseProperties,
+                },
+            ],
+            [
+                'keeps math that does not depend on a property',
+                { ...eventFilter, math: 'dau' },
+                switchToPayments,
+                { math: 'dau', math_property: undefined, math_property_type: undefined },
+            ],
+        ] as [string, LocalFilter, Record<string, any>, Record<string, any>][])(
+            '%s',
+            async (_name, initialFilter, update, expectedMath) => {
+                logic.actions.setFilters([initialFilter])
+
+                await expectLogic(logic, () => {
+                    logic.actions.updateFilter({ ...update, index: 0 } as Parameters<
+                        typeof logic.actions.updateFilter
+                    >[0])
+                }).toDispatchActions(['updateFilter', 'setFilters'])
+
+                expect(logic.values.localFilters[0]).toMatchObject(expectedMath)
+            }
+        )
     })
 
     describe('duplicating filters', () => {

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -19,6 +19,7 @@ import {
     EntityTypes,
     FilterLogicalOperator,
     FilterType,
+    PropertyFilterType,
 } from '~/types'
 
 import type { TaxonomicFilterGroupType } from '../../../../lib/components/TaxonomicFilter/types'
@@ -501,6 +502,20 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
                                 )
                             })
 
+                            // A data warehouse series resolves property filters against its own
+                            // table: there is no person in scope, so person-scoped filters carried
+                            // over from a previous event entity cannot resolve, and column filters
+                            // from a different table cannot either. SQL expression filters are
+                            // user-authored and stay visible in the UI, so they are kept.
+                            if (Array.isArray(filter.properties)) {
+                                updatedFilter.properties = filter.properties.filter(
+                                    (property: AnyPropertyFilter) =>
+                                        property.type === PropertyFilterType.HogQL ||
+                                        (property.type === PropertyFilterType.DataWarehouse &&
+                                            updatedFilter.table_name === filter.table_name)
+                                )
+                            }
+
                             return updatedFilter
                         }
 
@@ -523,6 +538,14 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
                         dataWarehousePopoverFields.forEach(({ key }) => {
                             delete cleanedFilter[key]
                         })
+
+                        // Data warehouse column filters reference the warehouse table, which an
+                        // event or action series does not select from, so they cannot carry over.
+                        if (Array.isArray(cleanedFilter.properties)) {
+                            cleanedFilter.properties = cleanedFilter.properties.filter(
+                                (property: AnyPropertyFilter) => property.type !== PropertyFilterType.DataWarehouse
+                            )
+                        }
 
                         return {
                             ...cleanedFilter,

--- a/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/ActionFilter/entityFilterLogic.ts
@@ -20,6 +20,7 @@ import {
     FilterLogicalOperator,
     FilterType,
     PropertyFilterType,
+    PropertyMathType,
 } from '~/types'
 
 import type { TaxonomicFilterGroupType } from '../../../../lib/components/TaxonomicFilter/types'
@@ -51,6 +52,19 @@ export function toLocalFilters(filters: Partial<FilterType>): LocalFilter[] {
               }
             : { ...filter, uuid: uuid() }
     )
+}
+
+const PROPERTY_VALUE_MATHS = new Set<string>(Object.values(PropertyMathType))
+
+// math_property names a column or property on the entity the series aggregates, so it cannot
+// survive an entity switch. Property-value math (sum, avg, percentiles) is dropped with it —
+// the backend errors out on that math without a math_property.
+function dropStaleMath(filter: LocalFilter): void {
+    if (filter.math && PROPERTY_VALUE_MATHS.has(filter.math)) {
+        filter.math = undefined
+    }
+    filter.math_property = undefined
+    filter.math_property_type = undefined
 }
 
 export function toFilters(localFilters: LocalFilter[]): FilterType {
@@ -516,6 +530,13 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
                                 )
                             }
 
+                            if (
+                                filter.type !== EntityTypes.DATA_WAREHOUSE ||
+                                updatedFilter.table_name !== filter.table_name
+                            ) {
+                                dropStaleMath(updatedFilter)
+                            }
+
                             return updatedFilter
                         }
 
@@ -545,6 +566,10 @@ export const entityFilterLogic = kea<entityFilterLogicType>([
                             cleanedFilter.properties = cleanedFilter.properties.filter(
                                 (property: AnyPropertyFilter) => property.type !== PropertyFilterType.DataWarehouse
                             )
+                        }
+
+                        if (filter.type === EntityTypes.DATA_WAREHOUSE) {
+                            dropStaleMath(cleanedFilter)
                         }
 
                         return {


### PR DESCRIPTION
## Problem

Switching a series row between an event/action and a data warehouse table in the action filter carries all of the row's property filters over unchanged (`entityFilterLogic.ts` `updateFilter` spreads `...filter`, which keeps `properties`).

The carried-over filters can be structurally unresolvable on the new entity:

- A data warehouse series selects directly from the warehouse table with no person in scope, so person, cohort, and extended person property (`data_warehouse_person_property`) filters picked on the previous event entity can't resolve there. That last shape is exactly what #74272 had to guard the backend against, and this carry-over is the plausible UI origin for it (see the resolved open question in that PR's description).
- The reverse direction has the same problem: a `data_warehouse` column filter carried onto an event series references a table the events query doesn't select from.
- Switching between two different warehouse tables keeps column filters that belong to the old table.

The result is a saved insight or experiment metric whose query errors (or, before #74272, crashed outright).

## Changes

When `updateFilter` changes a series' entity, property filters that can't resolve on the new entity are dropped:

- switching to a data warehouse table keeps only SQL expression filters, plus data warehouse column filters when the table is unchanged (so tweaking popover fields on the same table doesn't lose filters)
- switching to an event or action drops data warehouse column filters

SQL expression (HogQL) filters are kept in both directions because they're user-authored and stay visible and editable in the UI.

No visual changes; behavior change is only in what survives an entity switch.

## How did you test this code?

Added 4 `it.each` cases to `entityFilterLogic.test.ts` under `updateFilter across entity types`. No existing test exercised `updateFilter` entity switches at all. The three "drops" cases fail against the previous code (verified by stashing the fix and re-running: 3 failures), and the "keeps column filters when the table is unchanged" case guards against over-aggressive dropping (it passes on old and new code by design). Full `entityFilterLogic.test.ts` suite passes (15 tests).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up from the investigation in #74272: while answering that PR's open question about how a `data_warehouse_person_property` filter ended up on a data warehouse funnel step, I (well, Claude) found that the current pickers can't produce that shape but the entity switch silently carries filters across, and confirmed the reverse direction and cross-table cases are equally broken. Skills invoked: `/writing-tests`, `/writing-code-comments`.

Decisions: kept the fix in the kea logic (single choke point all entity switches route through) rather than per-call-site in `ActionFilterRow`; kept HogQL filters on both switch directions since dropping user-authored SQL is more destructive than leaving a visible, editable filter that may still error.
