### PR TITLE
fix(visual-review): skip baseline healing on merge-queue branches

### DIFF
--- a/products/visual_review/backend/logic.py
+++ b/products/visual_review/backend/logic.py
@@ -63,6 +63,8 @@ logger = structlog.get_logger(__name__)
 
 ARTIFACT_HASH_BATCH_SIZE = 500
 
+MERGE_QUEUE_BRANCH_PREFIX = "trunk-merge/"
+
 
 def _iter_batches(values: Iterable[str], batch_size: int) -> Iterator[list[str]]:
     batch: list[str] = []
@@ -543,6 +545,8 @@ def _resolve_baselines_with_merge_base(
     tip.  This prevents a race where a newer commit updates the
     baseline file before an older commit's VR run completes.
 
+    Merge-queue branches are exempt: see _is_merge_queue_branch.
+
     Returns (merged_baseline, healed_count).
     """
     try:
@@ -558,7 +562,7 @@ def _resolve_baselines_with_merge_base(
     baseline_ref = commit_sha if (commit_sha and branch == default_branch) else branch
     branch_baseline = _resolve_baselines_at_ref(repo, github, run_type, baseline_ref)
 
-    if branch == default_branch:
+    if branch == default_branch or _is_merge_queue_branch(branch):
         return branch_baseline, 0
 
     merge_base_sha = _get_merge_base_sha(github, repo.repo_full_name, default_branch, branch)
@@ -597,6 +601,24 @@ def _resolve_baselines_with_merge_base(
         )
 
     return merged, len(healed)
+
+
+def _is_merge_queue_branch(branch: str) -> bool:
+    """Whether this branch is one of Trunk's ephemeral merge-queue batch branches.
+
+    Healing exists to repair a baseline that a rebase replayed destructively,
+    and tombstones (below) keep it from resurrecting approved removals. Both
+    are keyed to a durable branch. A batch branch is created fresh per attempt,
+    so it carries no run history and therefore no tombstones, which means
+    healing resurrects every removal the batched PRs already approved on their
+    own branches and re-flags it as REMOVED, failing the gate. Nobody can
+    approve it away either, because the branch is gone before a human could
+    review the run.
+
+    A batch branch is master with the batched PR heads merged in, so its
+    baseline file is exactly what is about to land. Trust it as written.
+    """
+    return branch.startswith(MERGE_QUEUE_BRANCH_PREFIX)
 
 
 def _tombstoned_identifiers(repo: Repo, run_type: str, branch: str) -> set[str]:

--- a/products/visual_review/backend/tests/test_logic.py
+++ b/products/visual_review/backend/tests/test_logic.py
@@ -1976,6 +1976,7 @@ class TestMergeBaseBaselineHealing:
         merge_base_sha="abc123",
         default_branch="master",
         commit_sha_baselines=None,
+        branch_name="my-branch",
     ):
         mock_github = mocker.MagicMock()
         mock_github.integration.sensitive_config = {"access_token": "fake"}
@@ -1987,7 +1988,7 @@ class TestMergeBaseBaselineHealing:
         def fake_fetch(github, repo_full_name, file_path, ref):
             if ref in _commit_sha_baselines:
                 return {k: {"hash": v} for k, v in _commit_sha_baselines[ref].items()}, f"sha-{ref}"
-            if ref in ("my-branch", default_branch):
+            if ref in (branch_name, default_branch):
                 return {k: {"hash": v} for k, v in branch_baseline.items()}, "sha1"
             if ref == merge_base_sha:
                 baselines = merge_base_baseline if merge_base_baseline is not None else branch_baseline
@@ -2041,6 +2042,22 @@ class TestMergeBaseBaselineHealing:
 
         assert "NewStory" in merged
         assert merged["NewStory"] == "new_hash"
+        assert healed == 0
+
+    def test_skips_merge_base_for_merge_queue_branch(self, repo, mocker):
+        branch = "trunk-merge/pr-1234/e86d4a18-8453-4018-992c-2adc2a0f8d4d"
+        branch_baseline = {"A": "h1"}
+        merge_base_baseline = {"A": "h1", "DeletedStory": "h2"}
+        self._mock_github(
+            mocker,
+            branch_baseline=branch_baseline,
+            merge_base_baseline=merge_base_baseline,
+            branch_name=branch,
+        )
+
+        merged, healed = logic._resolve_baselines_with_merge_base(repo, "storybook", branch)
+
+        assert merged == branch_baseline
         assert healed == 0
 
     def test_skips_merge_base_for_default_branch(self, repo, mocker):


### PR DESCRIPTION
## Problem

Any PR that deletes a snapshot identifier currently cannot get through the merge queue. It fails `Visual regression tests pass`, gets bisected out, re-enters, and fails again forever.

That covers renaming a story, dropping one, or making a story single-theme. Concretely, [#74295](https://github.com/PostHog/posthog/pull/74295) renames `CollapsibleFrame`'s `InitiallyExpanded` dark story, and has been stuck in the queue for hours. [#74746](https://github.com/PostHog/posthog/pull/74746)'s batch hit the same thing yesterday.

The failing job is `Complete Visual Review run`, which the gate collates:

```
Done: 4110 snapshots — 4109 unchanged, 0 changed, 0 new, 1 removed
Visual changes detected — review at: .../visual_review/runs/4dc40c1a-...
##[error]Process completed with exit code 1
```

Nothing looks different. `0 changed, 0 new`. The gate fails purely on a phantom `removed`.

### Where the phantom comes from

`_resolve_baselines_with_merge_base` merges the branch baseline with the merge-base baseline, to repair entries a rebase replayed destructively. `_tombstoned_identifiers` is what stops that healing from resurrecting a removal a human already approved, and it filters on `run__branch=branch`. Tombstones are strictly branch-scoped.

That pairing holds on a normal PR branch. It falls apart in the queue:

| | PR branch | Merge-queue batch branch |
|---|---|---|
| Branch | `hp/error-tracking-code-contrast` | `trunk-merge/pr-68901/<uuid>`, fresh per attempt |
| Run history | yes | none |
| Tombstones | removal approved, bot commits baseline, check green | none exist |
| Result | healing suppressed | healing resurrects the deletion, flags it `REMOVED`, gate fails |

Nobody can approve it away either. The batch branch is gone before a human could review the run, and the merge base keeps the deleted entry until the PR lands. Deadlock.

I confirmed the merge commit's own baseline file is correct: `275fcac2999:frontend/snapshots.yml` has 4109 entries with the deleted identifier absent. The 4110th is added server-side by healing. Master pushes are all clean at `0 removed`, so the baseline itself is fine.

`ci-storybook.yml` already special-cases `trunk-merge/` branches twice (the `no-ci` bypass and the narrowed story selection). The Visual Review backend had no notion of them.

## Changes

Skip merge-base healing on `trunk-merge/` branches, next to the existing default-branch early return.

```diff
-    if branch == default_branch:
+    if branch == default_branch or _is_merge_queue_branch(branch):
         return branch_baseline, 0
```

This is semantically right, not just a workaround. Healing exists to repair rebase-rewritten history, and an ephemeral batch branch has none. A batch branch is master with the batched PR heads merged in, so its baseline file is already exactly what is about to land.

> [!NOTE]
> The tradeoff: a rebase-mangled baseline would now pass silently in the queue instead of being caught. That is fine, because the queue branch's file is the one that lands on master, and the next master run validates it.

A broader alternative is making tombstone lookup ancestry-aware so it inherits from the batched PRs' branches. That is a bigger change and it does not unblock the queue today.

## How did you test this code?

Added `test_skips_merge_base_for_merge_queue_branch` to `TestMergeBaseBaselineHealing`. It catches the exact regression: if the exemption is dropped, an identifier deleted on the branch but still present at the merge base gets healed back in. No existing test in that class uses a merge-queue branch name, so nothing covered this.

I verified it actually fails without the fix, rather than assuming:

<details>
<summary>Test run against the unfixed logic</summary>

```
>       assert merged == branch_baseline
E       AssertionError: assert equals failed
E          -{
E          ^  'A': 'h1' ^,              ^{'A': 'h1' ^}
E          -  'DeletedStory': 'h2',
E          -}
FAILED products/visual_review/backend/tests/test_logic.py::TestMergeBaseBaselineHealing::test_skips_merge_base_for_merge_queue_branch
```

</details>

`_mock_github`'s hardcoded `"my-branch"` became a `branch_name` parameter so the helper can serve a differently-named branch. Default unchanged, so every existing case is untouched.

Ran locally: the full `products/visual_review/backend/tests/` suite (411 passed in 16m15s), `ruff check`, `ruff format`, and repo-wide `uv run mypy --cache-fine-grained .` (clean, 17184 files).

No manual testing. The failure only reproduces inside a real Trunk batch, which I cannot stand up locally.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude Code (Opus 5) to work out why visual regression checks kept failing in the merge queue, starting from a Trunk queue screenshot and nothing else. It traced the gate to `vr-complete`, pulled the job logs, and found `0 changed, 0 new, 1 removed`, which ruled out an actual visual diff. From there it fetched the batch merge commit to prove the baseline file on disk was correct, then read `logic.py` to find healing as the source of the extra entry and the branch-scoped tombstone query as the reason it only bites in the queue.

Two fixes were on the table. Ancestry-aware tombstones is the more general one, but it is a real change to how approvals resolve and would not land in time to unblock anything. The prefix exemption is narrow and matches what the healing code is actually for, so we went with it and noted the alternative above.

Skills invoked: `/writing-tests` (gated whether the new test earns its place, which is why there is one test and not a matrix), `/writing-code-comments` (the `_is_merge_queue_branch` docstring, and rewriting an em-dash into a connective).

