### PR TITLE
fix(support): use the shared enterprise org list for the plan tag

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -32,6 +32,7 @@ import type { BillingType, PreflightStatus } from '../../../types'
 import type { FeatureFlagsSet } from '../../logic/featureFlagLogic'
 import { parseExceptionEvent } from './exceptionUtils'
 import { openSupportModal } from './SupportModal'
+import { KNOWN_ENTERPRISE_ORG_IDS } from './supportResponseTime'
 
 export function getPublicSupportSnippet(
     cloudRegion: Region | null | undefined,
@@ -904,8 +905,9 @@ export const supportLogic = kea<supportLogicType>([
 
             let planLevelTag = 'plan_free'
 
-            const knownEnterpriseOrgIds = ['018713f3-8d56-0000-32fa-75ce97e6662f']
-            const isKnownEnterpriseOrg = knownEnterpriseOrgIds.includes(userLogic?.values?.user?.organization?.id || '')
+            const isKnownEnterpriseOrg = KNOWN_ENTERPRISE_ORG_IDS.includes(
+                userLogic?.values?.user?.organization?.id || ''
+            )
 
             const isNewOrganization = values.isCurrentOrganizationNew
 


### PR DESCRIPTION
## Problem

Support tickets carry a `plan_level` tag that Zendesk uses for routing. The code that builds it resolves known-enterprise organizations against its own inline copy of the org id list, rather than the `KNOWN_ENTERPRISE_ORG_IDS` constant that the help panel's response times table and the ticket response time both read.

Both copies were added by the same PR, [#33681](https://github.com/PostHog/posthog/pull/33681), to close one detection hole in two places. When the shared constant later moved into `supportResponseTime.ts`, this copy stayed behind. So adding an organization to the constant now updates what the UI shows that organization, but leaves its tickets tagged by billing plan instead of `plan_enterprise`. That surfaces as a routing problem rather than a visible bug, which is a bad way to find out.

## Changes

`supportLogic` imports `KNOWN_ENTERPRISE_ORG_IDS` and drops the inline array. One source of truth for which organizations count as enterprise.

No behavior change today: the two lists hold the same single org id. This is about the next edit to that list, not this one.

## How did you test this code?

**Automated:** `jest frontend/src/lib/components/Support`, 32 tests pass. Full `tsc --noEmit` over the frontend reports the same error count with and without the change, so it introduces none.

**Manual:** none, and none is warranted. The change swaps a local constant for an imported one holding identical contents. Nothing in the plan tag logic around it moved. Worth noting that no test anywhere asserts the plan tag mapping, so this path is uncovered either way, which is part of why the drift went unnoticed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed. No user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found by Claude Code while reviewing a bot suggestion on [#74173](https://github.com/PostHog/posthog/pull/74173), which deduplicated a selector in the same area. I asked it to sweep for other duplication of the same kind, and this was the highest-value hit: the only one with a real consequence attached rather than just repeated lines.

Deliberately kept narrow. Two related cleanups came out of the same sweep and are being handled separately: the active-trial check is written out five times across four files, and the `planLevelTag` block re-implements `getCurrentSupportPlan` with extra branches. The second one changes tags that route real tickets, so it wants its own review and its own tests rather than riding along here.
