### PR TITLE
fix(session-replay): constrain oversized construction hog placeholder

### DIFF
--- a/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
+++ b/frontend/src/scenes/session-recordings/player/PurePlayer.tsx
@@ -316,7 +316,7 @@ export function PurePlayer({ noMeta = false, noBorder = false }: PurePlayerProps
                     <div className="SessionRecordingPlayer__main flex flex-col h-full w-full">
                         {isRecentAndInvalid ? (
                             <div className="flex flex-1 flex-col items-center justify-center">
-                                <HedgehogConstruction2 height={200} />
+                                <HedgehogConstruction2 height={200} width={200} />
                                 <h1>We're still working on it</h1>
                                 <p>
                                     This recording hasn't been fully ingested yet. It should be ready to watch in a few


### PR DESCRIPTION
## Problem

On a very recent session recording that hasn't finished ingesting yet, the replay player shows a "We're still working on it" placeholder. The construction hoggie in that placeholder rendered at its intrinsic (oversized) dimensions, crowding out the message and reload button so the rest of the content was hard to read.

## Changes

The placeholder passed only `height={200}` to the construction hoggie, with no `width` and no `className`. Because a height was set, the "fill container" fallback in `pngHoggie` didn't apply either, so the image had no width constraint and fell back to its natural size. Now it passes both `height` and `width`, matching the sibling `WarningHog` placeholder rendered one branch below in the same component.

## How did you test this code?

Not manually tested by the agent (no running frontend). The change mirrors the existing, correctly-sized `WarningHog` placeholder in the same file (`height={200} width={200}`), and `pngHoggie` applies `objectFit: 'contain'` so the aspect ratio is preserved within the constrained box.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raised from a Slack thread reporting an oversized placeholder hedgehog on recent, not-yet-ingested session replays. An explore agent located the placeholder in `PurePlayer.tsx` and confirmed the sibling `WarningHog` branch as the correct pattern to match. One-line fix.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1785348989094499?thread_ts=1785348989.094499&cid=C0ACRAMJUAG)*