### PR TITLE
feat(signals): restore Slack dismiss button and add "Not me" to inbox reports

### DIFF
--- a/products/signals/backend/facade/api.py
+++ b/products/signals/backend/facade/api.py
@@ -128,14 +128,31 @@ def validate_signal_input(
 
 
 def dismiss_report_from_slack(
-    team_id: int, report_id: str, *, slack_user_id: str | None = None, user_id: int | None = None
+    team_id: int,
+    report_id: str,
+    *,
+    slack_user_id: str | None = None,
+    user_id: int | None = None,
+    reason: str | None = None,
+    note: str | None = None,
 ) -> bool:
     """Facade entrypoint for the Slack 'Dismiss' button. See report_actions.suppress_report_from_slack."""
     from products.signals.backend.report_actions import (
         suppress_report_from_slack,  # noqa: PLC0415 — avoids importing model layer at facade import time
     )
 
-    return suppress_report_from_slack(team_id, report_id, slack_user_id=slack_user_id, user_id=user_id)
+    return suppress_report_from_slack(
+        team_id, report_id, slack_user_id=slack_user_id, user_id=user_id, reason=reason, note=note
+    )
+
+
+def remove_reviewer_from_slack(team_id: int, report_id: str, *, user_id: int) -> str:
+    """Facade entrypoint for the Slack 'Not me' button. See report_actions.remove_reviewer_from_slack."""
+    from products.signals.backend.report_actions import (
+        remove_reviewer_from_slack as _remove_reviewer_from_slack,  # noqa: PLC0415 — avoids importing model layer at facade import time
+    )
+
+    return _remove_reviewer_from_slack(team_id, report_id, user_id=user_id)
 
 
 def get_default_slack_notification_channel(team_id: int) -> str | None:

--- a/products/signals/backend/report_actions.py
+++ b/products/signals/backend/report_actions.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import json
 import logging
+from typing import Literal
 
 from django.db import transaction
 
-from products.signals.backend.artefact_schemas import Dismissal
+from posthog.models.user import User
+
+from products.signals.backend.artefact_schemas import Dismissal, SuggestedReviewerEntry, SuggestedReviewers
 from products.signals.backend.models import (
     ArtefactAttribution,
     InvalidStatusTransition,
@@ -18,7 +22,13 @@ logger = logging.getLogger(__name__)
 
 
 def suppress_report_from_slack(
-    team_id: int, report_id: str, *, slack_user_id: str | None = None, user_id: int | None = None
+    team_id: int,
+    report_id: str,
+    *,
+    slack_user_id: str | None = None,
+    user_id: int | None = None,
+    reason: str | None = None,
+    note: str | None = None,
 ) -> bool:
     """Suppress (dismiss) a report from a Slack 'Dismiss' click. Idempotent — an
     already-suppressed report is treated as success; returns False if the report
@@ -27,6 +37,9 @@ def suppress_report_from_slack(
     `user_id` is the PostHog user the clicking Slack identity resolved to — the caller already
     resolves it to gate the dismiss to org members. When present the dismissal is attributed to
     them; the `slack_user_id` is kept in the content either way as the Slack-side trace.
+
+    `reason` is the code chosen in the dismiss modal (falls back to "slack_dismiss" when the
+    click carried none) and `note` is the optional free-form text from the same modal.
     """
     # Row-lock the report so concurrent Dismiss clicks can't both transition + write artefacts.
     with transaction.atomic():
@@ -57,9 +70,67 @@ def suppress_report_from_slack(
         SignalReportArtefact.append_dismissal(
             team_id=team_id,
             report_id=str(report.id),
-            content=Dismissal(reason="slack_dismiss", slack_user_id=slack_user_id),
+            content=Dismissal(reason=reason or "slack_dismiss", note=note, slack_user_id=slack_user_id),
             attribution=attribution,
         )
     # The linked implementation PR is closed by the post_save receiver on suppression or snooze
     # (see receivers.close_pr_when_report_dismissed) — no per-caller call needed here.
     return True
+
+
+RemoveReviewerOutcome = Literal["removed", "not_a_reviewer", "not_found"]
+
+
+def remove_reviewer_from_slack(team_id: int, report_id: str, *, user_id: int) -> RemoveReviewerOutcome:
+    """Drop `user_id` from a report's suggested reviewers, triggered by the Slack 'Not me' button.
+
+    Appends a new `suggested_reviewers` status (latest-wins) with the user's GitHub login removed,
+    attributed to them. Row-locks the report so concurrent 'Not me' clicks can't clobber each
+    other's removals. Returns "not_a_reviewer" when the user isn't a listed reviewer (no linked
+    GitHub login, or a login that isn't on the report), and "not_found" when the report is gone.
+    """
+    # Prefetch the GitHub identity relations get_github_login() reads, so resolving the login is one
+    # query rather than a lookup per relation.
+    from products.signals.backend.report_generation.resolve_reviewers import (  # noqa: PLC0415 — keeps repo-activity deps off the module import path
+        _github_identity_prefetches,
+    )
+
+    user = User.objects.filter(id=user_id).prefetch_related(*_github_identity_prefetches()).first()
+    login = user.get_github_login() if user is not None else None
+    login_lc = login.lower() if login else None
+
+    with transaction.atomic():
+        report = SignalReport.objects.filter(id=report_id, team_id=team_id).select_for_update().first()
+        if report is None:
+            return "not_found"
+
+        artefact = (
+            report.artefacts.filter(type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS)
+            .order_by("-created_at")
+            .first()
+        )
+        if artefact is None or login_lc is None:
+            return "not_a_reviewer"
+
+        try:
+            entries = json.loads(artefact.content)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return "not_a_reviewer"
+        if not isinstance(entries, list):
+            return "not_a_reviewer"
+
+        remaining = [
+            entry
+            for entry in entries
+            if not (isinstance(entry, dict) and str(entry.get("github_login", "")).strip().lower() == login_lc)
+        ]
+        if len(remaining) == len(entries):
+            return "not_a_reviewer"
+
+        SignalReportArtefact.append_status(
+            team_id=team_id,
+            report_id=str(report.id),
+            content=SuggestedReviewers([SuggestedReviewerEntry.model_validate(entry) for entry in remaining]),
+            attribution=ArtefactAttribution.from_user(user_id),
+        )
+    return "removed"

--- a/products/signals/backend/slack_inbox_notifications.py
+++ b/products/signals/backend/slack_inbox_notifications.py
@@ -85,6 +85,11 @@ _SOURCE_PRODUCT_LABELS: dict[str, str] = {
     product.value: label for product, label in SIGNAL_SOURCE_PRODUCT_LABELS.items()
 }
 
+# Slack action_ids for the interactive buttons — must match the handlers in
+# products/slack_app/backend/api.py (SIGNALS_DISMISS_REPORT_ACTION_ID / SIGNALS_NOT_ME_REVIEWER_ACTION_ID).
+_DISMISS_ACTION_ID = "signals_dismiss_report"
+_NOT_ME_ACTION_ID = "signals_not_me_reviewer"
+
 
 def _priority_rank(value: str | None) -> int | None:
     if value is None:
@@ -315,6 +320,7 @@ def _build_message_blocks(
     source_products: list[str],
     reviewer_mentions: list[str],
     repository: str | None = None,
+    integration_id: int | None = None,
 ) -> tuple[list[dict], str]:
     title_line = report.title or "New signals inbox item"
     header_text = (
@@ -369,6 +375,30 @@ def _build_message_blocks(
             "url": f"{settings.SITE_URL}/project/{report.team_id}/inbox/reports/{report.id}",
         }
     ]
+    # The interactive buttons carry the identifiers their handlers need. Omitted when we don't know
+    # the integration (e.g. unit-testing the block shape) since the click couldn't be routed back.
+    if integration_id is not None:
+        action_value = json.dumps(
+            {"integration_id": integration_id, "report_id": str(report.id), "team_id": report.team_id}
+        )
+        action_elements.append(
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "text": "Dismiss", "emoji": True},
+                "action_id": _DISMISS_ACTION_ID,
+                "value": action_value,
+            }
+        )
+        # "Not me" only makes sense when reviewers were tagged — it removes the clicker from them.
+        if reviewer_mentions:
+            action_elements.append(
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Not me", "emoji": True},
+                    "action_id": _NOT_ME_ACTION_ID,
+                    "value": action_value,
+                }
+            )
     blocks.append({"type": "actions", "elements": action_elements})
 
     priority_suffix = f" ({priority})" if priority else ""
@@ -615,6 +645,7 @@ def _deliver_route_notification(
             source_products=source_products,
             reviewer_mentions=mentions,
             repository=repository,
+            integration_id=route.integration.id,
         )
         response = slack.client.chat_postMessage(channel=channel_id, blocks=blocks, text=text)
         thread_ts = response.get("ts") if hasattr(response, "get") else None

--- a/products/signals/backend/test/test_slack_inbox_notifications.py
+++ b/products/signals/backend/test/test_slack_inbox_notifications.py
@@ -112,10 +112,50 @@ def test_build_message_blocks_includes_recipient_and_open_in_posthog_button() ->
     assert "👤 Suggested reviewers: <@U123>" in context_text
     assert "Inbox" not in context_text
     buttons = blocks[3]["elements"]
+    # Without an integration_id the interactive buttons are omitted (the click couldn't be routed).
     assert len(buttons) == 1
     assert buttons[0]["text"]["text"] == "Review in PostHog"
     assert buttons[0]["url"] == f"{settings.SITE_URL}/project/42/inbox/reports/report-uuid"
     assert text == "Inbox item (P1): Checkout errors spiked"
+
+
+def test_build_message_blocks_adds_dismiss_and_not_me_when_routable() -> None:
+    report = SignalReport(id="report-uuid", team_id=42, title="Checkout errors spiked", signal_count=1)
+    blocks, _ = _build_message_blocks(
+        report,
+        priority="P1",
+        source_products=["error_tracking"],
+        reviewer_mentions=["<@U123>"],
+        integration_id=7,
+    )
+
+    buttons = blocks[-1]["elements"]
+    by_action = {b.get("action_id"): b for b in buttons}
+    assert buttons[0]["text"]["text"] == "Review in PostHog"  # link button stays first
+    assert by_action["signals_dismiss_report"]["text"]["text"] == "Dismiss"
+    assert by_action["signals_not_me_reviewer"]["text"]["text"] == "Not me"
+    # Each interactive button carries the identifiers its handler routes on.
+    assert json.loads(by_action["signals_dismiss_report"]["value"]) == {
+        "integration_id": 7,
+        "report_id": "report-uuid",
+        "team_id": 42,
+    }
+
+
+def test_build_message_blocks_omits_not_me_without_reviewers() -> None:
+    report = SignalReport(id="report-uuid", team_id=42, title="Team-wide report", signal_count=1)
+    blocks, _ = _build_message_blocks(
+        report,
+        priority="P1",
+        source_products=["error_tracking"],
+        reviewer_mentions=[],
+        integration_id=7,
+    )
+
+    action_ids = {b.get("action_id") for b in blocks[-1]["elements"]}
+    # Dismiss is always offered when routable; "Not me" only when reviewers were tagged.
+    assert "signals_dismiss_report" in action_ids
+    assert "signals_not_me_reviewer" not in action_ids
 
 
 def test_build_message_blocks_mentions_every_routed_reviewer() -> None:

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -3210,14 +3210,28 @@ def _handle_channel_approval_deny(payload: dict) -> HttpResponse:
     return HttpResponse(status=200)
 
 
-# Handles the Dismiss button on inbox notifications delivered before that button was removed.
+# Interactive buttons on inbox report notifications. "Dismiss" opens a confirmation modal with a
+# reason picker; "Not me" removes the clicker from the report's suggested reviewers. Keep these
+# action_ids in sync with the message builder in products/signals/backend/slack_inbox_notifications.py.
 SIGNALS_DISMISS_REPORT_ACTION_ID = "signals_dismiss_report"
+SIGNALS_NOT_ME_REVIEWER_ACTION_ID = "signals_not_me_reviewer"
+SIGNALS_DISMISS_MODAL_CALLBACK_ID = "signals_dismiss_report_modal"
+SIGNALS_DISMISS_MODAL_REASON_BLOCK = "signals_dismiss_reason"
+SIGNALS_DISMISS_MODAL_NOTE_BLOCK = "signals_dismiss_note"
+
+# (reason code, label) for the dismiss modal's picker. The code is stored as the dismissal reason.
+SIGNALS_DISMISS_REASONS: tuple[tuple[str, str], ...] = (
+    ("wrong_reviewer", "Assigned to the wrong person"),
+    ("low_priority", "Not important enough"),
+    ("already_handled", "Already being handled"),
+    ("not_actionable", "Not actionable"),
+    ("other", "Something else"),
+)
+SIGNALS_DISMISS_REASON_LABELS: dict[str, str] = dict(SIGNALS_DISMISS_REASONS)
 
 
-def _dismiss_action_value(payload: dict) -> dict | None:
-    action = next(
-        (a for a in payload.get("actions", []) if a.get("action_id") == SIGNALS_DISMISS_REPORT_ACTION_ID), None
-    )
+def _signals_action_value(payload: dict, action_id: str) -> dict | None:
+    action = next((a for a in payload.get("actions", []) if a.get("action_id") == action_id), None)
     if not action:
         return None
     try:
@@ -3227,31 +3241,56 @@ def _dismiss_action_value(payload: dict) -> dict | None:
     return value if isinstance(value, dict) else None
 
 
-def _extract_dismiss_hints(payload: dict) -> int | None:
-    """Integration id carried by a signals 'Dismiss' button, used for region-ownership routing."""
-    value = _dismiss_action_value(payload)
-    if not value:
-        return None
-    integration_id = value.get("integration_id")
+def _signals_action_integration_id(payload: dict, action_id: str) -> int | None:
+    """The integration_id carried in a signals button's JSON value, for region-ownership routing."""
+    value = _signals_action_value(payload, action_id)
+    integration_id = value.get("integration_id") if value else None
     return integration_id if isinstance(integration_id, int) else None
 
 
-def _handle_signals_dismiss_report(payload: dict) -> HttpResponse:
-    """Suppress a signals inbox report when a reviewer clicks 'Dismiss' in Slack."""
-    from products.signals.backend.facade.api import (  # noqa: PLC0415 — cross-product action kept off the slack import path
-        dismiss_report_from_slack,
-    )
+def _signals_dismiss_modal_meta(view: dict) -> dict | None:
+    try:
+        meta = json.loads(view.get("private_metadata", "") or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return meta if isinstance(meta, dict) else None
 
-    value = _dismiss_action_value(payload)
+
+def _extract_dismiss_hints(payload: dict) -> int | None:
+    """Integration id carried by a signals Dismiss interaction, used for region-ownership routing.
+
+    Covers both the button block_action (id in the action value) and the confirmation modal's
+    view_submission (id in the view's private_metadata, which has no action to read from).
+    """
+    view = payload.get("view")
+    if isinstance(view, dict) and view.get("callback_id") == SIGNALS_DISMISS_MODAL_CALLBACK_ID:
+        meta = _signals_dismiss_modal_meta(view)
+        integration_id = meta.get("integration_id") if meta else None
+        return integration_id if isinstance(integration_id, int) else None
+    return _signals_action_integration_id(payload, SIGNALS_DISMISS_REPORT_ACTION_ID)
+
+
+def _extract_not_me_hints(payload: dict) -> int | None:
+    """Integration id carried by a signals 'Not me' button, used for region-ownership routing."""
+    return _signals_action_integration_id(payload, SIGNALS_NOT_ME_REVIEWER_ACTION_ID)
+
+
+def _resolve_signals_report_action(payload: dict, value: dict | None) -> tuple[Integration, int, str, User] | None:
+    """Shared auth for the Dismiss/'Not me' buttons: validate the button value, match the
+    workspace integration to the report's team, and gate on org membership. Returns
+    (integration, report_team_id, report_id, org_member) or None when any check fails.
+
+    Intended trust boundary is org membership: any PostHog org member may act on the org's reports.
+    """
     slack_team_id = payload.get("team", {}).get("id")
     if not value or not slack_team_id:
-        return HttpResponse(status=200)
+        return None
 
     integration_id = value.get("integration_id")
     report_id = value.get("report_id")
     report_team_id = value.get("team_id")
     if not (isinstance(integration_id, int) and report_id and isinstance(report_team_id, int)):
-        return HttpResponse(status=200)
+        return None
 
     try:
         # Slack webhook: no team context; scoped by PK + kind + workspace ID. The team match below
@@ -3261,33 +3300,161 @@ def _handle_signals_dismiss_report(payload: dict) -> HttpResponse:
             id=integration_id, kind=SLACK_INTEGRATION_KIND, integration_id=slack_team_id
         )
     except Integration.DoesNotExist:
-        logger.info("signals_dismiss_report_no_integration", integration_id=integration_id)
-        return HttpResponse(status=200)
+        logger.info("signals_report_action_no_integration", integration_id=integration_id)
+        return None
 
     if integration.team_id != report_team_id:
         logger.warning(
-            "signals_dismiss_report_team_mismatch",
+            "signals_report_action_team_mismatch",
             integration_team_id=integration.team_id,
             report_team_id=report_team_id,
         )
-        return HttpResponse(status=200)
+        return None
 
     slack_user_id = payload.get("user", {}).get("id", "")
-    # Only PostHog org members may dismiss — a non-member in a shared channel must not suppress reports.
     org_member = _is_org_member(integration, slack_user_id)
     if org_member is None:
         logger.warning(
-            "signals_dismiss_report_not_org_member",
-            integration_id=integration.id,
-            slack_user_id=slack_user_id,
+            "signals_report_action_not_org_member", integration_id=integration.id, slack_user_id=slack_user_id
         )
-        return HttpResponse(status=200)
+        return None
 
-    suppressed = dismiss_report_from_slack(
-        report_team_id, str(report_id), slack_user_id=slack_user_id, user_id=org_member.id
+    return integration, report_team_id, str(report_id), org_member
+
+
+def _signals_message_title(payload: dict) -> str | None:
+    """The report title from the notification's header block, echoed back on the dismissed message."""
+    for block in payload.get("message", {}).get("blocks", []):
+        if block.get("type") == "header":
+            text = (block.get("text") or {}).get("text")
+            return text if isinstance(text, str) else None
+    return None
+
+
+def _render_signals_dismiss_modal(private_metadata: str) -> dict:
+    return {
+        "type": "modal",
+        "callback_id": SIGNALS_DISMISS_MODAL_CALLBACK_ID,
+        "private_metadata": private_metadata,
+        "title": {"type": "plain_text", "text": "Dismiss report"},
+        "submit": {"type": "plain_text", "text": "Dismiss"},
+        "close": {"type": "plain_text", "text": "Cancel"},
+        "blocks": [
+            {
+                "type": "input",
+                "block_id": SIGNALS_DISMISS_MODAL_REASON_BLOCK,
+                "label": {"type": "plain_text", "text": "Why are you dismissing this?"},
+                "element": {
+                    "type": "static_select",
+                    "action_id": "reason",
+                    "placeholder": {"type": "plain_text", "text": "Pick a reason"},
+                    "options": [
+                        {"text": {"type": "plain_text", "text": label}, "value": code}
+                        for code, label in SIGNALS_DISMISS_REASONS
+                    ],
+                },
+            },
+            {
+                "type": "input",
+                "block_id": SIGNALS_DISMISS_MODAL_NOTE_BLOCK,
+                "optional": True,
+                "label": {"type": "plain_text", "text": "Anything to add?"},
+                "element": {"type": "plain_text_input", "action_id": "note", "multiline": True, "max_length": 500},
+            },
+        ],
+    }
+
+
+def _open_signals_dismiss_modal(integration: Integration, payload: dict, report_team_id: int, report_id: str) -> None:
+    trigger_id = payload.get("trigger_id")
+    if not trigger_id:
+        return
+    # response_url is stashed so the modal submit can replace the original channel message from a
+    # context where it has no message of its own; the title re-labels the dismissed acknowledgement.
+    private_metadata = json.dumps(
+        {
+            "integration_id": integration.id,
+            "team_id": report_team_id,
+            "report_id": report_id,
+            "response_url": payload.get("response_url"),
+            "title": _signals_message_title(payload),
+        }
+    )
+    try:
+        SlackIntegration(integration).client.views_open(
+            trigger_id=trigger_id, view=_render_signals_dismiss_modal(private_metadata)
+        )
+    except Exception:
+        logger.exception("signals_dismiss_modal_open_failed", report_id=report_id)
+
+
+def _handle_signals_dismiss_report(payload: dict) -> HttpResponse:
+    """Open the dismiss-confirmation modal when a reviewer clicks 'Dismiss' on a report.
+
+    The suppression itself happens on modal submit (_handle_signals_dismiss_modal_submit), which
+    re-runs this same auth — a modal can be submitted by anyone who still has it open.
+    """
+    resolved = _resolve_signals_report_action(payload, _signals_action_value(payload, SIGNALS_DISMISS_REPORT_ACTION_ID))
+    if resolved is None:
+        return HttpResponse(status=200)
+    integration, report_team_id, report_id, _org_member = resolved
+    _open_signals_dismiss_modal(integration, payload, report_team_id, report_id)
+    return HttpResponse(status=200)
+
+
+def _signals_dismiss_modal_error(message: str) -> JsonResponse:
+    # A view_submission error keeps the modal open and shows the message under the reason field.
+    return JsonResponse({"response_action": "errors", "errors": {SIGNALS_DISMISS_MODAL_REASON_BLOCK: message}})
+
+
+def _handle_signals_dismiss_modal_submit(payload: dict) -> HttpResponse:
+    """Suppress the report chosen in the dismiss modal, recording the picked reason and note."""
+    from products.signals.backend.facade.api import (  # noqa: PLC0415 — cross-product action kept off the slack import path
+        dismiss_report_from_slack,
     )
 
-    _post_signals_dismiss_feedback(payload, dismissed=suppressed, slack_user_id=slack_user_id)
+    view = payload.get("view", {})
+    meta = _signals_dismiss_modal_meta(view)
+    if not meta:
+        return HttpResponse(status=200)
+
+    # A modal can be submitted by anyone who still has it open, so re-run the same auth the opening
+    # click did. `meta` carries the same integration_id/report_id/team_id the button value does.
+    resolved = _resolve_signals_report_action(payload, meta)
+    if resolved is None:
+        return _signals_dismiss_modal_error(
+            "You can't dismiss this report. It may already be resolved, or you may not have access."
+        )
+    _integration, report_team_id, report_id, org_member = resolved
+    slack_user_id = payload.get("user", {}).get("id", "")
+
+    values = view.get("state", {}).get("values", {})
+    selected = values.get(SIGNALS_DISMISS_MODAL_REASON_BLOCK, {}).get("reason", {}).get("selected_option") or {}
+    reason = selected.get("value")
+    note = values.get(SIGNALS_DISMISS_MODAL_NOTE_BLOCK, {}).get("note", {}).get("value") or None
+
+    dismissed = dismiss_report_from_slack(
+        report_team_id, str(report_id), slack_user_id=slack_user_id, user_id=org_member.id, reason=reason, note=note
+    )
+    _post_signals_dismiss_modal_result(meta, dismissed=dismissed, slack_user_id=slack_user_id, reason=reason)
+    return HttpResponse(status=200)
+
+
+def _handle_signals_not_me_reviewer(payload: dict) -> HttpResponse:
+    """Remove the clicker from a report's suggested reviewers when they click 'Not me'."""
+    from products.signals.backend.facade.api import (  # noqa: PLC0415 — cross-product action kept off the slack import path
+        remove_reviewer_from_slack,
+    )
+
+    resolved = _resolve_signals_report_action(
+        payload, _signals_action_value(payload, SIGNALS_NOT_ME_REVIEWER_ACTION_ID)
+    )
+    if resolved is None:
+        return HttpResponse(status=200)
+    _integration, report_team_id, report_id, org_member = resolved
+
+    outcome = remove_reviewer_from_slack(report_team_id, report_id, user_id=org_member.id)
+    _post_signals_not_me_result(payload, outcome=outcome)
     return HttpResponse(status=200)
 
 
@@ -3316,19 +3483,50 @@ def _replace_message_stripping_actions(payload: dict, text: str, *, keep_link_bu
     inbox_interactivity.post_response_url(response_url, {"replace_original": True, "text": text, "blocks": kept_blocks})
 
 
-def _post_signals_dismiss_feedback(payload: dict, *, dismissed: bool, slack_user_id: str) -> None:
-    """Best-effort: replace the original message so it reads as dismissed."""
+def _post_signals_dismiss_modal_result(meta: dict, *, dismissed: bool, slack_user_id: str, reason: str | None) -> None:
+    """Best-effort: replace the original channel message (via the stashed response_url) so it
+    reads as dismissed. A view_submission has no message of its own, so it can't use the
+    block_action message-replace path; the response_url from the opening click stands in for it.
+    """
+    response_url = meta.get("response_url")
+    if not response_url:
+        return
+
     if dismissed:
         actor = f"<@{slack_user_id}>" if slack_user_id else "a reviewer"
-        text = f"✅ Dismissed by {actor}"
+        reason_label = SIGNALS_DISMISS_REASON_LABELS.get(reason or "")
+        text = f"✅ Dismissed by {actor}: {reason_label}" if reason_label else f"✅ Dismissed by {actor}"
+        title = meta.get("title")
+        blocks: list[dict] = []
+        if isinstance(title, str) and title:
+            blocks.append({"type": "header", "text": {"type": "plain_text", "text": title[:150]}})
+        blocks.append({"type": "context", "elements": [{"type": "mrkdwn", "text": text}]})
+        inbox_interactivity.post_response_url(response_url, {"replace_original": True, "text": text, "blocks": blocks})
     else:
-        text = "This report could not be dismissed — it may already be resolved or removed."
+        inbox_interactivity.post_response_url(
+            response_url,
+            {
+                "response_type": "ephemeral",
+                "replace_original": False,
+                "text": "This report could not be dismissed. It may already be resolved or removed.",
+            },
+        )
 
-    # keep_link_buttons=False: historical dismiss-capable messages carried "Review PR"/"Open in
-    # PostHog" link buttons in the same actions block as Dismiss (see the pre-removal
-    # slack_inbox_notifications.py block construction), so dropping the whole block here matches
-    # existing behavior rather than the default.
-    _replace_message_stripping_actions(payload, text, keep_link_buttons=False)
+
+def _post_signals_not_me_result(payload: dict, *, outcome: str) -> None:
+    """Best-effort ephemeral reply to the clicker confirming whether they were removed."""
+    response_url = payload.get("response_url")
+    if not response_url:
+        return
+    if outcome == "removed":
+        text = "Done, you've been removed as a suggested reviewer on this report."
+    elif outcome == "not_a_reviewer":
+        text = "You're not listed as a reviewer on this report, so there was nothing to remove."
+    else:
+        text = "This report could not be updated. It may already be resolved or removed."
+    inbox_interactivity.post_response_url(
+        response_url, {"response_type": "ephemeral", "replace_original": False, "text": text}
+    )
 
 
 # Snoozes an insight alert from the button on its firing Slack message.
@@ -3709,6 +3907,7 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
     terminate_integration_id, terminate_user_id = _extract_terminate_hints(payload)
     authorship_integration_id, _ = _extract_action_value_hints(payload, "posthog_code_continue_as_bot")
     dismiss_integration_id = _extract_dismiss_hints(payload)
+    not_me_integration_id = _extract_not_me_hints(payload)
     alert_snooze_uuid = _extract_alert_snooze_hints(payload)
     inbox_integration_id = inbox_interactivity.extract_inbox_hints(payload)
     requesting_user = payload.get("user", {}).get("id", "")
@@ -3742,12 +3941,13 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
             kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
-    elif slack_team_id and dismiss_integration_id:
+    elif slack_team_id and (dismiss_integration_id or not_me_integration_id):
         # Routing/region-ownership only — this just claims the workspace's integration locally.
-        # Authorization (report-team match + org-member gate) is enforced in _handle_signals_dismiss_report.
-        # Intended trust boundary for dismiss is org membership (any org member can dismiss the org's reports).
+        # Authorization (report-team match + org-member gate) is enforced in the signals report-action
+        # handlers. Intended trust boundary is org membership (any org member can act on the org's
+        # reports). Covers the Dismiss button, its confirmation modal's submit, and the 'Not me' button.
         local = Integration.objects.filter(  # nosemgrep: idor-lookup-without-team
-            id=dismiss_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
+            id=dismiss_integration_id or not_me_integration_id,  # nosemgrep: idor-taint-user-input-to-model-get
             kind=SLACK_INTEGRATION_KIND,
             integration_id=slack_team_id,
         ).exists()
@@ -3853,8 +4053,11 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
         return _handle_repo_picker_options(payload)
 
     if payload_type == "view_submission":
-        if payload.get("view", {}).get("callback_id") == INSIGHT_ALERT_SNOOZE_MODAL_CALLBACK_ID:
+        callback_id = payload.get("view", {}).get("callback_id")
+        if callback_id == INSIGHT_ALERT_SNOOZE_MODAL_CALLBACK_ID:
             return _handle_insight_alert_snooze_modal_submit(payload)
+        if callback_id == SIGNALS_DISMISS_MODAL_CALLBACK_ID:
+            return _handle_signals_dismiss_modal_submit(payload)
         return _handle_app_home_view_submission(payload)
 
     if payload_type == "block_actions":
@@ -3875,6 +4078,8 @@ def posthog_code_interactivity_handler(request: HttpRequest) -> HttpResponse:
                 return _handle_channel_approval_deny(payload)
             if action_id == SIGNALS_DISMISS_REPORT_ACTION_ID:
                 return _handle_signals_dismiss_report(payload)
+            if action_id == SIGNALS_NOT_ME_REVIEWER_ACTION_ID:
+                return _handle_signals_not_me_reviewer(payload)
             if action_id in (INSIGHT_ALERT_SNOOZE_ACTION_ID, INSIGHT_ALERT_SNOOZE_UNTIL_ACTION_ID):
                 return _handle_insight_alert_snooze(payload)
             if action_id == onboarding.INBOX_CREATE_ACTION_ID:

--- a/products/slack_app/backend/tests/test_posthog_code_interactivity.py
+++ b/products/slack_app/backend/tests/test_posthog_code_interactivity.py
@@ -30,6 +30,9 @@ from products.slack_app.backend.api import (
     _extract_alert_snooze_hints,
     _handle_insight_alert_snooze,
     _handle_insight_alert_snooze_modal_submit,
+    _handle_signals_dismiss_modal_submit,
+    _handle_signals_dismiss_report,
+    _handle_signals_not_me_reviewer,
 )
 from products.slack_app.backend.tests.helpers import sign_slack_request
 
@@ -869,9 +872,6 @@ class TestInteractivityRegionRouting(TestCase):
 
 class TestSignalsDismissReport(TestCase):
     def setUp(self):
-        self.client = APIClient()
-        self.signing_secret = "posthog-code-test-secret"
-
         self.organization = Organization.objects.create(name="Dismiss Org")
         self.team = Team.objects.create(organization=self.organization, name="Dismiss Team")
         self.user = User.objects.create(email="dismisser@example.com", distinct_id="dismiss-user-1")
@@ -895,7 +895,161 @@ class TestSignalsDismissReport(TestCase):
             total_weight=1.0,
         )
 
-    def _dismiss_payload(self, report_id: str, *, team_id: int | None = None) -> dict:
+    def _click_payload(self, report_id: str) -> dict:
+        return {
+            "type": "block_actions",
+            "team": {"id": "T12345"},
+            "user": {"id": "U777"},
+            "trigger_id": "trig.1",
+            "response_url": "https://hooks.slack.test/response",
+            "actions": [
+                {
+                    "action_id": "signals_dismiss_report",
+                    "value": json.dumps(
+                        {"integration_id": self.integration.id, "report_id": report_id, "team_id": self.team.id}
+                    ),
+                }
+            ],
+            "message": {
+                "ts": "1234.9999",
+                "blocks": [{"type": "header", "text": {"type": "plain_text", "text": "Dismissable report"}}],
+            },
+        }
+
+    def _submit_payload(self, report_id: str, *, reason: str = "wrong_reviewer", note=None, team_id=None) -> dict:
+        return {
+            "type": "view_submission",
+            "team": {"id": "T12345"},
+            "user": {"id": "U777"},
+            "view": {
+                "callback_id": "signals_dismiss_report_modal",
+                "private_metadata": json.dumps(
+                    {
+                        "integration_id": self.integration.id,
+                        "team_id": team_id if team_id is not None else self.team.id,
+                        "report_id": report_id,
+                        "response_url": "https://hooks.slack.test/response",
+                        "title": "Dismissable report",
+                    }
+                ),
+                "state": {
+                    "values": {
+                        "signals_dismiss_reason": {"reason": {"selected_option": {"value": reason}}},
+                        "signals_dismiss_note": {"note": {"value": note}},
+                    }
+                },
+            },
+        }
+
+    @patch("products.slack_app.backend.api.SlackIntegration")
+    @patch("products.slack_app.backend.api._is_org_member")
+    def test_click_opens_modal_without_suppressing(self, mock_is_org_member, mock_slack):
+        from products.signals.backend.models import SignalReport
+
+        mock_is_org_member.return_value = self.user
+        report = self._make_ready_report()
+
+        response = _handle_signals_dismiss_report(self._click_payload(str(report.id)))
+
+        assert response.status_code == 200
+        mock_slack.return_value.client.views_open.assert_called_once()
+        view = mock_slack.return_value.client.views_open.call_args.kwargs["view"]
+        assert view["callback_id"] == "signals_dismiss_report_modal"
+        report.refresh_from_db()
+        assert report.status == SignalReport.Status.READY  # not suppressed until the modal is submitted
+
+    @patch("products.slack_app.backend.services.inbox_interactivity.requests.post")
+    @patch("products.slack_app.backend.api._is_org_member")
+    def test_modal_submit_suppresses_and_records_reason_and_note(self, mock_is_org_member, mock_requests_post):
+        from products.signals.backend.models import SignalReport, SignalReportArtefact
+
+        mock_is_org_member.return_value = self.user
+        report = self._make_ready_report()
+
+        response = _handle_signals_dismiss_modal_submit(
+            self._submit_payload(str(report.id), reason="wrong_reviewer", note="not my area")
+        )
+
+        assert response.status_code == 200
+        report.refresh_from_db()
+        assert report.status == SignalReport.Status.SUPPRESSED
+        dismissal = SignalReportArtefact.objects.get(report=report, type=SignalReportArtefact.ArtefactType.DISMISSAL)
+        assert dismissal.created_by_id == self.user.id  # attributed to the resolved user, not system
+        content = json.loads(dismissal.content)
+        assert content["reason"] == "wrong_reviewer"
+        assert content["note"] == "not my area"
+        assert mock_requests_post.call_args.kwargs["json"]["replace_original"] is True
+
+    @patch("products.slack_app.backend.services.inbox_interactivity.requests.post")
+    @patch("products.slack_app.backend.api._is_org_member")
+    def test_modal_submit_refuses_non_org_member(self, mock_is_org_member, mock_requests_post):
+        from products.signals.backend.models import SignalReport
+
+        mock_is_org_member.return_value = None  # a modal can be submitted by anyone; the gate must re-run here
+        report = self._make_ready_report()
+
+        response = _handle_signals_dismiss_modal_submit(self._submit_payload(str(report.id)))
+
+        assert json.loads(response.content)["response_action"] == "errors"
+        report.refresh_from_db()
+        assert report.status == SignalReport.Status.READY
+
+    @patch("products.slack_app.backend.services.inbox_interactivity.requests.post")
+    @patch("products.slack_app.backend.api._is_org_member")
+    def test_modal_submit_ignores_report_from_another_team(self, mock_is_org_member, mock_requests_post):
+        from products.signals.backend.models import SignalReport
+
+        mock_is_org_member.return_value = self.user
+        report = self._make_ready_report()
+
+        # A forged private_metadata team_id that doesn't match the integration's team must not suppress.
+        response = _handle_signals_dismiss_modal_submit(
+            self._submit_payload(str(report.id), team_id=self.team.id + 9999)
+        )
+
+        assert response.status_code == 200
+        report.refresh_from_db()
+        assert report.status == SignalReport.Status.READY
+
+
+class TestSignalsNotMeReviewer(TestCase):
+    def setUp(self):
+        from social_django.models import UserSocialAuth
+
+        self.organization = Organization.objects.create(name="NotMe Org")
+        self.team = Team.objects.create(organization=self.organization, name="NotMe Team")
+        self.user = User.objects.create(email="reviewer@example.com", distinct_id="notme-user-1")
+        OrganizationMembership.objects.create(user=self.user, organization=self.organization)
+        UserSocialAuth.objects.create(user=self.user, provider="github", uid="1", extra_data={"login": "octocat"})
+        self.integration = Integration.objects.create(
+            team=self.team,
+            kind="slack",
+            integration_id="T12345",
+            sensitive_config={"access_token": "xoxb-test"},
+        )
+
+    def _report_with_reviewers(self, logins: list[str]):
+        from products.signals.backend.artefact_schemas import SuggestedReviewerEntry, SuggestedReviewers
+        from products.signals.backend.models import ArtefactAttribution, SignalReport, SignalReportArtefact
+
+        report = SignalReport.objects.create(
+            team=self.team,
+            status=SignalReport.Status.READY,
+            title="Report",
+            summary="S",
+            signal_count=1,
+            total_weight=1.0,
+        )
+        SignalReportArtefact.append_status(
+            team_id=self.team.id,
+            report_id=str(report.id),
+            content=SuggestedReviewers([SuggestedReviewerEntry(github_login=login) for login in logins]),
+            attribution=ArtefactAttribution.system(),
+            reevaluate_autostart=False,
+        )
+        return report
+
+    def _not_me_payload(self, report_id: str) -> dict:
         return {
             "type": "block_actions",
             "team": {"id": "T12345"},
@@ -903,81 +1057,59 @@ class TestSignalsDismissReport(TestCase):
             "response_url": "https://hooks.slack.test/response",
             "actions": [
                 {
-                    "action_id": "signals_dismiss_report",
+                    "action_id": "signals_not_me_reviewer",
                     "value": json.dumps(
-                        {
-                            "integration_id": self.integration.id,
-                            "report_id": report_id,
-                            "team_id": team_id if team_id is not None else self.team.id,
-                        }
+                        {"integration_id": self.integration.id, "report_id": report_id, "team_id": self.team.id}
                     ),
                 }
             ],
-            "message": {"ts": "1234.9999", "blocks": []},
         }
 
-    def _post_interactivity(self, payload: dict) -> Any:
-        body_str = f"payload={json.dumps(payload)}"
-        signature, ts = sign_slack_request(body_str.encode(), self.signing_secret)
-        return self.client.post(
-            "/slack/interactivity-callback/",
-            data=body_str,
-            content_type="application/x-www-form-urlencoded",
-            HTTP_X_SLACK_SIGNATURE=signature,
-            HTTP_X_SLACK_REQUEST_TIMESTAMP=ts,
+    def _latest_reviewer_logins(self, report) -> frozenset[str]:
+        from products.signals.backend.models import SignalReportArtefact
+        from products.signals.backend.report_generation.resolve_reviewers import (
+            normalized_github_logins_from_suggested_reviewer_artefacts,
         )
 
+        latest = (
+            SignalReportArtefact.objects.filter(
+                report=report, type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS
+            )
+            .order_by("-created_at")
+            .first()
+        )
+        return normalized_github_logins_from_suggested_reviewer_artefacts([latest])
+
+    @patch("products.slack_app.backend.services.inbox_interactivity.requests.post")
     @patch("products.slack_app.backend.api._is_org_member")
-    @patch("products.slack_app.backend.services.inbox_interactivity.requests.post")
-    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
-    def test_dismiss_suppresses_report_and_writes_artefact(self, mock_config, mock_requests_post, mock_is_org_member):
-        from products.signals.backend.models import SignalReport, SignalReportArtefact
+    def test_not_me_removes_only_the_clicker(self, mock_is_org_member, mock_requests_post):
+        mock_is_org_member.return_value = self.user
+        report = self._report_with_reviewers(["octocat", "hubot"])
 
-        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
-        mock_is_org_member.return_value = self.user  # clicker resolves to this org member
-        report = self._make_ready_report()
-
-        response = self._post_interactivity(self._dismiss_payload(str(report.id)))
+        response = _handle_signals_not_me_reviewer(self._not_me_payload(str(report.id)))
 
         assert response.status_code == 200
-        report.refresh_from_db()
-        assert report.status == SignalReport.Status.SUPPRESSED
-        dismissal = SignalReportArtefact.objects.get(report=report, type=SignalReportArtefact.ArtefactType.DISMISSAL)
-        # Attributed to the resolved PostHog user, not system.
-        assert dismissal.created_by_id == self.user.id
-        # The original message is replaced with a dismissed acknowledgement.
-        assert mock_requests_post.call_args.kwargs["json"]["replace_original"] is True
+        assert self._latest_reviewer_logins(report) == frozenset({"hubot"})
+        assert mock_requests_post.call_args.kwargs["json"]["response_type"] == "ephemeral"
 
+    @patch("products.slack_app.backend.services.inbox_interactivity.requests.post")
     @patch("products.slack_app.backend.api._is_org_member")
-    @patch("products.slack_app.backend.services.inbox_interactivity.requests.post")
-    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
-    def test_dismiss_refuses_non_org_member(self, mock_config, mock_requests_post, mock_is_org_member):
-        from products.signals.backend.models import SignalReport
+    def test_not_me_writes_nothing_when_clicker_not_listed(self, mock_is_org_member, mock_requests_post):
+        from products.signals.backend.models import SignalReportArtefact
 
-        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
-        mock_is_org_member.return_value = None  # clicker is not a PostHog org member
-        report = self._make_ready_report()
+        mock_is_org_member.return_value = self.user
+        report = self._report_with_reviewers(["hubot"])  # clicker (octocat) isn't a reviewer
 
-        response = self._post_interactivity(self._dismiss_payload(str(report.id)))
+        response = _handle_signals_not_me_reviewer(self._not_me_payload(str(report.id)))
 
         assert response.status_code == 200
-        report.refresh_from_db()
-        assert report.status == SignalReport.Status.READY  # not suppressed
-
-    @patch("products.slack_app.backend.services.inbox_interactivity.requests.post")
-    @patch("products.slack_app.backend.api.SlackIntegration.slack_config")
-    def test_dismiss_ignores_report_from_another_team(self, mock_config, mock_requests_post):
-        from products.signals.backend.models import SignalReport
-
-        mock_config.return_value = {"SLACK_APP_SIGNING_SECRET": self.signing_secret}
-        report = self._make_ready_report()
-
-        # team_id in the button value doesn't match the integration's team.
-        response = self._post_interactivity(self._dismiss_payload(str(report.id), team_id=self.team.id + 9999))
-
-        assert response.status_code == 200
-        report.refresh_from_db()
-        assert report.status == SignalReport.Status.READY
+        # No new reviewers artefact appended — the original one stands.
+        assert (
+            SignalReportArtefact.objects.filter(
+                report=report, type=SignalReportArtefact.ArtefactType.SUGGESTED_REVIEWERS
+            ).count()
+            == 1
+        )
 
 
 class TestInsightAlertSnooze(TestCase):


### PR DESCRIPTION
## Problem

Reviewers were getting flooded with signals inbox reports in Slack analytics channels — including reports routed to the wrong person — with no quick way to triage from Slack. The message only carried a "Review in PostHog" link, so dismissing or correcting a misassignment meant opening the app for each item. A Slack dismiss button used to exist but was removed.

## Changes

Restores the interactive buttons on signals inbox report notifications:

- **Dismiss** now opens a confirmation modal with a reason picker (wrong person / not important / already being handled / not actionable / something else) plus an optional note. On submit it suppresses the report, records the reason + note on the dismissal, and replaces the channel message with a dismissed acknowledgement.
- **Not me** removes the clicking reviewer from the report's suggested reviewers (shown only when reviewers were tagged), confirming with an ephemeral reply. This is the quick "you tagged the wrong person" path.

Both actions are gated on PostHog org membership, re-checked at modal-submit time, and route across regions via the integration id carried on the button/modal. All backend mutations go through the signals facade. Old messages already in channels keep working — their Dismiss button now opens the same modal.

## How did you test this code?

Automated tests added/updated (the DB-backed handler tests run in CI — this environment had no Postgres, so I ran only the DB-free builder tests here, which pass):

- `test_slack_inbox_notifications.py`: builder emits Dismiss + "Not me" when routable and omits "Not me" without reviewers; buttons carry the routing identifiers. Catches a regression where the buttons or their payloads go missing.
- `test_posthog_code_interactivity.py` (`TestSignalsDismissReport`): Dismiss click opens the modal *without* suppressing; modal submit suppresses and records reason/note; submit re-checks org membership (rejects non-members) and rejects a forged cross-team `private_metadata`. Catches an auth bypass on the submit path and the two-step flow breaking.
- `TestSignalsNotMeReviewer`: "Not me" removes only the clicker's login and is a no-op when they aren't listed. Catches the reviewer-removal logic regressing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785420157243329?thread_ts=1785420157.243329&cid=C09SK2PAGKF). Skills invoked: `/writing-tests` (test value gate) and `/simplify` (four parallel cleanup reviewers). The simplify pass folded the modal-submit auth into the shared `_resolve_signals_report_action` helper, deduped the region-routing hint extraction and routing branches, and prefetched the GitHub identity relations when resolving a reviewer's login. The action-id string constants are deliberately duplicated across the two products (synced by comment) rather than shared, to respect the product boundary — `slack_app` reaches `signals` only through its facade.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785420157243329?thread_ts=1785420157.243329&cid=C09SK2PAGKF)*
