### PR TITLE
fix(data-modeling): sweep legacy schedule on DAGs with no schedulable nodes

### DIFF
--- a/products/data_modeling/backend/logic/schedule_reconcile.py
+++ b/products/data_modeling/backend/logic/schedule_reconcile.py
@@ -177,10 +177,12 @@ def reconcile_dag_schedules(dag: DAG, *, require_tiered: bool = False, graph: Fr
     """Make Temporal's schedules for this DAG match its nodes' effective cadences.
 
     Converging a covered DAG to zero schedules is refused only while it still has just legacy
-    (non-tier) schedules — an empty tier set there almost always means unseeded targets. Once tier
-    schedules exist, an empty tier set is a deliberate wind-down (last target reverted/cleared) and
-    those tiers are torn down. With `require_tiered`, a DAG that has no tiered schedule yet (legacy
-    single schedule or nothing) is left untouched.
+    (non-tier) schedules AND schedulable nodes — an empty tier set there almost always means
+    unseeded targets. A DAG with no schedulable nodes has nothing to seed, so its legacy schedule
+    is swept rather than left firing no-op runs. Once tier schedules exist, an empty tier set is a
+    deliberate wind-down (last target reverted/cleared) and those tiers are torn down. With
+    `require_tiered`, a DAG that has no tiered schedule yet (legacy single schedule or nothing) is
+    left untouched.
     """
     team = dag.team
     if graph is None:
@@ -197,6 +199,7 @@ def reconcile_dag_schedules(dag: DAG, *, require_tiered: bool = False, graph: Fr
         team_timezone=team.timezone,
         desired_tiers=desired_tiers,
         require_tiered=require_tiered,
+        has_schedulable_nodes=bool(graph.nodes),
     )
 
 
@@ -321,6 +324,7 @@ async def _apply_reconciliation(
     team_timezone: str,
     desired_tiers: dict[timedelta, set[str]],
     require_tiered: bool = False,
+    has_schedulable_nodes: bool = True,
 ) -> None:
     unsupported = sorted(interval for interval in desired_tiers if interval not in SCHEDULABLE_BUCKETS)
     if unsupported:
@@ -335,10 +339,17 @@ async def _apply_reconciliation(
         logger.debug("DAG not converted to cadence tiers yet, skipping reconcile", dag_id=dag_id)
         return
     # An empty tier set on a DAG that still has only legacy (non-tier) schedules means an unseeded
-    # conversion — protect it. Once tier schedules exist, empty desired is a deliberate wind-down
-    # (last target reverted/cleared/"never"), so let the teardown sweep the stale tiers instead of
-    # leaving them firing execute-dag on node_ids that no longer materialize.
-    if not desired_tiers and existing_ids and not any(is_tier_schedule_id(schedule_id) for schedule_id in existing_ids):
+    # conversion — protect it, but only when there is anything to seed: a DAG with no schedulable
+    # nodes gets its legacy schedule swept instead of firing no-op runs forever. Once tier
+    # schedules exist, empty desired is a deliberate wind-down (last target reverted/cleared/
+    # "never"), so let the teardown sweep the stale tiers instead of leaving them firing
+    # execute-dag on node_ids that no longer materialize.
+    if (
+        not desired_tiers
+        and has_schedulable_nodes
+        and existing_ids
+        and not any(is_tier_schedule_id(schedule_id) for schedule_id in existing_ids)
+    ):
         logger.warning(
             "Refusing to unschedule an unseeded DAG with only legacy schedules",
             dag_id=dag_id,

--- a/products/data_modeling/backend/test/test_schedule_reconcile.py
+++ b/products/data_modeling/backend/test/test_schedule_reconcile.py
@@ -186,6 +186,33 @@ class TestReconcileDagSchedules(BaseTest):
         create.assert_not_called()
         delete.assert_not_called()
 
+    def test_sweeps_legacy_schedule_when_dag_has_no_schedulable_nodes(self):
+        # a DAG holding only source tables has nothing to seed, so the unseeded-conversion
+        # guard must not apply: its legacy schedule just fires no-op execute-dag runs forever
+        dag = DAG.get_or_create_default(self.team)
+        _table_node(self.team, dag, "events", {"origin": "posthog"})
+
+        legacy_id = str(dag.id)
+
+        async def fake_list_schedules(*_args, **_kwargs):
+            async def gen():
+                yield _listing(legacy_id)
+
+            return gen()
+
+        temporal = mock.Mock()
+        temporal.list_schedules = fake_list_schedules
+
+        with (
+            mock.patch(f"{RECONCILE}.async_connect", new=mock.AsyncMock(return_value=temporal)),
+            mock.patch(f"{RECONCILE}.a_create_schedule", new=mock.AsyncMock()) as create,
+            mock.patch(f"{RECONCILE}.a_delete_schedule", new=mock.AsyncMock()) as delete,
+        ):
+            reconcile_dag_schedules(dag)
+
+        create.assert_not_called()
+        delete.assert_called_once_with(temporal, schedule_id=legacy_id)
+
     def test_winds_down_tier_schedules_when_all_targets_cleared(self):
         # reverting/clearing the last target leaves empty desired tiers; once tier schedules exist
         # that is a deliberate wind-down, so the stale tier must be torn down rather than left


### PR DESCRIPTION
## Problem

`reconcile_dag_schedules` refuses to converge a DAG to zero schedules while it still has only legacy (non-tier) schedules, because an empty desired tier set there usually means an unseeded conversion. But the guard fired for every legacy DAG with empty tiers, including DAGs that have no schedulable nodes at all (only source-table nodes). Those DAGs have nothing to seed, so:

- the dry-run preview printed `DELETE 1` for the legacy schedule, and
- the apply silently skipped it, leaving the schedule firing no-op execute-dag runs forever.

Hit in practice converting a team whose `Default` DAG holds only `events`/`persons` table nodes: the plan said the bare schedule would be deleted, the apply left it running, and it had to be deleted by hand in Temporal.

## Changes

- `reconcile_dag_schedules` now passes `has_schedulable_nodes` (from the frequency graph) into `_apply_reconciliation`.
- The unseeded-conversion guard only refuses when the DAG actually has schedulable nodes. A DAG without any proceeds to the normal plan, so its stale legacy schedule is swept.
- Genuinely unseeded DAGs (schedulable nodes present, no targets) keep the existing protection, and the tier wind-down path is unchanged.

## How did you test this code?

Red-first test `test_sweeps_legacy_schedule_when_dag_has_no_schedulable_nodes`: a DAG with only a source-table node and a live legacy schedule must get that schedule deleted. It fails on master (delete never called) and passes with the fix. No existing test covered the no-schedulable-nodes shape; the neighboring guard test (`test_refuses_to_unschedule_covered_dag_without_targets`) covers the seeded-protection case and still passes.

Ran `test_schedule_reconcile.py` (13 passed), `test_reconcile_freshness_schedules.py` + `test_preview_freshness_schedules.py` (11 passed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal scheduling behavior, no docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, driven by the assignee after the mismatch surfaced during a live tiered-schedules conversion. Skills invoked: /writing-tests, /quick-fix-pr. The fix deliberately keys on "has schedulable nodes" rather than making the preview mirror the guard: the schedule is a pure no-op on such DAGs, and sweeping it matches what the plan already promises.
