### PR TITLE
fix(replay): shrink still-ingesting placeholder and keep activity panel reachable

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -314,31 +314,42 @@ export function PurePlayer({ noMeta = false, noBorder = false }: PurePlayerProps
                     <SessionRecordingPlayerExplorer {...explorerMode} onClose={() => closeExplorer()} />
                 ) : (
                     <div className="SessionRecordingPlayer__main flex flex-col h-full w-full">
-                        {isRecentAndInvalid ? (
-                            <div className="flex flex-1 flex-col items-center justify-center">
-                                <HedgehogConstruction2 height={200} />
-                                <h1>We're still working on it</h1>
-                                <p>
-                                    This recording hasn't been fully ingested yet. It should be ready to watch in a few
-                                    minutes.
-                                </p>
-                                <LemonButton type="secondary" onClick={loadSnapshots}>
-                                    Reload
-                                </LemonButton>
-                            </div>
-                        ) : isOldAndInvalid ? (
-                            <div className="flex flex-1 flex-col items-center justify-center p-4 text-center">
-                                <WarningHog height={200} width={200} />
-                                <h1>This recording can't be played</h1>
-                                <p className="max-w-120">
-                                    The snapshot of the screen taken when this recording started never reached PostHog,
-                                    so there is nothing to play back. This usually happens when the browser is closed or
-                                    goes offline before the recording finishes uploading.{' '}
-                                    <Link to="https://posthog.com/docs/session-replay/troubleshooting">Learn more</Link>
-                                </p>
-                                <LemonButton type="secondary" onClick={loadSnapshots}>
-                                    Reload
-                                </LemonButton>
+                        {isRecentAndInvalid || isOldAndInvalid ? (
+                            <div className="flex flex-col flex-1 w-full relative">
+                                {/* Keep the meta bar so the activity/inspector panel stays reachable */}
+                                <div className="relative">{showMeta ? <PlayerMetaBar /> : null}</div>
+                                <div className="flex flex-1 flex-col items-center justify-center p-4 text-center">
+                                    {isOldAndInvalid && !isRecentAndInvalid ? (
+                                        <>
+                                            <WarningHog height={200} width={200} />
+                                            <h1>This recording can't be played</h1>
+                                            <p className="max-w-120">
+                                                The snapshot of the screen taken when this recording started never
+                                                reached PostHog, so there is nothing to play back. This usually happens
+                                                when the browser is closed or goes offline before the recording finishes
+                                                uploading.{' '}
+                                                <Link to="https://posthog.com/docs/session-replay/troubleshooting">
+                                                    Learn more
+                                                </Link>
+                                            </p>
+                                            <LemonButton type="secondary" onClick={loadSnapshots}>
+                                                Reload
+                                            </LemonButton>
+                                        </>
+                                    ) : (
+                                        <>
+                                            <HedgehogConstruction2 className="h-50" />
+                                            <h1>We're still working on it</h1>
+                                            <p className="max-w-120">
+                                                This recording hasn't been fully ingested yet. It should be ready to
+                                                watch in a few minutes.
+                                            </p>
+                                            <LemonButton type="secondary" onClick={loadSnapshots}>
+                                                Reload
+                                            </LemonButton>
+                                        </>
+                                    )}
+                                </div>
                             </div>
                         ) : (
                             <div className="flex w-full h-full">


### PR DESCRIPTION
## Problem

When a session recording is still going through ingestion, the player shows a "We're still working on it" placeholder.
That placeholder broke in two ways:

- The hedgehog illustration rendered at full player width instead of a small fixed size, and the text under it was left-aligned and ran the full pane width, so it read awkwardly.
- The placeholder replaced the entire player, including the meta bar. That bar holds the inspector/activity toggle, so while a recording was ingesting there was no way to open the activity panel and see what events had come in.

## Changes

**Illustration sizing.** The hog was sized with a presentational `height={200}` attribute. Tailwind v4's Preflight reset applies `img, video { max-width: 100%; height: auto }`, and that element-level `height: auto` overrides the HTML attribute. With no width constraint the image expanded to `max-width: 100%` (the whole pane) and derived its height from the inline `aspect-ratio`. This regressed in #66238 when the state moved from an SVG component to a PNG-backed `<img>` (SVGs aren't touched by the reset). Fixed by sizing with a utility class (`h-50`), which beats the reset on specificity; the intrinsic aspect ratio derives the width.

**Text layout.** Added `p-4 text-center` to the wrapper and `max-w-120` to the paragraph, matching the sibling "This recording can't be played" state.

**Activity panel reachability.** Both invalid states now render the `PlayerMetaBar` above the placeholder message instead of taking over the whole player, so the inspector/activity toggle stays available and you can open the panel while ingestion finishes.

The two invalid states (recent-and-invalid → "still working on it", old-and-invalid → "can't be played") now share one wrapper that keeps the meta bar, branching only on the message body.

## How did you test this code?

![Screenshot 2026-07-29 at 10.18.24 AM.png](https://app.graphite.com/user-attachments/assets/3ff3e1b5-3af3-4634-a5bb-a7b6782efc48.png)



- `pnpm --filter=@posthog/frontend typescript:check` — clean.
- `pnpm --filter=@posthog/frontend fix` (Oxlint + Oxfmt) — clean.

No automated tests added: this is a JSX layout fix with no logic branch that a unit test would meaningfully cover. Worth a human eyeball on a real still-ingesting recording to confirm the hog size, centered text, and that the activity panel opens from the meta-bar toggle.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Kim drove this: reported the oversized placeholder from a screenshot, asked when it regressed, then asked to keep the activity panel reachable. I (Claude) traced the regression to #66238's SVG→PNG migration and root-caused the sizing to Tailwind Preflight overriding the `height` attribute. I confirmed this was the only `pngHoggie` call site passing `height` alone (every other site uses a class or sets both dimensions), so the fix is local rather than in the shared `pngHoggie` helper. Hardening `pngHoggie` to emit an inline height would prevent recurrence but touches ~40 call sites, so I left it out as a possible follow-up. No repo skills were needed for a change this small.

---

_Created with_ [_PostHog Code_](https://posthog.com/code?ref=pr)