### PR TITLE
fix(data-imports): keep source-classified retryable errors out of error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -14,6 +14,7 @@ from posthog.clickhouse.query_tagging import Feature, Product, tag_queries
 from posthog.models.integration import UndecryptedIntegrationSecretError
 from posthog.sync import database_sync_to_async_pool
 from posthog.temporal.common.activity_context import current_activity_attempt
+from posthog.temporal.common.errors import NonReportableError
 from posthog.temporal.common.heartbeat import LivenessHeartbeater as Heartbeater
 from posthog.temporal.common.logger import get_logger
 from posthog.temporal.common.shutdown import ShutdownMonitor
@@ -326,9 +327,12 @@ async def _handle_import_error(
 
     Errors the source classifies as retryable (rate limits, transient 5xx) reach us only after
     the source's own retries are exhausted. Temporal retries the whole activity and the error is
-    transient and self-recovering, so we log at ``warning`` rather than ``exception`` to keep
-    this benign, recoverable failure out of error tracking. ``RESTClientRetryableError`` gets the
-    same treatment by type, since every REST-based source hits that condition already.
+    transient and self-recovering, so we log at ``warning`` rather than ``exception`` and re-raise
+    as ``NonReportableError`` — log level alone doesn't stop the activity interceptor
+    (``posthog/temporal/common/posthog_client.py``) from reporting whatever exception type escapes
+    the activity; only that marker type does. ``RESTClientRetryableError`` gets the same treatment
+    by type, since it's already a ``NonReportableError`` subclass and every REST-based source hits
+    that condition already.
 
     Everything else is logged as an exception and re-raised so Temporal retries it as usual.
     """
@@ -384,7 +388,7 @@ async def _handle_import_error(
     if any(match in error_msg for match in retryable_errors):
         await logger.awarning(error_msg)
         await logger.adebug("Source-classified retryable error - re-raising for Temporal retry")
-        raise error
+        raise NonReportableError(error_msg) from error
 
     await logger.aexception(error_msg)
     await logger.adebug("Error encountered during import_data_activity - re-raising")

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -5,6 +5,8 @@ from datetime import datetime
 import pytest
 from unittest import mock
 
+from posthog.temporal.common.errors import NonReportableError
+
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
     SchemaColumnTypeChangedException,
 )
@@ -141,7 +143,11 @@ async def test_unparseable_config_routes_through_handler():
 async def test_source_classified_retryable_error_logged_as_warning_not_exception():
     # A rate-limit / transient error the source retries internally reaches _handle_import_error only
     # once those retries exhaust. Temporal retries the whole activity, so it must be logged at
-    # warning (not aexception, which mints error-tracking noise) while still being re-raised.
+    # warning (not aexception, which mints error-tracking noise) while still being re-raised. Logging
+    # alone doesn't keep it out of error tracking though: the Temporal activity interceptor
+    # (posthog_client.py) captures whatever exception type escapes the activity regardless of log
+    # level, unless it's a NonReportableError — so the re-raise must wrap it as one, the same way
+    # RESTClientRetryableError already does for REST sources.
     error = Exception("Mixpanel API error (retryable): status=429, url=https://data.mixpanel.com/api/2.0/export")
     source = mock.MagicMock(spec=SimpleSource)
     source.get_non_retryable_errors.return_value = {}
@@ -153,9 +159,10 @@ async def test_source_classified_retryable_error_logged_as_warning_not_exception
     logger.adebug = mock.AsyncMock()
 
     with mock.patch.object(module.SourceRegistry, "get_source", return_value=source):
-        with pytest.raises(Exception, match="retryable"):
+        with pytest.raises(NonReportableError, match="retryable") as exc_info:
             await module._handle_import_error(mock.MagicMock(), logger, error)
 
+    assert exc_info.value.__cause__ is error
     logger.awarning.assert_awaited_once()
     logger.aexception.assert_not_awaited()
 


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError: (2013, 'Lost connection to MySQL server during query (The read operation timed out)')` from the MySQL data-warehouse import source, raised from the streaming row-fetch loop in `mysql.py`'s `_stream_with_optional_force_index`.

This is exactly the class of error MySQL's `get_retryable_errors()` already lists ("Lost connection to MySQL server during query"), specifically so it stays out of error tracking as benign, self-recovering noise — Temporal retries the whole activity and the connection drop resolves itself. But it still got reported.

The gap is in the shared `_handle_import_error` (`import_data_sync.py`): when an error matches a source's `get_retryable_errors()`, it logs at `warning` (not `exception`) and re-raises the *original* exception. Logging at `warning` only affects our own structured logs — the Temporal activity interceptor (`posthog/temporal/common/posthog_client.py`) reports whatever exception type escapes the activity to error tracking regardless of log level. It only skips reporting for `NonReportableError` (and a couple of other known-benign marker types). Since the message-matched retryable path re-raised the bare exception instead of a `NonReportableError`, it was captured anyway — silently defeating the intent already documented in this function's docstring and in `MySQLSource.get_non_retryable_errors`'s sibling `get_retryable_errors`.

This affects every source that implements `get_retryable_errors()` (MySQL, Postgres, Snowflake, Salesforce, Mixpanel, HubSpot, and others), not just MySQL.

Nothing here needed adding to `NonRetryableErrors` — the failure is transient infrastructure (a read timeout mid-stream) and Temporal's retry already handles it correctly; the only problem was the error-tracking noise.

## Changes

- `_handle_import_error` now re-raises a source-classified retryable error as `NonReportableError(error_msg) from error` instead of the bare exception, so Temporal still retries the activity as usual but the interceptor no longer reports it. Mirrors how `RESTClientRetryableError` (already a `NonReportableError` subclass) achieves this for REST-based sources.
- Updated the docstring to describe the actual mechanism instead of the previously-aspirational claim that logging at `warning` alone kept these out of error tracking.

## How did you test this code?

- Extended `test_source_classified_retryable_error_logged_as_warning_not_exception` in `test_import_data_sync.py` to assert the re-raised exception is a `NonReportableError` (not just any `Exception`) with the original error chained via `__cause__` — this is the regression guard: reverting to `raise error` would fail this assertion even though the log-level assertions would still pass.
- Ran `pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py` (12 passed) and the MySQL source's retryable/non-retryable classification tests (35 passed).
- `ruff check` / `ruff format --check` on the changed files: clean.
- `mypy --cache-fine-grained` targeted at the changed file: clean. A repo-wide mypy run (as CI runs it) was still in progress when this PR was opened; will follow up if it surfaces anything.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification/reporting change, no user-facing or API behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from the linked error-tracking issue via PostHog's error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`), which surfaced the full stack trace confirming the failure genuinely originated in `mysql.py`. Traced the call path from the MySQL streaming cursor through `get_rows`/`_handle_import_error`/`import_data_activity_sync` up to the Temporal activity interceptor, and read `posthog/temporal/common/posthog_client.py` to confirm it captures by exception type, not log level.

Checked for duplicate open PRs by exception type, message phrase, and module path, and scanned the maintainer's own open PR queue. Found one closely related PR, #74388 ("keep transient S3 credential blips out of error tracking"), which fixes the same class of interceptor-reporting gap but for a different, non-overlapping branch of `_handle_import_error` (a new `is_transient_object_store_error` check) — it doesn't touch the `get_retryable_errors()` branch this PR fixes.

Invoked `/writing-tests` before extending the regression test.