### PR TITLE
fix(replay-vision): render ranked tags as pills again

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6903,9 +6903,9 @@ snapshots:
     scenes-app-replay-vision--scanners-list--light:
         hash: v1.k794b7964.99f5f4499dca089b44d7bce7dee60424c7bdeefb860a8882d5ca8cbf06abce69.MHJZLg5-Q8USBaHeY-N_hqBMtEfuRArXAsAgnwEk4gs
     scenes-app-replay-vision--summarizer-overview--dark:
-        hash: v1.k794b7964.c801b1da1f1c38a3e6560c462008a090ecb86373896e7974c4996c07b9bcef0d.G0L7uSVxm7HgUbRrYPlfWLNTq4K1uLVER89MMY9yQj0
+        hash: v1.k794b7964.e5827be3112c9cb7af5526a41eb02da1c5ef1982eb9d2af887e0649119f8def5.-yMhrm4zkIgcYpOcdAKwqy1w5SEDHRXT5pTfaNENKFg
     scenes-app-replay-vision--summarizer-overview--light:
-        hash: v1.k794b7964.6c3926b9189f1b772238b9fcdcb356c659f069faea561727fc50bf9aae40c620.umdwMDJ9PO4HQvOsDy5ry_XAuke9swpQAjZVowYt8tQ
+        hash: v1.k794b7964.f4cd388175bf16358030e2ad02abff949e1dccb34b702bb9ce8c4ce65ff32dfe.gfKH-mJ2VVS664K3yW1pg4gqSkPEBoFSspoe-446uOc
     scenes-app-saved-insights--empty-state--dark:
         hash: v1.k794b7964.43545664c9133c8afd354be6a6ed8f808c35b381101325d9605114632fcdc0c9.l8w9uEOEmrH6Xl1kNd9ueRtg_51cJUSjWLdjWDM0Fko
     scenes-app-saved-insights--empty-state--light:

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -56,16 +56,25 @@ function PanelEmpty({ loading, message }: { loading: boolean; message: string })
 // Cap the rows so a panel can't outgrow the one beside it.
 const RANKED_ROWS = 5
 
-// The bar is the row background rather than a column, so long friction phrases wrap instead of truncating.
+/**
+ * Two row shapes, because the terms differ in kind:
+ * - `tag` renders short vocabulary terms as pills, which is what marks them as tags rather than prose.
+ * - `phrase` renders model-written sentences as plain text with the bar behind the row, so they wrap
+ *   instead of being truncated into a pill.
+ */
+type RankedTermVariant = 'tag' | 'phrase'
+
 function RankedTermList({
     ranked,
     loading,
     emptyMessage,
+    variant,
     renderAction,
 }: {
     ranked: [string, number][]
     loading: boolean
     emptyMessage: string
+    variant: RankedTermVariant
     renderAction?: (term: string) => JSX.Element
 }): JSX.Element {
     if (ranked.length === 0) {
@@ -75,6 +84,34 @@ function RankedTermList({
     const maxCount = top[0][1]
     // When no term repeats, every bar is full width and falsely reads as "these all dominate", so drop the bars.
     const showBars = maxCount > 1
+    const percent = (count: number): number => Math.round((count / maxCount) * 100)
+
+    if (variant === 'tag') {
+        return (
+            <div className="space-y-1.5">
+                {top.map(([term, count]) => (
+                    <div key={term} className="flex items-center gap-2">
+                        {/* Fixed-width label column so every bar shares the same left edge and their lengths stay comparable. */}
+                        <div className="w-40 shrink-0 flex">
+                            <LemonTag type="option" title={term} className="max-w-full truncate">
+                                {term}
+                            </LemonTag>
+                        </div>
+                        {showBars ? (
+                            <LemonProgress percent={percent(count)} className="flex-1" />
+                        ) : (
+                            <div className="flex-1" />
+                        )}
+                        <span className="text-xs text-muted tabular-nums text-right whitespace-nowrap shrink-0 w-12">
+                            {count.toLocaleString()}
+                        </span>
+                        {renderAction?.(term)}
+                    </div>
+                ))}
+            </div>
+        )
+    }
+
     return (
         <div className="space-y-1">
             {top.map(([term, count]) => (
@@ -84,7 +121,7 @@ function RankedTermList({
                             className="absolute inset-y-0 left-0 bg-accent-highlight-secondary"
                             // Width is data-derived, so it can't live in a class.
                             // eslint-disable-next-line react/forbid-dom-props
-                            style={{ width: `${Math.round((count / maxCount) * 100)}%` }}
+                            style={{ width: `${percent(count)}%` }}
                         />
                     )}
                     <div className="relative flex items-baseline justify-between gap-2 px-2 py-1">
@@ -245,6 +282,7 @@ function ClassifierOverview({ scannerId }: { scannerId: string }): JSX.Element |
                     ranked={fixedRanked}
                     loading={overviewStatsApiLoading}
                     emptyMessage={fixedEmpty}
+                    variant="tag"
                     renderAction={cohortAction}
                 />
             </OverviewPanel>
@@ -260,6 +298,7 @@ function ClassifierOverview({ scannerId }: { scannerId: string }): JSX.Element |
                         ranked={freeformRanked}
                         loading={overviewStatsApiLoading}
                         emptyMessage={freeformEmpty}
+                        variant="tag"
                         renderAction={cohortAction}
                     />
                 ) : (
@@ -344,10 +383,16 @@ function SummarizerOverview({ scannerId }: { scannerId: string }): JSX.Element |
                     ranked={frictionRanked}
                     loading={overviewStatsApiLoading}
                     emptyMessage={frictionEmpty}
+                    variant="phrase"
                 />
             </OverviewPanel>
             <OverviewPanel title="Common keywords" subtitle={keywordSubtitle} fill>
-                <RankedTermList ranked={keywordRanked} loading={overviewStatsApiLoading} emptyMessage={keywordEmpty} />
+                <RankedTermList
+                    ranked={keywordRanked}
+                    loading={overviewStatsApiLoading}
+                    emptyMessage={keywordEmpty}
+                    variant="tag"
+                />
             </OverviewPanel>
         </div>
     )


### PR DESCRIPTION
## Problem

The shared `RankedTermList` I added in #74881 rendered every ranked term the same way: plain text with the share bar behind the row. That works for model-written friction phrases, which are long and need to wrap, but it dropped the `LemonTag` pills from the tag panels. Tue flagged it on the "Common keywords" panel ([Slack](https://posthog.slack.com/archives/C03PB072FMJ/p1785410396847859)): the pills are what tell you those terms are tags and not prose.

## Changes

`RankedTermList` now takes a `variant`, so one component still owns the shared parts (row cap, empty and loading state, count column, the optional save-as-cohort action, and dropping the bars when nothing repeats) while the row shape follows the kind of term:

- `tag` renders the term as a `LemonTag` pill with a `LemonProgress` bar, used by the classifier's fixed and freeform tag panels and by the summarizer's keyword panel.
- `phrase` keeps the wrapping row with the bar behind the text, used by the summarizer's friction points.

Before:

![summarizer-before](https://raw.githubusercontent.com/PostHog/pr-assets/3968031011639f3aef6979c09b1fbcd09fd08541/2026/07/a9e0a40f-ecdb-411d-b19f-c00598ea5301.png)

After:

![summarizer-after](https://raw.githubusercontent.com/PostHog/pr-assets/59f9760f663829de7faebb709e5a8c5e9d06d27e/2026/07/80a1f9a5-9aaa-4a1a-8042-cde2b755786c.png)

## How did you test this code?

The `scenes-app-replay-vision--summarizer-overview` story already covers both panels, so its visual snapshot is the regression test here and needs its baseline updated with this PR. I rendered that story in a local Storybook to take the screenshots above, and ran the full frontend typecheck. No new tests: the change is presentational and the story already exercises both variants.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change: the panels and their data are unchanged, only how a term is drawn.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5) wrote this after the review comment on #74881. Skills invoked: `/writing-code-comments`, plus `frontend/src/AGENTS.md` for the reuse and typecheck cadence rules.

Two options were on the table. Keep the single row layout and just wrap the term in a pill, or split the row shape by variant and restore the previous pill-and-progress look exactly. I went with the second: a pill floating on top of the tinted bar background reads busier than either of the two shapes it replaces, and the point of the review comment was that the old tag rows were better. The `showBars` rule from #74881 stays shared, so a tag panel where nothing repeats still hides its bars instead of showing five full ones.
