### PR TITLE
fix(mcp): order union branches so coercion stops swallowing arrays

### DIFF
--- a/services/mcp/scripts/lib/json-schema-to-zod.ts
+++ b/services/mcp/scripts/lib/json-schema-to-zod.ts
@@ -105,7 +105,7 @@ export function getEntryVarName(entryDefName: string): string {
 // Core conversion
 // ------------------------------------------------------------------
 
-function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
+function schemaToZod(schema: JsonSchema, ctx: ConvertContext, strictScalars = false): string {
     // $ref
     if (schema.$ref) {
         const refName = schema.$ref.replace('#/definitions/', '')
@@ -141,7 +141,10 @@ function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
         if (variants.length === 1) {
             return schemaToZod(variants[0]!, ctx)
         }
-        const members = variants.map((v) => schemaToZod(v, ctx)).join(', ')
+        const hasStringBranch = variants.some((v) => variantTypes(v, ctx).includes('string'))
+        const members = orderUnionVariants(variants, ctx)
+            .map((v) => schemaToZod(v, ctx, hasStringBranch))
+            .join(', ')
         return `z.union([${members}])`
     }
 
@@ -159,10 +162,12 @@ function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
     if (Array.isArray(schema.type)) {
         const types = schema.type.filter((t) => t !== 'null')
         const hasNull = schema.type.includes('null')
-        const base =
-            types.length === 1
-                ? primitiveToZod(types[0]!)
-                : `z.union([${types.map((t) => primitiveToZod(t)).join(', ')}])`
+        const strict = strictScalars || types.includes('string')
+        const ordered = orderUnionVariants(
+            types.map((t) => ({ type: t })),
+            ctx
+        ).map((v) => primitiveToZod(v.type as string, types.length > 1 && strict))
+        const base = ordered.length === 1 ? ordered[0]! : `z.union([${ordered.join(', ')}])`
         return hasNull ? `${base}.nullable()` : base
     }
 
@@ -191,7 +196,7 @@ function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
 
     // primitives
     if (schema.type) {
-        const base = primitiveToZod(schema.type as string)
+        const base = primitiveToZod(schema.type as string, strictScalars)
         if (schema.type === 'integer' || schema.type === 'number') {
             return applyNumericConstraints(base, schema)
         }
@@ -200,6 +205,44 @@ function schemaToZod(schema: JsonSchema, ctx: ConvertContext): string {
 
     // Fallback
     return 'z.unknown()'
+}
+
+/**
+ * Zod takes the first union branch that accepts the input, and `z.coerce.*` is
+ * `Number(x)` / `Boolean(x)`, which never reject. A coercing branch placed before a
+ * branch that can reject makes that branch unreachable, so the selective ones sort
+ * first. The sort is stable, leaving string-versus-number order as authored.
+ */
+function orderUnionVariants(variants: JsonSchema[], ctx: ConvertContext): JsonSchema[] {
+    return variants
+        .map((variant, index) => ({ variant, index, rank: unionVariantRank(variant, ctx) }))
+        .sort((a, b) => a.rank - b.rank || a.index - b.index)
+        .map(({ variant }) => variant)
+}
+
+function resolveVariant(variant: JsonSchema, ctx: ConvertContext): JsonSchema | undefined {
+    return variant.$ref ? ctx.root.definitions[variant.$ref.replace('#/definitions/', '')] : variant
+}
+
+function variantTypes(variant: JsonSchema, ctx: ConvertContext): string[] {
+    const resolved = resolveVariant(variant, ctx)
+    return [resolved?.type].flat().filter((t): t is string => typeof t === 'string')
+}
+
+function unionVariantRank(variant: JsonSchema, ctx: ConvertContext): number {
+    const resolved = resolveVariant(variant, ctx)
+    if (!resolved) {
+        return 0
+    }
+    // Objects, arrays, null, enums and literals all reject anything outside their shape
+    if (resolved.properties || resolved.enum || resolved.const !== undefined) {
+        return 0
+    }
+    const types = variantTypes(variant, ctx)
+    if (types.length === 0 || types.some((t) => t === 'object' || t === 'array' || t === 'null')) {
+        return 0
+    }
+    return types.includes('boolean') ? 2 : 1
 }
 
 /** Append `.min(...).max(...)` for numeric schemas. */
@@ -214,17 +257,23 @@ function applyNumericConstraints(expr: string, schema: JsonSchema): string {
     return out
 }
 
-/** Use z.coerce for numbers/booleans — some MCP clients send primitives as strings */
-function primitiveToZod(type: string): string {
+/**
+ * Use z.coerce for numbers/booleans — some MCP clients send primitives as strings.
+ *
+ * `strict` drops the coercion next to a `z.string()` branch, which already matches
+ * every string first. All coercion can do there is misread a sibling type, since
+ * `Number(true)` is `1`.
+ */
+function primitiveToZod(type: string, strict = false): string {
     switch (type) {
         case 'string':
             return 'z.string()'
         case 'number':
-            return 'z.coerce.number()'
+            return strict ? 'z.number()' : 'z.coerce.number()'
         case 'integer':
-            return 'z.coerce.number().int()'
+            return strict ? 'z.number().int()' : 'z.coerce.number().int()'
         case 'boolean':
-            return 'z.coerce.boolean()'
+            return strict ? 'z.boolean()' : 'z.coerce.boolean()'
         case 'null':
             return 'z.null()'
         default:

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -291,9 +291,9 @@ const PropertyOperator = z.enum([
     'not_icontains_multi',
 ])
 
-const PropertyFilterBaseValue = z.union([z.string(), z.coerce.number(), z.coerce.boolean()])
+const PropertyFilterBaseValue = z.union([z.string(), z.number(), z.boolean()])
 
-const PropertyFilterValue = z.union([PropertyFilterBaseValue, z.array(PropertyFilterBaseValue), z.null()])
+const PropertyFilterValue = z.union([z.array(PropertyFilterBaseValue), z.null(), PropertyFilterBaseValue])
 
 const EventPropertyFilter = z.object({
     key: z.string(),
@@ -383,7 +383,7 @@ const LogEntryPropertyFilter = z.object({
 
 const GroupPropertyFilter = z.object({
     group_key_names: z.record(z.string(), z.string()).optional(),
-    group_type_index: z.union([z.coerce.number().int(), z.null()]).optional(),
+    group_type_index: z.union([z.null(), z.coerce.number().int()]).optional(),
     key: z.string(),
     label: z.string().optional(),
     operator: PropertyOperator,
@@ -407,7 +407,7 @@ const FlagPropertyFilter = z.object({
         .describe('Only flag_evaluates_to operator is allowed for flag dependencies')
         .default('flag_evaluates_to'),
     type: z.literal('flag').describe('Feature flag dependency').default('flag'),
-    value: z.union([z.coerce.boolean(), z.string()]).describe('The value can be true, false, or a variant name'),
+    value: z.union([z.string(), z.boolean()]).describe('The value can be true, false, or a variant name'),
 })
 
 const HogQLPropertyFilter = z.object({

--- a/services/mcp/src/tools/generated/query-wrappers.ts
+++ b/services/mcp/src/tools/generated/query-wrappers.ts
@@ -10,7 +10,7 @@ const integer = z.coerce.number().int()
 
 const AssistantGroupMultipleBreakdownFilter = z.object({
     group_type_index: z
-        .union([integer, z.null()])
+        .union([z.null(), integer])
         .describe('Index of the group type from the group mapping.')
         .optional(),
     property: z.string().describe('Property name from the plan to break down by.'),
@@ -324,7 +324,7 @@ const AssistantFlagPropertyFilter = z.object({
         )
         .default('flag'),
     value: z
-        .union([z.coerce.boolean(), z.string()])
+        .union([z.string(), z.boolean()])
         .describe('`true`/`false` for boolean flags, or a variant name string for multivariate flags.'),
 })
 
@@ -602,7 +602,7 @@ const AssistantTrendsFilter = z.object({
 })
 
 const AssistantTrendsQuery = z.object({
-    aggregation_group_type_index: z.union([integer, z.null()]).describe('Groups aggregation').optional(),
+    aggregation_group_type_index: z.union([z.null(), integer]).describe('Groups aggregation').optional(),
     breakdownFilter: AssistantTrendsBreakdownFilter.describe(
         'Breakdowns are used to segment data by property values of maximum three properties. They divide all defined trends series to multiple subseries based on the values of the property. Include breakdowns **only when they are essential to directly answer the user’s question**. You must not add breakdowns if the question can be addressed without additional segmentation. Always use the minimum set of breakdowns needed to answer the question. When using breakdowns, you must:\n- **Identify the property group** and name for each breakdown.\n- **Provide the property name** for each breakdown.\n- **Validate that the property value accurately reflects the intended criteria**. Examples of using breakdowns:\n- page views trend by country: you need to find a property such as `$geoip_country_code` and set it as a breakdown.\n- number of users who have completed onboarding by an organization: you need to find a property such as `organization name` and set it as a breakdown.'
     ).optional(),
@@ -631,7 +631,7 @@ const AssistantFunnelsBreakdownType = z.enum(['person', 'event', 'group', 'sessi
 const AssistantFunnelsBreakdownFilter = z.object({
     breakdown: z.string().describe('The entity property to break down by.'),
     breakdown_group_type_index: z
-        .union([integer, z.null()])
+        .union([z.null(), integer])
         .describe(
             'If `breakdown_type` is `group`, this is the index of the group. Use the index from the group mapping.'
         )
@@ -906,7 +906,7 @@ const AssistantRetentionFilter = z.object({
 })
 
 const AssistantRetentionQuery = z.object({
-    aggregation_group_type_index: z.union([integer, z.null()]).describe('Groups aggregation').optional(),
+    aggregation_group_type_index: z.union([z.null(), integer]).describe('Groups aggregation').optional(),
     dateRange: AssistantDateRangeFilter.describe('Date range for the query').optional(),
     filterTestAccounts: z.coerce
         .boolean()
@@ -994,7 +994,7 @@ const AssistantStickinessFilter = z.object({
 })
 
 const AssistantStickinessQuery = z.object({
-    aggregation_group_type_index: z.union([integer, z.null()]).describe('Groups aggregation').optional(),
+    aggregation_group_type_index: z.union([z.null(), integer]).describe('Groups aggregation').optional(),
     compareFilter: CompareFilter.describe(
         'Compare to date range. When enabled, shows the current and previous period side by side.'
     ).optional(),
@@ -1126,7 +1126,7 @@ const AssistantPathsFilter = z.object({
 })
 
 const AssistantPathsQuery = z.object({
-    aggregation_group_type_index: z.union([integer, z.null()]).describe('Groups aggregation').optional(),
+    aggregation_group_type_index: z.union([z.null(), integer]).describe('Groups aggregation').optional(),
     dateRange: AssistantDateRangeFilter.describe('Date range for the query').optional(),
     filterTestAccounts: z.coerce
         .boolean()
@@ -1185,7 +1185,7 @@ const AssistantLifecycleActionsNode = z.object({
 const AssistantLifecycleSeriesNode = z.union([AssistantLifecycleEventsNode, AssistantLifecycleActionsNode])
 
 const AssistantLifecycleQuery = z.object({
-    aggregation_group_type_index: z.union([integer, z.null()]).describe('Groups aggregation').optional(),
+    aggregation_group_type_index: z.union([z.null(), integer]).describe('Groups aggregation').optional(),
     dateRange: AssistantDateRangeFilter.describe('Date range for the query').optional(),
     filterTestAccounts: z.coerce
         .boolean()

--- a/services/mcp/src/tools/generated/replay.ts
+++ b/services/mcp/src/tools/generated/replay.ts
@@ -513,7 +513,7 @@ const AssistantFlagPropertyFilter = z.object({
         )
         .default('flag'),
     value: z
-        .union([z.coerce.boolean(), z.string()])
+        .union([z.string(), z.boolean()])
         .describe('`true`/`false` for boolean flags, or a variant name string for multivariate flags.'),
 })
 

--- a/services/mcp/src/tools/generated/web_analytics.ts
+++ b/services/mcp/src/tools/generated/web_analytics.ts
@@ -312,9 +312,9 @@ const PropertyOperator = z.enum([
     'not_icontains_multi',
 ])
 
-const PropertyFilterBaseValue = z.union([z.string(), z.coerce.number(), z.coerce.boolean()])
+const PropertyFilterBaseValue = z.union([z.string(), z.number(), z.boolean()])
 
-const PropertyFilterValue = z.union([PropertyFilterBaseValue, z.array(PropertyFilterBaseValue), z.null()])
+const PropertyFilterValue = z.union([z.array(PropertyFilterBaseValue), z.null(), PropertyFilterBaseValue])
 
 const EventPropertyFilter = z.object({
     key: z.string(),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-funnel-actors.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-funnel-actors.json
@@ -57,12 +57,12 @@
                         "breakdown_group_type_index": {
                             "anyOf": [
                                 {
+                                    "type": "null"
+                                },
+                                {
                                     "maximum": 9007199254740991,
                                     "minimum": -9007199254740991,
                                     "type": "integer"
-                                },
-                                {
-                                    "type": "null"
                                 }
                             ],
                             "description": "If `breakdown_type` is `group`, this is the index of the group. Use the index from the group mapping."
@@ -724,10 +724,10 @@
                                     "value": {
                                         "anyOf": [
                                             {
-                                                "type": "boolean"
+                                                "type": "string"
                                             },
                                             {
-                                                "type": "string"
+                                                "type": "boolean"
                                             }
                                         ],
                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1284,10 +1284,10 @@
                                                         "value": {
                                                             "anyOf": [
                                                                 {
-                                                                    "type": "boolean"
+                                                                    "type": "string"
                                                                 },
                                                                 {
-                                                                    "type": "string"
+                                                                    "type": "boolean"
                                                                 }
                                                             ],
                                                             "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1848,10 +1848,10 @@
                                                         "value": {
                                                             "anyOf": [
                                                                 {
-                                                                    "type": "boolean"
+                                                                    "type": "string"
                                                                 },
                                                                 {
-                                                                    "type": "string"
+                                                                    "type": "boolean"
                                                                 }
                                                             ],
                                                             "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -2532,10 +2532,10 @@
                                                                             "value": {
                                                                                 "anyOf": [
                                                                                     {
-                                                                                        "type": "boolean"
+                                                                                        "type": "string"
                                                                                     },
                                                                                     {
-                                                                                        "type": "string"
+                                                                                        "type": "boolean"
                                                                                     }
                                                                                 ],
                                                                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -3198,10 +3198,10 @@
                                                                             "value": {
                                                                                 "anyOf": [
                                                                                     {
-                                                                                        "type": "boolean"
+                                                                                        "type": "string"
                                                                                     },
                                                                                     {
-                                                                                        "type": "string"
+                                                                                        "type": "boolean"
                                                                                     }
                                                                                 ],
                                                                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-funnel.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-funnel.json
@@ -17,12 +17,12 @@
                 "breakdown_group_type_index": {
                     "anyOf": [
                         {
+                            "type": "null"
+                        },
+                        {
                             "maximum": 9007199254740991,
                             "minimum": -9007199254740991,
                             "type": "integer"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "If `breakdown_type` is `group`, this is the index of the group. Use the index from the group mapping."
@@ -668,10 +668,10 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "type": "boolean"
+                                        "type": "string"
                                     },
                                     {
-                                        "type": "string"
+                                        "type": "boolean"
                                     }
                                 ],
                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1208,10 +1208,10 @@
                                                 "value": {
                                                     "anyOf": [
                                                         {
-                                                            "type": "boolean"
+                                                            "type": "string"
                                                         },
                                                         {
-                                                            "type": "string"
+                                                            "type": "boolean"
                                                         }
                                                     ],
                                                     "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1752,10 +1752,10 @@
                                                 "value": {
                                                     "anyOf": [
                                                         {
-                                                            "type": "boolean"
+                                                            "type": "string"
                                                         },
                                                         {
-                                                            "type": "string"
+                                                            "type": "boolean"
                                                         }
                                                     ],
                                                     "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -2408,10 +2408,10 @@
                                                                     "value": {
                                                                         "anyOf": [
                                                                             {
-                                                                                "type": "boolean"
+                                                                                "type": "string"
                                                                             },
                                                                             {
-                                                                                "type": "string"
+                                                                                "type": "boolean"
                                                                             }
                                                                         ],
                                                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -3046,10 +3046,10 @@
                                                                     "value": {
                                                                         "anyOf": [
                                                                             {
-                                                                                "type": "boolean"
+                                                                                "type": "string"
                                                                             },
                                                                             {
-                                                                                "type": "string"
+                                                                                "type": "boolean"
                                                                             }
                                                                         ],
                                                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-lifecycle-actors.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-lifecycle-actors.json
@@ -22,12 +22,12 @@
                 "aggregation_group_type_index": {
                     "anyOf": [
                         {
+                            "type": "null"
+                        },
+                        {
                             "maximum": 9007199254740991,
                             "minimum": -9007199254740991,
                             "type": "integer"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Groups aggregation"
@@ -598,10 +598,10 @@
                                     "value": {
                                         "anyOf": [
                                             {
-                                                "type": "boolean"
+                                                "type": "string"
                                             },
                                             {
-                                                "type": "string"
+                                                "type": "boolean"
                                             }
                                         ],
                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1158,10 +1158,10 @@
                                                         "value": {
                                                             "anyOf": [
                                                                 {
-                                                                    "type": "boolean"
+                                                                    "type": "string"
                                                                 },
                                                                 {
-                                                                    "type": "string"
+                                                                    "type": "boolean"
                                                                 }
                                                             ],
                                                             "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1712,10 +1712,10 @@
                                                         "value": {
                                                             "anyOf": [
                                                                 {
-                                                                    "type": "boolean"
+                                                                    "type": "string"
                                                                 },
                                                                 {
-                                                                    "type": "string"
+                                                                    "type": "boolean"
                                                                 }
                                                             ],
                                                             "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-lifecycle.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-lifecycle.json
@@ -4,12 +4,12 @@
         "aggregation_group_type_index": {
             "anyOf": [
                 {
+                    "type": "null"
+                },
+                {
                     "maximum": 9007199254740991,
                     "minimum": -9007199254740991,
                     "type": "integer"
-                },
-                {
-                    "type": "null"
                 }
             ],
             "description": "Groups aggregation"
@@ -564,10 +564,10 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "type": "boolean"
+                                        "type": "string"
                                     },
                                     {
-                                        "type": "string"
+                                        "type": "boolean"
                                     }
                                 ],
                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1104,10 +1104,10 @@
                                                 "value": {
                                                     "anyOf": [
                                                         {
-                                                            "type": "boolean"
+                                                            "type": "string"
                                                         },
                                                         {
-                                                            "type": "string"
+                                                            "type": "boolean"
                                                         }
                                                     ],
                                                     "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1638,10 +1638,10 @@
                                                 "value": {
                                                     "anyOf": [
                                                         {
-                                                            "type": "boolean"
+                                                            "type": "string"
                                                         },
                                                         {
-                                                            "type": "string"
+                                                            "type": "boolean"
                                                         }
                                                     ],
                                                     "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-llm-trace.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-llm-trace.json
@@ -506,10 +506,10 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "type": "boolean"
+                                        "type": "string"
                                     },
                                     {
-                                        "type": "string"
+                                        "type": "boolean"
                                     }
                                 ],
                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-llm-traces-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-llm-traces-list.json
@@ -544,10 +544,10 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "type": "boolean"
+                                        "type": "string"
                                     },
                                     {
-                                        "type": "string"
+                                        "type": "boolean"
                                     }
                                 ],
                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-paths-actors.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-paths-actors.json
@@ -23,12 +23,12 @@
                 "aggregation_group_type_index": {
                     "anyOf": [
                         {
+                            "type": "null"
+                        },
+                        {
                             "maximum": 9007199254740991,
                             "minimum": -9007199254740991,
                             "type": "integer"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Groups aggregation"
@@ -663,10 +663,10 @@
                                     "value": {
                                         "anyOf": [
                                             {
-                                                "type": "boolean"
+                                                "type": "string"
                                             },
                                             {
-                                                "type": "string"
+                                                "type": "boolean"
                                             }
                                         ],
                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-paths.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-paths.json
@@ -4,12 +4,12 @@
         "aggregation_group_type_index": {
             "anyOf": [
                 {
+                    "type": "null"
+                },
+                {
                     "maximum": 9007199254740991,
                     "minimum": -9007199254740991,
                     "type": "integer"
-                },
-                {
-                    "type": "null"
                 }
             ],
             "description": "Groups aggregation"
@@ -628,10 +628,10 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "type": "boolean"
+                                        "type": "string"
                                     },
                                     {
-                                        "type": "string"
+                                        "type": "boolean"
                                     }
                                 ],
                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-retention-actors.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-retention-actors.json
@@ -24,12 +24,12 @@
                 "aggregation_group_type_index": {
                     "anyOf": [
                         {
+                            "type": "null"
+                        },
+                        {
                             "maximum": 9007199254740991,
                             "minimum": -9007199254740991,
                             "type": "integer"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Groups aggregation"
@@ -565,10 +565,10 @@
                                     "value": {
                                         "anyOf": [
                                             {
-                                                "type": "boolean"
+                                                "type": "string"
                                             },
                                             {
-                                                "type": "string"
+                                                "type": "boolean"
                                             }
                                         ],
                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1221,10 +1221,10 @@
                                                             "value": {
                                                                 "anyOf": [
                                                                     {
-                                                                        "type": "boolean"
+                                                                        "type": "string"
                                                                     },
                                                                     {
-                                                                        "type": "string"
+                                                                        "type": "boolean"
                                                                     }
                                                                 ],
                                                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1822,10 +1822,10 @@
                                                             "value": {
                                                                 "anyOf": [
                                                                     {
-                                                                        "type": "boolean"
+                                                                        "type": "string"
                                                                     },
                                                                     {
-                                                                        "type": "string"
+                                                                        "type": "boolean"
                                                                     }
                                                                 ],
                                                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -2432,10 +2432,10 @@
                                                             "value": {
                                                                 "anyOf": [
                                                                     {
-                                                                        "type": "boolean"
+                                                                        "type": "string"
                                                                     },
                                                                     {
-                                                                        "type": "string"
+                                                                        "type": "boolean"
                                                                     }
                                                                 ],
                                                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -3033,10 +3033,10 @@
                                                             "value": {
                                                                 "anyOf": [
                                                                     {
-                                                                        "type": "boolean"
+                                                                        "type": "string"
                                                                     },
                                                                     {
-                                                                        "type": "string"
+                                                                        "type": "boolean"
                                                                     }
                                                                 ],
                                                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-retention.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-retention.json
@@ -4,12 +4,12 @@
         "aggregation_group_type_index": {
             "anyOf": [
                 {
+                    "type": "null"
+                },
+                {
                     "maximum": 9007199254740991,
                     "minimum": -9007199254740991,
                     "type": "integer"
-                },
-                {
-                    "type": "null"
                 }
             ],
             "description": "Groups aggregation"
@@ -529,10 +529,10 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "type": "boolean"
+                                        "type": "string"
                                     },
                                     {
-                                        "type": "string"
+                                        "type": "boolean"
                                     }
                                 ],
                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1115,10 +1115,10 @@
                                                     "value": {
                                                         "anyOf": [
                                                             {
-                                                                "type": "boolean"
+                                                                "type": "string"
                                                             },
                                                             {
-                                                                "type": "string"
+                                                                "type": "boolean"
                                                             }
                                                         ],
                                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1646,10 +1646,10 @@
                                                     "value": {
                                                         "anyOf": [
                                                             {
-                                                                "type": "boolean"
+                                                                "type": "string"
                                                             },
                                                             {
-                                                                "type": "string"
+                                                                "type": "boolean"
                                                             }
                                                         ],
                                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -2186,10 +2186,10 @@
                                                     "value": {
                                                         "anyOf": [
                                                             {
-                                                                "type": "boolean"
+                                                                "type": "string"
                                                             },
                                                             {
-                                                                "type": "string"
+                                                                "type": "boolean"
                                                             }
                                                         ],
                                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -2717,10 +2717,10 @@
                                                     "value": {
                                                         "anyOf": [
                                                             {
-                                                                "type": "boolean"
+                                                                "type": "string"
                                                             },
                                                             {
-                                                                "type": "string"
+                                                                "type": "boolean"
                                                             }
                                                         ],
                                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-session-recordings-list.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-session-recordings-list.json
@@ -555,10 +555,10 @@
                                     "value": {
                                         "anyOf": [
                                             {
-                                                "type": "boolean"
+                                                "type": "string"
                                             },
                                             {
-                                                "type": "string"
+                                                "type": "boolean"
                                             }
                                         ],
                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-stickiness-actors.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-stickiness-actors.json
@@ -35,12 +35,12 @@
                 "aggregation_group_type_index": {
                     "anyOf": [
                         {
+                            "type": "null"
+                        },
+                        {
                             "maximum": 9007199254740991,
                             "minimum": -9007199254740991,
                             "type": "integer"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Groups aggregation"
@@ -603,10 +603,10 @@
                                     "value": {
                                         "anyOf": [
                                             {
-                                                "type": "boolean"
+                                                "type": "string"
                                             },
                                             {
-                                                "type": "string"
+                                                "type": "boolean"
                                             }
                                         ],
                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1276,10 +1276,10 @@
                                                         "value": {
                                                             "anyOf": [
                                                                 {
-                                                                    "type": "boolean"
+                                                                    "type": "string"
                                                                 },
                                                                 {
-                                                                    "type": "string"
+                                                                    "type": "boolean"
                                                                 }
                                                             ],
                                                             "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1943,10 +1943,10 @@
                                                         "value": {
                                                             "anyOf": [
                                                                 {
-                                                                    "type": "boolean"
+                                                                    "type": "string"
                                                                 },
                                                                 {
-                                                                    "type": "string"
+                                                                    "type": "boolean"
                                                                 }
                                                             ],
                                                             "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-stickiness.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-stickiness.json
@@ -4,12 +4,12 @@
         "aggregation_group_type_index": {
             "anyOf": [
                 {
+                    "type": "null"
+                },
+                {
                     "maximum": 9007199254740991,
                     "minimum": -9007199254740991,
                     "type": "integer"
-                },
-                {
-                    "type": "null"
                 }
             ],
             "description": "Groups aggregation"
@@ -556,10 +556,10 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "type": "boolean"
+                                        "type": "string"
                                     },
                                     {
-                                        "type": "string"
+                                        "type": "boolean"
                                     }
                                 ],
                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1195,10 +1195,10 @@
                                                 "value": {
                                                     "anyOf": [
                                                         {
-                                                            "type": "boolean"
+                                                            "type": "string"
                                                         },
                                                         {
-                                                            "type": "string"
+                                                            "type": "boolean"
                                                         }
                                                     ],
                                                     "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1828,10 +1828,10 @@
                                                 "value": {
                                                     "anyOf": [
                                                         {
-                                                            "type": "boolean"
+                                                            "type": "string"
                                                         },
                                                         {
-                                                            "type": "string"
+                                                            "type": "boolean"
                                                         }
                                                     ],
                                                     "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends-actors.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends-actors.json
@@ -45,12 +45,12 @@
                 "aggregation_group_type_index": {
                     "anyOf": [
                         {
+                            "type": "null"
+                        },
+                        {
                             "maximum": 9007199254740991,
                             "minimum": -9007199254740991,
                             "type": "integer"
-                        },
-                        {
-                            "type": "null"
                         }
                     ],
                     "description": "Groups aggregation"
@@ -78,12 +78,12 @@
                                             "group_type_index": {
                                                 "anyOf": [
                                                     {
+                                                        "type": "null"
+                                                    },
+                                                    {
                                                         "maximum": 9007199254740991,
                                                         "minimum": -9007199254740991,
                                                         "type": "integer"
-                                                    },
-                                                    {
-                                                        "type": "null"
                                                     }
                                                 ],
                                                 "description": "Index of the group type from the group mapping."
@@ -686,10 +686,10 @@
                                     "value": {
                                         "anyOf": [
                                             {
-                                                "type": "boolean"
+                                                "type": "string"
                                             },
                                             {
-                                                "type": "string"
+                                                "type": "boolean"
                                             }
                                         ],
                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1362,10 +1362,10 @@
                                                         "value": {
                                                             "anyOf": [
                                                                 {
-                                                                    "type": "boolean"
+                                                                    "type": "string"
                                                                 },
                                                                 {
-                                                                    "type": "string"
+                                                                    "type": "boolean"
                                                                 }
                                                             ],
                                                             "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -2036,10 +2036,10 @@
                                                         "value": {
                                                             "anyOf": [
                                                                 {
-                                                                    "type": "boolean"
+                                                                    "type": "string"
                                                                 },
                                                                 {
-                                                                    "type": "string"
+                                                                    "type": "boolean"
                                                                 }
                                                             ],
                                                             "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -2948,10 +2948,10 @@
                                                                             "value": {
                                                                                 "anyOf": [
                                                                                     {
-                                                                                        "type": "boolean"
+                                                                                        "type": "string"
                                                                                     },
                                                                                     {
-                                                                                        "type": "string"
+                                                                                        "type": "boolean"
                                                                                     }
                                                                                 ],
                                                                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -3721,10 +3721,10 @@
                                                                             "value": {
                                                                                 "anyOf": [
                                                                                     {
-                                                                                        "type": "boolean"
+                                                                                        "type": "string"
                                                                                     },
                                                                                     {
-                                                                                        "type": "string"
+                                                                                        "type": "boolean"
                                                                                     }
                                                                                 ],
                                                                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-trends.json
@@ -4,12 +4,12 @@
         "aggregation_group_type_index": {
             "anyOf": [
                 {
+                    "type": "null"
+                },
+                {
                     "maximum": 9007199254740991,
                     "minimum": -9007199254740991,
                     "type": "integer"
-                },
-                {
-                    "type": "null"
                 }
             ],
             "description": "Groups aggregation"
@@ -37,12 +37,12 @@
                                     "group_type_index": {
                                         "anyOf": [
                                             {
+                                                "type": "null"
+                                            },
+                                            {
                                                 "maximum": 9007199254740991,
                                                 "minimum": -9007199254740991,
                                                 "type": "integer"
-                                            },
-                                            {
-                                                "type": "null"
                                             }
                                         ],
                                         "description": "Index of the group type from the group mapping."
@@ -629,10 +629,10 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "type": "boolean"
+                                        "type": "string"
                                     },
                                     {
-                                        "type": "string"
+                                        "type": "boolean"
                                     }
                                 ],
                                 "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1271,10 +1271,10 @@
                                                 "value": {
                                                     "anyOf": [
                                                         {
-                                                            "type": "boolean"
+                                                            "type": "string"
                                                         },
                                                         {
-                                                            "type": "string"
+                                                            "type": "boolean"
                                                         }
                                                     ],
                                                     "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -1911,10 +1911,10 @@
                                                 "value": {
                                                     "anyOf": [
                                                         {
-                                                            "type": "boolean"
+                                                            "type": "string"
                                                         },
                                                         {
-                                                            "type": "string"
+                                                            "type": "boolean"
                                                         }
                                                     ],
                                                     "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -2784,10 +2784,10 @@
                                                                     "value": {
                                                                         "anyOf": [
                                                                             {
-                                                                                "type": "boolean"
+                                                                                "type": "string"
                                                                             },
                                                                             {
-                                                                                "type": "string"
+                                                                                "type": "boolean"
                                                                             }
                                                                         ],
                                                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."
@@ -3532,10 +3532,10 @@
                                                                     "value": {
                                                                         "anyOf": [
                                                                             {
-                                                                                "type": "boolean"
+                                                                                "type": "string"
                                                                             },
                                                                             {
-                                                                                "type": "string"
+                                                                                "type": "boolean"
                                                                             }
                                                                         ],
                                                                         "description": "`true`/`false` for boolean flags, or a variant name string for multivariate flags."

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-overview.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-overview.json
@@ -160,19 +160,6 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "anyOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            },
-                                            {
-                                                "type": "boolean"
-                                            }
-                                        ]
-                                    },
-                                    {
                                         "items": {
                                             "anyOf": [
                                                 {
@@ -190,6 +177,19 @@
                                     },
                                     {
                                         "type": "null"
+                                    },
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
                                     }
                                 ]
                             }
@@ -253,19 +253,6 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "anyOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            },
-                                            {
-                                                "type": "boolean"
-                                            }
-                                        ]
-                                    },
-                                    {
                                         "items": {
                                             "anyOf": [
                                                 {
@@ -283,6 +270,19 @@
                                     },
                                     {
                                         "type": "null"
+                                    },
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
                                     }
                                 ]
                             }
@@ -345,19 +345,6 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "anyOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            },
-                                            {
-                                                "type": "boolean"
-                                            }
-                                        ]
-                                    },
-                                    {
                                         "items": {
                                             "anyOf": [
                                                 {
@@ -375,6 +362,19 @@
                                     },
                                     {
                                         "type": "null"
+                                    },
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
                                     }
                                 ]
                             }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-stats.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-stats.json
@@ -226,19 +226,6 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "anyOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            },
-                                            {
-                                                "type": "boolean"
-                                            }
-                                        ]
-                                    },
-                                    {
                                         "items": {
                                             "anyOf": [
                                                 {
@@ -256,6 +243,19 @@
                                     },
                                     {
                                         "type": "null"
+                                    },
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
                                     }
                                 ]
                             }
@@ -319,19 +319,6 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "anyOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            },
-                                            {
-                                                "type": "boolean"
-                                            }
-                                        ]
-                                    },
-                                    {
                                         "items": {
                                             "anyOf": [
                                                 {
@@ -349,6 +336,19 @@
                                     },
                                     {
                                         "type": "null"
+                                    },
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
                                     }
                                 ]
                             }
@@ -411,19 +411,6 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "anyOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            },
-                                            {
-                                                "type": "boolean"
-                                            }
-                                        ]
-                                    },
-                                    {
                                         "items": {
                                             "anyOf": [
                                                 {
@@ -441,6 +428,19 @@
                                     },
                                     {
                                         "type": "null"
+                                    },
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
                                     }
                                 ]
                             }

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-vitals.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/query-web-vitals.json
@@ -123,19 +123,6 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "anyOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            },
-                                            {
-                                                "type": "boolean"
-                                            }
-                                        ]
-                                    },
-                                    {
                                         "items": {
                                             "anyOf": [
                                                 {
@@ -153,6 +140,19 @@
                                     },
                                     {
                                         "type": "null"
+                                    },
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
                                     }
                                 ]
                             }
@@ -216,19 +216,6 @@
                             "value": {
                                 "anyOf": [
                                     {
-                                        "anyOf": [
-                                            {
-                                                "type": "string"
-                                            },
-                                            {
-                                                "type": "number"
-                                            },
-                                            {
-                                                "type": "boolean"
-                                            }
-                                        ]
-                                    },
-                                    {
                                         "items": {
                                             "anyOf": [
                                                 {
@@ -246,6 +233,19 @@
                                     },
                                     {
                                         "type": "null"
+                                    },
+                                    {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "number"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
                                     }
                                 ]
                             }

--- a/services/mcp/tests/unit/json-schema-to-zod.test.ts
+++ b/services/mcp/tests/unit/json-schema-to-zod.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
 
 import { generateZodFromSchemaRef } from '../../scripts/lib/json-schema-to-zod'
+
+/** Evaluate generated Zod source so assertions run against real parse behavior. */
+function buildSchema(root: Parameters<typeof generateZodFromSchemaRef>[0], entry: string): z.ZodTypeAny {
+    const src = generateZodFromSchemaRef(root, entry)
+    return new Function('z', `${src}; return ${entry}`)(z) as z.ZodTypeAny
+}
 
 describe('generateZodFromSchemaRef — array constraints', () => {
     it.each([
@@ -49,5 +56,91 @@ describe('generateZodFromSchemaRef — array constraints', () => {
         expect(out).toContain('z.array(z.string())')
         expect(out).not.toMatch(/\.min\(/)
         expect(out).not.toMatch(/\.max\(/)
+    })
+})
+
+describe('generateZodFromSchemaRef — union branch ordering', () => {
+    // Shape of PropertyFilterValue: a coercing scalar branch authored alongside array
+    // and null branches, which it would otherwise swallow.
+    const propertyFilterRoot = {
+        definitions: {
+            Filter: {
+                type: 'object',
+                properties: {
+                    value: {
+                        anyOf: [
+                            { type: ['string', 'number', 'boolean'] },
+                            { type: 'array', items: { type: ['string', 'number', 'boolean'] } },
+                            { type: 'null' },
+                        ],
+                    },
+                },
+            },
+        },
+    }
+
+    it.each([
+        { label: 'string array', value: ['Mobile'] },
+        { label: 'multi-element string array', value: ['Mobile', 'Desktop'] },
+        { label: 'empty array', value: [] },
+        { label: 'number array', value: [2500, 4000] },
+        { label: 'null', value: null },
+        { label: 'bare string', value: 'Mobile' },
+        { label: 'bare boolean', value: true },
+        { label: 'bare number', value: 42 },
+    ])('preserves $label instead of collapsing it into a coerced scalar', ({ value }) => {
+        const Filter = buildSchema(propertyFilterRoot, 'Filter')
+
+        expect(Filter.parse({ value })).toEqual({ value })
+    })
+
+    it('keeps a variant name as a string when the union also accepts a boolean', () => {
+        const FlagValue = buildSchema(
+            {
+                definitions: {
+                    FlagValue: {
+                        type: 'object',
+                        properties: { value: { type: ['boolean', 'string'] } },
+                    },
+                },
+            },
+            'FlagValue'
+        )
+
+        expect(FlagValue.parse({ value: 'control' })).toEqual({ value: 'control' })
+        expect(FlagValue.parse({ value: true })).toEqual({ value: true })
+    })
+
+    it('keeps null distinct from zero on a nullable integer', () => {
+        const Grouped = buildSchema(
+            {
+                definitions: {
+                    Grouped: {
+                        type: 'object',
+                        properties: { group_type_index: { anyOf: [{ type: 'integer' }, { type: 'null' }] } },
+                    },
+                },
+            },
+            'Grouped'
+        )
+
+        expect(Grouped.parse({ group_type_index: null })).toEqual({ group_type_index: null })
+        expect(Grouped.parse({ group_type_index: 0 })).toEqual({ group_type_index: 0 })
+    })
+
+    it('still coerces numeric strings for MCP clients that send numbers as strings', () => {
+        const Grouped = buildSchema(
+            {
+                definitions: {
+                    Grouped: {
+                        type: 'object',
+                        properties: { group_type_index: { anyOf: [{ type: 'integer' }, { type: 'null' }] } },
+                    },
+                },
+            },
+            'Grouped'
+        )
+
+        expect(Grouped.parse({ group_type_index: '3' })).toEqual({ group_type_index: 3 })
     })
 })


### PR DESCRIPTION
## Problem

Zod returns the first union branch that accepts an input. `z.coerce.number()` and `z.coerce.boolean()` are `Number(x)` and `Boolean(x)`, and neither ever rejects. So when the codegen puts a coercing branch in front of a branch that can reject, the later branch is unreachable.

That is what happened to property filter values. The generator emitted:

```ts
const PropertyFilterBaseValue = z.union([z.string(), z.coerce.number(), z.coerce.boolean()])
const PropertyFilterValue = z.union([PropertyFilterBaseValue, z.array(PropertyFilterBaseValue), z.null()])
```

An array falls through `z.string()` and `z.coerce.number()`, hits `z.coerce.boolean()`, and comes out as `true`. The array and null branches are dead code. So a filter the agent wrote as

```json
{ "type": "event", "key": "$device_type", "operator": "exact", "value": ["Mobile"] }
```

reached ClickHouse as `equals(mat_$device_type, 1.)` and the query failed with `There is no supertype for types String, Float64`. Passing the same value as a bare string worked, which is what made this confusing to chase.

Two more instances of the same defect, both silent rather than loud:

| Union | Input | Was | Now |
| --- | --- | --- | --- |
| property filter `value` | `["Mobile"]` / `[]` / `null` | `true` / `0` / `0` | preserved |
| feature flag `value` (`boolean \| string`) | `"control"` | `true` | `"control"` |
| `group_type_index` (`integer \| null`) | `null` | `0` | `null` |

The feature flag one is the nastiest: the field is documented as "true, false, or a variant name", and every variant name was being turned into `true`.

There is already a hand-written workaround for a symptom of this in `query-wrapper-factory.ts`, noting that coercion turns the string `"false"` into `true`. This fixes the cause rather than one field.

> [!NOTE]
> Coercion is kept everywhere it can still do its job. `z.union([z.null(), z.coerce.number().int()])` keeps its coercion, so a client sending `"3"` for a nullable integer still works. That was the original reason for `z.coerce`, and none of it is lost.

## Changes

- Sort union branches by selectivity, so branches that can reject (null, array, object, enum, literal) come before scalars, and coercing booleans come last. The sort is stable, so string versus number order is left as authored.
- Drop coercion for scalar branches that sit next to a `z.string()` branch. A string always matches the string branch first, so coercion there is unreachable for strings and can only misread a sibling type, since `Number(true)` is `1`.
- Regenerate the four affected tool modules and the tool schema snapshots. The snapshot diff is `anyOf` member reordering only, with no change to any `default` or `required`.

Only unions that mix these categories change. Everything else generates byte-identical output.

## How did you test this code?

Automated only, no manual testing.

Built a differential harness that imports the old and new generated schemas side by side and parses the same corpus through both. Every top-level field of every affected tool, set to each of 20 input shapes (strings, numeric strings, `"true"`/`"false"`, numbers, booleans, `null`, empty and populated and mixed arrays, objects), plus a targeted sweep at the nested `properties[].value` position. Tools with required fields got a synthesized minimal-valid base payload so probes actually reached validation.

**51 tools, 5,810 probes: 0 newly rejected, 0 newly accepted, 37 values corrected.** Nothing that used to validate stops validating. The only behavior delta is values that stop being mangled.

Added 15 cases to `json-schema-to-zod.test.ts`, asserting parse behavior rather than emitted strings. The regressions they catch, none of which any existing test covered:

- a union carrying array and null branches must preserve those shapes instead of collapsing them to a coerced scalar (8 parameterized cases)
- a `boolean | string` union must keep a variant name as a string
- a nullable integer must keep `null` distinct from `0`
- numeric strings must still coerce, so the fix does not quietly tighten the MCP client compatibility the coercion exists for

Negative control: 8 of these fail against the pre-fix generator and pass after, so they are pinned to the actual defect.

`pnpm --filter=@posthog/mcp test` (95 files, 2,445 tests), `typecheck`, and `lint` all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing surface changes. Tool schemas keep the same fields and descriptions, only `anyOf` ordering moves.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I pointed Claude (Opus 5) at a tool quality dashboard showing a high error rate on `query-web-vitals` and asked it to find the cause. It reproduced the failure live, traced it from the ClickHouse error text back through the generated Zod to the codegen, and found the same defect in two other unions along the way.

Skills invoked: `/writing-tests` and `/writing-code-comments`.

Worth knowing about the road here, since the first two attempts were worse:

- First fix used `z.preprocess` to build non-swallowing primitives. It worked, and it also fixed a related bug where standalone `z.coerce.boolean()` turns the string `"false"` into `true`. Rejected it: any `preprocess` in the subtree makes Zod drop `default` from the emitted JSON Schema in `io: "input"` mode, which silently deleted 93 `default` annotations across the tool catalog. Losing documented defaults is worse for agent accuracy than the bug it fixed.
- Second attempt made all union scalars strict. Correct, but it also removed string coercion from common `number | null` params, which is real client compatibility. Backed off to the narrower rule in this PR.
- That standalone `"false"` to `true` bug is therefore still present and deliberately out of scope here. It needs the `preprocess` approach plus a story for the `default` annotations, so it should be its own change.

A follow-up PR stacked on this one makes `percentile` and `thresholds` optional on `query-web-vitals`.
