### PR TITLE
fix(batch-exports): freeze time in flaky backfills GET api test

### DIFF
--- a/products/batch_exports/backend/tests/api/backfills/test_get.py
+++ b/products/batch_exports/backend/tests/api/backfills/test_get.py
@@ -1,9 +1,15 @@
 import datetime as dt
 
 import pytest
+from freezegun import freeze_time
 
 from django.test.client import Client as HttpClient
 
+# Pre-import pydantic.v1.types so that pydantic.v1.types.ConstrainedDate is created against the real
+# datetime.date class. Otherwise, when Django lazily resolves URLs inside a freeze_time() block below,
+# pydantic.v1.modules get imported with freezegun's FakeDate in place and pydantic's
+# `class ConstrainedDate(date, metaclass=ConstrainedNumberMeta)` raises a metaclass conflict.
+import pydantic.v1.types  # noqa: F401
 from rest_framework import status
 
 from products.batch_exports.backend.models.batch_export import BatchExportBackfill, BatchExportRun
@@ -160,7 +166,11 @@ def test_can_get_backfills_for_your_organizations(
 
     client.force_login(user)
 
-    backfill_data = get_batch_export_backfill_ok(client, team.pk, batch_export.id, backfill.id)
+    # Freeze time so that BatchExportBackfill.total_expected_runs (which uses datetime.now() for RUNNING backfills
+    # without end_at) yields deterministic results. TEST_TIME is captured at module import, and without this the
+    # asserted total_runs can drift as other tests in the same shard run before this one.
+    with freeze_time(TEST_TIME):
+        backfill_data = get_batch_export_backfill_ok(client, team.pk, batch_export.id, backfill.id)
 
     # as long as the created_at and last_updated_at are strings, we don't care about their exact values
     created_at = backfill_data.pop("created_at")


### PR DESCRIPTION
## Problem

\`test_can_get_backfills_for_your_organizations\` is flaky under shards that run >20 min before reaching it.

The test captures \`TEST_TIME = datetime.now(UTC)\` at module import and uses \`start_at = TEST_TIME - 100min\` for a RUNNING backfill case, expecting \`total_runs = ceil(100min / 1h) = 2\`. But \`BatchExportBackfill.total_expected_runs\` calls \`datetime.now(UTC)\` at request time for RUNNING backfills with \`end_at=None\` ([batch_export.py](https://github.com/PostHog/posthog/blob/master/products/batch_exports/backend/models/batch_export.py#L588)). As elapsed time between module import and test execution grows, the window \`now() - (TEST_TIME - 100min)\` drifts upward. Past 120 min it flips \`ceil\` from 2 to 3 and the assertion fails (\`total_runs: 3 vs 2\`).

## Changes

Freeze time at \`TEST_TIME\` around the API call so serializer and test expectation share the same reference clock.

One subtlety: pydantic v1's \`ConstrainedDate(date, metaclass=ConstrainedNumberMeta)\` is defined at import time, and freezegun swaps \`datetime.date\` inside \`freeze_time()\`. When Django's lazy URL resolution first triggers pydantic v1's import inside a frozen block, the class body executes against \`FakeDate\` and raises a metaclass conflict. Pre-importing \`pydantic.v1.types\` at module scope ensures the class is built once with the real \`date\` before any freeze runs, after which \`sys.modules\` caching keeps it out of every frozen window.

## How did you test this code?

No manual testing. Automated runs in the local flox dev env (Python 3.13, pydantic v1, freezegun 1.5.5):

- \`pytest products/batch_exports/backend/tests/api/backfills/test_get.py\` — 12/12 pass (previously 1/12 failed standalone due to the pydantic v1 import-under-freeze crash)
- \`pytest products/batch_exports/backend/tests/api/backfills/\` — 41/41 pass

On master the standalone run passed only because pydantic v1 happened to be imported before the freeze in this environment; the freeze-time / pre-import combo is robust regardless of import order.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

skip-inkeep-docs

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — ross@posthog.com

Authored by Claude Code via PostHog Code. Approach after confirming the original hypothesis (TEST_TIME captured at import, serializer reads real-now at request time): first tried \`mock.patch(wraps=dt.datetime)\`, which hit a pydantic v1 validators.py inheritance-check crash. Switched to \`freeze_time\` matching the pattern in \`test_create.py\`, which surfaced the pydantic v1 / FakeDate metaclass conflict on the first lazy import inside the freeze. Diagnosed via standalone pytest run; the sibling test file (and full-directory runs) never hit it because an earlier test absorbs the lazy import before any freeze. Settled on pre-importing \`pydantic.v1.types\` at module scope. No repo skills invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*