### PR TITLE
fix(tasks): archive signal report when its PR closes unmerged

### DIFF
--- a/products/tasks/backend/tests/test_webhooks.py
+++ b/products/tasks/backend/tests/test_webhooks.py
@@ -692,7 +692,7 @@ class TestGitHubPRWebhook(TestCase):
 
 
 class TestGitHubPRWebhookResolvesSignalReports(TestCase):
-    """Webhook resolves any SignalReport linked to the merged PR's task."""
+    """Webhook resolves a SignalReport when its PR merges, and archives it when the PR closes unmerged."""
 
     organization: ClassVar[Organization]
     team: ClassVar[Team]
@@ -763,11 +763,11 @@ class TestGitHubPRWebhookResolvesSignalReports(TestCase):
                 SignalReport.Status.RESOLVED,
             ),
             (
-                "closed_without_merge_is_noop",
+                "closed_without_merge_archives_ready_report",
                 "closed",
                 False,
                 SignalReport.Status.READY,
-                SignalReport.Status.READY,
+                SignalReport.Status.SUPPRESSED,
             ),
             (
                 "suppressed_report_is_skipped",

--- a/products/tasks/backend/webhooks.py
+++ b/products/tasks/backend/webhooks.py
@@ -196,13 +196,23 @@ def handle_pull_request_event(payload: dict) -> HttpResponse:
         run_output = task_run.output if isinstance(task_run.output, dict) else {}
         if run_output.get("pr_url") == pr_url:
             _record_run_pr_merged(task_run)
-        _resolve_signal_reports_for_task(task_run.task_id, pr_url)
+        # Ungated on the pr_url match above: unlike the run-bookkeeping calls, this keys off
+        # task_id (reports_for_task_filter), not output.pr_url, so the same-branch trust rule
+        # doesn't apply — a merged PR resolves its report.
+        _transition_signal_reports_for_task(
+            task_run.task_id, pr_url, SignalReport.Status.RESOLVED, "github_pr_webhook_signal_report_resolved"
+        )
 
     if task_run and action == "closed" and not merged:
         # Same trust rule as the merge branch: only the run that claims this PR URL.
         run_output = task_run.output if isinstance(task_run.output, dict) else {}
         if run_output.get("pr_url") == pr_url:
             _cancel_wizard_run_on_close(task_run)
+        # Ungated for the same reason as the merge branch's resolve call: a closed-unmerged PR
+        # archives (suppresses) its report so it leaves the inbox instead of lingering.
+        _transition_signal_reports_for_task(
+            task_run.task_id, pr_url, SignalReport.Status.SUPPRESSED, "github_pr_webhook_signal_report_archived"
+        )
 
     return HttpResponse(status=200)
 
@@ -429,11 +439,15 @@ def _resolve_external_team(payload: dict) -> Team | None:
     return integration.team if integration else None
 
 
-def _resolve_signal_reports_for_task(task_id: uuid.UUID, pr_url: str) -> None:
-    """Mark signal reports linked to a merged PR's task as resolved.
+def _transition_signal_reports_for_task(
+    task_id: uuid.UUID, pr_url: str, target_status: SignalReport.Status, success_log_event: str
+) -> None:
+    """Transition signal reports linked to a task's PR to ``target_status``.
 
-    Kept tolerant: a single bad transition should not fail the whole webhook,
-    since GitHub retries 5xx responses and we've already acknowledged the PR event.
+    Covers both PR outcomes: a merged PR resolves its reports, a closed-unmerged PR archives
+    (suppresses) them so they leave the inbox instead of lingering as if work were still pending.
+    Kept tolerant: a single bad transition should not fail the whole webhook, since GitHub retries
+    5xx responses and we've already acknowledged the PR event.
     """
     reports = (
         SignalReport.objects.filter(SignalReport.reports_for_task_filter(task_id))
@@ -449,7 +463,7 @@ def _resolve_signal_reports_for_task(task_id: uuid.UUID, pr_url: str) -> None:
 
     for report in reports:
         try:
-            updated_fields = report.transition_to(SignalReport.Status.RESOLVED)
+            updated_fields = report.transition_to(target_status)
         except InvalidStatusTransition:
             logger.warning(
                 "github_pr_webhook_signal_report_invalid_transition",
@@ -460,7 +474,7 @@ def _resolve_signal_reports_for_task(task_id: uuid.UUID, pr_url: str) -> None:
             continue
         report.save(update_fields=updated_fields)
         logger.info(
-            "github_pr_webhook_signal_report_resolved",
+            success_log_event,
             report_id=str(report.id),
             task_id=str(task_id),
             pr_url=pr_url,


### PR DESCRIPTION
## Problem

When a task's implementation PR is **merged**, the GitHub PR webhook resolves the linked signal report(s), removing them from the inbox. But when the PR is **closed without merging**, nothing happened to the report — it stayed in the inbox as if work were still pending, and had to be dismissed by hand.

This was raised from a Slack thread where a report's PR was opened and then closed unmerged, yet the report lingered in the inbox for weeks until manually archived.

## Changes

- Added the symmetric branch to `handle_pull_request_event`: a closed-unmerged PR now **suppresses (archives)** its linked reports, mirroring the resolve-on-merge path. `SUPPRESSED` (restorable archive) is used rather than `RESOLVED`, which is reserved for genuinely-shipped work.
- Collapsed the near-identical `_resolve_signal_reports_for_task` / (new) archive helper into a single status-parameterized `_transition_signal_reports_for_task`, so the shared query/exclude/loop/log logic lives in one place.
- Updated the webhook test that previously asserted close-without-merge was a no-op to assert it now archives the report.

## How did you test this code?

Automated: updated `TestGitHubPRWebhookResolvesSignalReports` — the parameterized `closed_without_merge_archives_ready_report` case asserts a `READY` report transitions to `SUPPRESSED` on a closed-unmerged PR webhook, while the merge case still resolves and the already-suppressed case is still skipped. This catches the regression where a closed-unmerged PR left the report untouched.

I (the agent) could not run the Django test suite here — no database was available in the environment (`OperationalError` on connect). I verified the changed files byte-compile, pass `ruff check` and `ruff format --check`, and that test collection picks up the renamed case.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) from a Slack thread investigating why a closed PR left its inbox report open. Root cause: the webhook only handled the `merged` case. Fix adds the closed-unmerged branch. Ran the `/simplify` skill afterward — four parallel review agents converged on collapsing the two near-duplicate transition helpers into one parameterized function, which was applied; they also confirmed the webhook-handler placement, the ungated call, and the `SUPPRESSED` status choice are all consistent with the existing resolve-on-merge pattern and the refund-flow's archive semantics.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785321671898799?thread_ts=1785321671.898799&cid=C09SK2PAGKF)*
