### PR TITLE
fix(bigquery): stop retrying a NaN-in-NUMERIC value from a source view

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -260,6 +260,16 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # source view. Matched on BigQuery's stable wording, not the volatile peak-usage percentage
             # or job id.
             BIGQUERY_RESOURCES_EXCEEDED_ERROR: "BigQuery couldn't run a query for this source because it exceeded the memory allowed for a single query. This is usually caused by heavy sorts or analytic (window) functions over a large table or view. Retrying won't help — please reduce how much data you're syncing (for example add row filters or an incremental field), or simplify the source view, then re-enable the source.",
+            # Raised as a 400 BadRequest from `jobs.getQueryResults` (the poll `_run_destination_query_
+            # with_job_retry` / `_query_result_with_job_retry` in `bigquery.py` do while awaiting a query
+            # job) when the job's result set holds a NaN in a column typed NUMERIC/BIGNUMERIC — that type
+            # can't represent NaN the way FLOAT64 can. This traces back to the source table or view itself
+            # (a computed column doing arithmetic like division by zero) rather than anything our SELECT
+            # constructs, so it's a deterministic property of the customer's data: the same query keeps
+            # producing the same NaN on every retry, and Google's own default job-retry doesn't cover it.
+            # The user must fix the source view/column; retrying just spams error tracking. Matched on
+            # BigQuery's stable wording, not the volatile job id/URL.
+            "Invalid NUMERIC value: NaN": "BigQuery couldn't complete a query for this source because it produced a NaN (not-a-number) value in a column typed NUMERIC, which that type can't represent. This is usually caused by a computed column or view doing arithmetic like division by zero. Please fix the underlying view or column in BigQuery, then re-enable the source.",
         }
 
     def validate_credentials(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -1284,6 +1284,26 @@ def test_non_retryable_errors_match_unparseable_view(observed_error):
 @pytest.mark.parametrize(
     "observed_error",
     [
+        # A NaN in a NUMERIC-typed column, surfaced from `jobs.getQueryResults` while polling a query
+        # job — BigQuery's NUMERIC type can't represent NaN the way FLOAT64 can.
+        str(
+            BadRequest(
+                "GET https://bigquery.googleapis.com/bigquery/v2/projects/p/queries/j?maxResults=0"
+                "&location=EU&prettyPrint=false: Invalid NUMERIC value: NaN\n\nLocation: EU\nJob ID: j"
+            )
+        ),
+    ],
+)
+def test_non_retryable_errors_match_numeric_nan(observed_error):
+    """A NUMERIC-typed column holding NaN traces back to the customer's source view/data, and the
+    same query keeps producing it on every retry — the user must fix the underlying view/column."""
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    assert any(key in observed_error for key in non_retryable_errors)
+
+
+@pytest.mark.parametrize(
+    "observed_error",
+    [
         # Administrator-set custom cost control on the customer's BigQuery project — surfaced as a
         # `Forbidden` whose str() is "403 Custom quota exceeded: ...".
         str(


### PR DESCRIPTION
## Problem

PostHog error tracking flagged a recurring `BadRequest` from the BigQuery data-warehouse source: `Invalid NUMERIC value: NaN`, raised while polling a query job (`jobs.getQueryResults`) during `_run_destination_query_with_job_retry` / `_query_result_with_job_retry`.

BigQuery's `NUMERIC`/`BIGNUMERIC` types can't represent NaN the way `FLOAT64` can. When a query job's result set holds a NaN in a column typed NUMERIC, the poll fails with this error. That traces back to the source view/column itself (a computed column doing arithmetic like division by zero), not anything our `SELECT` clause constructs — so the same query keeps producing the identical error on every retry, and Google's own default job-retry predicate doesn't cover it. Retrying just spams error tracking without ever recovering; the customer needs to fix the underlying view or column.

## Changes

Added `"Invalid NUMERIC value: NaN"` to `BigQuerySource.get_non_retryable_errors` (mirrors the existing pattern for other deterministic source-data problems in this dict, e.g. `BIGQUERY_RESOURCES_EXCEEDED_ERROR`, `"failed to parse view"`). Matched on BigQuery's stable wording rather than the volatile job id/URL, so the sync stops retrying and the source surfaces an actionable message pointing the customer at the underlying view/column.

## How did you test this code?

Added `test_non_retryable_errors_match_numeric_nan`, parameterized like the existing BigQuery non-retryable-error tests, asserting the new key matches a representative `BadRequest` string shaped like the real error (with the job id/location kept out of the fixed test value, since those are volatile).

Ran:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py -q` — all 159 tests pass.
- `uv run ruff check` / `ruff format --check` on the changed files — clean.

I did not do any manual/UI testing; this is a backend-only classifier change covered by the unit test above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — this only changes an internal retry classifier, no user-facing docs to update.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from a PostHog error-tracking issue (BigQuery source, `BadRequest: Invalid NUMERIC value: NaN`) delivered via webhook. Confirmed the stack trace originates in `products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py` (`_run_destination_query_with_job_retry` → `_with_job_not_found_retry` → `job.result()` → `google.cloud.bigquery` internals), then read `bigquery.py` and `source.py` to understand the existing `get_non_retryable_errors` pattern before extending it.
- Searched open PRs (by error text, module path, and the `bigquery.py` maintainer's own open PRs) and found no existing fix for this specific error.
- Decision: classified as an upstream/customer-data issue (NaN can only appear in a NUMERIC-typed BigQuery column via a computed expression in the customer's view), not a bug in our query construction — so extended `NonRetryableErrors` rather than changing sync logic.