### PR TITLE
fix(data-warehouse): redirect bare /data-warehouse path to sources list

### DIFF
--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -361,6 +361,7 @@ export const productRedirects: Record<
             : '/customer_analytics/dashboard'
         return combineUrl(defaultTab, searchParams, hashParams).url
     },
+    '/data-warehouse': () => urls.sources(),
     '/data-warehouse/sources': () => urls.sources(),
     '/data-warehouse/sources/:id': ({ id }) => urls.dataWarehouseSource(id, 'schemas'),
     '/data-warehouse/sources/:id/:tab': ({ id, tab }) => urls.dataWarehouseSource(id, tab as SourceSceneTab),

--- a/products/data_warehouse/manifest.tsx
+++ b/products/data_warehouse/manifest.tsx
@@ -91,6 +91,9 @@ export const manifest: ProductManifest = {
         '/data-warehouse/connect': ['DataWarehouseSourceConnect', 'dataWarehouseSourceConnect'],
     },
     redirects: {
+        // Switching projects while in the new-source wizard truncates the URL to bare
+        // `/data-warehouse`, which otherwise 404s. Send it to the sources list instead.
+        '/data-warehouse': () => urls.sources(),
         '/data-warehouse/sources': () => urls.sources(),
         '/data-warehouse/sources/:id': ({ id }) => urls.dataWarehouseSource(id, 'schemas'),
         '/data-warehouse/sources/:id/:tab': ({ id, tab }) => urls.dataWarehouseSource(id, tab as SourceSceneTab),


### PR DESCRIPTION
## Problem

Users in the new-source onboarding wizard sometimes hit a "Page not found" error, most often right after switching projects mid-setup. Session replays of real onboarding runs show people recovering by clicking their way back through the sidebar (Data management > Sources) rather than retrying, which is friction on a flow we want to be smooth.

The root cause is a URL truncation on project switch. `getProjectSwitchTargetUrl` reduces a two-segment resource path to its first segment when moving between projects. So `/data-warehouse/new-source` (and `/data-warehouse/connect`) becomes bare `/data-warehouse`. That path has no registered route or redirect, so it falls through to the `/*` 404 catch-all and renders `Scene.Error404`.

The sibling area `/data-management` does not have this problem because `/data-management` is registered as a redirect, so the same truncation lands on a valid scene. `/data-warehouse` was simply missing the equivalent entry.

## Changes

Add a redirect for bare `/data-warehouse` to the sources list, mirroring the existing `/data-management` redirect. Carrying wizard state across a project switch is not possible anyway, so the sources list of the newly selected project is the right place to land.

The generated `frontend/src/products.tsx` is regenerated from the manifest via `build:products`.

## How did you test this code?

I (Claude) could not run the full frontend dev server in this environment. I verified the change by regenerating the product manifest aggregate (`pnpm build:products`) and confirming the only diff is the new redirect entry, and by format-checking the touched manifest with oxfmt. The routing behavior itself is a one-line redirect that matches the established `/data-management` pattern.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code while triaging recurring friction in data-warehouse new-source onboarding. The 404-on-project-switch theme recurred across several real onboarding sessions. I traced it to `getProjectSwitchTargetUrl` truncating the path and `/data-warehouse` lacking a redirect (unlike `/data-management`), then picked the minimal, obviously-correct fix: register the missing redirect rather than change the shared project-switch URL logic, which is broader and riskier.

No repo skills were required for the routing change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
