### PR TITLE
feat(capture-logs): pick the newest valid exemplar deterministically

### DIFF
--- a/rust/capture-logs/src/metric_record.rs
+++ b/rust/capture-logs/src/metric_record.rs
@@ -7,6 +7,7 @@ use chrono::serde::ts_microseconds;
 use chrono::DateTime;
 use chrono::TimeDelta;
 use chrono::Utc;
+use metrics::counter;
 use opentelemetry_proto::tonic::{
     common::v1::{
         any_value::{self, Value},
@@ -264,16 +265,23 @@ fn build_number_row(
     flags: u32,
 ) -> Result<(KafkaMetricRow, bool)> {
     // OTel exemplars attach trace context (and per-bucket trace context on histograms) to
-    // data points. V1 picks the first exemplar with a spec-conformant 16-byte trace_id and
-    // runs it through the shared extract_trace_id / extract_span_id helpers (same encoding
-    // path as log_record / trace_record). Filtering by length up front avoids the case
-    // where a malformed exemplar earlier in the vec would shadow a valid one — exemplar
-    // selection is a metrics-specific concern with no precedent in logs/traces, which
-    // each carry a single trace_id field. Per-bucket attribution on histograms is lossy
-    // in this representation; revisit when we add a multi-row or array exemplar column.
-    let (exemplar_trace_id, exemplar_span_id) = exemplars
+    // data points. The row stores one exemplar, so among those with a spec-conformant
+    // 16-byte trace_id the NEWEST wins: vec order varies with SDK batching and collector
+    // reordering, while recency is deterministic and biases toward the trace most likely
+    // still retained by trace sampling. Ties keep the later entry (max_by_key semantics).
+    // The rest flow through the shared extract_trace_id / extract_span_id helpers (same
+    // encoding path as log_record / trace_record). Per-bucket attribution on histograms
+    // is lossy in this representation; dropped counts are observable via
+    // capture_metrics_exemplars_dropped_total until a multi-row or array exemplar column.
+    let picked = exemplars
         .iter()
-        .find(|e| e.trace_id.len() == 16)
+        .filter(|e| e.trace_id.len() == 16)
+        .max_by_key(|e| e.time_unix_nano);
+    let dropped = exemplars.len() - usize::from(picked.is_some());
+    if dropped > 0 {
+        counter!("capture_metrics_exemplars_dropped_total").increment(dropped as u64);
+    }
+    let (exemplar_trace_id, exemplar_span_id) = picked
         .map(|e| {
             (
                 BASE64_STANDARD.encode(extract_trace_id(&e.trace_id)),
@@ -639,7 +647,7 @@ mod tests {
     }
 
     #[test]
-    fn test_first_well_formed_exemplar_is_picked() {
+    fn test_well_formed_exemplar_is_picked_over_contextless() {
         // First exemplar has an empty trace_id (no context attached) and is skipped;
         // second carries spec-conformant 16-byte bytes and wins.
         let other_trace = [9u8; 16];
@@ -652,6 +660,54 @@ mod tests {
 
         assert_eq!(row.trace_id, BASE64_STANDARD.encode(other_trace));
         assert_eq!(row.span_id, BASE64_STANDARD.encode(other_span));
+    }
+
+    fn make_timed_exemplar(trace_id: Vec<u8>, span_id: Vec<u8>, time_unix_nano: u64) -> Exemplar {
+        Exemplar {
+            time_unix_nano,
+            ..make_exemplar(trace_id, span_id)
+        }
+    }
+
+    #[test]
+    fn test_latest_valid_exemplar_wins_regardless_of_vec_order() {
+        // The schema stores one exemplar per data point, so selection must be
+        // deterministic under collector batching/reordering: the newest valid
+        // exemplar wins, not whichever happens to appear first in the vec.
+        let older_trace = [1u8; 16];
+        let newer_trace = [2u8; 16];
+        let newer_span = [2u8; 8];
+
+        let newest_first = vec![
+            make_timed_exemplar(newer_trace.to_vec(), newer_span.to_vec(), 200),
+            make_timed_exemplar(older_trace.to_vec(), [1u8; 8].to_vec(), 100),
+        ];
+        let newest_last = vec![
+            make_timed_exemplar(older_trace.to_vec(), [1u8; 8].to_vec(), 100),
+            make_timed_exemplar(newer_trace.to_vec(), newer_span.to_vec(), 200),
+        ];
+
+        for exemplars in [newest_first, newest_last] {
+            let row = build_test_row(&exemplars);
+            assert_eq!(row.trace_id, BASE64_STANDARD.encode(newer_trace));
+            assert_eq!(row.span_id, BASE64_STANDARD.encode(newer_span));
+        }
+    }
+
+    #[test]
+    fn test_latest_wins_ignores_malformed_newer_exemplar() {
+        // A malformed exemplar with the newest timestamp must not beat an older
+        // valid one: recency only ranks exemplars that carry usable context.
+        let valid_trace = [3u8; 16];
+        let valid_span = [3u8; 8];
+        let exemplars = vec![
+            make_timed_exemplar(valid_trace.to_vec(), valid_span.to_vec(), 100),
+            make_timed_exemplar(vec![1, 2, 3], vec![], 999),
+        ];
+        let row = build_test_row(&exemplars);
+
+        assert_eq!(row.trace_id, BASE64_STANDARD.encode(valid_trace));
+        assert_eq!(row.span_id, BASE64_STANDARD.encode(valid_span));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The metrics schema stores **one** exemplar per data point, but the selection among an OTLP data point's exemplars was "first in the vec with a valid 16-byte trace_id". Vec order depends on SDK batching and collector reordering, so two identical exports could keep *different* exemplars - nondeterministic trace links - and whatever was dropped was dropped silently. The dream-state review flagged deciding an exemplar retention policy before volume decides it for us; this is that decision for the current one-exemplar representation.

## Changes

- **Latest-wins, deterministically:** among exemplars carrying a spec-conformant 16-byte trace_id, the one with the greatest `time_unix_nano` is kept, regardless of vec order. Recency also biases toward the trace most likely still retained by trace sampling. Malformed exemplars never outrank valid ones regardless of timestamp.
- **Observable drops:** every exemplar not carried into the row increments `capture_metrics_exemplars_dropped_total`, so the cost of the one-exemplar representation is measurable (and becomes the sizing input for a future multi-exemplar column).

No schema change; applies to every OTLP metric type that carries exemplars (the remote-write path has none in v1).

## How did you test this code?

TDD on the `metric_record` suite (23 tests green):

- New: `test_latest_valid_exemplar_wins_regardless_of_vec_order` - written first and observed failing against the old first-wins selection (it picked the older exemplar when ordered first), then green after the change, asserted in both vec orders.
- New: `test_latest_wins_ignores_malformed_newer_exemplar` - a malformed exemplar with the newest timestamp must not beat an older valid one.
- All pre-existing exemplar semantics tests unchanged and green (valid-over-contextless, malformed-never-shadows, all-malformed-yields-empty, histogram path, base64 encoding).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A - ingest implementation detail; trace links simply become deterministic.

## 🤖 Agent context

**Autonomy:** Fully autonomous (overnight run)

Part of the metrics dream-state gap-closing series (with #75153 token rejection and #75199 remote-write, which this stacks on). Scoped deliberately small: the full "exemplar sampling policy at scale" question (rate-limiting exemplar storage at 1M samples/sec) belongs to the events-model schema work; what could be decided now without schema changes is determinism and observability of the existing cap, so that's what shipped.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
