### PR TITLE
fix(custom): treat a malformed OAuth2 integration id as not found

### DIFF
--- a/products/warehouse_sources/backend/models/custom_oauth2_integration.py
+++ b/products/warehouse_sources/backend/models/custom_oauth2_integration.py
@@ -2,6 +2,7 @@ import time
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Optional
 
+from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import Q
 
@@ -212,6 +213,11 @@ def get_custom_oauth2_integration(integration_id: str, team_id: int) -> CustomOA
     """Load a custom OAuth2 integration for a team, outside request context (Temporal activities).
 
     Uses `for_team()` — the prescribed fail-closed escape hatch — so a caller can never read another
-    team's credentials by id. Raises `CustomOAuth2Integration.DoesNotExist` when the id isn't this team's.
+    team's credentials by id. Raises `CustomOAuth2Integration.DoesNotExist` when the id isn't this
+    team's, or isn't even a well-formed UUID (a malformed id can never match a row, so every caller
+    already treats this the same as a genuinely missing row).
     """
-    return CustomOAuth2Integration.objects.for_team(team_id).get(id=integration_id)
+    try:
+        return CustomOAuth2Integration.objects.for_team(team_id).get(id=integration_id)
+    except ValidationError as exc:
+        raise CustomOAuth2Integration.DoesNotExist(f"Invalid integration id: {integration_id!r}") from exc

--- a/products/warehouse_sources/backend/tests/test_custom_oauth2_integration.py
+++ b/products/warehouse_sources/backend/tests/test_custom_oauth2_integration.py
@@ -237,6 +237,13 @@ class TestCustomOAuth2Integration(BaseTest):
         with self.assertRaises(CustomOAuth2Integration.DoesNotExist):
             get_custom_oauth2_integration(str(other_integration.pk), self.team.pk)
 
+    def test_malformed_id_raises_does_not_exist(self):
+        # A malformed id used to hit the UUID field lookup unguarded, raising a raw
+        # `django.core.exceptions.ValidationError` that none of this helper's callers catch — it escaped
+        # as an unhandled error instead of the `DoesNotExist` every caller already handles gracefully.
+        with self.assertRaises(CustomOAuth2Integration.DoesNotExist):
+            get_custom_oauth2_integration("not-a-uuid", self.team.pk)
+
     def test_admin_get_queryset_reads_outside_team_scope(self):
         # Django admin runs outside request/team scope, so the model's fail-closed default manager would
         # raise TeamScopeError the moment the changelist evaluates the queryset. The admin's get_queryset()


### PR DESCRIPTION
## Problem

Error tracking surfaced an unhandled `ValidationError: "%(value)s" is not a valid UUID.` from the `custom` data-warehouse source ([issue](https://us.posthog.com/project/2/error_tracking/019fae53-a6b8-7422-a18a-ad5e8e8ac4eb)).

The stack trace shows the failure passing through `preview_resource` → `_adopt_static_oauth2_secrets` in `products/warehouse_sources/backend/temporal/data_imports/sources/custom/source.py`, into `get_custom_oauth2_integration` in `products/warehouse_sources/backend/models/custom_oauth2_integration.py`, which does:

```python
CustomOAuth2Integration.objects.for_team(team_id).get(id=integration_id)
```

`integration_id` comes from a client-supplied, untyped config field (`CustomSourceConfig.auth_oauth2_integration_id`) that's never validated as a UUID before reaching this lookup. When it isn't a well-formed UUID, Django's UUID field raises `django.core.exceptions.ValidationError` rather than `CustomOAuth2Integration.DoesNotExist`. Every call site of this helper in `source.py` (preview, validate, and sync) only catches `DoesNotExist` and turns it into a clean, user-facing config error — none catch `ValidationError`, so it escaped as an unhandled error instead.

## Changes

`get_custom_oauth2_integration` now catches `ValidationError` from the lookup and re-raises `CustomOAuth2Integration.DoesNotExist` — a malformed id can never match a row anyway, so this is the same outcome every caller already handles gracefully. This fixes all six call sites in `source.py` at once without touching each individually.

## How did you test this code?

Added `test_malformed_id_raises_does_not_exist` to `TestCustomOAuth2Integration`, asserting `get_custom_oauth2_integration` raises `DoesNotExist` (not a raw `ValidationError`) for a non-UUID id — this is the exact regression the fix addresses; the existing `test_team_scoping_is_fail_closed` only covered well-formed-but-wrong-team ids.

Ran `ruff check` and `mypy --cache-fine-grained` on the changed files (both clean). I wasn't able to run the full Django test suite in this environment (no live Postgres available), so I verified the fix logic directly by invoking the real helper function with the DB-only team-resolution step mocked out, confirming it now raises `DoesNotExist` instead of the raw `ValidationError`.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I (Claude) pulled the issue's stack trace and a sample event via the PostHog error-tracking MCP tools, confirmed the failing frame chain runs through the `custom` source's own code, and traced the call path from the API preview endpoint down to the raw ORM lookup. Decided this is a fixable bug rather than a user/upstream error: an unvalidated request param should produce a clean config error, not an unhandled crash — the code already has an established pattern (`DoesNotExist` → friendly message) that just needed to also cover the malformed-format case. Invoked `/writing-tests` before adding the regression test. Checked open PRs (including the maintainer's own) for a duplicate fix and found none.