### PR TITLE
feat(dashboards): capture event on dashboard export

### DIFF
--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -7,8 +7,8 @@ import { TriggerExportProps, downloadBlob, downloadExportedAsset } from 'lib/com
 import { isLongRunningExportFormat } from 'lib/components/ExportButton/exportStatus'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { delay } from 'lib/utils/async'
-import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { uuid } from 'lib/utils/dom'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import type { SessionRecordingPlayerMode } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { urls } from 'scenes/urls'
 

--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -7,6 +7,7 @@ import { TriggerExportProps, downloadBlob, downloadExportedAsset } from 'lib/com
 import { isLongRunningExportFormat } from 'lib/components/ExportButton/exportStatus'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { delay } from 'lib/utils/async'
+import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { uuid } from 'lib/utils/dom'
 import type { SessionRecordingPlayerMode } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { urls } from 'scenes/urls'
@@ -238,6 +239,12 @@ export const exportsLogic = kea<exportsLogicType>([
 
     listeners(({ actions, values, cache }) => ({
         startExport: async ({ exportData }) => {
+            // Fires for every dashboard export entry point (menu bar, dropdown, export button)
+            // regardless of edit permission. Format is a property so PNG is filterable.
+            if (exportData.dashboard && exportData.export_format) {
+                eventUsageLogic.actions.reportDashboardExported(exportData.dashboard, exportData.export_format)
+            }
+
             if (isLocalExport(exportData.export_context)) {
                 try {
                     const blob = new Blob([exportData.export_context.localData], {

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -60,6 +60,7 @@ import {
     ExperimentHoldoutType,
     ExperimentIdType,
     ExperimentStatsMethod,
+    ExporterFormat,
     FilterLogicalOperator,
     FunnelCorrelation,
     HelpType,
@@ -612,6 +613,13 @@ export interface eventUsageLogicActions {
     ) => {
         dashboardId: number | undefined
         promptLabel: string
+    }
+    reportDashboardExported: (
+        dashboardId: number,
+        exportFormat: ExporterFormat
+    ) => {
+        dashboardId: number
+        exportFormat: ExporterFormat
     }
     reportDashboardFiltersChanged: (
         dashboard: DashboardType<QueryBasedInsightModel> | null,
@@ -2232,6 +2240,10 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             promptLabel,
             dashboardId,
         }),
+        reportDashboardExported: (dashboardId: number, exportFormat: ExporterFormat) => ({
+            dashboardId,
+            exportFormat,
+        }),
         reportUpgradeModalShown: (featureName: string) => ({ featureName }),
         reportTimezoneComponentViewed: (
             component: 'label' | 'indicator',
@@ -3234,6 +3246,12 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
                 prompt_label: promptLabel,
                 dashboard_id: dashboardId,
                 source: 'web',
+            })
+        },
+        reportDashboardExported: async ({ dashboardId, exportFormat }) => {
+            posthog.capture('dashboard exported', {
+                dashboard_id: dashboardId,
+                export_format: exportFormat,
             })
         },
         reportUpgradeModalShown: async (payload) => {


### PR DESCRIPTION
## Problem

We had no first-class analytics event for dashboard exports. The export buttons relied on generic autocapture (`data-attr` clicks), which is brittle and hard to slice by format. This request was specifically about knowing when people export a `.png` from a dashboard page.

## Changes

Added a `dashboard exported` event, captured from `exportsLogic`'s `startExport` listener. Firing there (rather than at each button) means it covers every entry point: the dashboard menu bar PNG item, the shared export dropdown, and the older export button, and it fires regardless of whether the user can edit the dashboard.

The export format is sent as a property, so PNG exports are just `export_format = png`. That also gives us PDF/CSV/etc. for free.

```
posthog.capture('dashboard exported', {
    dashboard_id,
    export_format,   // 'image/png' for PNG
})
```

Wired through `eventUsageLogic` (`reportDashboardExported`) to match how every other dashboard event is reported.

> [!NOTE]
> To answer the original question ("who exports a PNG"), filter this event to `export_format = png`.

## How did you test this code?

No automated tests added. This is a thin instrumentation event following the exact `reportDashboard*` pattern already in `eventUsageLogic`. I (the agent) could not run the frontend typecheck in this environment because dependencies weren't installed, so I updated the inline kea-typegen type block for `eventUsageLogic` by hand to match the new action. Worth a quick local `pnpm --filter=@posthog/frontend typescript:check` before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The requester asked for a new event whenever someone exports a PNG from any dashboard page. I chose to instrument centrally in `exportsLogic.startExport` rather than on each export button, so the event is complete across all export UIs and unaffected by the `canEditDashboard` gate on the menu-bar item, and to record `export_format` as a property so a single event answers PNG and every other format. No skills were required for this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ASA4U0AG3/p1785331725240599?thread_ts=1785331725.240599&cid=C0ASA4U0AG3)*
