### PR TITLE
chore(ci): migrate remaining CD image workflows off the shared ECR role

### DIFF
--- a/.github/workflows/cd-agent-proxy-image.yml
+++ b/.github/workflows/cd-agent-proxy-image.yml
@@ -38,7 +38,10 @@ jobs:
               uses: ./.github/actions/docker-meta
               with:
                   image-name: posthog-agent-proxy
-                  aws-role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  # Publishes only from the default branch — assume the role and touch ECR only there
+                  # (a non-default-branch workflow_dispatch builds nothing to push).
+                  aws-role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+                  push-to-ecr: ${{ github.ref == 'refs/heads/master' }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/cd-llm-analytics-image.yml
+++ b/.github/workflows/cd-llm-analytics-image.yml
@@ -55,7 +55,24 @@ jobs:
             id-token: write
             contents: read
 
+        # ECR repo + role resolved once, keyed on the branch, so the configure-aws role and the
+        # tags target can't drift: default branch → posthog-llm-analytics via the default-branch
+        # role; a labeled PR → posthog-llm-analytics-prs via the any-branch prs role.
+        env:
+            ECR_IMAGE: ${{ github.ref == 'refs/heads/master' && 'posthog-llm-analytics' || 'posthog-llm-analytics-prs' }}
+            ECR_ROLE: ${{ github.ref == 'refs/heads/master' && vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE || vars.AWS_ECR_POSTHOG_PRS_PUBLISH_IAM_ROLE }}
+
         steps:
+            - name: Assert default-branch publish role is configured
+              if: github.ref == 'refs/heads/master'
+              env:
+                  DEFAULT_BRANCH_ROLE: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+              run: |
+                  if [[ -z "$DEFAULT_BRANCH_ROLE" ]]; then
+                    echo "::error::AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE is not set — refusing to fall back to the PRS role on the default branch."
+                    exit 1
+                  fi
+
             - name: Check out
               uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
               with:
@@ -73,7 +90,7 @@ jobs:
             - name: Configure AWS credentials
               uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
               with:
-                  role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  role-to-assume: ${{ env.ECR_ROLE }}
                   aws-region: us-east-1
 
             - name: Login to Amazon ECR
@@ -88,7 +105,7 @@ jobs:
                   file: ./Dockerfile.llm-analytics
                   buildx-fallback: false
                   push: ${{ github.event_name == 'pull_request' || vars.CD_DEPLOY_ENABLED == 'true' }}
-                  tags: ${{ github.ref == 'refs/heads/master' && format('{0}/posthog-llm-analytics:master,{0}/posthog-llm-analytics:{1}', steps.aws-ecr.outputs.registry, github.sha) || format('{0}/posthog-llm-analytics:{1}', steps.aws-ecr.outputs.registry, github.sha) }}
+                  tags: ${{ github.ref == 'refs/heads/master' && format('{0}/{1}:master,{0}/{1}:{2}', steps.aws-ecr.outputs.registry, env.ECR_IMAGE, github.sha) || format('{0}/{1}:{2}', steps.aws-ecr.outputs.registry, env.ECR_IMAGE, github.sha) }}
                   platforms: linux/arm64,linux/amd64
                   build-args: COMMIT_HASH=${{ github.sha }}
 

--- a/.github/workflows/cd-mcp-image.yml
+++ b/.github/workflows/cd-mcp-image.yml
@@ -52,7 +52,10 @@ jobs:
               uses: ./.github/actions/docker-meta
               with:
                   image-name: posthog-mcp
-                  aws-role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  # Publishes only from the default branch — assume the role and touch ECR only there;
+                  # labeled PRs still build (push=false) without assuming it.
+                  aws-role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+                  push-to-ecr: ${{ github.ref == 'refs/heads/master' }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/llm-gateway-cd.yml
+++ b/.github/workflows/llm-gateway-cd.yml
@@ -37,7 +37,10 @@ jobs:
               uses: ./.github/actions/docker-meta
               with:
                   image-name: llm-gateway
-                  aws-role-to-assume: ${{ secrets.AWS_ECR_PUBLISH_IAM_ROLE }}
+                  # Publishes only from the default branch — assume the role and touch ECR only there
+                  # (a non-default-branch workflow_dispatch builds nothing to push).
+                  aws-role-to-assume: ${{ vars.AWS_ECR_POSTHOG_MASTER_PUBLISH_IAM_ROLE }}
+                  push-to-ecr: ${{ github.ref == 'refs/heads/master' }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   dockerhub-username: ${{ secrets.DOCKERHUB_USER }}
                   dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Four CD image workflows — `cd-mcp-image`, `llm-gateway-cd`, `cd-agent-proxy-image`, `cd-llm-analytics-image` — still publish to ECR via the broad, any-repo/any-branch `AWS_ECR_PUBLISH_IAM_ROLE`. They're the last posthog workflows on that shared role; migrating them lets us take posthog off it entirely.

## Changes

- **`cd-mcp-image`, `llm-gateway-cd`, `cd-agent-proxy-image`** publish only from the default branch → switched to the dedicated default-branch publish role, and only touch ECR on the default branch (`push-to-ecr` gated on `github.ref`). PR / non-default-branch builds still run for validation; they just don't assume the role. No `-prs` repo (they never push a PR image).
- **`cd-llm-analytics-image`** keeps its `build-llm-analytics-image` labeled-PR build+push, now routed by branch: default branch → `posthog-llm-analytics` (default-branch role); labeled PR → `posthog-llm-analytics-prs` (any-branch prs role). Repo + role are resolved once per job so they can't drift, plus a guard against a missing role var.

DockerHub / ghcr publishing unchanged.

## How did you test this code?

`actionlint` and `hogli lint:workflows` (7 checks, 106 workflows) pass. No runtime test is possible pre-rollout — the infra role-scope change must be applied first.

> ⚠️ Blocked on rollout: apply the paired infra PR (`PostHog/posthog-cloud-infra#9667`) and confirm it's live **before** merging, or these workflows can't assume the role for their default-branch ECR pushes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (`/authoring-ci-workflows`, `/gating-production-deploys`). Reuses the branch-keyed routing from the earlier split PR. The three default-branch-only workflows just gate ECR to the default branch rather than route to a `-prs` repo, since they never push a PR image; `cd-llm-analytics` gets a `-prs` repo because its labeled-PR push is a deliberate way to get a testable ML image. Once this lands, no posthog workflow references the shared role, so a follow-up can drop `repo:PostHog/posthog:*` from its trust in the infra repo.
