### PR TITLE
fix(signals): Limit breadth of area to nominate reviewers for

### DIFF
--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -387,7 +387,7 @@ def _has_live_reviewer(
     login_weights: Counter[str],
     activity_by_login: dict[str, _AreaContributor],
 ) -> bool:
-    """Whether a weighted candidate is still committing in the report's areas.
+    """Whether a candidate with a blame or agent-proposed weight is still committing in the report's areas.
 
     Recency decides, not membership in the cached map: it is served while a rebuild is
     scheduled, so an entry can have aged past the window.
@@ -423,6 +423,7 @@ def _score_candidates(
     if _has_live_reviewer(login_weights, activity_by_login):
         return scores
 
+    # If not, nobody the report points at is around to review, so fall back to area contributors.
     max_blame_weight = float(max(login_weights.values(), default=0)) or 1.0
     for login, activity in activity_by_login.items():
         if login in scores or not activity.is_likely_owner_of_area:

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -283,10 +283,10 @@ class _AreaContributor:
     last_commit_sha: str
     last_commit_url: str
     area: str  # the area of the evidence (freshest) commit, for evidence wording
-    # Whether *any* area this contributor was drawn from is focused enough to imply ownership.
+    # True if *any* area this contributor was drawn from is focused enough to count as owned.
     # Not tied to the evidence area: a crowded area still supplies recency, it just proposes
     # nobody, and it must not cancel a claim earned in a focused one.
-    implies_ownership: bool
+    is_likely_owner_of_area: bool
 
 
 def _relevant_area_activity(
@@ -320,10 +320,10 @@ def _relevant_area_activity(
         if level is None or level in used_levels:
             continue
         used_levels.add(level)
-        implies_ownership = len(activity_by_area[level]) <= MAX_CONTRIBUTORS_FOR_OWNERSHIP
+        is_likely_owner_of_area = len(activity_by_area[level]) <= MAX_CONTRIBUTORS_FOR_OWNERSHIP
         for contributor in activity_by_area[level]:
             existing = merged.get(contributor.login)
-            merged[contributor.login] = _merge_contributor(existing, contributor, level, now, implies_ownership)
+            merged[contributor.login] = _merge_contributor(existing, contributor, level, now, is_likely_owner_of_area)
     return merged
 
 
@@ -342,7 +342,7 @@ def _merge_contributor(
     incoming: ContributorActivity,
     area: str,
     now: datetime,
-    implies_ownership: bool,
+    is_likely_owner_of_area: bool,
 ) -> _AreaContributor:
     days_since = max(0.0, (now - incoming.last_commit_at).total_seconds() / 86400)
     if existing is None:
@@ -353,7 +353,7 @@ def _merge_contributor(
             last_commit_sha=incoming.last_commit_sha,
             last_commit_url=incoming.last_commit_url,
             area=area,
-            implies_ownership=implies_ownership,
+            is_likely_owner_of_area=is_likely_owner_of_area,
         )
     # Evidence follows the freshest commit, so sha/url/area always agree with
     # days_since_last_commit. Ownership does not: it accumulates, so a fresher commit in a
@@ -366,7 +366,7 @@ def _merge_contributor(
         last_commit_sha=incoming.last_commit_sha if keep_incoming_evidence else existing.last_commit_sha,
         last_commit_url=incoming.last_commit_url if keep_incoming_evidence else existing.last_commit_url,
         area=area if keep_incoming_evidence else existing.area,
-        implies_ownership=existing.implies_ownership or implies_ownership,
+        is_likely_owner_of_area=existing.is_likely_owner_of_area or is_likely_owner_of_area,
     )
 
 
@@ -425,7 +425,7 @@ def _score_candidates(
 
     max_blame_weight = float(max(login_weights.values(), default=0)) or 1.0
     for login, activity in activity_by_login.items():
-        if login in scores or not activity.implies_ownership:
+        if login in scores or not activity.is_likely_owner_of_area:
             continue
         saturation = min(activity.commit_count, ACTIVITY_BONUS_SATURATION_COMMITS) / ACTIVITY_BONUS_SATURATION_COMMITS
         base = STALE_BLAME_MULTIPLIER + (ACTIVITY_ONLY_SCORE_CAP - STALE_BLAME_MULTIPLIER) * saturation

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -47,14 +47,10 @@ STALE_BLAME_MULTIPLIER = 0.15
 # Caps activity-only fallbacks below blame candidates: they only win when every blame author is stale.
 ACTIVITY_ONLY_SCORE_CAP = 0.25
 ACTIVITY_BONUS_SATURATION_COMMITS = 10
-# Above this many recent contributors, an area is a crowd rather than an ownership signal:
-# being one of them says nothing about who should review a file inside it. Sized to sit above
-# a product-sized area and below a repo-sized one (on posthog/posthog, per-product areas run
-# 15-30 contributors, while `products`, `frontend/src` and repo-wide run 100+). A whole
-# repository below the threshold stays usable as a fallback area, which is intended: on a
-# 20-person team, "active in this repository lately" really does imply ownership. Must stay
-# under `MAX_CONTRIBUTORS_PER_AREA`, since the count comes from the truncated stored list and
-# a threshold at or above the storage cap can never be exceeded.
+# Above this many recent contributors, an area is a crowd rather than an ownership signal.
+# Sized above a product-sized area and below a repo-sized one; a small team's whole repository
+# stays under it, which is intended. Must stay under MAX_CONTRIBUTORS_PER_AREA, which truncates
+# the list this counts.
 MAX_CONTRIBUTORS_FOR_OWNERSHIP = 30
 GitHubLoginFieldLookup = Literal[
     "extra_data__login",
@@ -287,8 +283,8 @@ class _AreaContributor:
     last_commit_sha: str
     last_commit_url: str
     area: str  # the area of the evidence (freshest) commit, for evidence wording
-    # Whether that evidence area is focused enough to imply ownership. Recency still counts
-    # everywhere; only nominating someone on area activity alone needs this.
+    # Whether the evidence area is focused enough to imply ownership. A crowded area still
+    # supplies recency, it just proposes nobody.
     implies_ownership: bool
 
 
@@ -302,9 +298,9 @@ def _relevant_area_activity(
     Cache-only; a missing or stale map schedules an async rebuild and this report falls
     back to whatever is cached (possibly nothing). An area with no active contributors
     falls back up its chain (parent directory, then repo-wide) — someone active nearby
-    beats nobody. Levels with more than ``MAX_CONTRIBUTORS_FOR_OWNERSHIP`` contributors
-    still supply recency, but are marked as not implying ownership. Returns an empty dict
-    when nothing is known — callers must treat that as "no signal", not "nobody is active".
+    beats nobody. Levels above ``MAX_CONTRIBUTORS_FOR_OWNERSHIP`` contributors still supply
+    recency, but imply no ownership. Returns an empty dict when nothing is known — callers
+    must treat that as "no signal", not "nobody is active".
     """
     areas = areas_for_paths(touched_paths)
     if not areas:
@@ -385,13 +381,20 @@ def _recency_multiplier(days_since_last_commit: float | None) -> float:
     return 1.0 - progress * (1.0 - RECENCY_DECAY_FLOOR)
 
 
-def _is_active_in_area(activity: _AreaContributor | None) -> bool:
-    """Whether someone has committed in the report's areas inside the activity window.
+def _has_live_reviewer(
+    login_weights: Counter[str],
+    activity_by_login: dict[str, _AreaContributor],
+) -> bool:
+    """Whether a weighted candidate is still committing in the report's areas.
 
-    Recency decides this, not presence in the cached area map: the map is served while a
-    rebuild is scheduled, so an entry can have aged past the window.
+    Recency decides, not membership in the cached map: it is served while a rebuild is
+    scheduled, so an entry can have aged past the window.
     """
-    return activity is not None and activity.days_since_last_commit < ACTIVITY_WINDOW_DAYS
+    for login in login_weights:
+        activity = activity_by_login.get(login)
+        if activity is not None and activity.days_since_last_commit < ACTIVITY_WINDOW_DAYS:
+            return True
+    return False
 
 
 def _score_candidates(
@@ -400,13 +403,10 @@ def _score_candidates(
 ) -> dict[str, float]:
     """Blend blame weights with area recency; add capped activity-only fallbacks.
 
-    Weighted candidates (blame authors and agent-proposed assignees) decay toward the stale
-    floor as their last commit in the area recedes. Area contributors are proposed as
-    candidates in their own right only as a last resort, when two things hold: no weighted
-    candidate is still active in the area (one who is would be the live reviewer, so adding
-    area contributors beside them is noise), and the area is focused enough to imply
-    ownership (a crowd still decays blame weights but proposes nobody). Their base starts
-    above the stale floor, so they outrank blame authors who have left the area. With no
+    Blame and agent-proposed weights decay toward the stale floor as their author's last
+    commit in the area recedes. Area contributors are proposed in their own right only as a
+    last resort: no live reviewer, and an area focused enough to imply ownership. Their base
+    starts above the stale floor, so they outrank authors who have left the area. With no
     activity data at all, blame weights pass through unchanged (legacy behavior).
     """
     if not activity_by_login:
@@ -418,7 +418,7 @@ def _score_candidates(
         multiplier = _recency_multiplier(activity.days_since_last_commit if activity else None)
         scores[login] = float(weight) * multiplier
 
-    if any(_is_active_in_area(activity_by_login.get(login)) for login in login_weights):
+    if _has_live_reviewer(login_weights, activity_by_login):
         return scores
 
     max_blame_weight = float(max(login_weights.values(), default=0)) or 1.0

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -47,6 +47,15 @@ STALE_BLAME_MULTIPLIER = 0.15
 # Caps activity-only fallbacks below blame candidates: they only win when every blame author is stale.
 ACTIVITY_ONLY_SCORE_CAP = 0.25
 ACTIVITY_BONUS_SATURATION_COMMITS = 10
+# Above this many recent contributors, an area is a crowd rather than an ownership signal:
+# being one of them says nothing about who should review a file inside it. Sized to sit above
+# a product-sized area and below a repo-sized one (on posthog/posthog, per-product areas run
+# 15-30 contributors, while `products`, `frontend/src` and repo-wide run 100+). A whole
+# repository below the threshold stays usable as a fallback area, which is intended: on a
+# 20-person team, "active in this repository lately" really does imply ownership. Must stay
+# under `MAX_CONTRIBUTORS_PER_AREA`, since the count comes from the truncated stored list and
+# a threshold at or above the storage cap can never be exceeded.
+MAX_CONTRIBUTORS_FOR_OWNERSHIP = 30
 GitHubLoginFieldLookup = Literal[
     "extra_data__login",
     "config__github_user__login",
@@ -288,6 +297,9 @@ class _AreaContributor:
     last_commit_sha: str
     last_commit_url: str
     area: str  # the area of the evidence (freshest) commit, for evidence wording
+    # Whether that evidence area is focused enough to imply ownership. Recency still counts
+    # everywhere; only nominating someone on area activity alone needs this.
+    implies_ownership: bool
 
 
 def _relevant_area_activity(
@@ -300,8 +312,9 @@ def _relevant_area_activity(
     Cache-only; a missing or stale map schedules an async rebuild and this report falls
     back to whatever is cached (possibly nothing). An area with no active contributors
     falls back up its chain (parent directory, then repo-wide) — someone active nearby
-    beats nobody. Returns an empty dict when nothing is known — callers must treat that
-    as "no signal", not "nobody is active".
+    beats nobody. Levels with more than ``MAX_CONTRIBUTORS_FOR_OWNERSHIP`` contributors
+    still supply recency, but are marked as not implying ownership. Returns an empty dict
+    when nothing is known — callers must treat that as "no signal", not "nobody is active".
     """
     areas = areas_for_paths(touched_paths)
     if not areas:
@@ -320,9 +333,10 @@ def _relevant_area_activity(
         if level is None or level in used_levels:
             continue
         used_levels.add(level)
+        implies_ownership = len(activity_by_area[level]) <= MAX_CONTRIBUTORS_FOR_OWNERSHIP
         for contributor in activity_by_area[level]:
             existing = merged.get(contributor.login)
-            merged[contributor.login] = _merge_contributor(existing, contributor, level, now)
+            merged[contributor.login] = _merge_contributor(existing, contributor, level, now, implies_ownership)
     return merged
 
 
@@ -341,6 +355,7 @@ def _merge_contributor(
     incoming: ContributorActivity,
     area: str,
     now: datetime,
+    implies_ownership: bool,
 ) -> _AreaContributor:
     days_since = max(0.0, (now - incoming.last_commit_at).total_seconds() / 86400)
     if existing is None:
@@ -351,6 +366,7 @@ def _merge_contributor(
             last_commit_sha=incoming.last_commit_sha,
             last_commit_url=incoming.last_commit_url,
             area=area,
+            implies_ownership=implies_ownership,
         )
     # Evidence follows the freshest commit, so sha/url/area always agree with
     # days_since_last_commit.
@@ -362,6 +378,7 @@ def _merge_contributor(
         last_commit_sha=incoming.last_commit_sha if keep_incoming_evidence else existing.last_commit_sha,
         last_commit_url=incoming.last_commit_url if keep_incoming_evidence else existing.last_commit_url,
         area=area if keep_incoming_evidence else existing.area,
+        implies_ownership=implies_ownership if keep_incoming_evidence else existing.implies_ownership,
     )
 
 
@@ -389,7 +406,9 @@ def _score_candidates(
     *top-weighted* blame author while that author is active in the window (the cap sits
     below the decay floor). Lower-weighted active blame authors can still be outranked by
     a very active area owner — deliberate: weight-1 blame is one marginal commit, not a
-    stronger claim than sustained area ownership. With no activity data at all, blame
+    stronger claim than sustained area ownership. Only contributors whose evidence area is
+    focused enough to imply ownership are nominated this way; activity in a crowded area
+    still decays blame weights but proposes nobody. With no activity data at all, blame
     weights pass through unchanged (legacy behavior).
     """
     if not activity_by_login:
@@ -403,7 +422,7 @@ def _score_candidates(
         scores[login] = float(weight) * multiplier
 
     for login, activity in activity_by_login.items():
-        if login in scores:
+        if login in scores or not activity.implies_ownership:
             continue
         saturation = min(activity.commit_count, ACTIVITY_BONUS_SATURATION_COMMITS) / ACTIVITY_BONUS_SATURATION_COMMITS
         base = STALE_BLAME_MULTIPLIER + (ACTIVITY_ONLY_SCORE_CAP - STALE_BLAME_MULTIPLIER) * saturation

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -283,8 +283,9 @@ class _AreaContributor:
     last_commit_sha: str
     last_commit_url: str
     area: str  # the area of the evidence (freshest) commit, for evidence wording
-    # Whether the evidence area is focused enough to imply ownership. A crowded area still
-    # supplies recency, it just proposes nobody.
+    # Whether *any* area this contributor was drawn from is focused enough to imply ownership.
+    # Not tied to the evidence area: a crowded area still supplies recency, it just proposes
+    # nobody, and it must not cancel a claim earned in a focused one.
     implies_ownership: bool
 
 
@@ -355,7 +356,8 @@ def _merge_contributor(
             implies_ownership=implies_ownership,
         )
     # Evidence follows the freshest commit, so sha/url/area always agree with
-    # days_since_last_commit.
+    # days_since_last_commit. Ownership does not: it accumulates, so a fresher commit in a
+    # crowded level can't erase a claim earned in a focused one.
     keep_incoming_evidence = days_since < existing.days_since_last_commit
     return _AreaContributor(
         name=existing.name or incoming.name,
@@ -364,7 +366,7 @@ def _merge_contributor(
         last_commit_sha=incoming.last_commit_sha if keep_incoming_evidence else existing.last_commit_sha,
         last_commit_url=incoming.last_commit_url if keep_incoming_evidence else existing.last_commit_url,
         area=area if keep_incoming_evidence else existing.area,
-        implies_ownership=implies_ownership if keep_incoming_evidence else existing.implies_ownership,
+        implies_ownership=existing.implies_ownership or implies_ownership,
     )
 
 

--- a/products/signals/backend/report_generation/resolve_reviewers.py
+++ b/products/signals/backend/report_generation/resolve_reviewers.py
@@ -241,16 +241,6 @@ def _rank_scored_candidates(
 ) -> list[_ResolvedReviewer]:
     scores = _score_candidates(login_weights, activity_by_login)
 
-    # Activity-only owners are a last resort: only surface them when no weighted (blame/agent)
-    # candidate is still active in the area, so we don't pad noise next to a live reviewer.
-    # Recency, not map membership, decides "active" — the cached area map can be stale.
-    def _weighted_candidate_still_active(login: str) -> bool:
-        activity = activity_by_login.get(login)
-        return activity is not None and activity.days_since_last_commit < ACTIVITY_WINDOW_DAYS
-
-    if any(_weighted_candidate_still_active(login) for login in login_weights):
-        scores = {login: score for login, score in scores.items() if login in login_weights}
-
     def rank_key(item: tuple[str, float]) -> tuple[float, int, str]:
         login, score = item
         activity = activity_by_login.get(login)
@@ -395,32 +385,43 @@ def _recency_multiplier(days_since_last_commit: float | None) -> float:
     return 1.0 - progress * (1.0 - RECENCY_DECAY_FLOOR)
 
 
+def _is_active_in_area(activity: _AreaContributor | None) -> bool:
+    """Whether someone has committed in the report's areas inside the activity window.
+
+    Recency decides this, not presence in the cached area map: the map is served while a
+    rebuild is scheduled, so an entry can have aged past the window.
+    """
+    return activity is not None and activity.days_since_last_commit < ACTIVITY_WINDOW_DAYS
+
+
 def _score_candidates(
     login_weights: Counter[str],
     activity_by_login: dict[str, _AreaContributor],
 ) -> dict[str, float]:
     """Blend blame weights with area recency; add capped activity-only fallbacks.
 
-    Invariants: a freshly-active area contributor always outranks a blame author who is
-    gone from the area (their base starts above the stale floor), and never outranks the
-    *top-weighted* blame author while that author is active in the window (the cap sits
-    below the decay floor). Lower-weighted active blame authors can still be outranked by
-    a very active area owner — deliberate: weight-1 blame is one marginal commit, not a
-    stronger claim than sustained area ownership. Only contributors whose evidence area is
-    focused enough to imply ownership are nominated this way; activity in a crowded area
-    still decays blame weights but proposes nobody. With no activity data at all, blame
-    weights pass through unchanged (legacy behavior).
+    Weighted candidates (blame authors and agent-proposed assignees) decay toward the stale
+    floor as their last commit in the area recedes. Area contributors are proposed as
+    candidates in their own right only as a last resort, when two things hold: no weighted
+    candidate is still active in the area (one who is would be the live reviewer, so adding
+    area contributors beside them is noise), and the area is focused enough to imply
+    ownership (a crowd still decays blame weights but proposes nobody). Their base starts
+    above the stale floor, so they outrank blame authors who have left the area. With no
+    activity data at all, blame weights pass through unchanged (legacy behavior).
     """
     if not activity_by_login:
         return {login: float(weight) for login, weight in login_weights.items()}
 
-    max_blame_weight = float(max(login_weights.values(), default=0)) or 1.0
     scores: dict[str, float] = {}
     for login, weight in login_weights.items():
         activity = activity_by_login.get(login)
         multiplier = _recency_multiplier(activity.days_since_last_commit if activity else None)
         scores[login] = float(weight) * multiplier
 
+    if any(_is_active_in_area(activity_by_login.get(login)) for login in login_weights):
+        return scores
+
+    max_blame_weight = float(max(login_weights.values(), default=0)) or 1.0
     for login, activity in activity_by_login.items():
         if login in scores or not activity.implies_ownership:
             continue

--- a/products/signals/backend/test/test_resolve_reviewers.py
+++ b/products/signals/backend/test/test_resolve_reviewers.py
@@ -276,6 +276,26 @@ class TestAreaWalkUp:
         assert len(merged) == contributor_count
         assert all(contributor.implies_ownership is implies_ownership for contributor in merged.values())
 
+    def test_fresher_crowded_commit_does_not_erase_focused_area_ownership(self, team):
+        _seed_area(team, "products/signals", [("alice", 4, 10)])
+        _seed_area(
+            team,
+            "*",
+            [("alice", 9, 1), *[(f"dev-{i}", 3, 2) for i in range(MAX_CONTRIBUTORS_FOR_OWNERSHIP)]],
+        )
+
+        with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
+            merged = _relevant_area_activity(
+                team.id, "acme/app", ["products/signals/backend/models.py", "bin/deploy.sh"]
+            )
+
+        # Evidence still follows alice's freshest commit, which landed repo-wide...
+        assert merged["alice"].area == "*"
+        assert merged["alice"].days_since_last_commit == pytest.approx(1, abs=0.01)
+        # ...but the claim she earned in products/signals survives it.
+        assert merged["alice"].implies_ownership
+        assert not merged["dev-0"].implies_ownership
+
 
 @pytest.mark.django_db
 class TestRankAssigneeCandidates:

--- a/products/signals/backend/test/test_resolve_reviewers.py
+++ b/products/signals/backend/test/test_resolve_reviewers.py
@@ -18,6 +18,7 @@ from posthog.models.user_integration import UserIntegration
 from products.signals.backend.models import SignalRepositoryAreaActivity
 from products.signals.backend.report_generation.repo_activity import ACTIVITY_WINDOW_DAYS, ContributorActivity
 from products.signals.backend.report_generation.resolve_reviewers import (
+    MAX_CONTRIBUTORS_FOR_OWNERSHIP,
     RECENCY_DECAY_FLOOR,
     RECENCY_FULL_WEIGHT_DAYS,
     STALE_BLAME_MULTIPLIER,
@@ -132,6 +133,23 @@ def test_skips_users_outside_organization(organization, team):
 # ── recency-aware scoring ─────────────────────────────────────────────────────
 
 
+def _area_contributor(
+    *,
+    days_since_last_commit: float,
+    commit_count: int = 12,
+    implies_ownership: bool = True,
+) -> _AreaContributor:
+    return _AreaContributor(
+        name=None,
+        commit_count=commit_count,
+        days_since_last_commit=days_since_last_commit,
+        last_commit_sha="a" * 7,
+        last_commit_url="https://github.com/acme/app/commit/aaaaaaa",
+        area="products/signals",
+        implies_ownership=implies_ownership,
+    )
+
+
 class TestRecencyScoring:
     def test_recency_multiplier_shape(self):
         assert _recency_multiplier(None) == STALE_BLAME_MULTIPLIER
@@ -151,16 +169,7 @@ class TestRecencyScoring:
 
     def test_stale_blame_author_loses_to_active_area_contributor(self):
         weights = Counter({"old-timer": 10})
-        activity = {
-            "active-owner": _AreaContributor(
-                name="Active Owner",
-                commit_count=12,
-                days_since_last_commit=2,
-                last_commit_sha="a" * 7,
-                last_commit_url="https://github.com/acme/app/commit/aaaaaaa",
-                area="products/signals",
-            ),
-        }
+        activity = {"active-owner": _area_contributor(days_since_last_commit=2)}
 
         scores = _score_candidates(weights, activity)
 
@@ -168,20 +177,10 @@ class TestRecencyScoring:
         assert scores["active-owner"] > scores["old-timer"]
 
     def test_recently_active_blame_author_beats_activity_only_contributor(self):
-        def contributor(days_since: float) -> _AreaContributor:
-            return _AreaContributor(
-                name=None,
-                commit_count=12,
-                days_since_last_commit=days_since,
-                last_commit_sha="b" * 7,
-                last_commit_url="https://github.com/acme/app/commit/bbbbbbb",
-                area="products/signals",
-            )
-
         weights = Counter({"active-author": 10})
         activity = {
-            "active-author": contributor(days_since=5),
-            "bystander": contributor(days_since=1),
+            "active-author": _area_contributor(days_since_last_commit=5),
+            "bystander": _area_contributor(days_since_last_commit=1),
         }
 
         scores = _score_candidates(weights, activity)
@@ -192,65 +191,61 @@ class TestRecencyScoring:
         # Regression: a single old blame commit (weight 1) used to crush activity-only
         # candidates via the cap, so the long-gone author still won the assign.
         weights = Counter({"long-gone": 1})
-        activity = {
-            "light-owner": _AreaContributor(
-                name=None,
-                commit_count=3,
-                days_since_last_commit=1,
-                last_commit_sha="c" * 7,
-                last_commit_url="",
-                area="posthog/migrations",
-            ),
-        }
+        activity = {"light-owner": _area_contributor(days_since_last_commit=1, commit_count=3)}
 
         scores = _score_candidates(weights, activity)
 
         assert scores["light-owner"] > scores["long-gone"]
 
+    def test_crowded_area_nominates_nobody_but_still_decays_blame(self):
+        weights = Counter({"old-timer": 10})
+        activity = {
+            "old-timer": _area_contributor(days_since_last_commit=80, implies_ownership=False),
+            "prolific-stranger": _area_contributor(days_since_last_commit=1, implies_ownership=False),
+        }
+
+        scores = _score_candidates(weights, activity)
+
+        assert set(scores) == {"old-timer"}
+        assert scores["old-timer"] < 10.0
+
     def test_half_stale_bystander_does_not_beat_stale_blame(self):
         weights = Counter({"long-gone": 1})
-        activity = {
-            "half-stale": _AreaContributor(
-                name=None,
-                commit_count=3,
-                days_since_last_commit=70,
-                last_commit_sha="c" * 7,
-                last_commit_url="",
-                area="posthog/migrations",
-            ),
-        }
+        activity = {"half-stale": _area_contributor(days_since_last_commit=70, commit_count=3)}
 
         scores = _score_candidates(weights, activity)
 
         assert scores["long-gone"] >= scores["half-stale"]
 
 
+def _seed_area(team: Team, area: str, entries: list[tuple[str, int, int]]) -> None:
+    """Seed one refreshed area row from (login, commit_count, days_ago) entries."""
+    with team_scope(team.id, canonical=True):
+        SignalRepositoryAreaActivity.objects.create(
+            team=team,
+            repository="acme/app",
+            area=area,
+            contributors=[
+                {
+                    "login": login,
+                    "name": login.title(),
+                    "commit_count": count,
+                    "last_commit_at": (timezone.now() - timedelta(days=days_ago)).isoformat(),
+                    "last_commit_sha": "a" * 7,
+                    "last_commit_url": "https://github.com/acme/app/commit/aaaaaaa",
+                }
+                for login, count, days_ago in entries
+            ],
+            refreshed_at=timezone.now(),
+        )
+
+
 @pytest.mark.django_db
 class TestAreaWalkUp:
     def test_empty_area_falls_back_to_parent_then_repo_wide(self, team):
-        def _row(area: str, logins: list[str]) -> None:
-            SignalRepositoryAreaActivity.objects.create(
-                team=team,
-                repository="acme/app",
-                area=area,
-                contributors=[
-                    {
-                        "login": login,
-                        "name": login.title(),
-                        "commit_count": 3,
-                        "last_commit_at": timezone.now().isoformat(),
-                        "last_commit_sha": "a" * 7,
-                        "last_commit_url": "https://github.com/acme/app/commit/aaaaaaa",
-                    }
-                    for login in logins
-                ],
-                refreshed_at=timezone.now(),
-            )
-
-        with team_scope(team.id, canonical=True):
-            _row("products/dead", [])  # refreshed, nobody active
-            _row("products", ["parent-owner"])
-            _row("*", ["repo-regular"])
+        _seed_area(team, "products/dead", [])  # refreshed, nobody active
+        _seed_area(team, "products", [("parent-owner", 3, 0)])
+        _seed_area(team, "*", [("repo-regular", 3, 0)])
 
         with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
             merged = _relevant_area_activity(team.id, "acme/app", ["products/dead/models.py"])
@@ -266,31 +261,24 @@ class TestAreaWalkUp:
 
         assert set(merged) == {"repo-regular"}
 
+    @pytest.mark.parametrize(
+        ("contributor_count", "implies_ownership"),
+        [(MAX_CONTRIBUTORS_FOR_OWNERSHIP, True), (MAX_CONTRIBUTORS_FOR_OWNERSHIP + 1, False)],
+    )
+    def test_ownership_needs_a_focused_area(self, team, contributor_count, implies_ownership):
+        _seed_area(team, "products/tasks", [(f"dev-{i}", 3, 0) for i in range(contributor_count)])
+
+        with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
+            merged = _relevant_area_activity(team.id, "acme/app", ["products/tasks/management/commands/demo.py"])
+
+        assert len(merged) == contributor_count
+        assert all(contributor.implies_ownership is implies_ownership for contributor in merged.values())
+
 
 @pytest.mark.django_db
 class TestRankAssigneeCandidates:
-    def _seed_area(self, team, area: str, entries: list[tuple[str, int, int]]) -> None:
-        with team_scope(team.id, canonical=True):
-            SignalRepositoryAreaActivity.objects.create(
-                team=team,
-                repository="acme/app",
-                area=area,
-                contributors=[
-                    {
-                        "login": login,
-                        "name": login.title(),
-                        "commit_count": count,
-                        "last_commit_at": (timezone.now() - timedelta(days=days_ago)).isoformat(),
-                        "last_commit_sha": "a" * 7,
-                        "last_commit_url": "https://github.com/acme/app/commit/aaaaaaa",
-                    }
-                    for login, count, days_ago in entries
-                ],
-                refreshed_at=timezone.now(),
-            )
-
     def test_stale_agent_candidate_demoted_below_active_area_owner(self, team):
-        self._seed_area(team, "products/signals", [("active-owner", 12, 2)])
+        _seed_area(team, "products/signals", [("active-owner", 12, 2)])
 
         with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
             ranked = rank_assignee_candidates(
@@ -304,7 +292,7 @@ class TestRankAssigneeCandidates:
         assert ranked[1].commits == []
 
     def test_active_agent_candidate_keeps_top_spot(self, team):
-        self._seed_area(team, "products/signals", [("agent-pick", 5, 3), ("bystander", 12, 1)])
+        _seed_area(team, "products/signals", [("agent-pick", 5, 3), ("bystander", 12, 1)])
 
         with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
             ranked = rank_assignee_candidates(
@@ -316,7 +304,7 @@ class TestRankAssigneeCandidates:
         assert [candidate.login for candidate in ranked] == ["agent-pick"]
 
     def test_paths_alone_yield_activity_candidates(self, team):
-        self._seed_area(team, "products/signals", [("area-owner", 8, 1)])
+        _seed_area(team, "products/signals", [("area-owner", 8, 1)])
 
         with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
             ranked = rank_assignee_candidates(team.id, "acme/app", [], ["products/signals/backend/models.py"])

--- a/products/signals/backend/test/test_resolve_reviewers.py
+++ b/products/signals/backend/test/test_resolve_reviewers.py
@@ -176,7 +176,7 @@ class TestRecencyScoring:
         # old-timer authored the blame commits but has no recent commits in the area.
         assert scores["active-owner"] > scores["old-timer"]
 
-    def test_recently_active_blame_author_beats_activity_only_contributor(self):
+    def test_active_blame_author_suppresses_activity_only_candidates(self):
         weights = Counter({"active-author": 10})
         activity = {
             "active-author": _area_contributor(days_since_last_commit=5),
@@ -185,7 +185,8 @@ class TestRecencyScoring:
 
         scores = _score_candidates(weights, activity)
 
-        assert scores["active-author"] > scores["bystander"]
+        # The blame author is the live reviewer, so the fresher bystander is not proposed.
+        assert set(scores) == {"active-author"}
 
     def test_lightly_active_contributor_beats_stale_blame_even_with_tiny_blame_weight(self):
         # Regression: a single old blame commit (weight 1) used to crush activity-only
@@ -199,8 +200,10 @@ class TestRecencyScoring:
 
     def test_crowded_area_nominates_nobody_but_still_decays_blame(self):
         weights = Counter({"old-timer": 10})
+        # The blame author is past the activity window, so the last-resort path is open and
+        # only the crowded area keeps the stranger out.
         activity = {
-            "old-timer": _area_contributor(days_since_last_commit=80, implies_ownership=False),
+            "old-timer": _area_contributor(days_since_last_commit=ACTIVITY_WINDOW_DAYS + 5, implies_ownership=False),
             "prolific-stranger": _area_contributor(days_since_last_commit=1, implies_ownership=False),
         }
 

--- a/products/signals/backend/test/test_resolve_reviewers.py
+++ b/products/signals/backend/test/test_resolve_reviewers.py
@@ -200,8 +200,7 @@ class TestRecencyScoring:
 
     def test_crowded_area_nominates_nobody_but_still_decays_blame(self):
         weights = Counter({"old-timer": 10})
-        # The blame author is past the activity window, so the last-resort path is open and
-        # only the crowded area keeps the stranger out.
+        # The blame author is past the window, so only the crowded area keeps the stranger out.
         activity = {
             "old-timer": _area_contributor(days_since_last_commit=ACTIVITY_WINDOW_DAYS + 5, implies_ownership=False),
             "prolific-stranger": _area_contributor(days_since_last_commit=1, implies_ownership=False),

--- a/products/signals/backend/test/test_resolve_reviewers.py
+++ b/products/signals/backend/test/test_resolve_reviewers.py
@@ -137,7 +137,7 @@ def _area_contributor(
     *,
     days_since_last_commit: float,
     commit_count: int = 12,
-    implies_ownership: bool = True,
+    is_likely_owner_of_area: bool = True,
 ) -> _AreaContributor:
     return _AreaContributor(
         name=None,
@@ -146,7 +146,7 @@ def _area_contributor(
         last_commit_sha="a" * 7,
         last_commit_url="https://github.com/acme/app/commit/aaaaaaa",
         area="products/signals",
-        implies_ownership=implies_ownership,
+        is_likely_owner_of_area=is_likely_owner_of_area,
     )
 
 
@@ -202,8 +202,10 @@ class TestRecencyScoring:
         weights = Counter({"old-timer": 10})
         # The blame author is past the window, so only the crowded area keeps the stranger out.
         activity = {
-            "old-timer": _area_contributor(days_since_last_commit=ACTIVITY_WINDOW_DAYS + 5, implies_ownership=False),
-            "prolific-stranger": _area_contributor(days_since_last_commit=1, implies_ownership=False),
+            "old-timer": _area_contributor(
+                days_since_last_commit=ACTIVITY_WINDOW_DAYS + 5, is_likely_owner_of_area=False
+            ),
+            "prolific-stranger": _area_contributor(days_since_last_commit=1, is_likely_owner_of_area=False),
         }
 
         scores = _score_candidates(weights, activity)
@@ -264,17 +266,17 @@ class TestAreaWalkUp:
         assert set(merged) == {"repo-regular"}
 
     @pytest.mark.parametrize(
-        ("contributor_count", "implies_ownership"),
+        ("contributor_count", "is_likely_owner_of_area"),
         [(MAX_CONTRIBUTORS_FOR_OWNERSHIP, True), (MAX_CONTRIBUTORS_FOR_OWNERSHIP + 1, False)],
     )
-    def test_ownership_needs_a_focused_area(self, team, contributor_count, implies_ownership):
+    def test_ownership_needs_a_focused_area(self, team, contributor_count, is_likely_owner_of_area):
         _seed_area(team, "products/tasks", [(f"dev-{i}", 3, 0) for i in range(contributor_count)])
 
         with patch("products.signals.backend.report_generation.resolve_reviewers._schedule_activity_rebuild"):
             merged = _relevant_area_activity(team.id, "acme/app", ["products/tasks/management/commands/demo.py"])
 
         assert len(merged) == contributor_count
-        assert all(contributor.implies_ownership is implies_ownership for contributor in merged.values())
+        assert all(contributor.is_likely_owner_of_area is is_likely_owner_of_area for contributor in merged.values())
 
     def test_fresher_crowded_commit_does_not_erase_focused_area_ownership(self, team):
         _seed_area(team, "products/signals", [("alice", 4, 10)])
@@ -293,8 +295,8 @@ class TestAreaWalkUp:
         assert merged["alice"].area == "*"
         assert merged["alice"].days_since_last_commit == pytest.approx(1, abs=0.01)
         # ...but the claim she earned in products/signals survives it.
-        assert merged["alice"].implies_ownership
-        assert not merged["dev-0"].implies_ownership
+        assert merged["alice"].is_likely_owner_of_area
+        assert not merged["dev-0"].is_likely_owner_of_area
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Human tldr: If a directory has more than 30 contributors, do not use it for "assigning this person to report as they look like an owner of the area" - those cases, e.g. `frontend/src` in PostHog - are way too noisy and not useful.

## Problem

Signals suggests reviewers, and when it has no live blame-based candidate it falls back to whoever is recently active in the report's area. The area comes from a fixed path prefix (`AREA_PATH_DEPTH = 2`), and when that area has no cached contributors the lookup walks up to its parent and then to the whole repository.

On a monorepo that walk-up lands somewhere useless. A report about `products/tasks/management/commands/generate_task_demo_data.py` gets a reviewer justified by ``Recently active in `products` `` - a directory with 151 distinct contributors in the last 90 days. Being one of them says nothing about who should review that file. #74970 narrowed *when* the fallback fires, but not *where* it draws from, so this case survives: the gate there only suppresses the fallback if a blame author happens to be in the same crowded contributor list.

## Changes

An area only implies ownership if it has at most `MAX_CONTRIBUTORS_FOR_OWNERSHIP` (30) recent contributors. Contributors from a crowded area still supply recency, so a departed blame author is still demoted, but they are no longer proposed as candidates in their own right.

Sizing, measured over the last 90 days of this repo:

| Area | Recent contributors | Implies ownership |
| --- | --- | --- |
| `products/notebooks`, `products/llm_analytics` | 19 | yes |
| `products/surveys`, `products/cdp`, `products/web_analytics` | 26-30 | yes |
| `products/tasks` | 48 | no |
| `posthog/api`, `frontend/src` | 110, 152 | no |
| `products`, `posthog`, repo-wide | 151, 151, 211 | no |

The threshold sits above a product-sized area and below a repo-sized one. It also degrades the right way for smaller teams, which matters more than the numbers above suggest: a repository with fewer than 30 active committers stays under the threshold at every level including repo-wide, so those teams keep the fallback everywhere. "Active in this repository lately" really is an ownership signal on a 20-person team. The gate only bites once an area is too big for that to be true.

> [!NOTE]
> On this repo the fallback will now go quiet for most reports, since ~80% of file touches land in an area above the threshold. That is the intent: those suggestions were noise. Reports still get blame-based reviewers, which are unaffected.

The second commit is a flyby readability pass on #74970's gate, no behavior change. It scored every candidate, then rebuilt the score dict to drop the activity-only ones, deciding via an inline closure. It now lives in `_score_candidates` where those candidates are created: score the weighted candidates, return early if one of them is still active, otherwise fall back to area contributors. The liveness check becomes a named `_is_active_in_area` helper.

## How did you test this code?

Automated tests only, run locally: `hogli test products/signals/backend/test/test_resolve_reviewers.py` (22 passed) plus `test_repo_activity.py`, and `uv run mypy --cache-fine-grained .` clean. No manual run of the pipeline.

Two new tests, each guarding a distinct regression no existing test covered:

- `test_ownership_needs_a_focused_area` - if the threshold is wired to the wrong list or the wrong constant, an area at the boundary flips. Parameterized on either side of it.
- `test_crowded_area_nominates_nobody_but_still_decays_blame` - if the gate were implemented by dropping crowded levels at lookup time (the obvious cheaper fix), blame decay would silently stop working. This pins both halves: nobody nominated, blame still decayed.

`test_recently_active_blame_author_beats_activity_only_contributor` asserted an ordering that #74970 made unobservable, since the bystander is no longer a candidate at all. Renamed and tightened to assert the stronger fact. The end-to-end tests from #74970 are untouched and green, which is what pins the refactor as behavior-preserving.

Also collapsed the near-duplicate `_AreaContributor` literals and the two copies of the area-seeding helper in that file, which is most of the line count in the test diff.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I asked Claude (Claude Code, Opus 5) to look into why our reports keep suggesting reviewers on the strength of ``Recently active in `products` ``, and to fix it. Skills invoked: `/writing-tests`, `/writing-code-comments`, `/simplify`.

Two other approaches were considered and dropped. Capping the walk-up by depth misfires in both directions, since `products/signals` and `frontend/src` are both depth-2 and only one is an ownership unit - breadth is the property that actually matters. Filtering crowded levels out at lookup time is a smaller diff, but it throws away the recency data blame decay needs, so a long-departed author would keep full weight.

Threshold started at 20 and moved to 30 after checking the contributor distribution per area: the 16-30 band is populated by real product areas with real owning teams, and those are exactly where the fallback does useful work.

One thing this does not fix: `AREA_PATH_DEPTH = 2` means `frontend/src/scenes/inbox/foo.ts` maps to area `frontend/src`, so the people who actually own `scenes/inbox` are never indexed as a level at all. Before this PR they lost to a `frontend/src` bystander; now nobody is suggested. The real fix is adaptive granularity - derive the area by splitting a directory while its contributor count exceeds this same threshold, which would collapse `AREA_PATH_DEPTH`, the fallback chain, and this gate into one concept. That is a rebuild-side change needing a migration story for cached maps, so it is deliberately not here.
