### PR TITLE
fix(data-modeling): derived node source floor follows freshest input

### DIFF
--- a/products/data_modeling/backend/logic/freshness.py
+++ b/products/data_modeling/backend/logic/freshness.py
@@ -15,9 +15,11 @@ Vocabulary, one term per concept:
 - tier: the group of nodes sharing one effective cadence; each tier gets one
   Temporal schedule (see cohort_scheduling).
 - bounds: a declarable target must sit in [source floor .. consumer ceiling].
-  source_floor = the slowest ancestor source interval (you cannot promise fresher
-  data than your slowest source delivers); consumer_ceiling = the finest declared
-  target among descendants (you cannot be staler than a consumer requires).
+  source_floor = how often a node's data can actually change: a source's own sync
+  interval, and for a derived node the finest floor among its parents (its output
+  changes whenever any input changes, so it can be as fresh as its freshest input);
+  consumer_ceiling = the finest declared target among descendants (you cannot be
+  staler than a consumer requires).
   In interval-space a smaller timedelta means fresher/more frequent, so as plain
   timedeltas: source_floor <= target <= consumer_ceiling.
 
@@ -145,10 +147,15 @@ def compute_effective_cadences(
 
 
 def all_source_floors(edges: list[tuple[str, str]], source_intervals: dict[str, timedelta]) -> dict[str, timedelta]:
-    """Every node's source floor (slowest ancestor source interval) in one forward pass.
+    """Every node's source floor in one forward pass.
+
+    A source node's floor is its own sync interval. A derived node's floor is the finest (min)
+    among its parents' floors, because its output changes whenever any input changes: a view
+    joining events with a weekly import produces new rows continuously, so the weekly side must
+    not drag the join to a weekly cadence. Only pure slow lineage keeps a coarse floor.
 
     One forward pass instead of a per-node ancestor walk, so a whole-graph check is O(N+E) rather
-    than O(N^2). STREAMING for a node with no ancestor source. Nodes in a cycle are omitted
+    than O(N^2). STREAMING for a derived node with no parents. Nodes in a cycle are omitted
     (callers default them to STREAMING; the scheduling path rejects cycles upstream).
     """
     children, parents = _adjacency(edges)
@@ -158,7 +165,10 @@ def all_source_floors(edges: list[tuple[str, str]], source_intervals: dict[str, 
     floor: dict[str, timedelta] = {}
     while queue:
         node = queue.popleft()
-        floor[node] = max([source_intervals.get(node, STREAMING), *(floor[parent] for parent in parents.get(node, []))])
+        if node in source_intervals:
+            floor[node] = source_intervals[node]
+        else:
+            floor[node] = min((floor[parent] for parent in parents.get(node, [])), default=STREAMING)
         for child in children.get(node, []):
             in_degree[child] -= 1
             if in_degree[child] == 0:
@@ -229,10 +239,10 @@ def clamp_to_source_floor(
     """Coarsen every node scheduled finer than its sources can deliver to the nearest bucket >= its
     source floor, returning the adjusted cadences and the list of changes.
 
-    Clamping each node independently stays consistent because the floor spans the whole ancestor
-    cone (`all_source_floors`): a consumer that pulled an ancestor too fine shares that same
-    source and clamps to the same bucket. Streaming/best-effort sources have a zero floor and are
-    never clamped.
+    Clamping each node independently can leave a slow-lineage ancestor coarser than a mixed-lineage
+    consumer, which is intended: the consumer's fast inputs keep it changing at its fine cadence,
+    while the columns derived from the slow lineage update as often as that lineage delivers.
+    Streaming/best-effort sources have a zero floor and are never clamped.
     """
     floors = all_source_floors(edges, source_intervals)
     clamped: dict[str, timedelta | None] = {}
@@ -285,8 +295,8 @@ def validate_declared_target(
     consumer_ceiling = all_consumer_ceilings(edges, declared_targets).get(node_id)
     if is_finer_than(target, source_floor):
         raise UnsatisfiableFrequencyError(
-            f"Requested freshness ({format_cadence(target)}) is more frequent than this node's sources can deliver;"
-            f" the slowest upstream source syncs every {format_cadence(source_floor)}"
+            f"Requested freshness ({format_cadence(target)}) is more frequent than this node's data can change;"
+            f" its upstream sources deliver new data every {format_cadence(source_floor)} at the fastest"
         )
     if consumer_ceiling is not None and is_coarser_than(target, consumer_ceiling):
         raise UnsatisfiableFrequencyError(

--- a/products/data_modeling/backend/test/test_freshness.py
+++ b/products/data_modeling/backend/test/test_freshness.py
@@ -244,8 +244,33 @@ class TestBatchBounds(TestCase):
         [
             # chain src->a->b: the 6h source floors every descendant
             ("chain_floors_descendants", [("src", "a"), ("a", "b")], {"src": H6}, "b", H6),
-            # fan-in of two sources: the node inherits the slowest (daily)
-            ("fan_in_takes_slowest_source", [("srcA", "m"), ("srcB", "m")], {"srcA": H6, "srcB": DAY}, "m", DAY),
+            # fan-in of two sources: the join's output changes whenever any input changes,
+            # so it follows its freshest input, not its slowest
+            ("fan_in_takes_freshest_source", [("srcA", "m"), ("srcB", "m")], {"srcA": H6, "srcB": DAY}, "m", H6),
+            # a streaming input (events) removes the floor entirely, however slow the other input
+            (
+                "streaming_input_removes_floor",
+                [("srcA", "m"), ("srcB", "m")],
+                {"srcA": STREAMING, "srcB": DAY},
+                "m",
+                STREAMING,
+            ),
+            # pure slow lineage keeps its floor even when a sibling branch is fast
+            (
+                "slow_only_branch_keeps_floor",
+                [("srcSlow", "a"), ("srcFast", "b"), ("a", "c"), ("b", "c")],
+                {"srcSlow": DAY, "srcFast": H6},
+                "a",
+                DAY,
+            ),
+            # ...while the join of both branches follows the fast one
+            (
+                "join_follows_fastest_branch",
+                [("srcSlow", "a"), ("srcFast", "b"), ("a", "c"), ("b", "c")],
+                {"srcSlow": DAY, "srcFast": H6},
+                "c",
+                H6,
+            ),
             # no ancestor source -> no floor
             ("no_source_is_streaming", [("a", "b")], {}, "b", STREAMING),
         ]


### PR DESCRIPTION
## Problem

`all_source_floors` computes a node's source floor as the **max** over its ancestor cone: the slowest upstream source wins. That is the wrong aggregation for a derived node with mixed lineage. A view joining a continuously-updating table (events) with a slow import (a weekly sheet, a 6-hourly Postgres sync) produces new output whenever *any* input changes, so its output can be as fresh as its *freshest* input. Under max, the slow side drags the whole join coarse.

Observed on tiered-schedule reconcile dry runs: views with a 15min freshness target get clamped to 6h because one branch of their lineage touches a 6-hourly source, and chains between a slow source and a fine-demanding consumer produce inverted legal ranges (floor 6h, ceiling 15min) where no declared target is accepted. `normalize_seed_target` then persists the coarsened value on a live reconcile, so the wrong clamp sticks.

## Changes

- `all_source_floors`: a source node keeps its own sync interval; a derived node's floor is now the **min** over its parents' floors instead of a max folded over the whole cone. Pure slow lineage keeps its coarse floor (a view reading only weekly tables still floors at 7 days), so honest clamps survive.
- Updated the module vocabulary docstring and `clamp_to_source_floor`'s consistency note to state the new semantics, including the intended asymmetry: a slow-lineage ancestor may clamp coarser than its mixed-lineage consumer.
- Reworded the `UnsatisfiableFrequencyError` message, since "the slowest upstream source syncs every X" no longer describes what the floor is.

> [!NOTE]
> Behavior change for scheduling bounds: mixed-lineage views become schedulable at fine cadences that were previously refused or clamped. Nodes whose entire lineage is slow are unaffected. No schedule is changed by this PR itself; effects apply on the next reconcile or target validation.

## How did you test this code?

Red-first: flipped the existing `fan_in_takes_slowest_source` case to `fan_in_takes_freshest_source` and added parameterized cases for a streaming input removing the floor, a pure-slow branch keeping its floor, and the join of a slow and a fast branch following the fast one. All three new/flipped cases fail on master's max aggregation and pass with the fix; the pure-slow cases pin that legitimate clamps are not lost. Full `products/data_modeling/backend/test/` suite: 428 passed. ruff + preflight clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No tracked docs describe the floor aggregation; module docstrings updated in place.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code during a tiered-schedules migration session; the wrong clamps surfaced on a reconcile dry run and the min-over-parents direction was chosen by the human driver. Skills invoked: /writing-tests, /writing-code-comments, /writing-user-facing-copy. Considered min over ancestor *sources* instead of parent floors; rejected as equivalent for DAGs but the parent-floor form keeps the single forward pass and the transitive property (a node behind a slow-only view inherits that view's floor).