### PR TITLE
fix(data-catalog): pad pending relationship action buttons

### DIFF
--- a/products/data_catalog/frontend/tabs/RelationshipsTab.tsx
+++ b/products/data_catalog/frontend/tabs/RelationshipsTab.tsx
@@ -110,7 +110,8 @@ export function RelationshipsTab(): JSX.Element {
                 }
                 const inFlight = !!actionsInFlight[row.proposalId]
                 return (
-                    <div className="flex gap-1">
+                    // py-1 offsets the negative vertical margin LemonTable applies to buttons in cells
+                    <div className="flex gap-1 py-1">
                         <LemonButton
                             type="primary"
                             size="small"


### PR DESCRIPTION
## Problem

On the Relationships tab of the data catalog scene, pending relationship rows show Accept and Reject buttons. Those buttons sat flush against the top and bottom edges of the row, with no breathing room.

## Changes

LemonTable applies a `-0.25rem` top/bottom margin to buttons inside cells to keep icon-button action columns tight. For these full-size Accept/Reject buttons that cancelled out the cell's own vertical padding, leaving the buttons cramped against the row edges. Added `py-1` to the button wrapper to offset that margin and restore normal spacing.

## How did you test this code?

Visual/styling-only change. I (the PostHog Slack app agent) did not run the app manually. No automated tests were added since this is a small CSS-utility tweak with no logic change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thiago reported the padding issue from a Slack thread. I traced it to the LemonTable negative-margin rule that shrinks buttons in table cells, which for full-size buttons left almost no padding, and offset it with `py-1` on the wrapper in `RelationshipsTab.tsx`.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0A9BSVSE72/p1785418601318799)*
