### PR TITLE
fix(batch-imports): use ambient region for the hop-1 STS assume in role chaining

### DIFF
--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -563,9 +563,15 @@ impl S3SourceConfig {
             )));
         };
 
+        // This hop must use the pod's ambient region, not the customer bucket's: the
+        // managed-migrations role's trust policy only allows assumes arriving through the
+        // workload VPC's STS endpoint (aws:SourceVpce), and that endpoint only serves the
+        // local region's STS hostname. Calling a cross-region STS endpoint here would
+        // egress publicly and be denied. The customer hop below keeps the bucket region.
+        let ambient_config = aws_config::defaults(BehaviorVersion::latest()).load().await;
         let intermediate = aws_config::sts::AssumeRoleProvider::builder(intermediate_arn)
             .session_name("posthog-batch-import")
-            .region(Region::new(self.region.clone()))
+            .configure(&ambient_config)
             .build()
             .await;
         // An unassumable intermediate role is a PostHog deployment problem, so surface the


### PR DESCRIPTION
## Problem

When using the assume role method of auth'ing Managed Migration access to a customer's S3 bucket, we need to get to do the first hop assume role chain against the pod's configured region, instead of the customer's s3 bucket. This is because the trust policy to assume the role only allows requests that have come through STS endpoints in the local VPC.

Hop 1 currently uses the customer bucket's region. If the bucket is in another region, the call goes to a cross-region public STS endpoint and is denied.

## Changes

- Hop 1 uses the pod's ambient region so the call stays on the local STS endpoint.
- Hop 2 keeps the bucket region; it has no SourceVpce condition.

## How did you test this code?

Agent-authored (Claude Code). Ran cargo check, fmt, clippy, and cargo test -p batch-import-worker --lib (384 passed). No live assume test; that needs posthog-cloud-infra#9650 applied and the charts env vars (PostHog/charts#13745). No new unit test: the regression is environmental (VPCE-pinned trust) and not reproducible in unit tests.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?