### PR TITLE
fix(tasks): disallow signal_report origin from task creation API

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5363,6 +5363,14 @@ const api = {
         async create(data: TaskUpsertProps): Promise<Task> {
             return await new ApiRequest().tasks().create({ data })
         },
+        async createSignalReport(
+            data: Omit<TaskUpsertProps, 'origin_product'> & {
+                signal_report: string
+                signal_report_task_relationship: 'implementation' | 'discussion'
+            }
+        ): Promise<Task> {
+            return await new ApiRequest().tasks().withAction('signal_report').create({ data })
+        },
         async update(id: string, data: Partial<TaskUpsertProps>): Promise<Task> {
             return await new ApiRequest().task(id).update({ data })
         },

--- a/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
+++ b/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
@@ -6,7 +6,6 @@ import { lemonToast } from '@posthog/lemon-ui'
 import api from 'lib/api'
 import { urls } from 'scenes/urls'
 
-import { OriginProduct } from 'products/posthog_ai/frontend/types/taskTypes'
 import {
     ClaudeRuntimeAdapterEnumApi,
     ClaudeTaskRunCreateSchemaApi,
@@ -96,15 +95,13 @@ async function createReportTask(
         throw new Error('No repository has been selected for this report yet — try again once analysis finishes.')
     }
 
-    const task = await api.tasks.create({
+    const task = await api.tasks.createSignalReport({
         title: report.title?.trim() || fallbackTitle,
         description: prompt,
-        origin_product: OriginProduct.SIGNAL_REPORT,
         repository,
-        // Linkage fields accepted by the tasks backend for the signal_report origin.
         signal_report: report.id,
         signal_report_task_relationship: relationship,
-    } as Parameters<typeof api.tasks.create>[0])
+    })
 
     // Kick off a cloud run so the task actually executes — creating it alone lands the user on a
     // "This task hasn't been run yet" screen. `run_source` ties the run to the report and makes any

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -646,6 +646,18 @@ class TaskWriteSerializer(serializers.Serializer):
         if "runtime" in self.initial_data and "runtime" not in self.fields:
             raise serializers.ValidationError({"runtime": "Runtime cannot be changed after task creation."})
 
+        if attrs.get("origin_product") == tasks_facade.TaskOriginProduct.SUPPORT_REPLY or attrs.get("internal") is True:
+            request = self.context.get("request")
+            logger.warning(
+                "Public task API accepted server-attributed task fields",
+                extra={
+                    "team_id": self.context.get("team_id"),
+                    "user_id": getattr(getattr(request, "user", None), "id", None),
+                    "origin_product": attrs.get("origin_product"),
+                    "internal": attrs.get("internal", False),
+                },
+            )
+
         trusted_signal_report = self.context.get("trusted_signal_report", False)
         if trusted_signal_report:
             attrs["origin_product"] = tasks_facade.TaskOriginProduct.SIGNAL_REPORT

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -646,14 +646,19 @@ class TaskWriteSerializer(serializers.Serializer):
         if "runtime" in self.initial_data and "runtime" not in self.fields:
             raise serializers.ValidationError({"runtime": "Runtime cannot be changed after task creation."})
 
-        if attrs.get("origin_product") == tasks_facade.TaskOriginProduct.SUPPORT_REPLY or attrs.get("internal") is True:
+        origin_product = attrs.get("origin_product")
+        if (
+            origin_product is not None
+            and origin_product != tasks_facade.TaskOriginProduct.USER_CREATED
+            or attrs.get("internal") is True
+        ):
             request = self.context.get("request")
-            logger.warning(
-                "Public task API accepted server-attributed task fields",
+            logger.info(
+                "task_api_client_attribution",
                 extra={
                     "team_id": self.context.get("team_id"),
                     "user_id": getattr(getattr(request, "user", None), "id", None),
-                    "origin_product": attrs.get("origin_product"),
+                    "origin_product": origin_product,
                     "internal": attrs.get("internal", False),
                 },
             )

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -56,19 +56,6 @@ from products.tasks.backend.facade.run_config import (
 
 logger = logging.getLogger(__name__)
 
-SERVER_CREATED_TASK_ORIGINS = frozenset(
-    {
-        tasks_facade.TaskOriginProduct.EXPERIMENTS,
-        tasks_facade.TaskOriginProduct.IMAGE_BUILDER,
-        tasks_facade.TaskOriginProduct.ONBOARDING,
-        tasks_facade.TaskOriginProduct.POSTHOG_AI,
-        tasks_facade.TaskOriginProduct.SIGNAL_REPORT,
-        tasks_facade.TaskOriginProduct.SIGNALS_SCOUT,
-        tasks_facade.TaskOriginProduct.SLACK,
-        tasks_facade.TaskOriginProduct.SUPPORT_REPLY,
-    }
-)
-
 
 def _capture_rejected_reasoning_effort(
     context: dict[str, Any],
@@ -608,8 +595,32 @@ class TaskWriteSerializer(serializers.Serializer):
         return value
 
     def validate_origin_product(self, value):
-        if value in SERVER_CREATED_TASK_ORIGINS:
-            raise serializers.ValidationError(f"origin_product '{value}' is reserved for server-created tasks")
+        """Reject internal-only origins that are set by server-side flows, never by API callers."""
+        if value == tasks_facade.TaskOriginProduct.SIGNAL_REPORT:
+            raise serializers.ValidationError("origin_product 'signal_report' is reserved for signal report tasks")
+        if value == tasks_facade.TaskOriginProduct.POSTHOG_AI:
+            raise serializers.ValidationError("origin_product 'posthog_ai' is reserved for PostHog AI tasks")
+        if value == tasks_facade.TaskOriginProduct.SLACK:
+            raise serializers.ValidationError("origin_product 'slack' is reserved for Slack tasks")
+        if value == tasks_facade.TaskOriginProduct.SUPPORT_REPLY:
+            raise serializers.ValidationError("origin_product 'support_reply' is reserved for support reply tasks")
+        if value == tasks_facade.TaskOriginProduct.IMAGE_BUILDER:
+            raise serializers.ValidationError("origin_product 'image_builder' is reserved for image-builder sessions")
+        if value == tasks_facade.TaskOriginProduct.EXPERIMENTS:
+            # Experiments tasks are team-readable, so letting API callers pick this origin
+            # would let them expose an arbitrary task to the whole team. The experiments
+            # flow creates its tasks server-side through the facade, never through here.
+            raise serializers.ValidationError("origin_product 'experiments' is reserved for the experiments flow")
+        if value == tasks_facade.TaskOriginProduct.SIGNALS_SCOUT:
+            # Scout tasks are created only by the signals scout harness. A forged scout origin
+            # would route the task's run logs into PostHog's internal Logs project
+            # (run_log_mirror) and inherit scout visibility semantics.
+            raise serializers.ValidationError("origin_product 'signals_scout' is reserved for signals scout runs")
+        if value == tasks_facade.TaskOriginProduct.ONBOARDING:
+            # This origin routes the run's LLM traffic to the unbilled `onboarding` gateway
+            # product, so a forged one would be free model access. Only create_wizard_cloud_run
+            # sets it, behind its own rate limits and daily cap.
+            raise serializers.ValidationError("origin_product 'onboarding' is reserved for setup wizard cloud runs")
         return value
 
     def validate_repository(self, value):

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -597,7 +597,7 @@ class TaskWriteSerializer(serializers.Serializer):
     def validate_origin_product(self, value):
         """Reject internal-only origins that are set by server-side flows, never by API callers."""
         if value == tasks_facade.TaskOriginProduct.SIGNAL_REPORT:
-            raise serializers.ValidationError("origin_product 'signal_report' is reserved for signal report tasks")
+            raise serializers.ValidationError("Update the PostHog app to create Signal Report tasks, then try again.")
         if value == tasks_facade.TaskOriginProduct.IMAGE_BUILDER:
             raise serializers.ValidationError("origin_product 'image_builder' is reserved for image-builder sessions")
         if value == tasks_facade.TaskOriginProduct.EXPERIMENTS:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -647,21 +647,16 @@ class TaskWriteSerializer(serializers.Serializer):
             raise serializers.ValidationError({"runtime": "Runtime cannot be changed after task creation."})
 
         origin_product = attrs.get("origin_product")
-        if (
-            origin_product is not None
-            and origin_product != tasks_facade.TaskOriginProduct.USER_CREATED
-            or attrs.get("internal") is True
-        ):
-            request = self.context.get("request")
-            logger.info(
-                "task_api_client_attribution",
-                extra={
-                    "team_id": self.context.get("team_id"),
-                    "user_id": getattr(getattr(request, "user", None), "id", None),
-                    "origin_product": origin_product,
-                    "internal": attrs.get("internal", False),
-                },
-            )
+        request = self.context.get("request")
+        logger.info(
+            "task_api_client_attribution",
+            extra={
+                "team_id": self.context.get("team_id"),
+                "user_id": getattr(getattr(request, "user", None), "id", None),
+                "origin_product": origin_product,
+                "internal": attrs.get("internal", False),
+            },
+        )
 
         trusted_signal_report = self.context.get("trusted_signal_report", False)
         if trusted_signal_report:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -646,14 +646,12 @@ class TaskWriteSerializer(serializers.Serializer):
         if "runtime" in self.initial_data and "runtime" not in self.fields:
             raise serializers.ValidationError({"runtime": "Runtime cannot be changed after task creation."})
 
-        origin_product = attrs.get("origin_product")
-        request = self.context.get("request")
         logger.info(
             "task_api_client_attribution",
             extra={
                 "team_id": self.context.get("team_id"),
-                "user_id": getattr(getattr(request, "user", None), "id", None),
-                "origin_product": origin_product,
+                "user_id": getattr(getattr(self.context.get("request"), "user", None), "id", None),
+                "origin_product": attrs.get("origin_product"),
                 "internal": attrs.get("internal", False),
             },
         )

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -664,16 +664,6 @@ class TaskWriteSerializer(serializers.Serializer):
                 {"signal_report": "Signal report attribution must use the signal report task endpoint."}
             )
 
-        rel = attrs.get("signal_report_task_relationship")
-        if rel is not None:
-            if not attrs.get("signal_report"):
-                raise serializers.ValidationError(
-                    {"signal_report_task_relationship": "Requires signal_report when set."}
-                )
-            if attrs.get("origin_product") != tasks_facade.TaskOriginProduct.SIGNAL_REPORT:
-                raise serializers.ValidationError(
-                    {"signal_report_task_relationship": ("Requires origin_product signal_report when set.")}
-                )
         if (
             attrs.get("origin_product") == tasks_facade.TaskOriginProduct.SIGNAL_REPORT
             and attrs.get("github_user_integration") is not None

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -653,13 +653,6 @@ class TaskWriteSerializer(serializers.Serializer):
                 {"signal_report": "Signal report attribution must use the signal report task endpoint."}
             )
 
-        if (
-            attrs.get("origin_product") == tasks_facade.TaskOriginProduct.SIGNAL_REPORT
-            and attrs.get("github_user_integration") is not None
-        ):
-            raise serializers.ValidationError(
-                {"github_user_integration": "Signal report tasks use the team GitHub integration."}
-            )
         return attrs
 
 
@@ -698,6 +691,14 @@ class SignalReportTaskCreateSerializer(TaskCreateSerializer):
         required=True,
         help_text="Whether the task implements or discusses the report.",
     )
+
+    def validate(self, attrs: dict) -> dict:
+        attrs = super().validate(attrs)
+        if attrs.get("github_user_integration") is not None:
+            raise serializers.ValidationError(
+                {"github_user_integration": "Signal report tasks use the team GitHub integration."}
+            )
+        return attrs
 
 
 class TaskRunSetOutputRequestSerializer(serializers.Serializer):

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -56,6 +56,19 @@ from products.tasks.backend.facade.run_config import (
 
 logger = logging.getLogger(__name__)
 
+SERVER_CREATED_TASK_ORIGINS = frozenset(
+    {
+        tasks_facade.TaskOriginProduct.EXPERIMENTS,
+        tasks_facade.TaskOriginProduct.IMAGE_BUILDER,
+        tasks_facade.TaskOriginProduct.ONBOARDING,
+        tasks_facade.TaskOriginProduct.POSTHOG_AI,
+        tasks_facade.TaskOriginProduct.SIGNAL_REPORT,
+        tasks_facade.TaskOriginProduct.SIGNALS_SCOUT,
+        tasks_facade.TaskOriginProduct.SLACK,
+        tasks_facade.TaskOriginProduct.SUPPORT_REPLY,
+    }
+)
+
 
 def _capture_rejected_reasoning_effort(
     context: dict[str, Any],
@@ -595,32 +608,8 @@ class TaskWriteSerializer(serializers.Serializer):
         return value
 
     def validate_origin_product(self, value):
-        """Reject internal-only origins that are set by server-side flows, never by API callers."""
-        reserved_billing_origins = {
-            tasks_facade.TaskOriginProduct.SIGNAL_REPORT,
-            tasks_facade.TaskOriginProduct.POSTHOG_AI,
-            tasks_facade.TaskOriginProduct.SLACK,
-            tasks_facade.TaskOriginProduct.SUPPORT_REPLY,
-        }
-        if value in reserved_billing_origins:
+        if value in SERVER_CREATED_TASK_ORIGINS:
             raise serializers.ValidationError(f"origin_product '{value}' is reserved for server-created tasks")
-        if value == tasks_facade.TaskOriginProduct.IMAGE_BUILDER:
-            raise serializers.ValidationError("origin_product 'image_builder' is reserved for image-builder sessions")
-        if value == tasks_facade.TaskOriginProduct.EXPERIMENTS:
-            # Experiments tasks are team-readable, so letting API callers pick this origin
-            # would let them expose an arbitrary task to the whole team. The experiments
-            # flow creates its tasks server-side through the facade, never through here.
-            raise serializers.ValidationError("origin_product 'experiments' is reserved for the experiments flow")
-        if value == tasks_facade.TaskOriginProduct.SIGNALS_SCOUT:
-            # Scout tasks are created only by the signals scout harness. A forged scout origin
-            # would route the task's run logs into PostHog's internal Logs project
-            # (run_log_mirror) and inherit scout visibility semantics.
-            raise serializers.ValidationError("origin_product 'signals_scout' is reserved for signals scout runs")
-        if value == tasks_facade.TaskOriginProduct.ONBOARDING:
-            # This origin routes the run's LLM traffic to the unbilled `onboarding` gateway
-            # product, so a forged one would be free model access. Only create_wizard_cloud_run
-            # sets it, behind its own rate limits and daily cap.
-            raise serializers.ValidationError("origin_product 'onboarding' is reserved for setup wizard cloud runs")
         return value
 
     def validate_repository(self, value):

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -596,6 +596,14 @@ class TaskWriteSerializer(serializers.Serializer):
 
     def validate_origin_product(self, value):
         """Reject internal-only origins that are set by server-side flows, never by API callers."""
+        reserved_billing_origins = {
+            tasks_facade.TaskOriginProduct.SIGNAL_REPORT,
+            tasks_facade.TaskOriginProduct.POSTHOG_AI,
+            tasks_facade.TaskOriginProduct.SLACK,
+            tasks_facade.TaskOriginProduct.SUPPORT_REPLY,
+        }
+        if value in reserved_billing_origins:
+            raise serializers.ValidationError(f"origin_product '{value}' is reserved for server-created tasks")
         if value == tasks_facade.TaskOriginProduct.IMAGE_BUILDER:
             raise serializers.ValidationError("origin_product 'image_builder' is reserved for image-builder sessions")
         if value == tasks_facade.TaskOriginProduct.EXPERIMENTS:
@@ -644,6 +652,16 @@ class TaskWriteSerializer(serializers.Serializer):
         if "runtime" in self.initial_data and "runtime" not in self.fields:
             raise serializers.ValidationError({"runtime": "Runtime cannot be changed after task creation."})
 
+        trusted_signal_report = self.context.get("trusted_signal_report", False)
+        if attrs.get("internal"):
+            raise serializers.ValidationError({"internal": "Internal tasks must be created by server-side flows."})
+        if trusted_signal_report:
+            attrs["origin_product"] = tasks_facade.TaskOriginProduct.SIGNAL_REPORT
+        elif "signal_report" in attrs or "signal_report_task_relationship" in attrs:
+            raise serializers.ValidationError(
+                {"signal_report": "Signal report attribution must use the signal report task endpoint."}
+            )
+
         rel = attrs.get("signal_report_task_relationship")
         if rel is not None:
             if not attrs.get("signal_report"):
@@ -683,6 +701,20 @@ class TaskCreateSerializer(TaskWriteSerializer):
         choices=tasks_facade.TaskRuntime.choices,
         required=False,
         help_text="Agent protocol and harness used for this task's runs. Defaults to ACP when omitted.",
+    )
+
+
+class SignalReportTaskCreateSerializer(TaskCreateSerializer):
+    signal_report = serializers.PrimaryKeyRelatedField(  # nosemgrep: unscoped-primary-key-related-field
+        queryset=Integration.objects.none(),
+        required=True,
+        allow_null=False,
+        help_text="Signal report that owns this task.",
+    )
+    signal_report_task_relationship = serializers.ChoiceField(
+        choices=("implementation", "discussion"),
+        required=True,
+        help_text="Whether the task implements or discusses the report.",
     )
 
 

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -646,16 +646,6 @@ class TaskWriteSerializer(serializers.Serializer):
         if "runtime" in self.initial_data and "runtime" not in self.fields:
             raise serializers.ValidationError({"runtime": "Runtime cannot be changed after task creation."})
 
-        logger.info(
-            "task_api_client_attribution",
-            extra={
-                "team_id": self.context.get("team_id"),
-                "user_id": getattr(getattr(self.context.get("request"), "user", None), "id", None),
-                "origin_product": attrs.get("origin_product"),
-                "internal": attrs.get("internal", False),
-            },
-        )
-
         if ("signal_report" in attrs or "signal_report_task_relationship" in attrs) and attrs.get(
             "origin_product"
         ) != tasks_facade.TaskOriginProduct.SIGNAL_REPORT:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -598,12 +598,6 @@ class TaskWriteSerializer(serializers.Serializer):
         """Reject internal-only origins that are set by server-side flows, never by API callers."""
         if value == tasks_facade.TaskOriginProduct.SIGNAL_REPORT:
             raise serializers.ValidationError("origin_product 'signal_report' is reserved for signal report tasks")
-        if value == tasks_facade.TaskOriginProduct.POSTHOG_AI:
-            raise serializers.ValidationError("origin_product 'posthog_ai' is reserved for PostHog AI tasks")
-        if value == tasks_facade.TaskOriginProduct.SLACK:
-            raise serializers.ValidationError("origin_product 'slack' is reserved for Slack tasks")
-        if value == tasks_facade.TaskOriginProduct.SUPPORT_REPLY:
-            raise serializers.ValidationError("origin_product 'support_reply' is reserved for support reply tasks")
         if value == tasks_facade.TaskOriginProduct.IMAGE_BUILDER:
             raise serializers.ValidationError("origin_product 'image_builder' is reserved for image-builder sessions")
         if value == tasks_facade.TaskOriginProduct.EXPERIMENTS:
@@ -653,8 +647,6 @@ class TaskWriteSerializer(serializers.Serializer):
             raise serializers.ValidationError({"runtime": "Runtime cannot be changed after task creation."})
 
         trusted_signal_report = self.context.get("trusted_signal_report", False)
-        if attrs.get("internal"):
-            raise serializers.ValidationError({"internal": "Internal tasks must be created by server-side flows."})
         if trusted_signal_report:
             attrs["origin_product"] = tasks_facade.TaskOriginProduct.SIGNAL_REPORT
         elif "signal_report" in attrs or "signal_report_task_relationship" in attrs:

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -656,10 +656,9 @@ class TaskWriteSerializer(serializers.Serializer):
             },
         )
 
-        trusted_signal_report = self.context.get("trusted_signal_report", False)
-        if trusted_signal_report:
-            attrs["origin_product"] = tasks_facade.TaskOriginProduct.SIGNAL_REPORT
-        elif "signal_report" in attrs or "signal_report_task_relationship" in attrs:
+        if ("signal_report" in attrs or "signal_report_task_relationship" in attrs) and attrs.get(
+            "origin_product"
+        ) != tasks_facade.TaskOriginProduct.SIGNAL_REPORT:
             raise serializers.ValidationError(
                 {"signal_report": "Signal report attribution must use the signal report task endpoint."}
             )
@@ -697,6 +696,7 @@ class TaskCreateSerializer(TaskWriteSerializer):
 
 
 class SignalReportTaskCreateSerializer(TaskCreateSerializer):
+    origin_product = serializers.HiddenField(default=tasks_facade.TaskOriginProduct.SIGNAL_REPORT)
     signal_report = serializers.PrimaryKeyRelatedField(  # nosemgrep: unscoped-primary-key-related-field
         queryset=Integration.objects.none(),
         required=True,

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -270,6 +270,15 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         partial: bool = False,
         serializer_class: type[TaskWriteSerializer] = TaskWriteSerializer,
     ) -> TaskWriteSerializer:
+        logger.info(
+            "task_api_client_attribution",
+            extra={
+                "team_id": self.team.id,
+                "user_id": self._user_id(),
+                "origin_product": data.get("origin_product"),
+                "internal": data.get("internal", False),
+            },
+        )
         serializer = serializer_class(
             data=data,
             partial=partial,
@@ -325,15 +334,10 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @extend_schema(request=SignalReportTaskCreateSerializer, responses={201: TaskSerializer})
     @action(detail=False, methods=["post"], url_path="signal_report", required_scopes=["task:write"])
     def create_signal_report_task(self, request, **kwargs):
-        serializer = SignalReportTaskCreateSerializer(
-            data=request.data,
-            context={
-                "team": self.team,
-                "team_id": self.team.id,
-                "request": self.request,
-            },
+        serializer = self._write_serializer(
+            request.data,
+            serializer_class=SignalReportTaskCreateSerializer,
         )
-        serializer.is_valid(raise_exception=True)
         task = tasks_facade.create_task(self.team_id, self._user_id(), validated_data=dict(serializer.validated_data))
         return Response(TaskSerializer(task).data, status=status.HTTP_201_CREATED)
 

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -331,7 +331,6 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
                 "team": self.team,
                 "team_id": self.team.id,
                 "request": self.request,
-                "trusted_signal_report": True,
             },
         )
         serializer.is_valid(raise_exception=True)

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -70,6 +70,7 @@ from products.tasks.backend.presentation.serializers import (
     SandboxEnvironmentListSerializer,
     SandboxEnvironmentSerializer,
     SandboxEnvironmentWriteSerializer,
+    SignalReportTaskCreateSerializer,
     SlackThreadContextQuerySerializer,
     SlackThreadContextResponseSerializer,
     StreamReadTokenResponseSerializer,
@@ -318,6 +319,22 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     @extend_schema(request=TaskCreateSerializer, responses={201: TaskSerializer})
     def create(self, request, **kwargs):
         serializer = self._write_serializer(request.data, serializer_class=TaskCreateSerializer)
+        task = tasks_facade.create_task(self.team_id, self._user_id(), validated_data=dict(serializer.validated_data))
+        return Response(TaskSerializer(task).data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(request=SignalReportTaskCreateSerializer, responses={201: TaskSerializer})
+    @action(detail=False, methods=["post"], url_path="signal_report", required_scopes=["task:write"])
+    def create_signal_report_task(self, request, **kwargs):
+        serializer = SignalReportTaskCreateSerializer(
+            data=request.data,
+            context={
+                "team": self.team,
+                "team_id": self.team.id,
+                "request": self.request,
+                "trusted_signal_report": True,
+            },
+        )
+        serializer.is_valid(raise_exception=True)
         task = tasks_facade.create_task(self.team_id, self._user_id(), validated_data=dict(serializer.validated_data))
         return Response(TaskSerializer(task).data, status=status.HTTP_201_CREATED)
 

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -1360,11 +1360,10 @@ class TestTaskAPI(BaseTaskAPITest):
 
         report = SignalReport.objects.create(team=self.team)
         response = self.client.post(
-            "/api/projects/@current/tasks/",
+            "/api/projects/@current/tasks/signal_report/",
             {
                 "title": "Signal Task",
                 "description": "From a signal report",
-                "origin_product": "signal_report",
                 "signal_report": str(report.id),
                 "signal_report_task_relationship": "implementation",
             },
@@ -1393,11 +1392,10 @@ class TestTaskAPI(BaseTaskAPITest):
 
         report = SignalReport.objects.create(team=self.team)
         response = self.client.post(
-            "/api/projects/@current/tasks/",
+            "/api/projects/@current/tasks/signal_report/",
             {
                 "title": "Discuss report",
                 "description": "Let's discuss this report",
-                "origin_product": "signal_report",
                 "signal_report": str(report.id),
                 "signal_report_task_relationship": "discussion",
             },
@@ -1412,28 +1410,21 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(signals_task_ids(report_id=str(report.id), type=TASK_RUN_TYPE_IMPLEMENTATION), [])
         self.assertFalse(SignalReportTask.objects.filter(report=report, task_id=data["id"]).exists())
 
-    def test_create_task_with_signal_report_accepts_free_form_relationship(self):
-        from products.signals.backend.models import SignalReport, SignalReportTask
-        from products.signals.backend.task_run_artefacts import signals_task_ids
+    def test_create_signal_report_task_rejects_unknown_relationship(self):
+        from products.signals.backend.models import SignalReport
 
-        # The relationship is a free-form task_run label — no value is reserved. A non-implementation
-        # relationship records only the work-log artefact (no SignalReportTask gate row).
         report = SignalReport.objects.create(team=self.team)
         response = self.client.post(
-            "/api/projects/@current/tasks/",
+            "/api/projects/@current/tasks/signal_report/",
             {
                 "title": "Research",
                 "description": "From a signal report",
-                "origin_product": "signal_report",
                 "signal_report": str(report.id),
                 "signal_report_task_relationship": "research",
             },
             format="json",
         )
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        data = response.json()
-        self.assertEqual(signals_task_ids(report_id=str(report.id), type="research"), [data["id"]])
-        self.assertFalse(SignalReportTask.objects.filter(report=report, task_id=data["id"]).exists())
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_create_task_with_signal_report_different_team_rejected(self):
         from products.signals.backend.models import SignalReport
@@ -1441,12 +1432,28 @@ class TestTaskAPI(BaseTaskAPITest):
         other_team = Team.objects.create(organization=self.organization, name="Other Team")
         report = SignalReport.objects.create(team=other_team)
         response = self.client.post(
-            "/api/projects/@current/tasks/",
+            "/api/projects/@current/tasks/signal_report/",
             {
                 "title": "Cross-team Task",
                 "description": "Should be rejected",
+                "signal_report": str(report.id),
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_generic_create_rejects_signal_report_attribution(self):
+        from products.signals.backend.models import SignalReport
+
+        report = SignalReport.objects.create(team=self.team)
+        response = self.client.post(
+            "/api/projects/@current/tasks/",
+            {
+                "title": "Forged Signal Task",
+                "description": "Should be rejected",
                 "origin_product": "signal_report",
                 "signal_report": str(report.id),
+                "signal_report_task_relationship": "implementation",
             },
             format="json",
         )
@@ -1460,7 +1467,7 @@ class TestTaskAPI(BaseTaskAPITest):
             {"origin_product": "signal_report"},
             format="json",
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         task.refresh_from_db()
         self.assertEqual(task.origin_product, Task.OriginProduct.USER_CREATED)
 
@@ -1474,7 +1481,7 @@ class TestTaskAPI(BaseTaskAPITest):
             {"signal_report": str(report.id)},
             format="json",
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         task.refresh_from_db()
         self.assertIsNone(task.signal_report_id)
 

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -1,6 +1,7 @@
 import ipaddress
+from types import SimpleNamespace
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import SimpleTestCase
 
@@ -26,6 +27,32 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
         serializer = TaskWriteSerializer(data={"origin_product": origin_product})
         serializer.is_valid()
         assert ("origin_product" in serializer.errors) is expected_rejected
+
+    @parameterized.expand(
+        [
+            ("support_reply", False),
+            ("user_created", True),
+        ]
+    )
+    @patch("products.tasks.backend.presentation.serializers.logger.warning")
+    def test_logs_client_writable_server_attribution(
+        self, origin_product: str, internal: bool, warning: MagicMock
+    ) -> None:
+        serializer = TaskWriteSerializer(
+            data={"origin_product": origin_product, "internal": internal},
+            context={"team_id": 123, "request": SimpleNamespace(user=SimpleNamespace(id=456))},
+        )
+
+        assert serializer.is_valid(), serializer.errors
+        warning.assert_called_once_with(
+            "Public task API accepted server-attributed task fields",
+            extra={
+                "team_id": 123,
+                "user_id": 456,
+                "origin_product": origin_product,
+                "internal": internal,
+            },
+        )
 
 
 class TestTaskRunLivingArtifactCreateRequestSerializer(SimpleTestCase):

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -18,6 +18,10 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
         [
             ("image_builder", True),
             ("signals_scout", True),
+            ("signal_report", True),
+            ("posthog_ai", True),
+            ("slack", True),
+            ("support_reply", True),
             ("user_created", False),
         ]
     )
@@ -25,6 +29,11 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
         serializer = TaskWriteSerializer(data={"origin_product": origin_product})
         serializer.is_valid()
         assert ("origin_product" in serializer.errors) is expected_rejected
+
+    def test_internal_tasks_are_rejected(self) -> None:
+        serializer = TaskWriteSerializer(data={"internal": True})
+        assert not serializer.is_valid()
+        assert "internal" in serializer.errors
 
 
 class TestTaskRunLivingArtifactCreateRequestSerializer(SimpleTestCase):

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -33,12 +33,11 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
             ("support_reply", False),
             ("error_tracking", False),
             ("user_created", True),
+            ("user_created", False),
         ]
     )
     @patch("products.tasks.backend.presentation.serializers.logger.info")
-    def test_logs_client_writable_server_attribution(
-        self, origin_product: str, internal: bool, info: MagicMock
-    ) -> None:
+    def test_logs_client_attribution(self, origin_product: str, internal: bool, info: MagicMock) -> None:
         serializer = TaskWriteSerializer(
             data={"origin_product": origin_product, "internal": internal},
             context={"team_id": 123, "request": SimpleNamespace(user=SimpleNamespace(id=456))},

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -27,6 +27,10 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
         serializer = TaskWriteSerializer(data={"origin_product": origin_product})
         serializer.is_valid()
         assert ("origin_product" in serializer.errors) is expected_rejected
+        if origin_product == "signal_report":
+            assert serializer.errors["origin_product"][0] == (
+                "Update the PostHog app to create Signal Report tasks, then try again."
+            )
 
     @parameterized.expand(
         [

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from django.test import SimpleTestCase
 
 from parameterized import parameterized
+from rest_framework import serializers
 
 from products.tasks.backend.presentation.serializers import (
     SignalReportTaskCreateSerializer,
@@ -37,6 +38,19 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
     def test_signal_report_serializer_assigns_origin(self) -> None:
         serializer = SignalReportTaskCreateSerializer()
         assert serializer.fields["origin_product"].default == "signal_report"
+
+    def test_signal_report_serializer_rejects_user_integration(self) -> None:
+        serializer = SignalReportTaskCreateSerializer(data={})
+        with self.assertRaises(serializers.ValidationError) as error:
+            serializer.validate(
+                {
+                    "origin_product": "signal_report",
+                    "signal_report": object(),
+                    "signal_report_task_relationship": "implementation",
+                    "github_user_integration": object(),
+                }
+            )
+        assert "github_user_integration" in error.exception.detail
 
 
 class TestTaskWriteTelemetry(SimpleTestCase):

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -7,7 +7,6 @@ from django.test import SimpleTestCase
 from parameterized import parameterized
 
 from products.tasks.backend.presentation.serializers import (
-    SERVER_CREATED_TASK_ORIGINS,
     TaskRunCreateRequestSerializer,
     TaskRunLivingArtifactCreateRequestSerializer,
     TaskWriteSerializer,
@@ -16,7 +15,15 @@ from products.tasks.backend.presentation.serializers import (
 
 class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
     @parameterized.expand(
-        [(origin, True) for origin in sorted(SERVER_CREATED_TASK_ORIGINS)] + [("user_created", False)]
+        [
+            ("image_builder", True),
+            ("signals_scout", True),
+            ("signal_report", True),
+            ("posthog_ai", True),
+            ("slack", True),
+            ("support_reply", True),
+            ("user_created", False),
+        ]
     )
     def test_internal_only_origins_are_rejected(self, origin_product: str, expected_rejected: bool) -> None:
         serializer = TaskWriteSerializer(data={"origin_product": origin_product})

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -7,6 +7,7 @@ from django.test import SimpleTestCase
 from parameterized import parameterized
 
 from products.tasks.backend.presentation.serializers import (
+    SERVER_CREATED_TASK_ORIGINS,
     TaskRunCreateRequestSerializer,
     TaskRunLivingArtifactCreateRequestSerializer,
     TaskWriteSerializer,
@@ -15,15 +16,7 @@ from products.tasks.backend.presentation.serializers import (
 
 class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
     @parameterized.expand(
-        [
-            ("image_builder", True),
-            ("signals_scout", True),
-            ("signal_report", True),
-            ("posthog_ai", True),
-            ("slack", True),
-            ("support_reply", True),
-            ("user_created", False),
-        ]
+        [(origin, True) for origin in sorted(SERVER_CREATED_TASK_ORIGINS)] + [("user_created", False)]
     )
     def test_internal_only_origins_are_rejected(self, origin_product: str, expected_rejected: bool) -> None:
         serializer = TaskWriteSerializer(data={"origin_product": origin_product})

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -19,9 +19,6 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
             ("image_builder", True),
             ("signals_scout", True),
             ("signal_report", True),
-            ("posthog_ai", True),
-            ("slack", True),
-            ("support_reply", True),
             ("user_created", False),
         ]
     )
@@ -29,11 +26,6 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
         serializer = TaskWriteSerializer(data={"origin_product": origin_product})
         serializer.is_valid()
         assert ("origin_product" in serializer.errors) is expected_rejected
-
-    def test_internal_tasks_are_rejected(self) -> None:
-        serializer = TaskWriteSerializer(data={"internal": True})
-        assert not serializer.is_valid()
-        assert "internal" in serializer.errors
 
 
 class TestTaskRunLivingArtifactCreateRequestSerializer(SimpleTestCase):

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -31,12 +31,13 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
     @parameterized.expand(
         [
             ("support_reply", False),
+            ("error_tracking", False),
             ("user_created", True),
         ]
     )
-    @patch("products.tasks.backend.presentation.serializers.logger.warning")
+    @patch("products.tasks.backend.presentation.serializers.logger.info")
     def test_logs_client_writable_server_attribution(
-        self, origin_product: str, internal: bool, warning: MagicMock
+        self, origin_product: str, internal: bool, info: MagicMock
     ) -> None:
         serializer = TaskWriteSerializer(
             data={"origin_product": origin_product, "internal": internal},
@@ -44,8 +45,8 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
         )
 
         assert serializer.is_valid(), serializer.errors
-        warning.assert_called_once_with(
-            "Public task API accepted server-attributed task fields",
+        info.assert_called_once_with(
+            "task_api_client_attribution",
             extra={
                 "team_id": 123,
                 "user_id": 456,

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -8,6 +8,7 @@ from django.test import SimpleTestCase
 from parameterized import parameterized
 
 from products.tasks.backend.presentation.serializers import (
+    SignalReportTaskCreateSerializer,
     TaskRunCreateRequestSerializer,
     TaskRunLivingArtifactCreateRequestSerializer,
     TaskWriteSerializer,
@@ -57,6 +58,10 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
                 "internal": internal,
             },
         )
+
+    def test_signal_report_serializer_assigns_origin(self) -> None:
+        serializer = SignalReportTaskCreateSerializer()
+        assert serializer.fields["origin_product"].default == "signal_report"
 
 
 class TestTaskRunLivingArtifactCreateRequestSerializer(SimpleTestCase):

--- a/products/tasks/backend/tests/test_presentation_serializers.py
+++ b/products/tasks/backend/tests/test_presentation_serializers.py
@@ -13,6 +13,7 @@ from products.tasks.backend.presentation.serializers import (
     TaskRunLivingArtifactCreateRequestSerializer,
     TaskWriteSerializer,
 )
+from products.tasks.backend.presentation.views.api import TaskViewSet
 
 
 class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
@@ -33,35 +34,36 @@ class TestTaskWriteSerializerOriginProduct(SimpleTestCase):
                 "Update the PostHog app to create Signal Report tasks, then try again."
             )
 
-    @parameterized.expand(
-        [
-            ("support_reply", False),
-            ("error_tracking", False),
-            ("user_created", True),
-            ("user_created", False),
-        ]
-    )
-    @patch("products.tasks.backend.presentation.serializers.logger.info")
-    def test_logs_client_attribution(self, origin_product: str, internal: bool, info: MagicMock) -> None:
-        serializer = TaskWriteSerializer(
-            data={"origin_product": origin_product, "internal": internal},
-            context={"team_id": 123, "request": SimpleNamespace(user=SimpleNamespace(id=456))},
+    def test_signal_report_serializer_assigns_origin(self) -> None:
+        serializer = SignalReportTaskCreateSerializer()
+        assert serializer.fields["origin_product"].default == "signal_report"
+
+
+class TestTaskWriteTelemetry(SimpleTestCase):
+    @patch("products.tasks.backend.presentation.views.api.logger.info")
+    def test_logs_client_attribution_before_validation(self, info: MagicMock) -> None:
+        view = TaskViewSet()
+        view.team = SimpleNamespace(id=123)
+        view.request = SimpleNamespace(user=SimpleNamespace(id=456))
+        serializer = MagicMock()
+        serializer_class = MagicMock(return_value=serializer)
+
+        result = view._write_serializer(
+            {"origin_product": "signal_report", "internal": True},
+            serializer_class=serializer_class,
         )
 
-        assert serializer.is_valid(), serializer.errors
+        assert result is serializer
         info.assert_called_once_with(
             "task_api_client_attribution",
             extra={
                 "team_id": 123,
                 "user_id": 456,
-                "origin_product": origin_product,
-                "internal": internal,
+                "origin_product": "signal_report",
+                "internal": True,
             },
         )
-
-    def test_signal_report_serializer_assigns_origin(self) -> None:
-        serializer = SignalReportTaskCreateSerializer()
-        assert serializer.fields["origin_product"].default == "signal_report"
+        serializer.is_valid.assert_called_once_with(raise_exception=True)
 
 
 class TestTaskRunLivingArtifactCreateRequestSerializer(SimpleTestCase):


### PR DESCRIPTION
## Problem

Task clients can currently choose origins that affect entitlement and usage attribution. Signal Report tasks need to remain attributed to Signals, while ordinary cloud tasks must not acquire that attribution through the generic task API.

## Changes

- Add a server-owned Signal Report task creation action for implementation and discussion tasks.
- Move the PostHog web Inbox flow to that action.
- Reserve the signal_report origin on the generic task API.
- Emit generic attribution telemetry for public task API requests.
- Return an actionable update message to legacy clients.

> [!WARNING]
> Ship the companion PostHog Code client first. After reasonable adoption, deploy this PR; remaining legacy clients will be prompted to update when they use a Signal Report action.

**Why**

Token and compute attribution should come from a backend-owned product flow, not task metadata supplied by a client.

## How did you test this code?

- Serializer origin and attribution tests: 8 passed.
- Ruff lint and formatting checks passed for the changed backend files.
- Database-backed task API tests and OpenAPI generation could not run locally because PostgreSQL was unavailable.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with PostHog Code/Codex. No repository skills were invoked. The API is intentionally narrow: only implementation and discussion relationships are accepted, and existing task/run machinery is reused.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*