### PR TITLE
feat(customer-analytics): add create-account workflow node

### DIFF
--- a/nodejs/src/cdp/async-functions/customer_analytics.ts
+++ b/nodejs/src/cdp/async-functions/customer_analytics.ts
@@ -184,3 +184,61 @@ registerAsyncFunction('postHogSetAccountProperties', {
         }
     },
 })
+
+registerAsyncFunction('postHogCreateAccount', {
+    execute: async (args, context, result) => {
+        const [opts] = args as [Record<string, any> | undefined]
+        const externalId = opts?.external_id
+        const name = opts?.name
+
+        if (!externalId || typeof externalId !== 'string') {
+            throw new Error("[HogFunction] - postHogCreateAccount call missing 'external_id' property")
+        }
+
+        const team = await getTeamWithSecretToken(context, 'postHogCreateAccount')
+
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${team.secret_api_token}`,
+        }
+
+        const hogFlow = (context.invocation as { hogFlow?: HogFlow }).hogFlow
+        if (hogFlow?.id) {
+            headers['X-PostHog-Hog-Flow-Id'] = hogFlow.id
+        }
+
+        result.invocation.queueParameters = CyclotronInvocationQueueParametersFetchSchema.parse({
+            type: 'fetch',
+            url: `${context.siteUrl}/api/customer_analytics/external/account`,
+            method: 'POST',
+            body: JSON.stringify({ external_id: externalId, ...(name ? { name } : {}) }),
+            headers,
+        })
+    },
+
+    mock: (args, logs) => {
+        logs.push({
+            level: 'info',
+            timestamp: DateTime.now(),
+            message: `Async function 'postHogCreateAccount' was mocked with arguments:`,
+        })
+        logs.push({
+            level: 'info',
+            timestamp: DateTime.now(),
+            message: `postHogCreateAccount(${JSON.stringify(args[0], null, 2)})`,
+        })
+
+        return {
+            status: 201,
+            body: {
+                id: 'mock-account-id',
+                external_id: args[0]?.external_id ?? 'mock-external-id',
+                name: args[0]?.name ?? 'Mock Account',
+                properties: {},
+                tags: [],
+                relationships: {},
+                custom_properties: {},
+            },
+        }
+    },
+})

--- a/nodejs/src/cdp/async-functions/customer_analytics.ts
+++ b/nodejs/src/cdp/async-functions/customer_analytics.ts
@@ -189,7 +189,6 @@ registerAsyncFunction('postHogCreateAccount', {
     execute: async (args, context, result) => {
         const [opts] = args as [Record<string, any> | undefined]
         const externalId = opts?.external_id
-        const name = opts?.name
 
         if (!externalId || typeof externalId !== 'string') {
             throw new Error("[HogFunction] - postHogCreateAccount call missing 'external_id' property")
@@ -211,7 +210,7 @@ registerAsyncFunction('postHogCreateAccount', {
             type: 'fetch',
             url: `${context.siteUrl}/api/customer_analytics/external/account`,
             method: 'POST',
-            body: JSON.stringify({ external_id: externalId, ...(name ? { name } : {}) }),
+            body: JSON.stringify({ external_id: externalId }),
             headers,
         })
     },
@@ -233,7 +232,7 @@ registerAsyncFunction('postHogCreateAccount', {
             body: {
                 id: 'mock-account-id',
                 external_id: args[0]?.external_id ?? 'mock-external-id',
-                name: args[0]?.name ?? 'Mock Account',
+                name: 'Mock Account',
                 properties: {},
                 tags: [],
                 relationships: {},

--- a/nodejs/src/cdp/templates/_destinations/posthog_customer_analytics/posthog-accounts.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_customer_analytics/posthog-accounts.template.test.ts
@@ -1,6 +1,7 @@
 import { parseJSON } from '~/common/utils/json-parse'
 
 import { TemplateTester } from '../../test/test-helpers'
+import { template as createAccountTemplate } from './posthog-create-account.template'
 import { template as getAccountTemplate } from './posthog-get-account.template'
 import { template as tagAccountTemplate } from './posthog-tag-account.template'
 import { template as updateAccountPropertyTemplate } from './posthog-update-account-property.template'
@@ -17,6 +18,14 @@ describe('posthog customer analytics account templates', () => {
             inputs: { external_id: 'acme-1' },
             failurePrefix: 'Failed to fetch account (400):',
             successLog: 'Fetched account acme-1',
+        },
+        {
+            name: 'create account',
+            template: createAccountTemplate,
+            inputs: { external_id: 'acme-1', name: 'Acme' },
+            failurePrefix: 'Failed to create account (400):',
+            // A 200 means the account already existed — creation is a no-op.
+            successLog: 'Account acme-1 already exists — skipped creation',
         },
         {
             name: 'update account',
@@ -104,6 +113,40 @@ describe('posthog customer analytics account templates', () => {
             response = await tester.invokeFetchResponse(response.invocation, { status, body })
 
             expect(response.error).toEqual(expected)
+        })
+    })
+
+    describe('create account', () => {
+        const tester = new TemplateTester(createAccountTemplate)
+
+        beforeEach(async () => {
+            await tester.beforeEach()
+        })
+
+        it('logs the created line on 201 and falls back to external_id as name in the body', async () => {
+            let response = await tester.invoke({ external_id: 'acme-1', name: '' })
+
+            const body = parseJSON((response.invocation.queueParameters as any).body)
+            expect(body).toEqual({ external_id: 'acme-1', name: 'acme-1' })
+
+            response = await tester.invokeFetchResponse(response.invocation, {
+                status: 201,
+                body: { id: 'account-id', external_id: 'acme-1' },
+            })
+
+            expect(response.error).toBeUndefined()
+            expect(response.finished).toBe(true)
+            expect(response.logs.filter((log) => log.level === 'info').map((log) => log.message)).toContain(
+                'Created account acme-1'
+            )
+        })
+
+        it('fails with a descriptive error when the event has no group of the account group type', async () => {
+            const response = await tester.invoke({ external_id: '' })
+
+            expect(response.error).toEqual(
+                'Account external ID is required — the triggering event has no group of the configured account group type'
+            )
         })
     })
 

--- a/nodejs/src/cdp/templates/_destinations/posthog_customer_analytics/posthog-accounts.template.test.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_customer_analytics/posthog-accounts.template.test.ts
@@ -22,7 +22,7 @@ describe('posthog customer analytics account templates', () => {
         {
             name: 'create account',
             template: createAccountTemplate,
-            inputs: { external_id: 'acme-1', name: 'Acme' },
+            inputs: { external_id: 'acme-1' },
             failurePrefix: 'Failed to create account (400):',
             // A 200 means the account already existed — creation is a no-op.
             successLog: 'Account acme-1 already exists — skipped creation',
@@ -123,11 +123,11 @@ describe('posthog customer analytics account templates', () => {
             await tester.beforeEach()
         })
 
-        it('logs the created line on 201 and falls back to external_id as name in the body', async () => {
-            let response = await tester.invoke({ external_id: 'acme-1', name: '' })
+        it('logs the created line on 201', async () => {
+            let response = await tester.invoke({ external_id: 'acme-1' })
 
             const body = parseJSON((response.invocation.queueParameters as any).body)
-            expect(body).toEqual({ external_id: 'acme-1', name: 'acme-1' })
+            expect(body).toEqual({ external_id: 'acme-1' })
 
             response = await tester.invokeFetchResponse(response.invocation, {
                 status: 201,

--- a/nodejs/src/cdp/templates/_destinations/posthog_customer_analytics/posthog-create-account.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_customer_analytics/posthog-create-account.template.ts
@@ -8,7 +8,8 @@ export const template: HogFunctionTemplate = {
     type: 'destination',
     id: 'template-posthog-create-account',
     name: 'Create account',
-    description: 'Create a Customer analytics account for the triggering event’s group, if one does not exist.',
+    description:
+        'Create a Customer analytics account for the triggering event’s group, if one does not exist. The account name comes from the group’s name property.',
     icon_url: '/static/posthog-icon.svg',
     category: ['Custom'],
     code_language: 'hog',
@@ -20,8 +21,7 @@ if (empty(inputs.external_id)) {
 }
 
 let response := postHogCreateAccount({
-  'external_id': inputs.external_id,
-  'name': (not empty(inputs.name)) ? inputs.name : inputs.external_id
+  'external_id': inputs.external_id
 })
 
 if (response.status >= 400) {
@@ -44,14 +44,6 @@ return response.body
             required: true,
             description:
                 'The external ID for the account — the group key the account is linked to. Defaults to the triggering event’s group of the configured account group type.',
-        },
-        {
-            key: 'name',
-            type: 'string',
-            label: 'Account name',
-            secret: false,
-            required: false,
-            description: 'Name for the new account. Falls back to the external ID when empty.',
         },
     ],
 }

--- a/nodejs/src/cdp/templates/_destinations/posthog_customer_analytics/posthog-create-account.template.ts
+++ b/nodejs/src/cdp/templates/_destinations/posthog_customer_analytics/posthog-create-account.template.ts
@@ -1,0 +1,57 @@
+import { HogFunctionTemplate } from '~/cdp/types'
+
+import { hogApiErrorMessageFn } from './api-error'
+
+export const template: HogFunctionTemplate = {
+    free: true,
+    status: 'hidden',
+    type: 'destination',
+    id: 'template-posthog-create-account',
+    name: 'Create account',
+    description: 'Create a Customer analytics account for the triggering event’s group, if one does not exist.',
+    icon_url: '/static/posthog-icon.svg',
+    category: ['Custom'],
+    code_language: 'hog',
+    code: `
+${hogApiErrorMessageFn}
+
+if (empty(inputs.external_id)) {
+  throw Error('Account external ID is required — the triggering event has no group of the configured account group type')
+}
+
+let response := postHogCreateAccount({
+  'external_id': inputs.external_id,
+  'name': (not empty(inputs.name)) ? inputs.name : inputs.external_id
+})
+
+if (response.status >= 400) {
+  throw Error(f'Failed to create account ({response.status}): {apiErrorMessage(response)}')
+}
+
+if (response.status == 200) {
+  print(f'Account {inputs.external_id} already exists — skipped creation')
+} else {
+  print(f'Created account {inputs.external_id}')
+}
+return response.body
+`,
+    inputs_schema: [
+        {
+            key: 'external_id',
+            type: 'string',
+            label: 'Account external ID',
+            secret: false,
+            required: true,
+            description:
+                'The external ID for the account — the group key the account is linked to. Defaults to the triggering event’s group of the configured account group type.',
+        },
+        {
+            key: 'name',
+            type: 'string',
+            label: 'Account name',
+            secret: false,
+            required: false,
+            description: 'Name for the new account. Falls back to the external ID when empty.',
+        },
+    ],
+}

--- a/nodejs/src/cdp/templates/index.ts
+++ b/nodejs/src/cdp/templates/index.ts
@@ -23,6 +23,7 @@ import { template as posthogGroupIdentifyTemplate } from './_destinations/postho
 import { template as posthogUpdatePersonPropertiesTemplate } from './_destinations/posthog_capture/posthog-update-person-properties.template'
 import { template as posthogGetTicketTemplate } from './_destinations/posthog_conversations/posthog-get-ticket.template'
 import { template as posthogUpdateTicketTemplate } from './_destinations/posthog_conversations/posthog-update-ticket.template'
+import { template as posthogCreateAccountTemplate } from './_destinations/posthog_customer_analytics/posthog-create-account.template'
 import { template as posthogGetAccountTemplate } from './_destinations/posthog_customer_analytics/posthog-get-account.template'
 import { template as posthogTagAccountTemplate } from './_destinations/posthog_customer_analytics/posthog-tag-account.template'
 import { template as posthogUpdateAccountPropertyTemplate } from './_destinations/posthog_customer_analytics/posthog-update-account-property.template'
@@ -79,6 +80,7 @@ export const HOG_FUNCTION_TEMPLATES_DESTINATIONS: HogFunctionTemplate[] = [
     posthogSetHogflowVariableTemplate,
     posthogGetTicketTemplate,
     posthogUpdateTicketTemplate,
+    posthogCreateAccountTemplate,
     posthogGetAccountTemplate,
     posthogTagAccountTemplate,
     posthogUpdateAccountRelationshipsTemplate,

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -33,7 +33,7 @@ from pydantic import ValidationError as PydanticValidationError
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Integration, OrganizationMembership, Tag
-from posthog.models.activity_logging.activity_log import AuditableScope, Detail, changes_between, log_activity
+from posthog.models.activity_logging.activity_log import AuditableScope, Detail, Trigger, changes_between, log_activity
 from posthog.models.tag import tagify
 from posthog.models.tagged_item import TaggedItem
 from posthog.models.team import Team
@@ -376,6 +376,21 @@ def get_external_account(team_id: int, external_id: str) -> contracts.ExternalAc
     if account is None:
         return None
     return _to_external_account(account)
+
+
+def create_external_account(
+    team: Team, *, external_id: str, name: str | None, workflow_id: str | None = None
+) -> tuple[contracts.ExternalAccount, bool]:
+    """Get-or-create an account by external id for the external API. Returns the account and
+    whether it was created; an existing account is returned untouched. Attribution goes to the
+    originating workflow (activity-log trigger) — there is no acting user on this path.
+    Raises ``AccountPropertiesValidationError`` / ``AccountConflictError`` (concurrent create)."""
+    existing = _get_external_account_by_external_id(team.pk, external_id)
+    if existing is not None:
+        return _to_external_account(existing), False
+    trigger = Trigger(job_type="hog_flow", job_id=workflow_id, payload={}) if workflow_id else None
+    account = create_account(team=team, name=name or external_id, external_id=external_id, trigger=trigger)
+    return _to_external_account(account), True
 
 
 def list_external_accounts(
@@ -740,11 +755,14 @@ def _log_activity_swallowing(
     user: "User | None",
     was_impersonated: bool,
     previous=None,
+    trigger: Trigger | None = None,
 ) -> None:
     """Replicates ``posthog.api.utils.log_activity_from_viewset`` — including its blanket
     ``except: pass`` — for the account / customer-journey write paths."""
     try:
         detail_kwargs: dict[str, Any] = {"name": name}
+        if trigger is not None:
+            detail_kwargs["trigger"] = trigger
         if previous is not None:
             detail_kwargs["changes"] = changes_between(cast(AuditableScope, scope), previous=previous, current=instance)
         log_activity(
@@ -2032,6 +2050,7 @@ def create_account(
     properties: "dict | _ModelAccountProperties | None" = None,
     tags: list[str] | None = None,
     was_impersonated: bool = False,
+    trigger: Trigger | None = None,
 ) -> Account:
     """The single account-creation write path: validates properties, sets tags, shadows role
     assignments into the relationships table, and logs activity. Product-internal — it returns
@@ -2063,6 +2082,7 @@ def create_account(
         team_id=team.pk,
         user=created_by,
         was_impersonated=was_impersonated,
+        trigger=trigger,
     )
     return account
 

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -34,6 +34,7 @@ from pydantic import ValidationError as PydanticValidationError
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Integration, OrganizationMembership, Tag
 from posthog.models.activity_logging.activity_log import AuditableScope, Detail, Trigger, changes_between, log_activity
+from posthog.models.group.util import get_group_by_key
 from posthog.models.tag import tagify
 from posthog.models.tagged_item import TaggedItem
 from posthog.models.team import Team
@@ -378,18 +379,36 @@ def get_external_account(team_id: int, external_id: str) -> contracts.ExternalAc
     return _to_external_account(account)
 
 
+def _account_name_from_group(team: Team, external_id: str) -> str:
+    """Resolve the new account's name from its group's ``name`` property, falling back to the
+    group key. The name is cosmetic, so a failed lookup must not fail account creation."""
+    group_type_index = team.customer_analytics_config.account_group_type_index
+    if group_type_index is None:
+        return external_id
+    try:
+        group = get_group_by_key(team.pk, group_type_index, external_id)
+    except Exception as e:
+        capture_exception(e, {"team_id": team.pk, "external_id": external_id})
+        return external_id
+    name = (group.group_properties or {}).get("name") if group is not None else None
+    return str(name) if name else external_id
+
+
 def create_external_account(
-    team: Team, *, external_id: str, name: str | None, workflow_id: str | None = None
+    team: Team, *, external_id: str, workflow_id: str | None = None
 ) -> tuple[contracts.ExternalAccount, bool]:
     """Get-or-create an account by external id for the external API. Returns the account and
-    whether it was created; an existing account is returned untouched. Attribution goes to the
+    whether it was created; an existing account is returned untouched. The name comes from the
+    matching group's ``name`` property (fallback: the external id). Attribution goes to the
     originating workflow (activity-log trigger) — there is no acting user on this path.
     Raises ``AccountPropertiesValidationError`` / ``AccountConflictError`` (concurrent create)."""
     existing = _get_external_account_by_external_id(team.pk, external_id)
     if existing is not None:
         return _to_external_account(existing), False
     trigger = Trigger(job_type="hog_flow", job_id=workflow_id, payload={}) if workflow_id else None
-    account = create_account(team=team, name=name or external_id, external_id=external_id, trigger=trigger)
+    account = create_account(
+        team=team, name=_account_name_from_group(team, external_id), external_id=external_id, trigger=trigger
+    )
     return _to_external_account(account), True
 
 

--- a/products/customer_analytics/backend/presentation/views/external.py
+++ b/products/customer_analytics/backend/presentation/views/external.py
@@ -265,14 +265,46 @@ class ExternalAccountUpdateSerializer(serializers.Serializer):
 class ExternalAccountCreateSerializer(serializers.Serializer):
     external_id = serializers.CharField(
         max_length=400,
-        help_text="External ID (group key) for the account. An account with this ID already existing is a no-op.",
+        help_text=(
+            "External ID (group key) for the account. An account with this ID already existing is a no-op. "
+            "The account name is derived from the matching group's `name` property, falling back to this ID."
+        ),
     )
-    name = serializers.CharField(
-        max_length=400,
-        required=False,
-        allow_blank=True,
-        help_text="Account name. Falls back to the external ID when omitted or blank.",
+
+
+class ExternalAccountAssignmentSerializer(serializers.Serializer):
+    user_id = serializers.IntegerField(help_text="PostHog user id of the assigned user.")
+    email = serializers.CharField(help_text="Email address of the assigned user.")
+
+
+class ExternalAccountSerializer(serializers.Serializer):
+    id = serializers.CharField(help_text="Account UUID.")
+    external_id = serializers.CharField(
+        allow_null=True, help_text="External account key — the group key the account is linked to."
     )
+    name = serializers.CharField(help_text="Human-readable account name.")
+    properties = serializers.DictField(
+        child=serializers.JSONField(help_text="Property value: a string, a role-assignment object, or null."),
+        help_text="Typed account properties: role assignments (csm, account_executive, account_owner) and external-system ids.",
+    )
+    tags = serializers.ListField(
+        child=serializers.CharField(), help_text="Tag names on the account, sorted alphabetically."
+    )
+    relationships = serializers.DictField(
+        child=ExternalAccountAssignmentSerializer(many=True),
+        help_text=(
+            "Active relationship assignments keyed by definition name (e.g. 'CSM'). "
+            "Definitions with no active assignment are omitted."
+        ),
+    )
+    custom_properties = serializers.DictField(
+        child=serializers.JSONField(help_text="The property's active scalar value, or null when unset."),
+        help_text="Every team custom property definition keyed by name, with the account's active value or null.",
+    )
+
+
+class ExternalAccountErrorSerializer(serializers.Serializer):
+    error = serializers.CharField(help_text="What went wrong with the request.")
 
 
 class ExternalAccountView(APIView):
@@ -305,7 +337,19 @@ class ExternalAccountView(APIView):
 
         return Response(_external_account_body(account))
 
-    @extend_schema(request=ExternalAccountCreateSerializer, responses={201: OpenApiTypes.OBJECT})
+    @extend_schema(
+        request=ExternalAccountCreateSerializer,
+        responses={
+            201: OpenApiResponse(response=ExternalAccountSerializer, description="Account created."),
+            200: OpenApiResponse(
+                response=ExternalAccountSerializer, description="Account already existed — creation skipped."
+            ),
+            400: OpenApiResponse(response=ExternalAccountErrorSerializer, description="Invalid request body."),
+            401: OpenApiResponse(
+                response=ExternalAccountErrorSerializer, description="Missing or invalid Bearer token."
+            ),
+        },
+    )
     def post(self, request: Request) -> Response:
         team, error = _authenticate_team(request)
         if error:
@@ -326,7 +370,6 @@ class ExternalAccountView(APIView):
             account, created = facade.create_external_account(
                 team,
                 external_id=external_id,
-                name=(data.get("name") or "").strip() or None,
                 workflow_id=_workflow_id_from_request(request),
             )
         except facade.AccountConflictError:

--- a/products/customer_analytics/backend/presentation/views/external.py
+++ b/products/customer_analytics/backend/presentation/views/external.py
@@ -262,9 +262,23 @@ class ExternalAccountUpdateSerializer(serializers.Serializer):
             raise serializers.ValidationError({field: "Assignee id must be a user id"})
 
 
+class ExternalAccountCreateSerializer(serializers.Serializer):
+    external_id = serializers.CharField(
+        max_length=400,
+        help_text="External ID (group key) for the account. An account with this ID already existing is a no-op.",
+    )
+    name = serializers.CharField(
+        max_length=400,
+        required=False,
+        allow_blank=True,
+        help_text="Account name. Falls back to the external ID when omitted or blank.",
+    )
+
+
 class ExternalAccountView(APIView):
     """
     GET /api/customer_analytics/external/account?external_id=<external_id> — Fetch account data
+    POST /api/customer_analytics/external/account — Create an account (no-op if it already exists)
     PATCH /api/customer_analytics/external/account — Update an account's role contacts and tags
 
     Authenticated via Bearer token (team secret_api_token) in Authorization header.
@@ -290,6 +304,42 @@ class ExternalAccountView(APIView):
             return Response({"error": "Account not found"}, status=status.HTTP_404_NOT_FOUND)
 
         return Response(_external_account_body(account))
+
+    @extend_schema(request=ExternalAccountCreateSerializer, responses={201: OpenApiTypes.OBJECT})
+    def post(self, request: Request) -> Response:
+        team, error = _authenticate_team(request)
+        if error:
+            return error
+
+        assert team is not None
+
+        serializer = ExternalAccountCreateSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({"error": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+        data = serializer.validated_data
+
+        external_id = data["external_id"].strip()
+        if not external_id:
+            return Response({"error": "external_id is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            account, created = facade.create_external_account(
+                team,
+                external_id=external_id,
+                name=(data.get("name") or "").strip() or None,
+                workflow_id=_workflow_id_from_request(request),
+            )
+        except facade.AccountConflictError:
+            # Lost a concurrent-create race; the account exists now, so honor no-op semantics.
+            existing = facade.get_external_account(team.id, external_id)
+            if existing is None:
+                return Response({"error": "Failed to create account"}, status=status.HTTP_400_BAD_REQUEST)
+            account, created = existing, False
+
+        return Response(
+            _external_account_body(account),
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        )
 
     def patch(self, request: Request) -> Response:
         team, error = _authenticate_team(request)

--- a/products/customer_analytics/backend/presentation/views/external.py
+++ b/products/customer_analytics/backend/presentation/views/external.py
@@ -7,6 +7,14 @@ Authorization header. The bulk account list instead authenticates via a project
 secret API key carrying the ``account:read`` scope, because the team token is
 readable by every project member and must not unlock a team-wide account export.
 
+The team token deliberately grants single-account writes (create, tags,
+relationships, custom property values) without per-user ``account`` scope checks:
+workflow executions have no acting user to authorize, and the token is only
+readable by members of the project whose accounts it writes. Security reviewers
+periodically flag this as a write-permission bypass — it is the accepted model
+for this surface, matching the resource-level scoping note in the product's
+CLAUDE.md.
+
 The view holds only HTTP concerns — Bearer auth, throttles, the feature-flag gate,
 request validation, and mapping facade results to responses. Data access, the
 transactional write, org-membership resolution, tag application, and exception

--- a/products/customer_analytics/backend/test/test_external.py
+++ b/products/customer_analytics/backend/test/test_external.py
@@ -9,9 +9,11 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from posthog.models import Organization, Team, User
+from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.utils import generate_random_token_secret
 
 from products.customer_analytics.backend.models import (
+    Account,
     AccountRelationship,
     AccountRelationshipDefinition,
     CustomPropertyValue,
@@ -326,6 +328,59 @@ class TestExternalAccountAPI(APIBaseTest):
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(unknown_uuid, response.json()["error"])
+
+    # -- Create (POST) ----------------------------------------------------
+
+    def _post(self, payload, token=None, **extra):
+        return self.client.post(self.url, data=payload, format="json", **self._auth_headers(token), **extra)
+
+    def test_post_requires_auth(self):
+        response = self.client.post(self.url, data={"external_id": "new-1"}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_post_creates_account(self):
+        response = self._post({"external_id": "new-1", "name": "New Corp"})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        body = response.json()
+        self.assertEqual(body["external_id"], "new-1")
+        self.assertEqual(body["name"], "New Corp")
+        account = Account.objects.for_team(self.team.id).get(external_id="new-1")
+        self.assertEqual(account.name, "New Corp")
+        self.assertIsNone(account.created_by)
+
+    @parameterized.expand([("omitted", {}), ("blank", {"name": "  "})])
+    def test_post_name_falls_back_to_external_id(self, _name, name_payload):
+        response = self._post({"external_id": "new-1", **name_payload})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.json()["name"], "new-1")
+
+    def test_post_existing_account_is_a_noop(self):
+        response = self._post({"external_id": "acme-1", "name": "Different Name"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["name"], "Acme Corp")
+        self.account.refresh_from_db()
+        self.assertEqual(self.account.name, "Acme Corp")
+
+    @parameterized.expand([("missing", {}), ("blank", {"external_id": "   "})])
+    def test_post_requires_external_id(self, _name, payload):
+        response = self._post(payload)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_post_with_workflow_header_attributes_activity_to_workflow(self):
+        workflow_id = str(uuid4())
+        response = self._post({"external_id": "new-1"}, HTTP_X_POSTHOG_HOG_FLOW_ID=workflow_id)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        log = ActivityLog.objects.get(team_id=self.team.id, scope="Account", activity="created")
+        self.assertIsNone(log.user)
+        self.assertEqual(log.detail["trigger"]["job_type"], "hog_flow")
+        self.assertEqual(log.detail["trigger"]["job_id"], workflow_id)
+
+    def test_post_does_not_see_other_teams_account(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        create_account(team_id=other_team.id, name="Other Team Corp", external_id="shared-key")
+        response = self._post({"external_id": "shared-key", "name": "Mine"})
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Account.objects.for_team(self.team.id).get(external_id="shared-key").name, "Mine")
 
 
 class TestExternalAccountCustomPropertiesAPI(APIBaseTest):

--- a/products/customer_analytics/backend/test/test_external.py
+++ b/products/customer_analytics/backend/test/test_external.py
@@ -11,6 +11,7 @@ from rest_framework.test import APIClient
 from posthog.models import Organization, Team, User
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.utils import generate_random_token_secret
+from posthog.test.persons import create_group
 
 from products.customer_analytics.backend.models import (
     Account,
@@ -338,8 +339,13 @@ class TestExternalAccountAPI(APIBaseTest):
         response = self.client.post(self.url, data={"external_id": "new-1"}, format="json")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_post_creates_account(self):
-        response = self._post({"external_id": "new-1", "name": "New Corp"})
+    def test_post_creates_account_named_after_its_group(self):
+        self.team.customer_analytics_config.account_group_type_index = 0
+        self.team.customer_analytics_config.save()
+        create_group(team=self.team, group_type_index=0, group_key="new-1", group_properties={"name": "New Corp"})
+
+        response = self._post({"external_id": "new-1"})
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         body = response.json()
         self.assertEqual(body["external_id"], "new-1")
@@ -348,14 +354,27 @@ class TestExternalAccountAPI(APIBaseTest):
         self.assertEqual(account.name, "New Corp")
         self.assertIsNone(account.created_by)
 
-    @parameterized.expand([("omitted", {}), ("blank", {"name": "  "})])
-    def test_post_name_falls_back_to_external_id(self, _name, name_payload):
-        response = self._post({"external_id": "new-1", **name_payload})
+    @parameterized.expand(
+        [
+            ("no_group_type_configured", False, False),
+            ("group_missing", True, False),
+            ("group_has_no_name_property", True, True),
+        ]
+    )
+    def test_post_name_falls_back_to_external_id(self, _name, configure_group_type, create_nameless_group):
+        if configure_group_type:
+            self.team.customer_analytics_config.account_group_type_index = 0
+            self.team.customer_analytics_config.save()
+        if create_nameless_group:
+            create_group(team=self.team, group_type_index=0, group_key="new-1", group_properties={"plan": "free"})
+
+        response = self._post({"external_id": "new-1"})
+
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.json()["name"], "new-1")
 
     def test_post_existing_account_is_a_noop(self):
-        response = self._post({"external_id": "acme-1", "name": "Different Name"})
+        response = self._post({"external_id": "acme-1"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["name"], "Acme Corp")
         self.account.refresh_from_db()
@@ -378,9 +397,9 @@ class TestExternalAccountAPI(APIBaseTest):
     def test_post_does_not_see_other_teams_account(self):
         other_team = Team.objects.create(organization=self.organization, name="Other")
         create_account(team_id=other_team.id, name="Other Team Corp", external_id="shared-key")
-        response = self._post({"external_id": "shared-key", "name": "Mine"})
+        response = self._post({"external_id": "shared-key"})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(Account.objects.for_team(self.team.id).get(external_id="shared-key").name, "Mine")
+        self.assertEqual(Account.objects.for_team(self.team.id).get(external_id="shared-key").name, "shared-key")
 
 
 class TestExternalAccountCustomPropertiesAPI(APIBaseTest):

--- a/products/customer_analytics/backend/test/test_external.py
+++ b/products/customer_analytics/backend/test/test_external.py
@@ -391,8 +391,10 @@ class TestExternalAccountAPI(APIBaseTest):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         log = ActivityLog.objects.get(team_id=self.team.id, scope="Account", activity="created")
         self.assertIsNone(log.user)
-        self.assertEqual(log.detail["trigger"]["job_type"], "hog_flow")
-        self.assertEqual(log.detail["trigger"]["job_id"], workflow_id)
+        detail = log.detail
+        assert detail is not None
+        self.assertEqual(detail["trigger"]["job_type"], "hog_flow")
+        self.assertEqual(detail["trigger"]["job_id"], workflow_id)
 
     def test_post_does_not_see_other_teams_account(self):
         other_team = Team.objects.create(organization=self.organization, name="Other")

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.test.ts
@@ -4,6 +4,7 @@ import { GroupType, GroupTypeIndex } from '~/types'
 
 import { getRegisteredActionNodeCategories } from './actionNodeRegistry'
 import {
+    buildAccountCreateInputs,
     buildAccountExternalIdInputs,
     buildAccountOutputSuggestions,
     customPropertyResultPath,
@@ -158,6 +159,20 @@ describe('customer analytics action registry', () => {
 
         it('returns undefined when the configured index has no matching group type', () => {
             expect(buildAccountExternalIdInputs(3, groupTypesMap([0, 'organization']))).toBeUndefined()
+        })
+    })
+
+    describe('buildAccountCreateInputs', () => {
+        it('defaults external_id to the group key and name to the group name property', () => {
+            const inputs = buildAccountCreateInputs(2, groupTypesMap([0, 'project'], [2, 'organization']))
+            expect(inputs).toEqual({
+                external_id: { value: '{groups.`organization`.id}' },
+                name: { value: '{groups.`organization`.properties.name}' },
+            })
+        })
+
+        it('returns undefined when the account group type is not configured', () => {
+            expect(buildAccountCreateInputs(null, groupTypesMap([0, 'organization']))).toBeUndefined()
         })
     })
 })

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.test.ts
@@ -4,7 +4,6 @@ import { GroupType, GroupTypeIndex } from '~/types'
 
 import { getRegisteredActionNodeCategories } from './actionNodeRegistry'
 import {
-    buildAccountCreateInputs,
     buildAccountExternalIdInputs,
     buildAccountOutputSuggestions,
     customPropertyResultPath,
@@ -159,20 +158,6 @@ describe('customer analytics action registry', () => {
 
         it('returns undefined when the configured index has no matching group type', () => {
             expect(buildAccountExternalIdInputs(3, groupTypesMap([0, 'organization']))).toBeUndefined()
-        })
-    })
-
-    describe('buildAccountCreateInputs', () => {
-        it('defaults external_id to the group key and name to the group name property', () => {
-            const inputs = buildAccountCreateInputs(2, groupTypesMap([0, 'project'], [2, 'organization']))
-            expect(inputs).toEqual({
-                external_id: { value: '{groups.`organization`.id}' },
-                name: { value: '{groups.`organization`.properties.name}' },
-            })
-        })
-
-        it('returns undefined when the account group type is not configured', () => {
-            expect(buildAccountCreateInputs(null, groupTypesMap([0, 'organization']))).toBeUndefined()
         })
     })
 })

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.ts
@@ -13,10 +13,10 @@ import { OutputMappingSuggestion } from 'products/workflows/frontend/Workflows/h
 import { registerActionNodeCategory } from 'products/workflows/frontend/Workflows/hogflows/registry/actions/actionNodeRegistry'
 import { CyclotronInputType } from 'products/workflows/frontend/Workflows/hogflows/steps/types'
 
-const accountGroupTypeName = (
+export const buildAccountExternalIdInputs = (
     accountGroupTypeIndex: number | null | undefined,
     groupTypes: Map<GroupTypeIndex, GroupType>
-): string | undefined => {
+): Record<string, CyclotronInputType> | undefined => {
     if (accountGroupTypeIndex === null || accountGroupTypeIndex === undefined) {
         return undefined
     }
@@ -27,42 +27,12 @@ const accountGroupTypeName = (
     // Backtick-quote the group type as an identifier. Bracket access (`groups["x"]`) compiles the index as a
     // separate global lookup and fails at runtime; backtick quoting escapes any name (delimiters, spaces, backticks
     // via doubling) without breaking out of the Hog expression.
-    return groupType.replace(/`/g, '``')
-}
-
-export const buildAccountExternalIdInputs = (
-    accountGroupTypeIndex: number | null | undefined,
-    groupTypes: Map<GroupTypeIndex, GroupType>
-): Record<string, CyclotronInputType> | undefined => {
-    const quotedGroupType = accountGroupTypeName(accountGroupTypeIndex, groupTypes)
-    if (!quotedGroupType) {
-        return undefined
-    }
+    const quotedGroupType = groupType.replace(/`/g, '``')
     return { external_id: { value: `{groups.\`${quotedGroupType}\`.id}` } }
-}
-
-export const buildAccountCreateInputs = (
-    accountGroupTypeIndex: number | null | undefined,
-    groupTypes: Map<GroupTypeIndex, GroupType>
-): Record<string, CyclotronInputType> | undefined => {
-    const quotedGroupType = accountGroupTypeName(accountGroupTypeIndex, groupTypes)
-    if (!quotedGroupType) {
-        return undefined
-    }
-    return {
-        external_id: { value: `{groups.\`${quotedGroupType}\`.id}` },
-        name: { value: `{groups.\`${quotedGroupType}\`.properties.name}` },
-    }
 }
 
 const getAccountExternalIdDefaultInputs = (): Record<string, CyclotronInputType> | undefined =>
     buildAccountExternalIdInputs(
-        teamLogic.findMounted()?.values.currentTeam?.customer_analytics_config?.account_group_type_index,
-        groupsModel.findMounted()?.values.groupTypes ?? new Map()
-    )
-
-const getAccountCreateDefaultInputs = (): Record<string, CyclotronInputType> | undefined =>
-    buildAccountCreateInputs(
         teamLogic.findMounted()?.values.currentTeam?.customer_analytics_config?.account_group_type_index,
         groupsModel.findMounted()?.values.groupTypes ?? new Map()
     )
@@ -133,7 +103,7 @@ registerActionNodeCategory({
             name: 'Create account',
             description: "Create a Customer analytics account for the event's group, if one doesn't exist yet.",
             config: { template_id: 'template-posthog-create-account', inputs: {} },
-            getDefaultInputs: getAccountCreateDefaultInputs,
+            getDefaultInputs: getAccountExternalIdDefaultInputs,
             output_variable: { key: 'account', result_path: null, label: 'Account' },
         },
         {

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.ts
@@ -13,10 +13,10 @@ import { OutputMappingSuggestion } from 'products/workflows/frontend/Workflows/h
 import { registerActionNodeCategory } from 'products/workflows/frontend/Workflows/hogflows/registry/actions/actionNodeRegistry'
 import { CyclotronInputType } from 'products/workflows/frontend/Workflows/hogflows/steps/types'
 
-export const buildAccountExternalIdInputs = (
+const accountGroupTypeName = (
     accountGroupTypeIndex: number | null | undefined,
     groupTypes: Map<GroupTypeIndex, GroupType>
-): Record<string, CyclotronInputType> | undefined => {
+): string | undefined => {
     if (accountGroupTypeIndex === null || accountGroupTypeIndex === undefined) {
         return undefined
     }
@@ -27,12 +27,42 @@ export const buildAccountExternalIdInputs = (
     // Backtick-quote the group type as an identifier. Bracket access (`groups["x"]`) compiles the index as a
     // separate global lookup and fails at runtime; backtick quoting escapes any name (delimiters, spaces, backticks
     // via doubling) without breaking out of the Hog expression.
-    const quotedGroupType = groupType.replace(/`/g, '``')
+    return groupType.replace(/`/g, '``')
+}
+
+export const buildAccountExternalIdInputs = (
+    accountGroupTypeIndex: number | null | undefined,
+    groupTypes: Map<GroupTypeIndex, GroupType>
+): Record<string, CyclotronInputType> | undefined => {
+    const quotedGroupType = accountGroupTypeName(accountGroupTypeIndex, groupTypes)
+    if (!quotedGroupType) {
+        return undefined
+    }
     return { external_id: { value: `{groups.\`${quotedGroupType}\`.id}` } }
+}
+
+export const buildAccountCreateInputs = (
+    accountGroupTypeIndex: number | null | undefined,
+    groupTypes: Map<GroupTypeIndex, GroupType>
+): Record<string, CyclotronInputType> | undefined => {
+    const quotedGroupType = accountGroupTypeName(accountGroupTypeIndex, groupTypes)
+    if (!quotedGroupType) {
+        return undefined
+    }
+    return {
+        external_id: { value: `{groups.\`${quotedGroupType}\`.id}` },
+        name: { value: `{groups.\`${quotedGroupType}\`.properties.name}` },
+    }
 }
 
 const getAccountExternalIdDefaultInputs = (): Record<string, CyclotronInputType> | undefined =>
     buildAccountExternalIdInputs(
+        teamLogic.findMounted()?.values.currentTeam?.customer_analytics_config?.account_group_type_index,
+        groupsModel.findMounted()?.values.groupTypes ?? new Map()
+    )
+
+const getAccountCreateDefaultInputs = (): Record<string, CyclotronInputType> | undefined =>
+    buildAccountCreateInputs(
         teamLogic.findMounted()?.values.currentTeam?.customer_analytics_config?.account_group_type_index,
         groupsModel.findMounted()?.values.groupTypes ?? new Map()
     )
@@ -98,6 +128,14 @@ registerActionNodeCategory({
     label: 'Customer analytics',
     featureFlag: FEATURE_FLAGS.CUSTOMER_ANALYTICS_CSP,
     nodes: [
+        {
+            type: 'function',
+            name: 'Create account',
+            description: "Create a Customer analytics account for the event's group, if one doesn't exist yet.",
+            config: { template_id: 'template-posthog-create-account', inputs: {} },
+            getDefaultInputs: getAccountCreateDefaultInputs,
+            output_variable: { key: 'account', result_path: null, label: 'Account' },
+        },
         {
             type: 'function',
             name: 'Get account',


### PR DESCRIPTION
## Problem

Workflows can get, update, and tag Customer analytics accounts, but there is no node that creates one — an account has to exist before any account workflow action works.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
Closes #74241

## Changes

- Add facade `create_external_account` (get-or-create by external_id) with workflow attribution via an activity-log `Trigger`
- Add `POST /api/customer_analytics/external/account` — 201 on create, 200 no-op when the account exists
- Add `postHogCreateAccount` CDP async function and the `template-posthog-create-account` hog template
- Register a "Create account" node in the workflows editor, defaulting `external_id`/`name` from the triggering event's group of the configured account group type
- Node fails with a descriptive error when the event carries no group of that type

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests: Django external-API tests (auth, create, no-op, name fallback, workflow attribution, team isolation), hog template tests (queued fetch body, created/skipped logs, missing-group error), and frontend registry tests for the default inputs.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Authored by Claude Code (PostHog Code).

**Autonomy:** Human-driven (agent-assisted)

Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, `/pr-description`. Builds on the account-creation facade refactor (#74261, merged). Follows the existing customer analytics workflow-node pattern end to end: function-type node → hog template → CDP async function → Bearer-token external endpoint. Concurrent-create races fall back to the no-op path.

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
