### PR TITLE
fix(signals): make report chart tables scroll and add chart spacing

### DIFF
--- a/frontend/src/scenes/inbox/components/detail/ReportChart.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportChart.tsx
@@ -175,13 +175,15 @@ export function ReportChart({ chartId }: { chartId: string }): JSX.Element | nul
     // `size` arrives as stored JSON, so an unknown value falls back to the inferred height rather
     // than dropping the box altogether.
     const size = chart.size && chart.size in SIZE_HEIGHTS ? chart.size : null
-    // A graph fills whatever box it's given and collapses without one. A data table sizes itself to
-    // its rows, so it only takes a box when its author asked for one — and then that box is a
-    // ceiling it scrolls within rather than a height it has to fill. Either way the box scrolls, so
-    // a grid taller than its size is reachable instead of cut off.
+    const inferredSize = size ?? inferChartSize(query)
+    // A graph fills whatever box it's given and collapses without one, so it takes a fixed height. A
+    // data table sizes itself to its rows, so its box is a ceiling it scrolls within rather than a
+    // height it has to fill. Every chart gets a bounded box either way: a table taller than its size
+    // then scrolls inside the card, instead of growing the whole report down the page with its last
+    // rows left unreachable at the bottom.
     const isSelfSizing = !(isInsightVizNode(query) || isSavedInsightNode(query) || isGraphicalSqlNode(query))
-    const height = isSelfSizing ? (size ? SIZE_MAX_HEIGHTS[size] : null) : SIZE_HEIGHTS[size ?? inferChartSize(query)]
-    const bodyClass = height ? `flex flex-col overflow-y-auto ${height}` : 'flex flex-col'
+    const height = isSelfSizing ? SIZE_MAX_HEIGHTS[inferredSize] : SIZE_HEIGHTS[inferredSize]
+    const bodyClass = `flex flex-col overflow-y-auto ${height}`
     // The SQLEditor prefix opts into container-governed chart sizing
     // (dataVisualizationLogic.presetChartHeight). Without it a graphical SQL chart renders at 60vh
     // and swallows the report, which is why NotebookNodeSQLV2 prefixes its key the same way.

--- a/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
@@ -352,7 +352,7 @@ export function InboxDetailFrame({
                     <DetailSection icon={summary.icon} title={summary.title}>
                         {report.summary ? (
                             <LemonMarkdown
-                                className="text-sm text-secondary leading-relaxed break-words [&>*+*]:mt-3 [&_li]:my-1 [&_ul]:my-2 [&_ol]:my-2 [&_h1]:mt-5 [&_h2]:mt-5 [&_h3]:mt-4"
+                                className="text-sm text-secondary leading-relaxed break-words [&>*+*]:mt-3 [&_[data-attr=report-chart]]:my-5 [&_li]:my-1 [&_ul]:my-2 [&_ol]:my-2 [&_h1]:mt-5 [&_h2]:mt-5 [&_h3]:mt-4"
                                 disableImages
                                 renderChartRef={renderChartRef}
                             >
@@ -364,7 +364,7 @@ export function InboxDetailFrame({
                             </p>
                         )}
                         {trailingCharts.length > 0 && (
-                            <div className="flex flex-col gap-3">
+                            <div className="flex flex-col gap-4 mt-5">
                                 {trailingCharts.map((chart) => (
                                     <ReportChart key={chart.chart_id} chartId={chart.chart_id} />
                                 ))}


### PR DESCRIPTION
## Problem

Charts embedded in inbox (Signals) reports had two rough edges: a data table whose chart artefact had no explicit `size` rendered in a plain flex column with no max-height and no overflow, so the table grew to its full row count and its last rows were left unreachable at the bottom of the card rather than scrolling. Charts also sat too tightly against the summary prose.

Raised in a Slack thread while reviewing a report where the chart added a lot but felt unpolished.

## Changes

- `ReportChart.tsx`: give every chart a bounded box. Graphs still fill a fixed height; self-sizing charts (data tables, single numbers) now always get a max-height ceiling they scroll within, instead of only when an explicit `size` was set. A table taller than its box scrolls inside the card instead of stretching the report down the page.
- `ReportDetail.tsx`: loosen the spacing between the summary text and the charts (inline charts and the trailing-charts block) so they no longer crowd the prose.

Frontend-only, styling/layout. No screenshots attached from this environment — needs a quick visual QA of a report that has a long data-table chart.

## How did you test this code?

Traced the render chain (`ReportChart` → `DataVisualization` embedded path → `LemonTable` `allowContentScroll`) to confirm the missing bounded height was why tables didn't scroll. I (the agent) did not run the app or the frontend lint/typecheck locally (no `node_modules` in this environment), and added no automated tests — this is a CSS/layout change best verified visually. Please QA a report with a tall table to confirm it scrolls within the card and that the added spacing looks right.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. Skills invoked: `/writing-code-comments`. Investigated with an Explore subagent to map the report/chart render path, verified the embedded `DataVisualization` short-circuit that drops the `overflow-auto`/`h-full` wrapper, then scoped the fix to `ReportChart`'s own box sizing (the smallest change that fixes both the no-`size` and clipped-table cases) rather than touching the shared embedded path.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785398308988499?thread_ts=1785398308.988499&cid=C09SK2PAGKF)*
