### PR TITLE
fix(convex): retry Cloudflare 530 DNS errors instead of failing the sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
@@ -26,11 +26,13 @@ logger = logging.getLogger(__name__)
 
 # Convex deployments are served behind Cloudflare, which surfaces transient edge/origin
 # problems as the 52x family (520 Unknown Error, 521 Web Server Down, 522 Connection Timed
-# Out, 523 Origin Unreachable, 524 Timeout). These are retryable just like the standard 5xx
-# codes, but urllib3's default forcelist doesn't include them — so a single transient 520
-# would otherwise fail the whole sync. All Convex requests are idempotent GETs, so retrying
-# them is safe. Derive from DEFAULT_RETRY so backoff/total/allowed-methods stay in sync.
-_CLOUDFLARE_TRANSIENT_STATUSES = frozenset({520, 521, 522, 523, 524})
+# Out, 523 Origin Unreachable, 524 Timeout) plus 530, which Cloudflare emits for edge-side
+# DNS resolution hiccups reaching the origin (its 1xxx error subcodes). These are retryable
+# just like the standard 5xx codes, but urllib3's default forcelist doesn't include them —
+# so a single transient 520/530 would otherwise fail the whole sync. All Convex requests are
+# idempotent GETs, so retrying them is safe. Derive from DEFAULT_RETRY so backoff/total/
+# allowed-methods stay in sync.
+_CLOUDFLARE_TRANSIENT_STATUSES = frozenset({520, 521, 522, 523, 524, 530})
 _CONVEX_RETRY = DEFAULT_RETRY.new(
     status_forcelist=frozenset(DEFAULT_RETRY.status_forcelist) | _CLOUDFLARE_TRANSIENT_STATUSES
 )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -311,6 +311,7 @@ class TestConvexRetryPolicy:
             ("cf_522_connection_timed_out", 522, True),
             ("cf_523_origin_unreachable", 523, True),
             ("cf_524_timeout", 524, True),
+            ("cf_530_dns_error", 530, True),
             # Standard transient codes inherited from DEFAULT_RETRY must still be retried.
             ("rate_limited_429", 429, True),
             ("internal_500", 500, True),


### PR DESCRIPTION
## Problem

Error tracking surfaced an `HTTPError` in the Convex source's `document_deltas` call: `530 Server Error` for a `document_deltas` request. Convex deployments sit behind Cloudflare, which already surfaces the 520-524 family as transient edge/origin problems (handled by extending the retryable status set on the HTTP session). 530 wasn't in that set, so it fell through to `raise_for_status()` and failed the sync outright instead of getting a fast, automatic retry.

The error hit three different deployments within the same few-second window, which points to a shared transient Cloudflare/Convex-side blip rather than a per-customer DNS misconfiguration.

## Changes

Added 530 to `_CLOUDFLARE_TRANSIENT_STATUSES` in `convex.py`, alongside the existing 520-524 family, so it's retried at the HTTP session layer the same way.

## How did you test this code?

Added a parameterized case (`cf_530_dns_error`) to `TestConvexRetryPolicy.test_retry_status_handling` asserting 530 is now classified as retryable, following the existing pattern for the 520-524 codes. Ran the full Convex source test suite locally — all 68 tests pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking (issue `019fb393-5f02-7781-a0fa-eaf67e365dba`), confirmed the failure originates in `document_deltas` at `convex.py`, and classified it as a fixable bug (missing retry coverage for a Cloudflare status code) rather than a user/upstream credential or config problem, since multiple unrelated deployments failed simultaneously. Searched open PRs for `convex`, `530`, and `document_deltas`, and reviewed the author's other open PRs — no existing PR addresses this.