### PR TITLE
fix(experiments): prevent reviving forced failed runs

### DIFF
--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -216,11 +216,21 @@ def _update_recalculation_progress_sync(update: RecalculationProgressUpdate) -> 
             if won:
                 return proposed_query_to.isoformat()
 
-            existing_query_to = (
+            existing = (
                 ExperimentMetricsRecalculation.objects.filter(id=update.recalculation_id)
-                .values_list("query_to", flat=True)
+                .values_list("query_to", "status")
                 .first()
             )
+
+            if existing is None:
+                return None
+
+            existing_query_to, existing_status = existing
+            if existing_status not in (
+                ExperimentMetricsRecalculation.Status.PENDING,
+                ExperimentMetricsRecalculation.Status.IN_PROGRESS,
+            ):
+                return None
 
             return existing_query_to.isoformat() if existing_query_to is not None else None
 

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -223,6 +223,7 @@ def _update_recalculation_progress_sync(update: RecalculationProgressUpdate) -> 
             )
 
             if existing is None:
+                logger.warning("mark_started_rejected_row_missing", recalculation_id=update.recalculation_id)
                 return None
 
             existing_query_to, existing_status = existing
@@ -230,6 +231,11 @@ def _update_recalculation_progress_sync(update: RecalculationProgressUpdate) -> 
                 ExperimentMetricsRecalculation.Status.PENDING,
                 ExperimentMetricsRecalculation.Status.IN_PROGRESS,
             ):
+                logger.warning(
+                    "mark_started_rejected_run_terminal",
+                    recalculation_id=update.recalculation_id,
+                    status=existing_status,
+                )
                 return None
 
             return existing_query_to.isoformat() if existing_query_to is not None else None

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -197,7 +197,12 @@ def _update_recalculation_progress_sync(update: RecalculationProgressUpdate) -> 
 
             won = (
                 ExperimentMetricsRecalculation.objects.filter(
-                    id=update.recalculation_id, query_to__isnull=True, completed_at__isnull=True
+                    id=update.recalculation_id,
+                    query_to__isnull=True,
+                    status__in=[
+                        ExperimentMetricsRecalculation.Status.PENDING,
+                        ExperimentMetricsRecalculation.Status.IN_PROGRESS,
+                    ],
                 ).update(
                     query_to=proposed_query_to,
                     started_at=timezone.now(),

--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -192,14 +192,13 @@ def _update_recalculation_progress_sync(update: RecalculationProgressUpdate) -> 
         # Temporal retry of this activity can't move query_to forward (which would orphan any rows persisted by
         # calc activities still in flight from the prior attempt).
         if update.mark_started:
-            # query_to is the run's data-window end, not bare "now": for a stopped experiment
-            # experiment_window_end resolves it to end_date (a fixed value), so repeated recalcs reuse the
-            # same (fingerprint, query_to)-keyed result row instead of appending a redundant post-end
-            # timeseries point on every run. A running experiment still advances with now.
             experiment = Experiment.objects.get(id=state.experiment_id)
             proposed_query_to = experiment_window_end(experiment, timezone.now())
+
             won = (
-                ExperimentMetricsRecalculation.objects.filter(id=update.recalculation_id, query_to__isnull=True).update(
+                ExperimentMetricsRecalculation.objects.filter(
+                    id=update.recalculation_id, query_to__isnull=True, completed_at__isnull=True
+                ).update(
                     query_to=proposed_query_to,
                     started_at=timezone.now(),
                     status=update.status or ExperimentMetricsRecalculation.Status.IN_PROGRESS,
@@ -208,13 +207,16 @@ def _update_recalculation_progress_sync(update: RecalculationProgressUpdate) -> 
                 )
                 == 1
             )
+
             if won:
                 return proposed_query_to.isoformat()
+
             existing_query_to = (
                 ExperimentMetricsRecalculation.objects.filter(id=update.recalculation_id)
                 .values_list("query_to", flat=True)
                 .first()
             )
+
             return existing_query_to.isoformat() if existing_query_to is not None else None
 
         # Finish: same first-write-wins guard so a retried mark_completed activity doesn't re-stamp the

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -239,6 +239,7 @@ class TestRecalculationActivities(BaseTest):
             ("sweep_leaves_completed_at_null", False),
         ]
     )
+    @freeze_time("2026-06-23T05:00:00Z")
     def test_mark_started_does_not_revive_a_force_failed_run(self, name: str, set_completed_at: bool):
         recalc = self._recalc(self._experiment(flag_key=f"progress-start-force-failed-{name}"))
         completed_at = timezone.now() if set_completed_at else None
@@ -266,6 +267,7 @@ class TestRecalculationActivities(BaseTest):
         # fails the run non-retryably instead of proceeding to calc activities on a dead run.
         assert returned is None
 
+    @freeze_time("2026-06-23T05:00:00Z")
     def test_mark_started_returns_none_when_force_failed_after_query_to_pinned(self):
         # mark_started ran first and pinned query_to (run went IN_PROGRESS), then an admin force-failed it.
         # A retried mark_started loses the guard, but the read-back must NOT hand back the pinned query_to as a

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -266,6 +266,36 @@ class TestRecalculationActivities(BaseTest):
         # fails the run non-retryably instead of proceeding to calc activities on a dead run.
         assert returned is None
 
+    def test_mark_started_returns_none_when_force_failed_after_query_to_pinned(self):
+        # mark_started ran first and pinned query_to (run went IN_PROGRESS), then an admin force-failed it.
+        # A retried mark_started loses the guard, but the read-back must NOT hand back the pinned query_to as a
+        # string: that would pass the workflow's isinstance(str) check and let calc activities run ClickHouse
+        # queries and persist results for a terminal, superseded run (they don't re-check terminal status).
+        recalc = self._recalc(self._experiment(flag_key="progress-start-pinned-then-failed"))
+        pinned_query_to = timezone.now()
+        ExperimentMetricsRecalculation.objects.filter(id=recalc.id).update(
+            status=ExperimentMetricsRecalculation.Status.FAILED,
+            completed_at=timezone.now(),
+            query_to=pinned_query_to,
+            started_at=timezone.now(),
+        )
+
+        returned = _update(
+            RecalculationProgressUpdate(
+                recalculation_id=str(recalc.id),
+                status="in_progress",
+                total_metrics=3,
+                metric_uuids=["m1", "m2", "m3"],
+                mark_started=True,
+            )
+        )
+
+        # Terminal read-back returns None despite query_to being pinned, so the workflow fails the run.
+        assert returned is None
+        recalc.refresh_from_db()
+        assert recalc.status == ExperimentMetricsRecalculation.Status.FAILED
+        assert recalc.query_to == pinned_query_to
+
     @parameterized.expand(
         [
             # name, end_date_offset_days (None = running experiment), expect query_to == end_date

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -230,6 +230,37 @@ class TestRecalculationActivities(BaseTest):
         # Both attempts return the same canonical query_to so the workflow threads the same value either way.
         assert first == second == first_query_to.isoformat()
 
+    def test_mark_started_does_not_revive_a_force_failed_run(self):
+        # A force-fail (admin "Mark as failed" or the staleness sweep) lands while discovery is still running:
+        # it sets status=FAILED + completed_at but never touches query_to, so the row is terminal with
+        # query_to still NULL. A later mark_started must NOT match — without the completed_at guard, its
+        # query_to__isnull=True filter would still match and flip the run back to IN_PROGRESS, wedging it.
+        recalc = self._recalc(self._experiment(flag_key="progress-start-force-failed"))
+        completed_at = timezone.now()
+        ExperimentMetricsRecalculation.objects.filter(id=recalc.id).update(
+            status=ExperimentMetricsRecalculation.Status.FAILED, completed_at=completed_at
+        )
+
+        returned = _update(
+            RecalculationProgressUpdate(
+                recalculation_id=str(recalc.id),
+                status="in_progress",
+                total_metrics=3,
+                metric_uuids=["m1", "m2", "m3"],
+                mark_started=True,
+            )
+        )
+
+        recalc.refresh_from_db()
+        # The run stays terminal: no revival, no started_at, query_to left NULL.
+        assert recalc.status == ExperimentMetricsRecalculation.Status.FAILED
+        assert recalc.completed_at == completed_at
+        assert recalc.started_at is None
+        assert recalc.query_to is None
+        # query_to was never pinned, so the read-back returns None; the workflow's isinstance(str) check then
+        # fails the run non-retryably instead of proceeding to calc activities on a dead run.
+        assert returned is None
+
     @parameterized.expand(
         [
             # name, end_date_offset_days (None = running experiment), expect query_to == end_date

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -230,13 +230,18 @@ class TestRecalculationActivities(BaseTest):
         # Both attempts return the same canonical query_to so the workflow threads the same value either way.
         assert first == second == first_query_to.isoformat()
 
-    def test_mark_started_does_not_revive_a_force_failed_run(self):
-        # A force-fail (admin "Mark as failed" or the staleness sweep) lands while discovery is still running:
-        # it sets status=FAILED + completed_at but never touches query_to, so the row is terminal with
-        # query_to still NULL. A later mark_started must NOT match — without the completed_at guard, its
-        # query_to__isnull=True filter would still match and flip the run back to IN_PROGRESS, wedging it.
-        recalc = self._recalc(self._experiment(flag_key="progress-start-force-failed"))
-        completed_at = timezone.now()
+    @parameterized.expand(
+        [
+            # name, set_completed_at — both force-fail shapes leave query_to NULL while discovery runs.
+            # admin "Mark as failed" stamps completed_at; the staleness sweep deliberately leaves it NULL, so
+            # a completed_at-only guard would miss the sweep. The status guard catches both.
+            ("admin_sets_completed_at", True),
+            ("sweep_leaves_completed_at_null", False),
+        ]
+    )
+    def test_mark_started_does_not_revive_a_force_failed_run(self, name: str, set_completed_at: bool):
+        recalc = self._recalc(self._experiment(flag_key=f"progress-start-force-failed-{name}"))
+        completed_at = timezone.now() if set_completed_at else None
         ExperimentMetricsRecalculation.objects.filter(id=recalc.id).update(
             status=ExperimentMetricsRecalculation.Status.FAILED, completed_at=completed_at
         )


### PR DESCRIPTION
## Problem

<!-- Who are we building for, what are their needs, why is this important? -->

A force-fail (admin "Mark as failed" or the staleness sweep) that lands while discovery is running gets silently reverted by `mark_started`, wedging the run `IN_PROGRESS` and locking the experiment out of recalculations for the full staleness TTL.

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- PostHog employees: `hogli pr:upload-image <file>` uploads to the public PostHog/pr-assets repo and prints markdown to paste here. Never upload customer data, secrets, or internal info. -->

<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

The `mark_started` activity guarded its first-write-wins UPDATE on `query_to__isnull=True`, which checks whether the data window was pinned, not whether the run is still open. A force-fail sets `status=FAILED` and `completed_at` but never touches `query_to`, so the filter still matched and flipped the terminal run back to `IN_PROGRESS`. Added `completed_at__isnull=True` to the filter so a terminal write is authoritative: the activity then matches zero rows, returns `None`, and the workflow's existing `isinstance(query_to, str)` check fails it non-retryably instead of proceeding to calc activities on a dead run. The `query_to__isnull=True` clause stays for idempotency against a retried `mark_started` on a live run. The `mark_completed` branch already guarded on `completed_at__isnull`; this brings the start branch in line.

- `products/experiments/backend/temporal/recalculation_logic.py`
- `products/experiments/backend/temporal/test_recalculation_activities.py`

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

The new test force-fails a run mid-discovery, calls `mark_started`, and asserts the row stays `FAILED`; it fails without the `completed_at__isnull` guard. No existing test covered a terminal-then-`mark_started` race, the sibling only covers retry idempotency on a live run.

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

```bash
uv run mypy --cache-fine-grained products/experiments/backend/temporal/recalculation_logic.py products/experiments/backend/temporal/test_recalculation_activities.py
```

![cat-type-small](https://github.com/user-attachments/assets/6609c383-62dd-4845-ae68-29692ea338ae)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

No user-facing docs impact.

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

Model: Opus 4.8
Manually refactored: **yes**

Skills used:

- /writing-tests (local)
- /writing-pull-requests (local)

Relevant decisions:

- Guarded on `completed_at__isnull=True` rather than `started_at__isnull`, because `completed_at` is the terminal marker (the `mark_completed` branch already uses it) while `started_at` is exactly what a revival would overwrite.
- Kept the `query_to__isnull=True` clause alongside the new guard: it still provides idempotency against a retried `mark_started` on a live run, so a network blip or worker crash mid-activity can't move `query_to`/`started_at` forward.
- Let the not-won read-back return `None` for a force-failed run (its `query_to` is NULL) so the workflow's `isinstance(query_to, str)` check fails the run cleanly instead of scheduling calc activities against a terminated row.