### PR TITLE
feat(signals): lift auto-derived suggested-reviewer cap to 10

### DIFF
--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -38,7 +38,7 @@ from ..models import SignalReportArtefact
 
 logger = logging.getLogger(__name__)
 
-MAX_SUGGESTED_REVIEWERS = 3
+MAX_SUGGESTED_REVIEWERS = 10
 MAX_COMMIT_LOOKUPS = 15
 
 RECENCY_FULL_WEIGHT_DAYS = 30
@@ -133,7 +133,7 @@ def resolve_suggested_reviewers(
     repository: str,
     commit_hashes_with_reasons: dict[str, str],
 ) -> list[_ResolvedReviewer]:
-    """Resolve commit hashes to up to 3 reviewers, preferring recently-active owners.
+    """Resolve commit hashes to up to ``MAX_SUGGESTED_REVIEWERS`` reviewers, preferring recently-active owners.
 
     Blame candidates (commit authors, weighted by finding position) are recency-shaped
     against cached area activity, and recently-active area contributors enter as capped


### PR DESCRIPTION
## Problem

The Self-driving Inbox routes each report to suggested reviewers. When those reviewers are derived automatically from commit authorship (the `resolve_reviewers` path, used when a scout doesn't set reviewers itself), the resolver capped the list at the top 3 ranked authors. For team-internal reports where the whole team should be looped in as reviewers, 3 is too low — people who haven't recently touched the exact code get dropped even when the report is squarely team-wide work.

Raised in a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785399011734159) while triaging inbox reports that only assigned one reviewer.

## Changes

- Raise `MAX_SUGGESTED_REVIEWERS` in `products/signals/backend/report_generation/resolve_reviewers.py` from `3` to `10`, matching the ceiling the scout-authored reviewer path already enforces.
- Update the resolver docstring to reference the constant rather than a hard-coded number.

This only affects the auto-derived (commit-authorship) path. The ranking is unchanged — it just keeps up to 10 ranked candidates instead of 3.

## How did you test this code?

No new tests. The existing reviewer tests (`test_reviewer_scenarios.py`, `test_resolve_reviewers.py`) reference `MAX_SUGGESTED_REVIEWERS` symbolically rather than asserting a hard-coded 3, so they continue to hold with the new value. I did not run the suite in this environment.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app after a maintainer noticed team-wide inbox reports were only being assigned a small number of reviewers and traced the limit to the `resolve_reviewers` cap. We confirmed there are two separate caps — the auto-derived path (this one, was 3) and the scout-authored path (already 10) — and lifted the lower one to match. The value is deliberately a starting point for team discussion, not a settled number.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785399011734159)*
