### PR TITLE
fix(capture): make the warnings emitter gauge reach prometheus

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2879,6 +2879,7 @@ dependencies = [
  "lz4",
  "metrics",
  "rdkafka",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -29,8 +29,8 @@ use limiters::token_dropper::TokenDropper;
 
 use crate::config::{AiRouting, CaptureMode};
 use crate::metrics_middleware::track_metrics;
-use crate::prometheus::setup_metrics_recorder;
 use crate::quota_limiters::CaptureQuotaLimiter;
+use metrics_exporter_prometheus::PrometheusHandle;
 
 const EVENT_BODY_SIZE: usize = 2 * 1024 * 1024; // 2MB
 pub const BATCH_BODY_SIZE: usize = 20 * 1024 * 1024; // 20MB, up from the default 2MB used for normal event payloads
@@ -164,9 +164,8 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
     quota_limiter: CaptureQuotaLimiter,
     token_dropper: TokenDropper,
     event_restriction_service: Option<EventRestrictionService>,
-    metrics: bool,
+    recorder_handle: Option<PrometheusHandle>,
     capture_mode: CaptureMode,
-    deploy_role: String,
     concurrency_limit: Option<usize>,
     event_payload_size_limit: usize,
     enable_historical_rerouting: bool,
@@ -454,11 +453,11 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
         .layer(axum::middleware::from_fn(track_metrics))
         .with_state(state);
 
-    // Don't install metrics unless asked to
-    // Installing a global recorder when capture is used as a library (during tests etc)
-    // does not work well.
-    if metrics {
-        let recorder_handle = setup_metrics_recorder(deploy_role, capture_mode.as_tag());
+    // The recorder is installed by the caller (`setup::build_components`), which
+    // must do it before any component emits, so all we do here is expose its
+    // output. `None` covers capture-as-a-library, where installing a global
+    // recorder does not work well.
+    if let Some(recorder_handle) = recorder_handle {
         router.route("/metrics", get(move || ready(recorder_handle.render())))
     } else {
         router

--- a/rust/capture/src/router.rs
+++ b/rust/capture/src/router.rs
@@ -453,10 +453,9 @@ pub fn router<TZ: TimeSource + Send + Sync + 'static, R: Client + Send + Sync + 
         .layer(axum::middleware::from_fn(track_metrics))
         .with_state(state);
 
-    // The recorder is installed by the caller (`setup::build_components`), which
-    // must do it before any component emits, so all we do here is expose its
-    // output. `None` covers capture-as-a-library, where installing a global
-    // recorder does not work well.
+    // The caller installs the recorder, before anything can emit; here we only
+    // expose its output. `None` for tests and library use, which have no
+    // recorder of their own.
     if let Some(recorder_handle) = recorder_handle {
         router.route("/metrics", get(move || ready(recorder_handle.render())))
     } else {

--- a/rust/capture/src/setup.rs
+++ b/rust/capture/src/setup.rs
@@ -17,6 +17,7 @@ use crate::ai_s3::AiBlobStorage;
 use crate::config::{AiRouting, AiSinkMode, CaptureMode, Config, KafkaConfig};
 use crate::event_restrictions::{EventRestrictionService, Pipeline, RedisRestrictionsRepository};
 use crate::global_rate_limiter::GlobalRateLimiter;
+use crate::prometheus::setup_metrics_recorder;
 use crate::quota_limiters::{
     is_exception_event, is_llm_event, is_survey_event, CaptureQuotaLimiter,
 };
@@ -160,6 +161,17 @@ pub async fn build_components(
         readiness,
         liveness,
     } = handles;
+
+    // First thing in the startup path: `gauge!`/`counter!` before the global
+    // recorder exists are silently dropped, and the recorder fixes its global
+    // `role`/`capture_mode` labels at install time. Anything built below is
+    // free to emit.
+    let recorder_handle = config.export_prometheus.then(|| {
+        setup_metrics_recorder(
+            config.otel_service_name.clone(),
+            config.capture_mode.as_tag(),
+        )
+    });
 
     let redis_client = Arc::new(
         RedisClient::with_config(
@@ -480,9 +492,8 @@ pub async fn build_components(
         quota_limiter,
         token_dropper,
         event_restriction_service,
-        config.export_prometheus,
+        recorder_handle,
         config.capture_mode,
-        config.otel_service_name.clone(),
         config.concurrency_limit,
         event_payload_max_bytes,
         config.enable_historical_rerouting,
@@ -750,9 +761,11 @@ async fn create_ingestion_warning_emitter(
     }
 
     // Past this point the operator asked for warnings, so every exit reports
-    // through the gauge. Leaving it unset above keeps "disabled" distinct from
-    // "enabled but broken".
-    let report_disabled = || gauge!(INGESTION_WARNINGS_EMITTER_ENABLED).set(0.0);
+    // through the gauge, labelled with which misconfiguration it hit. Leaving
+    // it unset above keeps "disabled" distinct from "enabled but broken".
+    let report_disabled = |reason: &'static str| {
+        gauge!(INGESTION_WARNINGS_EMITTER_ENABLED, "reason" => reason).set(0.0)
+    };
 
     let hosts = config.capture_ingestion_warnings_kafka_hosts.clone();
     let topic = config.capture_ingestion_warnings_kafka_topic.clone();
@@ -763,7 +776,7 @@ async fn create_ingestion_warning_emitter(
             "ingestion warnings enabled but CAPTURE_INGESTION_WARNINGS_KAFKA_HOSTS is unset; \
              emitter disabled"
         );
-        report_disabled();
+        report_disabled("hosts_unset");
         return None;
     }
 
@@ -772,7 +785,7 @@ async fn create_ingestion_warning_emitter(
             "ingestion warnings enabled but CAPTURE_INGESTION_WARNINGS_KAFKA_TOPIC is unset; \
              emitter disabled"
         );
-        report_disabled();
+        report_disabled("topic_unset");
         return None;
     }
 
@@ -780,7 +793,7 @@ async fn create_ingestion_warning_emitter(
         warn!(
             "ingestion warnings enabled but no lifecycle handle was registered; emitter disabled"
         );
-        report_disabled();
+        report_disabled("no_handle");
         return None;
     };
 
@@ -801,7 +814,7 @@ async fn create_ingestion_warning_emitter(
             tracing::error!(
                 "failed to create ingestion warnings producer, emitter disabled: {e:#}"
             );
-            report_disabled();
+            report_disabled("producer_create_failed");
             return None;
         }
     };
@@ -830,7 +843,7 @@ async fn create_ingestion_warning_emitter(
         }
     });
 
-    gauge!(INGESTION_WARNINGS_EMITTER_ENABLED).set(1.0);
+    gauge!(INGESTION_WARNINGS_EMITTER_ENABLED, "reason" => "ok").set(1.0);
     info!(topic = topic.as_str(), "ingestion warnings emitter enabled");
     Some(emitter)
 }
@@ -907,7 +920,68 @@ fn create_event_restriction_service(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+    use rstest::rstest;
     use std::collections::HashMap;
+
+    fn warnings_config(enabled: bool, hosts: &str, topic: &str) -> Config {
+        let cfg_env: HashMap<String, String> = [
+            ("REDIS_URL", "redis://localhost:6379/"),
+            ("CAPTURE_MODE", "events"),
+            ("KAFKA_HOSTS", "v0-broker:9092"),
+            ("KAFKA_TOPIC", "events_plugin_ingestion"),
+            (
+                "CAPTURE_INGESTION_WARNINGS_ENABLED",
+                if enabled { "true" } else { "false" },
+            ),
+            ("CAPTURE_INGESTION_WARNINGS_KAFKA_HOSTS", hosts),
+            ("CAPTURE_INGESTION_WARNINGS_KAFKA_TOPIC", topic),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+        envconfig::Envconfig::init_from_hashmap(&cfg_env).expect("test config")
+    }
+
+    /// The emitter gauge as `(reason, value)`, or `None` when it was never
+    /// emitted. Reads the `reason` label directly so a regression that drops it
+    /// from one branch fails rather than silently changing the label set.
+    fn emitter_enabled_gauge(snapshotter: &Snapshotter) -> Option<(String, f64)> {
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .find(|(ckey, _, _, _)| ckey.key().name() == INGESTION_WARNINGS_EMITTER_ENABLED)
+            .map(|(ckey, _, _, value)| {
+                let reason = ckey
+                    .key()
+                    .labels()
+                    .find(|label| label.key() == "reason")
+                    .map(|label| label.value().to_string())
+                    .expect("every emission must carry a reason label");
+                match value {
+                    DebugValue::Gauge(v) => (reason, v.into_inner()),
+                    other => panic!("expected a gauge, got {other:?}"),
+                }
+            })
+    }
+
+    /// Run `f` with metrics captured locally. `with_local_recorder` is
+    /// thread-scoped, so the future has to be driven on this thread — hence a
+    /// current-thread runtime rather than `#[tokio::test]`.
+    fn capture_metrics<T>(f: impl FnOnce() -> T) -> (T, Snapshotter) {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let out = metrics::with_local_recorder(&recorder, f);
+        (out, snapshotter)
+    }
+
+    fn current_thread_runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime")
+    }
 
     #[test]
     fn create_v1_sink_router_fails_on_invalid_config() {
@@ -1111,5 +1185,71 @@ mod tests {
         assert!(!set.contains(""));
 
         assert!(super::parse_token_allowlist("  ,  , ").is_empty());
+    }
+
+    /// The gauge is the only signal that separates "warnings are off on
+    /// purpose" (absent) from "an operator asked for warnings and we could not
+    /// build them" (`0`), and `reason` is what makes the second case
+    /// actionable without reading pod logs.
+    #[rstest]
+    #[case::off_on_purpose(false, "", "", None)]
+    #[case::hosts_unset(true, "", "", Some("hosts_unset"))]
+    #[case::topic_unset(true, "broker:9092", "", Some("topic_unset"))]
+    #[case::no_handle(true, "broker:9092", "client_ingestion_warning", Some("no_handle"))]
+    fn emitter_gauge_reports_why_warnings_are_off(
+        #[case] enabled: bool,
+        #[case] hosts: &str,
+        #[case] topic: &str,
+        #[case] expected_reason: Option<&str>,
+    ) {
+        let config = warnings_config(enabled, hosts, topic);
+        let runtime = current_thread_runtime();
+
+        let (emitter, snapshotter) =
+            capture_metrics(|| runtime.block_on(create_ingestion_warning_emitter(&config, None)));
+
+        assert!(emitter.is_none(), "no case here can build an emitter");
+        match expected_reason {
+            Some(reason) => assert_eq!(
+                emitter_enabled_gauge(&snapshotter),
+                Some((reason.to_string(), 0.0)),
+            ),
+            None => assert!(
+                emitter_enabled_gauge(&snapshotter).is_none(),
+                "a pod with warnings disabled must leave the gauge unset, or it \
+                 is indistinguishable from a misconfigured one",
+            ),
+        }
+    }
+
+    #[test]
+    fn healthy_emitter_reports_ok() {
+        // TEST-NET-1 host: the no-ping constructor never dials it, so this
+        // takes the real success path offline.
+        let config = warnings_config(true, "192.0.2.1:9092", "client_ingestion_warning");
+        let mut manager = lifecycle::Manager::builder("test")
+            .with_trap_signals(false)
+            .with_prestop_check(false)
+            .build();
+        // Mirrors the registration in `register_components`.
+        let handle = manager.register(
+            "ingestion-warnings",
+            lifecycle::ComponentOptions::new()
+                .with_liveness_deadline(Duration::from_secs(30))
+                .is_advisory(true),
+        );
+        let runtime = current_thread_runtime();
+
+        let (emitter, snapshotter) = capture_metrics(|| {
+            runtime.block_on(create_ingestion_warning_emitter(&config, Some(handle)))
+        });
+
+        assert!(emitter.is_some(), "emitter must be built");
+        assert_eq!(
+            emitter_enabled_gauge(&snapshotter),
+            Some(("ok".to_string(), 1.0)),
+            "the healthy path must label the gauge too, so both states share a \
+             label set and `min() == 0` needs no aggregation workaround",
+        );
     }
 }

--- a/rust/capture/src/setup.rs
+++ b/rust/capture/src/setup.rs
@@ -162,10 +162,8 @@ pub async fn build_components(
         liveness,
     } = handles;
 
-    // First thing in the startup path: `gauge!`/`counter!` before the global
-    // recorder exists are silently dropped, and the recorder fixes its global
-    // `role`/`capture_mode` labels at install time. Anything built below is
-    // free to emit.
+    // Must come first: metrics emitted before the global recorder exists are
+    // silently dropped, and its `role`/`capture_mode` labels are fixed here.
     let recorder_handle = config.export_prometheus.then(|| {
         setup_metrics_recorder(
             config.otel_service_name.clone(),
@@ -761,8 +759,8 @@ async fn create_ingestion_warning_emitter(
     }
 
     // Past this point the operator asked for warnings, so every exit reports
-    // through the gauge, labelled with which misconfiguration it hit. Leaving
-    // it unset above keeps "disabled" distinct from "enabled but broken".
+    // through the gauge with the reason it bailed. Leaving it unset above keeps
+    // "disabled" distinct from "enabled but broken".
     let report_disabled = |reason: &'static str| {
         gauge!(INGESTION_WARNINGS_EMITTER_ENABLED, "reason" => reason).set(0.0)
     };
@@ -943,9 +941,7 @@ mod tests {
         envconfig::Envconfig::init_from_hashmap(&cfg_env).expect("test config")
     }
 
-    /// The emitter gauge as `(reason, value)`, or `None` when it was never
-    /// emitted. Reads the `reason` label directly so a regression that drops it
-    /// from one branch fails rather than silently changing the label set.
+    /// The emitter gauge as `(reason, value)`, or `None` if never emitted.
     fn emitter_enabled_gauge(snapshotter: &Snapshotter) -> Option<(String, f64)> {
         snapshotter
             .snapshot()
@@ -966,9 +962,8 @@ mod tests {
             })
     }
 
-    /// Run `f` with metrics captured locally. `with_local_recorder` is
-    /// thread-scoped, so the future has to be driven on this thread — hence a
-    /// current-thread runtime rather than `#[tokio::test]`.
+    /// Run `f` with metrics captured locally. The recorder is thread-scoped, so
+    /// callers drive futures on this thread via `current_thread_runtime`.
     fn capture_metrics<T>(f: impl FnOnce() -> T) -> (T, Snapshotter) {
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();
@@ -1187,10 +1182,8 @@ mod tests {
         assert!(super::parse_token_allowlist("  ,  , ").is_empty());
     }
 
-    /// The gauge is the only signal that separates "warnings are off on
-    /// purpose" (absent) from "an operator asked for warnings and we could not
-    /// build them" (`0`), and `reason` is what makes the second case
-    /// actionable without reading pod logs.
+    /// Absent gauge means warnings are off on purpose; `0` means an operator
+    /// asked for them and we could not build them. `reason` says which.
     #[rstest]
     #[case::off_on_purpose(false, "", "", None)]
     #[case::hosts_unset(true, "", "", Some("hosts_unset"))]
@@ -1216,16 +1209,15 @@ mod tests {
             ),
             None => assert!(
                 emitter_enabled_gauge(&snapshotter).is_none(),
-                "a pod with warnings disabled must leave the gauge unset, or it \
-                 is indistinguishable from a misconfigured one",
+                "disabled must stay unset, or it looks misconfigured",
             ),
         }
     }
 
     #[test]
     fn healthy_emitter_reports_ok() {
-        // TEST-NET-1 host: the no-ping constructor never dials it, so this
-        // takes the real success path offline.
+        // TEST-NET-1 host: the no-ping constructor never dials it, so the real
+        // success path runs offline.
         let config = warnings_config(true, "192.0.2.1:9092", "client_ingestion_warning");
         let mut manager = lifecycle::Manager::builder("test")
             .with_trap_signals(false)
@@ -1248,8 +1240,7 @@ mod tests {
         assert_eq!(
             emitter_enabled_gauge(&snapshotter),
             Some(("ok".to_string(), 1.0)),
-            "the healthy path must label the gauge too, so both states share a \
-             label set and `min() == 0` needs no aggregation workaround",
+            "healthy and failed emissions must share a label set",
         );
     }
 }

--- a/rust/capture/src/v1/sinks/DESIGN.md
+++ b/rust/capture/src/v1/sinks/DESIGN.md
@@ -1057,7 +1057,9 @@ and the client-controlled `attempt` label is capped at `6+`, so
 All error-related metrics use stable, low-cardinality tags derived from:
 
 - `error_code_tag()` — maps `RDKafkaErrorCode` variants to snake_case strings
-  (e.g. `queue_full`, `message_size_too_large`, `all_brokers_down`)
+  (e.g. `queue_full`, `message_size_too_large`, `all_brokers_down`). Defined in
+  `common_kafka::error` and re-exported from `kafka/types.rs`, so producers
+  outside the sink share the same vocabulary
 - `KafkaSinkError::as_tag()` — sink-level tags
   (e.g. `sink_unavailable`, `timeout`, `task_panicked`)
 - `ProduceError::as_tag()` — producer-level tags

--- a/rust/capture/src/v1/sinks/kafka/types.rs
+++ b/rust/capture/src/v1/sinks/kafka/types.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use chrono::{DateTime, Utc};
-use rdkafka::error::RDKafkaErrorCode;
 use uuid::Uuid;
 
 use super::producer::ProduceError;
@@ -11,38 +10,10 @@ use crate::v1::sinks::types::{Outcome, SinkResult};
 // error_code_tag
 // ---------------------------------------------------------------------------
 
-/// Stable, low-cardinality snake_case tag for an RDKafkaErrorCode.
-/// Usable anywhere -- producer, sink, handler, logging.
-pub fn error_code_tag(code: RDKafkaErrorCode) -> &'static str {
-    match code {
-        RDKafkaErrorCode::QueueFull => "queue_full",
-        RDKafkaErrorCode::MessageSizeTooLarge => "message_size_too_large",
-        RDKafkaErrorCode::MessageTimedOut => "message_timed_out",
-        RDKafkaErrorCode::UnknownTopicOrPartition => "unknown_topic_or_partition",
-        RDKafkaErrorCode::TopicAuthorizationFailed => "topic_authorization_failed",
-        RDKafkaErrorCode::ClusterAuthorizationFailed => "cluster_authorization_failed",
-        RDKafkaErrorCode::InvalidMessage => "invalid_message",
-        RDKafkaErrorCode::InvalidMessageSize => "invalid_message_size",
-        RDKafkaErrorCode::NotLeaderForPartition => "not_leader_for_partition",
-        RDKafkaErrorCode::RequestTimedOut => "request_timed_out",
-        // Broker/idempotent-producer codes from delivery reports
-        RDKafkaErrorCode::NotEnoughReplicas => "not_enough_replicas",
-        RDKafkaErrorCode::NotEnoughReplicasAfterAppend => "not_enough_replicas_after_append",
-        RDKafkaErrorCode::OperationNotAttempted => "operation_not_attempted",
-        RDKafkaErrorCode::OutOfOrderSequenceNumber => "out_of_order_sequence_number",
-        RDKafkaErrorCode::DuplicateSequenceNumber => "duplicate_sequence_number",
-        RDKafkaErrorCode::NetworkException => "network_exception",
-        RDKafkaErrorCode::CoordinatorLoadInProgress => "coordinator_load_in_progress",
-        RDKafkaErrorCode::CoordinatorNotAvailable => "coordinator_not_available",
-        // Transport/infra codes surfaced by ClientContext::error() callback
-        RDKafkaErrorCode::BrokerTransportFailure => "broker_transport_failure",
-        RDKafkaErrorCode::AllBrokersDown => "all_brokers_down",
-        RDKafkaErrorCode::Resolve => "resolve",
-        RDKafkaErrorCode::Authentication => "authentication",
-        RDKafkaErrorCode::SaslAuthenticationFailed => "sasl_authentication_failed",
-        _ => "rdkafka_other",
-    }
-}
+/// Lives in `common_kafka::error` so producers outside capture share one error
+/// label vocabulary. Re-exported here because this is the path the sink's
+/// callers and DESIGN.md know it by.
+pub use common_kafka::error::error_code_tag;
 
 // ---------------------------------------------------------------------------
 // KafkaSinkError
@@ -164,67 +135,5 @@ impl SinkResult for KafkaResult {
     fn elapsed(&self) -> Option<std::time::Duration> {
         self.completed_at
             .and_then(|t| t.signed_duration_since(self.enqueued_at).to_std().ok())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[rstest::rstest]
-    #[case(RDKafkaErrorCode::QueueFull, "queue_full")]
-    #[case(RDKafkaErrorCode::MessageSizeTooLarge, "message_size_too_large")]
-    #[case(RDKafkaErrorCode::MessageTimedOut, "message_timed_out")]
-    #[case(
-        RDKafkaErrorCode::UnknownTopicOrPartition,
-        "unknown_topic_or_partition"
-    )]
-    #[case(
-        RDKafkaErrorCode::TopicAuthorizationFailed,
-        "topic_authorization_failed"
-    )]
-    #[case(
-        RDKafkaErrorCode::ClusterAuthorizationFailed,
-        "cluster_authorization_failed"
-    )]
-    #[case(RDKafkaErrorCode::InvalidMessage, "invalid_message")]
-    #[case(RDKafkaErrorCode::InvalidMessageSize, "invalid_message_size")]
-    #[case(RDKafkaErrorCode::NotLeaderForPartition, "not_leader_for_partition")]
-    #[case(RDKafkaErrorCode::RequestTimedOut, "request_timed_out")]
-    #[case(RDKafkaErrorCode::NotEnoughReplicas, "not_enough_replicas")]
-    #[case(
-        RDKafkaErrorCode::NotEnoughReplicasAfterAppend,
-        "not_enough_replicas_after_append"
-    )]
-    #[case(RDKafkaErrorCode::OperationNotAttempted, "operation_not_attempted")]
-    #[case(
-        RDKafkaErrorCode::OutOfOrderSequenceNumber,
-        "out_of_order_sequence_number"
-    )]
-    #[case(RDKafkaErrorCode::DuplicateSequenceNumber, "duplicate_sequence_number")]
-    #[case(RDKafkaErrorCode::NetworkException, "network_exception")]
-    #[case(
-        RDKafkaErrorCode::CoordinatorLoadInProgress,
-        "coordinator_load_in_progress"
-    )]
-    #[case(RDKafkaErrorCode::CoordinatorNotAvailable, "coordinator_not_available")]
-    #[case(RDKafkaErrorCode::BrokerTransportFailure, "broker_transport_failure")]
-    #[case(RDKafkaErrorCode::AllBrokersDown, "all_brokers_down")]
-    #[case(RDKafkaErrorCode::Resolve, "resolve")]
-    #[case(RDKafkaErrorCode::Authentication, "authentication")]
-    #[case(
-        RDKafkaErrorCode::SaslAuthenticationFailed,
-        "sasl_authentication_failed"
-    )]
-    fn error_code_tag_named_variants(#[case] code: RDKafkaErrorCode, #[case] expected: &str) {
-        assert_eq!(error_code_tag(code), expected);
-    }
-
-    #[rstest::rstest]
-    #[case(RDKafkaErrorCode::Unknown)]
-    #[case(RDKafkaErrorCode::OffsetOutOfRange)]
-    #[case(RDKafkaErrorCode::GroupAuthorizationFailed)]
-    fn error_code_tag_unlisted_codes_fall_through(#[case] code: RDKafkaErrorCode) {
-        assert_eq!(error_code_tag(code), "rdkafka_other");
     }
 }

--- a/rust/capture/tests/common/integration_utils.rs
+++ b/rust/capture/tests/common/integration_utils.rs
@@ -1101,9 +1101,8 @@ fn build_router_for_mode_at(mode: CaptureMode, fixed_time: &str) -> (Router, Mem
             quota_limiter,
             TokenDropper::default(),
             None, // event_restriction_service
-            false,
+            None, // recorder_handle
             mode,
-            String::from("capture"),
             None,
             25 * 1024 * 1024,
             enable_historical_rerouting,

--- a/rust/capture/tests/integration_ai_endpoint.rs
+++ b/rust/capture/tests/integration_ai_endpoint.rs
@@ -177,9 +177,8 @@ fn setup_ai_test_router() -> Router {
         quota_limiter,
         TokenDropper::default(),
         None, // event_restriction_service
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-ai"),
         None,
         25 * 1024 * 1024,
         false,
@@ -1644,9 +1643,8 @@ fn setup_ai_test_router_with_capturing_sink() -> (Router, CapturingSink) {
         quota_limiter,
         TokenDropper::default(),
         None, // event_restriction_service
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-ai"),
         None,
         25 * 1024 * 1024,
         false,
@@ -2562,10 +2560,9 @@ fn setup_ai_test_router_with_token_dropper(token_dropper: TokenDropper) -> (Rout
         None,
         quota_limiter,
         token_dropper,
-        None,  // event_restriction_service
-        false, // metrics
+        None, // event_restriction_service
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-ai"),
         None,                             // concurrency_limit
         25 * 1024 * 1024,                 // event_size_limit
         false,                            // enable_historical_rerouting
@@ -2777,9 +2774,8 @@ fn setup_ai_test_router_with_llm_quota_limited(token: &str) -> (Router, Capturin
         quota_limiter,
         TokenDropper::default(),
         None, // event_restriction_service
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-ai"),
         None,
         25 * 1024 * 1024,
         false,
@@ -2936,9 +2932,8 @@ fn setup_ai_test_router_with_overflow_limiter(
         quota_limiter,
         TokenDropper::default(),
         None, // event_restriction_service
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-ai"),
         None,
         25 * 1024 * 1024,
         false,
@@ -3079,9 +3074,8 @@ fn ai_router(
         quota_limiter,
         TokenDropper::default(),
         None,
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-ai"),
         None,
         25 * 1024 * 1024,
         false,

--- a/rust/capture/tests/integration_ai_restrictions.rs
+++ b/rust/capture/tests/integration_ai_restrictions.rs
@@ -175,9 +175,8 @@ async fn setup_ai_router_with_restriction(
         quota_limiter,
         TokenDropper::default(),
         Some(service),
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-ai"),
         None,
         25 * 1024 * 1024,
         false,
@@ -498,9 +497,8 @@ async fn setup_ai_router_with_redirect_to_topic(
         quota_limiter,
         TokenDropper::default(),
         Some(service),
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-ai"),
         None,
         25 * 1024 * 1024,
         false,
@@ -580,9 +578,8 @@ async fn setup_ai_router_with_force_overflow_and_limiter(
         quota_limiter,
         TokenDropper::default(),
         Some(service),
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-ai"),
         None,
         25 * 1024 * 1024,
         false,

--- a/rust/capture/tests/integration_analytics_ai_routing.rs
+++ b/rust/capture/tests/integration_analytics_ai_routing.rs
@@ -123,9 +123,8 @@ fn setup_router_for_mode(
         quota_limiter,
         TokenDropper::default(),
         None, // event_restriction_service
-        false,
+        None, // recorder_handle
         capture_mode,
-        String::from("capture-analytics"),
         None,
         25 * 1024 * 1024,
         false,

--- a/rust/capture/tests/integration_analytics_restrictions.rs
+++ b/rust/capture/tests/integration_analytics_restrictions.rs
@@ -115,9 +115,8 @@ async fn setup_analytics_router_with_restriction(
         quota_limiter,
         TokenDropper::default(),
         Some(service),
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-analytics"),
         None,
         25 * 1024 * 1024,
         false,
@@ -549,9 +548,8 @@ async fn setup_analytics_router_with_redirect_to_topic(
         quota_limiter,
         TokenDropper::default(),
         Some(service),
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-analytics"),
         None,
         25 * 1024 * 1024,
         false,

--- a/rust/capture/tests/integration_otel_endpoint.rs
+++ b/rust/capture/tests/integration_otel_endpoint.rs
@@ -164,9 +164,8 @@ fn make_test_client_with_options(sink: &CapturingSink, options: TestClientOption
         quota_limiter,
         TokenDropper::default(),
         options.event_restriction_service,
-        false, // metrics
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture-otel-test"),
         None,             // concurrency_limit
         25 * 1024 * 1024, // event_payload_size_limit
         false,            // enable_historical_rerouting

--- a/rust/capture/tests/integration_replay_restrictions.rs
+++ b/rust/capture/tests/integration_replay_restrictions.rs
@@ -111,9 +111,8 @@ async fn setup_recordings_router_with_restriction(
         quota_limiter,
         TokenDropper::default(),
         Some(service),
-        false,
+        None, // recorder_handle
         CaptureMode::Recordings,
-        String::from("capture-recordings"),
         None,
         25 * 1024 * 1024,
         false,
@@ -485,9 +484,8 @@ async fn setup_recordings_router_with_redirect_to_topic(
         quota_limiter,
         TokenDropper::default(),
         Some(service),
-        false,
+        None, // recorder_handle
         CaptureMode::Recordings,
-        String::from("capture-recordings"),
         None,
         25 * 1024 * 1024,
         false,

--- a/rust/capture/tests/metrics_startup.rs
+++ b/rust/capture/tests/metrics_startup.rs
@@ -1,11 +1,8 @@
-//! Metrics emitted while components are built must survive to the scrape
-//! endpoint. `build_components` installs the global recorder, so ordering
-//! inside it decides whether a startup metric is recorded or silently dropped
-//! — and that is only observable through the real startup path, never from a
-//! unit test with a local recorder.
+//! Metrics emitted during `build_components` must reach `/metrics`. Whether
+//! they do depends on the global recorder being installed first, which only the
+//! real startup path exercises: a unit test's local recorder always exists.
 //!
-//! Keep this binary to a single test: installing the Prometheus recorder is a
-//! once-per-process operation.
+//! One test per binary, since the recorder installs once per process.
 
 use std::time::Duration;
 
@@ -19,9 +16,7 @@ async fn startup_gauge_reaches_the_scrape_endpoint() {
 
     let mut config = DEFAULT_CONFIG.clone();
     config.export_prometheus = true;
-    // Warnings asked for but no dedicated hosts: the emitter reports `0` with a
-    // reason during `build_components`, which is precisely the window where the
-    // gauge used to be dropped.
+    // Warnings enabled but no hosts, so the emitter reports `0` during startup.
     config.capture_ingestion_warnings_enabled = true;
     config.capture_ingestion_warnings_kafka_hosts = String::new();
 
@@ -42,20 +37,15 @@ async fn startup_gauge_reaches_the_scrape_endpoint() {
     let line = body
         .lines()
         .find(|line| line.starts_with("ingestion_warnings_emitter_enabled{"))
-        .unwrap_or_else(|| {
-            panic!("emitter gauge missing from scrape output, startup metrics are being dropped")
-        });
+        .unwrap_or_else(|| panic!("gauge missing, startup metrics are being dropped"));
 
     assert!(
         line.contains(r#"reason="hosts_unset""#),
         "gauge must name the misconfiguration: {line}"
     );
-    assert!(
-        line.ends_with(" 0"),
-        "an enabled-but-unbuildable emitter must report 0: {line}"
-    );
-    // Recorder-level labels only exist when the recorder is installed before
-    // the emission, so their presence pins the ordering too.
+    assert!(line.ends_with(" 0"), "emitter is down, expected 0: {line}");
+    // The recorder's global labels only land if it was installed before the
+    // emission, so checking them also pins the ordering.
     assert!(
         line.contains(r#"capture_mode="events""#) && line.contains(r#"role="capture-testing""#),
         "gauge must carry the recorder's global labels: {line}"

--- a/rust/capture/tests/metrics_startup.rs
+++ b/rust/capture/tests/metrics_startup.rs
@@ -1,0 +1,63 @@
+//! Metrics emitted while components are built must survive to the scrape
+//! endpoint. `build_components` installs the global recorder, so ordering
+//! inside it decides whether a startup metric is recorded or silently dropped
+//! — and that is only observable through the real startup path, never from a
+//! unit test with a local recorder.
+//!
+//! Keep this binary to a single test: installing the Prometheus recorder is a
+//! once-per-process operation.
+
+use std::time::Duration;
+
+#[path = "common/utils.rs"]
+mod test_utils;
+use test_utils::{setup_tracing, ServerHandle, DEFAULT_CONFIG};
+
+#[tokio::test]
+async fn startup_gauge_reaches_the_scrape_endpoint() {
+    setup_tracing();
+
+    let mut config = DEFAULT_CONFIG.clone();
+    config.export_prometheus = true;
+    // Warnings asked for but no dedicated hosts: the emitter reports `0` with a
+    // reason during `build_components`, which is precisely the window where the
+    // gauge used to be dropped.
+    config.capture_ingestion_warnings_enabled = true;
+    config.capture_ingestion_warnings_kafka_hosts = String::new();
+
+    let server = ServerHandle::for_config(config).await;
+
+    let body = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("http client")
+        .get(format!("http://{}/metrics", server.addr))
+        .send()
+        .await
+        .expect("scrape /metrics")
+        .text()
+        .await
+        .expect("read scrape body");
+
+    let line = body
+        .lines()
+        .find(|line| line.starts_with("ingestion_warnings_emitter_enabled{"))
+        .unwrap_or_else(|| {
+            panic!("emitter gauge missing from scrape output, startup metrics are being dropped")
+        });
+
+    assert!(
+        line.contains(r#"reason="hosts_unset""#),
+        "gauge must name the misconfiguration: {line}"
+    );
+    assert!(
+        line.ends_with(" 0"),
+        "an enabled-but-unbuildable emitter must report 0: {line}"
+    );
+    // Recorder-level labels only exist when the recorder is installed before
+    // the emission, so their presence pins the ordering too.
+    assert!(
+        line.contains(r#"capture_mode="events""#) && line.contains(r#"role="capture-testing""#),
+        "gauge must carry the recorder's global labels: {line}"
+    );
+}

--- a/rust/capture/tests/quota_limiters.rs
+++ b/rust/capture/tests/quota_limiters.rs
@@ -132,10 +132,9 @@ async fn setup_router_with_limits(
         None,
         quota_limiter,
         TokenDropper::default(),
-        None,  // event_restriction_service
-        false, // metrics
+        None, // event_restriction_service
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture"),
         None,               // concurrency_limit
         1024 * 1024,        // event_payload_size_limit
         false,              // enable_historical_rerouting
@@ -1189,9 +1188,8 @@ async fn test_survey_quota_cross_batch_first_submission_allowed() {
         quota_limiter,
         TokenDropper::default(),
         None, // event_restriction_service
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture"),
         None,
         1024 * 1024,
         false,
@@ -1283,9 +1281,8 @@ async fn test_survey_quota_cross_batch_duplicate_submission_dropped() {
         quota_limiter,
         TokenDropper::default(),
         None, // event_restriction_service
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture"),
         None,
         1024 * 1024,
         false,
@@ -1381,9 +1378,8 @@ async fn test_survey_quota_cross_batch_redis_error_fail_open() {
         quota_limiter,
         TokenDropper::default(),
         None, // event_restriction_service
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture"),
         None,
         1024 * 1024,
         false,
@@ -1816,9 +1812,8 @@ async fn test_ai_quota_cross_batch_redis_error_fail_open() {
         quota_limiter,
         TokenDropper::default(),
         None, // event_restriction_service
-        false,
+        None, // recorder_handle
         CaptureMode::Events,
-        String::from("capture"),
         None,
         1024 * 1024,
         false,

--- a/rust/common/ingestion_warnings/src/lib.rs
+++ b/rust/common/ingestion_warnings/src/lib.rs
@@ -63,7 +63,27 @@ pub use throttle::{ThrottleDecision, WarningThrottle};
 /// cardinality_capped | queue_full | serialize_error | enqueue_error`.
 /// Delivery-time outcomes (reported asynchronously for each `emitted`
 /// message): `delivered | delivery_failed`.
+///
+/// The Node.js `clientwarnings` consumer exports the same metric name for the
+/// terminal rows it writes (`{type, emitted}`, see
+/// `nodejs/src/ingestion/common/ingestion-warnings.ts`), so the two count the
+/// same logical warning at different pipeline stages and at very different
+/// volumes. They never collide as series — only this side carries `source` —
+/// but any query must scope by `source` (or namespace) or it silently sums
+/// both stages.
 pub const INGESTION_WARNINGS_TOTAL: &str = "ingestion_warnings_total";
+
+/// Counter of delivery failures broken down by rdkafka error code: labels
+/// `source` and `error` (the [`RDKafkaErrorCode`] variant name, or `unknown`
+/// for an error carrying no code). [`INGESTION_WARNINGS_TOTAL`]'s
+/// `delivery_failed` outcome says warnings stopped landing; this says why,
+/// which is the difference between a bad topic and an unreachable broker.
+///
+/// Kept separate rather than adding `error` to [`INGESTION_WARNINGS_TOTAL`]:
+/// a label present on only one outcome breaks aggregations over the rest, and
+/// per-failure logging is not an option at post-throttle volume.
+pub const INGESTION_WARNINGS_DELIVERY_ERRORS_TOTAL: &str =
+    "ingestion_warnings_delivery_errors_total";
 
 /// Gauge of `(token, type)` keys currently tracked by the throttle, updated
 /// on each sweep. The early-warning signal for the cardinality cap.
@@ -74,6 +94,17 @@ pub const INGESTION_WARNINGS_THROTTLE_KEYS: &str = "ingestion_warnings_throttle_
 /// are disabled, because otherwise a misconfigured pod reporting `0` would be
 /// indistinguishable from an intentionally quiet one. Absence means "off",
 /// `0` means "broken".
+///
+/// Carries a `reason` label on every emission — `ok` when healthy, the
+/// specific misconfiguration otherwise (capture uses `hosts_unset`,
+/// `topic_unset`, `no_handle`, `producer_create_failed`) — so a firing alert
+/// names the cause. Set it on the healthy path too: a label present only on
+/// failures would leave the two states with different label sets, and
+/// `min(...) == 0` would need an aggregation workaround.
+///
+/// Emit this only *after* the process installs its global metrics recorder.
+/// `gauge!` before that point is silently dropped, which is exactly how this
+/// signal was lost once already.
 ///
 /// `1` means the emitter was built, not that its cluster is reachable:
 /// construction deliberately skips the broker ping, so a producer pointed at a
@@ -317,17 +348,39 @@ pub struct WarningDelivery {
     pub source: WarningSource,
 }
 
+/// Bounded metric label for a delivery failure: the [`RDKafkaErrorCode`]
+/// variant name (`MessageTimedOut`, `UnknownTopicOrPartition`, ...), or
+/// `unknown` for the few `KafkaError` variants that carry no code. Uses the
+/// variant name rather than `Display`, whose human-readable text is unfit for
+/// a label; the enum is closed, so cardinality is bounded by librdkafka.
+pub fn delivery_error_label(err: &KafkaError) -> String {
+    match err.rdkafka_error_code() {
+        Some(code) => format!("{code:?}"),
+        None => "unknown".to_string(),
+    }
+}
+
 /// Delivery-report callback for the warnings `ThreadedProducer`. Runs on
 /// rdkafka's poll thread for every produced message and ticks the
 /// `delivered`/`delivery_failed` outcome — the async half of the `emitted`
 /// counter, which alone only proves the message entered the local queue.
 /// Without this, a broken topic or broker at rollout looks healthy while
-/// nothing lands. Metric-only (no per-message log) since a broken topic at
-/// rollout would otherwise flood logs at post-throttle volume.
+/// nothing lands. Failures also tick
+/// [`INGESTION_WARNINGS_DELIVERY_ERRORS_TOTAL`] with the rdkafka error code.
+/// Metric-only (no per-message log) since a broken topic at rollout would
+/// otherwise flood logs at post-throttle volume.
 pub fn observe_delivery(result: &DeliveryResult, delivery: WarningDelivery) {
     let outcome = match result {
         Ok(_) => "delivered",
-        Err(_) => "delivery_failed",
+        Err((err, _message)) => {
+            counter!(
+                INGESTION_WARNINGS_DELIVERY_ERRORS_TOTAL,
+                "source" => delivery.source.service,
+                "error" => delivery_error_label(err),
+            )
+            .increment(1);
+            "delivery_failed"
+        }
     };
     counter!(
         INGESTION_WARNINGS_TOTAL,
@@ -344,6 +397,7 @@ mod tests {
     use common_kafka::config::KafkaConfig;
     use common_kafka::kafka_producer::create_threaded_kafka_producer_no_ping;
     use common_liveness::SyncLivenessReporter;
+    use rstest::rstest;
 
     use super::*;
 
@@ -375,6 +429,28 @@ mod tests {
         };
         create_threaded_kafka_producer_no_ping(&config, AlwaysHealthy, observe_delivery)
             .expect("client config is valid, so creation cannot fail without a broker round-trip")
+    }
+
+    // The label must stay a bare error-code name. `KafkaError`'s own `Display`
+    // is a human sentence ("Message production error: Broker: ..."), which as a
+    // label would be unreadable and effectively unbounded.
+    #[rstest]
+    #[case::timed_out(
+        KafkaError::MessageProduction(RDKafkaErrorCode::MessageTimedOut),
+        "MessageTimedOut"
+    )]
+    #[case::unknown_topic(
+        KafkaError::MessageProduction(RDKafkaErrorCode::UnknownTopicOrPartition),
+        "UnknownTopicOrPartition"
+    )]
+    #[case::carries_no_code(KafkaError::Canceled, "unknown")]
+    fn delivery_error_label_is_a_bare_error_code(#[case] err: KafkaError, #[case] expected: &str) {
+        let label = delivery_error_label(&err);
+        assert_eq!(label, expected);
+        assert!(
+            !label.contains(' '),
+            "label must be metric-safe, got {label:?}"
+        );
     }
 
     #[test]

--- a/rust/common/ingestion_warnings/src/lib.rs
+++ b/rust/common/ingestion_warnings/src/lib.rs
@@ -64,24 +64,18 @@ pub use throttle::{ThrottleDecision, WarningThrottle};
 /// Delivery-time outcomes (reported asynchronously for each `emitted`
 /// message): `delivered | delivery_failed`.
 ///
-/// The Node.js `clientwarnings` consumer exports the same metric name for the
-/// terminal rows it writes (`{type, emitted}`, see
-/// `nodejs/src/ingestion/common/ingestion-warnings.ts`), so the two count the
-/// same logical warning at different pipeline stages and at very different
-/// volumes. They never collide as series — only this side carries `source` —
-/// but any query must scope by `source` (or namespace) or it silently sums
+/// The Node.js `clientwarnings` consumer exports this same name for the rows it
+/// writes, at a later stage and far higher volume. Only this side carries
+/// `source`, so queries must scope by it (or by namespace) to avoid summing
 /// both stages.
 pub const INGESTION_WARNINGS_TOTAL: &str = "ingestion_warnings_total";
 
-/// Counter of delivery failures broken down by rdkafka error code: labels
-/// `source` and `error` (the [`RDKafkaErrorCode`] variant name, or `unknown`
-/// for an error carrying no code). [`INGESTION_WARNINGS_TOTAL`]'s
-/// `delivery_failed` outcome says warnings stopped landing; this says why,
-/// which is the difference between a bad topic and an unreachable broker.
+/// Counter of delivery failures by cause: labels `source` and `error` (the
+/// [`RDKafkaErrorCode`] variant name). Separates a bad topic from an
+/// unreachable broker, which `delivery_failed` alone cannot.
 ///
-/// Kept separate rather than adding `error` to [`INGESTION_WARNINGS_TOTAL`]:
-/// a label present on only one outcome breaks aggregations over the rest, and
-/// per-failure logging is not an option at post-throttle volume.
+/// Its own metric because an `error` label on only one outcome of
+/// [`INGESTION_WARNINGS_TOTAL`] would break aggregations over the rest.
 pub const INGESTION_WARNINGS_DELIVERY_ERRORS_TOTAL: &str =
     "ingestion_warnings_delivery_errors_total";
 
@@ -95,16 +89,13 @@ pub const INGESTION_WARNINGS_THROTTLE_KEYS: &str = "ingestion_warnings_throttle_
 /// indistinguishable from an intentionally quiet one. Absence means "off",
 /// `0` means "broken".
 ///
-/// Carries a `reason` label on every emission — `ok` when healthy, the
-/// specific misconfiguration otherwise (capture uses `hosts_unset`,
-/// `topic_unset`, `no_handle`, `producer_create_failed`) — so a firing alert
-/// names the cause. Set it on the healthy path too: a label present only on
-/// failures would leave the two states with different label sets, and
-/// `min(...) == 0` would need an aggregation workaround.
+/// Every emission carries a `reason` label naming the cause: `ok` when healthy,
+/// otherwise the misconfiguration (capture uses `hosts_unset`, `topic_unset`,
+/// `no_handle`, `producer_create_failed`). Labelling both states keeps their
+/// label sets identical, so `min(...) == 0` works without aggregating it away.
 ///
-/// Emit this only *after* the process installs its global metrics recorder.
-/// `gauge!` before that point is silently dropped, which is exactly how this
-/// signal was lost once already.
+/// Emit only after the process installs its global metrics recorder; earlier
+/// `gauge!` calls are silently dropped.
 ///
 /// `1` means the emitter was built, not that its cluster is reachable:
 /// construction deliberately skips the broker ping, so a producer pointed at a
@@ -348,11 +339,9 @@ pub struct WarningDelivery {
     pub source: WarningSource,
 }
 
-/// Bounded metric label for a delivery failure: the [`RDKafkaErrorCode`]
-/// variant name (`MessageTimedOut`, `UnknownTopicOrPartition`, ...), or
-/// `unknown` for the few `KafkaError` variants that carry no code. Uses the
-/// variant name rather than `Display`, whose human-readable text is unfit for
-/// a label; the enum is closed, so cardinality is bounded by librdkafka.
+/// Metric label for a delivery failure: the [`RDKafkaErrorCode`] variant name
+/// (`MessageTimedOut`, ...), or `unknown` when the error carries no code. The
+/// variant name rather than `Display`, which is prose and unbounded.
 pub fn delivery_error_label(err: &KafkaError) -> String {
     match err.rdkafka_error_code() {
         Some(code) => format!("{code:?}"),
@@ -366,7 +355,7 @@ pub fn delivery_error_label(err: &KafkaError) -> String {
 /// counter, which alone only proves the message entered the local queue.
 /// Without this, a broken topic or broker at rollout looks healthy while
 /// nothing lands. Failures also tick
-/// [`INGESTION_WARNINGS_DELIVERY_ERRORS_TOTAL`] with the rdkafka error code.
+/// [`INGESTION_WARNINGS_DELIVERY_ERRORS_TOTAL`] with the error code.
 /// Metric-only (no per-message log) since a broken topic at rollout would
 /// otherwise flood logs at post-throttle volume.
 pub fn observe_delivery(result: &DeliveryResult, delivery: WarningDelivery) {
@@ -431,9 +420,8 @@ mod tests {
             .expect("client config is valid, so creation cannot fail without a broker round-trip")
     }
 
-    // The label must stay a bare error-code name. `KafkaError`'s own `Display`
-    // is a human sentence ("Message production error: Broker: ..."), which as a
-    // label would be unreadable and effectively unbounded.
+    // Guards against switching to `KafkaError`'s `Display`, which is prose and
+    // would blow up label cardinality.
     #[rstest]
     #[case::timed_out(
         KafkaError::MessageProduction(RDKafkaErrorCode::MessageTimedOut),
@@ -447,10 +435,7 @@ mod tests {
     fn delivery_error_label_is_a_bare_error_code(#[case] err: KafkaError, #[case] expected: &str) {
         let label = delivery_error_label(&err);
         assert_eq!(label, expected);
-        assert!(
-            !label.contains(' '),
-            "label must be metric-safe, got {label:?}"
-        );
+        assert!(!label.contains(' '), "not metric-safe: {label:?}");
     }
 
     #[test]

--- a/rust/common/ingestion_warnings/src/lib.rs
+++ b/rust/common/ingestion_warnings/src/lib.rs
@@ -43,6 +43,7 @@ pub mod throttle;
 
 use std::time::Duration;
 
+use common_kafka::error::error_code_tag;
 use common_kafka::kafka_producer::ThreadedKafkaContext;
 use metrics::{counter, gauge};
 use rdkafka::error::KafkaError;
@@ -70,8 +71,9 @@ pub use throttle::{ThrottleDecision, WarningThrottle};
 /// both stages.
 pub const INGESTION_WARNINGS_TOTAL: &str = "ingestion_warnings_total";
 
-/// Counter of delivery failures by cause: labels `source` and `error` (the
-/// [`RDKafkaErrorCode`] variant name). Separates a bad topic from an
+/// Counter of delivery failures by cause: labels `source`, `path`, and `error`
+/// (a [`common_kafka::error::error_code_tag`] tag, shared with capture's sink
+/// metrics so the two can be queried together). Separates a bad topic from an
 /// unreachable broker, which `delivery_failed` alone cannot.
 ///
 /// Its own metric because an `error` label on only one outcome of
@@ -339,16 +341,6 @@ pub struct WarningDelivery {
     pub source: WarningSource,
 }
 
-/// Metric label for a delivery failure: the [`RDKafkaErrorCode`] variant name
-/// (`MessageTimedOut`, ...), or `unknown` when the error carries no code. The
-/// variant name rather than `Display`, which is prose and unbounded.
-pub fn delivery_error_label(err: &KafkaError) -> String {
-    match err.rdkafka_error_code() {
-        Some(code) => format!("{code:?}"),
-        None => "unknown".to_string(),
-    }
-}
-
 /// Delivery-report callback for the warnings `ThreadedProducer`. Runs on
 /// rdkafka's poll thread for every produced message and ticks the
 /// `delivered`/`delivery_failed` outcome — the async half of the `emitted`
@@ -365,7 +357,11 @@ pub fn observe_delivery(result: &DeliveryResult, delivery: WarningDelivery) {
             counter!(
                 INGESTION_WARNINGS_DELIVERY_ERRORS_TOTAL,
                 "source" => delivery.source.service,
-                "error" => delivery_error_label(err),
+                "path" => delivery.source.path,
+                "error" => err
+                    .rdkafka_error_code()
+                    .map(error_code_tag)
+                    .unwrap_or("unknown"),
             )
             .increment(1);
             "delivery_failed"
@@ -386,7 +382,6 @@ mod tests {
     use common_kafka::config::KafkaConfig;
     use common_kafka::kafka_producer::create_threaded_kafka_producer_no_ping;
     use common_liveness::SyncLivenessReporter;
-    use rstest::rstest;
 
     use super::*;
 
@@ -418,24 +413,6 @@ mod tests {
         };
         create_threaded_kafka_producer_no_ping(&config, AlwaysHealthy, observe_delivery)
             .expect("client config is valid, so creation cannot fail without a broker round-trip")
-    }
-
-    // Guards against switching to `KafkaError`'s `Display`, which is prose and
-    // would blow up label cardinality.
-    #[rstest]
-    #[case::timed_out(
-        KafkaError::MessageProduction(RDKafkaErrorCode::MessageTimedOut),
-        "MessageTimedOut"
-    )]
-    #[case::unknown_topic(
-        KafkaError::MessageProduction(RDKafkaErrorCode::UnknownTopicOrPartition),
-        "UnknownTopicOrPartition"
-    )]
-    #[case::carries_no_code(KafkaError::Canceled, "unknown")]
-    fn delivery_error_label_is_a_bare_error_code(#[case] err: KafkaError, #[case] expected: &str) {
-        let label = delivery_error_label(&err);
-        assert_eq!(label, expected);
-        assert!(!label.contains(' '), "not metric-safe: {label:?}");
     }
 
     #[test]

--- a/rust/common/ingestion_warnings/src/lib.rs
+++ b/rust/common/ingestion_warnings/src/lib.rs
@@ -341,6 +341,16 @@ pub struct WarningDelivery {
     pub source: WarningSource,
 }
 
+/// Metric label for a delivery failure: capture's shared [`error_code_tag`]
+/// vocabulary, or `unknown` when the error carries no rdkafka code (a cancel or
+/// purge during flush, for one). `&'static str`, so the poll thread never
+/// allocates to label a failure.
+fn delivery_error_tag(err: &KafkaError) -> &'static str {
+    err.rdkafka_error_code()
+        .map(error_code_tag)
+        .unwrap_or("unknown")
+}
+
 /// Delivery-report callback for the warnings `ThreadedProducer`. Runs on
 /// rdkafka's poll thread for every produced message and ticks the
 /// `delivered`/`delivery_failed` outcome — the async half of the `emitted`
@@ -358,10 +368,7 @@ pub fn observe_delivery(result: &DeliveryResult, delivery: WarningDelivery) {
                 INGESTION_WARNINGS_DELIVERY_ERRORS_TOTAL,
                 "source" => delivery.source.service,
                 "path" => delivery.source.path,
-                "error" => err
-                    .rdkafka_error_code()
-                    .map(error_code_tag)
-                    .unwrap_or("unknown"),
+                "error" => delivery_error_tag(err),
             )
             .increment(1);
             "delivery_failed"
@@ -382,6 +389,7 @@ mod tests {
     use common_kafka::config::KafkaConfig;
     use common_kafka::kafka_producer::create_threaded_kafka_producer_no_ping;
     use common_liveness::SyncLivenessReporter;
+    use rstest::rstest;
 
     use super::*;
 
@@ -413,6 +421,22 @@ mod tests {
         };
         create_threaded_kafka_producer_no_ping(&config, AlwaysHealthy, observe_delivery)
             .expect("client config is valid, so creation cannot fail without a broker round-trip")
+    }
+
+    // Errors reaching a delivery report don't all carry an rdkafka code. Without
+    // the fallback they'd land as an empty label, merging every one of them into
+    // a single anonymous series.
+    #[rstest]
+    #[case::has_code(
+        KafkaError::MessageProduction(RDKafkaErrorCode::MessageTimedOut),
+        "message_timed_out"
+    )]
+    #[case::carries_no_code(KafkaError::Canceled, "unknown")]
+    fn delivery_error_tag_names_the_code_or_falls_back(
+        #[case] err: KafkaError,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(delivery_error_tag(&err), expected);
     }
 
     #[test]

--- a/rust/common/kafka/Cargo.toml
+++ b/rust/common/kafka/Cargo.toml
@@ -21,3 +21,6 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+
+[dev-dependencies]
+rstest = "0.26"

--- a/rust/common/kafka/src/error.rs
+++ b/rust/common/kafka/src/error.rs
@@ -1,0 +1,102 @@
+use rdkafka::error::RDKafkaErrorCode;
+
+/// Stable, low-cardinality snake_case tag for an RDKafkaErrorCode.
+/// Usable anywhere -- producer, sink, handler, logging.
+///
+/// Deliberately a curated set rather than the full ~170-variant enum: every
+/// producer that tags errors shares this vocabulary, so codes stay comparable
+/// across metrics and unlisted ones collapse to `rdkafka_other` instead of
+/// growing label cardinality unbounded. Add a code here when it starts
+/// mattering and every caller gains it at once.
+pub fn error_code_tag(code: RDKafkaErrorCode) -> &'static str {
+    match code {
+        RDKafkaErrorCode::QueueFull => "queue_full",
+        RDKafkaErrorCode::MessageSizeTooLarge => "message_size_too_large",
+        RDKafkaErrorCode::MessageTimedOut => "message_timed_out",
+        RDKafkaErrorCode::UnknownTopicOrPartition => "unknown_topic_or_partition",
+        RDKafkaErrorCode::TopicAuthorizationFailed => "topic_authorization_failed",
+        RDKafkaErrorCode::ClusterAuthorizationFailed => "cluster_authorization_failed",
+        RDKafkaErrorCode::InvalidMessage => "invalid_message",
+        RDKafkaErrorCode::InvalidMessageSize => "invalid_message_size",
+        RDKafkaErrorCode::NotLeaderForPartition => "not_leader_for_partition",
+        RDKafkaErrorCode::RequestTimedOut => "request_timed_out",
+        // Broker/idempotent-producer codes from delivery reports
+        RDKafkaErrorCode::NotEnoughReplicas => "not_enough_replicas",
+        RDKafkaErrorCode::NotEnoughReplicasAfterAppend => "not_enough_replicas_after_append",
+        RDKafkaErrorCode::OperationNotAttempted => "operation_not_attempted",
+        RDKafkaErrorCode::OutOfOrderSequenceNumber => "out_of_order_sequence_number",
+        RDKafkaErrorCode::DuplicateSequenceNumber => "duplicate_sequence_number",
+        RDKafkaErrorCode::NetworkException => "network_exception",
+        RDKafkaErrorCode::CoordinatorLoadInProgress => "coordinator_load_in_progress",
+        RDKafkaErrorCode::CoordinatorNotAvailable => "coordinator_not_available",
+        // Transport/infra codes surfaced by ClientContext::error() callback
+        RDKafkaErrorCode::BrokerTransportFailure => "broker_transport_failure",
+        RDKafkaErrorCode::AllBrokersDown => "all_brokers_down",
+        RDKafkaErrorCode::Resolve => "resolve",
+        RDKafkaErrorCode::Authentication => "authentication",
+        RDKafkaErrorCode::SaslAuthenticationFailed => "sasl_authentication_failed",
+        _ => "rdkafka_other",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[rstest::rstest]
+    #[case(RDKafkaErrorCode::QueueFull, "queue_full")]
+    #[case(RDKafkaErrorCode::MessageSizeTooLarge, "message_size_too_large")]
+    #[case(RDKafkaErrorCode::MessageTimedOut, "message_timed_out")]
+    #[case(
+        RDKafkaErrorCode::UnknownTopicOrPartition,
+        "unknown_topic_or_partition"
+    )]
+    #[case(
+        RDKafkaErrorCode::TopicAuthorizationFailed,
+        "topic_authorization_failed"
+    )]
+    #[case(
+        RDKafkaErrorCode::ClusterAuthorizationFailed,
+        "cluster_authorization_failed"
+    )]
+    #[case(RDKafkaErrorCode::InvalidMessage, "invalid_message")]
+    #[case(RDKafkaErrorCode::InvalidMessageSize, "invalid_message_size")]
+    #[case(RDKafkaErrorCode::NotLeaderForPartition, "not_leader_for_partition")]
+    #[case(RDKafkaErrorCode::RequestTimedOut, "request_timed_out")]
+    #[case(RDKafkaErrorCode::NotEnoughReplicas, "not_enough_replicas")]
+    #[case(
+        RDKafkaErrorCode::NotEnoughReplicasAfterAppend,
+        "not_enough_replicas_after_append"
+    )]
+    #[case(RDKafkaErrorCode::OperationNotAttempted, "operation_not_attempted")]
+    #[case(
+        RDKafkaErrorCode::OutOfOrderSequenceNumber,
+        "out_of_order_sequence_number"
+    )]
+    #[case(RDKafkaErrorCode::DuplicateSequenceNumber, "duplicate_sequence_number")]
+    #[case(RDKafkaErrorCode::NetworkException, "network_exception")]
+    #[case(
+        RDKafkaErrorCode::CoordinatorLoadInProgress,
+        "coordinator_load_in_progress"
+    )]
+    #[case(RDKafkaErrorCode::CoordinatorNotAvailable, "coordinator_not_available")]
+    #[case(RDKafkaErrorCode::BrokerTransportFailure, "broker_transport_failure")]
+    #[case(RDKafkaErrorCode::AllBrokersDown, "all_brokers_down")]
+    #[case(RDKafkaErrorCode::Resolve, "resolve")]
+    #[case(RDKafkaErrorCode::Authentication, "authentication")]
+    #[case(
+        RDKafkaErrorCode::SaslAuthenticationFailed,
+        "sasl_authentication_failed"
+    )]
+    fn error_code_tag_named_variants(#[case] code: RDKafkaErrorCode, #[case] expected: &str) {
+        assert_eq!(error_code_tag(code), expected);
+    }
+
+    #[rstest::rstest]
+    #[case(RDKafkaErrorCode::Unknown)]
+    #[case(RDKafkaErrorCode::OffsetOutOfRange)]
+    #[case(RDKafkaErrorCode::GroupAuthorizationFailed)]
+    fn error_code_tag_unlisted_codes_fall_through(#[case] code: RDKafkaErrorCode) {
+        assert_eq!(error_code_tag(code), "rdkafka_other");
+    }
+}

--- a/rust/common/kafka/src/lib.rs
+++ b/rust/common/kafka/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod error;
 pub mod kafka_consumer;
 pub mod kafka_messages;
 pub mod kafka_producer;


### PR DESCRIPTION
## Problem

Capture risks losing several setup-stage metrics because the recorder is initialized too late in the setup flow on pod/app bootstrap. This change moves that step upstream prior to any emit sites. 

Also adds some additional tagging to the `ingestion_warnings_emitter_enabled` gauge to tag fail reasons, since the warnings publisher is intentionally fail-open.

Confirms in prod: `ingestion_warnings_emitter_enabled` has no series in either region, while `ingestion_warnings_throttle_keys` reports one per pod from the same namespace.

## Changes

**Install the recorder before anything can emit.** `build_components` now installs it as its first act and hands `router()` the handle, so `router()` takes `Option<PrometheusHandle>` instead of `metrics: bool`. `deploy_role: String` leaves the signature with it - its only use was feeding `setup_metrics_recorder`. The positional argument list is one shorter, and the router no longer installs a process-global singleton as a side effect of a boolean.

**One kafka error label vocabulary for the delivery-errors counter.** `ingestion_warnings_delivery_errors_total` labeled errors with the `RDKafkaErrorCode` variant name, which allocated a `String` per failed delivery on rdkafka's poll thread and reported `MessageTimedOut` where every other capture metric reports `message_timed_out`. Capture's curated `error_code_tag` moves from `capture/src/v1/sinks/kafka/types.rs` into `common_kafka::error`, re-exported from its old path so the sink's callers and `DESIGN.md` keep working, and `observe_delivery` calls it. Deletes a duplicate mapping and its test, and makes the label queryable alongside `capture_v1_kafka_produce_errors_total` and `kafka_client_errors_total`, which already publish snake_case codes.

The counter also gains `path`, matching `ingestion_warnings_total`, so a dashboard row can scope delivery failures to the v1 or legacy pipeline instead of showing both under whichever label the row claims.

Tradeoff worth knowing: the curated table collapses unlisted codes to `rdkafka_other`, so a novel delivery code won't name itself until someone adds it. That is already how capture's sink metrics behave, and the table has an explicit section for codes that arrive on delivery reports.

## How did you test this code?

Automated, all run locally against the docker rig. `cargo fmt --check` and `cargo clippy --all-targets` clean on all three crates.

- **`tests/metrics_startup.rs` (new) catches this exact bug.** It boots the real startup path and scrapes `/metrics`, asserting the gauge is present with `reason="hosts_unset"`, value `0`, and the recorder's global `role`/`capture_mode` labels. No unit test can catch the ordering, because a local test recorder bypasses the global-install question entirely. I verified it fails for the right reason: with the install moved back to its old position the test reports `emitter gauge missing from scrape output`, and passes with the fix. Kept to one test per binary since installing the recorder is once-per-process.
- **`setup::tests::emitter_gauge_reports_why_warnings_are_off`** covers all three config-reachable failure reasons plus the disabled case, which pins the contract that a deliberately quiet pod leaves the gauge *unset* rather than reporting `0`. Nothing covered that before, and it's the property that keeps "off" distinguishable from "broken". `producer_create_failed` has no deterministic trigger and is uncovered.
- **`setup::tests::healthy_emitter_reports_ok`** pins the healthy path's label, which is what keeps the two states sharing a label set.
- **`error_code_tag`'s 26 parameterized cases moved with the function** into `common-kafka`, so the curated mapping and the `rdkafka_other` fallback stay pinned in its new home. The old `delivery_error_label` test guarded against the label becoming `KafkaError`'s `Display` output; that's now a compile error, since `error_code_tag` returns `&'static str` from a closed match.
- **`delivery_error_tag_names_the_code_or_falls_back`** keeps the branch that test also covered: an error carrying no rdkafka code still labels as `unknown`. Worth its own assertion because an empty label there would merge every codeless failure into one anonymous series rather than failing loudly.

Suite state: `cargo test -p capture -p common-ingestion-warnings -p common-kafka` green against the local docker rig, all 22 capture integration binaries included (1014 capture unit + 32 warnings + 41 kafka, plus 257 integration tests).

Known gap, unchanged by this PR: the failure branch of `observe_delivery` has never run under test. It needs a real rdkafka `DeliveryResult`, and the callback fires on the producer's poll thread where a thread-local test recorder can't see it. The label values there are two struct fields and the tested `delivery_error_tag`, so what's untested is the wiring, and the blast radius is a metric label.

The remaining test churn is mechanical: 22 `router(...)` call sites lose an argument and swap `false` for `None`. All compiler-checked, since neither a `bool` to `Option<PrometheusHandle>` change nor a removed `String` can silently rebind to a neighbor.

I did not deploy or verify this in a live environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`rust/capture/src/v1/sinks/DESIGN.md` notes `error_code_tag`'s new home in the error-tagging section. No `docs/` page or chart references these metric names.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I drove this with Cursor (Opus 5) after noticing during the warnings rollout that I could only confirm the emitter was live by counting pods reporting `ingestion_warnings_throttle_keys`, which conflates "not scraped yet" with "failed to start". The agent traced it to the recorder-install ordering and confirmed these two `gauge!` calls are the only metrics emitted anywhere in the setup path, so the blast radius is one signal.

The error-label change came out of AI review on this PR flagging the per-failure `String` allocation. Following it up turned out to be worth more than the allocation: capture already had the curated `&'static str` mapping, so the duplicate was also publishing a second naming convention for the same error codes.
