### PR TITLE
fix(data-imports): keep app-DB connection blips out of error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -4,6 +4,7 @@ import datetime as dt
 import dataclasses
 from typing import Any, NoReturn, Optional
 
+from django.db import InterfaceError, OperationalError
 from django.db.models import Prefetch
 
 from structlog.contextvars import bind_contextvars
@@ -336,7 +337,8 @@ async def _handle_import_error(
     the activity; only that marker type does. ``RESTClientRetryableError`` gets the same treatment
     by type, since it's already a ``NonReportableError`` subclass and every REST-based source hits
     that condition already. A transient object-store hiccup talking to our own data-warehouse
-    bucket is re-raised as ``NonReportableError`` the same way.
+    bucket is re-raised as ``NonReportableError`` the same way, as is a Django
+    ``OperationalError``/``InterfaceError`` (a connection-pool blip against our own app DB).
 
     Everything else is logged as an exception and re-raised so Temporal retries it as usual.
     """
@@ -389,6 +391,18 @@ async def _handle_import_error(
     if is_transient_object_store_error(error):
         await logger.awarning(error_msg)
         await logger.adebug("Transient object-store error - re-raising for Temporal retry")
+        raise NonReportableError(error_msg) from error
+
+    # A Django OperationalError/InterfaceError here comes from a lookup against PostHog's own app
+    # DB (e.g. resolving a team or CustomPropertySource for the person-property staging hook) —
+    # every source that talks to a customer's own database (Postgres, MySQL, Redshift) does so over
+    # a raw driver connection, never Django's ORM, so this exception type can only mean a transient
+    # connection-pool blip on our side (e.g. a PgBouncer query_wait_timeout under load), not a
+    # customer data or config problem. Same classification already used for app-DB blips in
+    # delta_table_helper.is_transient_maintenance_error.
+    if isinstance(error, OperationalError | InterfaceError):
+        await logger.awarning(error_msg)
+        await logger.adebug("Transient app-DB error - re-raising for Temporal retry")
         raise NonReportableError(error_msg) from error
 
     # Cross-source non-retryable errors (missing primary key on an incremental table, bad SSH tunnel

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -5,6 +5,10 @@ from datetime import datetime
 import pytest
 from unittest import mock
 
+from django.db import InterfaceError, OperationalError
+
+from parameterized import parameterized
+
 from posthog.temporal.common.errors import NonReportableError
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
@@ -218,6 +222,39 @@ async def test_rest_client_retryable_error_logged_as_warning_without_source_opt_
         with pytest.raises(RESTClientRetryableError):
             await module._handle_import_error(mock.MagicMock(), logger, error)
 
+    logger.awarning.assert_awaited_once()
+    logger.aexception.assert_not_awaited()
+
+
+@parameterized.expand(
+    [
+        ("operational_error", OperationalError, "query_wait_timeout"),
+        ("interface_error", InterfaceError, "connection already closed"),
+    ]
+)
+@pytest.mark.asyncio
+async def test_app_db_connection_error_reraised_as_non_reportable(_name: str, error_cls: type[Exception], message: str):
+    # A Django OperationalError/InterfaceError here can only come from a lookup against PostHog's
+    # own app DB (e.g. resolving a team or CustomPropertySource for the person-property staging
+    # hook) — sources talk to a customer's own database over a raw driver connection, never Django's
+    # ORM. It's a transient connection-pool blip on our side (e.g. a PgBouncer query_wait_timeout
+    # under load), so it must be re-raised as NonReportableError (like RESTClientRetryableError
+    # above) rather than the bare exception, which the activity interceptor would still capture.
+    error = error_cls(message)
+    source = mock.MagicMock(spec=SimpleSource)
+    source.get_non_retryable_errors.return_value = {}
+    source.get_retryable_errors.return_value = set()
+
+    logger = mock.MagicMock()
+    logger.awarning = mock.AsyncMock()
+    logger.aexception = mock.AsyncMock()
+    logger.adebug = mock.AsyncMock()
+
+    with mock.patch.object(module.SourceRegistry, "get_source", return_value=source):
+        with pytest.raises(NonReportableError) as exc_info:
+            await module._handle_import_error(mock.MagicMock(), logger, error)
+
+    assert exc_info.value.__cause__ is error
     logger.awarning.assert_awaited_once()
     logger.aexception.assert_not_awaited()
 


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError: query_wait_timeout` (chained from `psycopg.errors.ProtocolViolation`) from the data-imports pipeline, with the top in-app frame in `posthog.models.scoping.manager.resolve_effective_team_id`.

The call chain: `import_data_activity_sync` -> pipeline `run()` -> `person_property_sink_clear_chunks` -> `PersonPropertyRowSink.should_stage()` -> `_get_projection()` -> the `person_property_projection_for` hook -> customer_analytics's resolver -> `CustomPropertySource.objects.for_team(...)` -> `resolve_effective_team_id`, which does a plain `Team.objects.get(id=...)` lookup. This is a lookup against PostHog's own app DB, not the source being synced (this occurrence happened during a Stripe sync, but the failing code has nothing Stripe-specific about it).

`query_wait_timeout` is PgBouncer signalling that a query waited too long for a server connection under pool pressure — a transient infra blip, not a data-shape or config bug. It was already retryable (nothing here is in any source's non-retryable list, and the activity's own Temporal retry policy applies), so the sync itself was never at risk. The gap is purely in error-tracking noise: every source that talks to a *customer's* own database (Postgres, MySQL, Redshift) does so over a raw driver connection, never Django's ORM, so a `django.db.OperationalError`/`InterfaceError` escaping the pipeline can only mean a blip on our own app DB — yet `_handle_import_error`'s final branch logs it at `exception` and re-raises the bare error, which the Temporal activity interceptor (`posthog/temporal/common/posthog_client.py`) reports regardless of log level.

This mirrors an existing, established pattern in this pipeline for the same shape of problem — e.g. `delta_table_helper.is_transient_maintenance_error` already treats `OperationalError`/`InterfaceError` from a pooled app-DB connection as transient, and `_handle_import_error` already gives `RESTClientRetryableError` the "log a warning, re-raise as `NonReportableError`" treatment for the analogous "retryable-but-shouldn't-page-anyone" case.

## Changes

- `_handle_import_error` in `import_data_sync.py` now classifies a Django `OperationalError`/`InterfaceError` by type: log a warning instead of an exception, and re-raise wrapped as `NonReportableError` (chained via `from error`) so Temporal still retries the activity as usual, but the interceptor no longer reports it.

## How did you test this code?

Added `test_app_db_connection_error_reraised_as_non_reportable` (parameterized over `OperationalError` and `InterfaceError`) to `test_import_data_sync.py`, asserting a warning is logged (not an exception) and the error is re-raised as `NonReportableError` chained to the original — guards the exact regression this fixes: without the classifier, both cases fall through to the generic `aexception` + bare re-raise branch and get reported as defects.

Ran:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py` — 15 passed
- `uv run mypy --cache-fine-grained .` (repo-wide) — clean
- `ruff check` / `ruff format` — clean
- `hogli ci:preflight --fix` — 0 failures

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification change, no user-facing or API behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from the linked error-tracking issue via PostHog's error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`), which surfaced the full stack trace and confirmed the failure originates in shared person-property-projection code, not the Stripe connector. Used Explore subagents to trace: the activity's retry-policy/non-retryable-error config, whether any source's `get_non_retryable_errors` could accidentally match a generic Postgres/PgBouncer substring (none do), and the existing `OperationalError` handling conventions elsewhere in this tree (`row_tracking.py`, `cdp_producer.py`, `delta_table_helper.is_transient_maintenance_error`).

Checked open PRs for a duplicate fix by exception type, message phrase, and module path, and reviewed the maintainer's own open PR queue — found several related-but-non-overlapping PRs applying the same "classify transient infra blip, re-raise as `NonReportableError`" pattern to other error classes in this same handler (object-store credential blips, Stripe rate limits, delta-log commit races). None cover this app-DB connection-pool error.

Invoked `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*