### PR TITLE
fix(web-analytics): make heatmap prewarm flag check variant-safe

### DIFF
--- a/frontend/src/scenes/heatmaps/flags.test.ts
+++ b/frontend/src/scenes/heatmaps/flags.test.ts
@@ -1,0 +1,17 @@
+import { FEATURE_FLAGS } from 'lib/constants'
+import { FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
+
+import { isPrewarmEnabled } from './flags'
+
+describe('heatmap flags', () => {
+    it.each([
+        ['boolean rollout is enabled', true, true],
+        ['experiment test arm is enabled', 'test', true],
+        ['experiment control arm is disabled', 'control', false],
+        ['boolean off is disabled', false, false],
+        ['unset flag is disabled', undefined, false],
+    ])('isPrewarmEnabled: %s', (_name, flagValue: boolean | string | undefined, expected: boolean) => {
+        const featureFlags: FeatureFlagsSet = { [FEATURE_FLAGS.HEATMAPS_SCREENSHOT_PREWARM]: flagValue }
+        expect(isPrewarmEnabled(featureFlags)).toBe(expected)
+    })
+})

--- a/frontend/src/scenes/heatmaps/flags.ts
+++ b/frontend/src/scenes/heatmaps/flags.ts
@@ -1,0 +1,7 @@
+import { FEATURE_FLAGS } from 'lib/constants'
+import { FeatureFlagsSet } from 'lib/logic/featureFlagLogic'
+
+export function isPrewarmEnabled(featureFlags: FeatureFlagsSet): boolean {
+    const variant = featureFlags[FEATURE_FLAGS.HEATMAPS_SCREENSHOT_PREWARM]
+    return variant === true || variant === 'test'
+}

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapCreationLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapCreationLogic.ts
@@ -20,11 +20,11 @@ import {
     authorizedUrlListLogic,
     defaultAuthorizedUrlProperties,
 } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
 import { ReplayIframeData, heatmapsBrowserLogic, isUrlPattern } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
+import { isPrewarmEnabled } from 'scenes/heatmaps/flags'
 import { sessionPlayerModalLogic } from 'scenes/session-recordings/player/modal/sessionPlayerModalLogic'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -738,7 +738,7 @@ export const heatmapCreationLogic = kea<heatmapCreationLogicType>([
                 captureWizardStepCompleted(values, 'review')
             },
             prewarmScreenshot: async () => {
-                if (!values.featureFlags[FEATURE_FLAGS.HEATMAPS_SCREENSHOT_PREWARM]) {
+                if (!isPrewarmEnabled(values.featureFlags)) {
                     return
                 }
                 const url = values.displayUrl?.trim()

--- a/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
+++ b/frontend/src/scenes/heatmaps/scenes/heatmap/heatmapLogic.ts
@@ -5,11 +5,11 @@ import posthog from 'posthog-js'
 import { exportsLogic } from 'lib/components/ExportButton/exportsLogic'
 import { heatmapDataLogic } from 'lib/components/heatmaps/heatmapDataLogic'
 import { DEFAULT_HEATMAP_WIDTH } from 'lib/components/IframedToolbarBrowser/utils'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { FeatureFlagsSet, featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { heatmapsBrowserLogic, isUrlPattern } from 'scenes/heatmaps/components/heatmapsBrowserLogic'
+import { isPrewarmEnabled } from 'scenes/heatmaps/flags'
 import { heatmapsSceneLogic } from 'scenes/heatmaps/scenes/heatmaps/heatmapsSceneLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -434,7 +434,7 @@ export const heatmapLogic = kea<heatmapLogicType>([
             posthog.capture('in-app heatmap screenshot ready', {
                 heatmap_id: values.heatmapId,
                 time_to_screenshot_ready_ms: Math.round(performance.now() - cache.screenshotWaitStartedAt),
-                prewarm_enabled: !!values.featureFlags[FEATURE_FLAGS.HEATMAPS_SCREENSHOT_PREWARM],
+                prewarm_enabled: isPrewarmEnabled(values.featureFlags),
                 ready_on_arrival: !cache.screenshotPolled,
                 initial_status: cache.screenshotInitialStatus ?? null,
                 screen_width: values.widthOverride,
@@ -511,7 +511,11 @@ export const heatmapLogic = kea<heatmapLogicType>([
                     block_consent_modals: values.blockConsentModals,
                 }
                 const created = await savedCreate(String(values.currentTeamIdStrict), data)
-                posthog.capture('in-app heatmap created', { heatmap_type: values.type, ...context })
+                posthog.capture('in-app heatmap created', {
+                    heatmap_id: created.id,
+                    heatmap_type: values.type,
+                    ...context,
+                })
                 actions.creationCompleted(created.short_id)
                 actions.loadSavedHeatmaps()
                 router.actions.push(`/heatmaps/${created.short_id}`)


### PR DESCRIPTION
## Problem

The heatmap screenshot prewarm from #72963 reads its feature flag with a truthiness check, in the gate itself and in the `prewarm_enabled` property it reports:

```ts
if (!values.featureFlags[FEATURE_FLAGS.HEATMAPS_SCREENSHOT_PREWARM]) {
    return
}
```

That is fine while the flag is boolean. The moment it becomes a multivariate experiment it breaks silently, because the variant string `'control'` is truthy. The control arm would prewarm like the test arm and report `prewarm_enabled: true`, so the experiment would look healthy and measure nothing.

Separately, `in-app heatmap created` carries no heatmap id, while `in-app heatmap screenshot ready` carries `heatmap_id`. There is no key to join them on.

## Changes

- Add `isPrewarmEnabled()` in `scenes/heatmaps/flags.ts` and route both call sites through it. It accepts the boolean the flag returns today and the `'test'` variant, and rejects `'control'`. Accepting both matters: the flag is live as a boolean, so a strict `=== 'test'` would silently switch prewarm off for everyone currently in the rollout.
- Record `heatmap_id: created.id` on `in-app heatmap created`. Same `SavedHeatmap.id` string that `in-app heatmap screenshot ready` already reports, so the two events join exactly. Note this is `id`, not the `short_id` used for routing.

No behavior change at the current rollout. This is a latent bug fix plus the join key.

> [!NOTE]
> Why the join key is worth having: measured over 14 days, only about 28% of screenshot heatmap creations are followed by the user actually seeing the screenshot render. Right now that number can only be estimated by correlating the two events per person inside a time window, which overcounts anyone who abandons a new heatmap and opens an older one. With `heatmap_id` it becomes an exact funnel.

## How did you test this code?

Automated only. I did not run this against a live stack, so the prewarm request path itself is unverified here - it is unchanged by this PR beyond which helper decides the boolean.

- New `flags.test.ts`, 5 cases over `isPrewarmEnabled`. The one that earns its place is `'control'` returning false, which is exactly the regression above and is not covered anywhere else. The others pin the boolean and unset cases so a future strict `=== 'test'` rewrite fails loudly instead of quietly disabling the live rollout.
- 45 existing heatmap tests across 6 suites still pass, including `heatmapLogic` and `heatmapCreationLogic`.
- `typescript:check`, oxlint and oxfmt clean on the touched files. `hogli ci:preflight --strict` reports 0 failures.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing surface changes, so no docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I had Claude (Claude Code, Opus 5) dig into what the prewarm PR was actually reporting in production. It found the flag had never been created, so the feature had been dark since merge and `prewarm_enabled` was false on every event. Creating the flag surfaced the truthiness problem as a precondition for ever running this as an experiment, which is where this PR came from.

We went a fair way down the path of also converting the heatmap creation wizard to a test/control experiment, then reverted all of it. Two reasons worth recording. The creation wizard has the identical truthiness bug in `HeatmapNewScene.tsx` and `heatmapsBrowserLogic.ts`, so that conversion needs the same treatment before it is safe. And prewarm cannot move creation-flow completion anyway: it fires after the URL step and its response is discarded, so the wizard renders identically in both arms. None of that is in this PR, which is deliberately just the flag fix and the join key.

Skills invoked: `/writing-tests` to gate the new test, `/setting-feature-flags-in-storybook` during the abandoned experiment work (the story used the array form, which sets `true` and would have rendered the legacy scene under a strict variant check - not relevant to this PR since that change was reverted).

One thing for the reviewer: `typescript:check` currently reports 153 errors on this branch, all pre-existing stale `*LogicType.ts` drift under `products/`. The count is byte-identical before and after these changes and none are in the touched files.
