### PR TITLE
fix(cli): speed up symbol set uploads

### DIFF
--- a/cli/.sampo/changesets/speed-up-symbol-set-uploads.md
+++ b/cli/.sampo/changesets/speed-up-symbol-set-uploads.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Symbol set uploads (`sourcemap upload`, `sourcemap upload-hermes`, `symbol-sets upload`, dSYM and Proguard uploads) are now significantly faster: chunk uploads reuse a single HTTP connection pool instead of opening a fresh TLS connection per chunk, payload content hashes are computed once (in parallel) instead of twice per file, and sourcemap payload preparation (serialization + compression) runs across all cores.

--- a/cli/src/api/symbol_sets.rs
+++ b/cli/src/api/symbol_sets.rs
@@ -1,9 +1,10 @@
 use anyhow::{anyhow, Context, Result};
 use rayon::{
-    iter::{IntoParallelIterator, ParallelIterator},
+    iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator},
     ThreadPool, ThreadPoolBuilder,
 };
 use reqwest::blocking::multipart::{Form, Part};
+use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap, fmt::Debug, iter, num::NonZeroUsize, thread::sleep, time::Duration,
@@ -103,12 +104,18 @@ pub fn upload_with_retry_and_concurrency(
     concurrency: NonZeroUsize,
 ) -> Result<()> {
     let thread_pool = build_upload_thread_pool(concurrency)?;
+    // One client for the whole run: reusing its connection pool avoids paying a
+    // TCP + TLS handshake per uploaded chunk.
+    let s3_client = context()
+        .build_http_client()
+        .context("Failed to initialize upload HTTP client")?;
     let res = upload_inner(
         &input_sets,
         batch_size,
         force,
         skip_on_conflict,
         &thread_pool,
+        &s3_client,
     );
     match res {
         Ok(()) => Ok(()),
@@ -128,6 +135,7 @@ pub fn upload_with_retry_and_concurrency(
                 force,
                 skip_on_conflict,
                 &thread_pool,
+                &s3_client,
             )
             .map_err(|e| e.into())
         }
@@ -148,6 +156,7 @@ fn upload_inner(
     force: bool,
     skip_on_conflict: bool,
     thread_pool: &ThreadPool,
+    s3_client: &Client,
 ) -> Result<(), UploadError> {
     let upload_requests: Vec<_> = input_sets
         .iter()
@@ -164,9 +173,17 @@ fn upload_inner(
 
     for (i, batch) in upload_requests.chunks(batch_size).enumerate() {
         info!("Starting upload of batch {i}, {} symbol sets", batch.len());
-        let start_response = start_upload(batch, force, skip_on_conflict)?;
+        // Hash each payload once, across the pool — the same hash is sent in the
+        // start request and used to confirm the upload when finishing.
+        let content_hashes: Vec<String> =
+            thread_pool.install(|| batch.par_iter().map(|u| content_hash([&u.data])).collect());
+        let start_response = start_upload(batch, &content_hashes, force, skip_on_conflict)?;
 
-        let id_map: HashMap<_, _> = batch.iter().map(|u| (u.chunk_id.as_str(), u)).collect();
+        let id_map: HashMap<_, _> = batch
+            .iter()
+            .zip(content_hashes.iter())
+            .map(|(u, hash)| (u.chunk_id.as_str(), (u, hash)))
+            .collect();
 
         info!(
             "Server returned {} upload keys ({} skipped as already present)",
@@ -180,13 +197,12 @@ fn upload_inner(
                 .into_par_iter()
                 .map(|(chunk_id, data)| {
                     debug!("uploading chunk {}", chunk_id);
-                    let upload = id_map.get(chunk_id.as_str()).ok_or(anyhow!(
+                    let (upload, content_hash) = id_map.get(chunk_id.as_str()).ok_or(anyhow!(
                         "Got a chunk ID back from posthog that we didn't expect!"
                     ))?;
 
-                    let content_hash = content_hash([&upload.data]);
-                    upload_to_s3(data.presigned_url.clone(), &upload.data)?;
-                    Ok((data.symbol_set_id, content_hash))
+                    upload_to_s3(s3_client, data.presigned_url.clone(), &upload.data)?;
+                    Ok((data.symbol_set_id, (*content_hash).clone()))
                 })
                 .collect()
         });
@@ -201,6 +217,7 @@ fn upload_inner(
 
 fn start_upload(
     symbol_sets: &[&SymbolSetUpload],
+    content_hashes: &[String],
     force: bool,
     skip_on_conflict: bool,
 ) -> Result<BulkUploadStartResponse, UploadError> {
@@ -209,7 +226,12 @@ fn start_upload(
     let request = BulkUploadStartRequest {
         symbol_sets: symbol_sets
             .iter()
-            .map(|s| CreateSymbolSetRequest::new(s))
+            .zip(content_hashes.iter())
+            .map(|(s, hash)| CreateSymbolSetRequest {
+                chunk_id: s.chunk_id.clone(),
+                release_id: s.release_id.clone(),
+                content_hash: hash.clone(),
+            })
             .collect(),
         force,
         skip_on_conflict,
@@ -238,8 +260,7 @@ fn start_upload(
     }
 }
 
-fn upload_to_s3(presigned_url: PresignedUrl, data: &[u8]) -> Result<()> {
-    let client = &context().build_http_client()?;
+fn upload_to_s3(client: &Client, presigned_url: PresignedUrl, data: &[u8]) -> Result<()> {
     retry(retry_policy(500, 2, 3), |_| -> Result<()> {
         let mut form = Form::new();
         for (key, value) in &presigned_url.fields {
@@ -373,16 +394,6 @@ struct CreateSymbolSetRequest {
     chunk_id: String,
     release_id: Option<String>,
     content_hash: String,
-}
-
-impl CreateSymbolSetRequest {
-    pub fn new(inner: &SymbolSetUpload) -> Self {
-        Self {
-            chunk_id: inner.chunk_id.clone(),
-            release_id: inner.release_id.clone(),
-            content_hash: content_hash([&inner.data]),
-        }
-    }
 }
 
 fn retry_policy(duration: u64, factor: u64, max_attempts: usize) -> impl Iterator<Item = Duration> {

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -1,6 +1,7 @@
 use std::{path::PathBuf, time::Instant};
 
 use anyhow::{Context, Result};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde_json::json;
 use tracing::{debug, info, warn};
 
@@ -129,8 +130,10 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
     }
     let empty_skipped = empty_pairs.len();
 
+    // Payload preparation (serialization + zstd compression) is CPU-bound,
+    // so spread it across cores.
     let uploads = valid_pairs
-        .into_iter()
+        .into_par_iter()
         .map(TryInto::try_into)
         .collect::<Result<Vec<SymbolSetUpload>>>()
         .context("While preparing files for upload")?;


### PR DESCRIPTION
## Problem

`posthog-cli` symbol uploads (sourcemaps, hermes maps, dSYMs, Proguard mappings, ELF debug info) are slow on projects with many chunks. Reading the upload path showed three self-inflicted costs:

- `upload_to_s3` built a brand-new HTTP client for every chunk, so every single chunk paid a fresh TCP + TLS handshake and no connection was ever reused, even at the default concurrency of 10.
- Each payload's SHA-512 content hash was computed twice (once when starting the upload, again when finishing), sequentially on the main thread, over payloads up to 100 MB.
- Plain sourcemap payload preparation (serialization + zstd compression) ran sequentially on one core.

## Changes

All in `cli/src/api/symbol_sets.rs` plus one call site in `cli/src/sourcemaps/plain/upload.rs`, so every upload command benefits:

- One `reqwest` client is built per upload run and shared across all chunk uploads (and the release-mismatch retry pass), so connections are pooled and kept alive across chunks and batches.
- Content hashes are computed once per payload, in parallel on the existing upload thread pool, and reused for both the start request and the finish confirmation.
- Plain sourcemap payload prep now runs on rayon across cores.

Also adds a sampo changeset for the next CLI release.

## How did you test this code?

- `cargo test` in `cli/` (all unit + integration tests pass)
- `cargo clippy --all-targets` and `cargo fmt --check` are clean
- No manual end-to-end upload or benchmark was performed; the wins are structural (handshake per chunk eliminated, duplicate hashing eliminated, prep parallelized).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing flags or behavior changed, only performance.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code cloud task) after being asked whether the CLI upload process could be sped up drastically. Claude traced the upload path, found the per-chunk client construction, duplicate hashing, and sequential payload prep, applied the fixes, and verified with cargo test/clippy/fmt. Two further candidates were deliberately left out to keep the change small: the multipart form still clones the payload per retry attempt (`data.to_vec()`), and `read_pairs` still parses sourcemap JSON sequentially.

**Why**

The CLI upload step is a recurring pain point in CI pipelines with many bundle chunks; these were the largest structural costs in the upload path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*