### PR TITLE
fix(aio): give ai observability its own clickhouse budget

### DIFF
--- a/posthog/clickhouse/client/connection.py
+++ b/posthog/clickhouse/client/connection.py
@@ -70,6 +70,7 @@ class ClickHouseUser(StrEnum):
     META = "meta"
     MESSAGING = "messaging"  # a.k.a. behavioral cohorts
     MAX_AI = "max_ai"  # llm/a
+    LLM_ANALYTICS = "llm_analytics"  # background AI observability workflows; interactive requests use APP
     ERROR_TRACKING = "error_tracking"
     ENDPOINTS = "endpoints"
     BILLING = "billing"

--- a/posthog/clickhouse/client/execute.py
+++ b/posthog/clickhouse/client/execute.py
@@ -4,7 +4,7 @@ import types
 import logging
 import threading
 import traceback
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from enum import StrEnum
 from functools import lru_cache
@@ -26,6 +26,7 @@ from posthog.clickhouse.client.connection import (
     get_default_clickhouse_workload_type,
 )
 from posthog.clickhouse.client.escape import substitute_params
+from posthog.clickhouse.client.limit import get_llm_analytics_rate_limiter
 from posthog.clickhouse.client.tracing import trace_clickhouse_query_decorator
 from posthog.clickhouse.query_tagging import (
     Feature,
@@ -255,6 +256,23 @@ class ClickHouseExternalTable(TypedDict):
     data: list[dict[str, Any]]
 
 
+@contextmanager
+def _llm_analytics_concurrency_slot(ch_user: ClickHouseUser, team_id: Optional[int]) -> Iterator[None]:
+    """Hold one of AI observability's ClickHouse slots, and nothing for every other user.
+
+    Acquired here rather than at the call sites because the ch_user routing above is tag-based and
+    so applies to every query this product issues, including ones that reach ClickHouse through
+    shared helpers like query_ai_events and TraceQueryRunner. A budget that call sites had to opt
+    into would cover only some of them, and would silently miss whatever gets added next.
+    """
+    if ch_user != ClickHouseUser.LLM_ANALYTICS:
+        yield
+        return
+
+    with get_llm_analytics_rate_limiter().run(team_id=team_id):
+        yield
+
+
 @patchable
 @trace_clickhouse_query_decorator
 def sync_execute(
@@ -399,6 +417,11 @@ def sync_execute(
         ch_user = ClickHouseUser.ENDPOINTS
     elif tags.product == Product.BILLING:
         ch_user = ClickHouseUser.BILLING
+    elif tags.product == Product.LLM_ANALYTICS and tags.kind == "temporal" and ch_user == ClickHouseUser.DEFAULT:
+        # Temporal only, because the interactive AI observability API shares this product tag and
+        # belongs on APP rather than behind a batch concurrency budget. Callers that named a user
+        # keep it, so HogQL's own metadata lookups don't spend the budget meant for real queries.
+        ch_user = ClickHouseUser.LLM_ANALYTICS
 
     # To humans and bots reading this, you might be tempted to add a catch-all tag to avoid
     # hitting this error. Please don't do this. This error is to let us know about queries
@@ -465,7 +488,10 @@ def sync_execute(
             access_method=tags.access_method or "other",
             chargeable=str(tags.chargeable or "0"),
         ).inc()
-        with sync_client or get_client_from_pool(workload, team_id, readonly, ch_user) as client:
+        with (
+            _llm_analytics_concurrency_slot(ch_user, team_id),
+            sync_client or get_client_from_pool(workload, team_id, readonly, ch_user) as client,
+        ):
             result = client.execute(
                 prepared_sql,
                 params=prepared_args,

--- a/posthog/clickhouse/client/limit.py
+++ b/posthog/clickhouse/client/limit.py
@@ -216,6 +216,7 @@ __APP_CONCURRENT_QUERY_PER_ORG: Optional[RateLimit] = None
 __APP_CONCURRENT_DASHBOARD_QUERIES_PER_ORG: Optional[RateLimit] = None
 __MATERIALIZED_ENDPOINTS_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
 __EVENTS_LIST_CONCURRENT_QUERY_PER_TEAM: Optional[RateLimit] = None
+__LLM_ANALYTICS_CONCURRENT_QUERIES: Optional[RateLimit] = None
 
 
 def get_api_team_rate_limiter():
@@ -373,6 +374,32 @@ def get_events_list_rate_limiter():
             retry_timeout=30.0,
         )
     return __EVENTS_LIST_CONCURRENT_QUERY_PER_TEAM
+
+
+def get_llm_analytics_rate_limiter():
+    """
+    Limits concurrent background AI observability queries (ClickHouseUser.LLM_ANALYTICS).
+
+    Slots are global rather than per team or per org because the resource being protected is the
+    ClickHouse user's server-side concurrency cap, which every team's queries draw from.
+    """
+    global __LLM_ANALYTICS_CONCURRENT_QUERIES
+    if __LLM_ANALYTICS_CONCURRENT_QUERIES is None:
+        __LLM_ANALYTICS_CONCURRENT_QUERIES = RateLimit(
+            max_concurrency=settings.CLICKHOUSE_LLM_ANALYTICS_MAX_CONCURRENT_QUERIES,
+            applicable=lambda *args, **kwargs: not TEST,
+            limit_name="llm_analytics_background",
+            get_task_name=lambda *args, **kwargs: "llm_analytics:query:background",
+            get_task_id=lambda *args, **kwargs: kwargs.get("task_id") or generate_short_id(),
+            # Exceeds the 600s QUERY_ASYNC ClickHouse timeout so a worker dying mid-query cannot
+            # release its slot while the query it stands for is still running on the cluster.
+            ttl=900,
+            retry=0.25,
+            # Must stay well under the tightest AIO activity heartbeat timeout of 30s, otherwise
+            # waiting for a slot looks like a dead worker.
+            retry_timeout=10.0,
+        )
+    return __LLM_ANALYTICS_CONCURRENT_QUERIES
 
 
 class ConcurrencyLimitExceeded(Exception):

--- a/posthog/clickhouse/client/test/test_execute.py
+++ b/posthog/clickhouse/client/test/test_execute.py
@@ -3,7 +3,8 @@ from unittest.mock import MagicMock, patch
 
 from posthog.clickhouse.client.connection import ClickHouseUser, Workload
 from posthog.clickhouse.client.execute import sync_execute
-from posthog.clickhouse.query_tagging import tags_context
+from posthog.clickhouse.client.limit import RateLimit, get_llm_analytics_rate_limiter
+from posthog.clickhouse.query_tagging import Product, tags_context
 
 
 @pytest.fixture
@@ -13,6 +14,15 @@ def client_from_pool():
         client.execute.return_value = [(1,)]
         mock.return_value.__enter__.return_value = client
         yield mock
+
+
+@pytest.fixture
+def llm_analytics_slots():
+    """Counts concurrency slots taken per query, with the limiter forced on (it is inert in tests)."""
+    limiter = get_llm_analytics_rate_limiter()
+    with patch.object(limiter, "applicable", lambda *args, **kwargs: True):
+        with patch.object(RateLimit, "use", return_value=("key", "task")) as use, patch.object(RateLimit, "release"):
+            yield use
 
 
 @pytest.mark.parametrize(
@@ -48,3 +58,42 @@ def test_endpoints_tag_workload_routing(client_from_pool, workload, expected_wor
         sync_execute("SELECT 1", workload=workload, flush=False)
 
     assert client_from_pool.call_args[0][0] == expected_workload
+
+
+@pytest.mark.parametrize(
+    "product,kind,tag_id,requested_ch_user,expected_ch_user",
+    [
+        (Product.LLM_ANALYTICS, "temporal", "llma-eval-reports", ClickHouseUser.DEFAULT, ClickHouseUser.LLM_ANALYTICS),
+        (Product.LLM_ANALYTICS, "request", "api/projects/2/llm_analytics", ClickHouseUser.DEFAULT, ClickHouseUser.APP),
+        (Product.WAREHOUSE, "temporal", "data-imports", ClickHouseUser.DEFAULT, ClickHouseUser.DEFAULT),
+        # The AI observability usage reports carry this product tag from Celery. The budget is sized
+        # for the per-team Temporal fan-out, so they stay off it.
+        (Product.LLM_ANALYTICS, "celery", "posthog.tasks.usage_report", ClickHouseUser.DEFAULT, ClickHouseUser.DEFAULT),
+        # HogQL's materialized-column lookups name their own user, and must keep it rather than
+        # spending a slot of the concurrency budget sized for real queries.
+        (Product.LLM_ANALYTICS, "temporal", "llma-eval-reports", ClickHouseUser.HOGQL, ClickHouseUser.HOGQL),
+        (Product.LLM_ANALYTICS, "temporal", "llma-eval-reports", ClickHouseUser.META, ClickHouseUser.META),
+    ],
+)
+def test_llm_analytics_ch_user_routing(client_from_pool, product, kind, tag_id, requested_ch_user, expected_ch_user):
+    with tags_context(product=product, kind=kind, id=tag_id):
+        sync_execute("SELECT 1", flush=False, ch_user=requested_ch_user)
+
+    assert client_from_pool.call_args[0][3] == expected_ch_user
+
+
+@pytest.mark.parametrize(
+    "product,expected_slots",
+    [
+        (Product.LLM_ANALYTICS, 1),
+        (Product.WAREHOUSE, 0),
+    ],
+)
+def test_llm_analytics_queries_take_a_concurrency_slot(client_from_pool, llm_analytics_slots, product, expected_slots):
+    # Asserted here rather than at the AI observability call sites because those reach ClickHouse
+    # through shared helpers too (query_ai_events, TraceQueryRunner). Holding the slot at this
+    # single funnel is what makes the budget cover all of them.
+    with tags_context(product=product, kind="temporal", id="llma-eval-reports"):
+        sync_execute("SELECT 1", flush=False)
+
+    assert llm_analytics_slots.call_count == expected_slots

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -420,6 +420,12 @@ with suppress(Exception):
     as_json = json.loads(os.getenv("API_QUERIES_PER_TEAM", "{}"))
     API_QUERIES_PER_TEAM = {int(k): int(v) for k, v in as_json.items()}
 
+# Fleet-wide, unlike ClickHouse's per-node max_concurrent_queries_for_user, so keep it at or below
+# that user's per-node value for the bound to mean anything.
+CLICKHOUSE_LLM_ANALYTICS_MAX_CONCURRENT_QUERIES: int = get_from_env(
+    "CLICKHOUSE_LLM_ANALYTICS_MAX_CONCURRENT_QUERIES", 8, type_cast=int
+)
+
 _clickhouse_http_protocol = "http://"
 _clickhouse_http_port = "8123"
 if CLICKHOUSE_SECURE:

--- a/posthog/temporal/ai_observability/trace_summarization/README.md
+++ b/posthog/temporal/ai_observability/trace_summarization/README.md
@@ -140,7 +140,7 @@ Key constants in `constants.py`:
 | ------------------------------------------- | -------------- | ----------------------------------------------- |
 | `DEFAULT_MAX_ITEMS_PER_WINDOW`              | 15             | Max items per window                            |
 | `DEFAULT_BATCH_SIZE`                        | 5              | Concurrent item processing                      |
-| `DEFAULT_MAX_CONCURRENT_TEAMS`              | 5              | Max teams to process in parallel                |
+| `DEFAULT_MAX_CONCURRENT_TEAMS`              | 20             | Max teams to process in parallel                |
 | `DEFAULT_MODE`                              | "detailed"     | Summary detail level                            |
 | `DEFAULT_MODEL`                             | "gpt-4.1-nano" | LLM model for summarization                     |
 | `DEFAULT_WINDOW_MINUTES`                    | 60             | Time window to query                            |
@@ -152,7 +152,10 @@ Key constants in `constants.py`:
 | `SUMMARIZE_AND_SAVE_START_TO_CLOSE_TIMEOUT` | 900s           | Summarize + save activity timeout (per attempt) |
 | `SUMMARIZE_AND_SAVE_HEARTBEAT_TIMEOUT`      | 60s            | Heartbeat window for summarize activity         |
 
-Retry policies: `SAMPLE_RETRY_POLICY` (3 attempts), `FETCH_AND_FORMAT_RETRY_POLICY` (3 attempts), `SUMMARIZE_AND_SAVE_RETRY_POLICY` (4 attempts with backoff, `TextReprExpiredError` non-retryable), `COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY` (2 attempts). All retry policies exclude `ValueError` and `TypeError` from retries.
+Retry policies: `SAMPLE_RETRY_POLICY` (5 attempts with backoff), `FETCH_AND_FORMAT_RETRY_POLICY` (2 attempts), `SUMMARIZE_AND_SAVE_RETRY_POLICY` (2 attempts with backoff, `TextReprExpiredError` non-retryable), `COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY` (1 attempt). All retry policies exclude `ValueError` and `TypeError` from retries.
+
+Sampling keeps ClickHouse capacity errors retryable deliberately: each run covers a disjoint wall-clock window with no persisted cursor, so a run that gives up loses that hour of traces for that team permanently.
+Concurrency is bounded centrally by `CLICKHOUSE_LLM_ANALYTICS_MAX_CONCURRENT_QUERIES`, not by this workflow's fan-out, because trace clustering and eval reports draw on the same budget.
 
 ## Redis Intermediate Storage
 

--- a/posthog/temporal/ai_observability/trace_summarization/constants.py
+++ b/posthog/temporal/ai_observability/trace_summarization/constants.py
@@ -106,8 +106,14 @@ WORKFLOW_EXECUTION_TIMEOUT_MINUTES = 30  # Max time for single team workflow —
 COORDINATOR_EXECUTION_TIMEOUT_MINUTES = 55  # Must finish before next hourly trigger to avoid silent skips
 
 # Retry policies
+# Do not make ClickHouse capacity errors non-retryable here. Each run samples a disjoint window
+# with no persisted cursor, so a run that gives up drops that window of traces for that team
+# permanently.
 SAMPLE_RETRY_POLICY = RetryPolicy(
-    maximum_attempts=2,
+    maximum_attempts=5,
+    initial_interval=timedelta(seconds=10),
+    backoff_coefficient=2.0,
+    maximum_interval=timedelta(seconds=120),
     non_retryable_error_types=["ValueError", "TypeError"],
 )
 COORDINATOR_CHILD_WORKFLOW_RETRY_POLICY = RetryPolicy(maximum_attempts=1)


### PR DESCRIPTION
## Problem

Background AI observability queries run as the shared `default` ClickHouse user with no concurrency bound, so their per-team fan-out exhausts that user's server-side cap. It surfaces as `Too many simultaneous queries for user default. Current: 30, maximum: 30` on the prod-us offline shards, and it has been firing continuously for weeks while trace summarization, clustering and eval reports silently come up short.

Two gaps. `sync_execute` already maps a product's query tags to a dedicated ClickHouse user (Max AI, Endpoints and Billing all have one), but `Product.LLM_ANALYTICS` was missing from that mapping, so every AI observability query fell through to `DEFAULT`. And the Redis concurrency limiter in `posthog/clickhouse/client/limit.py` is only wired into `query_runner.py`, which these workflows bypass by calling `execute_hogql_query` directly.

That is why four earlier attempts at this did not hold. Each tuned a single workflow's fan-out knob, but nothing bounded the aggregate: the evals worker alone runs 32 pods in prod-us at `MAX_CONCURRENT_ACTIVITIES: 50`, so no per-workflow number can cap the total.

## Changes

**Identity.** A new `ClickHouseUser.LLM_ANALYTICS`, routed by a single `elif` in the existing product chain in `sync_execute`. The condition is deliberately narrow:

```python
elif tags.product == Product.LLM_ANALYTICS and tags.kind == "temporal" and ch_user == ClickHouseUser.DEFAULT:
```

- `kind == "temporal"` keeps the `LLM_ANALYTICS`-tagged Celery usage reports off a budget sized for the per-team Temporal fan-out.
- `ch_user == DEFAULT` lets a caller that named its own user keep it. HogQL's materialized-column lookup passes `ch_user=HOGQL` and runs during query compilation, so without this every AI observability query would drag a metadata lookup into the same budget and halve its effective size. #70822 fixes this generally for all products; this condition is the local equivalent so the two are independent.

This is the whole change to a shared file: 5 added lines, no existing line modified.

**Budget.** A fleet-wide concurrency budget for that user, built on the existing `RateLimit`. The slot is acquired in `sync_execute`, on the same client context manager the query already opens, and is a no-op for every other ClickHouse user.

It sits there rather than at the call sites because routing is tag-based and therefore automatic, so it also covers the queries that reach ClickHouse through shared helpers (`query_ai_events`, `resolve_trace_ids_for_generation_uuids`, `TraceQueryRunner`). Those account for 12 of the 26 AI observability query entry points. A budget that call sites had to opt into would have covered only the other 14 and would silently miss whatever gets added next, which is the same automatic-routing / manual-enforcement asymmetry that caused this bug in the first place.

Redis-backed rather than a per-process `asyncio.Semaphore`, because the budget has to span worker replicas and all three products. It waits for a slot instead of failing, so a query succeeds on its first attempt rather than being rejected at the cap and rediscovered through a Temporal retry.

Two consequences of that placement worth knowing: a rejection after the full wait raises inside the existing `try`, so it ticks `clickhouse_query_failure` (the exception passes through `wrap_clickhouse_query_error` untouched, so control flow is unchanged), and time spent waiting for a slot counts toward the logged `execution_time`.

**Retries.** `SAMPLE_RETRY_POLICY` gets real backoff (5 attempts, 10s to 120s). Capacity errors stay retryable on purpose: each run samples a disjoint wall-clock window with no persisted cursor, so a run that gives up drops that window of traces for that team permanently. Master retried roughly a second apart, straight back into the same contention.

Also corrected the trace summarization README, which documented 5 concurrent teams against an actual 20 and had four wrong retry-attempt counts.

**Deploy sequence.** The budget works on merge with no infra dependency, and on its own it stops the errors. Companion PRs give the user its own server-side profile so AI observability cannot starve shared capacity: `posthog-cloud-infra` creates the user, then the passwords go into Secrets Manager, then `charts` wires the env vars.

## How did you test this code?

I am an agent and did no manual or production testing. Everything below is automated and run locally:

- `pytest posthog/clickhouse/client/ posthog/temporal/ai_observability/` gives 956 passed, 6 errors. Those 6 are Postgres test-setup errors, confirmed pre-existing by stashing this branch and reproducing them on clean master (they include a file this PR does not touch).
- `uv run mypy --cache-fine-grained .` clean across 17,067 files.
- `hogli ci:preflight` 0 failures.
Tests are two parameterized matrices in `test_execute.py`, each case verified to fail when the line it guards is reverted.

Routing, five cases:

| Case | Regression it catches |
| --- | --- |
| Temporal + `DEFAULT` | routing silently drops back to `DEFAULT`, which is the current broken state and fails silently |
| Interactive API request | interactive latency gets pulled behind a batch budget |
| Non-AI-observability Temporal | routing keys on running inside Temporal rather than on the product |
| Celery usage report | a job the budget was not sized for consumes its slots |
| Explicit `HOGQL` / `META` | cheap metadata lookups spend slots meant for real queries |

That fourth case is worth calling out: an earlier revision of this PR had no coverage for the `kind == "temporal"` guard at all. Removing the guard kept every test green, because the interactive-request case is already claimed by the earlier `APP` block at `execute.py:380` and never reaches this branch. The Celery case is what actually exercises it.

Budget, two cases: an AI observability query takes exactly one slot, a non-AI-observability query takes none. The first fails if the slot moves back out to the call sites (which is the bypass three review bots caught on an earlier revision), the second if the budget is ever applied to every user and throttles the whole app. The limiter is inert under `TEST`, so the fixture forces it on.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs. Updated the in-tree trace summarization README where it had drifted from the code.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (PostHog Code) did the investigation and the change; I directed it and made the calls below. Skills invoked: `superpowers:systematic-debugging`, `/writing-tests`, `/writing-code-comments`.

It started from four AI observability inbox reports that shared one error-tracking fingerprint, then traced the mechanism to the `ch_user` mapping rather than to any single workflow's fan-out.

Decisions worth a reviewer's attention:

- **Rejected** making capacity errors non-retryable, which one earlier attempt proposed. Combined with disjoint sampling windows, `maximum_attempts=1` on the child workflow, and a coordinator that swallows child failures, it would have turned degraded-but-eventually-correct into permanent per-team data loss. It also listed `ConcurrencyLimitExceeded`, the exception this PR's limiter raises.
- **Rejected** a per-process `asyncio.Semaphore`, the pattern `temporal/messaging` and `temporal/data_modeling` use. Their own comments concede the real total is the value times the replica count, and these queries run in `database_sync_to_async` threads rather than on the event loop, so it would not have gated them anyway.
- **Tried and reverted** moving the limiter out of `sync_execute` into a wrapper in the AI observability tree, to keep the shared file untouched. Greptile, hex-security and veria all independently caught the same hole in that revision: 12 of 26 entry points reach ClickHouse through shared helpers, so they were routed to the dedicated user without ever acquiring a slot. Their finding was correct, and the wrapper is gone. It is worth noting the reason the earlier attempt at this looked large: it restructured a `try`/`finally` (and I introduced a bug doing so, a counter escaping the `finally`). The version here acquires the slot on the client context manager the query already opens, which needs no restructuring.
- **Dropped** muting `ConcurrencyLimitExceeded` in the Temporal interceptor. It looked like the `EgressBudgetExhausted` precedent, but egress backpressure is routine whereas this only fires after a full 10s wait, so it is signal. Muting it would have traded a loud symptom for silent data loss.
- **Reverted** a commit that fixed eval reports delivering fabricated zero metrics, once #72126 landed with a more thorough version of the same fix.
- The limiter's wait window is 10s, well under the tightest AI observability activity heartbeat timeout of 30s, so waiting for a slot can never read as a dead worker.

Sizing is 8 concurrent fleet-wide, deliberately conservative while the user still shares `default`'s credentials. Tune against `posthog_clickhouse_query_concurrency_limit_exceeded` for `limit_name=llm_analytics_background`: `result=retry` is healthy queueing, `result=block` means too tight.

One gap I want to flag rather than bury: `llma_coordinator_team_failed` has no alert or dashboard anywhere, so a dropped sampling window is currently invisible. That predates this PR, but it is the metric that matters if the budget is ever set too low.
