### PR TITLE
feat(ingestion): count moved distinct id mappings in override metric

### DIFF
--- a/nodejs/src/ingestion/common/persons/person-merge-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.ts
@@ -259,21 +259,22 @@ export class PersonMergeService {
                 }
             })()
 
-            return await this.context.personStore.inTransaction('mergeDistinctIds-OneExists', async (tx) => {
+            this.discardOverrideCounts()
+            const result = await this.context.personStore.inTransaction('mergeDistinctIds-OneExists', async (tx) => {
                 // See comment above about `distinctIdVersion`
                 const insertedDistinctId = await tx.addPersonlessDistinctIdForMerge(
                     this.context.team.id,
                     distinctIdToAdd
                 )
                 const distinctIdVersion = insertedDistinctId ? 0 : 1
-                mergeDistinctIdOverrideCounter
-                    .labels({ call: 'oneExists', overrideWritten: String(distinctIdVersion > 0) })
-                    .inc()
+                this.recordOverrideCount('oneExists', distinctIdVersion > 0)
 
                 const kafkaMessages = await tx.addDistinctId(existingPerson, distinctIdToAdd, distinctIdVersion)
                 await this.context.produceMessages(kafkaMessages)
                 return mergeSuccess(existingPerson, Promise.resolve(), true)
             })
+            this.flushOverrideCounts()
+            return result
         } else if (otherPerson && mergeIntoPerson) {
             // Both Distinct IDs point at an existing Person
 
@@ -296,7 +297,8 @@ export class PersonMergeService {
             let distinctId1 = mergeIntoDistinctId
             let distinctId2 = otherPersonDistinctId
 
-            return await this.context.personStore.inTransaction('mergeDistinctIds-NeitherExist', async (tx) => {
+            this.discardOverrideCounts()
+            const result = await this.context.personStore.inTransaction('mergeDistinctIds-NeitherExist', async (tx) => {
                 // See comment above about `distinctIdVersion`
                 const insertedDistinctId1 = await tx.addPersonlessDistinctIdForMerge(this.context.team.id, distinctId1)
 
@@ -330,9 +332,7 @@ export class PersonMergeService {
                 // The first Distinct ID is used to create the new Person's UUID, and so it
                 // never needs an override.
                 const distinctId1Version = 0
-                mergeDistinctIdOverrideCounter
-                    .labels({ call: 'neitherExist', overrideWritten: String(distinctId2Version > 0) })
-                    .inc()
+                this.recordOverrideCount('neitherExist', distinctId2Version > 0)
 
                 const [person, wasCreated] = await this.personCreateService.createPerson(
                     timestamp,
@@ -351,6 +351,8 @@ export class PersonMergeService {
                 const needsPersonUpdate = !wasCreated && !person.is_identified
                 return mergeSuccess(person, Promise.resolve(), needsPersonUpdate)
             })
+            this.flushOverrideCounts()
+            return result
         }
     }
 
@@ -562,6 +564,7 @@ export class PersonMergeService {
         const version = Math.max(target.version, ...mergeSources.map((source) => source.version)) + 1
 
         const currentTarget = target
+        this.discardOverrideCounts()
         const [mergedPerson, kafkaMessages] = await this.context.personStore.inTransaction(
             'mergePeopleFold',
             async (tx) => {
@@ -597,18 +600,14 @@ export class PersonMergeService {
                 if (moveResult.distinctIdsMoved.length !== expectedMoveCount) {
                     throw new MergeFoldConflictError('folded merge moved an unexpected number of distinct ids')
                 }
-                mergeDistinctIdOverrideCounter
-                    .labels({ call: 'bothExistMove', overrideWritten: 'true' })
-                    .inc(moveResult.distinctIdsMoved.length)
+                this.recordOverrideCount('bothExistMove', true, moveResult.distinctIdsMoved.length)
 
                 const addMessages: PersonMessage[] = []
                 for (const pair of missingPairs) {
                     // See mergeDistinctIds for the personless distinctIdVersion logic.
                     const inserted = await tx.addPersonlessDistinctIdForMerge(teamId, pair.anonDistinctId)
                     const distinctIdVersion = inserted ? 0 : 1
-                    mergeDistinctIdOverrideCounter
-                        .labels({ call: 'fold', overrideWritten: String(distinctIdVersion > 0) })
-                        .inc()
+                    this.recordOverrideCount('fold', distinctIdVersion > 0)
                     addMessages.push(...(await tx.addDistinctId(person, pair.anonDistinctId, distinctIdVersion)))
                 }
 
@@ -627,6 +626,7 @@ export class PersonMergeService {
             }
         )
 
+        this.flushOverrideCounts()
         plan.status = 'executed'
         plan.mergedPerson = mergedPerson
         mergeFoldExecutedCounter.inc()
@@ -760,6 +760,7 @@ export class PersonMergeService {
                 })
                 .inc()
 
+            this.discardOverrideCounts()
             const [mergedPerson, kafkaMessages] = await this.context.personStore.inTransaction(
                 'mergePeople',
                 async (tx) => {
@@ -814,6 +815,7 @@ export class PersonMergeService {
                 }
             )
 
+            this.flushOverrideCounts()
             mergeTxnSuccessCounter
                 .labels({
                     call: this.context.event.event, // $identify, $create_alias or $merge_dangerously
@@ -856,6 +858,28 @@ export class PersonMergeService {
                 throw error
             }
         }
+    }
+
+    // Override-counter increments are buffered and flushed only after the enclosing
+    // transaction commits: merges retry and roll back, and rolled-back rows must not
+    // inflate a metric used for override-inflow capacity planning.
+    private pendingOverrideCounts: { call: string; overrideWritten: boolean; count: number }[] = []
+
+    private recordOverrideCount(call: string, overrideWritten: boolean, count: number = 1): void {
+        if (count > 0) {
+            this.pendingOverrideCounts.push({ call, overrideWritten, count })
+        }
+    }
+
+    private discardOverrideCounts(): void {
+        this.pendingOverrideCounts = []
+    }
+
+    private flushOverrideCounts(): void {
+        for (const { call, overrideWritten, count } of this.pendingOverrideCounts) {
+            mergeDistinctIdOverrideCounter.labels({ call, overrideWritten: String(overrideWritten) }).inc(count)
+        }
+        this.pendingOverrideCounts = []
     }
 
     private async moveDistinctIdsBasedOnMode(
@@ -914,9 +938,7 @@ export class PersonMergeService {
             } else {
                 allDistinctIdMessages.push(...distinctIdResult.messages)
                 hasProcessedAnyDistinctIds = true
-                mergeDistinctIdOverrideCounter
-                    .labels({ call: 'bothExistMove', overrideWritten: 'true' })
-                    .inc(distinctIdResult.distinctIdsMoved.length)
+                this.recordOverrideCount('bothExistMove', true, distinctIdResult.distinctIdsMoved.length)
 
                 // Check if we moved fewer than the batch size, indicating we're done
                 hasMore = distinctIdResult.distinctIdsMoved.length >= batchSize
@@ -966,7 +988,7 @@ export class PersonMergeService {
                 throw new PersonMergeLimitExceededError('person_merge_move_limit_hit')
             }
         }
-        mergeDistinctIdOverrideCounter.labels({ call: 'bothExistMove', overrideWritten: 'true' }).inc(movedCount)
+        this.recordOverrideCount('bothExistMove', true, movedCount)
 
         return allDistinctIdMessages
     }

--- a/nodejs/src/ingestion/common/persons/person-merge-service.ts
+++ b/nodejs/src/ingestion/common/persons/person-merge-service.ts
@@ -64,7 +64,7 @@ export const mergeFoldSizeHistogram = new Histogram({
 
 export const mergeDistinctIdOverrideCounter = new Counter({
     name: 'person_merge_distinct_id_override_total',
-    help: 'Merge-added distinct id mapping rows, split by whether their version writes a ClickHouse override row.',
+    help: 'Distinct id mapping rows written during merges, split by whether their version writes a ClickHouse override row.',
     labelNames: ['call', 'overrideWritten'],
 })
 
@@ -597,6 +597,9 @@ export class PersonMergeService {
                 if (moveResult.distinctIdsMoved.length !== expectedMoveCount) {
                     throw new MergeFoldConflictError('folded merge moved an unexpected number of distinct ids')
                 }
+                mergeDistinctIdOverrideCounter
+                    .labels({ call: 'bothExistMove', overrideWritten: 'true' })
+                    .inc(moveResult.distinctIdsMoved.length)
 
                 const addMessages: PersonMessage[] = []
                 for (const pair of missingPairs) {
@@ -911,6 +914,9 @@ export class PersonMergeService {
             } else {
                 allDistinctIdMessages.push(...distinctIdResult.messages)
                 hasProcessedAnyDistinctIds = true
+                mergeDistinctIdOverrideCounter
+                    .labels({ call: 'bothExistMove', overrideWritten: 'true' })
+                    .inc(distinctIdResult.distinctIdsMoved.length)
 
                 // Check if we moved fewer than the batch size, indicating we're done
                 hasMore = distinctIdResult.distinctIdsMoved.length >= batchSize
@@ -960,6 +966,7 @@ export class PersonMergeService {
                 throw new PersonMergeLimitExceededError('person_merge_move_limit_hit')
             }
         }
+        mergeDistinctIdOverrideCounter.labels({ call: 'bothExistMove', overrideWritten: 'true' }).inc(movedCount)
 
         return allDistinctIdMessages
     }


### PR DESCRIPTION
## Problem

#74718 added `person_merge_distinct_id_override_total` to measure how often merge-added distinct ids get version 0 vs 1. It covers the three sites where that decision is made, but not the both-persons-exist merge path, where every moved mapping row is bumped to version >= 1 and produces an override row - and one merge can move many mappings. Without it the metric shows the delta between the current and proposed worlds but not total merge-driven override production, which is what squash capacity planning needs.

## Changes

- Increments the counter by moved-row count in the both-exist paths (`call="bothExistMove"`, `overrideWritten="true"`): the folded merge move, the batched move loop, and the with-limit move.
- Placed after the abort/throw checks so rolled-back moves are not counted.
- Widens the counter help text accordingly. No behavior changes, metric only.
- Buffers all increments (including the decision sites from #74718) and flushes only after the enclosing transaction commits, so rolled-back and retried merges do not inflate the counts.

With this, `sum(overrideWritten="true")` across all call sites approximates merge-driven override inflow (residual vs the ClickHouse-measured total is deletes/splits, which are invariant to the proposal), and adding the `false` rate gives projected inflow under always-version-1.

## How did you test this code?

No new tests, counter increments only at existing decision points. Ran prettier on the touched file. I did not run the jest suite locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed, internal metric only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code as a follow-up to #74718 after José pointed out the metric could not show total override production, only the decision split. Originally pushed to the #74718 branch before noticing that PR had already merged; cherry-picked onto a fresh branch off master.

