### PR TITLE
fix(data-imports): honor a source's opt-out of non-retryable grace-period retries

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -196,7 +196,12 @@ async def handle_non_retryable_error(
     error_msg: str,
     logger: FilteringBoundLogger,
     error: Exception,
+    retry_before_giving_up: bool = True,
 ) -> NoReturn:
+    if not retry_before_giving_up:
+        await logger.adebug(f"Non-retryable error, source opted out of grace-period retries. error={error_msg}")
+        raise NonRetryableException() from error
+
     async with _get_redis() as redis_client:
         if redis_client is None:
             await logger.adebug(f"Failed to get Redis client for non-retryable error tracking. error={error_msg}")

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -14,6 +14,7 @@ from products.warehouse_sources.backend.models.external_data_source import Exter
 from products.warehouse_sources.backend.models.oom_event import ExternalDataSchemaOOMEvent
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import (
     handle_corrupted_delta_log,
+    handle_non_retryable_error,
     handle_reset_or_full_refresh,
     persist_primary_keys,
     report_heartbeat_timeout,
@@ -245,6 +246,30 @@ class TestReportHeartbeatTimeoutRecording(BaseTest):
             assert event.host == "pod-abc"
             assert event.run_id == "run-1"
             assert event.gap_seconds == pytest.approx(gap_seconds)
+
+
+class TestHandleNonRetryableError:
+    def test_retry_before_giving_up_false_skips_grace_period(self):
+        # A source whose non-retryable errors are a permanent condition (e.g. a revoked API key
+        # permission) must fail on the very first occurrence instead of going through the
+        # Redis-backed grace period meant to absorb a transient blip (a gateway reboot, a
+        # momentary auth hiccup) for sources that opt into it.
+        error = ValueError("403 Client Error: Forbidden for url: https://api.paddle.com/transactions")
+
+        with patch(f"{_EXTRACT_MODULE}._get_redis") as mock_get_redis:
+            with pytest.raises(NonRetryableException) as exc_info:
+                async_to_sync(handle_non_retryable_error)(
+                    team_id=1,
+                    source_id="source-1",
+                    run_id="run-1",
+                    error_msg=str(error),
+                    logger=MagicMock(adebug=AsyncMock()),
+                    error=error,
+                    retry_before_giving_up=False,
+                )
+
+        assert exc_info.value.__cause__ is error
+        mock_get_redis.assert_not_called()
 
 
 # transaction=True: handle_corrupted_delta_log writes to the DB from the async thread pool

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/base.py
@@ -211,6 +211,18 @@ class _BaseSource(ABC, Generic[ConfigType]):
 
         return set()
 
+    def should_retry_non_retryable_errors(self) -> bool:
+        """Whether a `get_non_retryable_errors()` match still gets a few grace-period retries
+        across activity attempts (see `handle_non_retryable_error`) before giving up.
+
+        Defaults to `True`: some non-retryable classifications turn out to be a transient blip
+        (a gateway reboot, a momentary auth hiccup) that clears up on a later attempt. Override
+        to `False` when the source's non-retryable errors are a static, permanent condition (e.g.
+        a revoked API key permission) where the grace period only delays an inevitable failure.
+        """
+
+        return True
+
     def get_canonical_descriptions(self) -> CanonicalDescriptions:
         """Curated, documentation-sourced descriptions for this source's well-known tables/endpoints.
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -334,6 +334,7 @@ async def _handle_import_error(
     """
     source_cls = SourceRegistry.get_source(job_inputs.job_type)
     error_msg = str(error)
+    retry_before_giving_up = source_cls.should_retry_non_retryable_errors()
 
     # The shared REST engine raises RESTClientNonRetryableError only for responses retrying can
     # never turn into data (a non-JSON body on an otherwise-successful response). Honor that
@@ -341,7 +342,13 @@ async def _handle_import_error(
     # source listing the message in get_non_retryable_errors.
     if isinstance(error, RESTClientNonRetryableError):
         await handle_non_retryable_error(
-            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+            job_inputs.team_id,
+            str(job_inputs.source_id),
+            job_inputs.run_id,
+            error_msg,
+            logger,
+            error,
+            retry_before_giving_up,
         )
 
     # Raised in shared pipeline code when incoming data can't be cast into the stored (narrower)
@@ -350,7 +357,13 @@ async def _handle_import_error(
     # relying on each source listing the message in get_non_retryable_errors.
     if isinstance(error, SchemaColumnTypeChangedException):
         await handle_non_retryable_error(
-            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+            job_inputs.team_id,
+            str(job_inputs.source_id),
+            job_inputs.run_id,
+            error_msg,
+            logger,
+            error,
+            retry_before_giving_up,
         )
 
     # An OAuth `Integration.access_token`/`refresh_token` that still looks like Fernet ciphertext
@@ -360,7 +373,13 @@ async def _handle_import_error(
     # get_non_retryable_errors to recognise this message.
     if isinstance(error, UndecryptedIntegrationSecretError):
         await handle_non_retryable_error(
-            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+            job_inputs.team_id,
+            str(job_inputs.source_id),
+            job_inputs.run_id,
+            error_msg,
+            logger,
+            error,
+            retry_before_giving_up,
         )
 
     # RESTClientRetryableError only escapes the shared REST engine's own tenacity retry loop once
@@ -377,7 +396,13 @@ async def _handle_import_error(
     non_retryable_errors = source_cls.get_non_retryable_errors()
     if any(match in error_msg for match in non_retryable_errors):
         await handle_non_retryable_error(
-            job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error
+            job_inputs.team_id,
+            str(job_inputs.source_id),
+            job_inputs.run_id,
+            error_msg,
+            logger,
+            error,
+            retry_before_giving_up,
         )
 
     retryable_errors = source_cls.get_retryable_errors()

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -250,6 +250,38 @@ async def test_schema_column_type_changed_routes_through_handler_without_source_
     logger.aexception.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_non_retryable_error_honors_source_opt_out_of_grace_period():
+    # A source can classify its own non-retryable errors as a permanent condition (e.g. Paddle's
+    # 403 "API key lacks permissions") rather than a possibly-transient blip, via
+    # should_retry_non_retryable_errors() returning False. _handle_import_error must thread that
+    # through to handle_non_retryable_error so the job fails on the first occurrence instead of
+    # burning the grace-period retries meant for sources that want them.
+    error = Exception("403 Client Error: Forbidden for url: https://api.paddle.com/transactions")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {"403 Client Error: Forbidden for url: https://api.paddle.com": ""}
+    source.get_retryable_errors.return_value = set()
+    source.should_retry_non_retryable_errors.return_value = False
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with (
+        mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
+        mock.patch.object(module, "handle_non_retryable_error", autospec=True) as handle_mock,
+    ):
+        handle_mock.side_effect = NonRetryableException()
+        with pytest.raises(NonRetryableException):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    handle_mock.assert_awaited_once()
+    assert handle_mock.await_args is not None
+    assert handle_mock.await_args.args[5] is error
+    assert handle_mock.await_args.args[6] is False
+
+
 def _incremental_schema(*, is_incremental: bool, lookback_seconds: int | None) -> mock.MagicMock:
     schema = mock.MagicMock()
     schema.should_use_incremental_field = True


### PR DESCRIPTION
## Problem

Error tracking surfaced a `403 Client Error: Forbidden` `HTTPError` from a Paddle sync (`products/warehouse_sources/backend/temporal/data_imports/sources/paddle/`), raised in the shared REST engine at `products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py`.

Tracing the call path, this 403 is already correctly classified: `PaddleSource.get_non_retryable_errors()` lists the exact message prefix, so `_handle_import_error` routes it to `handle_non_retryable_error`. That function gives every non-retryable-classified error a grace period — a few activity attempts (via a Redis counter) before finally raising `NonRetryableException` — to absorb a genuinely transient false positive (a gateway reboot, a momentary auth hiccup).

`PaddleSource` also defines `should_retry_non_retryable_errors()` returning `False` — its evident intent is to skip that grace period, since a Paddle API-key-permissions 403 is a static, permanent condition that a grace-period retry can't fix. But nothing in the codebase ever calls this method. It's dead code, so Paddle still burns through the full grace period (and mints one error-tracking event per attempt) on every occurrence.

## Changes

- `sources/common/base.py`: declare `should_retry_non_retryable_errors()` on `_BaseSource`, defaulting to `True` (today's behavior, unchanged for every other source).
- `workflow_activities/import_data_sync.py`: `_handle_import_error` resolves the source's value once and threads it through every `handle_non_retryable_error` call site.
- `pipelines/common/extract.py`: `handle_non_retryable_error` takes a `retry_before_giving_up` flag; when `False`, it raises `NonRetryableException` immediately instead of touching the Redis attempt counter.

No source other than Paddle overrides the new method, so this is a behavior change scoped to Paddle's already-classified non-retryable errors only.

## How did you test this code?

- Added `TestHandleNonRetryableError` in `pipelines/common/test/test_extract.py`: `retry_before_giving_up=False` raises `NonRetryableException` on the first call without touching Redis — the exact behavior the dead method was supposed to produce.
- Added `test_non_retryable_error_honors_source_opt_out_of_grace_period` in `workflow_activities/tests/test_import_data_sync.py`: a source with `should_retry_non_retryable_errors() -> False` causes `_handle_import_error` to call `handle_non_retryable_error` with that flag set — this is the wiring regression the original dead code could hide again.
- `ruff check`/`ruff format --check` on touched files, and a full repo-wide `mypy --cache-fine-grained .` (no issues).
- Ran both touched test files locally (`pytest`); all non-DB tests pass. A handful of unrelated `TestHandleCorruptedDeltaLog`/OOM tests in the same file need a live Postgres not available in this sandbox — they're unaffected by this change (pre-existing, unrelated to `handle_non_retryable_error`).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated a live PostHog error-tracking issue (`019fae49-746a-7e20-87fb-1974f08ddd2a`) for a Paddle sync HTTPError. Used the `posthog` MCP tool to pull the issue's stack trace and sample event, then traced the code path by hand across `rest_client.py`, `import_data_sync.py`, and `extract.py` to confirm the 403 was already correctly classified non-retryable and to find the actual gap: an unwired per-source override. Invoked `/writing-tests` before adding the two regression tests above. Ran `ruff`, `ruff format --check`, and a full repo-wide `mypy` pass locally.