### PR TITLE
fix(data-imports): retry transient DB connection drop in repartition flag check

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition_controller.py
@@ -20,6 +20,7 @@ from dateutil import parser
 from structlog.types import FilteringBoundLogger
 
 from posthog.exceptions_capture import capture_exception
+from posthog.temporal.common.utils import retry_on_db_connection_drop
 from posthog.utils import get_machine_id
 
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
@@ -76,7 +77,7 @@ def is_auto_repartition_enabled(schema: ExternalDataSchema) -> bool:
     from posthog.models import Team
 
     try:
-        team = Team.objects.only("uuid", "organization_id").get(id=schema.team_id)
+        team = retry_on_db_connection_drop(lambda: Team.objects.only("uuid", "organization_id").get(id=schema.team_id))
     except Team.DoesNotExist:
         return False
     try:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py
@@ -4,7 +4,7 @@ import datetime
 import tempfile
 
 import pytest
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.db import OperationalError
 
@@ -227,6 +227,25 @@ class TestRepartitionDetection:
         assert schema.repartition_pending is not None
         assert schema.repartition_pending["partition_mode"] is None
         assert schema.repartition_pending["partition_keys"] == ["id"]
+
+
+class TestIsAutoRepartitionEnabled:
+    def test_retries_once_on_transient_db_connection_drop(self, team):
+        # The Team lookup runs on a long-lived Temporal worker thread; a pooler-dropped connection
+        # raises OperationalError on first use. Without a retry this propagates out of
+        # is_auto_repartition_enabled uncaught (it's outside the function's Team.DoesNotExist/
+        # feature_enabled try blocks) instead of resolving the flag.
+        schema = _make_schema(team, {})
+        mock_queryset = MagicMock()
+        mock_queryset.get.side_effect = [OperationalError("server closed the connection unexpectedly"), team]
+
+        with (
+            patch("posthog.models.Team.objects.only", return_value=mock_queryset),
+            patch.object(ctrl.posthoganalytics, "feature_enabled", return_value=True),
+        ):
+            assert ctrl.is_auto_repartition_enabled(schema) is True
+
+        assert mock_queryset.get.call_count == 2
 
 
 class TestRepartitionOOMHistoryTrigger:


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError: consuming input failed: server closed the connection unexpectedly` from `is_auto_repartition_enabled` in `products/warehouse_sources/backend/temporal/data_imports/pipelines/core/repartition_controller.py`, during a Postgres source sync.

The failing line is a plain Django ORM read (`Team.objects.only(...).get(id=schema.team_id)`) against PostHog's own app database, not the customer's synced source. It runs via `asyncio.to_thread` inside a long-lived Temporal worker thread, so a pooler-recycled or dropped connection surfaces as `OperationalError` the first time it's reused — a known, transient failure mode in this codebase, not a bug in the sync logic itself.

The call is already wrapped in a broad `try/except` in `maybe_flag_for_repartition` that reports it via `capture_exception` and returns without breaking the sync (the function is documented to "never raise" — this is best-effort repartition detection). So the transient blip doesn't break anything, but it does add noise to error tracking on every occurrence, since the dead connection is neither evicted nor retried.

## Changes

- Wrap the `Team.objects.get()` read in `is_auto_repartition_enabled` with `retry_on_db_connection_drop` (`posthog/temporal/common/utils.py`), the existing helper built for exactly this failure class: it evicts the stale pooled connection and retries once on `OperationalError`/`InterfaceError`, matching the pattern already used elsewhere in this Temporal worker tree.
- Added a regression test that raises `OperationalError` on the first `Team` lookup and asserts the function retries and resolves the flag instead of the error propagating uncaught.

I checked for an existing fix first: [#73386](https://github.com/PostHog/posthog/pull/73386) classifies a similar DB-connection blip as transient, but in a different function (`run_pre_write_defensive_compact`'s `job.folder_path()` resolution) — it doesn't touch `is_auto_repartition_enabled` or this call site. No open PR covers this specific one.

## How did you test this code?

Added `TestIsAutoRepartitionEnabled::test_retries_once_on_transient_db_connection_drop`, which mocks the `Team.objects.only(...).get()` call to raise `OperationalError` once then succeed, and asserts the function returns the resolved flag value instead of the exception propagating. Without the fix this test fails, since the error isn't caught anywhere inside `is_auto_repartition_enabled` — it currently escapes to the caller's outer catch-all.

Ran:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test_repartition_controller.py` — 30 passed
- `uv run mypy --cache-fine-grained .` (repo-wide, as CI runs it) — clean on the changed files
- `ruff check --fix` / `ruff format` — clean
- `hogli ci:preflight --fix` — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-handling change, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error tracking issue using the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace and confirm the exact failing line and call path. Used a research subagent to check for an existing connection-hygiene pattern in this Temporal worker tree, which surfaced `retry_on_db_connection_drop`/`aretry_on_db_connection_drop` in `posthog/temporal/common/utils.py` as the established fix for this exact failure class. Checked for duplicate open PRs by exception type, message phrase, module path, and the maintainer's own open PRs before writing the fix — found a related-but-non-overlapping PR (noted above) rather than a duplicate. Invoked `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*