### PR TITLE
fix(alerts): use shared telemetry in insight SLOs

### DIFF
--- a/terraform/us/project-2/team-analytics-platform/slos/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slos/insights.tf
@@ -99,14 +99,17 @@ locals {
       name_prefix  = "SLO: Alert checks"
       description  = "Rolling burn rate for alert checks."
       error_budget = 0.01
-      regions      = ["us"]
+      regions      = ["us", "eu"]
       daily_sql    = <<-SQL
         SELECT
             toDate(timestamp) AS date,
-            countIf(event = 'alert check') AS total,
-            countIf(event = 'alert check failed') AS failures
+            count() AS total,
+            countIf(properties.outcome = 'failure') AS failures
         FROM events
-        WHERE event IN ('alert check', 'alert check failed')
+        WHERE event = 'slo_operation_completed'
+            AND properties.operation = 'alert_check'
+            AND properties.alert_type = 'insight'
+            AND properties.region = '{{REGION}}'
             AND timestamp >= now() - INTERVAL 30 DAY
         GROUP BY date
       SQL
@@ -121,11 +124,11 @@ locals {
       name_prefix  = "SLO: Alert timeliness"
       description  = "Rolling burn rate for alert check timeliness."
       error_budget = 0.01
-      regions      = ["us"]
+      regions      = ["us", "eu"]
       daily_sql    = <<-SQL
         WITH alert_checks AS (
             SELECT
-                properties.alert_id AS alert_id,
+                properties.resource_id AS alert_id,
                 properties.calculation_interval AS calculation_interval,
                 timestamp,
                 lagInFrame(timestamp) OVER (
@@ -134,7 +137,10 @@ locals {
                     ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                 ) AS prev_check
             FROM events
-            WHERE event IN ('alert check', 'alert check failed')
+            WHERE event = 'slo_operation_completed'
+                AND properties.operation = 'alert_check'
+                AND properties.alert_type = 'insight'
+                AND properties.region = '{{REGION}}'
                 AND properties.calculation_interval IN ('hourly', 'daily', 'weekly', 'monthly')
                 AND timestamp >= now() - INTERVAL 45 DAY
         )

--- a/terraform/us/project-2/team-analytics-platform/slos/insights.tf
+++ b/terraform/us/project-2/team-analytics-platform/slos/insights.tf
@@ -104,12 +104,13 @@ locals {
         SELECT
             toDate(timestamp) AS date,
             count() AS total,
-            countIf(properties.outcome = 'failure') AS failures
+            countIf(properties.outcome = 'failure' OR properties.alert_state = 'Errored') AS failures
         FROM events
         WHERE event = 'slo_operation_completed'
             AND properties.operation = 'alert_check'
             AND properties.alert_type = 'insight'
             AND properties.region = '{{REGION}}'
+            AND properties.skip_reason IS NULL
             AND timestamp >= now() - INTERVAL 30 DAY
         GROUP BY date
       SQL
@@ -132,7 +133,7 @@ locals {
                 properties.calculation_interval AS calculation_interval,
                 timestamp,
                 lagInFrame(timestamp) OVER (
-                    PARTITION BY properties.alert_id, properties.calculation_interval
+                    PARTITION BY properties.resource_id, properties.calculation_interval
                     ORDER BY timestamp ASC
                     ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
                 ) AS prev_check
@@ -141,6 +142,7 @@ locals {
                 AND properties.operation = 'alert_check'
                 AND properties.alert_type = 'insight'
                 AND properties.region = '{{REGION}}'
+                AND properties.skip_reason IS NULL
                 AND properties.calculation_interval IN ('hourly', 'daily', 'weekly', 'monthly')
                 AND timestamp >= now() - INTERVAL 45 DAY
         )


### PR DESCRIPTION
## Problem

Insight alert SLOs still query the legacy alert events, so they stop receiving data after alert evaluation moves to the shared service telemetry.

## Changes

- Read insight alert outcomes from `slo_operation_completed`
- Track alert cadence by the shared `resource_id`
- Split the existing SLOs by US and EU region

## How did you test this code?

- Ran both updated HogQL query shapes against current project telemetry
- Ran `git diff --check`
- Terraform formatting could not be fully verified because the formatter reports unrelated existing formatting in this file
- `hogli ci:preflight --fix` was unavailable in the checkout environment

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. This corrects internal Terraform-managed monitoring queries.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex updated the Terraform source of truth after validating the shared alert telemetry with PostHog MCP. Skills invoked: `querying-posthog-data`, `checking-deploy-timing`, and `investigating-logs`.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*