### PR TITLE
feat(sql-editor): default send raw query to on for the managed warehouse connection

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -24,7 +24,12 @@ import { ChartDisplayType, InsightShortId, QueryBasedInsightModel } from '~/type
 
 import { editorSceneLogic } from './editorSceneLogic'
 import { OutputTab } from './outputPaneLogic'
-import { activeTabMatchesUrlTarget, getDisplayTypeToSaveInsight, sqlEditorLogic, MANAGED_WAREHOUSE_SOURCE_PREFIX } from './sqlEditorLogic'
+import {
+    activeTabMatchesUrlTarget,
+    getDisplayTypeToSaveInsight,
+    sqlEditorLogic,
+    MANAGED_WAREHOUSE_SOURCE_PREFIX,
+} from './sqlEditorLogic'
 import { SQLEditorMode } from './sqlEditorModes'
 
 // endpointLogic uses permanentlyMount() with a keyed logic, which crashes in

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -24,7 +24,7 @@ import { ChartDisplayType, InsightShortId, QueryBasedInsightModel } from '~/type
 
 import { editorSceneLogic } from './editorSceneLogic'
 import { OutputTab } from './outputPaneLogic'
-import { activeTabMatchesUrlTarget, getDisplayTypeToSaveInsight, sqlEditorLogic } from './sqlEditorLogic'
+import { activeTabMatchesUrlTarget, getDisplayTypeToSaveInsight, sqlEditorLogic, MANAGED_WAREHOUSE_SOURCE_PREFIX } from './sqlEditorLogic'
 import { SQLEditorMode } from './sqlEditorModes'
 
 // endpointLogic uses permanentlyMount() with a keyed logic, which crashes in
@@ -1460,6 +1460,105 @@ describe('sqlEditorLogic', () => {
             expect(logic.values.sendRawQueryEnabled).toEqual(true)
             expect(logic.values.sourceQuery.source.connectionId).toEqual('conn-123')
             expect(String(router.values.hashParams.raw)).toEqual('1')
+        })
+
+        it('defaults to raw SQL mode for the managed warehouse connection', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/external_data_sources/connections/': [
+                        200,
+                        [
+                            {
+                                id: 'managed-conn-1',
+                                prefix: MANAGED_WAREHOUSE_SOURCE_PREFIX,
+                                engine: 'duckdb',
+                                source_type: 'Postgres',
+                                access_method: 'direct',
+                                supports_hogql: true,
+                            },
+                        ],
+                    ],
+                    '/api/environments/:team_id/external_data_sources/': [
+                        200,
+                        {
+                            results: [
+                                {
+                                    id: 'managed-conn-1',
+                                    source_id: 'src-managed-1',
+                                    prefix: MANAGED_WAREHOUSE_SOURCE_PREFIX,
+                                    source_type: 'Postgres',
+                                    access_method: 'direct',
+                                    engine: 'duckdb',
+                                } as any,
+                            ],
+                        },
+                    ],
+                },
+            })
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1', c: 'managed-conn-1' })
+
+            await expectLogic(logic).toDispatchActions(['setSourceQuery', 'createTab', 'updateTab'])
+            await expectLogic(logic).toDispatchActions(['setSendRawQuery'])
+
+            expect(logic.values.selectedConnectionSupportsHogQL).toEqual(true)
+            expect(logic.values.sourceQuery.source.sendRawQuery).toEqual(true)
+            expect(logic.values.sendRawQueryEnabled).toEqual(true)
+        })
+
+        it('does not force raw SQL mode for a user-managed Postgres direct connection', async () => {
+            useMocks({
+                get: {
+                    '/api/projects/:team_id/external_data_sources/connections/': [
+                        200,
+                        [
+                            {
+                                id: 'user-conn-1',
+                                prefix: 'my_postgres',
+                                engine: 'postgres',
+                                source_type: 'Postgres',
+                                access_method: 'direct',
+                                supports_hogql: true,
+                            },
+                        ],
+                    ],
+                    '/api/environments/:team_id/external_data_sources/': [
+                        200,
+                        {
+                            results: [
+                                {
+                                    id: 'user-conn-1',
+                                    source_id: 'src-user-1',
+                                    prefix: 'my_postgres',
+                                    source_type: 'Postgres',
+                                    access_method: 'direct',
+                                    engine: 'postgres',
+                                } as any,
+                            ],
+                        },
+                    ],
+                },
+            })
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            router.actions.push(urls.sqlEditor(), undefined, { q: 'SELECT 1', c: 'user-conn-1' })
+
+            await expectLogic(logic).toDispatchActions(['setSourceQuery', 'createTab', 'updateTab'])
+
+            expect(logic.values.selectedConnectionSupportsHogQL).toEqual(true)
+            expect(logic.values.sourceQuery.source.sendRawQuery).toBeUndefined()
+            expect(logic.values.sendRawQueryEnabled).toEqual(false)
         })
 
         it('forces raw SQL mode when the selected connection does not support HogQL', async () => {

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -86,6 +86,9 @@ import { validateEndpointName } from 'products/endpoints/frontend/common'
 
 import type { ExternalDataSourceConnectionOptionApi } from '../../../../../products/warehouse_sources/frontend/generated/api.schemas'
 import type { PaginatedResponse } from '../../../lib/api'
+
+// Mirrors MANAGED_WAREHOUSE_SOURCE_PREFIX in products/warehouse_sources/backend/models/external_data_source.py.
+export const MANAGED_WAREHOUSE_SOURCE_PREFIX = 'managed_warehouse'
 import type { FeatureFlagsSet } from '../../../lib/logic/featureFlagLogic'
 import type { DatabaseSchemaQueryResponse, Node } from '../../../queries/schema/schema-general'
 import type { DataModelingDAG, DataWarehouseSavedQueryFolder, UserType } from '../../../types'
@@ -1769,12 +1772,19 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
             },
             enforceConnectionRawQueryMode: () => {
                 // Raw-only connections cannot compile HogQL — force raw SQL mode.
-                if (
-                    values.selectedConnectionId &&
-                    !values.selectedConnectionSupportsHogQL &&
-                    !values.sourceQuery.source.sendRawQuery
-                ) {
-                    actions.setSendRawQuery(true)
+                // The managed warehouse (auto-provisioned Duckgres) speaks DuckDB
+                // natively end-to-end, so raw mode is the better default for it too:
+                // it skips the HogQL reprint and reaches the engine verbatim.
+                if (values.selectedConnectionId && !values.sourceQuery.source.sendRawQuery) {
+                    const option = (values.connectionOptions ?? []).find(
+                        (option) => option.id === values.selectedConnectionId
+                    )
+                    const isManagedWarehouseSource =
+                        option?.prefix === MANAGED_WAREHOUSE_SOURCE_PREFIX && option?.source_type === 'Postgres'
+
+                    if (!values.selectedConnectionSupportsHogQL || isManagedWarehouseSource) {
+                        actions.setSendRawQuery(true)
+                    }
                 }
             },
             // Options can load after a connection was restored from the URL.


### PR DESCRIPTION
## Problem

The managed warehouse connection (auto-provisioned Duckgres, engine displayed as `Postgres (duckdb)`) speaks DuckDB natively end-to-end, and since [#74535](https://github.com/PostHog/posthog/pull/74535) its stored credential is the org root. In the SQL editor it still defaults to HogQL mode, so every query pays a HogQL parse-resolve-reprint round trip that a DuckDB-native engine doesn't need — and table-level autocomplete/resolution on raw syntax is worse because the queries are reformatted. Users have to remember to flip **Send raw query** per query.

**Why:** raw mode is the right default for this connection, the same way it already is for engines with `supports_hogql = false`.

## Changes

Frontend only, in the SQL editor's connection-selection flow:

- `frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx` — `enforceConnectionRawQueryMode` now *also* calls `setSendRawQuery(true)` when the selected connection is the managed warehouse source, identified by the option payload's `prefix === 'managed_warehouse' && source_type === 'Postgres'`. Detection uses the connection-picker options (the lightweight list already loaded to fill the selector) rather than the full sources store, so the default also applies when the editor is restored from a URL or mounted embedded — anywhere `selectedConnectionId` resolves. Existing behavior for engines where `supports_hogql = false` is untouched.

The credential, the managed-source backend, and HogQL availability are all unchanged. The toggle is a per-query UI default: flipping it back to off still works, and the merge-into-`sourceQuery` behavior (`sendRawQuery: value || undefined`) is the pre-existing path.

## How did you test this code?

`pnpm --filter @posthog/frontend exec jest src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts` — **81/81 pass**, including two added cases:

- managed warehouse connection defaults to raw mode on selection (catches a regression where someone deletes the prefill)
- a user-added Postgres direct connection with the same `source_type` does **not** default to raw mode (catches over-broad detection — a name collision with a user prefix must not silently flip every Postgres direct connection)

Also ran `tsgo --noEmit` (no errors in touched files; repo has ~196 pre-existing errors in unrelated packages) and `oxlint` (no new warnings).

Could not exercise the live UI here.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`skip-inkeep-docs` (per-query default change inside existing editor UI, no docs impact).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent: Claude (PostHog Code session). Follow-up to #74535 on a fresh branch off latest master. Detection signal choice (connection-picker option payload vs the full sources store) was made for URL-restore/embedding coverage; no repo-provided skills invoked. Test evidence: full sqlEditorLogic suite plus targeted tsgo/oxlint runs. UI not exercised against a live backend.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*