### PR TITLE
fix(mongodb): classify connection pool paused as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
@@ -156,7 +156,14 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         # resolver PostHog's worker queries, unrelated to the user's cluster hostname — so Temporal
         # retrying the whole activity is self-recovering. Match dnspython's fixed message prefix,
         # not the variable timeout duration or nameserver address it's followed by.
-        return {"The resolution lifetime expired"}
+        #
+        # pymongo also raises a bare AutoReconnect("<address>: connection pool paused ...") when a
+        # connection checkout finds the pool not yet READY after an earlier network blip — the
+        # pool's background monitor clears this on its own once it reconnects, so it's distinct
+        # from the persistent "Topology Description:" server-selection failures above. Match the
+        # fixed "connection pool paused" phrase pymongo always uses for this state, not the
+        # surrounding host/timeout values.
+        return {"The resolution lifetime expired", "connection pool paused"}
 
     def get_schemas(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -487,6 +487,18 @@ class TestGetRetryableErrors(SimpleTestCase):
             f"MongoDB DNS SRV resolution timeout should be classified retryable: {error_msg}"
         )
 
+    def test_connection_pool_paused_is_classified_retryable(self):
+        # Bare AutoReconnect raised on connection checkout while the pool is recovering from an
+        # earlier network blip — no "Topology Description:" suffix, so it must not be mistaken
+        # for the persistent server-selection failure classified non-retryable above.
+        error_msg = (
+            "cluster0.example.mongodb.net:27017: connection pool paused "
+            "(configured timeouts: connectTimeoutMS: 20000.0ms)"
+        )
+        assert any(pattern in error_msg for pattern in self.retryable), (
+            f"MongoDB connection pool paused should be classified retryable: {error_msg}"
+        )
+
 
 class TestGetRowsToSync(SimpleTestCase):
     """rows_to_sync is a best-effort progress estimate; a failed count must degrade to


### PR DESCRIPTION
## Problem

PostHog's error tracking flagged an unhandled `pymongo.errors.AutoReconnect` from the MongoDB data-warehouse source, raised mid-sync while iterating a collection cursor:

```
AutoReconnect: <host>:27017: connection pool paused (configured timeouts: connectTimeoutMS: 20000.0ms)
```

pymongo raises this bare `AutoReconnect("connection pool paused")` on connection checkout whenever the pool hasn't finished recovering from an earlier network blip. It carries no `Topology Description:` suffix, so it's a different (and much shorter-lived) failure than the persistent server-selection timeouts `MongoDBSource.get_non_retryable_errors()` already matches on that marker.

The message didn't match any pattern in either `get_non_retryable_errors()` or `get_retryable_errors()`, so it fell through to the default path: logged as an unhandled exception and reported on every retry attempt, even though Temporal's automatic activity retry already resolves it once the pool's background monitor reconnects.

## Changes

Add `"connection pool paused"` to `MongoDBSource.get_retryable_errors()`, mirroring the existing DNS-SRV-timeout entry in the same method. This keeps Temporal's retry behavior unchanged (it was already retrying) but stops this transient, self-recovering blip from being reported as an unhandled exception.

## How did you test this code?

Added `test_connection_pool_paused_is_classified_retryable` to `TestGetRetryableErrors` in `test_mongo.py`, asserting the exact pymongo message shape (`<host>:<port>: connection pool paused (configured timeouts: ...)`) is recognized as retryable. Ran the full `test_mongo.py` suite (74 tests) locally — all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error classification only, no user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was authored by an agent triaging a PostHog error-tracking issue for the MongoDB warehouse source. No skills were invoked (this was a scoped, message-pattern classification change, not a migration/DRF/frontend change). The agent traced the error's call path into `mongo.py`'s `get_rows()`, confirmed via pymongo's source that `"connection pool paused"` is a fixed, host/timeout-independent phrase, and confirmed via the shared `_handle_import_error` routing logic that an unmatched retryable error is reported on every attempt even though Temporal already retries it successfully.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*