### PR TITLE
fix(data-imports): retry delta merge commit conflicts with a refreshed table

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
@@ -71,6 +71,14 @@ def is_transient_object_store_error(error: BaseException) -> bool:
     return isinstance(error, OSError) and any(needle in str(error) for needle in TRANSIENT_OBJECT_STORE_ERRORS)
 
 
+# A merge's conflict checker raises CommitFailedError the moment a concurrent commit added data
+# the merge predicate didn't account for — unlike a plain version-bump race, delta-rs does not
+# consume max_commit_retries or retry this itself (see delta-rs kernel/transaction/conflict_checker.rs),
+# because resolving it safely requires re-reading the table and re-running the merge, which is
+# exactly what its "must be rerun" error message asks the caller to do.
+DELTA_MERGE_CONFLICT_RETRIES = 3
+
+
 def _delta_merge_spill_kwargs() -> dict[str, int]:
     """delta-rs `merge` kwargs that let DataFusion spill to disk instead of OOMing on large merges.
 
@@ -386,6 +394,27 @@ class DeltaTableHelper:
 
         return await asyncio.to_thread(delta_table.file_uris)
 
+    async def _execute_merge_with_conflict_retry(
+        self, table: deltalake.DeltaTable, merge_fn: Callable[[], dict]
+    ) -> dict:
+        """Run a Delta merge, refreshing the table and re-running it on a commit conflict.
+
+        See DELTA_MERGE_CONFLICT_RETRIES for why this can't rely on delta-rs's own retry budget.
+        """
+        attempt = 0
+        while True:
+            try:
+                return await asyncio.to_thread(merge_fn)
+            except deltalake.exceptions.CommitFailedError:
+                if attempt >= DELTA_MERGE_CONFLICT_RETRIES:
+                    raise
+                attempt += 1
+                await self._logger.awarning(
+                    f"write_to_deltalake: merge commit conflict, retrying with refreshed table "
+                    f"(attempt {attempt}/{DELTA_MERGE_CONFLICT_RETRIES})"
+                )
+                await asyncio.to_thread(table.update_incremental)
+
     async def _dedupe_incremental_batch(
         self, data: pa.Table, primary_keys: Sequence[Any], use_partitioning: bool
     ) -> pa.Table:
@@ -501,11 +530,13 @@ class DeltaTableHelper:
 
                     merge_commit_properties = commit_properties if i == last_partition_index else None
 
+                    # Bind the current loop values as defaults so a conflict retry (which re-calls
+                    # this closure) can't accidentally pick up a later iteration's values.
                     def _do_merge(
-                        filtered_table: pa.Table,
-                        predicate: str,
-                        merge_commit_properties: deltalake.CommitProperties | None,
-                    ):
+                        filtered_table: pa.Table = filtered_table,
+                        predicate: str = predicate,
+                        merge_commit_properties: deltalake.CommitProperties | None = merge_commit_properties,
+                    ) -> dict:
                         return (
                             existing_delta_table.merge(
                                 source=filtered_table,
@@ -521,7 +552,7 @@ class DeltaTableHelper:
                             .execute()
                         )
 
-                    merge_stats = await asyncio.to_thread(_do_merge, filtered_table, predicate, merge_commit_properties)
+                    merge_stats = await self._execute_merge_with_conflict_retry(existing_delta_table, _do_merge)
 
                     await self._logger.adebug(f"Delta Merge Stats: {json.dumps(merge_stats)}")
 
@@ -545,7 +576,9 @@ class DeltaTableHelper:
                         .execute()
                     )
 
-                merge_stats = await asyncio.to_thread(_do_merge_unpartitioned, data, predicate_ops)
+                merge_stats = await self._execute_merge_with_conflict_retry(
+                    existing_delta_table, lambda: _do_merge_unpartitioned(data, predicate_ops)
+                )
                 await self._logger.adebug(f"Delta Merge Stats: {json.dumps(merge_stats)}")
         elif (
             write_type == "full_refresh"
@@ -691,7 +724,9 @@ class DeltaTableHelper:
                         .execute()
                     )
 
-                close_stats = await asyncio.to_thread(_do_scd2_close, first_per_pk, predicate)
+                close_stats = await self._execute_merge_with_conflict_retry(
+                    existing_delta_table, lambda: _do_scd2_close(first_per_pk, predicate)
+                )
                 await self._logger.adebug(f"SCD2 close stats: {json.dumps(close_stats)}")
 
         # Step 2: Append all new rows

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
@@ -17,6 +17,7 @@ from parameterized import parameterized
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import evolve_pyarrow_schema
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.consts import PARTITION_KEY
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper import (
+    DELTA_MERGE_CONFLICT_RETRIES,
     DeltaTableHelper,
     _delta_merge_spill_kwargs,
     _first_per_pk_table,
@@ -450,6 +451,74 @@ class TestWriteToDeltalakeCommitMetadataPassThrough:
             else:
                 assert isinstance(commit_properties, deltalake.CommitProperties)
                 assert commit_properties.custom_metadata == expected_custom_metadata
+
+
+class TestExecuteMergeWithConflictRetry:
+    """A merge's CommitFailedError means delta-rs's conflict checker rejected the commit
+    outright, without spending any of its own internal retry budget (see the comment on
+    DELTA_MERGE_CONFLICT_RETRIES). Regression coverage for the sync dying on the first such
+    conflict instead of refreshing the table and re-running the merge, as the error's own
+    "must be rerun" message calls for."""
+
+    def _helper(self) -> DeltaTableHelper:
+        return DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
+
+    @pytest.mark.asyncio
+    async def test_succeeds_without_retry(self):
+        helper = self._helper()
+        table = MagicMock()
+        merge_fn = MagicMock(return_value={"num_output_rows": 1})
+
+        result = await helper._execute_merge_with_conflict_retry(table, merge_fn)
+
+        assert result == {"num_output_rows": 1}
+        merge_fn.assert_called_once()
+        table.update_incremental.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_retries_on_conflict_then_succeeds(self):
+        helper = self._helper()
+        table = MagicMock()
+        merge_fn = MagicMock(
+            side_effect=[
+                deltalake.exceptions.CommitFailedError("Commit failed: a concurrent transactions added new data."),
+                {"num_output_rows": 1},
+            ]
+        )
+
+        result = await helper._execute_merge_with_conflict_retry(table, merge_fn)
+
+        assert result == {"num_output_rows": 1}
+        assert merge_fn.call_count == 2
+        table.update_incremental.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_exhausting_retries(self):
+        helper = self._helper()
+        table = MagicMock()
+        merge_fn = MagicMock(
+            side_effect=deltalake.exceptions.CommitFailedError(
+                "Commit failed: a concurrent transactions added new data."
+            )
+        )
+
+        with pytest.raises(deltalake.exceptions.CommitFailedError):
+            await helper._execute_merge_with_conflict_retry(table, merge_fn)
+
+        assert merge_fn.call_count == DELTA_MERGE_CONFLICT_RETRIES + 1
+        assert table.update_incremental.call_count == DELTA_MERGE_CONFLICT_RETRIES
+
+    @pytest.mark.asyncio
+    async def test_other_errors_propagate_without_retry(self):
+        helper = self._helper()
+        table = MagicMock()
+        merge_fn = MagicMock(side_effect=ValueError("not a commit conflict"))
+
+        with pytest.raises(ValueError):
+            await helper._execute_merge_with_conflict_retry(table, merge_fn)
+
+        merge_fn.assert_called_once()
+        table.update_incremental.assert_not_called()
 
 
 def _create_legacy_delta_table(path: str, *, partitioned: bool = False) -> deltalake.DeltaTable:


### PR DESCRIPTION
## Problem

Error tracking surfaced a `CommitFailedError` from a data warehouse import sync (Convex, though the failure is in shared pipeline code, not the connector):

```
Failed to commit transaction: Commit failed: a concurrent transactions added new data.
Help: This transaction's query must be rerun to include the new data. Also, if you don't
care to require this check to pass in the future, the isolation level can be set to
Snapshot Isolation.
```

The failing frame is `_do_merge` in `delta_table_helper.py`. Delta's merge conflict checker raises this the moment a concurrent commit touched data the merge predicate read — this is a genuine, expected optimistic-concurrency conflict, not a version-bump race. Tracing through delta-rs's transaction commit loop: this error path is raised *immediately*, without consuming any of delta-rs's own internal commit-retry budget (`max_commit_retries`), because resolving it safely requires re-reading the table and re-running the whole merge — exactly what the error's own "must be rerun" text says. The pipeline had no handling for this at all, so the sync activity died outright on the first such conflict.

## Changes

- Added `DeltaTableHelper._execute_merge_with_conflict_retry`, which runs a Delta merge and, on `CommitFailedError`, refreshes the table to the latest committed version and re-runs the merge, bounded at `DELTA_MERGE_CONFLICT_RETRIES` (3) attempts.
- Wired it into all three Delta merge call sites: the partitioned incremental merge loop, the unpartitioned incremental merge, and the SCD2 "close current rows" merge.

## How did you test this code?

Added `TestExecuteMergeWithConflictRetry` in `test_delta_table_helper.py`, covering:
- a merge that succeeds on the first try (no retry, no table refresh)
- a merge that hits one conflict then succeeds (confirms the table is refreshed and the merge re-run)
- a merge that keeps conflicting past the retry budget (confirms it eventually re-raises `CommitFailedError` rather than retrying forever)
- a non-conflict error (confirms it propagates immediately, unretried)

None of these existed before — the merge closures previously had no conflict-handling path to test. Ran the full `test_delta_table_helper.py` suite (`ruff check`, `ruff format --check`, and repo-wide `mypy --cache-fine-grained .`) locally; all pass except 4 pre-existing failures unrelated to this change (they require a live S3-compatible object store not available in this sandbox, and fail identically on `master`).

## Docs update

Not applicable — internal pipeline reliability fix, no user-facing behavior or API change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude, via PostHog Code) investigated an error-tracking issue reported by webhook, traced the stack trace to `_do_merge` in the shared Delta write path, and read delta-rs's own transaction/conflict-checker source (via GitHub) to confirm this conflict type is raised immediately rather than retried internally. Checked open PRs (including the same author's recent `data-imports` fixes touching this file) for an existing fix — found several adjacent but unrelated changes, no duplicate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
