### PR TITLE
fix(data-warehouse): add search aliases for Google Sheets and BigQuery connectors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -316,6 +316,7 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.BIG_QUERY,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["bq", "gbq"],
             featured=True,
             iconPath="/static/services/bigquery.png",
             caption=(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -193,6 +193,7 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.GOOGLE_SHEETS,
             category=DataWarehouseSourceCategory.PRODUCTIVITY,
+            keywords=["gsheet", "gsheets", "spreadsheet", "google sheet"],
             label="Google Sheets",
             caption="Ensure you have granted PostHog access to your Google Sheet as instructed in the [documentation](https://posthog.com/docs/cdp/sources/google-sheets). The first row of each sheet must contain unique column headers, since PostHog reads it as the column names when syncing.",
             releaseStatus=ReleaseStatus.GA,


### PR DESCRIPTION
## Problem

Session-replay analysis of the data-warehouse new-source onboarding flow shows users repeatedly failing to find an available connector because they search by a common alternate name instead of its full label. In one observed case a user searched "gsheet" and got no results even though Google Sheets is a featured, GA source. The catalog search fuzzy-matches `name`, `label`, `category`, and `keywords`, but Google Sheets and BigQuery had no `keywords` set — so short forms like "gsheet"/"gsheets" and "bq" matched nothing and dead-ended the user.

## Changes

Populate the existing (already-indexed) `keywords` search-alias field on two featured GA connectors:

- **Google Sheets** → `gsheet`, `gsheets`, `spreadsheet`, `google sheet`
- **BigQuery** → `bq`, `gbq`

This mirrors the precedent already in the catalog (Google Analytics → `ga4`/`ga`, Google Search Console → `gsc`). Search-only change: no sync behaviour, schemas, or connector logic are touched.

## How did you test this code?

`ruff check` passes on both touched files. No test or snapshot asserts on these source configs' keywords, and the wizard catalog already indexes `keywords` via the existing Fuse.js search, so no frontend change is required. I (the agent) did not run the app manually.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Change surfaced by reviewing anonymised session summaries of the new-source onboarding flow. The recurring theme was "user can't find a connector by the alternate name they typed". Only connectors with direct evidence (Google Sheets, "gsheet") plus a universal unambiguous abbreviation (BigQuery, "bq") were included; ambiguous cases (e.g. "http"/"post" searchers wanting event capture rather than a REST warehouse source) were deliberately left out to avoid mis-routing. No skills were required for this backend metadata change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
