### PR TITLE
feat(review_hog): link review turns to their LLM cost on the event

### DIFF
--- a/products/review_hog/ARCHITECTURE.md
+++ b/products/review_hog/ARCHITECTURE.md
@@ -220,8 +220,10 @@ pr_metadata.head_branch` is threaded (as explicit kwargs, alongside `team_id` / 
     "View them in PostHog" deep link to the exact report (`/project/<team>/code-review?review=<report id>`,
     a **permanent public contract** — the frontend URL sync and `report_deep_link` must keep agreeing on it).
     After the publish stage the workflow captures a **`reviewhog_review_completed`** product-analytics event —
-    one per finalized turn (published or stored), carrying repository / PR / trigger / finding-count / PR-size
-    properties (`track_review_completed_activity`). Best-effort: telemetry can never fail a review.
+    one per finalized turn (published or stored), carrying repository / PR / trigger / finding-count / PR-size /
+    sandbox-usage properties (`track_review_completed_activity`): the turn's `sandbox_task_ids` (recovered by
+    workflow-id-prefix, joining to `$ai_generation.task_id` for per-turn dollar cost) plus summed token totals.
+    Best-effort: telemetry can never fail a review.
 
 ---
 

--- a/products/review_hog/backend/temporal/activities.py
+++ b/products/review_hog/backend/temporal/activities.py
@@ -137,6 +137,7 @@ from products.signals.backend.artefact_attribution import ArtefactAttribution
 from products.signals.backend.artefact_schemas import CodeReview, CodeReviewCounts
 from products.signals.backend.models import SignalReport, SignalReportArtefact
 from products.signals.backend.report_generation.resolve_reviewers import resolve_org_github_login_to_users
+from products.tasks.backend.facade.api import list_sandbox_run_usage
 
 logger = logging.getLogger(__name__)
 
@@ -1249,7 +1250,49 @@ async def publish_review_activity(input: PublishInput) -> PublishResult:
     )
 
 
-def _track_review_completed(input: TrackReviewCompletedInput) -> None:
+_SANDBOX_TOKEN_KEYS = ("input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens", "total_tokens")
+
+
+def _collect_turn_sandbox_usage(input: TrackReviewCompletedInput, workflow_id: str | None) -> dict:
+    """The turn's sandbox task ids and summed token usage.
+
+    Every sandbox run a turn spawns carries a Temporal workflow id branded with the review
+    workflow's id (`_sandbox_workflow_id_prefix`), so prefix + the turn's start time recovers
+    exactly this turn's runs: Temporal allows one running turn per PR, and matching on the `:` / `/`
+    separators keeps PR 12's prefix from also matching PR 123. `sandbox_task_ids` joins the event to
+    `$ai_generation` (which carries `task_id`) for per-turn dollar cost; the token sums serve
+    token-level views without a join. Best-effort: a lookup failure nulls these properties, never
+    the capture.
+    """
+    absent: dict = {"sandbox_task_ids": None, "sandbox_run_count": None} | {
+        f"llm_{key}": None for key in _SANDBOX_TOKEN_KEYS
+    }
+    if not workflow_id:
+        return absent
+    try:
+        base = workflow_id.lower()
+        runs = list_sandbox_run_usage(
+            input.team_id,
+            workflow_id_prefixes=[f"{base}:", f"{base}/"],
+            created_after=datetime.datetime.fromisoformat(input.workflow_started_at),
+        )
+        totals = dict.fromkeys(_SANDBOX_TOKEN_KEYS, 0)
+        task_ids: set[str] = set()
+        for run in runs:
+            task_ids.add(str(run["task_id"]))
+            for key in _SANDBOX_TOKEN_KEYS:
+                value = run["token_usage"].get(key)
+                if isinstance(value, int | float) and not isinstance(value, bool):
+                    totals[key] += value
+        return {"sandbox_task_ids": sorted(task_ids), "sandbox_run_count": len(runs)} | {
+            f"llm_{key}": totals[key] for key in _SANDBOX_TOKEN_KEYS
+        }
+    except Exception:
+        logger.exception("Failed to collect sandbox usage for report %s; capturing without it", input.report_id)
+        return absent
+
+
+def _track_review_completed(input: TrackReviewCompletedInput, workflow_id: str | None) -> None:
     report = ReviewReport.objects.for_team(input.team_id).select_related("acting_user", "team").get(id=input.report_id)
     findings = load_turn_findings(team_id=input.team_id, report_id=input.report_id, run_index=input.run_index)
     snapshot = load_pr_snapshot(team_id=input.team_id, report_id=input.report_id, head_sha=input.head_sha)
@@ -1290,16 +1333,17 @@ def _track_review_completed(input: TrackReviewCompletedInput) -> None:
             # the honest denominator for per-line cost.
             "pr_reviewable_additions": count_reviewable_additions(snapshot.pr_files) if snapshot is not None else None,
             "duration_seconds": duration_seconds,
+            **_collect_turn_sandbox_usage(input, workflow_id),
         },
         groups=groups(team=report.team),
         send_feature_flags=True,
     )
 
 
-def _track_review_completed_safe(input: TrackReviewCompletedInput) -> None:
+def _track_review_completed_safe(input: TrackReviewCompletedInput, workflow_id: str | None) -> None:
     # Analytics must never fail a review: any load/capture failure is logged, not raised.
     try:
-        _track_review_completed(input)
+        _track_review_completed(input, workflow_id)
     except Exception:
         logger.exception("Failed to capture reviewhog_review_completed for report %s; continuing", input.report_id)
 
@@ -1315,7 +1359,8 @@ async def track_review_completed_activity(input: TrackReviewCompletedInput) -> N
     provide (one review fans out into many sandbox tasks). Best-effort: analytics must never fail
     a review, so any failure is logged, not raised.
     """
-    await database_sync_to_async(_track_review_completed_safe, thread_sensitive=False)(input)
+    workflow_id = activity.info().workflow_id
+    await database_sync_to_async(_track_review_completed_safe, thread_sensitive=False)(input, workflow_id)
 
 
 # --- The PR's live status comment -------------------------------------------------------------------

--- a/products/review_hog/backend/tests/test_review_completed_tracking.py
+++ b/products/review_hog/backend/tests/test_review_completed_tracking.py
@@ -19,8 +19,10 @@ from products.review_hog.backend.temporal.activities import (
     _track_review_completed,
     _track_review_completed_safe,
 )
+from products.tasks.backend.models import Task, TaskRun
 
 _PR_URL = "https://github.com/o/r/pull/7"
+_WORKFLOW_ID = "review-pr:2:o/r:7"
 
 
 def _pr_metadata() -> PRMetadata:
@@ -98,7 +100,7 @@ class TestTrackReviewCompleted(BaseTest):
         )
 
         with patch("products.review_hog.backend.temporal.activities.posthoganalytics.capture") as capture:
-            _track_review_completed(self._tracking_input(report_id, published=published))
+            _track_review_completed(self._tracking_input(report_id, published=published), _WORKFLOW_ID)
 
         capture.assert_called_once()
         kwargs = capture.call_args.kwargs
@@ -120,6 +122,10 @@ class TestTrackReviewCompleted(BaseTest):
         assert props["pr_commits"] == 3
         assert props["pr_reviewable_additions"] == 80
         assert 90 <= props["duration_seconds"] < 600
+        # No sandbox runs for this turn — the cost-linkage properties record an empty turn, not null.
+        assert props["sandbox_task_ids"] == []
+        assert props["sandbox_run_count"] == 0
+        assert props["llm_total_tokens"] == 0
 
     def test_missing_snapshot_still_captures_without_pr_size(self) -> None:
         # A turn whose pr_snapshot is unavailable must still count as a review — size props go
@@ -127,7 +133,7 @@ class TestTrackReviewCompleted(BaseTest):
         report_id = self._review_report()
 
         with patch("products.review_hog.backend.temporal.activities.posthoganalytics.capture") as capture:
-            _track_review_completed(self._tracking_input(report_id, published=False))
+            _track_review_completed(self._tracking_input(report_id, published=False), _WORKFLOW_ID)
 
         capture.assert_called_once()
         props = capture.call_args.kwargs["properties"]
@@ -142,8 +148,8 @@ class TestTrackReviewCompleted(BaseTest):
         tracking_input = self._tracking_input(report_id)
 
         with patch("products.review_hog.backend.temporal.activities.posthoganalytics.capture") as capture:
-            _track_review_completed(tracking_input)
-            _track_review_completed(tracking_input)
+            _track_review_completed(tracking_input, _WORKFLOW_ID)
+            _track_review_completed(tracking_input, _WORKFLOW_ID)
 
         first, second = capture.call_args_list
         assert first.kwargs["uuid"]
@@ -158,4 +164,50 @@ class TestTrackReviewCompleted(BaseTest):
             "products.review_hog.backend.temporal.activities.posthoganalytics.capture",
             side_effect=RuntimeError("analytics down"),
         ):
-            _track_review_completed_safe(self._tracking_input(report_id))
+            _track_review_completed_safe(self._tracking_input(report_id), _WORKFLOW_ID)
+
+    def test_collects_turn_sandbox_usage(self) -> None:
+        # Cost-per-PR dashboards join this event to $ai_generation through sandbox_task_ids — a
+        # broken prefix lookup or token summing silently zeroes them, and a loose prefix match
+        # would leak PR 74's runs into PR 7's turn.
+        report_id = self._review_report()
+        task = Task.objects.create(team=self.team, title="t", origin_product=Task.OriginProduct.REVIEW_HOG)
+        TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            state={
+                "workflow_id_prefix": f"{_WORKFLOW_ID}:chunking",
+                "token_usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            },
+        )
+        TaskRun.objects.create(
+            task=task,
+            team=self.team,
+            state={
+                "workflow_id_prefix": f"{_WORKFLOW_ID}/review:issues-review-p1-c1",
+                "token_usage": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+            },
+        )
+        # PR 74 shares PR 7's prefix as a string — the separator-suffixed match must exclude it.
+        neighbour_pr = Task.objects.create(team=self.team, title="t", origin_product=Task.OriginProduct.REVIEW_HOG)
+        TaskRun.objects.create(
+            task=neighbour_pr,
+            team=self.team,
+            state={"workflow_id_prefix": f"{_WORKFLOW_ID}4:chunking", "token_usage": {"input_tokens": 100}},
+        )
+        # A prior turn's run for the same PR sits before this turn's window.
+        stale = TaskRun.objects.create(
+            task=task, team=self.team, state={"workflow_id_prefix": f"{_WORKFLOW_ID}:chunking"}
+        )
+        TaskRun.objects.filter(id=stale.id).update(created_at=datetime.now(UTC) - timedelta(hours=2))
+
+        with patch("products.review_hog.backend.temporal.activities.posthoganalytics.capture") as capture:
+            # Real workflow ids carry the repo's casing; the stored prefixes are lowercased.
+            _track_review_completed(self._tracking_input(report_id), _WORKFLOW_ID.upper())
+
+        props = capture.call_args.kwargs["properties"]
+        assert props["sandbox_task_ids"] == [str(task.id)]
+        assert props["sandbox_run_count"] == 2
+        assert props["llm_input_tokens"] == 11
+        assert props["llm_output_tokens"] == 7
+        assert props["llm_total_tokens"] == 18

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -520,6 +520,31 @@ def get_task_id_for_run(run_id: str | UUID, team_id: int) -> UUID | None:
     return TaskRun.objects.filter(id=run_id, team_id=team_id).values_list("task_id", flat=True).first()
 
 
+def list_sandbox_run_usage(
+    team_id: int, *, workflow_id_prefixes: Sequence[str], created_after: datetime
+) -> list[dict[str, Any]]:
+    """Task ids + token usage for the team's runs whose ``workflow_id_prefix`` starts with any prefix.
+
+    Products that brand their sandbox runs' Temporal workflow ids (via ``workflow_id_prefix`` at
+    creation) can recover everything one logical operation spawned — e.g. a ReviewHog review turn
+    summing its LLM usage — without holding run ids themselves. ``created_after`` bounds the scan
+    to the operation's window. Read-only; returns ``{"task_id": UUID, "token_usage": dict}`` rows.
+    """
+    if not workflow_id_prefixes:
+        return []
+    prefix_q = Q()
+    for prefix in workflow_id_prefixes:
+        prefix_q |= Q(state__workflow_id_prefix__startswith=prefix)
+    rows = TaskRun.objects.filter(prefix_q, team_id=team_id, created_at__gte=created_after).values_list(
+        "task_id", "state"
+    )
+    usage_rows: list[dict[str, Any]] = []
+    for task_id, state in rows:
+        token_usage = state.get("token_usage") if isinstance(state, dict) else None
+        usage_rows.append({"task_id": task_id, "token_usage": token_usage if isinstance(token_usage, dict) else {}})
+    return usage_rows
+
+
 def task_exists(task_id: str | UUID, team_id: int) -> bool:
     """Whether a (non-deleted) task exists for the team."""
     return Task.objects.filter(id=task_id, team_id=team_id).exists()


### PR DESCRIPTION
## Problem

`reviewhog_review_completed` (shipped in #74616) counts review turns with size and duration, but a turn's LLM cost is unrecoverable in analytics: `$ai_generation` rows carry `task_id` and no review key, task rows carry no PR key, and time-window attribution breaks under same-repo concurrency. So "how much does reviewing a PR of size X cost" can't be answered.

## Changes

- The turn's sandbox runs are recoverable with data that already exists: every run's Temporal workflow id is branded with the review workflow's id (`_sandbox_workflow_id_prefix`), and `TaskRun.state` persists that prefix. A new read-only tasks facade helper, `list_sandbox_run_usage`, returns task ids + token usage for runs matching a workflow-id prefix within a time window.
- `track_review_completed_activity` now stamps onto the event: `sandbox_task_ids` (joins to `$ai_generation.task_id` for exact per-turn dollar cost — gateway cost numbers stay the single source of truth rather than duplicating pricing server-side), `sandbox_run_count`, and summed token totals (`llm_input_tokens` / `llm_output_tokens` / `llm_cache_read_tokens` / `llm_cache_write_tokens` / `llm_total_tokens`) for token-level views with no join.
- Correctness guards: prefix matching is separator-suffixed (`:` / `/`) so PR 12's prefix never matches PR 123; the lookup is bounded to the turn's window and Temporal allows only one running turn per PR, so attribution is exact. Best-effort throughout — a lookup failure nulls the linkage properties, never the capture.
- ARCHITECTURE.md event description updated in the same PR.

## How did you test this code?

- Extended `test_review_completed_tracking.py`: a new test drives real `Task`/`TaskRun` rows through the collector and asserts the task-id list, run count, and token sums, plus the three failure modes no existing test catches — a PR-number prefix collision (PR 74 run must not leak into PR 7's turn), a prior turn's run outside the window, and workflow-id casing (stored prefixes are lowercased). Existing tests now also pin the empty-turn shape (`[]`/`0`, not null) and pass the new argument.
- Agent limitations: authored in a sandboxed environment without the dev stack — `ruff check` / `ruff format` pass and all files compile, but I could not run pytest or repo-wide mypy locally; please rely on CI for those.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

ARCHITECTURE.md (the product's own doc) is updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude via a PostHog Code cloud task, requested while building cost-by-PR-size views on the internal ReviewHog dashboard — the event's size properties landed in #74616, but cost had no join path.
- Skills invoked: `/writing-tests` and `/writing-code-comments` (repo skills, applied as gates for the new test and comments).
- Decisions: recover runs by the existing workflow-id branding instead of threading report ids through every sandbox call site (zero pipeline plumbing); expose the lookup as a read-only facade helper rather than importing tasks models from ReviewHog (respects the facade boundary in products/architecture.md); carry task ids for a dollar join instead of computing dollars server-side (avoids a second pricing implementation that would drift from the gateway's).

**Why:** requested so the ReviewHog dashboard can chart average LLM spend by PR size — the histogram exists, the cost linkage didn't.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
