### PR TITLE
feat(conversations): keep ticket thread position, add "See new messages" pill

### DIFF
--- a/products/conversations/frontend/components/Chat/MessageList.test.tsx
+++ b/products/conversations/frontend/components/Chat/MessageList.test.tsx
@@ -1,0 +1,155 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import type { ChatMessage } from '../../types'
+import { MessageList } from './MessageList'
+
+// The real Message pulls in the tiptap-backed Editor exports for markdown and rich content; the
+// behavior under test is MessageList's own scroll handling, which only needs a stand-in row.
+jest.mock('./Message', () => {
+    const React = jest.requireActual<typeof import('react')>('react')
+    return {
+        Message: ({ message }: { message: ChatMessage }) =>
+            React.createElement('div', { 'data-attr': `message-${message.id}` }, message.content),
+    }
+})
+
+// jsdom has no layout, so the component's "is the reader at the bottom?" arithmetic
+// (scrollHeight - scrollTop - clientHeight < 120) needs fixed geometry. With these, the reader is
+// pinned to the bottom above scrollTop 480 and reading history below it.
+const SCROLL_HEIGHT = 1000
+const CLIENT_HEIGHT = 400
+const AT_BOTTOM = 600
+const SCROLLED_UP = 100
+
+const PILL = 'See new messages'
+
+function message(id: string, createdAt: string): ChatMessage {
+    return {
+        id,
+        content: `Message ${id}`,
+        authorType: 'customer',
+        authorName: 'Customer',
+        createdAt,
+    }
+}
+
+const FIRST = message('1', '2026-01-01T00:00:00Z')
+const SECOND = message('2', '2026-01-01T00:01:00Z')
+const OLDER = message('0', '2025-12-31T00:00:00Z')
+
+function scrollContainer(): HTMLElement {
+    return screen.getByTestId('message-list-scroll')
+}
+
+/** Move the reader and fire the scroll event the component listens for. */
+function scrollTo(top: number): void {
+    const container = scrollContainer()
+    container.scrollTop = top
+    fireEvent.scroll(container)
+}
+
+let scrollToSpy: jest.Mock
+
+describe('MessageList', () => {
+    beforeEach(() => {
+        scrollToSpy = jest.fn()
+        Element.prototype.scrollTo = scrollToSpy
+        Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+            configurable: true,
+            get: () => SCROLL_HEIGHT,
+        })
+        Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+            configurable: true,
+            get: () => CLIENT_HEIGHT,
+        })
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('opens the thread at the latest message when content first loads', () => {
+        render(<MessageList messages={[FIRST]} messagesLoading={false} />)
+
+        expect(scrollToSpy).toHaveBeenCalledWith({ top: SCROLL_HEIGHT, behavior: 'instant' })
+        expect(screen.queryByText(PILL)).not.toBeInTheDocument()
+    })
+
+    it('follows the tail when a new message arrives while the reader is at the bottom', () => {
+        const { rerender } = render(<MessageList messages={[FIRST]} messagesLoading={false} />)
+        scrollTo(AT_BOTTOM)
+        scrollToSpy.mockClear()
+
+        rerender(<MessageList messages={[FIRST, SECOND]} messagesLoading={false} />)
+
+        expect(scrollToSpy).toHaveBeenCalledWith({ top: SCROLL_HEIGHT, behavior: 'smooth' })
+        expect(screen.queryByText(PILL)).not.toBeInTheDocument()
+    })
+
+    it('holds position and offers the pill when a message arrives after the reader scrolls up', () => {
+        const { rerender } = render(<MessageList messages={[FIRST]} messagesLoading={false} />)
+        scrollTo(SCROLLED_UP)
+        scrollToSpy.mockClear()
+
+        rerender(<MessageList messages={[FIRST, SECOND]} messagesLoading={false} />)
+
+        expect(scrollToSpy).not.toHaveBeenCalled()
+        expect(screen.getByText(PILL)).toBeInTheDocument()
+    })
+
+    // The regression this PR exists for: agent reports load on their own async request, so one can
+    // land long after the messages have settled and must not yank a reader out of history.
+    it('holds position and offers the pill when an agent report arrives after the reader scrolls up', () => {
+        const { rerender } = render(<MessageList messages={[FIRST]} messagesLoading={false} extras={[]} />)
+        scrollTo(SCROLLED_UP)
+        scrollToSpy.mockClear()
+
+        rerender(
+            <MessageList
+                messages={[FIRST]}
+                messagesLoading={false}
+                extras={[{ at: '2026-01-01T00:02:00Z', element: <div key="report">Agent report</div> }]}
+            />
+        )
+
+        expect(scrollToSpy).not.toHaveBeenCalled()
+        expect(screen.getByText(PILL)).toBeInTheDocument()
+    })
+
+    it('does not offer the pill when older messages are prepended', () => {
+        const { rerender } = render(<MessageList messages={[FIRST]} messagesLoading={false} />)
+        scrollTo(SCROLLED_UP)
+        scrollToSpy.mockClear()
+
+        // "Load older" grows messages.length but leaves the newest message unchanged.
+        rerender(<MessageList messages={[OLDER, FIRST]} messagesLoading={false} />)
+
+        expect(scrollToSpy).not.toHaveBeenCalled()
+        expect(screen.queryByText(PILL)).not.toBeInTheDocument()
+    })
+
+    it('jumps to the latest and dismisses the pill when it is clicked', () => {
+        const { rerender } = render(<MessageList messages={[FIRST]} messagesLoading={false} />)
+        scrollTo(SCROLLED_UP)
+        rerender(<MessageList messages={[FIRST, SECOND]} messagesLoading={false} />)
+        scrollToSpy.mockClear()
+
+        fireEvent.click(screen.getByText(PILL))
+
+        expect(scrollToSpy).toHaveBeenCalledWith({ top: SCROLL_HEIGHT, behavior: 'smooth' })
+        expect(screen.queryByText(PILL)).not.toBeInTheDocument()
+    })
+
+    it('dismisses the pill once the reader scrolls back to the bottom themselves', () => {
+        const { rerender } = render(<MessageList messages={[FIRST]} messagesLoading={false} />)
+        scrollTo(SCROLLED_UP)
+        rerender(<MessageList messages={[FIRST, SECOND]} messagesLoading={false} />)
+        expect(screen.getByText(PILL)).toBeInTheDocument()
+
+        scrollTo(AT_BOTTOM)
+
+        expect(screen.queryByText(PILL)).not.toBeInTheDocument()
+    })
+})

--- a/products/conversations/frontend/components/Chat/MessageList.tsx
+++ b/products/conversations/frontend/components/Chat/MessageList.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
-import { Spinner } from '@posthog/lemon-ui'
+import { LemonButton, Spinner } from '@posthog/lemon-ui'
+
+import { IconArrowDown } from 'lib/lemon-ui/icons'
 
 import type { AiReplyFeedbackRating, ChatMessage, MessageDeliveryStatus } from '../../types'
 import { Message } from './Message'
@@ -73,6 +75,16 @@ export function MessageList({
     // Latches once the thread has been opened at the bottom, so that initial jump
     // happens exactly once per loaded thread rather than on every content change.
     const openedAtBottomRef = useRef(false)
+    // Raised when new tail content lands while the reader has scrolled up into
+    // history. Drives the "See new messages" pill so they can drop to the latest
+    // on their own terms instead of being yanked down.
+    const [newContentBelow, setNewContentBelow] = useState(false)
+    // The newest message id, so the effect can tell a real tail append (or a new
+    // agent report) from an older-page prepend — "Load older" grows messages.length
+    // too, but must never raise the pill.
+    const lastMessageId = messages.length > 0 ? messages[messages.length - 1].id : null
+    const prevLastMessageIdRef = useRef<string | null>(null)
+    const prevExtrasCountRef = useRef(0)
 
     const scrollToBottom = (behavior: ScrollBehavior = 'smooth'): void => {
         const container = containerRef.current
@@ -81,13 +93,28 @@ export function MessageList({
         }
     }
 
+    const jumpToLatest = (): void => {
+        pinnedToBottomRef.current = true
+        setNewContentBelow(false)
+        scrollToBottom()
+    }
+
     useEffect(() => {
-        // No content yet: reset the latch so a freshly loaded thread opens at the
-        // bottom again (e.g. after switching tickets).
+        // No content yet: reset the latch and tail tracking so a freshly loaded
+        // thread opens at the bottom again (e.g. after switching tickets).
         if (messages.length === 0 && extras.length === 0) {
             openedAtBottomRef.current = false
+            prevLastMessageIdRef.current = null
+            prevExtrasCountRef.current = 0
+            setNewContentBelow(false)
             return
         }
+
+        const prevLastMessageId = prevLastMessageIdRef.current
+        const prevExtrasCount = prevExtrasCountRef.current
+        prevLastMessageIdRef.current = lastMessageId
+        prevExtrasCountRef.current = extras.length
+
         // Open at the latest message the first time content lands, instantly.
         if (!openedAtBottomRef.current) {
             openedAtBottomRef.current = true
@@ -95,13 +122,23 @@ export function MessageList({
             scrollToBottom('instant')
             return
         }
-        // Afterwards only follow the tail when the reader is already there, so a
-        // message or an extra (agent report) arriving while they've scrolled up
-        // into history leaves their position untouched.
+
+        // Only a tail append (newest message id advanced) or a new extra (agent
+        // report) counts as new content below. Prepending older pages changes
+        // messages[0], not the last id, so "Load older" never raises the pill.
+        const tailGrew = lastMessageId !== prevLastMessageId || extras.length > prevExtrasCount
+        if (!tailGrew) {
+            return
+        }
+
+        // Follow the tail when the reader is already there; otherwise hold their
+        // position and raise the pill so they can drop to the latest themselves.
         if (pinnedToBottomRef.current) {
             scrollToBottom()
+        } else {
+            setNewContentBelow(true)
         }
-    }, [messages.length, extras.length])
+    }, [lastMessageId, extras.length, messages.length])
 
     const handleScroll = (): void => {
         const container = containerRef.current
@@ -112,6 +149,10 @@ export function MessageList({
         // Track whether the reader is pinned to the bottom. The window is generous
         // so a smooth auto-scroll still in flight keeps counting as pinned.
         pinnedToBottomRef.current = container.scrollHeight - container.scrollTop - container.clientHeight < 120
+        // Returning to the bottom (by the pill or by hand) clears the pill.
+        if (pinnedToBottomRef.current) {
+            setNewContentBelow(false)
+        }
 
         if (olderMessagesLoading || !hasMoreMessages || !onLoadOlderMessages) {
             return
@@ -185,28 +226,46 @@ export function MessageList({
         .map(({ element }) => element)
 
     return (
-        <div
-            ref={containerRef}
-            onScroll={handleScroll}
-            className={`flex-1 overflow-y-auto space-y-1.5 ${className}`}
-            style={{ minHeight, maxHeight }}
-        >
-            {olderMessagesLoading && (
-                <div className="flex items-center justify-center py-2">
-                    <Spinner className="text-sm" />
+        <div className="relative flex flex-col flex-1 min-h-0">
+            <div
+                ref={containerRef}
+                onScroll={handleScroll}
+                className={`flex-1 overflow-y-auto space-y-1.5 ${className}`}
+                style={{ minHeight, maxHeight }}
+            >
+                {olderMessagesLoading && (
+                    <div className="flex items-center justify-center py-2">
+                        <Spinner className="text-sm" />
+                    </div>
+                )}
+                {messagesLoading && messages.length === 0 ? (
+                    <div className="flex items-center justify-center h-full">
+                        <Spinner />
+                    </div>
+                ) : messages.length === 0 ? (
+                    <div className="flex items-center justify-center h-full text-muted-alt text-sm">{emptyMessage}</div>
+                ) : (
+                    <>
+                        {timeline}
+                        <div ref={messagesEndRef} />
+                    </>
+                )}
+            </div>
+            {/* Sits over the bottom of the thread, not in the scroll flow, so it stays put as a
+                jump-to-latest affordance while the reader is up in history. The strip ignores
+                pointer events so only the pill itself is clickable. */}
+            {newContentBelow && (
+                <div className="absolute inset-x-0 bottom-2 flex justify-center pointer-events-none">
+                    <LemonButton
+                        type="primary"
+                        size="small"
+                        icon={<IconArrowDown />}
+                        onClick={jumpToLatest}
+                        className="pointer-events-auto rounded-full shadow-md"
+                    >
+                        See new messages
+                    </LemonButton>
                 </div>
-            )}
-            {messagesLoading && messages.length === 0 ? (
-                <div className="flex items-center justify-center h-full">
-                    <Spinner />
-                </div>
-            ) : messages.length === 0 ? (
-                <div className="flex items-center justify-center h-full text-muted-alt text-sm">{emptyMessage}</div>
-            ) : (
-                <>
-                    {timeline}
-                    <div ref={messagesEndRef} />
-                </>
             )}
         </div>
     )

--- a/products/conversations/frontend/components/Chat/MessageList.tsx
+++ b/products/conversations/frontend/components/Chat/MessageList.tsx
@@ -226,12 +226,16 @@ export function MessageList({
         .map(({ element }) => element)
 
     return (
-        <div className="relative flex flex-col flex-1 min-h-0">
+        // The wrapper is the component root, so it keeps the contract the scroll container used to
+        // hold: it takes the caller's className and the height bounds, and stays the flex child
+        // callers lay out against. Without that, a caller's spacing (e.g. `mb-3`) would land inside
+        // the wrapper and stop separating the thread from whatever follows it.
+        <div className={`relative flex flex-col flex-1 ${className}`} style={{ minHeight, maxHeight }}>
             <div
                 ref={containerRef}
                 onScroll={handleScroll}
-                className={`flex-1 overflow-y-auto space-y-1.5 ${className}`}
-                style={{ minHeight, maxHeight }}
+                data-attr="message-list-scroll"
+                className="flex-1 min-h-0 overflow-y-auto space-y-1.5"
             >
                 {olderMessagesLoading && (
                     <div className="flex items-center justify-center py-2">

--- a/products/conversations/frontend/components/Chat/MessageList.tsx
+++ b/products/conversations/frontend/components/Chat/MessageList.tsx
@@ -63,26 +63,57 @@ export function MessageList({
 }: MessageListProps): JSX.Element {
     const messagesEndRef = useRef<HTMLDivElement>(null)
     const containerRef = useRef<HTMLDivElement>(null)
+    // Whether the reader is at (or near) the bottom of the thread. Starts true so
+    // the thread opens on its latest message; scrolling up clears it and scrolling
+    // back down restores it. Auto-scroll is gated on this so late-arriving content
+    // — notably a self-driving agent report, which loads on its own async request
+    // separate from the polled messages — never yanks a reader who has scrolled up
+    // into history back down to the bottom.
+    const pinnedToBottomRef = useRef(true)
+    // Latches once the thread has been opened at the bottom, so that initial jump
+    // happens exactly once per loaded thread rather than on every content change.
+    const openedAtBottomRef = useRef(false)
 
-    const scrollToBottom = (): void => {
-        if (containerRef.current && messagesEndRef.current) {
-            containerRef.current.scrollTo({
-                top: containerRef.current.scrollHeight,
-                behavior: 'smooth',
-            })
+    const scrollToBottom = (behavior: ScrollBehavior = 'smooth'): void => {
+        const container = containerRef.current
+        if (container) {
+            container.scrollTo({ top: container.scrollHeight, behavior })
         }
     }
 
     useEffect(() => {
-        if (messages.length > 0 || extras.length > 0) {
+        // No content yet: reset the latch so a freshly loaded thread opens at the
+        // bottom again (e.g. after switching tickets).
+        if (messages.length === 0 && extras.length === 0) {
+            openedAtBottomRef.current = false
+            return
+        }
+        // Open at the latest message the first time content lands, instantly.
+        if (!openedAtBottomRef.current) {
+            openedAtBottomRef.current = true
+            pinnedToBottomRef.current = true
+            scrollToBottom('instant')
+            return
+        }
+        // Afterwards only follow the tail when the reader is already there, so a
+        // message or an extra (agent report) arriving while they've scrolled up
+        // into history leaves their position untouched.
+        if (pinnedToBottomRef.current) {
             scrollToBottom()
         }
-        // Extras land in the same stream, so one arriving has to scroll like a message does.
     }, [messages.length, extras.length])
 
     const handleScroll = (): void => {
         const container = containerRef.current
-        if (!container || olderMessagesLoading || !hasMoreMessages || !onLoadOlderMessages) {
+        if (!container) {
+            return
+        }
+
+        // Track whether the reader is pinned to the bottom. The window is generous
+        // so a smooth auto-scroll still in flight keeps counting as pinned.
+        pinnedToBottomRef.current = container.scrollHeight - container.scrollTop - container.clientHeight < 120
+
+        if (olderMessagesLoading || !hasMoreMessages || !onLoadOlderMessages) {
             return
         }
 


### PR DESCRIPTION
## Problem

In a Conversations support ticket, the message thread jumps to the bottom whenever a self-driving PostHog agent note arrives, even when the reader has scrolled up to read earlier context. That interrupts anyone reading history while the agent is still posting.

The agent's findings render as thread "extras" (linked signal reports), which load through their own async request, separate from the polled messages. The `MessageList` auto-scroll effect called `scrollToBottom()` on every change to `messages.length` or `extras.length` with no check of where the reader was, so each extra that landed forced a scroll to the bottom.

## Changes

`MessageList` now gates auto-scroll on whether the reader is pinned to the bottom, tracked from the scroll container's position:

- The thread still opens at the latest message (once, instantly) when content first loads.
- While the reader sits at the bottom, new messages and extras keep following the tail as before.
- Once the reader scrolls up, a message or extra arriving leaves their position untouched.
- Instead of doing nothing in that case, a **"See new messages" pill** appears over the bottom of the thread (the Slack/Discord convention). Clicking it drops to the latest; scrolling back to the bottom by hand clears it.

Tail-append detection keys on the newest message id, so prepending older pages via "Load older" (which also grows `messages.length`) never raises the pill. As a side benefit, loading older messages no longer bounces back to the bottom either.

The pill needs a positioned wrapper around the scroll container. That wrapper is now the component root, so it takes the caller's `className` and the `minHeight`/`maxHeight` bounds — the contract the scroll container used to hold — and the inner element keeps only `flex-1 min-h-0 overflow-y-auto`.

## How did you test this code?

New `MessageList.test.tsx` covers the branches this logic turns on: opening at the latest message, following the tail while pinned, holding position and offering the pill when a message *or* an agent report lands after scrolling up, staying quiet when older messages are prepended, and dismissing the pill by click and by scrolling back down. jsdom has no layout, so the tests stub `scrollHeight`/`clientHeight` and drive `scrollTop` to place the reader.

I (Claude, agent-assisted) ran:

- `MessageList.test.tsx` — 7 passed
- all `products/conversations/frontend` tests — 13 suites, 134 passed
- `tsgo --noEmit` — no errors in the changed files
- `oxlint` / `oxfmt --check` — clean (one pre-existing `style`-prop warning, now on the wrapper)

I mutation-tested the new tests rather than trusting a green run: reverting the pinned-position guard fails 4 of the 7, and making the tail-growth check unconditional fails the prepend test — so every branch is genuinely covered.

Not done: I have not exercised this in a running app, so the visual placement of the pill (and how it reads over real thread content) still wants a human look.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Luke directed this from a Slack thread. I first fixed it in the wrong repo (the `hogdesk` support shell) before Luke pointed out the real code lives here in `products/conversations`; that hogdesk PR has been closed. Root-causing landed on `MessageList.tsx`'s scroll effect being keyed on counts alone, with agent reports (`extras`) arriving on a separate async loader (`loadLinkedReports` / `signalsReportsList`) than the polled messages (`api.comments.list`), so they fired the scroll at arbitrary times. Luke then asked for the jump-to-latest pill rather than silently holding position.

Both Greptile findings were valid and are fixed: the missing regression coverage, and a layout regression where the new wrapper swallowed the caller's spacing (`SidePanel/Ticket.tsx` passes `className="mb-3"` to separate the thread from the composer). Tools: Claude Code with a read-only Explore sub-agent for codebase search. No repo skills were invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C075D3C5HST/p1785407180695629)*
