### PR TITLE
perf(persons): skip no-op part rewrites in person overrides squash

### DIFF
--- a/posthog/dags/person_overrides.py
+++ b/posthog/dags/person_overrides.py
@@ -101,8 +101,13 @@ class PersonOverridesSnapshotDictionary(OverridesSnapshotDictionary):
 
     @property
     def update_commands(self):
+        # The person_id inequality lets ClickHouse skip rewriting parts whose matching rows
+        # already carry the correct person id (post-merge traffic on merged distinct ids).
+        # Mutation rewrites dominate the job's runtime, so no-op rewrites are pure waste.
         return {
-            "UPDATE person_id = dictGet(%(name)s, 'person_id', (team_id, distinct_id)) WHERE dictHas(%(name)s, (team_id, distinct_id))"
+            "UPDATE person_id = dictGet(%(name)s, 'person_id', (team_id, distinct_id)) "
+            "WHERE dictHas(%(name)s, (team_id, distinct_id)) "
+            "AND person_id != dictGet(%(name)s, 'person_id', (team_id, distinct_id))"
         }
 
     @property


### PR DESCRIPTION
## Problem

The person overrides squash job rewrites events with `UPDATE person_id = dictGet(...) WHERE dictHas((team_id, distinct_id))`. Any data part containing any event for a dict key is rewritten, including parts where every matching row already carries the correct person id - all post-merge traffic on merged distinct ids falls in this class, since ingestion stamps the correct person id once a person exists. Those rewrites are no-ops.

The mutation phase dominates the job (per Dagster op timings, `run_person_id_update_mutations` accounts for essentially the whole run, ~200x the dictionary load), so no-op rewrites are pure wasted IO. This matters more as override volume grows: we are evaluating always writing version >= 1 for merge-added distinct ids (see the personless removal RFC), which adds override rows whose distinct ids mostly have no stale events at all.

## Changes

- Adds `AND person_id != dictGet(...)` to the squash mutation predicate, so parts whose matching rows are already correct are scanned but not rewritten.
- Applies to both the events table and the events JSON table mutation (they share `update_commands`).
- Rows that do need correcting still match; final state is identical.

## How did you test this code?

`ruff` clean. `posthog/dags/tests/test_person_overrides.py::test_full_job` exercises the real job against a ClickHouse fixture and asserts final event attribution, which covers this predicate; it needs the dev stack running, which this environment does not have - please run `pytest posthog/dags/tests/test_person_overrides.py` with the stack up before undrafting.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code during the personless-table removal investigation. The no-op rewrite class was identified while sizing the override-volume increase that proposal would cause; the fix is independent of it and improves the current weekly run on its own.
