### PR TITLE
chore(inbox): rename signal source group to "External sources"

### DIFF
--- a/frontend/src/scenes/inbox/components/config/agentRosterMeta.ts
+++ b/frontend/src/scenes/inbox/components/config/agentRosterMeta.ts
@@ -93,7 +93,7 @@ export const AGENT_ROSTER_GROUPS: AgentRosterGroup[] = [
         ],
     },
     {
-        label: 'Connected tools',
+        label: 'External sources',
         agents: [
             {
                 source: 'github',


### PR DESCRIPTION
## Changes

Renames the inbox signal sources group header from **Connected tools** to **External sources**, so the label matches its counterpart in the PostHog Code app (also being renamed from "External connections"). This keeps the group naming consistent across both surfaces, sitting alongside the "PostHog data" group.

## 🤖 Agent context

Requested in a Slack thread: the signal-sources section that groups GitHub Issues / GitHub CI etc. was labeled inconsistently across surfaces ("Connected tools" here, "External connections" in posthog/code). Standardizing both to "External sources".

Paired with the matching change in [PostHog/code](https://github.com/PostHog/code).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785346918313609)*