### PR TITLE
feat(workflows): attribute email sends to SES tenants behind an env flag

### DIFF
--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -148,6 +148,7 @@ export type CdpCoreServicesConfig = Pick<
         | 'SES_ENDPOINT'
         | 'SES_TRACKED_CONFIGURATION_SET'
         | 'SES_UNTRACKED_CONFIGURATION_SET'
+        | 'EMAIL_SES_TENANT_ATTRIBUTION_ENABLED'
         | 'EMAIL_SUPPRESSION_TRANSIENT_BOUNCE_THRESHOLD'
         | 'CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN'
         | 'CDP_FETCH_RETRIES'
@@ -412,6 +413,7 @@ export function createCdpCoreServices(
             sesEndpoint: config.SES_ENDPOINT,
             sesTrackedConfigurationSet: config.SES_TRACKED_CONFIGURATION_SET,
             sesUntrackedConfigurationSet: config.SES_UNTRACKED_CONFIGURATION_SET,
+            sesTenantAttributionEnabled: config.EMAIL_SES_TENANT_ATTRIBUTION_ENABLED,
         },
         deps.integrationManager,
         teamWorkflowsConfigService,

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -140,6 +140,11 @@ export type CdpConfig = ClickhouseConfig & {
     // Comma-separated allowlist of SNS Topic ARNs the SES webhook accepts events from. Empty string
     // means no restriction (dev/test); production should set this to the workflow SES topic ARN(s).
     SES_ALLOWED_SNS_TOPIC_ARNS: string
+    // When true, sends carry TenantName (team-<team_id>) so SES attributes reputation per team
+    // and its Standard reputation policy can pause a single tenant instead of the shared account.
+    // Off by default: a send naming a tenant whose identity association is missing fails, so this
+    // flips on only after tenant coverage is verified (migrate_ses_tenants --dry-run comes back empty).
+    EMAIL_SES_TENANT_ATTRIBUTION_ENABLED: boolean
 
     // Consecutive soft bounces before an address is auto-suppressed. Tunable without a deploy.
     EMAIL_SUPPRESSION_TRANSIENT_BOUNCE_THRESHOLD: number
@@ -318,6 +323,7 @@ export function getDefaultCdpConfig(): CdpConfig {
         SES_TRACKED_CONFIGURATION_SET: 'posthog-messaging',
         SES_UNTRACKED_CONFIGURATION_SET: '',
         SES_ALLOWED_SNS_TOPIC_ARNS: '',
+        EMAIL_SES_TENANT_ATTRIBUTION_ENABLED: false,
         EMAIL_SUPPRESSION_TRANSIENT_BOUNCE_THRESHOLD: 5,
 
         // Destination migration diffing

--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -522,6 +522,7 @@ export function createHogTransformerService(
             sesEndpoint: config.SES_ENDPOINT,
             sesTrackedConfigurationSet: config.SES_TRACKED_CONFIGURATION_SET,
             sesUntrackedConfigurationSet: config.SES_UNTRACKED_CONFIGURATION_SET,
+            sesTenantAttributionEnabled: config.EMAIL_SES_TENANT_ATTRIBUTION_ENABLED,
         },
         deps.integrationManager,
         teamWorkflowsConfigService,

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -71,6 +71,7 @@ describe('Hog Executor', () => {
                 sesEndpoint: hub.SES_ENDPOINT,
                 sesTrackedConfigurationSet: hub.SES_TRACKED_CONFIGURATION_SET,
                 sesUntrackedConfigurationSet: hub.SES_UNTRACKED_CONFIGURATION_SET,
+                sesTenantAttributionEnabled: hub.EMAIL_SES_TENANT_ATTRIBUTION_ENABLED,
             },
             hub.integrationManager,
             new TeamWorkflowsConfigService(hub.postgres),

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -60,6 +60,7 @@ describe('HogFunctionHandler', () => {
                 sesEndpoint: hub.SES_ENDPOINT,
                 sesTrackedConfigurationSet: hub.SES_TRACKED_CONFIGURATION_SET,
                 sesUntrackedConfigurationSet: hub.SES_UNTRACKED_CONFIGURATION_SET,
+                sesTenantAttributionEnabled: false,
             },
             hub.integrationManager,
             new TeamWorkflowsConfigService(hub.postgres),

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -78,6 +78,7 @@ describe('Hogflow Executor', () => {
                 sesEndpoint: hub.SES_ENDPOINT,
                 sesTrackedConfigurationSet: hub.SES_TRACKED_CONFIGURATION_SET,
                 sesUntrackedConfigurationSet: hub.SES_UNTRACKED_CONFIGURATION_SET,
+                sesTenantAttributionEnabled: hub.EMAIL_SES_TENANT_ATTRIBUTION_ENABLED,
             },
             hub.integrationManager,
             new TeamWorkflowsConfigService(hub.postgres),

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -93,6 +93,7 @@ describe('EmailService', () => {
                 sesEndpoint: hub.SES_ENDPOINT,
                 sesTrackedConfigurationSet: hub.SES_TRACKED_CONFIGURATION_SET,
                 sesUntrackedConfigurationSet: hub.SES_UNTRACKED_CONFIGURATION_SET,
+                sesTenantAttributionEnabled: hub.EMAIL_SES_TENANT_ATTRIBUTION_ENABLED,
             },
             hub.integrationManager,
             new TeamWorkflowsConfigService(hub.postgres),
@@ -117,6 +118,7 @@ describe('EmailService', () => {
                     sesEndpoint: '',
                     sesTrackedConfigurationSet: 'posthog-messaging',
                     sesUntrackedConfigurationSet: '',
+                    sesTenantAttributionEnabled: false,
                 },
                 hub.integrationManager,
                 new TeamWorkflowsConfigService(hub.postgres),
@@ -501,6 +503,29 @@ describe('EmailService', () => {
 
                 expect(sendEmailSpy).toHaveBeenCalledTimes(1)
                 expect(result.metrics.map((m) => m.metric_name)).toContain('email_sent')
+            })
+        })
+
+        describe('SES tenant attribution', () => {
+            it('attributes the send to the team tenant when enabled', async () => {
+                service['sesConfig'].sesTenantAttributionEnabled = true
+                sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
+
+                const result = await service.executeSendEmail(invocation)
+
+                expect(result.error).toBeUndefined()
+                const sentCommand = sendEmailSpy.mock.calls[0][0] as { input: any }
+                expect(sentCommand.input.TenantName).toEqual(`team-${team.id}`)
+            })
+
+            it('omits TenantName by default (flag off)', async () => {
+                sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
+
+                const result = await service.executeSendEmail(invocation)
+
+                expect(result.error).toBeUndefined()
+                const sentCommand = sendEmailSpy.mock.calls[0][0] as { input: any }
+                expect(sentCommand.input.TenantName).toBeUndefined()
             })
         })
 

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -527,6 +527,17 @@ describe('EmailService', () => {
                 const sentCommand = sendEmailSpy.mock.calls[0][0] as { input: any }
                 expect(sentCommand.input.TenantName).toBeUndefined()
             })
+
+            it('omits TenantName for test-panel sends even when enabled', async () => {
+                service['sesConfig'].sesTenantAttributionEnabled = true
+                sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
+
+                const result = await service.executeSendEmail(invocation, true)
+
+                expect(result.error).toBeUndefined()
+                const sentCommand = sendEmailSpy.mock.calls[0][0] as { input: any }
+                expect(sentCommand.input.TenantName).toBeUndefined()
+            })
         })
 
         it('should include cc addresses in SES destination', async () => {

--- a/nodejs/src/cdp/services/messaging/email.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.test.ts
@@ -528,7 +528,7 @@ describe('EmailService', () => {
                 expect(sentCommand.input.TenantName).toBeUndefined()
             })
 
-            it('omits TenantName for test-panel sends even when enabled', async () => {
+            it('attributes test-panel sends too — they are real SES sends', async () => {
                 service['sesConfig'].sesTenantAttributionEnabled = true
                 sendEmailSpy.mockResolvedValue({ MessageId: 'test-message-id' })
 
@@ -536,7 +536,7 @@ describe('EmailService', () => {
 
                 expect(result.error).toBeUndefined()
                 const sentCommand = sendEmailSpy.mock.calls[0][0] as { input: any }
-                expect(sentCommand.input.TenantName).toBeUndefined()
+                expect(sentCommand.input.TenantName).toEqual(`team-${team.id}`)
             })
         })
 

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -86,6 +86,9 @@ export interface EmailServiceConfig {
     // Configuration set without open/click tracking. Empty means not provisioned: tracking-off
     // sends fall back to the tracked set (with a warning) rather than failing.
     sesUntrackedConfigurationSet: string
+    // When true, sends carry TenantName so SES attributes reputation per team. Requires every
+    // sending identity to have a tenant resource association — see EMAIL_SES_TENANT_ATTRIBUTION_ENABLED.
+    sesTenantAttributionEnabled: boolean
 }
 
 /**
@@ -551,6 +554,14 @@ export class EmailService {
             // environments where the configuration set isn't yet emitting original headers.
             EmailTags: [{ Name: 'ph_id', Value: shortTrackingCode }],
             FeedbackForwardingEmailAddress: from.email,
+        }
+
+        if (this.sesConfig.sesTenantAttributionEnabled) {
+            // Attributes the send to the team's SES tenant so AWS tracks reputation per team and
+            // its reputation policy can pause one tenant instead of the shared account. `team-<id>`
+            // is the provisioning convention (products/workflows/backend/providers/ses.py and
+            // posthog/management/commands/migrate_ses_tenants.py).
+            sendEmailParams.TenantName = `team-${result.invocation.teamId}`
         }
 
         // Authoritative tracking-code carrier: a custom MIME header. Header values aren't

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -556,11 +556,13 @@ export class EmailService {
             FeedbackForwardingEmailAddress: from.email,
         }
 
-        if (this.sesConfig.sesTenantAttributionEnabled) {
+        if (this.sesConfig.sesTenantAttributionEnabled && !isTest) {
             // Attributes the send to the team's SES tenant so AWS tracks reputation per team and
             // its reputation policy can pause one tenant instead of the shared account. `team-<id>`
             // is the provisioning convention (products/workflows/backend/providers/ses.py and
-            // posthog/management/commands/migrate_ses_tenants.py).
+            // posthog/management/commands/migrate_ses_tenants.py). Test-panel sends are excluded
+            // like every other reputation signal in this class: they're disproportionately
+            // bounce-prone and shouldn't count against the team's tenant.
             sendEmailParams.TenantName = `team-${result.invocation.teamId}`
         }
 

--- a/nodejs/src/cdp/services/messaging/email.service.ts
+++ b/nodejs/src/cdp/services/messaging/email.service.ts
@@ -556,13 +556,17 @@ export class EmailService {
             FeedbackForwardingEmailAddress: from.email,
         }
 
-        if (this.sesConfig.sesTenantAttributionEnabled && !isTest) {
+        if (this.sesConfig.sesTenantAttributionEnabled) {
             // Attributes the send to the team's SES tenant so AWS tracks reputation per team and
             // its reputation policy can pause one tenant instead of the shared account. `team-<id>`
             // is the provisioning convention (products/workflows/backend/providers/ses.py and
-            // posthog/management/commands/migrate_ses_tenants.py). Test-panel sends are excluded
-            // like every other reputation signal in this class: they're disproportionately
-            // bounce-prone and shouldn't count against the team's tenant.
+            // posthog/management/commands/migrate_ses_tenants.py). Deliberately NOT gated on
+            // isTest: test-panel sends are real over-the-wire SES sends, so leaving them
+            // unattributed would (a) push their bounces onto the shared account's reputation and
+            // (b) let a paused tenant keep sending via "Run test". The isTest skips elsewhere in
+            // this class only shield our internal metrics, a separate concern from SES-side
+            // attribution; test volume is far below the representative volume AWS needs for a
+            // reputation finding.
             sendEmailParams.TenantName = `team-${result.invocation.teamId}`
         }
 

--- a/nodejs/src/cdp/templates/test/test-helpers.ts
+++ b/nodejs/src/cdp/templates/test/test-helpers.ts
@@ -204,6 +204,7 @@ export class TemplateTester {
                 sesEndpoint: config.SES_ENDPOINT,
                 sesTrackedConfigurationSet: config.SES_TRACKED_CONFIGURATION_SET,
                 sesUntrackedConfigurationSet: config.SES_UNTRACKED_CONFIGURATION_SET,
+                sesTenantAttributionEnabled: false,
             },
             undefined as any,
             undefined as any,


### PR DESCRIPTION
## Problem

We're switching workflow email reputation from our own calculation to AWS SES tenant management: AWS judges per-team reputation (with mailbox-provider feedback loops and third-party signals we can't see) and its Standard reputation policy auto-pauses a single misbehaving tenant instead of AWS's only current escalation – pausing the entire shared PostHog account.

SES tenants already exist per team (`team-<team_id>`, provisioned by `migrate_ses_tenants` and automatically for new domains by `products/workflows/backend/providers/ses.py`), but no send has ever named one – so AWS's per-tenant reputation machinery has nothing to attribute. This PR turns attribution on.

## Changes

- New env config `EMAIL_SES_TENANT_ATTRIBUTION_ENABLED` (default **false**). When enabled, `sendEmailWithSES` adds `TenantName: team-<team_id>` to every `SendEmailCommand`. Maildev/dev path unaffected.
- Installed `@aws-sdk/client-sesv2@3.985.0` already supports `TenantName` on `SendEmailRequest` – no SDK bump.
- Flag defaults off because a send naming a tenant whose identity association is missing fails with a generic SES `BadRequestException`/`NotFoundException` (there is no tenant-specific error class); the flag is the instant rollback.

Not in this PR, discovered during implementation: setting the tenant **reputation policy to `Standard`** programmatically needs a newer botocore than our pinned 1.40.49 (its sesv2 model has no reputation-policy API – `CreateTenant` takes only name+tags). Policy configuration is therefore a rollout runbook step via console/up-to-date AWS CLI, and the codepath that creates tenants (`providers/ses.py`) should gain the policy parameter when we next bump boto3.

## Rollout runbook (verification, not migration – tenants should already exist)

1. Per region: `python manage.py migrate_ses_tenants --dry-run` – empty output confirms every SES identity has a tenant association; run for real only for stragglers.
2. Per region: verify/set reputation policy `Standard` on tenants (console or current AWS CLI; blocked from code by the botocore pin).
3. Flip `EMAIL_SES_TENANT_ATTRIBUTION_ENABLED=true` in dev (chart wiring: PostHog/charts#13721 — one-line `values.dev.yaml` change) → send a workflow email → confirm delivery and that per-tenant Send metrics appear in CloudWatch. Also send a test-panel email — test sends are attributed too (they're real SES sends; unattributed they'd hit the shared account and bypass tenant pauses).
4. Flip in prod (`values.prod-us.yaml` / `values.prod-eu.yaml`). Rollback = unset the flag.

> [!WARNING]
> With `Standard` policy active, AWS can auto-pause a tenant on high-impact reputation findings from day one. Until the EventBridge → comms wiring ships (next step in the plan), a paused team's sends fail visibly (`email_failed` in their Metrics tab) but nobody is proactively notified – interim mitigation is a manual tenant sending-status check.

## How did you test this code?

- Email service suite 69/69 locally, including two new tests: flag on → `TenantName` equals `team-<team.id>` on the SES command; flag off (default) → `TenantName` absent.
- nodejs typecheck clean for changed files (all `EmailServiceConfig` construction sites updated).
- I (Claude) can't exercise real SES tenants locally – the CloudWatch/delivery verification is in the runbook above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Skills invoked: /writing-tests. Part of the reputation-architecture switch to AWS SES tenant management (strategy doc with the team): this is step 1 (attribution); teardown of our Temporal reputation evaluator and the snapshot model follow in separate PRs; EventBridge wiring for pause/finding events is the team's next build.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
