### PR TITLE
chore(data-warehouse): require new sources to target the vendor's latest API version

### DIFF
--- a/.agents/skills/implementing-warehouse-sources/SKILL.md
+++ b/.agents/skills/implementing-warehouse-sources/SKILL.md
@@ -79,7 +79,7 @@ Follow this order. Each step maps to TODOs in `source.template`.
    - Airbyte: <https://airbyte.com/connectors> (connector pages often link to source code — useful reference)
    - Fivetran: <https://www.fivetran.com/connectors>
    - Stitch: <https://www.stitchdata.com/docs/integrations/>
-     Find the official API docs or OpenAPI spec. Make sure it's the current version, not a deprecated one.
+     Find the official API docs or OpenAPI spec, and **work out the vendor's latest generally-available API version before you write any request code** — that is the version the source must be built against. Check the vendor's changelog, versioning, or deprecation page, not just whichever page ranked first; docs sites routinely default to an older version, and Airbyte/Fivetran connectors are often years behind. See "Vendor API version metadata" for what counts as latest and what to do when the newest channel isn't GA.
 2. **Bootstrap the source.** Copy the template and wire up the enum/type references:
 
    ```sh
@@ -306,9 +306,24 @@ Two cases:
       api_docs_url = "https://vendor.example/docs/api"   # API reference or changelog page (https, not the marketing site)
   ```
 
-  Pin **the version the source's own code actually calls** (the base URL path, a version header, or a version
-  constant in `settings.py` / `{source}.py`) — not the vendor's newest version. Examples already in the tree:
-  GitHub `("2022-11-28",)` (dated header), HubSpot `("v3",)` (path), Klaviyo `("2024-10-15",)` (dated revision).
+  **Build the source against the vendor's latest generally-available version, and pin that.** A new source starts
+  on one version and every customer who connects it lands there, so shipping on an older version means shipping a
+  migration someone has to run later. Two rules, and they must agree:
+
+  1. Write the request code against the newest GA version the vendor offers.
+  2. Declare **the version that code actually calls** (the base URL path, a version header, or a version constant
+     in `settings.py` / `{source}.py`). Never declare a version the code doesn't send — that pin is a lie the
+     framework can't detect, and it makes the deprecation warnings and the upgrade path wrong for every customer.
+
+  If you can't reach the newest version — it's preview/beta/unstable/RC, it's gated behind an application or a
+  paid tier, or its response shapes aren't implemented yet — build against the newest GA version you can actually
+  call, pin that, and say why in a comment on the class. "Latest" means latest stable: don't pin Shopify's
+  `unstable`, a vendor's `-rc` channel, or a version whose docs are still marked preview.
+
+  Examples already in the tree: Anthropic `("2023-06-01",)` (dated `anthropic-version` header),
+  ActiveCampaign `("v3",)` (`/api/3` path segment), Alguna `("2026-04-01",)` (dated version header).
+  A source that later gains a second version declares them oldest→newest — GitHub `("2022-11-28", "2026-03-10")`,
+  HubSpot `("v3", "2026-03")` — but that's the `/warehouse-source-new-version` skill's job, not this one.
 
 - **The vendor has no meaningful API versioning** — set only `api_docs_url`; leave `supported_versions` /
   `default_version` at the framework default (`("v1",)`, the `UNVERSIONED_API_VERSION` sentinel). A bare `/v1/`
@@ -318,6 +333,11 @@ Rules:
 
 - `default_version` must equal the single entry in `supported_versions`, and `api_docs_url` must be `https://`.
 - Use the vendor's exact version string; never invent one.
+- **Never ship a new source on a version the vendor has already deprecated or given a sunset date.** A brand-new
+  source with a `deprecated_versions` entry covering its only version is a bug — it means the source was written
+  against the wrong version. `test_source_versions.py` fails the build if `default_version` is deprecated.
+- Prefer an `api_docs_url` that points at the vendor's versioning/changelog page over a generic API landing page —
+  it's where the next version gets announced, and it's what the next person checks before repinning.
 - Don't hardcode a fallback version in the transport/request layer — resolve it from the source class
   (`self.resolve_api_version(inputs.api_version)`), which already falls back to `default_version`.
 - Adding support for a **new** vendor version later, or **deprecating** an old one, is the


### PR DESCRIPTION
## Problem

The `implementing-warehouse-sources` skill told source authors to pin **"the version the source's own code actually calls ... not the vendor's newest version."**

The clause exists for a good reason — a declared `api_version` that doesn't match what the request layer actually sends is a lie the framework can't detect, and it makes deprecation warnings and the upgrade path wrong for every customer on that source. But read literally it also sanctions the thing we don't want: writing a brand-new source against whatever version the first Airbyte/Fivetran reference happened to use, then declaring that. New sources are the one place where the version is a free choice, and every customer who connects lands on it, so starting behind means shipping a migration for someone else to run later.

There's evidence this already happened. The tree has 27 multi-version sources, and several second versions were added shortly after the source itself landed (Klaviyo, Lightspeed Retail, Marketstack, Pipedrive, Clockodo, Harvey, Zendesk Sunshine all have repin migrations). Some of those were genuine vendor releases; some were catch-up.

## Changes

Docs only — one skill file, no production code.

- **Step 1 of the workflow** now makes establishing the vendor's latest GA version part of surveying the source, before any request code is written, and calls out that vendor docs sites default to older versions and that Airbyte/Fivetran connectors are frequently behind.
- **"Vendor API version metadata"** replaces the "not the vendor's newest version" phrasing with two rules that have to agree: write the request code against the newest GA version, *and* declare the version that code actually sends. The anti-lying invariant is kept and spelled out rather than implied.
- Adds the escape hatch, since "latest" isn't always reachable: if the newest channel is preview/beta/unstable/RC, gated behind an application or paid tier, or its response shapes aren't implemented, build against the newest version you can actually call, pin that, and leave a comment saying why. Explicitly rules out pinning Shopify's `unstable` or a vendor `-rc` channel.
- New rule: never ship a new source on a version the vendor has already deprecated or given a sunset date. A brand-new source whose only version carries a `deprecated_versions` entry is a bug, not a status report — and `test_source_versions.py` already fails the build when `default_version` is deprecated, so this documents an invariant CI enforces.
- Nudges `api_docs_url` toward the vendor's versioning/changelog page rather than a generic API landing page, since that's what the next person checks before repinning.
- Refreshes the examples. GitHub, HubSpot, and Klaviyo were cited as single-version sources and have all since gained a second entry, so the snippet was teaching from stale data. Swapped in three genuinely single-version sources (Anthropic, ActiveCampaign, Alguna) and kept GitHub/HubSpot as the illustration of the oldest→newest ordering, pointing at `/warehouse-source-new-version` for that path.

Deliberately not in scope: no lint or test can check this, because "the vendor's latest version" isn't knowable without a network call to the vendor. This is guidance at the point of authorship, which is the only place it can live.

## How did you test this code?

No automated tests — this changes a markdown skill file and no production code.

- `hogli ci:preflight` in a clean worktree off `origin/master`: 1 changed file, `markdown-format` ✓, 0 failures.
- `markdownlint-cli2` clean (0 errors), and `oxfmt` produces no diff on the file.
- Re-read the surrounding sections for contradictions: nothing else in the skill still says to pin behind the newest, and the "Base-class capability flags & API versioning" section's pointer to `/warehouse-source-new-version` is unchanged and still correct.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Tom asked for this after we went through which sources support multiple vendor API versions and how much of that is forked logic.

The starting question was an audit rather than a change request: 27 of 283 sources declare more than one version, and most of that is thin (a version header or a URL segment threaded through `resolve_api_version`). Only about seven fork on behavior — Greenhouse is the sharpest case, where v1 and v3 take *different credentials* (Harvest API key over HTTP Basic vs an OAuth2 client-credentials Bearer). Working backwards from why so many sources needed a second version so soon after landing pointed at the skill's own wording, which is what this PR fixes.

The main judgment call was not simply deleting the "not the vendor's newest version" clause. It's protecting a real invariant — declared version must equal sent version — so the rewrite keeps that as an explicit rule and adds "target the newest GA" alongside it, rather than trading one failure mode for the other. The preview/beta escape hatch is there because several vendors in the tree ship a perpetually-unstable channel that would otherwise read as "latest".

Skills read while producing this: `/implementing-warehouse-sources` (the file changed) and `/warehouse-source-new-version` (to keep the boundary between the two skills accurate).
