### PR TITLE
fix(data-warehouse): stop sources pagination refetch and scroll jump

### DIFF
--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -59,6 +59,8 @@ export interface LemonTableProps<T extends Record<string, any>, K extends BulkSe
     /** Whether the table is still interactable while `loading` is `true`. Defaults to `true`. **/
     disableTableWhileLoading?: boolean
     pagination?: PaginationAuto | PaginationManual
+    /** Whether changing the page scrolls the table back into view. Defaults to `true`. */
+    scrollToTopOnPageChange?: boolean
     expandable?: ExpandableConfig<T>
     /** Whether the header should be shown. The default value is `true`. */
     showHeader?: boolean
@@ -129,6 +131,7 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
     loading,
     disableTableWhileLoading = true,
     pagination,
+    scrollToTopOnPageChange = true,
     expandable,
     showHeader = true,
     uppercaseHeader = true,
@@ -336,6 +339,10 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
         }
         previousPageRef.current = paginationState.currentPage
 
+        if (!scrollToTopOnPageChange) {
+            return
+        }
+
         // When the current page changes, scroll back to the top of the table
         if (scrollRef.current) {
             const realTableOffsetTop = scrollRef.current.getBoundingClientRect().top - 320 // Extra breathing room
@@ -349,7 +356,7 @@ export function LemonTable<T extends Record<string, any>, K extends BulkSelectio
                 }
             }
         }
-    }, [paginationState.currentPage])
+    }, [paginationState.currentPage, scrollToTopOnPageChange])
 
     if (firstColumnSticky && expandable) {
         // Due to CSS, for firstColumnSticky to work the first column needs to be a content column

--- a/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
+++ b/frontend/src/lib/lemon-ui/LemonTable/LemonTable.tsx
@@ -59,7 +59,10 @@ export interface LemonTableProps<T extends Record<string, any>, K extends BulkSe
     /** Whether the table is still interactable while `loading` is `true`. Defaults to `true`. **/
     disableTableWhileLoading?: boolean
     pagination?: PaginationAuto | PaginationManual
-    /** Whether changing the page scrolls the table back into view. Defaults to `true`. */
+    /**
+     * Whether changing the page scrolls the table back into view. Defaults to `true`.
+     * Set to `false` for tables high up on a page where paging shouldn't move the viewport.
+     */
     scrollToTopOnPageChange?: boolean
     expandable?: ExpandableConfig<T>
     /** Whether the header should be shown. The default value is `true`. */

--- a/products/data_warehouse/frontend/shared/components/DirectConnectSourcesTable.tsx
+++ b/products/data_warehouse/frontend/shared/components/DirectConnectSourcesTable.tsx
@@ -28,6 +28,7 @@ export function DirectConnectSourcesTable(): JSX.Element {
                 dataSource={filteredDirectSources}
                 loading={dataWarehouseSourcesLoading}
                 pagination={{ pageSize: 10 }}
+                scrollToTopOnPageChange={false}
                 columns={[
                     {
                         width: 0,

--- a/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
+++ b/products/data_warehouse/frontend/shared/components/ManagedSourcesTable.tsx
@@ -69,6 +69,7 @@ export function ManagedSourcesTable(): JSX.Element {
                 loading={dataWarehouseSourcesLoading}
                 disableTableWhileLoading={false}
                 pagination={{ pageSize: 10 }}
+                scrollToTopOnPageChange={false}
                 emptyState={
                     <div className="flex flex-col items-center gap-2 py-2">
                         <span>{managedSearchTerm ? 'No sources matching your search' : 'No managed sources'}</span>

--- a/products/data_warehouse/frontend/shared/components/SelfManagedSourcesTable.tsx
+++ b/products/data_warehouse/frontend/shared/components/SelfManagedSourcesTable.tsx
@@ -22,6 +22,7 @@ export function SelfManagedSourcesTable(): JSX.Element {
                 dataSource={filteredSelfManagedTables}
                 loading={databaseLoading}
                 pagination={{ pageSize: 10 }}
+                scrollToTopOnPageChange={false}
                 columns={[
                     {
                         width: 0,

--- a/products/data_warehouse/frontend/shared/logics/sourceManagementLogic.ts
+++ b/products/data_warehouse/frontend/shared/logics/sourceManagementLogic.ts
@@ -427,9 +427,23 @@ export const sourceManagementLogic = kea<sourceManagementLogicType>([
         ],
     }),
     urlToAction(({ actions }) => {
-        const reload = (): void => actions.loadSources()
         // Reload (and restart polling) when landing on a page that renders the sources list, in
         // case this shared logic was already mounted by another scene and afterMount won't re-run.
+        // Skip same-path URL changes — the sources tables sync their pagination to the URL (e.g.
+        // ?managed-sources_page=2), and a full refetch on every page click would blink the table
+        // and shift the page.
+        const reload = (
+            _params: Record<string, string | undefined>,
+            _searchParams: Record<string, any>,
+            _hashParams: Record<string, any>,
+            currentLocation: { pathname: string; initial?: boolean },
+            previousLocation?: { pathname: string }
+        ): void => {
+            if (!currentLocation.initial && currentLocation.pathname === previousLocation?.pathname) {
+                return
+            }
+            actions.loadSources()
+        }
         return Object.fromEntries(SOURCE_LIST_PATHS.map((sourcePath) => [sourcePath, reload]))
     }),
     listeners(({ actions, values, cache }) => ({


### PR DESCRIPTION
## Problem

On the data management → sources page, paginating the sources tables (managed, direct connect, self-managed) caused the page to blink, shift content, and scroll to the top instead of just updating the rows. Reported from a Slack thread.

Two causes:
- Each table syncs its pagination to the URL. Clicking "next" pushed a page param on the same path, which re-triggered `sourceManagementLogic`'s `urlToAction` and refetched the *entire* sources list (the list is loaded once and paginated client-side, so no refetch is needed). The loading toggle plus new array identity produced the blink and content shift.
- `LemonTable` scrolls the table back into view on every page change, adding a scroll jump on top.

## Changes

- `sourceManagementLogic`: skip the reload on same-path URL changes (e.g. `?managed-sources_page=2`), matching the existing pattern used elsewhere in the app. Genuine navigation into a sources page still reloads and restarts polling; the 10s poll is unaffected since it self-schedules.
- `LemonTable`: add an opt-out `scrollToTopOnPageChange` prop (defaults to `true`, preserving current behavior for all other tables) and set it to `false` on the three sources tables.

## How did you test this code?

No automated tests added. This environment had no Node tooling available, so I could not run lint, typecheck, or the app; the change was verified by reading against the kea-router 3.4.1 `urlToAction` handler signature. Reviewer manual check: on the sources page, click through pagination on each table and confirm rows update in place without a blink, content shift, network refetch, or scroll.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. No repo skills were required for the change. Root cause was traced to a `urlToAction` reload firing on query-param-only navigations combined with `LemonTable`'s scroll-into-view effect; the fix scopes the reload to real navigation and makes the scroll opt-out-able rather than changing it globally.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1785350603210059?thread_ts=1785350603.210059&cid=C0ACRAMJUAG)*
