### PR TITLE
fix(alerts): seed schema defaults into alert wizard payloads

### DIFF
--- a/frontend/src/lib/components/Alerting/AlertWizard/alertWizardLogic.ts
+++ b/frontend/src/lib/components/Alerting/AlertWizard/alertWizardLogic.ts
@@ -164,6 +164,20 @@ export function decorateAlertName(baseName: string, selectedKinds: string[] | nu
     return `${baseName}${formatKindsSuffix(selectedKinds)}`
 }
 
+function buildAlertInputs(
+    template: HogFunctionTemplateType,
+    subTemplateInputs: Record<string, CyclotronJobInputType> | null | undefined,
+    inputValues: Record<string, CyclotronJobInputType>
+): Record<string, CyclotronJobInputType> {
+    const inputs: Record<string, CyclotronJobInputType> = {}
+    for (const schema of template.inputs_schema ?? []) {
+        if (schema.default !== undefined) {
+            inputs[schema.key] = { value: schema.default }
+        }
+    }
+    return { ...inputs, ...subTemplateInputs, ...inputValues }
+}
+
 function extractDestinationKeyFromAlert(alert: HogFunctionType, allDestinations: WizardDestination[]): string | null {
     const templateId = alert.template?.id
     if (!templateId) {
@@ -664,17 +678,14 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
                 return
             }
 
-            const mergedInputs: Record<string, any> = { ...subTemplate.inputs }
-            for (const [key, val] of Object.entries(values.inputValues)) {
-                mergedInputs[key] = val
-            }
-
             const selectedTemplate = values.selectedTemplate
             if (!selectedTemplate) {
                 lemonToast.error('Template not loaded yet')
                 actions.testConfigurationComplete()
                 return
             }
+
+            const mergedInputs = buildAlertInputs(selectedTemplate, subTemplate.inputs, values.inputValues)
 
             const configuration: Record<string, any> = {
                 type: 'internal_destination',
@@ -754,10 +765,13 @@ export const alertWizardLogic = kea<alertWizardLogicType>([
                     return
                 }
 
-                const mergedInputs: Record<string, any> = { ...subTemplate.inputs }
-                for (const [key, val] of Object.entries(values.inputValues)) {
-                    mergedInputs[key] = val
+                const selectedTemplate = values.selectedTemplate
+                if (!selectedTemplate) {
+                    lemonToast.error('Template not loaded yet')
+                    return
                 }
+
+                const mergedInputs = buildAlertInputs(selectedTemplate, subTemplate.inputs, values.inputValues)
 
                 const filters = applyKindFilter(subTemplate.filters, values.selectedKinds)
                 const name = decorateAlertName(subTemplate.name ?? '', values.selectedKinds)


### PR DESCRIPTION
## Problem

Creating a Discord alert through the error tracking alert wizard has been broken since #72486 added a required `allowedMentions` choice input (default `none`) to the Discord template.
The wizard only renders required inputs of type `integration`, `integration_field`, or `string`, so the new input is never submitted and the backend rejects save and test with "This field is required."

## Changes

Frontend-only: the wizard now seeds every schema default from the template's `inputs_schema` into the payload, then overlays sub-template inputs and user values.
Mirrors `templateToConfiguration` on the regular hog function configuration page. Simpler alternative to #74670.

## How did you test this code?

Existing `alertWizardLogic.test.ts` suite plus frontend TypeScript check. Not manually tested against a live Discord webhook.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Chose payload-level default seeding over #74670's backend validation fallback plus new wizard UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)