### PR TITLE
fix(mysql): coerce connection port to int

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/mysql.py
@@ -810,7 +810,9 @@ class MySQLImplementation(SQLSourceImplementation[MySQLSourceConfig, pymysql.Con
         with self._ssh_tunnel_endpoint(config) as (host, port):
             kwargs: dict[str, Any] = {
                 "host": host,
-                "port": port,
+                # pymysql rejects a non-int port; config.port can arrive as a string when the
+                # config is built directly rather than through the int-coercing from_dict.
+                "port": int(port),
                 "database": config.database,
                 "user": config.user,
                 "password": config.password,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -2137,3 +2137,30 @@ class TestConnectSSHTunnel:
         mock_connect.assert_not_called()
         non_retryable = MySQLSource().get_non_retryable_errors()
         assert any(pattern in str(exc_info.value) for pattern in non_retryable.keys())
+
+
+class TestConnectPortCoercion:
+    def test_string_port_is_coerced_to_int(self, mocker):
+        # A config built directly (not through the int-coercing `from_dict`) can carry a string
+        # port, which pymysql rejects with `ValueError: port should be of type int`.
+        config = MySQLSourceConfig(
+            host="localhost",
+            port="3306",  # type: ignore[arg-type]
+            database="d",
+            user="u",
+            password="p",
+            schema="mydb",
+            using_ssl=False,
+            ssh_tunnel=None,
+        )
+        mock_connect = mocker.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
+            return_value=MagicMock(),
+        )
+
+        with MySQLImplementation().connect(config):
+            pass
+
+        passed_port = mock_connect.call_args.kwargs["port"]
+        assert passed_port == 3306
+        assert isinstance(passed_port, int)


### PR DESCRIPTION
## Problem

MySQL data-warehouse imports can crash at connect time with `ValueError: port should be of type int`, surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019fb238-4e05-75c3-b1bf-f8f7819f61cd)).

pymysql validates that the port is an `int` and rejects anything else. The MySQL source config declares `port: int` with an `int` converter, but that converter only runs when the config is built through `from_dict`. When the config is constructed directly, the port can still be a string (for example a value typed into a setup-form field), and it flows straight into `pymysql.connect(...)`, which then throws.

## Changes

Coerce the port to `int` in `MySQLImplementation.connect` right before building the pymysql kwargs. The SSH-tunnel path already yields an int local bind port, so this only ever normalizes the direct-connection case, and `int(int)` is a no-op.

## How did you test this code?

Added `TestConnectPortCoercion::test_string_port_is_coerced_to_int`: it builds a config directly with a string port (bypassing the int-coercing `from_dict`, the exact shape that reproduces the crash), mocks `pymysql.connect`, and asserts the port handed to pymysql is the int `3306`. No existing connect test covered this — they all build configs via `from_dict`, which already coerces the port, so none would catch a regression here.

Ran the mysql connect suites locally: `TestConnectPortCoercion`, `TestConnectTransientRetry`, and `TestConnectSSHTunnel` — 15 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the MySQL warehouse source. The stack showed `connect` → `_connect_with_transient_retry` → pymysql's `__init__` raising `ValueError: port should be of type int`. Traced the port back through `_ssh_tunnel_endpoint` / `open_ssh_tunnel` to `config.port`, and found the config's `int` converter only applies on the `from_dict` path — so a directly-built config keeps a string port. Judged this a fixable fragility on our side rather than a user/upstream error (nothing to add to `NonRetryableErrors`), and fixed it at the connection boundary rather than the auto-generated config file, which can't be hand-edited.

Skills invoked: `/writing-tests`.

Authored by Claude (Opus 4.8) via PostHog Code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
