### PR TITLE
fix(retention): address 24h-window dwh review findings

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_builder.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from functools import cached_property
 from typing import TYPE_CHECKING, Optional, cast
 
+from rest_framework.exceptions import ValidationError
+
 from posthog.schema import EntityType
 
 from posthog.hogql import ast
@@ -71,10 +73,8 @@ class RetentionBaseQueryBuilder(ABC):
     def entity_timestamp_field(self, entity: RetentionEntity) -> ast.Expr:
         if entity.type == EntityType.DATA_WAREHOUSE:
             if not entity.table_name or not entity.timestamp_field:
-                raise ValueError(
-                    f"DATA_WAREHOUSE RetentionEntity requires table_name and timestamp_field, "
-                    f"got table_name={entity.table_name!r}, timestamp_field={entity.timestamp_field!r}"
-                )
+                # ValidationError so a half-configured entity surfaces as HTTP 400; a bare ValueError becomes a 500.
+                raise ValidationError("A data warehouse retention series requires table_name and timestamp_field.")
             return ast.Field(chain=[entity.table_name, entity.timestamp_field])
         return ast.Field(chain=["events", "timestamp"])
 
@@ -83,10 +83,7 @@ class RetentionBaseQueryBuilder(ABC):
         # for a data warehouse entity, or the runner's resolved person/group column for events.
         if entity.type == EntityType.DATA_WAREHOUSE:
             if not entity.aggregation_target_field:
-                raise ValueError(
-                    f"DATA_WAREHOUSE RetentionEntity requires aggregation_target_field, "
-                    f"got {entity.aggregation_target_field!r}"
-                )
+                raise ValidationError("A data warehouse retention series requires aggregation_target_field.")
             return entity.aggregation_target_field
         return self.aggregation_target_events_column
 

--- a/posthog/hogql_queries/insights/retention/retention_base_query_rolling.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_rolling.py
@@ -26,10 +26,49 @@ class RetentionRollingIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             self.start_event.type == EntityType.DATA_WAREHOUSE or self.return_event.type == EntityType.DATA_WAREHOUSE
         )
         if has_data_warehouse_series:
-            return self._build_base_query_data_warehouse(unit, count)
-        return self._build_base_query_events(unit, count)
+            return self._build_base_query_data_warehouse(
+                unit, count, start_interval_index_filter, selected_breakdown_value
+            )
+        return self._build_base_query_events(unit, count, start_interval_index_filter, selected_breakdown_value)
 
-    def _build_base_query_events(self, unit: str, count: int) -> ast.SelectQuery:
+    def _cell_selection_having(
+        self,
+        start_interval_index_filter: int | None,
+        selected_breakdown_value: str | list[str] | int | None,
+    ) -> ast.Expr | None:
+        # Actors-modal drill-down: restrict the base query to one grid cell. The conditions go in HAVING because
+        # both operands are select aliases; breakdown_value in particular is only appended to this same query
+        # object later, by apply_breakdown.
+        exprs: list[ast.Expr] = []
+        if start_interval_index_filter is not None:
+            exprs.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["start_interval_index"]),
+                    right=ast.Constant(value=start_interval_index_filter),
+                )
+            )
+        if selected_breakdown_value is not None:
+            exprs.append(
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.Eq,
+                    left=ast.Field(chain=["breakdown_value"]),
+                    right=ast.Constant(value=selected_breakdown_value),
+                )
+            )
+        if not exprs:
+            return None
+        if len(exprs) == 1:
+            return exprs[0]
+        return ast.And(exprs=exprs)
+
+    def _build_base_query_events(
+        self,
+        unit: str,
+        count: int,
+        start_interval_index_filter: int | None,
+        selected_breakdown_value: str | list[str] | int | None,
+    ) -> ast.SelectQuery:
         t0_expr: ast.Expr
         if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:
             t0_expr = self.get_first_time_anchor_expr(self.start_event)
@@ -112,14 +151,23 @@ class RetentionRollingIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             ),
             where=ast.And(exprs=[*self.global_event_filters, parse_expr("timestamp >= t_0")]),
             group_by=[ast.Field(chain=["actors_with_t0", "actor_id"]), ast.Field(chain=["actors_with_t0", "t_0"])],
+            having=self._cell_selection_having(start_interval_index_filter, selected_breakdown_value),
         )
 
         return inner_query
 
-    def _build_base_query_data_warehouse(self, unit: str, count: int) -> ast.SelectQuery:
+    def _build_base_query_data_warehouse(
+        self,
+        unit: str,
+        count: int,
+        start_interval_index_filter: int | None,
+        selected_breakdown_value: str | list[str] | int | None,
+    ) -> ast.SelectQuery:
         # Breakdowns are rejected upstream by DisallowBreakdownsWithDataWarehouse24HourWindows: apply_breakdown
-        # references events / person columns, which aren't in scope in this query shape. Global property filters,
-        # test-account filters, and sampling are rejected by DisallowUnsupportedDataWarehouseSettings.
+        # references events / person columns, which aren't in scope in this query shape. Group aggregation is
+        # rejected by DisallowGroupAggregationWithDataWarehouse24HourWindows: these scans identify actors by each
+        # entity's aggregation_target_field, which has no group counterpart to join against. Global property
+        # filters, test-account filters, and sampling are rejected by DisallowUnsupportedDataWarehouseSettings.
         first_event_cte = self._build_data_warehouse_first_event_cte()
         return_scan = self._build_return_scan()
 
@@ -196,6 +244,7 @@ class RetentionRollingIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 ),
             ),
             group_by=[ast.Field(chain=["actors_with_t0", "actor_id"]), ast.Field(chain=["actors_with_t0", "t_0"])],
+            having=self._cell_selection_having(start_interval_index_filter, selected_breakdown_value),
         )
 
     def _build_return_scan(self) -> ast.SelectQuery:
@@ -242,7 +291,10 @@ class RetentionRollingIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 "if({within_window}, {anchor}, NULL)",
                 {"within_window": self.events_timestamp_filter(field=anchor_expr), "anchor": anchor_expr},
             )
-            where = None
+            # An events-typed start still gets the entity matcher as WHERE: both anchor variants condition on the
+            # entity, so rows outside it never feed the aggregates, and without the pre-filter this scan reads the
+            # team's entire events table.
+            where = None if start_is_dwh else self.entity_expr_no_props(self.start_event)
             having = ast.CompareOperation(
                 op=ast.CompareOperationOp.NotEq, left=ast.Field(chain=["t_0"]), right=ast.Constant(value=None)
             )

--- a/posthog/hogql_queries/insights/retention/retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/retention_query_runner.py
@@ -41,6 +41,8 @@ from posthog.hogql_queries.insights.retention.retention_base_query_rolling impor
 from posthog.hogql_queries.insights.retention.retention_validation_rules import (
     DisallowBreakdownsWithDataWarehouse24HourWindows,
     DisallowCumulativeWith24HourWindows,
+    DisallowGroupAggregationWithDataWarehouse24HourWindows,
+    DisallowPropertyAggregationWith24HourWindows,
 )
 from posthog.hogql_queries.insights.utils.breakdowns import (
     ALL_USERS_COHORT_ID,
@@ -144,6 +146,8 @@ class RetentionQueryRunner(AnalyticsQueryRunner[RetentionQueryResponse]):
         return (
             DisallowCumulativeWith24HourWindows(),
             DisallowBreakdownsWithDataWarehouse24HourWindows(),
+            DisallowGroupAggregationWithDataWarehouse24HourWindows(),
+            DisallowPropertyAggregationWith24HourWindows(),
             DisallowUnsupportedDataWarehouseSettings(),
         )
 

--- a/posthog/hogql_queries/insights/retention/retention_validation_rules.py
+++ b/posthog/hogql_queries/insights/retention/retention_validation_rules.py
@@ -1,6 +1,6 @@
 from rest_framework.exceptions import ValidationError
 
-from posthog.schema import EntityType, RetentionQuery
+from posthog.schema import AggregationType, EntityType, RetentionQuery
 
 from posthog.hogql_queries.insights.utils.breakdowns import has_breakdown_filter
 from posthog.hogql_queries.validation.validation import QueryValidationContext
@@ -34,5 +34,51 @@ class DisallowBreakdownsWithDataWarehouse24HourWindows:
         if has_data_warehouse_series:
             raise ValidationError(
                 "Breakdowns are not supported for 24 hour windows with a data warehouse series.",
+                code=self.code,
+            )
+
+
+class DisallowGroupAggregationWithDataWarehouse24HourWindows:
+    """The 24-hour-window data warehouse scans identify actors by each entity's aggregation_target_field and join
+    the arms on it directly, so a group-typed events side contributes its $group_N key: the join keys mismatch in
+    type and empty group keys are not filtered out. The fixed-interval builder resolves group actors per arm and
+    stays allowed."""
+
+    code = "retention_data_warehouse_24_hour_windows_group_aggregation_unsupported"
+
+    def validate(self, context: QueryValidationContext[RetentionQuery]) -> None:
+        if context.query.aggregation_group_type_index is None:
+            return
+        retention_filter = context.query.retentionFilter
+        if retention_filter.timeWindowMode != "24_hour_windows":
+            return
+        has_data_warehouse_series = any(
+            entity is not None and entity.type == EntityType.DATA_WAREHOUSE
+            for entity in (retention_filter.targetEntity, retention_filter.returningEntity)
+        )
+        if has_data_warehouse_series:
+            raise ValidationError(
+                "Group aggregation is not supported for 24 hour windows with a data warehouse series.",
+                code=self.code,
+            )
+
+
+class DisallowPropertyAggregationWith24HourWindows:
+    """The 24-hour-window builder never emits the retention_value column that sum/avg aggregation reads in the
+    outer query."""
+
+    code = "retention_24_hour_windows_property_aggregation_unsupported"
+
+    def validate(self, context: QueryValidationContext[RetentionQuery]) -> None:
+        retention_filter = context.query.retentionFilter
+        if retention_filter.timeWindowMode != "24_hour_windows":
+            return
+        has_property_aggregation = (
+            retention_filter.aggregationType in (AggregationType.SUM, AggregationType.AVG)
+            and retention_filter.aggregationProperty
+        )
+        if has_property_aggregation:
+            raise ValidationError(
+                "Sum and average aggregation are not supported for 24 hour windows.",
                 code=self.code,
             )

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse_24h_window.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_data_warehouse_24h_window.ambr
@@ -1,4 +1,53 @@
 # serializer version: 1
+# name: TestRetentionDataWarehouse24hWindow.test_first_time_events_start_dwh_return_24h_window
+  '''
+  SELECT actor_activity.start_interval_index AS start_event_matching_interval,
+         actor_activity.intervals_from_base AS intervals_from_base,
+         count(DISTINCT actor_activity.actor_id) AS count
+  FROM
+    (SELECT actors_with_t0.actor_id AS actor_id,
+            floor(divide(dateDiff('hour', assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), actors_with_t0.t_0), 24)) AS start_interval_index,
+            arrayJoin(arrayDistinct(arrayConcat([0], arrayFilter(x -> ifNull(greaterOrEquals(x, 0), 0), groupUniqArray(if(ifNull(greaterOrEquals(return_events.timestamp, actors_with_t0.t_0), 0), floor(divide(dateDiff('hour', actors_with_t0.t_0, return_events.timestamp), 24)), -1)))))) AS intervals_from_base
+     FROM
+       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+               if(and(greaterOrEquals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$signup')), toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$signup')), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, '$signup')), NULL) AS t_0
+        FROM events
+        LEFT OUTER JOIN
+          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+                  person_distinct_id_overrides.distinct_id AS distinct_id
+           FROM person_distinct_id_overrides
+           WHERE equals(person_distinct_id_overrides.team_id, 99999)
+           GROUP BY person_distinct_id_overrides.distinct_id
+           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+        WHERE and(equals(events.team_id, 99999), equals(events.event, '$signup'))
+        GROUP BY actor_id
+        HAVING isNotNull(t_0)) AS actors_with_t0
+     LEFT JOIN
+       (SELECT posthog_test_warehouse_renewals_ft.person_id AS actor_id,
+               toTimeZone(posthog_test_warehouse_renewals_ft.occurred_at, 'UTC') AS timestamp
+        FROM s3('http://host.docker.internal:19000/posthog/test_storage_bucket-posthog.hogql_queries.insights.retention.data_warehouse_24h_window/posthog_test_warehouse_renewals_ft/*.csv', 'object_storage_root_user', 'object_storage_root_password', 'CSVWithNames', '`id` Int64, `person_id` UUID, `occurred_at` DateTime64(3, \'UTC\')') AS posthog_test_warehouse_renewals_ft
+        WHERE and(greaterOrEquals(posthog_test_warehouse_renewals_ft.occurred_at, toStartOfInterval(assumeNotNull(toDateTime('2025-01-01 00:00:00', 'UTC')), toIntervalDay(1))), less(posthog_test_warehouse_renewals_ft.occurred_at, toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))) AS return_events ON equals(actors_with_t0.actor_id, return_events.actor_id)
+     GROUP BY actors_with_t0.actor_id,
+              actors_with_t0.t_0) AS actor_activity
+  GROUP BY start_event_matching_interval,
+           intervals_from_base
+  ORDER BY start_event_matching_interval ASC,
+           intervals_from_base ASC
+  LIMIT 100000 SETTINGS format_csv_allow_double_quotes=1,
+                        readonly=2,
+                        max_execution_time=600,
+                        allow_experimental_object_type=1,
+                        max_ast_elements=4000000,
+                        max_expanded_ast_elements=4000000,
+                        max_bytes_before_external_group_by=23622320128,
+                        transform_null_in=1,
+                        optimize_min_equality_disjunction_chain_length=4294967295,
+                        optimize_rewrite_aggregate_function_with_if=0,
+                        optimize_min_inequality_conjunction_chain_length=4294967295,
+                        allow_experimental_join_condition=1,
+                        use_hive_partitioning=0
+  '''
+# ---
 # name: TestRetentionDataWarehouse24hWindow.test_same_table_dwh_start_and_return_24h_window
   '''
   SELECT actor_activity.start_interval_index AS start_event_matching_interval,

--- a/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse_24h_window.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_data_warehouse_24h_window.py
@@ -14,6 +14,8 @@ from posthog.test.base import (
 from parameterized import parameterized
 from rest_framework.exceptions import ValidationError
 
+from posthog.hogql.query import execute_hogql_query
+
 from posthog.hogql_queries.insights.retention.retention_query_runner import RetentionQueryRunner
 
 from products.warehouse_sources.backend.facade.testing import create_data_warehouse_table_from_csv
@@ -438,6 +440,18 @@ class TestRetentionDataWarehouse24hWindow(ClickhouseTestMixin, APIBaseTest):
                 {"breakdownFilter": {"breakdown": "$browser", "breakdown_type": "event"}},
                 "Breakdowns are not supported for 24 hour windows with a data warehouse series.",
             ),
+            (
+                "group_aggregation",
+                {},
+                {"aggregation_group_type_index": 0},
+                "Group aggregation is not supported for 24 hour windows with a data warehouse series.",
+            ),
+            (
+                "property_aggregation",
+                {"aggregationType": "sum", "aggregationProperty": "amount"},
+                {},
+                "Sum and average aggregation are not supported for 24 hour windows.",
+            ),
         ]
     )
     def test_unsupported_dwh_24h_window_combinations_are_rejected(
@@ -459,3 +473,110 @@ class TestRetentionDataWarehouse24hWindow(ClickhouseTestMixin, APIBaseTest):
                     **query_extra,
                 }
             )
+
+    @parameterized.expand(
+        [
+            ("missing_aggregation_target_field", "aggregation_target_field", "requires aggregation_target_field"),
+            ("missing_timestamp_field", "timestamp_field", "requires table_name and timestamp_field"),
+        ]
+    )
+    def test_incomplete_dwh_entity_is_rejected_with_validation_error(
+        self, _name: str, missing_field: str, expected_error: str
+    ):
+        # The exception type is the contract: ValidationError maps to HTTP 400 at the API, a bare ValueError to a
+        # 500. The error raises while building the query, so no warehouse table fixture is needed.
+        entity = self._renewals_entity("warehouse_incomplete")
+        del entity[missing_field]
+
+        runner = RetentionQueryRunner(
+            team=self.team,
+            query={
+                "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "timeWindowMode": "24_hour_windows",
+                    "targetEntity": entity,
+                    "returningEntity": self._renewals_entity("warehouse_incomplete"),
+                },
+            },
+        )
+
+        with self.assertRaisesMessage(ValidationError, expected_error):
+            runner.to_query()
+
+    def test_actors_query_filters_to_selected_interval_24h_window(self):
+        person_ids = self._create_people()
+        activity_table = self._create_data_warehouse_table(
+            filename="warehouse_actors_activity.csv",
+            table_name="warehouse_actors_activity",
+            header=["id", "person_id", "activity_type", "occurred_at"],
+            rows=[
+                [1, person_ids["user-1"], "signed_up", "2025-01-01 09:00:00"],
+                [2, person_ids["user-2"], "signed_up", "2025-01-01 10:00:00"],
+                [3, person_ids["user-3"], "signed_up", "2025-01-02 09:00:00"],
+                [4, person_ids["user-4"], "signed_up", "2025-01-02 10:00:00"],
+                [5, person_ids["user-1"], "renewed", "2025-01-02 12:00:00"],
+            ],
+            table_columns=ACTIVITY_TABLE_COLUMNS,
+        )
+
+        runner = RetentionQueryRunner(
+            team=self.team,
+            query={
+                "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "timeWindowMode": "24_hour_windows",
+                    "targetEntity": _signed_up_entity(activity_table),
+                    "returningEntity": _renewed_entity(activity_table),
+                },
+            },
+        )
+        response = execute_hogql_query(query=runner.to_actors_query(interval=1), team=self.team)
+
+        # Only the Day 1 cohort (user-3 and user-4); without the start_interval_index filter every cohort leaks in.
+        self.assertEqual(
+            sorted(str(row[0]) for row in response.results),
+            [person_ids["user-3"], person_ids["user-4"]],
+        )
+
+    @snapshot_clickhouse_queries
+    def test_first_time_events_start_dwh_return_24h_window(self):
+        person_ids = self._create_people()
+        self._create_events(
+            [
+                ("user-1", "$browse", "2024-12-28 08:00:00"),  # unrelated activity must not affect the anchor
+                ("user-1", "$signup", "2024-12-30 09:00:00"),  # first signup, before the window
+                ("user-1", "$signup", "2025-01-03 09:00:00"),  # repeat signup in window must not re-cohort
+                ("user-2", "$signup", "2025-01-01 10:00:00"),  # first signup, in window
+            ]
+        )
+        renewals_table = self._create_renewals_table(
+            "warehouse_renewals_ft",
+            rows=[
+                [1, person_ids["user-2"], "2025-01-02 13:00:00"],  # 27h after t_0 -> interval 1
+            ],
+        )
+
+        result = self.run_query(
+            query={
+                "dateRange": {"date_from": "2025-01-01T00:00:00Z", "date_to": "2025-01-05T00:00:00Z"},
+                "retentionFilter": {
+                    "period": "Day",
+                    "totalIntervals": 4,
+                    "timeWindowMode": "24_hour_windows",
+                    "retentionType": "retention_first_time",
+                    "targetEntity": {"id": "$signup", "name": "$signup", "type": "events"},
+                    "returningEntity": self._renewals_entity(renewals_table),
+                },
+            }
+        )
+
+        # user-1's first matching signup predates the window, so the guard nulls their anchor and the repeat
+        # signup inside the window must not resurrect them. Only user-2 is cohorted (Day 0, returning +27h).
+        day_0 = self._row(result, "Day 0")
+        self.assertEqual(day_0["values"][0]["count"], 1)
+        self.assertEqual(day_0["values"][1]["count"], 1)
+        self.assertEqual(sum(row["values"][0]["count"] for row in result), 1)

--- a/posthog/hogql_queries/insights/retention/test/test_retention_validation_rules.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_validation_rules.py
@@ -9,6 +9,8 @@ from posthog.schema import AggregationType, BreakdownFilter, EntityType, Retenti
 from posthog.hogql_queries.insights.retention.retention_validation_rules import (
     DisallowBreakdownsWithDataWarehouse24HourWindows,
     DisallowCumulativeWith24HourWindows,
+    DisallowGroupAggregationWithDataWarehouse24HourWindows,
+    DisallowPropertyAggregationWith24HourWindows,
 )
 from posthog.hogql_queries.validation.rules import DisallowUnsupportedDataWarehouseSettings
 from posthog.hogql_queries.validation.validation import QueryValidationContext
@@ -132,3 +134,80 @@ class TestRetentionValidationRules(BaseTest):
         )
 
         DisallowUnsupportedDataWarehouseSettings().validate(self._context(query))
+
+    @parameterized.expand(
+        [
+            ("groups_with_dwh_target_24h", 0, True, False, TimeWindowMode.FIELD_24_HOUR_WINDOWS, True),
+            ("groups_with_dwh_return_24h", 0, False, True, TimeWindowMode.FIELD_24_HOUR_WINDOWS, True),
+            ("groups_without_dwh_series_24h", 0, False, False, TimeWindowMode.FIELD_24_HOUR_WINDOWS, False),
+            ("no_groups_with_dwh_series_24h", None, True, True, TimeWindowMode.FIELD_24_HOUR_WINDOWS, False),
+            ("groups_with_dwh_series_default_window", 0, True, True, None, False),
+        ]
+    )
+    def test_disallow_group_aggregation_with_data_warehouse_24h_windows(
+        self,
+        _name: str,
+        group_type_index: int | None,
+        dwh_target: bool,
+        dwh_return: bool,
+        time_window_mode: TimeWindowMode | None,
+        raises_error: bool,
+    ) -> None:
+        query = RetentionQuery(
+            aggregation_group_type_index=group_type_index,
+            retentionFilter=RetentionFilter(
+                timeWindowMode=time_window_mode,
+                targetEntity=self._data_warehouse_entity() if dwh_target else None,
+                returningEntity=self._data_warehouse_entity() if dwh_return else None,
+            ),
+        )
+
+        if not raises_error:
+            DisallowGroupAggregationWithDataWarehouse24HourWindows().validate(self._context(query))
+            return
+
+        with self.assertRaises(ValidationError) as context:
+            DisallowGroupAggregationWithDataWarehouse24HourWindows().validate(self._context(query))
+
+        self.assertIn(
+            "Group aggregation is not supported for 24 hour windows with a data warehouse series.",
+            str(context.exception),
+        )
+        self.assertEqual(
+            context.exception.get_codes(), ["retention_data_warehouse_24_hour_windows_group_aggregation_unsupported"]
+        )
+
+    @parameterized.expand(
+        [
+            ("sum_24h_windows", AggregationType.SUM, "amount", TimeWindowMode.FIELD_24_HOUR_WINDOWS, True),
+            ("avg_24h_windows", AggregationType.AVG, "amount", TimeWindowMode.FIELD_24_HOUR_WINDOWS, True),
+            ("count_24h_windows", AggregationType.COUNT, None, TimeWindowMode.FIELD_24_HOUR_WINDOWS, False),
+            ("sum_without_property_24h", AggregationType.SUM, None, TimeWindowMode.FIELD_24_HOUR_WINDOWS, False),
+            ("sum_default_window", AggregationType.SUM, "amount", None, False),
+        ]
+    )
+    def test_disallow_property_aggregation_with_24h_windows(
+        self,
+        _name: str,
+        aggregation_type: AggregationType,
+        aggregation_property: str | None,
+        time_window_mode: TimeWindowMode | None,
+        raises_error: bool,
+    ) -> None:
+        query = RetentionQuery(
+            retentionFilter=RetentionFilter(
+                timeWindowMode=time_window_mode,
+                aggregationType=aggregation_type,
+                aggregationProperty=aggregation_property,
+            )
+        )
+
+        if not raises_error:
+            DisallowPropertyAggregationWith24HourWindows().validate(self._context(query))
+            return
+
+        with self.assertRaises(ValidationError) as context:
+            DisallowPropertyAggregationWith24HourWindows().validate(self._context(query))
+
+        self.assertIn("Sum and average aggregation are not supported for 24 hour windows.", str(context.exception))
+        self.assertEqual(context.exception.get_codes(), ["retention_24_hour_windows_property_aggregation_unsupported"])


### PR DESCRIPTION
## Problem

#65139 adds data warehouse support to 24h-window retention. A hands-on pre-merge review of that branch (each finding reproduced against a live local stack) found five defects:

1. Clicking a retention grid cell showed every cohort's actors: the rolling builder accepted `start_interval_index_filter` / `selected_breakdown_value` but never applied them.
2. Group aggregation combined with a warehouse series in 24h mode died with a raw ClickHouse `NoCommonType` join error (the events arm joins `$group_N` against the warehouse actor column).
3. Sum/avg property aggregation with 24h windows failed with an opaque `retention_value` resolution error (the rolling shape never emits that column).
4. First-occurrence retention with an events start + warehouse return scanned the entire events table: the t0 CTE had no WHERE at all.
5. A warehouse entity missing `aggregation_target_field` or `timestamp_field` returned HTTP 500 (`ValueError`) instead of 400.

Refs #42271

## Changes

- Thread the actors-modal cell filters through `RetentionRollingIntervalBaseQueryBuilder` as a `HAVING` on the select aliases, mirroring the fixed-interval builder.
- Two new validation rules, `DisallowGroupAggregationWithDataWarehouse24HourWindows` and `DisallowPropertyAggregationWith24HourWindows`, registered next to the existing 24h rules. Both are 24h-scoped: calendar-mode group aggregation with warehouse series is tested and keeps working.
- The first-time t0 events scan now carries the start-entity pre-filter. Semantics are unchanged because both first-time anchor variants already condition on the entity; the new snapshot pins the filtered scan shape.
- `ValueError` → DRF `ValidationError` for half-configured warehouse entities, so the query API returns a 400 envelope.

Known pre-existing issue, intentionally not fixed here: calendar-mode retention with an events start + a warehouse return entity that has a property filter fails with `Unable to resolve field`. This is group-independent and predates this change; flagged for follow-up.

## How did you test this code?

- Full retention test directory: 222 passed, 32 snapshots passed. The snapshot diff is additive-only (one new entry), showing generated SQL for existing queries is unchanged.
- New tests, and the regression each catches that nothing caught before:
  - actors-interval test: re-dropping the interval filter returns every cohort's actors again.
  - first-time events-start + warehouse-return test (snapshot-pinned): removing the entity pre-filter reappears as an unfiltered `FROM events` scan in the snapshot; the assertions also cover first-time cohorting on this previously untested arm combination.
  - validator unit tests plus two cases in the existing rejection test: loosening either rule resurfaces the raw ClickHouse/resolution errors.
  - incomplete-entity tests: reverting `ValidationError` to `ValueError` turns API 400s back into 500s.
- `uv run mypy --cache-fine-grained .` (what CI runs): no issues in 16933 files. `ruff check` / `ruff format` clean.
- Verified end to end on a live local stack with seeded warehouse tables: the persons-modal query returns only the selected cohort, the API returns the 400 validation envelope for half-configured entities, and baseline 24h retention numbers are byte-identical before/after.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed: hardening of an unreleased, feature-flagged capability with no documented behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by PostHog Code (Claude) as the fix stage of a pre-merge review of #65139; each of the five findings was reproduced empirically on a live stack before fixing and re-verified after.
- Skills invoked: /run-posthog, /writing-tests, /writing-user-facing-copy, /writing-code-comments.
- Notable decision: the group-aggregation rule was first drafted to cover any window mode, but the full retention suite showed calendar-mode group support is tested and working (`test_retention_data_warehouse_actor_query_maps_back_to_actors`), and the calendar failure originally attributed to groups turned out to be the group-independent pre-existing issue noted above. The rule was scoped to 24h windows; pure warehouse-to-warehouse group aggregation in 24h mode stays fail-closed until it has test coverage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
