### PR TITLE
chore(max): scope the prefill guard to request building and log when it trims

### DIFF
--- a/ee/hogai/core/agent_modes/executables.py
+++ b/ee/hogai/core/agent_modes/executables.py
@@ -46,7 +46,7 @@ from ee.hogai.core.executable import BaseAgentExecutable
 from ee.hogai.llm import MaxChatAnthropic
 from ee.hogai.tool import MaxTool, ToolMessagesArtifact
 from ee.hogai.tool_errors import MaxToolError
-from ee.hogai.utils.anthropic import add_cache_control, convert_to_anthropic_messages
+from ee.hogai.utils.anthropic import add_cache_control, convert_to_anthropic_messages, drop_trailing_assistant_messages
 from ee.hogai.utils.conversation_summarizer import AnthropicConversationSummarizer
 from ee.hogai.utils.feature_flags import get_llm_gateway_variant
 from ee.hogai.utils.helpers import convert_tool_messages_to_dict, normalize_ai_message
@@ -316,6 +316,18 @@ class AgentExecutable(BaseAgentLoopRootExecutable):
 
         # Convert to Anthropic messages
         history = self._convert_to_langchain_messages(conversation_window, tool_result_messages)
+
+        # Anthropic reads a trailing assistant turn as a prefill, which Sonnet 4.6+ rejects.
+        without_prefill = drop_trailing_assistant_messages(history)
+        if len(without_prefill) < len(history):
+            # Expected for conversations predating the summarize_sessions migration. Anything else
+            # reaching here means a tool call lost its result, so it is worth knowing about.
+            logger.warning(
+                "Dropped trailing assistant messages to avoid prefilling",
+                dropped=len(history) - len(without_prefill),
+                team_id=self._team.id,
+            )
+        history = without_prefill
 
         # Force the agent to stop if the tool call limit is reached.
         history = self._add_limit_message_if_reached(history, tool_calls_count)

--- a/ee/hogai/core/agent_modes/test/test_executables.py
+++ b/ee/hogai/core/agent_modes/test/test_executables.py
@@ -172,6 +172,24 @@ class TestAgentNode(ClickhouseTestMixin, BaseTest):
         )
 
     @patch(
+        "ee.hogai.core.agent_modes.executables.AgentExecutable._get_model", return_value=FakeChatOpenAI(responses=[])
+    )
+    async def test_constructed_prompt_never_ends_on_an_assistant_turn(self, mock_model):
+        node = _create_agent_node(self.team, self.user)
+        # Shape left behind by the pre-migration summarize_sessions tool, which appended its own
+        # assistant message after the tool result.
+        state = AssistantState(
+            messages=[
+                HumanMessage(content="Summarize my sessions", id="1"),
+                AssistantMessage(content="Report complete: Sessions summary", id="2"),
+            ]
+        )
+
+        result = node._construct_messages(state.messages, state.root_conversation_start_id, None)
+
+        self.assertNotIsInstance(result[-1], LangchainAIMessage)
+
+    @patch(
         "ee.hogai.core.agent_modes.executables.AgentExecutable._get_model",
         return_value=FakeChatAnthropic(responses=[]),
     )

--- a/ee/hogai/utils/anthropic.py
+++ b/ee/hogai/utils/anthropic.py
@@ -128,11 +128,11 @@ def convert_to_anthropic_messages(
             history.extend(convert_to_anthropic_message(message, tool_result_map))
         except ValueError:
             continue
-    return drop_trailing_assistant_messages(history)
+    return history
 
 
 def drop_trailing_assistant_messages(history: list[messages.BaseMessage]) -> list[messages.BaseMessage]:
-    """Drop assistant messages the conversation ends on, so we never prefill.
+    """Drop assistant messages the conversation ends on, so a request never prefills.
 
     Anthropic reads a trailing assistant turn as content to continue from, which Sonnet 4.6 and
     later reject outright. A conversation can end on one when a tool appended its own assistant
@@ -140,7 +140,13 @@ def drop_trailing_assistant_messages(history: list[messages.BaseMessage]) -> lis
     "Open report" button.
 
     Assistant messages carrying tool calls are left in place: dropping one would orphan the tool
-    result that follows it, which Anthropic rejects too.
+    result that follows it, which Anthropic rejects too. Note that an assistant message whose tool
+    calls all lack results is not one of those, because `convert_assistant_message_to_anthropic_message`
+    has already stripped the unanswered calls by this point, leaving content only. Dropping that is
+    the right call for the request, but it also hides that the results went missing, so callers
+    should report when this trims anything.
+
+    Only shapes a request. Do not use it to derive what the conversation contains.
     """
     end = len(history)
     while end > 0:
@@ -148,6 +154,6 @@ def drop_trailing_assistant_messages(history: list[messages.BaseMessage]) -> lis
         if not isinstance(message, messages.AIMessage) or message.tool_calls:
             break
         end -= 1
-    # A history that is nothing but assistant messages has no valid prefix to send, so leave it
-    # alone and let the caller's own validation report it.
+    # Everything being an assistant turn means there is no valid request to build. Return the
+    # history unchanged so the API rejects it loudly, rather than silently sending nothing.
     return history[:end] if end > 0 else history

--- a/ee/hogai/utils/test/test_anthropic.py
+++ b/ee/hogai/utils/test/test_anthropic.py
@@ -3,20 +3,12 @@ from posthog.test.base import BaseTest
 from langchain_core.messages import AIMessage, HumanMessage
 from parameterized import parameterized
 
-from posthog.schema import (
-    AssistantForm,
-    AssistantFormOption,
-    AssistantMessage,
-    AssistantMessageMetadata,
-    AssistantToolCall,
-    AssistantToolCallMessage,
-    HumanMessage as SchemaHumanMessage,
-)
+from posthog.schema import AssistantMessage, AssistantMessageMetadata
 
 from ee.hogai.utils.anthropic import (
     add_cache_control,
     convert_assistant_message_to_anthropic_message,
-    convert_to_anthropic_messages,
+    drop_trailing_assistant_messages,
     get_anthropic_thinking_from_assistant_message,
 )
 
@@ -155,44 +147,30 @@ class TestAnthropicUtils(BaseTest):
         [
             # Legacy summarize_sessions appended its "Open report" message after the tool result,
             # leaving the conversation on an assistant turn.
-            ["legacy_form_message_last", True, 1],
-            ["human_message_last", False, 3],
+            ["ends_on_assistant", [HumanMessage(content="hi"), AIMessage(content="report ready")], 1],
+            ["ends_on_human", [AIMessage(content="hi"), HumanMessage(content="thanks")], 2],
+            [
+                "several_trailing_assistants",
+                [HumanMessage(content="hi"), AIMessage(content="a"), AIMessage(content="b")],
+                1,
+            ],
+            ["nothing_to_drop", [HumanMessage(content="hi")], 1],
+            # No valid request can be built, so it is returned as-is to fail loudly at the API.
+            ["only_assistants", [AIMessage(content="a"), AIMessage(content="b")], 2],
         ]
     )
-    def test_conversation_never_ends_on_an_assistant_turn(self, _name, ends_with_assistant, expected_length):
-        conversation: list = [
-            SchemaHumanMessage(content="Summarize my sessions"),
-            AssistantMessage(
-                content="Report complete: Sessions summary",
-                id="report",
-                meta=AssistantMessageMetadata(
-                    form=AssistantForm(
-                        options=[AssistantFormOption(value="Open report", href="/session-summaries/abc")]
-                    )
-                ),
-            ),
-        ]
-        if not ends_with_assistant:
-            conversation.append(SchemaHumanMessage(content="Thanks"))
-
-        result = convert_to_anthropic_messages(conversation, {})
+    def test_drop_trailing_assistant_messages(self, _name, history, expected_length):
+        result = drop_trailing_assistant_messages(history)
 
         self.assertEqual(len(result), expected_length)
-        self.assertNotIsInstance(result[-1], AIMessage)
 
-    def test_assistant_message_with_tool_calls_is_not_dropped(self):
-        conversation: list = [
-            SchemaHumanMessage(content="Run it"),
-            AssistantMessage(
-                content="Running",
-                id="call",
-                tool_calls=[AssistantToolCall(id="t1", name="read_data", args={})],
-            ),
+    def test_assistant_message_with_tool_calls_is_never_dropped(self):
+        # Dropping it would orphan the tool result that follows it, which Anthropic also rejects.
+        history = [
+            HumanMessage(content="run it"),
+            AIMessage(content="running", tool_calls=[{"id": "t1", "name": "read_data", "args": {}}]),
         ]
-        tool_results = {"t1": AssistantToolCallMessage(content="done", tool_call_id="t1", id="result")}
 
-        result = convert_to_anthropic_messages(conversation, tool_results)
+        result = drop_trailing_assistant_messages(history)
 
-        # The assistant turn stays because dropping it would orphan its tool result, which follows it.
-        self.assertIsInstance(result[1], AIMessage)
-        self.assertEqual(len(result), 3)
+        self.assertEqual(result, history)


### PR DESCRIPTION
## Problem

Follow-up to #74590, which shipped `drop_trailing_assistant_messages` to stop Anthropic prefill errors on conversations left ending on an assistant turn. The guard works, but it went in the wrong place and it hides something.

**It lives inside the shared converter.** `convert_to_anthropic_messages` ends with:

```python
    return drop_trailing_assistant_messages(history)
```

"Never end on an assistant turn" is a rule about the shape of an Anthropic *request*, not about what a conversation contains. Sitting in the general converter, every future caller inherits request-shaping it never asked for, and anyone using the converter to inspect a conversation gets a silently truncated view. There is one caller today, so this is about where the next one lands.

**It silently swallows a second, unrelated failure.** In `convert_assistant_message_to_anthropic_message`:

```python
# Filter out tool calls without a tool response, so the completion doesn't fail.
tool_calls = [tool for tool in (message.model_dump()["tool_calls"] or []) if tool["id"] in tool_result_map]
```

An assistant message whose tool calls all lack results has those calls stripped, leaving content only. The `message.tool_calls` guard therefore does not protect it, so a trailing one is deleted outright. That is the correct thing to send, but it is a different situation from the legacy one the guard was written for: a tool call lost its result. Today that happens with no trace at all.

## Changes

- Move the call out of `convert_to_anthropic_messages` and into `_construct_messages`, where the Anthropic request is actually assembled. The converter goes back to returning what it converted.
- Log when anything is trimmed, with the count and team. Legacy conversations are expected here; anything else means a tool call lost its result, which is worth knowing.
- Document the orphaned-tool-call interaction on the helper, and note that it shapes a request rather than describing a conversation.
- Fix a comment that claimed an all-assistant history would be caught by "the caller's own validation". There is no such validation; it reaches the API and 400s. The comment now says that.

No behaviour change for the legacy path #74590 fixed. Same messages get dropped, from the same requests.

## How did you test this code?

I (Claude) ran these against latest master in a worktree, no manual UI testing:

- `ee/hogai/utils/test/test_anthropic.py` + `ee/hogai/core/agent_modes/test/test_executables.py` — 57 passed
- `ee/hogai/core`, `ee/hogai/utils`, `ee/hogai/chat_agent` — 965 passed
- `mypy --cache-fine-grained .` — clean, 17,183 files
- `ruff check` / `ruff format --check` — clean

Tests were restructured to match the move. `drop_trailing_assistant_messages` is now covered directly as the pure function it is, with five cases: ends on assistant, ends on human, several trailing assistants, nothing to drop, and the all-assistant history that is deliberately returned unchanged. Plus one case asserting an assistant message with tool calls is never dropped, since removing it would orphan the tool result that follows.

The previous tests went through `convert_to_anthropic_messages`, which no longer applies the guard, so they would have been testing nothing. A new test in `test_executables.py` covers the wiring through `_construct_messages` instead — it fails if the guard is ever unhooked from request building, which I verified by unhooking it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This came out of review pushback on #74590 rather than from the original investigation. I had written the guard into the converter because that is where the file's existing no-prefill convention lives (the provenance-note path avoids prefill the same way), and it looked like the natural home. Asked to justify it, the placement did not hold up: the convention in that file is per-message conversion, whereas this is a rule about the assembled request.

The orphaned-tool-call interaction I had missed entirely. My `message.tool_calls` guard reads as though it protects any assistant message with tool calls, but by that point unanswered calls have already been stripped, so it protects only the answered ones. Dropping is still right for the request; doing it silently was not.

Split out because #74590 merged while I was still fighting an unrelated local git problem, so this commit landed on that branch after the merge. Cherry-picked onto master rather than reusing the merged branch.

Skills invoked: `/writing-code-comments`, `/writing-tests`.
