### PR TITLE
fix(data-imports): disable hive-partitioning inference on warehouse table introspection queries

### DIFF
--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -107,6 +107,15 @@ HIDDEN_COLUMNS: frozenset[str] = frozenset({"_dlt_id", "_dlt_load_id", "_ph_debu
 # subprocess lets us kill it and degrade to the ClickHouse-cluster fallback.
 CHDB_QUERY_TIMEOUT_SECONDS = 30.0
 
+# ClickHouse's Hive-style partition inference guesses a type per partition-folder value it
+# samples (e.g. our internal `_ph_partition_key`), independently of the physical column type.
+# A table whose partition granularity changed over time (see repartition.py's tiering from
+# week -> hour) mixes value shapes across folders — e.g. an hour-tier "2017-06-30T05" next to
+# older week-tier folders — and CH can misclassify the column as Date, then fail to parse it.
+# HogQLGlobalSettings.use_hive_partitioning disables this for the normal HogQL query path; the
+# raw ClickHouse queries below bypass that path and must opt out the same way.
+DISABLE_HIVE_PARTITIONING_SETTINGS: dict[str, int] = {"use_hive_partitioning": 0}
+
 _CHDB_SUBPROCESS_SCRIPT = """
 import sys
 
@@ -441,7 +450,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
 
             quoted_placeholders = {k: escape_param_clickhouse(v) for k, v in placeholder_context.values.items()}
             # chdb doesn't support parameterized queries
-            chdb_query = f"DESCRIBE TABLE {s3_table_func}" % quoted_placeholders
+            chdb_query = f"SET use_hive_partitioning = 0; DESCRIBE TABLE {s3_table_func}" % quoted_placeholders
 
             # TODO: upgrade chdb once https://github.com/chdb-io/chdb/issues/342 is actually resolved
             # See https://github.com/chdb-io/chdb/pull/374 for the fix
@@ -472,7 +481,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
             attempts = 5
             for i in range(attempts):
                 try:
-                    get_columns_settings: dict[str, int] = {}
+                    get_columns_settings: dict[str, int] = dict(DISABLE_HIVE_PARTITIONING_SETTINGS)
                     if self._is_csv_format() and self.csv_allow_double_quotes is not None:
                         get_columns_settings["format_csv_allow_double_quotes"] = (
                             1 if self.csv_allow_double_quotes else 0
@@ -531,6 +540,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
             result = sync_execute(
                 f"SELECT max({escape_clickhouse_identifier(column)}) FROM {s3_table_func}",
                 args=placeholder_context.values,
+                settings=DISABLE_HIVE_PARTITIONING_SETTINGS,
             )
 
             return result[0][0]
@@ -564,7 +574,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
 
             quoted_placeholders = {k: escape_param_clickhouse(v) for k, v in placeholder_context.values.items()}
             # chdb doesn't support parameterized queries
-            chdb_query = f"SELECT count() FROM {s3_table_func}" % quoted_placeholders
+            chdb_query = f"SET use_hive_partitioning = 0; SELECT count() FROM {s3_table_func}" % quoted_placeholders
 
             chdb_result = run_chdb_query(chdb_query)
             reader = csv.reader(StringIO(chdb_result))
@@ -585,6 +595,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
                 result = sync_execute(
                     f"SELECT count() FROM {s3_table_func}",
                     args=placeholder_context.values,
+                    settings=DISABLE_HIVE_PARTITIONING_SETTINGS,
                 )
             except Exception as err:
                 capture_exception(err)
@@ -880,7 +891,7 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
             sync_execute(
                 f"SELECT 1 FROM {func} LIMIT 100",
                 args=ctx.values,
-                settings={"format_csv_allow_double_quotes": 1 if setting else 0},
+                settings={**DISABLE_HIVE_PARTITIONING_SETTINGS, "format_csv_allow_double_quotes": 1 if setting else 0},
             )
         except ClickHouseServerException as e:
             if e.code in self._CSV_PARSE_ERROR_CODES:

--- a/products/warehouse_sources/backend/tests/test_table.py
+++ b/products/warehouse_sources/backend/tests/test_table.py
@@ -89,6 +89,35 @@ class TestDataWarehouseTableColumnOrder(BaseTest):
         assert table.column_order == ["z", "a"]
 
 
+class TestWarehouseQueryDisablesHivePartitioning(BaseTest):
+    # ClickHouse infers a type for each Hive-style partition-folder value it samples (e.g. our
+    # internal `_ph_partition_key`) independently of the column's declared type. A table whose
+    # partition granularity changed over time mixes value shapes across folders (e.g. an
+    # hour-tier "2017-06-30T05" alongside older week-tier folders), and CH can misclassify the
+    # column as Date and then fail to parse it — HogQLGlobalSettings disables this inference for
+    # the normal HogQL query path, so these raw `sync_execute` calls must opt out the same way.
+    def _table(self) -> DataWarehouseTable:
+        return DataWarehouseTable(name="t", format="Delta", team=self.team, url_pattern="s3://bucket/team_1/t")
+
+    def test_get_count_disables_hive_partitioning(self) -> None:
+        with patch(
+            "products.warehouse_sources.backend.models.table.sync_execute", return_value=[(5,)]
+        ) as mock_sync_execute:
+            count = self._table().get_count()
+
+        assert count == 5
+        assert mock_sync_execute.call_args.kwargs["settings"]["use_hive_partitioning"] == 0
+
+    def test_get_max_value_for_column_disables_hive_partitioning(self) -> None:
+        with patch(
+            "products.warehouse_sources.backend.models.table.sync_execute", return_value=[(42,)]
+        ) as mock_sync_execute:
+            value = self._table().get_max_value_for_column("created_at")
+
+        assert value == 42
+        assert mock_sync_execute.call_args.kwargs["settings"]["use_hive_partitioning"] == 0
+
+
 class TestSafeExposeChError:
     # ClickHouseAtCapacity is a DRF APIException with no `.message`, so the capacity check
     # must run before the message-matching loop — reordering them would reintroduce an


### PR DESCRIPTION
## Problem

Error tracking surfaced a generic `Could not read the files from your storage bucket` exception raised from `DataWarehouseTable.get_count`, wrapping an underlying ClickHouse error: `DB::Exception: Cannot convert string '2017-06-30T05' to type Date`, thrown while reading a warehouse table's Delta/S3 files (`ReadFromObjectStorage` / `HivePartitioningUtils::addPartitionColumnsToChunk`).

ClickHouse's Hive-style partitioning support infers a type for each partition-folder value it samples (here, our internal `_ph_partition_key` column) independently of the physical column type actually written to the table. Our automatic repartitioning controller steps an oversized datetime-partitioned table through progressively finer tiers over time (month → week → day → hour), so a long-lived table's partition folders can mix value shapes across tiers, e.g. an hour-tier value like `2017-06-30T05` alongside older week-tier folders. ClickHouse misclassifies the column as `Date` from a sample and then fails outright when it hits a value that doesn't fit.

`HogQLGlobalSettings.use_hive_partitioning` already disables this inference by default for every normal HogQL query, clearly to avoid exactly this class of failure. But `get_columns`, `get_max_value_for_column`, `get_count`, and `_validate_csv_double_quotes_setting` on `DataWarehouseTable` issue raw ClickHouse queries directly against the table's own S3 table function, bypassing the HogQL query path entirely, and never applied the same setting. Any warehouse table whose partition scheme has stepped through more than one granularity tier can hit this on introspection.

## Changes

- Added a shared `DISABLE_HIVE_PARTITIONING_SETTINGS` constant in `products/warehouse_sources/backend/models/table.py`.
- Applied it to every raw ClickHouse query issued directly against a table's Delta/S3 data: the chdb and cluster-fallback branches of `get_columns` and `get_count`, `get_max_value_for_column`, and `_validate_csv_double_quotes_setting`.
- This is shared pipeline code, not source-specific — the fix applies regardless of which connector wrote the table.

## How did you test this code?

- `ruff check` / `ruff format --check` on the touched files: pass.
- `mypy` on the touched files: pass, no new issues.
- Added `TestWarehouseQueryDisablesHivePartitioning` in `products/warehouse_sources/backend/tests/test_table.py`, covering `get_count` and `get_max_value_for_column`: mocks `sync_execute` and asserts `use_hive_partitioning: 0` is present in the settings passed on the ClickHouse-cluster fallback path (the path this incident actually hit, since `TEST=True` always short-circuits the chdb attempt in this environment). Regression this catches: a future change dropping the settings kwarg from either call would silently reintroduce the crash.
- I could not run the Django test suite live in this environment (no Postgres/ClickHouse/docker available), so I verified the new tests via static/manual code tracing against the existing test patterns in the same file rather than a live pytest run — flagging this explicitly since I can't claim to have executed them.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Investigated via PostHog error tracking MCP tools (issue details, stack trace, and event properties) to identify the failing frame and scope which sync/schema reproduced it, then read the shared pipeline code (`table.py`, `partitioning.py`, `repartition.py`) to trace the root cause to ClickHouse's Hive-partition type inference against a repartitioned table's `_ph_partition_key` folder values.
- Skills invoked: `/writing-tests` before adding the regression test.
- Considered whether this was upstream/user error (bad credentials, deleted data) vs. our bug — ruled that out once the DeltaLake stack frame and the `HogQLGlobalSettings.use_hive_partitioning=0` precedent made clear this is our own raw-query code path not applying a setting the rest of the codebase already treats as mandatory.
- Checked for duplicate open PRs (by exception text, module path, and the maintainer's own open PRs) — found two open PRs touching the same file (#73490, #74001) but addressing unrelated bugs (error-message mapping, DeltaS3Wrapper schema drift), not this Hive-partitioning issue.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*