### PR TITLE
fix(dashboards): don't commit rejected tile refreshes as empty results

### DIFF
--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1355,6 +1355,51 @@ describe('dashboardLogic', () => {
                     })
             })
 
+            it('keeps tile data and marks the tile errored when a refresh terminates in a rejection stub', async () => {
+                const dashboard = dashboards[5]
+                const insight1 = dashboard.tiles[0].insight!
+                const insight2 = dashboard.tiles[1].insight!
+                const resultsBeforeRefresh = logic.values.insightTiles.map((t) => t.insight!.result)
+                expect(resultsBeforeRefresh.every((r) => r != null)).toBe(true)
+
+                // What getInsightWithRetry resolves to when the app-level concurrency limiter (or a
+                // server-side calculation error) rejects every attempt: an insight-shaped payload with
+                // no result and an errored query_status
+                const getInsightWithRetrySpy = jest
+                    .spyOn(dashboardUtils, 'getInsightWithRetry')
+                    .mockImplementation(async (_teamId, insight) => ({
+                        ...insight,
+                        result: null,
+                        query_status: {
+                            id: 'rejected-query',
+                            team_id: 2,
+                            query_async: true,
+                            complete: false,
+                            error: true,
+                            error_code: null,
+                            error_message: 'concurrency_limit_exceeded',
+                        },
+                    }))
+
+                try {
+                    await expectLogic(logic, () => {
+                        logic.actions.triggerDashboardRefresh()
+                    }).toFinishAllListeners()
+
+                    // The stub must not be committed as a successful refresh: tiles keep their data
+                    expect(logic.values.insightTiles.map((t) => t.insight!.result)).toEqual(resultsBeforeRefresh)
+                    // and surface an error state instead of rendering the null result as an empty insight
+                    expect(logic.values.refreshStatus[insight1.short_id]).toEqual(
+                        expect.objectContaining({ errored: true })
+                    )
+                    expect(logic.values.refreshStatus[insight2.short_id]).toEqual(
+                        expect.objectContaining({ errored: true })
+                    )
+                } finally {
+                    getInsightWithRetrySpy.mockRestore()
+                }
+            })
+
             it('pins the "X out of Y" denominator when a tile aborts mid-cycle and keeps siblings tracked', async () => {
                 const dashboard = dashboards[5]
                 const insight1 = dashboard.tiles[0].insight!
@@ -1801,6 +1846,30 @@ describe('dashboardLogic', () => {
             })
                 .toDispatchActions(['saveEditModeChanges', 'saveEditModeChangesSuccess', 'refreshDashboardItems'])
                 .toFinishAllListeners()
+        })
+
+        it('applying a variable value refreshes every tile with the new value attached to the request', async () => {
+            await mountDashboardWithVariable({})
+
+            const getInsightWithRetrySpy = jest
+                .spyOn(dashboardUtils, 'getInsightWithRetry')
+                .mockImplementation(async (_teamId, insight) => insight)
+
+            try {
+                await expectLogic(logic, () => {
+                    logic.actions.overrideVariableValue(variableId, 'applied-value', false)
+                })
+                    .toDispatchActions(['overrideVariableValue', 'refreshDashboardItems'])
+                    .toFinishAllListeners()
+
+                expect(getInsightWithRetrySpy).toHaveBeenCalledTimes(1)
+                const variablesOverride = getInsightWithRetrySpy.mock.calls[0][7]
+                expect(variablesOverride).toEqual({
+                    [variableId]: expect.objectContaining({ code_name: 'organization', value: 'applied-value' }),
+                })
+            } finally {
+                getInsightWithRetrySpy.mockRestore()
+            }
         })
     })
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -137,6 +137,7 @@ import {
     getInsightQueryError,
     getInsightWithRetry,
     isLayoutEditEventSource,
+    isRefreshRejectionStub,
     layoutsByTile,
     parseURLFilters,
     parseURLVariables,
@@ -3526,7 +3527,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     true
                 )
 
-                if (refreshedInsight) {
+                if (refreshedInsight && !isRefreshRejectionStub(refreshedInsight)) {
                     const queryError = getInsightQueryError(refreshedInsight)
                     if (queryError) {
                         actions.setRefreshError(insight.short_id, queryError)
@@ -3626,7 +3627,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             tile.filters_overrides
                         )
 
-                        if (refreshedInsight) {
+                        if (refreshedInsight && !isRefreshRejectionStub(refreshedInsight)) {
                             const queryError = getInsightQueryError(refreshedInsight)
                             if (queryError) {
                                 actions.setRefreshError(insight.short_id, queryError)
@@ -3638,7 +3639,6 @@ export const dashboardLogic = kea<dashboardLogicType>([
                                 if (refreshedInsight.is_cached) {
                                     tilesRefreshedCachedCount++
                                 }
-
                                 eventUsageLogic.actions.reportDashboardTileRefreshed(
                                     dashboardId,
                                     tile,

--- a/frontend/src/scenes/dashboard/dashboardUtils.ts
+++ b/frontend/src/scenes/dashboard/dashboardUtils.ts
@@ -177,6 +177,13 @@ export const DEFAULT_AUTO_PREVIEW_TILE_LIMIT = 10
 
 const RATE_LIMIT_ERROR_MESSAGE = 'concurrency_limit_exceeded'
 
+// A refresh that was rejected (concurrency limit, server-side calculation error) still resolves with an
+// insight-shaped payload: no result, an errored query_status. Committing it to the dashboard would wipe
+// the tile's existing data and render as an empty insight instead of an error.
+export function isRefreshRejectionStub(insight: QueryBasedInsightModel): boolean {
+    return !!insight.query_status?.error && insight.result == null
+}
+
 function staleAgeMinutes(effectiveLastRefresh: Dayjs | null): number | null {
     if (!effectiveLastRefresh) {
         return null


### PR DESCRIPTION
## Problem

A dashboard contains tiles that visualize query results. Dashboard variables let users change a shared value, such as a customer or environment, and apply it to every tile. Applying a variable refreshes the tiles so they show results for the new value.

During a refresh, each tile keeps its existing result until a new result arrives. If the refresh fails, the expected behavior is to retain that existing result and show an error.

Some query failures arrive as an HTTP 200 response containing an error and no result. The dashboard treated that response as a successful empty result, replaced the tile's existing result, and showed "There are no matching rows for this query." This made a failed refresh look like the query had run successfully but found no data.

One way this happens is when the organization already has too many dashboard queries running. Each browser limits a dashboard refresh to 4 simultaneous requests, but the server's default limit of 6 is shared across the whole organization. Queries from other dashboards or users can therefore cause one of these refreshes to be rejected.

## Changes

- Treat a response containing an error and no result as a failed refresh.
- Preserve the tile's existing result when this happens.
- Show the tile's error state instead of an incorrect empty-result message.

## How did you test this code?

- Added a regression test confirming a failed refresh preserves the existing tile result and marks the tile as errored.
- Added coverage confirming that changing a dashboard variable refreshes tiles with the new value.
- `dashboardLogic.test.ts`, `dashboardUtils.test.ts`, and `typescript:check` pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and authored with Claude Code (session: https://claude.ai/code/session_01RppeNoiDgKVaJRy4WwXm5i). Root-caused from production evidence after a dashboard rendered tiles as empty following a variable change. ClickHouse query logs showed the variable override was present, while application logs showed requests rejected by the per-org concurrency limiter. Considered handling terminal rejection inside `getInsightWithRetry`, but guarded the commit sites so calculation-error responses that bypass retry handling follow the same error path.
