### PR TITLE
feat(experiments): add per-link shared metric endpoints

### DIFF
--- a/frontend/src/scenes/experiments/experimentLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentLogic.test.ts
@@ -352,85 +352,26 @@ describe('experimentLogic', () => {
             api.update.mockClear()
         })
 
-        it('removes orphaned shared metric from metrics array', async () => {
-            const orphanedSharedMetricId = 46275
-            const experimentWithOrphan = {
-                ...experiment,
+        it('unlinks through the per-link endpoint, never a whole-array write', async () => {
+            // The orphaned-inline-copy cleanup this used to do client-side is now the
+            // server's job, covered by TestExperimentSharedMetricLinks on the backend.
+            const sharedMetricId = 46275
+            logic.actions.setExperiment({ ...experiment, saved_metrics: [] } as unknown as Experiment)
+            jest.spyOn(api, 'delete')
+            api.delete.mockClear()
+            api.delete.mockResolvedValue({
                 saved_metrics: [],
-                metrics: [
-                    {
-                        kind: 'ExperimentMetric',
-                        name: 'Orphaned Shared Metric',
-                        uuid: 'orphan-uuid',
-                        isSharedMetric: true,
-                        sharedMetricId: orphanedSharedMetricId,
-                    },
-                    experiment.metrics[0],
-                ],
-                metrics_secondary: [],
-            } as unknown as Experiment
-
-            logic.actions.setExperiment(experimentWithOrphan)
-            api.update.mockResolvedValue(experimentWithOrphan)
-
-            useMocks({
-                get: {
-                    '/api/projects/:team/experiments/:id': experimentWithOrphan,
-                },
+                primary_metrics_ordered_uuids: [],
+                secondary_metrics_ordered_uuids: [],
             })
 
             await expectLogic(logic, () => {
-                logic.actions.removeSharedMetricFromExperiment(orphanedSharedMetricId)
+                logic.actions.removeSharedMetricFromExperiment(sharedMetricId)
             }).toFinishAllListeners()
 
-            expect(api.update).toHaveBeenCalledWith(
-                expect.stringContaining('/experiments/'),
-                expect.objectContaining({
-                    saved_metrics_ids: [],
-                    metrics: [experiment.metrics[0]],
-                    metrics_secondary: [],
-                })
-            )
-        })
-
-        it('removes orphaned shared metric from metrics_secondary array', async () => {
-            const orphanedSharedMetricId = 99999
-            const experimentWithOrphan = {
-                ...experiment,
-                saved_metrics: [],
-                metrics: [],
-                metrics_secondary: [
-                    {
-                        kind: 'ExperimentMetric',
-                        name: 'Orphaned Secondary Metric',
-                        uuid: 'orphan-secondary-uuid',
-                        isSharedMetric: true,
-                        sharedMetricId: orphanedSharedMetricId,
-                    },
-                ],
-            } as unknown as Experiment
-
-            logic.actions.setExperiment(experimentWithOrphan)
-            api.update.mockResolvedValue(experimentWithOrphan)
-
-            useMocks({
-                get: {
-                    '/api/projects/:team/experiments/:id': experimentWithOrphan,
-                },
-            })
-
-            await expectLogic(logic, () => {
-                logic.actions.removeSharedMetricFromExperiment(orphanedSharedMetricId)
-            }).toFinishAllListeners()
-
-            expect(api.update).toHaveBeenCalledWith(
-                expect.stringContaining('/experiments/'),
-                expect.objectContaining({
-                    saved_metrics_ids: [],
-                    metrics: [],
-                    metrics_secondary: [],
-                })
-            )
+            expect(api.delete).toHaveBeenCalledWith(expect.stringContaining(`/shared_metrics/${sharedMetricId}/`))
+            expect(api.update).not.toHaveBeenCalled()
+            api.delete.mockRestore()
         })
     })
     describe('duplicateSharedMetricAsInlineMetric', () => {

--- a/frontend/src/scenes/experiments/experimentLogic.tsx
+++ b/frontend/src/scenes/experiments/experimentLogic.tsx
@@ -89,8 +89,14 @@ import {
     experimentsMetricsDestroy,
     experimentsMetricsOrderUpdate,
     experimentsMetricsPartialUpdate,
+    experimentsSharedMetricsCreate,
+    experimentsSharedMetricsDestroy,
+    experimentsSharedMetricsPartialUpdate,
 } from 'products/experiments/frontend/generated/api'
-import type { ExperimentMetricMutationResponseApi } from 'products/experiments/frontend/generated/api.schemas'
+import type {
+    ExperimentMetricMutationResponseApi,
+    ExperimentSharedMetricLinkResponseApi,
+} from 'products/experiments/frontend/generated/api.schemas'
 
 import type { ProductIntentProperties } from '../../lib/utils/product-intents'
 import type { Noun } from '../../models/groupsModel'
@@ -821,6 +827,9 @@ export interface experimentLogicActions {
     ) => {
         replacesUuid: string | null
         response: ExperimentMetricMutationResponseApi
+    }
+    applySharedMetricLinks: (response: ExperimentSharedMetricLinkResponseApi) => {
+        response: ExperimentSharedMetricLinkResponseApi
     }
     archiveExperiment: (disableFeatureFlag?: boolean) => {
         disableFeatureFlag: boolean
@@ -1674,6 +1683,7 @@ export const experimentLogic = kea<experimentLogicType>([
             response,
             replacesUuid,
         }),
+        applySharedMetricLinks: (response: ExperimentSharedMetricLinkResponseApi) => ({ response }),
         removeMetric: (uuid: string, context: 'primary' | 'secondary') => ({ uuid, context }),
         saveMetricsReorder: (
             isSecondary: boolean,
@@ -1775,6 +1785,17 @@ export const experimentLogic = kea<experimentLogicType>([
                     }
                     return next
                 },
+                /**
+                 * Apply a per-link write's response. The client is never the source of truth for
+                 * which shared metrics are linked, so taking the server's set wholesale is safe
+                 * here — unlike the inline metric arrays, which the client edits.
+                 */
+                applySharedMetricLinks: (state, { response }) => ({
+                    ...state,
+                    saved_metrics: response.saved_metrics as unknown as ExperimentSavedMetric[],
+                    primary_metrics_ordered_uuids: response.primary_metrics_ordered_uuids,
+                    secondary_metrics_ordered_uuids: response.secondary_metrics_ordered_uuids,
+                }),
                 setExposureCriteria: (
                     state,
                     { exposureCriteria }: { exposureCriteria: ExperimentExposureCriteria }
@@ -2274,10 +2295,23 @@ export const experimentLogic = kea<experimentLogicType>([
                 return
             }
 
-            await asyncActions.updateExperiment({
-                saved_metrics_ids: savedMetrics.map(({ saved_metric, metadata }) => ({ id: saved_metric, metadata })),
-                update_feature_flag_params: false,
-            })
+            const link = savedMetrics.find(({ query: { uuid: savedMetricUuid } }) => savedMetricUuid === uuid)
+            if (!link) {
+                return
+            }
+
+            try {
+                const response = await experimentsSharedMetricsPartialUpdate(
+                    String(values.currentProjectId),
+                    Number(values.experimentId),
+                    String(link.saved_metric),
+                    { metadata: link.metadata }
+                )
+                actions.applySharedMetricLinks(response)
+            } catch (error: any) {
+                lemonToast.error(error.detail || 'Failed to save breakdown')
+                actions.loadExperiment({ triggeredBy: 'config_change' })
+            }
         }
 
         return {
@@ -2961,26 +2995,31 @@ export const experimentLogic = kea<experimentLogicType>([
                 })
             },
             addSharedMetricsToExperiment: async ({ sharedMetricIds, metadata }) => {
-                const existingMetricsIds = values.experiment.saved_metrics.map((sharedMetric) => ({
-                    id: sharedMetric.saved_metric,
-                    metadata: sharedMetric.metadata,
-                }))
-
-                const newMetricsIds = sharedMetricIds.map((id: SharedMetric['id']) => ({ id, metadata }))
-                newMetricsIds.forEach((metricId) => {
-                    const metric = values.sharedMetrics.find((m: SharedMetric) => m.id === metricId.id)
+                sharedMetricIds.forEach((id: SharedMetric['id']) => {
+                    const metric = values.sharedMetrics.find((m: SharedMetric) => m.id === id)
                     if (metric) {
                         actions.reportExperimentSharedMetricAssigned(values.experimentId, metric)
                     }
                 })
-                const combinedMetricsIds = [...existingMetricsIds, ...newMetricsIds]
 
-                await api.update(`api/projects/${values.currentProjectId}/experiments/${values.experimentId}`, {
-                    saved_metrics_ids: combinedMetricsIds,
-                    update_feature_flag_params: false,
-                })
-
-                actions.loadExperiment({ triggeredBy: 'config_change' })
+                try {
+                    // One request per link. Sequential rather than concurrent because each takes
+                    // the same experiment row lock, so firing them together would just contend.
+                    let response
+                    for (const id of sharedMetricIds) {
+                        response = await experimentsSharedMetricsCreate(
+                            String(values.currentProjectId),
+                            Number(values.experimentId),
+                            { saved_metric_id: id, section: metadata.type }
+                        )
+                    }
+                    if (response) {
+                        actions.applySharedMetricLinks(response)
+                    }
+                } catch (error: any) {
+                    lemonToast.error(error.detail || 'Failed to add shared metric')
+                    actions.loadExperiment({ triggeredBy: 'config_change' })
+                }
             },
             duplicateSharedMetricAsInlineMetric: ({ isSecondary, newUuid }) => {
                 // Listeners run after reducers, so the copy is only there if the shared metric was actually found
@@ -2989,30 +3028,22 @@ export const experimentLogic = kea<experimentLogicType>([
                     lemonToast.success('Metric duplicated as a single-use metric')
                 }
             },
+            // Any orphaned inline copy of this shared metric is cleaned up server-side, so
+            // unlinking no longer has to rewrite the metric arrays to get rid of it.
             removeSharedMetricFromExperiment: async ({ sharedMetricId }) => {
-                const sharedMetricsIds = values.experiment.saved_metrics
-                    .filter((sharedMetric) => sharedMetric.saved_metric !== sharedMetricId)
-                    .map((sharedMetric) => ({
-                        id: sharedMetric.saved_metric,
-                        metadata: sharedMetric.metadata,
-                    }))
-
-                // Also remove orphaned shared metrics that were incorrectly stored in the metrics arrays
-                const cleanedMetrics = (values.experiment.metrics || []).filter(
-                    (m) => !('isSharedMetric' in m && m.isSharedMetric && m.sharedMetricId === sharedMetricId)
-                )
-                const cleanedMetricsSecondary = (values.experiment.metrics_secondary || []).filter(
-                    (m) => !('isSharedMetric' in m && m.isSharedMetric && m.sharedMetricId === sharedMetricId)
-                )
-
-                await api.update(`api/projects/${values.currentProjectId}/experiments/${values.experimentId}`, {
-                    saved_metrics_ids: sharedMetricsIds,
-                    metrics: cleanedMetrics,
-                    metrics_secondary: cleanedMetricsSecondary,
-                    update_feature_flag_params: false,
-                })
-
-                actions.loadExperiment({ triggeredBy: 'config_change' })
+                try {
+                    const response = await experimentsSharedMetricsDestroy(
+                        String(values.currentProjectId),
+                        Number(values.experimentId),
+                        String(sharedMetricId)
+                    )
+                    actions.applySharedMetricLinks(response)
+                    // The inline arrays can change too when a stale copy is cleaned up, so
+                    // reload rather than guess at what the server removed.
+                    actions.loadExperiment({ triggeredBy: 'config_change' })
+                } catch (error: any) {
+                    lemonToast.error(error.detail || 'Failed to remove shared metric')
+                }
             },
             createExperimentDashboard: async () => {
                 actions.setIsCreatingExperimentDashboard(true)

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -3194,6 +3194,108 @@ class ExperimentService:
                 serializer_context=serializer_context,
             )
 
+    # --- per-link shared-metric writes -----------------------------------------
+    # Same shape as the per-metric writes above, for the experiment↔shared-metric
+    # links. A client addresses one link; the server rebuilds saved_metrics_ids
+    # under the row lock, so linking a shared metric can't drop one someone else
+    # linked meanwhile.
+
+    def link_shared_metric(
+        self,
+        experiment_id: int,
+        *,
+        saved_metric_id: int,
+        metric_type: MetricType,
+        serializer_context: dict | None = None,
+    ) -> Experiment:
+        """Link one shared metric into a section, or move it if already linked."""
+        with transaction.atomic():
+            experiment = self._locked_experiment(experiment_id)
+            links = self._shared_metric_links(experiment)
+            links[saved_metric_id] = {**(links.get(saved_metric_id) or {}), "type": metric_type}
+            return self._write_shared_metric_links(experiment, links, serializer_context)
+
+    def unlink_shared_metric(
+        self,
+        experiment_id: int,
+        *,
+        saved_metric_id: int,
+        serializer_context: dict | None = None,
+    ) -> Experiment:
+        """Unlink one shared metric, and drop any inline copy of it left behind.
+
+        Some experiments carry a stale inline entry marked ``isSharedMetric`` from before links
+        were the only representation, sometimes with no link at all. Cleaning it here means
+        clients no longer have to rewrite the metric arrays to unlink a shared metric — so this
+        succeeds when there is only an orphan to clean, and 404s only when there is neither.
+        """
+        with transaction.atomic():
+            experiment = self._locked_experiment(experiment_id)
+            links = self._shared_metric_links(experiment)
+            # Membership, not the popped value: a link's metadata can legitimately be null.
+            was_linked = saved_metric_id in links
+            links.pop(saved_metric_id, None)
+
+            extra_update: dict = {}
+            for field in METRIC_FIELD_BY_TYPE.values():
+                metrics = getattr(experiment, field) or []
+                kept = [
+                    m for m in metrics if not (m.get("isSharedMetric") and m.get("sharedMetricId") == saved_metric_id)
+                ]
+                if len(kept) != len(metrics):
+                    extra_update[field] = kept
+
+            if not was_linked and not extra_update:
+                raise NotFound(f"Shared metric {saved_metric_id} is not on this experiment.")
+
+            return self._write_shared_metric_links(experiment, links, serializer_context, extra_update=extra_update)
+
+    def patch_shared_metric_link(
+        self,
+        experiment_id: int,
+        *,
+        saved_metric_id: int,
+        metadata: dict,
+        serializer_context: dict | None = None,
+    ) -> Experiment:
+        """Shallow-merge metadata (breakdowns, section) onto one link, leaving others alone."""
+        with transaction.atomic():
+            experiment = self._locked_experiment(experiment_id)
+            links = self._shared_metric_links(experiment)
+            if saved_metric_id not in links:
+                raise NotFound(f"Shared metric {saved_metric_id} is not linked to this experiment.")
+            links[saved_metric_id] = {**(links[saved_metric_id] or {}), **metadata}
+            return self._write_shared_metric_links(experiment, links, serializer_context)
+
+    @staticmethod
+    def _shared_metric_links(experiment: Experiment) -> dict[int, dict | None]:
+        """The experiment's shared-metric links as ``{saved_metric_id: metadata}``."""
+        return dict(experiment.experimenttosavedmetric_set.values_list("saved_metric_id", "metadata"))
+
+    def _write_shared_metric_links(
+        self,
+        experiment: Experiment,
+        links: dict[int, dict | None],
+        serializer_context: dict | None,
+        *,
+        extra_update: dict | None = None,
+    ) -> Experiment:
+        """Persist a rebuilt link set through update_experiment's saved-metrics sync."""
+        return self.update_experiment(
+            experiment,
+            {
+                "saved_metrics_ids": [
+                    {"id": link_id, "metadata": metadata or {"type": "primary"}} for link_id, metadata in links.items()
+                ],
+                **(extra_update or {}),
+                "update_feature_flag_params": False,
+            },
+            serializer_context=serializer_context,
+            # A link write must not be blocked by an inline metric referencing an event
+            # this project never ingested — that metric isn't what's being changed.
+            allow_unknown_events=True,
+        )
+
     def _locked_experiment(self, experiment_id: int) -> Experiment:
         """Row-lock an experiment for the duration of the caller's transaction."""
         try:

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -1161,6 +1161,50 @@ class ExperimentMetricMutationResponseSerializer(serializers.Serializer):
     secondary_metrics_ordered_uuids = serializers.ListField(child=serializers.CharField(), allow_null=True)
 
 
+class ExperimentSharedMetricLinkSerializer(serializers.Serializer):
+    saved_metric_id = serializers.IntegerField(help_text="The shared metric to link to this experiment.")
+    section = serializers.ChoiceField(choices=["primary", "secondary"], help_text=_SECTION_HELP_TEXT)
+
+
+# Declared as an inline schema rather than a nested serializer: the metadata's own "type"
+# key would generate a TypeEnum component that collides with other enums repo-wide.
+@extend_schema_field(
+    {
+        "type": "object",
+        "properties": {
+            "type": {"type": "string", "enum": ["primary", "secondary"]},
+            "breakdowns": {"type": "array", "items": {"type": "object"}},
+        },
+    }
+)
+class SharedMetricLinkMetadataField(serializers.JSONField):
+    pass
+
+
+class ExperimentSharedMetricLinkPatchSerializer(serializers.Serializer):
+    metadata = SharedMetricLinkMetadataField(
+        help_text=(
+            "Link metadata to merge, such as breakdowns, or a 'type' of 'primary'/'secondary' to move "
+            "the shared metric between sections. Keys you omit are preserved."
+        )
+    )
+
+
+class ExperimentSharedMetricLinkResponseSerializer(serializers.Serializer):
+    """What a per-link write returns — the link set plus both ordering arrays.
+
+    Unlike the metric collections, a client is never the source of truth for which shared
+    metrics are linked, so returning the resolved set is safe. It still never returns the
+    whole experiment.
+    """
+
+    saved_metrics = ExperimentToSavedMetricSerializer(
+        many=True, read_only=True, help_text="The experiment's shared-metric links after the write."
+    )
+    primary_metrics_ordered_uuids = serializers.ListField(child=serializers.CharField(), allow_null=True)
+    secondary_metrics_ordered_uuids = serializers.ListField(child=serializers.CharField(), allow_null=True)
+
+
 class CopyExperimentToProjectSerializer(serializers.Serializer):
     target_team_id = serializers.IntegerField(help_text="The team ID to copy the experiment to.")
     feature_flag_key = serializers.CharField(

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -68,6 +68,9 @@ from products.experiments.backend.presentation.serializers import (
     ExperimentMetricWriteSerializer,
     ExperimentSerializer,
     ExperimentSessionContextResponseSerializer,
+    ExperimentSharedMetricLinkPatchSerializer,
+    ExperimentSharedMetricLinkResponseSerializer,
+    ExperimentSharedMetricLinkSerializer,
     ExperimentWriteSerializer,
     RecalculateMetricsRequestSerializer,
     RunningTimeCalculationInputSerializer,
@@ -1296,6 +1299,95 @@ class EnterpriseExperimentsViewSet(
                 }
             ).data,
             status=status_code,
+        )
+
+    # --- per-link shared-metric writes ----------------------------------------
+    # Same reasoning as the per-metric routes above, for experiment↔shared-metric
+    # links. Addressing one link means a client no longer rewrites the whole
+    # saved_metrics_ids array to add or remove a single shared metric.
+
+    @validated_request(
+        request_serializer=ExperimentSharedMetricLinkSerializer,
+        responses={200: OpenApiResponse(response=ExperimentSharedMetricLinkResponseSerializer)},
+        summary="Link a shared metric to an experiment",
+        description=(
+            "Links one shared metric into the experiment's primary or secondary section, or moves it "
+            "if it is already linked. Other links are left untouched, so this is safe from a client "
+            "whose local copy of the experiment is out of date."
+        ),
+    )
+    @action(methods=["POST"], detail=True, url_path="shared_metrics", required_scopes=["experiment:write"])
+    def shared_metrics(self, request: ValidatedRequest, *args: Any, **kwargs: Any) -> Response:
+        experiment: Experiment = self.get_object()
+        data = request.validated_data
+        updated = ExperimentService(team=self.team, user=request.user).link_shared_metric(
+            experiment.id,
+            saved_metric_id=data["saved_metric_id"],
+            metric_type=data["section"],
+            serializer_context=self.get_serializer_context(),
+        )
+        return self._shared_metric_link_response(updated)
+
+    @extend_schema(
+        methods=["PATCH"],
+        request=ExperimentSharedMetricLinkPatchSerializer,
+        responses={200: OpenApiResponse(response=ExperimentSharedMetricLinkResponseSerializer)},
+        summary="Update a shared metric's link metadata",
+        description=(
+            "Shallow-merges metadata onto one experiment↔shared-metric link — breakdowns, or a 'type' "
+            "of 'primary'/'secondary' to move it between sections. Keys you omit are preserved and "
+            "other links are untouched."
+        ),
+    )
+    @extend_schema(
+        methods=["DELETE"],
+        request=None,
+        responses={200: OpenApiResponse(response=ExperimentSharedMetricLinkResponseSerializer)},
+        summary="Unlink a shared metric from an experiment",
+        description=(
+            "Removes one experiment↔shared-metric link. Any stale inline copy of that shared metric "
+            "left in the metric arrays is cleaned up server-side, so the client does not have to "
+            "rewrite them."
+        ),
+    )
+    @action(
+        methods=["PATCH", "DELETE"],
+        detail=True,
+        url_path=r"shared_metrics/(?P<saved_metric_id>[0-9]+)",
+        required_scopes=["experiment:write"],
+    )
+    def shared_metrics_detail(self, request: Request, saved_metric_id: str, *args: Any, **kwargs: Any) -> Response:
+        experiment: Experiment = self.get_object()
+        service = ExperimentService(team=self.team, user=request.user)
+
+        if request.method == "DELETE":
+            updated = service.unlink_shared_metric(
+                experiment.id,
+                saved_metric_id=int(saved_metric_id),
+                serializer_context=self.get_serializer_context(),
+            )
+            return self._shared_metric_link_response(updated)
+
+        request_serializer = ExperimentSharedMetricLinkPatchSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+        updated = service.patch_shared_metric_link(
+            experiment.id,
+            saved_metric_id=int(saved_metric_id),
+            metadata=request_serializer.validated_data["metadata"],
+            serializer_context=self.get_serializer_context(),
+        )
+        return self._shared_metric_link_response(updated)
+
+    def _shared_metric_link_response(self, experiment: Experiment) -> Response:
+        return Response(
+            ExperimentSharedMetricLinkResponseSerializer(
+                {
+                    "saved_metrics": experiment.experimenttosavedmetric_set.select_related("saved_metric").all(),
+                    "primary_metrics_ordered_uuids": experiment.primary_metrics_ordered_uuids,
+                    "secondary_metrics_ordered_uuids": experiment.secondary_metrics_ordered_uuids,
+                },
+                context=self.get_serializer_context(),
+            ).data
         )
 
     @action(methods=["GET"], detail=False, url_path="stats", required_scopes=["experiment:read"])

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -8939,3 +8939,128 @@ class TestExperimentPerMetricWrites(_HoistFlagConfigClientMixin, APILicensedTest
             ),
             "Per-metric writes must SELECT ... FOR UPDATE the experiment row.",
         )
+
+
+class TestExperimentSharedMetricLinks(_HoistFlagConfigClientMixin, APILicensedTest):
+    """Linking a shared metric used to mean rewriting the whole saved_metrics_ids array,
+    so a stale client dropped links it never saw. These cover the per-link writes."""
+
+    def _create_experiment(self) -> int:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {"name": "Shared metric links", "feature_flag_key": "shared-metric-links"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.json())
+        return response.json()["id"]
+
+    def _create_shared_metric(self, name: str, uuid: str) -> ExperimentSavedMetric:
+        return ExperimentSavedMetric.objects.create(
+            team=self.team,
+            name=name,
+            query={
+                "kind": "ExperimentMetric",
+                "uuid": uuid,
+                "metric_type": "mean",
+                "source": {"kind": "EventsNode", "event": "shared_event"},
+            },
+        )
+
+    def _link(self, experiment_id: int, saved_metric_id: int, section: str = "primary") -> dict[str, Any]:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/shared_metrics/",
+            {"saved_metric_id": saved_metric_id, "section": section},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        return response.json()
+
+    def test_linking_one_shared_metric_leaves_the_others(self):
+        experiment_id = self._create_experiment()
+        first = self._create_shared_metric("First", "shared-uuid-1")
+        second = self._create_shared_metric("Second", "shared-uuid-2")
+
+        self._link(experiment_id, first.id)
+        body = self._link(experiment_id, second.id, section="secondary")
+
+        linked = {link["saved_metric"]: link["metadata"]["type"] for link in body["saved_metrics"]}
+        self.assertEqual(linked, {first.id: "primary", second.id: "secondary"})
+        self.assertEqual(body["primary_metrics_ordered_uuids"], ["shared-uuid-1"])
+        self.assertEqual(body["secondary_metrics_ordered_uuids"], ["shared-uuid-2"])
+
+    def test_unlinking_one_shared_metric_leaves_the_others(self):
+        experiment_id = self._create_experiment()
+        first = self._create_shared_metric("First", "shared-uuid-1")
+        second = self._create_shared_metric("Second", "shared-uuid-2")
+        self._link(experiment_id, first.id)
+        self._link(experiment_id, second.id)
+
+        response = self.client.delete(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/shared_metrics/{first.id}/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        self.assertEqual([link["saved_metric"] for link in response.json()["saved_metrics"]], [second.id])
+        self.assertEqual(response.json()["primary_metrics_ordered_uuids"], ["shared-uuid-2"])
+
+    def test_patching_link_metadata_merges_and_can_move_sections(self):
+        experiment_id = self._create_experiment()
+        shared = self._create_shared_metric("First", "shared-uuid-1")
+        self._link(experiment_id, shared.id)
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/shared_metrics/{shared.id}/",
+            {"metadata": {"breakdowns": [{"property": "$browser"}]}},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        metadata = response.json()["saved_metrics"][0]["metadata"]
+        # The breakdown lands and the section it was linked into is preserved.
+        self.assertEqual(metadata["breakdowns"], [{"property": "$browser"}])
+        self.assertEqual(metadata["type"], "primary")
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/shared_metrics/{shared.id}/",
+            {"metadata": {"type": "secondary"}},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        metadata = response.json()["saved_metrics"][0]["metadata"]
+        self.assertEqual(metadata["type"], "secondary")
+        self.assertEqual(metadata["breakdowns"], [{"property": "$browser"}])
+        self.assertEqual(response.json()["primary_metrics_ordered_uuids"], [])
+        self.assertEqual(response.json()["secondary_metrics_ordered_uuids"], ["shared-uuid-1"])
+
+    def test_writing_an_unlinked_shared_metric_is_not_found(self):
+        experiment_id = self._create_experiment()
+        shared = self._create_shared_metric("Unlinked", "shared-uuid-1")
+
+        response = self.client.delete(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/shared_metrics/{shared.id}/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.json())
+
+    @parameterized.expand([("metrics", "primary"), ("metrics_secondary", "secondary")])
+    def test_unlinking_cleans_up_an_orphaned_inline_copy(self, field: str, section: str):
+        # Some experiments carry an inline entry flagged isSharedMetric with no link behind it.
+        # The client used to strip these by rewriting the whole array; the server does it now.
+        experiment_id = self._create_experiment()
+        orphan_id = 46275
+        experiment = Experiment.objects.get(pk=experiment_id)
+        setattr(
+            experiment,
+            field,
+            [
+                {
+                    "kind": "ExperimentMetric",
+                    "uuid": "orphan-uuid",
+                    "metric_type": "mean",
+                    "source": {"kind": "EventsNode", "event": "shared_event"},
+                    "isSharedMetric": True,
+                    "sharedMetricId": orphan_id,
+                }
+            ],
+        )
+        setattr(experiment, f"{section}_metrics_ordered_uuids", ["orphan-uuid"])
+        experiment.save()
+
+        response = self.client.delete(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}/shared_metrics/{orphan_id}/"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+        self.assertEqual(getattr(Experiment.objects.get(pk=experiment_id), field), [])

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -2113,6 +2113,55 @@ export interface ExperimentMetricsRecalculationApi {
     estimated_rows_total?: number | null
 }
 
+export interface ExperimentSharedMetricLinkApi {
+    /** The shared metric to link to this experiment. */
+    saved_metric_id: number
+    /** Which metric section to write: 'primary' or 'secondary'.
+     *
+     * * `primary` - primary
+     * * `secondary` - secondary */
+    section: SectionEnumApi
+}
+
+/**
+ * What a per-link write returns — the link set plus both ordering arrays.
+ *
+ * Unlike the metric collections, a client is never the source of truth for which shared
+ * metrics are linked, so returning the resolved set is safe. It still never returns the
+ * whole experiment.
+ */
+export interface ExperimentSharedMetricLinkResponseApi {
+    /** The experiment's shared-metric links after the write. */
+    readonly saved_metrics: readonly ExperimentToSavedMetricApi[]
+    /** @nullable */
+    primary_metrics_ordered_uuids: string[] | null
+    /** @nullable */
+    secondary_metrics_ordered_uuids: string[] | null
+}
+
+export type PatchedExperimentSharedMetricLinkPatchApiMetadataType =
+    (typeof PatchedExperimentSharedMetricLinkPatchApiMetadataType)[keyof typeof PatchedExperimentSharedMetricLinkPatchApiMetadataType]
+
+export const PatchedExperimentSharedMetricLinkPatchApiMetadataType = {
+    Primary: 'primary',
+    Secondary: 'secondary',
+} as const
+
+export type PatchedExperimentSharedMetricLinkPatchApiMetadataBreakdownsItem = { [key: string]: unknown }
+
+/**
+ * Link metadata to merge, such as breakdowns, or a 'type' of 'primary'/'secondary' to move the shared metric between sections. Keys you omit are preserved.
+ */
+export type PatchedExperimentSharedMetricLinkPatchApiMetadata = {
+    type?: PatchedExperimentSharedMetricLinkPatchApiMetadataType
+    breakdowns?: PatchedExperimentSharedMetricLinkPatchApiMetadataBreakdownsItem[]
+}
+
+export interface PatchedExperimentSharedMetricLinkPatchApi {
+    /** Link metadata to merge, such as breakdowns, or a 'type' of 'primary'/'secondary' to move the shared metric between sections. Keys you omit are preserved. */
+    metadata?: PatchedExperimentSharedMetricLinkPatchApiMetadata
+}
+
 export interface ShipVariantApi {
     /** The conclusion of the experiment.
      *

--- a/products/experiments/frontend/generated/api.ts
+++ b/products/experiments/frontend/generated/api.ts
@@ -25,6 +25,8 @@ import type {
     ExperimentSavedMetricApi,
     ExperimentSavedMetricsListParams,
     ExperimentSessionContextResponseApi,
+    ExperimentSharedMetricLinkApi,
+    ExperimentSharedMetricLinkResponseApi,
     ExperimentWriteApi,
     ExperimentsActivityRetrieveParams,
     ExperimentsListParams,
@@ -37,6 +39,7 @@ import type {
     PatchedExperimentHoldoutApi,
     PatchedExperimentMetricWriteApi,
     PatchedExperimentSavedMetricApi,
+    PatchedExperimentSharedMetricLinkPatchApi,
     PatchedExperimentWriteApi,
     RecalculateMetricsRequestApi,
     RunningTimeCalculationInputApi,
@@ -931,6 +934,77 @@ export const experimentsResumeCreate = async (
         ...options,
         method: 'POST',
     })
+}
+
+export const getExperimentsSharedMetricsCreateUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/experiments/${id}/shared_metrics/`
+}
+
+/**
+ * Links one shared metric into the experiment's primary or secondary section, or moves it if it is already linked. Other links are left untouched, so this is safe from a client whose local copy of the experiment is out of date.
+ * @summary Link a shared metric to an experiment
+ */
+export const experimentsSharedMetricsCreate = async (
+    projectId: string,
+    id: number,
+    experimentSharedMetricLinkApi: ExperimentSharedMetricLinkApi,
+    options?: RequestInit
+): Promise<ExperimentSharedMetricLinkResponseApi> => {
+    return apiMutator<ExperimentSharedMetricLinkResponseApi>(getExperimentsSharedMetricsCreateUrl(projectId, id), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(experimentSharedMetricLinkApi),
+    })
+}
+
+export const getExperimentsSharedMetricsPartialUpdateUrl = (projectId: string, id: number, savedMetricId: string) => {
+    return `/api/projects/${projectId}/experiments/${id}/shared_metrics/${savedMetricId}/`
+}
+
+/**
+ * Shallow-merges metadata onto one experiment↔shared-metric link — breakdowns, or a 'type' of 'primary'/'secondary' to move it between sections. Keys you omit are preserved and other links are untouched.
+ * @summary Update a shared metric's link metadata
+ */
+export const experimentsSharedMetricsPartialUpdate = async (
+    projectId: string,
+    id: number,
+    savedMetricId: string,
+    patchedExperimentSharedMetricLinkPatchApi?: PatchedExperimentSharedMetricLinkPatchApi,
+    options?: RequestInit
+): Promise<ExperimentSharedMetricLinkResponseApi> => {
+    return apiMutator<ExperimentSharedMetricLinkResponseApi>(
+        getExperimentsSharedMetricsPartialUpdateUrl(projectId, id, savedMetricId),
+        {
+            ...options,
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(patchedExperimentSharedMetricLinkPatchApi),
+        }
+    )
+}
+
+export const getExperimentsSharedMetricsDestroyUrl = (projectId: string, id: number, savedMetricId: string) => {
+    return `/api/projects/${projectId}/experiments/${id}/shared_metrics/${savedMetricId}/`
+}
+
+/**
+ * Removes one experiment↔shared-metric link. Any stale inline copy of that shared metric left in the metric arrays is cleaned up server-side, so the client does not have to rewrite them.
+ * @summary Unlink a shared metric from an experiment
+ */
+export const experimentsSharedMetricsDestroy = async (
+    projectId: string,
+    id: number,
+    savedMetricId: string,
+    options?: RequestInit
+): Promise<ExperimentSharedMetricLinkResponseApi> => {
+    return apiMutator<ExperimentSharedMetricLinkResponseApi>(
+        getExperimentsSharedMetricsDestroyUrl(projectId, id, savedMetricId),
+        {
+            ...options,
+            method: 'DELETE',
+        }
+    )
 }
 
 export const getExperimentsShipVariantCreateUrl = (projectId: string, id: number) => {

--- a/products/experiments/frontend/generated/api.zod.ts
+++ b/products/experiments/frontend/generated/api.zod.ts
@@ -3039,6 +3039,36 @@ export const ExperimentsRecalculateTimeseriesCreateBody = /* @__PURE__ */ zod
     .describe('Deep\/recursive schema (opaque in Zod — use TypeScript types for full shape)')
 
 /**
+ * Links one shared metric into the experiment's primary or secondary section, or moves it if it is already linked. Other links are left untouched, so this is safe from a client whose local copy of the experiment is out of date.
+ * @summary Link a shared metric to an experiment
+ */
+export const ExperimentsSharedMetricsCreateBody = /* @__PURE__ */ zod.object({
+    saved_metric_id: zod.number().describe('The shared metric to link to this experiment.'),
+    section: zod
+        .enum(['primary', 'secondary'])
+        .describe('\* `primary` - primary\n\* `secondary` - secondary')
+        .describe(
+            "Which metric section to write: 'primary' or 'secondary'.\n\n\* `primary` - primary\n\* `secondary` - secondary"
+        ),
+})
+
+/**
+ * Shallow-merges metadata onto one experiment↔shared-metric link — breakdowns, or a 'type' of 'primary'/'secondary' to move it between sections. Keys you omit are preserved and other links are untouched.
+ * @summary Update a shared metric's link metadata
+ */
+export const ExperimentsSharedMetricsPartialUpdateBody = /* @__PURE__ */ zod.object({
+    metadata: zod
+        .object({
+            type: zod.enum(['primary', 'secondary']).optional(),
+            breakdowns: zod.array(zod.looseObject({})).optional(),
+        })
+        .optional()
+        .describe(
+            "Link metadata to merge, such as breakdowns, or a 'type' of 'primary'\/'secondary' to move the shared metric between sections. Keys you omit are preserved."
+        ),
+})
+
+/**
  * Ship a variant and (optionally) end the experiment.
  *
  * Updates the feature flag so the selected variant gets 100% of the variant

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -1257,6 +1257,18 @@ tools:
     experiments-flag-cleanup-task-retrieve:
         operation: experiments_flag_cleanup_task_retrieve
         enabled: false
+    experiments-metrics-create:
+        operation: experiments_metrics_create
+        enabled: false
+    experiments-metrics-destroy:
+        operation: experiments_metrics_destroy
+        enabled: false
+    experiments-metrics-order-update:
+        operation: experiments_metrics_order_update
+        enabled: false
+    experiments-metrics-partial-update:
+        operation: experiments_metrics_partial_update
+        enabled: false
     experiments-prompt-templates-retrieve:
         operation: experiments_prompt_templates_retrieve
         enabled: false
@@ -1265,6 +1277,15 @@ tools:
         enabled: false
     experiments-session-context-retrieve:
         operation: experiments_session_context_retrieve
+        enabled: false
+    experiments-shared-metrics-create:
+        operation: experiments_shared_metrics_create
+        enabled: false
+    experiments-shared-metrics-destroy:
+        operation: experiments_shared_metrics_destroy
+        enabled: false
+    experiments-shared-metrics-partial-update:
+        operation: experiments_shared_metrics_partial_update
         enabled: false
     experiments-update:
         operation: experiments_update

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -27960,6 +27960,32 @@ export namespace Schemas {
       results: ExperimentSessionContextItem[];
     }
 
+    export interface ExperimentSharedMetricLink {
+      /** The shared metric to link to this experiment. */
+      saved_metric_id: number;
+      /** Which metric section to write: 'primary' or 'secondary'.
+       *
+       * * `primary` - primary
+       * * `secondary` - secondary */
+      section: SectionEnum;
+    }
+
+    /**
+     * What a per-link write returns — the link set plus both ordering arrays.
+     *
+     * Unlike the metric collections, a client is never the source of truth for which shared
+     * metrics are linked, so returning the resolved set is safe. It still never returns the
+     * whole experiment.
+     */
+    export interface ExperimentSharedMetricLinkResponse {
+      /** The experiment's shared-metric links after the write. */
+      readonly saved_metrics: readonly ExperimentToSavedMetric[];
+      /** @nullable */
+      primary_metrics_ordered_uuids: string[] | null;
+      /** @nullable */
+      secondary_metrics_ordered_uuids: string[] | null;
+    }
+
     /**
      * Experiment write payload. Identical to Experiment, plus the writable `feature_flag` config input.
      */
@@ -49166,6 +49192,29 @@ export namespace Schemas {
          * @nullable
          */
       readonly user_access_level?: string | null;
+    }
+
+    export type PatchedExperimentSharedMetricLinkPatchMetadataType = typeof PatchedExperimentSharedMetricLinkPatchMetadataType[keyof typeof PatchedExperimentSharedMetricLinkPatchMetadataType];
+
+
+    export const PatchedExperimentSharedMetricLinkPatchMetadataType = {
+      Primary: 'primary',
+      Secondary: 'secondary',
+    } as const;
+
+    export type PatchedExperimentSharedMetricLinkPatchMetadataBreakdownsItem = { [key: string]: unknown };
+
+    /**
+     * Link metadata to merge, such as breakdowns, or a 'type' of 'primary'/'secondary' to move the shared metric between sections. Keys you omit are preserved.
+     */
+    export type PatchedExperimentSharedMetricLinkPatchMetadata = {
+      type?: PatchedExperimentSharedMetricLinkPatchMetadataType;
+      breakdowns?: PatchedExperimentSharedMetricLinkPatchMetadataBreakdownsItem[];
+    };
+
+    export interface PatchedExperimentSharedMetricLinkPatch {
+      /** Link metadata to merge, such as breakdowns, or a 'type' of 'primary'/'secondary' to move the shared metric between sections. Keys you omit are preserved. */
+      metadata?: PatchedExperimentSharedMetricLinkPatchMetadata;
     }
 
     /**


### PR DESCRIPTION
> [!NOTE]
> **Top of a 3-PR stack.** Base branch is [#74644](https://github.com/PostHog/posthog/pull/74644), which is based on [#74641](https://github.com/PostHog/posthog/pull/74641). Review in order. The diff here is only this PR's changes.

## Problem

The two PRs below this fixed inline metrics. Shared metrics still had the bug.

Adding or removing one shared metric meant rewriting the whole `saved_metrics_ids` array from local state, so a client whose copy was stale dropped links it had never seen. Identical failure mode, different collection.

Unlinking was worse: it also rewrote **both** metric arrays, because some experiments carry a stale inline entry flagged `isSharedMetric` and the frontend was cleaning those up itself. So removing one shared metric wrote three collections, any of which could be stale.

## Changes

| Verb | Path | Semantics |
| --- | --- | --- |
| `POST` | `experiments/{id}/shared_metrics` | Link one shared metric into a section, or move it if already linked. |
| `PATCH` | `experiments/{id}/shared_metrics/{id}` | Shallow-merge link metadata (breakdowns, or a `type` to move sections). |
| `DELETE` | `experiments/{id}/shared_metrics/{id}` | Unlink one, and clean up any orphaned inline copy. |

Each rebuilds the link set server-side under the row lock and delegates to `update_experiment`, so the M2M diff, ordering sync and activity logging behave exactly as before.

The orphan cleanup moves to the server. It succeeds when only an orphan exists with no link behind it (the real-world case the old frontend code handled), and 404s only when there is neither. That means unlinking no longer touches the metric arrays from the client at all.

On the frontend, `addSharedMetricsToExperiment`, `removeSharedMetricFromExperiment` and the shared-metric breakdown path all go through the new endpoints. `applySharedMetricLinks` takes the server's link set wholesale — safe here, unlike the inline metric arrays, because a client is never the source of truth for which shared metrics are linked.

Links are written one request each, sequentially. They all take the same experiment row lock, so firing them concurrently would only contend.

## How did you test this code?

Six backend tests in `TestExperimentSharedMetricLinks`, one parameterized over both metric sections:

- linking one shared metric leaves the others, and the ordering arrays land in the right sections
- unlinking one leaves the others
- patching metadata merges (a breakdown does not wipe the section, a section move does not wipe the breakdown) and moves the uuid between ordering arrays
- unlinking cleans up an orphaned inline copy, parameterized over `metrics` and `metrics_secondary`
- writing a shared metric that is not on the experiment 404s

Two frontend tests were **deleted and replaced by one**. They asserted the client-side orphan cleanup, which is now the server's job, so the coverage moved to the parameterized backend test above rather than being dropped. The replacement asserts the unlink goes through the per-link endpoint and that `api.update` is never called at all.

Also ran, all green:

- 740 backend tests across `test_presentation_api.py` + `test_experiment_service.py`
- 92 tests in `experimentLogic.test.ts`
- `uv run mypy --cache-fine-grained .` repo-wide
- `hogli build:openapi`; `find_enum_collisions` clean
- Frontend typecheck: 196 errors, byte-identical to master

I (Claude) did not click through this in a running app. A reviewer should exercise: add a shared metric to primary and to secondary, add and remove a breakdown on a shared metric, move one between sections, and unlink one.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 5). Skills invoked: `/improving-drf-endpoints`, `/adopting-generated-api-types`, `/writing-tests`, `/writing-code-comments`.

Two details worth a reviewer's attention:

**The orphan-with-no-link case was a near miss.** My first version 404'd whenever the shared metric was not linked, which would have broken cleaning up a pure orphan. The two frontend tests I was about to delete are what surfaced it: they set `saved_metrics: []` and still expected the inline entry gone. Worth reading those deleted tests to confirm the new backend behavior matches what they were asserting.

**Link metadata is typed via an inline OpenAPI schema, not a nested serializer.** A nested serializer would have needed a `type` field, and drf-spectacular names enum components after the field, so it would have generated a `TypeEnum` that collides repo-wide (the failure mode `ENUM_NAME_OVERRIDES` exists for). An inline schema dict on the `JSONField` sidesteps component naming entirely while still generating a real type instead of `unknown`.

### After this stack

The reorder path that also *moves or removes* metrics is the last whole-array writer left. It legitimately spans three collections at once (both metric arrays plus the links), so it needs a batch endpoint rather than a per-item one. Left out deliberately: it is no worse than before, and it deserves its own PR rather than being bolted onto this one.

Once this stack lands, [#70388](https://github.com/PostHog/posthog/pull/70388) (client-side write queue) and [#71032](https://github.com/PostHog/posthog/pull/71032) (version column plus 3-way merge) are both solving a problem that no longer exists. My recommendation is to close them.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
