### PR TITLE
fix(llm-gateway): separate Baseten GLM telemetry

### DIFF
--- a/services/llm-gateway/src/llm_gateway/baseten.py
+++ b/services/llm-gateway/src/llm_gateway/baseten.py
@@ -14,7 +14,7 @@ from llm_gateway.config import Settings
 
 BASETEN_PUBLIC_MODEL = "@cf/zai-org/glm-5.2"
 BASETEN_GLM_MODEL = "zai-org/GLM-5.2"
-BASETEN_METRIC_MODEL = f"baseten/{BASETEN_GLM_MODEL}"
+BASETEN_METRIC_MODEL = "baseten/zai-org/glm-5.2"
 _BASETEN_LITELLM_MODEL = f"openai/{BASETEN_GLM_MODEL}"
 
 

--- a/services/llm-gateway/src/llm_gateway/baseten.py
+++ b/services/llm-gateway/src/llm_gateway/baseten.py
@@ -14,6 +14,7 @@ from llm_gateway.config import Settings
 
 BASETEN_PUBLIC_MODEL = "@cf/zai-org/glm-5.2"
 BASETEN_GLM_MODEL = "zai-org/GLM-5.2"
+BASETEN_METRIC_MODEL = f"baseten/{BASETEN_GLM_MODEL}"
 _BASETEN_LITELLM_MODEL = f"openai/{BASETEN_GLM_MODEL}"
 
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
@@ -8,6 +8,7 @@ import structlog
 from litellm import model_cost_map_url
 from litellm.litellm_core_utils.get_model_cost_map import get_model_cost_map
 
+from llm_gateway.baseten import BASETEN_METRIC_MODEL
 from llm_gateway.rate_limiting.model_cost_overrides import apply_model_cost_overrides
 
 logger = structlog.get_logger(__name__)
@@ -28,15 +29,14 @@ COST_ALIASES: dict[str, str] = {
     "openai/zai-org/GLM-5.2-FP8": "cloudflare/@cf/zai-org/glm-5.2",
 }
 
-# For aliased models, litellm's reported (provider, model) labels don't match what the user asked
-# for. Map the litellm-view model key → the user-facing (provider, model) pair to emit in metrics.
-# Separate from COST_ALIASES: cost lookups key on litellm.model_cost, metric labels on user intent.
+# Map LiteLLM's provider and model labels to stable telemetry identifiers. This stays separate from
+# COST_ALIASES because cost lookups and telemetry have different canonical names.
 ALIAS_METRIC_LABELS: dict[str, tuple[str, str]] = {
     "openai/@cf/moonshotai/kimi-k2.6": ("cloudflare", "@cf/moonshotai/kimi-k2.6"),
     "openai/@cf/zai-org/glm-5.2": ("cloudflare", "@cf/zai-org/glm-5.2"),
     # Same public model id as the CF entry so dashboards slice one model across both backends.
     "openai/zai-org/GLM-5.2-FP8": ("modal", "@cf/zai-org/glm-5.2"),
-    "openai/zai-org/GLM-5.2": ("baseten", "@cf/zai-org/glm-5.2"),
+    "openai/zai-org/GLM-5.2": ("baseten", BASETEN_METRIC_MODEL),
     "openai/moonshotai/kimi-k3": ("modal", "moonshotai/kimi-k3"),
 }
 

--- a/services/llm-gateway/tests/test_baseten.py
+++ b/services/llm-gateway/tests/test_baseten.py
@@ -5,13 +5,12 @@ import pytest
 from fastapi import HTTPException
 
 from llm_gateway.baseten import (
-    BASETEN_METRIC_MODEL,
     _inject_baseten_params,
     ensure_baseten_configured,
     make_baseten_responses_call,
 )
 from llm_gateway.config import Settings
-from llm_gateway.rate_limiting.cost_refresh import ALIAS_METRIC_LABELS
+from llm_gateway.rate_limiting.cost_refresh import normalize_metric_labels
 from llm_gateway.rate_limiting.model_cost_overrides import MODEL_COST_OVERRIDES
 
 GLM_MODEL = "@cf/zai-org/glm-5.2"
@@ -36,7 +35,7 @@ def test_inject_baseten_params_maps_model_and_pins_api_key() -> None:
     assert MODEL_COST_OVERRIDES[BASETEN_MODEL]["input_cost_per_token"] == 1.4e-06
     assert MODEL_COST_OVERRIDES[BASETEN_MODEL]["cache_read_input_token_cost"] == 1.4e-07
     assert MODEL_COST_OVERRIDES[BASETEN_MODEL]["output_cost_per_token"] == 4.4e-06
-    assert ALIAS_METRIC_LABELS[BASETEN_MODEL] == ("baseten", BASETEN_METRIC_MODEL)
+    assert normalize_metric_labels(BASETEN_MODEL, "openai") == ("baseten", "baseten/zai-org/glm-5.2")
 
 
 def test_inject_baseten_params_forces_streaming_usage() -> None:

--- a/services/llm-gateway/tests/test_baseten.py
+++ b/services/llm-gateway/tests/test_baseten.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi import HTTPException
 
 from llm_gateway.baseten import (
+    BASETEN_METRIC_MODEL,
     _inject_baseten_params,
     ensure_baseten_configured,
     make_baseten_responses_call,
@@ -35,7 +36,7 @@ def test_inject_baseten_params_maps_model_and_pins_api_key() -> None:
     assert MODEL_COST_OVERRIDES[BASETEN_MODEL]["input_cost_per_token"] == 1.4e-06
     assert MODEL_COST_OVERRIDES[BASETEN_MODEL]["cache_read_input_token_cost"] == 1.4e-07
     assert MODEL_COST_OVERRIDES[BASETEN_MODEL]["output_cost_per_token"] == 4.4e-06
-    assert ALIAS_METRIC_LABELS[BASETEN_MODEL] == ("baseten", GLM_MODEL)
+    assert ALIAS_METRIC_LABELS[BASETEN_MODEL] == ("baseten", BASETEN_METRIC_MODEL)
 
 
 def test_inject_baseten_params_forces_streaming_usage() -> None:


### PR DESCRIPTION
## Problem

**Why:** Baseten-served GLM requests appear under the Cloudflare model ID in LLM gateway dashboards, which makes backend traffic hard to distinguish.

## Changes

Baseten GLM telemetry now uses `baseten/zai-org/glm-5.2`, while Cloudflare keeps `@cf/zai-org/glm-5.2`. The public request model remains unchanged so server-side feature flag routing stays transparent to callers