### PR TITLE
docs(deltalite): rewrite PyPI README as a standalone package doc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,7 +200,7 @@ dependencies = [
     "braintrust-core>=0.0.59,<1",
     "wrapt==1.17.3",
     "limits==5.8.0",
-    "deltalite==0.1.1",
+    "deltalite==0.1.2",
 ]
 
 [dependency-groups]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "deltalite-python"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/rust/deltalite/python/Cargo.toml
+++ b/rust/deltalite/python/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "deltalite-python"
 # Mirrors pyproject.toml in this directory (always identical); bump both together.
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 # CI compiles with this exact toolchain; cargo's MSRV-aware resolver uses it to
 # avoid picking dependency versions CI cannot build (aws-* crates move MSRV often).

--- a/rust/deltalite/python/README.md
+++ b/rust/deltalite/python/README.md
@@ -1,15 +1,178 @@
-# deltalite (Python package)
+# deltalite
 
-Thin pyo3 binding over `deltalite-core`, built with maturin and imported as
-`deltalite`. See [`../README.md`](../README.md) for what deltalite is, why the
-crate is split in two, how the wheel is built and consumed, the operational
-knobs, and the pre-rollout conditions.
+Streaming, partition-level **upsert for [Delta Lake](https://delta.io/) tables**
+that replaces delta-rs's SQL `MERGE` with a bounded-memory merge engine. Memory
+is bounded by the size of the incoming batch and a few concurrency knobs —
+**never by the size of the target table**.
 
-- `src/lib.rs` — the pyo3 module: `DeltaLiteTable.open(...).upsert(...)`,
-  `UpsertStats`, and the `DeltaLiteError` exception hierarchy.
-- `tests/` — the differential parity suite (delta-rs MERGE vs deltalite upsert)
-  plus probe/operations/types/crash-redelivery/interop/planner tests.
-- `harness/` — the two write paths and logical-content comparison the tests use.
-- `deltalite_planner.py` — rough knob-tuning helper (concurrent upserts + pod
-  memory in, suggested mpp/mpf/byte-budget out).
-- `bench/` — test-data generation helpers shared by the tests.
+delta-rs stays the storage and protocol layer (transaction log, checkpoints,
+Parquet writing, Add-action statistics, S3 conditional-put commits, conflict
+resolution). deltalite replaces only the *merge execution*.
+
+```python
+import deltalite
+
+table = deltalite.DeltaLiteTable.open("s3://bucket/my_table")
+stats = table.upsert(record_batch, primary_keys=["id"], partition_key="day")
+print(f"v{stats.version}: +{stats.rows_inserted} / ~{stats.rows_updated}")
+```
+
+## Why
+
+delta-rs `MERGE` executes a DataFusion hash join whose memory scales with the
+*scanned target*, and it can **deadlock under a bounded memory pool**
+([delta-io/delta-rs#4614](https://github.com/delta-io/delta-rs/issues/4614)).
+For a large, slowly-changing table merged against a comparatively small batch —
+the typical incremental-sync shape — that means either OOM risk or a hang.
+
+deltalite takes a different route:
+
+1. Build a primary-key hash set over the (small) **source** batch.
+2. Stream the (large) **target** one Parquet row group at a time, dropping rows
+   whose key is in the source set.
+3. Write survivors plus the source rows into new files.
+4. Commit every touched partition in **one atomic Delta commit**.
+
+Peak memory is bounded by the source batch and the concurrency knobs, not by
+the table. In validation, resident memory stayed flat from 62k- to 1M-row
+partitions (~4× below `MERGE`) at matching write volume, via exact
+content-based file selection.
+
+## Installation
+
+```bash
+pip install deltalite
+# or
+uv add deltalite
+```
+
+Prebuilt `cp312-abi3` wheels are published for manylinux (2_28) and musllinux
+on x86_64/aarch64, and macOS on arm64/x86_64. A single wheel works on **any
+CPython 3.12 or newer**. No Rust toolchain is needed to install.
+
+## Usage
+
+`upsert` accepts anything with the pyarrow C-stream interface — a
+`pyarrow.Table`, a `RecordBatch`, or a `RecordBatchReader`:
+
+```python
+import pyarrow as pa
+import deltalite
+
+table = deltalite.DeltaLiteTable.open(
+    "s3://bucket/events",
+    storage_options={
+        "AWS_REGION": "us-east-1",
+        "AWS_ACCESS_KEY_ID": "...",
+        "AWS_SECRET_ACCESS_KEY": "...",
+    },
+)
+
+batch = pa.table({
+    "id":  [1, 2, 3],
+    "day": ["2026-01-01", "2026-01-01", "2026-01-02"],
+    "val": ["a", "b", "c"],
+})
+
+stats = table.upsert(
+    batch,
+    primary_keys=["id"],
+    partition_key="day",          # omit for an unpartitioned table
+    commit_metadata={"source": "my-sync"},
+)
+
+print(stats)
+# UpsertStats(version=42, partitions_touched=2, files_added=2, files_removed=1, ...)
+```
+
+Rows in the batch whose primary key already exists are **replaced**; new keys
+are **inserted**. Deletes are not expressed through `upsert` — it is an
+insert-or-replace by key. Duplicate primary keys *within a single batch* are
+rejected (raising `DeltaLiteError`) rather than silently double-inserted.
+
+## API
+
+### `DeltaLiteTable`
+
+| Method | Description |
+|---|---|
+| `DeltaLiteTable.open(uri, storage_options=None)` | Open an existing Delta table. `storage_options` is the usual object-store dict (S3/GCS/Azure/local). |
+| `DeltaLiteTable.is_deltatable(uri, storage_options=None)` | `True` if a Delta table exists at `uri`. |
+| `.upsert(data, primary_keys, partition_key=None, **opts)` | Insert-or-replace `data` by key. Returns `UpsertStats`. See knobs below. |
+| `.version()` | Current table version (`int`). |
+| `.reload()` | Reload the table state from the log. |
+| `.schema_arrow()` | Table schema as a pyarrow `Schema`. |
+| `.partition_columns()` | Partition column names (`list[str]`). |
+| `.file_uris()` | URIs of the table's active data files. |
+| `.history(limit)` | Recent commit history entries. |
+
+### `UpsertStats`
+
+Returned by `upsert`. Fields: `version`, `partitions_touched`, `files_added`,
+`files_removed`, `files_carried_over`, `files_probed`, `rows_updated`,
+`rows_inserted`, `rows_copied`, `source_rows`, `null_pk_rows`.
+
+### Exceptions
+
+All inherit from `DeltaLiteError`, so you can catch the base or branch on kind:
+
+| Exception | Raised when |
+|---|---|
+| `DeltaLiteError` | Base class / generic failure. |
+| `DeltaLiteCommitConflictError` | Concurrent commit won the conditional-put race (retry-exhausted). |
+| `DeltaLiteSchemaMismatchError` | Batch schema is incompatible with the table. |
+| `DeltaLiteTableNotFoundError` | No Delta table at the URI. |
+| `DeltaLiteUnsupportedTableError` | Table uses a feature deltalite can't handle (e.g. deletion vectors, column mapping). |
+| `DeltaLiteSourceTooLargeError` | Batch exceeds `max_source_bytes` (see below). |
+
+## Operational knobs
+
+**Per-call** — keyword arguments to `upsert` (defaults in parentheses):
+
+| Argument | Default | Purpose |
+|---|---|---|
+| `max_parallel_partitions` | `2` | Partitions merged concurrently. |
+| `max_parallel_files` | `4` | Files read concurrently within a partition. |
+| `max_buffered_bytes` | `64 MiB` | Output buffered in memory before flushing. |
+| `prune_strategy` | `"probe"` | `"probe"` skips files that can't contain a source key; `"none"` scans all. |
+| `skip_unmatched_files` | `True` | Convenience toggle: `False` ≡ `prune_strategy="none"`. |
+| `probe_concurrency` | `8` | Concurrent statistics/probe reads. |
+| `read_batch_size` | `8192` | Row-group read batch size. |
+| `target_file_size` | table setting, else 100 MiB | Output file size target. |
+| `max_source_bytes` | `2 GiB` | Oversized-batch guard (`0` disables). |
+| `multipart_threshold` / `multipart_part_size` | `64 MiB` / `16 MiB` | Multipart upload thresholds (`0` threshold disables). |
+| `commit_max_retries` | `15` | Conditional-put commit retry budget. |
+| `commit_metadata` | `None` | Extra key/values recorded in the Delta commit. |
+
+**Process-global** — environment variables, enforced *on top of* the per-call
+knobs so that many concurrent upsert threads in one process cannot multiply the
+budgets:
+
+`DELTALITE_PROCESS_MAX_PARALLEL_PARTITIONS` (8),
+`DELTALITE_PROCESS_MAX_PARALLEL_FILES` (16),
+`DELTALITE_PROCESS_MAX_BUFFERED_BYTES` (256 MiB),
+`DELTALITE_MAX_SOURCE_BYTES`, `DELTALITE_MULTIPART_THRESHOLD_BYTES`,
+`DELTALITE_MULTIPART_PART_SIZE_BYTES`.
+
+## Metrics
+
+deltalite emits via the Rust [`metrics`](https://docs.rs/metrics) facade (static
+labels only): `deltalite_upserts_total` (`outcome`, `prune_strategy`,
+`error_kind`), `deltalite_upsert_duration_seconds`,
+`deltalite_files_{added,removed,carried_over,probed}_total`, and
+`deltalite_rows_{updated,inserted,copied}_total`.
+
+## Compatibility & status
+
+- Built against `deltalake` (delta-rs) `0.32.x` as the storage/protocol layer.
+  Correctness is guaranteed by a **differential parity suite** that runs the
+  same batch sequences through real delta-rs `MERGE` and through
+  `deltalite.upsert` and asserts identical logical content — not by version
+  equality.
+- **Not supported:** tables with deletion vectors or column mapping (detected
+  and raised as `DeltaLiteUnsupportedTableError`), and SCD2 merges.
+- deltalite rejects duplicate source primary keys that `MERGE` silently
+  double-inserts — check pre-existing data if you migrate an existing pipeline.
+
+This package is developed in the [PostHog monorepo](https://github.com/PostHog/posthog)
+under `rust/deltalite/`. Issues and source live there.

--- a/rust/deltalite/python/pyproject.toml
+++ b/rust/deltalite/python/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "maturin"
 [project]
 name = "deltalite"
 # Mirrors `rust/deltalite/python/Cargo.toml` (always identical); bump both together.
-version = "0.1.1"
+version = "0.1.2"
 description = "Streaming partition upsert for Delta tables, replacing delta-rs SQL MERGE"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1731,16 +1731,16 @@ pyarrow = [
 
 [[package]]
 name = "deltalite"
-version = "0.1.1"
+version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/eb/294ae8238a492a8751782c505e4f1baa03c988a18fe2b4d8f27024af3656/deltalite-0.1.1.tar.gz", hash = "sha256:a36666ed4916bca754be649fca418d43536c75e99b8236bd742296cae502e444", size = 164828, upload-time = "2026-07-28T22:11:22.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/1e/49659fed92532267fbfc9298a16504ce8f13a26382e6355a0b43e337dade/deltalite-0.1.2.tar.gz", hash = "sha256:9555b17d7e57dc7e869317db4db772acfe067ad53aed2ac0699e751c401e3f02", size = 172868, upload-time = "2026-07-29T13:57:28.814Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/1f/5b0c37e0ad68aba0744140d4d99b40285f97d53a1d263bbfbcb7c706789f/deltalite-0.1.1-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ce05c3ceb0c66d5e1fa6067cafd54416fc7b72547d1f833dd70e31ff4ffae4e1", size = 17954501, upload-time = "2026-07-28T22:10:59.924Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/4d/3fdda303726b7005a2383b4681e9d3df5f8b63e2c019c2c75ed21b245e2e/deltalite-0.1.1-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:801a7eada9de6143831e0d06ada42daea584e6ccc7262884a816f5e7a6420d06", size = 17835888, upload-time = "2026-07-28T22:11:02.949Z" },
-    { url = "https://files.pythonhosted.org/packages/73/da/e084d26f656e71b583a99f7dda4770496cf3e8ee8a4503390f5b81c4480e/deltalite-0.1.1-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ef9f8e6f3d07aaa8939e9d4d0bbc099059e3f9e25df3d1599fd6823f3e339ac1", size = 63131234, upload-time = "2026-07-28T22:11:06.931Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/fb/c465ff56c9b5075b9897b656df96b1d0f8105698c6d8f7707590f9a3d5ae/deltalite-0.1.1-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7e86ac4ecce2cf9afd41c24f38e995870affc2f1499eb36fe5d9df4593ada715", size = 65438702, upload-time = "2026-07-28T22:11:11.32Z" },
-    { url = "https://files.pythonhosted.org/packages/75/5d/9fb91fa0effadcb0b42c4c4f374e90c1c5af31a083d26cfbbc04fd5fcab0/deltalite-0.1.1-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0b270ad5c1b522a0539476a88a8a3037338c6be0a53f90e28c58921c136526fa", size = 62717513, upload-time = "2026-07-28T22:11:15.663Z" },
-    { url = "https://files.pythonhosted.org/packages/39/9f/6d52ffa7d8a98b66c3dc28a7b0d00873cd936dac894de4094073e8996764/deltalite-0.1.1-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3d944bc32404721036225dfbad0fb611a16075650b6bf58c0eeb23e86ff4c6a4", size = 63791320, upload-time = "2026-07-28T22:11:20.172Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b0/2618124dc3bc8433248ffa3855bae050f6e12f0cc098857e2adc187545e5/deltalite-0.1.2-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:de3506abd5c07df8f270b6ab125a62324eda64b968614d2daf7e35a97d031123", size = 17957003, upload-time = "2026-07-29T13:57:08.139Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/d5/a4ca6595ad7efcc1550a39cd4a3fff67a13076db5623582100e26a6dd5c0/deltalite-0.1.2-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:e48f84c81c894ffb394aa92824989b64c017fc1bd4ffe4ba97b4d79d72e06829", size = 17838440, upload-time = "2026-07-29T13:57:10.827Z" },
+    { url = "https://files.pythonhosted.org/packages/10/7c/da3966cf9ab0db82285dc35932dde36da665ad22808051c51841bae999f4/deltalite-0.1.2-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1c0a45ce1bcf920170d35f707018d66da9476e1c12adcc8589742c9fdce74537", size = 63133529, upload-time = "2026-07-29T13:57:14.25Z" },
+    { url = "https://files.pythonhosted.org/packages/05/60/fa7c805b09f7f8d96da93572f640c3a7a256417d5a4b3a4425a7b46770a2/deltalite-0.1.2-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:fc4af9d59fa944ebd906d9b395f8dcf75ff41a5c5f95540abc90914f417c9851", size = 65444603, upload-time = "2026-07-29T13:57:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/22/9c/52d86d4ffb7d30dc761888b130f217e6a09d37e0ca436d3d18adba9aaed6/deltalite-0.1.2-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1eb6b872730d03367b572f8fdb876dfb08875d0d1d3a06fc35bbd40db42a6aaf", size = 62721871, upload-time = "2026-07-29T13:57:22.439Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b2/f7268ff3f7731d2421264ab2b342307893ce7e09659e98b36608ef9b5503/deltalite-0.1.2-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5b7ab6824c16a0a6fa23ce4dca15c3fdc7fbbbd98eb25dd9a290f1809842e524", size = 63793714, upload-time = "2026-07-29T13:57:26.13Z" },
 ]
 
 [[package]]
@@ -5859,7 +5859,7 @@ requires-dist = [
     { name = "databricks-sql-connector", specifier = "~=4.3.0" },
     { name = "defusedxml", specifier = "~=0.7.1" },
     { name = "deltalake", extras = ["pyarrow"], specifier = "==1.6.1" },
-    { name = "deltalite", specifier = "==0.1.1" },
+    { name = "deltalite", specifier = "==0.1.2" },
     { name = "disposable-email-domains", specifier = "~=0.0.140" },
     { name = "dj-database-url", specifier = "~=3.0.0" },
     { name = "django", specifier = "~=5.2.0" },


### PR DESCRIPTION
## Problem

The [`deltalite` page on PyPI](https://pypi.org/project/deltalite/) renders a stub README that only points at a repo-relative `../README.md` (a dead link once it's on PyPI) and lists internal source-tree paths. Anyone landing on the package page gets nothing useful about what the library is or how to use it.

## Changes

Replace `rust/deltalite/python/README.md` with a self-contained package doc, since that file is what PyPI renders:

- What deltalite is and why it exists (bounded-memory streaming upsert vs the delta-rs `MERGE` deadlock/OOM shape), with the 4-step algorithm.
- Install instructions and the wheel/platform matrix.
- A runnable usage example (`open` + `upsert` with `storage_options`).
- Full API reference: `DeltaLiteTable` methods, `UpsertStats` fields, and the `DeltaLiteError` exception hierarchy.
- The per-call and process-global operational knobs, the metrics, and compatibility/unsupported-feature notes.

Version bumped `0.1.1 -> 0.1.2` so the `Release deltalite` workflow republishes the wheel with the new README (PyPI README is per-release; the live page only updates on a new upload). `rust/Cargo.lock` updated to match.

This is stacked on `tom/deltalite-shadow` (#74242) because that branch carries `build-deltalite.yml`; base it there so the diff stays to just the README + bump. Rebase onto master if #74242 merges first.

## How did you test this code?

No code changes - docs plus a version bump. I rendered the Markdown locally to confirm the tables and fenced blocks are well-formed, and cross-checked every documented symbol (methods, `UpsertStats` fields, exception classes, `upsert` keyword defaults) against `rust/deltalite/python/src/lib.rs` so the API reference matches the binding exactly. `cargo update` regenerated the single-line `Cargo.lock` change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?