### PR TITLE
fix(replay-vision): warn when a scanner has no recording filters

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.test.ts
@@ -1,0 +1,35 @@
+import {
+    EventPropertyFilter,
+    FilterLogicalOperator,
+    PropertyFilterType,
+    PropertyOperator,
+    UniversalFiltersGroup,
+} from '~/types'
+
+import { groupHasNoFilters } from './ScannerTriggers'
+
+const leaf: EventPropertyFilter = {
+    type: PropertyFilterType.Event,
+    key: '$current_url',
+    operator: PropertyOperator.IContains,
+    value: 'checkout',
+}
+
+function group(...values: UniversalFiltersGroup['values']): UniversalFiltersGroup {
+    return { type: FilterLogicalOperator.And, values }
+}
+
+describe('groupHasNoFilters', () => {
+    it.each([
+        // The shape recordingsQueryToUniversalFilters produces for a scanner with no filters: an outer group
+        // wrapping one empty inner group, so a length check on the outer group would wrongly report a filter.
+        ['outer group wrapping an empty inner group', group(group()), true],
+        ['a group with no values at all', group(), true],
+        ['empty groups nested several levels deep', group(group(group(group()))), true],
+        ['outer group wrapping an inner group with a leaf', group(group(leaf)), false],
+        ['a leaf directly on the outer group', group(leaf), false],
+        ['one empty group alongside one holding a leaf', group(group(), group(leaf)), false],
+    ])('%s', (_name, value, expected) => {
+        expect(groupHasNoFilters(value as UniversalFiltersGroup)).toBe(expected)
+    })
+})

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
@@ -57,6 +57,12 @@ function groupHasEventProperty(group: UniversalFiltersGroup): boolean {
     )
 }
 
+// True when the group holds no leaf filter at any depth. The stored shape is an outer group wrapping one inner
+// group (see recordingsQueryToUniversalFilters), so an unfiltered scanner still arrives as a non-empty `values`.
+export function groupHasNoFilters(group: UniversalFiltersGroup): boolean {
+    return group.values.every((value) => isUniversalGroupFilterLike(value) && groupHasNoFilters(value))
+}
+
 // Renders the bound universal-filter group's values; adding is handled by the search bar above, not an inline button.
 function ScannerFilterGroup(): JSX.Element {
     const { filterGroup } = useValues(universalFiltersLogic)
@@ -126,8 +132,7 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
                                 <div className="space-y-1">
                                     <LemonLabel>Recording filters</LemonLabel>
                                     <div className="text-xs text-muted">
-                                        Filter by event, action, person, session, or cohort. Leave empty to scan all
-                                        completed recordings.
+                                        Filter by event, action, person, session, or cohort.
                                     </div>
                                 </div>
                                 <TestAccountFilterSwitch
@@ -159,6 +164,15 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
                                     size="small"
                                 />
                             </div>
+                            {groupHasNoFilters(universal.filter_group) && (
+                                <LemonBanner type="warning">
+                                    <span className="text-xs">
+                                        No filters set, so this scanner watches every recording. Describing the sessions
+                                        you want in the prompt doesn't narrow what gets scanned, and recordings that
+                                        can't match still use credits. Add a filter to limit what this scanner watches.
+                                    </span>
+                                </LemonBanner>
+                            )}
                             {groupHasEventProperty(universal.filter_group) && (
                                 <LemonBanner type="info" dismissKey="replay-vision-event-vs-person-property-hint">
                                     <span className="text-xs">

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerTriggers.tsx
@@ -167,9 +167,9 @@ export function ScannerTriggers({ scannerId }: { scannerId: string }): JSX.Eleme
                             {groupHasNoFilters(universal.filter_group) && (
                                 <LemonBanner type="warning">
                                     <span className="text-xs">
-                                        No filters set, so this scanner watches every recording. Describing the sessions
-                                        you want in the prompt doesn't narrow what gets scanned, and recordings that
-                                        can't match still use credits. Add a filter to limit what this scanner watches.
+                                        No recording filters set. Your prompt describes what to look for, but it doesn't
+                                        limit which recordings get scanned, so this scanner spends credits scanning
+                                        recordings that aren't relevant to your prompt. Add a filter to narrow it down.
                                     </span>
                                 </LemonBanner>
                             )}


### PR DESCRIPTION
## Problem

Customer feedback from the closed beta keeps landing on the same failure: a scanner set up with no recording filters, a prompt describing one specific flow, and a pile of noise that burns the team's credits before they see any value.

It came up four separate times in #launch-replay-vision. One customer's scanner produced noise until we spotted the missing event filter. Another burned their whole free tier and got nothing out of it. A third wrote replay filters into the prompt text itself, which silently does nothing. Hayne recalled a fourth doing the same.

The UI was actively encouraging it. The Recording filters helper text read "Leave empty to scan all completed recordings", which is true and reads as a reassurance, right at the moment where leaving it empty is what costs you.

## Changes

Warn on the scan conditions step while the filter list is empty. The banner leads with the misconception it exists to correct, that the prompt describes what to look for but does not limit which recordings get scanned, and ties the credit cost to relevance:

> No recording filters set. Your prompt describes what to look for, but it doesn't limit which recordings get scanned, so this scanner spends credits scanning recordings that aren't relevant to your prompt. Add a filter to narrow it down.

It is not dismissible, because it reflects live form state: add a filter and it goes away. I also dropped the "Leave empty to scan all completed recordings" sentence from the helper text, since the banner now says the same thing with the consequence attached.

### Before

![before](https://raw.githubusercontent.com/PostHog/pr-assets/87c046f3c23553ac7fcabda642bf792ef8fd7298/2026/07/ff9989d3-af5c-49b3-abb2-1ba603b748f3.png)

### After

The screenshot shows the layout. Its wording predates the rewording above, which came out of review, so read the blockquote for the copy that actually ships.

![after](https://raw.githubusercontent.com/PostHog/pr-assets/239d4a2cb05f7c571cb286ba374235115e66e7d0/2026/07/f2d6d07e-8498-4a3e-a046-4246d18ca4a8.png)

### And it clears as soon as you add a filter

![with a filter](https://raw.githubusercontent.com/PostHog/pr-assets/dc418b5bad494a5aacd33ae82b71c5802bf20dc1/2026/07/33b57a55-21da-413d-a8f9-b5326dbad1a1.png)

## How did you test this code?

Manually, in the local dev app: opened the new-scanner flow on the scan conditions step, confirmed the banner renders, added a `$pageview` filter through the search bar, and confirmed it disappears. The three screenshots above are from that run, before the copy was reworded. I could not re-shoot them afterwards because the local stack is mid-migration on an unrelated branch, and the reword touches only the sentence, not the layout or the show/hide logic.

New jest tests cover `groupHasNoFilters`. The regression they catch: an unfiltered scanner does not arrive as an empty `values` array, it arrives as an outer group wrapping one empty inner group, so the obvious `values.length === 0` check would never fire the banner. The cases pin both that shape and the nested-with-a-leaf shapes that must not fire it.

Also ran repo-wide `tsgo --noEmit` and oxlint/oxfmt on the changed files, all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change. This warns about behavior the docs already describe.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude Code (Opus 5) to read through #launch-replay-vision, pull out the customer feedback that was still open and fixable with a PR, and then implement it. Most of what is in that channel has already shipped, so the first pass was verification: checking each candidate against `origin/master` rather than against the thread, and checking the file lists of all 21 open vision PRs to be sure nothing already covered this.

Skills invoked: `/writing-user-facing-copy` for the banner text, `/writing-tests` for the test gate.

One judgment call worth flagging. Cory's original ask in the thread went further, detect when the prompt names a flow that the filters don't cover, or have PostHog AI apply a filter for you. I deliberately did not build that here. It needs prompt/filter semantic matching, which is a much bigger change and a much easier one to get wrong, and the simple version covers every instance we actually saw. The prompt-side half of the same problem is in a separate PR, which teaches the scanner to say "this session isn't relevant" rather than inventing a finding.

