### PR TITLE
fix(google-ads): surface a clean error for INVALID_ARGUMENT at validate time

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
@@ -480,4 +480,15 @@ class GoogleAdsSource(
                     "Google Ads returned a temporary error while validating your credentials. This is "
                     "usually a transient issue on Google's side — please try again in a moment.",
                 )
+            # A gRPC INVALID_ARGUMENT ("Request contains an invalid argument") means Google rejected the
+            # request as malformed — most often a customer ID (or MCC manager ID) that isn't a valid
+            # account. Its str() is the same raw protobuf dump (with a per-request peer IP) the user
+            # can't act on, so surface an actionable prompt instead of leaking it.
+            if "INVALID_ARGUMENT" in error_message:
+                return (
+                    False,
+                    "Google Ads rejected the request as invalid while validating your credentials. Check "
+                    "that your customer ID (and your manager account ID, if using an MCC) is correct, then "
+                    "try again.",
+                )
             return False, f"Error validating credentials: {error_message}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -446,6 +446,26 @@ class TestValidateCredentials:
         assert "try again" in (message or "")
         assert "Internal error encountered" not in (message or "")
 
+    def test_invalid_argument_returns_actionable_message(self):
+        # A malformed request surfaces as a raw gRPC INVALID_ARGUMENT dump (with a per-request peer IP)
+        # at validate time. Surface a clean, actionable prompt rather than leaking the protobuf dump.
+        config = GoogleAdsSourceConfig(customer_id="1234567890", google_ads_integration_id=1)
+        client = mock.Mock()
+        client.get_service.return_value.list_accessible_customers.side_effect = Exception(
+            'status = StatusCode.INVALID_ARGUMENT\n\tdetails = "Request contains an invalid argument."\n\t'
+            'debug_error_string = "peer_address:ipv4:172.217.112.4:443"'
+        )
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.google_ads.google_ads_client",
+            return_value=client,
+        ):
+            ok, message = GoogleAdsSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert "customer ID" in (message or "")
+        assert "172.217.112.4" not in (message or "")
+        assert "StatusCode" not in (message or "")
+
 
 def _google_ads_exception(request_error: int) -> GoogleAdsException:
     failure = GoogleAdsFailure(


### PR DESCRIPTION
## Problem

When a user connects Google Ads as a data warehouse source, credential validation catches most gRPC failures and swaps in an actionable message (`PERMISSION_DENIED`, transient `INTERNAL`/`UNAVAILABLE`, missing integration, etc.). One status slipped through: a gRPC `INVALID_ARGUMENT` fell to the catch-all `return False, f"Error validating credentials: {error_message}"`.

For a raw `_InactiveRpcError`, `str(e)` is the full protobuf failure dump — the gRPC status, the debug string, and a per-request peer IP. None of that is actionable, and it surfaces straight into the setup wizard. It showed up in source-creation failures as a truncated `_InactiveRpcError ... StatusCode.INVALID_ARGUMENT ... "Request contains an invalid argument."` blob.

## Changes

Add an `INVALID_ARGUMENT` branch alongside the existing status-code handling in `GoogleAdsSource.validate_credentials`, mirroring the `PERMISSION_DENIED` and transient-error handling. `INVALID_ARGUMENT` means Google rejected the request as malformed — most often a customer ID (or MCC manager ID) that isn't a valid account — so the message points the user at those inputs instead of leaking the dump.

## How did you test this code?

Added `TestValidateCredentials::test_invalid_argument_returns_actionable_message`, which mocks `list_accessible_customers` to raise an `INVALID_ARGUMENT`-shaped error (with a peer IP in the string) and asserts the returned message is actionable and contains neither the peer IP nor `StatusCode`. It mirrors the existing `test_permission_denied_returns_actionable_message` and catches the regression that no existing test covered: `INVALID_ARGUMENT` was the one status still reaching the raw-leak fallback. I ran the `TestValidateCredentials` class (5 passed) and `ruff check` / `ruff format --check` on both touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) while triaging data-warehouse source-creation failures. I confirmed the leak path in `validate_credentials`: `INVALID_ARGUMENT` matched none of the existing branches (`ACCESS_TOKEN_SCOPE_INSUFFICIENT`, `NOT_ADS_USER`, matching-query, `PERMISSION_DENIED`, `_is_transient_grpc_error`) and hit the catch-all. Checked open PR #66221, which handles the sync-time `PERMISSION_DENIED` mapping and a frontend reconnect button — a different root cause and code path, so this is not a duplicate. Invoked the `/writing-tests`, `/writing-user-facing-copy`, and `/writing-code-comments` conventions while shaping the change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
