### PR TITLE
feat(capture-logs): reject unknown project tokens at the ingest edge

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2238,6 +2238,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "apache-avro",
+ "async-trait",
  "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
@@ -2255,6 +2256,7 @@ dependencies = [
  "jsonwebtoken",
  "limiters",
  "metrics",
+ "moka",
  "opentelemetry-proto 0.29.0",
  "prost 0.13.5",
  "rdkafka",
@@ -2262,6 +2264,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "siphasher 1.0.2",
+ "sqlx",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.12.3",

--- a/rust/capture-logs/Cargo.toml
+++ b/rust/capture-logs/Cargo.toml
@@ -17,6 +17,9 @@ common-continuous-profiling = { path = "../common/continuous_profiling" }
 common-compression = { path = "../common/compression" }
 limiters = { path = "../common/limiters" }
 capture = { path = "../capture" }
+async-trait = { workspace = true }
+moka = { workspace = true }
+sqlx = { workspace = true }
 opentelemetry-proto = { workspace = true }
 tonic = { workspace = true }
 jsonwebtoken = "8.3"

--- a/rust/capture-logs/src/config.rs
+++ b/rust/capture-logs/src/config.rs
@@ -26,6 +26,18 @@ pub struct Config {
 
     pub drop_events_by_token: Option<String>, // "<token>,<token>..."
 
+    // When set, tokens are validated against posthog_team (cached, fail-open)
+    // and unknown tokens get 401 instead of a silent consumer-side drop.
+    // Unset = no validation, today's behavior.
+    #[envconfig(from = "TOKEN_VALIDATION_DATABASE_URL")]
+    pub token_validation_database_url: Option<String>,
+
+    #[envconfig(from = "TOKEN_CACHE_CAPACITY", default = "100000")]
+    pub token_cache_capacity: u64,
+
+    #[envconfig(from = "TOKEN_CACHE_TTL_SECS", default = "300")]
+    pub token_cache_ttl_secs: u64,
+
     #[envconfig(from = "MAX_REQUEST_BODY_SIZE_BYTES", default = "2097152")] // 2MB (Axum default)
     pub max_request_body_size_bytes: usize,
 }

--- a/rust/capture-logs/src/endpoints/datadog.rs
+++ b/rust/capture-logs/src/endpoints/datadog.rs
@@ -321,7 +321,6 @@ pub async fn export_datadog_logs_http(
             Json(json!({"error": "Invalid token"})),
         ));
     }
-    crate::service::reject_unknown_token(&service, &token).await?;
 
     tracing::Span::current().record("token", &token);
 

--- a/rust/capture-logs/src/endpoints/datadog.rs
+++ b/rust/capture-logs/src/endpoints/datadog.rs
@@ -321,6 +321,7 @@ pub async fn export_datadog_logs_http(
             Json(json!({"error": "Invalid token"})),
         ));
     }
+    crate::service::reject_unknown_token(&service, &token).await?;
 
     tracing::Span::current().record("token", &token);
 

--- a/rust/capture-logs/src/lib.rs
+++ b/rust/capture-logs/src/lib.rs
@@ -8,5 +8,6 @@ pub mod metric_record;
 pub mod metrics_avro_schema;
 pub mod middleware;
 pub mod service;
+pub mod token_validator;
 pub mod trace_record;
 pub mod traces_avro_schema;

--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -23,6 +23,7 @@ use tracing::level_filters::LevelFilter;
 use tracing::{error, info};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
 
+use capture_logs::token_validator::{PgTokenStore, TokenValidator};
 use limiters::token_dropper::TokenDropper;
 
 common_alloc::used!();
@@ -118,9 +119,31 @@ async fn main() {
 
     let token_dropper = TokenDropper::new(&config.drop_events_by_token.unwrap_or_default());
     let token_dropper_arc = Arc::new(token_dropper);
+
+    let token_validator = match &config.token_validation_database_url {
+        Some(url) => match PgTokenStore::connect(url).await {
+            Ok(store) => {
+                info!("Token validation enabled (cached, fail-open)");
+                TokenValidator::new(
+                    Some(Arc::new(store)),
+                    config.token_cache_capacity,
+                    Duration::from_secs(config.token_cache_ttl_secs),
+                )
+            }
+            Err(e) => {
+                // Fail open at startup too: run without validation rather
+                // than refusing to serve ingest because Postgres is away.
+                error!("Token validation disabled, could not reach its database: {e}");
+                TokenValidator::disabled()
+            }
+        },
+        None => TokenValidator::disabled(),
+    };
+
     let logs_service = match Service::new(
         kafka_sink,
         token_dropper_arc,
+        Arc::new(token_validator),
         config.max_request_body_size_bytes,
     )
     .await

--- a/rust/capture-logs/src/main.rs
+++ b/rust/capture-logs/src/main.rs
@@ -121,9 +121,9 @@ async fn main() {
     let token_dropper_arc = Arc::new(token_dropper);
 
     let token_validator = match &config.token_validation_database_url {
-        Some(url) => match PgTokenStore::connect(url).await {
+        Some(url) => match PgTokenStore::connect(url) {
             Ok(store) => {
-                info!("Token validation enabled (cached, fail-open)");
+                info!("Token validation enabled (cached, lazy pool, fail-open)");
                 TokenValidator::new(
                     Some(Arc::new(store)),
                     config.token_cache_capacity,
@@ -131,9 +131,9 @@ async fn main() {
                 )
             }
             Err(e) => {
-                // Fail open at startup too: run without validation rather
-                // than refusing to serve ingest because Postgres is away.
-                error!("Token validation disabled, could not reach its database: {e}");
+                // Only an unparseable URL lands here (the pool is lazy);
+                // run without validation rather than refusing to boot.
+                error!("Token validation disabled, invalid database URL: {e}");
                 TokenValidator::disabled()
             }
         },

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -10,6 +10,8 @@ use axum::{
 use bytes::Bytes;
 use common_compression::{decompress_gzip_capped, has_gzip_magic_header, CompressionError};
 use limiters::token_dropper::TokenDropper;
+
+use crate::token_validator::{TokenValidator, TokenVerdict};
 use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
 use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use opentelemetry_proto::tonic::collector::trace::v1::ExportTraceServiceRequest;
@@ -304,6 +306,7 @@ pub fn parse_otel_message(json_bytes: &Bytes) -> Result<ExportLogsServiceRequest
 pub struct Service {
     pub(crate) sink: KafkaSink,
     pub(crate) token_dropper: Arc<TokenDropper>,
+    pub(crate) token_validator: Arc<TokenValidator>,
     pub(crate) max_request_body_size_bytes: usize,
 }
 
@@ -316,14 +319,31 @@ impl Service {
     pub async fn new(
         kafka_sink: KafkaSink,
         token_dropper: Arc<TokenDropper>,
+        token_validator: Arc<TokenValidator>,
         max_request_body_size_bytes: usize,
     ) -> Result<Self, anyhow::Error> {
         Ok(Self {
             sink: kafka_sink,
             token_dropper,
+            token_validator,
             max_request_body_size_bytes,
         })
     }
+}
+
+/// 401 for tokens no team owns; unavailable validation fails open.
+pub(crate) async fn reject_unknown_token(
+    service: &Service,
+    token: &str,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    if service.token_validator.check(token).await == TokenVerdict::Unknown {
+        error!("Unknown project API key");
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error": "Unknown project API key"})),
+        ));
+    }
+    Ok(())
 }
 
 pub(crate) fn decode_body_if_gzip_magic(
@@ -416,6 +436,7 @@ pub async fn export_logs_http(
             Json(json!({"error": format!("Invalid token")})),
         ));
     }
+    reject_unknown_token(&service, token).await?;
 
     tracing::Span::current().record("token", token);
 
@@ -607,6 +628,8 @@ pub async fn export_traces_http(
         ));
     }
 
+    reject_unknown_token(&service, token).await?;
+
     tracing::Span::current().record("token", token);
 
     let body = decode_body_if_gzip_magic(body, service.max_request_body_size_bytes)?;
@@ -783,6 +806,8 @@ pub async fn export_metrics_http(
             Json(json!({"error": "Invalid token"})),
         ));
     }
+
+    reject_unknown_token(&service, token).await?;
 
     tracing::Span::current().record("token", token);
 

--- a/rust/capture-logs/src/service.rs
+++ b/rust/capture-logs/src/service.rs
@@ -331,7 +331,9 @@ impl Service {
     }
 }
 
-/// 401 for tokens no team owns; unavailable validation fails open.
+/// 401 for tokens no team owns; unavailable validation fails open. Applied to
+/// the metrics endpoint only (where a typo'd onboarding token otherwise 200s
+/// and silently drops); the higher-volume logs/traces paths are left untouched.
 pub(crate) async fn reject_unknown_token(
     service: &Service,
     token: &str,
@@ -436,7 +438,6 @@ pub async fn export_logs_http(
             Json(json!({"error": format!("Invalid token")})),
         ));
     }
-    reject_unknown_token(&service, token).await?;
 
     tracing::Span::current().record("token", token);
 
@@ -627,8 +628,6 @@ pub async fn export_traces_http(
             Json(json!({"error": "Invalid token"})),
         ));
     }
-
-    reject_unknown_token(&service, token).await?;
 
     tracing::Span::current().record("token", token);
 

--- a/rust/capture-logs/src/token_validator.rs
+++ b/rust/capture-logs/src/token_validator.rs
@@ -36,13 +36,16 @@ pub struct PgTokenStore {
 }
 
 impl PgTokenStore {
-    pub async fn connect(database_url: &str) -> anyhow::Result<Self> {
-        // A tiny pool: lookups happen only on cache misses.
+    pub fn connect(database_url: &str) -> anyhow::Result<Self> {
+        // A tiny lazy pool: lookups happen only on cache misses, and no
+        // connection is made until the first one — a database that is slow or
+        // down at boot must not disable validation for the process lifetime.
+        // Per-lookup failures fail open in check() and self-heal when the
+        // database returns.
         let pool = PgPoolOptions::new()
             .max_connections(2)
             .acquire_timeout(Duration::from_secs(1))
-            .connect(database_url)
-            .await?;
+            .connect_lazy(database_url)?;
         Ok(Self { pool })
     }
 }

--- a/rust/capture-logs/src/token_validator.rs
+++ b/rust/capture-logs/src/token_validator.rs
@@ -1,0 +1,219 @@
+//! Validates project API tokens against real teams, so a typo'd key gets an
+//! immediate 401 at the edge instead of a 200 followed by a silent
+//! `team_not_found` drop in the ingestion consumer.
+//!
+//! The hot path never blocks on Postgres: verdicts are cached (positive and
+//! negative), and any store failure fails OPEN — ingestion availability wins
+//! over rejecting bad tokens. With no store configured the validator is a
+//! no-op, preserving today's behavior.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use metrics::counter;
+use moka::future::Cache;
+use sqlx::postgres::{PgPool, PgPoolOptions};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenVerdict {
+    /// The token maps to a real team (or validation is disabled).
+    Valid,
+    /// The store definitively answered: no team has this token.
+    Unknown,
+    /// The store could not answer; callers must fail open.
+    Unavailable,
+}
+
+#[async_trait]
+pub trait TokenStore: Send + Sync {
+    /// Ok(true) = a team owns this token; Ok(false) = definitively unknown.
+    async fn token_exists(&self, token: &str) -> anyhow::Result<bool>;
+}
+
+pub struct PgTokenStore {
+    pool: PgPool,
+}
+
+impl PgTokenStore {
+    pub async fn connect(database_url: &str) -> anyhow::Result<Self> {
+        // A tiny pool: lookups happen only on cache misses.
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .acquire_timeout(Duration::from_secs(1))
+            .connect(database_url)
+            .await?;
+        Ok(Self { pool })
+    }
+}
+
+#[async_trait]
+impl TokenStore for PgTokenStore {
+    async fn token_exists(&self, token: &str) -> anyhow::Result<bool> {
+        let row: Option<i64> =
+            sqlx::query_scalar("SELECT 1::bigint FROM posthog_team WHERE api_token = $1 LIMIT 1")
+                .bind(token)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.is_some())
+    }
+}
+
+pub struct TokenValidator {
+    store: Option<Arc<dyn TokenStore>>,
+    cache: Cache<String, bool>,
+}
+
+impl TokenValidator {
+    pub fn new(store: Option<Arc<dyn TokenStore>>, cache_size: u64, cache_ttl: Duration) -> Self {
+        Self {
+            store,
+            cache: Cache::builder()
+                .max_capacity(cache_size)
+                .time_to_live(cache_ttl)
+                .build(),
+        }
+    }
+
+    pub fn disabled() -> Self {
+        Self::new(None, 1, Duration::from_secs(1))
+    }
+
+    pub async fn check(&self, token: &str) -> TokenVerdict {
+        let Some(store) = &self.store else {
+            counter!("capture_logs_token_validation_total", "result" => "disabled").increment(1);
+            return TokenVerdict::Valid;
+        };
+
+        if let Some(exists) = self.cache.get(token).await {
+            let result = if exists {
+                "valid_cached"
+            } else {
+                "unknown_cached"
+            };
+            counter!("capture_logs_token_validation_total", "result" => result).increment(1);
+            return if exists {
+                TokenVerdict::Valid
+            } else {
+                TokenVerdict::Unknown
+            };
+        }
+
+        match store.token_exists(token).await {
+            Ok(exists) => {
+                self.cache.insert(token.to_string(), exists).await;
+                let result = if exists { "valid" } else { "unknown" };
+                counter!("capture_logs_token_validation_total", "result" => result).increment(1);
+                if exists {
+                    TokenVerdict::Valid
+                } else {
+                    TokenVerdict::Unknown
+                }
+            }
+            Err(e) => {
+                // Fail open: never let a store outage take down ingestion.
+                tracing::warn!("token validation unavailable, accepting: {e}");
+                counter!("capture_logs_token_validation_total", "result" => "unavailable")
+                    .increment(1);
+                TokenVerdict::Unavailable
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct FakeStore {
+        exists: Option<bool>, // None = error
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl TokenStore for FakeStore {
+        async fn token_exists(&self, _token: &str) -> anyhow::Result<bool> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            match self.exists {
+                Some(v) => Ok(v),
+                None => anyhow::bail!("pg down"),
+            }
+        }
+    }
+
+    fn validator_with(store: Arc<FakeStore>) -> TokenValidator {
+        TokenValidator::new(Some(store), 100, Duration::from_secs(60))
+    }
+
+    #[tokio::test]
+    async fn disabled_validator_accepts_everything_without_a_store() {
+        let v = TokenValidator::disabled();
+        assert_eq!(v.check("phc_anything").await, TokenVerdict::Valid);
+    }
+
+    #[tokio::test]
+    async fn known_token_is_valid_and_cached() {
+        let store = Arc::new(FakeStore {
+            exists: Some(true),
+            calls: AtomicUsize::new(0),
+        });
+        let v = validator_with(store.clone());
+        assert_eq!(v.check("phc_real").await, TokenVerdict::Valid);
+        assert_eq!(v.check("phc_real").await, TokenVerdict::Valid);
+        assert_eq!(
+            store.calls.load(Ordering::SeqCst),
+            1,
+            "second check must hit the cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_token_is_rejected_and_negative_cached() {
+        let store = Arc::new(FakeStore {
+            exists: Some(false),
+            calls: AtomicUsize::new(0),
+        });
+        let v = validator_with(store.clone());
+        assert_eq!(v.check("phc_typo").await, TokenVerdict::Unknown);
+        assert_eq!(v.check("phc_typo").await, TokenVerdict::Unknown);
+        assert_eq!(
+            store.calls.load(Ordering::SeqCst),
+            1,
+            "negative verdicts must also cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn store_error_fails_open_and_is_not_cached() {
+        let store = Arc::new(FakeStore {
+            exists: None,
+            calls: AtomicUsize::new(0),
+        });
+        let v = validator_with(store.clone());
+        assert_eq!(v.check("phc_any").await, TokenVerdict::Unavailable);
+        assert_eq!(v.check("phc_any").await, TokenVerdict::Unavailable);
+        assert_eq!(
+            store.calls.load(Ordering::SeqCst),
+            2,
+            "unavailable verdicts must not be cached, so recovery is immediate"
+        );
+    }
+
+    #[tokio::test]
+    async fn distinct_tokens_get_distinct_verdicts() {
+        let store = Arc::new(FakeStore {
+            exists: Some(true),
+            calls: AtomicUsize::new(0),
+        });
+        let v = validator_with(store);
+        assert_eq!(v.check("phc_a").await, TokenVerdict::Valid);
+        // A different token is a cache miss, not a reuse of phc_a's verdict.
+        let store2 = Arc::new(FakeStore {
+            exists: Some(false),
+            calls: AtomicUsize::new(0),
+        });
+        let v2 = validator_with(store2);
+        assert_eq!(v2.check("phc_b").await, TokenVerdict::Unknown);
+    }
+}

--- a/rust/capture-logs/src/token_validator.rs
+++ b/rust/capture-logs/src/token_validator.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use capture::token::validate_token;
 use metrics::counter;
 use moka::future::Cache;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -88,23 +89,26 @@ impl TokenValidator {
             return TokenVerdict::Valid;
         };
 
-        if let Some(exists) = self.cache.get(token).await {
-            let result = if exists {
-                "valid_cached"
-            } else {
-                "unknown_cached"
-            };
-            counter!("capture_logs_token_validation_total", "result" => result).increment(1);
-            return if exists {
-                TokenVerdict::Valid
-            } else {
-                TokenVerdict::Unknown
-            };
+        // Shape-check before touching the cache or Postgres. A token that isn't
+        // even a well-formed project key has no team, so reject it here — and,
+        // critically, unauthenticated junk (unique garbage tokens) can never
+        // drive a cache miss or a database lookup, closing the DoS amplifier.
+        if validate_token(token).is_err() {
+            counter!("capture_logs_token_validation_total", "result" => "malformed").increment(1);
+            return TokenVerdict::Unknown;
         }
 
-        match store.token_exists(token).await {
+        // try_get_with coalesces concurrent misses for the same token into a
+        // single query (one Postgres round trip per key, not one per request),
+        // caches the Ok verdict (positive and negative), and does NOT cache
+        // errors — so a store blip fails open per-request and self-heals.
+        let token_owned = token.to_string();
+        match self
+            .cache
+            .try_get_with(token_owned, async { store.token_exists(token).await })
+            .await
+        {
             Ok(exists) => {
-                self.cache.insert(token.to_string(), exists).await;
                 let result = if exists { "valid" } else { "unknown" };
                 counter!("capture_logs_token_validation_total", "result" => result).increment(1);
                 if exists {
@@ -200,6 +204,25 @@ mod tests {
             store.calls.load(Ordering::SeqCst),
             2,
             "unavailable verdicts must not be cached, so recovery is immediate"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_tokens_are_rejected_without_touching_the_store() {
+        // A personal API key (phx_) is not a project token — it must be
+        // rejected on shape alone, and must never reach Postgres, so garbage
+        // traffic can't drive database load.
+        let store = Arc::new(FakeStore {
+            exists: Some(true),
+            calls: AtomicUsize::new(0),
+        });
+        let v = validator_with(store.clone());
+        assert_eq!(v.check("phx_personal_key").await, TokenVerdict::Unknown);
+        assert_eq!(v.check("").await, TokenVerdict::Unknown);
+        assert_eq!(
+            store.calls.load(Ordering::SeqCst),
+            0,
+            "malformed tokens must never query the store"
         );
     }
 


### PR DESCRIPTION
## Problem

An agent or SDK configured with a wrong project API key gets **HTTP 200** from `capture-logs` and then nothing: the edge only checks that a token is present (plus the static drop-list), and the `ingestion-metrics` consumer later drops every batch with `team_not_found`. The customer sees no error anywhere - the worst possible onboarding failure mode, found live during the metrics agent E2E (a bogus key produced 200s and zero rows).

## Changes

`capture-logs` can now validate tokens against real teams and return **401 for tokens no team owns**, on all four ingest surfaces (OTLP logs, metrics, traces, and the Datadog logs shim).

Reliability posture, because this adds a lookup to an ingest hot path:

- **Off by default.** Without `TOKEN_VALIDATION_DATABASE_URL` set, behavior is byte-for-byte today's (a disabled validator short-circuits to accept).
- **Fail open everywhere.** A store error accepts the request; an unreachable database at startup disables validation instead of refusing to boot. Only a *definitive* "no team has this token" answer rejects.
- **Cached, tiny pool.** Verdicts (positive and negative) cache in-process (moka, default 100k entries / 300s TTL), so steady state does zero database work; the pool is 2 connections with a 1s acquire timeout. Same pattern as cymbal's token cache.
- Every verdict increments `capture_logs_token_validation_total{result=...}` so the rollout is observable (`valid`/`unknown`/`unavailable`/`disabled` + cached variants).

New env: `TOKEN_VALIDATION_DATABASE_URL`, `TOKEN_CACHE_CAPACITY` (100000), `TOKEN_CACHE_TTL_SECS` (300).

## How did you test this code?

TDD unit tests on the validator semantics (a counting fake store): disabled-accepts, known-token cached, unknown-token negative-cached, store-error fails open *and is not cached* (so recovery is immediate), per-token verdicts.

E2E observed against the local dev stack (screenshots below): a branch build with validation enabled returns **401 `{"error":"Unknown project API key"}`** for a bogus key and **200** for the real project token, and the accepted metric lands in ClickHouse `posthog.metrics`:

![unknown token gets 401 at the edge, real token lands in ClickHouse](https://raw.githubusercontent.com/PostHog/pr-assets/f9ee82328b519200a268cc1cc7a5964b2a9bfc5f/2026/07/bc9e44c3-9da3-456d-b88a-3e9d0e6c5488.png)

**Follow-up commit (lazy pool):** the Postgres pool now uses `connect_lazy`, so a database that is slow or down at service boot no longer disables validation for the process lifetime - observed live when a 1s connect timeout during a busy stack boot permanently disabled it. No connection is made until the first cache miss; per-lookup failures fail open and self-heal when the database returns.

## Rollout

1. Ship dark (no env set, no behavior change).
2. Set `TOKEN_VALIDATION_DATABASE_URL` on one region's deployment and watch `capture_logs_token_validation_total` - `unknown` counts are exactly the requests that were previously silently dropped by the consumer.
3. The `unavailable` counter is the fail-open safety signal: it should be ~0; sustained nonzero means the database/pool needs attention, while ingest keeps working.

## Update: scoped to metrics + hardened (addressing review)

Three changes in response to the greptile/veria/stamphog concerns, all narrowing blast radius:

- **Metrics endpoint only.** Validation was removed from the logs, traces, and Datadog paths — those higher-volume, latency-sensitive hot paths are now byte-for-byte unchanged. The bug this fixes (a typo'd onboarding token silently dropped) is metrics-specific, so that's the only path that needs it. Logs ingestion is untouched.
- **Shape-check before any lookup** (reuses `capture::token::validate_token`). Malformed/oversized/personal-key tokens are rejected with zero cache or Postgres interaction, which closes the unauthenticated-unique-token DoS amplifier veria flagged — junk traffic can't reach the database.
- **Coalescing loader** (`moka try_get_with`). Concurrent misses for the same token collapse into a single Postgres query instead of a thundering herd (greptile's "concurrent misses" P1). Errors are still not cached, so a store blip fails open per-request and self-heals.

Unchanged safety floor: validator is still off unless `TOKEN_VALIDATION_DATABASE_URL` is set (merging is dark), and any Postgres failure fails **open** — metrics flow rather than drop. The P2 "deployment wiring is external" is intentional: this ships dark and is enabled per-environment via charts once we choose to, exactly as the rollout section describes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The metrics troubleshooting docs currently say a wrong token "fails silently" - accurate until this is enabled in production; [PostHog/posthog.com#19089](https://github.com/PostHog/posthog.com/pull/19089) will be updated to describe the 401 when this rolls out.

## 🤖 Agent context

**Autonomy:** Fully autonomous (overnight run)

Built as part of closing the metrics dream-state gaps: this was a diagnosed-and-documented bug from the scrape-agent E2E (wrong key → 200 + silent drop). Design follows the candidate fix documented at diagnosis time: hypercache-style cached team lookup, fail-open on any infrastructure error, gated by config so the capture-logs team controls enablement per environment. The store is a trait so the cache/verdict semantics are unit-tested without Postgres; `cymbal`'s moka token cache is the in-repo precedent.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


