### PR TITLE
fix(marketing-analytics): expose conversion goal kind as a real enum

### DIFF
--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -589,6 +589,8 @@ SPECTACULAR_SETTINGS = {
         "EmailReputationScopeEnum": "products.workflows.backend.models.email_reputation.EmailReputationSnapshot.Scope",
         "EmailReputationStateEnum": "products.workflows.backend.models.email_reputation.EmailReputationSnapshot.State",
         "MCPAuthTypeEnum": "products.mcp_store.backend.models.AUTH_TYPE_CHOICES",
+        # Shared by ConversionGoalSummary.kind and GoalExplanation.kind (same choice set).
+        "ConversionGoalKindEnum": "products.marketing_analytics.backend.hogql_queries.constants.CONVERSION_GOAL_KIND_CHOICES",
         "MCPInstallationScopeEnum": ["personal", "shared"],
         # Disambiguates from data_modeling's node_type (table/view/matview/endpoint).
         "NotebookSQLV2NodeTypeEnum": ["hogql", "python"],

--- a/products/marketing_analytics/backend/api.py
+++ b/products/marketing_analytics/backend/api.py
@@ -25,6 +25,7 @@ from posthog.models.user import User
 from products.marketing_analytics.backend.hogql_queries.adapters.base import ExternalConfig, QueryContext
 from products.marketing_analytics.backend.hogql_queries.adapters.factory import MarketingSourceFactory
 from products.marketing_analytics.backend.hogql_queries.adapters.self_managed import SelfManagedAdapter
+from products.marketing_analytics.backend.hogql_queries.constants import CONVERSION_GOAL_KIND_CHOICES
 from products.marketing_analytics.backend.hogql_queries.utils import map_url_to_provider
 from products.marketing_analytics.backend.services.conversion_goals_inspector import (
     explain_conversion_goal,
@@ -109,10 +110,12 @@ class UtmAuditResponseSerializer(serializers.Serializer):
 class ConversionGoalSummarySerializer(serializers.Serializer):
     id = serializers.CharField(help_text="Unique id of the goal (event name, action id, or DW goal id)")
     name = serializers.CharField(help_text="Display name of the conversion goal")
-    # `kind` is a collision-prone enum name in drf-spectacular, so we expose it as a
-    # documented string rather than a ChoiceField to avoid a CI --fail-on-warn break.
-    kind = serializers.CharField(
-        help_text="Goal type — one of: EventsNode (PostHog event), ActionsNode (PostHog action), DataWarehouseNode (external table)"
+    # `kind` collides with other enums in drf-spectacular, so it carries a stable name via
+    # ENUM_NAME_OVERRIDES ("ConversionGoalKindEnum") — a plain CharField would leave consumers
+    # reading the valid values out of this help text.
+    kind = serializers.ChoiceField(
+        choices=CONVERSION_GOAL_KIND_CHOICES,
+        help_text="Goal type: EventsNode (PostHog event), ActionsNode (PostHog action), or DataWarehouseNode (external table)",
     )
     target_label = serializers.CharField(
         help_text="Human-readable target the goal matches (event/action name or table)"
@@ -248,7 +251,10 @@ class GoalExplanationPeriodSerializer(serializers.Serializer):
 class GoalExplanationSerializer(serializers.Serializer):
     goal_id = serializers.CharField(help_text="Id of the explained conversion goal")
     goal_name = serializers.CharField(help_text="Display name of the conversion goal")
-    kind = serializers.CharField(help_text="EventsNode/ActionsNode/DataWarehouseNode")
+    kind = serializers.ChoiceField(
+        choices=CONVERSION_GOAL_KIND_CHOICES,
+        help_text="Goal type: EventsNode (PostHog event), ActionsNode (PostHog action), or DataWarehouseNode (external table)",
+    )
     period = GoalExplanationPeriodSerializer(help_text="The period the breakdown was computed over")
     total_count = serializers.IntegerField(help_text="Total matching conversion events in the period")
     integrated_count = serializers.IntegerField(

--- a/products/marketing_analytics/backend/hogql_queries/constants.py
+++ b/products/marketing_analytics/backend/hogql_queries/constants.py
@@ -37,6 +37,7 @@ from posthog.schema import (
     MetaAdsTableExclusions,
     MetaAdsTableKeywords,
     NativeMarketingSource,
+    NodeKind,
     PinterestAdsDefaultSources,
     PinterestAdsTableExclusions,
     PinterestAdsTableKeywords,
@@ -60,6 +61,16 @@ from posthog.hogql import ast
 DEFAULT_LIMIT = 100
 PAGINATION_EXTRA = 1  # Request one extra for pagination
 FALLBACK_COST_VALUE = 999999999
+# The three node kinds a conversion goal can be, derived from the schema enum so they can't drift
+# from ConversionGoalFilter1/2/3. Referenced by name from SPECTACULAR_SETTINGS["ENUM_NAME_OVERRIDES"]
+# so the API serializers can expose `kind` as a real enum: the name collides in drf-spectacular, and
+# without a stable override the generated type degrades to a plain string.
+CONVERSION_GOAL_KIND_CHOICES = [
+    NodeKind.EVENTS_NODE.value,
+    NodeKind.ACTIONS_NODE.value,
+    NodeKind.DATA_WAREHOUSE_NODE.value,
+]
+
 UNKNOWN_CAMPAIGN = "Unknown Campaign"
 UNKNOWN_SOURCE = "Unknown Source"
 ORGANIC_CAMPAIGN = "organic"

--- a/products/marketing_analytics/frontend/generated/api.schemas.ts
+++ b/products/marketing_analytics/frontend/generated/api.schemas.ts
@@ -7,13 +7,30 @@
  * PostHog API - generated
  * OpenAPI spec version: 1.0.0
  */
+/**
+ * * `EventsNode` - EventsNode
+ * * `ActionsNode` - ActionsNode
+ * * `DataWarehouseNode` - DataWarehouseNode
+ */
+export type ConversionGoalKindEnumApi = (typeof ConversionGoalKindEnumApi)[keyof typeof ConversionGoalKindEnumApi]
+
+export const ConversionGoalKindEnumApi = {
+    EventsNode: 'EventsNode',
+    ActionsNode: 'ActionsNode',
+    DataWarehouseNode: 'DataWarehouseNode',
+} as const
+
 export interface ConversionGoalSummaryApi {
     /** Unique id of the goal (event name, action id, or DW goal id) */
     id: string
     /** Display name of the conversion goal */
     name: string
-    /** Goal type — one of: EventsNode (PostHog event), ActionsNode (PostHog action), DataWarehouseNode (external table) */
-    kind: string
+    /** Goal type: EventsNode (PostHog event), ActionsNode (PostHog action), or DataWarehouseNode (external table)
+     *
+     * * `EventsNode` - EventsNode
+     * * `ActionsNode` - ActionsNode
+     * * `DataWarehouseNode` - DataWarehouseNode */
+    kind: ConversionGoalKindEnumApi
     /** Human-readable target the goal matches (event/action name or table) */
     target_label: string
     /** Count of matching conversion events in the last 30 days */
@@ -271,8 +288,12 @@ export interface GoalExplanationApi {
     goal_id: string
     /** Display name of the conversion goal */
     goal_name: string
-    /** EventsNode/ActionsNode/DataWarehouseNode */
-    kind: string
+    /** Goal type: EventsNode (PostHog event), ActionsNode (PostHog action), or DataWarehouseNode (external table)
+     *
+     * * `EventsNode` - EventsNode
+     * * `ActionsNode` - ActionsNode
+     * * `DataWarehouseNode` - DataWarehouseNode */
+    kind: ConversionGoalKindEnumApi
     /** The period the breakdown was computed over */
     period: GoalExplanationPeriodApi
     /** Total matching conversion events in the period */

--- a/products/marketing_analytics/frontend/generated/api.zod.schemas.ts
+++ b/products/marketing_analytics/frontend/generated/api.zod.schemas.ts
@@ -9,13 +9,25 @@
  */
 import { z as zod } from 'zod'
 
+export const ConversionGoalKindEnumApi = zod
+    .enum(['EventsNode', 'ActionsNode', 'DataWarehouseNode'])
+    .describe(
+        '\* `EventsNode` - EventsNode\n\* `ActionsNode` - ActionsNode\n\* `DataWarehouseNode` - DataWarehouseNode'
+    )
+
+export type ConversionGoalKindEnumApi = zod.input<typeof ConversionGoalKindEnumApi>
+export type ConversionGoalKindEnumApiOutput = zod.output<typeof ConversionGoalKindEnumApi>
+
 export const ConversionGoalSummaryApi = zod.object({
     id: zod.string().describe('Unique id of the goal (event name, action id, or DW goal id)'),
     name: zod.string().describe('Display name of the conversion goal'),
     kind: zod
-        .string()
+        .enum(['EventsNode', 'ActionsNode', 'DataWarehouseNode'])
         .describe(
-            'Goal type — one of: EventsNode (PostHog event), ActionsNode (PostHog action), DataWarehouseNode (external table)'
+            '\* `EventsNode` - EventsNode\n\* `ActionsNode` - ActionsNode\n\* `DataWarehouseNode` - DataWarehouseNode'
+        )
+        .describe(
+            'Goal type: EventsNode (PostHog event), ActionsNode (PostHog action), or DataWarehouseNode (external table)\n\n\* `EventsNode` - EventsNode\n\* `ActionsNode` - ActionsNode\n\* `DataWarehouseNode` - DataWarehouseNode'
         ),
     target_label: zod.string().describe('Human-readable target the goal matches (event\/action name or table)'),
     last_30d_count: zod.number().describe('Count of matching conversion events in the last 30 days'),
@@ -61,9 +73,12 @@ export const ConversionGoalsListResponseApi = zod.object({
                 id: zod.string().describe('Unique id of the goal (event name, action id, or DW goal id)'),
                 name: zod.string().describe('Display name of the conversion goal'),
                 kind: zod
-                    .string()
+                    .enum(['EventsNode', 'ActionsNode', 'DataWarehouseNode'])
                     .describe(
-                        'Goal type — one of: EventsNode (PostHog event), ActionsNode (PostHog action), DataWarehouseNode (external table)'
+                        '\* `EventsNode` - EventsNode\n\* `ActionsNode` - ActionsNode\n\* `DataWarehouseNode` - DataWarehouseNode'
+                    )
+                    .describe(
+                        'Goal type: EventsNode (PostHog event), ActionsNode (PostHog action), or DataWarehouseNode (external table)\n\n\* `EventsNode` - EventsNode\n\* `ActionsNode` - ActionsNode\n\* `DataWarehouseNode` - DataWarehouseNode'
                     ),
                 target_label: zod
                     .string()
@@ -545,9 +560,12 @@ export const MarketingDiagnosticResponseApi = zod.object({
                             id: zod.string().describe('Unique id of the goal (event name, action id, or DW goal id)'),
                             name: zod.string().describe('Display name of the conversion goal'),
                             kind: zod
-                                .string()
+                                .enum(['EventsNode', 'ActionsNode', 'DataWarehouseNode'])
                                 .describe(
-                                    'Goal type — one of: EventsNode (PostHog event), ActionsNode (PostHog action), DataWarehouseNode (external table)'
+                                    '\* `EventsNode` - EventsNode\n\* `ActionsNode` - ActionsNode\n\* `DataWarehouseNode` - DataWarehouseNode'
+                                )
+                                .describe(
+                                    'Goal type: EventsNode (PostHog event), ActionsNode (PostHog action), or DataWarehouseNode (external table)\n\n\* `EventsNode` - EventsNode\n\* `ActionsNode` - ActionsNode\n\* `DataWarehouseNode` - DataWarehouseNode'
                                 ),
                             target_label: zod
                                 .string()
@@ -652,7 +670,14 @@ export type GoalEventSampleApiOutput = zod.output<typeof GoalEventSampleApi>
 export const GoalExplanationApi = zod.object({
     goal_id: zod.string().describe('Id of the explained conversion goal'),
     goal_name: zod.string().describe('Display name of the conversion goal'),
-    kind: zod.string().describe('EventsNode\/ActionsNode\/DataWarehouseNode'),
+    kind: zod
+        .enum(['EventsNode', 'ActionsNode', 'DataWarehouseNode'])
+        .describe(
+            '\* `EventsNode` - EventsNode\n\* `ActionsNode` - ActionsNode\n\* `DataWarehouseNode` - DataWarehouseNode'
+        )
+        .describe(
+            'Goal type: EventsNode (PostHog event), ActionsNode (PostHog action), or DataWarehouseNode (external table)\n\n\* `EventsNode` - EventsNode\n\* `ActionsNode` - ActionsNode\n\* `DataWarehouseNode` - DataWarehouseNode'
+        ),
     period: zod
         .object({
             date_from: zod.string().nullable().describe('Start of the analyzed period (ISO)'),

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14569,13 +14569,31 @@ export namespace Schemas {
       images?: ConversationsTicketImage[] | null;
     }
 
+    /**
+     * * `EventsNode` - EventsNode
+     * * `ActionsNode` - ActionsNode
+     * * `DataWarehouseNode` - DataWarehouseNode
+     */
+    export type ConversionGoalKindEnum = typeof ConversionGoalKindEnum[keyof typeof ConversionGoalKindEnum];
+
+
+    export const ConversionGoalKindEnum = {
+      EventsNode: 'EventsNode',
+      ActionsNode: 'ActionsNode',
+      DataWarehouseNode: 'DataWarehouseNode',
+    } as const;
+
     export interface ConversionGoalSummary {
       /** Unique id of the goal (event name, action id, or DW goal id) */
       id: string;
       /** Display name of the conversion goal */
       name: string;
-      /** Goal type — one of: EventsNode (PostHog event), ActionsNode (PostHog action), DataWarehouseNode (external table) */
-      kind: string;
+      /** Goal type: EventsNode (PostHog event), ActionsNode (PostHog action), or DataWarehouseNode (external table)
+       *
+       * * `EventsNode` - EventsNode
+       * * `ActionsNode` - ActionsNode
+       * * `DataWarehouseNode` - DataWarehouseNode */
+      kind: ConversionGoalKindEnum;
       /** Human-readable target the goal matches (event/action name or table) */
       target_label: string;
       /** Count of matching conversion events in the last 30 days */
@@ -32587,8 +32605,12 @@ export namespace Schemas {
       goal_id: string;
       /** Display name of the conversion goal */
       goal_name: string;
-      /** EventsNode/ActionsNode/DataWarehouseNode */
-      kind: string;
+      /** Goal type: EventsNode (PostHog event), ActionsNode (PostHog action), or DataWarehouseNode (external table)
+       *
+       * * `EventsNode` - EventsNode
+       * * `ActionsNode` - ActionsNode
+       * * `DataWarehouseNode` - DataWarehouseNode */
+      kind: ConversionGoalKindEnum;
       /** The period the breakdown was computed over */
       period: GoalExplanationPeriod;
       /** Total matching conversion events in the period */


### PR DESCRIPTION
## Problem

Two serializers on the marketing analytics API describe a conversion goal's type, and both declared it as a plain string with the three valid values written into prose:

```python
kind = serializers.CharField(
    help_text="Goal type — one of: EventsNode (PostHog event), ActionsNode (PostHog action), DataWarehouseNode (external table)"
)
```

The reason was real: a `ChoiceField` named `kind` collides with other enums in drf-spectacular, and the collision fails CI because `--fail-on-warn` is set. So the workaround traded the type away to keep the build green.

The cost lands downstream. `kind` generated as `kind: string`, so frontend and MCP consumers had to read the valid values out of a help text and restate them by hand, with nothing checking that their copy still matched the backend.

## Changes

Both fields are `ChoiceField`s again. The collision is resolved the documented way, with a stable name in `ENUM_NAME_OVERRIDES`, which is what the `/improving-drf-endpoints` skill points at for exactly this case.

The choice list is derived from the schema's `NodeKind` rather than restating the three strings, so it can't drift from `ConversionGoalFilter1/2/3`:

```python
CONVERSION_GOAL_KIND_CHOICES = [
    NodeKind.EVENTS_NODE.value,
    NodeKind.ACTIONS_NODE.value,
    NodeKind.DATA_WAREHOUSE_NODE.value,
]
```

Both serializers share it, so one override entry covers both. The generated type goes from `kind: string` to:

```ts
export const ConversionGoalKindEnumApi = {
    EventsNode: 'EventsNode',
    ActionsNode: 'ActionsNode',
    DataWarehouseNode: 'DataWarehouseNode',
} as const
```

No behaviour changes: the serializers already only ever emitted these three values.

## How did you test this code?

**Automated, run locally.** `python manage.py find_enum_collisions` reports no collisions, which is the check that would otherwise fail CI. `hogli build:openapi` regenerates cleanly and the generated types now carry the enum. The marketing analytics suite passes at 894 with 72 snapshots and no drift, `uv run mypy --cache-fine-grained .` is clean across 17,152 files, and `tach check --dependencies --interfaces` validates.

No new tests. The change is a type-level one with no new branches, and the values were already covered by the existing serializer tests; the regression this guards against is a generated-type regression, which `find_enum_collisions` and the committed generated files catch directly.

**Not tested:** nothing was exercised through the UI. No consumer reads these fields today beyond the generated types, so there was no rendered surface to check.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed. No API shape or behaviour change, only a tighter type on an existing field.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude (Claude Code) wrote it. Skills invoked: `/improving-drf-endpoints`, which is where the `ENUM_NAME_OVERRIDES` route came from.

This came out of reviewing #74681, which had the same `CharField` workaround with the same comment. That PR fixed its own instance; this one clears the two remaining ones in the same file. Deriving the choices from `NodeKind` instead of writing the three strings into the override was the one call worth making: it means adding a goal kind to the schema surfaces here rather than silently leaving the API enum behind.
