### PR TITLE
feat(dashboards): show user's last viewed time

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5563,9 +5563,9 @@ snapshots:
     scenes-app-dashboards--erroring--light:
         hash: v1.k794b7964.1679f49acc091fc932acd5aee0d19e379c6f5158aefea7edb399f9b0d5a6fc71.F46jqKuhhvYhXv4E9pFTt13CpvLyaNv5AJy0pqSt81Y
     scenes-app-dashboards--list--dark:
-        hash: v1.k794b7964.77a682a12b54c824f2105d0209088c4830b950deba55fa6c63f3d1a7ae6b12d9.GPMpy6SAAlg3ijRxYAR-Ekpum8USxQdWhP7-H8qLCx8
+        hash: v1.k794b7964.00d0fa213e763d116afb415f4a3fea1e98d5d6e81ca29d30e842cd74cf50d7ac.e1Co2_8OmCVBy1IWy67r9-Uo-nt8tATEi1TPcyiV25Y
     scenes-app-dashboards--list--light:
-        hash: v1.k794b7964.492786d0772c83e3b11606338a691ed547b7137fffc02e9b79159dc95cc7bc18.9mQw3R7NBYWTw4lpa77ljwV28B9kFA9-39k0RFw8CeQ
+        hash: v1.k794b7964.8a9ad756d6aff75458241be69cb48a69d8df5a812aafa312256d312f581b5629.TPQoZ3DkpZdldKCS5hx9f5WAaMAHY8TTGoUWjrXA-Zw
     scenes-app-dashboards--new--dark:
         hash: v1.k794b7964.0a812dc0a14bd20dd0b2c88701ee5ef011ced558218f55f787b73d5e6e200557.uUIqLrdSaRIgntHU8Y8ounYiTocCFv55lEntTH7iWUA
     scenes-app-dashboards--new--light:

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -201,6 +201,10 @@ export function DashboardsTable({
             DashboardType,
             keyof DashboardType | undefined
         >,
+        atColumn<DashboardType>('last_viewed_at', 'You last viewed') as LemonTableColumn<
+            DashboardType,
+            keyof DashboardType | undefined
+        >,
         hideActions
             ? {}
             : {


### PR DESCRIPTION
## Problem

The dashboard list shows when anyone last accessed a dashboard, but not when the current user last viewed it. Both signals help users distinguish team-wide usage from their own activity.

Refs #34617

## Changes

| Column | Scope |
| --- | --- |
| Last accessed at | All dashboard access |
| You last viewed | Current user |

The new column uses the existing `last_viewed_at` API field and supports the table existing date sorting.

## How did you test this code?

- `oxfmt --check` passed for `DashboardsTable.tsx`
- `oxlint` passed for `DashboardsTable.tsx`
- Full frontend typecheck was attempted but is blocked in this fresh checkout by unbuilt workspace packages such as `@posthog/quill` and `@posthog/hogvm`. No reported errors referenced the changed file.
- No new test added. The API field already has contract coverage and the change reuses the tested date-column helper.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation change needed for this dashboard-list column.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code using Codex. Invoked `/writing-user-facing-copy` for the column label and `/writing-tests` to assess coverage. Kept the dashboard-wide access column and added a separate current-user column because they answer different usage questions.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*