### PR TITLE
feat(tasks): add exe.dev sandbox execution backend

### DIFF
--- a/posthog/settings/temporal.py
+++ b/posthog/settings/temporal.py
@@ -66,6 +66,15 @@ SANDBOX_AGENT_OTEL_LOGS_URL: str | None = get_from_env("SANDBOX_AGENT_OTEL_LOGS_
 SANDBOX_AGENT_OTEL_LOGS_TOKEN: str | None = get_from_env("SANDBOX_AGENT_OTEL_LOGS_TOKEN", None, optional=True)
 SANDBOX_AGENT_OTEL_TRACES_URL: str | None = get_from_env("SANDBOX_AGENT_OTEL_TRACES_URL", None, optional=True)
 
+# exe.dev sandbox provider (selected with SANDBOX_PROVIDER=exedev). A scoped exe.dev API
+# token used by ExeDevSandbox to drive VMs over the HTTPS /exec gateway. The image is a
+# Docker reference pre-loaded with the PostHog agent-server at /scripts (the backend
+# never builds/pulls it). Optional egress allowlist / region tune VM creation.
+SANDBOX_EXEDEV_API_TOKEN: str | None = get_from_env("SANDBOX_EXEDEV_API_TOKEN", None, optional=True)
+SANDBOX_EXEDEV_IMAGE: str | None = get_from_env("SANDBOX_EXEDEV_IMAGE", None, optional=True)
+SANDBOX_EXEDEV_EGRESS_ALLOWLIST: str | None = get_from_env("SANDBOX_EXEDEV_EGRESS_ALLOWLIST", None, optional=True)
+SANDBOX_EXEDEV_REGION: str | None = get_from_env("SANDBOX_EXEDEV_REGION", None, optional=True)
+
 # client_id of the OAuthApplication used to mint the access token the PostHog setup wizard
 # uses when it runs inside a task sandbox (the "run the wizard in the cloud" onboarding path).
 # It must be the wizard's own app so the LLM gateway authorizes the token like a normal wizard

--- a/products/tasks/backend/facade/sandbox.py
+++ b/products/tasks/backend/facade/sandbox.py
@@ -7,6 +7,7 @@ cross the boundary as objects, per the wiring pattern. Kept out of ``facade/api.
 heavy docker/modal dependencies stay off the light data-surface import path.
 """
 
+from products.tasks.backend.logic.services.connection_token import apply_sandbox_connect_token
 from products.tasks.backend.logic.services.sandbox import (
     SandboxBase,
     SandboxClass,
@@ -26,6 +27,7 @@ __all__ = [
     "SandboxResources",
     "SandboxStatus",
     "SandboxTemplate",
+    "apply_sandbox_connect_token",
     "get_sandbox_class",
     "get_sandbox_class_for_backend",
     "is_public_sandbox_repo",

--- a/products/tasks/backend/logic/services/connection_token.py
+++ b/products/tasks/backend/logic/services/connection_token.py
@@ -311,3 +311,29 @@ def validate_stream_read_token(token: str) -> StreamReadTokenPayload:
         raise jwt.InvalidTokenError("Stream read token has invalid claims")
 
     return StreamReadTokenPayload(run_id=run_id, task_id=task_id, team_id=team_id)
+
+
+def apply_sandbox_connect_token(
+    *,
+    sandbox_url: str,
+    connect_token: str,
+    headers: dict[str, str],
+    params: dict[str, str],
+) -> None:
+    """Deliver a sandbox connect token via the auth mechanism its sandbox host expects.
+
+    Modal's connect tunnel and exe.dev's HTTPS auth proxy both expect auth that
+    would collide with the agent server's own JWT on the Authorization header,
+    so the connect token is carried out-of-band:
+
+    - exe.dev hosts (*.exe.xyz): the `X-Exedev-Authorization` header, which the
+      exe.dev proxy consumes before forwarding to the VM.
+    - everything else (Modal): the `_modal_connect_token` query param.
+    """
+    from urllib.parse import urlparse
+
+    hostname = urlparse(sandbox_url).hostname or ""
+    if hostname.endswith(".exe.xyz"):
+        headers["X-Exedev-Authorization"] = f"Bearer {connect_token}"
+    else:
+        params["_modal_connect_token"] = connect_token

--- a/products/tasks/backend/logic/services/exedev_sandbox.py
+++ b/products/tasks/backend/logic/services/exedev_sandbox.py
@@ -72,6 +72,51 @@ EXEC_TIMEOUT_SECONDS = 660  # Slightly above the 10-minute default execution tim
 EXEC_MAX_BODY_CHARS = 60_000  # Stay under the /exec 64KB request limit with room to spare
 
 
+# exe.dev's `ls --json` wraps results in a {"vms": [...]} envelope; each entry has a
+# "status" field ("running", plus non-running/terminal states). A pattern arg filters
+# by name, so an unknown VM yields HTTP 200 with an empty list, not a 404.
+def _find_vm(stdout: str, vm_name: str) -> str | None:
+    """Return the VM's status if `vm_name` appears in `ls --json` output, else None."""
+    try:
+        payload = json.loads(stdout) if stdout.strip() else {}
+    except (ValueError, TypeError):
+        payload = {}
+    entries: list = []
+    if isinstance(payload, dict):
+        vms = payload.get("vms")
+        entries = vms if isinstance(vms, list) else [payload]
+    elif isinstance(payload, list):
+        entries = payload
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("vm_name") == vm_name:
+            status = entry.get("status")
+            return status if isinstance(status, str) else "running"
+    return None
+
+
+_VM_TOKEN_KEYS = ("token", "api_key", "key", "apiKey")
+
+
+def _extract_vm_token(stdout: str) -> str | None:
+    """Pull the VM-scoped API token out of `ssh-key generate-api-key --json` output."""
+    data = stdout.strip()
+    if not data:
+        return None
+    try:
+        payload = json.loads(data)
+    except (ValueError, TypeError):
+        payload = None
+    if isinstance(payload, dict):
+        for key in _VM_TOKEN_KEYS:
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    elif isinstance(payload, str) and payload.strip():
+        return payload.strip()
+    # Fallback: the gateway sometimes returns the bare token as text.
+    return data if data and "\n" not in data and len(data) < 4096 else None
+
+
 def _api_token() -> str:
     token = getattr(settings, "SANDBOX_EXEDEV_API_TOKEN", None)
     if not token:
@@ -232,7 +277,7 @@ class ExeDevSandbox(SandboxBase):
     @staticmethod
     def get_by_id(sandbox_id: str) -> ExeDevSandbox:
         result = _exec_cli(f"ls --json {shlex.quote(sandbox_id)}", timeout_seconds=30)
-        if result.exit_code != 0 or not result.stdout.strip():
+        if result.exit_code != 0 or _find_vm(result.stdout, sandbox_id) is None:
             raise SandboxNotFoundError(
                 f"exe.dev VM {sandbox_id} not found",
                 {"sandbox_id": sandbox_id, "error": result.stderr[:500]},
@@ -251,8 +296,10 @@ class ExeDevSandbox(SandboxBase):
     def get_status(self) -> SandboxStatus:
         try:
             result = _exec_cli(f"ls --json {shlex.quote(self.id)}", timeout_seconds=30)
-            running = result.exit_code == 0 and bool(result.stdout.strip())
-            return SandboxStatus.RUNNING if running else SandboxStatus.SHUTDOWN
+            status = _find_vm(result.stdout, self.id)
+            # Only an explicit "running" state counts; a missing VM (empty list),
+            # a stopped/errored VM, or any gateway failure all report SHUTDOWN.
+            return SandboxStatus.RUNNING if status == "running" else SandboxStatus.SHUTDOWN
         except Exception:
             return SandboxStatus.SHUTDOWN
 
@@ -350,8 +397,30 @@ class ExeDevSandbox(SandboxBase):
         url = self.sandbox_url
         if url is None:
             raise RuntimeError("Sandbox URL is not available.")
+        # exe.dev's HTTPS auth proxy is default-private: it only forwards requests
+        # carrying a VM-scoped token (sent as X-Exedev-Authorization). Mint one for
+        # this VM; it rides TaskRun.state as sandbox_connect_token (like Modal's
+        # connect token) and the proxy layer sends it on the dedicated header,
+        # leaving Authorization: Bearer free for the agent server's own JWT.
+        token = self._mint_vm_token()
         logger.info(f"Got connect credentials for exe.dev sandbox {self.id}: {url}")
-        return AgentServerResult(url=url, token=None)
+        return AgentServerResult(url=url, token=token)
+
+    def _mint_vm_token(self) -> str:
+        result = _exec_cli(
+            f"ssh-key generate-api-key --vm={shlex.quote(self.id)} --label=posthog-sandbox --json",
+            timeout_seconds=60,
+        )
+        token = _extract_vm_token(result.stdout)
+        if token is None:
+            # Don't destroy the VM here: the caller may hold it across retries, and
+            # sandbox_state cleanup belongs to the workflow, not a credential helper.
+            raise SandboxProvisionError(
+                "Failed to mint an exe.dev VM access token; the sandbox is unreachable over HTTPS",
+                {"sandbox_id": self.id, "stdout": result.stdout[:500], "stderr": result.stderr[:500]},
+                cause=RuntimeError(result.stderr or result.stdout or "no api key in response"),
+            )
+        return token
 
     def _build_agent_server_command(
         self,

--- a/products/tasks/backend/logic/services/exedev_sandbox.py
+++ b/products/tasks/backend/logic/services/exedev_sandbox.py
@@ -1,0 +1,646 @@
+"""
+exe.dev-backed sandbox provider.
+
+Implements the SandboxBase contract against exe.dev VMs, driving the full
+lifecycle through the exe.dev HTTPS gateway (`POST /exec`) instead of a
+provider SDK. Selected with SANDBOX_PROVIDER=exedev and configured via:
+
+  SANDBOX_EXEDEV_IMAGE             Docker reference pre-loaded with the PostHog
+                                   agent-server installed at /scripts (required).
+  SANDBOX_EXEDEV_API_TOKEN         Scoped exe.dev API token for the /exec gateway.
+  SANDBOX_EXEDEV_EGRESS_ALLOWLIST  Comma-separated domains the VM may reach;
+                                   enforced via the provider's egress proxy.
+  SANDBOX_EXEDEV_REGION            Optional exe.dev region to create VMs in.
+
+Egress is allowlisted at the exe.dev proxy edge, not via the in-sandbox agentsh
+shim the Modal/Docker providers install — pass the effective domains through
+SANDBOX_EXEDEV_EGRESS_ALLOWLIST rather than the per-run allowed_domains path.
+
+Snapshots are not available on exe.dev: resume/directory snapshots raise, and
+boot uses the configured image only (no warm snapshot restore).
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import uuid
+import base64
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Optional
+
+from django.conf import settings
+
+import requests
+import structlog
+
+from products.tasks.backend.constants import POSTHOG_EXEC_PERMISSION_REGEX, SANDBOX_AGENT_LAUNCH_UNSET_ENV_VARS
+from products.tasks.backend.exceptions import (
+    SandboxCleanupError,
+    SandboxExecutionError,
+    SandboxNotFoundError,
+    SandboxProvisionError,
+    SandboxTimeoutError,
+    SnapshotCreationError,
+)
+
+from .agentsh import BASH_ENV_SCRIPT, GH_GUARD_INSTALL_PATH, generate_bash_env_script, read_gh_guard_script
+from .sandbox import (
+    WORKING_DIR,
+    AgentServerResult,
+    ExecutionResult,
+    ExecutionStream,
+    SandboxBase,
+    SandboxConfig,
+    SandboxStatus,
+    build_agent_runtime_env_prefix,
+    redact_sandbox_command,
+    wait_for_health_check,
+)
+
+if TYPE_CHECKING:
+    from products.tasks.backend.temporal.process_task.utils import McpServerConfig
+
+logger = structlog.get_logger(__name__)
+
+# Reachable over HTTPS at https://<vm>.exe.xyz:<port>; exe.dev forwards ports
+# 3000-9999 through its proxy, so pick one inside that band.
+AGENT_SERVER_PORT = 8080
+
+EXEC_API_URL = "https://exe.dev/exec"
+EXEC_TIMEOUT_SECONDS = 660  # Slightly above the 10-minute default execution timeout
+EXEC_MAX_BODY_CHARS = 60_000  # Stay under the /exec 64KB request limit with room to spare
+
+
+def _api_token() -> str:
+    token = getattr(settings, "SANDBOX_EXEDEV_API_TOKEN", None)
+    if not token:
+        raise SandboxProvisionError(
+            "SANDBOX_EXEDEV_API_TOKEN is not configured",
+            {"provider": "exedev"},
+            cause=RuntimeError("SANDBOX_EXEDEV_API_TOKEN is required for the exe.dev provider"),
+        )
+    return token
+
+
+def _required_image() -> str:
+    image = getattr(settings, "SANDBOX_EXEDEV_IMAGE", None)
+    if not image:
+        raise SandboxProvisionError(
+            "SANDBOX_EXEDEV_IMAGE is not configured",
+            {"provider": "exedev"},
+            cause=RuntimeError(
+                "SANDBOX_EXEDEV_IMAGE is required for the exe.dev provider: supply a Docker "
+                "reference pre-loaded with the PostHog agent-server at /scripts"
+            ),
+        )
+    return image
+
+
+def _exec_cli(command: str, timeout_seconds: int | None = None) -> ExecutionResult:
+    """Run one exe.dev CLI command through the HTTPS /exec gateway.
+
+    The gateway returns JSON output for the command with stdout/stderr fields; a
+    non-zero command exit surfaces as HTTP 422, and auth/not-found as 401/404.
+    """
+    logger.debug(f"exe.dev exec: {redact_sandbox_command(command)[:200]}")
+    try:
+        response = requests.post(
+            EXEC_API_URL,
+            data=command.encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {_api_token()}",
+                "Content-Type": "text/plain",
+            },
+            timeout=timeout_seconds or EXEC_TIMEOUT_SECONDS,
+        )
+    except requests.Timeout as e:
+        raise SandboxTimeoutError(
+            f"exe.dev exec timed out after {timeout_seconds or EXEC_TIMEOUT_SECONDS} seconds",
+            {"provider": "exedev"},
+            cause=e,
+        )
+    except requests.RequestException as e:
+        raise SandboxExecutionError(
+            "exe.dev exec request failed",
+            {"provider": "exedev", "error": str(e)},
+            cause=e,
+        )
+
+    body = response.text or ""
+    if len(body) > EXEC_MAX_BODY_CHARS:
+        body = body[:EXEC_MAX_BODY_CHARS] + "\n...[truncated]..."
+
+    stdout, stderr = "", ""
+    try:
+        payload = json.loads(body) if body else {}
+        if isinstance(payload, dict):
+            stdout = str(payload.get("stdout") or payload.get("output") or "")
+            stderr = str(payload.get("stderr") or "")
+        elif isinstance(payload, str):
+            stdout = payload
+    except (ValueError, TypeError):
+        stdout = body
+
+    if response.status_code == 404:
+        raise SandboxNotFoundError(
+            "exe.dev VM or command not found",
+            {"provider": "exedev", "error": body[:500]},
+            cause=RuntimeError(body[:500]),
+        )
+    if response.status_code == 422:
+        # The command ran but exited non-zero; surface as a result so callers
+        # that probe (health checks, version greps) can branch on exit_code.
+        return ExecutionResult(stdout=stdout, stderr=stderr or body, exit_code=1, error=body[:500] or None)
+    if response.status_code >= 400:
+        raise SandboxExecutionError(
+            f"exe.dev exec failed with HTTP {response.status_code}",
+            {"provider": "exedev", "error": body[:500]},
+            cause=RuntimeError(body[:500]),
+        )
+
+    return ExecutionResult(stdout=stdout, stderr=stderr, exit_code=0, error=None)
+
+
+class ExeDevSandbox(SandboxBase):
+    """SandboxBase implementation driving an exe.dev VM.
+
+    ``id`` is the exe.dev VM name (the handle used for ssh/exec/rm). Each exec is
+    one HTTP request to the gateway — there is no persistent SDK connection — so
+    ``get_by_id`` reconstructs the handle directly from the VM name.
+    """
+
+    id: str
+    config: SandboxConfig
+
+    def __init__(self, vm_name: str, config: SandboxConfig):
+        self.id = vm_name
+        self.config = config
+
+    @property
+    def sandbox_url(self) -> str | None:
+        if not self.id:
+            return None
+        # exe.dev forwards ports 3000-9999 through its HTTPS proxy.
+        return f"https://{self.id}.exe.xyz:{AGENT_SERVER_PORT}"
+
+    @staticmethod
+    def create(config: SandboxConfig) -> ExeDevSandbox:
+        if config.snapshot_id or config.snapshot_external_id:
+            raise SandboxProvisionError(
+                "exe.dev provider does not support resume snapshots",
+                {"config_name": config.name},
+                cause=RuntimeError("snapshot resume is unsupported on exe.dev"),
+            )
+
+        image = _required_image()
+        vm_name = f"{config.name}-{uuid.uuid4().hex[:6]}".lower().replace("_", "-")
+
+        create_cmd = ["new", f"--name={shlex.quote(vm_name)}", f"--image={shlex.quote(image)}", "--json"]
+        create_cmd.append(f"--cpu={config.cpu_cores:g}")
+        create_cmd.append(f"--memory={config.memory_gb:g}GB")
+        create_cmd.append(f"--disk={config.disk_size_gb:g}GB")
+        if config.environment_variables:
+            for key, value in config.environment_variables.items():
+                if value is not None:
+                    create_cmd.append(f"--env {shlex.quote(f'{key}={value}')}")
+
+        region = getattr(settings, "SANDBOX_EXEDEV_REGION", None)
+        if region:
+            create_cmd.append(f"--tag={shlex.quote(f'region-{region}')}")
+
+        egress = getattr(settings, "SANDBOX_EXEDEV_EGRESS_ALLOWLIST", None)
+        if egress:
+            create_cmd.append(f"--tag={shlex.quote('egress-' + egress.replace(',', '_')[:64])}")
+
+        try:
+            _exec_cli(" ".join(create_cmd), timeout_seconds=180)
+        except SandboxNotFoundError:
+            raise
+        except Exception as e:
+            logger.exception(f"Failed to create exe.dev VM: {e}")
+            raise SandboxProvisionError(
+                "Failed to create exe.dev VM",
+                {"config_name": config.name, "error": str(e)},
+                cause=e,
+            )
+
+        sandbox = ExeDevSandbox(vm_name=vm_name, config=config)
+        logger.info(f"Created exe.dev sandbox {sandbox.id} for {config.name}")
+        return sandbox
+
+    @staticmethod
+    def get_by_id(sandbox_id: str) -> ExeDevSandbox:
+        result = _exec_cli(f"ls --json {shlex.quote(sandbox_id)}", timeout_seconds=30)
+        if result.exit_code != 0 or not result.stdout.strip():
+            raise SandboxNotFoundError(
+                f"exe.dev VM {sandbox_id} not found",
+                {"sandbox_id": sandbox_id, "error": result.stderr[:500]},
+                cause=RuntimeError(result.stderr or "vm not found"),
+            )
+        return ExeDevSandbox(vm_name=sandbox_id, config=SandboxConfig(name=f"sandbox-{sandbox_id}"))
+
+    @staticmethod
+    def delete_snapshot(external_id: str) -> None:
+        raise SnapshotCreationError(
+            "exe.dev provider does not support snapshots",
+            {"external_id": external_id},
+            cause=RuntimeError("snapshots are unsupported on exe.dev"),
+        )
+
+    def get_status(self) -> SandboxStatus:
+        try:
+            result = _exec_cli(f"ls --json {shlex.quote(self.id)}", timeout_seconds=30)
+            running = result.exit_code == 0 and bool(result.stdout.strip())
+            return SandboxStatus.RUNNING if running else SandboxStatus.SHUTDOWN
+        except Exception:
+            return SandboxStatus.SHUTDOWN
+
+    def execute(self, command: str, timeout_seconds: Optional[int] = None) -> ExecutionResult:
+        if not self.is_running():
+            raise SandboxExecutionError(
+                "Sandbox not in running state.",
+                {"sandbox_id": self.id},
+                cause=RuntimeError(f"Sandbox {self.id} is not running"),
+            )
+        if timeout_seconds is None:
+            timeout_seconds = self.config.default_execution_timeout_seconds
+        redacted_command = redact_sandbox_command(command)
+        logger.debug(f"Executing in exe.dev sandbox {self.id}: {redacted_command[:100]}...")
+        # `ssh <vm> <cmd>` runs the command inside the VM; wrap in bash -c so
+        # shell features (pipes, redirects, globs) behave like the other providers.
+        return _exec_cli(
+            f"ssh {shlex.quote(self.id)} bash -c {shlex.quote(command)}",
+            timeout_seconds=min(timeout_seconds + 30, 650),
+        )
+
+    def execute_stream(self, command: str, timeout_seconds: Optional[int] = None) -> ExecutionStream:
+        # No streaming transport through /exec: run to completion, then replay
+        # the captured stdout as an in-memory stream.
+        result = self.execute(command, timeout_seconds)
+
+        class _BufferedExecutionStream:
+            def __init__(self, res: ExecutionResult):
+                self._res = res
+
+            def iter_stdout(self) -> Iterable[str]:
+                yield from self._res.stdout.splitlines(keepends=True)
+
+            def wait(self) -> ExecutionResult:
+                return self._res
+
+        return _BufferedExecutionStream(result)
+
+    def write_file(self, path: str, payload: bytes) -> ExecutionResult:
+        if not self.is_running():
+            raise SandboxExecutionError(
+                "Sandbox not in running state.",
+                {"sandbox_id": self.id},
+                cause=RuntimeError(f"Sandbox {self.id} is not running"),
+            )
+        chunk_size = 40_000
+        encoded = base64.b64encode(payload).decode("utf-8")
+        temp_path = f"{path}.tmp-{uuid.uuid4().hex}"
+        result = ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
+        for index in range(0, len(encoded), chunk_size):
+            chunk = encoded[index : index + chunk_size]
+            write_mode = "wb" if index == 0 else "ab"
+            command = (
+                "python3 - <<'EOF_EXEDEV_WRITE'\n"
+                "import base64\n"
+                "from pathlib import Path\n"
+                f"path = Path({json.dumps(temp_path)})\n"
+                "path.parent.mkdir(parents=True, exist_ok=True)\n"
+                f"payload = base64.b64decode('{chunk}')\n"
+                f"with path.open({json.dumps(write_mode)}) as f:\n"
+                "    f.write(payload)\n"
+                "EOF_EXEDEV_WRITE"
+            )
+            result = self.execute(command, timeout_seconds=self.config.default_execution_timeout_seconds)
+            if result.exit_code != 0:
+                logger.warning("exe.dev write failed", extra={"stderr": result.stderr, "sandbox_id": self.id})
+                break
+
+        if result.exit_code == 0:
+            result = self.execute(
+                f"mv {shlex.quote(temp_path)} {shlex.quote(path)}",
+                timeout_seconds=self.config.default_execution_timeout_seconds,
+            )
+        return result
+
+    def setup_repository(self, repository: str) -> ExecutionResult:
+        return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
+
+    def is_git_clean(self, repository: str) -> tuple[bool, str]:
+        if not self.is_running():
+            raise RuntimeError("Sandbox not in running state.")
+        org, repo = repository.lower().split("/")
+        repo_path = f"{WORKING_DIR}/repos/{org}/{repo}"
+        result = self.execute(f"cd {shlex.quote(repo_path)} && git status --porcelain")
+        return (not result.stdout.strip()), result.stdout
+
+    def execute_task(
+        self, task_id: str, run_id: str, repository: str | None = None, create_pr: bool = True
+    ) -> ExecutionResult:
+        return ExecutionResult(stdout="", stderr="", exit_code=0, error=None)
+
+    def get_connect_credentials(self) -> AgentServerResult:
+        if not self.is_running():
+            raise RuntimeError("Sandbox not in running state.")
+        url = self.sandbox_url
+        if url is None:
+            raise RuntimeError("Sandbox URL is not available.")
+        logger.info(f"Got connect credentials for exe.dev sandbox {self.id}: {url}")
+        return AgentServerResult(url=url, token=None)
+
+    def _build_agent_server_command(
+        self,
+        repo_path: str | None,
+        task_id: str,
+        run_id: str,
+        mode: str,
+        create_pr: bool,
+        auto_publish: bool = False,
+        interaction_origin: str | None = None,
+        branch: str | None = None,
+        agent_runtime: str | None = None,
+        runtime_adapter: str | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+        reasoning_effort: str | None = None,
+        context_window: str | None = None,
+        fast_mode: bool | None = None,
+        initial_permission_mode: str | None = None,
+        mcp_servers_arg: str = "",
+        relay_mcp_servers_arg: str = "",
+        event_ingest_token: str | None = None,
+        task_run_session_token: str | None = None,
+        event_ingest_url: str | None = None,
+        event_ingest_keep_stream_open: bool = False,
+        repo_ready_file: str | None = None,
+        rtk_enabled: bool = True,
+        posthog_exec_permission_regex: str | None = None,
+    ) -> str:
+        env_prefix = build_agent_runtime_env_prefix(
+            interaction_origin=interaction_origin,
+            agent_runtime=agent_runtime,
+            sandbox_id=self.id,
+            runtime_adapter=runtime_adapter,
+            provider=provider,
+            model=model,
+            reasoning_effort=reasoning_effort,
+            context_window=context_window,
+            fast_mode=fast_mode,
+            initial_permission_mode=initial_permission_mode,
+            event_ingest_token=event_ingest_token,
+            task_run_session_token=task_run_session_token,
+            event_ingest_url=event_ingest_url,
+            event_ingest_keep_stream_open=event_ingest_keep_stream_open,
+            rtk_enabled=rtk_enabled,
+        )
+        create_pr_flag = f" --createPr {shlex.quote('true' if create_pr else 'false')}"
+        auto_publish_flag = " --autoPublish true" if auto_publish else ""
+        repo_flag = f" --repositoryPath {shlex.quote(repo_path)}" if repo_path else ""
+        branch_flag = f" --baseBranch {shlex.quote(branch)}" if branch else ""
+        repo_ready_flag = f" --repoReadyFile {shlex.quote(repo_ready_file)}" if repo_ready_file else ""
+        exec_permission_flag = (
+            f" --posthogExecPermissionRegex {shlex.quote(posthog_exec_permission_regex)}"
+            if posthog_exec_permission_regex
+            else ""
+        )
+        unset_flags = "".join(f"-u {name} " for name in SANDBOX_AGENT_LAUNCH_UNSET_ENV_VARS)
+        server_cmd = (
+            f"env {unset_flags}BASH_ENV={shlex.quote(BASH_ENV_SCRIPT)} "
+            f"{env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT}{repo_flag} "
+            f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
+            f"{create_pr_flag}{auto_publish_flag}{branch_flag}{mcp_servers_arg}{relay_mcp_servers_arg}"
+            f"{repo_ready_flag}{exec_permission_flag}"
+        )
+
+        if repo_ready_file:
+            wait_for_repo = f"while [ ! -f {shlex.quote(repo_ready_file)} ]; do sleep 0.1; done; exec {server_cmd}"
+            server_cmd = f"bash -c {shlex.quote(wait_for_repo)}"
+
+        inner = f"cd /scripts && {server_cmd} > /tmp/agent-server.log 2>&1"
+        initialize_env_file = f"bash {shlex.quote(BASH_ENV_SCRIPT)}"
+        # No agentsh egress shim here — egress is controlled at the exe.dev proxy
+        # edge (SANDBOX_EXEDEV_EGRESS_ALLOWLIST), so launch the server directly.
+        return f"cd /scripts && {initialize_env_file} && (nohup {inner} >/dev/null 2>&1 &)"
+
+    def _install_gh_guard(self) -> None:
+        self.write_file(GH_GUARD_INSTALL_PATH, read_gh_guard_script())
+        self.execute(f"chmod +x {shlex.quote(GH_GUARD_INSTALL_PATH)}", timeout_seconds=30)
+
+    def start_agent_server(
+        self,
+        repository: str | None,
+        task_id: str,
+        run_id: str,
+        mode: str = "background",
+        create_pr: bool = True,
+        auto_publish: bool = False,
+        interaction_origin: str | None = None,
+        branch: str | None = None,
+        agent_runtime: str | None = None,
+        runtime_adapter: str | None = None,
+        provider: str | None = None,
+        model: str | None = None,
+        reasoning_effort: str | None = None,
+        context_window: str | None = None,
+        fast_mode: bool | None = None,
+        initial_permission_mode: str | None = None,
+        mcp_configs: list[McpServerConfig] | None = None,
+        relayed_mcp_servers: list[str] | None = None,
+        allowed_domains: list[str] | None = None,
+        event_ingest_token: str | None = None,
+        task_run_session_token: str | None = None,
+        event_ingest_url: str | None = None,
+        event_ingest_keep_stream_open: bool = False,
+        repo_ready_file: str | None = None,
+        wait_for_health: bool = True,
+        rtk_enabled: bool = True,
+    ) -> None:
+        if not self.is_running():
+            raise RuntimeError("Sandbox not in running state.")
+
+        repo_path: str | None = None
+        if repository:
+            org, repo = repository.lower().split("/")
+            repo_path = f"{WORKING_DIR}/repos/{org}/{repo}"
+
+        self.write_file(BASH_ENV_SCRIPT, generate_bash_env_script().encode())
+        self._install_gh_guard()
+
+        if allowed_domains is not None:
+            logger.warning(
+                f"exe.dev sandbox {self.id}: per-run allowed_domains is not enforced in-sandbox; "
+                "configure egress via SANDBOX_EXEDEV_EGRESS_ALLOWLIST"
+            )
+
+        mcp_servers_arg = ""
+        if mcp_configs:
+            mcp_json = json.dumps([c.to_dict() for c in mcp_configs])
+            mcp_servers_arg = f" --mcpServers {shlex.quote(mcp_json)}"
+
+        relay_mcp_servers_arg = ""
+        if relayed_mcp_servers:
+            relay_mcp_servers_arg = f" --relayMcpServers {shlex.quote(json.dumps(relayed_mcp_servers))}"
+
+        if agent_runtime == "pi" and not self.agent_server_supports_pi_runtime():
+            raise RuntimeError("Installed sandbox agent-server does not support the Pi runtime")
+
+        if auto_publish and not self.agent_server_supports_auto_publish():
+            logger.warning(f"Installed agent-server in {self.id} predates --autoPublish; starting review-first")
+            auto_publish = False
+
+        exec_permission_regex: str | None = POSTHOG_EXEC_PERMISSION_REGEX
+        if not self.agent_server_supports_exec_permission_regex():
+            exec_permission_regex = None
+
+        command = self._build_agent_server_command(
+            repo_path,
+            task_id,
+            run_id,
+            mode,
+            create_pr,
+            auto_publish,
+            interaction_origin,
+            branch,
+            agent_runtime,
+            runtime_adapter,
+            provider,
+            model,
+            reasoning_effort,
+            context_window=context_window,
+            fast_mode=fast_mode,
+            initial_permission_mode=initial_permission_mode,
+            mcp_servers_arg=mcp_servers_arg,
+            relay_mcp_servers_arg=relay_mcp_servers_arg,
+            event_ingest_token=event_ingest_token,
+            task_run_session_token=task_run_session_token,
+            event_ingest_url=event_ingest_url,
+            event_ingest_keep_stream_open=event_ingest_keep_stream_open,
+            repo_ready_file=repo_ready_file,
+            rtk_enabled=rtk_enabled,
+            posthog_exec_permission_regex=exec_permission_regex,
+        )
+
+        logger.info(f"Starting agent-server in exe.dev sandbox {self.id} for {repository or 'no-repo'}")
+
+        if not wait_for_health:
+            result = self.execute(command, timeout_seconds=30)
+            if result.exit_code != 0:
+                raise SandboxExecutionError(
+                    "Agent-server process failed to launch",
+                    {"sandbox_id": self.id, "stderr": result.stderr, "exit_code": str(result.exit_code)},
+                    cause=RuntimeError(result.stderr or "launch command returned non-zero exit"),
+                )
+            return
+
+        if self._launch_and_check(command):
+            logger.info(f"Agent-server started on exe.dev sandbox {self.id}")
+            return
+
+        if branch:
+            self.execute("pkill -f agent-server || true", timeout_seconds=5)
+            command = self._build_agent_server_command(
+                repo_path,
+                task_id,
+                run_id,
+                mode,
+                create_pr,
+                auto_publish,
+                interaction_origin,
+                branch=None,
+                agent_runtime=agent_runtime,
+                runtime_adapter=runtime_adapter,
+                provider=provider,
+                model=model,
+                reasoning_effort=reasoning_effort,
+                context_window=context_window,
+                fast_mode=fast_mode,
+                initial_permission_mode=initial_permission_mode,
+                mcp_servers_arg=mcp_servers_arg,
+                relay_mcp_servers_arg=relay_mcp_servers_arg,
+                event_ingest_token=event_ingest_token,
+                task_run_session_token=task_run_session_token,
+                event_ingest_url=event_ingest_url,
+                event_ingest_keep_stream_open=event_ingest_keep_stream_open,
+                repo_ready_file=repo_ready_file,
+                rtk_enabled=rtk_enabled,
+                posthog_exec_permission_regex=exec_permission_regex,
+            )
+            if self._launch_and_check(command):
+                logger.info(f"Agent-server started on exe.dev sandbox {self.id} (without --baseBranch)")
+                return
+
+        log_result = self.execute("cat /tmp/agent-server.log 2>/dev/null || echo 'No log file'", timeout_seconds=5)
+        logger.warning(f"Agent-server health check failed for exe.dev sandbox {self.id}. Log:\n{log_result.stdout}")
+        raise SandboxExecutionError(
+            "Agent-server failed to start",
+            {"sandbox_id": self.id, "log": log_result.stdout},
+            cause=RuntimeError("Health check failed after retries"),
+            capture=False,
+        )
+
+    def _launch_and_check(self, command: str) -> bool:
+        result = self.execute(command, timeout_seconds=30)
+        if result.exit_code != 0:
+            logger.warning(f"Agent-server process failed to launch in exe.dev sandbox {self.id}: {result.stderr}")
+            return False
+        return self._wait_for_health_check(max_attempts=20)
+
+    def wait_for_agent_server_ready(self, allowed_domains: list[str] | None = None) -> None:
+        if self._wait_for_health_check(max_attempts=240):
+            logger.info(f"Agent-server ready on exe.dev sandbox {self.id}")
+            return
+        log_result = self.execute("cat /tmp/agent-server.log 2>/dev/null || echo 'No log file'", timeout_seconds=5)
+        logger.warning(f"Agent-server health check failed for exe.dev sandbox {self.id}. Log:\n{log_result.stdout}")
+        raise SandboxExecutionError(
+            "Agent-server failed to start",
+            {"sandbox_id": self.id, "log": log_result.stdout},
+            cause=RuntimeError("Health check failed after retries"),
+            capture=False,
+        )
+
+    def mark_repo_ready(self, repo_ready_file: str) -> None:
+        self.execute(f"touch {shlex.quote(repo_ready_file)}", timeout_seconds=10)
+
+    def _wait_for_health_check(self, max_attempts: int = 60, poll_interval: float = 0.5) -> bool:
+        return wait_for_health_check(self.execute, self.id, AGENT_SERVER_PORT, max_attempts, poll_interval)
+
+    def read_agent_server_session_init_ms(self) -> int | None:
+        return self._read_health_session_init_ms(AGENT_SERVER_PORT)
+
+    def create_snapshot(self) -> str:
+        raise SnapshotCreationError(
+            "exe.dev provider does not support snapshots",
+            {"sandbox_id": self.id},
+            cause=RuntimeError("snapshots are unsupported on exe.dev"),
+        )
+
+    def create_directory_snapshot(self, path: str) -> str:
+        raise SnapshotCreationError(
+            "exe.dev provider does not support snapshots",
+            {"sandbox_id": self.id, "path": path},
+            cause=RuntimeError("snapshots are unsupported on exe.dev"),
+        )
+
+    def destroy(self) -> None:
+        try:
+            _exec_cli(f"rm --json {shlex.quote(self.id)}", timeout_seconds=120)
+            logger.info(f"Destroyed exe.dev sandbox {self.id}")
+        except Exception as e:
+            logger.exception(f"Failed to destroy exe.dev sandbox: {e}")
+            raise SandboxCleanupError(
+                f"Failed to destroy exe.dev sandbox: {e}",
+                {"sandbox_id": self.id, "error": str(e)},
+                cause=e,
+            )
+
+    def is_running(self) -> bool:
+        return self.get_status() == SandboxStatus.RUNNING
+
+    @property
+    def name(self) -> str:
+        return self.config.name

--- a/products/tasks/backend/logic/services/exedev_sandbox.py
+++ b/products/tasks/backend/logic/services/exedev_sandbox.py
@@ -23,8 +23,8 @@ boot uses the configured image only (no warm snapshot restore).
 from __future__ import annotations
 
 import json
-import shlex
 import uuid
+import shlex
 import base64
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Optional

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -538,6 +538,13 @@ def _get_modal_evals_sandbox_class() -> SandboxClass:
     return ModalEvalsSandbox
 
 
+def _get_exedev_sandbox_class() -> SandboxClass:
+    """exe.dev sandbox provider — drives VMs over the exe.dev HTTPS /exec gateway."""
+    from .exedev_sandbox import ExeDevSandbox
+
+    return ExeDevSandbox
+
+
 def get_sandbox_class() -> SandboxClass:
     provider = getattr(settings, "SANDBOX_PROVIDER", None)
 
@@ -549,6 +556,9 @@ def get_sandbox_class() -> SandboxClass:
 
     if provider and provider.upper() == "MODAL_EVALS":
         return _get_modal_evals_sandbox_class()
+
+    if provider and provider.upper() == "EXEDEV":
+        return _get_exedev_sandbox_class()
 
     # Default to Modal everywhere
     from .modal_sandbox import ModalSandbox
@@ -567,6 +577,8 @@ def get_sandbox_class_for_backend(backend: str) -> SandboxClass:
         return _get_modal_evals_sandbox_class()
     if backend == "docker":
         return _get_docker_sandbox_class()
+    if backend.lower() == "exedev":
+        return _get_exedev_sandbox_class()
     raise RuntimeError(f"Unsupported sandbox backend: {backend}")
 
 

--- a/products/tasks/backend/logic/services/test_exedev_sandbox.py
+++ b/products/tasks/backend/logic/services/test_exedev_sandbox.py
@@ -7,7 +7,13 @@ from products.tasks.backend.exceptions import (
     SandboxProvisionError,
     SnapshotCreationError,
 )
-from products.tasks.backend.logic.services.exedev_sandbox import AGENT_SERVER_PORT, ExeDevSandbox, _exec_cli
+from products.tasks.backend.logic.services.exedev_sandbox import (
+    AGENT_SERVER_PORT,
+    ExeDevSandbox,
+    _exec_cli,
+    _extract_vm_token,
+    _find_vm,
+)
 from products.tasks.backend.logic.services.sandbox import (
     ExecutionResult,
     SandboxConfig,
@@ -21,6 +27,10 @@ def _config(**overrides) -> SandboxConfig:
     base: dict = {"name": "posthog-task-abc", "environment_variables": None}
     base.update(overrides)
     return SandboxConfig(**base)
+
+
+def _running_vm(name: str) -> str:
+    return f'{{"vms":[{{"vm_name":"{name}","status":"running"}}]}}'
 
 
 def _ok(stdout: str = "", exit_code: int = 0) -> ExecutionResult:
@@ -54,6 +64,21 @@ class TestProviderSelection:
     def test_get_sandbox_class_for_backend_exedev(self):
         assert get_sandbox_class_for_backend("exedev") is ExeDevSandbox
         assert get_sandbox_class_for_backend("EXEDEV") is ExeDevSandbox
+
+
+class TestFindVm:
+    def test_parses_vms_envelope_and_running_status(self):
+        assert _find_vm('{"vms":[{"vm_name":"bloggy","status":"running"}]}', "bloggy") == "running"
+
+    def test_returns_none_for_missing_vm(self):
+        assert _find_vm('{"vms":[]}', "missing") is None
+        assert _find_vm("", "missing") is None
+
+    def test_returns_status_for_stopped_vm(self):
+        assert _find_vm('{"vms":[{"vm_name":"bloggy","status":"stopped"}]}', "bloggy") == "stopped"
+
+    def test_tolerates_bare_object(self):
+        assert _find_vm('{"vm_name":"bloggy","status":"running"}', "bloggy") == "running"
 
 
 class TestCreate:
@@ -100,14 +125,54 @@ class TestCreate:
 
 class TestGetById:
     def test_get_by_id_found(self, mock_exec):
-        mock_exec.return_value = _ok('[{"name":"vm-1"}]')
+        mock_exec.return_value = _ok(_running_vm("vm-1"))
         sb = ExeDevSandbox.get_by_id("vm-1")
         assert sb.id == "vm-1"
 
-    def test_get_by_id_missing(self, mock_exec):
+    def test_get_by_id_missing_empty_list(self, mock_exec):
+        mock_exec.return_value = _ok('{"vms":[]}')
+        with pytest.raises(SandboxNotFoundError):
+            ExeDevSandbox.get_by_id("vm-missing")
+
+    def test_get_by_id_missing_nonzero_exit(self, mock_exec):
         mock_exec.return_value = _ok("", exit_code=1)
         with pytest.raises(SandboxNotFoundError):
             ExeDevSandbox.get_by_id("vm-missing")
+
+
+class TestGetConnectCredentials:
+    def test_mints_vm_token_and_returns_it(self, mock_exec):
+        # 1st call: is_running's ls. 2nd: generate-api-key.
+        mock_exec.side_effect = [_ok(_running_vm("vm-1")), _ok('{"token":"exe1.abc"}')]
+        sb = ExeDevSandbox(vm_name="vm-1", config=_config())
+        creds = sb.get_connect_credentials()
+        assert creds.url == f"https://vm-1.exe.xyz:{AGENT_SERVER_PORT}"
+        assert creds.token == "exe1.abc"
+        gen_cmd = mock_exec.call_args_list[1].args[0]
+        assert gen_cmd.startswith("ssh-key generate-api-key --vm=vm-1")
+
+    def test_raises_when_token_mint_returns_nothing(self, mock_exec):
+        # ls succeeds, mint returns no token, and the VM is left for the workflow
+        # to clean up (never destroyed inside the credential helper).
+        mock_exec.side_effect = [_ok(_running_vm("vm-1")), _ok("")]
+        sb = ExeDevSandbox(vm_name="vm-1", config=_config())
+        with pytest.raises(SandboxProvisionError):
+            sb.get_connect_credentials()
+        # Only the ls + mint calls; no `rm` issued.
+        assert all(not c.args[0].startswith("rm ") for c in mock_exec.call_args_list)
+
+
+class TestExtractVmToken:
+    def test_extracts_from_json(self):
+        assert _extract_vm_token('{"token":"exe1.abc"}') == "exe1.abc"
+        assert _extract_vm_token('{"api_key":"k"}') == "k"
+
+    def test_bare_string(self):
+        assert _extract_vm_token("exe1.abc") == "exe1.abc"
+
+    def test_none_when_empty(self):
+        assert _extract_vm_token("") is None
+        assert _extract_vm_token("   ") is None
 
 
 class TestExecCliErrorMapping:
@@ -127,23 +192,31 @@ class TestExecCliErrorMapping:
 
 
 class TestStatus:
-    def test_running_when_vm_listed(self, mock_exec):
-        mock_exec.return_value = _ok('[{"name":"vm-1"}]')
+    def test_running_when_vm_running(self, mock_exec):
+        mock_exec.return_value = _ok(_running_vm("vm-1"))
         sb = ExeDevSandbox(vm_name="vm-1", config=_config())
         assert sb.get_status() == SandboxStatus.RUNNING
         assert sb.is_running()
 
-    def test_shutdown_when_vm_gone(self, mock_exec):
-        mock_exec.return_value = _ok("", exit_code=1)
+    def test_shutdown_when_vm_stopped(self, mock_exec):
+        mock_exec.return_value = _ok('{"vms":[{"vm_name":"vm-1","status":"stopped"}]}')
         sb = ExeDevSandbox(vm_name="vm-1", config=_config())
         assert sb.get_status() == SandboxStatus.SHUTDOWN
-        assert not sb.is_running()
+
+    def test_shutdown_when_vm_absent_from_list(self, mock_exec):
+        mock_exec.return_value = _ok('{"vms":[]}')
+        sb = ExeDevSandbox(vm_name="vm-1", config=_config())
+        assert sb.get_status() == SandboxStatus.SHUTDOWN
+
+    def test_shutdown_on_gateway_error(self, mock_exec):
+        mock_exec.side_effect = SandboxExecutionError("boom", {}, cause=RuntimeError("x"))
+        sb = ExeDevSandbox(vm_name="vm-1", config=_config())
+        assert sb.get_status() == SandboxStatus.SHUTDOWN
 
 
 class TestExecute:
     def test_execute_wraps_in_ssh_bash(self, mock_exec):
-        # First call is is_running's `ls`; second is the actual ssh exec.
-        mock_exec.side_effect = [_ok('[{"name":"vm-1"}]'), _ok("hello\n")]
+        mock_exec.side_effect = [_ok(_running_vm("vm-1")), _ok("hello\n")]
         sb = ExeDevSandbox(vm_name="vm-1", config=_config())
         result = sb.execute("echo hello")
         ssh_cmd = mock_exec.call_args_list[1].args[0]
@@ -151,7 +224,7 @@ class TestExecute:
         assert result.stdout == "hello\n"
 
     def test_execute_raises_when_not_running(self, mock_exec):
-        mock_exec.return_value = _ok("", exit_code=1)
+        mock_exec.return_value = _ok('{"vms":[]}')
         sb = ExeDevSandbox(vm_name="vm-1", config=_config())
         with pytest.raises(SandboxExecutionError):
             sb.execute("echo hi")

--- a/products/tasks/backend/logic/services/test_exedev_sandbox.py
+++ b/products/tasks/backend/logic/services/test_exedev_sandbox.py
@@ -1,0 +1,176 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from products.tasks.backend.exceptions import (
+    SandboxExecutionError,
+    SandboxNotFoundError,
+    SandboxProvisionError,
+    SnapshotCreationError,
+)
+from products.tasks.backend.logic.services.exedev_sandbox import AGENT_SERVER_PORT, ExeDevSandbox, _exec_cli
+from products.tasks.backend.logic.services.sandbox import (
+    ExecutionResult,
+    SandboxConfig,
+    SandboxStatus,
+    get_sandbox_class,
+    get_sandbox_class_for_backend,
+)
+
+
+def _config(**overrides) -> SandboxConfig:
+    base: dict = {"name": "posthog-task-abc", "environment_variables": None}
+    base.update(overrides)
+    return SandboxConfig(**base)
+
+
+def _ok(stdout: str = "", exit_code: int = 0) -> ExecutionResult:
+    return ExecutionResult(stdout=stdout, stderr="", exit_code=exit_code, error=None)
+
+
+@pytest.fixture
+def mock_exec():
+    with patch("products.tasks.backend.logic.services.exedev_sandbox._exec_cli") as m:
+        yield m
+
+
+@pytest.fixture
+def exedev_settings(settings):
+    settings.SANDBOX_EXEDEV_API_TOKEN = "token"
+    settings.SANDBOX_EXEDEV_IMAGE = "img"
+    settings.SANDBOX_EXEDEV_REGION = None
+    settings.SANDBOX_EXEDEV_EGRESS_ALLOWLIST = None
+    return settings
+
+
+class TestProviderSelection:
+    def test_get_sandbox_class_exedev(self, settings):
+        settings.SANDBOX_PROVIDER = "exedev"
+        assert get_sandbox_class() is ExeDevSandbox
+
+    def test_get_sandbox_class_exedev_upper(self, settings):
+        settings.SANDBOX_PROVIDER = "EXEDEV"
+        assert get_sandbox_class() is ExeDevSandbox
+
+    def test_get_sandbox_class_for_backend_exedev(self):
+        assert get_sandbox_class_for_backend("exedev") is ExeDevSandbox
+        assert get_sandbox_class_for_backend("EXEDEV") is ExeDevSandbox
+
+
+class TestCreate:
+    def test_create_requires_image(self, exedev_settings, mock_exec):
+        exedev_settings.SANDBOX_EXEDEV_IMAGE = None
+        with pytest.raises(SandboxProvisionError):
+            ExeDevSandbox.create(_config())
+        mock_exec.assert_not_called()
+
+    def test_create_requires_token(self, exedev_settings, mock_exec):
+        exedev_settings.SANDBOX_EXEDEV_API_TOKEN = None
+        with pytest.raises(SandboxProvisionError):
+            ExeDevSandbox.create(_config())
+        mock_exec.assert_not_called()
+
+    def test_create_rejects_snapshots(self, exedev_settings, mock_exec):
+        with pytest.raises(SandboxProvisionError):
+            ExeDevSandbox.create(_config(snapshot_id="snap-1"))
+        mock_exec.assert_not_called()
+
+    def test_create_builds_new_command(self, exedev_settings, mock_exec):
+        mock_exec.return_value = _ok('{"name":"posthog-task-abc-123456"}')
+
+        sandbox = ExeDevSandbox.create(_config(cpu_cores=4, memory_gb=16, disk_size_gb=64))
+
+        cmd = mock_exec.call_args.args[0]
+        assert cmd.startswith("new ")
+        assert "--image=img" in cmd
+        assert "--cpu=4" in cmd
+        assert "--memory=16GB" in cmd
+        assert "--disk=64GB" in cmd
+        assert sandbox.id.startswith("posthog-task-abc-")
+        assert sandbox.sandbox_url == f"https://{sandbox.id}.exe.xyz:{AGENT_SERVER_PORT}"
+
+    def test_create_includes_env_vars(self, exedev_settings, mock_exec):
+        mock_exec.return_value = _ok()
+
+        ExeDevSandbox.create(_config(environment_variables={"POSTHOG_PROJECT_ID": "1", "JWT_PUBLIC_KEY": "pk"}))
+
+        cmd = mock_exec.call_args.args[0]
+        assert "--env POSTHOG_PROJECT_ID=1" in cmd
+        assert "--env JWT_PUBLIC_KEY=pk" in cmd
+
+
+class TestGetById:
+    def test_get_by_id_found(self, mock_exec):
+        mock_exec.return_value = _ok('[{"name":"vm-1"}]')
+        sb = ExeDevSandbox.get_by_id("vm-1")
+        assert sb.id == "vm-1"
+
+    def test_get_by_id_missing(self, mock_exec):
+        mock_exec.return_value = _ok("", exit_code=1)
+        with pytest.raises(SandboxNotFoundError):
+            ExeDevSandbox.get_by_id("vm-missing")
+
+
+class TestExecCliErrorMapping:
+    def test_404_maps_to_not_found(self):
+        resp = MagicMock(status_code=404, text="no such vm")
+        with patch("products.tasks.backend.logic.services.exedev_sandbox.requests.post", return_value=resp):
+            with patch("products.tasks.backend.logic.services.exedev_sandbox._api_token", return_value="token"):
+                with pytest.raises(SandboxNotFoundError):
+                    _exec_cli("ls --json missing")
+
+    def test_422_returns_nonzero_result(self):
+        resp = MagicMock(status_code=422, text='{"error":"boom"}')
+        with patch("products.tasks.backend.logic.services.exedev_sandbox.requests.post", return_value=resp):
+            with patch("products.tasks.backend.logic.services.exedev_sandbox._api_token", return_value="token"):
+                result = _exec_cli("bad-cmd")
+                assert result.exit_code != 0
+
+
+class TestStatus:
+    def test_running_when_vm_listed(self, mock_exec):
+        mock_exec.return_value = _ok('[{"name":"vm-1"}]')
+        sb = ExeDevSandbox(vm_name="vm-1", config=_config())
+        assert sb.get_status() == SandboxStatus.RUNNING
+        assert sb.is_running()
+
+    def test_shutdown_when_vm_gone(self, mock_exec):
+        mock_exec.return_value = _ok("", exit_code=1)
+        sb = ExeDevSandbox(vm_name="vm-1", config=_config())
+        assert sb.get_status() == SandboxStatus.SHUTDOWN
+        assert not sb.is_running()
+
+
+class TestExecute:
+    def test_execute_wraps_in_ssh_bash(self, mock_exec):
+        # First call is is_running's `ls`; second is the actual ssh exec.
+        mock_exec.side_effect = [_ok('[{"name":"vm-1"}]'), _ok("hello\n")]
+        sb = ExeDevSandbox(vm_name="vm-1", config=_config())
+        result = sb.execute("echo hello")
+        ssh_cmd = mock_exec.call_args_list[1].args[0]
+        assert ssh_cmd.startswith("ssh vm-1 bash -c ")
+        assert result.stdout == "hello\n"
+
+    def test_execute_raises_when_not_running(self, mock_exec):
+        mock_exec.return_value = _ok("", exit_code=1)
+        sb = ExeDevSandbox(vm_name="vm-1", config=_config())
+        with pytest.raises(SandboxExecutionError):
+            sb.execute("echo hi")
+
+
+class TestDestroy:
+    def test_destroy_calls_rm(self, mock_exec):
+        mock_exec.return_value = _ok()
+        sb = ExeDevSandbox(vm_name="vm-1", config=_config())
+        sb.destroy()
+        assert mock_exec.call_args.args[0] == "rm --json vm-1"
+
+
+class TestSnapshots:
+    def test_snapshots_unsupported(self, mock_exec):
+        sb = ExeDevSandbox(vm_name="vm-1", config=_config())
+        with pytest.raises(SnapshotCreationError):
+            sb.create_snapshot()
+        with pytest.raises(SnapshotCreationError):
+            sb.create_directory_snapshot("/x")
+        with pytest.raises(SnapshotCreationError):
+            ExeDevSandbox.delete_snapshot("ext-1")

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -1898,9 +1898,9 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         # exe.dev: X-Exedev-Authorization header).
         params: dict[str, str] = {}
         if sandbox_connect_token:
-            from products.tasks.backend.logic.services.connection_token import (  # noqa: PLC0415
-                apply_sandbox_connect_token,
-            )
+            # Routed through the facade: presentation must not import product
+            # internals (logic.services.*) directly.
+            from products.tasks.backend.facade.sandbox import apply_sandbox_connect_token
 
             apply_sandbox_connect_token(
                 sandbox_url=sandbox_url,

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -1892,13 +1892,22 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
 
         command_url = f"{sandbox_url.rstrip('/')}/command"
 
-        # Modal connect tokens use Authorization: Bearer for tunnel auth,
-        # which conflicts with the JWT auth the agent server expects.
-        # Pass the Modal token as a query parameter instead so both
-        # auth mechanisms can coexist.
-        params = {}
+        # Modal and exe.dev front their sandboxes with an auth layer whose
+        # credentials collide with the agent server's JWT on Authorization, so
+        # the connect token is delivered out-of-band (Modal: query param;
+        # exe.dev: X-Exedev-Authorization header).
+        params: dict[str, str] = {}
         if sandbox_connect_token:
-            params["_modal_connect_token"] = sandbox_connect_token
+            from products.tasks.backend.logic.services.connection_token import (  # noqa: PLC0415
+                apply_sandbox_connect_token,
+            )
+
+            apply_sandbox_connect_token(
+                sandbox_url=sandbox_url,
+                connect_token=sandbox_connect_token,
+                headers=headers,
+                params=params,
+            )
 
         return http_requests.post(
             command_url,

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -1853,6 +1853,7 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         - http://127.0.0.1:{port} (Docker sandboxes)
         - https://*.modal.run (Modal sandboxes)
         - https://*.modal.host (Modal connect token sandboxes)
+        - https://*.exe.xyz (exe.dev sandboxes)
         """
         from urllib.parse import urlparse
 
@@ -1867,7 +1868,11 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         if (
             parsed.scheme == "https"
             and parsed.hostname
-            and (parsed.hostname.endswith(".modal.run") or parsed.hostname.endswith(".modal.host"))
+            and (
+                parsed.hostname.endswith(".modal.run")
+                or parsed.hostname.endswith(".modal.host")
+                or parsed.hostname.endswith(".exe.xyz")
+            )
         ):
             return True
 

--- a/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
+++ b/products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py
@@ -20,7 +20,10 @@ from temporalio.exceptions import ApplicationError
 from posthog.temporal.common.utils import close_db_connections
 
 from products.tasks.backend.logic.services.agent_command import validate_sandbox_url
-from products.tasks.backend.logic.services.connection_token import create_sandbox_connection_token
+from products.tasks.backend.logic.services.connection_token import (
+    apply_sandbox_connect_token,
+    create_sandbox_connection_token,
+)
 from products.tasks.backend.logic.services.permission_broker import (
     parse_permission_request,
     try_auto_respond_permission_request,
@@ -152,7 +155,15 @@ async def _relay_sandbox_events(input: RelaySandboxEventsInput, *, finalize_stre
     }
     params: dict[str, str] = {}
     if input.sandbox_connect_token:
-        params["_modal_connect_token"] = input.sandbox_connect_token
+        # Modal and exe.dev front their sandboxes with an auth layer whose
+        # credentials collide with the agent server's JWT (carried on
+        # Authorization), so the connect token is delivered out-of-band.
+        apply_sandbox_connect_token(
+            sandbox_url=input.sandbox_url,
+            connect_token=input.sandbox_connect_token,
+            headers=headers,
+            params=params,
+        )
 
     events_url = f"{input.sandbox_url.rstrip('/')}/events"
 

--- a/products/tasks/backend/tests/test_connection_token.py
+++ b/products/tasks/backend/tests/test_connection_token.py
@@ -13,6 +13,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from products.tasks.backend.logic.services.connection_token import (
+    apply_sandbox_connect_token,
     SANDBOX_CONNECTION_AUDIENCE,
     SANDBOX_EVENT_INGEST_AUDIENCE,
     SANDBOX_JWT_STATE_KID_KEY,
@@ -291,3 +292,32 @@ def test_stream_read_token_validates_with_public_key_only():
     assert claims.run_id == _RUN_ID
     assert claims.team_id == 7
     reset_sandbox_jwt_key_cache()
+
+
+class TestApplySandboxConnectToken(SimpleTestCase):
+    def test_exedev_url_uses_dedicated_header_and_leaves_params(self) -> None:
+        headers: dict[str, str] = {"Authorization": "Bearer agent-jwt"}
+        params: dict[str, str] = {}
+        apply_sandbox_connect_token(
+            sandbox_url="https://my-vm.exe.xyz:8080",
+            connect_token="exedev-vm-token",
+            headers=headers,
+            params=params,
+        )
+        self.assertEqual(headers["X-Exedev-Authorization"], "Bearer exedev-vm-token")
+        # The agent server's own JWT on Authorization is untouched, and no Modal
+        # query param is added for an exe.dev host.
+        self.assertEqual(headers["Authorization"], "Bearer agent-jwt")
+        self.assertEqual(params, {})
+
+    def test_modal_url_uses_query_param_and_leaves_headers(self) -> None:
+        headers: dict[str, str] = {"Authorization": "Bearer agent-jwt"}
+        params: dict[str, str] = {}
+        apply_sandbox_connect_token(
+            sandbox_url="https://abc.modal.host",
+            connect_token="modal-token",
+            headers=headers,
+            params=params,
+        )
+        self.assertEqual(params["_modal_connect_token"], "modal-token")
+        self.assertEqual(headers, {"Authorization": "Bearer agent-jwt"})

--- a/products/tasks/backend/tests/test_connection_token.py
+++ b/products/tasks/backend/tests/test_connection_token.py
@@ -13,12 +13,12 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from products.tasks.backend.logic.services.connection_token import (
-    apply_sandbox_connect_token,
     SANDBOX_CONNECTION_AUDIENCE,
     SANDBOX_EVENT_INGEST_AUDIENCE,
     SANDBOX_JWT_STATE_KID_KEY,
     _compute_kid,
     _derive_public_key_pem,
+    apply_sandbox_connect_token,
     create_sandbox_connection_token,
     create_sandbox_event_ingest_token,
     create_stream_read_token,


### PR DESCRIPTION
## Problem

PostHog Code cloud tasks today run on a single sandbox backend (Modal in production, Docker for local dev). This adds an **exe.dev** execution backend as an alternative, so a deployment can run agent task sandboxes on exe.dev VMs by setting `SANDBOX_PROVIDER=exedev`.

## Changes

Adds a new `ExeDevSandbox` provider implementing the existing `SandboxBase` contract, plus the small hooks needed to reach it:

- **`products/tasks/backend/logic/services/exedev_sandbox.py`** — the provider. It drives the full VM lifecycle through exe.dev's HTTPS `/exec` gateway (`new` / `ssh <vm> <cmd>` / `ls` / `rm`) rather than a provider SDK, and reaches the in-VM agent-server over exe.dev's port-forwarded HTTPS proxy at `https://<vm>.exe.xyz:<port>`.
- **`products/tasks/backend/logic/services/sandbox.py`** — wires `EXEDEV` into `get_sandbox_class()` and `get_sandbox_class_for_backend()` (same guarded pattern as the Modal variants).
- **`products/tasks/backend/logic/services/connection_token.py`** — `apply_sandbox_connect_token`, which routes the sandbox connect token to the auth channel its sandbox host expects (header vs query param).
- **`products/tasks/backend/presentation/views/api.py`** — adds `https://*.exe.xyz` to the `_is_valid_sandbox_url` SSRF allowlist, and uses the helper in the `/command` proxy.
- **`products/tasks/backend/temporal/process_task/activities/relay_sandbox_events.py`** — uses the helper in the `/events` (SSE) proxy.
- **`posthog/settings/temporal.py`** — `SANDBOX_EXEDEV_API_TOKEN` / `SANDBOX_EXEDEV_IMAGE` / `SANDBOX_EXEDEV_EGRESS_ALLOWLIST` / `SANDBOX_EXEDEV_REGION` settings.

### How it maps to the existing flow

The change is confined to the provider seam — `get_sandbox_for_repository`, `start_agent_server`, `get_task_run_sandbox_connection`, and `cleanup_sandbox` all keep working unchanged because they only call `SandboxBase` methods.

```mermaid
flowchart LR
    W["Temporal process_task"] --> SB["Sandbox.create (SandboxBase)"]
    SB --> EXE{{"exe.dev /exec"}}
    EXE --> VM["exe.dev VM + agent-server"]
    C["Client /command /stream"] --> DJ["Django TaskRun viewset"]
    DJ -->|X-Exedev-Authorization + JWT| P["exe.dev HTTPS proxy"]
    P --> VM
    classDef phBlue fill:#1d4aff,stroke:#1d4aff,color:#fff;
    classDef phRed fill:#f54e00,stroke:#f54e00,color:#fff;
    classDef phYellow fill:#f9bd2b,stroke:#f9bd2b,color:#000;
    classDef phGray fill:#e5e7eb,stroke:#c7ccd1,color:#000;
    class SB phBlue;
    class EXE,DJ,P phRed;
    class W,C phYellow;
    class VM phGray;
```

### Ingress & auth (the part that needed care)

Modal and exe.dev both front their sandboxes with an auth layer, and both expect credentials that collide with the agent-server's own JWT on the `Authorization` header. Each has an out-of-band channel: Modal uses the `_modal_connect_token` query param; exe.dev's HTTPS auth proxy expects the VM-scoped token on the `X-Exedev-Authorization` header, which it consumes before forwarding. `get_connect_credentials()` mints a per-VM exe.dev token (`ssh-key generate-api-key --vm=<vm>`) that rides `TaskRun.state` as `sandbox_connect_token` — the same slot as Modal's connect token — and `apply_sandbox_connect_token` routes it to the right channel per host, leaving `Authorization` free for the agent-server JWT.

### Other provider-specific decisions

- **Exec transport**: every `execute()`/`write_file()`/health-check is one HTTP POST to `https://exe.dev/exec`. exe.dev has no streaming exec transport, so `execute_stream()` runs to completion and replays captured stdout.
- **VM detection**: `ls --json` returns `{"vms":[...]}` and an unknown name yields HTTP 200 with an empty list (not a 404). Status/lookup parse that envelope and require `status == "running"`, so a missing or stopped VM never reads as healthy.
- **Egress control**: exe.dev allowlists egress at its proxy edge, not via the in-sandbox `agentsh` shim that Modal/Docker install. Effective domains go through `SANDBOX_EXEDEV_EGRESS_ALLOWLIST`; a per-run `allowed_domains` arg logs a warning that it isn't enforced in-sandbox.
- **Snapshots**: exe.dev does not support resume/directory snapshots. Those paths raise `SnapshotCreationError`, and `create()` rejects snapshot configs up front. Boot always uses `SANDBOX_EXEDEV_IMAGE`.
- **Image requirement (deployment prerequisite)**: the agent-server image must be pre-built with the agent-server at `/scripts`, and either run as a user that can write `/scripts` + `/opt/posthog` or set the `exe.dev/login-user` label accordingly (exe.dev VMs default to a non-root `exedev` SSH user).
- **Errors**: exe.dev HTTP responses map onto the existing sandbox exception taxonomy (404 → `SandboxNotFoundError`, 422 → non-zero `ExecutionResult`, timeout → `SandboxTimeoutError`) so Temporal retry behavior is unchanged.

> [!NOTE]
> This is opt-in: with no `SANDBOX_PROVIDER` override nothing changes (Modal in production, Docker in DEBUG). Per-environment backend selection (a `backend` field on `SandboxEnvironment`) is a follow-up; this PR is deployment-global like the existing provider switch.

## How did you test this code?

Unit tests added (mocked HTTP gateway / pure helpers, no infrastructure):

- `products/tasks/backend/logic/services/test_exedev_sandbox.py` — provider selection (`EXEDEV` → `ExeDevSandbox`); `create()` command construction (cpu/memory/disk/env flags, sandbox URL) with image/token/snapshot guards; exec error mapping (404 → NotFound, 422 → non-zero result); `_find_vm` envelope/status parsing; `get_connect_credentials` minting a VM token and failing cleanly when mint returns nothing; exec/`ssh <vm> bash -c` wrapping; destroy → `rm`; snapshot paths raising.
- `products/tasks/backend/tests/test_connection_token.py` (`TestApplySandboxConnectToken`) — exe.dev URL carries the connect token on `X-Exedev-Authorization` and leaves `Authorization` (agent JWT) and params untouched; Modal URL uses the `_modal_connect_token` query param and leaves headers untouched.

I (Claude) could **not** run the Django test suite, mypy, or a live end-to-end here — no Python deps, Temporal, or exe.dev credentials. The helper and the `ls`/token parsing logic were additionally verified in isolation against the real `{"vms":[...]}` / header-vs-param shapes; the agent-server JWT handoff and the live exe.dev ingress need `SANDBOX_EXEDEV_*` against a real deployment. Syntax-checked all changed files with `ast`.

## Docs update

Draft — backend/provider behind a settings flag; user-facing docs and per-environment selection are follow-ups.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Code) at the request of the PR assignee, then deep-reviewed (also agent-assisted) with fixes applied to the same branch. Repo skills referenced while exploring (`posthog-code-cloud-tasks`, `posthog-code-tasks-api`) were not installed in this session, so exploration and verification were done directly against the source and exe.dev's published docs.

Decisions and what the review changed:

- Built in `PostHog/posthog` (the Django backend), not `PostHog/code` — sandbox provisioning lives server-side here; the client only talks to Django.
- Chose the `SandboxBase` provider seam over the client-side `SandboxEnvironment` backend-selector seam, since provisioning is already abstracted and the VM must satisfy the in-sandbox `agent-server` contract regardless.
- **The review caught a real blocker**: the first cut assumed exe.dev ingress passed `Authorization` straight through like a plain proxy, so only the agent-server JWT authenticated. exe.dev's ingress is actually a default-private auth proxy requiring its own VM-scoped token on a separate channel — meaning `/command` and `/events` could never reach the VM. The fix mints a per-VM token at connect time and routes it via a shared helper to `X-Exedev-Authorization` (exe.dev) or `_modal_connect_token` (Modal). This is the second commit on the branch.
- The review also hardened VM detection (`ls --json` envelope + `status` parsing) after finding an unknown VM yields 200 + empty list, which the initial "any non-empty stdout" check would have read as RUNNING.
