### PR TITLE
fix(data-imports): force nullable on delta columns added via schema evolution

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/delta_table_helper.py
@@ -305,8 +305,14 @@ class DeltaTableHelper:
 
         delta_table_schema = pyarrow_schema_from_arrow_exportable(delta_table.schema())
 
+        # Columns added here always predate their own addition: every file the table already
+        # holds was written without this column, so it must tolerate absent values on those
+        # rows. Forcing nullable regardless of the incoming batch's own nullability (which
+        # reflects only whether *this* batch happened to contain nulls) is what lets a later
+        # `optimize.compact()` read those old files at all — a non-nullable add otherwise fails
+        # compaction with "Non-nullable column '<name>' is missing from the physical schema".
         new_fields = [
-            deltalake.Field.from_arrow(field)
+            deltalake.Field.from_arrow(field.with_nullable(True))
             for field in ensure_delta_compatible_arrow_schema(schema)
             if field.name not in delta_table_schema.names
         ]

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_delta_table_helper.py
@@ -762,6 +762,43 @@ class TestAppendDecimalReconciliation:
             )
 
 
+class TestSchemaEvolutionNullability:
+    """A column added mid-table-lifetime always predates its own addition: every file the
+    table already holds was written without it, so `optimize.compact()` must be able to
+    treat those rows as null for that column. If schema evolution adds the column as NOT
+    NULL — which happens whenever the batch that introduces it has no nulls, since delta-rs
+    takes the new field's nullability straight from the incoming Arrow field — compaction
+    later fails with "Non-nullable column '<name>' is missing from the physical schema"."""
+
+    @pytest.mark.asyncio
+    async def test_compact_survives_a_column_added_by_an_all_non_null_batch(self, tmp_path: Path) -> None:
+        delta_path = str(tmp_path / "table")
+        deltalake.write_deltalake(delta_path, pa.table({"id": pa.array([1, 2], type=pa.int64())}))
+
+        helper = _make_local_helper(delta_path)
+
+        # The incoming field is non-nullable because every value in *this* batch is
+        # non-null — exactly how upstream Arrow construction infers it, unrelated to
+        # whether the column can appear in prior or future batches.
+        fields: list[pa.Field] = [pa.field("id", pa.int64()), pa.field("status", pa.string(), nullable=False)]
+        batch_schema = pa.schema(fields)
+        batch = pa.table(
+            {"id": pa.array([3, 4], type=pa.int64()), "status": pa.array(["ok", "ok"])}, schema=batch_schema
+        )
+
+        result = await helper.write_to_deltalake(
+            data=batch, write_type="append", should_overwrite_table=False, primary_keys=None
+        )
+        status_field = next(f for f in result.schema().fields if f.name == "status")
+        assert status_field.nullable is True
+
+        await helper.compact_table()
+
+        final = result.to_pyarrow_table()
+        by_id = dict(zip(final.column("id").to_pylist(), final.column("status").to_pylist()))
+        assert by_id == {1: None, 2: None, 3: "ok", 4: "ok"}
+
+
 class TestIncrementalBatchDeduplication:
     """Duplicate PKs in a source batch must never reach the Delta write.
 


### PR DESCRIPTION
## Problem

An [error tracking issue](https://us.posthog.com/project/2/error_tracking/019fadd3-7e01-7fc0-9595-11c9f476a165) surfaced a `DeltaError`:

```
Failed to parse parquet: Parquet error: Optimize selected-file scan failed while scanning data:
Execution error: Non-nullable column 'real_model' is missing from the physical schema
```

raised from `compact_table()` → `table.optimize.compact()` in `delta_table_helper.py`, called from `run_post_load_operations` in `common/load.py` at the end of a sync. The failure lives in shared pipeline code, not a specific source connector.

Root cause: `_evolve_delta_schema` adds newly-seen columns to a Delta table via `delta_table.alter.add_columns(...)`, converting them straight from the incoming Arrow batch's field with `deltalake.Field.from_arrow(field)`. That preserves whatever `nullable` value the incoming field happens to carry — which is `False` whenever the batch that first introduces the column contains no nulls. Once the column is added as NOT NULL, every file the table already holds (written before the column existed, so it's entirely absent from their physical schema) can never satisfy that constraint. A later `optimize.compact()` scans those old files and fails hard trying to reconcile them.

I reproduced this locally against the real `deltalake` library: seed a table, add a column via `alter.add_columns` with a non-nullable field, write a batch with it, then call `optimize.compact()` — it raises the exact same `DeltaError` message. Forcing the newly-added field to `nullable=True` before conversion makes compaction succeed and correctly backfills the pre-existing rows with `null` for the new column.

## Changes

- `_evolve_delta_schema` (`delta_table_helper.py`) now forces every newly-added column to `nullable=True` before calling `deltalake.Field.from_arrow`, regardless of the incoming batch's own field nullability.

No retry policy, `NonRetryableErrors`, or write-path behavior changed for existing columns — this only affects the nullability assigned to a column the very first time it's added to an existing table.

## How did you test this code?

- Added `TestSchemaEvolutionNullability::test_compact_survives_a_column_added_by_an_all_non_null_batch` to `test_delta_table_helper.py`: writes an initial batch without a column, appends a second batch that introduces the column with a non-nullable Arrow field (all values present, mirroring how upstream Arrow construction infers nullability), then runs `compact_table()` against the real local `deltalake` library. Verified this test fails with the exact production error on the pre-fix code and passes with the fix — the regression this PR closes.
- Ran the full `test_delta_table_helper.py` suite: 67 passed (4 pre-existing failures in `TestGetDeltaTableUnrecoverableErrors` need a live object-storage service unavailable in this sandbox; identical on unmodified `master`).
- `ruff check` / `ruff format --check` clean on both changed files.
- Full-repo `uv run mypy --cache-fine-grained .` clean (17074 source files).

## Docs update

N/A — internal pipeline implementation detail, no user-facing or API surface change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error-tracking issue (webhook-delivered) using Claude Code. Pulled the stack trace and event properties via the PostHog MCP tools, traced the call path from `run_post_load_operations` into `compact_table()`/`optimize.compact()`, and reproduced the exact `DeltaError` locally against the real `deltalake` library to confirm the root cause before writing the fix. Searched open PRs for duplicates across several `delta_table_helper.py`/compaction-related fixes already in flight (#74635, #74630, #74541, #74658) — all address distinct root causes (transient S3/object-store races, a redundant re-fetch, a stale file list), none touch schema-evolution nullability. Invoked `/writing-tests` before adding the regression test.