### PR TITLE
feat(tasks): unfurl task deep-links with OpenGraph tags

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -5,6 +5,22 @@
         {# head.html first: it carries <meta charset>, which must stay within the first 1024 bytes #}
         {# so the browser's encoding prescan finds it #}
         {% include "head.html" %}
+        {# Server-rendered OpenGraph/Twitter tags for public share links (e.g. task deep-links). #}
+        {# Gated on add_og_tags so normal app loads are unchanged; noindex keeps capability URLs #}
+        {# out of search engines. Values are autoescaped, so titles are safe in attributes. #}
+        {% if add_og_tags %}
+            <meta name="robots" content="noindex" />
+            <meta property="og:site_name" content="PostHog" />
+            <meta property="og:type" content="website" />
+            <meta property="og:title" content="{{ og_title }}" />
+            <meta property="og:description" content="{{ og_description }}" />
+            <meta property="og:url" content="{{ request.build_absolute_uri }}" />
+            <meta property="og:image" content="{{ og_image }}" />
+            <meta name="twitter:card" content="summary" />
+            <meta name="twitter:title" content="{{ og_title }}" />
+            <meta name="twitter:description" content="{{ og_description }}" />
+            <meta name="twitter:image" content="{{ og_image }}" />
+        {% endif %}
         {# Critical CSS for the pre-React shell (background, spinner, boot-failure message), so the #}
         {# page doesn't flash white. Everything visual is scoped to #root:empty and .Preloader — the #}
         {# app never styles <body> background itself, so an unscoped rule here would persist after #}

--- a/posthog/urls.py
+++ b/posthog/urls.py
@@ -358,6 +358,40 @@ def home_with_region_redirect(request: HttpRequest, *args: Any, **kwargs: Any) -
     return _login_required_render_home(request, *args, **kwargs)
 
 
+@ensure_csrf_cookie
+def code_channel_task_link(request: HttpRequest, channel_id: Any, task_id: Any) -> HttpResponse:
+    """Public bridge for desktop-app task deep-links (`/code/channel/<channel_id>/tasks/<task_id>`).
+
+    Renders the SPA — whose `CodeChannelLink` scene deep-links into PostHog Desktop — but
+    injects server-rendered OpenGraph/Twitter tags so a pasted link unfurls with the task
+    title, channel, and creator. Unauthenticated on purpose: link-unfurl crawlers are never
+    logged in, and the task is resolved by its two unguessable UUIDs (a capability URL).
+    `noindex` (set in the template) keeps the page out of search engines if a link leaks
+    somewhere crawlable. Falls back to a plain SPA render when the task can't be resolved.
+    """
+    region_redirect = app_region_redirect(request)
+    if region_redirect is not None:
+        return region_redirect
+
+    from products.tasks.backend.facade.api import (  # noqa: PLC0415 — keep the tasks import off the django.setup() path
+        get_task_link_preview,
+    )
+
+    context: dict[str, Any] = {}
+    preview = get_task_link_preview(channel_id, task_id)
+    if preview is not None:
+        description = f"Task in #{preview.channel_name}"
+        if preview.creator_name:
+            description += f", created by {preview.creator_name}"
+        context = {
+            "add_og_tags": True,
+            "og_title": preview.task_title,
+            "og_description": description,
+            "og_image": request.build_absolute_uri("/static/icons/android-chrome-512x512.png"),
+        }
+    return render_template("index.html", request, context=context)
+
+
 _CONNECT_REDIRECT_ALLOWED_KINDS = {"github", "slack", "linear"}
 # Surfaces allowed to start a connect flow and be returned to afterwards (see
 # posthog/api/github_callback/types.py APP_CONNECT_FROM_VALUES, plus Slack).
@@ -642,6 +676,11 @@ urlpatterns = [
         sharing.SharingViewerPageViewSet.as_view({"get": "retrieve"}),
     ),
     path("site_app/<int:id>/<str:token>/<str:hash>/", site_app.get_site_app),
+    # Public bridge for desktop-app task share links — deep-links into PostHog Desktop and
+    # renders OpenGraph tags so pasted links unfurl. Registered ahead of the SPA catch-all,
+    # which is login-gated (link-unfurl crawlers are unauthenticated). The sibling
+    # `/code/canvas/...` and `/code/channel/...` bridges stay on the SPA catch-all/unauth list.
+    path("code/channel/<uuid:channel_id>/tasks/<uuid:task_id>", code_channel_task_link),
     re_path(r"^demo.*", login_required(demo_route)),
     path("", include((oauth2_urls, "oauth2_provider"), namespace="oauth2_provider")),
     # ingestion

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -4944,7 +4944,10 @@ def get_task_link_preview(channel_id: str | UUID, task_id: str | UUID) -> contra
     dashboard), so it is intentionally not team-scoped — link-unfurl requests arrive
     unauthenticated. Returns ``None`` when either id is malformed, the task is missing or
     soft-deleted, or the task doesn't belong to the given channel, letting the caller fall
-    back to a generic preview.
+    back to a generic preview. Also refuses to preview ``internal`` tasks (system-generated,
+    "not exposed to end users") and tasks in ``PERSONAL`` channels (a user's private ``#me``
+    feed) — those aren't shareable artifacts, so they stay out of a public unfurl even if
+    their link leaks.
     """
     try:
         task_uuid = UUID(str(task_id))
@@ -4953,11 +4956,13 @@ def get_task_link_preview(channel_id: str | UUID, task_id: str | UUID) -> contra
         return None
 
     task = (
-        Task.objects.filter(id=task_uuid, channel_id=channel_uuid, deleted=False)
+        Task.objects.filter(id=task_uuid, channel_id=channel_uuid, deleted=False, internal=False)
         .select_related("channel", "created_by")
         .first()
     )
     if task is None or task.channel is None or task.channel.deleted:
+        return None
+    if task.channel.channel_type == Channel.ChannelType.PERSONAL:
         return None
 
     creator = task.created_by

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -156,6 +156,7 @@ __all__ = [
     "get_task_automation",
     "get_task_detail",
     "get_task_id_for_run",
+    "get_task_link_preview",
     "get_task_run",
     "get_task_run_detail",
     "get_task_run_sandbox_connection",
@@ -4934,6 +4935,41 @@ def send_cancel(run_id: str | UUID, *, auth_token: str | None = None):
 
 
 # --- Channels & task threads ---
+
+
+def get_task_link_preview(channel_id: str | UUID, task_id: str | UUID) -> contracts.TaskLinkPreview | None:
+    """Public link-preview data for a ``/code/channel/<channel_id>/tasks/<task_id>`` deep-link.
+
+    Resolved globally by the two unguessable UUIDs (a capability URL, like a shared
+    dashboard), so it is intentionally not team-scoped — link-unfurl requests arrive
+    unauthenticated. Returns ``None`` when either id is malformed, the task is missing or
+    soft-deleted, or the task doesn't belong to the given channel, letting the caller fall
+    back to a generic preview.
+    """
+    try:
+        task_uuid = UUID(str(task_id))
+        channel_uuid = UUID(str(channel_id))
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+    task = (
+        Task.objects.filter(id=task_uuid, channel_id=channel_uuid, deleted=False)
+        .select_related("channel", "created_by")
+        .first()
+    )
+    if task is None or task.channel is None or task.channel.deleted:
+        return None
+
+    creator = task.created_by
+    creator_name: str | None = None
+    if creator is not None:
+        creator_name = f"{creator.first_name} {creator.last_name}".strip() or None
+
+    return contracts.TaskLinkPreview(
+        task_title=task.title,
+        channel_name=task.channel.name,
+        creator_name=creator_name,
+    )
 
 
 def normalize_channel_name(name: str) -> str:

--- a/products/tasks/backend/facade/contracts.py
+++ b/products/tasks/backend/facade/contracts.py
@@ -572,6 +572,20 @@ class TaskUserBasicInfo:
 
 
 @dataclass(frozen=True)
+class TaskLinkPreview:
+    """Public-safe fields for an OpenGraph/link-unfurl preview of a task deep-link.
+
+    Deliberately minimal: the task title, its channel name, and the creator's display
+    name. No task body, run output, repository, or team data crosses into an
+    unauthenticated preview.
+    """
+
+    task_title: str
+    channel_name: str
+    creator_name: str | None = None
+
+
+@dataclass(frozen=True)
 class SandboxEnvironmentDTO:
     """A sandbox execution environment."""
 

--- a/products/tasks/backend/tests/test_link_preview.py
+++ b/products/tasks/backend/tests/test_link_preview.py
@@ -1,0 +1,161 @@
+from typing import ClassVar
+
+from django.test import TestCase
+
+from parameterized import parameterized
+
+from posthog.models import Organization, Team
+from posthog.models.user import User
+
+from products.tasks.backend.facade import api as facade
+from products.tasks.backend.models import Channel, Task
+
+
+class TestGetTaskLinkPreview(TestCase):
+    organization: ClassVar[Organization]
+    team: ClassVar[Team]
+    user: ClassVar[User]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.organization = Organization.objects.create(name="Test Org")
+        cls.team = Team.objects.create(organization=cls.organization, name="Test Team")
+        cls.user = User.objects.create(
+            email="creator@test.com", distinct_id="creator", first_name="Ada", last_name="Lovelace"
+        )
+
+    def _make_channel(self, **kwargs) -> Channel:
+        defaults = {"team": self.team, "name": "growth", "created_by": self.user}
+        defaults.update(kwargs)
+        channel = Channel(**defaults)
+        channel.save()
+        return channel
+
+    def _make_task(self, channel: Channel | None, **kwargs) -> Task:
+        defaults = {
+            "team": self.team,
+            "title": "Fix the login redirect",
+            "description": "desc",
+            "origin_product": Task.OriginProduct.USER_CREATED,
+            "created_by": self.user,
+            "channel": channel,
+        }
+        defaults.update(kwargs)
+        return Task.objects.create(**defaults)
+
+    def test_returns_title_channel_and_creator(self):
+        channel = self._make_channel()
+        task = self._make_task(channel)
+
+        preview = facade.get_task_link_preview(channel.id, task.id)
+
+        assert preview is not None
+        self.assertEqual(preview.task_title, "Fix the login redirect")
+        self.assertEqual(preview.channel_name, "growth")
+        self.assertEqual(preview.creator_name, "Ada Lovelace")
+
+    def test_creator_name_is_none_without_creator(self):
+        channel = self._make_channel(created_by=None)
+        task = self._make_task(channel, created_by=None)
+
+        preview = facade.get_task_link_preview(channel.id, task.id)
+
+        assert preview is not None
+        self.assertIsNone(preview.creator_name)
+
+    def test_task_in_a_different_channel_does_not_resolve(self):
+        # The two ids must belong together — a valid task id under the wrong channel id
+        # must not leak a preview.
+        channel = self._make_channel()
+        other_channel = self._make_channel(name="support")
+        task = self._make_task(channel)
+
+        self.assertIsNone(facade.get_task_link_preview(other_channel.id, task.id))
+
+    @parameterized.expand(
+        [
+            ("malformed_channel_id", "not-a-uuid", None),
+            ("malformed_task_id", None, "not-a-uuid"),
+        ]
+    )
+    def test_malformed_ids_return_none(self, _name, channel_id, task_id):
+        channel = self._make_channel()
+        task = self._make_task(channel)
+
+        self.assertIsNone(facade.get_task_link_preview(channel_id or channel.id, task_id or task.id))
+
+    def test_soft_deleted_task_does_not_resolve(self):
+        channel = self._make_channel()
+        task = self._make_task(channel, deleted=True)
+
+        self.assertIsNone(facade.get_task_link_preview(channel.id, task.id))
+
+    def test_deleted_channel_does_not_resolve(self):
+        channel = self._make_channel(deleted=True)
+        task = self._make_task(channel)
+
+        self.assertIsNone(facade.get_task_link_preview(channel.id, task.id))
+
+
+class TestCodeChannelTaskLinkPage(TestCase):
+    """Wiring guard: the public `/code/channel/.../tasks/...` route renders OG tags and
+    escapes the (user-controlled) task title into the meta attribute."""
+
+    organization: ClassVar[Organization]
+    team: ClassVar[Team]
+    user: ClassVar[User]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.organization = Organization.objects.create(name="Test Org")
+        cls.team = Team.objects.create(organization=cls.organization, name="Test Team")
+        cls.user = User.objects.create(email="pager@test.com", distinct_id="pager", first_name="Grace")
+
+    def _url(self, channel_id, task_id) -> str:
+        return f"/code/channel/{channel_id}/tasks/{task_id}"
+
+    def test_renders_og_title_for_existing_task(self):
+        channel = Channel(team=self.team, name="growth", created_by=self.user)
+        channel.save()
+        task = Task.objects.create(
+            team=self.team,
+            title="Fix the login redirect",
+            description="desc",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            created_by=self.user,
+            channel=channel,
+        )
+
+        response = self.client.get(self._url(channel.id, task.id))
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('property="og:title" content="Fix the login redirect"', content)
+        self.assertIn('property="og:description" content="Task in #growth, created by Grace"', content)
+        self.assertIn('name="robots" content="noindex"', content)
+
+    def test_escapes_malicious_title(self):
+        channel = Channel(team=self.team, name="growth", created_by=self.user)
+        channel.save()
+        task = Task.objects.create(
+            team=self.team,
+            title='pwn"><script>alert(1)</script>',
+            description="desc",
+            origin_product=Task.OriginProduct.USER_CREATED,
+            created_by=self.user,
+            channel=channel,
+        )
+
+        content = self.client.get(self._url(channel.id, task.id)).content.decode()
+
+        self.assertNotIn("<script>alert(1)</script>", content)
+        self.assertIn("&lt;script&gt;", content)
+
+    def test_missing_task_renders_app_without_og_tags(self):
+        channel = Channel(team=self.team, name="growth", created_by=self.user)
+        channel.save()
+        # A well-formed but non-existent task id: the SPA still loads, but no OG tags leak.
+        response = self.client.get(self._url(channel.id, "0e5947d9-11d5-41a7-b9b0-25d102bbf4f8"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn('property="og:title"', response.content.decode())

--- a/products/tasks/backend/tests/test_link_preview.py
+++ b/products/tasks/backend/tests/test_link_preview.py
@@ -96,6 +96,20 @@ class TestGetTaskLinkPreview(TestCase):
 
         self.assertIsNone(facade.get_task_link_preview(channel.id, task.id))
 
+    def test_internal_task_does_not_resolve(self):
+        # `internal` tasks are system-generated and "not exposed to end users".
+        channel = self._make_channel()
+        task = self._make_task(channel, internal=True)
+
+        self.assertIsNone(facade.get_task_link_preview(channel.id, task.id))
+
+    def test_task_in_personal_channel_does_not_resolve(self):
+        # A user's private `#me` feed is not a shareable artifact.
+        channel = self._make_channel(name="me", channel_type=Channel.ChannelType.PERSONAL)
+        task = self._make_task(channel)
+
+        self.assertIsNone(facade.get_task_link_preview(channel.id, task.id))
+
 
 class TestCodeChannelTaskLinkPage(TestCase):
     """Wiring guard: the public `/code/channel/.../tasks/...` route renders OG tags and


### PR DESCRIPTION
## Problem

Task share links like `/code/channel/<channel_id>/tasks/<task_id>` produced no link preview when pasted into Slack, iMessage, Discord, etc. — the unfurl just showed a bare URL, so you couldn't tell what the task was about, which channel it lives in, or who created it.

Two things were in the way:
- No OpenGraph/Twitter meta tags were ever emitted for these URLs.
- The route fell through to the SPA catch-all, which is login-gated — so unfurl crawlers (always unauthenticated, never run JS) couldn't reach the page at all. The sibling `/code/canvas/...` bridge is already public; the channel/task bridge was not.

**Why:** make a shared task link legible at a glance in chat, without opening the app.

## Changes

- New public Django view for `/code/channel/<uuid>/tasks/<uuid>` that renders the existing SPA (the `CodeChannelLink` interstitial + desktop deep-link stays exactly as-is for real browsers) with server-rendered OpenGraph/Twitter tags in the `<head>`:
  - `og:title` → task title
  - `og:description` → `Task in #channel, created by <name>`
  - `og:image` → static PostHog logo (`summary` card)
  - `robots: noindex` so these capability URLs stay out of search indexes
- New tasks-facade helper `get_task_link_preview(channel_id, task_id)` returning a minimal, public-safe DTO (`TaskLinkPreview`: title, channel name, creator name only — no task body, run output, repository, or team data). It resolves the task **globally by the two UUIDs** (a capability URL, like a shared dashboard) since unfurl fetches are unauthenticated, and returns `None` — falling back to a generic app render — for malformed ids, soft-deleted task/channel, or a task/channel id mismatch.
- OG meta block added to the SPA shell (`frontend/src/index.html`), gated on `add_og_tags` so normal app loads are unchanged; values are Django-autoescaped, so user-controlled titles are safe in the attribute context.

## Security posture

The endpoint is intentionally public and not team-scoped, because link-unfurl fetches are unauthenticated and can't run JS. Its load-bearing control is that both ids are random `uuid4` (~122 bits each) and must belong together, so links are **not discoverable or enumerable** — only readable if you already hold the link (the capability-URL model, same as shared dashboards). `noindex` keeps leaked links out of search engines.

Because a leaked link exposes the title/channel/creator, the lookup also **refuses to preview**:
- `internal` tasks (system-generated, flagged "not exposed to end users"), and
- tasks in `PERSONAL` channels (a user's private `#me` feed).

Those aren't shareable artifacts, so they stay off the public preview surface entirely. Everything else with a channel is previewable-if-you-know-the-UUID.

A per-task dynamically generated image (title + channel rendered on the card) is a possible follow-up; this ships the static branded image first.

## How did you test this code?

- Added `products/tasks/backend/tests/test_link_preview.py`:
  - **Facade** (`get_task_link_preview`): resolves title/channel/creator; creator is `None` when unset; returns `None` for a task under the wrong channel id (guards against a valid-task-id + wrong-channel-id leak), for malformed ids, for soft-deleted task/channel, for `internal` tasks, and for tasks in `PERSONAL` channels.
  - **Endpoint** wiring guard: the public route renders `og:title`/`og:description`/`noindex`; a malicious title (`"><script>…`) is HTML-escaped into the meta attribute rather than breaking out (XSS guard); a well-formed but non-existent task id still returns 200 with **no** OG tags leaked.
  - Each group targets a concrete regression not covered elsewhere (route wiring, cross-channel leak, internal/personal exclusion, attribute escaping).
- The agent could not run the DB-backed tests in this environment (no Postgres reachable). Verified without a DB: URL resolves to the new view with UUID kwargs, the DTO constructs, the malformed-id branch returns `None`, the `Channel.ChannelType` reference resolves, and Django autoescaping neutralizes a `<script>` payload in the meta attribute. The DB-backed cases run in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Directed by @jonathanlab; authored with Claude Code (PostHog Code).
- Skills invoked: `/writing-tests` (shaped the test set to concrete regressions and pushed the case matrix to the cheapest layer).
- Key decisions: OG tags must be server-rendered on a **public** route (crawlers don't run JS and aren't logged in), so a client-side approach was rejected; modeled the view on the existing shared-dashboard/exporter OG pattern. Chose a capability-URL lookup (global by UUID, not team-scoped) to match how unfurl fetches actually arrive, and kept the preview DTO minimal. Added `internal`-task and `PERSONAL`-channel exclusions as defense-in-depth after reviewing the exposure model. Chose a static og:image over net-new dynamic-image infrastructure for v1.
- Kept the plain `/code/channel/<id>` (channel-only) bridge out of scope; only the task URL gets the OG view.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
