### PR TITLE
refactor(support): give plan detection one source of truth

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
@@ -12,6 +12,7 @@ import {
     PAY_AS_YOU_GO_RESPONSE_TIME,
     getCurrentSupportPlan,
     getSupportResponseTimeFeature,
+    hasActiveSupportTrial,
 } from 'lib/components/Support/supportResponseTime'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
@@ -120,9 +121,7 @@ const SupportResponseTimesTable = ({
     const { supportPlans, billingPlan } = useValues(billingLogic)
     const { user } = useValues(userLogic)
 
-    const hasBoostTrial = billing?.trial?.status === 'active' && billing.trial?.target === 'boost'
-    const hasScaleTrial = billing?.trial?.status === 'active' && billing.trial?.target === 'scale'
-    const hasEnterpriseTrial = billing?.trial?.status === 'active' && billing.trial?.target === 'enterprise'
+    const hasSupportTrial = hasActiveSupportTrial(billing)
 
     const hasExpiredTrial = billing?.trial?.status === 'expired'
     const expiredTrialDate = hasExpiredTrial ? dayjs(billing?.trial?.expires_at) : null
@@ -229,14 +228,14 @@ const SupportResponseTimesTable = ({
             })}
 
             {/* Display expired trial information */}
-            {!(hasBoostTrial || hasScaleTrial || hasEnterpriseTrial) && hasExpiredTrial && expiredTrialDate && (
+            {!hasSupportTrial && hasExpiredTrial && expiredTrialDate && (
                 <>
                     <div className="border-t text-muted col-span-2">Trial expired</div>
                 </>
             )}
 
             {/* Display active trial information integrated into the table */}
-            {(hasBoostTrial || hasScaleTrial || hasEnterpriseTrial) && (
+            {hasSupportTrial && (
                 <>
                     <div className="font-bold border-t">Your trial</div>
                     <div className="font-bold border-t text-right">{DEFAULT_PAID_RESPONSE_TIME}</div>

--- a/frontend/src/lib/components/Support/supportLogic.test.ts
+++ b/frontend/src/lib/components/Support/supportLogic.test.ts
@@ -6,15 +6,26 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
 import { initKeaTests } from '~/test/init'
-import { OrganizationBasicType, Region, SidePanelTab, TeamPublicType } from '~/types'
+import {
+    BillingPlan,
+    BillingType,
+    OrganizationBasicType,
+    Region,
+    SidePanelTab,
+    StartupProgramLabel,
+    TeamPublicType,
+} from '~/types'
 
 import {
     CONVERSATIONS_MESSAGE_MAX_LENGTH,
+    getPlanLevelTag,
     getPublicSupportSnippet,
+    PlanLevelTagContext,
     SupportFormFields,
     supportLogic,
 } from './supportLogic'
 import * as SupportModal from './SupportModal'
+import { KNOWN_ENTERPRISE_ORG_IDS } from './supportResponseTime'
 
 // supportLogic and SupportModal import each other, so jest.mock('./SupportModal') leaves supportLogic
 // bound to the real openSupportModal — spy on the live module export instead so the call is intercepted.
@@ -47,6 +58,84 @@ describe('supportLogic', () => {
             mockedGetReplayUrl.mockReturnValue(undefined)
             const snippet = getPublicSupportSnippet(Region.US, organization, team, false)
             expect(snippet).toContain('Admin (internal): http://go/adminOrg')
+        })
+    })
+
+    describe('getPlanLevelTag', () => {
+        const billingWith = (billing: Partial<BillingType>): BillingType => billing as BillingType
+        const activeTrial = (target: string): BillingType =>
+            billingWith({ trial: { status: 'active', target } } as Partial<BillingType>)
+
+        it.each([
+            [
+                'a known enterprise org id, whatever its plan',
+                { organizationId: KNOWN_ENTERPRISE_ORG_IDS[0] },
+                'plan_enterprise',
+            ],
+            ['the enterprise plan', { billingPlan: BillingPlan.Enterprise }, 'plan_enterprise'],
+            ['an active enterprise trial', { billing: activeTrial('enterprise') }, 'plan_enterprise'],
+            ['an active scale trial', { billing: activeTrial('scale') }, 'plan_scale'],
+            ['an active boost trial', { billing: activeTrial('boost') }, 'plan_boost'],
+            ['the scale plan', { billingPlan: BillingPlan.Scale }, 'plan_scale'],
+            ['the boost plan', { billingPlan: BillingPlan.Boost }, 'plan_boost'],
+            ['the legacy teams plan', { billingPlan: BillingPlan.Teams }, 'plan_teams_legacy'],
+            ['the free plan', { billingPlan: BillingPlan.Free }, 'plan_free'],
+            ['no billing plan at all', {}, 'plan_free'],
+            ['a new organization', { isNewOrganization: true }, 'plan_onboarding'],
+            [
+                'a new organization on the enterprise plan, which outranks onboarding',
+                { billingPlan: BillingPlan.Enterprise, isNewOrganization: true },
+                'plan_enterprise',
+            ],
+            [
+                'a new organization on an active scale trial, where onboarding outranks the trial',
+                { billing: activeTrial('scale'), isNewOrganization: true },
+                'plan_onboarding',
+            ],
+            [
+                'pay-as-you-go projecting nothing',
+                { billingPlan: BillingPlan.Paid, billing: billingWith({ projected_total_amount_usd_with_limit: '0' }) },
+                'plan_pay-as-you-go_free',
+            ],
+            [
+                'pay-as-you-go projecting a spend',
+                {
+                    billingPlan: BillingPlan.Paid,
+                    billing: billingWith({ projected_total_amount_usd_with_limit: '250.50' }),
+                },
+                'plan_pay-as-you-go_paying',
+            ],
+            [
+                'an expired trial, which falls back to the billing plan',
+                {
+                    billingPlan: BillingPlan.Free,
+                    billing: billingWith({ trial: { status: 'expired', target: 'scale' } } as Partial<BillingType>),
+                },
+                'plan_free',
+            ],
+            [
+                'an active trial on a target that carries no support',
+                { billingPlan: BillingPlan.Free, billing: activeTrial('teams') },
+                'plan_free',
+            ],
+            [
+                'the YC label, which outranks the plan',
+                {
+                    billingPlan: BillingPlan.Enterprise,
+                    billing: billingWith({ startup_program_label: StartupProgramLabel.YC }),
+                },
+                'plan_yc',
+            ],
+            [
+                'the startup label, which outranks the plan',
+                {
+                    billingPlan: BillingPlan.Scale,
+                    billing: billingWith({ startup_program_label: StartupProgramLabel.Startup }),
+                },
+                'plan_startup',
+            ],
+        ])('tags %s as %s', (_case, context: PlanLevelTagContext, expected) => {
+            expect(getPlanLevelTag(context)).toEqual(expected)
         })
     })
 

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -32,7 +32,7 @@ import type { BillingType, PreflightStatus } from '../../../types'
 import type { FeatureFlagsSet } from '../../logic/featureFlagLogic'
 import { parseExceptionEvent } from './exceptionUtils'
 import { openSupportModal } from './SupportModal'
-import { KNOWN_ENTERPRISE_ORG_IDS } from './supportResponseTime'
+import { KNOWN_ENTERPRISE_ORG_IDS, getActiveTrialTarget } from './supportResponseTime'
 
 export function getPublicSupportSnippet(
     cloudRegion: Region | null | undefined,
@@ -911,17 +911,15 @@ export const supportLogic = kea<supportLogicType>([
 
             const isNewOrganization = values.isCurrentOrganizationNew
 
-            const hasBoostTrial = billing?.trial?.status === 'active' && billing.trial?.target === 'boost'
-            const hasScaleTrial = billing?.trial?.status === 'active' && billing.trial?.target === 'scale'
-            const hasEnterpriseTrial = billing?.trial?.status === 'active' && billing.trial?.target === 'enterprise'
+            const activeTrialTarget = getActiveTrialTarget(billing)
 
-            if (isKnownEnterpriseOrg || hasEnterpriseTrial || billingPlan === BillingPlan.Enterprise) {
+            if (isKnownEnterpriseOrg || activeTrialTarget === 'enterprise' || billingPlan === BillingPlan.Enterprise) {
                 planLevelTag = 'plan_enterprise'
             } else if (isNewOrganization) {
                 planLevelTag = 'plan_onboarding'
-            } else if (hasScaleTrial) {
+            } else if (activeTrialTarget === 'scale') {
                 planLevelTag = 'plan_scale'
-            } else if (hasBoostTrial) {
+            } else if (activeTrialTarget === 'boost') {
                 planLevelTag = 'plan_boost'
             } else if (billingPlan) {
                 switch (billingPlan) {

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -32,6 +32,7 @@ import type { BillingType, PreflightStatus } from '../../../types'
 import type { FeatureFlagsSet } from '../../logic/featureFlagLogic'
 import { parseExceptionEvent } from './exceptionUtils'
 import { openSupportModal } from './SupportModal'
+import { KNOWN_ENTERPRISE_ORG_IDS } from './supportResponseTime'
 
 export function getPublicSupportSnippet(
     cloudRegion: Region | null | undefined,
@@ -904,8 +905,9 @@ export const supportLogic = kea<supportLogicType>([
 
             let planLevelTag = 'plan_free'
 
-            const knownEnterpriseOrgIds = ['018713f3-8d56-0000-32fa-75ce97e6662f']
-            const isKnownEnterpriseOrg = knownEnterpriseOrgIds.includes(userLogic?.values?.user?.organization?.id || '')
+            const isKnownEnterpriseOrg = KNOWN_ENTERPRISE_ORG_IDS.includes(
+                userLogic?.values?.user?.organization?.id || ''
+            )
 
             const isNewOrganization = values.isCurrentOrganizationNew
 

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -100,6 +100,65 @@ function getErrorTrackingLink(uuid?: string): string {
     return `\nExceptions: https://us.posthog.com/project/2/error_tracking?filterGroup=${filterGroup}`
 }
 
+export interface PlanLevelTagContext {
+    billing?: BillingType | null
+    billingPlan?: BillingPlan | null
+    organizationId?: string | null
+    isNewOrganization?: boolean
+}
+
+export function getPlanLevelTag({
+    billing,
+    billingPlan,
+    organizationId,
+    isNewOrganization,
+}: PlanLevelTagContext): string {
+    let planLevelTag = 'plan_free'
+
+    const isKnownEnterpriseOrg = KNOWN_ENTERPRISE_ORG_IDS.includes(organizationId || '')
+    const activeTrialTarget = getActiveTrialTarget(billing)
+
+    if (isKnownEnterpriseOrg || activeTrialTarget === 'enterprise' || billingPlan === BillingPlan.Enterprise) {
+        planLevelTag = 'plan_enterprise'
+    } else if (isNewOrganization) {
+        planLevelTag = 'plan_onboarding'
+    } else if (activeTrialTarget === 'scale') {
+        planLevelTag = 'plan_scale'
+    } else if (activeTrialTarget === 'boost') {
+        planLevelTag = 'plan_boost'
+    } else if (billingPlan) {
+        switch (billingPlan) {
+            case BillingPlan.Scale:
+                planLevelTag = 'plan_scale'
+                break
+            case BillingPlan.Boost:
+                planLevelTag = 'plan_boost'
+                break
+            case BillingPlan.Teams:
+                planLevelTag = 'plan_teams_legacy'
+                break
+            case BillingPlan.Paid:
+                const projectedAmount = parseFloat(billing?.projected_total_amount_usd_with_limit || '0')
+                const shouldMarkAsFree = projectedAmount === 0
+
+                planLevelTag = shouldMarkAsFree ? 'plan_pay-as-you-go_free' : 'plan_pay-as-you-go_paying'
+                break
+            case BillingPlan.Free:
+                planLevelTag = 'plan_free'
+                break
+        }
+    }
+
+    const startupProgramLabel = billing?.startup_program_label
+    if (startupProgramLabel === StartupProgramLabel.YC) {
+        planLevelTag = 'plan_yc'
+    } else if (startupProgramLabel === StartupProgramLabel.Startup) {
+        planLevelTag = 'plan_startup'
+    }
+
+    return planLevelTag
+}
+
 function getDjangoAdminLink(
     user: UserType | null,
     cloudRegion: Region | null | undefined,
@@ -903,53 +962,12 @@ export const supportLogic = kea<supportLogicType>([
             const billing = billingLogic.values.billing
             const billingPlan = billingLogic.values.billingPlan
 
-            let planLevelTag = 'plan_free'
-
-            const isKnownEnterpriseOrg = KNOWN_ENTERPRISE_ORG_IDS.includes(
-                userLogic?.values?.user?.organization?.id || ''
-            )
-
-            const isNewOrganization = values.isCurrentOrganizationNew
-
-            const activeTrialTarget = getActiveTrialTarget(billing)
-
-            if (isKnownEnterpriseOrg || activeTrialTarget === 'enterprise' || billingPlan === BillingPlan.Enterprise) {
-                planLevelTag = 'plan_enterprise'
-            } else if (isNewOrganization) {
-                planLevelTag = 'plan_onboarding'
-            } else if (activeTrialTarget === 'scale') {
-                planLevelTag = 'plan_scale'
-            } else if (activeTrialTarget === 'boost') {
-                planLevelTag = 'plan_boost'
-            } else if (billingPlan) {
-                switch (billingPlan) {
-                    case BillingPlan.Scale:
-                        planLevelTag = 'plan_scale'
-                        break
-                    case BillingPlan.Boost:
-                        planLevelTag = 'plan_boost'
-                        break
-                    case BillingPlan.Teams:
-                        planLevelTag = 'plan_teams_legacy'
-                        break
-                    case BillingPlan.Paid:
-                        const projectedAmount = parseFloat(billing?.projected_total_amount_usd_with_limit || '0')
-                        const shouldMarkAsFree = projectedAmount === 0
-
-                        planLevelTag = shouldMarkAsFree ? 'plan_pay-as-you-go_free' : 'plan_pay-as-you-go_paying'
-                        break
-                    case BillingPlan.Free:
-                        planLevelTag = 'plan_free'
-                        break
-                }
-            }
-
-            const startupProgramLabel = billing?.startup_program_label
-            if (startupProgramLabel === StartupProgramLabel.YC) {
-                planLevelTag = 'plan_yc'
-            } else if (startupProgramLabel === StartupProgramLabel.Startup) {
-                planLevelTag = 'plan_startup'
-            }
+            const planLevelTag = getPlanLevelTag({
+                billing,
+                billingPlan,
+                organizationId: userLogic?.values?.user?.organization?.id,
+                isNewOrganization: values.isCurrentOrganizationNew,
+            })
 
             const { accountOwner } = billingLogic.values
 

--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -32,7 +32,7 @@ import type { BillingType, PreflightStatus } from '../../../types'
 import type { FeatureFlagsSet } from '../../logic/featureFlagLogic'
 import { parseExceptionEvent } from './exceptionUtils'
 import { openSupportModal } from './SupportModal'
-import { KNOWN_ENTERPRISE_ORG_IDS, getActiveTrialTarget } from './supportResponseTime'
+import { getCurrentSupportPlan } from './supportResponseTime'
 
 export function getPublicSupportSnippet(
     cloudRegion: Region | null | undefined,
@@ -113,50 +113,38 @@ export function getPlanLevelTag({
     organizationId,
     isNewOrganization,
 }: PlanLevelTagContext): string {
-    let planLevelTag = 'plan_free'
-
-    const isKnownEnterpriseOrg = KNOWN_ENTERPRISE_ORG_IDS.includes(organizationId || '')
-    const activeTrialTarget = getActiveTrialTarget(billing)
-
-    if (isKnownEnterpriseOrg || activeTrialTarget === 'enterprise' || billingPlan === BillingPlan.Enterprise) {
-        planLevelTag = 'plan_enterprise'
-    } else if (isNewOrganization) {
-        planLevelTag = 'plan_onboarding'
-    } else if (activeTrialTarget === 'scale') {
-        planLevelTag = 'plan_scale'
-    } else if (activeTrialTarget === 'boost') {
-        planLevelTag = 'plan_boost'
-    } else if (billingPlan) {
-        switch (billingPlan) {
-            case BillingPlan.Scale:
-                planLevelTag = 'plan_scale'
-                break
-            case BillingPlan.Boost:
-                planLevelTag = 'plan_boost'
-                break
-            case BillingPlan.Teams:
-                planLevelTag = 'plan_teams_legacy'
-                break
-            case BillingPlan.Paid:
-                const projectedAmount = parseFloat(billing?.projected_total_amount_usd_with_limit || '0')
-                const shouldMarkAsFree = projectedAmount === 0
-
-                planLevelTag = shouldMarkAsFree ? 'plan_pay-as-you-go_free' : 'plan_pay-as-you-go_paying'
-                break
-            case BillingPlan.Free:
-                planLevelTag = 'plan_free'
-                break
-        }
-    }
-
     const startupProgramLabel = billing?.startup_program_label
     if (startupProgramLabel === StartupProgramLabel.YC) {
-        planLevelTag = 'plan_yc'
-    } else if (startupProgramLabel === StartupProgramLabel.Startup) {
-        planLevelTag = 'plan_startup'
+        return 'plan_yc'
+    }
+    if (startupProgramLabel === StartupProgramLabel.Startup) {
+        return 'plan_startup'
     }
 
-    return planLevelTag
+    const supportPlan = getCurrentSupportPlan({ billing, billingPlan, organizationId })
+    if (supportPlan === BillingPlan.Enterprise) {
+        return 'plan_enterprise'
+    }
+    if (isNewOrganization) {
+        return 'plan_onboarding'
+    }
+
+    switch (supportPlan) {
+        case 'scale_trial':
+        case BillingPlan.Scale:
+            return 'plan_scale'
+        case 'boost_trial':
+        case BillingPlan.Boost:
+            return 'plan_boost'
+        case BillingPlan.Teams:
+            return 'plan_teams_legacy'
+        case BillingPlan.Paid:
+            return parseFloat(billing?.projected_total_amount_usd_with_limit || '0') === 0
+                ? 'plan_pay-as-you-go_free'
+                : 'plan_pay-as-you-go_paying'
+        case BillingPlan.Free:
+            return 'plan_free'
+    }
 }
 
 function getDjangoAdminLink(

--- a/frontend/src/lib/components/Support/supportResponseTime.ts
+++ b/frontend/src/lib/components/Support/supportResponseTime.ts
@@ -7,6 +7,19 @@ export const KNOWN_ENTERPRISE_ORG_IDS = ['018713f3-8d56-0000-32fa-75ce97e6662f']
 
 export type CurrentSupportPlan = BillingPlan | 'boost_trial' | 'scale_trial'
 
+export type TrialTarget = NonNullable<BillingType['trial']>['target']
+
+const SUPPORT_TRIAL_TARGETS: TrialTarget[] = ['boost', 'scale', 'enterprise']
+
+export function getActiveTrialTarget(billing: BillingType | null | undefined): TrialTarget | null {
+    return billing?.trial?.status === 'active' ? billing.trial.target : null
+}
+
+export function hasActiveSupportTrial(billing: BillingType | null | undefined): boolean {
+    const target = getActiveTrialTarget(billing)
+    return target !== null && SUPPORT_TRIAL_TARGETS.includes(target)
+}
+
 export interface SupportPlanContext {
     billing?: BillingType | null
     billingPlan?: BillingPlan | null
@@ -19,7 +32,7 @@ export function getCurrentSupportPlan({
     billingPlan,
     organizationId,
 }: SupportPlanContext): CurrentSupportPlan {
-    const activeTrialTarget = billing?.trial?.status === 'active' ? billing.trial.target : null
+    const activeTrialTarget = getActiveTrialTarget(billing)
 
     if (
         KNOWN_ENTERPRISE_ORG_IDS.includes(organizationId || '') ||
@@ -53,8 +66,7 @@ export function getSupportResponseTimeFeature(
  * callers can leave the promise out entirely rather than fall back to a made-up one.
  */
 export function getSupportResponseTime(context: SupportPlanContext): string | null {
-    const activeTrialTarget = context.billing?.trial?.status === 'active' ? context.billing.trial.target : null
-    if (activeTrialTarget === 'boost' || activeTrialTarget === 'scale' || activeTrialTarget === 'enterprise') {
+    if (hasActiveSupportTrial(context.billing)) {
         return null
     }
 

--- a/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
+++ b/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
@@ -16,7 +16,7 @@ import { subscriptions } from 'kea-subscriptions'
 import posthog from 'posthog-js'
 
 import { appendExceptionToMessage, supportLogic, warnIfMessageTooLong } from 'lib/components/Support/supportLogic'
-import { getSupportResponseTime } from 'lib/components/Support/supportResponseTime'
+import { getSupportResponseTime, hasActiveSupportTrial } from 'lib/components/Support/supportResponseTime'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { EMAIL_SUPPORT_BUTTON, lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -368,9 +368,7 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
         canCreateTicket: [
             (s) => [s.billing, s.isCurrentOrganizationNew, s.hasBillingExemption],
             (billing: BillingType | null, isCurrentOrganizationNew: boolean, hasBillingExemption: boolean): boolean => {
-                const hasSupportTrial =
-                    billing?.trial?.status === 'active' &&
-                    ['boost', 'scale', 'enterprise'].includes(billing.trial?.target ?? '')
+                const hasSupportTrial = hasActiveSupportTrial(billing)
                 return (
                     billing?.subscription_level === 'paid' ||
                     billing?.subscription_level === 'custom' ||


### PR DESCRIPTION
## Problem

Which support plan an organization is on gets decided in several places, and they had drifted.

`getCurrentSupportPlan` in `supportResponseTime.ts` is the shared answer, used by the help panel's response times table and the ticket response time. The Zendesk `plan_level` tag in `supportLogic` did not use it. It re-derived the same thing inline: its own copy of the known-enterprise org id list, its own active-trial checks, its own fallback to the billing plan.

That inline copy of the org list is a live drift risk. Both copies were added by the same PR, [#33681](https://github.com/PostHog/posthog/pull/33681), to close one detection hole in two places, and when the constant later moved into `supportResponseTime.ts` this one stayed behind. Adding an organization to `KNOWN_ENTERPRISE_ORG_IDS` today updates what the UI shows that organization but leaves its tickets tagged by billing plan instead of `plan_enterprise`. It surfaces as a routing problem, not a visible bug.

Separately, "does an active trial count as paid support?" was written out five times across four files, each copy independently encoding that `boost`, `scale`, and `enterprise` carry support while `paid` and `teams` do not.

And none of the tag logic was reachable from a test, which is how the drift went unnoticed.

## Changes

Four commits, reviewable in order:

1. **`fix(support)`** - the tag path reads `KNOWN_ENTERPRISE_ORG_IDS` instead of its inline copy. No behavior change today, both lists hold the same org id. This is about the next edit to that list.
2. **`refactor(support)`** - `getActiveTrialTarget` and `hasActiveSupportTrial` replace the five hand-written trial checks. `TrialTarget` derives from `BillingType['trial']` rather than restating the union, so a new trial target upstream surfaces here instead of falling through.
3. **`refactor(support)`** - the inline tag logic moves verbatim into an exported `getPlanLevelTag`, plus 19 parameterized cases pinning the mapping.
4. **`refactor(support)`** - `getPlanLevelTag`'s internals rebuild on `getCurrentSupportPlan`, with the tests from commit 3 untouched.

Commits 3 and 4 are split on purpose. The tests were written against the old logic and never changed, so they verify the refactor rather than describe it.

`getPlanLevelTag` keeps the two rules the shared helper does not model: onboarding organizations rank below enterprise but above everything else, and the startup labels override the plan entirely. Both are now stated at the top of the function instead of being implied by position in a long `else if` chain. Net effect on the listener, 40 lines of branching become a four-line call.

> [!NOTE]
> Conflicts with #74173 on one import line in `sidepanelTicketsLogic`. That PR removes the `getSupportResponseTime` import; this one extends it. Whichever lands second resolves to `{ hasActiveSupportTrial }`.

## How did you test this code?

**Automated:** `jest frontend/src/lib/components/Support products/conversations/frontend/components/SidePanel`, 59 tests pass. Full `tsc --noEmit` over the frontend reports the same error count as master, so this introduces none.

The 19 new cases cover every tag the function can return plus the four precedence rules that reordering would break: enterprise over onboarding, onboarding over an active trial, startup labels over the plan, and the pay-as-you-go split by projected spend. Two more pin behavior worth keeping honest, that an expired trial falls back to the billing plan and that a `teams` trial carries no support. The regression they catch that nothing did before is any change to tag precedence, including this PR's own commit 4. That path had zero coverage.

The trial helper needed no new tests. `supportResponseTime.test.ts` already exercises active boost, scale, and enterprise trials through its callers, so a broken helper fails there.

**Manual:** none. The tag is only observable in the Zendesk payload and I did not submit real tickets across plan fixtures. The mapping is covered by the pure-function cases, and the listener change substitutes one expression for the block that produced it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None needed. No user-facing or documented behavior changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code found all of this while I had it look at a bot suggestion on #74173, which pointed out a duplicated selector in the same area. I asked it to sweep for more of the same, then work through what it found.

It first opened this as three stacked PRs, one per finding. That was the wrong shape: the last one deletes the lines the first two add, so reviewing the stack meant watching the same region change three times. Consolidated to one PR with the commits kept separate.

Skills invoked: /writing-tests, which is what produced the extract-then-rewrite split. Its gate is whether a test catches a realistic regression no existing test does, and an uncovered refactor of ticket routing logic is squarely that.
