### PR TITLE
fix(capture): don't let an unreachable cluster mute ingestion warnings

### DIFF
--- a/rust/capture/src/setup.rs
+++ b/rust/capture/src/setup.rs
@@ -8,7 +8,7 @@ use common_ingestion_warnings::{
     observe_delivery, KafkaWarningEmitter, WarningEmitter, INGESTION_WARNINGS_EMITTER_ENABLED,
 };
 use common_kafka::config::KafkaConfig as WarningsKafkaConfig;
-use common_kafka::kafka_producer::create_threaded_kafka_producer;
+use common_kafka::kafka_producer::create_threaded_kafka_producer_no_ping;
 use common_redis::RedisClient;
 use metrics::gauge;
 use tracing::{info, warn};
@@ -725,7 +725,7 @@ fn build_warnings_kafka_config(
 /// any misconfiguration or producer-creation failure logs and returns `None`
 /// (capture runs without warnings) instead of failing startup. The producer
 /// is a `common_kafka` `ThreadedProducer`, built via
-/// `common_kafka::kafka_producer::create_threaded_kafka_producer` from a
+/// `common_kafka::kafka_producer::create_threaded_kafka_producer_no_ping` from a
 /// dedicated, warnings-only `common_kafka::config::KafkaConfig` (fire-and-forget
 /// acks/retries, a small queue) with `observe_delivery` as its delivery
 /// callback — by default it shares only the destination cluster (hosts/TLS) and
@@ -735,10 +735,12 @@ fn build_warnings_kafka_config(
 /// task heartbeats the advisory lifecycle handle, sweeps the throttle's per-key
 /// state, and flushes the producer once at shutdown.
 ///
-/// Fail-open note: unlike the previous bespoke producer (which never pinged
-/// brokers at startup), `create_threaded_kafka_producer` does a one-time
-/// metadata fetch. If brokers are unreachable at boot, the emitter stays
-/// disabled for the pod's life rather than retrying.
+/// Uses the no-ping constructor so an unreachable warnings cluster costs
+/// capture nothing at boot: no 15s metadata fetch on the startup path, and no
+/// pod that serves events for hours with warnings permanently off because the
+/// cluster happened to be down the moment it started. librdkafka reconnects on
+/// its own, so read `delivered`/`delivery_failed` to judge whether warnings are
+/// landing — the enabled gauge only reports that the emitter exists.
 async fn create_ingestion_warning_emitter(
     config: &Config,
     handle: Option<lifecycle::Handle>,
@@ -798,13 +800,11 @@ async fn create_ingestion_warning_emitter(
         config.capture_ingestion_warnings_kafka_message_max_bytes,
     );
 
-    let producer = match create_threaded_kafka_producer(
+    let producer = match create_threaded_kafka_producer_no_ping(
         &warnings_kafka_config,
         handle.clone(),
         observe_delivery,
-    )
-    .await
-    {
+    ) {
         Ok(producer) => producer,
         Err(e) => {
             tracing::error!(

--- a/rust/common/ingestion_warnings/src/lib.rs
+++ b/rust/common/ingestion_warnings/src/lib.rs
@@ -17,11 +17,14 @@
 //! counted and dropped — the caller's hot path is never blocked or failed.
 //!
 //! The producer is a `common_kafka` `ThreadedProducer` (built by
-//! [`common_kafka::kafka_producer::create_threaded_kafka_producer`]) rather
-//! than a bespoke client: callers supply their own dedicated, warnings-tuned
-//! [`common_kafka::config::KafkaConfig`] (fire-and-forget acks/retries, a
-//! small queue) so warnings never share tuning or a connection with a
-//! caller's main event producer. Delivery reports are observed on the
+//! [`common_kafka::kafka_producer::create_threaded_kafka_producer_no_ping`])
+//! rather than a bespoke client: callers supply their own dedicated,
+//! warnings-tuned [`common_kafka::config::KafkaConfig`] (fire-and-forget
+//! acks/retries, a small queue) so warnings never share tuning or a connection
+//! with a caller's main event producer. The no-ping constructor is the one that
+//! matches this crate's contract — an unreachable cluster at boot must not
+//! disable warnings for the process's life, let alone block the caller's
+//! startup on a metadata fetch. Delivery reports are observed on the
 //! producer's own poll thread via [`observe_delivery`] (no per-message task);
 //! `emit` attaches the warning type/source as the delivery opaque so the
 //! async `delivered`/`delivery_failed` metric is attributed correctly.
@@ -70,10 +73,16 @@ pub const INGESTION_WARNINGS_THROTTLE_KEYS: &str = "ingestion_warnings_throttle_
 /// indistinguishable from an intentionally quiet one. Absence means "off",
 /// `0` means "broken".
 ///
-/// Emitter construction is one-shot (`create_threaded_kafka_producer` fetches
-/// metadata once, with no retry), so a broker blip at boot mutes that process
-/// for its entire life. The only other symptom is lower-than-expected warning
-/// volume, which is unobservable without a baseline. Alert on `min() == 0`.
+/// `1` means the emitter was built, not that its cluster is reachable:
+/// construction deliberately skips the broker ping, so a producer pointed at a
+/// dead cluster still reports `1` and recovers on its own once the cluster
+/// comes back. Only a genuinely unusable configuration reports `0`.
+///
+/// Whether warnings are actually landing is therefore a delivery question, not
+/// a construction one — read the `delivered` and `delivery_failed` outcomes of
+/// [`INGESTION_WARNINGS_TOTAL`] for that. Alert on `min() == 0` here to catch
+/// misconfiguration, and on a sustained `delivery_failed` rate to catch a
+/// broken destination.
 pub const INGESTION_WARNINGS_EMITTER_ENABLED: &str = "ingestion_warnings_emitter_enabled";
 
 /// Identifies which service — and which code path within it — produced a
@@ -130,10 +139,10 @@ pub trait WarningEmitter: Send + Sync {
 
 /// Production emitter: per-(token, type) throttle in front of a
 /// `common_kafka` `ThreadedProducer`. Callers build the producer themselves
-/// (via `common_kafka::kafka_producer::create_threaded_kafka_producer` with a
-/// dedicated, fire-and-forget-tuned `KafkaConfig` and [`observe_delivery`] as
-/// the delivery callback) and hand it in — this type never constructs its own
-/// client. The producer's opaque is [`WarningDelivery`], so each message's
+/// (via `common_kafka::kafka_producer::create_threaded_kafka_producer_no_ping`
+/// with a dedicated, fire-and-forget-tuned `KafkaConfig` and
+/// [`observe_delivery`] as the delivery callback) and hand it in — this type
+/// never constructs its own client. The producer's opaque is [`WarningDelivery`], so each message's
 /// delivery report carries the type/source needed to label the async outcome
 /// metric.
 pub struct KafkaWarningEmitter {
@@ -312,14 +321,14 @@ pub fn observe_delivery(result: &DeliveryResult, delivery: WarningDelivery) {
 
 #[cfg(test)]
 mod tests {
+    use common_kafka::config::KafkaConfig;
+    use common_kafka::kafka_producer::create_threaded_kafka_producer_no_ping;
     use common_liveness::SyncLivenessReporter;
-    use rdkafka::ClientConfig;
 
     use super::*;
 
-    /// No-op liveness sink: these tests build a producer directly (not via
-    /// `create_kafka_producer`) specifically to skip its 15s broker-metadata
-    /// ping, so there is no real health signal to report.
+    /// No-op liveness sink: nothing in these tests polls a broker, so there is
+    /// no real health signal to report.
     #[derive(Clone, Copy)]
     struct AlwaysHealthy;
 
@@ -329,22 +338,22 @@ mod tests {
     }
 
     /// Build a threaded producer against an unreachable broker (TEST-NET-1)
-    /// without `create_threaded_kafka_producer`'s startup metadata fetch, so
-    /// tests stay fast and offline while still exercising the exact
-    /// `ThreadedProducer<ThreadedKafkaContext<WarningDelivery>>` type
-    /// `KafkaWarningEmitter` holds in production. `observe_delivery` is wired
-    /// as the callback, matching the production path.
+    /// through the same constructor production uses, so these tests exercise
+    /// the real construction path and not just the right type. It returns
+    /// without a broker round-trip, which is what keeps them fast and offline.
     fn unreachable_producer(
         message_timeout_ms: u32,
         linger_ms: u32,
     ) -> ThreadedProducer<ThreadedKafkaContext<WarningDelivery>> {
-        ClientConfig::new()
-            .set("bootstrap.servers", "192.0.2.1:9092")
-            .set("message.timeout.ms", message_timeout_ms.to_string())
-            .set("linger.ms", linger_ms.to_string())
-            .set("queue.buffering.max.messages", "10")
-            .set("retries", "0")
-            .create_with_context(ThreadedKafkaContext::new(AlwaysHealthy, observe_delivery))
+        let config = KafkaConfig {
+            kafka_hosts: "192.0.2.1:9092".to_string(),
+            kafka_message_timeout_ms: message_timeout_ms,
+            kafka_producer_linger_ms: linger_ms,
+            kafka_producer_queue_messages: 10,
+            kafka_producer_retries: Some(0),
+            ..Default::default()
+        };
+        create_threaded_kafka_producer_no_ping(&config, AlwaysHealthy, observe_delivery)
             .expect("client config is valid, so creation cannot fail without a broker round-trip")
     }
 

--- a/rust/common/kafka/src/kafka_producer.rs
+++ b/rust/common/kafka/src/kafka_producer.rs
@@ -239,7 +239,47 @@ impl<K: Send + Sync + 'static> ProducerContext for ThreadedKafkaContext<K> {
 /// the opt-in path for fire-and-forget producers that want delivery
 /// observability without a per-message task; existing `FutureProducer` callers
 /// are unaffected.
+///
+/// Pings the brokers before returning, so an unreachable cluster fails here
+/// rather than silently later. That costs up to 15s at startup and makes an
+/// unreachable cluster fatal to construction: appropriate when the producer
+/// carries data the service exists to deliver. Best-effort producers should
+/// use [`create_threaded_kafka_producer_no_ping`] instead.
 pub async fn create_threaded_kafka_producer<K, L, F>(
+    config: &KafkaConfig,
+    liveness: L,
+    on_delivery: F,
+) -> Result<ThreadedProducer<ThreadedKafkaContext<K>>, KafkaError>
+where
+    K: Send + Sync + 'static,
+    L: SyncLivenessReporter + Clone + 'static,
+    F: Fn(&DeliveryResult, K) + Send + Sync + 'static,
+{
+    let producer = create_threaded_kafka_producer_no_ping(config, liveness, on_delivery)?;
+
+    ping_brokers(&producer)?;
+
+    Ok(producer)
+}
+
+/// Same as [`create_threaded_kafka_producer`] but returns as soon as the client
+/// is built, with no startup broker ping.
+///
+/// librdkafka connects and fetches metadata lazily on its own refresh
+/// schedule, so a producer built this way recovers by itself once the cluster
+/// becomes reachable. The ping only converts that transient state into an
+/// immediate error, which is the wrong trade for a best-effort producer: a
+/// broker blip at boot would disable the feature for the process's whole life,
+/// and the 15s fetch runs while the caller is still assembling itself.
+///
+/// Because construction no longer proves the cluster is reachable, judge these
+/// producers by their delivery reports (see [`ThreadedKafkaContext`]) rather
+/// than by whether they were built.
+///
+/// Synchronous by design: there is nothing to await once the ping is gone, and
+/// callers building a producer outside an async context (including tests)
+/// shouldn't need a runtime for it.
+pub fn create_threaded_kafka_producer_no_ping<K, L, F>(
     config: &KafkaConfig,
     liveness: L,
     on_delivery: F,
@@ -251,12 +291,7 @@ where
 {
     let client_config = build_client_config(config);
     debug!("rdkafka configuration (threaded): {:?}", client_config);
-    let producer: ThreadedProducer<ThreadedKafkaContext<K>> =
-        client_config.create_with_context(ThreadedKafkaContext::new(liveness, on_delivery))?;
-
-    ping_brokers(&producer)?;
-
-    Ok(producer)
+    client_config.create_with_context(ThreadedKafkaContext::new(liveness, on_delivery))
 }
 
 #[derive(Error, Debug)]
@@ -493,11 +528,52 @@ mod tests {
 
     use lz4::Decoder;
 
+    use common_liveness::SyncLivenessReporter;
+    use rdkafka::producer::DeliveryResult;
+
     use super::{
-        build_client_config, compress_lz4_frame, maybe_compress_lz4_frame, EnvelopeEncoding,
+        build_client_config, compress_lz4_frame, create_threaded_kafka_producer_no_ping,
+        maybe_compress_lz4_frame, EnvelopeEncoding,
     };
     use crate::config::KafkaConfig;
     use crate::kafka_consumer::LZ4_FRAME_MAGIC;
+
+    #[derive(Clone, Copy)]
+    struct AlwaysHealthy;
+
+    impl SyncLivenessReporter for AlwaysHealthy {
+        fn report_healthy(&self) {}
+        fn report_unhealthy(&self) {}
+    }
+
+    /// The no-ping builder must return promptly against an unreachable cluster
+    /// (TEST-NET-1) instead of failing after the 15s metadata fetch its pinging
+    /// sibling performs. That is the whole reason best-effort producers use it,
+    /// and this is also what keeps it callable without a tokio runtime.
+    #[test]
+    fn no_ping_producer_builds_promptly_against_unreachable_broker() {
+        let config = KafkaConfig {
+            kafka_hosts: "192.0.2.1:9092".to_string(),
+            ..Default::default()
+        };
+
+        let start = std::time::Instant::now();
+        let producer = create_threaded_kafka_producer_no_ping(
+            &config,
+            AlwaysHealthy,
+            |_: &DeliveryResult, ()| {},
+        );
+        let elapsed = start.elapsed();
+
+        assert!(
+            producer.is_ok(),
+            "an unreachable cluster must not fail construction"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "took {elapsed:?}, so a broker round-trip is still happening"
+        );
+    }
 
     #[test]
     fn client_id_is_set_only_when_non_empty() {


### PR DESCRIPTION
## Problem

Capture's ingestion warnings emitter is best-effort by contract. Every runtime path in it fails open: a warning that can't be serialized, throttled, or enqueued is counted and dropped, and the caller's hot path is never blocked or failed.

Startup didn't follow that rule. The emitter is built with `create_threaded_kafka_producer`, which pings the brokers with a blocking 15s metadata fetch and treats failure as fatal to construction. Two consequences, both bad for a feature nobody should notice:

- A broker blip at the wrong moment returns `Err`, so the emitter is disabled for the pod's entire life, even after the cluster recovers. There's no self-healing and the only symptom is warning volume that's lower than a baseline nobody has.
- The fetch runs on capture's startup path. An unhealthy warnings cluster delays a process whose actual job has nothing to do with warnings.

Capture's main event sink already treats the identical condition as non-fatal, calling `fetch_metadata` and discarding the result with `is_ok()` so construction still succeeds. So the strict behavior on the warnings path was asymmetric rather than a decision, and it applied to the one producer whose payload is optional.

> [!NOTE]
> Worth flagging how the two startup failure modes stack up. Before [#75038](https://github.com/PostHog/posthog/pull/75038), an emitter that failed to build dropped its advisory lifecycle handle during normal operation, which triggered a global shutdown and turned this into a crash-loop. That PR stops the crash-loop. This one stops the far more likely quiet outcome, where the pod serves traffic happily with warnings silently off. They're independent fixes and neither depends on the other.

## Changes

Added `create_threaded_kafka_producer_no_ping` and pointed the emitter at it. librdkafka connects and refreshes metadata lazily on its own schedule, so a producer built this way starts working by itself once the cluster is reachable. The ping's only effect was to convert that transient state into a permanent one.

`create_threaded_kafka_producer` keeps its existing contract for callers whose payload is the reason the service exists. It now delegates to the no-ping builder and pings on top, so the two can't drift.

```diff
-    let producer = match create_threaded_kafka_producer(
+    let producer = match create_threaded_kafka_producer_no_ping(
         &warnings_kafka_config,
         handle.clone(),
         observe_delivery,
-    )
-    .await
-    {
+    ) {
```

The new builder is synchronous, because once the ping is gone there's nothing to await. That has a nice side effect. The emitter's tests used to hand-roll a `ClientConfig` against TEST-NET-1 specifically to dodge the 15s ping, which meant they exercised the correct producer *type* but not the real construction path, and their tuning could drift from production's. They now go through the same constructor capture does.

Since the emitter no longer proves its cluster is reachable at boot, I also fixed the docs on `INGESTION_WARNINGS_EMITTER_ENABLED`, which claimed the opposite. `1` now means the emitter exists, and whether warnings are landing is a delivery question: read the `delivered` and `delivery_failed` outcomes on `ingestion_warnings_total`. Alert on `min() == 0` for misconfiguration, and on a sustained `delivery_failed` rate for a broken destination.

One thing for reviewers to weigh: capture was the only caller of `create_threaded_kafka_producer`, so it now has none. I kept it rather than folding the ping into the one remaining shape, since the strict behavior is the right default for a producer carrying data a service exists to deliver, and `create_kafka_producer` still pings for its 14 `FutureProducer` callers. Happy to delete it instead if you'd rather not carry an uncalled path.

## How did you test this code?

Automated only. I have not run this against a real broker or a deployed pod, and the destination config it will use in production lands in a separate charts PR.

New test `no_ping_producer_builds_promptly_against_unreachable_broker` points a producer at TEST-NET-1 and asserts construction returns `Ok` in under 2s. It catches the regression of the ping coming back, whether directly or by someone re-pointing the emitter at the pinging constructor, which no existing test could see: the emitter's own tests bypassed the constructor entirely, so the 15s fatal fetch was untested in either direction. It returns in about 30ms.

Routing the emitter's `unreachable_producer` helper through the real constructor also means the 27 existing emitter tests now cover production construction rather than a look-alike.

Ran under flox: `cargo test -p common-kafka -p common-ingestion-warnings` (15 and 27 passed), `cargo test -p capture --lib` (1025 passed), `cargo clippy -p capture -p common-kafka -p common-ingestion-warnings --all-targets -- -D warnings`, and `cargo fmt --all --check`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Crate-level docs are updated in this PR. No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I drove this, Claude wrote it in Cursor. It came out of an audit of the warnings emitter against a simple rule I wanted to hold everywhere: a warning must never kill, block, or mute the service emitting it. Every runtime path already passed. Startup was the only violation, and it violated all three.

The fix went through a couple of shapes. Adding a `ping: bool` parameter would have touched every existing caller for no benefit, and relaxing `create_threaded_kafka_producer` itself would have quietly weakened the guarantee for any future caller who wants a hard failure. A separate entry point keeps the strict path strict and makes the choice explicit at each call site.

Making it synchronous wasn't the original plan. It fell out of wanting the emitter's tests to use the real constructor, since those are plain `#[test]` functions with no runtime, and it turned out to be correct on its own terms because the async version never awaited anything.

No skills applied to this one.
