### PR TITLE
fix(notifications): always show "Mark all read" when unread count > 0

### DIFF
--- a/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
@@ -74,9 +74,9 @@ export function NotificationsPanel(): JSX.Element {
                     </span>
                 )}
             </div>
-            {/* Only surface "Mark all read" when unread items sit on not-yet-loaded pages — the ones
-                already loaded get cleared by the 3s auto-mark-on-view as the user scrolls. */}
-            {!isArchivedTab && hasMoreNotifications && inAppUnreadCount > loadedUnreadCount && (
+            {/* Surface "Mark all read" whenever the bell shows an unread count, so a single click
+                clears it — the 3s auto-mark-on-view only covers items the user keeps on screen. */}
+            {!isArchivedTab && inAppUnreadCount > 0 && (
                 <LemonButton
                     size="xsmall"
                     type="secondary"


### PR DESCRIPTION
## Problem

Getting to "inbox zero" on notifications was only possible by opening or dwelling on every single item. The panel's "Mark all read" button was hidden unless there were unread notifications on not-yet-loaded pages. When your unread all fit on screen (the common case for a count like 10), the button disappeared, and the only way to clear the bell's unread bubble was to let each item sit ≥50% visible for the 3-second auto-mark-on-view — even for items that are outdated or irrelevant.

Raised in a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785410267737239?thread_ts=1785410267.737239&cid=C09G8Q32R6F).

## Changes

Show "Mark all read" whenever the bell has an unread count (`inAppUnreadCount > 0`) and we're not on the archived tab, instead of only when unread items sit on unloaded pages. One click now clears the count.

No new wiring was needed: the `markAllAsRead` action already marks loaded rows read, zeroes the badge, and calls the backend `mark_all_read` endpoint (which marks every unread, non-archived notification read for the user). This change just loosens the render guard on the existing button.

## How did you test this code?

No automated tests were added — this is a one-line change to a render condition, and no existing test asserted the old guard. I did not run the app manually. The behavior of the underlying `markAllAsRead` action (clearing loaded rows and zeroing the count) is already covered in `sidePanelNotificationsLogic.test.ts`. Worth a quick manual check that the button appears with a small unread count and clears the bubble in one click.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The request was framed as "add a Mark all as read button" — investigation found the button already exists in `NotificationsPanel.tsx` but was gated to only appear when unread items were on unloaded pages, which is exactly why it was missing in the reporter's case. The fix reframes to that root cause rather than adding a second button. No repo skills were required for this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8Q32R6F/p1785410267737239?thread_ts=1785410267.737239&cid=C09G8Q32R6F)*
