### PR TITLE
feat(data-warehouse): default event row groups to 512 MiB

### DIFF
--- a/posthog/dags/README_DUCKLINGS.md
+++ b/posthog/dags/README_DUCKLINGS.md
@@ -85,9 +85,9 @@ To run the full backfill immediately (without waiting for tomorrow):
    - `skip_ducklake_registration: true` - Export to S3 only
    - `delete_tables: true` - Reset duckling tables first
 
-#### Rewriting one events day with larger Parquet row groups
+#### Rewriting one events day with the default Parquet layout
 
-Select exactly one daily `<team_id>_YYYY-MM-DD` partition in `duckling_events_backfill_job`, then use this Launchpad configuration:
+Events exports use a 512 MiB uncompressed row-group byte target by default. To pin that layout when rewriting a day, select exactly one daily `<team_id>_YYYY-MM-DD` partition in `duckling_events_backfill_job`, then use this Launchpad configuration:
 
 ```yaml
 ops:
@@ -100,7 +100,7 @@ ops:
       delete_tables: false
 ```
 
-The 250,000-row target still applies. ClickHouse closes a row group when either the row or byte target is reached, so wide rows may reach the byte target first. The exporter limits fan-out automatically so `fan-out × events_parquet_row_group_size_bytes` does not exceed the nominal 32 GiB row-group buffer budget. A 512 MiB target therefore allows at most 64 writers. The day's row count and `max_s3_file_fanout` can reduce it further. Encoding and other query memory are not included in the 32 GiB estimate; ClickHouse's `max_memory_usage` remains the hard query limit.
+The 250,000-row cap also applies. ClickHouse closes a row group when either the row or byte target is reached, so wide rows may reach the byte target first. The exporter limits fan-out automatically so `fan-out × events_parquet_row_group_size_bytes` does not exceed the nominal 32 GiB row-group buffer budget. A 512 MiB target therefore allows at most 64 writers. The day's row count and `max_s3_file_fanout` can reduce it further. Encoding and other query memory are not included in the 32 GiB estimate; ClickHouse's `max_memory_usage` remains the hard query limit.
 
 The rewrite is not atomic. The existing DuckLake day is removed before export and registration finish, so queries may temporarily see no rows for that day. After a transient failure, rerun the same daily partition with the same configuration. After a memory or resource failure, lower `max_s3_file_fanout` and rerun. Keep `cleanup_existing_partition_data: true` so the retry clears partial registration and regenerates the day from current ClickHouse data. Do not manually delete the run's S3 objects.
 
@@ -125,7 +125,7 @@ class DucklingBackfillConfig:
     create_tables_if_missing: bool = True     # Auto-create events/persons tables
     delete_tables: bool = False               # DANGER: Drop and recreate tables
     dry_run: bool = False                     # Preview mode, no writes
-    events_parquet_row_group_size_bytes: int = 134_217_728  # Events only; 128 MiB
+    events_parquet_row_group_size_bytes: int = 536_870_912  # Events only; 512 MiB
     target_rows_per_file: int = 5_000_000      # Target rows per exported file
     max_s3_file_fanout: int = 256              # Maximum before the automatic buffer-budget limit
 ```

--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -645,6 +645,7 @@ TARGET_ROWS_PER_FILE = 5_000_000
 MAX_S3_FILE_FANOUT = 256
 
 DEFAULT_PARQUET_ROW_GROUP_SIZE_BYTES = 128 * 1024 * 1024
+DEFAULT_EVENTS_PARQUET_ROW_GROUP_SIZE_BYTES = 512 * 1024 * 1024
 EVENTS_PARQUET_ROW_GROUP_BUFFER_BUDGET_BYTES = 32 * ONE_GB_IN_BYTES
 
 # Parquet writer defaults shared by every export. The byte target sets the nominal size
@@ -828,7 +829,7 @@ class DucklingBackfillConfig(Config):
     delete_tables: bool = False  # Danger: drops and recreates tables, losing all data
     dry_run: bool = False
     events_parquet_row_group_size_bytes: int = pydantic.Field(
-        default=DEFAULT_PARQUET_ROW_GROUP_SIZE_BYTES,
+        default=DEFAULT_EVENTS_PARQUET_ROW_GROUP_SIZE_BYTES,
         gt=0,
         description="Uncompressed byte target for each Parquet row group written by the events export.",
     )

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -1676,11 +1676,14 @@ class TestExportFanOut:
         # A handful of rows collapses to one bucket → one file.
         assert "PARTITION BY toString(cityHash64(distinct_id) % 1)" in insert_sql
 
-    def test_huge_events_day_clamps_to_max_fanout(self, target):
-        insert_sql, _count_sql, _glob, _ = self._run_export(
+    def test_huge_events_day_clamps_to_default_writer_buffer_budget(self, target):
+        insert_sql, _count_sql, _glob, client = self._run_export(
             export_events_to_duckling_s3, target, row_count=10_000_000_000, team_id=2, date=datetime(2026, 6, 17)
         )
-        assert f"PARTITION BY toString(cityHash64(distinct_id) % {MAX_S3_FILE_FANOUT})" in insert_sql
+        assert "PARTITION BY toString(cityHash64(distinct_id) % 64)" in insert_sql
+
+        export_call = next(call for call in client.execute.call_args_list if "INSERT INTO FUNCTION" in call.args[0])
+        assert export_call.kwargs["settings"]["output_format_parquet_row_group_size_bytes"] == 512 * 1024 * 1024
 
     def test_config_can_tune_target_and_max(self, target):
         config = DucklingBackfillConfig(
@@ -1698,7 +1701,7 @@ class TestExportFanOut:
         assert "PARTITION BY toString(cityHash64(distinct_id) % 5)" in insert_sql
 
     def test_events_export_applies_configured_row_group_size(self, target):
-        row_group_size_bytes = 512 * 1024 * 1024
+        row_group_size_bytes = 256 * 1024 * 1024
         config = DucklingBackfillConfig(
             dry_run=False,
             skip_ducklake_registration=True,
@@ -1753,7 +1756,7 @@ class TestExportFanOut:
 
     def test_persons_daily_export_sizes_fanout_and_returns_glob(self, target):
         # 15M rows at the 5M-row default target → 3 files.
-        insert_sql, count_sql, s3_glob, _ = self._run_export(
+        insert_sql, count_sql, s3_glob, client = self._run_export(
             export_persons_to_duckling_s3, target, row_count=15_000_000, team_id=2, date=datetime(2026, 6, 17)
         )
         assert "PARTITION BY toString(cityHash64(distinct_id) % 3)" in insert_sql
@@ -1761,14 +1764,20 @@ class TestExportFanOut:
         assert "FROM person WHERE team_id = 2 AND toDate(_timestamp) = '2026-06-17' AND is_deleted = 0" in count_sql
         assert s3_glob == "s3://bkt/backfill/persons/2/year=2026/month=06/run1_*.parquet"
 
+        export_call = next(call for call in client.execute.call_args_list if "INSERT INTO FUNCTION" in call.args[0])
+        assert export_call.kwargs["settings"]["output_format_parquet_row_group_size_bytes"] == 128 * 1024 * 1024
+
     def test_persons_full_export_sizes_fanout_and_returns_glob(self, target):
         # 25M rows at the 5M-row default target → 5 files.
-        insert_sql, count_sql, s3_glob, _ = self._run_export(
+        insert_sql, count_sql, s3_glob, client = self._run_export(
             export_persons_full_to_duckling_s3, target, row_count=25_000_000, team_id=2
         )
         assert "PARTITION BY toString(cityHash64(distinct_id) % 5)" in insert_sql
         assert "FROM person_distinct_id2 WHERE team_id = 2 AND is_deleted = 0" in count_sql
         assert s3_glob == "s3://bkt/backfill/persons/2/year=0/month=0/run1_*.parquet"
+
+        export_call = next(call for call in client.execute.call_args_list if "INSERT INTO FUNCTION" in call.args[0])
+        assert export_call.kwargs["settings"]["output_format_parquet_row_group_size_bytes"] == 128 * 1024 * 1024
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Problem

Events backfills default to a 128 MiB Parquet row-group byte target even though larger row groups reduce remote scan overhead for common projected queries. In the [public benchmark](https://github.com/PostHog/duckgres/blob/1366415/docs/events-rowgroup-byte-cap-benchmark.md), bypassing both S3 caches made a full-day count 2.13x faster at 512 MiB. Controlled identical-data runs made four projected query shapes 2.08x–2.50x faster, while the full property scan remained essentially flat at 0.98x.

The exporter already limits events fan-out to a 32 GiB nominal row-group staging budget. Raising the default target to 512 MiB lowers the automatic writer cap from 256 to 64, so the nominal staging budget does not increase.

## Changes

- Default events exports to a 512 MiB uncompressed row-group byte target.
- Keep daily and full persons exports at 128 MiB.
- Preserve per-run events overrides, the 250,000-row cap, the 5,000,000-row file target, and the 32 GiB fan-out budget.
- Update regression coverage and the one-day rewrite runbook.

## How did you test this code?

- `flox activate -- bin/hogli test posthog/dags/test_events_backfill_to_duckling.py` (227 passed)
- `flox activate -- bin/hogli ci:preflight --strict` (no failures)
- The tests catch regressions in the 512 MiB events default, its 64-writer automatic cap, non-default per-run overrides, and both persons export paths remaining at 128 MiB.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `posthog/dags/README_DUCKLINGS.md` to document the 512 MiB events default, its independent row cap, and the reproducible one-day rewrite configuration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

OpenAI Codex implemented and validated this directed change in a local desktop task; there is no public session link. It invoked the GitHub `/yeet`, `/writing-tests`, `/writing-user-facing-copy`, and `/writing-code-comments` skills.

The events and persons defaults remain separate so the read optimization does not change persons writer memory. The existing per-run override remains available for workloads that need a different byte target.