### PR TITLE
chore(personhog): parallelize stateright model checkers

### DIFF
--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -7,11 +7,21 @@
 # suite from saturating the runner while a cluster is up.
 [test-groups]
 k3s = { max-threads = 1 }
+# The two-partition double-zombie models are the stateright suite's long
+# pole (roughly 15x anything else in it). Their checkers explore
+# multi-threaded, so each gets the whole thread budget to itself instead
+# of contending with the rest of the suite mid-explore.
+stateright-heavy = { max-threads = 1 }
 
 [[profile.default.overrides]]
 filter = 'binary(k3s_integration)'
 test-group = 'k3s'
 threads-required = 4
+
+[[profile.default.overrides]]
+filter = 'package(personhog-stateright) & test(two_partitions_double_zombie)'
+test-group = 'stateright-heavy'
+threads-required = "num-cpus"
 
 # CI profile: emits JUnit XML (target/nextest/ci/junit.xml) so test results can be
 # uploaded to Trunk for flaky-test detection.

--- a/rust/personhog-stateright/tests/model_tests.rs
+++ b/rust/personhog-stateright/tests/model_tests.rs
@@ -25,6 +25,15 @@ use std::time::Instant;
 use personhog_stateright::model::{HandoffModel, Variant};
 use stateright::{Checker, Model};
 
+/// Every checker explores in parallel: stateright defaults to a single
+/// thread, which left the largest models (the two-partition
+/// double-zombie pair) as multi-minute single-core BFS runs. The
+/// nextest `stateright-heavy` group gives those tests the machine to
+/// themselves so this parallelism gets real cores.
+fn parallelism() -> usize {
+    std::thread::available_parallelism().map_or(1, Into::into)
+}
+
 /// Baseline configuration; tests override fields with struct-update
 /// syntax. Reads default on so every scenario also exercises the read
 /// path under the shipped (stashed) design.
@@ -62,6 +71,7 @@ fn model(variant: Variant, crashes: u8, zombie_window: u8) -> HandoffModel {
 fn current_protocol_without_failures_is_safe_and_live() {
     model(Variant::Current, 0, 0)
         .checker()
+        .threads(parallelism())
         .spawn_bfs()
         .join()
         .assert_properties();
@@ -74,6 +84,7 @@ fn current_protocol_without_failures_is_safe_and_live() {
 fn current_protocol_with_crashes_is_safe_and_live() {
     model(Variant::Current, 1, 0)
         .checker()
+        .threads(parallelism())
         .spawn_bfs()
         .join()
         .assert_properties();
@@ -89,6 +100,7 @@ fn current_protocol_with_crashes_is_safe_and_live() {
 fn current_protocol_single_zombie_pod_is_safe() {
     model(Variant::Current, 1, 1)
         .checker()
+        .threads(parallelism())
         .spawn_bfs()
         .join()
         .assert_properties();
@@ -101,7 +113,11 @@ fn current_protocol_single_zombie_pod_is_safe() {
 /// but sits beyond the warm HWM, invisible to the new owner forever.
 #[test]
 fn current_protocol_double_zombie_loses_acked_writes() {
-    let checker = model(Variant::Current, 2, 1).checker().spawn_bfs().join();
+    let checker = model(Variant::Current, 2, 1)
+        .checker()
+        .threads(parallelism())
+        .spawn_bfs()
+        .join();
     assert!(
         checker.discovery("no_lost_acked_write").is_some(),
         "the double zombie must produce an acked-write-loss counterexample"
@@ -119,6 +135,7 @@ fn current_protocol_double_zombie_loses_acked_writes() {
 fn epoch_fenced_double_zombie_is_safe() {
     let checker = model(Variant::EpochFenced, 2, 1)
         .checker()
+        .threads(parallelism())
         .spawn_bfs()
         .join();
     assert!(
@@ -149,6 +166,7 @@ fn current_two_partitions_single_zombie_is_safe() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join()
     .assert_properties();
@@ -173,6 +191,7 @@ fn current_with_rejoin_is_safe_and_live() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join()
     .assert_properties();
@@ -193,6 +212,7 @@ fn strong_reads_are_complete_across_cutover() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join()
     .assert_properties();
@@ -211,6 +231,7 @@ fn two_partitions_double_zombie_loses_acked_writes() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join();
     assert!(checker.discovery("no_lost_acked_write").is_some());
@@ -229,6 +250,7 @@ fn epoch_fenced_two_partitions_double_zombie_is_safe() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join();
     assert!(checker.discovery("no_lost_acked_write").is_none());
@@ -260,6 +282,7 @@ fn late_router_join_is_safe_and_live() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join()
     .assert_properties();
@@ -284,6 +307,7 @@ fn probe_silent_late_joiner_advance_is_reachable_and_safe() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join();
     assert!(
@@ -321,6 +345,7 @@ fn zero_router_creation_with_late_joiner_is_safe_and_live() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join();
     assert!(
@@ -368,6 +393,7 @@ fn probe_divergent_quorums_are_reachable_and_safe() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join();
     assert!(
@@ -409,6 +435,7 @@ fn epoch_fenced_double_zombie_with_late_joiner_is_safe() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join();
     assert!(
@@ -441,6 +468,7 @@ fn probe_concurrent_handoffs_are_reachable() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join();
     assert!(
@@ -470,6 +498,7 @@ fn probe_dual_role_pod_is_reachable_and_safe() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join();
     assert!(
@@ -551,6 +580,7 @@ fn state_space_report() {
             ..base()
         }
         .checker()
+        .threads(parallelism())
         .spawn_bfs()
         .join();
         println!(
@@ -576,6 +606,7 @@ fn deadline_cancellation_by_replacement_is_safe_and_live() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join()
     .assert_properties();
@@ -604,6 +635,7 @@ fn cancellation_with_live_owner_reaffirms_and_resumes() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join()
     .assert_properties();
@@ -622,6 +654,7 @@ fn cancellation_with_dead_owner_replaces_atomically() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join()
     .assert_properties();
@@ -641,6 +674,7 @@ fn rejoin_two_partitions_without_cancellation() {
         ..base()
     }
     .checker()
+    .threads(parallelism())
     .spawn_bfs()
     .join()
     .assert_properties();


### PR DESCRIPTION
## Problem

The stateright shard has grown to ~40 minutes in CI. Profiling the suite shows the cost is concentrated in two tests — the two-partition double-zombie models (two_partitions_double_zombie_loses_acked_writes and epoch_fenced_two_partitions_double_zombie_is_safe) — which run for many minutes each because stateright's checker defaults to a single thread: every .checker().spawn_bfs() call explores its state space on one core, regardless of runner size. The opt-level overrides in the workspace Cargo.toml already handle the compile side; single-threaded exploration was the remaining bottleneck.

## Changes

- Every checker in model_tests.rs now explores with .threads(available_parallelism()) via a shared helper.
- A stateright-heavy nextest test-group (same pattern as the existing k3s group) gives the two heaviest tests threads-required = "num-cpus" and max-threads = 1: each gets the whole machine to itself, and they never contend with each other or the rest of the suite mid-explore.

State spaces and properties are unchanged — no proof is weakened; only the exploration is parallel.

## How did you test this code?

Measured locally in release mode (matching CI's opt-level for these crates): the slowest test drops 427s → 62s, and suite wall-clock drops 548s → 216s. All 21 tests pass with the same skip set as the baseline; cargo nextest list validates the config change. No new tests — this changes no behavior under test.

Follow-ups deliberately deferred: re-measure the shard's weight-table entry (personhog-stateright: 700) from a real CI run, and only consider a bigger runner for the shard if it's still the workflow's long pole after this.

## 🤖 Agent context

Autonomy: Human-driven (agent-assisted)

Claude Code session. Diagnosis ruled out the debug-build theory (the workspace already pins opt-level 3 for the checker crates) and located the bottleneck by timing the suite locally; the fix was chosen over a bigger CI runner to change one variable at a time, and over symmetry reduction / demoting tests to nightly to avoid touching what the proofs mean.