### PR TITLE
feat(tasks): file Slack-created tasks into the creator's #me channel

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/task_creation.py
+++ b/posthog/temporal/ai/slack_app/activities/task_creation.py
@@ -636,6 +636,20 @@ def create_posthog_code_task_for_repo_activity(
 
     ai_prefs = resolve_ai_preferences(integration, slack_user_id)
 
+    # File into the creator's personal "#me" channel so the task surfaces in PostHog
+    # Desktop's Spaces feed, which is strictly channel-scoped — a NULL-channel task
+    # shows up in no space. Best-effort: channel resolution must never block creating
+    # the task from a Slack mention.
+    personal_channel_id: str | None = None
+    try:
+        personal_channel_id = str(tasks_facade.ensure_personal_channel(integration.team_id, user_id).id)
+    except Exception:
+        logger.warning(
+            "posthog_code_personal_channel_resolution_failed",
+            team_id=integration.team_id,
+            user_id=user_id,
+        )
+
     # 1. Create task + run WITHOUT starting the workflow
     try:
         created = tasks_facade.create_and_run_task(
@@ -655,6 +669,7 @@ def create_posthog_code_task_for_repo_activity(
             runtime_adapter=ai_prefs.runtime_adapter,
             model=ai_prefs.model,
             reasoning_effort=ai_prefs.reasoning_effort,
+            channel_id=personal_channel_id,
         )
     except Exception as e:
         logger.exception(

--- a/posthog/temporal/ai/slack_app/activities/task_creation.py
+++ b/posthog/temporal/ai/slack_app/activities/task_creation.py
@@ -640,9 +640,9 @@ def create_posthog_code_task_for_repo_activity(
     # Desktop's Spaces feed, which is strictly channel-scoped — a NULL-channel task
     # shows up in no space. Best-effort: channel resolution must never block creating
     # the task from a Slack mention.
-    personal_channel_id: str | None = None
+    personal_channel_id: uuid.UUID | None = None
     try:
-        personal_channel_id = str(tasks_facade.ensure_personal_channel(integration.team_id, user_id).id)
+        personal_channel_id = tasks_facade.ensure_personal_channel(integration.team_id, user_id).id
     except Exception:
         logger.warning(
             "posthog_code_personal_channel_resolution_failed",

--- a/posthog/temporal/ai/slack_app/activities/task_creation.py
+++ b/posthog/temporal/ai/slack_app/activities/task_creation.py
@@ -636,13 +636,11 @@ def create_posthog_code_task_for_repo_activity(
 
     ai_prefs = resolve_ai_preferences(integration, slack_user_id)
 
-    # File into the creator's personal "#me" channel so the task surfaces in PostHog
-    # Desktop's Spaces feed, which is strictly channel-scoped — a NULL-channel task
-    # shows up in no space. Best-effort: channel resolution must never block creating
-    # the task from a Slack mention.
+    # File into the creator's personal "#me" channel so the task surfaces in PostHog Desktop's
+    # Spaces feed, which is strictly channel-scoped — a NULL-channel task shows up in no space.
     personal_channel_id: uuid.UUID | None = None
     try:
-        personal_channel_id = tasks_facade.ensure_personal_channel(integration.team_id, user_id).id
+        personal_channel_id = tasks_facade.ensure_personal_channel_id(integration.team_id, user_id)
     except Exception:
         logger.warning(
             "posthog_code_personal_channel_resolution_failed",

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -135,7 +135,7 @@ __all__ = [
     "claim_and_fail_stale_run",
     "delete_sandbox_custom_image",
     "delete_sandbox_environment",
-    "ensure_personal_channel",
+    "ensure_personal_channel_id",
     "ensure_sandbox_custom_image_builder_task",
     "delete_task_automation",
     "edit_task_run_living_artifact",
@@ -864,10 +864,9 @@ def create_and_run_task(
     instead of leaking the ORM ``Task``. ``team`` is a core ``posthog.Team`` (not a tasks
     model). Less-common keyword arguments are forwarded verbatim via ``**extra``.
 
-    ``channel_id`` files the task into a channel's feed (the channel it was kicked off in);
-    left NULL for non-channel surfaces. A channel the creator can't file into — unknown,
-    deleted, or someone else's personal channel — is ignored rather than raising: feed
-    placement must never break task creation.
+    ``channel_id`` files the task into a channel's feed; left NULL for non-channel surfaces.
+    An id the creator can't file into (see ``_visible_channel``) is ignored rather than
+    raising — feed placement must never break task creation.
     """
     channel = _visible_channel(channel_id, team.id, user_id) if channel_id is not None else None
     task = Task.create_and_run(
@@ -5010,11 +5009,15 @@ def _channel_to_dto(channel: Channel) -> contracts.ChannelDTO:
     )
 
 
+def _team_channels(team_id: int) -> QuerySet[Channel]:
+    # for_team rather than a bare team_id filter so these reads also resolve outside request
+    # scope (Temporal activities), where the fail-closed manager raises on an unscoped read.
+    return Channel.objects.for_team(team_id)
+
+
 def _ensure_personal_channel(team_id: int, user_id: int) -> Channel:
-    # for_team so this works outside request scope too (Temporal activities filing a
-    # Slack task into #me) — the fail-closed manager raises on a bare read without it.
     # select_related so _channel_to_dto doesn't lazy-load created_by per call.
-    channels = Channel.objects.for_team(team_id).select_related("created_by")
+    channels = _team_channels(team_id).select_related("created_by")
     lookup = {
         "team_id": team_id,
         "created_by_id": user_id,
@@ -5028,13 +5031,12 @@ def _ensure_personal_channel(team_id: int, user_id: int) -> Channel:
     return channel
 
 
-def ensure_personal_channel(team_id: int, user_id: int) -> contracts.ChannelDTO:
-    """Get-or-create the user's personal "#me" channel and return it as a DTO.
+def ensure_personal_channel_id(team_id: int, user_id: int) -> UUID:
+    """Get-or-create the user's personal "#me" channel and return its id.
 
-    Public counterpart of ``_ensure_personal_channel`` for callers outside a request
-    (Temporal activities) that need the channel id without touching the ORM.
+    For callers outside a request (Temporal activities) that need somewhere to file a task.
     """
-    return _channel_to_dto(_ensure_personal_channel(team_id, user_id))
+    return _ensure_personal_channel(team_id, user_id).id
 
 
 def list_channels(team_id: int, user_id: int | None) -> list[contracts.ChannelDTO]:
@@ -5147,15 +5149,8 @@ def _channel_feed_message_to_dto(message: ChannelFeedMessage) -> contracts.Chann
 
 def _visible_channel(channel_id: str | UUID, team_id: int, user_id: int | None) -> Channel | None:
     """A channel the requester may read: any live public channel on the team, or their
-    own personal channel. ``None`` when it's missing or someone else's personal channel.
-
-    Scoped via ``for_team`` rather than a bare ``team_id`` filter so it also resolves outside
-    request scope (Temporal activities), where the fail-closed manager raises on an
-    unscoped read.
-    """
-    channel = (
-        Channel.objects.for_team(team_id).select_related("created_by").filter(id=channel_id, deleted=False).first()
-    )
+    own personal channel. ``None`` when it's missing or someone else's personal channel."""
+    channel = _team_channels(team_id).filter(id=channel_id, deleted=False).first()
     if channel is None:
         return None
     if channel.channel_type == Channel.ChannelType.PERSONAL and channel.created_by_id != user_id:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -135,6 +135,7 @@ __all__ = [
     "claim_and_fail_stale_run",
     "delete_sandbox_custom_image",
     "delete_sandbox_environment",
+    "ensure_personal_channel",
     "ensure_sandbox_custom_image_builder_task",
     "delete_task_automation",
     "edit_task_run_living_artifact",
@@ -864,9 +865,11 @@ def create_and_run_task(
     model). Less-common keyword arguments are forwarded verbatim via ``**extra``.
 
     ``channel_id`` files the task into a channel's feed (the channel it was kicked off in);
-    left NULL for non-channel surfaces. A stale/foreign id is ignored rather than raising —
-    feed placement must never break task creation.
+    left NULL for non-channel surfaces. A channel the creator can't file into — unknown,
+    deleted, or someone else's personal channel — is ignored rather than raising: feed
+    placement must never break task creation.
     """
+    channel = _visible_channel(channel_id, team.id, user_id) if channel_id is not None else None
     task = Task.create_and_run(
         team=team,
         title=title,
@@ -874,6 +877,7 @@ def create_and_run_task(
         origin_product=origin_product,
         user_id=user_id,
         repository=repository,
+        channel=channel,
         create_pr=create_pr,
         mode=mode,
         start_workflow=start_workflow,
@@ -883,11 +887,6 @@ def create_and_run_task(
         sandbox_environment_id=sandbox_environment_id,
         **extra,
     )
-    if channel_id is not None:
-        channel = Channel.objects.for_team(task.team_id).filter(id=channel_id, deleted=False).first()
-        if channel is not None:
-            task.channel = channel
-            task.save(update_fields=["channel", "updated_at"])
     latest = task.latest_run
     return contracts.CreatedTaskDTO(
         task_id=task.id,
@@ -5015,29 +5014,17 @@ def _ensure_personal_channel(team_id: int, user_id: int) -> Channel:
     # for_team so this works outside request scope too (Temporal activities filing a
     # Slack task into #me) — the fail-closed manager raises on a bare read without it.
     # select_related so _channel_to_dto doesn't lazy-load created_by per call.
+    channels = Channel.objects.for_team(team_id).select_related("created_by")
+    lookup = {
+        "team_id": team_id,
+        "created_by_id": user_id,
+        "channel_type": Channel.ChannelType.PERSONAL,
+        "deleted": False,
+    }
     try:
-        channel, _ = (
-            Channel.objects.for_team(team_id)
-            .select_related("created_by")
-            .get_or_create(
-                team_id=team_id,
-                created_by_id=user_id,
-                channel_type=Channel.ChannelType.PERSONAL,
-                deleted=False,
-                defaults={"name": Channel.PERSONAL_CHANNEL_NAME},
-            )
-        )
+        channel, _ = channels.get_or_create(**lookup, defaults={"name": Channel.PERSONAL_CHANNEL_NAME})
     except IntegrityError:
-        channel = (
-            Channel.objects.for_team(team_id)
-            .select_related("created_by")
-            .get(
-                team_id=team_id,
-                created_by_id=user_id,
-                channel_type=Channel.ChannelType.PERSONAL,
-                deleted=False,
-            )
-        )
+        channel = channels.get(**lookup)
     return channel
 
 
@@ -5160,8 +5147,15 @@ def _channel_feed_message_to_dto(message: ChannelFeedMessage) -> contracts.Chann
 
 def _visible_channel(channel_id: str | UUID, team_id: int, user_id: int | None) -> Channel | None:
     """A channel the requester may read: any live public channel on the team, or their
-    own personal channel. ``None`` when it's missing or someone else's personal channel."""
-    channel = Channel.objects.select_related("created_by").filter(id=channel_id, team_id=team_id, deleted=False).first()
+    own personal channel. ``None`` when it's missing or someone else's personal channel.
+
+    Scoped via ``for_team`` rather than a bare ``team_id`` filter so it also resolves outside
+    request scope (Temporal activities), where the fail-closed manager raises on an
+    unscoped read.
+    """
+    channel = (
+        Channel.objects.for_team(team_id).select_related("created_by").filter(id=channel_id, deleted=False).first()
+    )
     if channel is None:
         return None
     if channel.channel_type == Channel.ChannelType.PERSONAL and channel.created_by_id != user_id:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -854,6 +854,7 @@ def create_and_run_task(
     signal_report_id: str | None = None,
     internal: bool = False,
     sandbox_environment_id: str | None = None,
+    channel_id: str | UUID | None = None,
     **extra,
 ) -> contracts.CreatedTaskDTO:
     """Create a task and (optionally) kick off its processing workflow.
@@ -861,6 +862,10 @@ def create_and_run_task(
     Thin wrapper over ``Task.create_and_run`` that returns ids + the created run as a DTO
     instead of leaking the ORM ``Task``. ``team`` is a core ``posthog.Team`` (not a tasks
     model). Less-common keyword arguments are forwarded verbatim via ``**extra``.
+
+    ``channel_id`` files the task into a channel's feed (the channel it was kicked off in);
+    left NULL for non-channel surfaces. A stale/foreign id is ignored rather than raising —
+    feed placement must never break task creation.
     """
     task = Task.create_and_run(
         team=team,
@@ -878,6 +883,11 @@ def create_and_run_task(
         sandbox_environment_id=sandbox_environment_id,
         **extra,
     )
+    if channel_id is not None:
+        channel = Channel.objects.for_team(task.team_id).filter(id=channel_id, deleted=False).first()
+        if channel is not None:
+            task.channel = channel
+            task.save(update_fields=["channel", "updated_at"])
     latest = task.latest_run
     return contracts.CreatedTaskDTO(
         task_id=task.id,
@@ -5002,23 +5012,42 @@ def _channel_to_dto(channel: Channel) -> contracts.ChannelDTO:
 
 
 def _ensure_personal_channel(team_id: int, user_id: int) -> Channel:
+    # for_team so this works outside request scope too (Temporal activities filing a
+    # Slack task into #me) — the fail-closed manager raises on a bare read without it.
     # select_related so _channel_to_dto doesn't lazy-load created_by per call.
     try:
-        channel, _ = Channel.objects.select_related("created_by").get_or_create(
-            team_id=team_id,
-            created_by_id=user_id,
-            channel_type=Channel.ChannelType.PERSONAL,
-            deleted=False,
-            defaults={"name": Channel.PERSONAL_CHANNEL_NAME},
+        channel, _ = (
+            Channel.objects.for_team(team_id)
+            .select_related("created_by")
+            .get_or_create(
+                team_id=team_id,
+                created_by_id=user_id,
+                channel_type=Channel.ChannelType.PERSONAL,
+                deleted=False,
+                defaults={"name": Channel.PERSONAL_CHANNEL_NAME},
+            )
         )
     except IntegrityError:
-        channel = Channel.objects.select_related("created_by").get(
-            team_id=team_id,
-            created_by_id=user_id,
-            channel_type=Channel.ChannelType.PERSONAL,
-            deleted=False,
+        channel = (
+            Channel.objects.for_team(team_id)
+            .select_related("created_by")
+            .get(
+                team_id=team_id,
+                created_by_id=user_id,
+                channel_type=Channel.ChannelType.PERSONAL,
+                deleted=False,
+            )
         )
     return channel
+
+
+def ensure_personal_channel(team_id: int, user_id: int) -> contracts.ChannelDTO:
+    """Get-or-create the user's personal "#me" channel and return it as a DTO.
+
+    Public counterpart of ``_ensure_personal_channel`` for callers outside a request
+    (Temporal activities) that need the channel id without touching the ORM.
+    """
+    return _channel_to_dto(_ensure_personal_channel(team_id, user_id))
 
 
 def list_channels(team_id: int, user_id: int | None) -> list[contracts.ChannelDTO]:

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -495,6 +495,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         origin_product: "Task.OriginProduct",
         user_id: int,
         repository: str | None = None,
+        channel: Channel | None = None,
         slack_thread_context: Optional["SlackThreadContext"] = None,
         slack_thread_url: str | None = None,
         branch: str | None = None,
@@ -598,6 +599,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
             github_integration=github_integration,
             github_user_integration=github_user_integration,
             repository=repository,
+            channel=channel,
             internal=internal,
             json_schema=resolve_schema(output_schema) if output_schema else None,
             **({"signal_report_id": signal_report_id} if signal_report_id else {}),
@@ -760,6 +762,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         origin_product: "Task.OriginProduct",
         user_id: int,  # Will be used to validate the tasks feature flag and create a personal api key for interacting with PostHog.
         repository: str | None = None,  # Format: "organization/repository", e.g. "posthog/posthog-js"
+        channel: Channel | None = None,
         create_pr: bool = True,
         mode: str = "background",
         slack_thread_context: Optional["SlackThreadContext"] = None,
@@ -797,6 +800,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
             origin_product=origin_product,
             user_id=user_id,
             repository=repository,
+            channel=channel,
             slack_thread_context=slack_thread_context,
             slack_thread_url=slack_thread_url,
             branch=branch,

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -1,7 +1,7 @@
 import importlib
 from datetime import timedelta
 from typing import ClassVar
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from unittest.mock import patch
 
@@ -561,13 +561,38 @@ class TestFacadeReadsAndMappers(TestCase):
         self.assertEqual(run.state["pending_dispatch"]["posthog_mcp_scopes"], "full")
         self.assertEqual(run.state["pending_dispatch"]["user_id"], self.user.id)
 
-    @parameterized.expand([("valid_channel", True), ("stale_channel", False)])
+    def _make_channel(self, **kwargs) -> Channel:
+        # unscoped: no ambient team_scope in these tests, and the fail-closed manager
+        # raises on a bare write just as it does on a bare read.
+        defaults = {
+            "team": self.team,
+            "name": "engineering",
+            "channel_type": Channel.ChannelType.PUBLIC,
+            "created_by": self.user,
+        }
+        return Channel.objects.unscoped().create(**{**defaults, **kwargs})
+
+    @parameterized.expand(["public", "unknown", "other_users_personal"])
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
-    def test_create_and_run_task_files_into_channel(self, _name, use_real_channel, _mock_workflow):
+    def test_create_and_run_task_files_into_channel(self, channel_kind, _mock_workflow):
         Integration.objects.create(team=self.team, kind="github", config={})
-        channel = Channel.objects.create(
-            team=self.team, name="engineering", channel_type=Channel.ChannelType.PUBLIC, created_by=self.user
-        )
+        expected: UUID | None
+        if channel_kind == "public":
+            channel_id = self._make_channel().id
+            expected = channel_id
+        elif channel_kind == "unknown":
+            channel_id, expected = uuid4(), None
+        else:
+            # Someone else's "#me" is private: filing into it would leak the task into
+            # their personal feed, so it must be dropped like an unknown id.
+            teammate = User.objects.create(email="teammate@test.com", distinct_id="teammate")
+            channel_id = self._make_channel(
+                name=Channel.PERSONAL_CHANNEL_NAME,
+                channel_type=Channel.ChannelType.PERSONAL,
+                created_by=teammate,
+            ).id
+            expected = None
+
         created = facade.create_and_run_task(
             team=self.team,
             title="Created via facade",
@@ -575,12 +600,11 @@ class TestFacadeReadsAndMappers(TestCase):
             origin_product=facade.TaskOriginProduct.USER_CREATED,
             user_id=self.user.id,
             repository="posthog/posthog",
-            channel_id=str(channel.id) if use_real_channel else str(uuid4()),
+            channel_id=channel_id,
         )
-        task = Task.objects.get(id=created.task_id)
-        # A real id files the task into that channel's feed; a stale/foreign id is dropped
+        # A channel the creator can file into lands on the task; anything else is dropped
         # rather than raising, so feed placement never breaks task creation.
-        self.assertEqual(task.channel_id, channel.id if use_real_channel else None)
+        self.assertEqual(Task.objects.get(id=created.task_id).channel_id, expected)
 
     def test_ensure_personal_channel_idempotent_outside_request_scope(self):
         # No ambient team_scope here, like a Temporal activity — the fail-closed manager

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -1,7 +1,7 @@
 import importlib
 from datetime import timedelta
 from typing import ClassVar
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from unittest.mock import patch
 
@@ -572,26 +572,27 @@ class TestFacadeReadsAndMappers(TestCase):
         }
         return Channel.objects.unscoped().create(**{**defaults, **kwargs})
 
-    @parameterized.expand(["public", "unknown", "other_users_personal"])
-    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
-    def test_create_and_run_task_files_into_channel(self, channel_kind, _mock_workflow):
-        Integration.objects.create(team=self.team, kind="github", config={})
-        expected: UUID | None
-        if channel_kind == "public":
-            channel_id = self._make_channel().id
-            expected = channel_id
-        elif channel_kind == "unknown":
-            channel_id, expected = uuid4(), None
-        else:
+    def _make_teammates_personal_channel(self) -> Channel:
+        teammate = User.objects.create(email="teammate@test.com", distinct_id="teammate")
+        return self._make_channel(
+            name=Channel.PERSONAL_CHANNEL_NAME,
+            channel_type=Channel.ChannelType.PERSONAL,
+            created_by=teammate,
+        )
+
+    @parameterized.expand(
+        [
+            ("public", lambda self: self._make_channel().id, True),
+            ("unknown", lambda _self: uuid4(), False),
             # Someone else's "#me" is private: filing into it would leak the task into
             # their personal feed, so it must be dropped like an unknown id.
-            teammate = User.objects.create(email="teammate@test.com", distinct_id="teammate")
-            channel_id = self._make_channel(
-                name=Channel.PERSONAL_CHANNEL_NAME,
-                channel_type=Channel.ChannelType.PERSONAL,
-                created_by=teammate,
-            ).id
-            expected = None
+            ("other_users_personal", lambda self: self._make_teammates_personal_channel().id, False),
+        ]
+    )
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_and_run_task_files_into_channel(self, _name, make_channel_id, expect_filed, _mock_workflow):
+        Integration.objects.create(team=self.team, kind="github", config={})
+        channel_id = make_channel_id(self)
 
         created = facade.create_and_run_task(
             team=self.team,
@@ -602,22 +603,20 @@ class TestFacadeReadsAndMappers(TestCase):
             repository="posthog/posthog",
             channel_id=channel_id,
         )
-        # A channel the creator can file into lands on the task; anything else is dropped
-        # rather than raising, so feed placement never breaks task creation.
-        self.assertEqual(Task.objects.get(id=created.task_id).channel_id, expected)
+        self.assertEqual(Task.objects.get(id=created.task_id).channel_id, channel_id if expect_filed else None)
 
-    def test_ensure_personal_channel_idempotent_outside_request_scope(self):
-        # No ambient team_scope here, like a Temporal activity — the fail-closed manager
-        # would raise on a bare read, so this also guards the for_team scoping.
-        first = facade.ensure_personal_channel(self.team.id, self.user.id)
-        second = facade.ensure_personal_channel(self.team.id, self.user.id)
-        self.assertEqual(first.id, second.id)
-        self.assertEqual(first.channel_type, Channel.ChannelType.PERSONAL)
+    def test_ensure_personal_channel_id_idempotent_outside_request_scope(self):
+        # No ambient team_scope here, like a Temporal activity — guards the for_team scoping.
+        first = facade.ensure_personal_channel_id(self.team.id, self.user.id)
+        second = facade.ensure_personal_channel_id(self.team.id, self.user.id)
+        self.assertEqual(first, second)
         self.assertEqual(
-            Channel.objects.unscoped()
-            .filter(team=self.team, channel_type=Channel.ChannelType.PERSONAL, deleted=False)
-            .count(),
-            1,
+            list(
+                Channel.objects.unscoped()
+                .filter(team=self.team, channel_type=Channel.ChannelType.PERSONAL, deleted=False)
+                .values_list("id", flat=True)
+            ),
+            [first],
         )
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")

--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -1,6 +1,7 @@
 import importlib
 from datetime import timedelta
 from typing import ClassVar
+from uuid import uuid4
 
 from unittest.mock import patch
 
@@ -17,7 +18,7 @@ from products.tasks.backend.facade import (
     contracts,
     warm as warm_facade,
 )
-from products.tasks.backend.models import SandboxCustomImage, SandboxEnvironment, Task, TaskRun
+from products.tasks.backend.models import Channel, SandboxCustomImage, SandboxEnvironment, Task, TaskRun
 from products.tasks.backend.prompts import WIZARD_HEAD_BRANCH_PLACEHOLDER, build_wizard_pr_agent_prompt
 
 FACADE_MODULES = [
@@ -559,6 +560,41 @@ class TestFacadeReadsAndMappers(TestCase):
         self.assertEqual(run.state["pending_dispatch"]["create_pr"], False)
         self.assertEqual(run.state["pending_dispatch"]["posthog_mcp_scopes"], "full")
         self.assertEqual(run.state["pending_dispatch"]["user_id"], self.user.id)
+
+    @parameterized.expand([("valid_channel", True), ("stale_channel", False)])
+    @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
+    def test_create_and_run_task_files_into_channel(self, _name, use_real_channel, _mock_workflow):
+        Integration.objects.create(team=self.team, kind="github", config={})
+        channel = Channel.objects.create(
+            team=self.team, name="engineering", channel_type=Channel.ChannelType.PUBLIC, created_by=self.user
+        )
+        created = facade.create_and_run_task(
+            team=self.team,
+            title="Created via facade",
+            description="desc",
+            origin_product=facade.TaskOriginProduct.USER_CREATED,
+            user_id=self.user.id,
+            repository="posthog/posthog",
+            channel_id=str(channel.id) if use_real_channel else str(uuid4()),
+        )
+        task = Task.objects.get(id=created.task_id)
+        # A real id files the task into that channel's feed; a stale/foreign id is dropped
+        # rather than raising, so feed placement never breaks task creation.
+        self.assertEqual(task.channel_id, channel.id if use_real_channel else None)
+
+    def test_ensure_personal_channel_idempotent_outside_request_scope(self):
+        # No ambient team_scope here, like a Temporal activity — the fail-closed manager
+        # would raise on a bare read, so this also guards the for_team scoping.
+        first = facade.ensure_personal_channel(self.team.id, self.user.id)
+        second = facade.ensure_personal_channel(self.team.id, self.user.id)
+        self.assertEqual(first.id, second.id)
+        self.assertEqual(first.channel_type, Channel.ChannelType.PERSONAL)
+        self.assertEqual(
+            Channel.objects.unscoped()
+            .filter(team=self.team, channel_type=Channel.ChannelType.PERSONAL, deleted=False)
+            .count(),
+            1,
+        )
 
     @patch("products.tasks.backend.temporal.client.execute_task_processing_workflow")
     def test_create_wizard_cloud_run_seeds_pending_user_message(self, _mock_workflow):


### PR DESCRIPTION
## Problem

Tasks kicked off by mentioning the PostHog bot in Slack were created with no channel (`Task.channel` left NULL). PostHog Desktop's new Spaces layout (behind `code-spaces-layout`) renders strictly channel-scoped feeds — each space asks for `getTasks({ channel })` — and there is no cross-space "unfiled" view. So a NULL-channel Slack task landed in no space at all, including the user's own `#me`. The old repository-grouped sidebar still listed them (with a Slack badge), which is why this only shows up as a gap under the Spaces UX.

The bot already resolves the mentioning Slack user to a PostHog user, so we know exactly whose `#me` a Slack task belongs in.

## Changes

Route Slack-origin tasks into the creator's personal `#me` channel so they surface in the Spaces feed.

- `Task._build_task` / `Task.create_and_run` take a `channel`, so it lands in the same INSERT as the rest of the row. This mirrors what the REST create path already does with a client-supplied channel.
- `create_and_run_task` takes an optional `channel_id` and resolves it through the existing `_visible_channel` helper, which drops an unknown, deleted, or someone else's personal channel — so the facade enforces the same ownership rule as the write serializer. An unusable id is ignored rather than raising: feed placement must never break task creation.
- `create_posthog_code_task_for_repo_activity` resolves the creator's personal channel and passes its id. Best-effort — if resolution fails the task is still created (just unfiled), so a mention never silently drops.
- `ensure_personal_channel` added to the tasks facade; `_visible_channel` and the personal-channel get-or-create are now scoped via `for_team`, so both work from a Temporal activity where there is no ambient request team-scope (the fail-closed manager would otherwise raise on the read).

The internal repo-discovery research task (`repo_selection`) is deliberately left unfiled; only the user-facing task gets a home in `#me`.

> [!NOTE]
> Other backend origins (onboarding wizard, image builder, signals auto-start, replay-vision, PostHog AI) also create tasks with a NULL channel and have the same invisible-in-Spaces gap. This PR does not change them — whether an internal machinery task belongs in someone's personal feed is a product call, and dumping image-builder or scout tasks into `#me` would be worse than leaving them unfiled. Now that the mechanism takes a `channel`, doing it per-origin is a one-liner each.

## How did you test this code?

Facade tests in `test_facade.py`:

- `test_create_and_run_task_files_into_channel`, parameterized over three channel kinds — a public channel on the team is filed; an unknown id is dropped; **another user's personal `#me` is dropped**. The last case is the one worth having: without the ownership check a caller could file a task into a teammate's private feed. The first two catch the `channel_id` wiring being dropped or starting to raise on a bad id.
- `test_ensure_personal_channel_idempotent_outside_request_scope` — provisions `#me` idempotently with no ambient team-scope active. Guards the `for_team` scoping specifically: revert it and this path raises from a Temporal activity, silently breaking the whole feature.

I (Claude, via the PostHog Slack app) could not run the DB-backed suite in this sandbox — no Postgres/ClickHouse reachable. The tests collect cleanly (all four cases discovered) and error only on DB connection. I did run: `ruff check` (clean), `ruff format`, and repo-style `mypy --cache-fine-grained` on the changed modules including the test file (no issues). `hogli ci:preflight` isn't available in this environment. Please rely on CI for the test run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread: does a Slack-created task show up in `#me` under the new `code-spaces-layout` Spaces UX? It did not — traced the Slack task-creation path (`posthog/temporal/ai/slack_app`) and the tasks facade and found `channel` was never set, while the Spaces feed hooks (`useChannelFeed`) query strictly by channel.

Skills invoked: `/writing-tests` (to gate the tests), then `/simplify` over the first draft. That review pass changed three things worth calling out for reviewers:

- The first draft assigned `channel` in a follow-up `task.save(update_fields=["channel"])` after `create_and_run`. That re-fired the unconditional file-system-sync `post_save` receiver for 3 queries of no-op work (the file-system representation never reads `channel`) and left a window where the run's workflow dispatch could fire before the channel was attached. Threading `channel` into the INSERT removes both.
- The first draft hand-rolled the channel lookup. `_visible_channel` already existed and already rejected someone else's personal channel, so reusing it closed a validation gap I hadn't noticed rather than just deduplicating.
- The first draft's test built channels with `Channel.objects.create(...)`, which raises `TeamScopeError` under the fail-closed manager with no ambient team scope — it would have failed CI.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785267350722269)*
