### PR TITLE
fix(google_pagespeed_insights): keep transport timeouts out of tracked error noise

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/source.py
@@ -111,7 +111,15 @@ Each analysis is a full Lighthouse run and can take several seconds. Each URL is
         # tenacity-wrapped `_fetch`); if those retries still exhaust, the failure is transient and
         # self-recovering, so let Temporal retry the activity without surfacing it as tracked
         # exception noise.
-        return {"PageSpeed Insights API error (retryable)"}
+        return {
+            "PageSpeed Insights API error (retryable)",
+            # Transport-level failures (read timeouts, connection resets/SSL) are retried the same way
+            # by `_fetch`; once exhausted they re-raise as a urllib3 `HTTPSConnectionPool(...)` message.
+            # Same self-recovering class as the 429/5xx path — keep them retryable and out of tracked
+            # noise. Scoped to the fixed API host so it can only match a transient connection failure to
+            # PageSpeed, never the `... Client Error ... for url` shape the auth 400/403s carry.
+            "HTTPSConnectionPool(host='pagespeedonline.googleapis.com'",
+        }
 
     def get_schemas(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/tests/test_google_pagespeed_insights_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_pagespeed_insights/tests/test_google_pagespeed_insights_source.py
@@ -114,6 +114,21 @@ class TestGooglePageSpeedInsightsSource:
         retryable_errors = self.source.get_retryable_errors()
         assert any(pattern in error_message for pattern in retryable_errors)
 
+    def test_transport_timeout_is_retryable_not_terminal(self):
+        # A read timeout / connection reset to the API host exhausts `_fetch`'s internal retries and
+        # re-raises as a urllib3 `HTTPSConnectionPool(...)` message (key already redacted). It is
+        # transient and self-recovering, so it must classify as retryable and never match the
+        # auth-failure patterns that would permanently stop the sync.
+        error_message = (
+            "HTTPSConnectionPool(host='pagespeedonline.googleapis.com', port=443): Max retries exceeded "
+            "with url: /pagespeedonline/v5/runPagespeed?url=https%3A%2F%2Fexample.com&strategy=DESKTOP&key=REDACTED "
+            "(Caused by ReadTimeoutError(\"HTTPSConnectionPool(host='pagespeedonline.googleapis.com', port=443): "
+            'Read timed out. (read timeout=120)"))'
+        )
+
+        assert any(pattern in error_message for pattern in self.source.get_retryable_errors())
+        assert not any(pattern in error_message for pattern in self.source.get_non_retryable_errors())
+
     def test_documented_tables_render_without_credentials(self):
         # Exercises the public-docs path: a credential-free placeholder config must list every table.
         tables = self.source.get_documented_tables()


### PR DESCRIPTION
## Problem

Error tracking is receiving `ConnectionError` exceptions from the `google_pagespeed_insights` data-warehouse source. The message is a urllib3 read timeout to the PageSpeed API host:

```
HTTPSConnectionPool(host='pagespeedonline.googleapis.com', port=443): Max retries exceeded
with url: /pagespeedonline/v5/runPagespeed?...&key=REDACTED (Caused by ReadTimeoutError(
"HTTPSConnectionPool(host='pagespeedonline.googleapis.com', port=443): Read timed out. (read timeout=120)"))
```

A PageSpeed run is a full Lighthouse analysis that takes several seconds, so read timeouts to the API are expected background noise. This is a transient, self-recovering failure. It is already retried twice - by `_fetch`'s tenacity loop, then by Temporal once those exhaust - and it should stay retryable. The only problem is that it lands in error tracking as a tracked exception and fires alert webhooks.

The source already has this exact suppression for its 429/5xx path via `get_retryable_errors`: those are logged as warnings and retried by Temporal without being reported. Transport-level timeouts are the same class of failure but were missing from that set, so they leaked through as noise.

## Changes

Add the transport-failure message to `get_retryable_errors` in the source, alongside the existing 429/5xx entry. It is scoped to the fixed API host (`HTTPSConnectionPool(host='pagespeedonline.googleapis.com'`) so it can only match a transient connection failure to PageSpeed, never the `... Client Error ... for url` shape the auth 400/403s carry (those stay non-retryable and permanently stop the sync).

This does not change retry policy. The error stays retryable at every layer. It just stops being logged as an exception and reported to error tracking.

> [!NOTE]
> No new errors are swallowed. Only transport-level connection failures to the PageSpeed host, which are already retried, move from `exception` to `warning` logging.

## How did you test this code?

Added `test_transport_timeout_is_retryable_not_terminal` to the source tests. It asserts the observed (redacted) read-timeout message matches `get_retryable_errors` and does not match any `get_non_retryable_errors` pattern. This guards against the pattern being dropped or colliding with the auth-failure matching. No existing test covered transport-level retryable classification - the prior `test_retryable_errors_match_exhausted_backoff` only exercises the 429/5xx `(retryable)` tag.

Ran the source's full test suite locally (87 passed) plus ruff check and format-check on the two changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the `google_pagespeed_insights` source. I (Claude) confirmed the issue originates in `_fetch` (the frame that re-raises the redacted transport error), traced how `get_retryable_errors` / `get_non_retryable_errors` are consumed in `import_data_sync.py`, and classified the failure as transient infrastructure - neither a user/upstream error nor a code bug. Per the source's own design intent (the existing `get_retryable_errors` comment about keeping self-recovering failures out of tracked noise), the fix extends that set rather than touching retry policy or adding to `NonRetryableErrors`.

I considered instead wrapping the transport error inside `_fetch` as a tagged retryable exception, but rejected it: that path is deliberately tested to preserve the original exception type and key redaction, and a source-level classification is smaller and more consistent with how other sources match connection failures.

Skills invoked: `/writing-tests`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
