### PR TITLE
fix(data-warehouse): don't repartition finer on OOM history when partitions are tiny

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition_controller.py
@@ -46,6 +46,13 @@ REPARTITION_COOLDOWN_SECONDS = 24 * 60 * 60
 # doesn't re-attempt the rewrite on every sync forever.
 MAX_REPARTITION_ATTEMPTS = 3
 
+# Worst-case assumed ratio between a partition's in-memory working set and its compressed at-rest
+# size — the amplification that justifies the oom_history trigger at all. When even this generous
+# multiple of the largest partition fits the budget, partition size can't be what's killing the
+# worker (heartbeat timeouts also come from slow merges, deploys, and pod churn), so repartitioning
+# finer can't help.
+OOM_WORKING_SET_AMPLIFICATION = 100
+
 
 def target_partition_bytes() -> int:
     return int(getattr(settings, "DATA_WAREHOUSE_TARGET_PARTITION_BYTES", 500_000_000))
@@ -196,6 +203,22 @@ async def maybe_flag_for_repartition(
                 budget_bytes=budget,
                 recent_oom_count=oom_count,
                 partition_count=len(partition_bytes),
+            )
+            return
+
+        # A tiny largest partition can't be the OOM cause: without this guard, oom_history drives the
+        # scheme finer tier by tier until it bottoms out (e.g. datetime at hour) and then emits a
+        # skipped event + exception on every cooldown expiry forever — while the extra partitions
+        # multiply per-partition merge commits, slowing the sync that produced the timeouts.
+        if not over_budget and max_bytes * OOM_WORKING_SET_AMPLIFICATION < budget:
+            await logger.adebug(
+                f"repartition: OOM history present but largest partition is far under budget, "
+                f"partitioning is not the cause — leaving layout alone schema_id={schema.id} "
+                f"max_partition_bytes={max_bytes} budget_bytes={budget} recent_oom_count={oom_count}",
+                schema_id=str(schema.id),
+                max_partition_bytes=max_bytes,
+                budget_bytes=budget,
+                recent_oom_count=oom_count,
             )
             return
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
@@ -248,7 +248,9 @@ class TestRepartitionOOMHistoryTrigger:
         with tempfile.TemporaryDirectory() as d:
             delta = _write_partitioned_delta(f"{d}/t", ["0", "1"])
             with (
-                patch.object(ctrl, "target_partition_bytes", return_value=10**12),  # well within the size budget
+                # Within the size budget, but close enough that the amplified working set exceeds it —
+                # a bigger budget would (correctly) hit the tiny-partition guard instead.
+                patch.object(ctrl, "target_partition_bytes", return_value=10_000),
                 patch.object(ctrl, "repartition_oom_threshold", return_value=3),
                 patch.object(ctrl, "is_auto_repartition_enabled", return_value=True),
                 patch.object(ctrl, "capture_repartition_event"),
@@ -284,7 +286,8 @@ class TestRepartitionOOMHistoryTrigger:
         with tempfile.TemporaryDirectory() as d:
             delta = _write_partitioned_delta(f"{d}/t", ["0", "1"])
             with (
-                patch.object(ctrl, "target_partition_bytes", return_value=10**12),
+                # Small enough that the tiny-partition guard doesn't mask the revive guard under test.
+                patch.object(ctrl, "target_partition_bytes", return_value=10_000),
                 patch.object(ctrl, "repartition_oom_threshold", return_value=3),
                 patch.object(ctrl, "is_auto_repartition_enabled", return_value=True),
                 patch.object(ctrl, "capture_repartition_event"),
@@ -293,6 +296,35 @@ class TestRepartitionOOMHistoryTrigger:
 
         schema.refresh_from_db()
         assert schema.repartition_pending is None
+
+    def test_tiny_partitions_do_not_flag_on_oom_history(self, team):
+        # deals/contacts loop from prod: heartbeat timeouts recorded as OOMs on a table whose largest
+        # partition is KBs against a 500 MB budget. Without the amplification guard the trigger steps
+        # the scheme finer until it bottoms out at hour, then emits skipped + capture_exception daily
+        # forever. The guard must be a quiet no-op: nothing pending, no events at all.
+        schema = _make_schema(
+            team,
+            {"partitioning_enabled": True, "partition_mode": "md5", "partition_count": 2, "partitioning_keys": ["id"]},
+        )
+        for _ in range(3):
+            ExternalDataSchemaOOMEvent.objects.for_team(schema.team_id).create(team_id=schema.team_id, schema=schema)
+
+        with tempfile.TemporaryDirectory() as d:
+            delta = _write_partitioned_delta(f"{d}/t", ["0", "1"])
+            with (
+                patch.object(
+                    ctrl, "target_partition_bytes", return_value=10**12
+                ),  # partitions orders of magnitude under
+                patch.object(ctrl, "repartition_oom_threshold", return_value=3),
+                patch.object(ctrl, "is_auto_repartition_enabled", return_value=True),
+                patch.object(ctrl, "capture_repartition_event") as capture,
+            ):
+                self._detect(team, schema, delta)
+
+        schema.refresh_from_db()
+        assert schema.repartition_pending is None
+        assert schema.max_partition_bytes is not None  # observability measurement still recorded
+        assert capture.call_args_list == []
 
 
 # An Exception-derived cancellation, named exactly `CancelledError`: models how `async_to_sync` can


### PR DESCRIPTION
## Problem

The auto-repartition controller's `oom_history` trigger treats heartbeat timeouts as OOM signals. On tables whose largest partition is tiny (KBs against a 500 MB budget), partition size cannot be what is killing the worker, yet the trigger still steps the datetime scheme finer one tier per cooldown until it bottoms out at `hour`. From there the controller emits a `warehouse_repartition_skipped` event plus a `capture_exception` on every cooldown expiry, forever. Worse, the extra partitions multiply the per-partition merge commits, slowing the very syncs whose slowness produced the heartbeat timeouts in the first place. Seen in production on an incremental HubSpot source (support ticket, internal: https://us.posthog.com/project/2/support/tickets/62976).

## Changes

`maybe_flag_for_repartition` now refuses to flag on the `oom_history` path when even a generous working-set amplification (100x) of the largest measured partition still fits the budget. In that case the OOM signal can't be caused by partition size, so going finer can't help. The guard is a quiet no-op before any event, alert, or cooldown stamp; the `max_partition_bytes` observability measurement is still recorded. The `proactive_threshold` (genuinely over budget) path is unchanged.

The guard lives in the controller rather than `select_repartition_target` because that's where both the measured max partition size and the real (un-halved) budget are in scope.

## How did you test this code?

Ran `products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py` locally - 29 passed.

- Added `test_tiny_partitions_do_not_flag_on_oom_history`: catches removal of the guard - a KB-scale table with 3 recorded OOMs must stay unflagged with zero telemetry events. No existing test covered the tiny-partition OOM path.
- Adjusted the two existing OOM-path tests from a `10**12` budget to `10_000` so their fixtures (KB-scale delta tables) sit within budget but above the amplification floor, keeping them exercising the paths they were written for.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - internal controller behavior, no user-facing or documented workflow change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Fable) directed by Daniel. Investigation traced a production repartition feedback loop: heartbeat timeouts recorded as OOM events drove a within-budget table to hour partitioning, after which incremental merges (one Delta merge commit per touched partition) slowed enough to cause more heartbeat timeouts. Considered placing the guard inside `select_repartition_target` as originally scoped, but it only receives the pre-halved split budget and importing the real budget there would be circular, so the guard sits in the controller. Skills invoked: /writing-tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
