### PR TITLE
fix(data-imports): stop retrying unsupported interval date_trunc units on postgres sources

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -671,6 +671,21 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
             # against the source data, so retrying re-evaluates the same view and hits the same row.
             "cannot call jsonb_each on a non-object": "A view you're syncing calls jsonb_each() on a JSON value that isn't an object for at least one row, so Postgres can't evaluate the view and we can't read it. Guard the call in your view definition (for example only call jsonb_each() when jsonb_typeof(col) = 'object'), or remove that view from the sync.",
             "cannot call jsonb_each_text on a non-object": "A view you're syncing calls jsonb_each_text() on a JSON value that isn't an object for at least one row, so Postgres can't evaluate the view and we can't read it. Guard the call in your view definition (for example only call jsonb_each_text() when jsonb_typeof(col) = 'object'), or remove that view from the sync.",
+            # A selected relation's own definition calls date_trunc()/extract() with a unit
+            # PostgreSQL doesn't support for the interval type (SQLSTATE 0A000) — e.g.
+            # `date_trunc('week', some_interval_column)`, since week truncation is only defined
+            # for timestamp/timestamptz, not interval. We only ever run `SELECT ... FROM
+            # <relation>`; the expression lives in the customer's own generated column or view
+            # definition, so it's deterministic against the schema and retrying re-evaluates the
+            # same relation into the same wall.
+            "not supported for type interval": (
+                "A table or view you're syncing has a computed column or definition that calls "
+                "date_trunc() or extract() with a unit PostgreSQL doesn't support for interval "
+                'values (PostgreSQL reported "not supported for type interval") — for example '
+                "truncating to a week on an interval column, which is only supported on "
+                "timestamps. Update that column's definition to use a supported unit, or remove "
+                "it from the sync, then re-enable the sync."
+            ),
             # A selected relation's own definition writes to the database while we read it — a view or
             # trigger that calls a function which runs REFRESH MATERIALIZED VIEW (or INSERT/UPDATE/DELETE).
             # We read inside a read-only transaction and never write to the source, so Postgres rejects

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -996,6 +996,27 @@ class TestPostgresSourceNonRetryableErrors:
         "error_msg",
         [
             # Raw psycopg message (what the activity-level check sees via str(e)).
+            'unit "week" not supported for type interval',
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            'FeatureNotSupported: unit "week" not supported for type interval',
+        ],
+    )
+    def test_interval_unit_not_supported_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Unsupported interval-unit error should be non-retryable: {error_msg}"
+
+    def test_interval_unit_not_supported_returns_friendly_message(self, source):
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = 'unit "week" not supported for type interval'
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "Unsupported interval-unit error should surface an actionable message"
+        assert "interval" in friendly[0]
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
+            # Raw psycopg message (what the activity-level check sees via str(e)).
             'user mapping not found for user "svc_role", server "remote_server"',
             # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
             'UndefinedObject: user mapping not found for user "svc_role", server "remote_server"',


### PR DESCRIPTION
## Problem

Error tracking surfaced a `psycopg.errors.FeatureNotSupported` failure in the shared Postgres-family sync path (`sources/postgres/postgres.py`'s `get_rows`, reused by Postgres, Supabase, and other Postgres-compatible sources), with the message `unit "week" not supported for type interval`.

PostgreSQL's `date_trunc()`/`extract()` reject some units — `week` among them — when the argument is an `interval`-typed value, even though the same units work fine against `timestamp`/`timestamptz`. This only happens when a synced table or view has a computed column or definition that applies one of these functions to an interval expression with an unsupported unit. We only ever run `SELECT ... FROM <relation>`, so the failing expression lives entirely in the customer's own schema — the same relation and the same rows fail identically on every retry, and no amount of retrying will ever succeed.

## Changes

Added `"not supported for type interval"` to `PostgresSource.get_non_retryable_errors()`, following the same pattern already used for other "the customer's own view definition is fundamentally broken" cases in this dict (e.g. `jsonb_each` on non-objects, writes inside a read-only transaction, unpopulated materialized views). This stops the sync from being retried and surfaces an actionable message pointing the customer at the offending column/view definition.

## How did you test this code?

Added `test_interval_unit_not_supported_is_non_retryable` (raw + Temporal-wrapped message forms) and `test_interval_unit_not_supported_returns_friendly_message` to `TestPostgresSourceNonRetryableErrors` in `test_postgres.py`, following the existing parametrized test style for this class. Ran the full `TestPostgresSourceNonRetryableErrors` class (119 tests) plus ruff lint/format — all pass.

I did not manually reproduce against a live Postgres/Supabase database (no such environment available here); the fix is a message-classification change validated by the added unit tests.

## Docs update

N/A — internal error-classification change, no user-facing docs to update.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool used: Claude Code, triaging a PostHog error-tracking issue (`FeatureNotSupported: unit "week" not supported for type interval`) reported via webhook for a Supabase sync.
- Investigation: pulled the issue's stack trace and `warehouse_sources_*` event properties via the PostHog MCP error-tracking tools, confirmed the failure lands in the shared Postgres source connector (Supabase is a thin `PostgresSource` subclass with no query-building logic of its own), and ruled out our own code ever emitting a `date_trunc(...)`/`extract(...)` call against an interval value — the expression must originate from the customer's own view/generated-column definition.
- Decision: classified as a permanent, upstream/schema issue (not a pipeline bug) and extended `get_non_retryable_errors`, matching the established convention for similarly-shaped "customer's view definition can't be evaluated" errors already in that dict, rather than touching retry/backoff policy or widening an existing key.
- Searched open PRs (by exception type, message substring, and module path, plus the maintainer's own open PRs) and found no existing PR addressing this specific error.