### PR TITLE
fix(llm-gateway): preserve routed provider in cost aliases

### DIFF
--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
@@ -21,12 +21,12 @@ CACHE_TTL_SECONDS = 300
 # CF entries: alias to litellm's native `cloudflare/@cf/...` price where it carries one (CF's actual
 # resold rate). For models litellm only prices under the vendor's own key, alias to that direct rate
 # as a proxy — not CF's resold rate, and may drift if CF adds markup or flat-rate billing.
-COST_ALIASES: dict[str, str] = {
-    "openai/@cf/moonshotai/kimi-k2.6": "moonshot/kimi-k2.6",
-    "openai/@cf/zai-org/glm-5.2": "cloudflare/@cf/zai-org/glm-5.2",
+COST_ALIASES: dict[str, tuple[str, str]] = {
+    "openai/@cf/moonshotai/kimi-k2.6": ("moonshot/kimi-k2.6", "openai"),
+    "openai/@cf/zai-org/glm-5.2": ("cloudflare/@cf/zai-org/glm-5.2", "openai"),
     # Modal serves the same GLM checkpoint; billed at the CF rate until trued
     # up against Modal's GPU-time invoices.
-    "openai/zai-org/GLM-5.2-FP8": "cloudflare/@cf/zai-org/glm-5.2",
+    "openai/zai-org/GLM-5.2-FP8": ("cloudflare/@cf/zai-org/glm-5.2", "openai"),
 }
 
 # Map LiteLLM's provider and model labels to stable telemetry identifiers. This stays separate from
@@ -53,12 +53,11 @@ def normalize_metric_labels(litellm_model: str, litellm_provider: str) -> tuple[
 
 def apply_cost_aliases(model_cost: dict[str, Any]) -> None:
     """Add alias keys for non-canonical provider routings. Prefer `set_litellm_model_cost`."""
-    for alias, canonical in COST_ALIASES.items():
+    for alias, (canonical, provider) in COST_ALIASES.items():
         if alias in model_cost:
             continue
         if canonical in model_cost:
-            # Shallow copy so a future in-place mutation under one key doesn't bleed into the other.
-            model_cost[alias] = dict(model_cost[canonical])
+            model_cost[alias] = {**model_cost[canonical], "litellm_provider": provider}
         else:
             logger.warning("cost_alias_canonical_missing", alias=alias, canonical=canonical)
 

--- a/services/llm-gateway/src/llm_gateway/services/model_registry.py
+++ b/services/llm-gateway/src/llm_gateway/services/model_registry.py
@@ -13,6 +13,7 @@ from llm_gateway.modal import (
     is_modal_model_configured,
 )
 from llm_gateway.products.config import get_product_config
+from llm_gateway.rate_limiting.cost_refresh import COST_ALIASES
 from llm_gateway.rate_limiting.model_cost_service import ModelCost, ModelCostService
 
 # Cloudflare Workers AI models are served via the `@cf/` path (CLOUDFLARE_ALLOWED_MODELS), not
@@ -120,6 +121,8 @@ class ModelRegistryService:
         all_litellm_models = ModelCostService.get_instance().get_all_models()
         models = []
         for model_id, cost_data in all_litellm_models.items():
+            if model_id in COST_ALIASES:
+                continue
             provider = cost_data.get("litellm_provider", "")
             if provider not in configured_providers:
                 continue

--- a/services/llm-gateway/tests/test_cost_refresh.py
+++ b/services/llm-gateway/tests/test_cost_refresh.py
@@ -37,10 +37,17 @@ def restore_litellm_globals() -> Iterator[None]:
 class TestApplyCostAliases:
     def test_adds_alias_when_canonical_present(self) -> None:
         cost: dict[str, Any] = {
-            "moonshot/kimi-k2.6": {"input_cost_per_token": 0.001, "output_cost_per_token": 0.002},
+            "moonshot/kimi-k2.6": {
+                "input_cost_per_token": 0.001,
+                "output_cost_per_token": 0.002,
+                "litellm_provider": "moonshot",
+            },
         }
         apply_cost_aliases(cost)
-        assert cost["openai/@cf/moonshotai/kimi-k2.6"] == cost["moonshot/kimi-k2.6"]
+        assert cost["openai/@cf/moonshotai/kimi-k2.6"] == {
+            **cost["moonshot/kimi-k2.6"],
+            "litellm_provider": "openai",
+        }
         # Load-bearing: the alias must be a copy, not a shared reference — otherwise an
         # in-place mutation under one key silently mutates the other.
         assert cost["openai/@cf/moonshotai/kimi-k2.6"] is not cost["moonshot/kimi-k2.6"]
@@ -55,7 +62,7 @@ class TestApplyCostAliases:
 
     @patch.dict(
         "llm_gateway.rate_limiting.cost_refresh.COST_ALIASES",
-        {"openai/@cf/moonshotai/kimi-k2.6": "moonshot/kimi-k2.6"},
+        {"openai/@cf/moonshotai/kimi-k2.6": ("moonshot/kimi-k2.6", "openai")},
         clear=True,
     )
     @patch("llm_gateway.rate_limiting.cost_refresh.logger")
@@ -71,7 +78,7 @@ class TestApplyCostAliases:
 
     @patch.dict(
         "llm_gateway.rate_limiting.cost_refresh.COST_ALIASES",
-        {"openai/@cf/moonshotai/kimi-k2.6": "moonshot/kimi-k2.6"},
+        {"openai/@cf/moonshotai/kimi-k2.6": ("moonshot/kimi-k2.6", "openai")},
         clear=True,
     )
     @patch("llm_gateway.rate_limiting.cost_refresh.logger")
@@ -86,8 +93,23 @@ class TestApplyCostAliases:
         letting `apply_cost_aliases` log `cost_alias_canonical_missing` every refresh
         in production and falling back to the default cost for those models.
         """
-        missing = [canonical for canonical in COST_ALIASES.values() if canonical not in litellm.model_cost]
+        missing = [canonical for canonical, _ in COST_ALIASES.values() if canonical not in litellm.model_cost]
         assert not missing, f"COST_ALIASES canonicals missing from litellm.model_cost: {missing}"
+
+    def test_alias_is_priced_for_routed_provider(self) -> None:
+        model_cost = dict(litellm.model_cost)
+        apply_cost_aliases(model_cost)
+        litellm.model_cost = model_cost
+
+        input_cost, output_cost = litellm.cost_per_token(
+            model="@cf/zai-org/glm-5.2",
+            prompt_tokens=1000,
+            completion_tokens=100,
+            custom_llm_provider="openai",
+        )
+
+        assert input_cost == pytest.approx(0.0014)
+        assert output_cost == pytest.approx(0.00044)
 
 
 class TestNormalizeMetricLabels:
@@ -122,7 +144,11 @@ class TestModelCostServiceAliases:
         service = ModelCostService.get_instance()
         cost_for_alias = service.get_costs("openai/@cf/moonshotai/kimi-k2.6")
 
-        assert cost_for_alias == {"input_cost_per_token": 0.001, "output_cost_per_token": 0.002}
+        assert cost_for_alias == {
+            "input_cost_per_token": 0.001,
+            "output_cost_per_token": 0.002,
+            "litellm_provider": "openai",
+        }
         assert "openai/@cf/moonshotai/kimi-k2.6" in litellm.model_cost
 
 

--- a/services/llm-gateway/tests/test_model_registry.py
+++ b/services/llm-gateway/tests/test_model_registry.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from llm_gateway.cloudflare import CLOUDFLARE_ALLOWED_MODELS
+from llm_gateway.rate_limiting.cost_refresh import COST_ALIASES
 from llm_gateway.rate_limiting.model_cost_service import ModelCost, ModelCostService
 from llm_gateway.services.model_registry import (
     ModelInfo,
@@ -248,6 +249,16 @@ class TestGetAvailableModels:
     def test_returns_model_info_objects(self):
         models = get_available_models("llm_gateway")
         assert all(isinstance(m, ModelInfo) for m in models)
+
+    @pytest.mark.parametrize("alias", COST_ALIASES)
+    def test_excludes_internal_cost_aliases(self, alias: str) -> None:
+        with patch.dict(
+            MOCK_COST_DATA,
+            {alias: {"litellm_provider": "openai", "max_input_tokens": 128000, "mode": "chat"}},
+        ):
+            model_ids = {model.id for model in get_available_models("llm_gateway")}
+
+        assert alias not in model_ids
 
 
 class TestProviderFiltering:


### PR DESCRIPTION
## Problem

Cost aliases copied canonical pricing without changing the provider metadata. OpenAI-compatible model routes could therefore fail LiteLLM provider matching and report zero cost despite having a configured price.

## Changes

Cost aliases now declare both their canonical pricing model and routed provider. Copied entries preserve the full rate card while using the provider that handles the request.

## How did you test this code?

Ran the focused cost refresh, Cloudflare, and Modal suites: 54 tests passed. Added a regression test proving GLM token usage resolves positive input and output costs through the OpenAI-compatible route.

Repository-wide mypy remains blocked by pre-existing errors outside the changed files. The changed files pass Ruff formatting and lint checks.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation changes are needed for this internal pricing correction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex reproduced the zero-cost path using the pinned LiteLLM version and the real Cloudflare adapter with a mocked provider response. The reproduction showed that copied aliases retained canonical provider metadata, so the implementation makes the routed provider explicit instead of deriving it from a string or injecting partial per-request prices.

Repository skills used: /writing-tests and /writing-code-comments.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*