### PR TITLE
fix: export leaf rows in query_log_archive export

### DIFF
--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -138,7 +138,7 @@ SELECT
     normalizeQuery(query) AS query_shape,
     normalizeQuery(lc_query__query) AS hogql_shape
 FROM {SOURCE_TABLE}
-WHERE event_date = toDate('{day}') AND is_initial_query
+WHERE event_date = toDate('{day}')
 SETTINGS s3_truncate_on_insert = 1, max_threads = {config.max_threads}
 """
 


### PR DESCRIPTION
## Problem

The daily `query_log_archive` S3 export only keeps rows with `is_initial_query = 1`.
That silently drops remote ProfileEvents like CPU time. 

The archive table itself already stores the leaf rows (the ingest MV has no initial filter), so this is fixable in the export query alone.

## Changes

Drop the `is_initial_query` filter so the export mirrors the archive table 1:1 (same rows, still restricted to the PII-safe `KEEP_COLUMNS` allowlist)


## How did you test this code?

- Rendered the exact SQL the op generates and ran it against a local dev ClickHouse (26.6.1): executes cleanly end to end.
- `ruff check` and `ruff format` pass; `hogli ci:preflight --strict` passed on push.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs page covers this export job; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Claude Fable 5) in a session driven by Andy Zhao, after a teammate flagged that the export's `is_initial_query` filter drops leaf-node profile events.
- Verification was done by tracing the ClickHouse source (links above) at Andy's direction; a prod `query_log` cross-check via the internal query tooling was attempted first but blocked on expired auth.
- Skills invoked: querying-clickhouse-via-metabase, writing-code-comments.
- Design evolution: the first version kept one exported row per initial query and joined per-`initial_query_id` leaf ProfileEvents aggregates onto it as `leaf_*` columns, to avoid changing semantics for existing consumers. Andy chose the 1:1 mirror instead for full per-host fidelity and a simpler export, accepting that consumers add `is_initial_query` filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
