### PR TITLE
fix(clickhouse): cast Date incremental cursor to toDate32 in source query

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -981,6 +981,7 @@ def _get_incremental_row_count(
     incremental_field: str,
     last_value: Any,
     logger: FilteringBoundLogger,
+    incremental_field_type: Optional[IncrementalFieldType] = None,
 ) -> int | None:
     """Count rows the incremental sync will actually pull.
 
@@ -991,7 +992,8 @@ def _get_incremental_row_count(
     back to the total-table count.
     """
     quoted_field = _quote_identifier(incremental_field)
-    query = f"SELECT count() FROM {_qualified_table(database, table_name)} WHERE {quoted_field} > %(last_value)s"
+    last_value_expr = _last_value_expr(incremental_field_type)
+    query = f"SELECT count() FROM {_qualified_table(database, table_name)} WHERE {quoted_field} > {last_value_expr}"
     try:
         result = client.query(
             query,
@@ -1147,6 +1149,21 @@ def _project_columns(
     return projected or columns
 
 
+def _last_value_expr(incremental_field_type: Optional[IncrementalFieldType]) -> str:
+    """SQL expression binding the `last_value` parameter for the incremental cursor.
+
+    The stored cursor for a `Date` column can arrive as a raw day-count integer
+    (ClickHouse's own on-disk representation) rather than a date/string, e.g. after a
+    round-trip through JSON. Comparing that integer directly against a `Date` column
+    fails with "Illegal types of arguments (Date, UInt16) of function greater". Casting
+    through `toDate32` accepts both a day-count integer and a date string, so the
+    comparison always type-checks regardless of which shape the cursor is in.
+    """
+    if incremental_field_type == IncrementalFieldType.Date:
+        return "toDate32(%(last_value)s)"
+    return "%(last_value)s"
+
+
 def _build_query(
     *,
     database: str,
@@ -1154,6 +1171,7 @@ def _build_query(
     columns: list[ClickHouseColumn],
     should_use_incremental_field: bool,
     incremental_field: Optional[str],
+    incremental_field_type: Optional[IncrementalFieldType] = None,
     row_filters: Optional[list[ValidatedRowFilter]] = None,
 ) -> tuple[str, dict[str, Any]]:
     """Build the data extraction query and its bound parameters.
@@ -1179,7 +1197,7 @@ def _build_query(
         raise ValueError("incremental_field can't be None when should_use_incremental_field is True")
 
     quoted_field = _quote_identifier(incremental_field)
-    conditions = [f"{quoted_field} > %(last_value)s", *filter_conditions]
+    conditions = [f"{quoted_field} > {_last_value_expr(incremental_field_type)}", *filter_conditions]
     query = f"SELECT {select_list} FROM {qualified} WHERE {' AND '.join(conditions)} ORDER BY {quoted_field} ASC"
     return query, filter_params
 
@@ -1309,6 +1327,7 @@ def clickhouse_source(
                     incremental_field,
                     db_incremental_field_last_value,
                     logger,
+                    incremental_field_type=incremental_field_type,
                 )
                 if incremental_count is not None:
                     rows_to_sync = incremental_count
@@ -1350,6 +1369,7 @@ def clickhouse_source(
                     columns=projected_columns,
                     should_use_incremental_field=should_use_incremental_field,
                     incremental_field=incremental_field,
+                    incremental_field_type=incremental_field_type,
                     row_filters=row_filters,
                 )
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -186,6 +186,21 @@ class TestBuildQuery:
         assert "ORDER BY `created_at` ASC" in query
         assert params == {}
 
+    def test_incremental_casts_date_last_value_through_todate32(self):
+        # A `Date` cursor can come back from storage as a raw day-count integer
+        # (ClickHouse's own on-disk representation), which `greater(Date, UInt16)`
+        # rejects when bound directly. toDate32 accepts both an integer day-count
+        # and a date string, so the comparison always type-checks.
+        query, _ = _build_query(
+            database="default",
+            table_name="events",
+            columns=self._cols(("id", "Int64"), ("day", "Date")),
+            should_use_incremental_field=True,
+            incremental_field="day",
+            incremental_field_type=IncrementalFieldType.Date,
+        )
+        assert "WHERE `day` > toDate32(%(last_value)s)" in query
+
     def test_incremental_quotes_field_with_special_chars(self):
         query, _ = _build_query(
             database="my-db",
@@ -1178,6 +1193,20 @@ class TestGetIncrementalRowCount:
         assert "`created_at` > %(last_value)s" in args[0]
         assert kwargs["parameters"] == {"last_value": "2024-01-01"}
         assert kwargs["settings"] == {"max_execution_time": 30}
+
+    def test_casts_date_last_value_through_todate32(self):
+        client = MagicMock()
+        result = MagicMock()
+        result.result_rows = [(7,)]
+        client.query.return_value = result
+
+        count = _get_incremental_row_count(
+            client, "db", "t", "day", 20657, self._logger(), incremental_field_type=IncrementalFieldType.Date
+        )
+        assert count == 7
+
+        args, _ = client.query.call_args
+        assert "`day` > toDate32(%(last_value)s)" in args[0]
 
     def test_returns_none_on_error(self):
         client = MagicMock()


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `DatabaseError` on the ClickHouse data-warehouse source: `Illegal types of arguments (\`Date\`, \`UInt16\`) of function \`greater\`` while building the incremental sync's WHERE clause (`get_rows` in `products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py`).

A `Date`-typed incremental cursor can be stored as a raw day-count integer (ClickHouse's own on-disk representation for `Date`) rather than a date string, e.g. after round-tripping through the schema's JSON sync state. Binding that integer directly into `WHERE day > %(last_value)s` fails because ClickHouse won't implicitly coerce a bare integer literal into a `Date` operand for comparison.

## Changes

- Added `_last_value_expr()`, which wraps the bound cursor parameter in `toDate32(...)` when the incremental field is `Date`. `toDate32` accepts both a day-count integer and a date string, so the comparison type-checks regardless of which shape the stored cursor is in.
- Threaded `incremental_field_type` through to `_build_query()` (used by the main streaming query) and `_get_incremental_row_count()` (used for the incremental progress-count estimate), so both queries get the same cast.
- Non-`Date` incremental fields are unaffected — the expression falls back to the existing bare `%(last_value)s` binding.

## How did you test this code?

Added two regression cases:
- `TestBuildQuery.test_incremental_casts_date_last_value_through_todate32` — asserts the streaming query wraps the cursor param in `toDate32(...)` for a `Date` incremental field. Without the fix, this generates the same bare `> %(last_value)s` clause that ClickHouse rejected in production.
- `TestGetIncrementalRowCount.test_casts_date_last_value_through_todate32` — same assertion for the incremental row-count query, which has the identical WHERE-clause shape.

Ran the full `test_clickhouse.py` suite locally (227 passed; 1 pre-existing failure unrelated to this change, from a test that needs a live Postgres connection not available in this environment) plus repo-wide `mypy` and `ruff`/`ci:preflight`, all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal query-building fix, no user-facing or documented behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude, via Claude Code) triaged a ClickHouse-source error-tracking issue, traced it to the incremental cursor's WHERE clause, and wrote the fix plus regression tests described above. No skills were invoked for this change beyond `/writing-tests` before adding the test cases.