### PR TITLE
fix(data-imports): keep known-transient S3 blips out of error tracking in get_delta_table

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
@@ -279,6 +279,17 @@ class DeltaTableHelper:
         """Public accessor for the delta-rs storage options (used by the in-place repartitioner)."""
         return self._get_credentials()
 
+    async def _capture_unless_transient(self, e: Exception) -> None:
+        """capture_exception unless `e` is a known-transient object-store blip (see
+        is_transient_object_store_error) — those recover on retry and aren't a defect, so reporting
+        them to error tracking is just noise. Never suppresses the re-raise itself, so Temporal's
+        activity retry policy is unaffected either way.
+        """
+        if is_transient_object_store_error(e):
+            await self._logger.awarning(f"get_delta_table: transient object-store error, not reporting: {e}")
+        else:
+            capture_exception(e)
+
     async def _evolve_delta_schema(self, schema: pa.Schema) -> deltalake.DeltaTable:
         delta_table = await self.get_delta_table()
         if delta_table is None:
@@ -310,7 +321,7 @@ class DeltaTableHelper:
             # best-effort maintenance to the main write path, so this can't safely swallow the
             # error and report "no table" here — that would trip should_overwrite_table for a
             # table that actually exists, risking data loss.
-            capture_exception(e)
+            await self._capture_unless_transient(e)
             raise
 
         if is_delta:
@@ -319,7 +330,7 @@ class DeltaTableHelper:
                     deltalake.DeltaTable, table_uri=delta_uri, storage_options=storage_options
                 )
             except Exception as e:
-                capture_exception(e)
+                await self._capture_unless_transient(e)
                 error_text = "".join(str(arg) for arg in e.args)
                 # Unrecoverable tables (bugged decimals, or an orphaned _delta_log missing its
                 # metadata action — impossible on a healthy table): wipe so the sync starts fresh.

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
@@ -394,15 +394,38 @@ class TestGetDeltaTableUnrecoverableErrors:
             patch(f"{module}.deltalake.DeltaTable") as mock_delta_table,
             patch(f"{module}.capture_exception") as mock_capture,
         ):
-            mock_delta_table.is_deltatable.side_effect = OSError(
-                "Generic S3 error: Received redirect without LOCATION, this normally indicates "
-                "an incorrectly configured region"
-            )
+            mock_delta_table.is_deltatable.side_effect = OSError("Access Denied: not authorized to list bucket")
 
-            with pytest.raises(OSError, match="Received redirect without LOCATION"):
+            with pytest.raises(OSError, match="Access Denied"):
                 await helper.get_delta_table()
 
             mock_capture.assert_called_once()
+            assert helper.is_first_sync is False
+
+    @pytest.mark.asyncio
+    async def test_is_deltatable_transient_error_is_not_captured_but_still_reraised(self):
+        """A known-transient object-store blip (e.g. an S3 LIST request timing out) must not be
+        reported to error tracking as a defect — it's a self-recovering network hiccup, not a bug —
+        but it must still propagate so Temporal's activity retry policy retries the sync."""
+        helper = DeltaTableHelper(resource_name="t", job=MagicMock(), logger=_make_logger())
+        delta_uri = "s3://bucket/team_id/job_id/t"
+
+        module = "products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper"
+        with (
+            patch.object(helper, "_get_delta_table_uri", AsyncMock(return_value=delta_uri)),
+            patch(f"{module}.deltalake.DeltaTable") as mock_delta_table,
+            patch(f"{module}.capture_exception") as mock_capture,
+        ):
+            mock_delta_table.is_deltatable.side_effect = OSError(
+                "Generic S3 error\nError getting list response body\nHTTP error\n"
+                "request or response body error\noperation timed out"
+            )
+
+            with pytest.raises(OSError, match="operation timed out"):
+                await helper.get_delta_table()
+
+            mock_capture.assert_not_called()
+            cast(AsyncMock, helper._logger.awarning).assert_awaited_once()
             assert helper.is_first_sync is False
 
 


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OSError: Generic S3 error ... operation timed out` from `DeltaTableHelper.get_delta_table()`, raised while calling `deltalake.DeltaTable.is_deltatable(...)`.

This is the same class of self-recovering S3 blip already documented by `TRANSIENT_OBJECT_STORE_ERRORS`/`is_transient_object_store_error` in `delta_table_helper.py` — a transient network hiccup on an S3 LIST request, not a customer credential problem or a bug in our code. It's already retryable today: nothing here is in any source's `NonRetryableErrors`, and Temporal's default activity retry policy applies, so the sync itself was never at risk. The gap is purely reporting noise: `get_delta_table()`'s two except blocks (around the `is_deltatable` existence check and the `DeltaTable()` open) call `capture_exception` unconditionally, without ever consulting the classifier that already exists in the same file for exactly this error family.

## Changes

- Added `DeltaTableHelper._capture_unless_transient`, which calls `capture_exception` only when the error is *not* a known-transient object-store blip (falls back to a warning log otherwise). The exception is always re-raised regardless, so Temporal's retry behavior is unchanged.
- Wired both except blocks in `get_delta_table()` through it.

## How did you test this code?

- Extended `TestGetDeltaTableUnrecoverableErrors` in `test_delta_table_helper.py`:
  - Adjusted the existing `is_deltatable` capture test to use a genuinely non-transient error (`Access Denied`), since its previous example text happened to match the transient-error substring pattern.
  - Added `test_is_deltatable_transient_error_is_not_captured_but_still_reraised`, reproducing the exact production error text — asserts `capture_exception` is *not* called, a warning is logged, and the exception still propagates (so Temporal still retries).
- Ran the affected test class locally with the object-store network call mocked out (this sandbox has no local S3-compatible service to hit `ensure_bucket_exists` against, same pre-existing constraint as the rest of this test file); both new/updated cases pass with the expected behavior.
- `uv run mypy --cache-fine-grained .` (repo-wide) — clean.
- `ruff check --fix` / `ruff format` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification change, no user-facing or API behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from the linked error-tracking issue via PostHog's error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`), which surfaced the stack trace pinning the failure to `get_delta_table`'s `is_deltatable` call. Traced the call path and confirmed via a research subagent that Temporal's retry policy already treats this `OSError` as retryable — the actual gap was reporting noise, not retry correctness.

Checked for duplicate open PRs by exception type, message phrase, and module path, and scanned the maintainer's own open PR queue. Found several related-but-non-overlapping PRs touching transient S3 handling elsewhere in the same file/module (e.g. #74388 for the `_handle_import_error` fallback path, #69306 and #74630 for vacuum/compact maintenance, #73395 for query-folder cleanup) — none of them touch `get_delta_table`'s own `capture_exception` calls, which is the gap this PR closes.

Invoked `/writing-tests` before adding the regression tests.