### PR TITLE
feat(data-catalog): manage warehouse joins from the relationships tab

### DIFF
--- a/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/viewLinkLogic.tsx
@@ -672,8 +672,14 @@ export const viewLinkLogic = kea<viewLinkLogicType>([
             },
         ],
     }),
-    subscriptions(({ actions }) => ({
+    subscriptions(({ actions, values }) => ({
         isJoinTableModalOpen: (isOpen) => {
+            if (isOpen && values.allTables.length === 0) {
+                // Not every surface that opens this modal mounts a logic that loads the
+                // database schema (the data catalog doesn't); without it the table and
+                // key pickers render empty.
+                actions.loadDatabase()
+            }
             if (!isOpen) {
                 actions.clearModalFields()
                 actions.resetViewLink()

--- a/products/data_catalog/frontend/relationshipsLogic.test.ts
+++ b/products/data_catalog/frontend/relationshipsLogic.test.ts
@@ -1,8 +1,11 @@
 import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { viewLinkLogic } from 'scenes/data-warehouse/viewLinkLogic'
 
 import { initKeaTests } from '~/test/init'
 import { expectLogic } from '~/test/keaTestUtils'
+import { DataWarehouseViewLink } from '~/types'
 
 import {
     dataCatalogRelationshipProposalsAcceptCreate,
@@ -38,6 +41,10 @@ jest.mock('./generated/api', () => ({
     dataCatalogRelationshipProposalsList: jest.fn(),
     dataCatalogRelationshipProposalsAcceptCreate: jest.fn(),
     dataCatalogRelationshipProposalsRejectCreate: jest.fn(),
+}))
+
+jest.mock('lib/utils/deleteWithUndo', () => ({
+    deleteWithUndo: jest.fn().mockResolvedValue(undefined),
 }))
 
 function buildProposal(overrides: Partial<DataCatalogRelationshipProposalApi>): DataCatalogRelationshipProposalApi {
@@ -124,8 +131,42 @@ describe('relationshipsLogic', () => {
         const manual = rows.find((row) => row.key === 'join-join-2')
         expect(manual?.viaCatalog).toEqual(false)
         expect(manual?.rowStatus).toEqual('active')
+        expect(manual?.joinId).toEqual('join-2')
 
-        expect(rows.find((row) => row.proposalId === 'pending')?.rowStatus).toEqual('pending')
+        const pending = rows.find((row) => row.proposalId === 'pending')
+        expect(pending?.rowStatus).toEqual('pending')
+        expect(pending?.joinId).toBeNull()
+    })
+
+    it('reloads joins when the shared join modal saves', async () => {
+        await mountWith([], [])
+        ;(api.dataWarehouseViewLinks.list as jest.Mock).mockClear()
+
+        viewLinkLogic.build().actions.submitViewLinkSuccess({} as any)
+
+        await expectLogic(logic).toDispatchActions(['loadJoins', 'loadJoinsSuccess'])
+        expect(api.dataWarehouseViewLinks.list).toHaveBeenCalledTimes(1)
+    })
+
+    it('deletes a join against the singular view-link endpoint and reloads', async () => {
+        await mountWith([], [{ id: 'join-1', source_table_name: 'events' }])
+
+        logic.actions.deleteJoin({
+            id: 'join-1',
+            field_name: 'person',
+            source_table_name: 'events',
+        } as DataWarehouseViewLink)
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(deleteWithUndo).toHaveBeenCalledWith(
+            expect.objectContaining({
+                endpoint: 'environments/1/warehouse_view_link',
+                object: expect.objectContaining({ id: 'join-1' }),
+            })
+        )
+        ;(api.dataWarehouseViewLinks.list as jest.Mock).mockClear()
+        ;(deleteWithUndo as jest.Mock).mock.calls[0][0].callback()
+        await expectLogic(logic).toDispatchActions(['loadJoins', 'loadJoinsSuccess'])
     })
 
     it('passes the rejection reason through when rejecting', async () => {

--- a/products/data_catalog/frontend/relationshipsLogic.tsx
+++ b/products/data_catalog/frontend/relationshipsLogic.tsx
@@ -215,8 +215,6 @@ export const relationshipsLogic = kea<relationshipsLogicType>([
                     .filter((proposal) => proposal.status === 'accepted' && proposal.created_join)
                     .forEach((proposal) => acceptedByJoinId.set(proposal.created_join as string, proposal))
 
-                const joinIds = new Set(joins.map((join) => join.id))
-
                 const joinRows: RelationshipRow[] = joins.map((join) => {
                     const proposal = acceptedByJoinId.get(join.id)
                     return {
@@ -238,14 +236,12 @@ export const relationshipsLogic = kea<relationshipsLogicType>([
                     }
                 })
 
-                // Accepted proposals whose created join isn't in the loaded joins (null, soft-deleted,
-                // or beyond the paginated response) would otherwise vanish — surface them as active rows.
+                // An accepted proposal that never persisted a join would otherwise vanish — surface it
+                // as an active row. A proposal whose created join is absent from the loaded joins was
+                // deleted (soft delete drops it from the list), and the backend treats it as gone, so
+                // it must not reappear as an uneditable active row.
                 const orphanedAcceptedRows: RelationshipRow[] = proposals
-                    .filter(
-                        (proposal) =>
-                            proposal.status === 'accepted' &&
-                            !(proposal.created_join && joinIds.has(proposal.created_join))
-                    )
+                    .filter((proposal) => proposal.status === 'accepted' && !proposal.created_join)
                     .map((proposal) => ({
                         key: `proposal-${proposal.id}`,
                         sourceTableName: proposal.source_table_name,
@@ -335,15 +331,11 @@ export const relationshipsLogic = kea<relationshipsLogicType>([
             }
         },
         deleteJoin: async ({ join }) => {
-            try {
-                await deleteWithUndo({
-                    endpoint: `environments/${projectId()}/warehouse_view_link`,
-                    object: { id: join.id, name: `${join.field_name} on ${join.source_table_name}` },
-                    callback: () => actions.loadJoins(),
-                })
-            } catch (error) {
-                lemonToast.error(apiErrorDetail(error) || 'Could not delete the join. Try again.')
-            }
+            await deleteWithUndo({
+                endpoint: `environments/${projectId()}/warehouse_view_link`,
+                object: { id: join.id, name: `${join.field_name} on ${join.source_table_name}` },
+                callback: () => actions.loadJoins(),
+            })
         },
         // Refresh after the shared join modal saves. Referencing actionTypes builds
         // viewLinkLogic without mounting it, so the catalog scene doesn't eagerly load

--- a/products/data_catalog/frontend/relationshipsLogic.tsx
+++ b/products/data_catalog/frontend/relationshipsLogic.tsx
@@ -4,6 +4,8 @@ import { urlToAction } from 'kea-router'
 
 import api, { ApiConfig, ApiError } from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { viewLinkLogic } from 'scenes/data-warehouse/viewLinkLogic'
 import { urls } from 'scenes/urls'
 
 import { DataWarehouseViewLink } from '~/types'
@@ -33,6 +35,7 @@ export interface RelationshipRow {
     reviewedBy: string | null
     viaCatalog: boolean
     proposalId: string | null
+    joinId: string | null
 }
 
 function projectId(): string {
@@ -48,6 +51,7 @@ export interface relationshipsLogicValues {
     actionsInFlight: Record<string, boolean>
     filteredRows: RelationshipRow[]
     joins: DataWarehouseViewLink[]
+    joinsById: Record<string, DataWarehouseViewLink>
     joinsLoading: boolean
     pendingCount: number
     pendingCountLoading: boolean
@@ -61,6 +65,9 @@ export interface relationshipsLogicValues {
 export interface relationshipsLogicActions {
     acceptProposal: (id: string) => {
         id: string
+    }
+    deleteJoin: (join: DataWarehouseViewLink) => {
+        join: DataWarehouseViewLink
     }
     loadJoins: () => any
     loadJoinsFailure: (
@@ -131,6 +138,7 @@ export interface relationshipsLogicMeta {
     __keaTypeGenInternalSelectorTypes: {
         rows: (proposals: DataCatalogRelationshipProposalApi[], joins: DataWarehouseViewLink[]) => RelationshipRow[]
         filteredRows: (rows: RelationshipRow[], statusFilter: RelationshipStatusFilter) => RelationshipRow[]
+        joinsById: (joins: DataWarehouseViewLink[]) => Record<string, DataWarehouseViewLink>
     }
 }
 
@@ -148,6 +156,7 @@ export const relationshipsLogic = kea<relationshipsLogicType>([
         acceptProposal: (id: string) => ({ id }),
         rejectProposal: (id: string, rejectionReason: string) => ({ id, rejectionReason }),
         setActionInFlight: (id: string, inFlight: boolean) => ({ id, inFlight }),
+        deleteJoin: (join: DataWarehouseViewLink) => ({ join }),
     }),
     loaders(() => ({
         // Badge count only — never pull the full proposal payloads (unbounded reasoning/evidence)
@@ -225,6 +234,7 @@ export const relationshipsLogic = kea<relationshipsLogicType>([
                         reviewedBy: proposal?.reviewed_by?.email ?? null,
                         viaCatalog: !!proposal,
                         proposalId: null,
+                        joinId: join.id,
                     }
                 })
 
@@ -251,6 +261,7 @@ export const relationshipsLogic = kea<relationshipsLogicType>([
                         reviewedBy: proposal.reviewed_by?.email ?? null,
                         viaCatalog: true,
                         proposalId: proposal.id,
+                        joinId: null,
                     }))
 
                 const proposalRows: RelationshipRow[] = proposals
@@ -270,6 +281,7 @@ export const relationshipsLogic = kea<relationshipsLogicType>([
                         reviewedBy: proposal.reviewed_by?.email ?? null,
                         viaCatalog: false,
                         proposalId: proposal.id,
+                        joinId: null,
                     }))
 
                 return [...joinRows, ...orphanedAcceptedRows, ...proposalRows]
@@ -279,6 +291,11 @@ export const relationshipsLogic = kea<relationshipsLogicType>([
             (s) => [s.rows, s.statusFilter],
             (rows: RelationshipRow[], statusFilter: RelationshipStatusFilter) =>
                 statusFilter === 'all' ? rows : rows.filter((row) => row.rowStatus === statusFilter),
+        ],
+        joinsById: [
+            (s) => [s.joins],
+            (joins: DataWarehouseViewLink[]): Record<string, DataWarehouseViewLink> =>
+                Object.fromEntries(joins.map((join) => [join.id, join])),
         ],
     }),
     listeners(({ values, actions }) => ({
@@ -316,6 +333,23 @@ export const relationshipsLogic = kea<relationshipsLogicType>([
             } finally {
                 actions.setActionInFlight(id, false)
             }
+        },
+        deleteJoin: async ({ join }) => {
+            try {
+                await deleteWithUndo({
+                    endpoint: `environments/${projectId()}/warehouse_view_link`,
+                    object: { id: join.id, name: `${join.field_name} on ${join.source_table_name}` },
+                    callback: () => actions.loadJoins(),
+                })
+            } catch (error) {
+                lemonToast.error(apiErrorDetail(error) || 'Could not delete the join. Try again.')
+            }
+        },
+        // Refresh after the shared join modal saves. Referencing actionTypes builds
+        // viewLinkLogic without mounting it, so the catalog scene doesn't eagerly load
+        // the database schema; the modal in RelationshipsTab mounts it when visible.
+        [viewLinkLogic.actionTypes.submitViewLinkSuccess]: () => {
+            actions.loadJoins()
         },
     })),
     urlToAction(({ actions }) => ({

--- a/products/data_catalog/frontend/tabs/RelationshipsTab.tsx
+++ b/products/data_catalog/frontend/tabs/RelationshipsTab.tsx
@@ -1,15 +1,18 @@
 import { useActions, useValues } from 'kea'
 
-import { IconRefresh } from '@posthog/icons'
+import { IconPlus, IconRefresh } from '@posthog/icons'
 import { LemonButton, LemonDialog } from '@posthog/lemon-ui'
 
 import { CodeSnippet, Language } from 'lib/components/CodeSnippet/CodeSnippet'
+import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonSegmentedButton } from 'lib/lemon-ui/LemonSegmentedButton'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { viewLinkLogic } from 'scenes/data-warehouse/viewLinkLogic'
+import { ViewLinkModal } from 'scenes/data-warehouse/ViewLinkModal'
 
 import { RelationshipRow, RelationshipStatusFilter, relationshipsLogic } from '../relationshipsLogic'
 
@@ -40,9 +43,11 @@ function TableRefCell({ table, refKey }: { table: string; refKey: string }): JSX
 }
 
 export function RelationshipsTab(): JSX.Element {
-    const { filteredRows, proposalsLoading, joinsLoading, statusFilter, actionsInFlight } =
+    const { filteredRows, proposalsLoading, joinsLoading, statusFilter, actionsInFlight, joinsById } =
         useValues(relationshipsLogic)
-    const { setStatusFilter, acceptProposal, rejectProposal, loadProposals, loadJoins } = useActions(relationshipsLogic)
+    const { setStatusFilter, acceptProposal, rejectProposal, loadProposals, loadJoins, deleteJoin } =
+        useActions(relationshipsLogic)
+    const { toggleNewJoinModal, toggleEditJoinModal } = useActions(viewLinkLogic)
 
     const confirmReject = (row: RelationshipRow): void => {
         if (!row.proposalId) {
@@ -105,6 +110,23 @@ export function RelationshipsTab(): JSX.Element {
             key: 'actions',
             width: 0,
             render: (_, row) => {
+                const join = row.joinId ? joinsById[row.joinId] : null
+                if (row.rowStatus === 'active' && join) {
+                    return (
+                        <More
+                            overlay={
+                                <>
+                                    <LemonButton fullWidth onClick={() => toggleEditJoinModal(join)}>
+                                        Edit
+                                    </LemonButton>
+                                    <LemonButton status="danger" fullWidth onClick={() => deleteJoin(join)}>
+                                        Delete
+                                    </LemonButton>
+                                </>
+                            }
+                        />
+                    )
+                }
                 if (row.rowStatus !== 'pending' || !row.proposalId) {
                     return null
                 }
@@ -143,18 +165,29 @@ export function RelationshipsTab(): JSX.Element {
                     options={STATUS_FILTER_OPTIONS}
                     size="small"
                 />
-                <LemonButton
-                    type="secondary"
-                    icon={<IconRefresh />}
-                    size="small"
-                    loading={proposalsLoading || joinsLoading}
-                    onClick={() => {
-                        loadProposals()
-                        loadJoins()
-                    }}
-                >
-                    Reload
-                </LemonButton>
+                <div className="flex gap-2">
+                    <LemonButton
+                        type="secondary"
+                        icon={<IconRefresh />}
+                        size="small"
+                        loading={proposalsLoading || joinsLoading}
+                        onClick={() => {
+                            loadProposals()
+                            loadJoins()
+                        }}
+                    >
+                        Reload
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        icon={<IconPlus />}
+                        size="small"
+                        data-attr="data-catalog-new-join"
+                        onClick={() => toggleNewJoinModal()}
+                    >
+                        New join
+                    </LemonButton>
+                </div>
             </div>
             <LemonTable
                 data-attr="data-catalog-relationships-table"
@@ -170,6 +203,7 @@ export function RelationshipsTab(): JSX.Element {
                     expandedRowRender: (row) => <RelationshipDetail row={row} />,
                 }}
             />
+            <ViewLinkModal />
         </div>
     )
 }


### PR DESCRIPTION
## Problem

The data catalog's Relationships tab already lists every warehouse join (merged with AI-proposed relationships), but it's read-only for joins.
To create, edit, or delete a join you have to leave the catalog and go to the SQL editor or database settings, even though the catalog is exactly where you're looking at the relationship model.

## Changes

Makes the Relationships tab a full join-management surface by reusing the existing shared join editor (`ViewLinkModal` + `viewLinkLogic`, already used by the SQL editor, database tree, database settings, and revenue analytics):

- A "New join" button in the tab toolbar opens the shared modal.
- Active rows backed by a real `DataWarehouseJoin` get a more-menu with Edit (opens the modal prefilled) and Delete (`deleteWithUndo`, same pattern as database settings).
- The tab refreshes automatically when the shared modal saves, via a listener on the modal logic's submit-success action. The listener references the action type without `connect`ing, so the catalog scene doesn't eagerly mount the database schema load on unrelated tabs.
- Proposal-only rows (pending/rejected/orphaned-accepted) are unchanged and get no join actions.

Deliberate design choice: joins created by a human here do not go through the propose/accept review flow. That flow exists to review AI-generated proposals, so manual creation goes straight to `dataWarehouseViewLinks` like every other surface.

Known edge case (accepted): manually creating a join for a pair that has a pending proposal shows both an active row and a pending row. Accepting the proposal later reuses the exact-match join, so nothing breaks. Auto-resolving the pending proposal is a possible follow-up.

## How did you test this code?

- Extended `relationshipsLogic.test.ts` (all 6 tests pass):
  - `joinId` present on join-backed rows and null on proposal rows - catches the edit/delete menu breaking or appearing on rows with no live join.
  - Shared modal save triggers a join reload - guards this cross-logic wiring against the planned `viewLinkLogic` refactor in a follow-up PR.
  - Delete hits the singular `warehouse_view_link` endpoint and reloads - catches the easy singular/plural endpoint typo.
- `pnpm --filter=@posthog/frontend typescript:check`: no errors in touched files (remaining errors are the known local-typegen noise in unrelated products).
- I (Claude) was not able to verify this in a browser yet: the local dev stack is currently serving a different worktree. Manual QA of the flow (create/edit/delete from the tab) is still pending.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs cover the Relationships tab actions yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Fable 5). Skills invoked: `/writing-user-facing-copy` (button/menu labels) and `/writing-tests` (test value gate).
This is PR 1 of a planned Graphite stack; later PRs revamp the shared join modal itself (typed validate response with match-rate stats, single consolidated form with debounced auto-validation, searchable table pickers).
Considered routing manual creation through the catalog's relationship-proposal accept flow and rejected it: that flow is a review step for AI proposals, and a human creating a join is already the review.
