### PR TITLE
fix(data-catalog): truncate long relationship cells with tooltip

### DIFF
--- a/products/data_catalog/frontend/tabs/RelationshipsTab.tsx
+++ b/products/data_catalog/frontend/tabs/RelationshipsTab.tsx
@@ -30,6 +30,15 @@ function tableRef(table: string, key: string): string {
     return key ? `${table}.${key}` : table
 }
 
+function TableRefCell({ table, refKey }: { table: string; refKey: string }): JSX.Element {
+    const value = tableRef(table, refKey)
+    return (
+        <Tooltip title={value}>
+            <span className="font-mono text-xs truncate inline-block max-w-[280px] align-bottom">{value}</span>
+        </Tooltip>
+    )
+}
+
 export function RelationshipsTab(): JSX.Element {
     const { filteredRows, proposalsLoading, joinsLoading, statusFilter, actionsInFlight } =
         useValues(relationshipsLogic)
@@ -56,16 +65,12 @@ export function RelationshipsTab(): JSX.Element {
         {
             title: 'Source',
             key: 'source',
-            render: (_, row) => (
-                <span className="font-mono text-xs">{tableRef(row.sourceTableName, row.sourceTableKey)}</span>
-            ),
+            render: (_, row) => <TableRefCell table={row.sourceTableName} refKey={row.sourceTableKey} />,
         },
         {
             title: 'Joins to',
             key: 'joining',
-            render: (_, row) => (
-                <span className="font-mono text-xs">{tableRef(row.joiningTableName, row.joiningTableKey)}</span>
-            ),
+            render: (_, row) => <TableRefCell table={row.joiningTableName} refKey={row.joiningTableKey} />,
         },
         {
             title: (


### PR DESCRIPTION
## Problem

On the data catalog Relationships tab, the "Source" and "Joins to" cells render the full fully-qualified `table.key` string in an uncapped span. When a source or join target has a long name, the cell pushes the table past its container width and the whole table gets a horizontal scrollbar — a poor experience for reading the rest of the row.

Raised in a [Slack thread](https://posthog.slack.com/archives/C0A9BSVSE72/p1785350291663519).

## Changes

Truncate the "Source" and "Joins to" cells with a max width and `truncate`, and show the full value in a tooltip on hover. Extracted a small `TableRefCell` renderer used by both columns.

## How did you test this code?

Not able to run the frontend locally in this environment (`node_modules` not installed, so `typescript:check` could not run). The change is a contained render-only tweak: it wraps the existing `tableRef(...)` string in the already-imported `Tooltip` and adds Tailwind truncation classes — no logic or type-shape changes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. A user reported that long source/join names in the newly released data catalog Relationships tab caused a horizontal scroll on the table, and suggested truncating with a hover/click to reveal the full name. Explored `products/data_catalog/frontend/` to locate the table (`RelationshipsTab.tsx`), confirmed the two cells render an uncapped `<span>`, and applied the suggested fix — truncate + tooltip — since wrapping would make rows tall and ragged given how long these keys get. `Tooltip` was already imported in the file, so the change is minimal.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A9BSVSE72/p1785350291663519)*
