### PR TITLE
fix(data-imports): stop reporting transient billing-check DB connection blips

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/row_tracking.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/row_tracking.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.db.models import F, Q, Sum
+from django.db.utils import OperationalError
 
 from dateutil import parser
 from redis import exceptions as redis_exceptions
@@ -239,6 +240,12 @@ async def will_hit_billing_limit(team_id: int, source: "ExternalDataSource", log
         # DNS resolution failure reaching the quota-limiting cache) shouldn't be reported
         # as an error-tracking issue.
         await logger.awarning(f"BillingLimits: Redis error while checking billing limits, failing open: {e}")
+
+        return False
+    except OperationalError as e:
+        # Same rationale as above: a dropped Postgres connection while fetching billing
+        # data is a transient infra blip, and the check already fails open.
+        await logger.awarning(f"BillingLimits: Database error while checking billing limits, failing open: {e}")
 
         return False
     except Exception as e:

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_row_tracking.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_row_tracking.py
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 from posthog.test.base import BaseTest
 from unittest import mock
 
+from django.db.utils import OperationalError
 from django.test import override_settings
 
 from asgiref.sync import sync_to_async
@@ -213,6 +214,28 @@ class TestRowTracking(BaseTest):
         ):
             mock_get_billing.side_effect = redis_exceptions.ConnectionError(
                 "Error -3 connecting to redis:6379. Temporary failure in name resolution."
+            )
+
+            assert await self._run(source, 10) is False
+
+        mock_capture_exception.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_row_tracking_fails_open_on_operational_error_without_capturing_exception(self):
+        # A dropped Postgres connection while fetching billing data is a transient infra
+        # blip, not a bug, and must fail open like any other billing-check error without
+        # being reported to error tracking.
+        source = await self._create_source()
+
+        with (
+            mock.patch("ee.billing.billing_manager.BillingManager.get_billing") as mock_get_billing,
+            mock.patch(
+                "products.warehouse_sources.backend.temporal.data_imports.row_tracking.capture_exception"
+            ) as mock_capture_exception,
+        ):
+            mock_get_billing.side_effect = OperationalError(
+                'connection failed: connection to server at "127.0.0.1", port 5432 failed: '
+                "server closed the connection unexpectedly"
             )
 
             assert await self._run(source, 10) is False


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError` ("server closed the connection unexpectedly") during a data warehouse sync: [issue](https://us.posthog.com/project/2/error_tracking/019fb04f-d3cb-72d1-b357-e87b6c823c37).

The stack trace traces back to `will_hit_billing_limit` / `_get_billing_data` in `products/warehouse_sources/backend/temporal/data_imports/row_tracking.py` — the shared, source-agnostic billing-limit check that runs for every sync. The failure happened while the Django ORM was querying PostHog's own Postgres for the billing check, not while talking to the source being synced. It's a transient dropped connection, not a data or connector bug.

That check already fails open (`return False`) on any exception, so the sync itself is unaffected. The problem is purely that this transient blip gets reported as a new error-tracking issue every time it happens, via the broad `except Exception` → `capture_exception` fallback. The function already has a precedent for this: a `RedisError` carve-out just above it that logs a warning instead of capturing, since row tracking is best-effort and this check fails open regardless.

## Changes

Add an `OperationalError` (from `django.db.utils`) carve-out to `will_hit_billing_limit`, mirroring the existing `RedisError` handling — log a warning and fail open instead of sending it to error tracking.

## How did you test this code?

Added `test_row_tracking_fails_open_on_operational_error_without_capturing_exception`, modeled directly on the existing `test_row_tracking_fails_open_on_redis_error_without_capturing_exception`: it makes the billing lookup raise `django.db.utils.OperationalError` and asserts the check still fails open (`False`) without calling `capture_exception`. This is the exact regression the carve-out fixes — no existing test covered an `OperationalError` during this path.

I wasn't able to run the Django test suite in this sandbox (no reachable Postgres instance), the same limitation noted on the prior Redis-blip fix for this file (#69750). I did verify:
- `ruff check` / `ruff format` pass on both changed files (via `hogli ci:preflight --fix`).
- `mypy --cache-fine-grained` passes on `row_tracking.py` with no issues.
- The exception class matches production: `django.db.utils.OperationalError` is exactly what the captured stack trace shows (module `django.db.utils`, wrapping the underlying `psycopg.OperationalError`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-handling behavior, no user-facing or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog's error tracking MCP tools to pull the full stack trace and confirm the failure originates in the shared billing-check path (not the Supabase source connector that happened to be running). Searched open PRs for an existing fix (none found; the closest match, #69750, only covers Redis blips in the same file) before making this change. Invoked `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*