### PR TITLE
feat(tasks): mirror user-created task run logs to posthog logs

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -113,10 +113,10 @@ TASKS_CREDENTIAL_REFRESH_INITIAL_DELAY_SECONDS: int = get_from_env(
 # Entries appended to a run's S3 JSONL log are also emitted as structured stdout log lines;
 # the per-cluster OTel collector already ships container stdout into the region's internal
 # PostHog project's Logs, so no transport or credentials are needed here. Only runs whose
-# task origin_product is in this list are mirrored — scoped to signals scouts for now;
-# widen the list to cover more task origins, or set it empty to disable.
+# task origin_product is in this list are mirrored — signals scouts plus user-created runs
+# for now; widen the list to cover more task origins, or set it empty to disable.
 TASK_RUN_LOGS_MIRROR_ORIGIN_PRODUCTS: list[str] = get_list(
-    os.getenv("TASK_RUN_LOGS_MIRROR_ORIGIN_PRODUCTS", "signals_scout")
+    os.getenv("TASK_RUN_LOGS_MIRROR_ORIGIN_PRODUCTS", "signals_scout,user_created")
 )
 
 # Direct OTLP delivery for the mirror above. The token pins the destination: scout runs


### PR DESCRIPTION
## Problem

Individual user-created ("user_created") agent task runs weren't mirroring their logs into PostHog's internal Logs product — only signals scouts were. That left staff without a way to debug those runs in `/logs`, falling back to Temporal (not very revealing) or digging through S3/AWS directly.

## Changes

Add `user_created` to the default `TASK_RUN_LOGS_MIRROR_ORIGIN_PRODUCTS`, so user-authored runs mirror their logs alongside signals scouts. The setting stays overridable via env var.

## How did you test this code?

No new tests. Existing coverage in `products/tasks/backend/tests/test_run_log_mirror.py` exercises the mirroring gate via `override_settings`, so it's unaffected by the default change. Verified the value matches the `Task.OriginProduct.USER_CREATED = "user_created"` enum.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread about improving observability for individual cloud agent runs. One-line default change to the mirror allowlist in `posthog/settings/temporal.py`; confirmed the origin-product string against the `Task.OriginProduct` enum in `products/tasks/backend/models.py`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785403748889839?thread_ts=1785403748.889839&cid=C09G8Q32R6F)*
