### PR TITLE
fix(postgres): treat Supavisor's auth_query secret-check timeout as a transient drop

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -228,6 +228,17 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
     # ("password authentication failed", "SASL authentication failed"), and exclude the volatile
     # millisecond value.
     "authentication did not complete within",
+    # Supavisor authenticates a tenant with no static user record by running an `auth_query` against
+    # the tenant's own backend database to fetch/cache the password secret used to validate the
+    # client's credentials. If that secret isn't cached yet (e.g. right after Supavisor starts
+    # managing the tenant) and the backend is briefly slow to answer, Supavisor's own wait for the
+    # secret times out and it refuses the connect with a bare OperationalError carrying its
+    # "(EAUTHQUERY)" code: "FATAL: (EAUTHQUERY) auth_query secret check timed out". This is a race in
+    # the pooler's own bookkeeping, not a rejection of the credentials, so a fresh connect once the
+    # secret is cached typically succeeds — recover by reconnecting rather than failing the whole
+    # activity. Match the stable code, distinct from genuine credential-rejection wordings
+    # ("password authentication failed", "SASL authentication failed").
+    "(eauthquery)",
     # pgcat (a Rust Postgres pooler) refuses to hand out a backend when every server in the pool is
     # currently banned/down — a failed health check bans a server and pgcat auto-unbans it after
     # `ban_time` — reporting it as SQLSTATE 58000 ("could not get connection from the pool -

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1532,6 +1532,14 @@ class TestIsConnectionDroppedError:
             psycopg.errors.ConnectionFailure(
                 "Failed to connect to database: authentication did not complete within 15000ms"
             ),
+            # Supavisor's own auth_query secret lookup (used to authenticate a tenant with no static
+            # user record) times out waiting for the backend, reporting a bare OperationalError
+            # carrying its "(EAUTHQUERY)" code. A race in the pooler's bookkeeping, not a credential
+            # rejection — transient and recovers once the secret is cached.
+            psycopg.OperationalError(
+                'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+                "FATAL:  (EAUTHQUERY) auth_query secret check timed out"
+            ),
             # pgcat refuses to hand out a backend when every pooled server is banned/down, reporting
             # it as SQLSTATE 58000 (psycopg's SystemError, an OperationalError) rather than the
             # Supavisor XX000 InternalError_ codes above. Transient — a banned server rejoins on a


### PR DESCRIPTION
## Problem

PostHog's error tracking [surfaced a Postgres import error](https://us.posthog.com/project/2/error_tracking/019faeff-1068-7a40-bba9-e93f563a1a50):

```
OperationalError: connection failed: connection to server at "<host>", port 5432 failed: FATAL:  (EAUTHQUERY) auth_query secret check timed out
```

The stack trace shows it originates in `get_connection` inside `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py`, hit while the streaming read path was reconnecting.

`(EAUTHQUERY)` is Supabase's Supavisor pooler. Supavisor authenticates a tenant that has no static user record by running an `auth_query` against the tenant's own backend database to fetch/cache the password secret used to validate the client's credentials. When that secret isn't cached yet and the backend is briefly slow to answer, Supavisor's own wait for the secret times out and it refuses the connect with this message.

This is a race in the pooler's internal bookkeeping, not a rejection of the credentials — the same transient class as the other Supavisor pooler drops this file already recognizes (`EDBHANDLEREXITED`, `ECHECKOUTRETRIES`, `ECHECKOUTTIMEOUT`, Neon's `authentication did not complete within`, etc.), all matched in `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` so the in-process reconnect retries them instead of failing the whole sync activity.

## Changes

Add the stable `(EAUTHQUERY)` code to `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, with a comment explaining the Supavisor auth_query/secret-cache race. This is a pure addition to an existing retry classification list — it does not touch `NonRetryableErrors`/`get_non_retryable_errors`, since the condition is transient rather than permanent.

## How did you test this code?

Added a parameterized case to `TestIsConnectionDroppedError::test_connection_dropped_errors_are_detected` asserting `_is_connection_dropped_error` recognizes this message — guards against a regression where the new substring stops matching. Ran the full `TestIsConnectionDroppedError` class (34 cases, all pass) plus `ruff check`/`ruff format --check` on both changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code (PostHog Code), triaging a live error-tracking issue end-to-end (confirm → understand → classify → fix → test → PR).
- Decision: classified as a transient pooler-side race (analogous to the existing Neon "authentication did not complete within" and Supavisor `EDBHANDLEREXITED`/`ECHECKOUTRETRIES` entries), not a permanent credential rejection, so it was added to the connection-dropped retry list rather than `NonRetryableErrors`.
- Checked for duplicate open PRs (by exception message, module path, and the maintainer's own recent PRs) — none found.