### PR TITLE
feat(product-analytics): add paths v2 anchored mode

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -34675,6 +34675,27 @@
             "required": ["results"],
             "type": "object"
         },
+        "PathsV2Anchor": {
+            "additionalProperties": false,
+            "description": "The start or end point an anchored-mode chart is built around.",
+            "properties": {
+                "item": {
+                    "$ref": "#/definitions/PathsV2Item",
+                    "description": "The path item the chart anchors on. Its event must be one of the step sources."
+                },
+                "type": {
+                    "$ref": "#/definitions/PathsV2AnchorType",
+                    "description": "`start` runs each actor's single sequence forward from the anchor item; `end` runs it up to the anchor item. Either way the anchor is the grid's single 100% node."
+                }
+            },
+            "required": ["type", "item"],
+            "type": "object"
+        },
+        "PathsV2AnchorType": {
+            "description": "Whether an anchored chart is built around the journeys' start or their end.",
+            "enum": ["start", "end"],
+            "type": "string"
+        },
         "PathsV2Edge": {
             "additionalProperties": false,
             "description": "A displayed transition between path items at adjacent journey grid columns.",
@@ -34716,10 +34737,23 @@
         "PathsV2Filter": {
             "additionalProperties": false,
             "properties": {
+                "anchor": {
+                    "$ref": "#/definitions/PathsV2Anchor",
+                    "description": "Anchor selecting anchored mode. When set, each actor contributes exactly one sequence bounded by the conversion window, so every displayed segment equals a plain funnel. Absent selects open mode, which splits an actor's events into journeys on the inactivity gap instead."
+                },
                 "collapseRepeats": {
                     "default": true,
                     "description": "Merge immediate repeats of the same path item within a journey.",
                     "type": "boolean"
+                },
+                "conversionWindowInterval": {
+                    "default": 30,
+                    "description": "Anchored mode's single conversion window W, anchored at the anchor and reused verbatim as the emitted funnel's window. Bounds per unit are validated server-side against CONVERSION_WINDOW_INTERVAL_BOUNDS, the same funnel conversion window bounds as the gap.",
+                    "type": "integer"
+                },
+                "conversionWindowIntervalUnit": {
+                    "$ref": "#/definitions/FunnelConversionWindowTimeUnit",
+                    "default": "minute"
                 },
                 "gapInterval": {
                     "default": 30,
@@ -34770,6 +34804,25 @@
                 }
             },
             "required": ["event"],
+            "type": "object"
+        },
+        "PathsV2Prefix": {
+            "additionalProperties": false,
+            "description": "A concrete anchored chain from the anchor and the unique actors whose single sequence begins with exactly these path items. Powers the hover funnel preview over the journey grid.",
+            "properties": {
+                "count": {
+                    "description": "Unique actors whose anchored sequence begins with exactly these items.",
+                    "type": "number"
+                },
+                "items": {
+                    "description": "The chain's path items in order, starting at the anchor.",
+                    "items": {
+                        "$ref": "#/definitions/PathsV2Item"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["items", "count"],
             "type": "object"
         },
         "PathsV2Query": {
@@ -34901,6 +34954,13 @@
                     },
                     "type": "array"
                 },
+                "prefixes": {
+                    "description": "Concrete anchored chains with per-chain unique-actor counts, ordered by descending count. Empty in open mode; in anchored mode it carries the counts the hover funnel preview reads per chain.",
+                    "items": {
+                        "$ref": "#/definitions/PathsV2Prefix"
+                    },
+                    "type": "array"
+                },
                 "steps": {
                     "items": {
                         "$ref": "#/definitions/PathsV2Step"
@@ -34908,7 +34968,7 @@
                     "type": "array"
                 }
             },
-            "required": ["steps", "edges"],
+            "required": ["steps", "edges", "prefixes"],
             "type": "object"
         },
         "PathsV2Row": {

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2072,9 +2072,25 @@ export type PathsV2Edge = {
     count: number
 }
 
+/**
+ * A concrete anchored chain from the anchor and the unique actors whose single sequence begins with
+ * exactly these path items. Powers the hover funnel preview over the journey grid.
+ */
+export type PathsV2Prefix = {
+    /** The chain's path items in order, starting at the anchor. */
+    items: PathsV2Item[]
+    /** Unique actors whose anchored sequence begins with exactly these items. */
+    count: number
+}
+
 export type PathsV2Results = {
     steps: PathsV2Step[]
     edges: PathsV2Edge[]
+    /**
+     * Concrete anchored chains with per-chain unique-actor counts, ordered by descending count. Empty
+     * in open mode; in anchored mode it carries the counts the hover funnel preview reads per chain.
+     */
+    prefixes: PathsV2Prefix[]
 }
 
 export interface PathsV2QueryResponse extends AnalyticsQueryResponseBase {
@@ -2082,6 +2098,23 @@ export interface PathsV2QueryResponse extends AnalyticsQueryResponseBase {
 }
 
 export type CachedPathsV2QueryResponse = CachedQueryResponse<PathsV2QueryResponse>
+
+/** Whether an anchored chart is built around the journeys' start or their end. */
+export enum PathsV2AnchorType {
+    Start = 'start',
+    End = 'end',
+}
+
+/** The start or end point an anchored-mode chart is built around. */
+export type PathsV2Anchor = {
+    /**
+     * `start` runs each actor's single sequence forward from the anchor item; `end` runs it up to the
+     * anchor item. Either way the anchor is the grid's single 100% node.
+     */
+    type: PathsV2AnchorType
+    /** The path item the chart anchors on. Its event must be one of the step sources. */
+    item: PathsV2Item
+}
 
 export type PathsV2Filter = {
     /**
@@ -2091,6 +2124,22 @@ export type PathsV2Filter = {
      * @maxItems 20
      */
     stepSources?: PathsV2StepSource[]
+    /**
+     * Anchor selecting anchored mode. When set, each actor contributes exactly one sequence bounded by
+     * the conversion window, so every displayed segment equals a plain funnel. Absent selects open
+     * mode, which splits an actor's events into journeys on the inactivity gap instead.
+     */
+    anchor?: PathsV2Anchor
+    /**
+     * Anchored mode's single conversion window W, anchored at the anchor and reused verbatim as the
+     * emitted funnel's window. Bounds per unit are validated server-side against
+     * CONVERSION_WINDOW_INTERVAL_BOUNDS, the same funnel conversion window bounds as the gap.
+     * @asType integer
+     * @default 30
+     */
+    conversionWindowInterval?: number
+    /** @default minute */
+    conversionWindowIntervalUnit?: FunnelConversionWindowTimeUnit
     /**
      * Number of journey steps (columns) shown.
      * @asType integer

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -196,6 +196,7 @@ from posthog.schema_enums import (
     OrderDirection1 as OrderDirection1,
     OrderDirection2 as OrderDirection2,
     ParserMode as ParserMode,
+    PathsV2AnchorType as PathsV2AnchorType,
     PathType as PathType,
     PersonsArgMaxVersion as PersonsArgMaxVersion,
     PersonsJoinMode as PersonsJoinMode,
@@ -2199,6 +2200,17 @@ class PathsV2Item(BaseModel):
             " without a naming property."
         ),
     )
+
+
+class PathsV2Prefix(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    count: float = Field(
+        ...,
+        description=("Unique actors whose anchored sequence begins with exactly these items."),
+    )
+    items: list[PathsV2Item] = Field(..., description="The chain's path items in order, starting at the anchor.")
 
 
 class PathsV2Row(BaseModel):
@@ -5719,6 +5731,24 @@ class PathsFilter(BaseModel):
     stepLimit: int | None = 5
 
 
+class PathsV2Anchor(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    item: PathsV2Item = Field(
+        ...,
+        description=("The path item the chart anchors on. Its event must be one of the step sources."),
+    )
+    type: PathsV2AnchorType = Field(
+        ...,
+        description=(
+            "`start` runs each actor's single sequence forward from the anchor item;"
+            " `end` runs it up to the anchor item. Either way the anchor is the grid's"
+            " single 100% node."
+        ),
+    )
+
+
 class PathsV2Edge(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -5745,10 +5775,29 @@ class PathsV2Filter(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
     )
+    anchor: PathsV2Anchor | None = Field(
+        default=None,
+        description=(
+            "Anchor selecting anchored mode. When set, each actor contributes exactly"
+            " one sequence bounded by the conversion window, so every displayed segment"
+            " equals a plain funnel. Absent selects open mode, which splits an actor's"
+            " events into journeys on the inactivity gap instead."
+        ),
+    )
     collapseRepeats: bool | None = Field(
         default=True,
         description="Merge immediate repeats of the same path item within a journey.",
     )
+    conversionWindowInterval: int | None = Field(
+        default=30,
+        description=(
+            "Anchored mode's single conversion window W, anchored at the anchor and"
+            " reused verbatim as the emitted funnel's window. Bounds per unit are"
+            " validated server-side against CONVERSION_WINDOW_INTERVAL_BOUNDS, the same"
+            " funnel conversion window bounds as the gap."
+        ),
+    )
+    conversionWindowIntervalUnit: FunnelConversionWindowTimeUnit | None = FunnelConversionWindowTimeUnit.MINUTE
     gapInterval: int | None = Field(
         default=30,
         description=(
@@ -17481,6 +17530,14 @@ class PathsV2Results(BaseModel):
         extra="forbid",
     )
     edges: list[PathsV2Edge]
+    prefixes: list[PathsV2Prefix] = Field(
+        ...,
+        description=(
+            "Concrete anchored chains with per-chain unique-actor counts, ordered by"
+            " descending count. Empty in open mode; in anchored mode it carries the"
+            " counts the hover funnel preview reads per chain."
+        ),
+    )
     steps: list[PathsV2Step]
 
 

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -3243,6 +3243,11 @@ class PathType(StrEnum):
     HOGQL = "hogql"
 
 
+class PathsV2AnchorType(StrEnum):
+    START = "start"
+    END = "end"
+
+
 class SliceContent(StrEnum):
     LABELS = "labels"
     VALUES = "values"

--- a/products/product_analytics/backend/hogql_queries/paths_v2/funnel_converter.py
+++ b/products/product_analytics/backend/hogql_queries/paths_v2/funnel_converter.py
@@ -1,5 +1,3 @@
-from rest_framework.exceptions import ValidationError
-
 from posthog.schema import (
     EventsNode,
     FunnelConversionWindowTimeUnit,
@@ -19,27 +17,19 @@ from posthog.hogql import ast
 from posthog.models.team.team import Team
 
 from products.product_analytics.backend.hogql_queries.paths_v2.path_item import (
+    DEFAULT_CONVERSION_WINDOW_INTERVAL,
+    DEFAULT_CONVERSION_WINDOW_INTERVAL_UNIT,
     DEFAULT_GAP_INTERVAL,
     DEFAULT_GAP_INTERVAL_UNIT,
     PATHS_V2_OTHER,
+    item_label,
+    item_tuple_expr,
     path_item_expr,
     resolve_step_sources,
     source_events_filter_expr,
     source_label_expr,
     step_source_for_event,
 )
-
-
-def _item_label(item: PathsV2Item, source: PathsV2StepSource) -> str:
-    if source.namingProperty is None:
-        return ""
-    if item.label is None:
-        raise ValidationError(f"Path item for event {item.event!r} needs a label, as its source has a naming property.")
-    return item.label
-
-
-def _item_tuple_expr(item: PathsV2Item, source: PathsV2StepSource) -> ast.Expr:
-    return ast.Tuple(exprs=[ast.Constant(value=item.event), ast.Constant(value=_item_label(item, source))])
 
 
 def _step_node(item: PathsV2Item, source: PathsV2StepSource, team: Team) -> EventsNode:
@@ -49,7 +39,7 @@ def _step_node(item: PathsV2Item, source: PathsV2StepSource, team: Team) -> Even
     label_matches = ast.CompareOperation(
         op=ast.CompareOperationOp.Eq,
         left=source_label_expr(source, team),
-        right=ast.Constant(value=_item_label(item, source)),
+        right=ast.Constant(value=item_label(item, source)),
     )
     return EventsNode(event=item.event, properties=[HogQLPropertyFilter(key=label_matches.to_hogql())])
 
@@ -58,10 +48,13 @@ def _item_strict_exclusion(
     sources: list[PathsV2StepSource],
     segment_item_exprs: list[ast.Expr],
     team: Team,
+    to_step: int,
 ) -> FunnelExclusionEventsNode:
-    """The item-strict universe as one all-events exclusion: an event breaks the funnel iff it is
-    an included path item whose derived item is not one of the segment's own items. Events outside
-    the step sources stay invisible, exactly as in the paths runner."""
+    """The item-strict universe as one all-events exclusion spanning the whole segment: an event
+    breaks the funnel iff it is an included path item whose derived item is not one of the segment's
+    own items. Events outside the step sources stay invisible, exactly as in the paths runner. Active
+    from the first step through `to_step` (the last), so any intervening included item between any two
+    consecutive segment steps disqualifies that attempt."""
     not_a_segment_item = ast.And(
         exprs=[
             ast.CompareOperation(op=ast.CompareOperationOp.NotEq, left=path_item_expr(sources, team), right=item_expr)
@@ -72,7 +65,7 @@ def _item_strict_exclusion(
     return FunnelExclusionEventsNode(
         event=None,
         funnelFromStep=0,
-        funnelToStep=1,
+        funnelToStep=to_step,
         properties=[HogQLPropertyFilter(key=universe.to_hogql())],
     )
 
@@ -85,49 +78,76 @@ def _ensure_convertible(item: PathsV2Item | None, endpoint: str) -> PathsV2Item:
     return item
 
 
+def segment_to_funnels_query(
+    query: PathsV2Query,
+    team: Team,
+    items: list[PathsV2Item | None],
+    window_interval: int,
+    window_interval_unit: FunnelConversionWindowTimeUnit,
+) -> FunnelsQuery:
+    """Convert a displayed segment of named path items into the funnel that reproduces its
+    unique-actor count exactly: an ordered funnel over the same date range and properties, with the
+    given conversion window and the item-strict universe as one all-events exclusion spanning every
+    step. The items are in funnel (forward-time) order; anchored segments pass window W, open-mode
+    single edges pass gap G."""
+    if len(items) < 2:
+        raise ValueError("A segment needs at least two path items to convert to a funnel.")
+
+    convertible = [_ensure_convertible(item, f"step {index}") for index, item in enumerate(items)]
+    sources = resolve_step_sources(query)
+    item_sources = [step_source_for_event(sources, item.event) for item in convertible]
+
+    seen: set[tuple[str, str]] = set()
+    segment_item_exprs: list[ast.Expr] = []
+    for item, source in zip(convertible, item_sources):
+        key = (item.event, item_label(item, source))
+        if key not in seen:
+            seen.add(key)
+            segment_item_exprs.append(item_tuple_expr(item, source))
+
+    return FunnelsQuery(
+        series=[_step_node(item, source, team) for item, source in zip(convertible, item_sources)],
+        funnelsFilter=FunnelsFilter(
+            exclusions=[_item_strict_exclusion(sources, segment_item_exprs, team, to_step=len(convertible) - 1)],
+            funnelOrderType=StepOrderValue.ORDERED,
+            funnelWindowInterval=window_interval,
+            funnelWindowIntervalUnit=window_interval_unit,
+        ),
+        dateRange=query.dateRange,
+        properties=query.properties,
+        filterTestAccounts=query.filterTestAccounts,
+    )
+
+
 def edge_to_funnels_query(
     query: PathsV2Query,
     team: Team,
     source_item: PathsV2Item | None,
     target_item: PathsV2Item | None,
 ) -> FunnelsQuery:
-    """Convert an edge between two named path items into the funnel that reproduces its
-    position-free unique-actor count: an ordered two-step funnel over the same date range and
-    properties, with the gap G as conversion window and the item-strict universe encoded as an
-    all-events exclusion between the steps."""
-    source_item = _ensure_convertible(source_item, "source")
-    target_item = _ensure_convertible(target_item, "target")
-
+    """Convert an open-mode edge between two named path items into the funnel that reproduces its
+    position-free unique-actor count: an ordered two-step funnel with the gap G as conversion window
+    and the item-strict universe as an all-events exclusion between the steps."""
     paths_filter = query.pathsV2Filter or PathsV2Filter()
-    sources = resolve_step_sources(query)
-
-    source_source = step_source_for_event(sources, source_item.event)
-    target_source = step_source_for_event(sources, target_item.event)
-
-    segment_item_exprs = [_item_tuple_expr(source_item, source_source)]
-    if (target_item.event, _item_label(target_item, target_source)) != (
-        source_item.event,
-        _item_label(source_item, source_source),
-    ):
-        segment_item_exprs.append(_item_tuple_expr(target_item, target_source))
-
     gap_interval = paths_filter.gapInterval if paths_filter.gapInterval is not None else DEFAULT_GAP_INTERVAL
     gap_interval_unit: FunnelConversionWindowTimeUnit = (
         paths_filter.gapIntervalUnit if paths_filter.gapIntervalUnit is not None else DEFAULT_GAP_INTERVAL_UNIT
     )
+    return segment_to_funnels_query(query, team, [source_item, target_item], gap_interval, gap_interval_unit)
 
-    return FunnelsQuery(
-        series=[
-            _step_node(source_item, source_source, team),
-            _step_node(target_item, target_source, team),
-        ],
-        funnelsFilter=FunnelsFilter(
-            exclusions=[_item_strict_exclusion(sources, segment_item_exprs, team)],
-            funnelOrderType=StepOrderValue.ORDERED,
-            funnelWindowInterval=gap_interval,
-            funnelWindowIntervalUnit=gap_interval_unit,
-        ),
-        dateRange=query.dateRange,
-        properties=query.properties,
-        filterTestAccounts=query.filterTestAccounts,
+
+def anchored_segment_to_funnels_query(query: PathsV2Query, team: Team, items: list[PathsV2Item | None]) -> FunnelsQuery:
+    """Convert an anchored-mode segment (any depth) into its funnel, reading window W from the query.
+    Anchored mode's promise: every displayed segment equals this plain funnel with window W."""
+    paths_filter = query.pathsV2Filter or PathsV2Filter()
+    window_interval = (
+        paths_filter.conversionWindowInterval
+        if paths_filter.conversionWindowInterval is not None
+        else DEFAULT_CONVERSION_WINDOW_INTERVAL
     )
+    window_interval_unit: FunnelConversionWindowTimeUnit = (
+        paths_filter.conversionWindowIntervalUnit
+        if paths_filter.conversionWindowIntervalUnit is not None
+        else DEFAULT_CONVERSION_WINDOW_INTERVAL_UNIT
+    )
+    return segment_to_funnels_query(query, team, items, window_interval, window_interval_unit)

--- a/products/product_analytics/backend/hogql_queries/paths_v2/path_item.py
+++ b/products/product_analytics/backend/hogql_queries/paths_v2/path_item.py
@@ -1,6 +1,6 @@
 from rest_framework.exceptions import ValidationError
 
-from posthog.schema import FunnelConversionWindowTimeUnit, PathsV2Query, PathsV2StepSource
+from posthog.schema import FunnelConversionWindowTimeUnit, PathsV2Item, PathsV2Query, PathsV2StepSource
 
 from posthog.hogql import ast
 from posthog.hogql.property import apply_path_cleaning
@@ -17,6 +17,8 @@ DEFAULT_MAX_ROWS_PER_STEP = 3
 DEFAULT_GAP_INTERVAL = 30
 DEFAULT_GAP_INTERVAL_UNIT = FunnelConversionWindowTimeUnit.MINUTE
 DEFAULT_COLLAPSE_REPEATS = True
+DEFAULT_CONVERSION_WINDOW_INTERVAL = 30
+DEFAULT_CONVERSION_WINDOW_INTERVAL_UNIT = FunnelConversionWindowTimeUnit.MINUTE
 
 
 def default_step_sources() -> list[PathsV2StepSource]:
@@ -74,3 +76,20 @@ def source_events_filter_expr(sources: list[PathsV2StepSource]) -> ast.Expr:
         left=ast.Field(chain=["event"]),
         right=ast.Constant(value=[source.event for source in sources]),
     )
+
+
+def item_label(item: PathsV2Item, source: PathsV2StepSource) -> str:
+    """The label an item contributes to its `(event, label)` identity: the empty string for a source
+    without a naming property (the event alone identifies the item), otherwise the item's label,
+    which must be present."""
+    if source.namingProperty is None:
+        return ""
+    if item.label is None:
+        raise ValidationError(f"Path item for event {item.event!r} needs a label, as its source has a naming property.")
+    return item.label
+
+
+def item_tuple_expr(item: PathsV2Item, source: PathsV2StepSource) -> ast.Expr:
+    """Constant `(event, label)` identity of a concrete path item, matching `path_item_expr`'s shape
+    so the runner can compare a derived item against a chosen anchor and the converter can name it."""
+    return ast.Tuple(exprs=[ast.Constant(value=item.event), ast.Constant(value=item_label(item, source))])

--- a/products/product_analytics/backend/hogql_queries/paths_v2/paths_v2_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/paths_v2/paths_v2_query_runner.py
@@ -7,9 +7,12 @@ from rest_framework.exceptions import ValidationError
 from posthog.schema import (
     CachedPathsV2QueryResponse,
     FunnelConversionWindowTimeUnit,
+    PathsV2Anchor,
+    PathsV2AnchorType,
     PathsV2Edge,
     PathsV2Filter,
     PathsV2Item,
+    PathsV2Prefix,
     PathsV2Query,
     PathsV2QueryResponse,
     PathsV2Results,
@@ -33,19 +36,29 @@ from posthog.hogql_queries.validation.validation import QueryValidationContext, 
 
 from products.product_analytics.backend.hogql_queries.paths_v2.path_item import (
     DEFAULT_COLLAPSE_REPEATS,
+    DEFAULT_CONVERSION_WINDOW_INTERVAL,
+    DEFAULT_CONVERSION_WINDOW_INTERVAL_UNIT,
     DEFAULT_GAP_INTERVAL,
     DEFAULT_GAP_INTERVAL_UNIT,
     DEFAULT_MAX_ROWS_PER_STEP,
     DEFAULT_MAX_STEPS,
     PATHS_V2_OTHER,
+    item_tuple_expr,
     path_item_expr,
     resolve_step_sources,
     source_events_filter_expr,
+    step_source_for_event,
 )
 
 ELEMENT_KIND_NODE = "node"
 ELEMENT_KIND_EDGE = "edge"
 ELEMENT_KIND_DROP_OFF = "dropoff"
+
+# Anchored mode carries per-chain prefix counts for the hover funnel preview. This caps how many the
+# runner returns, keeping the response bounded on large teams; the most common chains (which include
+# every visible top-item chain) survive the descending-count ordering, and the long tail of chains
+# through non-top items is dropped from the hover data only — the grid and persons modal stay whole.
+MAX_PREFIX_ROWS = 10_000
 
 
 class ValidateGapBounds:
@@ -82,12 +95,49 @@ class ValidateStepSources:
             raise ValidationError("stepSources must not contain duplicate events.", code=self.code)
 
 
+class ValidateWindowBounds:
+    """Reject anchored windows outside the shared funnel conversion window bounds; never clamp. The
+    window is reused verbatim as the emitted funnel's conversion window, so it must stay in bounds."""
+
+    code = "paths_v2_window_out_of_bounds"
+
+    def validate(self, context: QueryValidationContext[PathsV2Query]) -> None:
+        paths_filter = context.query.pathsV2Filter
+        if paths_filter is None or paths_filter.conversionWindowInterval is None:
+            return
+        unit = paths_filter.conversionWindowIntervalUnit or DEFAULT_CONVERSION_WINDOW_INTERVAL_UNIT
+        lower, upper = CONVERSION_WINDOW_INTERVAL_BOUNDS[unit]
+        if not lower <= paths_filter.conversionWindowInterval <= upper:
+            raise ValidationError(
+                f"conversionWindowInterval must be between {lower} and {upper} for unit {unit.value!r}.",
+                code=self.code,
+            )
+
+
+class ValidateAnchor:
+    """An anchor's event must be one of the step sources, otherwise no event could ever derive it and
+    the chart would be empty for a reason the config does not reveal."""
+
+    code = "paths_v2_anchor_invalid"
+
+    def validate(self, context: QueryValidationContext[PathsV2Query]) -> None:
+        paths_filter = context.query.pathsV2Filter
+        if paths_filter is None or paths_filter.anchor is None:
+            return
+        source_events = {source.event for source in resolve_step_sources(context.query)}
+        if paths_filter.anchor.item.event not in source_events:
+            raise ValidationError(
+                f"The anchor event {paths_filter.anchor.item.event!r} must be one of the step sources.",
+                code=self.code,
+            )
+
+
 class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
     query: PathsV2Query
     cached_response: CachedPathsV2QueryResponse
 
     def validators(self) -> tuple[QueryValidationRule[PathsV2Query], ...]:
-        return (ValidateGapBounds(), ValidateStepSources())
+        return (ValidateGapBounds(), ValidateWindowBounds(), ValidateStepSources(), ValidateAnchor())
 
     @cached_property
     def paths_v2_filter(self) -> PathsV2Filter:
@@ -127,6 +177,28 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
             return self.paths_v2_filter.collapseRepeats
         return DEFAULT_COLLAPSE_REPEATS
 
+    @property
+    def anchor(self) -> PathsV2Anchor | None:
+        return self.paths_v2_filter.anchor
+
+    @property
+    def is_anchored(self) -> bool:
+        """Anchored mode when an anchor is set: one sequence per actor within window W, every segment a
+        plain funnel. Otherwise open mode: gap-split journeys."""
+        return self.anchor is not None
+
+    @property
+    def window_interval(self) -> int:
+        if self.paths_v2_filter.conversionWindowInterval is not None:
+            return self.paths_v2_filter.conversionWindowInterval
+        return DEFAULT_CONVERSION_WINDOW_INTERVAL
+
+    @property
+    def window_interval_unit(self) -> FunnelConversionWindowTimeUnit:
+        if self.paths_v2_filter.conversionWindowIntervalUnit is not None:
+            return self.paths_v2_filter.conversionWindowIntervalUnit
+        return DEFAULT_CONVERSION_WINDOW_INTERVAL_UNIT
+
     @cached_property
     def query_date_range(self) -> QueryDateRange:
         return QueryDateRange(date_range=self.query.dateRange, team=self.team, interval=None, now=datetime.now())
@@ -149,6 +221,30 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
         return parse_expr(
             f"toIntervalSecond({conversion_window_to_seconds(self.gap_interval, self.gap_interval_unit)})"
         )
+
+    def _window_interval_expr(self) -> ast.Expr:
+        # Window W realized the same fixed-seconds way as the gap, so it always equals the emitted
+        # funnel's conversion window.
+        return parse_expr(
+            f"toIntervalSecond({conversion_window_to_seconds(self.window_interval, self.window_interval_unit)})"
+        )
+
+    def _split_interval_expr(self) -> ast.Expr:
+        """The interval that splits an actor's events into journeys. Open mode splits on gap G. Anchored
+        mode splits on window W: the anchor prefilter already bounds every kept event to within W of the
+        anchor, so no adjacent pair can exceed W and the actor's events stay a single sequence."""
+        if self.is_anchored:
+            return self._window_interval_expr()
+        return self._gap_expr()
+
+    def _sorted_events_expr(self) -> ast.Expr:
+        """The per-actor event tuples in the order the grid reads them. Ascending time everywhere except
+        an end anchor, which sorts descending so the anchor (each actor's latest anchor event) lands at
+        step 0 and the grid reads backward in time toward it."""
+        events = "groupArray(tuple(timestamp, path_item))"
+        if self.is_anchored and self.anchor is not None and self.anchor.type == PathsV2AnchorType.END:
+            return parse_expr(f"arrayReverseSort(x -> x.1, {events})")
+        return parse_expr(f"arraySort(x -> x.1, {events})")
 
     def _event_base_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
         """One row per in-range event matching a step source: (timestamp, actor_id, path_item)."""
@@ -192,12 +288,69 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
             },
         )
 
+    def _anchor_source(self) -> PathsV2StepSource:
+        assert self.anchor is not None
+        return step_source_for_event(self.step_sources, self.anchor.item.event)
+
+    def _anchor_item_expr(self) -> ast.Expr:
+        assert self.anchor is not None
+        return item_tuple_expr(self.anchor.item, self._anchor_source())
+
+    def _anchored_event_base_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
+        """Anchored mode's prefilter (a performance guardrail, not an optimization): resolve the anchor
+        actors and each actor's anchor timestamp first, then keep only those actors' events within
+        window W of their anchor. A start anchor takes the actor's first anchor-item occurrence and the
+        events from it forward; an end anchor takes the last occurrence and the events up to it. Either
+        way each kept actor contributes exactly the events of their single anchored sequence."""
+        assert self.anchor is not None
+        if self.anchor.type == PathsV2AnchorType.END:
+            anchor_ts_expr = parse_expr("max(timestamp)")
+            window_bounds = parse_expr(
+                "base.timestamp <= anchor.anchor_ts AND base.timestamp >= anchor.anchor_ts - {window}",
+                {"window": self._window_interval_expr()},
+            )
+        else:
+            anchor_ts_expr = parse_expr("min(timestamp)")
+            window_bounds = parse_expr(
+                "base.timestamp >= anchor.anchor_ts AND base.timestamp <= anchor.anchor_ts + {window}",
+                {"window": self._window_interval_expr()},
+            )
+        return parse_select(
+            """
+            WITH ranged_events AS ({event_base_query})
+            SELECT base.timestamp AS timestamp, base.actor_id AS actor_id, base.path_item AS path_item
+            FROM ranged_events AS base
+            INNER JOIN (
+                SELECT actor_id, {anchor_ts} AS anchor_ts
+                FROM ranged_events
+                WHERE path_item = {anchor_item}
+                GROUP BY actor_id
+            ) AS anchor ON base.actor_id = anchor.actor_id
+            WHERE {window_bounds}
+            """,
+            placeholders={
+                "event_base_query": self._event_base_query(),
+                "anchor_ts": anchor_ts_expr,
+                "anchor_item": self._anchor_item_expr(),
+                "window_bounds": window_bounds,
+            },
+        )
+
+    def _events_for_journeys_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
+        """The event rows the journey builder groups: prefiltered to the anchored window in anchored
+        mode, the full in-range set in open mode."""
+        if self.is_anchored:
+            return self._anchored_event_base_query()
+        return self._event_base_query()
+
     def _elements_per_actor_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
         """Per actor: build journeys, then flatten them into the elements the actor touches.
 
-        - Events sort by time and split into journeys wherever the inactivity gap exceeds gap G
-          (a gap of exactly G keeps the journey together, matching the funnel conversion window's
-          inclusive comparison).
+        - Events sort by time and split into journeys wherever the gap exceeds the split interval
+          (a gap of exactly the interval keeps the journey together, matching the funnel conversion
+          window's inclusive comparison). Open mode splits on gap G; anchored mode splits on window W
+          over events the prefilter already bounded to within W of the anchor, so the actor keeps a
+          single sequence.
         - Immediate repeats of the same path item collapse when collapseRepeats is on.
         - Journeys keep only their first maxSteps items.
         - Elements are tuples of (kind, step index, item, target item):
@@ -215,7 +368,7 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
             """
             SELECT
                 actor_id,
-                arraySort(x -> x.1, groupArray(tuple(timestamp, path_item))) AS event_tuples,
+                {sorted_events} AS event_tuples,
                 arrayPopBack(arrayPushFront(arrayMap(x -> x.1, event_tuples), NULL)) AS previous_timestamps,
                 arraySplit((x, previous_timestamp) -> ifNull(x.1 > previous_timestamp + {gap}, 1), event_tuples, previous_timestamps) AS journeys,
                 arrayMap(journey -> arrayMap(event_tuple -> event_tuple.2, journey), journeys) AS journey_items,
@@ -229,8 +382,9 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
             GROUP BY actor_id
             """,
             placeholders={
-                "event_base_query": self._event_base_query(),
-                "gap": self._gap_expr(),
+                "event_base_query": self._events_for_journeys_query(),
+                "sorted_events": self._sorted_events_expr(),
+                "gap": self._split_interval_expr(),
                 "collapsed_journeys": collapsed_journeys_expr,
                 "max_steps": ast.Constant(value=self.max_steps),
                 "node_kind": ast.Constant(value=ELEMENT_KIND_NODE),
@@ -329,6 +483,31 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
         query.limit = ast.Constant(value=self.result_row_limit)
         return query
 
+    def _anchored_prefix_counts_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
+        """Per-chain prefix counts for the hover funnel preview (anchored mode only). Each actor has
+        one sequence, so its prefixes nest into the chain tree the hover walks; a prefix's count is the
+        unique actors whose sequence begins with exactly that chain. Ordered by descending count and
+        capped at MAX_PREFIX_ROWS, so the visible top-item chains are always carried and only long-tail
+        chains through non-top items can be dropped from the hover data."""
+        return parse_select(
+            """
+            WITH sequences AS (
+                SELECT actor_id, arrayElement(trimmed_journeys, 1) AS sequence
+                FROM {elements_per_actor_query}
+            )
+            SELECT arraySlice(sequence, 1, prefix_length) AS prefix, uniqExact(actor_id) AS actor_count
+            FROM sequences
+            ARRAY JOIN arrayEnumerate(sequence) AS prefix_length
+            GROUP BY prefix
+            ORDER BY length(prefix) ASC, actor_count DESC, prefix ASC
+            LIMIT {max_prefix_rows}
+            """,
+            placeholders={
+                "elements_per_actor_query": self._elements_per_actor_query(),
+                "max_prefix_rows": ast.Constant(value=MAX_PREFIX_ROWS),
+            },
+        )
+
     def _to_path_item(self, item: tuple[str, str]) -> PathsV2Item | None:
         event, label = item
         if event == PATHS_V2_OTHER:
@@ -338,7 +517,19 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
                 return PathsV2Item(event=event, label=label if source.namingProperty is not None else None)
         return PathsV2Item(event=event, label=label)
 
-    def _to_results(self, rows: list[tuple[Any, ...]]) -> PathsV2Results:
+    def _to_prefixes(self, rows: list[tuple[Any, ...]]) -> list[PathsV2Prefix]:
+        prefixes: list[PathsV2Prefix] = []
+        for prefix_items, actor_count in rows:
+            items: list[PathsV2Item] = []
+            for raw_item in prefix_items:
+                item = self._to_path_item(raw_item)
+                # Raw sequence items always name a real path item, never the other bucket.
+                assert item is not None
+                items.append(item)
+            prefixes.append(PathsV2Prefix(items=items, count=actor_count))
+        return prefixes
+
+    def _to_results(self, rows: list[tuple[Any, ...]], prefixes: list[PathsV2Prefix]) -> PathsV2Results:
         steps: dict[int, PathsV2Step] = {}
         edges: list[PathsV2Edge] = []
 
@@ -379,14 +570,10 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
             key=lambda edge: (edge.stepIndex, -edge.count, item_sort_key(edge.source), item_sort_key(edge.target))
         )
 
-        return PathsV2Results(steps=[steps[index] for index in sorted(steps)], edges=edges)
+        return PathsV2Results(steps=[steps[index] for index in sorted(steps)], edges=edges, prefixes=prefixes)
 
-    def _calculate(self) -> PathsV2QueryResponse:
-        query = self.to_query()
-        # Display-only response HogQL (never executed); bypass warehouse ACL so printing doesn't fail closed userless.
-        hogql = to_printed_hogql(query, self.team, bypass_warehouse_access_control=True)
-
-        response = execute_hogql_query(
+    def _execute(self, query: ast.SelectQuery | ast.SelectSetQuery) -> Any:
+        return execute_hogql_query(
             query_type="PathsV2Query",
             query=query,
             team=self.team,
@@ -400,9 +587,24 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
             ),
         )
 
+    def _calculate(self) -> PathsV2QueryResponse:
+        query = self.to_query()
+        # Display-only response HogQL (never executed); bypass warehouse ACL so printing doesn't fail closed userless.
+        hogql = to_printed_hogql(query, self.team, bypass_warehouse_access_control=True)
+
+        response = self._execute(query)
         assert response.results is not None
+
+        prefixes: list[PathsV2Prefix] = []
+        if self.is_anchored:
+            # A second aggregation over the same anchored sequences: the grid carries positional
+            # counts, this carries the per-chain counts the hover preview reads.
+            prefix_response = self._execute(self._anchored_prefix_counts_query())
+            assert prefix_response.results is not None
+            prefixes = self._to_prefixes(prefix_response.results)
+
         return PathsV2QueryResponse(
-            results=self._to_results(response.results),
+            results=self._to_results(response.results, prefixes),
             timings=response.timings,
             hogql=hogql,
             modifiers=self.modifiers,

--- a/products/product_analytics/backend/hogql_queries/paths_v2/paths_v2_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/paths_v2/paths_v2_query_runner.py
@@ -116,7 +116,8 @@ class ValidateWindowBounds:
 
 class ValidateAnchor:
     """An anchor's event must be one of the step sources, otherwise no event could ever derive it and
-    the chart would be empty for a reason the config does not reveal."""
+    the chart would be empty for a reason the config does not reveal. When that source names its items
+    by a property, the anchor must carry the label that pins which item it is."""
 
     code = "paths_v2_anchor_invalid"
 
@@ -124,10 +125,16 @@ class ValidateAnchor:
         paths_filter = context.query.pathsV2Filter
         if paths_filter is None or paths_filter.anchor is None:
             return
-        source_events = {source.event for source in resolve_step_sources(context.query)}
-        if paths_filter.anchor.item.event not in source_events:
+        anchor_item = paths_filter.anchor.item
+        source = next((s for s in resolve_step_sources(context.query) if s.event == anchor_item.event), None)
+        if source is None:
             raise ValidationError(
-                f"The anchor event {paths_filter.anchor.item.event!r} must be one of the step sources.",
+                f"The anchor event {anchor_item.event!r} must be one of the step sources.",
+                code=self.code,
+            )
+        if source.namingProperty is not None and anchor_item.label is None:
+            raise ValidationError(
+                f"The anchor item for event {anchor_item.event!r} needs a label, as its source has a naming property.",
                 code=self.code,
             )
 
@@ -243,7 +250,9 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
         step 0 and the grid reads backward in time toward it."""
         events = "groupArray(tuple(timestamp, path_item))"
         if self.is_anchored and self.anchor is not None and self.anchor.type == PathsV2AnchorType.END:
-            return parse_expr(f"arrayReverseSort(x -> x.1, {events})")
+            # arrayReverse(arraySort(...)), not arrayReverseSort: HogQL aliases arrayReverseSort to the
+            # ascending arraySort, which would silently keep forward order.
+            return parse_expr(f"arrayReverse(arraySort(x -> x.1, {events}))")
         return parse_expr(f"arraySort(x -> x.1, {events})")
 
     def _event_base_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
@@ -499,7 +508,7 @@ class PathsV2QueryRunner(AnalyticsQueryRunner[PathsV2QueryResponse]):
             FROM sequences
             ARRAY JOIN arrayEnumerate(sequence) AS prefix_length
             GROUP BY prefix
-            ORDER BY length(prefix) ASC, actor_count DESC, prefix ASC
+            ORDER BY actor_count DESC, length(prefix) ASC, prefix ASC
             LIMIT {max_prefix_rows}
             """,
             placeholders={

--- a/products/product_analytics/backend/hogql_queries/paths_v2/test/test_funnel_converter.py
+++ b/products/product_analytics/backend/hogql_queries/paths_v2/test/test_funnel_converter.py
@@ -13,6 +13,8 @@ from posthog.schema import (
     FunnelConversionWindowTimeUnit,
     FunnelExclusionEventsNode,
     HogQLPropertyFilter,
+    PathsV2Anchor,
+    PathsV2AnchorType,
     PathsV2Filter,
     PathsV2Item,
     PathsV2Query,
@@ -24,7 +26,11 @@ from posthog.schema import (
 from posthog.hogql_queries.insights.funnels.funnels_query_runner import FunnelsQueryRunner
 from posthog.test.test_journeys import journeys_for
 
-from products.product_analytics.backend.hogql_queries.paths_v2.funnel_converter import edge_to_funnels_query
+from products.product_analytics.backend.hogql_queries.paths_v2.funnel_converter import (
+    anchored_segment_to_funnels_query,
+    edge_to_funnels_query,
+    segment_to_funnels_query,
+)
 from products.product_analytics.backend.hogql_queries.paths_v2.paths_v2_query_runner import PathsV2QueryRunner
 
 DATE_RANGE = DateRange(date_from="2023-03-01", date_to="2023-03-31")
@@ -407,3 +413,104 @@ class TestEdgeToFunnelsQuery(APIBaseTest):
         query = PathsV2Query(pathsV2Filter=PathsV2Filter(stepSources=_sources("a")))
         with self.assertRaises(ValidationError):
             edge_to_funnels_query(query, self.team, _item("a"), _item("unknown"))
+
+    def test_segment_funnel_shape(self):
+        query = PathsV2Query(dateRange=DATE_RANGE, pathsV2Filter=PathsV2Filter(stepSources=SIMPLE_SOURCES))
+
+        funnels_query = segment_to_funnels_query(
+            query,
+            self.team,
+            [_item("a"), _item("b"), _item("c")],
+            15,
+            FunnelConversionWindowTimeUnit.MINUTE,
+        )
+
+        self.assertEqual([step.event for step in funnels_query.series], ["a", "b", "c"])
+        assert funnels_query.funnelsFilter is not None
+        self.assertEqual(funnels_query.funnelsFilter.funnelWindowInterval, 15)
+        self.assertEqual(funnels_query.funnelsFilter.funnelOrderType, StepOrderValue.ORDERED)
+
+        assert funnels_query.funnelsFilter.exclusions is not None
+        exclusion = funnels_query.funnelsFilter.exclusions[0]
+        assert isinstance(exclusion, FunnelExclusionEventsNode)
+        # The exclusion spans every step, so an intervening included item anywhere in the chain drops it.
+        self.assertEqual(exclusion.funnelFromStep, 0)
+        self.assertEqual(exclusion.funnelToStep, 2)
+        assert exclusion.properties is not None
+        universe_filter = exclusion.properties[0]
+        assert isinstance(universe_filter, HogQLPropertyFilter)
+        self.assertIn("tuple('a', '')", universe_filter.key)
+        self.assertIn("tuple('b', '')", universe_filter.key)
+        self.assertIn("tuple('c', '')", universe_filter.key)
+
+    def test_anchored_segment_reads_window_from_query(self):
+        query = PathsV2Query(
+            dateRange=DATE_RANGE,
+            pathsV2Filter=PathsV2Filter(
+                stepSources=SIMPLE_SOURCES,
+                conversionWindowInterval=2,
+                conversionWindowIntervalUnit=FunnelConversionWindowTimeUnit.HOUR,
+            ),
+        )
+
+        funnels_query = anchored_segment_to_funnels_query(query, self.team, [_item("a"), _item("b")])
+
+        assert funnels_query.funnelsFilter is not None
+        self.assertEqual(funnels_query.funnelsFilter.funnelWindowInterval, 2)
+        self.assertEqual(funnels_query.funnelsFilter.funnelWindowIntervalUnit, FunnelConversionWindowTimeUnit.HOUR)
+
+    def test_segment_requires_two_items(self):
+        query = PathsV2Query(pathsV2Filter=PathsV2Filter(stepSources=SIMPLE_SOURCES))
+        with self.assertRaises(ValueError):
+            segment_to_funnels_query(query, self.team, [_item("a")], 30, FunnelConversionWindowTimeUnit.MINUTE)
+
+
+ANCHORED_SEGMENT_CASES: list[tuple[str, list[PathsV2Item], int]] = [
+    # Segment items in funnel (forward-time) order; expected count is both the displayed chain's prefix
+    # count and the plain funnel's count — the anchored contract holds when the two agree.
+    ("edge", [_item("a"), _item("b")], 4),
+    ("three_step", [_item("a"), _item("b"), _item("c")], 2),
+    ("revisit", [_item("a"), _item("b"), _item("a")], 1),
+]
+
+
+class TestPathsV2AnchoredSegmentContract(ClickhouseTestMixin, APIBaseTest):
+    maxDiff = None
+
+    def _query(self) -> PathsV2Query:
+        return PathsV2Query(
+            dateRange=DATE_RANGE,
+            pathsV2Filter=PathsV2Filter(
+                stepSources=SIMPLE_SOURCES, anchor=PathsV2Anchor(type=PathsV2AnchorType.START, item=_item("a"))
+            ),
+        )
+
+    def _prefix_count(self, query: PathsV2Query, chain: list[PathsV2Item]) -> float:
+        results = PathsV2QueryRunner(query=query, team=self.team).calculate().results
+        wanted = [(item.event, item.label) for item in chain]
+        for prefix in results.prefixes:
+            if [(item.event, item.label) for item in prefix.items] == wanted:
+                return prefix.count
+        return 0
+
+    def _funnel_count(self, query: PathsV2Query, chain: list[PathsV2Item]) -> float:
+        funnels_query = anchored_segment_to_funnels_query(query, self.team, list(chain))
+        results = FunnelsQueryRunner(query=funnels_query, team=self.team).calculate().results
+        return results[len(chain) - 1]["count"]
+
+    @parameterized.expand(ANCHORED_SEGMENT_CASES)
+    def test_anchored_segment_equals_plain_funnel(self, _name: str, chain: list[PathsV2Item], expected: int):
+        journeys_for(
+            team=self.team,
+            events_by_person={
+                "p1": _timeline("a", "b", "c"),
+                "p2": _timeline("a", "b"),
+                "p3": _timeline("a", "b", "c"),
+                "p4": _timeline("a", "b", "a"),
+            },
+        )
+        query = self._query()
+
+        # The displayed anchored chain and the plain funnel with window W count the same actors.
+        self.assertEqual(self._prefix_count(query, chain), expected)
+        self.assertEqual(self._funnel_count(query, chain), expected)

--- a/products/product_analytics/backend/hogql_queries/paths_v2/test/test_funnel_converter.py
+++ b/products/product_analytics/backend/hogql_queries/paths_v2/test/test_funnel_converter.py
@@ -425,7 +425,11 @@ class TestEdgeToFunnelsQuery(APIBaseTest):
             FunnelConversionWindowTimeUnit.MINUTE,
         )
 
-        self.assertEqual([step.event for step in funnels_query.series], ["a", "b", "c"])
+        events = []
+        for step in funnels_query.series:
+            assert isinstance(step, EventsNode)
+            events.append(step.event)
+        self.assertEqual(events, ["a", "b", "c"])
         assert funnels_query.funnelsFilter is not None
         self.assertEqual(funnels_query.funnelsFilter.funnelWindowInterval, 15)
         self.assertEqual(funnels_query.funnelsFilter.funnelOrderType, StepOrderValue.ORDERED)

--- a/products/product_analytics/backend/hogql_queries/paths_v2/test/test_paths_v2_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/paths_v2/test/test_paths_v2_query_runner.py
@@ -12,6 +12,8 @@ from rest_framework.exceptions import ValidationError
 from posthog.schema import (
     DateRange,
     FunnelConversionWindowTimeUnit,
+    PathsV2Anchor,
+    PathsV2AnchorType,
     PathsV2Filter,
     PathsV2Item,
     PathsV2Query,
@@ -83,7 +85,10 @@ class TestPathsV2FilterConstraints(SimpleTestCase):
         self.assertEqual(paths_filter.gapInterval, 30)
         self.assertEqual(paths_filter.gapIntervalUnit, FunnelConversionWindowTimeUnit.MINUTE)
         self.assertEqual(paths_filter.collapseRepeats, True)
+        self.assertEqual(paths_filter.conversionWindowInterval, 30)
+        self.assertEqual(paths_filter.conversionWindowIntervalUnit, FunnelConversionWindowTimeUnit.MINUTE)
         self.assertIsNone(paths_filter.stepSources)
+        self.assertIsNone(paths_filter.anchor)
 
 
 class TestPathsV2Validation(ClickhouseTestMixin, APIBaseTest):
@@ -125,6 +130,38 @@ class TestPathsV2Validation(ClickhouseTestMixin, APIBaseTest):
     def test_invalid_step_sources_reject(self, _name: str, sources: list[PathsV2StepSource]) -> None:
         runner = self._runner(PathsV2Filter(stepSources=sources))
         with self.assertRaisesMessage(ValidationError, "stepSources"):
+            runner.validate()
+
+    @parameterized.expand(
+        [
+            ("second_above_max", 3601, FunnelConversionWindowTimeUnit.SECOND),
+            ("minute_above_max", 1441, FunnelConversionWindowTimeUnit.MINUTE),
+            ("day_above_max", 366, FunnelConversionWindowTimeUnit.DAY),
+            ("minute_below_min", 0, FunnelConversionWindowTimeUnit.MINUTE),
+        ]
+    )
+    def test_out_of_bounds_window_rejects(
+        self, _name: str, interval: int, unit: FunnelConversionWindowTimeUnit
+    ) -> None:
+        runner = self._runner(PathsV2Filter(conversionWindowInterval=interval, conversionWindowIntervalUnit=unit))
+        with self.assertRaisesMessage(ValidationError, "conversionWindowInterval"):
+            runner.validate()
+
+    def test_window_bounds_are_inclusive(self) -> None:
+        self._runner(
+            PathsV2Filter(
+                conversionWindowInterval=1440, conversionWindowIntervalUnit=FunnelConversionWindowTimeUnit.MINUTE
+            )
+        ).validate()
+
+    def test_anchor_event_must_be_a_step_source(self) -> None:
+        runner = self._runner(
+            PathsV2Filter(
+                stepSources=_sources("a", "b"),
+                anchor=PathsV2Anchor(type=PathsV2AnchorType.START, item=PathsV2Item(event="missing")),
+            )
+        )
+        with self.assertRaisesMessage(ValidationError, "must be one of the step sources"):
             runner.validate()
 
 
@@ -532,4 +569,191 @@ class TestPathsV2QueryRunner(ClickhouseTestMixin, APIBaseTest):
                 ("node", 1, ("c", ""), ("", "")),
                 ("dropoff", 1, ("", ""), ("", "")),
             ],
+        )
+
+
+def _anchor(event: str, anchor_type: PathsV2AnchorType = PathsV2AnchorType.START) -> PathsV2Anchor:
+    return PathsV2Anchor(type=anchor_type, item=PathsV2Item(event=event))
+
+
+def _prefix(items: list[tuple[str, str | None]], count: float) -> tuple[tuple[tuple[str, str | None], ...], float]:
+    return (tuple(items), count)
+
+
+class TestPathsV2AnchoredMode(ClickhouseTestMixin, APIBaseTest):
+    maxDiff = None
+
+    def _run(self, query: PathsV2Query) -> Any:
+        return PathsV2QueryRunner(query=query, team=self.team).calculate().results
+
+    def _steps(self, results: Any) -> list[tuple[int, list[PathsV2Row], float, float]]:
+        return [(step.stepIndex, step.rows, step.otherCount, step.dropOffCount) for step in results.steps]
+
+    def _edges(self, results: Any) -> list[tuple[int, PathsV2Item | None, PathsV2Item | None, float]]:
+        return [(edge.stepIndex, edge.source, edge.target, edge.count) for edge in results.edges]
+
+    def _prefixes(self, results: Any) -> set[tuple[tuple[tuple[str, str | None], ...], float]]:
+        return {(tuple((item.event, item.label) for item in prefix.items), prefix.count) for prefix in results.prefixes}
+
+    def test_anchored_start_journey_grid(self):
+        journeys_for(
+            team=self.team,
+            events_by_person={
+                **_timeline("p1", "a", "b", "c"),
+                **_timeline("p2", "a", "b", "d"),
+                **_timeline("p3", "a", "x"),
+                # z precedes the anchor, so the prefilter drops it and the sequence starts at a.
+                **_timeline("p4", "z", "a", "b"),
+            },
+        )
+
+        query = PathsV2Query(
+            dateRange=DATE_RANGE,
+            pathsV2Filter=PathsV2Filter(
+                stepSources=_sources("a", "b", "c", "d", "x", "z"), anchor=_anchor("a"), maxRowsPerStep=10
+            ),
+        )
+        results = self._run(query)
+
+        # One sequence per actor from the anchor: p1 [a,b,c], p2 [a,b,d], p3 [a,x], p4 [a,b]. The anchor
+        # is the single 100% node; drop-offs count actors whose sequence ends at that step.
+        self.assertEqual(
+            self._steps(results),
+            [
+                (0, [_row("a", 4)], 0, 0),
+                (1, [_row("b", 3), _row("x", 1)], 0, 2),
+                (2, [_row("c", 1), _row("d", 1)], 0, 2),
+            ],
+        )
+        self.assertEqual(
+            self._edges(results),
+            [
+                _edge(0, _item("a"), _item("b"), 3),
+                _edge(0, _item("a"), _item("x"), 1),
+                _edge(1, _item("b"), _item("c"), 1),
+                _edge(1, _item("b"), _item("d"), 1),
+            ],
+        )
+        # Prefix counts nest into the chain tree the hover preview walks.
+        self.assertEqual(
+            self._prefixes(results),
+            {
+                _prefix([("a", None)], 4),
+                _prefix([("a", None), ("b", None)], 3),
+                _prefix([("a", None), ("x", None)], 1),
+                _prefix([("a", None), ("b", None), ("c", None)], 1),
+                _prefix([("a", None), ("b", None), ("d", None)], 1),
+            },
+        )
+
+    def test_anchored_prefilter_bounds_actors_to_the_window(self):
+        journeys_for(
+            team=self.team,
+            events_by_person={
+                # b sits 40 min past the anchor, beyond the 30 min window, so it never joins the sequence.
+                "p1": [
+                    {"event": "a", "timestamp": "2023-03-10 10:00:00"},
+                    {"event": "b", "timestamp": "2023-03-10 10:40:00"},
+                ],
+                # No anchor event at all, so this actor is excluded entirely.
+                **_timeline("p2", "b", "c"),
+                # Anchor plus an in-window step.
+                "p3": [
+                    {"event": "a", "timestamp": "2023-03-10 10:00:00"},
+                    {"event": "b", "timestamp": "2023-03-10 10:20:00"},
+                ],
+            },
+        )
+
+        query = PathsV2Query(
+            dateRange=DATE_RANGE,
+            pathsV2Filter=PathsV2Filter(stepSources=_sources("a", "b", "c"), anchor=_anchor("a"), maxRowsPerStep=10),
+        )
+        results = self._run(query)
+
+        self.assertEqual(
+            self._steps(results),
+            [(0, [_row("a", 2)], 0, 1), (1, [_row("b", 1)], 0, 1)],
+        )
+        self.assertEqual(self._edges(results), [_edge(0, _item("a"), _item("b"), 1)])
+        self.assertEqual(
+            self._prefixes(results),
+            {_prefix([("a", None)], 2), _prefix([("a", None), ("b", None)], 1)},
+        )
+
+    def test_anchored_keeps_single_sequence_across_a_gap(self):
+        # A 45 min gap would split into two journeys in open mode (gap G defaults to 30 min); anchored
+        # mode never splits, so with a 60 min window the two events stay one sequence and the edge exists.
+        journeys_for(
+            team=self.team,
+            events_by_person={
+                "p1": [
+                    {"event": "a", "timestamp": "2023-03-10 10:00:00"},
+                    {"event": "b", "timestamp": "2023-03-10 10:45:00"},
+                ]
+            },
+        )
+
+        query = PathsV2Query(
+            dateRange=DATE_RANGE,
+            pathsV2Filter=PathsV2Filter(
+                stepSources=_sources("a", "b"),
+                anchor=_anchor("a"),
+                conversionWindowInterval=60,
+                conversionWindowIntervalUnit=FunnelConversionWindowTimeUnit.MINUTE,
+            ),
+        )
+        results = self._run(query)
+
+        self.assertEqual(
+            self._steps(results),
+            [(0, [_row("a", 1)], 0, 0), (1, [_row("b", 1)], 0, 1)],
+        )
+        self.assertEqual(self._edges(results), [_edge(0, _item("a"), _item("b"), 1)])
+
+    def test_anchored_end_anchor_reads_backward(self):
+        journeys_for(
+            team=self.team,
+            events_by_person={
+                **_timeline("p1", "a", "b", "x"),
+                **_timeline("p2", "c", "b", "x"),
+            },
+        )
+
+        query = PathsV2Query(
+            dateRange=DATE_RANGE,
+            pathsV2Filter=PathsV2Filter(
+                stepSources=_sources("a", "b", "c", "x"),
+                anchor=_anchor("x", PathsV2AnchorType.END),
+                maxRowsPerStep=10,
+            ),
+        )
+        results = self._run(query)
+
+        # End anchor: x is the single 100% node at step 0 and the grid reads backward in time toward it,
+        # so p1 becomes [x, b, a] and p2 becomes [x, b, c].
+        self.assertEqual(
+            self._steps(results),
+            [
+                (0, [_row("x", 2)], 0, 0),
+                (1, [_row("b", 2)], 0, 0),
+                (2, [_row("a", 1), _row("c", 1)], 0, 2),
+            ],
+        )
+        self.assertEqual(
+            self._edges(results),
+            [
+                _edge(0, _item("x"), _item("b"), 2),
+                _edge(1, _item("b"), _item("a"), 1),
+                _edge(1, _item("b"), _item("c"), 1),
+            ],
+        )
+        self.assertEqual(
+            self._prefixes(results),
+            {
+                _prefix([("x", None)], 2),
+                _prefix([("x", None), ("b", None)], 2),
+                _prefix([("x", None), ("b", None), ("a", None)], 1),
+                _prefix([("x", None), ("b", None), ("c", None)], 1),
+            },
         )

--- a/products/product_analytics/backend/hogql_queries/paths_v2/test/test_paths_v2_query_runner.py
+++ b/products/product_analytics/backend/hogql_queries/paths_v2/test/test_paths_v2_query_runner.py
@@ -164,6 +164,16 @@ class TestPathsV2Validation(ClickhouseTestMixin, APIBaseTest):
         with self.assertRaisesMessage(ValidationError, "must be one of the step sources"):
             runner.validate()
 
+    def test_anchor_on_naming_property_source_needs_a_label(self) -> None:
+        runner = self._runner(
+            PathsV2Filter(
+                stepSources=[PathsV2StepSource(event="$pageview", namingProperty="$pathname")],
+                anchor=PathsV2Anchor(type=PathsV2AnchorType.START, item=PathsV2Item(event="$pageview")),
+            )
+        )
+        with self.assertRaisesMessage(ValidationError, "needs a label"):
+            runner.validate()
+
 
 class TestPathsV2QueryRunner(ClickhouseTestMixin, APIBaseTest):
     maxDiff = None

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -54947,6 +54947,21 @@ export namespace Schemas {
       label?: string | null;
     }
 
+    export type PathsV2AnchorType = typeof PathsV2AnchorType[keyof typeof PathsV2AnchorType];
+
+
+    export const PathsV2AnchorType = {
+      Start: 'start',
+      End: 'end',
+    } as const;
+
+    export interface PathsV2Anchor {
+      /** The path item the chart anchors on. Its event must be one of the step sources. */
+      item: PathsV2Item;
+      /** `start` runs each actor's single sequence forward from the anchor item; `end` runs it up to the anchor item. Either way the anchor is the grid's single 100% node. */
+      type: PathsV2AnchorType;
+    }
+
     export interface PathsV2Edge {
       /** Unique actors with a journey that transitions from source to target between these steps. */
       count: number;
@@ -54966,8 +54981,13 @@ export namespace Schemas {
     }
 
     export interface PathsV2Filter {
+      /** Anchor selecting anchored mode. When set, each actor contributes exactly one sequence bounded by the conversion window, so every displayed segment equals a plain funnel. Absent selects open mode, which splits an actor's events into journeys on the inactivity gap instead. */
+      anchor?: PathsV2Anchor | null;
       /** Merge immediate repeats of the same path item within a journey. */
       collapseRepeats?: boolean | null;
+      /** Anchored mode's single conversion window W, anchored at the anchor and reused verbatim as the emitted funnel's window. Bounds per unit are validated server-side against CONVERSION_WINDOW_INTERVAL_BOUNDS, the same funnel conversion window bounds as the gap. */
+      conversionWindowInterval?: number | null;
+      conversionWindowIntervalUnit?: FunnelConversionWindowTimeUnit | null;
       /** Inactivity gap that splits an actor's events into journeys. Bounds per unit are validated server-side against CONVERSION_WINDOW_INTERVAL_BOUNDS, the funnel conversion window bounds. */
       gapInterval?: number | null;
       gapIntervalUnit?: FunnelConversionWindowTimeUnit | null;
@@ -54977,6 +54997,13 @@ export namespace Schemas {
       maxSteps?: number | null;
       /** Step sources defining which events can become path items. Defaults to the pageviews preset: `$pageview` named by `$pathname`. */
       stepSources?: PathsV2StepSource[] | null;
+    }
+
+    export interface PathsV2Prefix {
+      /** Unique actors whose anchored sequence begins with exactly these items. */
+      count: number;
+      /** The chain's path items in order, starting at the anchor. */
+      items: PathsV2Item[];
     }
 
     export interface PathsV2Row {
@@ -54998,6 +55025,8 @@ export namespace Schemas {
 
     export interface PathsV2Results {
       edges: PathsV2Edge[];
+      /** Concrete anchored chains with per-chain unique-actor counts, ordered by descending count. Empty in open mode; in anchored mode it carries the counts the hover funnel preview reads per chain. */
+      prefixes: PathsV2Prefix[];
       steps: PathsV2Step[];
     }
 


### PR DESCRIPTION
## TL;DR

Paths v2 gets a second chart mode. Today's "open" mode splits each person's events into journeys on an inactivity gap. This adds "anchored" mode: pick a start or end point and one time window, and the chart shows each person's single path within that window from (or up to) that point. Because there's one path per person, any slice of the chart can be opened as a funnel with the exact same numbers.

## Problem

Paths v2 needs the anchored chart mode from the design: an anchor plus a single conversion window W, under which every displayed segment maps to a plain funnel with identical counts. This is slice 2 of the paths v2 build (Refs #37285), stacked on the schema + open-mode runner from slice 1 (#74689).

**Why:** anchored mode is what makes "view this path as a funnel" exact — one sequence per person means a displayed segment and the funnel it converts to count the same actors by construction.

## Changes

Ships dark behind the `paths-v2` flag (verified at 0%, untouched).

- **Schema** (`PathsV2Filter`): an `anchor` (a start or end path item) and window `W` (`conversionWindowInterval`/`Unit`, same bounds as the gap, server-validated). Results gain `prefixes` — per-chain unique-actor counts the later hover preview reads.
- **Runner**: anchored mode prefilters to actors who hit the anchor and keeps only their events within `W` of it, then builds one sequence per actor by reusing the open-mode grid pipeline (the window prefilter guarantees a single sequence, so no gap split). End anchors read backward in time so the anchor is the grid's step-0 node. A second aggregation carries the per-chain prefix counts.
- **Converter**: grows from single edges to any-depth segments — an ordered funnel with window `W` and one item-strict exclusion spanning every step. `edge_to_funnels_query` is now a thin wrapper over the general `segment_to_funnels_query`.

## How did you test this code?

This was built in a sandbox without ClickHouse or Postgres, so the ClickHouse-backed tests were **authored but run in CI**, not locally. What I (the agent) ran locally and passed:

- schema codegen (`hogli build:schema`) — the generated `schema.py`/`schema_enums.py`/`schema.json` are committed
- pydantic bounds + defaults (`TestPathsV2FilterConstraints`, `SimpleTestCase`, no DB)
- a HogQL parse smoke test that builds every new query (open, anchored start/end, prefix, converter) — all parse to valid HogQL
- full test-module collection (no import errors), `ruff` lint/format, `hogli ci:preflight --fix`, repo-wide `mypy`

New tests and the regression each guards (all ClickHouse-backed, verified in CI):

- `TestPathsV2AnchoredMode` — the anchored grid, prefixes, the window prefilter (drops pre-anchor events and non-anchor actors), the single-sequence-across-a-gap semantic (anchored uses `W`, never the gap), and end-anchor reverse ordering. None of these paths existed before this slice.
- `TestPathsV2AnchoredSegmentContract` — an anchored segment's displayed count equals its plain funnel's count (2-step, 3-step, revisit). This is the backbone that keeps runner, converter, and funnels engine from drifting.
- Converter shape + window + arity, and window-bound / anchor-source validation.

Open-mode SQL is byte-identical (the new mode branches only change placeholder values that resolve to the same AST in open mode), so slice 1's snapshot stays valid.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs yet — the mode is dark with no UI (the viz and editor land in later slices).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code) as a standalone build session for slice 2 of the paths v2 build playbook. Skills invoked: `/writing-tests`.

Decisions worth a reviewer's eye:

- **Anchored sequence = first anchor occurrence (start) / last (end), one window W, item-strict by construction.** This reuses slice 1's whole grid pipeline unchanged (only the event source is prefiltered and the journey-split interval becomes W), which keeps open mode's generated SQL — and its snapshot — untouched.
- **Re-anchoring nuance:** the funnel engine re-anchors step 1 across a window timeout (confirmed in the Rust UDF). The runner anchors at the first/last occurrence and does not re-anchor. For the journeys these tests cover (and the common case) the two coincide; a pathological input — an anchor occurrence whose window misses the rest of the chain, followed by a later occurrence that completes it — is the one place they can diverge. Worth confirming against real data when the stack is tried locally.
- **End anchors** reuse the forward machinery by sorting the actor's within-window events descending, so the anchor sits at step 0 and the grid reads backward in time. The converter always takes items in forward-time order.
- **Prefix counts** are capped (`MAX_PREFIX_ROWS`) and ordered by count, so the response stays bounded on large teams; the visible top-item chains always survive and only the long tail through non-top items can be dropped from the hover data. Bucketing prefixes into the "other" row is left to the slice-5 hover work.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
