### PR TITLE
fix(workflows): let cohort branch split evenly across any number of branches

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
@@ -113,6 +113,9 @@ export function StepRandomCohortBranchConfiguration({
         }
         const normalized = normalizeCohortPercentages(cohorts.length)
         setCohorts(cohorts.map((cohort, i) => ({ ...cohort, percentage: normalized[i] })))
+        // Every share is replaced, so any draft still open is stale text sitting over a new value. The
+        // button cannot be relied on to blur the field first: Safari leaves focus where it was.
+        setPercentageDrafts({})
     }
 
     const percentages = cohorts.map((cohort) => cohort.percentage)

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
@@ -1,6 +1,6 @@
 import { Node } from '@xyflow/react'
 import { useActions, useValues } from 'kea'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 
 import { IconBalance, IconPlus, IconX } from '@posthog/icons'
 
@@ -11,7 +11,7 @@ import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { HogFlow, HogFlowAction } from '../types'
 import { StepSchemaErrors } from './components/StepSchemaErrors'
-import { useDebouncedNameInputs } from './utils'
+import { normalizeCohortPercentages, useDebouncedNameInputs } from './utils'
 
 export function StepRandomCohortBranchConfiguration({
     node,
@@ -77,25 +77,45 @@ export function StepRandomCohortBranchConfiguration({
         setWorkflowActionEdges(action.id, [...newBranchEdges, ...nonBranchEdges])
     }
 
-    const updateCohortPercentage = (index: number, percentage: number): void => {
-        setCohorts(cohorts.map((cohort, i) => (i === index ? { ...cohort, percentage } : cohort)))
+    // While a percentage field is focused it displays the raw text being typed, keyed by cohort index.
+    // Feeding the parsed number straight back as the input's value would drop a trailing decimal
+    // point, so a fractional share could never be typed: "3." parses to 3 and the field re-renders
+    // without the dot, leaving "3.3" unreachable.
+    const [percentageDrafts, setPercentageDrafts] = useState<Record<number, string>>({})
+
+    const updateCohortPercentage = (index: number, value: string): void => {
+        setPercentageDrafts((drafts) => ({ ...drafts, [index]: value }))
+        const parsed = Number.parseFloat(value)
+        setCohorts(
+            cohorts.map((cohort, i) =>
+                i === index ? { ...cohort, percentage: Number.isFinite(parsed) ? parsed : 0 } : cohort
+            )
+        )
+    }
+
+    const clearPercentageDraft = (index: number): void => {
+        setPercentageDrafts((drafts) => {
+            const remaining = { ...drafts }
+            delete remaining[index]
+            return remaining
+        })
     }
 
     const normalizePercentages = (): void => {
-        const count = cohorts.length
-        if (count === 0) {
+        if (cohorts.length === 0) {
             return
         }
-        const base = Math.floor(100 / count)
-        const remainder = 100 - base * count
-        const normalized = cohorts.map((cohort, i) => {
-            // Distribute remainder to the first cohorts
-            return { ...cohort, percentage: base + (i < remainder ? 1 : 0) }
-        })
-        setCohorts(normalized)
+        const normalized = normalizeCohortPercentages(cohorts.length)
+        setCohorts(cohorts.map((cohort, i) => ({ ...cohort, percentage: normalized[i] })))
     }
 
     const totalPercentage = cohorts.reduce((sum, cohort) => sum + cohort.percentage, 0)
+    // Summing fractional shares in binary lands a hair off a round number (an even thirty-way split
+    // totals 99.99999999999997), so compare against a tolerance finer than the smallest share the
+    // field can express rather than against 100 exactly, which would warn on a correct split.
+    const displayTotal = Math.round(totalPercentage * 100) / 100
+    const isBalanced = Math.abs(totalPercentage - 100) < 0.005
+    const shortfall = Math.round((100 - totalPercentage) * 100) / 100
 
     return (
         <>
@@ -120,8 +140,10 @@ export function StepRandomCohortBranchConfiguration({
                             type="number"
                             min="0"
                             max="100"
-                            value={cohort.percentage}
-                            onChange={(e) => updateCohortPercentage(index, parseInt(e.target.value) || 0)}
+                            step="any"
+                            value={percentageDrafts[index] ?? String(cohort.percentage)}
+                            onChange={(e) => updateCohortPercentage(index, e.target.value)}
+                            onBlur={() => clearPercentageDraft(index)}
                             className="w-20 px-2 py-1 border rounded"
                         />
                         <span>%</span>
@@ -129,15 +151,19 @@ export function StepRandomCohortBranchConfiguration({
                 </div>
             ))}
 
-            {totalPercentage !== 100 && (
-                <div className="text-sm text-orange-600">Total percentage: {totalPercentage}% (should equal 100%)</div>
+            {!isBalanced && (
+                <div className="text-sm text-orange-600">
+                    {shortfall > 0
+                        ? `These add up to ${displayTotal}%. The remaining ${shortfall}% will go to the last cohort.`
+                        : `These add up to ${displayTotal}%. Later cohorts will get less than their share, and some may never be used.`}
+                </div>
             )}
 
             <div className="flex gap-2">
                 <LemonButton type="secondary" icon={<IconPlus />} onClick={() => addCohort()} className="flex-1">
                     Add cohort
                 </LemonButton>
-                <LemonButton type="secondary" onClick={normalizePercentages} tooltip="Normalize cohort percentages">
+                <LemonButton type="secondary" onClick={normalizePercentages} tooltip="Split evenly across all cohorts">
                     <IconBalance />
                 </LemonButton>
             </div>

--- a/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepRandomCohortBranch.tsx
@@ -11,7 +11,17 @@ import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { HogFlow, HogFlowAction } from '../types'
 import { StepSchemaErrors } from './components/StepSchemaErrors'
-import { normalizeCohortPercentages, useDebouncedNameInputs } from './utils'
+import {
+    cohortPercentagesAddUp,
+    normalizeCohortPercentages,
+    parseCohortPercentage,
+    useDebouncedNameInputs,
+} from './utils'
+
+// Print enough precision that the two figures in the imbalance warning cannot contradict each other:
+// rounding a 99.996% total to hundredths would claim it adds up to 100% with 0% left over. Number()
+// then drops the zeros toFixed pads with, and clears float noise like 0.0040000000000048.
+const formatPercentage = (value: number): string => Number(value.toFixed(10)).toString()
 
 export function StepRandomCohortBranchConfiguration({
     node,
@@ -85,12 +95,8 @@ export function StepRandomCohortBranchConfiguration({
 
     const updateCohortPercentage = (index: number, value: string): void => {
         setPercentageDrafts((drafts) => ({ ...drafts, [index]: value }))
-        const parsed = Number.parseFloat(value)
-        setCohorts(
-            cohorts.map((cohort, i) =>
-                i === index ? { ...cohort, percentage: Number.isFinite(parsed) ? parsed : 0 } : cohort
-            )
-        )
+        const percentage = parseCohortPercentage(value)
+        setCohorts(cohorts.map((cohort, i) => (i === index ? { ...cohort, percentage } : cohort)))
     }
 
     const clearPercentageDraft = (index: number): void => {
@@ -109,13 +115,10 @@ export function StepRandomCohortBranchConfiguration({
         setCohorts(cohorts.map((cohort, i) => ({ ...cohort, percentage: normalized[i] })))
     }
 
-    const totalPercentage = cohorts.reduce((sum, cohort) => sum + cohort.percentage, 0)
-    // Summing fractional shares in binary lands a hair off a round number (an even thirty-way split
-    // totals 99.99999999999997), so compare against a tolerance finer than the smallest share the
-    // field can express rather than against 100 exactly, which would warn on a correct split.
-    const displayTotal = Math.round(totalPercentage * 100) / 100
-    const isBalanced = Math.abs(totalPercentage - 100) < 0.005
-    const shortfall = Math.round((100 - totalPercentage) * 100) / 100
+    const percentages = cohorts.map((cohort) => cohort.percentage)
+    const totalPercentage = percentages.reduce((sum, percentage) => sum + percentage, 0)
+    const isBalanced = cohortPercentagesAddUp(percentages)
+    const shortfall = 100 - totalPercentage
 
     return (
         <>
@@ -151,11 +154,11 @@ export function StepRandomCohortBranchConfiguration({
                 </div>
             ))}
 
-            {!isBalanced && (
+            {cohorts.length > 0 && !isBalanced && (
                 <div className="text-sm text-orange-600">
                     {shortfall > 0
-                        ? `These add up to ${displayTotal}%. The remaining ${shortfall}% will go to the last cohort.`
-                        : `These add up to ${displayTotal}%. Later cohorts will get less than their share, and some may never be used.`}
+                        ? `These add up to ${formatPercentage(totalPercentage)}%. The remaining ${formatPercentage(shortfall)}% will go to the last cohort.`
+                        : `These add up to ${formatPercentage(totalPercentage)}%. Later cohorts will get less than their share, and some may never be used.`}
                 </div>
             )}
 

--- a/products/workflows/frontend/Workflows/hogflows/steps/utils.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/utils.test.ts
@@ -1,6 +1,8 @@
 import {
+    cohortPercentagesAddUp,
     getBranchRemovalDisabledReason,
     normalizeCohortPercentages,
+    parseCohortPercentage,
     removeBranchEdge,
     updateItemWithOptionalName,
     updateOptionalName,
@@ -247,6 +249,46 @@ describe('utils', () => {
             for (const percentage of percentages) {
                 expect(Math.abs(percentage - 100 / count)).toBeLessThanOrEqual(0.01)
             }
+        })
+    })
+
+    describe('cohortPercentagesAddUp', () => {
+        // Both directions of this have bitten: comparing against 100 exactly reports the balance
+        // button's own output as unbalanced, while a tolerance wide enough to cover a hundredth of a
+        // percent hides shortfalls the runtime really does reroute to the last cohort.
+        it.each([2, 3, 7, 8, 30, 99])('accepts the even split produced for %i cohorts', (count) => {
+            expect(cohortPercentagesAddUp(normalizeCohortPercentages(count))).toBe(true)
+        })
+
+        it.each([
+            { name: 'accepts shares totalling exactly 100', percentages: [50, 50], expected: true },
+            {
+                name: 'rejects a shortfall smaller than a hundredth of a percent',
+                percentages: [50, 49.996],
+                expected: false,
+            },
+            { name: 'rejects a whole-percent shortfall', percentages: [30, 30, 30], expected: false },
+            { name: 'rejects an excess', percentages: [60, 60], expected: false },
+            { name: 'rejects no shares at all', percentages: [], expected: false },
+        ])('$name', ({ percentages, expected }) => {
+            expect(cohortPercentagesAddUp(percentages)).toBe(expected)
+        })
+    })
+
+    describe('parseCohortPercentage', () => {
+        // A number field accepts more than plain decimals, and its max attribute only gates form
+        // validation, which this input is not wired to. Without the clamp, "1e5" stores 100000 and
+        // every cohort after the first becomes unreachable.
+        it.each([
+            { name: 'keeps a fractional share', value: '3.3', expected: 3.3 },
+            { name: 'keeps a whole share', value: '50', expected: 50 },
+            { name: 'clamps scientific notation over the maximum', value: '1e5', expected: 100 },
+            { name: 'clamps a value over the maximum', value: '500', expected: 100 },
+            { name: 'clamps a negative value up to zero', value: '-5', expected: 0 },
+            { name: 'reads empty text as zero', value: '', expected: 0 },
+            { name: 'reads unparseable text as zero', value: 'abc', expected: 0 },
+        ])('$name', ({ value, expected }) => {
+            expect(parseCohortPercentage(value)).toBe(expected)
         })
     })
 

--- a/products/workflows/frontend/Workflows/hogflows/steps/utils.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/utils.test.ts
@@ -1,5 +1,6 @@
 import {
     getBranchRemovalDisabledReason,
+    normalizeCohortPercentages,
     removeBranchEdge,
     updateItemWithOptionalName,
     updateOptionalName,
@@ -213,6 +214,39 @@ describe('utils', () => {
             const result = removeBranchEdge(edges, 1)
 
             expect(result).not.toBe(edges)
+        })
+    })
+
+    describe('normalizeCohortPercentages', () => {
+        it.each([
+            { name: 'splits evenly when the count divides 100', count: 4, expected: [25, 25, 25, 25] },
+            {
+                name: 'uses a fractional share when whole percents cannot divide 100',
+                count: 8,
+                expected: [12.5, 12.5, 12.5, 12.5, 12.5, 12.5, 12.5, 12.5],
+            },
+            {
+                name: 'spreads the leftover hundredths across the leading cohorts',
+                count: 3,
+                expected: [33.34, 33.33, 33.33],
+            },
+            { name: 'returns nothing when there are no cohorts', count: 0, expected: [] },
+        ])('$name', ({ count, expected }) => {
+            expect(normalizeCohortPercentages(count)).toEqual(expected)
+        })
+
+        // Allocating in whole percents summed to 100 too, but unevenly: 30 cohorts came out as ten
+        // shares of 4% and twenty of 3%, so a third of the branches took 33% more traffic than the
+        // rest. Asserting the total alone would not have caught that, hence the per-share bound.
+        it.each([2, 3, 7, 8, 30, 99])('gives %i cohorts an equal share totalling 100', (count) => {
+            const percentages = normalizeCohortPercentages(count)
+            const total = percentages.reduce((sum, percentage) => sum + percentage, 0)
+
+            expect(percentages).toHaveLength(count)
+            expect(total).toBeCloseTo(100, 6)
+            for (const percentage of percentages) {
+                expect(Math.abs(percentage - 100 / count)).toBeLessThanOrEqual(0.01)
+            }
         })
     })
 

--- a/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
@@ -51,6 +51,33 @@ export function normalizeCohortPercentages(count: number): number[] {
     return Array.from({ length: count }, (_, i) => (base + (i < leftover ? 1 : 0)) / hundredthsPerPercent)
 }
 
+// Adding floats accumulates error, so a set of shares that ought to total 100 can land a hair off (an
+// even thirty-way split sums to 99.99999999999997). Anything under this counts as that noise. The
+// bound is three orders of magnitude above the worst error an even split accumulates at any workable
+// branch count, and far below a difference anyone would type, so a real imbalance still registers.
+const FLOAT_SUM_TOLERANCE = 1e-9
+
+/** Whether a set of cohort shares adds up to a whole 100%, ignoring float summing error. */
+export function cohortPercentagesAddUp(percentages: number[]): boolean {
+    const total = percentages.reduce((sum, percentage) => sum + percentage, 0)
+    return Math.abs(total - 100) < FLOAT_SUM_TOLERANCE
+}
+
+/**
+ * Read a percentage field's raw text into the value to store, clamped to the 0-100 the field declares.
+ *
+ * The clamp is load-bearing: min/max on a number input only gate form validation, which this field is
+ * not wired to, so without it any out-of-range text a browser accepts as a number gets persisted.
+ * Scientific notation is the easy one to miss, since "1e5" is valid input to a number field.
+ */
+export function parseCohortPercentage(value: string): number {
+    const parsed = Number.parseFloat(value)
+    if (!Number.isFinite(parsed)) {
+        return 0
+    }
+    return Math.min(100, Math.max(0, parsed))
+}
+
 export function updateOptionalName<T>(obj: T & { name?: string }, name: string | undefined): T & { name?: string } {
     const updated = { ...obj }
     if (name) {

--- a/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/utils.ts
@@ -30,6 +30,27 @@ export function removeBranchEdge(branchEdges: HogFlowEdge[], conditionIndex: num
     return branchEdges.filter((e) => e.index !== conditionIndex).map((edge, i) => ({ ...edge, index: i }))
 }
 
+/**
+ * Percentages for an even N-way cohort split, summing to exactly 100.
+ *
+ * Shares are allocated in hundredths of a percent rather than whole percents, because whole percents
+ * can't divide 100 evenly for most counts and the runtime routes any shortfall to the last cohort
+ * (see getRandomCohort). Allocating in whole percents therefore gave 30 cohorts ten shares of 4% and
+ * twenty of 3%, so a third of the branches carried 33% more than the rest. The leftover hundredths
+ * are spread one each across the leading cohorts, which keeps every share within 0.01 of its fair
+ * value.
+ */
+export function normalizeCohortPercentages(count: number): number[] {
+    if (count <= 0) {
+        return []
+    }
+    const hundredthsPerPercent = 100
+    const totalHundredths = 100 * hundredthsPerPercent
+    const base = Math.floor(totalHundredths / count)
+    const leftover = totalHundredths - base * count
+    return Array.from({ length: count }, (_, i) => (base + (i < leftover ? 1 : 0)) / hundredthsPerPercent)
+}
+
 export function updateOptionalName<T>(obj: T & { name?: string }, name: string | undefined): T & { name?: string } {
     const updated = { ...obj }
     if (name) {


### PR DESCRIPTION
## Problem

Cohort branch cannot express an even split across most numbers of branches, and it fails quietly rather than telling you.

**Fractional percentages could not be entered at all.** The field parsed with `parseInt` and fed the parsed number straight back as the input's `value`, so typing `3.3` was impossible: after `3.` the keystroke parsed to `3` and the field re-rendered without the dot. The API has always accepted floats (`percentage` is a plain number, and the serializer checks `isinstance(..., (int, float))`), so this was a UI-only ceiling.

**That made an even split unreachable for most counts.** Whole percents divide 100 evenly for only a handful of branch counts. For everything else you either leave a shortfall, which `getRandomCohort` routes entirely to the last cohort, or you overshoot and later cohorts stop being reachable.

**The balance button had the same limit**, so the one escape hatch was also skewed. Allocating in whole percents gave:

| Branches | Before | After |
| --- | --- | --- |
| 8 | 13 / 13 / 13 / 13 / 12 / 12 / 12 / 12 | 12.5 each |
| 30 | ten at 4%, twenty at 3% | ten at 3.34%, twenty at 3.33% |

At 30 branches the heavy branches took **33% more traffic** than the light ones. That is the case where it matters most, because a many-way split plus incremental delays is how you spread one send across a month, and the whole point is that each day carries the same share.

Two smaller things in the same corner: the warning said only "should equal 100%" without saying what an unbalanced split actually does, and the balance button's tooltip called it "Normalize cohort percentages", which does not tell you it splits evenly.

## Changes

- **Percentages accept decimals.** `parseFloat` plus `step="any"`, and the field keeps the raw text it is being given while focused so a decimal point survives typing. The draft clears on blur, so the committed value is what shows the rest of the time (including after the balance button runs).
- **Even splits are exact.** Share allocation moves into `normalizeCohortPercentages` in `steps/utils.ts`, allocating hundredths of a percent instead of whole percents. Leftover hundredths spread one each across the leading cohorts, so every share lands within 0.01 of its fair value and the total is still exactly 100. It is a pure function next to the other step helpers, so it is unit-testable.
- **The warning tolerates float summing and says what happens.** An even 30-way split sums to `99.99999999999997`, which the old `!== 100` check would have flagged as broken, so the comparison now uses a tolerance finer than the smallest share the field can express. When a split really is unbalanced it now names the consequence: which cohort absorbs the shortfall, or that later cohorts may go unused.
- Balance button tooltip is now "Split evenly across all cohorts".

> [!NOTE]
> Refs #75114 rather than closing it. This fixes the titled defect: an even N-way split no longer skews, and an unbalanced one is no longer silent. What stays open in that issue is whether a total that is not 100 should be rejected or redistributed at all, which is a behavior change to a shipped node (an existing test asserts today's shortfall routing, and the API help text documents it) and wants a call from team-workflows rather than a quiet fix here.

> [!NOTE]
> Touches the same file as #75109, in different regions (that one adds a toggle below the buttons; this one changes the input, the balance handler, and the warning). They are independent and either can merge first.

## How did you test this code?

I (Claude) added `normalizeCohortPercentages` cases to the existing `steps/utils.test.ts`. The regression they catch, which nothing covered before because the allocation was inline in the component:

- **Four `it.each` rows for exact output** across a count that divides 100 (4 → 25 each), one that only works fractionally (8 → 12.5 each), one with leftover hundredths (3 → 33.34 / 33.33 / 33.33), and the empty case.
- **One parameterized row per count (2, 3, 7, 8, 30, 99)** asserting the total is 100 *and* that every individual share is within 0.01 of `100 / count`. The per-share bound is the load-bearing half: whole-percent allocation also summed to 100, so a total-only assertion would have passed the 4%/3% skew this PR fixes.

Ran:

- `jest hogflows/steps/utils.test` — 34 passed (24 existing, 10 new)
- `tsc --noEmit` for `@posthog/frontend` — 281 pre-existing errors from unbuilt `@posthog/quill*` workspace packages, **zero** in any file this PR touches (and none anywhere in `products/workflows` beyond three pre-existing ones in an untouched file)
- `oxfmt --check`, `oxlint` clean on the changed files. The one `oxlint` warning on `StepRandomCohortBranch.tsx` is pre-existing on a line this PR does not touch, which I verified by diffing that region against master.

Before wiring the helper up I also ran the allocation standalone to confirm the float behavior rather than assuming it: that `3334/100` compares equal to the literal `33.34` (so `toEqual` is safe), that the worst per-share deviation across those counts peaks at 0.0099 for 99 branches, and that an even 30-way split totals `99.99999999999997` — which is what told me the warning needed a tolerance.

> [!WARNING]
> No manual UI testing and no screenshot: I cannot run the app in this environment. The typing behavior is the part that wants a human for thirty seconds — type `3.3` into a cohort percentage, confirm the decimal point survives, then hit the balance button with several cohorts and confirm the fields land on even fractional shares with no warning showing.

## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No doc change needed. The graph schema reference already describes `percentage` as a number and documents the shortfall routing, both still accurate.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Opus 4.5) in Claude Code, directed by @jakesciotto. Follow-up to #75109, from the same conversation about reproducing a monthly staggered send that a sender had built in another messaging tool. Skills invoked: `/writing-tests`, `/writing-user-facing-copy`, `/writing-code-comments`.

Two decisions worth surfacing. The local draft state for the input is more than the one-line `parseInt` → `parseFloat` this looked like from the outside: without it the controlled `value` round-trips the parsed number on every keystroke and eats the decimal point, so `parseFloat` alone would not actually let anyone type `3.3`. And I kept the allocation in hundredths rather than exposing arbitrary precision, so the balance button lands on values that read cleanly in a 20px-wide field while still summing exactly; the field itself accepts any precision the user wants to type.

I deliberately did not touch the shortfall-routing behavior in the runtime handler, and this PR makes that question much less urgent, since an even split no longer produces a shortfall for the balance button to route.


---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
