### PR TITLE
fix(data-imports): skip incremental-field lookup for xmin/CDC schemas

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
@@ -66,7 +66,10 @@ class IncrementalFieldMissingFromDataError(Exception):
 def get_incremental_field_value(
     schema: ExternalDataSchema | None, table: pa.Table, aggregate: Literal["max"] | Literal["min"] = "max"
 ) -> Any:
-    if schema is None or schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH:
+    # CDC and xmin schemas track their own cursor (CDC log position, xmin ceiling) outside of
+    # sync_type_config["incremental_field"] — that key can be a stale leftover from a prior
+    # incremental config and must not be looked up for these sync types.
+    if schema is None or not schema.should_use_incremental_field:
         return None
 
     incremental_field_name: str | None = schema.sync_type_config.get("incremental_field")

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py
@@ -218,11 +218,16 @@ class TestRunPostLoadDeltaMaintenance:
 
 
 class TestGetIncrementalFieldValue:
-    def _schema(self, incremental_field: str) -> MagicMock:
+    def _schema(self, incremental_field: str, sync_type: str = ExternalDataSchema.SyncType.INCREMENTAL) -> MagicMock:
         schema = MagicMock()
-        schema.sync_type = ExternalDataSchema.SyncType.INCREMENTAL
+        schema.sync_type = sync_type
         schema.sync_type_config = {"incremental_field": incremental_field, "incremental_field_type": "integer"}
         schema.incremental_field_type = "integer"
+        schema.should_use_incremental_field = sync_type in (
+            ExternalDataSchema.SyncType.INCREMENTAL,
+            ExternalDataSchema.SyncType.APPEND,
+            ExternalDataSchema.SyncType.WEBHOOK,
+        )
         return schema
 
     def test_returns_max_of_configured_column(self):
@@ -243,3 +248,19 @@ class TestGetIncrementalFieldValue:
         assert "created" in message  # available columns are listed for self-service fixing
         matching_keys = [key for key in Any_Source_Errors if key in message]
         assert matching_keys, "exception message must stay matched by an Any_Source_Errors entry"
+
+    @parameterized.expand(
+        [
+            ("xmin", ExternalDataSchema.SyncType.XMIN),
+            ("cdc", ExternalDataSchema.SyncType.CDC),
+        ]
+    )
+    def test_stale_incremental_field_ignored_for_self_tracking_sync_types(self, _name: str, sync_type: str):
+        # xmin/cdc track their cursor outside sync_type_config (xmin_ceiling, cdc_last_log_position).
+        # A schema switched from incremental to xmin/cdc keeps the old incremental_field key around,
+        # which used to raise IncrementalFieldMissingFromDataError even though this sync type never
+        # reads that column.
+        table = pa.table({"id": ["a"], "created": [10]})
+        schema = self._schema("updated_at", sync_type=sync_type)
+
+        assert get_incremental_field_value(schema, table) is None


### PR DESCRIPTION
## Problem

Error tracking surfaced `IncrementalFieldMissingFromDataError` firing on a Postgres source's `xmin` sync (see the linked issue). The failing table's incremental field was configured as an ordinary column name, but the sync type had since been switched to `xmin`, which tracks progress via Postgres's synthetic `xmin` system column instead of any user-picked column.

`get_incremental_field_value` in the shared pipeline (`products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py`) only skipped its `sync_type_config["incremental_field"]` lookup for `full_refresh` schemas. Every other sync type — including `xmin` and `cdc`, both of which track their cursor elsewhere (xmin ceiling, CDC log position) and never read this key — went through the lookup. A schema that was previously `incremental` and got switched to `xmin`/`cdc` keeps the old `incremental_field` value sitting in `sync_type_config`, so the lookup found a column name that no longer exists in the extracted data and raised.

This isn't a genuine user misconfiguration (the schema's actual sync mode never needed that field), so pausing the sync with "pick a valid incremental field" guidance was the wrong outcome — reference: [error tracking issue](https://us.posthog.com/project/2/error_tracking/019faf06-b55b-79a2-b130-cd7a48db0559).

## Changes

- `get_incremental_field_value` now uses the existing `schema.should_use_incremental_field` property (already used elsewhere in the model to draw exactly this line: `is_incremental`/`is_append`/`is_webhook`) instead of a `sync_type == FULL_REFRESH` check. This is a strict superset of the old guard, so `full_refresh` behavior is unchanged, while `xmin` and `cdc` schemas now correctly skip the lookup regardless of what's left over in `sync_type_config`.

## How did you test this code?

Extended `TestGetIncrementalFieldValue` in `products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py` with a parameterized case (`xmin`, `cdc`) that configures a stale `incremental_field` pointing at a column absent from the batch, and asserts `get_incremental_field_value` returns `None` instead of raising — this reproduces the exact crash from the error tracking issue. Existing tests for the `incremental` sync type (max-of-column, missing-column error) still pass unchanged, confirming the fix doesn't affect schemas that actually use `incremental_field`.

Ran the full test file: `uv run pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_load.py` — 15 passed. Also ran `uv run mypy --cache-fine-grained` against the changed file — no issues.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal pipeline bug fix, no documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude, via PostHog Code) triaged this from an error-tracking webhook alert for `IncrementalFieldMissingFromDataError`. I pulled the issue's stack trace and a representative event via the PostHog MCP error-tracking tools, traced the failure into `get_incremental_field_value`, and used the `warehouse_sources_*` event properties (`sync_type: xmin`) to identify that the failure was specific to schemas whose sync type doesn't actually use `incremental_field`. I compared against the `is_cdc`/`is_xmin`/`should_use_incremental_field` conventions already established in `ExternalDataSchema` (e.g. `table_row_count_is_cumulative`) to find the minimal, convention-consistent fix rather than special-casing `xmin` directly. Searched open PRs (by exception type, module path, and the maintainer's own recent PRs) and found no existing fix for this.