### PR TITLE
chore(mcp-store): auto-label mcp-store scoped PRs

### DIFF
--- a/.github/auto-assign-labels.json
+++ b/.github/auto-assign-labels.json
@@ -8,6 +8,10 @@
         {
             "scopes": ["cohort", "cohorts"],
             "labels": ["team/feature-flags", "feature/cohorts"]
+        },
+        {
+            "scopes": ["mcp-store", "mcp_store"],
+            "labels": ["feature/mcp-store", "team/self-driving"]
         }
     ]
 }

--- a/.github/auto-assign-labels.json
+++ b/.github/auto-assign-labels.json
@@ -11,7 +11,7 @@
         },
         {
             "scopes": ["mcp-store", "mcp_store"],
-            "labels": ["feature/mcp-store", "team/self-driving"]
+            "labels": ["feature/mcp-store"]
         }
     ]
 }


### PR DESCRIPTION
## Problem

`products/mcp_store` PRs (scope `mcp-store`/`mcp_store` in the commit title) don't pick up any label automatically, and there was no `feature/mcp-store` label to begin with.

## Changes

- Created the `feature/mcp-store` label on this repo.
- Added a rule to `.github/auto-assign-labels.json` mapping the `mcp-store`/`mcp_store` scopes to `feature/mcp-store`, following the existing feature-flags rules in that file.

## How did you test this code?

Ran the existing `label-pr-from-title.test.js` suite locally, which includes a generic "shipped config loads into well-formed rules" check that covers this addition. Didn't add a new test since the rule-matching logic itself is already covered and this is just new config data.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A, internal CI config only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I drove this as a follow-up to updating feature ownership on posthog.com (PostHog/posthog.com#19110), which added an `mcp-store` entry pointing at the `self-driving` team. Claude Code created the GitHub label and wrote the scope rule; I asked for just the feature label, no team label, since `products/mcp_store/product.yaml` already carries the ownership info.