### PR TITLE
fix(customer-analytics): show the value next to account sparklines

### DIFF
--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -282,11 +282,14 @@ function CustomPropertyHistoryCell({
     }
 
     if (display.mode === 'sparkline') {
+        // Each sparkline auto-scales to its own range, so the line shows the trend but not the
+        // magnitude — every row looks alike without the latest value spelled out next to it.
         return (
-            <div className="w-32">
+            <div className="flex items-center gap-2 w-40">
+                <span className="tabular-nums whitespace-nowrap">{formatValue(latest[1])}</span>
                 <Sparkline
                     type="line"
-                    className="h-8"
+                    className="h-8 min-w-0"
                     data={chartPoints.map(([, value]) => value)}
                     labels={chartPoints.map(([timestamp]) => dayjs.unix(timestamp).format('MMM D, YYYY HH:mm'))}
                     renderTooltipValue={formatValue}

--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -285,11 +285,13 @@ function CustomPropertyHistoryCell({
         // Each sparkline auto-scales to its own range, so the line shows the trend but not the
         // magnitude — every row looks alike without the latest value spelled out next to it.
         return (
-            <div className="flex items-center gap-2 w-40">
+            // `min-w-min` lets the cell outgrow w-40 instead of spilling a long value into the next
+            // column, and the chart keeps a floor so it degrades rather than vanishing.
+            <div className="flex items-center gap-2 w-40 min-w-min">
                 <span className="tabular-nums whitespace-nowrap">{formatValue(latest[1])}</span>
                 <Sparkline
                     type="line"
-                    className="h-8 min-w-0"
+                    className="h-8 min-w-8"
                     data={chartPoints.map(([, value]) => value)}
                     labels={chartPoints.map(([timestamp]) => dayjs.unix(timestamp).format('MMM D, YYYY HH:mm'))}
                     renderTooltipValue={formatValue}


### PR DESCRIPTION
## Problem

Sparkline columns in the accounts list auto-scale to each row's own range, so every row draws roughly the same line. A $169 account and a $39,000 one are indistinguishable.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Print the latest formatted value beside the sparkline in `CustomPropertyHistoryCell`
- Widen the cell to `w-40` and let the chart shrink (`min-w-0`) so the number never gets clipped
- Use `tabular-nums` so values line up down the column

Top row is before, bottom is after — same three accounts.

![sparkline-compare](https://raw.githubusercontent.com/PostHog/pr-assets/743a20cc59bea8e48cb0ae17e27117088e12884b/2026/07/5a158fe4-44fe-42c0-8a5b-779ab817c360.png)

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Claude ran `tsc --noEmit` and drove the accounts list in a local browser with seeded numeric history, capturing before/after screenshots. No new automated tests.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (PostHog Code). I asked for a y-axis scale on the sparklines. Claude pushed back: a 10px axis tick in a 32px cell is unreadable, and it still wouldn't make rows comparable since each row scales independently. We picked the value-text option instead. A shared cross-row scale is the real fix for ranking accounts by eye, but that needs a column-wide min/max in `accountsColumnConfigLogic` and was left out.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
