### PR TITLE
fix(batch-exports): match non-retryable errors by class

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/azure_blob_batch_export.py
@@ -4,14 +4,14 @@ import dataclasses
 
 from django.conf import settings
 
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import ClientAuthenticationError, HttpResponseError, ResourceNotFoundError
 from azure.storage.blob import StorageErrorCode
 from azure.storage.blob.aio import BlobServiceClient, ContainerClient, ExponentialRetry
 from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
-from posthog.models.integration import AzureBlobIntegration, Integration
+from posthog.models.integration import AzureBlobIntegration, AzureBlobIntegrationError, Integration
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_write_only_logger
@@ -43,17 +43,6 @@ from products.batch_exports.backend.temporal.pipeline.transformer import (
 from products.batch_exports.backend.temporal.pipeline.types import BatchExportResult
 from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, wait_for_schema_or_producer
 from products.batch_exports.backend.temporal.utils import handle_non_retryable_errors
-
-NON_RETRYABLE_ERROR_TYPES = (
-    "AzureBlobIntegrationError",
-    "AzureBlobIntegrationNotFoundError",
-    "ClientAuthenticationError",
-    "MalformedConnectionStringError",
-    "MissingRequiredPermissionsError",
-    "ResourceNotFoundError",
-    "UnsupportedCompressionError",
-    "UnsupportedFileFormatError",
-)
 
 FILE_FORMAT_EXTENSIONS = {
     "Parquet": "parquet",
@@ -103,6 +92,18 @@ class MalformedConnectionStringError(Exception):
         super().__init__(
             "The provided connection string was rejected by Azure. Ensure the connection string is made up of key=value pairs separated only by a semicolon (;) with no additional characters in between. Example: AccountName=name;AccountKey=key;SomeKey=somevalue"
         )
+
+
+NON_RETRYABLE_ERROR_TYPES = (
+    AzureBlobIntegrationError,
+    AzureBlobIntegrationNotFoundError,
+    ClientAuthenticationError,
+    MalformedConnectionStringError,
+    MissingRequiredPermissionsError,
+    ResourceNotFoundError,
+    UnsupportedCompressionError,
+    UnsupportedFileFormatError,
+)
 
 
 def _is_authorization_failure_response_error(err: HttpResponseError) -> bool:

--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -78,34 +78,6 @@ from products.batch_exports.backend.temporal.utils import (
     make_retryable_with_exponential_backoff,
 )
 
-NON_RETRYABLE_ERROR_TYPES = (
-    # Raised on missing permissions.
-    "Forbidden",
-    # Invalid token.
-    "RefreshError",
-    # Usually means the dataset or project_id doesn't exist.
-    "NotFound",
-    # Raised when something about dataset is wrong (not alphanumeric, too long, etc).
-    "BadRequest",
-    # Raised when table_id isn't valid. Sadly, `ValueError` is rather generic, but we
-    # don't anticipate a `ValueError` thrown from our own export code.
-    "ValueError",
-    # Raised when attempting to run a batch export without required BigQuery permissions.
-    # Our own version of `Forbidden`.
-    "MissingRequiredPermissionsError",
-    # Raised when a query takes too long to start (i.e. remains in "PENDING" state for too long).
-    "StartQueryTimeoutError",
-    # A service account we are supposed to impersonate does not exist.
-    "ServiceAccountNotFoundError",
-    # We could not verify that the service account we are meant to use belongs to the
-    # organization this batch export is running for.
-    "ServiceAccountOwnershipError",
-    # Raised when the BigQuery integration is not found.
-    "BigQueryIntegrationNotFoundError",
-    # Raised when the destination table schema is incompatible with the schema of the file we are trying to load.
-    "BigQueryIncompatibleSchemaError",
-)
-
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger("EXTERNAL")
 
@@ -1337,6 +1309,35 @@ class BigQueryIntegrationNotFoundError(Exception):
     """Error raised when the BigQuery integration is not found."""
 
     pass
+
+
+NON_RETRYABLE_ERROR_TYPES = (
+    # Raised on missing permissions.
+    Forbidden,
+    # Invalid token.
+    google.auth.exceptions.RefreshError,
+    # Usually means the dataset or project_id doesn't exist.
+    NotFound,
+    # Raised when something about dataset is wrong (not alphanumeric, too long, etc).
+    BadRequest,
+    # Raised when table_id isn't valid. Sadly, `ValueError` is rather generic, but we
+    # don't anticipate a `ValueError` thrown from our own export code.
+    ValueError,
+    # Raised when attempting to run a batch export without required BigQuery permissions.
+    # Our own version of `Forbidden`.
+    MissingRequiredPermissionsError,
+    # Raised when a query takes too long to start (i.e. remains in "PENDING" state for too long).
+    StartQueryTimeoutError,
+    # A service account we are supposed to impersonate does not exist.
+    ServiceAccountNotFoundError,
+    # We could not verify that the service account we are meant to use belongs to the
+    # organization this batch export is running for.
+    ServiceAccountOwnershipError,
+    # Raised when the BigQuery integration is not found.
+    BigQueryIntegrationNotFoundError,
+    # Raised when the destination table schema is incompatible with the schema of the file we are trying to load.
+    BigQueryIncompatibleSchemaError,
+)
 
 
 async def _get_google_cloud_service_account_integration(

--- a/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/databricks_batch_export.py
@@ -24,7 +24,7 @@ from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
-from posthog.models.integration import DatabricksIntegration, Integration
+from posthog.models.integration import DatabricksIntegration, DatabricksIntegrationError, Integration
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger, get_write_only_logger
@@ -56,29 +56,6 @@ from products.batch_exports.backend.temporal.utils import JsonType, handle_non_r
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger("EXTERNAL")
 
-
-NON_RETRYABLE_ERROR_TYPES: list[str] = [
-    # Our own exception when we can't connect to Databricks, usually due to invalid parameters.
-    "DatabricksConnectionError",
-    # Raised when we don't have sufficient permissions to perform an operation.
-    "DatabricksInsufficientPermissionsError",
-    # Raised when the Databricks integration is not found.
-    "DatabricksIntegrationNotFoundError",
-    # Raised when the Databricks integration is not valid.
-    "DatabricksIntegrationError",
-    # Raised when we hit our self-imposed long running operation timeout.
-    # We don't want to continually retry as it could consume a lot of compute resources in the user's account.
-    "DatabricksOperationTimeoutError",
-    # Raised when the Databricks catalog is not found.
-    "DatabricksCatalogNotFoundError",
-    # Raised when the Databricks schema is not found.
-    "DatabricksSchemaNotFoundError",
-    # Raised when the Databricks warehouse is stopped.
-    "DatabricksWarehouseStoppedError",
-    # Raised when the destination table's column names or types are incompatible with the exported
-    # data (e.g. the table column is VARIANT but the export is configured to write STRING).
-    "DatabricksIncompatibleSchemaError",
-]
 
 DatabricksField = tuple[str, str]
 
@@ -179,6 +156,30 @@ class DatabricksIncompatibleSchemaError(DatabricksOperationError):
             "This means the destination table's column names/types don't match the data being exported. "
             "Please check the schema of your destination table.",
         )
+
+
+NON_RETRYABLE_ERROR_TYPES = (
+    # Our own exception when we can't connect to Databricks, usually due to invalid parameters.
+    DatabricksConnectionError,
+    # Raised when we don't have sufficient permissions to perform an operation.
+    DatabricksInsufficientPermissionsError,
+    # Raised when the Databricks integration is not found.
+    DatabricksIntegrationNotFoundError,
+    # Raised when the Databricks integration is not valid.
+    DatabricksIntegrationError,
+    # Raised when we hit our self-imposed long running operation timeout.
+    # We don't want to continually retry as it could consume a lot of compute resources in the user's account.
+    DatabricksOperationTimeoutError,
+    # Raised when the Databricks catalog is not found.
+    DatabricksCatalogNotFoundError,
+    # Raised when the Databricks schema is not found.
+    DatabricksSchemaNotFoundError,
+    # Raised when the Databricks warehouse is stopped.
+    DatabricksWarehouseStoppedError,
+    # Raised when the destination table's column names or types are incompatible with the exported
+    # data (e.g. the table column is VARIANT but the export is configured to write STRING).
+    DatabricksIncompatibleSchemaError,
+)
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/products/batch_exports/backend/temporal/destinations/http_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/http_batch_export.py
@@ -32,7 +32,6 @@ from products.batch_exports.backend.temporal.spmc import compose_filters_clause
 from products.batch_exports.backend.temporal.temporary_file import BatchExportTemporaryFile, json_dumps_bytes
 from products.batch_exports.backend.temporal.utils import handle_non_retryable_errors
 
-NON_RETRYABLE_ERROR_TYPES = ("NonRetryableResponseError", "InvalidDestinationURLError")
 LOGGER = get_logger(__name__)
 
 
@@ -55,6 +54,9 @@ class InvalidDestinationURLError(Exception):
 
     def __init__(self, url):
         super().__init__(f"Invalid destination URL: {url}")
+
+
+NON_RETRYABLE_ERROR_TYPES = (NonRetryableResponseError, InvalidDestinationURLError)
 
 
 async def raise_for_status(response: aiohttp.ClientResponse):

--- a/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/postgres_batch_export.py
@@ -75,66 +75,6 @@ UNPAIRED_SURROGATE_PATTERN_2 = re.compile(
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger("EXTERNAL")
 
-NON_RETRYABLE_ERROR_TYPES = (
-    # Raised on errors that are related to database operation.
-    # For example: unexpected disconnect, database or other object not found.
-    "OperationalError",
-    # The schema name provided is invalid (usually because it doesn't exist).
-    "InvalidSchemaName",
-    # Missing permissions to, e.g., insert into table.
-    "InsufficientPrivilege",
-    # Issue with exported data compared to schema, retrying won't help.
-    "NotNullViolation",
-    # A user added a unique constraint on their table, but batch exports (particularly events)
-    # can cause duplicates.
-    "UniqueViolation",
-    # Something changed in the target table's schema that we were not expecting.
-    "UndefinedColumn",
-    # Only if raised by the copy method, would indicate missing USAGE permissions on the schema.
-    # Otherwise we should create the table and not see this.
-    "UndefinedTable",
-    # A VARCHAR column is too small.
-    "StringDataRightTruncation",
-    # Raised by PostgreSQL client. Self explanatory.
-    "DiskFull",
-    # Raised by our PostgreSQL client when failing to connect after several attempts.
-    "PostgreSQLConnectionError",
-    # The integration backing this export was deleted. Retrying can never recover it,
-    # so fail fast and let the user reconnect the destination.
-    "PostgreSQLIntegrationNotFoundError",
-    # Raised when merging without a primary key.
-    "MissingPrimaryKeyError",
-    # Raised when the database doesn't support a particular feature we use.
-    # Generally, we have seen this when the database is read-only.
-    "FeatureNotSupported",
-    # A check constraint has been violated.
-    # We do not create any ourselves, so this generally is a user-managed check, so we
-    # should not retry.
-    "CheckViolation",
-    # We do not create foreign keys, so this is a user managed check we have failed.
-    "ForeignKeyViolation",
-    # Data (usually event properties) contains garbage that we cannot clean.
-    "UntranslatableCharacter",
-    "InvalidTextRepresentation",
-    # Can be raised when merging tables with an incompatible schema (eg if the destination table has been
-    # created manually)
-    "DatatypeMismatch",
-    # Exceeded limits for indexes that we do not maintain.
-    "ProgramLimitExceeded",
-    # Raised when the destination table schema is incompatible with the schema of the data we are trying to export.
-    "PostgreSQLIncompatibleSchemaError",
-    # Raised when a transaction fails to complete after a certain number of retries.
-    "PostgreSQLTransactionError",
-    # Raised when a query takes too long.
-    "TimeoutError",
-    # Raised when a PostgreSQL stored procedure or function fails.
-    # We don't (at the moment) create or run any ourselves, so it must be something set up by the user.
-    "SqlRoutineException",
-    # The inputs are missing required connection details (e.g. credentials or host).
-    # This usually means the backing integration is misconfigured or absent, so retrying won't help.
-    "PostgreSQLMissingRequiredInputsError",
-)
-
 
 class PostgreSQLConnectionError(Exception):
     pass
@@ -859,6 +799,67 @@ class PostgreSQLIntegrationNotFoundError(Exception):
     """Error raised when the PostgreSQL integration is not found."""
 
     pass
+
+
+NON_RETRYABLE_ERROR_TYPES = (
+    # Raised on errors that are related to database operation.
+    # For example: unexpected disconnect, database or other object not found.
+    psycopg.OperationalError,
+    # The schema name provided is invalid (usually because it doesn't exist).
+    psycopg.errors.InvalidSchemaName,
+    # Missing permissions to, e.g., insert into table.
+    psycopg.errors.InsufficientPrivilege,
+    # Issue with exported data compared to schema, retrying won't help.
+    psycopg.errors.NotNullViolation,
+    # A user added a unique constraint on their table, but batch exports (particularly events)
+    # can cause duplicates.
+    psycopg.errors.UniqueViolation,
+    # Something changed in the target table's schema that we were not expecting.
+    psycopg.errors.UndefinedColumn,
+    # Only if raised by the copy method, would indicate missing USAGE permissions on the schema.
+    # Otherwise we should create the table and not see this.
+    psycopg.errors.UndefinedTable,
+    # A VARCHAR column is too small.
+    psycopg.errors.StringDataRightTruncation,
+    # Raised by PostgreSQL client. Self explanatory.
+    psycopg.errors.DiskFull,
+    # Raised by our PostgreSQL client when failing to connect after several attempts.
+    PostgreSQLConnectionError,
+    # The integration backing this export was deleted. Retrying can never recover it,
+    # so fail fast and let the user reconnect the destination.
+    PostgreSQLIntegrationNotFoundError,
+    # Raised when merging without a primary key.
+    MissingPrimaryKeyError,
+    # Raised when the database doesn't support a particular feature we use.
+    # Generally, we have seen this when the database is read-only.
+    psycopg.errors.FeatureNotSupported,
+    # A check constraint has been violated.
+    # We do not create any ourselves, so this generally is a user-managed check, so we
+    # should not retry.
+    psycopg.errors.CheckViolation,
+    # We do not create foreign keys, so this is a user managed check we have failed.
+    psycopg.errors.ForeignKeyViolation,
+    # Data (usually event properties) contains garbage that we cannot clean.
+    psycopg.errors.UntranslatableCharacter,
+    psycopg.errors.InvalidTextRepresentation,
+    # Can be raised when merging tables with an incompatible schema (eg if the destination table has been
+    # created manually)
+    psycopg.errors.DatatypeMismatch,
+    # Exceeded limits for indexes that we do not maintain.
+    psycopg.errors.ProgramLimitExceeded,
+    # Raised when the destination table schema is incompatible with the schema of the data we are trying to export.
+    PostgreSQLIncompatibleSchemaError,
+    # Raised when a transaction fails to complete after a certain number of retries.
+    PostgreSQLTransactionError,
+    # Raised when a query takes too long.
+    TimeoutError,
+    # Raised when a PostgreSQL stored procedure or function fails.
+    # We don't (at the moment) create or run any ourselves, so it must be something set up by the user.
+    psycopg.errors.SqlRoutineException,
+    # The inputs are missing required connection details (e.g. credentials or host).
+    # This usually means the backing integration is misconfigured or absent, so retrying won't help.
+    PostgreSQLMissingRequiredInputsError,
+)
 
 
 async def _get_postgresql_integration(

--- a/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/redshift_batch_export.py
@@ -43,10 +43,12 @@ from products.batch_exports.backend.temporal.batch_exports import (
 from products.batch_exports.backend.temporal.destinations.postgres_batch_export import (
     Fields,
     PostgreSQLClient,
+    PostgreSQLConnectionError,
     PostgreSQLField,
 )
 from products.batch_exports.backend.temporal.destinations.s3_batch_export import (
     ConcurrentS3Consumer,
+    InvalidCredentialsError,
     PolicyStatement,
     get_credentials_using_user_aws_role,
     s3_client,
@@ -65,54 +67,6 @@ from products.batch_exports.backend.temporal.utils import JsonType, handle_non_r
 
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger()
-
-
-NON_RETRYABLE_ERROR_TYPES = (
-    # Raised on errors that are related to database operation.
-    # For example: unexpected disconnect, database or other object not found.
-    "OperationalError",
-    # The schema name provided is invalid (usually because it doesn't exist).
-    "InvalidSchemaName",
-    # Missing permissions to, e.g., insert into table.
-    "InsufficientPrivilege",
-    # A column, usually properties, exceeds the limit for a VARCHAR field,
-    # usually the max of 65535 bytes
-    "StringDataRightTruncation",
-    "StringLimitExceededError",
-    # Raised by our PostgreSQL client when failing to connect after several attempts.
-    "PostgreSQLConnectionError",
-    # Column missing in Redshift, likely the schema was altered.
-    "UndefinedColumn",
-    # Raised by our PostgreSQL client when a given feature is not supported.
-    # This can also happen when merging tables with a different number of columns:
-    # "Target relation and source relation must have the same number of columns"
-    "FeatureNotSupported",
-    # There is a mismatch between the schema of the table and our data. This
-    # usually means the table was created by the user, as we resolve types the
-    # same way every time.
-    "DatatypeMismatch",
-    # Raised when multiple S3 operations failed with a ClientError.
-    "ClientErrorGroup",
-    # Raised by PostgreSQL client when a function doesn't exist for the specified types.
-    # This can indicate, for example, attempting to compare two types that cannot be
-    # compared.
-    "UndefinedFunction",
-    # Unretryable error raised by S3 client when using `copy_into_redshift_activity_from_stage`.
-    "ClientError",
-    # An S3 bucket doesn't exist when using `copy_into_redshift_activity_from_stage`.
-    "NoSuchBucket",
-    # S3 parameter validation failed.
-    "ParamValidationError",
-    # Invalid S3 credentials when using `copy_into_redshift_activity_from_stage`.
-    "InvalidCredentialsError",
-    # Raised by Redshift client when the cluster has insufficient system resources.
-    "InsufficientSystemResourcesError",
-    # The S3 credentials provided for the COPY can't read the staged files.
-    "InsufficientS3PermissionsError",
-    # Redshift failed to COPY the staged files from S3 (IAM role auth, cause not locally confirmable).
-    # These (read access, region, manifest) don't self-heal, so retrying is pointless.
-    "RedshiftS3CopyError",
-)
 
 
 class StringLimitExceededError(Exception):
@@ -233,6 +187,53 @@ class ClientErrorGroup(ExceptionGroup):
 
     def derive(self, excs):
         return ClientErrorGroup(excs)
+
+
+NON_RETRYABLE_ERROR_TYPES = (
+    # Raised on errors that are related to database operation.
+    # For example: unexpected disconnect, database or other object not found.
+    psycopg.OperationalError,
+    # The schema name provided is invalid (usually because it doesn't exist).
+    psycopg.errors.InvalidSchemaName,
+    # Missing permissions to, e.g., insert into table.
+    psycopg.errors.InsufficientPrivilege,
+    # A column, usually properties, exceeds the limit for a VARCHAR field,
+    # usually the max of 65535 bytes
+    psycopg.errors.StringDataRightTruncation,
+    StringLimitExceededError,
+    # Raised by our PostgreSQL client when failing to connect after several attempts.
+    PostgreSQLConnectionError,
+    # Column missing in Redshift, likely the schema was altered.
+    psycopg.errors.UndefinedColumn,
+    # Raised by our PostgreSQL client when a given feature is not supported.
+    # This can also happen when merging tables with a different number of columns:
+    # "Target relation and source relation must have the same number of columns"
+    psycopg.errors.FeatureNotSupported,
+    # There is a mismatch between the schema of the table and our data. This
+    # usually means the table was created by the user, as we resolve types the
+    # same way every time.
+    psycopg.errors.DatatypeMismatch,
+    # Raised when multiple S3 operations failed with a ClientError.
+    ClientErrorGroup,
+    # Raised by PostgreSQL client when a function doesn't exist for the specified types.
+    # This can indicate, for example, attempting to compare two types that cannot be
+    # compared.
+    psycopg.errors.UndefinedFunction,
+    # Unretryable error raised by S3 client when using `copy_into_redshift_activity_from_stage`.
+    # This also covers generated service exceptions such as NoSuchBucket.
+    botocore.exceptions.ClientError,
+    # S3 parameter validation failed.
+    botocore.exceptions.ParamValidationError,
+    # Invalid S3 credentials when using `copy_into_redshift_activity_from_stage`.
+    InvalidCredentialsError,
+    # Raised by Redshift client when the cluster has insufficient system resources.
+    InsufficientSystemResourcesError,
+    # The S3 credentials provided for the COPY can't read the staged files.
+    InsufficientS3PermissionsError,
+    # Redshift failed to COPY the staged files from S3 (IAM role auth, cause not locally confirmable).
+    # These (read access, region, manifest) don't self-heal, so retrying is pointless.
+    RedshiftS3CopyError,
+)
 
 
 class RedshiftClient(PostgreSQLClient):

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -69,33 +69,6 @@ from products.batch_exports.backend.temporal.pipeline.types import BatchExportRe
 from products.batch_exports.backend.temporal.spmc import RecordBatchQueue, wait_for_schema_or_producer
 from products.batch_exports.backend.temporal.utils import handle_non_retryable_errors
 
-NON_RETRYABLE_ERROR_TYPES = (
-    # S3 parameter validation failed.
-    "ParamValidationError",
-    # This error usually indicates credentials are incorrect or permissions are missing.
-    "ClientError",
-    # An S3 bucket doesn't exist.
-    "NoSuchBucket",
-    # Couldn't connect to custom S3 endpoint
-    "EndpointConnectionError",
-    # TLS handshake failed against a custom S3 endpoint
-    "SSLError",
-    # User provided an invalid S3 key
-    "InvalidS3Key",
-    # Invalid S3 endpoint URL
-    "InvalidS3EndpointError",
-    # Invalid file_format input
-    "UnsupportedFileFormatError",
-    # Invalid compression input
-    "UnsupportedCompressionError",
-    # Invalid S3 credentials
-    "InvalidCredentialsError",
-    # The linked Integration was deleted or doesn't belong to the team
-    "S3IntegrationNotFoundError",
-    # The linked Integration is the wrong kind or has invalid/missing credentials
-    "S3CredentialIntegrationError",
-)
-
 FILE_FORMAT_EXTENSIONS = {
     "Parquet": "parquet",
     "JSONLines": "jsonl",
@@ -250,6 +223,33 @@ class InvalidCredentialsError(Exception):
 
     def __init__(self, message: str = "Credentials are invalid."):
         super().__init__(message)
+
+
+NON_RETRYABLE_ERROR_TYPES = (
+    # S3 parameter validation failed.
+    botocore.exceptions.ParamValidationError,
+    # This error usually indicates credentials are incorrect or permissions are missing.
+    # This also covers generated service exceptions such as NoSuchBucket.
+    botocore.exceptions.ClientError,
+    # Couldn't connect to custom S3 endpoint
+    botocore.exceptions.EndpointConnectionError,
+    # TLS handshake failed against a custom S3 endpoint
+    botocore.exceptions.SSLError,
+    # User provided an invalid S3 key
+    InvalidS3Key,
+    # Invalid S3 endpoint URL
+    InvalidS3EndpointError,
+    # Invalid file_format input
+    UnsupportedFileFormatError,
+    # Invalid compression input
+    UnsupportedCompressionError,
+    # Invalid S3 credentials
+    InvalidCredentialsError,
+    # The linked Integration was deleted or doesn't belong to the team
+    S3IntegrationNotFoundError,
+    # The linked Integration is the wrong kind or has invalid/missing credentials
+    S3CredentialIntegrationError,
+)
 
 
 def s3_default_fields() -> list[BatchExportField]:

--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -24,7 +24,7 @@ from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
-from posthog.models.integration import Integration, SnowflakeIntegration
+from posthog.models.integration import Integration, SnowflakeIntegration, SnowflakeIntegrationError
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger, get_write_only_logger
@@ -76,44 +76,6 @@ class NamedBytesIO(io.BytesIO):
 
 # One batch export allowed to connect at a time (in theory) per worker.
 CONNECTION_SEMAPHORE = asyncio.Semaphore(value=1)
-
-NON_RETRYABLE_ERROR_TYPES = (
-    # Raised when we cannot connect to Snowflake.
-    "DatabaseError",
-    # Raised by Snowflake when a query cannot be compiled.
-    # Usually this means we don't have table permissions or something doesn't exist (db, schema).
-    "ProgrammingError",
-    # Raised by Snowflake with an incorrect account name.
-    "ForbiddenError",
-    # Our own exception when we can't connect to Snowflake, usually due to invalid parameters.
-    "SnowflakeConnectionError",
-    # Raised when a table is not found in Snowflake.
-    "SnowflakeTableNotFoundError",
-    # Raised when a using key-pair auth and the private key or passphrase is not valid.
-    "InvalidPrivateKeyError",
-    # Raised when a valid authentication method is not provided.
-    "SnowflakeAuthenticationError",
-    # Raised when a Warehouse is suspended.
-    "SnowflakeWarehouseSuspendedError",
-    # Raised when the destination table schema is incompatible with the schema of the file we are trying to load.
-    "SnowflakeIncompatibleSchemaError",
-    # Raised when Snowflake denies an operation due to missing privileges. This is a customer-side
-    # configuration issue that retrying cannot fix.
-    "SnowflakeInsufficientPrivilegesError",
-    # Raised when we hit our self-imposed query timeout.
-    # We don't want to continually retry as it could consume a lot of compute resources in the user's account and can
-    # lead to a lot of queries queuing up for a given warehouse.
-    "SnowflakeQueryClientTimeoutError",
-    # Raised when a Snowflake query exceeds the timeout set in the user's account. This is typically set by
-    # STATEMENT_TIMEOUT_IN_SECONDS, which can be set at various levels (account, warehouse, user).
-    "SnowflakeQueryServerTimeoutError",
-    # Raised when either the warehouse does not exist or we are missing 'USAGE' permissions on it
-    "SnowflakeWarehouseUsageError",
-    # The linked Integration was deleted or doesn't belong to the team.
-    "SnowflakeIntegrationNotFoundError",
-    # The linked Integration is the wrong kind or has invalid/missing credentials.
-    "SnowflakeIntegrationError",
-)
 
 
 class SnowflakeFileNotUploadedError(Exception):
@@ -253,6 +215,45 @@ class SnowflakeQueryServerTimeoutError(TimeoutError):
     """
 
     pass
+
+
+NON_RETRYABLE_ERROR_TYPES = (
+    # Raised when we cannot connect to Snowflake.
+    snowflake.connector.errors.DatabaseError,
+    # Raised by Snowflake when a query cannot be compiled.
+    # Usually this means we don't have table permissions or something doesn't exist (db, schema).
+    snowflake.connector.errors.ProgrammingError,
+    # Raised by Snowflake with an incorrect account name.
+    snowflake.connector.errors.ForbiddenError,
+    # Our own exception when we can't connect to Snowflake, usually due to invalid parameters.
+    SnowflakeConnectionError,
+    # Raised when a table is not found in Snowflake.
+    SnowflakeTableNotFoundError,
+    # Raised when using key-pair auth and the private key or passphrase is not valid.
+    InvalidPrivateKeyError,
+    # Raised when a valid authentication method is not provided.
+    SnowflakeAuthenticationError,
+    # Raised when a Warehouse is suspended.
+    SnowflakeWarehouseSuspendedError,
+    # Raised when the destination table schema is incompatible with the schema of the file we are trying to load.
+    SnowflakeIncompatibleSchemaError,
+    # Raised when Snowflake denies an operation due to missing privileges. This is a customer-side
+    # configuration issue that retrying cannot fix.
+    SnowflakeInsufficientPrivilegesError,
+    # Raised when we hit our self-imposed query timeout.
+    # We don't want to continually retry as it could consume a lot of compute resources in the user's account and can
+    # lead to a lot of queries queuing up for a given warehouse.
+    SnowflakeQueryClientTimeoutError,
+    # Raised when a Snowflake query exceeds the timeout set in the user's account. This is typically set by
+    # STATEMENT_TIMEOUT_IN_SECONDS, which can be set at various levels (account, warehouse, user).
+    SnowflakeQueryServerTimeoutError,
+    # Raised when either the warehouse does not exist or we are missing 'USAGE' permissions on it
+    SnowflakeWarehouseUsageError,
+    # The linked Integration was deleted or doesn't belong to the team.
+    SnowflakeIntegrationNotFoundError,
+    # The linked Integration is the wrong kind or has invalid/missing credentials.
+    SnowflakeIntegrationError,
+)
 
 
 SnowflakeTypeName = typing.Literal[

--- a/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/workflows_batch_export.py
@@ -44,11 +44,6 @@ if typing.TYPE_CHECKING:
 LOGGER = get_write_only_logger(__name__)
 EXTERNAL_LOGGER = get_logger("EXTERNAL")
 
-NON_RETRYABLE_ERROR_TYPES: list[str] = [
-    "NotFoundErrorGroup",
-    "BadRequestErrorGroup",
-    "HogFunctionErrorThresholdExceeded",
-]
 HOG_FUNCTION_API_PATH = "/api/projects/{team_id}/hog_functions/{hog_function_id}/batch_export_invocations"
 
 
@@ -130,6 +125,13 @@ class HogFunctionErrorThresholdExceeded(Exception):
         if latest_error:
             message += f" Latest error message: '{latest_error}'"
         super().__init__(message)
+
+
+NON_RETRYABLE_ERROR_TYPES = (
+    NotFoundErrorGroup,
+    BadRequestErrorGroup,
+    HogFunctionErrorThresholdExceeded,
+)
 
 
 def _make_exception(

--- a/products/batch_exports/backend/temporal/utils.py
+++ b/products/batch_exports/backend/temporal/utils.py
@@ -321,7 +321,12 @@ def make_retryable_with_exponential_backoff(
     return inner
 
 
-def handle_non_retryable_errors(non_retryable_error_types: typing.Sequence[str]):
+def handle_non_retryable_errors(
+    non_retryable_error_types: collections.abc.Sequence[type[Exception]],
+) -> typing.Callable[
+    [typing.Callable[_P, collections.abc.Awaitable[BatchExportResult]]],
+    typing.Any,
+]:
     """Decorator to handle non-retryable errors in batch export activities.
 
     This decorator wraps batch export activities to catch exceptions and determine
@@ -329,34 +334,33 @@ def handle_non_retryable_errors(non_retryable_error_types: typing.Sequence[str])
     a) an internal error and should be retried (by allowing the activity to fail) or
     b) a user error and should be returned as a BatchExportResult with an error.
 
-    For now, we just take in a list of error class names that should not be retried.
-    In the future, we should use actual exception classes instead of strings.
-
     Args:
-        non_retryable_error_types: List of error class names that should not be retried.
+        non_retryable_error_types: Exception classes that should not be retried.
 
     Returns:
         A decorator function that handles exceptions according to the retry policy.
 
     Example:
         @activity.defn
-        @handle_non_retryable_errors(("ClientError", "ParamValidationError"))
+        @handle_non_retryable_errors((ClientError, ParamValidationError))
         async def insert_into_s3_activity(inputs: S3InsertInputs) -> BatchExportResult:
             # Activity implementation here
             return BatchExportResult(records_completed=100)
     """
+    non_retryable_errors = tuple(non_retryable_error_types)
 
-    def decorator(func: typing.Callable[..., collections.abc.Awaitable[BatchExportResult]]):
+    def decorator(
+        func: typing.Callable[_P, collections.abc.Awaitable[BatchExportResult]],
+    ) -> typing.Any:
         @functools.wraps(func)
-        async def wrapper(*args, **kwargs) -> BatchExportResult:
+        async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> BatchExportResult:
             try:
                 return await func(*args, **kwargs)
             except Exception as e:
                 # If we catch an error at any point during this activity, we check if it's a non-retryable error.
                 # If it is, we return a BatchExportResult with the error.
                 # If it's not, we re-raise the error.
-                # TODO: Use actual exception classes instead of strings.
-                if e.__class__.__name__ in non_retryable_error_types:
+                if type(e) in non_retryable_errors:
                     LOGGER.exception("Non-retryable error caught in activity")
                     return BatchExportResult.from_exception(e)
                 LOGGER.exception("Retryable error caught in activity")

--- a/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/bigquery/test_workflow.py
@@ -10,6 +10,7 @@ import unittest.mock
 from django.conf import settings
 
 import pytest_asyncio
+from google.auth.exceptions import RefreshError
 from temporalio import activity
 from temporalio.client import WorkflowFailureError
 from temporalio.common import RetryPolicy
@@ -426,9 +427,6 @@ async def test_bigquery_export_workflow_handles_insert_activity_non_retryable_er
         interval=interval,
         **bigquery_batch_export.destination.config,
     )
-
-    class RefreshError(Exception):
-        pass
 
     async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
         async with Worker(

--- a/products/batch_exports/backend/tests/temporal/destinations/postgres/test_postgres_client.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/postgres/test_postgres_client.py
@@ -62,7 +62,7 @@ def test_from_inputs_raises_value_error_when_connection_inputs_missing(missing_f
 
 
 def test_missing_required_inputs_error_is_non_retryable():
-    assert PostgreSQLMissingRequiredInputsError.__name__ in NON_RETRYABLE_ERROR_TYPES
+    assert PostgreSQLMissingRequiredInputsError in NON_RETRYABLE_ERROR_TYPES
 
 
 async def test_run_in_retryable_transaction_raises_non_retryable_error_after_max_retries(

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_error_handling.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/test_workflow_error_handling.py
@@ -129,9 +129,6 @@ async def test_s3_export_workflow_handles_insert_activity_non_retryable_errors(
         **s3_compatible_batch_export.destination.config,
     )
 
-    class ParamValidationError(Exception):
-        pass
-
     @activity.defn(name="insert_into_internal_stage_activity")
     async def insert_into_internal_stage_activity_mocked(_: BatchExportInsertIntoInternalStageInputs):
         return InternalStageResult(stage_folder="test-stage-folder", records_total=None)
@@ -151,7 +148,7 @@ async def test_s3_export_workflow_handles_insert_activity_non_retryable_errors(
         ):
             with mock.patch(
                 "products.batch_exports.backend.temporal.destinations.s3_batch_export.ProducerFromInternalStage.start",
-                side_effect=ParamValidationError("A useful error message"),
+                side_effect=botocore.exceptions.ParamValidationError(report="A useful error message"),
             ):
                 await activity_environment.client.execute_workflow(
                     S3BatchExportWorkflow.run,
@@ -166,7 +163,7 @@ async def test_s3_export_workflow_handles_insert_activity_non_retryable_errors(
 
     run = runs[0]
     assert run.status == "Failed"
-    assert run.latest_error == "ParamValidationError: A useful error message"
+    assert run.latest_error == "ParamValidationError: Parameter validation failed:\nA useful error message"
 
 
 async def test_s3_export_workflow_handles_cancellation(ateam, s3_compatible_batch_export, interval):

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
@@ -14,6 +14,7 @@ import unittest.mock
 from django.conf import settings
 from django.test import override_settings
 
+from snowflake.connector.errors import ForbiddenError
 from temporalio import activity
 from temporalio.client import WorkflowFailureError
 from temporalio.common import RetryPolicy
@@ -341,12 +342,9 @@ async def test_snowflake_export_workflow_handles_insert_activity_non_retryable_e
     To simulate a user error, we mock the `Producer.start` method.
     """
 
-    class ForbiddenError(Exception):
-        pass
-
     with unittest.mock.patch(
         "products.batch_exports.backend.temporal.destinations.snowflake_batch_export.Producer.start",
-        side_effect=ForbiddenError("A useful error message"),
+        side_effect=ForbiddenError(msg="A useful error message"),
     ):
         run = await _run_workflow(
             team_id=ateam.pk,
@@ -355,7 +353,7 @@ async def test_snowflake_export_workflow_handles_insert_activity_non_retryable_e
             snowflake_batch_export=snowflake_batch_export,
         )
     assert run.status == "Failed"
-    assert run.latest_error == "ForbiddenError: A useful error message"
+    assert run.latest_error == "ForbiddenError: 290000: A useful error message"
     assert run.records_completed is None
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/test_http_batch_export_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/test_http_batch_export_workflow.py
@@ -34,6 +34,7 @@ from products.batch_exports.backend.temporal.destinations.http_batch_export impo
     HttpBatchExportInputs,
     HttpBatchExportWorkflow,
     HttpInsertInputs,
+    NonRetryableResponseError,
     RetryableResponseError,
     http_default_fields,
     insert_into_http_activity,
@@ -651,9 +652,6 @@ async def test_http_export_workflow_handles_insert_activity_non_retryable_errors
         **http_batch_export.destination.config,
     )
 
-    class NonRetryableResponseError(Exception):
-        pass
-
     async with await WorkflowEnvironment.start_time_skipping() as activity_environment:
         async with Worker(
             activity_environment.client,
@@ -668,7 +666,7 @@ async def test_http_export_workflow_handles_insert_activity_non_retryable_errors
         ):
             with unittest.mock.patch(
                 "products.batch_exports.backend.temporal.destinations.http_batch_export.aiohttp.ClientSession",
-                side_effect=NonRetryableResponseError("A useful error message"),
+                side_effect=NonRetryableResponseError(400, "A useful error message"),
             ):
                 await activity_environment.client.execute_workflow(
                     HttpBatchExportWorkflow.run,
@@ -683,7 +681,9 @@ async def test_http_export_workflow_handles_insert_activity_non_retryable_errors
 
     run = runs[0]
     assert run.status == "Failed"
-    assert run.latest_error == "NonRetryableResponseError: A useful error message"
+    assert (
+        run.latest_error == "NonRetryableResponseError: NonRetryableResponseError (status: 400): A useful error message"
+    )
     assert run.records_completed is None
 
 

--- a/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
+++ b/products/batch_exports/backend/tests/temporal/pipeline/test_entrypoint.py
@@ -87,7 +87,7 @@ class DummyRetryableError(Exception):
         super().__init__(message)
 
 
-NON_RETRYABLE_ERROR_TYPES = ("DummyNonRetryableError",)
+NON_RETRYABLE_ERROR_TYPES = (DummyNonRetryableError,)
 
 
 @dataclass(kw_only=True)

--- a/products/batch_exports/backend/tests/temporal/test_error_handling.py
+++ b/products/batch_exports/backend/tests/temporal/test_error_handling.py
@@ -1,0 +1,45 @@
+import pytest
+
+from parameterized import parameterized
+
+from products.batch_exports.backend.temporal.pipeline.types import BatchExportError, BatchExportResult
+from products.batch_exports.backend.temporal.utils import handle_non_retryable_errors
+
+
+class ConfiguredError(Exception):
+    pass
+
+
+class ConfiguredSubclassError(ConfiguredError):
+    pass
+
+
+SameNamedConfiguredError = type("ConfiguredError", (Exception,), {})
+
+
+async def test_handle_non_retryable_errors_returns_errors_matching_configured_class() -> None:
+    @handle_non_retryable_errors((ConfiguredError,))
+    async def raise_error() -> BatchExportResult:
+        raise ConfiguredError("user error")
+
+    result = await raise_error()
+
+    assert result.error == BatchExportError(type="ConfiguredError", message="user error")
+
+
+@parameterized.expand(
+    [
+        ("configured_subclass", ConfiguredSubclassError),
+        ("unrelated_same_named_class", SameNamedConfiguredError),
+    ]
+)
+async def test_handle_non_retryable_errors_reraises_non_matching_error(
+    _name: str,
+    error_type: type[Exception],
+) -> None:
+    @handle_non_retryable_errors((ConfiguredError,))
+    async def raise_error() -> BatchExportResult:
+        raise error_type("internal error")
+
+    with pytest.raises(error_type, match="internal error"):
+        await raise_error()


### PR DESCRIPTION
## Problem

Batch export activities classified non-retryable errors by exception class name. An unrelated exception with the same class name as a configured user error could therefore be treated as non-retryable, marking the run as failed instead of allowing Temporal to retry an internal error.

## Changes

- Match non-retryable errors with `type` and configured exception classes, while avoiding class-name collisions.
- Replace string-based exception lists with concrete exception classes for Azure Blob Storage, BigQuery, Databricks, HTTP, PostgreSQL, Redshift, S3, Snowflake, and workflows batch exports.
- Update destination workflow tests to raise the real configured exception types.
- Add focused regression coverage for exact class matches, subclass matches, and unrelated exceptions that share a configured class name.

## How did you test this code?

- `.codex/with-flox hogli test products/batch_exports/backend/tests/temporal/test_error_handling.py` (3 passed)
- The focused tests guard against swallowing an unrelated same-named exception while confirming configured exact exceptions remain non-retryable.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update is needed. This changes internal batch export error classification without changing the documented workflow or configuration.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The `/writing-tests` and `/writing-code-comments` repository skills were used to assess the regression coverage and the comments moved with the exception-class lists.

The implementation uses concrete exception classes and `type` so class matching behavior is preserved without allowing unrelated same-named exceptions to collide.
