### PR TITLE
fix(llm-gateway): normalize Kimi K3 context management

### DIFF
--- a/services/llm-gateway/src/llm_gateway/modal_routing.py
+++ b/services/llm-gateway/src/llm_gateway/modal_routing.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from fastapi.responses import StreamingResponse
 
+from llm_gateway.anthropic_request import drop_orphaned_clear_thinking
 from llm_gateway.api.handler import (
     MODAL_ANTHROPIC_CONFIG,
     MODAL_OPENAI_CONFIG,
@@ -51,7 +52,12 @@ async def send_modal_anthropic_messages(
     request_data: dict[str, Any], user: AuthenticatedUser, is_streaming: bool, product: str
 ) -> dict[str, Any] | StreamingResponse:
     return await send_modal_request(
-        request_data, user, is_streaming, product, MODAL_ANTHROPIC_CONFIG, make_modal_anthropic_call
+        drop_orphaned_clear_thinking(request_data, product=product),
+        user,
+        is_streaming,
+        product,
+        MODAL_ANTHROPIC_CONFIG,
+        make_modal_anthropic_call,
     )
 
 

--- a/services/llm-gateway/tests/test_modal.py
+++ b/services/llm-gateway/tests/test_modal.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -14,6 +14,7 @@ from llm_gateway.modal import (
     make_modal_responses_call,
     should_route_glm_to_modal,
 )
+from llm_gateway.modal_routing import send_modal_anthropic_messages
 from llm_gateway.rate_limiting.cost_refresh import ALIAS_METRIC_LABELS, COST_ALIASES
 from llm_gateway.rate_limiting.model_cost_overrides import MODEL_COST_OVERRIDES
 
@@ -87,6 +88,22 @@ def test_kimi_uses_its_endpoint_with_shared_credentials() -> None:
         "wk-test",
         "ws-test",
     )
+
+
+async def test_modal_anthropic_drops_clear_thinking_when_thinking_is_disabled() -> None:
+    request = {
+        "model": KIMI_MODEL,
+        "messages": [{"role": "user", "content": "Hello"}],
+        "thinking": {"type": "disabled"},
+        "context_management": {"edits": [{"type": "clear_thinking_20251015", "keep": "all"}]},
+    }
+
+    with patch("llm_gateway.modal_routing.send_modal_request", new=AsyncMock(return_value={})) as send_request:
+        await send_modal_anthropic_messages(request, MagicMock(), False, "posthog_code")
+
+    forwarded_request = send_request.call_args.args[0]
+    assert "context_management" not in forwarded_request
+    assert request["context_management"] == {"edits": [{"type": "clear_thinking_20251015", "keep": "all"}]}
 
 
 @pytest.mark.parametrize("model", ["@cf/moonshotai/kimi-k2.6", "@cf/unknown/model", "zai-org/GLM-5.2-FP8"])


### PR DESCRIPTION
## Problem

Kimi K3 requests sent through the Modal Anthropic route can include a clear-thinking context edit while thinking is disabled. The Modal route bypasses the existing request normalization, so the upstream API rejects the turn.

**Why:** Cloud tasks using Kimi K3 should continue when the runtime disables thinking instead of failing on an incompatible context-management optimization