### PR TITLE
chore(dags): move query_log_archive export ownership to analytics-platform

### DIFF
--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -159,7 +159,7 @@ SETTINGS s3_truncate_on_insert = 1, max_threads = {config.max_threads}
     resource_defs={
         "cluster": OpsClickhouseClusterResource(max_execution_time=2 * 60 * 60, max_memory_usage=20 * ONE_GB)
     },
-    tags={"owner": JobOwners.TEAM_QUERY_PERFORMANCE.value},
+    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value},
 )
 def export_query_log_archive_to_s3():
     export_query_log_archive_day()


### PR DESCRIPTION
## Problem

The `export_query_log_archive_to_s3` Dagster job is tagged with `JobOwners.TEAM_QUERY_PERFORMANCE`, but the query-performance team no longer exists, so failure alerts for this job route to a dead Slack channel.

## Changes

Retag the job's `owner` to `JobOwners.TEAM_ANALYTICS_PLATFORM`, which already exists in the enum and routes to `#alerts-analytics-platform` in `slack_alerts.py`.


## How did you test this code?

- `ruff check` passes; the change is a one-line tag swap between two existing enum members, exercised by Dagster's job definition loading in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`posthog/dags/README.md` uses `TEAM_ANALYTICS_PLATFORM` as its example; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Claude Fable 5) in a session driven by Andy Zhao.
- Kept deliberately scoped to this one job per Andy's request; the remaining `team-query-performance` references are listed above for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
