### PR TITLE
fix(sql-editor): keep raw mode when opening managed queries

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -1599,6 +1599,25 @@ describe('sqlEditorLogic', () => {
             expect(logic.values.selectedConnectionSupportsHogQL).toEqual(true)
             expect(logic.values.sourceQuery.source.sendRawQuery).toEqual(true)
             expect(logic.values.sendRawQueryEnabled).toEqual(true)
+
+            // The database sidebar opens a query through this URL without a raw hash param.
+            // The connection stays the same, so the query-opening path must reapply the default.
+            router.actions.push(
+                urls.sqlEditor({
+                    query: 'SELECT * FROM managed_warehouse.events',
+                    connectionId: 'managed-conn-1',
+                })
+            )
+
+            await expectLogic(logic).toDispatchActions(['setSourceQuery', 'createTab', 'updateTab'])
+
+            expect(logic.values.sourceQuery.source.sendRawQuery).toEqual(true)
+            expect(logic.values.sendRawQueryEnabled).toEqual(true)
+            expect(String(router.values.hashParams.raw)).toEqual('1')
+
+            logic.actions.setSendRawQuery(false)
+
+            expect(logic.values.sendRawQueryEnabled).toEqual(false)
         })
 
         it('does not force raw SQL mode for a user-managed Postgres direct connection', async () => {

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -1814,6 +1814,10 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                     actions.setQueryInput(insightVisualizationQuery.source.query || '')
                 }
 
+                // Opening another query can replace sourceQuery without changing the connection,
+                // so the selectedConnectionId subscription does not run again.
+                actions.enforceConnectionRawQueryMode()
+
                 // Focus the editor after creating a new tab
                 props.editor?.focus()
             },


### PR DESCRIPTION
## Problem

The managed warehouse connection defaults to Send raw query, but opening another query from the editor database sidebar clears the URL raw flag. Because the connection ID does not change, the connection-change guard does not run again and the checkbox becomes unchecked.

Follow-up to #74679.

## Changes

Reapply the connection raw-query default whenever the SQL editor opens or creates a query. This shared path covers sidebar table queries, view previews, saved views, insights, and URL-opened queries while preserving a manual toggle change on the current query.

Extend the managed warehouse logic test with the same-connection sidebar URL flow and verify that manually turning the option off still works afterward.

## How did you test this code?

- Ran the complete SQL editor logic Jest suite: 86 tests passed.
- Ran frontend formatting and lint fixes successfully.
- Ran hogli ci:preflight --fix after updating from master. It passed with no failures or advisories.
- The repository-wide TypeScript check was attempted before updating from master, but the isolated worktree could not resolve existing quill and hogvm workspace packages. No reported errors referenced the two changed files.

The extended logic case catches the regression where opening a query on the already-selected managed connection drops Send raw query because the connection subscription does not fire.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation change is needed for this correction to the existing SQL editor default. Added the skip-inkeep-docs label.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex desktop implemented this follow-up and used the writing-kea-logics, writing-tests, running-ci-preflight, and GitHub publish workflow skills. The shared create-query listener was chosen over patching only the sidebar so all full-editor query entry points apply the same default without overriding a manual toggle on the current query.