### PR TITLE
fix(et): deduplicate exception properties

### DIFF
--- a/frontend/src/lib/components/DefinitionPopover/definitionPopoverLogic.ts
+++ b/frontend/src/lib/components/DefinitionPopover/definitionPopoverLogic.ts
@@ -360,7 +360,7 @@ export const definitionPopoverLogic = kea<definitionPopoverLogicType>([
                     TaxonomicFilterGroupType.DataWarehousePersonProperties,
                     TaxonomicFilterGroupType.RevenueAnalyticsProperties,
                     TaxonomicFilterGroupType.AccountCustomProperties,
-                    TaxonomicFilterGroupType.ErrorTrackingProperties,
+                    TaxonomicFilterGroupType.ExceptionProperties,
                 ].includes(type) || type.startsWith(TaxonomicFilterGroupType.GroupsPrefix),
         ],
         isVirtual: [

--- a/frontend/src/lib/components/EventPropertyTabs/EventPropertyTabs.tsx
+++ b/frontend/src/lib/components/EventPropertyTabs/EventPropertyTabs.tsx
@@ -1,10 +1,9 @@
 import { useValues } from 'kea'
 import { useState } from 'react'
 
-import { INTERNAL_EXCEPTION_PROPERTY_KEYS } from '@posthog/products-error-tracking/frontend/utils'
-
 import { eventPropertyFilteringLogic } from 'lib/components/EventPropertyTabs/eventPropertyFilteringLogic'
 import { HTMLElementsDisplay } from 'lib/components/HTMLElementsDisplay/HTMLElementsDisplay'
+import { INTERNAL_EXCEPTION_PROPERTY_KEYS } from 'lib/components/TaxonomicFilter/utils/errorTrackingProperties'
 import { dayjs } from 'lib/dayjs'
 import { LemonTab, LemonTabs, LemonTabsProps } from 'lib/lemon-ui/LemonTabs'
 import { isKeyOf } from 'lib/utils/guards'

--- a/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/InfiniteList.tsx
@@ -31,6 +31,7 @@ import {
     TaxonomicFilterGroupType,
     TaxonomicFilterGroupValueMap,
 } from 'lib/components/TaxonomicFilter/types'
+import { resolveTaxonomicItemGroup as getItemGroup } from 'lib/components/TaxonomicFilter/utils/resolveTaxonomicItemGroup'
 import { dayjs } from 'lib/dayjs'
 import { LemonRow } from 'lib/lemon-ui/LemonRow'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
@@ -280,7 +281,7 @@ const renderItemContents = ({
         listGroupType === TaxonomicFilterGroupType.Metadata ||
         listGroupType === TaxonomicFilterGroupType.SessionProperties ||
         listGroupType === TaxonomicFilterGroupType.MaxAIContext ||
-        listGroupType === TaxonomicFilterGroupType.ErrorTrackingProperties ||
+        listGroupType === TaxonomicFilterGroupType.ExceptionProperties ||
         listGroupType === TaxonomicFilterGroupType.MCPProperties ||
         listGroupType.startsWith(TaxonomicFilterGroupType.GroupsPrefix) ? (
         <>
@@ -1076,27 +1077,4 @@ function resolveItemRendering({
     }
 
     return { listGroupType, itemGroup }
-}
-
-export function getItemGroup(
-    item: TaxonomicDefinitionTypes | undefined,
-    groups: TaxonomicFilterGroup[],
-    defaultGroup: TaxonomicFilterGroup | undefined
-): TaxonomicFilterGroup | undefined {
-    let group = defaultGroup
-
-    const sourceType = item ? getSourceGroupType(item) : undefined
-    if (sourceType) {
-        const itemGroup = groups.find((g) => g.type === sourceType)
-        if (itemGroup) {
-            group = itemGroup
-        }
-    } else if (item && 'group' in item) {
-        const itemGroup = groups.find((g) => item.group === g.type)
-        if (itemGroup) {
-            group = itemGroup
-        }
-    }
-
-    return group
 }

--- a/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterGallery.stories.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/TaxonomicFilterGallery.stories.tsx
@@ -259,7 +259,7 @@ const USAGES: Usage[] = [
         entry: 'search',
         props: {
             taxonomicGroupTypes: [
-                G.ErrorTrackingProperties,
+                G.ExceptionProperties,
                 G.ErrorTrackingIssues,
                 G.EventProperties,
                 G.PersonProperties,

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.test.tsx
@@ -9,6 +9,7 @@ import { performQuery } from '~/queries/query'
 import { initKeaTests } from '~/test/init'
 
 import { recentTaxonomicFiltersLogic } from '../recentTaxonomicFiltersLogic'
+import { taxonomicFilterPinnedPropertiesLogic } from '../taxonomicFilterPinnedPropertiesLogic'
 import { TaxonomicFilterGroupType } from '../types'
 import { useTaxonomicFilter } from './useTaxonomicFilter'
 import { __clearTaxonomicResourceCache } from './useTaxonomicResource'
@@ -295,6 +296,96 @@ describe('useTaxonomicFilter', () => {
         act(() => result.current.selectItem(eventsGroup, 'evt', { name: 'evt' }))
         expect(onChange).toHaveBeenCalledWith(eventsGroup, 'evt', { name: 'evt' })
         expect(result.current.searchQuery).toBe('')
+    })
+
+    it.each([TaxonomicFilterGroupType.EventProperties, TaxonomicFilterGroupType.ExceptionProperties])(
+        'selects an exception display-category item declared as %s as an event property',
+        (declaredGroupType) => {
+            const onChange = jest.fn()
+            const { result } = renderHook(
+                () =>
+                    useTaxonomicFilter({
+                        taxonomicGroupTypes: [TaxonomicFilterGroupType.ExceptionProperties],
+                        onChange,
+                    }),
+                { wrapper }
+            )
+            const exceptionGroup = result.current.groups.find(
+                (group) => group.type === TaxonomicFilterGroupType.ExceptionProperties
+            )!
+            const item = {
+                name: '$exception_values',
+                value: '$exception_values',
+                group: declaredGroupType,
+            }
+
+            act(() => result.current.selectItem(exceptionGroup, '$exception_values', item))
+
+            expect(onChange).toHaveBeenCalledWith(
+                expect.objectContaining({ type: TaxonomicFilterGroupType.EventProperties }),
+                '$exception_values',
+                item
+            )
+        }
+    )
+
+    it('keeps list-only exception exclusions out of shortcut exclusions', () => {
+        const { result } = renderHook(
+            () =>
+                useTaxonomicFilter({
+                    taxonomicGroupTypes: [TaxonomicFilterGroupType.ExceptionProperties],
+                }),
+            { wrapper }
+        )
+
+        expect(result.current.groups[0].sourceGroupType).toBe(TaxonomicFilterGroupType.EventProperties)
+        const shortcutExclusions = result.current.excludedProperties?.[TaxonomicFilterGroupType.EventProperties]
+        expect(shortcutExclusions).not.toContain('$exception_values')
+        expect(shortcutExclusions).toEqual(
+            expect.arrayContaining(['$exception_steps', '$exception_list', '$exception_fingerprint_record'])
+        )
+    })
+
+    it('keeps curated exception properties visible in Recent and Pinned shortcuts', () => {
+        const recentLogic = recentTaxonomicFiltersLogic.build()
+        const pinnedLogic = taxonomicFilterPinnedPropertiesLogic.build()
+        recentLogic.mount()
+        pinnedLogic.mount()
+        recentLogic.actions.recordRecentFilter({
+            groupType: TaxonomicFilterGroupType.EventProperties,
+            groupName: 'Event properties',
+            value: '$exception_values',
+            item: { name: '$exception_values' },
+        })
+        pinnedLogic.actions.setPinnedFilters([
+            {
+                groupType: TaxonomicFilterGroupType.EventProperties,
+                groupName: 'Event properties',
+                value: '$exception_values',
+                item: { name: '$exception_values' },
+                timestamp: 1,
+            },
+        ])
+
+        try {
+            const { result } = renderHook(
+                () =>
+                    useTaxonomicFilter({
+                        taxonomicGroupTypes: [TaxonomicFilterGroupType.ExceptionProperties],
+                    }),
+                { wrapper }
+            )
+            const exceptionGroup = result.current.groups.find(
+                (group) => group.type === TaxonomicFilterGroupType.ExceptionProperties
+            )!
+            const listInput = result.current.getGroupListInput(exceptionGroup)
+
+            expect(listInput.promoteRecentItemsToTop).toEqual([expect.objectContaining({ name: '$exception_values' })])
+            expect(listInput.promotePinnedItemsToTop).toEqual([expect.objectContaining({ name: '$exception_values' })])
+        } finally {
+            recentLogic.unmount()
+            pinnedLogic.unmount()
+        }
     })
 
     it('selectItem records recents under an option-declared group, not the curated tab group', async () => {

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicFilter.ts
@@ -44,6 +44,7 @@ import {
 import { isQuickFilterItem } from 'lib/components/TaxonomicFilter/types'
 import { buildTaxonomicGroups } from 'lib/components/TaxonomicFilter/utils/buildTaxonomicGroups'
 import { isContainsShortcutItem } from 'lib/components/TaxonomicFilter/utils/collapsedContainsRow'
+import { resolveTaxonomicItemGroup } from 'lib/components/TaxonomicFilter/utils/resolveTaxonomicItemGroup'
 import { MaxContextTaxonomicFilterOption } from 'scenes/max/maxTypes'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -117,6 +118,7 @@ export interface TaxonomicFilterApi {
     searchPlaceholder: string
 
     // selection
+    resolveItemGroup: (group: TaxonomicFilterGroup, item: any) => TaxonomicFilterGroup
     selectItem: (group: TaxonomicFilterGroup, value: TaxonomicFilterValue | null, item: any) => void
     /** Forwards Enter to the registered active list, falling back to onEnter(query). */
     selectSelected: () => void
@@ -322,17 +324,40 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         [taxonomicGroupTypes, allGroupTypes, eventNames]
     )
 
-    const getLocalOverride = useTaxonomicLocalOverrides({
-        taxonomicGroupTypes: groupTypes,
-        excludedOperators,
-        selectingKeyOnly,
-        excludedProperties,
-    })
-
     const groups = useMemo(() => {
         const byType = new Map(allGroups.map((g) => [g.type, g]))
         return groupTypes.map((t) => byType.get(t)!).filter(Boolean)
     }, [allGroups, groupTypes])
+
+    const sourceGroupTypes = useMemo(
+        () => Array.from(new Set(groups.flatMap((group) => [group.type, group.sourceGroupType ?? group.type]))),
+        [groups]
+    )
+
+    const effectiveShortcutExcludedProperties = useMemo<ExcludedProperties>(() => {
+        const merged: ExcludedProperties = Object.fromEntries(
+            Object.entries(excludedProperties ?? {}).map(([type, values]) => [type, [...(values ?? [])]])
+        )
+        for (const displayGroup of groups) {
+            const sourceGroup = resolveTaxonomicItemGroup(undefined, allGroups, displayGroup)
+            const shortcutExcludedProperties =
+                sourceGroup?.shortcutExcludedProperties ?? sourceGroup?.excludedProperties
+            if (!shortcutExcludedProperties?.length) {
+                continue
+            }
+            merged[sourceGroup.type] = Array.from(
+                new Set([...(merged[sourceGroup.type] ?? []), ...shortcutExcludedProperties])
+            )
+        }
+        return merged
+    }, [allGroups, excludedProperties, groups])
+
+    const getLocalOverride = useTaxonomicLocalOverrides({
+        taxonomicGroupTypes: sourceGroupTypes,
+        excludedOperators,
+        selectingKeyOnly,
+        excludedProperties: effectiveShortcutExcludedProperties,
+    })
 
     const metaGroupTypes = useMemo(
         () => new Set(groups.filter((g) => g.isMetaGroup || META_GROUP_TYPES.has(g.type)).map((g) => g.type)),
@@ -456,8 +481,17 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         return activeListGetterRef.current?.() ?? null
     }, [])
 
+    const resolveItemGroup = useCallback(
+        (group: TaxonomicFilterGroup, item: any): TaxonomicFilterGroup => {
+            return resolveTaxonomicItemGroup(item as TaxonomicDefinitionTypes, allGroups, group) ?? group
+        },
+        [allGroups]
+    )
+
     const selectItem = useCallback(
         (group: TaxonomicFilterGroup, valueIn: TaxonomicFilterValue | null, item: any) => {
+            const resolvedGroup = resolveItemGroup(group, item)
+            const resolvedValue = hasRecentContext(item) ? valueIn : (resolvedGroup.getValue?.(item) ?? valueIn)
             // Mirror the legacy `taxonomicFilterLogic.selectItem` recent
             // recording so menu commits show up in the dropdown's
             // "Recent" entry. Quick-filter items and the synthetic
@@ -466,26 +500,15 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
             // shortcut would shadow it on the next search, since the recent
             // shares its entryKey but lacks the contains label/telemetry);
             // pinned/recent context wrappers get stripped before persisting.
-            if (valueIn != null && item && !isQuickFilterItem(item) && !isContainsShortcutItem(item)) {
+            if (resolvedValue != null && item && !isQuickFilterItem(item) && !isContainsShortcutItem(item)) {
                 const recentContext = hasRecentContext(item) ? item._recentContext : undefined
                 const stripped = recentContext ? stripRecentContext(item) : item
-                // Options in curated tabs (MCP properties, internal event properties) declare
-                // the canonical group they commit as. Legacy resolves it via `getItemGroup`
-                // before dispatching, so recents must be recorded under the declared group
-                // here too — otherwise the same property gets near-duplicate Recent rows
-                // across variants (recents dedupe on groupType + value and share storage).
-                const declaredGroup =
-                    !recentContext && stripped && typeof stripped === 'object' && 'group' in stripped
-                        ? // Resolve against every group definition (like legacy `getItemGroup`), not just
-                          // the visible tabs — a curated tab can be requested without its canonical group.
-                          allGroups.find((g) => g.type === stripped.group)
-                        : undefined
-                const sourceGroupType = recentContext?.sourceGroupType ?? declaredGroup?.type ?? group.type
+                const sourceGroupType = recentContext?.sourceGroupType ?? resolvedGroup.type
                 const cleanItem = {
                     name: stripped.name,
                     ...(stripped.id ? { id: stripped.id } : {}),
                 }
-                const sourceGroupName = recentContext?.sourceGroupName ?? declaredGroup?.name ?? group.name
+                const sourceGroupName = recentContext?.sourceGroupName ?? resolvedGroup.name
                 const propertyFilterFromRecent = recentContext?.propertyFilter
                 // Defer one tick — keeps the recents write off the
                 // commit's render cycle so React doesn't re-render the
@@ -495,7 +518,7 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
                         recentTaxonomicFiltersLogic.actions.recordRecentFilter({
                             groupType: sourceGroupType,
                             groupName: sourceGroupName,
-                            value: valueIn,
+                            value: resolvedValue,
                             item: cleanItem,
                             teamId: teamLogic.values.currentTeamId ?? undefined,
                             propertyFilter: propertyFilterFromRecent,
@@ -503,10 +526,10 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
                     }
                 }, 0)
             }
-            onChange?.(group, valueIn, item)
+            onChange?.(resolvedGroup, resolvedValue, item)
             setSearchQuery('')
         },
-        [allGroups, onChange, setSearchQuery]
+        [onChange, resolveItemGroup, setSearchQuery]
     )
 
     const selectSelected = useCallback(() => {
@@ -605,6 +628,7 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         searchQuery,
         setSearchQuery,
         searchPlaceholder,
+        resolveItemGroup,
         selectItem,
         selectSelected,
         registerActiveList,
@@ -612,7 +636,7 @@ export function useTaxonomicFilter(opts: UseTaxonomicFilterOptions): TaxonomicFi
         value,
         selectingKeyOnly,
         excludedOperators,
-        excludedProperties,
+        excludedProperties: effectiveShortcutExcludedProperties,
         rootProps: { onKeyDown },
         inputProps: {
             value: searchQuery,

--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicLocalOverrides.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicLocalOverrides.ts
@@ -21,7 +21,10 @@ import {
     TaxonomicDefinitionTypes,
     TaxonomicFilterGroupType,
 } from 'lib/components/TaxonomicFilter/types'
-import { filterRecentsForContext } from 'lib/components/TaxonomicFilter/utils/suggestedContextFilters'
+import {
+    filterPinnedForContext,
+    filterRecentsForContext,
+} from 'lib/components/TaxonomicFilter/utils/suggestedContextFilters'
 import { dataWarehouseSettingsSceneLogic } from 'scenes/data-warehouse/settings/dataWarehouseSettingsSceneLogic'
 import { experimentsLogic } from 'scenes/experiments/experimentsLogic'
 
@@ -61,6 +64,10 @@ export function useTaxonomicLocalOverrides(context: {
             ),
         [recentFilterItems, taxonomicGroupTypes, excludedOperators, selectingKeyOnly, excludedProperties]
     )
+    const contextFilteredPinnedItems = useMemo(
+        () => filterPinnedForContext(pinnedFilterItems, taxonomicGroupTypes, excludedProperties),
+        [pinnedFilterItems, taxonomicGroupTypes, excludedProperties]
+    )
 
     return useCallback(
         (groupType: TaxonomicFilterGroupType): TaxonomicDefinitionTypes[] | undefined => {
@@ -70,7 +77,7 @@ export function useTaxonomicLocalOverrides(context: {
                 case TaxonomicFilterGroupType.RecentFilters:
                     return contextFilteredRecentItems
                 case TaxonomicFilterGroupType.PinnedFilters:
-                    return pinnedFilterItems
+                    return contextFilteredPinnedItems
                 case TaxonomicFilterGroupType.Dashboards:
                     return nameSortedDashboards as unknown as TaxonomicDefinitionTypes[]
                 case TaxonomicFilterGroupType.Experiments:
@@ -86,7 +93,7 @@ export function useTaxonomicLocalOverrides(context: {
         [
             actionsSorted,
             contextFilteredRecentItems,
-            pinnedFilterItems,
+            contextFilteredPinnedItems,
             nameSortedDashboards,
             experiments,
             dataWarehouseTablesAndViews,

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.test.ts
@@ -1615,6 +1615,66 @@ describe('infiniteListLogic', () => {
             expect(names).toContain('level')
         })
 
+        it('hides a pinned value excluded for its source group', () => {
+            const pinnedLogic = taxonomicFilterPinnedPropertiesLogic.build()
+            pinnedLogic.mount()
+            pinnedLogic.actions.setPinnedFilters([
+                {
+                    groupType: TaxonomicFilterGroupType.LogAttributes,
+                    groupName: 'Log attributes',
+                    value: 'message',
+                    item: { name: 'message' },
+                    timestamp: 1,
+                },
+                {
+                    groupType: TaxonomicFilterGroupType.LogAttributes,
+                    groupName: 'Log attributes',
+                    value: 'level',
+                    item: { name: 'level' },
+                    timestamp: 2,
+                },
+            ])
+
+            const listLogic = infiniteListLogic({
+                taxonomicFilterLogicKey: 'logs-group-by-pins-test',
+                listGroupType: TaxonomicFilterGroupType.PinnedFilters,
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.LogAttributes, TaxonomicFilterGroupType.PinnedFilters],
+                showNumericalPropsOnly: false,
+                excludedProperties: { [TaxonomicFilterGroupType.LogAttributes]: ['message'] },
+            })
+            listLogic.mount()
+
+            const names = listLogic.values.contextFilteredPinnedItems.map((item) => (item as { name: string }).name)
+            expect(names).toEqual(['level'])
+        })
+
+        it('hides structured exception payloads recorded before they became non-filterable', () => {
+            const recentLogic = recentTaxonomicFiltersLogic.build()
+            recentLogic.mount()
+            for (const value of ['$exception_steps', '$browser']) {
+                recentLogic.actions.recordRecentFilter({
+                    groupType: TaxonomicFilterGroupType.EventProperties,
+                    groupName: 'Event properties',
+                    value,
+                    item: { name: value },
+                })
+            }
+
+            const listLogic = infiniteListLogic({
+                taxonomicFilterLogicKey: 'exception-recents-test',
+                listGroupType: TaxonomicFilterGroupType.RecentFilters,
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.EventProperties, TaxonomicFilterGroupType.RecentFilters],
+                showNumericalPropsOnly: false,
+            })
+            listLogic.mount()
+
+            const names = listLogic.values.contextFilteredRecentItems
+                .filter((item) => 'name' in item)
+                .map((item) => (item as { name: string }).name)
+            expect(names).not.toContain('$exception_steps')
+            expect(names).toContain('$browser')
+        })
+
         it('preserves sourceValue on recent Persons items so the row resolves the correct distinct_id', () => {
             // Persons items are stored stripped ({name, id?}) — distinct_ids is not persisted.
             // The fix in InfiniteListRow falls back to _recentContext.sourceValue instead of

--- a/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/infiniteListLogic.ts
@@ -51,6 +51,7 @@ import {
     COLLAPSED_TO_CONTAINS_ROW,
     partitionContainsShortcuts,
 } from 'lib/components/TaxonomicFilter/utils/collapsedContainsRow'
+import { isFilterableExceptionPropertyForGroup } from 'lib/components/TaxonomicFilter/utils/errorTrackingProperties'
 import {
     floatRecentAndPinnedToTop,
     groupItemKey,
@@ -59,6 +60,7 @@ import {
 } from 'lib/components/TaxonomicFilter/utils/floatRecentPinned'
 import { floatToFront } from 'lib/components/TaxonomicFilter/utils/floatToFront'
 import { promoteMatchingProperties } from 'lib/components/TaxonomicFilter/utils/promoteProperties'
+import { resolveTaxonomicItemGroup as getItemGroup } from 'lib/components/TaxonomicFilter/utils/resolveTaxonomicItemGroup'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { createFuse } from 'lib/utils/fuseSearch'
 import { mapGroupQueryResponse } from 'lib/utils/groups'
@@ -67,7 +69,6 @@ import { getCoreFilterDefinition } from '~/taxonomy/helpers'
 import { CohortType, EventDefinition, GroupTypeIndex, PropertyType } from '~/types'
 
 import { teamLogic } from '../../../scenes/teamLogic'
-import { getItemGroup } from './InfiniteList'
 import type { SelectItemMeta, TopMatchItem } from './taxonomicFilterLogic'
 
 function pinnedItemMatchesSearch(
@@ -503,7 +504,8 @@ export interface infiniteListLogicMeta {
         ) => TaxonomicDefinitionTypes[]
         contextFilteredPinnedItems: (
             pinnedFilterItems: TaxonomicDefinitionTypes[],
-            taxonomicGroupTypes: TaxonomicFilterGroupType[]
+            taxonomicGroupTypes: TaxonomicFilterGroupType[],
+            arg: import('lib/components/TaxonomicFilter/types').TaxonomicFilterGroupValueMap | undefined
         ) => TaxonomicDefinitionTypes[]
         isSoleSubstantiveGroup: (
             listGroupType: TaxonomicFilterGroupType,
@@ -1075,6 +1077,14 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
                     if (!hasRecentContext(item) || !availableTypes.has(item._recentContext.sourceGroupType)) {
                         return false
                     }
+                    if (
+                        !isFilterableExceptionPropertyForGroup(
+                            item._recentContext.sourceGroupType,
+                            item._recentContext.sourceValue
+                        )
+                    ) {
+                        return false
+                    }
                     // A group's excluded values (e.g. `message` for the logs group-by picker) must be
                     // dropped from the Recent tab too, not just the group's own option list — otherwise
                     // an excluded key recorded elsewhere leaks back in as a selectable recent.
@@ -1097,18 +1107,34 @@ export const infiniteListLogic = kea<infiniteListLogicType>([
             },
         ],
         contextFilteredPinnedItems: [
-            (s) => [s.pinnedFilterItems, s.taxonomicGroupTypes],
+            (s) => [
+                s.pinnedFilterItems,
+                s.taxonomicGroupTypes,
+                (_, props: InfiniteListLogicProps) => props.excludedProperties,
+            ],
             (
                 pinnedFilterItems: TaxonomicDefinitionTypes[],
-                taxonomicGroupTypes: TaxonomicFilterGroupType[]
+                taxonomicGroupTypes: TaxonomicFilterGroupType[],
+                excludedProperties: ExcludedProperties | undefined
             ): TaxonomicDefinitionTypes[] => {
                 if (!pinnedFilterItems?.length) {
                     return []
                 }
                 const availableTypes = new Set(taxonomicGroupTypes)
-                return pinnedFilterItems.filter(
-                    (item) => hasPinnedContext(item) && availableTypes.has(item._pinnedContext.sourceGroupType)
-                )
+                return pinnedFilterItems.filter((item) => {
+                    if (
+                        !hasPinnedContext(item) ||
+                        !availableTypes.has(item._pinnedContext.sourceGroupType) ||
+                        !isFilterableExceptionPropertyForGroup(
+                            item._pinnedContext.sourceGroupType,
+                            item._pinnedContext.value
+                        )
+                    ) {
+                        return false
+                    }
+                    const excludedValues = excludedProperties?.[item._pinnedContext.sourceGroupType]
+                    return !excludedValues?.includes(item._pinnedContext.value)
+                })
             },
         ],
         // This list is the filter's only substantive (non-meta) group. There are no separate

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.test.tsx
@@ -58,6 +58,7 @@ function renderAll(options: {
     groupTypes: TaxonomicFilterGroupType[]
     recentEntries?: any[]
     pinnedEntries?: any[]
+    selectedEntry?: MenuFilterEntry
     searchQuery?: string
     onCommit?: any
     eventNames?: string[]
@@ -74,6 +75,7 @@ function renderAll(options: {
                     drillTo="all"
                     recentEntries={options.recentEntries}
                     pinnedEntries={options.pinnedEntries}
+                    selectedEntry={options.selectedEntry}
                     onCommit={options.onCommit ?? jest.fn()}
                     onBack={jest.fn()}
                 />
@@ -494,6 +496,94 @@ describe('MenuFilterCombobox', () => {
         await waitFor(() => expect(rowTexts().some((t) => t.includes('autocapture'))).toBe(true))
         const promotedRows = rowTexts().filter((t) => t.includes('MCP tool name') || t.includes('$mcp_tool_name'))
         expect(promotedRows).toHaveLength(1)
+    })
+
+    it('shows exception properties once under their display category', async () => {
+        const user = userEvent.setup()
+        apiGet.mockImplementation((url: string) => {
+            if (url.includes('property_definitions')) {
+                const excluded = new URL(url, 'http://localhost').searchParams.get('excluded_properties') ?? ''
+                const results = [
+                    { id: 1, name: '$exception_values' },
+                    { id: 2, name: '$browser' },
+                    { id: 3, name: '$exception_steps' },
+                    { id: 4, name: '$exception_list' },
+                    { id: 5, name: '$exception_fingerprint_record' },
+                ].filter(({ name }) => !excluded.includes(name))
+                return Promise.resolve({ results, count: results.length })
+            }
+            return Promise.resolve({ results: [], count: 0 })
+        })
+
+        renderAll({
+            groupTypes: [TaxonomicFilterGroupType.ExceptionProperties, TaxonomicFilterGroupType.EventProperties],
+        })
+
+        await waitFor(() => {
+            expect(rowTexts().filter((text) => text.includes('Exception message'))).toHaveLength(1)
+            expect(rowTexts().some((text) => text.includes('Browser'))).toBe(true)
+            expect(rowTexts().some((text) => text.includes('Exception steps'))).toBe(false)
+            expect(rowTexts().some((text) => text.includes('Exception list'))).toBe(false)
+            expect(rowTexts().some((text) => text.includes('Exception fingerprint record'))).toBe(false)
+        })
+
+        await user.click(screen.getByLabelText('Filter category'))
+        await user.click(within(await openedCategoryPopup()).getByText('Exception properties'))
+
+        await waitFor(() => {
+            expect(rowTexts().filter((text) => text.includes('Exception message'))).toHaveLength(1)
+            expect(rowTexts().some((text) => text.includes('Browser'))).toBe(false)
+        })
+    })
+
+    it('matches a canonical event-property selection to its exception display row', async () => {
+        const user = userEvent.setup()
+        const onCommit = jest.fn()
+        renderAll({
+            groupTypes: [TaxonomicFilterGroupType.ExceptionProperties],
+            selectedEntry: makeEntry(TaxonomicFilterGroupType.EventProperties, '$exception_values', 'Event properties'),
+            onCommit,
+        })
+
+        await waitFor(() => expect(rowTexts().filter((text) => text.includes('Exception message'))).toHaveLength(1))
+
+        const row = document.getElementById('menu-filter-row-event_properties-$exception_values')
+        expect(row).toBeInTheDocument()
+        expect(row?.classList.contains('bg-(--fill-hover)')).toBe(true)
+        expect(row?.textContent).toContain('Exception properties')
+
+        await user.click(row!)
+        expect(onCommit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                group: expect.objectContaining({ type: TaxonomicFilterGroupType.EventProperties }),
+                displayGroup: expect.objectContaining({ type: TaxonomicFilterGroupType.ExceptionProperties }),
+            }),
+            undefined,
+            expect.any(Object)
+        )
+    })
+
+    it.each([
+        ['recent', 'Recent'],
+        ['pinned', 'Pinned'],
+    ] as const)('shows a canonical %s exception property once under its display category', async (kind, badge) => {
+        const shortcut = {
+            ...makeEntry(TaxonomicFilterGroupType.EventProperties, '$exception_values', 'Event properties'),
+            displayGroup: {
+                type: TaxonomicFilterGroupType.ExceptionProperties,
+                name: 'Exception properties',
+            },
+            friendlyLabel: 'Exception message',
+        }
+
+        renderAll({
+            groupTypes: [TaxonomicFilterGroupType.ExceptionProperties],
+            ...(kind === 'recent' ? { recentEntries: [shortcut] } : { pinnedEntries: [shortcut] }),
+        })
+
+        await waitFor(() => expect(rowTexts().filter((text) => text.includes('Exception message'))).toHaveLength(1))
+        expect(rowTexts()[0]).toContain('Exception properties')
+        expect(rowTexts()[0]).toContain(badge)
     })
 
     it('shows a recent that is also in the catalog only once (deduped from content)', async () => {

--- a/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/Combobox.tsx
@@ -114,6 +114,10 @@ function entryValue(entry: MenuFilterEntry): string {
     return String(entry.group.getValue?.(entry.item) ?? entry.name)
 }
 
+function entryDisplayGroup(entry: MenuFilterEntry): TaxonomicFilterGroup {
+    return entry.displayGroup ?? entry.group
+}
+
 /** Identity for an entry's underlying definition — source group + value.
  *  Uses `::` as separator to serve as a dedup key (distinct from DOM ids). */
 function entryKey(entry: MenuFilterEntry): string {
@@ -209,7 +213,7 @@ export function MenuFilterCombobox({
     // (Pageview URLs, Screens, etc.) actually fetch — `useGroupList` reads
     // `searchQuery` from the orchestrator's `getGroupListInput`, not from
     // us. Keeping a local mirror just for the controlled input ergonomics.
-    const { groups, searchQuery, setSearchQuery } = useTaxonomicFilterContext()
+    const { groups, resolveItemGroup, searchQuery, setSearchQuery } = useTaxonomicFilterContext()
     // Open on the drill scope ("All" for the default surface). Reopening with a committed
     // selection used to jump to that item's category; we now lead with "All" so the user
     // lands on recents/pinned + a cross-category search (the selection still surfaces via
@@ -217,8 +221,8 @@ export function MenuFilterCombobox({
     // columns reach the combobox as DataWarehouseProperties) — they reopen on their own
     // chip so the user can reconfigure, mirroring the legacy `activeTab`.
     const [activeChip, setActiveChip] = useState<DrillCategory>(() =>
-        drillTo === 'all' && selectedEntry && OPEN_AS_SELF_ON_REOPEN.has(selectedEntry.group.type)
-            ? selectedEntry.group.type
+        drillTo === 'all' && selectedEntry && OPEN_AS_SELF_ON_REOPEN.has(entryDisplayGroup(selectedEntry).type)
+            ? entryDisplayGroup(selectedEntry).type
             : drillTo
     )
     // The scope the user is actually looking at: the active chip when chips show
@@ -374,6 +378,7 @@ export function MenuFilterCombobox({
                             isContainsShortcut: true,
                         } as unknown as TaxonomicDefinitionTypes,
                         group,
+                        displayGroup: group,
                         name: label,
                         friendlyLabel: label,
                     })
@@ -381,7 +386,7 @@ export function MenuFilterCombobox({
                 continue
             }
             for (const item of items) {
-                merged.push(buildMenuFilterEntry(item, group))
+                merged.push(buildMenuFilterEntry(item, group, resolveItemGroup))
             }
         }
         // Make sure the committed selection is reachable from the list
@@ -394,7 +399,7 @@ export function MenuFilterCombobox({
         if (selectedEntry) {
             // `recent`/`pinned` scopes already returned above, so the only
             // mixed scope left here is `all`.
-            const fitsScope = scope === 'all' || scope === selectedEntry.group.type
+            const fitsScope = scope === 'all' || scope === entryDisplayGroup(selectedEntry).type
             if (fitsScope) {
                 // `entryMatchesSelection` reconciles a synthetic `selected`
                 // shimmed in by callers like `TaxonomicPopoverMenu` against the
@@ -426,6 +431,7 @@ export function MenuFilterCombobox({
         drillTo,
         searchQuery,
         surveyQuestionLabels,
+        resolveItemGroup,
     ])
 
     // Stable DOM id for the selected row — drives `Row`'s checkmark, the
@@ -520,13 +526,13 @@ export function MenuFilterCombobox({
                 continue
             }
             const item = { name: option.name } as unknown as TaxonomicDefinitionTypes
-            const entry = buildMenuFilterEntry(item, realGroup)
+            const entry = buildMenuFilterEntry(item, realGroup, resolveItemGroup)
             if (!prefixKeys.has(entryKey(entry))) {
                 entries.push(entry)
             }
         }
         return entries
-    }, [showChips, activeChip, drillTo, searchQuery, groups, recentsPinnedPrefix])
+    }, [showChips, activeChip, drillTo, searchQuery, groups, recentsPinnedPrefix, resolveItemGroup])
 
     // Recency lookup so any row that is one of the user's recents/pinned gets a
     // "- recent" / "- pinned" tag on its category label, wherever it appears
@@ -562,7 +568,7 @@ export function MenuFilterCombobox({
             // vanish at "posthog team". So only Fuse locally-sourced groups
             // (Actions, etc., which load their full list client-side); pass
             // server-searched entries through untouched, preserving order.
-            const localSourced = indexed.filter((e) => !e.group.endpoint)
+            const localSourced = indexed.filter((e) => !entryDisplayGroup(e).endpoint)
             const localMatches =
                 localSourced.length > 0
                     ? new Set(
@@ -571,7 +577,7 @@ export function MenuFilterCombobox({
                               .map((r) => r.item)
                       )
                     : null
-            base = indexed.filter((e) => !!e.group.endpoint || (localMatches?.has(e) ?? false))
+            base = indexed.filter((e) => !!entryDisplayGroup(e).endpoint || (localMatches?.has(e) ?? false))
         }
         const scope = showChips ? activeChip : drillTo
         // Promote the committed selection to index 0 so base-ui's
@@ -1255,7 +1261,7 @@ function resolveRowCells(entry: MenuFilterEntry): {
     category: string
 } {
     if (entry.recentLabel) {
-        return { name: entry.recentLabel, category: entry.group.name }
+        return { name: entry.recentLabel, category: entryDisplayGroup(entry).name }
     }
     const friendly = entry.friendlyLabel
     const pathTail = parseUrlPathTail(entry.name)
@@ -1263,17 +1269,17 @@ function resolveRowCells(entry: MenuFilterEntry): {
         return {
             name: pathTail,
             value: entry.name,
-            category: entry.group.name,
+            category: entryDisplayGroup(entry).name,
         }
     }
     if (friendly && friendly.length > 0 && friendly !== entry.name) {
         return {
             name: friendly,
             value: entry.name,
-            category: entry.group.name,
+            category: entryDisplayGroup(entry).name,
         }
     }
-    return { name: entry.name, category: entry.group.name }
+    return { name: entry.name, category: entryDisplayGroup(entry).name }
 }
 
 function Row({
@@ -1454,15 +1460,22 @@ function getFriendlyLabel(item: TaxonomicDefinitionTypes, group: TaxonomicFilter
     if (!raw) {
         return undefined
     }
-    return getCoreFilterDefinition(raw, group.type)?.label
+    const sourceGroupType = (item as unknown as { group?: TaxonomicFilterGroupType }).group ?? group.type
+    return getCoreFilterDefinition(raw, sourceGroupType)?.label
 }
 
-function buildMenuFilterEntry(item: TaxonomicDefinitionTypes, group: TaxonomicFilterGroup): MenuFilterEntry {
+function buildMenuFilterEntry(
+    item: TaxonomicDefinitionTypes,
+    displayGroup: TaxonomicFilterGroup,
+    resolveItemGroup: (group: TaxonomicFilterGroup, item: TaxonomicDefinitionTypes) => TaxonomicFilterGroup
+): MenuFilterEntry {
+    const sourceGroup = resolveItemGroup(displayGroup, item)
     return {
         item,
-        group,
-        name: getRawName(item, group),
-        friendlyLabel: getFriendlyLabel(item, group),
+        group: sourceGroup,
+        displayGroup,
+        name: getRawName(item, sourceGroup),
+        friendlyLabel: getFriendlyLabel(item, sourceGroup),
     }
 }
 

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -51,6 +51,7 @@ import { useTaxonomicFilterContext } from '../headless/context'
 import { recentTaxonomicFiltersLogic } from '../recentTaxonomicFiltersLogic'
 import { taxonomicFilterPinnedPropertiesLogic } from '../taxonomicFilterPinnedPropertiesLogic'
 import { isQuickFilterItem, META_GROUP_TYPES, TaxonomicDefinitionTypes, TaxonomicFilterGroupType } from '../types'
+import { getTaxonomicItemSourceGroupType, resolveTaxonomicDisplayGroup } from '../utils/resolveTaxonomicItemGroup'
 import { filterPinnedForContext, filterRecentsForContext } from '../utils/suggestedContextFilters'
 import { MenuFilterCombobox } from './Combobox'
 import { MenuFilterDwhConfig } from './DwhFlow'
@@ -252,6 +253,7 @@ export function TaxonomicFilterMenu({
 }: TaxonomicFilterMenuProps): JSX.Element {
     const {
         groups,
+        resolveItemGroup,
         selectItem,
         inputProps,
         searchQuery,
@@ -351,7 +353,10 @@ export function TaxonomicFilterMenu({
     // a global recent from a different picker (e.g. a cohort in an events-only
     // picker) would otherwise be remapped onto a fallback group and shown under
     // the wrong category.
-    const taxonomicGroupTypes = useMemo(() => groups.map((g) => g.type), [groups])
+    const taxonomicGroupTypes = useMemo(
+        () => Array.from(new Set(groups.flatMap((group) => [group.type, group.sourceGroupType ?? group.type]))),
+        [groups]
+    )
     const recentEntries = useMemo<MenuFilterEntry[]>(
         () =>
             mapShortcutItems(
@@ -362,20 +367,31 @@ export function TaxonomicFilterMenu({
                     selectingKeyOnly,
                     excludedProperties
                 ) as ShortcutItem[],
-                groups
+                groups,
+                resolveItemGroup
             ),
-        [recentFilterItems, taxonomicGroupTypes, groups, excludedOperators, selectingKeyOnly, excludedProperties]
+        [
+            recentFilterItems,
+            taxonomicGroupTypes,
+            groups,
+            excludedOperators,
+            selectingKeyOnly,
+            excludedProperties,
+            resolveItemGroup,
+        ]
     )
     const pinnedEntries = useMemo<MenuFilterEntry[]>(
         () =>
             mapShortcutItems(
                 filterPinnedForContext(
                     pinnedFilterItems as TaxonomicDefinitionTypes[],
-                    taxonomicGroupTypes
+                    taxonomicGroupTypes,
+                    excludedProperties
                 ) as ShortcutItem[],
-                groups
+                groups,
+                resolveItemGroup
             ),
-        [pinnedFilterItems, taxonomicGroupTypes, groups]
+        [pinnedFilterItems, taxonomicGroupTypes, excludedProperties, groups, resolveItemGroup]
     )
 
     const hasDwh = groups.some((g) => g.type === TaxonomicFilterGroupType.DataWarehouse)
@@ -388,10 +404,12 @@ export function TaxonomicFilterMenu({
             const mergedItem = extra
                 ? ({ ...(entry.item as unknown as object), ...extra } as unknown as TaxonomicDefinitionTypes)
                 : entry.item
-            const itemValue = entry.group.getValue?.(mergedItem) ?? null
+            const resolvedGroup = resolveItemGroup(entry.group, mergedItem)
+            const resolvedEntry = resolvedGroup === entry.group ? entry : { ...entry, group: resolvedGroup }
+            const itemValue = resolvedGroup.getValue?.(mergedItem) ?? entry.group.getValue?.(mergedItem) ?? null
             hadCommitRef.current = true
             posthog.capture('taxonomic filter menu item selected', {
-                groupType: entry.group.type,
+                groupType: resolvedGroup.type,
                 hadSearchInput: !!searchQuery,
                 query: searchQuery || undefined,
                 hadExtras: !!extra,
@@ -418,23 +436,23 @@ export function TaxonomicFilterMenu({
             posthog.capture('taxonomic filter item selected', {
                 surface: TAXONOMIC_FILTER_SURFACE,
                 groupType: selection?.groupType,
-                sourceGroupType: entry.group.type,
+                sourceGroupType: resolvedGroup.type,
                 wasFromRecents: selection?.wasFromRecents ?? false,
                 wasFromPinnedList: selection?.wasFromPinnedList ?? false,
                 wasQuickFilter: isQuickFilterItem(entry.item),
                 hadSearchInput: !!searchQuery,
                 position: selection?.position,
                 query: searchQuery || undefined,
-                wasStale: eventSelectionWasStale(entry.group.type, entry.item),
+                wasStale: eventSelectionWasStale(resolvedGroup.type, entry.item),
                 // True when the row is the synthetic "URL contains <query>" shortcut
                 // rather than a real picked item — lets us measure its adoption.
                 wasUrlContainsShortcut: (entry.item as { isContainsShortcut?: boolean }).isContainsShortcut === true,
             })
-            selectItem(entry.group, itemValue, mergedItem)
-            onCommit?.({ ...entry, item: mergedItem }, extra)
+            selectItem(resolvedGroup, itemValue, mergedItem)
+            onCommit?.({ ...resolvedEntry, item: mergedItem }, extra)
             closeAll()
         },
-        [selectItem, onCommit, closeAll, searchQuery]
+        [resolveItemGroup, selectItem, onCommit, closeAll, searchQuery]
     )
 
     // -- Trigger render --
@@ -839,11 +857,7 @@ interface ShortcutItem {
     name?: string
     id?: unknown
     value?: unknown
-    // `_pinnedContext.value` and `_recentContext.sourceValue` mean the
-    // same thing — the source-group field name diverged in master while
-    // this branch was in flight; consumers (this menu) read whichever
-    // shape exists. See `taxonomicFilterPinnedPropertiesLogic` /
-    // `recentTaxonomicFiltersLogic`.
+    // Pinned and recent storage use different field names for the canonical value.
     _pinnedContext?: { sourceGroupType?: TaxonomicFilterGroupType; value?: unknown }
     _recentContext?: {
         sourceGroupType?: TaxonomicFilterGroupType
@@ -852,69 +866,50 @@ interface ShortcutItem {
     }
 }
 
-/**
- * Resolve the most appropriate `TaxonomicFilterGroup` for a shortcut
- * item.
- *
- *   1. Recorded `sourceGroupType` if it points at a real content group
- *      that's available right now.
- *   2. If the recorded source is a META group (Suggested / Recent /
- *      Pinned), find a non-meta group in `groups` whose `getValue(item)`
- *      matches the saved value — that's the underlying definition the
- *      item really belongs to (e.g. SuggestedFilters → Events).
- *   3. Fall back to the first non-meta group so the row at least has a
- *      sensible category subtitle instead of "Suggested filters".
- */
-function resolveShortcutGroup(
-    item: ShortcutItem,
-    sourceType: TaxonomicFilterGroupType | undefined,
-    sourceValue: unknown,
-    groups: TaxonomicFilterGroup[]
-): TaxonomicFilterGroup | null {
-    if (sourceType && !META_GROUP_TYPES.has(sourceType)) {
-        const direct = groups.find((g) => g.type === sourceType)
-        if (direct) {
-            return direct
-        }
+function groupMatchesShortcutValue(
+    group: TaxonomicFilterGroup,
+    item: TaxonomicDefinitionTypes,
+    sourceValue: unknown
+): boolean {
+    if (META_GROUP_TYPES.has(group.type)) {
+        return false
     }
-    const matchByValue = groups.find((g) => {
-        if (META_GROUP_TYPES.has(g.type)) {
-            return false
-        }
-        try {
-            const candidate = g.getValue?.(item as TaxonomicDefinitionTypes)
-            return candidate != null && candidate === sourceValue
-        } catch {
-            return false
-        }
-    })
-    if (matchByValue) {
-        return matchByValue
+    try {
+        return group.getValue?.(item) === sourceValue
+    } catch {
+        return false
     }
-    return groups.find((g) => !META_GROUP_TYPES.has(g.type)) ?? null
 }
 
-function mapShortcutItems(items: ShortcutItem[], groups: TaxonomicFilterGroup[]): MenuFilterEntry[] {
+function mapShortcutItems(
+    items: ShortcutItem[],
+    groups: TaxonomicFilterGroup[],
+    resolveItemGroup: (group: TaxonomicFilterGroup, item: TaxonomicDefinitionTypes) => TaxonomicFilterGroup
+): MenuFilterEntry[] {
     return items
         .map((item) => {
-            const ctx = item._recentContext ?? item._pinnedContext
-            const sourceType = ctx?.sourceGroupType
-            // Recent stores the value under `sourceValue`, pinned under
-            // `value`. Read whichever side exists.
-            const sourceValue =
-                (ctx as { sourceValue?: unknown } | undefined)?.sourceValue ??
-                (ctx as { value?: unknown } | undefined)?.value
-            const group = resolveShortcutGroup(item, sourceType, sourceValue, groups)
-            if (!group) {
+            const sourceGroupType = getTaxonomicItemSourceGroupType(item as TaxonomicDefinitionTypes)
+            const sourceValue = item._recentContext?.sourceValue ?? item._pinnedContext?.value
+            const defaultGroup =
+                (!sourceGroupType || META_GROUP_TYPES.has(sourceGroupType)
+                    ? undefined
+                    : groups.find(
+                          (group) => group.type === sourceGroupType || group.sourceGroupType === sourceGroupType
+                      )) ??
+                groups.find((group) => groupMatchesShortcutValue(group, item as TaxonomicDefinitionTypes, sourceValue))
+            if (!defaultGroup) {
                 return null
             }
-            const name = (item.name as string) ?? group.getName?.(item as TaxonomicDefinitionTypes) ?? ''
+            const sourceGroup = resolveItemGroup(defaultGroup, item as TaxonomicDefinitionTypes)
+            const displayGroup = resolveTaxonomicDisplayGroup(item as TaxonomicDefinitionTypes, groups, sourceGroup)
+            const name = (item.name as string) ?? sourceGroup.getName?.(item as TaxonomicDefinitionTypes) ?? ''
             const recentPropertyFilter = item._recentContext?.propertyFilter
             return {
                 item: item as TaxonomicDefinitionTypes,
-                group,
+                group: sourceGroup,
+                displayGroup,
                 name,
-                friendlyLabel: getCoreFilterDefinition(name, group.type)?.label,
+                friendlyLabel: getCoreFilterDefinition(name, sourceGroup.type)?.label,
                 ...(recentPropertyFilter
                     ? { recentPropertyFilter, recentLabel: formatPropertyLabel(recentPropertyFilter, {}) }
                     : {}),

--- a/frontend/src/lib/components/TaxonomicFilter/menu/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/types.ts
@@ -20,7 +20,10 @@ export const TAXONOMIC_FILTER_SURFACE = 'rebuild-menu'
 /** A single selectable entry — what the picker commits when chosen. */
 export interface MenuFilterEntry {
     item: TaxonomicDefinitionTypes
+    /** Canonical source group used for identity, values, persistence, recents, and pinning. */
     group: TaxonomicFilterGroup
+    /** Category where the entry is rendered when it differs from the canonical source group. */
+    displayGroup?: TaxonomicFilterGroup
     name: string
     friendlyLabel?: string
     recentPropertyFilter?: AnyPropertyFilter

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -887,6 +887,44 @@ describe('taxonomicFilterLogic', () => {
         )
     })
 
+    describe('Exception properties display category', () => {
+        it.each([
+            { includeCategory: true, expectCuratedExcluded: true },
+            { includeCategory: false, expectCuratedExcluded: false },
+        ])(
+            'excludes exception keys from Event properties when category is present=$includeCategory',
+            ({ includeCategory, expectCuratedExcluded }) => {
+                const testLogic = taxonomicFilterLogic({
+                    taxonomicFilterLogicKey: `testExceptionProperties-${includeCategory}`,
+                    taxonomicGroupTypes: [
+                        ...(includeCategory ? [TaxonomicFilterGroupType.ExceptionProperties] : []),
+                        TaxonomicFilterGroupType.EventProperties,
+                    ],
+                })
+                testLogic.mount()
+
+                const eventProperties = testLogic.values.taxonomicGroups.find(
+                    (group) => group.type === TaxonomicFilterGroupType.EventProperties
+                )
+                const exceptionProperties = testLogic.values.taxonomicGroups.find(
+                    (group) => group.type === TaxonomicFilterGroupType.ExceptionProperties
+                )
+
+                expect(eventProperties?.excludedProperties?.includes('$exception_values')).toBe(expectCuratedExcluded)
+                expect(eventProperties?.excludedProperties).toEqual(
+                    expect.arrayContaining(['$exception_steps', '$exception_list', '$exception_fingerprint_record'])
+                )
+                expect(exceptionProperties?.options).toContainEqual({
+                    name: '$exception_values',
+                    value: '$exception_values',
+                    group: TaxonomicFilterGroupType.EventProperties,
+                })
+
+                testLogic.unmount()
+            }
+        )
+    })
+
     describe('SuggestedFilters presence by variant', () => {
         afterEach(() => {
             featureFlagLogic.actions.setFeatureFlags([], {

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -51,6 +51,11 @@ import {
     isQuickFilterItem,
 } from 'lib/components/TaxonomicFilter/types'
 import {
+    getCuratedExceptionPropertyExclusions,
+    getCuratedExceptionPropertyOptions,
+    getNonFilterableExceptionProperties,
+} from 'lib/components/TaxonomicFilter/utils/errorTrackingProperties'
+import {
     MCP_TOOL_CALL_EVENT,
     MCP_TOOL_CALL_SUGGESTED_PROPERTIES,
     getMCPExcludedEventProperties,
@@ -361,6 +366,7 @@ export interface taxonomicFilterLogicValues {
     endpointFilters: Record<string, any>
     eventNames: any
     eventNamesWithPrimaryProperties: {
+        errorTrackingExcludedEventProperties: string[]
         eventNames: string[]
         mcpExcludedEventProperties: string[]
         primaryPropertiesForContextEvents: string[]
@@ -500,6 +506,7 @@ export interface taxonomicFilterLogicMeta {
             primaryProperties: Record<string, string>,
             arg: any
         ) => {
+            errorTrackingExcludedEventProperties: string[]
             eventNames: string[]
             mcpExcludedEventProperties: string[]
             primaryPropertiesForContextEvents: string[]
@@ -542,6 +549,7 @@ export interface taxonomicFilterLogicMeta {
             groupAnalyticsTaxonomicGroups: TaxonomicFilterGroup[],
             groupAnalyticsTaxonomicGroupNames: TaxonomicFilterGroup[],
             eventNamesWithPrimaryProperties: {
+                errorTrackingExcludedEventProperties: string[]
                 eventNames: string[]
                 mcpExcludedEventProperties: string[]
                 primaryPropertiesForContextEvents: string[]
@@ -581,12 +589,12 @@ export interface taxonomicFilterLogicMeta {
         groupAnalyticsTaxonomicGroupNames: (
             groupTypes: Map<GroupTypeIndex, GroupType>,
             currentTeamId: number | null,
-            aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun
+            aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun // groupsModel
         ) => TaxonomicFilterGroup[]
         groupAnalyticsTaxonomicGroups: (
             groupTypes: Map<GroupTypeIndex, GroupType>,
             currentProjectId: number | null,
-            aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun
+            aggregationLabel: (groupTypeIndex: number | null | undefined, deferToUserWording?: boolean) => Noun // groupsModel
         ) => TaxonomicFilterGroup[]
         infiniteListLogics: (
             taxonomicGroupTypes: TaxonomicFilterGroupType[],
@@ -806,10 +814,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
             (eventNames) => eventNames ?? [],
             { resultEqualityCheck: objectsEqual },
         ],
-        // Combined selector that returns the event names, the distinct primary properties for
-        // those events, and the known MCP schema to hide from Event properties when the MCP tab
-        // hosts it. Combined into a single selector so taxonomicGroups stays under kea's 16-dep
-        // tuple type limit; consumers destructure the fields.
+        // Combined to keep taxonomicGroups under kea's 16-dependency tuple limit.
         eventNamesWithPrimaryProperties: [
             (s) => [s.eventNames, s.primaryProperties, (_, props) => props.taxonomicGroupTypes],
             (
@@ -820,6 +825,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 eventNames: string[]
                 primaryPropertiesForContextEvents: string[]
                 mcpExcludedEventProperties: string[]
+                errorTrackingExcludedEventProperties: string[]
             } => {
                 return {
                     eventNames,
@@ -828,6 +834,10 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         primaryProperties
                     ),
                     mcpExcludedEventProperties: getMCPExcludedEventProperties(eventNames, taxonomicGroupTypes),
+                    errorTrackingExcludedEventProperties: [
+                        ...getNonFilterableExceptionProperties(),
+                        ...getCuratedExceptionPropertyExclusions(taxonomicGroupTypes),
+                    ],
                 }
             },
             { resultEqualityCheck: objectsEqual },
@@ -943,6 +953,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                     eventNames: string[]
                     primaryPropertiesForContextEvents: string[]
                     mcpExcludedEventProperties: string[]
+                    errorTrackingExcludedEventProperties: string[]
                 },
                 schemaColumns: DatabaseSchemaField[],
                 schemaColumnsLoading: boolean | undefined,
@@ -970,8 +981,12 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                 },
                 featureFlags: Record<string, boolean | string | undefined>
             ): TaxonomicFilterGroup[] => {
-                const { eventNames, primaryPropertiesForContextEvents, mcpExcludedEventProperties } =
-                    eventNamesWithPrimaryProperties
+                const {
+                    eventNames,
+                    primaryPropertiesForContextEvents,
+                    mcpExcludedEventProperties,
+                    errorTrackingExcludedEventProperties,
+                } = eventNamesWithPrimaryProperties
                 const { id: teamId } = currentTeam
                 const { excludedProperties, propertyAllowList } = propertyFilters
                 const groups: TaxonomicFilterGroup[] = [
@@ -1165,6 +1180,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                             // present — excluded via the same mechanism as TRAFFIC_TYPE_VIRTUAL_PROPERTIES
                             // above; the exclusivity intent is documented on getMCPExcludedEventProperties.
                             ...mcpExcludedEventProperties,
+                            ...errorTrackingExcludedEventProperties,
                         ],
                         propertyAllowList:
                             propertyAllowList?.[TaxonomicFilterGroupType.EventProperties]?.filter(isString),
@@ -1284,21 +1300,13 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                     {
                         name: 'Exception properties',
                         searchPlaceholder: 'exceptions',
-                        type: TaxonomicFilterGroupType.ErrorTrackingProperties,
-                        options: [
-                            ...getProductEventPropertyFilterOptions('error-tracking').map((value) => ({
-                                name: value,
-                                value,
-                                group: TaxonomicFilterGroupType.EventProperties,
-                            })),
-                            ...(currentTeam?.person_display_name_properties
-                                ? currentTeam.person_display_name_properties.map((property) => ({
-                                      name: property,
-                                      value: property,
-                                      group: TaxonomicFilterGroupType.PersonProperties,
-                                  }))
-                                : []),
-                        ],
+                        type: TaxonomicFilterGroupType.ExceptionProperties,
+                        sourceGroupType: TaxonomicFilterGroupType.EventProperties,
+                        options: getCuratedExceptionPropertyOptions().map((value) => ({
+                            name: value,
+                            value,
+                            group: TaxonomicFilterGroupType.EventProperties,
+                        })),
                         getIcon: getPropertyDefinitionIcon,
                         getPopoverHeader: () => 'Exception properties',
                     },

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic.test.ts
@@ -154,6 +154,34 @@ describe('taxonomicFilterPinnedPropertiesLogic', () => {
         expect(logic.values.pinnedFilters).toHaveLength(0)
     })
 
+    it('treats persisted exception property pins as event property pins', () => {
+        logic.actions.setPinnedFilters([
+            {
+                groupType: TaxonomicFilterGroupType.ExceptionProperties,
+                groupName: 'Exception properties',
+                value: '$exception_values',
+                item: { name: '$exception_values' },
+                timestamp: 1,
+            },
+        ])
+
+        expect(logic.values.isPinned(TaxonomicFilterGroupType.EventProperties, '$exception_values')).toBe(true)
+        const pinnedItem = logic.values.pinnedFilterItems[0]
+        expect(hasPinnedContext(pinnedItem)).toBe(true)
+        if (hasPinnedContext(pinnedItem)) {
+            expect(pinnedItem._pinnedContext).toEqual({
+                sourceGroupType: TaxonomicFilterGroupType.EventProperties,
+                sourceGroupName: 'Event properties',
+                value: '$exception_values',
+            })
+        }
+
+        logic.actions.togglePin(TaxonomicFilterGroupType.EventProperties, 'Event properties', '$exception_values', {
+            name: '$exception_values',
+        })
+        expect(logic.values.pinnedFilters).toEqual([])
+    })
+
     it('allows the same value in different group types', () => {
         logic.actions.togglePin(TaxonomicFilterGroupType.Events, 'Events', 'name', { name: 'name' })
         logic.actions.togglePin(TaxonomicFilterGroupType.PersonProperties, 'Person properties', 'name', {

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic.ts
@@ -80,6 +80,12 @@ function makeDefaultPinnedFilter(
     return { groupType, groupName, value, item: { name: value }, timestamp: Date.now() }
 }
 
+function canonicalPinnedGroupType(groupType: TaxonomicFilterGroupType): TaxonomicFilterGroupType {
+    return groupType === TaxonomicFilterGroupType.ExceptionProperties
+        ? TaxonomicFilterGroupType.EventProperties
+        : groupType
+}
+
 const DEFAULT_PIN_CANDIDATES = [
     {
         contextFlag: 'has_pageview' as const,
@@ -208,15 +214,26 @@ export const taxonomicFilterPinnedPropertiesLogic = kea<taxonomicFilterPinnedPro
                         return state
                     }
 
-                    const existingIndex = state.findIndex((f) => f.groupType === groupType && f.value === value)
+                    const canonicalGroupType = canonicalPinnedGroupType(groupType)
+                    const hasExistingPin = state.some(
+                        (filter) =>
+                            canonicalPinnedGroupType(filter.groupType) === canonicalGroupType && filter.value === value
+                    )
 
-                    if (existingIndex !== -1) {
-                        return state.filter((_, i) => i !== existingIndex)
+                    if (hasExistingPin) {
+                        return state.filter(
+                            (filter) =>
+                                canonicalPinnedGroupType(filter.groupType) !== canonicalGroupType ||
+                                filter.value !== value
+                        )
                     }
 
                     const entry: PinnedTaxonomicFilter = {
-                        groupType,
-                        groupName,
+                        groupType: canonicalGroupType,
+                        groupName:
+                            canonicalGroupType === TaxonomicFilterGroupType.EventProperties
+                                ? 'Event properties'
+                                : groupName,
                         value,
                         item: pickMinimalPinnedItem(item, value),
                         timestamp: Date.now(),
@@ -236,8 +253,11 @@ export const taxonomicFilterPinnedPropertiesLogic = kea<taxonomicFilterPinnedPro
                         ({
                             ...f.item,
                             _pinnedContext: {
-                                sourceGroupType: f.groupType,
-                                sourceGroupName: f.groupName,
+                                sourceGroupType: canonicalPinnedGroupType(f.groupType),
+                                sourceGroupName:
+                                    canonicalPinnedGroupType(f.groupType) === TaxonomicFilterGroupType.EventProperties
+                                        ? 'Event properties'
+                                        : f.groupName,
                                 value: f.value,
                             } as PinnedItemContext,
                         }) as unknown as TaxonomicDefinitionTypes
@@ -247,7 +267,11 @@ export const taxonomicFilterPinnedPropertiesLogic = kea<taxonomicFilterPinnedPro
             (s) => [s.pinnedFilters],
             (pinnedFilters: PinnedTaxonomicFilter[]) =>
                 (groupType: TaxonomicFilterGroupType, value: TaxonomicFilterValue): boolean =>
-                    pinnedFilters.some((f) => f.groupType === groupType && f.value === value),
+                    pinnedFilters.some(
+                        (filter) =>
+                            canonicalPinnedGroupType(filter.groupType) === canonicalPinnedGroupType(groupType) &&
+                            filter.value === value
+                    ),
         ],
     }),
     listeners(({ values }) => ({

--- a/frontend/src/lib/components/TaxonomicFilter/types.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/types.ts
@@ -233,6 +233,8 @@ export interface TaxonomicFilterGroup {
      * */
     categoryLabel?: (count: number) => ReactNode
     type: TaxonomicFilterGroupType
+    /** Canonical group used for values, persistence, recents, and pinning when this group is only a curated display category. */
+    sourceGroupType?: TaxonomicFilterGroupType
     /** Component to show instead of the usual taxonomic list. */
     render?: TaxonomicFilterRender
     /** if you want to override the default local items search behaviour e.g. for the replay group type */
@@ -264,6 +266,8 @@ export interface TaxonomicFilterGroup {
     groupTypeIndex?: number
     getFullDetailUrl?: (instance: any) => string
     excludedProperties?: string[]
+    /** Values hidden from Recent and Pinned shortcuts. Defaults to excludedProperties. */
+    shortcutExcludedProperties?: string[]
     propertyAllowList?: string[]
     /** Passed to the component specified via the `render` key */
     componentProps?: Record<string, any>
@@ -343,7 +347,8 @@ export enum TaxonomicFilterGroupType {
     RevenueAnalyticsProperties = 'revenue_analytics_properties',
     AccountCustomProperties = 'account_custom_properties',
     Resources = 'resources',
-    ErrorTrackingProperties = 'error_tracking_properties',
+    // The serialized value is persisted in saved filters and URLs, so it remains stable for backward compatibility.
+    ExceptionProperties = 'error_tracking_properties',
     ActivityLogProperties = 'activity_log_properties',
     MCPProperties = 'mcp_properties',
     // Max AI Context

--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -16,6 +16,11 @@ import {
     TaxonomicFilterGroupType,
     TaxonomicFilterValue,
 } from 'lib/components/TaxonomicFilter/types'
+import {
+    getCuratedExceptionPropertyExclusions,
+    getCuratedExceptionPropertyOptions,
+    getNonFilterableExceptionProperties,
+} from 'lib/components/TaxonomicFilter/utils/errorTrackingProperties'
 import { withKeywordShortcuts } from 'lib/components/TaxonomicFilter/utils/keywordShortcuts'
 import {
     MCP_TOOL_CALL_EVENT,
@@ -196,6 +201,11 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
     } = ctx
     const { id: teamId } = currentTeam
     const { excludedProperties, propertyAllowList } = propertyFilters
+    const eventPropertyShortcutExclusions = [
+        ...(excludedProperties?.[TaxonomicFilterGroupType.EventProperties]?.filter(isString) ?? []),
+        ...(!featureFlags[FEATURE_FLAGS.TRAFFIC_TYPE_VIRTUAL_PROPERTIES] ? TRAFFIC_TYPE_VIRTUAL_PROPERTIES : []),
+        ...getNonFilterableExceptionProperties(),
+    ]
     // Opt the cohort picker into the trimmed `?basic=true` payload (drops the
     // filters/query/groups JSON the picker never reads). Gated by a flag so the
     // smaller response shape can be rolled out and rolled back independently.
@@ -363,15 +373,14 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
                     false
                 )}n't been seen with ${pluralize(eventNames.length, 'this event', 'these events', false)}`,
             excludedProperties: [
-                ...(excludedProperties?.[TaxonomicFilterGroupType.EventProperties]?.filter(isString) ?? []),
-                ...(!featureFlags[FEATURE_FLAGS.TRAFFIC_TYPE_VIRTUAL_PROPERTIES]
-                    ? TRAFFIC_TYPE_VIRTUAL_PROPERTIES
-                    : []),
+                ...eventPropertyShortcutExclusions,
                 // The known MCP schema lives only in its own group when that tab is
                 // present — excluded via the same mechanism as TRAFFIC_TYPE_VIRTUAL_PROPERTIES
                 // above; the exclusivity intent is documented on getMCPExcludedEventProperties.
                 ...getMCPExcludedEventProperties(eventNames, ctx.taxonomicGroupTypes),
+                ...getCuratedExceptionPropertyExclusions(ctx.taxonomicGroupTypes),
             ],
+            shortcutExcludedProperties: eventPropertyShortcutExclusions,
             propertyAllowList: propertyAllowList?.[TaxonomicFilterGroupType.EventProperties]?.filter(isString),
             ...withKeywordShortcuts<PropertyDefinition>(
                 {
@@ -479,21 +488,13 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
         {
             name: 'Exception properties',
             searchPlaceholder: 'exceptions',
-            type: TaxonomicFilterGroupType.ErrorTrackingProperties,
-            options: [
-                ...getProductEventPropertyFilterOptions('error-tracking').map((value) => ({
-                    name: value,
-                    value,
-                    group: TaxonomicFilterGroupType.EventProperties,
-                })),
-                ...(currentTeam?.person_display_name_properties
-                    ? currentTeam.person_display_name_properties.map((property) => ({
-                          name: property,
-                          value: property,
-                          group: TaxonomicFilterGroupType.PersonProperties,
-                      }))
-                    : []),
-            ],
+            type: TaxonomicFilterGroupType.ExceptionProperties,
+            sourceGroupType: TaxonomicFilterGroupType.EventProperties,
+            options: getCuratedExceptionPropertyOptions().map((value) => ({
+                name: value,
+                value,
+                group: TaxonomicFilterGroupType.EventProperties,
+            })),
             getIcon: getPropertyDefinitionIcon,
             getPopoverHeader: () => 'Exception properties',
         },

--- a/frontend/src/lib/components/TaxonomicFilter/utils/errorTrackingProperties.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/errorTrackingProperties.ts
@@ -1,0 +1,55 @@
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+
+const EXCEPTION_PROPERTY_CAPABILITIES: Record<
+    string,
+    { curated: boolean; searchable: boolean; internal: boolean; filterable: boolean }
+> = {
+    $exception_types: { curated: true, searchable: true, internal: true, filterable: true },
+    $exception_values: { curated: true, searchable: true, internal: true, filterable: true },
+    $exception_sources: { curated: true, searchable: true, internal: true, filterable: true },
+    $exception_functions: { curated: true, searchable: true, internal: true, filterable: true },
+    $exception_handled: { curated: true, searchable: false, internal: false, filterable: true },
+    $exception_steps: { curated: false, searchable: false, internal: false, filterable: false },
+    $exception_list: { curated: false, searchable: false, internal: true, filterable: false },
+    $exception_fingerprint_record: { curated: false, searchable: false, internal: true, filterable: false },
+    $exception_proposed_fingerprint: { curated: false, searchable: false, internal: true, filterable: true },
+}
+
+function exceptionPropertiesWith(capability: keyof (typeof EXCEPTION_PROPERTY_CAPABILITIES)[string]): string[] {
+    return Object.entries(EXCEPTION_PROPERTY_CAPABILITIES)
+        .filter(([, capabilities]) => capabilities[capability])
+        .map(([property]) => property)
+}
+
+export const SEARCHABLE_EXCEPTION_PROPERTIES = exceptionPropertiesWith('searchable')
+export const INTERNAL_EXCEPTION_PROPERTY_KEYS = exceptionPropertiesWith('internal')
+
+export function getCuratedExceptionPropertyOptions(): string[] {
+    return exceptionPropertiesWith('curated')
+}
+
+export function getNonFilterableExceptionProperties(): string[] {
+    return Object.entries(EXCEPTION_PROPERTY_CAPABILITIES)
+        .filter(([, capabilities]) => !capabilities.filterable)
+        .map(([property]) => property)
+}
+
+function isFilterableExceptionProperty(property: unknown): boolean {
+    return typeof property !== 'string' || EXCEPTION_PROPERTY_CAPABILITIES[property]?.filterable !== false
+}
+
+export function isFilterableExceptionPropertyForGroup(groupType: TaxonomicFilterGroupType, property: unknown): boolean {
+    return (
+        (groupType !== TaxonomicFilterGroupType.EventProperties &&
+            groupType !== TaxonomicFilterGroupType.ExceptionProperties) ||
+        isFilterableExceptionProperty(property)
+    )
+}
+
+export function getCuratedExceptionPropertyExclusions(
+    requestedGroupTypes: TaxonomicFilterGroupType[] | undefined
+): string[] {
+    return requestedGroupTypes?.includes(TaxonomicFilterGroupType.ExceptionProperties)
+        ? getCuratedExceptionPropertyOptions()
+        : []
+}

--- a/frontend/src/lib/components/TaxonomicFilter/utils/resolveTaxonomicItemGroup.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/resolveTaxonomicItemGroup.ts
@@ -1,0 +1,65 @@
+import { hasRecentContext } from 'lib/components/TaxonomicFilter/recentTaxonomicFiltersLogic'
+import { hasPinnedContext } from 'lib/components/TaxonomicFilter/taxonomicFilterPinnedPropertiesLogic'
+import {
+    TaxonomicDefinitionTypes,
+    TaxonomicFilterGroup,
+    TaxonomicFilterGroupType,
+    TaxonomicFilterValue,
+} from 'lib/components/TaxonomicFilter/types'
+
+export function getTaxonomicItemSourceGroupType(
+    item: TaxonomicDefinitionTypes | undefined
+): TaxonomicFilterGroupType | undefined {
+    if (hasRecentContext(item)) {
+        return item._recentContext.sourceGroupType
+    }
+    if (hasPinnedContext(item)) {
+        return item._pinnedContext.sourceGroupType
+    }
+    if (item && typeof item === 'object' && 'group' in item) {
+        return item.group as TaxonomicFilterGroupType
+    }
+    return undefined
+}
+
+export function resolveTaxonomicItemGroup(
+    item: TaxonomicDefinitionTypes | undefined,
+    groups: TaxonomicFilterGroup[],
+    defaultGroup: TaxonomicFilterGroup | undefined
+): TaxonomicFilterGroup | undefined {
+    const declaredGroupType = getTaxonomicItemSourceGroupType(item) ?? defaultGroup?.type
+    const declaredGroup = groups.find((group) => group.type === declaredGroupType) ?? defaultGroup
+    return groups.find((group) => group.type === declaredGroup?.sourceGroupType) ?? declaredGroup
+}
+
+export function getTaxonomicItemValue(
+    item: TaxonomicDefinitionTypes,
+    sourceGroup: TaxonomicFilterGroup
+): TaxonomicFilterValue | null {
+    if (hasRecentContext(item)) {
+        return item._recentContext.sourceValue ?? sourceGroup.getValue?.(item) ?? null
+    }
+    if (hasPinnedContext(item)) {
+        return item._pinnedContext.value ?? sourceGroup.getValue?.(item) ?? null
+    }
+    return sourceGroup.getValue?.(item) ?? null
+}
+
+export function resolveTaxonomicDisplayGroup(
+    item: TaxonomicDefinitionTypes,
+    groups: TaxonomicFilterGroup[],
+    sourceGroup: TaxonomicFilterGroup
+): TaxonomicFilterGroup {
+    const sourceValue = getTaxonomicItemValue(item, sourceGroup)
+    if (sourceValue != null) {
+        const curatedGroup = groups.find(
+            (group) =>
+                group.sourceGroupType === sourceGroup.type &&
+                group.options?.some((option) => sourceGroup.getValue?.(option) === sourceValue)
+        )
+        if (curatedGroup) {
+            return curatedGroup
+        }
+    }
+    return groups.find((group) => group.type === sourceGroup.type) ?? sourceGroup
+}

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.test.ts
@@ -144,4 +144,15 @@ describe('suggestedContextFilters', () => {
             expect(names(filterPinnedForContext(items, types))).toEqual(expected)
         })
     })
+
+    it.each([EventProperties, TaxonomicFilterGroupType.ExceptionProperties])(
+        'drops non-filterable exception payloads from %s shortcuts',
+        (sourceGroupType) => {
+            const recentItems = [recent(sourceGroupType, '$exception_steps'), recent(sourceGroupType, '$browser')]
+            const pinnedItems = [pinned(sourceGroupType, '$exception_steps'), pinned(sourceGroupType, '$browser')]
+
+            expect(names(filterRecentsForContext(recentItems, [sourceGroupType]))).toEqual(['$browser'])
+            expect(names(filterPinnedForContext(pinnedItems, [sourceGroupType]))).toEqual(['$browser'])
+        }
+    )
 })

--- a/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/suggestedContextFilters.ts
@@ -7,6 +7,7 @@ import {
     TaxonomicDefinitionTypes,
     TaxonomicFilterGroupType,
 } from 'lib/components/TaxonomicFilter/types'
+import { isFilterableExceptionPropertyForGroup } from 'lib/components/TaxonomicFilter/utils/errorTrackingProperties'
 
 /*
  * These mirror the legacy `infiniteListLogic` context-filter selectors
@@ -36,6 +37,11 @@ export function filterRecentsForContext(
         if (!hasRecentContext(item) || !availableTypes.has(item._recentContext.sourceGroupType)) {
             return false
         }
+        if (
+            !isFilterableExceptionPropertyForGroup(item._recentContext.sourceGroupType, item._recentContext.sourceValue)
+        ) {
+            return false
+        }
         // A group's excluded values (e.g. `message` for the logs group-by picker) must be dropped
         // from the Recent tab too, not just the group's own option list.
         const excludedValues = excludedProperties?.[item._recentContext.sourceGroupType]
@@ -58,13 +64,21 @@ export function filterRecentsForContext(
 /** Pinned items whose source group is one of the picker's groups. */
 export function filterPinnedForContext(
     pinnedFilterItems: TaxonomicDefinitionTypes[],
-    taxonomicGroupTypes: TaxonomicFilterGroupType[]
+    taxonomicGroupTypes: TaxonomicFilterGroupType[],
+    excludedProperties?: ExcludedProperties
 ): TaxonomicDefinitionTypes[] {
     if (!pinnedFilterItems?.length) {
         return []
     }
     const availableTypes = new Set(taxonomicGroupTypes)
-    return pinnedFilterItems.filter(
-        (item) => hasPinnedContext(item) && availableTypes.has(item._pinnedContext.sourceGroupType)
-    )
+    return pinnedFilterItems.filter((item) => {
+        if (!hasPinnedContext(item) || !availableTypes.has(item._pinnedContext.sourceGroupType)) {
+            return false
+        }
+        if (!isFilterableExceptionPropertyForGroup(item._pinnedContext.sourceGroupType, item._pinnedContext.value)) {
+            return false
+        }
+        const excludedValues = excludedProperties?.[item._pinnedContext.sourceGroupType]
+        return !excludedValues?.includes(item._pinnedContext.value)
+    })
 }

--- a/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
+++ b/frontend/src/scenes/hog-functions/filters/HogFunctionFiltersInternal.tsx
@@ -113,14 +113,6 @@ export const getProductEventPropertyFilterOptions = (contextId: HogFunctionConfi
                 'detail.changes',
                 'created_at',
             ]
-        case 'error-tracking':
-            return [
-                '$exception_types',
-                '$exception_values',
-                '$exception_sources',
-                '$exception_functions',
-                '$exception_handled',
-            ]
     }
 
     return []
@@ -162,7 +154,7 @@ export function HogFunctionFiltersInternal(): JSX.Element {
         if (contextId === 'error-tracking') {
             return [
                 TaxonomicFilterGroupType.ErrorTrackingIssues,
-                TaxonomicFilterGroupType.ErrorTrackingProperties,
+                TaxonomicFilterGroupType.ExceptionProperties,
                 TaxonomicFilterGroupType.EventProperties,
             ]
         } else if (contextId === 'insight-alerts') {

--- a/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
+++ b/frontend/src/scenes/insights/filters/BreakdownFilter/taxonomicBreakdownFilterLogic.ts
@@ -123,7 +123,7 @@ export interface taxonomicBreakdownFilterLogicValues {
         | TaxonomicFilterGroupType.RevenueAnalyticsProperties
         | TaxonomicFilterGroupType.AccountCustomProperties
         | TaxonomicFilterGroupType.Resources
-        | TaxonomicFilterGroupType.ErrorTrackingProperties
+        | TaxonomicFilterGroupType.ExceptionProperties
         | TaxonomicFilterGroupType.ActivityLogProperties
         | TaxonomicFilterGroupType.MCPProperties
         | TaxonomicFilterGroupType.MaxAIContext
@@ -287,7 +287,7 @@ export interface taxonomicBreakdownFilterLogicMeta {
             | TaxonomicFilterGroupType.RevenueAnalyticsProperties
             | TaxonomicFilterGroupType.AccountCustomProperties
             | TaxonomicFilterGroupType.Resources
-            | TaxonomicFilterGroupType.ErrorTrackingProperties
+            | TaxonomicFilterGroupType.ExceptionProperties
             | TaxonomicFilterGroupType.ActivityLogProperties
             | TaxonomicFilterGroupType.MCPProperties
             | TaxonomicFilterGroupType.MaxAIContext

--- a/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
+++ b/products/error_tracking/frontend/components/IssueFilters/FilterGroup.tsx
@@ -99,7 +99,7 @@ const FilterPicker = ({ taxonomicGroupTypes }: { taxonomicGroupTypes: TaxonomicF
         <TaxonomicFilterHeadless.Root
             className="contents"
             bindRootProps={false}
-            groupType={taxonomicGroupTypes[0] ?? TaxonomicFilterGroupType.ErrorTrackingProperties}
+            groupType={taxonomicGroupTypes[0] ?? TaxonomicFilterGroupType.ExceptionProperties}
             taxonomicGroupTypes={taxonomicGroupTypes}
             eventNames={ERROR_TRACKING_EVENT_NAMES}
             onChange={(group, value, item) => addGroupFilter(group, value, item)}

--- a/products/error_tracking/frontend/components/IssueFilters/consts.ts
+++ b/products/error_tracking/frontend/components/IssueFilters/consts.ts
@@ -2,7 +2,7 @@ import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 
 export const TAXONOMIC_FILTER_LOGIC_KEY = 'error-tracking'
 export const TAXONOMIC_GROUP_TYPES = [
-    TaxonomicFilterGroupType.ErrorTrackingProperties,
+    TaxonomicFilterGroupType.ExceptionProperties,
     TaxonomicFilterGroupType.ErrorTrackingIssues,
     TaxonomicFilterGroupType.EventProperties,
     TaxonomicFilterGroupType.PersonProperties,

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/bypass_rules/BypassRuleModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/bypass_rules/BypassRuleModal.tsx
@@ -12,7 +12,7 @@ export function BypassRuleModal(): JSX.Element {
             pageKey="bypass-rule-modal"
             width={800}
             taxonomicGroupTypes={[
-                TaxonomicFilterGroupType.ErrorTrackingProperties,
+                TaxonomicFilterGroupType.ExceptionProperties,
                 TaxonomicFilterGroupType.EventProperties,
             ]}
             showTestButton={false}

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/bypass_rules/BypassRules.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/bypass_rules/BypassRules.tsx
@@ -12,7 +12,7 @@ export function BypassRules(): JSX.Element {
             modalLogic={bypassRuleModalLogic}
             modal={<BypassRuleModal />}
             taxonomicGroupTypes={[
-                TaxonomicFilterGroupType.ErrorTrackingProperties,
+                TaxonomicFilterGroupType.ExceptionProperties,
                 TaxonomicFilterGroupType.EventProperties,
             ]}
             pageKeyPrefix="bypass-rule"

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/SuppressionRuleModal.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/SuppressionRuleModal.tsx
@@ -25,7 +25,7 @@ export function SuppressionRuleModal(): JSX.Element {
             pageKey="suppression-rule-modal"
             width={800}
             taxonomicGroupTypes={[
-                TaxonomicFilterGroupType.ErrorTrackingProperties,
+                TaxonomicFilterGroupType.ExceptionProperties,
                 TaxonomicFilterGroupType.EventProperties,
             ]}
             suffix={(issuesLink, dateRangeLabel) => (

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/SuppressionRules.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/SuppressionRules.tsx
@@ -13,7 +13,7 @@ export function SuppressionRules(): JSX.Element {
             modalLogic={suppressionRuleModalLogic}
             modal={<SuppressionRuleModal />}
             taxonomicGroupTypes={[
-                TaxonomicFilterGroupType.ErrorTrackingProperties,
+                TaxonomicFilterGroupType.ExceptionProperties,
                 TaxonomicFilterGroupType.EventProperties,
             ]}
             pageKeyPrefix="suppression-rule"

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/insights/InsightsFilters.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/insights/InsightsFilters.tsx
@@ -7,7 +7,7 @@ import { ErrorFilters } from 'products/error_tracking/frontend/components/IssueF
 import { ErrorTrackingQuickFilters } from 'products/error_tracking/frontend/components/IssueFilters/QuickFilters'
 
 const INSIGHTS_TAXONOMIC_GROUP_TYPES = [
-    TaxonomicFilterGroupType.ErrorTrackingProperties,
+    TaxonomicFilterGroupType.ExceptionProperties,
     TaxonomicFilterGroupType.EventProperties,
     TaxonomicFilterGroupType.PersonProperties,
     TaxonomicFilterGroupType.Cohorts,

--- a/products/error_tracking/frontend/utils.ts
+++ b/products/error_tracking/frontend/utils.ts
@@ -12,6 +12,11 @@ import { Params } from 'scenes/sceneTypes'
 import { DateRange, ErrorTrackingIssue } from '~/queries/schema/schema-general'
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
+export {
+    INTERNAL_EXCEPTION_PROPERTY_KEYS,
+    SEARCHABLE_EXCEPTION_PROPERTIES,
+} from 'lib/components/TaxonomicFilter/utils/errorTrackingProperties'
+
 /** Reason error tracking write actions are disabled, or null when the user has editor access. */
 export function errorTrackingEditAccessDisabledReason(): string | null {
     return getAccessControlDisabledReason(AccessControlResourceType.ErrorTracking, AccessControlLevel.Editor)
@@ -22,19 +27,6 @@ export const ERROR_TRACKING_LISTING_RESOLUTION = 20
 export const ERROR_TRACKING_DETAILS_RESOLUTION = 50
 
 const THIRD_PARTY_SCRIPT_ERROR = 'Script error.'
-
-export const SEARCHABLE_EXCEPTION_PROPERTIES = [
-    '$exception_types',
-    '$exception_values',
-    '$exception_sources',
-    '$exception_functions',
-]
-export const INTERNAL_EXCEPTION_PROPERTY_KEYS = [
-    '$exception_list',
-    '$exception_fingerprint_record',
-    '$exception_proposed_fingerprint',
-    ...SEARCHABLE_EXCEPTION_PROPERTIES,
-]
 
 export const ISSUE_STATUS_OPTIONS: ErrorTrackingIssue['status'][] = ['active', 'resolved', 'suppressed']
 


### PR DESCRIPTION
## Problem

Exception properties are displayed in a dedicated category, but they are stored as event properties. The picker used the display category for row identity and the event property category for persistence.

This meant a selected, recent, or pinned exception property could appear twice, lose its selected state after reopening the picker, or show under an inconsistent category. The general Event properties category also included the same curated fields and structured exception payloads that are useful for displaying an exception but not for filtering.

## Changes

- Keep Exception properties as the display category while using Event properties as the canonical identity for selection, persistence, recents, and pins.
- Use the canonical identity consistently for deduplication, selected state, row IDs, metadata, and commits.
- Define exception property behavior in one place and derive the curated, searchable, internal, and non-filterable sets from it.
- Hide `$exception_steps`, `$exception_list`, and `$exception_fingerprint_record` from filter results, including existing recent and pinned entries. They remain available for exception display and direct queries.
- Apply the same behavior to the legacy and rebuilt taxonomic filters.

Exception properties now appear once, remain selected when the picker is reopened, and keep consistent recent and pinned state.

## How did you test this code?

- Targeted Jest suites for TaxonomicFilter and Error Tracking: 260 tests passed.
- `pnpm --filter=@posthog/frontend fix`
- `./bin/hogli ci:preflight --fix`

The regression tests cover selected, recent, and pinned exception properties, canonical event property serialization, conditional deduplication, and exclusion of structured payloads. I did not perform manual browser testing.

The full frontend typecheck is currently blocked by unrelated generated `*LogicType` errors. It did not report errors in the changed files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update. This is a frontend filter picker behavior change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used the pi coding agent with GPT-5.6. The repo skills used were `/error-tracking`, `/modifying-taxonomic-filter`, `/qa-team`, `/react-doctor`, `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`, and `/running-ci-preflight`. There is no shareable session link.

`ExceptionProperties` keeps the existing `error_tracking_properties` serialized value for compatibility while `EventProperties` remains the canonical source group. Person properties remain limited to filter contexts that can resolve person records.

