### PR TITLE
fix(experiments): clamp hypothesis to two lines in experiments list

### DIFF
--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -17,6 +17,7 @@ import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { atColumn, createdAtColumn, createdByColumn } from 'lib/lemon-ui/LemonTable/columnUtils'
@@ -254,7 +255,14 @@ const ExperimentsTable = ({
                                 )}
                             </>
                         }
-                        description={experiment.description}
+                        description={
+                            experiment.description ? (
+                                // Hypotheses can run many paragraphs, so clamp to keep list rows compact
+                                <LemonMarkdown className="max-w-[30rem] line-clamp-2" lowKeyHeadings>
+                                    {experiment.description}
+                                </LemonMarkdown>
+                            ) : undefined
+                        }
                     />
                 )
             },

--- a/frontend/src/scenes/experiments/Experiments.tsx
+++ b/frontend/src/scenes/experiments/Experiments.tsx
@@ -258,7 +258,7 @@ const ExperimentsTable = ({
                         description={
                             experiment.description ? (
                                 // Hypotheses can run many paragraphs, so clamp to keep list rows compact
-                                <LemonMarkdown className="max-w-[30rem] line-clamp-2" lowKeyHeadings>
+                                <LemonMarkdown className="max-w-[30rem] line-clamp-2" lowKeyHeadings disableImages>
                                     {experiment.description}
                                 </LemonMarkdown>
                             ) : undefined


### PR DESCRIPTION
## Problem

Experiment descriptions render as full markdown in the experiments list. A long hypothesis makes its row several hundred pixels tall, and a few of them make the list unusable.

## Changes

Clamp the description in the list to two lines with an ellipsis (`line-clamp-2` on the `LemonMarkdown` block). The full hypothesis is still available on the experiment page.

## How did you test this code?

Not verified visually or typechecked locally (light worktree without node_modules); relying on CI for the typecheck. The change is a single JSX wrapper using props `LemonTableLink` already passes to `LemonMarkdown`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Considered clamping in the shared `LemonTableLink` description rendering (would fix all list views at once) but scoped it to the experiments list to avoid touching every table. Skills invoked: /writing-code-comments.
