### PR TITLE
feat(insights): add date range exclusions to the insight date filter

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -408,8 +408,9 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
                     {showExplicitDateToggle && (
                         <div
                             className={clsx(
-                                'LemonSwitch LemonSwitch--full-width',
-                                `LemonSwitch--${optionsSize}`,
+                                // Deliberately medium at every optionsSize: LemonButton--small keeps the default
+                                // 14px font, while LemonSwitch--small would drop the label to 12px
+                                'LemonSwitch LemonSwitch--full-width LemonSwitch--medium',
                                 optionsSize === 'small' ? 'pb-1 pt-1' : 'pb-2 pt-2'
                             )}
                         >

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -100,7 +100,6 @@ interface RawDateFilterProps extends DateFilterProps {
     onExclusionsChange?: (exclusions: DateFilterExclusions) => void
     showIncompletePeriodExclusion?: boolean
     showDaysOfWeekExclusions?: boolean
-    /** Size of the option rows in the dropdown. Defaults to medium. */
     optionsSize?: 'small' | 'medium'
 }
 
@@ -290,14 +289,9 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
             />
         ) : (
             <div className="flex max-h-full min-h-0 flex-col" ref={optionsRef} onClick={(e) => e.stopPropagation()}>
-                {/* The preset list scrolls on short screens; the custom options, toggles, and
-                    exclusions below stay pinned (mirrors the quill DateRangePresetsPanel). The
-                    scroll area's own border doubles as the divider so it sits exactly at the
-                    scroll cutoff. */}
                 <ScrollableShadows
                     direction="vertical"
-                    // max-h shows ~9 preset rows with a sliver of the tenth as a scroll hint; the
-                    // shadow and clipped row signal scrollability, so skip the scrollbar gutter
+                    // max-h-80 shows ~9 preset rows with a sliver of the tenth as a scroll hint
                     hideScrollbars
                     className={clsx('min-h-0 flex-1 border-b', optionsSize === 'small' && 'max-h-80')}
                     innerClassName="deprecated-space-y-px p-1"
@@ -478,8 +472,6 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
             additionalRefs={[rollingDateRangeRef]}
             onClickOutside={close}
             closeParentPopoverOnClickInside={false}
-            // The quick list manages its own scrolling (presets scroll, footer pinned); the
-            // calendar views keep the popover's default scroll container.
             overflowHidden={view === DateFilterView.QuickList}
         >
             {renderTrigger ? (

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -13,6 +13,7 @@ import {
     DateFilterView,
     NO_OVERRIDE_RANGE_PLACEHOLDER,
 } from 'lib/components/DateFilter/types'
+import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { dayjs } from 'lib/dayjs'
 import { LemonCalendarSelect, LemonCalendarSelectProps } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
 import { LemonCalendarRange } from 'lib/lemon-ui/LemonCalendarRange/LemonCalendarRange'
@@ -26,9 +27,11 @@ import { ResolvedDateRangeResponse } from '~/queries/schema/schema-general'
 import { DateMappingOption, PropertyOperator } from '~/types'
 
 import { PropertyFilterDatePicker } from '../PropertyFilters/components/PropertyFilterDatePicker'
+import type { DateFilterExclusions } from './DateFilterExclusionsControl'
 import { dateFilterLogic } from './dateFilterLogic'
 import { FixedRangeWithTimePicker } from './FixedRangeWithTimePicker'
 import { JumpToTimestampPicker } from './JumpToTimestampPicker'
+import { LemonDateFilterExclusions } from './LemonDateFilterExclusions'
 import { RelativeDateRangeSelector } from './RelativeDateRangeSelector'
 import { RollingDateRangeFilter } from './RollingDateRangeFilter'
 import { DateOption } from './rollingDateRangeFilterLogic'
@@ -93,6 +96,12 @@ interface RawDateFilterProps extends DateFilterProps {
     use24HourFormat?: boolean
     explicitDate?: boolean
     showExplicitDateToggle?: boolean
+    exclusions?: DateFilterExclusions
+    onExclusionsChange?: (exclusions: DateFilterExclusions) => void
+    showIncompletePeriodExclusion?: boolean
+    showDaysOfWeekExclusions?: boolean
+    /** Size of the option rows in the dropdown. Defaults to medium. */
+    optionsSize?: 'small' | 'medium'
 }
 
 export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(function DateFilter(
@@ -121,6 +130,11 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
         use24HourFormat = false,
         explicitDate,
         showExplicitDateToggle = false,
+        exclusions,
+        onExclusionsChange,
+        showIncompletePeriodExclusion = false,
+        showDaysOfWeekExclusions = false,
+        optionsSize,
         resolvedDateRange,
         showJumpToTimestamp = false,
         showCustomRelativeRange = false,
@@ -198,6 +212,8 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
     )
 
     const showFixedRangeTimeToggle = allowTimePrecision || allowFixedRangeWithTime
+    const showExclusions =
+        (showIncompletePeriodExclusion || showDaysOfWeekExclusions) && !!exclusions && !!onExclusionsChange
 
     const popoverOverlay =
         view === DateFilterView.FixedRange ? (
@@ -273,109 +289,135 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
                 initialTo={typeof dateTo === 'string' ? dateTo : null}
             />
         ) : (
-            <div className="deprecated-space-y-px" ref={optionsRef} onClick={(e) => e.stopPropagation()}>
-                {dateOptions.map(({ key, values, inactive }) => {
-                    if (key === CUSTOM_OPTION_KEY && !showCustom) {
-                        return null
-                    }
-
-                    if (inactive && label !== key) {
-                        return null
-                    }
-
-                    const isActive =
-                        (dateFrom ?? null) === (values[0] ?? null) && (dateTo ?? null) === (values[1] ?? null)
-                    const dateValue = dateFilterToText(
-                        values[0],
-                        values[1],
-                        CUSTOM_OPTION_DESCRIPTION,
-                        dateOptions,
-                        isDateFormatted,
-                        undefined,
-                        undefined,
-                        weekStartDay
-                    )
-                    const startOfRangeDateValue = dateFilterToText(
-                        values[0],
-                        undefined,
-                        '',
-                        [],
-                        false,
-                        'MMMM D, YYYY',
-                        true
-                    )
-                    const endOfRangeDateValue = values[1]
-                        ? dateFilterToText(values[1], undefined, '', [], false, 'MMMM D, YYYY', true)
-                        : undefined
-
-                    return (
-                        <Tooltip
-                            key={key}
-                            title={
-                                makeLabel ? makeLabel(dateValue, startOfRangeDateValue, endOfRangeDateValue) : undefined
-                            }
-                        >
-                            <LemonButton
-                                key={key}
-                                data-attr={`date-filter-${key.toLowerCase().replace(/\s+/g, '-')}`}
-                                onClick={() => setDate(values[0] || null, values[1] || null, false, explicitDate)}
-                                active={isActive}
-                                fullWidth
-                            >
-                                {key === CUSTOM_OPTION_KEY ? NO_OVERRIDE_RANGE_PLACEHOLDER : key}
-                            </LemonButton>
-                        </Tooltip>
-                    )
-                })}
-                {showRollingRangePicker && (
-                    <RollingDateRangeFilter
-                        pageKey={key}
-                        dateFrom={dateFrom}
-                        dateRangeFilterLabel={isFixedDateMode ? 'Last' : undefined}
-                        selected={isRollingDateRange}
-                        onChange={(fromDate) => {
-                            setDate(fromDate, '', true, explicitDate)
-                        }}
-                        makeLabel={makeLabel}
-                        popover={{
-                            ref: rollingDateRangeRef,
-                        }}
-                        max={max}
-                        allowedDateOptions={
-                            isFixedDateMode && !allowedRollingDateOptions
-                                ? ['hours', 'days', 'weeks', 'months', 'years']
-                                : allowedRollingDateOptions
+            <div className="flex max-h-full min-h-0 flex-col" ref={optionsRef} onClick={(e) => e.stopPropagation()}>
+                {/* The preset list scrolls on short screens; the custom options, toggles, and
+                    exclusions below stay pinned (mirrors the quill DateRangePresetsPanel). The
+                    scroll area's own border doubles as the divider so it sits exactly at the
+                    scroll cutoff. */}
+                <ScrollableShadows
+                    direction="vertical"
+                    // max-h shows ~9 preset rows with a sliver of the tenth as a scroll hint; the
+                    // shadow and clipped row signal scrollability, so skip the scrollbar gutter
+                    hideScrollbars
+                    className={clsx('min-h-0 flex-1 border-b', optionsSize === 'small' && 'max-h-80')}
+                    innerClassName="deprecated-space-y-px p-1"
+                >
+                    {dateOptions.map(({ key, values, inactive }) => {
+                        if (key === CUSTOM_OPTION_KEY && !showCustom) {
+                            return null
                         }
-                        fullWidth
-                    />
-                )}
-                <LemonDivider />
-                {(isFixedDateMode || allowSingleAndRange) && (
-                    <LemonButton onClick={openFixedDate} active={isFixedDate} fullWidth>
-                        Custom date...
-                    </LemonButton>
-                )}
-                {(!isFixedDateMode || allowSingleAndRange) && (
-                    <>
-                        {!allowSingleAndRange && (
-                            <LemonButton onClick={openDateToNow} active={isDateToNow} fullWidth>
-                                From custom date until now…
-                            </LemonButton>
-                        )}
-                        <LemonButton onClick={openFixedRange} active={isFixedRange} fullWidth>
-                            Custom fixed date range…
+
+                        if (inactive && label !== key) {
+                            return null
+                        }
+
+                        const isActive =
+                            (dateFrom ?? null) === (values[0] ?? null) && (dateTo ?? null) === (values[1] ?? null)
+                        const dateValue = dateFilterToText(
+                            values[0],
+                            values[1],
+                            CUSTOM_OPTION_DESCRIPTION,
+                            dateOptions,
+                            isDateFormatted,
+                            undefined,
+                            undefined,
+                            weekStartDay
+                        )
+                        const startOfRangeDateValue = dateFilterToText(
+                            values[0],
+                            undefined,
+                            '',
+                            [],
+                            false,
+                            'MMMM D, YYYY',
+                            true
+                        )
+                        const endOfRangeDateValue = values[1]
+                            ? dateFilterToText(values[1], undefined, '', [], false, 'MMMM D, YYYY', true)
+                            : undefined
+
+                        return (
+                            <Tooltip
+                                key={key}
+                                title={
+                                    makeLabel
+                                        ? makeLabel(dateValue, startOfRangeDateValue, endOfRangeDateValue)
+                                        : undefined
+                                }
+                            >
+                                <LemonButton
+                                    key={key}
+                                    data-attr={`date-filter-${key.toLowerCase().replace(/\s+/g, '-')}`}
+                                    onClick={() => setDate(values[0] || null, values[1] || null, false, explicitDate)}
+                                    active={isActive}
+                                    size={optionsSize}
+                                    fullWidth
+                                >
+                                    {key === CUSTOM_OPTION_KEY ? NO_OVERRIDE_RANGE_PLACEHOLDER : key}
+                                </LemonButton>
+                            </Tooltip>
+                        )
+                    })}
+                    {showRollingRangePicker && (
+                        <RollingDateRangeFilter
+                            pageKey={key}
+                            size={optionsSize}
+                            dateFrom={dateFrom}
+                            dateRangeFilterLabel={isFixedDateMode ? 'Last' : undefined}
+                            selected={isRollingDateRange}
+                            onChange={(fromDate) => {
+                                setDate(fromDate, '', true, explicitDate)
+                            }}
+                            makeLabel={makeLabel}
+                            popover={{
+                                ref: rollingDateRangeRef,
+                            }}
+                            max={max}
+                            allowedDateOptions={
+                                isFixedDateMode && !allowedRollingDateOptions
+                                    ? ['hours', 'days', 'weeks', 'months', 'years']
+                                    : allowedRollingDateOptions
+                            }
+                            fullWidth
+                        />
+                    )}
+                </ScrollableShadows>
+                <div className="shrink-0 deprecated-space-y-px p-1">
+                    {(isFixedDateMode || allowSingleAndRange) && (
+                        <LemonButton onClick={openFixedDate} active={isFixedDate} size={optionsSize} fullWidth>
+                            Custom date...
                         </LemonButton>
-                        {effectiveShowCustomRelativeRange && (
-                            <LemonButton onClick={openCustomRelativeRange} active={isCustomRelativeRange} fullWidth>
-                                Custom relative range…
+                    )}
+                    {(!isFixedDateMode || allowSingleAndRange) && (
+                        <>
+                            {!allowSingleAndRange && (
+                                <LemonButton onClick={openDateToNow} active={isDateToNow} size={optionsSize} fullWidth>
+                                    From custom date until now…
+                                </LemonButton>
+                            )}
+                            <LemonButton onClick={openFixedRange} active={isFixedRange} size={optionsSize} fullWidth>
+                                Custom fixed date range…
                             </LemonButton>
-                        )}
-                    </>
-                )}
-                {showExplicitDateToggle && (
-                    <>
-                        <LemonDivider />
-                        <div className="LemonSwitch pb-2 pt-2 LemonSwitch--medium LemonSwitch--full-width">
+                            {effectiveShowCustomRelativeRange && (
+                                <LemonButton
+                                    onClick={openCustomRelativeRange}
+                                    active={isCustomRelativeRange}
+                                    size={optionsSize}
+                                    fullWidth
+                                >
+                                    Custom relative range…
+                                </LemonButton>
+                            )}
+                        </>
+                    )}
+                    {(showExplicitDateToggle || showExclusions) && <LemonDivider />}
+                    {showExplicitDateToggle && (
+                        <div
+                            className={clsx(
+                                'LemonSwitch LemonSwitch--medium LemonSwitch--full-width',
+                                optionsSize === 'small' ? 'pb-1 pt-1' : 'pb-2 pt-2'
+                            )}
+                        >
                             <label className="flex items-center gap-1">
                                 <span>Exact time range</span>
                                 <Tooltip
@@ -400,16 +442,30 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
                                 }}
                             />
                         </div>
-                    </>
-                )}
-                {showJumpToTimestamp && (
-                    <>
-                        <LemonDivider />
-                        <LemonButton onClick={openJumpToTimestamp} fullWidth data-attr="jump-to-timestamp-option">
-                            Jump to timestamp…
-                        </LemonButton>
-                    </>
-                )}
+                    )}
+                    {showExclusions && (
+                        <LemonDateFilterExclusions
+                            exclusions={exclusions}
+                            onChange={onExclusionsChange}
+                            showDays={showDaysOfWeekExclusions}
+                            showIncomplete={showIncompletePeriodExclusion}
+                            size={optionsSize}
+                        />
+                    )}
+                    {showJumpToTimestamp && (
+                        <>
+                            <LemonDivider />
+                            <LemonButton
+                                onClick={openJumpToTimestamp}
+                                size={optionsSize}
+                                fullWidth
+                                data-attr="jump-to-timestamp-option"
+                            >
+                                Jump to timestamp…
+                            </LemonButton>
+                        </>
+                    )}
+                </div>
             </div>
         )
 
@@ -422,6 +478,9 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
             additionalRefs={[rollingDateRangeRef]}
             onClickOutside={close}
             closeParentPopoverOnClickInside={false}
+            // The quick list manages its own scrolling (presets scroll, footer pinned); the
+            // calendar views keep the popover's default scroll container.
+            overflowHidden={view === DateFilterView.QuickList}
         >
             {renderTrigger ? (
                 renderTrigger({

--- a/frontend/src/lib/components/DateFilter/DateFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/DateFilter.tsx
@@ -291,8 +291,8 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
             <div className="flex max-h-full min-h-0 flex-col" ref={optionsRef} onClick={(e) => e.stopPropagation()}>
                 <ScrollableShadows
                     direction="vertical"
-                    // max-h-80 shows ~9 preset rows with a sliver of the tenth as a scroll hint
                     hideScrollbars
+                    // max-h-80 shows ~9 preset rows with a sliver of the tenth as a scroll hint
                     className={clsx('min-h-0 flex-1 border-b', optionsSize === 'small' && 'max-h-80')}
                     innerClassName="deprecated-space-y-px p-1"
                 >
@@ -408,7 +408,8 @@ export const DateFilter = forwardRef<HTMLButtonElement, RawDateFilterProps>(func
                     {showExplicitDateToggle && (
                         <div
                             className={clsx(
-                                'LemonSwitch LemonSwitch--medium LemonSwitch--full-width',
+                                'LemonSwitch LemonSwitch--full-width',
+                                `LemonSwitch--${optionsSize}`,
                                 optionsSize === 'small' ? 'pb-1 pt-1' : 'pb-2 pt-2'
                             )}
                         >

--- a/frontend/src/lib/components/DateFilter/LemonDateFilterExclusions.tsx
+++ b/frontend/src/lib/components/DateFilter/LemonDateFilterExclusions.tsx
@@ -81,6 +81,7 @@ export function LemonDateFilterExclusions({
                                             }
                                             tooltip={name}
                                             aria-label={`Exclude ${name}`}
+                                            aria-pressed={selected}
                                         >
                                             {label}
                                         </LemonButton>

--- a/frontend/src/lib/components/DateFilter/LemonDateFilterExclusions.tsx
+++ b/frontend/src/lib/components/DateFilter/LemonDateFilterExclusions.tsx
@@ -9,9 +9,6 @@ import {
     dateFilterExclusionsSummary,
 } from 'lib/components/DateFilter/DateFilterExclusionsControl'
 
-/** LemonUI twin of the quill DateFilterExclusionsControl: an "Exclude" row that opens a flyout
- * with an incomplete-period switch and exclude-day chips. Speaks _excluded_ ISO days ('1'–'7'). */
-
 const DAYS_OF_WEEK: { day: string; label: string; name: string }[] = [
     { day: '1', label: 'M', name: 'Monday' },
     { day: '2', label: 'T', name: 'Tuesday' },
@@ -42,8 +39,7 @@ export function LemonDateFilterExclusions({
             visible={visible}
             onClickOutside={() => setVisible(false)}
             placement="right-end"
-            // Side placements only: flip's bestFit keeps the flyout beside the row (like the quill
-            // control) and shift nudges it vertically, instead of flipping to above/below.
+            // side fallbacks only, so collision handling keeps the flyout beside the row instead of flipping above/below
             fallbackPlacements={['left-end']}
             padded={false}
             overlay={

--- a/frontend/src/lib/components/DateFilter/LemonDateFilterExclusions.tsx
+++ b/frontend/src/lib/components/DateFilter/LemonDateFilterExclusions.tsx
@@ -1,0 +1,128 @@
+import clsx from 'clsx'
+import { useState } from 'react'
+
+import { IconChevronRight } from '@posthog/icons'
+import { LemonButton, LemonDivider, LemonSwitch, Popover } from '@posthog/lemon-ui'
+
+import {
+    type DateFilterExclusions,
+    dateFilterExclusionsSummary,
+} from 'lib/components/DateFilter/DateFilterExclusionsControl'
+
+/** LemonUI twin of the quill DateFilterExclusionsControl: an "Exclude" row that opens a flyout
+ * with an incomplete-period switch and exclude-day chips. Speaks _excluded_ ISO days ('1'–'7'). */
+
+const DAYS_OF_WEEK: { day: string; label: string; name: string }[] = [
+    { day: '1', label: 'M', name: 'Monday' },
+    { day: '2', label: 'T', name: 'Tuesday' },
+    { day: '3', label: 'W', name: 'Wednesday' },
+    { day: '4', label: 'T', name: 'Thursday' },
+    { day: '5', label: 'F', name: 'Friday' },
+    { day: '6', label: 'S', name: 'Saturday' },
+    { day: '7', label: 'S', name: 'Sunday' },
+]
+
+export function LemonDateFilterExclusions({
+    exclusions,
+    onChange,
+    showDays,
+    showIncomplete,
+    size,
+}: {
+    exclusions: DateFilterExclusions
+    onChange: (exclusions: DateFilterExclusions) => void
+    showDays: boolean
+    showIncomplete: boolean
+    size?: 'small' | 'medium'
+}): JSX.Element {
+    const [visible, setVisible] = useState(false)
+    const summary = dateFilterExclusionsSummary(exclusions)
+    return (
+        <Popover
+            visible={visible}
+            onClickOutside={() => setVisible(false)}
+            placement="right-end"
+            // Side placements only: flip's bestFit keeps the flyout beside the row (like the quill
+            // control) and shift nudges it vertically, instead of flipping to above/below.
+            fallbackPlacements={['left-end']}
+            padded={false}
+            overlay={
+                <div className="w-64">
+                    {showIncomplete && (
+                        <div className="px-3 py-2.5">
+                            <LemonSwitch
+                                fullWidth
+                                label="Incomplete period"
+                                checked={exclusions.incomplete}
+                                onChange={(incomplete) => onChange({ ...exclusions, incomplete })}
+                                data-attr="date-filter-exclude-incomplete-periods"
+                            />
+                        </div>
+                    )}
+                    {showIncomplete && showDays && <LemonDivider className="my-0" />}
+                    {showDays && (
+                        <div className="flex flex-col gap-2 px-3 py-2.5">
+                            <div className="flex gap-1">
+                                {DAYS_OF_WEEK.map(({ day, label, name }) => {
+                                    const selected = exclusions.days.includes(day)
+                                    return (
+                                        <LemonButton
+                                            key={day}
+                                            size="xsmall"
+                                            type="secondary"
+                                            center
+                                            className={clsx(
+                                                'flex-1',
+                                                selected && 'border-accent bg-accent-highlight-secondary text-accent'
+                                            )}
+                                            onClick={() =>
+                                                onChange({
+                                                    ...exclusions,
+                                                    days: selected
+                                                        ? exclusions.days.filter((d) => d !== day)
+                                                        : [...exclusions.days, day],
+                                                })
+                                            }
+                                            tooltip={name}
+                                            aria-label={`Exclude ${name}`}
+                                        >
+                                            {label}
+                                        </LemonButton>
+                                    )
+                                })}
+                            </div>
+                            <div className="flex items-center justify-center gap-3">
+                                <LemonButton
+                                    size="xsmall"
+                                    onClick={() => onChange({ ...exclusions, days: ['6', '7'] })}
+                                >
+                                    Weekends
+                                </LemonButton>
+                                <LemonButton
+                                    size="xsmall"
+                                    onClick={() => onChange({ ...exclusions, days: ['1', '2', '3', '4', '5'] })}
+                                >
+                                    Weekdays
+                                </LemonButton>
+                                <LemonButton size="xsmall" onClick={() => onChange({ ...exclusions, days: [] })}>
+                                    Clear
+                                </LemonButton>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            }
+        >
+            <LemonButton
+                fullWidth
+                onClick={() => setVisible(!visible)}
+                active={visible}
+                size={size}
+                sideIcon={<IconChevronRight />}
+                data-attr="date-filter-exclusions"
+            >
+                {summary || 'Exclude'}
+            </LemonButton>
+        </Popover>
+    )
+}

--- a/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.scss
+++ b/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.scss
@@ -11,6 +11,10 @@
     cursor: pointer;
     transition: background 0.3s ease;
 
+    &.RollingDateRangeFilter--small {
+        padding: 0.375rem 0;
+    }
+
     &:hover {
         background-color: var(--color-bg-primary);
     }

--- a/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.scss
+++ b/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.scss
@@ -1,19 +1,11 @@
 .RollingDateRangeFilter {
     display: flex;
     align-items: center;
-    height: 1.6875rem;
-    min-height: 2rem;
-    padding: 1.25rem 0;
-    font-size: 0.875rem;
     font-weight: normal;
     line-height: 1.375em;
     color: var(--text-3000);
     cursor: pointer;
     transition: background 0.3s ease;
-
-    &.RollingDateRangeFilter--small {
-        padding: 0.375rem 0;
-    }
 
     &:hover {
         background-color: var(--color-bg-primary);

--- a/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
@@ -1,6 +1,5 @@
 import './RollingDateRangeFilter.scss'
 
-import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 
 import { LemonButton, LemonButtonProps, LemonInput, LemonSelect, LemonSelectOptionLeaf } from '@posthog/lemon-ui'
@@ -118,7 +117,7 @@ export function RollingDateRangeFilter({
     if (isButton) {
         contents = (
             <LemonButton
-                className={clsx('RollingDateRangeFilter', size === 'small' && 'RollingDateRangeFilter--small')}
+                className="RollingDateRangeFilter"
                 data-attr="rolling-date-range-filter"
                 onClick={select}
                 active={selected}

--- a/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
+++ b/frontend/src/lib/components/DateFilter/RollingDateRangeFilter.tsx
@@ -1,5 +1,6 @@
 import './RollingDateRangeFilter.scss'
 
+import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 
 import { LemonButton, LemonButtonProps, LemonInput, LemonSelect, LemonSelectOptionLeaf } from '@posthog/lemon-ui'
@@ -38,6 +39,7 @@ type RollingDateRangeFilterProps = {
     dateRangeFilterSuffixLabel?: string
     allowedDateOptions?: DateOption[]
     fullWidth?: LemonButtonProps['fullWidth']
+    size?: 'small' | 'medium'
 }
 
 export function RollingDateRangeFilter({
@@ -54,6 +56,7 @@ export function RollingDateRangeFilter({
     pageKey,
     allowedDateOptions = ['days', 'weeks', 'months', 'years'],
     fullWidth,
+    size,
 }: RollingDateRangeFilterProps): JSX.Element {
     const logicProps = { onChange, dateFrom, inUse: selected || inUse, max, pageKey }
     const { increaseCounter, decreaseCounter, setCounter, setDateOption, toggleDateOptionsSelector, select } =
@@ -115,10 +118,11 @@ export function RollingDateRangeFilter({
     if (isButton) {
         contents = (
             <LemonButton
-                className="RollingDateRangeFilter"
+                className={clsx('RollingDateRangeFilter', size === 'small' && 'RollingDateRangeFilter--small')}
                 data-attr="rolling-date-range-filter"
                 onClick={select}
                 active={selected}
+                size={size}
                 fullWidth={fullWidth}
             >
                 {contents}

--- a/frontend/src/lib/lemon-ui/Tooltip/Tooltip.test.tsx
+++ b/frontend/src/lib/lemon-ui/Tooltip/Tooltip.test.tsx
@@ -80,4 +80,44 @@ describe('Tooltip', () => {
 
         await waitFor(() => expect(screen.queryByText(TITLE)).toBeNull())
     })
+
+    it('dismisses on scroll outside the tooltip', async () => {
+        renderTooltip()
+
+        fireEvent.pointerEnter(screen.getByText('Outdated'), { pointerType: 'mouse' })
+        fireEvent.mouseEnter(screen.getByText('Outdated'))
+        expect(await screen.findByText(TITLE)).toBeTruthy()
+
+        fireEvent.scroll(window)
+
+        await waitFor(() => expect(screen.queryByText(TITLE)).toBeNull())
+    })
+
+    it('does not dismiss on scroll inside the tooltip', async () => {
+        renderTooltip()
+
+        fireEvent.pointerEnter(screen.getByText('Outdated'), { pointerType: 'mouse' })
+        fireEvent.mouseEnter(screen.getByText('Outdated'))
+        const title = await screen.findByText(TITLE)
+
+        fireEvent.scroll(title)
+
+        expect(screen.getByText(TITLE)).toBeTruthy()
+    })
+
+    it('does not dismiss a controlled tooltip on scroll', async () => {
+        render(
+            <div>
+                <Tooltip title={TITLE} visible>
+                    <span>Outdated</span>
+                </Tooltip>
+            </div>
+        )
+
+        expect(await screen.findByText(TITLE)).toBeTruthy()
+
+        fireEvent.scroll(window)
+
+        expect(screen.getByText(TITLE)).toBeTruthy()
+    })
 })

--- a/frontend/src/lib/lemon-ui/Tooltip/Tooltip.tsx
+++ b/frontend/src/lib/lemon-ui/Tooltip/Tooltip.tsx
@@ -127,14 +127,12 @@ export function Tooltip({
         }
     }, [open, onOpen])
 
-    // Dismiss on scroll: the trigger can scroll away (or out of a clipped container) from under
-    // the pointer, leaving the tooltip floating detached from anything.
+    // Dismiss on scroll, otherwise the tooltip lingers detached after its trigger scrolls away
     useEffect(() => {
         if (!open || controlledOpen !== undefined) {
             return
         }
         const handleScroll = (event: Event): void => {
-            // Scrolls within the tooltip's own popup (interactive content) shouldn't dismiss it
             if (event.target instanceof Element && event.target.closest('.Tooltip')) {
                 return
             }

--- a/frontend/src/lib/lemon-ui/Tooltip/Tooltip.tsx
+++ b/frontend/src/lib/lemon-ui/Tooltip/Tooltip.tsx
@@ -127,6 +127,23 @@ export function Tooltip({
         }
     }, [open, onOpen])
 
+    // Dismiss on scroll: the trigger can scroll away (or out of a clipped container) from under
+    // the pointer, leaving the tooltip floating detached from anything.
+    useEffect(() => {
+        if (!open || controlledOpen !== undefined) {
+            return
+        }
+        const handleScroll = (event: Event): void => {
+            // Scrolls within the tooltip's own popup (interactive content) shouldn't dismiss it
+            if (event.target instanceof Element && event.target.closest('.Tooltip')) {
+                return
+            }
+            setUncontrolledOpen(false)
+        }
+        window.addEventListener('scroll', handleScroll, { capture: true, passive: true })
+        return () => window.removeEventListener('scroll', handleScroll, { capture: true })
+    }, [open, controlledOpen])
+
     const child = React.isValidElement(children) ? children : <span>{children}</span>
 
     if (!title && !docLink) {

--- a/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
@@ -21,8 +21,9 @@ export const InsightResultMetadata = ({
     const { samplingFactor, trendsFilter, dateRange, isTrends } = useValues(insightVizDataLogic(insightProps))
     const { featureFlags } = useValues(featureFlagLogic)
 
+    const quillDateFilterEnabled = featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_DATE_FILTER] === 'test'
     // Only trends applies daysOfWeek server-side, so only trends gets the note
-    const excludedDays = isTrends ? getExcludedDaysOfWeek(dateRange) : []
+    const excludedDays = quillDateFilterEnabled && isTrends ? getExcludedDaysOfWeek(dateRange) : []
     const excludedLabel = daysOfWeekLabel(excludedDays)
     const excludedText = ['Weekends', 'Weekdays'].includes(excludedLabel) ? excludedLabel.toLowerCase() : excludedLabel
 
@@ -47,7 +48,7 @@ export const InsightResultMetadata = ({
                     Weekends hidden
                 </span>
             ) : null}
-            {dateRange?.excludeIncompletePeriods ? (
+            {quillDateFilterEnabled && dateRange?.excludeIncompletePeriods ? (
                 <span className="text-secondary">
                     <span className="mx-1">•</span>
                     Incomplete period excluded

--- a/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
@@ -21,9 +21,8 @@ export const InsightResultMetadata = ({
     const { samplingFactor, trendsFilter, dateRange, isTrends } = useValues(insightVizDataLogic(insightProps))
     const { featureFlags } = useValues(featureFlagLogic)
 
-    const quillDateFilterEnabled = featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_DATE_FILTER] === 'test'
     // Only trends applies daysOfWeek server-side, so only trends gets the note
-    const excludedDays = quillDateFilterEnabled && isTrends ? getExcludedDaysOfWeek(dateRange) : []
+    const excludedDays = isTrends ? getExcludedDaysOfWeek(dateRange) : []
     const excludedLabel = daysOfWeekLabel(excludedDays)
     const excludedText = ['Weekends', 'Weekdays'].includes(excludedLabel) ? excludedLabel.toLowerCase() : excludedLabel
 
@@ -48,7 +47,7 @@ export const InsightResultMetadata = ({
                     Weekends hidden
                 </span>
             ) : null}
-            {quillDateFilterEnabled && dateRange?.excludeIncompletePeriods ? (
+            {dateRange?.excludeIncompletePeriods ? (
                 <span className="text-secondary">
                     <span className="mx-1">•</span>
                     Incomplete period excluded

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
@@ -1,5 +1,5 @@
 import { useActions, useValues } from 'kea'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { IconCalendar } from '@posthog/icons'
 
@@ -35,13 +35,16 @@ export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Ele
     const smoothingActive = isTrends && (trendsFilter?.smoothingIntervals ?? 1) > 1
     const showDaysOfWeekExclusions = isTrends && !smoothingActive
 
-    // Clear daysOfWeek when the control hides, otherwise it lingers with no UI left to remove it
+    // Enabling smoothing hides the control, so clear daysOfWeek on that transition (never on
+    // mount): the backend rejects the combination and there'd be no UI left to remove it
+    const prevShowDaysOfWeekExclusions = useRef(showDaysOfWeekExclusions)
     useEffect(() => {
-        if (!showDaysOfWeekExclusions && dateRange?.daysOfWeek?.length) {
+        const wasShown = prevShowDaysOfWeekExclusions.current
+        prevShowDaysOfWeekExclusions.current = showDaysOfWeekExclusions
+        if (wasShown && !showDaysOfWeekExclusions && smoothingActive && dateRange?.daysOfWeek?.length) {
             updateQuerySource(computeDaysOfWeekUpdate([], dateRange))
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [showDaysOfWeekExclusions])
+    }, [showDaysOfWeekExclusions, smoothingActive, dateRange, updateQuerySource])
 
     const exclusions: DateFilterExclusions = {
         days: showDaysOfWeekExclusions ? excludedDaysOfWeek.map(String) : [],

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
@@ -24,16 +24,13 @@ export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Ele
     const { insightData } = useValues(insightVizDataLogic(insightProps))
     const { reportInsightDatePickerOpened } = useActions(eventUsageLogic)
 
-    // The picker speaks excluded days; the query schema stores included days. The legacy
-    // display-only trendsFilter.hideWeekends is deliberately NOT folded in — different semantics.
+    // The picker speaks excluded days; the query schema stores included days
     const excludedDaysOfWeek = getExcludedDaysOfWeek(dateRange)
     // The backend rejects daysOfWeek together with smoothing, so don't offer it
     const smoothingActive = isTrends && (trendsFilter?.smoothingIntervals ?? 1) > 1
     const showDaysOfWeekExclusions = isTrends && !smoothingActive
 
-    // Hiding the exclusions control (smoothing turned on, or the insight type changed away from
-    // trends) must also clear any daysOfWeek already on the query — otherwise it lingers with no
-    // UI left to remove it, and the backend rejects daysOfWeek alongside smoothing.
+    // Clear daysOfWeek when the control hides, otherwise it lingers with no UI left to remove it
     useEffect(() => {
         if (!showDaysOfWeekExclusions && dateRange?.daysOfWeek?.length) {
             updateQuerySource(computeDaysOfWeekUpdate([], dateRange))

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
@@ -11,7 +11,12 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
-import { computeDaysOfWeekUpdate, getExcludedDaysOfWeek, type IsoDayOfWeek } from './daysOfWeekFilterUtils'
+import {
+    computeDaysOfWeekUpdate,
+    daysOfWeekSetsEqual,
+    getExcludedDaysOfWeek,
+    parseIsoDaysOfWeek,
+} from './daysOfWeekFilterUtils'
 
 type InsightDateFilterProps = {
     disabled: boolean
@@ -43,8 +48,9 @@ export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Ele
         incomplete: !!dateRange?.excludeIncompletePeriods,
     }
     const handleExclusionsChange = (next: DateFilterExclusions): void => {
-        if (isTrends && next.days.join(',') !== exclusions.days.join(',')) {
-            updateQuerySource(computeDaysOfWeekUpdate(next.days.map(Number) as IsoDayOfWeek[], dateRange))
+        const nextExcludedDaysOfWeek = parseIsoDaysOfWeek(next.days)
+        if (isTrends && !daysOfWeekSetsEqual(nextExcludedDaysOfWeek, excludedDaysOfWeek)) {
+            updateQuerySource(computeDaysOfWeekUpdate(nextExcludedDaysOfWeek, dateRange))
         }
         if (next.incomplete !== exclusions.incomplete) {
             updateDateRange({ excludeIncompletePeriods: next.incomplete ? true : null }, true)

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
@@ -1,13 +1,17 @@
 import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
 
 import { IconCalendar } from '@posthog/icons'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
+import { type DateFilterExclusions } from 'lib/components/DateFilter/DateFilterExclusionsControl'
 import { dateMapping } from 'lib/utils/dateFilters'
 import { alignResolvedDateRangeToInterval } from 'lib/utils/datetime'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+
+import { computeDaysOfWeekUpdate, getExcludedDaysOfWeek, type IsoDayOfWeek } from './daysOfWeekFilterUtils'
 
 type InsightDateFilterProps = {
     disabled: boolean
@@ -15,10 +19,40 @@ type InsightDateFilterProps = {
 
 export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Element {
     const { insightProps, editingDisabledReason } = useValues(insightLogic)
-    const { dateRange, interval, querySource } = useValues(insightVizDataLogic(insightProps))
-    const { updateDateRange } = useActions(insightVizDataLogic(insightProps))
+    const { dateRange, interval, querySource, trendsFilter, isTrends } = useValues(insightVizDataLogic(insightProps))
+    const { updateDateRange, updateQuerySource } = useActions(insightVizDataLogic(insightProps))
     const { insightData } = useValues(insightVizDataLogic(insightProps))
     const { reportInsightDatePickerOpened } = useActions(eventUsageLogic)
+
+    // The picker speaks excluded days; the query schema stores included days. The legacy
+    // display-only trendsFilter.hideWeekends is deliberately NOT folded in — different semantics.
+    const excludedDaysOfWeek = getExcludedDaysOfWeek(dateRange)
+    // The backend rejects daysOfWeek together with smoothing, so don't offer it
+    const smoothingActive = isTrends && (trendsFilter?.smoothingIntervals ?? 1) > 1
+    const showDaysOfWeekExclusions = isTrends && !smoothingActive
+
+    // Hiding the exclusions control (smoothing turned on, or the insight type changed away from
+    // trends) must also clear any daysOfWeek already on the query — otherwise it lingers with no
+    // UI left to remove it, and the backend rejects daysOfWeek alongside smoothing.
+    useEffect(() => {
+        if (!showDaysOfWeekExclusions && dateRange?.daysOfWeek?.length) {
+            updateQuerySource(computeDaysOfWeekUpdate([], dateRange))
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [showDaysOfWeekExclusions])
+
+    const exclusions: DateFilterExclusions = {
+        days: showDaysOfWeekExclusions ? excludedDaysOfWeek.map(String) : [],
+        incomplete: !!dateRange?.excludeIncompletePeriods,
+    }
+    const handleExclusionsChange = (next: DateFilterExclusions): void => {
+        if (isTrends && next.days.join(',') !== exclusions.days.join(',')) {
+            updateQuerySource(computeDaysOfWeekUpdate(next.days.map(Number) as IsoDayOfWeek[], dateRange))
+        }
+        if (next.incomplete !== exclusions.incomplete) {
+            updateDateRange({ excludeIncompletePeriods: next.incomplete ? true : null }, true)
+        }
+    }
 
     return (
         <DateFilter
@@ -26,6 +60,11 @@ export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Ele
             dateTo={dateRange?.date_to ?? undefined}
             dateFrom={dateRange?.date_from ?? '-7d'}
             explicitDate={dateRange?.explicitDate ?? false}
+            exclusions={exclusions}
+            onExclusionsChange={handleExclusionsChange}
+            showIncompletePeriodExclusion
+            showDaysOfWeekExclusions={showDaysOfWeekExclusions}
+            optionsSize="small"
             allowTimePrecision
             allowFixedRangeWithTime
             disabled={disabled}

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
@@ -11,6 +11,8 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
+import { FunnelVizType } from '~/types'
+
 import {
     computeDaysOfWeekUpdate,
     daysOfWeekSetsEqual,
@@ -24,16 +26,21 @@ type InsightDateFilterProps = {
 
 export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Element {
     const { insightProps, editingDisabledReason } = useValues(insightLogic)
-    const { dateRange, interval, querySource, trendsFilter, isTrends } = useValues(insightVizDataLogic(insightProps))
+    const { dateRange, interval, querySource, trendsFilter, funnelsFilter, isTrends, isFunnels, isLifecycle } =
+        useValues(insightVizDataLogic(insightProps))
     const { updateDateRange, updateQuerySource } = useActions(insightVizDataLogic(insightProps))
     const { insightData } = useValues(insightVizDataLogic(insightProps))
     const { reportInsightDatePickerOpened } = useActions(eventUsageLogic)
 
     // The picker speaks excluded days; the query schema stores included days
     const excludedDaysOfWeek = getExcludedDaysOfWeek(dateRange)
+    // Funnel steps and time-to-convert deliberately lack backend daysOfWeek support: dropping
+    // mid-sequence events has ambiguous semantics (see funnel_event_query.py)
+    const supportsDaysOfWeek =
+        isTrends || isLifecycle || (isFunnels && funnelsFilter?.funnelVizType === FunnelVizType.Trends)
     // The backend rejects daysOfWeek together with smoothing, so don't offer it
     const smoothingActive = isTrends && (trendsFilter?.smoothingIntervals ?? 1) > 1
-    const showDaysOfWeekExclusions = isTrends && !smoothingActive
+    const showDaysOfWeekExclusions = supportsDaysOfWeek && !smoothingActive
 
     // Enabling smoothing hides the control, so clear daysOfWeek on that transition (never on
     // mount): the backend rejects the combination and there'd be no UI left to remove it
@@ -52,7 +59,7 @@ export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Ele
     }
     const handleExclusionsChange = (next: DateFilterExclusions): void => {
         const nextExcludedDaysOfWeek = parseIsoDaysOfWeek(next.days)
-        if (isTrends && !daysOfWeekSetsEqual(nextExcludedDaysOfWeek, excludedDaysOfWeek)) {
+        if (showDaysOfWeekExclusions && !daysOfWeekSetsEqual(nextExcludedDaysOfWeek, excludedDaysOfWeek)) {
             updateQuerySource(computeDaysOfWeekUpdate(nextExcludedDaysOfWeek, dateRange))
         }
         if (next.incomplete !== exclusions.incomplete) {

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.test.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.test.ts
@@ -1,0 +1,64 @@
+import type { DateRange } from '~/queries/schema/schema-general'
+
+import {
+    computeDaysOfWeekUpdate,
+    getExcludedDaysOfWeek,
+    invertDaysOfWeek,
+    type IsoDayOfWeek,
+} from './daysOfWeekFilterUtils'
+
+describe('daysOfWeekFilterUtils', () => {
+    it.each([
+        [[], []],
+        [[1, 2, 3, 4, 5, 6, 7], []],
+        [
+            [6, 7],
+            [1, 2, 3, 4, 5],
+        ],
+        [
+            [1, 2, 3, 4, 5],
+            [6, 7],
+        ],
+        [[3], [1, 2, 4, 5, 6, 7]],
+    ] as [IsoDayOfWeek[], IsoDayOfWeek[]][])('inverts %j to %j', (days, expected) => {
+        expect(invertDaysOfWeek(days)).toEqual(expected)
+    })
+
+    it.each([
+        [undefined, []],
+        [null, []],
+        [{ daysOfWeek: null }, []],
+        [{ daysOfWeek: [] }, []],
+        [{ daysOfWeek: [6, 7] }, [1, 2, 3, 4, 5]],
+        [{ daysOfWeek: [5, 1, 3] }, [2, 4, 6, 7]],
+    ] as [DateRange | null | undefined, IsoDayOfWeek[]][])(
+        'reads excluded days from dateRange %j as %j',
+        (dateRange, expected) => {
+            expect(getExcludedDaysOfWeek(dateRange)).toEqual(expected)
+        }
+    )
+
+    it.each([
+        [[], null],
+        [[1, 2, 3, 4, 5, 6, 7], null],
+        [
+            [6, 7],
+            [1, 2, 3, 4, 5],
+        ],
+        [
+            [1, 2, 3, 4, 5],
+            [6, 7],
+        ],
+    ] as [IsoDayOfWeek[], number[] | null][])(
+        'computes a daysOfWeek update excluding %j as %j, normalizing none/all excluded to null',
+        (excludedDays, expectedDaysOfWeek) => {
+            const update = computeDaysOfWeekUpdate(excludedDays, { date_from: '-7d' })
+            expect(update.dateRange?.daysOfWeek ?? null).toEqual(expectedDaysOfWeek)
+        }
+    )
+
+    it('preserves the rest of the dateRange when computing an update', () => {
+        const update = computeDaysOfWeekUpdate([6, 7], { date_from: '-7d', date_to: null })
+        expect(update.dateRange).toEqual({ date_from: '-7d', date_to: null, daysOfWeek: [1, 2, 3, 4, 5] })
+    })
+})

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.ts
@@ -31,6 +31,23 @@ export function getExcludedDaysOfWeek(dateRange: DateRange | null | undefined): 
     return dateRange?.daysOfWeek?.length ? invertDaysOfWeek(sortDays(dateRange.daysOfWeek)) : []
 }
 
+/** Parses the day picker's string values, dropping anything outside 1-7 rather than casting. */
+export function parseIsoDaysOfWeek(days: string[]): IsoDayOfWeek[] {
+    return days
+        .map((day) => parseInt(day, 10))
+        .filter((day): day is IsoDayOfWeek => (ALL_DAY_NUMBERS as number[]).includes(day))
+}
+
+/** Order-insensitive equality, so re-picking the same days in a different order isn't a change. */
+export function daysOfWeekSetsEqual(a: IsoDayOfWeek[], b: IsoDayOfWeek[]): boolean {
+    if (a.length !== b.length) {
+        return false
+    }
+    const sortedA = sortDays(a)
+    const sortedB = sortDays(b)
+    return sortedA.every((day, i) => day === sortedB[i])
+}
+
 export function daysOfWeekLabel(days: IsoDayOfWeek[]): string {
     if (days.length === 0 || days.length === DAYS_IN_WEEK) {
         return 'All days'

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.ts
@@ -1,4 +1,4 @@
-import { DateRange, TrendsQuery } from '~/queries/schema/schema-general'
+import { DateRange } from '~/queries/schema/schema-general'
 
 export type IsoDayOfWeek = NonNullable<DateRange['daysOfWeek']>[number]
 
@@ -67,7 +67,7 @@ export function daysOfWeekLabel(days: IsoDayOfWeek[]): string {
 export function computeDaysOfWeekUpdate(
     excludedDays: IsoDayOfWeek[],
     dateRange: DateRange | null | undefined
-): Partial<TrendsQuery> {
+): { dateRange: DateRange } {
     const included = invertDaysOfWeek(excludedDays)
     const daysOfWeek = included.length === 0 || included.length === DAYS_IN_WEEK ? null : sortDays(included)
     return { dateRange: { ...dateRange, daysOfWeek } }


### PR DESCRIPTION
## Problem

The insight date filter has no way to exclude the current, still-collecting period (so the last data point always dips) or to exclude days of the week (weekends skew many business metrics). The backend supports both via `DateRange.excludeIncompletePeriods` and `DateRange.daysOfWeek`, but the only UI for them lives in the quill date filter behind the `PRODUCT_ANALYTICS_QUILL_DATE_FILTER` flag.

The dropdown also had some rough edges that showed up while working on this: it stretched to the full screen height, and row tooltips could stick around detached from the list after scrolling.

## Changes

https://github.com/user-attachments/assets/02507a65-ae1b-46b2-aa78-00e1383adc95


Ports the exclusions UI from the flagged quill version to the default lemon insight date filter:

- New `LemonDateFilterExclusions` component, a LemonUI twin of the quill `DateFilterExclusionsControl`: an "Exclude" row that opens a right-side flyout with an incomplete-period switch and excluded days-of-week chips (with Weekends / Weekdays / Clear shortcuts). It reuses the quill control's `DateFilterExclusions` type and summary helpers, so the row reads "Excluding weekends, incomplete" the same way.
- `InsightDateFilter` wires it up like the flagged `InsightQuillDateFilter`: day exclusions are offered exactly where the backend applies them — trends (without smoothing, which the backend rejects in combination), lifecycle, and the funnel trends visualization; funnel steps and time-to-convert deliberately don't get them (dropping mid-sequence events has ambiguous semantics, per `funnel_event_query.py`). A clear-on-hide effect — firing only on the shown→hidden transition caused by enabling smoothing, never on mount — keeps a lingering `daysOfWeek` from stranding the query, and rendering a saved insight never rewrites it.

Dropdown polish, opt-in via a new `optionsSize` prop so only the insights caller changes:

- Rows use the standard lemon menu small size instead of medium.
- The presets list scrolls inside a max height of about 9 rows with the custom options, toggles, and Exclude row pinned below (mirrors the quill `DateRangePresetsPanel`), instead of the whole dropdown growing to the screen height. The scroll area's own border doubles as the divider so it sits exactly at the scroll cutoff, and the scrollbar gutter is hidden (the scroll shadow and clipped row signal scrollability).

One app-wide fix: `Tooltip` now dismisses on scroll (capture-phase listener, ignoring scrolls inside an interactive tooltip's own popup). Previously a tooltip could stay open while its trigger scrolled out of a clipped container, leaving it floating over unrelated parts of the page.

Screenshots incoming.

## How did you test this code?

- Jest suites pass: `DateFilter.test.tsx`, `dateFilterLogic.test.ts`, `rollingDateRangeFilterLogic.test.ts`, `Tooltip.test.tsx` — including new scroll-dismiss cases and a new parameterized `daysOfWeekFilterUtils.test.ts` covering the excluded↔included day inversion, added during review.
- `tsgo --noEmit` and scoped oxlint/oxfmt pass.
- I (well, Claude) verified in the running app via Playwright: the flyout opens to the right of the Exclude row and stays on a side on collision, day chips show the accent selected state and write `daysOfWeek: [1,2,3,4,5]` when excluding weekends, the incomplete switch writes `excludeIncompletePeriods: true`, the presets list is the only scroller with the footer pinned and reachable at a 720px viewport, and a hovered row tooltip dismisses the moment the list scrolls.
- Not covered by automated tests: the new flyout component itself has no dedicated jest test; behavior was verified in the browser as above.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed throughout. The exclusions UI is a deliberate port of the flagged quill implementation (`InsightQuillDateFilter` + `DateFilterExclusionsControl`) so the two stay behaviorally identical while the flag decision plays out. Skills invoked: `/writing-user-facing-copy`. Decisions worth knowing:

- Sizing and the presets max height are behind the opt-in `optionsSize` prop because the `DateFilter` is shared by replay, web analytics, and others; only insights opts in. The pinned-footer scroll structure applies to all callers, but is visually identical whenever content fits, which it does for the other callers' shorter lists.
- The flyout uses `fallbackPlacements={['left-end']}`: lemon Popover's default fallbacks are all top/bottom, which flipped the flyout above the row whenever the bottom clearance was tight. Side-only fallbacks plus the flip middleware's bestFit strategy reproduce the quill `side: flip, align: shift` behavior.
- The tooltip scroll dismissal went into the shared `Tooltip` rather than the date filter because any scrollable list under a tooltip had the same detached-tooltip bug.


