### PR TITLE
feat(insights): ship grouped variant as the only new insight menu

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6915,9 +6915,9 @@ snapshots:
     scenes-app-saved-insights--search-results--light:
         hash: v1.k794b7964.a7e1c5334e9e3c3ea3c616dbf31ab9d8e0cc428db4376f10152b022959500d5e.CNZ66Ebm_c7BNBYLPPBwS9iiz2O3P-mkE46XuBkGKos
     scenes-app-saved-insights-new-insight-menu--overlay--dark:
-        hash: v1.k794b7964.5a65f3fe94b288f66e436ecd8677bc2d1b3fe08ca885f03eae64bc8847b783ee.Rbg5_4VnhqIM110O92Rsb0SKEPt3aFNSAEDRY-msHPc
+        hash: v1.k794b7964.5a65f3fe94b288f66e436ecd8677bc2d1b3fe08ca885f03eae64bc8847b783ee.YfBWEDQwkl46pC03TjLQBVNXq96nOm91Lc0KcpIXegc
     scenes-app-saved-insights-new-insight-menu--overlay--light:
-        hash: v1.k794b7964.1ed49ef01f24d1bf519ec7a184b4ae9a809705421510221f60fe5d22ab5052f7.FTV3mfkHio4riI82tiGFRA4e-rcdasqh62XJtba9AXU
+        hash: v1.k794b7964.b1f8b76506ff046ee7667a54f64fc587413ce238932d26039b8fa398d864f19f.X8ZiWahHO3f74wwMcFkt2tCuh29Dn6IZL_CXzVZUxHI
     scenes-app-sessionattributionexplorer--session-attribution-explorer--dark:
         hash: v1.k794b7964.f155136ab341d343517047052786c945b29e035f5c6688c170ddb34644977402.YdTYmTEtPQ8DA5jLsTAJuOZMdr956Jug7d1kOO4BvDM
     scenes-app-sessionattributionexplorer--session-attribution-explorer--light:

--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6914,13 +6914,9 @@ snapshots:
         hash: v1.k794b7964.e9ffaf5a9af0f5e766cba20128491f842dce8849c041b3d3f4e6432e94306998.dHNQ6L9tFR-OVJ-o_zgDyElo7v8pXfSoXl8ZEBl20eE
     scenes-app-saved-insights--search-results--light:
         hash: v1.k794b7964.a7e1c5334e9e3c3ea3c616dbf31ab9d8e0cc428db4376f10152b022959500d5e.CNZ66Ebm_c7BNBYLPPBwS9iiz2O3P-mkE46XuBkGKos
-    scenes-app-saved-insights-new-insight-menu--chips-overlay--dark:
-        hash: v1.k794b7964.fcabcc79cc98ec8be499627e122f1d8e85c04cef4904ed35937c58402487bd88.pdnqrw_LEDnkyYxZPkmenVsjYaWYuHl2GOpAqMIA9Fg
-    scenes-app-saved-insights-new-insight-menu--chips-overlay--light:
-        hash: v1.k794b7964.734bf73c0aacf34fa60365106192d1a705ce2470faccd609b493bc6013427bff.DlKlVXWYBikhZE9lb-F8QKKTFPHVLET5XZdYeS0GRH4
-    scenes-app-saved-insights-new-insight-menu--grouped-overlay--dark:
+    scenes-app-saved-insights-new-insight-menu--overlay--dark:
         hash: v1.k794b7964.5a65f3fe94b288f66e436ecd8677bc2d1b3fe08ca885f03eae64bc8847b783ee.Rbg5_4VnhqIM110O92Rsb0SKEPt3aFNSAEDRY-msHPc
-    scenes-app-saved-insights-new-insight-menu--grouped-overlay--light:
+    scenes-app-saved-insights-new-insight-menu--overlay--light:
         hash: v1.k794b7964.1ed49ef01f24d1bf519ec7a184b4ae9a809705421510221f60fe5d22ab5052f7.FTV3mfkHio4riI82tiGFRA4e-rcdasqh62XJtba9AXU
     scenes-app-sessionattributionexplorer--session-attribution-explorer--dark:
         hash: v1.k794b7964.f155136ab341d343517047052786c945b29e035f5c6688c170ddb34644977402.YdTYmTEtPQ8DA5jLsTAJuOZMdr956Jug7d1kOO4BvDM

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -178,7 +178,6 @@ export const FEATURE_FLAGS = {
     CREATE_BUTTON_NAV_EXPERIMENT: 'create-button-nav-experiment', // owner: #team-platform-ux multivariate=control,test — adds a Create dropdown to the top of the Browse tab in the left nav
     FEATURE_FLAG_DISABLE_AND_ARCHIVE_EXPERIMENT: 'feature-flag-disable-and-archive-experiment', // owner: #team-feature-flags multivariate=control,test, makes "Disable and archive" the primary CTA in the disable-flag confirmation dialog, control keeps the plain disable confirmation
     INSIGHT_NOTIFICATION_ENTRYPOINT: 'insight-notification-entrypoint', // owner: #team-product-analytics multivariate=control,notifications,get-updates,monitor — tests notification-entry-point copy against the prominent Subscribe button
-    NEW_INSIGHT_MENU_EXPERIMENT: 'new-insight-menu-experiment', // owner: @thmsobrmlr #team-product-analytics multivariate=control,chips,grouped — experiment on the saved insights "New" menu: control = text list, chips = visual card grid with sub-insight chips, grouped = two-column card grid grouped by question
     STARRED_REORDER: 'starred-reorder', // owner: #team-platform-ux, drag-and-drop reorder of starred shortcuts in the side panel
     UX_HIDE_PROJECT_NOTICE: 'ux-hide-project-notice', // owner: #team-platform-ux, hides the project notice banner across all scenes
 

--- a/frontend/src/scenes/saved-insights/NewInsightMenu.stories.tsx
+++ b/frontend/src/scenes/saved-insights/NewInsightMenu.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 
-import { NewInsightMenuChipsOverlay, NewInsightMenuGroupedOverlay } from './NewInsightMenu'
+import { NewInsightMenuOverlay } from './NewInsightMenu'
 
 const meta: Meta = {
     title: 'Scenes-App/Saved Insights/New Insight Menu',
@@ -9,18 +9,10 @@ export default meta
 
 type Story = StoryObj
 
-export const ChipsOverlay: Story = {
+export const Overlay: Story = {
     render: () => (
         <div className="border border-primary rounded bg-surface-primary w-fit p-1">
-            <NewInsightMenuChipsOverlay />
-        </div>
-    ),
-}
-
-export const GroupedOverlay: Story = {
-    render: () => (
-        <div className="border border-primary rounded bg-surface-primary w-fit p-1">
-            <NewInsightMenuGroupedOverlay />
+            <NewInsightMenuOverlay />
         </div>
     ),
 }

--- a/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
+++ b/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
@@ -10,7 +10,6 @@ import { IconInsightNumber, IconInsightPie, IconInsightTable, IconInsightWorldMa
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { LemonDropdown } from 'lib/lemon-ui/LemonDropdown'
-import { LemonMenu, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
 import { Link } from 'lib/lemon-ui/Link'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { cn } from 'lib/utils/css-classes'
@@ -20,13 +19,12 @@ import { INSIGHT_TYPES_METADATA } from 'scenes/saved-insights/insightTypesMetada
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
-import { FunnelsQuery, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import {
     AccessControlLevel,
     AccessControlResourceType,
     BaseMathType,
     ChartDisplayType,
-    FunnelVizType,
     InsightType,
 } from '~/types'
 
@@ -69,24 +67,6 @@ function trendsPresetUrl(overrides: Partial<TrendsQuery>): string {
             ],
             trendsFilter: {},
             ...overrides,
-        },
-    }
-    return urls.insightNew({ query })
-}
-
-function funnelsPresetUrl(vizType: FunnelVizType): string {
-    const query: InsightVizNode<FunnelsQuery> = {
-        kind: NodeKind.InsightVizNode,
-        source: {
-            kind: NodeKind.FunnelsQuery,
-            series: [
-                {
-                    kind: NodeKind.EventsNode,
-                    event: '$pageview',
-                    name: '$pageview',
-                },
-            ],
-            funnelsFilter: { funnelVizType: vizType },
         },
     }
     return urls.insightNew({ query })
@@ -182,13 +162,11 @@ const AI_CARD: NewInsightCardSpec = {
 
 function useNewInsightCards(): {
     ai: NewInsightCardSpec
-    ordered: NewInsightCardSpec[]
     byType: Partial<Record<InsightType, NewInsightCardSpec>>
 } {
     const { featureFlags } = useValues(featureFlagLogic)
 
     const byType: Partial<Record<InsightType, NewInsightCardSpec>> = {}
-    const ordered: NewInsightCardSpec[] = []
     for (const [insightType, metadata] of Object.entries(INSIGHT_TYPES_METADATA)) {
         if (
             !metadata.inMenu ||
@@ -208,9 +186,8 @@ function useNewInsightCards(): {
             onClick: () => reportNewInsightClicked(insightType as InsightType),
         }
         byType[insightType as InsightType] = spec
-        ordered.push(spec)
     }
-    return { ai: AI_CARD, ordered, byType }
+    return { ai: AI_CARD, byType }
 }
 
 function NewInsightCard({
@@ -251,123 +228,9 @@ function NewInsightCard({
     )
 }
 
-// -- Chips variant: flat card grid, Trends and Funnel cards carry sub-insight chips --
+// -- Two columns of question-framed sections with a divider --
 
-interface NewInsightCardChip {
-    label: string
-    to: string
-    dataAttr: string
-    onClick: () => void
-}
-
-const CARD_CHIPS: Partial<Record<InsightType, NewInsightCardChip[]>> = {
-    [InsightType.TRENDS]: [
-        {
-            label: 'Table',
-            to: TRENDS_PRESET_URLS.table,
-            dataAttr: 'new-insight-menu-chip-table',
-            onClick: () => reportNewInsightClicked(InsightType.TRENDS, 'table'),
-        },
-        {
-            label: 'Map',
-            to: TRENDS_PRESET_URLS.worldMap,
-            dataAttr: 'new-insight-menu-chip-map',
-            onClick: () => reportNewInsightClicked(InsightType.TRENDS, 'world-map'),
-        },
-        {
-            label: 'Number',
-            to: TRENDS_PRESET_URLS.number,
-            dataAttr: 'new-insight-menu-chip-number',
-            onClick: () => reportNewInsightClicked(InsightType.TRENDS, 'number'),
-        },
-        {
-            label: 'Pie',
-            to: TRENDS_PRESET_URLS.pie,
-            dataAttr: 'new-insight-menu-chip-pie',
-            onClick: () => reportNewInsightClicked(InsightType.TRENDS, 'pie'),
-        },
-    ],
-    [InsightType.FUNNELS]: [
-        {
-            label: 'Time to convert',
-            to: funnelsPresetUrl(FunnelVizType.TimeToConvert),
-            dataAttr: 'new-insight-menu-chip-time-to-convert',
-            onClick: () => reportNewInsightClicked(InsightType.FUNNELS, 'time-to-convert'),
-        },
-        {
-            label: 'Conversion trend',
-            to: funnelsPresetUrl(FunnelVizType.Trends),
-            dataAttr: 'new-insight-menu-chip-conversion-trend',
-            onClick: () => reportNewInsightClicked(InsightType.FUNNELS, 'conversion-trend'),
-        },
-    ],
-}
-
-function NewInsightCardWithChips({
-    spec,
-    chips,
-}: {
-    spec: NewInsightCardSpec
-    chips: NewInsightCardChip[]
-}): JSX.Element {
-    const Icon = spec.icon
-    return (
-        <div
-            className={cn(
-                'flex flex-col overflow-hidden rounded border border-primary bg-surface-primary',
-                'transition-all duration-100 hover:-translate-y-0.5 hover:border-accent hover:shadow-md'
-            )}
-        >
-            <Link to={spec.to} data-attr={spec.dataAttr} onClick={spec.onClick} className="flex flex-col">
-                <div className="shrink-0 border-b border-primary bg-fill-secondary">
-                    <spec.sketch />
-                </div>
-                <div className="flex flex-col gap-0.5 p-2 pb-1">
-                    <div className="flex items-center gap-1.5">
-                        <Icon className={cn('text-base shrink-0', spec.iconClassName ?? 'text-secondary')} />
-                        <span className="whitespace-nowrap text-sm font-semibold text-default">{spec.name}</span>
-                    </div>
-                    <span className="text-xs leading-snug text-secondary">{spec.description}</span>
-                </div>
-            </Link>
-            <div className="flex flex-wrap gap-1 px-2 pb-2 pt-1">
-                {chips.map((chip) => (
-                    <Link
-                        key={chip.label}
-                        to={chip.to}
-                        data-attr={chip.dataAttr}
-                        onClick={chip.onClick}
-                        className="rounded-full border border-primary px-1.5 py-0.5 text-[11px] leading-none text-secondary hover:border-accent hover:text-accent"
-                    >
-                        {chip.label}
-                    </Link>
-                ))}
-            </div>
-        </div>
-    )
-}
-
-export function NewInsightMenuChipsOverlay(): JSX.Element {
-    const { ai, ordered } = useNewInsightCards()
-    return (
-        <div className="w-[42rem] max-w-[calc(100vw-1rem)] p-1" data-attr="new-insight-menu-chips">
-            <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
-                {[ai, ...ordered].map((spec) => {
-                    const chips = CARD_CHIPS[spec.key as InsightType]
-                    return chips ? (
-                        <NewInsightCardWithChips key={spec.key} spec={spec} chips={chips} />
-                    ) : (
-                        <NewInsightCard key={spec.key} spec={spec} />
-                    )
-                })}
-            </div>
-        </div>
-    )
-}
-
-// -- Grouped variant: two columns of question-framed sections with a divider --
-
-// Terse copy so every description fits the two-line slot at the grouped variant's card width
+// Terse copy so every description fits the two-line slot at the card width
 const SHORT_CARD_DESCRIPTIONS: Record<string, string> = {
     [InsightType.TRENDS]: 'How metrics change over time.',
     [InsightType.STICKINESS]: 'How often users repeat actions.',
@@ -442,13 +305,13 @@ function QuestionSectionBlock({ section }: { section: QuestionSection }): JSX.El
     )
 }
 
-export function NewInsightMenuGroupedOverlay(): JSX.Element {
+export function NewInsightMenuOverlay(): JSX.Element {
     const sections = useQuestionSections()
     const columns = [sections.slice(0, 2), sections.slice(2)]
     return (
         <div
             className="flex w-[58rem] max-w-[calc(100vw-1rem)] gap-4 overflow-y-auto p-4 max-h-[calc(100vh-10rem)]"
-            data-attr="new-insight-menu-grouped"
+            data-attr="new-insight-menu"
         >
             <div className="flex flex-1 flex-col gap-6">
                 {columns[0].map((section) => (
@@ -465,56 +328,7 @@ export function NewInsightMenuGroupedOverlay(): JSX.Element {
     )
 }
 
-// -- Button with the experiment switch --
-
-function useControlMenuItems(): LemonMenuItems {
-    const { featureFlags } = useValues(featureFlagLogic)
-
-    const insightEntries = Object.entries(INSIGHT_TYPES_METADATA).filter(
-        ([insightType]) =>
-            insightType !== InsightType.JSON && (featureFlags[FEATURE_FLAGS.HOG] || insightType !== InsightType.HOG)
-    )
-    return [
-        {
-            icon: <IconSparkles className="text-ai" />,
-            label: (
-                <div className="flex flex-col text-sm py-1">
-                    <strong>AI</strong>
-                    <span className="text-xs font-normal">
-                        Ask PostHog AI to create insights using natural language and query any of your data
-                    </span>
-                </div>
-            ),
-            to: urls.ai(),
-            'data-attr': 'new-insight-menu-ai',
-        },
-        {
-            title: 'Insight types',
-            items: insightEntries
-                .filter(([, metadata]) => metadata.inMenu)
-                .map(([insightType, metadata]) => ({
-                    icon: metadata.icon ? <metadata.icon /> : undefined,
-                    label: (
-                        <div className="flex flex-col text-sm py-1">
-                            <strong>{metadata.name}</strong>
-                            <span className="text-xs font-normal">{metadata.description}</span>
-                        </div>
-                    ),
-                    to: INSIGHT_TYPE_URLS[insightType as InsightType],
-                    'data-attr': `new-insight-menu-${insightType.toLowerCase()}`,
-                    onClick: () => {
-                        reportNewInsightClicked(insightType as InsightType)
-                    },
-                })),
-        },
-    ]
-}
-
 export function NewInsightButton(): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-    const controlMenuItems = useControlMenuItems()
-    const menuVariant = featureFlags[FEATURE_FLAGS.NEW_INSIGHT_MENU_EXPERIMENT]
-
     const button = (
         <LemonButton
             type="primary"
@@ -540,20 +354,9 @@ export function NewInsightButton(): JSX.Element {
                 scope={Scene.SavedInsights}
                 priority={100}
             >
-                {menuVariant === 'chips' || menuVariant === 'grouped' ? (
-                    <LemonDropdown
-                        overlay={
-                            menuVariant === 'chips' ? <NewInsightMenuChipsOverlay /> : <NewInsightMenuGroupedOverlay />
-                        }
-                        placement="bottom-end"
-                    >
-                        {button}
-                    </LemonDropdown>
-                ) : (
-                    <LemonMenu items={controlMenuItems} placement="bottom-end">
-                        {button}
-                    </LemonMenu>
-                )}
+                <LemonDropdown overlay={<NewInsightMenuOverlay />} placement="bottom-end">
+                    {button}
+                </LemonDropdown>
             </Shortcut>
         </AccessControlAction>
     )

--- a/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
+++ b/frontend/src/scenes/saved-insights/NewInsightMenu.tsx
@@ -20,13 +20,7 @@ import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
 import { InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
-import {
-    AccessControlLevel,
-    AccessControlResourceType,
-    BaseMathType,
-    ChartDisplayType,
-    InsightType,
-} from '~/types'
+import { AccessControlLevel, AccessControlResourceType, BaseMathType, ChartDisplayType, InsightType } from '~/types'
 
 import {
     AiSketch,


### PR DESCRIPTION
## TL;DR

The saved insights "New" menu ran as a three-way experiment (text list vs card grid with chips vs two-column grouped grid). The grouped grid won and the flag now serves it to everyone, so this PR deletes the other two variants. The grouped menu is now the only implementation.

## Problem

The [New insight menu experiment](https://us.posthog.com/project/2/experiments/386658) reached significance with the grouped variant winning the primary metric (sub-insight saves). The winning variant has been shipped on the feature flag, so the losing variants and the flag switch are dead code.

## Changes

- `NewInsightButton` always renders the grouped overlay, renamed to `NewInsightMenuOverlay` since it is no longer one of several variants
- Removed the control text menu (`useControlMenuItems`) and the chips variant (`CARD_CHIPS`, `NewInsightCardWithChips`, `NewInsightMenuChipsOverlay`)
- Removed the `NEW_INSIGHT_MENU_EXPERIMENT` flag constant
- Stories and visual snapshots reduced to the single remaining overlay

No visual change for users in the grouped variant. Control and chips users already get the grouped menu via the shipped flag.

## How did you test this code?

- Grepped repo-wide for leftover references to the flag key, the constant, and the removed components; none remain
- Updated the Storybook story; the snapshot entry reuses the hash of the unchanged grouped render
- I (well, Claude) could not run typecheck or lint in this environment, so CI needs to confirm those

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs reference this menu.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code session driven by @thmsobrmlr after the experiment significance notification. The agent shipped the `grouped` variant via the experiments API first (flag rewritten to serve grouped at 100%, experiment ended as won), then removed the experiment code in this PR. Skill invoked: managing-experiment-lifecycle.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
