### PR TITLE
feat(aio): align AI observability signal source

### DIFF
--- a/frontend/src/scenes/inbox/components/config/agentRosterMeta.ts
+++ b/frontend/src/scenes/inbox/components/config/agentRosterMeta.ts
@@ -71,9 +71,9 @@ export const AGENT_ROSTER_GROUPS: AgentRosterGroup[] = [
                 source: 'llm_analytics',
                 sourceProduct: SignalSourceProduct.LlmAnalytics,
                 label: 'AI observability',
-                description: 'Findings from evaluation reports on your LLM traffic.',
-                docsUrl: 'https://posthog.com/docs/ai-evals/evaluations',
-                docsLabel: 'AI observability',
+                description: 'Quality problems in your AI features. Set up evaluations to start getting signals.',
+                docsUrl: 'https://posthog.com/docs/ai-evals',
+                docsLabel: 'evaluations',
             },
             {
                 source: 'analytics',

--- a/frontend/src/scenes/inbox/signalSourcesLogic.test.ts
+++ b/frontend/src/scenes/inbox/signalSourcesLogic.test.ts
@@ -168,4 +168,28 @@ describe('signalSourcesLogic', () => {
         expect(createSourceConfig).toHaveBeenCalledTimes(1)
         expect(logic.values.isGithubIssuesToggling).toBe(false)
     })
+
+    it('creates an AI observability config for evaluation reports', async () => {
+        const createSourceConfig = jest.spyOn(api.signalSourceConfigs, 'create').mockResolvedValue({
+            id: 'config-evaluation-reports',
+            source_product: SignalSourceProduct.LlmAnalytics,
+            source_type: SignalSourceType.EvaluationReport,
+            enabled: true,
+            config: {},
+            created_at: '2026-07-30T00:00:00Z',
+            updated_at: '2026-07-30T00:00:00Z',
+            status: null,
+        })
+        logic.actions.loadSourceConfigsSuccess([])
+
+        logic.actions.toggleEvalReports()
+        await expectLogic(logic).toFinishAllListeners()
+
+        expect(createSourceConfig).toHaveBeenCalledWith({
+            source_product: SignalSourceProduct.LlmAnalytics,
+            source_type: SignalSourceType.EvaluationReport,
+            enabled: true,
+            config: {},
+        })
+    })
 })


### PR DESCRIPTION
## Problem

The web app AI observability source should match the Self-driving inbox source in [PostHog/code#4006](https://github.com/PostHog/code/pull/4006). Both surfaces need to describe the same setup and toggle evaluation report signals.

## Changes

- Align the AI observability source description and evaluations docs link with PostHog Code.
- Cover the web toggle contract so it creates an llm_analytics source config with the evaluation_report source type.

No screenshot is included because the card layout is unchanged. This only updates its copy and link.

## How did you test this code?

- Automated logic coverage for the regression where the web toggle could create a different source type from PostHog Code.
- Frontend lint, formatting, and CI preflight passed.
- The full TypeScript check was run but is blocked by existing SelectTriggerIcon export errors in unchanged error tracking files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change is needed. The source card now points to the existing AI evaluations documentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex Desktop prepared this change in the current task at the direction of Radu-Raicea. Skills used: /github, /writing-user-facing-copy, /writing-tests, /adopting-generated-api-types, /posthog-efficient-validation, /running-ci-preflight, and /create-pr.

Fresh master already used evaluation_report for the web toggle and backend gate. The change therefore aligns the visible source-card contract and adds focused regression coverage without changing the backend API.