### PR TITLE
fix(data-warehouse): give actionable copy for an invalid Clockify API key

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clockify/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clockify/source.py
@@ -111,7 +111,10 @@ The key is user-scoped — it can read exactly what your Clockify user can. Use 
         if validate_clockify_credentials(config.api_key):
             return True, None
 
-        return False, "Invalid Clockify API key"
+        return (
+            False,
+            "Your Clockify API key is invalid or has been revoked. Generate a new key in your Clockify profile settings, then reconnect.",
+        )
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[ClockifyResumeConfig]:
         return ResumableSourceManager[ClockifyResumeConfig](inputs, ClockifyResumeConfig)


### PR DESCRIPTION
## Problem

When someone connects a Clockify data warehouse source with a bad key, the connect-time validation surfaced the bare toast "Invalid Clockify API key". That is a dead end. It does not say the key might have been revoked, where to generate a new one, or that reconnecting is the next step. Session scans of the new-source onboarding flow show users getting stuck on terse credential errors like this with no clear recovery path.

## Changes

Reuse the actionable wording that already exists in the same file's `get_non_retryable_errors` (used on the sync path for the identical 401 failure) for the connect-time return value:

```diff
-        return False, "Invalid Clockify API key"
+        return (
+            False,
+            "Your Clockify API key is invalid or has been revoked. Generate a new key in your Clockify profile settings, then reconnect.",
+        )
```

Copy-only change. No behavior, schema, or sync changes.

## How did you test this code?

This is a one-line string change with no logic change. I (Claude) ran `ruff check` and `ruff format` over the file. I did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found while reviewing friction themes in the data-warehouse new-source onboarding flow. Terse credential errors with no recovery guidance recurred across several sessions. Clockify's connect-time message was the cleanest fix: the file already contains a well-worded, actionable sibling message for the same failure on the sync path, so aligning the two is obviously correct and loses no information. I deliberately left the heavily-curated Postgres/MySQL error dictionaries alone.

Skills invoked: `/writing-user-facing-copy`, `/writing-code-comments`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
