### PR TITLE
feat(signals): replace replay thumbnail with a view button on evidence cards

### DIFF
--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -35,7 +35,7 @@ Django serializers are the source of truth. `hogli build:openapi` generates Type
 - Types: `import type { UserAuthSessionApi } from '~/generated/core/api.schemas'`
   (exemplar: `frontend/src/scenes/settings/user/loginSessionsLogic.ts`)
 - Request functions: `import { getExportsContentRetrieveUrl } from '~/generated/core/api'`
-  (exemplar: `frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx`)
+  (exemplar: `frontend/src/scenes/inbox/components/signalCards/ScannerFindingSignalCard.tsx`)
 - Generated output lives in `frontend/src/generated/core/` and `products/*/frontend/generated/`. **These files are codegen output — never edit them by hand.** Change the serializer and rerun.
 
 When touching `lib/api`, `api.get<`, `api.create<`, or any handwritten API interface, invoke the `/adopting-generated-api-types` skill first.

--- a/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
+++ b/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
@@ -1,22 +1,13 @@
-import clsx from 'clsx'
-import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
-import { IconBug, IconCursorClick, IconGlobe, IconKeyboard, IconPlay } from '@posthog/icons'
+import { IconBug, IconCursorClick, IconGlobe, IconKeyboard } from '@posthog/icons'
 import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 import type { LemonTagType } from '@posthog/lemon-ui'
 
-import { sessionRecordingInfoLogic } from 'lib/components/ViewRecordingButton/sessionRecordingInfoLogic'
-import ViewRecordingButton, {
-    RecordingPlayerType,
-    useRecordingButton,
-} from 'lib/components/ViewRecordingButton/ViewRecordingButton'
+import ViewRecordingButton, { RecordingPlayerType } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { Dayjs, dayjs } from 'lib/dayjs'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { humanFriendlyDuration, reverseColonDelimitedDuration } from 'lib/utils/durations'
-import { teamLogic } from 'scenes/teamLogic'
-
-import { getExportsContentRetrieveUrl } from '~/generated/core/api'
 
 import type {
     SessionProblemEventEntryApi,
@@ -109,37 +100,14 @@ function TimelineRow({
     )
 }
 
-/** Live card for a session-replay problem segment: thumbnail preview, replay link-out, and an event timeline. */
+/** Live card for a session-replay problem segment: a replay link-out and an event timeline. */
 export function SessionReplaySignalCard({ signal }: SignalCardProps): JSX.Element {
-    const { currentTeamId } = useValues(teamLogic)
     const [showAllEvents, setShowAllEvents] = useState(false)
-    const [thumbnailFailed, setThumbnailFailed] = useState(false)
 
     const extra = signal.extra as Record<string, unknown> & SessionProblemSignalExtraApi
     const problemTag = PROBLEM_TYPE_TAG[extra.problem_type]
 
-    const hasThumbnail = extra.exported_asset_id !== undefined && currentTeamId !== null && !thumbnailFailed
-    const thumbnailSrc = hasThumbnail
-        ? getExportsContentRetrieveUrl(String(currentTeamId), extra.exported_asset_id as number)
-        : undefined
-
     const segmentSeekTime = recordingSeekTime(extra.session_start_time ?? undefined, extra.start_time)
-
-    // Mirror ViewRecordingButton's `checkRecordingExists`: batch-check the recording so the play
-    // affordance disables (rather than opening an empty player) when the recording wasn't captured.
-    const { checkRecordingInfo } = useActions(sessionRecordingInfoLogic)
-    const { getRecordingExists } = useValues(sessionRecordingInfoLogic)
-    useEffect(() => {
-        checkRecordingInfo(extra.session_id)
-    }, [extra.session_id, checkRecordingInfo])
-    const hasRecording = getRecordingExists(extra.session_id)
-
-    const { onClick: openRecording, disabledReason } = useRecordingButton({
-        sessionId: extra.session_id,
-        timestamp: segmentSeekTime,
-        openPlayerIn: RecordingPlayerType.Modal,
-        hasRecording,
-    })
 
     const events = extra.event_history ?? []
     const visibleEvents = showAllEvents ? events : events.slice(0, TIMELINE_PREVIEW_COUNT)
@@ -167,35 +135,16 @@ export function SessionReplaySignalCard({ signal }: SignalCardProps): JSX.Elemen
                 </LemonMarkdown>
             )}
 
-            {/* The 16:9 preview frame is itself the play affordance — clicking it opens the recording at the segment. */}
-            <button
-                type="button"
-                onClick={openRecording}
-                disabled={!!disabledReason}
-                title={typeof disabledReason === 'string' ? disabledReason : undefined}
-                aria-label="Play recording"
-                className="group relative w-full aspect-video rounded overflow-hidden border bg-surface-secondary mb-2 cursor-pointer disabled:cursor-default disabled:opacity-70"
-            >
-                {thumbnailSrc && (
-                    <img
-                        src={thumbnailSrc}
-                        alt={`Recording preview for ${extra.segment_title}`}
-                        className="absolute inset-0 size-full object-cover"
-                        onError={() => setThumbnailFailed(true)}
-                    />
-                )}
-                <div
-                    className={clsx(
-                        'absolute inset-0 flex items-center justify-center transition-colors',
-                        thumbnailSrc ? 'bg-black/20 group-hover:bg-black/30' : 'group-hover:bg-fill-highlight-100'
-                    )}
-                >
-                    <IconPlay
-                        className={clsx('size-10 drop-shadow', thumbnailSrc ? 'text-white' : 'text-tertiary')}
-                        aria-hidden
-                    />
-                </div>
-            </button>
+            {/* Opens the recording at the segment in the player modal. */}
+            <ViewRecordingButton
+                sessionId={extra.session_id}
+                timestamp={segmentSeekTime}
+                openPlayerIn={RecordingPlayerType.Modal}
+                label="View replay"
+                type="secondary"
+                size="small"
+                className="mb-2"
+            />
 
             {/* Dot-separated meta line: affected user, segment window, active/total duration. */}
             <div className="flex items-center gap-1.5 flex-wrap text-xs text-tertiary mb-2">

--- a/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
+++ b/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
@@ -135,11 +135,12 @@ export function SessionReplaySignalCard({ signal }: SignalCardProps): JSX.Elemen
                 </LemonMarkdown>
             )}
 
-            {/* Opens the recording at the segment in the player modal. */}
+            {/* Opens the recording at the segment in the player modal; disables when it wasn't captured. */}
             <ViewRecordingButton
                 sessionId={extra.session_id}
                 timestamp={segmentSeekTime}
                 openPlayerIn={RecordingPlayerType.Modal}
+                checkRecordingExists
                 label="View replay"
                 type="secondary"
                 size="small"


### PR DESCRIPTION
## Problem

The session-replay cards in the report **Evidence** section rendered a large 16:9 thumbnail preview of the recording. The thumbnails frequently failed to load, and the big box didn't earn its space since the replay opens in a pop-up modal rather than playing inline. Raised in a Slack thread.

## Changes

Replaced the thumbnail preview button with a compact "View replay" button on `SessionReplaySignalCard`. The button still opens the recording at the problem segment in the player modal via `ViewRecordingButton` (which does its own recording-exists check and disabling), so the removed manual thumbnail/team/recording-check plumbing was no longer needed. Re-pointed the generated-API-types exemplar reference in `frontend/src/AGENTS.md` to `ScannerFindingSignalCard.tsx`, which still uses `getExportsContentRetrieveUrl`.

Card layout now:

```
┌──────────────────────────────────────────────────┐
│ ⏺ session_replay · <time ago>        [Exception]  │  ← header + problem tag
│ <segment title>                                    │
│                                                    │
│ <summary markdown>                                 │
│                                                    │
│ [ ▷ View replay ]                                  │  ← was a big 16:9 thumbnail
│                                                    │
│ abc123def…  ·  00:12 – 00:47  ·  20s active / 45s  │  ← meta line
│ ──────────────────────────────────────────────    │
│ 🖱  Clicked "Checkout"                     00:14 ▷ │  ┐
│ ⌨  Typed in card field                     00:22 ▷ │  │ event timeline
│ 🐛  TypeError: undefined                    00:31 ▷ │  │ (rows link to the moment)
│ 🌐  /checkout                               00:40 ▷ │  ┘
│ Show all 9 events                                  │
└──────────────────────────────────────────────────┘
```

## How did you test this code?

Pure frontend change. I (the agent) verified all imports in the edited file are still used after removing the thumbnail plumbing, and re-pointed the doc exemplar that cited the removed API usage. I was not able to run the frontend lint/typecheck or the app in this environment (tooling not installed) — CI will run typecheck and lint.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Located the card via an Explore subagent, then edited `SessionReplaySignalCard.tsx` to swap the `<button>`-wrapped thumbnail `<img>` for a `ViewRecordingButton`, deleting the `useRecordingButton`/`sessionRecordingInfoLogic`/`teamLogic`/`getExportsContentRetrieveUrl` plumbing that only existed to serve the preview. Since that removed the file's only `getExportsContentRetrieveUrl` usage — which `frontend/src/AGENTS.md` cited as the exemplar — I updated the doc to point at `ScannerFindingSignalCard.tsx` instead.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785402929099539?thread_ts=1785402929.099539&cid=C09SK2PAGKF)*
