### PR TITLE
fix(ci): run frontend typecheck on a 32 GB runner

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -581,7 +581,10 @@ jobs:
         name: Frontend typechecking
         needs: [changes]
         if: needs.changes.outputs.frontend_code == 'true'
-        # tsgo peaks around 10 GB checking the whole frontend, so 16 GB runners OOM mid-check.
+        # tsgo peaks ~10 GB RSS type-checking the whole frontend, which OOM-kills it on ~6% of
+        # runs on any 16 GB runner (ubuntu-latest and depot-ubuntu-24.04-4 alike). Peak tracks
+        # the type graph, not parallelism, so GOMAXPROCS does not shrink it; 32 GB is the next
+        # rung on Depot's ladder. Talk to #team-devex before changing.
         runs-on: depot-ubuntu-24.04-8
         # Kea typegen invalidates on changes to any logic plus everything that depends on it.
         # For changes to shared core (TaxonomicFilter, Insight, etc.) the dependent set is large

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -587,7 +587,12 @@ jobs:
         # and declaration:false change nothing, and dropping all of products/ from include
         # removes only 891 of 13703 files because imports pull them back in. 32 GB is the next
         # rung on Depot's ladder. Talk to #team-devex before changing.
-        runs-on: depot-ubuntu-24.04-8
+        #
+        # Forks stay on GitHub-hosted: this job runs `pnpm install`, so a fork PR controls
+        # lifecycle scripts, and Depot runners inject shared cache credentials ambiently
+        # (see _rust-build-images.yml, which skips sccache creds for the same reason).
+        # Fork PRs keep the pre-existing OOM flake; internal PRs and master get the fix.
+        runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && 'depot-ubuntu-24.04-8' || 'ubuntu-latest' }}
         # Kea typegen invalidates on changes to any logic plus everything that depends on it.
         # For changes to shared core (TaxonomicFilter, Insight, etc.) the dependent set is large
         # and the cache miss costs ~5min on top of the master baseline (~10min). 15 is too tight.

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -581,7 +581,8 @@ jobs:
         name: Frontend typechecking
         needs: [changes]
         if: needs.changes.outputs.frontend_code == 'true'
-        runs-on: ubuntu-latest
+        # tsgo peaks around 10 GB checking the whole frontend, so 16 GB runners OOM mid-check.
+        runs-on: depot-ubuntu-24.04-8
         # Kea typegen invalidates on changes to any logic plus everything that depends on it.
         # For changes to shared core (TaxonomicFilter, Insight, etc.) the dependent set is large
         # and the cache miss costs ~5min on top of the master baseline (~10min). 15 is too tight.

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -581,9 +581,11 @@ jobs:
         name: Frontend typechecking
         needs: [changes]
         if: needs.changes.outputs.frontend_code == 'true'
-        # tsgo peaks ~10 GB RSS type-checking the whole frontend, which OOM-kills it on ~6% of
-        # runs on any 16 GB runner (ubuntu-latest and depot-ubuntu-24.04-4 alike). Peak tracks
-        # the type graph, not parallelism, so GOMAXPROCS does not shrink it; 32 GB is the next
+        # tsgo peaks ~12 GB type-checking the whole frontend, which OOM-kills it on ~6% of runs
+        # on any 16 GB runner (ubuntu-latest and depot-ubuntu-24.04-4 alike). Peak tracks the
+        # type graph, not parallelism or lib checking: skipLibCheck is already on, GOMAXPROCS
+        # and declaration:false change nothing, and dropping all of products/ from include
+        # removes only 891 of 13703 files because imports pull them back in. 32 GB is the next
         # rung on Depot's ladder. Talk to #team-devex before changing.
         runs-on: depot-ubuntu-24.04-8
         # Kea typegen invalidates on changes to any logic plus everything that depends on it.


### PR DESCRIPTION
## Problem

- `Frontend typechecking` fails ~6% of runs with `The runner has received a shutdown signal`, on master and PRs alike.
- Not a type error. `tsgo` OOMs mid-check (`Killed`, exit 137). Its live set is ~10.4 GB, 65% of a 16 GB `ubuntu-latest` before the OS, runner agent and page cache.
- Retrying cannot help: the runner agent goes down with it.

## Changes

- `frontend-typescript-checks` moves to `depot-ubuntu-24.04-8` (8 vCPU, 32 GB) for internal PRs and master. No other job touched.
- Fork PRs stay on `ubuntu-latest`. This job runs `pnpm install`, so a fork controls lifecycle scripts, and Depot runners inject shared cache credentials ambiently (`_rust-build-images.yml` skips sccache creds for the same reason). Forks keep the pre-existing flake rather than gaining credential reach.

| Evidence | Value |
|---|---|
| Kill rate, 7 days, matched window per day | 31 / 489 (6.3%) |
| Kills that were this one step | 60 / 60 |
| Other jobs scanned same day, zero hits | 7,528 |
| tsgo peak / live floor | 12.3 GB / 10.4 GB |

Cheaper levers, all measured, none clear 16 GB:

| Lever | Peak | Verdict |
|---|---|---|
| `skipLibCheck` | - | already on |
| `GOMAXPROCS` 12 vs 4 | 11.4 GB | noise |
| `declaration: false` | 12.6 GB | no effect |
| `GOMEMLIMIT` 10 / 8 / 6 / 4 GiB | 10.9 / 10.5 / 10.4 / 10.4 GB | floors at 10.4 GB |
| Drop `products/` from `include` | 11.1 GB | only 891 of 13,703 files leave the program |
| Restore `tsconfig.tsbuildinfo` | 12.5 GB | 2.5 GB only for a no-op rerun |

Two of those answer "why not just use 16 GB". `GOMEMLIMIT` bottoms out at ~10.4 GB no matter how low you set it, trading CPU for nothing (37s unlimited, 68s at 4 GiB), because that floor is live type graph rather than collectable garbage. And narrowing `include` does not partition the graph, since imports pull `products/` straight back in.

## How did you test this code?

- `bin/hogli lint:workflows` 6/6, `actionlint` clean on the changed job.
- Memory measured locally at `GOMAXPROCS=4`, cold every run. CI is always cold: `tsconfig.tsbuildinfo` is gitignored and never cached.
- Not yet observed on the new runner. This PR's own CI is the first real signal.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude (Opus 5) investigated and made the edit. Skills invoked: `/authoring-ci-workflows`, `/depot-github-runners`.

Depot's Linux ladder is 8 / 16 / 32 GB. The 16 GB rung has the same memory as today, so 32 GB is simply the next size that clears a 12.3 GB peak. Playwright E2E, the only job already on `-8`, documents a 30% peak of 32 GB (~9.6 GB), so this is a comparable profile rather than an escalation.

Untested: real TypeScript project references, where downstream projects consume emitted `.d.ts` instead of re-parsing sources. That could partition memory where narrowing `include` did not, but it is a large refactor given the `"*": ["./frontend/*"]` path mapping.

