### PR TITLE
test(data-imports): guard post-maintenance file listing before S3 prep

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
@@ -173,6 +173,22 @@ class TestRunPostLoadDeltaMaintenance:
         else:
             update_config.assert_not_called()
 
+    @parameterized.expand([("non_cdc", False), ("cdc", True)])
+    @pytest.mark.asyncio
+    async def test_prepares_s3_files_with_post_maintenance_file_list(self, _name: str, is_cdc: bool) -> None:
+        # Compaction/vacuum maintenance above can rewrite or delete files referenced by the
+        # pre-maintenance file_uris snapshot the caller passed in. Regression: prepare_s3_files_for_querying
+        # was called with that stale snapshot, raising FileNotFoundError on files maintenance just removed.
+        schema = _make_schema(is_cdc=is_cdc)
+        post_maintenance_uris = ["s3://bucket/orders/compacted.parquet"]
+        helper = _make_helper(file_uris=post_maintenance_uris)
+
+        _, prepare_s3 = await _run_post_load(schema, helper, cdc_write_mode="incremental" if is_cdc else None)
+
+        prepare_s3.assert_awaited_once()
+        assert prepare_s3.await_args is not None
+        assert prepare_s3.await_args.args[2] == post_maintenance_uris
+
     @parameterized.expand(
         [
             # A genuine maintenance bug must still be captured for visibility.


### PR DESCRIPTION
## Problem

An [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fadb9-cb26-7831-849c-ec9539045b43) surfaced a bare `FileNotFoundError` naming a Delta table data file (a `_ph_partition_key=<N>/part-....snappy.parquet` path) during a Postgres source sync. Compaction/vacuum maintenance in the post-load path rewrites fragmented files and physically deletes the superseded ones from S3; the subsequent step that populates the queryable folder was reading from a pre-maintenance `file_uris` snapshot, so it tried to copy a file maintenance had just deleted.

## Changes

The production fix — re-listing the Delta table's files after maintenance before preparing the S3 query files — has since landed on `master` independently: `_publish_queryable_files` now calls `get_file_uris()` fresh after maintenance runs. After rebasing, this PR retains only the **regression test** that guards that behavior.

- `test_prepares_s3_files_with_post_maintenance_file_list` (parameterized over CDC and non-CDC schemas) asserts `prepare_s3_files_for_querying` is called with the post-maintenance file list (the one returned by `get_file_uris`), not a stale snapshot. The existing failure-handling tests only assert the call happened, not which file list it used — so this closes a real regression gap.

## How did you test this code?

- Ran `products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py`: 13 passed.
- `ruff check` / `ruff format --check` clean.

## Docs update

N/A — internal pipeline test, no user-facing or API surface change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error-tracking issue. During rebase onto `master`, the production fix was found to already exist there (a refactor that separates maintenance from queryable-folder prep and re-lists files fresh), so the redundant duplicate `get_file_uris()` call the merge would have introduced was dropped, leaving the regression test as the PR's contribution.
