### PR TITLE
fix(braintree): cap search page size at braintree's 50 per-request limit

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
@@ -22,8 +22,10 @@ BRAINTREE_HOSTS = {
 # GraphQL API version (date-versioned header, required). Opaque vendor labels — never parsed.
 BRAINTREE_VERSION_2019_01_01 = "2019-01-01"
 BRAINTREE_VERSION_2026_07_14 = "2026-07-14"
-# Braintree's GraphQL search fields reject `first` above 50.
-PAGE_SIZE = 50
+# Braintree's GraphQL search fields reject `first` above 50, so this is a vendor
+# ceiling rather than a tuning knob.
+MAX_PAGE_SIZE = 50
+PAGE_SIZE = MAX_PAGE_SIZE
 # Braintree recommends generous timeouts due to async transaction processing.
 REQUEST_TIMEOUT_SECONDS = 120
 MAX_RETRY_ATTEMPTS = 5

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/braintree.py
@@ -22,7 +22,8 @@ BRAINTREE_HOSTS = {
 # GraphQL API version (date-versioned header, required). Opaque vendor labels — never parsed.
 BRAINTREE_VERSION_2019_01_01 = "2019-01-01"
 BRAINTREE_VERSION_2026_07_14 = "2026-07-14"
-PAGE_SIZE = 100
+# Braintree's GraphQL search fields reject `first` above 50.
+PAGE_SIZE = 50
 # Braintree recommends generous timeouts due to async transaction processing.
 REQUEST_TIMEOUT_SECONDS = 120
 MAX_RETRY_ATTEMPTS = 5

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
@@ -7,7 +7,7 @@ from unittest import mock
 from products.warehouse_sources.backend.temporal.data_imports.sources.braintree.braintree import (
     BRAINTREE_VERSION_2019_01_01,
     BRAINTREE_VERSION_2026_07_14,
-    PAGE_SIZE,
+    MAX_PAGE_SIZE,
     BraintreeGraphQLError,
     BraintreeResumeConfig,
     _base_url,
@@ -45,12 +45,6 @@ def _search_response(search_field: str, edges: list[dict[str, Any]], has_next: b
 
 def _edge(node_id: str) -> dict[str, Any]:
     return {"cursor": f"cur-{node_id}", "node": {"id": node_id, "createdAt": "2024-01-01T00:00:00Z"}}
-
-
-class TestPageSize:
-    def test_page_size_does_not_exceed_braintree_limit(self):
-        # Braintree's GraphQL search fields reject `first` above 50.
-        assert PAGE_SIZE <= 50
 
 
 class TestBaseUrl:
@@ -137,7 +131,12 @@ class TestGetRows:
         assert manager.save_state.call_args.args[0].after == "cur-t2"
         second_vars = mock_session.return_value.post.call_args_list[1].kwargs["json"]["variables"]
         assert second_vars["after"] == "cur-t2"
-        assert second_vars["first"] == PAGE_SIZE
+
+        # Braintree rejects `first` above its cap on the very first page, so assert
+        # against the vendor ceiling rather than echoing our own page size back.
+        for call in mock_session.return_value.post.call_args_list:
+            requested = call.kwargs["json"]["variables"]["first"]
+            assert 0 < requested <= MAX_PAGE_SIZE
 
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_incremental_search_input_has_gte_filter(self, mock_session):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/braintree/tests/test_braintree.py
@@ -47,6 +47,12 @@ def _edge(node_id: str) -> dict[str, Any]:
     return {"cursor": f"cur-{node_id}", "node": {"id": node_id, "createdAt": "2024-01-01T00:00:00Z"}}
 
 
+class TestPageSize:
+    def test_page_size_does_not_exceed_braintree_limit(self):
+        # Braintree's GraphQL search fields reject `first` above 50.
+        assert PAGE_SIZE <= 50
+
+
 class TestBaseUrl:
     def test_production_and_sandbox_hosts(self):
         assert _base_url("production") == "https://payments.braintree-api.com/graphql"


### PR DESCRIPTION
## Problem

Braintree data warehouse imports failed on every sync with `BraintreeGraphQLError: Braintree GraphQL error: You may not request more than 50 per request.`, reported by error tracking.

Braintree's GraphQL search fields (`transactions`, `refunds`, `disputes`) reject a `first` value above 50, but our source requested pages of 100 on every call. The error fired on the very first page of every sync, regardless of the connected account's credentials or data, so this is a bug in our request rather than an upstream or credential issue. `BraintreeGraphQLError` also isn't in the tenacity retry set, so it escaped `get_rows` and burned the non-retryable retry budget before giving up.

## Changes

- `PAGE_SIZE` in `braintree.py` dropped from 100 to 50, Braintree's documented per-request cap, and the cap itself is now named `MAX_PAGE_SIZE`.
- Reworked the page-size guard: instead of asserting `PAGE_SIZE <= 50` against a literal, the pagination test now checks the `first` argument on every outgoing search request stays within `MAX_PAGE_SIZE`. The old assertion in that test compared `first` to `PAGE_SIZE`, which was self-consistent with the bug and passed happily while the real API refused the call.

## How did you test this code?

Automated only, no live Braintree sync:

- `uv run pytest .../braintree/tests/ -q` — 50 passed
- `ruff check` / `ruff format --check` on the source directory — clean

The reworked assertion catches the regression the original test could not: bumping `PAGE_SIZE` back above Braintree's ceiling now fails, whereas before the test just echoed our own constant back at us.

I also looked at whether other search-connection sources share the assumption. Braintree is the only source hitting Braintree's GraphQL search connections, and the other GraphQL sources carry their own vendor-specific limits, so nothing else needed changing here.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking issue flagging `BraintreeGraphQLError` firing on every occurrence. Traced the stack trace to `_execute` in `braintree.py`, then to the hardcoded `PAGE_SIZE = 100` constant used as the GraphQL `first` argument. A follow-up pass (Claude, via PostHog Code) tightened the test so it validates the outgoing request instead of the constant. Invoked `/writing-tests` before touching the test file.

---
*Created with [PostHog Desktop](https://posthog.com/code?ref=pr) from [this inbox report](https://us.posthog.com/project/2/inbox/reports/019faea3-5b6f-7192-9a00-40cb76622eb6).*
