### PR TITLE
feat(error-tracking): log per-run chunk upload summary in the CLI

### DIFF
--- a/cli/.sampo/changesets/upload-summary-counts.md
+++ b/cli/.sampo/changesets/upload-summary-counts.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Sourcemap, dSYM, and ProGuard uploads now end with a single per-run summary line reporting how many chunks were uploaded, skipped as already present on the server, and skipped as too large. The summary is logged even when a run fails partway, and the same counts are attached to the `error_tracking_cli_sourcemaps_upload_finished` telemetry event so skip rates are queryable.

--- a/cli/src/api/symbol_sets.rs
+++ b/cli/src/api/symbol_sets.rs
@@ -118,13 +118,17 @@ struct BulkUploadFinishRequest {
 /// the upload will be retried without release IDs.
 /// If `force` is true, symbol sets whose content has changed are overwritten rather than skipped.
 /// If `skip_on_conflict` is true, symbol sets whose content has changed are skipped rather than failing.
+///
+/// The summary is returned beside the result rather than inside it, because a
+/// failed run still needs to report the chunks it uploaded and skipped before
+/// it gave up.
 pub fn upload_with_retry(
     input_sets: Vec<SymbolSetUpload>,
     batch_size: usize,
     skip_release_on_fail: bool,
     force: bool,
     skip_on_conflict: bool,
-) -> Result<UploadSummary> {
+) -> (UploadSummary, Result<()>) {
     upload_with_retry_and_concurrency(
         input_sets,
         batch_size,
@@ -142,14 +146,21 @@ pub fn upload_with_retry_and_concurrency(
     force: bool,
     skip_on_conflict: bool,
     concurrency: NonZeroUsize,
-) -> Result<UploadSummary> {
-    let thread_pool = build_upload_thread_pool(concurrency)?;
+) -> (UploadSummary, Result<()>) {
+    let mut summary = UploadSummary::default();
+    let thread_pool = match build_upload_thread_pool(concurrency) {
+        Ok(thread_pool) => thread_pool,
+        Err(e) => return (summary, Err(e)),
+    };
     // One client for the whole run: reusing its connection pool avoids paying a
     // TCP + TLS handshake per uploaded chunk.
-    let s3_client = context()
+    let s3_client = match context()
         .build_http_client()
-        .context("Failed to initialize upload HTTP client")?;
-    let mut summary = UploadSummary::default();
+        .context("Failed to initialize upload HTTP client")
+    {
+        Ok(client) => client,
+        Err(e) => return (summary, Err(e)),
+    };
     let res = upload_inner(
         &input_sets,
         batch_size,
@@ -186,7 +197,7 @@ pub fn upload_with_retry_and_concurrency(
     // Logged on failure too, so a partial run still reports how far it got.
     summary.log();
 
-    res.map(|()| summary).map_err(Into::into)
+    (summary, res.map_err(Into::into))
 }
 
 fn build_upload_thread_pool(concurrency: NonZeroUsize) -> Result<ThreadPool> {

--- a/cli/src/api/symbol_sets.rs
+++ b/cli/src/api/symbol_sets.rs
@@ -40,6 +40,46 @@ pub struct SymbolSetUpload {
     pub data: Vec<u8>,
 }
 
+/// Per-run tally of what an upload actually did. Without it a run that skipped
+/// every chunk is indistinguishable from one that uploaded every chunk, since
+/// both just exit zero.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct UploadSummary {
+    pub uploaded: usize,
+    pub skipped_already_present: usize,
+    pub skipped_too_large: usize,
+}
+
+impl UploadSummary {
+    pub fn skipped(&self) -> usize {
+        self.skipped_already_present + self.skipped_too_large
+    }
+
+    pub fn telemetry_props(&self) -> Vec<(&'static str, serde_json::Value)> {
+        vec![
+            ("uploaded", serde_json::json!(self.uploaded)),
+            (
+                "skipped_already_present",
+                serde_json::json!(self.skipped_already_present),
+            ),
+            (
+                "skipped_too_large",
+                serde_json::json!(self.skipped_too_large),
+            ),
+        ]
+    }
+
+    fn log(&self) {
+        info!(
+            "Upload summary: {} chunk(s) uploaded, {} skipped ({} already present, {} too large)",
+            self.uploaded,
+            self.skipped(),
+            self.skipped_already_present,
+            self.skipped_too_large
+        );
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 struct StartUploadResponseData {
     presigned_url: PresignedUrl,
@@ -84,7 +124,7 @@ pub fn upload_with_retry(
     skip_release_on_fail: bool,
     force: bool,
     skip_on_conflict: bool,
-) -> Result<()> {
+) -> Result<UploadSummary> {
     upload_with_retry_and_concurrency(
         input_sets,
         batch_size,
@@ -102,13 +142,14 @@ pub fn upload_with_retry_and_concurrency(
     force: bool,
     skip_on_conflict: bool,
     concurrency: NonZeroUsize,
-) -> Result<()> {
+) -> Result<UploadSummary> {
     let thread_pool = build_upload_thread_pool(concurrency)?;
     // One client for the whole run: reusing its connection pool avoids paying a
     // TCP + TLS handshake per uploaded chunk.
     let s3_client = context()
         .build_http_client()
         .context("Failed to initialize upload HTTP client")?;
+    let mut summary = UploadSummary::default();
     let res = upload_inner(
         &input_sets,
         batch_size,
@@ -116,9 +157,9 @@ pub fn upload_with_retry_and_concurrency(
         skip_on_conflict,
         &thread_pool,
         &s3_client,
+        &mut summary,
     );
-    match res {
-        Ok(()) => Ok(()),
+    let res = match res {
         Err(UploadError::ReleaseIdMismatch) if skip_release_on_fail => {
             warn!("Release ID mismatch detected. Retrying upload without release IDs...");
             let sets_without_release: Vec<_> = input_sets
@@ -136,11 +177,16 @@ pub fn upload_with_retry_and_concurrency(
                 skip_on_conflict,
                 &thread_pool,
                 &s3_client,
+                &mut summary,
             )
-            .map_err(|e| e.into())
         }
-        Err(e) => Err(e.into()),
-    }
+        res => res,
+    };
+
+    // Logged on failure too, so a partial run still reports how far it got.
+    summary.log();
+
+    res.map(|()| summary).map_err(Into::into)
 }
 
 fn build_upload_thread_pool(concurrency: NonZeroUsize) -> Result<ThreadPool> {
@@ -157,11 +203,17 @@ fn upload_inner(
     skip_on_conflict: bool,
     thread_pool: &ThreadPool,
     s3_client: &Client,
+    summary: &mut UploadSummary,
 ) -> Result<(), UploadError> {
+    // A release-id-mismatch retry re-uploads the same sets from scratch, so the
+    // tally starts over rather than double-counting the first attempt.
+    *summary = UploadSummary::default();
+
     let upload_requests: Vec<_> = input_sets
         .iter()
         .filter(|s| {
             if s.data.len() > MAX_FILE_SIZE {
+                summary.skipped_too_large += 1;
                 warn!(
                     "Skipping symbol set with id: {}, file too large",
                     s.chunk_id
@@ -185,6 +237,7 @@ fn upload_inner(
             .map(|(u, hash)| (u.chunk_id.as_str(), (u, hash)))
             .collect();
 
+        summary.skipped_already_present += batch.len() - start_response.id_map.len();
         info!(
             "Server returned {} upload keys ({} skipped as already present)",
             start_response.id_map.len(),
@@ -208,8 +261,10 @@ fn upload_inner(
         });
 
         let content_hashes = res?;
+        let uploaded = content_hashes.len();
 
         finish_upload(content_hashes)?;
+        summary.uploaded += uploaded;
     }
 
     Ok(())

--- a/cli/src/api/symbol_sets.rs
+++ b/cli/src/api/symbol_sets.rs
@@ -173,6 +173,10 @@ pub fn upload_with_retry_and_concurrency(
     let res = match res {
         Err(UploadError::ReleaseIdMismatch) if skip_release_on_fail => {
             warn!("Release ID mismatch detected. Retrying upload without release IDs...");
+            // Batches finalized before the mismatch are on the server by the time
+            // the retry runs, so upload_inner recounts them as already present.
+            // Remember them and reclassify below, because this run did upload them.
+            let uploaded_before_retry = summary.uploaded;
             let sets_without_release: Vec<_> = input_sets
                 .into_iter()
                 .map(|s| SymbolSetUpload {
@@ -181,7 +185,7 @@ pub fn upload_with_retry_and_concurrency(
                     data: s.data,
                 })
                 .collect();
-            upload_inner(
+            let res = upload_inner(
                 &sets_without_release,
                 batch_size,
                 force,
@@ -189,7 +193,12 @@ pub fn upload_with_retry_and_concurrency(
                 &thread_pool,
                 &s3_client,
                 &mut summary,
-            )
+            );
+            summary.uploaded += uploaded_before_retry;
+            summary.skipped_already_present = summary
+                .skipped_already_present
+                .saturating_sub(uploaded_before_retry);
+            res
         }
         res => res,
     };

--- a/cli/src/debug_symbols/upload.rs
+++ b/cli/src/debug_symbols/upload.rs
@@ -123,13 +123,14 @@ pub fn upload(args: &Args) -> Result<()> {
     // --include-source implies force unless the user explicitly asked to keep
     // existing symbol sets with --skip-on-conflict.
     let effective_force = conflict.force || (*include_source && !conflict.skip_on_conflict);
-    api::symbol_sets::upload_with_retry(
+    let (_summary, upload_result) = api::symbol_sets::upload_with_retry(
         uploads,
         10,
         release_args.skip_release_on_fail,
         effective_force,
         conflict.skip_on_conflict,
-    )?;
+    );
+    upload_result?;
     info!("Debug symbol upload complete");
 
     Ok(())

--- a/cli/src/dsym/upload.rs
+++ b/cli/src/dsym/upload.rs
@@ -201,13 +201,14 @@ pub fn upload(args: &Args) -> Result<()> {
     // --include-source implies force unless the user explicitly asked to keep
     // existing symbol sets with --skip-on-conflict.
     let effective_force = conflict.force || (*include_source && !conflict.skip_on_conflict);
-    api::symbol_sets::upload_with_retry(
+    let (_summary, upload_result) = api::symbol_sets::upload_with_retry(
         uploads,
         10,
         release_args.skip_release_on_fail,
         effective_force,
         conflict.skip_on_conflict,
-    )?;
+    );
+    upload_result?;
     info!("dSYM upload complete");
 
     Ok(())

--- a/cli/src/proguard/upload.rs
+++ b/cli/src/proguard/upload.rs
@@ -77,13 +77,14 @@ pub fn upload(args: &Args) -> Result<()> {
 
     let to_upload: SymbolSetUpload = file.try_into()?;
 
-    api::symbol_sets::upload_with_retry(
+    let (_summary, upload_result) = api::symbol_sets::upload_with_retry(
         vec![to_upload],
         *batch_size,
         *skip_release_on_fail,
         conflict.force,
         conflict.skip_on_conflict,
-    )?;
+    );
+    upload_result?;
 
     Ok(())
 }

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -107,8 +107,9 @@ pub fn upload(args: &Args) -> Result<()> {
         ("duration_ms", json!(duration_ms)),
         ("success", json!(upload_result.is_ok())),
     ];
-    if let Err(ref e) = upload_result {
-        props.push(("error", json!(format!("{:#}", e))));
+    match upload_result {
+        Ok(ref summary) => props.extend(summary.telemetry_props()),
+        Err(ref e) => props.push(("error", json!(format!("{:#}", e)))),
     }
     context().capture_event("error_tracking_cli_sourcemaps_upload_finished", props);
 

--- a/cli/src/sourcemaps/hermes/upload.rs
+++ b/cli/src/sourcemaps/hermes/upload.rs
@@ -91,7 +91,7 @@ pub fn upload(args: &Args) -> Result<()> {
     );
 
     let started_at = Instant::now();
-    let upload_result = symbol_sets::upload_with_retry(
+    let (summary, upload_result) = symbol_sets::upload_with_retry(
         uploads,
         *batch_size,
         release.skip_release_on_fail,
@@ -107,9 +107,9 @@ pub fn upload(args: &Args) -> Result<()> {
         ("duration_ms", json!(duration_ms)),
         ("success", json!(upload_result.is_ok())),
     ];
-    match upload_result {
-        Ok(ref summary) => props.extend(summary.telemetry_props()),
-        Err(ref e) => props.push(("error", json!(format!("{:#}", e)))),
+    props.extend(summary.telemetry_props());
+    if let Err(ref e) = upload_result {
+        props.push(("error", json!(format!("{:#}", e))));
     }
     context().capture_event("error_tracking_cli_sourcemaps_upload_finished", props);
 

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -170,8 +170,9 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
         ("duration_ms", json!(duration_ms)),
         ("success", json!(upload_result.is_ok())),
     ];
-    if let Err(ref e) = upload_result {
-        props.push(("error", json!(format!("{:#}", e))));
+    match upload_result {
+        Ok(ref summary) => props.extend(summary.telemetry_props()),
+        Err(ref e) => props.push(("error", json!(format!("{:#}", e)))),
     }
     context().capture_event("error_tracking_cli_sourcemaps_upload_finished", props);
 

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -153,7 +153,7 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
     );
 
     let started_at = Instant::now();
-    let upload_result = symbol_sets::upload_with_retry_and_concurrency(
+    let (summary, upload_result) = symbol_sets::upload_with_retry_and_concurrency(
         uploads,
         args.batch_size,
         args.release.skip_release_on_fail,
@@ -170,9 +170,9 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
         ("duration_ms", json!(duration_ms)),
         ("success", json!(upload_result.is_ok())),
     ];
-    match upload_result {
-        Ok(ref summary) => props.extend(summary.telemetry_props()),
-        Err(ref e) => props.push(("error", json!(format!("{:#}", e)))),
+    props.extend(summary.telemetry_props());
+    if let Err(ref e) = upload_result {
+        props.push(("error", json!(format!("{:#}", e))));
     }
     context().capture_event("error_tracking_cli_sourcemaps_upload_finished", props);
 


### PR DESCRIPTION
## Problem

We're about to make the CLI skip more chunks on upload. Right now there's no way to tell from a run whether that's working.

The upload path only logged per batch:

```
Server returned 12 upload keys (38 skipped as already present)
```

With a 50-chunk default batch size, a big project prints a pile of those lines and nobody adds them up. Nothing reports a per-run total, and the `error_tracking_cli_sourcemaps_upload_finished` event only carried `file_count`, which is what we *considered* uploading, not what we actually uploaded. So a run that skipped everything and a run that uploaded everything look identical from the outside.

## Changes

Track the tally across all batches in `upload_inner` and report it once per run.

New `UploadSummary` returned by `upload_with_retry` / `upload_with_retry_and_concurrency`:

| field | meaning |
| --- | --- |
| `uploaded` | chunks that made it through S3 and got finalized |
| `skipped_already_present` | server didn't hand back an upload key (content already there) |
| `skipped_too_large` | dropped locally, over `MAX_FILE_SIZE` |

Every run now ends with one line:

```
Upload summary: 12 chunk(s) uploaded, 38 skipped (38 already present, 0 too large)
```

It's logged on the failure path too, so a run that dies halfway still says how far it got.

The three counts also go onto `error_tracking_cli_sourcemaps_upload_finished` for both the plain and hermes sourcemap paths, so the skip rate is queryable rather than something you eyeball in terminal output.

Two details worth flagging for review:

> [!NOTE]
> The release-id-mismatch retry re-uploads every set from scratch, so the summary resets at the top of `upload_inner` instead of accumulating across both attempts. Otherwise the retry would double count.

`uploaded` increments after `finish_upload` succeeds for a batch, not after the S3 PUTs. A batch whose finalize call fails isn't counted, which matches the error message we already show there ("maps were not attached").

The dSYM and proguard paths get the log line for free since they share `upload_with_retry`; I left their existing "upload complete" lines alone.

## How did you test this code?

`cargo test` in `cli/` (160 passed) and `cargo clippy --all-targets` clean. Release build succeeds. I did not run a real upload against a PostHog instance.

No new tests. All three counters are increments sitting next to log lines we already emit, and the interesting one (already-present) needs a server returning a partial `id_map`, which is integration territory. Nothing here is worth a test that only restates the arithmetic.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude Code (Opus 5) to check whether the CLI already reported per-run skipped/uploaded counts before I land a change that increases skipping, and to add it if not. It found only the per-batch log and the `file_count` telemetry prop.

Skills invoked: `/writing-tests`, `/writing-code-comments`, `/writing-user-facing-copy`.

Decisions along the way: the first shape threaded an accumulator through `upload_inner` and returned it only on success, which loses the tally when a run fails partway. Switched to a `&mut UploadSummary` so partial progress survives the error path. An earlier revision also extracted the oversized-file filter into a standalone `partition_oversized` function purely so the too-large counter could be unit tested without allocating a 100 MB buffer; I had it reverted, since restructuring a 3-line filter to serve a test wasn't worth the diff.
