### PR TITLE
fix(data-imports): honor shared non-retryable errors in import handler

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -378,7 +378,16 @@ async def _handle_import_error(
         await logger.adebug("REST client exhausted its retries - re-raising for Temporal retry")
         raise error
 
-    non_retryable_errors = source_cls.get_non_retryable_errors()
+    # Cross-source non-retryable errors (missing primary key on an incremental table, bad SSH tunnel
+    # auth, a widened column type) are raised from shared pipeline code, not any one source. The
+    # finalization activity already consults this shared dict; this in-activity handler decides whether
+    # to re-raise for a full retry, so without it a shared config error retries the activity's whole
+    # budget and reports on every attempt. Merge it in — source-specific entries win on overlap.
+    from products.warehouse_sources.backend.temporal.data_imports.external_data_job import (  # noqa: PLC0415 — deferred to break the external_data_job -> import_data_sync import cycle
+        Any_Source_Errors,
+    )
+
+    non_retryable_errors = {**Any_Source_Errors, **source_cls.get_non_retryable_errors()}
     if any(match in error_msg for match in non_retryable_errors):
         await handle_non_retryable_error(
             job_inputs.team_id, str(job_inputs.source_id), job_inputs.run_id, error_msg, logger, error

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -257,6 +257,37 @@ async def test_schema_column_type_changed_routes_through_handler_without_source_
     logger.aexception.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_shared_non_retryable_error_routes_through_handler_without_source_opt_in():
+    # "Primary key required for incremental syncs" is raised in shared pipeline code (delta merge),
+    # not any one source, and lives in the shared Any_Source_Errors dict. It must be non-retryable in
+    # this in-activity handler for every source, not just those that duplicate the message into their
+    # own get_non_retryable_errors — otherwise a keyless incremental table retries the activity's whole
+    # budget and reports on every attempt.
+    error = Exception("Primary key required for incremental syncs")
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with (
+        mock.patch.object(module.SourceRegistry, "get_source", return_value=source),
+        mock.patch.object(module, "handle_non_retryable_error", autospec=True) as handle_mock,
+    ):
+        handle_mock.side_effect = NonRetryableException()
+        with pytest.raises(NonRetryableException):
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    handle_mock.assert_awaited_once()
+    assert handle_mock.await_args is not None
+    assert handle_mock.await_args.args[5] is error
+    logger.aexception.assert_not_awaited()
+
+
 def _incremental_schema(*, is_incremental: bool, lookback_seconds: int | None) -> mock.MagicMock:
     schema = mock.MagicMock()
     schema.should_use_incremental_field = True


### PR DESCRIPTION
## Problem

An incremental data-warehouse sync was failing repeatedly and minting error-tracking noise with `Exception: Primary key required for incremental syncs`. The failing frame is in shared pipeline code (`delta_table_helper.write_to_deltalake`), reached when an incremental table has no resolvable primary key at all (for example a database view, which has no primary key). This is a genuine config error — retrying can never make a keyless table incrementally mergeable.

The message is already registered in the shared `Any_Source_Errors` non-retryable dict, and the finalization activity consults it to pause the schema with user guidance. But the in-activity handler `_handle_import_error` only consulted each source's own `get_non_retryable_errors()`. So the error fell through to the generic `raise error` path, Temporal retried the whole activity across its full budget, and the exception was reported to error tracking on every attempt.

This is a whole class of gap, not one message. Several sources already work around it by copying shared `Any_Source_Errors` entries (SSH tunnel auth, etc.) into their own per-source dicts — see the comment in the ClickHouse source that spells this out.

## Changes

`_handle_import_error` now merges the shared `Any_Source_Errors` into its non-retryable check, with source-specific entries winning on overlap:

```diff
-    non_retryable_errors = source_cls.get_non_retryable_errors()
+    non_retryable_errors = {**Any_Source_Errors, **source_cls.get_non_retryable_errors()}
```

Any error listed in the shared dict now stops after the handler's grace-period retries instead of the activity's full budget, and stops being reported as a defect on every attempt. `handle_non_retryable_error` still provides a small Redis-backed grace period, so a mis-classified transient still gets a few retries.

The import is deferred inside the function to break the existing `external_data_job -> import_data_sync` module cycle.

> [!NOTE]
> Behavior change: shared non-retryable errors (missing primary key on an incremental table, bad SSH tunnel auth, a widened column type, and the rest of `Any_Source_Errors`) now stop retrying in the in-activity handler for every source, not just sources that duplicated the message into their own list.

This is complementary to #74611, which addresses a different case (declared keys that are absent from the batch columns) and does not touch `_handle_import_error`.

## How did you test this code?

Added one regression test in `test_import_data_sync.py`: `test_shared_non_retryable_error_routes_through_handler_without_source_opt_in`. It calls `_handle_import_error` with the "Primary key required for incremental syncs" message while the source's `get_non_retryable_errors()` returns `{}`, and asserts the error routes through `handle_non_retryable_error` (not the generic re-raise). It catches a revert of this change — no existing test covered the shared-dict merge, since they all stub the source's own dict.

Ran the full file locally: `uv run pytest .../workflow_activities/tests/test_import_data_sync.py` → 13 passed. Ruff clean. I (Claude) could not run the live pipeline against a real source.

Refs #47664

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged from an error-tracking issue via the PostHog MCP tools, then implemented with Claude Code. Confirmed the failing frame and sync context (Supabase source syncing a keyless extension view, incremental, v2 pipeline) from the exception's `warehouse_sources_*` properties. Invoked the `/writing-tests` skill before adding the test. Considered moving `Any_Source_Errors` to a neutral module vs a deferred import; chose the deferred import to keep the change scoped and avoid rippling through the many existing importers. Checked open PRs (including #74611 and the maintainer's own) to rule out a duplicate.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
