### PR TITLE
fix(ducklake): scope register-data-imports workflow id per generation

### DIFF
--- a/posthog/temporal/ducklake/ducklake_register_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_register_data_imports_workflow.py
@@ -2,6 +2,7 @@ import re
 import json
 import uuid
 import typing
+import hashlib
 import datetime as dt
 import contextlib
 import dataclasses
@@ -205,6 +206,43 @@ def copy_and_register_ducklake_data_imports_activity(inputs: DuckLakeRegisterDat
 
 def _is_valid_queryable_folder(queryable_folder: str) -> bool:
     return bool(queryable_folder) and "/" not in queryable_folder and queryable_folder not in {".", ".."}
+
+
+# `<table>__query_<epoch_seconds>[_<8 hex>]`, produced by prepare_s3_files_for_querying.
+_GENERATION_SUFFIX_PATTERN = re.compile(r"__query_(\d+(?:_[0-9a-f]{8})?)$")
+
+
+def _generation_token(prepared_queryable_folder: str) -> str:
+    match = _GENERATION_SUFFIX_PATTERN.search(prepared_queryable_folder)
+    if match:
+        return match.group(1)
+    # Folders predating the timestamped naming carry no generation, so derive a stable
+    # token from the whole name to keep the workflow id unique per generation.
+    return hashlib.sha256(prepared_queryable_folder.encode()).hexdigest()[:12]
+
+
+def build_register_data_imports_workflow_id(
+    *,
+    team_id: int,
+    schema_id: str,
+    job_id: str,
+    prepared_queryable_folder: str,
+) -> str:
+    """Workflow id for one registration attempt, scoped to a single prepared generation.
+
+    The generation belongs in the id because one job can publish several prepared
+    generations: the v3 load consumer re-runs post-load on a redelivered final batch, and
+    each run mints a new timestamped queryable folder. A job-scoped id makes every
+    generation after the first collide with the in-flight run, and the caller treats
+    WorkflowAlreadyStartedError as "already handled" and drops the trigger. The in-flight
+    run is pinned to the older generation and correctly refuses to publish it, so the
+    newest generation reaches DuckLake only on the next sync. Including the generation
+    gives each one its own run, and a same-generation duplicate still coalesces, which is
+    what that error should mean.
+    """
+    return (
+        f"ducklake-register-data-imports-{team_id}-{schema_id}-{job_id}-{_generation_token(prepared_queryable_folder)}"
+    )
 
 
 def _resolve_data_imports_landing_uri(

--- a/posthog/temporal/tests/ducklake/test_ducklake_register_data_imports_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_register_data_imports_workflow.py
@@ -3,6 +3,7 @@ import contextlib
 import pytest
 from unittest.mock import MagicMock
 
+from parameterized import parameterized
 from temporalio.exceptions import ApplicationError
 
 from posthog.ducklake import cp_teams
@@ -14,6 +15,7 @@ from posthog.temporal.ducklake.ducklake_register_data_imports_workflow import (
     DuckLakeRegisterDataImportsGateInputs,
     DuckLakeRegisterDataImportsInputs,
     DuckLakeRegisterDataImportsMetadata,
+    build_register_data_imports_workflow_id,
     copy_and_register_ducklake_data_imports_activity,
     ducklake_register_data_imports_gate_activity,
     prepare_ducklake_data_imports_registration_activity,
@@ -258,3 +260,40 @@ def _activity_inputs() -> DuckLakeRegisterDataImportsActivityInputs:
             ducklake_table_name="postgres_customers",
         ),
     )
+
+
+_WORKFLOW_ID_SCOPE = {
+    "team_id": 473662,
+    "schema_id": "019ef5df-e4c7-0000-b543-8ef7f13b5f15",
+    "job_id": "019fb012-26e7-0000-2959-704b254131bd",
+}
+
+
+@parameterized.expand(
+    [
+        (
+            "timestamped",
+            "customer_balance_transaction__query_1785365519_02076d94",
+            "customer_balance_transaction__query_1785365530_d3277966",
+        ),
+        (
+            "untimestamped",
+            "customer_balance_transaction__query",
+            "customer_balance_transaction__query_legacy",
+        ),
+    ]
+)
+def test_workflow_id_differs_per_prepared_generation(_name, earlier_folder, later_folder):
+    earlier = build_register_data_imports_workflow_id(**_WORKFLOW_ID_SCOPE, prepared_queryable_folder=earlier_folder)
+    later = build_register_data_imports_workflow_id(**_WORKFLOW_ID_SCOPE, prepared_queryable_folder=later_folder)
+
+    assert earlier != later
+
+
+def test_workflow_id_is_stable_for_one_prepared_generation():
+    folder = "customer_balance_transaction__query_1785365530_d3277966"
+
+    first = build_register_data_imports_workflow_id(**_WORKFLOW_ID_SCOPE, prepared_queryable_folder=folder)
+    second = build_register_data_imports_workflow_id(**_WORKFLOW_ID_SCOPE, prepared_queryable_folder=folder)
+
+    assert first == second

--- a/posthog/temporal/tests/ducklake/test_ducklake_register_data_imports_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_register_data_imports_workflow.py
@@ -262,11 +262,13 @@ def _activity_inputs() -> DuckLakeRegisterDataImportsActivityInputs:
     )
 
 
-_WORKFLOW_ID_SCOPE = {
-    "team_id": 473662,
-    "schema_id": "019ef5df-e4c7-0000-b543-8ef7f13b5f15",
-    "job_id": "019fb012-26e7-0000-2959-704b254131bd",
-}
+def _workflow_id(prepared_queryable_folder: str) -> str:
+    return build_register_data_imports_workflow_id(
+        team_id=473662,
+        schema_id="019ef5df-e4c7-0000-b543-8ef7f13b5f15",
+        job_id="019fb012-26e7-0000-2959-704b254131bd",
+        prepared_queryable_folder=prepared_queryable_folder,
+    )
 
 
 @parameterized.expand(
@@ -284,8 +286,8 @@ _WORKFLOW_ID_SCOPE = {
     ]
 )
 def test_workflow_id_differs_per_prepared_generation(_name, earlier_folder, later_folder):
-    earlier = build_register_data_imports_workflow_id(**_WORKFLOW_ID_SCOPE, prepared_queryable_folder=earlier_folder)
-    later = build_register_data_imports_workflow_id(**_WORKFLOW_ID_SCOPE, prepared_queryable_folder=later_folder)
+    earlier = _workflow_id(earlier_folder)
+    later = _workflow_id(later_folder)
 
     assert earlier != later
 
@@ -293,7 +295,7 @@ def test_workflow_id_differs_per_prepared_generation(_name, earlier_folder, late
 def test_workflow_id_is_stable_for_one_prepared_generation():
     folder = "customer_balance_transaction__query_1785365530_d3277966"
 
-    first = build_register_data_imports_workflow_id(**_WORKFLOW_ID_SCOPE, prepared_queryable_folder=folder)
-    second = build_register_data_imports_workflow_id(**_WORKFLOW_ID_SCOPE, prepared_queryable_folder=folder)
+    first = _workflow_id(folder)
+    second = _workflow_id(folder)
 
     assert first == second

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/load/processor.py
@@ -470,6 +470,7 @@ def _trigger_ducklake_register_data_imports(export_signal: ExportSignalMessage, 
         from posthog.temporal.ducklake.ducklake_register_data_imports_workflow import (
             DuckLakeRegisterDataImportsInputs,
             DuckLakeRegisterDataImportsWorkflow,
+            build_register_data_imports_workflow_id,
         )
 
         # Connect and start inside one event loop: sync_connect() builds the client in
@@ -485,9 +486,11 @@ def _trigger_ducklake_register_data_imports(export_signal: ExportSignalMessage, 
                     schema_id=uuid.UUID(export_signal.schema_id),
                     prepared_queryable_folder=prepared_queryable_folder,
                 ),
-                id=(
-                    f"ducklake-register-data-imports-{export_signal.team_id}-"
-                    f"{export_signal.schema_id}-{export_signal.job_id}"
+                id=build_register_data_imports_workflow_id(
+                    team_id=export_signal.team_id,
+                    schema_id=export_signal.schema_id,
+                    job_id=export_signal.job_id,
+                    prepared_queryable_folder=prepared_queryable_folder,
                 ),
                 task_queue=settings.DUCKLAKE_TASK_QUEUE,
             )
@@ -500,8 +503,8 @@ def _trigger_ducklake_register_data_imports(export_signal: ExportSignalMessage, 
             external_data_job_id=export_signal.job_id,
         )
     except WorkflowAlreadyStartedError:
-        # Same job already has a registration in flight (e.g. a V2 child, or a duplicate
-        # final-batch redelivery) — registration is already handled, nothing to do.
+        # The id is scoped to this prepared generation, so a collision means this exact
+        # generation is already being registered and dropping the duplicate is correct.
         logger.info(
             "ducklake_registration_workflow_already_started",
             team_id=export_signal.team_id,


### PR DESCRIPTION
## Problem

One import job can publish several prepared Parquet generations. When a final batch is redelivered, the v3 load consumer re-runs post-load, and `prepare_s3_files_for_querying` mints a **new** timestamped queryable folder each time instead of reusing the current one (`use_timestamped_folders` defaults to `True`). Each new folder advances `schema.table.queryable_folder` and fires another registration trigger.

The registration workflow id was scoped to `(team, schema, job)`, so every generation after the first collided with the run already in flight. `_trigger_ducklake_register_data_imports` catches `WorkflowAlreadyStartedError` and treats it as "registration is already handled, nothing to do" — dropping the trigger.

That assumption is wrong: the in-flight run is pinned to the **older** generation, and its staleness check correctly refuses to publish it. So both declined, and the newest generation only reached DuckLake on the next sync.

Seen in production: one job produced four generations in 26 seconds. Three runs skipped as stale, the fourth trigger was dropped, and nothing was registered for that job. Other jobs in the same window registered fine, so it is a race — it bites when the final trigger lands while a prior registration is still running. Registration takes ~14s and redeliveries arrived 6–11s apart, so the overlap is likely rather than exotic.

## Changes

- Add `build_register_data_imports_workflow_id`, which appends a generation token to the id. The token is the `__query_<epoch>[_<hex>]` suffix, falling back to a short hash for folders that predate the timestamped naming.
- Use it from the v3 consumer trigger.
- Correct the `WorkflowAlreadyStartedError` comment: with a generation-scoped id, a collision now means this exact generation is already being registered, so dropping the duplicate is right. The catch becomes correct rather than harmful.

**Only the v3 consumer trigger changes.** The v2 child start in `external_data_job.py` builds its id inside a `@workflow.defn` body, so changing it would fail replay for in-flight executions (per `.claude/rules/temporal-workflow-versioning.md`). v2 also publishes one generation per job and doesn't hit this.

No change to the staleness guards. They stay as the ordering safety net, and with per-generation ids the newest generation's run now reaches them and publishes.

## How did you test this code?

Authored by an agent (Claude Code). Only the checks below were actually run.

- Added 3 cases to `test_ducklake_register_data_imports_workflow.py` — 2 parameterized (timestamped and untimestamped folder pairs must yield different ids) plus 1 that the id is stable for a single generation. `pytest -k workflow_id` → 3 passed. The parameterized pair guards the regression directly: revert to a job-scoped id and they fail. The stability case guards the opposite mistake, making the token random so genuine duplicates each spawn a run.
- Couldn't extend an existing test — none exercised id construction.
- `ruff check` and `ruff format --check` clean on all three files.
- lint-staged ran `lint:python:fix`, `format:python`, and `uv run ty check` on commit; all passed.
- **Not run:** repo-wide `mypy`, and the DB-backed cases in that test file. Also no production verification of the fix itself, which needs a redelivered batch to reproduce.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. `posthog/ducklake/README.md` documents the workflow and its flags, not the workflow id format.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) at @EDsCODE's direction. This came out of a live production investigation, not a code read: a registration workflow was expected to no-op behind its feature flag, Temporal showed failed runs, and tracing those led first to a missing charts env var (fixed separately) and then to this.

Decisions worth flagging for review:

- **Scoped to v3 only.** My first instinct was to change both call sites for consistency. The Temporal versioning rule in this repo makes that unsafe for the v2 child start, and v2 doesn't have the bug, so consistency wasn't worth a `workflow.patched` gate.
- **Did not add a monotonic generation guard.** I had proposed one (store the installed generation, refuse to swap backwards) alongside this change. On closer reading it is less load-bearing than I thought: the existing in-transaction check compares against the *live* pointer rather than install order, so it already rejects an out-of-order older generation. The residual is a millisecond-scale window between that check and the swap, which spans two databases. Closing it properly needs new metadata storage in the DuckLake catalog that I could not test locally, so it did not belong in the same PR as the fix for an observed bug.
- **Left the churn alone.** Redelivery still produces N generations and N S3 copies, and stale runs still leave objects under `_imports/<schema_id>/<job_id>/` with no reaper. This PR stops a generation being *lost*; it does not stop the extra work. The upstream fix is making `_run_post_load_for_already_processed_batch` reuse the existing folder rather than minting a new one, which is a separate change in the consumer.

Open question a reviewer may know the answer to: whether a final batch being redelivered 3–4 times in ~26s is expected at-least-once behavior, or a symptom of something else (offset commit not landing, a rebalance). If the latter, the redelivery is the real bug and these generations are its shadow.
