### PR TITLE
fix(data-modeling): write empty parquet without a zero-row row group

### DIFF
--- a/posthog/temporal/data_modeling/activities/materialize_view.py
+++ b/posthog/temporal/data_modeling/activities/materialize_view.py
@@ -259,7 +259,10 @@ async def _write_empty_parquet_for_zero_rows(table_uri: str, schema: pa.Schema, 
     is still queryable.
     """
     buf = pa.BufferOutputStream()
-    pq.write_table(schema.empty_table(), buf)
+    # write_table() on an empty table emits a 0-row row group, which ClickHouse rejects,
+    # so write only the schema with no row groups.
+    with pq.ParquetWriter(buf, schema):
+        pass
     parquet_bytes = buf.getvalue().to_pybytes()
     file_uri = f"{table_uri}/empty_{uuid.uuid4().hex}.parquet"
     s3 = get_s3_client()

--- a/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
+++ b/posthog/temporal/tests/data_modeling/test_materialize_view_activities.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 from collections.abc import AsyncIterator, Collection, Iterable
+from io import BytesIO
 from typing import Any, cast
 
 import pytest
@@ -12,6 +13,7 @@ from django.test import override_settings
 import pyarrow as pa
 import deltalake
 import pytest_asyncio
+import pyarrow.parquet as pq
 
 from posthog.hogql.resolver import ResolverFactory
 
@@ -32,6 +34,7 @@ from posthog.temporal.data_modeling.activities.materialize_view import (
     LOGGER,
     InvalidNodeTypeException,
     _get_aws_storage_options,
+    get_s3_client,
     hogql_table,
 )
 
@@ -1057,6 +1060,12 @@ class TestMaterializeViewActivity:
             pyarrow_table = delta_table.to_pyarrow_table()
             assert pyarrow_table.num_rows == 0
             assert set(pyarrow_table.column_names) == {"id", "name"}
+            # ClickHouse rejects a parquet containing a 0-row row group, so the file must be metadata-only
+            s3 = get_s3_client()
+            with s3.open(result.file_uris[0], "rb") as f:
+                empty_parquet = pq.ParquetFile(BytesIO(f.read()))
+            assert empty_parquet.metadata.num_row_groups == 0
+            assert empty_parquet.schema_arrow.names == ["id", "name"]
 
     async def test_write_failure_surfaces(self, activity_environment, ateam, anode, ajob, bucket_name, adag):
         # regression: a failure in a per-batch write_deltalake call must surface from the


### PR DESCRIPTION
## Problem

A materialization whose query legitimately returns zero rows fails instead of producing an empty table. The v2 activity synthesizes an empty parquet for zero-row results via `pq.write_table(schema.empty_table())`, and pyarrow emits that as a file with one row group containing 0 rows. ClickHouse rejects such files on any real column read:

```
Code: 117. DB::Exception: Row group 0 has <= 0 rows: 0 ... (INCORRECT_DATA)
```

So "no data right now" is recorded as a failed job, and each occurrence feeds the consecutive-failure counter that suspends the node. The failure is sneaky because `count()` and `DESCRIBE` both succeed on the malformed file - only a materialized column read touches the row group.

## Changes

- `_write_empty_parquet_for_zero_rows` now opens a `pq.ParquetWriter` and closes it without writing a batch, producing a metadata-only parquet (schema present, zero row groups) that ClickHouse reads as an empty table.
- Extended the existing zero-row regression test with the structural assertion that the written file has zero row groups.

## How did you test this code?

Automated only (agent-run):

- The sharpened assertion in `test_zero_row_materialization_writes_empty_parquet` was red first (`num_row_groups` was 1) and is green with the fix. It catches a regression no other test does: a re-introduction of an empty row group in the zero-row file, which breaks every ClickHouse read of the materialized table.
- Full `posthog/temporal/tests/data_modeling/test_materialize_view_activities.py` passes.
- ClickHouse-level validation of the assumption: on CH 26.3 (the strict version) a `SELECT` of real columns over the old-style file fails with exactly the error above, while the metadata-only file reads clean for `count()`, `DESCRIBE`, and column selects. CH 26.6 tolerates both (upstream relaxed the check from `<= 0` to `< 0`), which is why the durable guard is the pyarrow-level assertion rather than a CH-backed test.

v1 (`run_workflow.py`) is unaffected: it never synthesizes a parquet, and delta-rs writes no data file for an empty batch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this fix; Claude (Claude Code) root-caused it from production job errors, wrote the red-first assertion, applied the fix, and ran the ClickHouse validation on both 26.3 and 26.6. Skills invoked: /writing-tests. The alternative of teaching the read side to tolerate empty row groups was rejected - the write side is ours, and prod ClickHouse enforces the strict check.
