### PR TITLE
fix(bigquery): stop retrying an ambiguous-column query

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -270,6 +270,17 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # The user must fix the source view/column; retrying just spams error tracking. Matched on
             # BigQuery's stable wording, not the volatile job id/URL.
             "Invalid NUMERIC value: NaN": "BigQuery couldn't complete a query for this source because it produced a NaN (not-a-number) value in a column typed NUMERIC, which that type can't represent. This is usually caused by a computed column or view doing arithmetic like division by zero. Please fix the underlying view or column in BigQuery, then re-enable the source.",
+            # Raised as a 400 BadRequest (reason `invalidQuery`) when the table or view being synced
+            # has a column name BigQuery can't resolve to a single source, e.g. "Column name x is
+            # ambiguous". We select each configured column by its own unqualified name (see
+            # `_get_query`/`_bq_select_clause` in `bigquery.py`), so this only happens when the
+            # underlying relation itself has the conflict — a view that joins tables sharing a column
+            # name, or a table/external table with two columns differing only by letter case. It's a
+            # deterministic property of the customer's view/table definition: the same query fails
+            # identically on every retry, so it just hammers BigQuery and spams error tracking. The
+            # user must fix the view or table definition. Matched on BigQuery's stable wording, not
+            # the volatile column name or [row:col] location.
+            "is ambiguous": "BigQuery couldn't run a query for this source because a column name in the table or view being synced is ambiguous. This usually happens when a view joins tables that share a column name, or two columns differ only by letter case. Retrying won't help — please update the view or table definition to remove the naming conflict (for example by aliasing the duplicate column), then reconnect the source.",
         }
 
     def validate_credentials(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -736,6 +736,26 @@ def test_bigquery_unparseable_private_key_is_non_retryable(observed_error):
 
 
 @pytest.mark.parametrize(
+    "observed_error",
+    [
+        # Column collision surfaced with the raw BigQuery [row:col] location.
+        "400 Column name organization is ambiguous at [1:113]; reason: invalidQuery, location: query, "
+        "message: Column name organization is ambiguous at [1:113]\n\nLocation: us-west1\nJob ID: cc9e1e07-9d3a-4fcc-a51c-09b2f4237894\n",
+        # Different column name and location — the match must not rely on either.
+        "400 Column name id is ambiguous at [2:45]; reason: invalidQuery, location: query, "
+        "message: Column name id is ambiguous at [2:45]",
+    ],
+)
+def test_bigquery_ambiguous_column_is_non_retryable(observed_error):
+    """A view/table whose own definition yields a colliding column name (e.g. a join of tables
+    sharing a column, or two columns differing only by case) makes every retry fail identically."""
+    non_retryable_errors = BigQuerySource().get_non_retryable_errors()
+    matching = [key for key in non_retryable_errors if key in observed_error]
+    assert matching, "Ambiguous column error should be recognised as non-retryable"
+    assert all(non_retryable_errors[key] is not None for key in matching)
+
+
+@pytest.mark.parametrize(
     "transient_error",
     [
         # A token refresh that failed for a transient reason must stay retryable.


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring BigQuery sync failure: [BadRequest: Column name ... is ambiguous](https://us.posthog.com/project/2/error_tracking/019fae12-7171-7382-92d6-5f753ff48d55), raised from `jobs.getQueryResults` (`reason: invalidQuery`) while copying an incremental/view/row-filtered read into a temp destination table.

The stack trace confirms this originates in the BigQuery source's own copy-to-temp-table path (`_run_destination_query_with_job_retry` / `_with_job_not_found_retry` in `bigquery.py`), not elsewhere.

## Changes

This is a compile-time SQL validation error rooted in the synced table or view's own schema — BigQuery can't resolve a bare column reference to a single source column. That happens when the underlying view joins tables that share a column name, or the table has two columns differing only by letter case. Our query only ever selects a single relation with fully-qualified, backtick-quoted column names (no joins are introduced by our SQL builder), so the ambiguity can't come from our generated query shape — it's a property of the customer's view/table definition, and the same query fails identically on every retry.

Added `"is ambiguous"` to `BigQuerySource.get_non_retryable_errors()`, following the existing pattern used for other deterministic, view/schema-rooted BigQuery failures (e.g. `"failed to parse view"`). The fix stops the sync from retrying forever and surfaces an actionable message asking the user to fix the naming conflict in their view/table definition.

## How did you test this code?

Added `test_bigquery_ambiguous_column_is_non_retryable`, parametrized over two observed error strings (different column name and `[row:col]` location) to guard against a key that accidentally depends on those volatile parts. Ran the full bigquery source test suite locally:

```
products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py — 160 passed
```

Also ran `ruff check` and `ruff format --check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification change, no user-facing behavior or docs to update beyond the in-app error message shown when the sync is disabled.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the BigQuery data-warehouse source. Confirmed the failure genuinely originates in `products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py` via the sampled event's stack trace, then classified it as a deterministic, view/schema-rooted upstream error (not a bug in our query-building code) and extended `NonRetryableErrors` accordingly, mirroring the existing `"failed to parse view"` precedent in the same file.

Searched open PRs (by error phrase, module path, and the account's own recent PRs) for a duplicate fix before proceeding — none covered this specific ambiguous-column error.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*