### PR TITLE
fix(exports): stop the metric image export squeezing its chart flat

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2285,9 +2285,13 @@ snapshots:
     exporter-other--sql-insight-no-results--light:
         hash: v1.k794b7964.61d2bc9e86a0f575ed9653d7a8591219e402a06f6e53021eee8efcc7eb87d644._4TYA0cVTREdm7CEPknXXiutaQB4rZKngjK1MrAGE-Y
     exporter-trends--trends-metric-insight--dark:
-        hash: v1.k794b7964.cf3fe4db037b81c1da572706946b49e6c92aa70951bce07ebba3d7d7dd4befb0.3brUeK-WhFsdEAxR7gWVWAsrkVwv3C7Me4MiX7CHHvM
+        hash: v1.k794b7964.b98d85ed23d2217983a6af3c3e26c619eb1b127740286c0c2fcde8b9a9061f80.jy33WcgkTnYivlpUdM1G7XUd0K1l9VFyA4F0jbuixAQ
     exporter-trends--trends-metric-insight--light:
-        hash: v1.k794b7964.312a58724b4972bd2eb142ff2591025408edf13663b9c1d1fa77a14c68e7924a.F2Yl15jP_qWWs0Yamx5tPRz8ZLTzbMtn71HB2C0rxjU
+        hash: v1.k794b7964.3ac22e9e0970b0aad2dddc54f0b992090749e747f65456759bd78b54463b02e3.U4LTvYbvCJX3WP5Wh8ipV1VNcPzjAaJxYKBxh15x5Sg
+    exporter-trends--trends-metric-insight-long-description--dark:
+        hash: v1.k794b7964.a3e948cac8df850d07f19453d3673b3af964de60c035783828d40dbc07c9510c.Ug8lyaKpYbYf7q2FUzYtcrs3mqizSPkwqYGIWEUuMyY
+    exporter-trends--trends-metric-insight-long-description--light:
+        hash: v1.k794b7964.7ef74ec9ef5f02c0b687455fb81b8c6a9759ad706a9e737c0217d8e8ed630697.Dh8uWZrhEunDTpFMVH0tCoUqLSHYPtKoMe8T0T4TUC0
     exporter-trends--trends-pie-insight--dark:
         hash: v1.k794b7964.e5e7c9e36ec62680c87794152b474fcd8ae0061bc7e8145416512ee745e05d21.uVeV9IUiset22yU0BtIEzyXgbkadZEoT1M-mMbalaVw
     exporter-trends--trends-pie-insight--light:
@@ -7758,6 +7762,10 @@ snapshots:
         hash: v1.k794b7964.8ebd0fb0b9db1f2cc68bcb63d890a44003403e27688a938e5cb04fbffb3b5d5e.aKxLz7jngQZcJL6b0nrArk3V-pDEoGNoPsYUiGbIYy4
     scenes-other-onboarding-shared-wizard-sync-card--local-running--light:
         hash: v1.k794b7964.644de0941a464befbdd1c1173307918762ec7bf580d08b6bb73e0170da71ab57.roPN1jIIWT47y5Xh3Gluqd744nCUVhJkfniX1oq__3M
+    scenes-other-onboarding-shared-wizard-sync-card--local-running-started-by-teammate--dark:
+        hash: v1.k794b7964.9238cd8306270044b6be400d8b253942a6ebc7639dac27e091afe3afb5900291.1tQS7yVR_gZ7fmjjzoegrw7GXmePG9-QafLgOaddLfo
+    scenes-other-onboarding-shared-wizard-sync-card--local-running-started-by-teammate--light:
+        hash: v1.k794b7964.311090aa83634a64027ca60d44a1ac93ecb22124f9144032439c364e0e513105.jEWKZmu_Lw9ugOlP0970x-jQom-SKcWM7N__q-UTgT8
     scenes-other-onboarding-shared-wizard-sync-card--local-waiting-for-input--dark:
         hash: v1.k794b7964.882a0f73b32a910ae1582ef69720f025078bc35867e04d6a03e4931999999ae1.udwLNxP_oZh1qhyS1Ce07RtoSfNpckSBGlOxC41rVp0
     scenes-other-onboarding-shared-wizard-sync-card--local-waiting-for-input--light:
@@ -7766,10 +7774,6 @@ snapshots:
         hash: v1.k794b7964.f074463c40fd8b34d0ca55c651b409fb35668ecc69fefb4e631208b3f5db1bde.zioGxlu5eKa64EXl2wzmAT4K-EC_0eK5uoUMxZIu98Y
     scenes-other-onboarding-shared-wizard-sync-card--local-waiting-for-sensitive-input--light:
         hash: v1.k794b7964.57524d53d6835dd9472c87a6aca291266fb8e8971d95ba311842386f94347fc8.sMjUBzJVzLkCThwa5LT8ntVK63w5tJ0lYltmn2pD70E
-    scenes-other-onboarding-shared-wizard-sync-card--local-running-started-by-teammate--dark:
-        hash: v1.k794b7964.9238cd8306270044b6be400d8b253942a6ebc7639dac27e091afe3afb5900291.1tQS7yVR_gZ7fmjjzoegrw7GXmePG9-QafLgOaddLfo
-    scenes-other-onboarding-shared-wizard-sync-card--local-running-started-by-teammate--light:
-        hash: v1.k794b7964.311090aa83634a64027ca60d44a1ac93ecb22124f9144032439c364e0e513105.jEWKZmu_Lw9ugOlP0970x-jQom-SKcWM7N__q-UTgT8
     scenes-other-onboarding-shared-wizard-sync-card--playground--dark:
         hash: v1.k794b7964.c69534afe39d0311b0ed3247beb145b94381706a25f2e6c7b5d3415c87564375.ViSw0_amXLmDYynCEuR_kgnY5Ncm4ULveglgIJoTIaU
     scenes-other-onboarding-shared-wizard-sync-card--playground--light:

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.scss
@@ -32,21 +32,16 @@
         border-radius: 0 0 var(--radius) var(--radius);
     }
 
-    // A metric card renders best as a wide 2:1 card — header plus chart, proportioned like a dashboard
-    // tile — rather than stretched to the full exporter height. The aspect-ratio derives the card's
-    // height from the export width, and the content flex-fills the space under the header so the
-    // filling sparkline hugs the bottom of the card.
+    // A metric renders as a dashboard-tile-like card — header plus chart band — rather than stretched to
+    // the full exporter height. The ratio sits on the band, not the card, so a tall header (a long
+    // description wrapping over several lines) grows the card instead of squeezing the chart to a sliver.
     &--metric {
         flex: 0 0 auto;
         height: auto;
-        aspect-ratio: 2 / 1;
 
         .ExportedInsight__content {
-            flex: 1 1 0;
-
-            // `min-height: 0` overrides the flex-item `auto` floor so the aspect-ratio governs the card's
-            // height instead of the content's min-content height stretching the card taller.
-            min-height: 0;
+            flex: 0 0 auto;
+            aspect-ratio: 2 / 1;
         }
 
         // The quill sparkline shifts itself down 6px (`top-[6px]`) so its zero-baseline — drawn 6px

--- a/frontend/src/exporter/stories/ExporterTrends.stories.tsx
+++ b/frontend/src/exporter/stories/ExporterTrends.stories.tsx
@@ -146,10 +146,32 @@ export const TrendsNumberInsight: Story = {
 /** The Metric sparkline is SVG/canvas, so it captures cleanly and guards against the exported card
  * collapsing to a fixed-height sparkline that floats mid-card instead of filling and hugging the bottom.
  * The fixed-width wrapper mirrors the backend's 600px metric export viewport — the test runner's
- * shrink-to-fit root would otherwise collapse the aspect-ratio card to its text width, leaving the
- * filling sparkline no height at all. */
+ * shrink-to-fit root would otherwise collapse the chart band to its text width, leaving the filling
+ * sparkline no height at all. */
 export const TrendsMetricInsight: Story = {
     args: { insight: __trendsMetric as any },
+    decorators: [(StoryFn): JSX.Element => <div className="w-[600px]">{StoryFn()}</div>],
+    parameters: {
+        mockDate: '2022-04-01',
+        testOptions: {
+            snapshotBrowsers: ['chromium'],
+            waitForSelector: '.Metric canvas',
+        },
+    },
+}
+
+/** A long description pushes the metric card's header tall. The card has to grow to keep the chart band
+ * at full height — a ratio on the card itself squeezed the sparkline to a sliver that spilled past the
+ * bottom edge. */
+export const TrendsMetricInsightLongDescription: Story = {
+    args: {
+        insight: {
+            ...(__trendsMetric as any),
+            name: 'Scanners created — total',
+            description:
+                'Total Replay Vision scanners created (autocaptured "Create scanner" clicks, data-attr=vision-editor-save). Last 90 days, excludes internal/test accounts.',
+        },
+    },
     decorators: [(StoryFn): JSX.Element => <div className="w-[600px]">{StoryFn()}</div>],
     parameters: {
         mockDate: '2022-04-01',

--- a/products/exports/backend/tasks/image_exporter.py
+++ b/products/exports/backend/tasks/image_exporter.py
@@ -159,8 +159,8 @@ def _insight_query_screenshot_width(query: dict) -> ScreenWidth:
     layout) grow vertically, not horizontally. Small funnels are constrained later by the
     width measurement. The higher the number, the more RAM the Chromium driver needs.
 
-    A metric renders as a wide 2:1 card whose height derives from the viewport width, so a
-    narrower viewport keeps it at dashboard-tile size instead of a 400px-tall banner.
+    A metric renders as a card whose height derives from the viewport width, so a narrower
+    viewport keeps it at dashboard-tile size instead of a 400px-tall banner.
     Mirrors the frontend's check (InsightVizNode wrapper required), which gates the
     metric card CSS — a bare TrendsQuery gets neither, so it must keep the default viewport.
     """


### PR DESCRIPTION
## Problem

Metric image exports (the ones subscriptions email/Slack out) looked wide, short and cut off — the chart rendered as a flat line hugging the bottom edge, with the card's bottom border missing entirely.

`ExportedInsight--metric` carried `aspect-ratio: 2 / 1` on the **whole card**, so the card's height was pinned to the export width (600px viewport → 268px card). The header is variable height, so an insight whose description wraps over several lines ate most of that budget and left the sparkline an 18px sliver — which then spilled 3px past the card's bottom edge, which is why the bottom border is missing in the shot above.

Measured at the backend's 600px metric export viewport, before this change:

| | header | chart | card |
|---|---|---|---|
| no description | 94 | 174 | 268 |
| 3-line description | 160 | **18** | 268 (chart overflows) |

The `min-height: 0` on the content was what allowed the squeeze — it was there deliberately, to stop the content stretching the card past the ratio.

## Fix

Move the ratio off the card and onto the chart band. The band is always 2:1 off the export width; the card grows to fit whatever the header needs.

```diff
 &--metric {
     flex: 0 0 auto;
     height: auto;
-    aspect-ratio: 2 / 1;

     .ExportedInsight__content {
-        flex: 1 1 0;
-        min-height: 0;
+        flex: 0 0 auto;
+        aspect-ratio: 2 / 1;
     }
```

Note a `min-height` floor on the content does *not* work here — Chrome gives `aspect-ratio` priority over a flex item's automatic minimum size, so the card refuses to grow and the chart just overflows. Sizing the band is what actually lets the card expand.

## Result

Chart band is a constant 267px and stays inside the card in every case:

| | header | chart | card | overall |
|---|---|---|---|---|
| no description | 94 | 267 | 363 | 1.48:1 (≈3:2) |
| 3-line description | 160 | 267 | 429 | 1.25:1 |
| 6-line description | 292 | 267 | 561 | 0.96:1 |

## Testing

Verified in Storybook with `type=image` at the 600px metric export viewport across all three cases above — measured the real geometry, confirmed `content.bottom <= card.bottom` throughout.

Added `TrendsMetricInsightLongDescription` as a visual regression guard, since the existing metric fixture has no description and so never exercised the tall-header path that broke.

Backend change is comment-only — the 600px viewport selection is unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
