### PR TITLE
fix(data-warehouse): skip sentry org stats summary when token has no project access

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/sentry.py
@@ -536,6 +536,9 @@ def _iter_issue_tag_values_rows(
 _UNAVAILABLE_DATASET_STATUSES = (400, 403, 404)
 # Per-project surfaces only ever go missing through permissions or an absent config.
 _MISSING_PROJECT_RESOURCE_STATUSES = (403, 404)
+# Sentry's stats-summary endpoint 400s with this detail when the token's user has no
+# project membership in the org, even though the token itself is otherwise valid.
+_NO_PROJECTS_AVAILABLE_DETAIL = "No projects available"
 
 
 def _iter_rows_tolerating_unavailable(
@@ -672,12 +675,30 @@ def _iter_organization_stats_summary_rows(
     organization_slug: str,
 ) -> Iterator[dict[str, Any]]:
     """Per-project event volume for the retention window, one row per project per category."""
-    payload = _fetch_json(
-        base_api_url,
-        _endpoint_path("organization_stats_summary", organization_slug=organization_slug),
-        headers,
-        {"field": "sum(quantity)", "statsPeriod": f"{SENTRY_RETENTION_DAYS}d"},
-    )
+    try:
+        payload = _fetch_json(
+            base_api_url,
+            _endpoint_path("organization_stats_summary", organization_slug=organization_slug),
+            headers,
+            {"field": "sum(quantity)", "statsPeriod": f"{SENTRY_RETENTION_DAYS}d"},
+        )
+    except HTTPError as exc:
+        response = exc.response
+        if response is not None and response.status_code == 400:
+            try:
+                detail = response.json().get("detail")
+            except JSONDecodeError:
+                detail = None
+            if detail == _NO_PROJECTS_AVAILABLE_DETAIL:
+                # The requesting token's user isn't a member of any project in this
+                # org — Sentry rejects that as a 400 rather than an empty result.
+                # Skip the table rather than failing the whole sync.
+                logger.warning(
+                    "sentry_source.organization_stats_summary_no_projects_skipped",
+                    organization_slug=organization_slug,
+                )
+                return
+        raise
 
     period_start = payload.get("start")
     period_end = payload.get("end")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sentry/tests/test_sentry.py
@@ -1380,6 +1380,40 @@ class TestSentryCustomIteratorEndpoints:
         assert rows[0]["period_end"] == "2026-03-01T00:00:00Z"
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry._request_with_retry")
+    def test_stats_summary_skips_when_token_has_no_project_access(self, mock_request) -> None:
+        # The requesting token's user can be a member of the org without being a
+        # member of any project's team — Sentry 400s this specific endpoint rather
+        # than returning an empty result.
+        mock_request.return_value = _response({"detail": "No projects available"}, status_code=400)
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="organization_stats_summary",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        assert list(cast(Any, resp.items())) == []
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry._request_with_retry")
+    def test_stats_summary_propagates_other_400_errors(self, mock_request) -> None:
+        mock_request.return_value = _response({"detail": 'Invalid field: "bogus"'}, status_code=400)
+
+        resp = sentry_source(
+            auth_token="token",
+            organization_slug="acme",
+            api_base_url="https://sentry.io",
+            endpoint="organization_stats_summary",
+            team_id=123,
+            job_id="job-id",
+        )
+
+        with pytest.raises(HTTPError):
+            list(cast(Any, resp.items()))
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.sentry.sentry._request_with_retry")
     def test_trace_item_attributes_stamps_dataset_and_skips_unavailable_ones(self, mock_request) -> None:
         def side_effect(url, headers=None, params=None, timeout=None):
             dataset = (params or {}).get("dataset")


### PR DESCRIPTION
## Problem

Error tracking surfaced an `HTTPError: 400 Client Error: Bad Request` from the Sentry data-warehouse source, raised in `_fetch_json` inside `organization_stats_summary`'s custom iterator ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019faf29-bdb9-78e1-bb10-8a28d596b9d5)).

Sentry's `stats-summary` endpoint (`/organizations/{slug}/stats-summary/`) resolves the calling token's accessible projects by team membership. When the token's user isn't a member of any project's team in the org, Sentry returns `400 {"detail": "No projects available"}` — even though the token's auth and scopes are otherwise completely valid. That crashed the whole `organization_stats_summary` table sync instead of just leaving it empty.

## Changes

- `sentry.py`: catch this specific 400 in `_iter_organization_stats_summary_rows` and skip the table (yield nothing) instead of propagating, matching the existing graceful-skip pattern already used elsewhere in this source for other org-gated Sentry endpoints (e.g. `project_service_hooks`, issue tag values). Other 400s (bad field, bad param, etc.) still propagate as real errors.

## How did you test this code?

- Added `test_stats_summary_skips_when_token_has_no_project_access`, asserting the table yields no rows instead of raising when Sentry returns this specific 400.
- Added `test_stats_summary_propagates_other_400_errors` to confirm unrelated 400s still surface as failures.
- Ran the full `test_sentry.py` suite locally (119 passed) and `ruff check`/`ruff format` on the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-handling fix, no user-facing behavior or docs change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) triaged a live error-tracking issue for the Sentry data-warehouse source, read the stack trace and confirmed it originated in this source's `_fetch_json`/`organization_stats_summary` code path, then researched Sentry's public `stats-summary` endpoint source/tests upstream to confirm the "No projects available" 400 is a permission-shaped condition tied to the token's project membership rather than a malformed request. I checked open PRs and the source maintainer's recent PRs for an existing fix; found none. Decided this was a "fixable bug" (missing graceful-skip) rather than a NonRetryableErrors case, since it only affects one table and other Sentry-gated-endpoint precedent in this file already handles similar org-level gating by skipping gracefully rather than failing the whole schema.