### PR TITLE
chore(cohorts): disable realtime cohort calculation for p80-p100 tiers

### DIFF
--- a/posthog/temporal/messaging/schedule.py
+++ b/posthog/temporal/messaging/schedule.py
@@ -231,7 +231,13 @@ async def create_reconcile_precalculated_data_schedule(client: Client):
 
 
 async def create_all_realtime_cohort_calculation_schedules(client: Client):
-    """Create or update all six percentile-based schedules for realtime cohort calculation.
+    """Create or update the active percentile-based schedules for realtime cohort calculation.
+
+    Only the p0-p80 tiers (p0-p50, p50-p80) are active. The p80-p100 tiers (p80-p90, p90-p95,
+    p95-p99, p99-p100) are intentionally disabled for now — they cover the slowest, most expensive
+    cohorts — so their schedules are deleted here if they exist. Re-enabling is a matter of
+    re-adding the create calls below and dropping the corresponding deletes; the per-tier
+    create_* helpers, settings, and schedule-ID constants are kept in place for that.
 
     Note: This migration is non-atomic. Between creating new schedules and deleting the old one,
     both schedules may fire simultaneously. The old schedule processes ALL cohorts while the new
@@ -240,13 +246,19 @@ async def create_all_realtime_cohort_calculation_schedules(client: Client):
     """
     from posthog.temporal.common.schedule import a_delete_schedule, a_schedule_exists
 
-    # First ensure all new percentile-based schedules are in place
+    # First ensure the active p0-p80 percentile-based schedules are in place
     await create_realtime_cohort_calculation_p0_p50_schedule(client)
     await create_realtime_cohort_calculation_p50_p80_schedule(client)
-    await create_realtime_cohort_calculation_p80_p90_schedule(client)
-    await create_realtime_cohort_calculation_p90_p95_schedule(client)
-    await create_realtime_cohort_calculation_p95_p99_schedule(client)
-    await create_realtime_cohort_calculation_p99_p100_schedule(client)
+
+    # Delete the disabled p80-p100 tiers so any previously registered schedules stop firing
+    for disabled_schedule_id in (
+        REALTIME_COHORT_CALCULATION_P80_P90_SCHEDULE_ID,
+        REALTIME_COHORT_CALCULATION_P90_P95_SCHEDULE_ID,
+        REALTIME_COHORT_CALCULATION_P95_P99_SCHEDULE_ID,
+        REALTIME_COHORT_CALCULATION_P99_P100_SCHEDULE_ID,
+    ):
+        if await a_schedule_exists(client, disabled_schedule_id):
+            await a_delete_schedule(client, disabled_schedule_id)
 
     # Then clean up the legacy schedules if they exist to prevent duplicate runs
     if await a_schedule_exists(client, REALTIME_COHORT_CALCULATION_SCHEDULE_ID):


### PR DESCRIPTION
## Problem

Realtime cohorts are recalculated by a set of Temporal schedules, each bucketed by the cohort's historical calculation duration into percentile tiers (p0-p50, p50-p80, p80-p90, p90-p95, p95-p99, p99-p100). The p80-p100 tiers cover the slowest, most expensive cohorts to recalculate. We want to only keep calculating the p0-p80 tiers for now and turn off p80-p100 to reduce ClickHouse and Temporal load while we evaluate the cost/benefit.

## Changes

In `create_all_realtime_cohort_calculation_schedules`:

- Only create the p0-p50 and p50-p80 schedules.
- Delete the p80-p90, p90-p95, p95-p99, and p99-p100 schedules if they already exist, so previously registered schedules stop firing on the next `schedule_temporal_workflows` run.
- Left the per-tier `create_*` helpers, settings, and schedule-ID constants in place, so re-enabling is a one-line revert.

This is a schedule-registration change only. It does not touch any `@workflow.defn` body, so there are no Temporal determinism concerns.

## How did you test this code?

I (Claude) did not run the app or a live Temporal instance. I ran `ruff check` and `ruff format --check` on the changed file (both pass). The repo's `hogli ci:preflight` was unavailable in this environment. Verified by re-reading the function that it now creates exactly p0-p50 and p50-p80, deletes the four p80+ tiers when present, and still cleans up the legacy schedule IDs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @gustavohstrassburger and implemented by Claude. The change is confined to `posthog/temporal/messaging/schedule.py`. I explored the realtime cohort calculation system first to confirm the percentile tiers are registered in a single entry point (`create_all_realtime_cohort_calculation_schedules`) and that disabling a tier is a matter of not creating its schedule plus deleting any already-registered one. I chose to delete the disabled schedules (matching the existing legacy-cleanup pattern in the same function) rather than pause them, and to keep the now-unused create helpers, settings, and constants so re-enabling is trivial. No skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
