### PR TITLE
fix(snowflake): Include batch export id in table stage prefix

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -995,7 +995,7 @@ class SnowflakeClient:
         self,
         file: BatchExportTemporaryFile | NamedBytesIO,
         table: SnowflakeTable,
-    ):
+    ) -> None:
         """Executes a PUT query using the provided cursor to the provided table_name.
 
         Sadly, Snowflake's execute_async does not work with PUT statements. So, we pass the execute

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -1454,7 +1454,7 @@ async def insert_into_snowflake_activity_from_stage(
             database=inputs.database,
             primary_key=merge_settings.primary_key if merge_settings else (),
             version_key=merge_settings.version_key if merge_settings else (),
-            stage_prefix=data_interval_end_str,
+            stage_prefix=f"{inputs.batch_export_id}/{data_interval_end_str}",
         )
         if "elements" in target_table:
             # `elements` is exported into a 'VARIANT' column, despite it being a

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_activity_e2e.py
@@ -68,6 +68,7 @@ async def _run_activity(
     extra_fields: dict[str, t.Any] | None = None,
     min_ingested_timestamp: dt.datetime | None = None,
     integration_id: int | None = None,
+    batch_export_id: str | None = None,
 ):
     """Helper function to run insert_into_snowflake_activity_from_stage and assert records in Snowflake"""
     config = dict(snowflake_config)
@@ -84,7 +85,7 @@ async def _run_activity(
         exclude_events=exclude_events,
         batch_export_schema=batch_export_schema,
         batch_export_model=batch_export_model,
-        batch_export_id=str(uuid.uuid4()),
+        batch_export_id=batch_export_id or str(uuid.uuid4()),
         integration_id=integration_id,
         **config,
     )
@@ -431,7 +432,7 @@ async def test_insert_into_snowflake_activity_removes_internal_stage_files(
     model = BatchExportModel(name="events", schema=None)
     table_name = f"test_insert_activity_table_remove_{ateam.pk}"
     min_ingested_timestamp = dt.datetime.now(dt.UTC).replace(tzinfo=None)
-
+    batch_export_id = str(uuid.uuid4())
     await _run_activity(
         activity_environment=activity_environment,
         snowflake_cursor=snowflake_cursor,
@@ -444,6 +445,7 @@ async def test_insert_into_snowflake_activity_removes_internal_stage_files(
         batch_export_model=model,
         sort_key="event",
         min_ingested_timestamp=min_ingested_timestamp,
+        batch_export_id=batch_export_id,
     )
 
     snowflake_cursor.execute(f'TRUNCATE TABLE "{table_name}"')
@@ -451,7 +453,7 @@ async def test_insert_into_snowflake_activity_removes_internal_stage_files(
     data_interval_end_str = data_interval_end.strftime("%Y-%m-%d_%H-%M-%S")
 
     put_query = f"""
-    PUT file://{garbage_jsonl_file} '@%"{table_name}"/{data_interval_end_str}'
+    PUT file://{garbage_jsonl_file} '@%"{table_name}"/{batch_export_id}/{data_interval_end_str}'
     """
     snowflake_cursor.execute(put_query)
 
@@ -463,7 +465,9 @@ async def test_insert_into_snowflake_activity_removes_internal_stage_files(
     columns = {index: metadata.name for index, metadata in enumerate(snowflake_cursor.description)}
     stage_files = [{columns[index]: row[index] for index in columns.keys()} for row in rows]
     assert len(stage_files) == 1
-    assert stage_files[0]["name"] == f"{data_interval_end_str}/{os.path.basename(garbage_jsonl_file)}.gz"
+    assert (
+        stage_files[0]["name"] == f"{batch_export_id}/{data_interval_end_str}/{os.path.basename(garbage_jsonl_file)}.gz"
+    )
 
     await _run_activity(
         activity_environment=activity_environment,
@@ -477,6 +481,7 @@ async def test_insert_into_snowflake_activity_removes_internal_stage_files(
         batch_export_model=model,
         sort_key="event",
         min_ingested_timestamp=min_ingested_timestamp,
+        batch_export_id=batch_export_id,
     )
 
     snowflake_cursor.execute(list_query)

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_client.py
@@ -5,6 +5,7 @@ Note: This module uses a real Snowflake connection.
 """
 
 import os
+import uuid
 import asyncio
 import datetime as dt
 
@@ -12,8 +13,10 @@ import pytest
 
 import pyarrow as pa
 import pytest_asyncio
+import pyarrow.parquet as pq
 
 from products.batch_exports.backend.temporal.destinations.snowflake_batch_export import (
+    NamedBytesIO,
     SnowflakeClient,
     SnowflakeField,
     SnowflakeIncompatibleSchemaError,
@@ -244,3 +247,106 @@ async def test_get_table_raises_incompatible_schema_on_missing_version_key_field
 
     assert "'missing_key_one'" in str(excinfo.value)
     assert "'missing_key_two'" in str(excinfo.value)
+
+
+async def test_put_file_to_snowflake_table_stage(snowflake_client, database, schema, test_table):
+    """Test files are put into Snowflake table stage."""
+    test_table.stage_prefix = f"{str(uuid.uuid4())}/{dt.datetime.now(dt.UTC):%Y-%m-%d_%H-%M-%S}"
+
+    n_legs = pa.array([2, 2, 4, 4, 5, 100])
+    animals = pa.array(["Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"])
+    table = pa.Table.from_arrays([n_legs, animals], names=["id", "text"])
+    file_like = NamedBytesIO(b"", name="test_file")
+    pq.write_table(table, file_like)
+
+    file_like.seek(0)
+    await snowflake_client.put_file_to_snowflake_table_stage(file_like, test_table)
+
+    result = await snowflake_client.execute_async_query(
+        f"""
+        LIST '@%"{test_table.name}"/{test_table.stage_prefix}'
+        """,
+        timeout=60.0,
+    )
+    assert result is not None, "Expected at least one file"
+
+    rows, metadata = result
+    assert len(rows) == 1, "Expected only one file"
+
+    row = rows[0]
+    row_dict = dict(zip((field.name for field in metadata), row))
+    assert row_dict["name"] == f"{test_table.stage_prefix}/test_file"
+
+
+async def test_copy_loaded_files_to_snowflake_table_only_works_on_stage_prefix(
+    snowflake_client, database, schema, test_table
+):
+    """Test copying only copies and purges files under stage prefix.
+
+    This ensures that multiple COPY queries to the same table do not PURGE or
+    COPY each other files.
+    """
+    test_table.stage_prefix = first_prefix = f"{str(uuid.uuid4())}/{dt.datetime.now(dt.UTC):%Y-%m-%d_%H-%M-%S}"
+
+    ids = [2, 2, 4, 4, 5, 100]
+    text = ["Flamingo", "Parrot", "Dog", "Horse", "Brittle stars", "Centipede"]
+    n_legs = pa.array(ids)
+    animals = pa.array(text)
+    table = pa.Table.from_arrays([n_legs, animals], names=["id", "text"])
+    file_like = NamedBytesIO(b"", name="test_file")
+    pq.write_table(table, file_like)
+
+    file_like.seek(0)
+    await snowflake_client.put_file_to_snowflake_table_stage(file_like, test_table)
+
+    # Same file, different prefix
+    file_like.seek(0)
+    test_table.stage_prefix = second_prefix = f"{str(uuid.uuid4())}/{dt.datetime.now(dt.UTC):%Y-%m-%d_%H-%M-%S}"
+    await snowflake_client.put_file_to_snowflake_table_stage(file_like, test_table)
+
+    await snowflake_client.copy_loaded_files_to_snowflake_table(test_table, timeout=30.0)
+
+    # Check data was actually copied
+    result = await snowflake_client.execute_async_query(
+        f"""
+        SELECT * FROM "{test_table.name}"
+        """,
+        timeout=60.0,
+    )
+    assert result is not None, "Expected at least one row in table was copied"
+
+    rows, metadata = result
+    data: dict[str, list[int] | list[str]] = {"id": [], "text": []}
+    for row in rows:
+        dict_row = dict(zip((field.name for field in metadata), row))
+        data["id"].append(dict_row["id"])
+        data["text"].append(dict_row["text"])
+
+    assert sorted(data["id"]) == sorted(ids)
+    assert sorted(data["text"]) == sorted(text)
+
+    # Check that first prefix file should still be there
+    result = await snowflake_client.execute_async_query(
+        f"""
+        LIST '@%"{test_table.name}"/{first_prefix}'
+        """,
+        timeout=60.0,
+    )
+    assert result is not None, "Expected at least one file"
+
+    rows, metadata = result
+    assert len(rows) == 1, "Expected only one file"
+
+    row = rows[0]
+    row_dict = dict(zip((field.name for field in metadata), row))
+    assert row_dict["name"] == f"{first_prefix}/test_file"
+
+    # Check that second prefix file should have been purged by COPY
+    result = await snowflake_client.execute_async_query(
+        f"""
+        LIST '@%"{test_table.name}"/{second_prefix}'
+        """,
+        timeout=60.0,
+    )
+    rows, metadata = result
+    assert rows == []

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
@@ -180,11 +180,15 @@ async def test_snowflake_export_workflow_exports_events(
     assert all(query.startswith("PUT") for query in execute_calls[0:9])
 
     assert execute_async_calls[5].startswith(f'SELECT * FROM "{table_name}" LIMIT 0')
-    assert execute_async_calls[6].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
+    assert execute_async_calls[6].startswith(
+        f"""REMOVE '@%"{table_name}"/{snowflake_batch_export.id}/{data_interval_end_str}'"""
+    )
     assert execute_async_calls[7].startswith(f'CREATE TABLE IF NOT EXISTS "{table_name}"')
     assert execute_async_calls[8].startswith(f'SELECT * FROM "{table_name}" LIMIT 0')
     assert execute_async_calls[9].startswith(f'COPY INTO "{table_name}"')
-    assert execute_async_calls[10].startswith(f"""REMOVE '@%"{table_name}"/{data_interval_end_str}'""")
+    assert execute_async_calls[10].startswith(
+        f"""REMOVE '@%"{table_name}"/{snowflake_batch_export.id}/{data_interval_end_str}'"""
+    )
 
 
 @pytest.mark.parametrize("interval", ["hour"], indirect=True)


### PR DESCRIPTION
## Problem
We do not expect users to run multiple batch exports against the same table. But if somebody does do that, then a batch export can PURGE the files from other batch exports when running a COPY query.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

We should include the batch export ID in the table's staging area, so that each batch export has its own isolated prefix for its own files.
<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Added new tests, ran e2e tests.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Hmmm, no, I don't think so
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Nothing

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Definition of done (agents): not done until each gate below holds. Verify against the named artifact or skill — don't assume. Add gates as the PR touches more areas.
     - Patch coverage: the lines this PR changed are covered, or the uncovered ones are justified under "How did you test this code?". Don't pad untouched code to lift the number. Check the "🧪 Backend test coverage" PR comment (and its patch-coverage artifact).
-->

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Body: pass it straight to the creation tool's `body` arg (GitHub MCP `create_pull_request` body, or `gh pr create --body-file -` via stdin) — don't write it to a temp file first; the arg preserves markdown and newlines verbatim.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Draft by default: open new PRs as drafts (`gh pr create --draft`) — drafts run only a narrow CI subset and save runner credits. Fix CI and run affected tests locally before marking ready for review.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Use GitHub's rich markdown when it makes review faster, never as decoration:
  - If the change alters a flow or topology (CI wiring, pipelines, state machines, request paths), include before/after mermaid diagrams as two separate `flowchart` blocks, before first. Pick `TD` (tall pipelines) or `LR` (wide paths). Keep them simple; a syntax error renders as an error block. Skip for trivial changes.
    - Brand the nodes with PostHog colors: use the hex directly (mermaid can't read CSS vars), and pair every `fill` with a text `color` so nodes stay legible in GitHub light and dark.
      ```
      classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
      classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
      classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
      classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
      ```
      Assign by role (`class NodeA,NodeB phBlue;`): `phBlue` agents/primary, `phRed` APIs/external, `phYellow` entry+exit, `phGray` data/artifacts. Shape by kind: `{{hexagon}}` agents, `[rect]` steps.
  - Use alerts (`> [!WARNING]`, `> [!NOTE]`) for behavior changes and risk callouts.
  - If you have to include long supporting content (test output, logs), collapse it in `<details>` blocks.
  - Use fenced `diff` code blocks for config before/after.
  - Line-range permalinks to code in this repo render as embedded snippets: prefer them over pasting existing code.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
