### PR TITLE
fix(warehouse_sources): skip schema discovery on undecryptable OAuth secrets

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -6,6 +6,7 @@ from django.db import close_old_connections
 from structlog.contextvars import bind_contextvars
 from temporalio import activity
 
+from posthog.models.integration import UndecryptedIntegrationSecretError
 from posthog.temporal.common.logger import get_logger
 
 from products.data_warehouse.backend.facade.api import delete_discover_schemas_schedule
@@ -82,6 +83,14 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
             # retry here, and the per-schema sync path surfaces and disables the source on the
             # same error. Skip quietly on known non-retryable source errors rather than spamming
             # retries and error tracking on every discovery run. Other errors still propagate.
+            #
+            # UndecryptedIntegrationSecretError is checked by type, not message, mirroring
+            # import_data_sync.py's handling: it's shared across every OAuth-based source and
+            # fails identically on every retry, so it shouldn't depend on each source listing the
+            # message in get_non_retryable_errors.
+            if isinstance(e, UndecryptedIntegrationSecretError):
+                logger.warning(f"Skipping schema discovery due to non-retryable source error: {e}")
+                return
             error_msg = str(e)
             non_retryable_errors = new_source.get_non_retryable_errors()
             if any(pattern in error_msg for pattern in non_retryable_errors):

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
@@ -3,6 +3,8 @@ import contextlib
 import pytest
 from unittest import mock
 
+from posthog.models.integration import UndecryptedIntegrationSecretError
+
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities import sync_new_schemas as module
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.sync_new_schemas import (
     SyncNewSchemasActivityInputs,
@@ -67,6 +69,20 @@ def test_get_schemas_error_handling(error_msg, non_retryable, expected_exc):
     else:
         with pytest.raises(Exception, match=expected_exc):
             _run_activity(source_mock)
+
+
+def test_undecrypted_integration_secret_error_is_skipped():
+    # Checked by type, not message, so it must be skipped even when get_non_retryable_errors
+    # has no matching entry — otherwise discovery retries forever on an unrecoverable decryption
+    # failure and spams error tracking every cycle.
+    source_mock = mock.MagicMock()
+    source_mock.parse_config.return_value = {}
+    source_mock.get_schemas.side_effect = UndecryptedIntegrationSecretError(
+        "Integration.sensitive_config['refresh_token'] is still encrypted; the stored credentials could not be decrypted"
+    )
+    source_mock.get_non_retryable_errors.return_value = {}
+
+    _run_activity(source_mock)
 
 
 def test_discovery_uses_source_pinned_api_version():


### PR DESCRIPTION
## Problem

Error tracking surfaced `UndecryptedIntegrationSecretError` firing repeatedly from the Google Ads schema-discovery path ([issue](https://us.posthog.com/project/2/error_tracking/019fae2d-d69a-7201-b577-3b6113fbe229)): `Integration.refresh_token` raises this when a stored OAuth secret still looks like Fernet ciphertext after decryption is attempted (a lost/rotated encryption key, or a corrupted row) — see `posthog/models/integration.py`.

The stack trace goes through `sync_new_schemas_activity` → `GoogleAdsSource.get_schemas` → `google_ads_client` → `Integration.refresh_token`, all under `products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/`.

This isn't Google Ads-specific and isn't really actionable by retrying: decryption fails identically every time until the user reconnects the integration. `import_data_sync.py`'s `_handle_import_error` already classifies `UndecryptedIntegrationSecretError` as non-retryable by type for the main sync path, shared across every OAuth-based source — but `sync_new_schemas_activity` (the periodic ~6h schema-discovery activity) only checked each source's `get_non_retryable_errors()` message list, which this error's message never matched. So discovery kept retrying and re-raising this into error tracking on every cycle, for any OAuth source hitting the condition, not just Google Ads.

## Changes

Add the same type-based check to `sync_new_schemas_activity`'s `get_schemas` error handling, mirroring the existing `import_data_sync.py` pattern: skip discovery quietly (log a warning) when the error is an `UndecryptedIntegrationSecretError`, instead of falling through to the message-based `get_non_retryable_errors` check and re-raising.

## How did you test this code?

Added `test_undecrypted_integration_secret_error_is_skipped` to `test_sync_new_schemas.py`, asserting the activity returns quietly (no raise) when `get_schemas` raises `UndecryptedIntegrationSecretError`, even with an empty `get_non_retryable_errors()` — this is the regression the message-matching code path couldn't catch, since the error message never matches any source's non-retryable string list.

Ran the full `test_sync_new_schemas.py` suite (7 passed), `ruff check --fix` / `ruff format`, and `uv run mypy --cache-fine-grained .` repo-wide (no issues).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue details + stack trace + event samples) to confirm the failure originates in the Google Ads schema-discovery call path, then traced the exception's raise site and existing handling in `posthog/models/integration.py` and `import_data_sync.py`. Decision: this is a shared-layer gap (not Google Ads-specific), so the fix lives in the shared `sync_new_schemas.py` activity rather than Google Ads' `get_non_retryable_errors`, mirroring the established type-based classification pattern already used elsewhere in the codebase. Invoked `/writing-tests` before adding the regression test.