### PR TITLE
fix(clerk): skip non-numeric timestamp fields instead of crashing

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/clerk.py
@@ -163,10 +163,14 @@ TIMESTAMP_FIELDS = [
 def _convert_timestamps(item: dict[str, Any]) -> dict[str, Any]:
     """Convert Clerk timestamp fields from milliseconds to seconds."""
     for field in TIMESTAMP_FIELDS:
-        if field in item and item[field] is not None:
-            # Clerk returns timestamps in milliseconds, convert to seconds
-            # Use integer division to maintain int64 type for delta table compatibility
-            item[field] = item[field] // 1000
+        value = item.get(field)
+        # Some endpoints return these fields as an ISO string (or other non-numeric shape)
+        # rather than epoch milliseconds; leave those untouched instead of crashing on `//`.
+        # bool is an int subclass, so exclude it explicitly.
+        if isinstance(value, int) and not isinstance(value, bool):
+            # Clerk returns timestamps in milliseconds, convert to seconds.
+            # Use integer division to maintain int64 type for delta table compatibility.
+            item[field] = value // 1000
     return item
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py
@@ -305,6 +305,19 @@ class TestClerkEndpoints:
             assert converted[field] == (value // 1000 if value is not None else None)
 
     @pytest.mark.parametrize(
+        "value",
+        [
+            "2026-07-29T12:52:50Z",  # ISO string instead of epoch ms
+            "1700000000000",  # numeric string
+            True,  # bool is an int subclass but not a timestamp
+        ],
+    )
+    def test_non_integer_timestamps_pass_through_unchanged(self, value: Any) -> None:
+        # Clerk occasionally returns a timestamp field as a non-numeric value; `//` on it used
+        # to raise TypeError and abort the whole import.
+        assert _convert_timestamps({"created_at": value}) == {"created_at": value}
+
+    @pytest.mark.parametrize(
         "item,paths,expected",
         [
             # top-level redeemable link on invitations / organization_invitations


### PR DESCRIPTION
## Problem

The Clerk data-warehouse import was crashing with `TypeError: unsupported operand type(s) for //: 'str' and 'int'`, surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019faf6f-5631-7962-b1ca-6c916a5fc91b)).

`_convert_timestamps` walks a fixed list of Clerk timestamp fields and converts milliseconds to seconds with `value // 1000`, assuming every one of those fields is always an epoch-millisecond integer. Clerk occasionally returns one of them as a non-numeric value (an ISO string, for example), and `//` on a string blows up. Because this runs as an `add_map` over every row, a single bad row aborts the whole sync rather than just skipping the field.

## Changes

Only integer-divide values that are genuine ints. Anything else (strings, other shapes) passes through unchanged instead of crashing. `bool` is excluded explicitly since it is an `int` subclass but never a real timestamp.

## How did you test this code?

Automated only, no manual run against live Clerk.

- Added `test_non_integer_timestamps_pass_through_unchanged` next to the existing conversion test. It covers an ISO string, a numeric string, and a bool, none of which any existing case exercised. It directly reproduces and locks in the fix for the crash. The existing `test_millisecond_timestamps_are_converted_to_seconds` continues to prove integer conversion still works.
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/clerk/tests/test_clerk.py` — 92 passed.
- ruff check + format check clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude (Claude Code). Confirmed the stack trace originated in `clerk.py:_convert_timestamps` via the PostHog error-tracking MCP tools, then read the source to confirm the unconditional `//` was the fault.

Decision: this is a fixable bug, not a user/upstream credential error, so it does not belong in `NonRetryableErrors` — a retry would fail identically. Chose to skip non-numeric values rather than coerce them (e.g. parsing numeric strings), keeping the change minimal and avoiding guesses about Clerk's exact string format. Skills invoked: `/writing-tests`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
