### PR TITLE
fix(warehouse-sources): isolate source module imports so one broken source can't take down the rest

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/__init__.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/__init__.py
@@ -1,8 +1,16 @@
+import importlib
+from pathlib import Path
 from typing import Any
+
+import structlog
+
+from posthog.exceptions_capture import capture_exception
 
 from .common.registry import SourceRegistry
 
 __all__ = ["SourceRegistry", "load_all_sources"]
+
+logger = structlog.get_logger(__name__)
 
 
 def load_all_sources() -> None:
@@ -12,16 +20,51 @@ def load_all_sources() -> None:
     doesn't drag every vendor SDK at app startup. Importing ``_load_all`` runs each
     source module's ``@SourceRegistry.register`` decorator. Idempotent — re-imports are
     cheap dict lookups in ``sys.modules``.
+
+    Best-effort: a source module that can't be imported is reported and skipped, leaving the
+    rest of the catalog usable.
     """
+    try:
+        _bulk_load()
+    except Exception:
+        # `_load_all` is one flat import list, so a single unimportable source module aborts it
+        # and leaves every later source unregistered — failing every sync and the whole sources
+        # UI rather than just the offending source. Import the rest individually so one broken
+        # vendor module costs only its own source.
+        logger.exception("load_all_sources: bulk import failed, falling back to per-source import")
+        for module_path in _source_module_paths():
+            _load_source(module_path)
+
+
+def _bulk_load() -> None:
     from . import _load_all  # noqa: F401, PLC0415
+
+
+def _source_module_paths() -> list[str]:
+    """Every source module `_load_all` imports, derived from the directory layout.
+
+    A test asserts this stays in step with `_load_all`'s import list.
+    """
+    package_dir = Path(__path__[0])
+    return sorted(f"{__name__}.{source.parent.name}.source" for source in package_dir.glob("*/source.py"))
+
+
+def _load_source(module_path: str) -> None:
+    try:
+        importlib.import_module(module_path)
+    except Exception as e:
+        logger.exception("load_all_sources: source module failed to import", module=module_path)
+        capture_exception(e)
 
 
 def __getattr__(name: str) -> Any:
     # Back-compat: source classes used to be re-exported here. Resolve them lazily so
     # `from ...sources import StripeSource` keeps working without eager-loading every SDK.
     # Guard private/dunder names (including `_load_all` itself) to avoid recursing through
-    # the very import we use to populate the namespace.
-    if name.startswith("_"):
+    # the very import we use to populate the namespace. Every re-exported class is a
+    # `*Source`, so anything else is an attribute probe (pytest looking for `pytest_plugins`,
+    # a `hasattr` check) that must not drag in 1200-odd vendor modules to answer.
+    if name.startswith("_") or not name.endswith("Source"):
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
     from . import _load_all  # noqa: PLC0415

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/registry.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/registry.py
@@ -20,8 +20,10 @@ class SourceRegistry:
         # on first registry use rather than at package import, so a process that never
         # touches the registry (most of them) doesn't pay for every vendor SDK at startup.
         # Double-checked lock: concurrent first-callers in a web worker must not observe a
-        # half-populated registry, and `_loaded` flips only after the import succeeds — so a
-        # failed load (e.g. a broken optional dependency) is retried rather than cached.
+        # half-populated registry, and `_loaded` flips only after the load returns — so a load
+        # that raises outright is retried rather than cached. A single source module that can't
+        # be imported is skipped by `load_all_sources`, leaving it absent here (and reported as
+        # an unknown type by `get_source`) rather than taking every other source down with it.
         if cls._loaded:
             return
         with cls._load_lock:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_source_loading.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tests/test_source_loading.py
@@ -1,0 +1,37 @@
+import ast
+from pathlib import Path
+
+from unittest.mock import patch
+
+from products.warehouse_sources.backend.temporal.data_imports.sources import _source_module_paths, load_all_sources
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+_SOURCES = "products.warehouse_sources.backend.temporal.data_imports.sources"
+
+
+def test_broken_source_module_does_not_block_the_rest_of_the_catalog():
+    with (
+        patch(f"{_SOURCES}._bulk_load", side_effect=ModuleNotFoundError("No module named 'gone'")),
+        patch(
+            f"{_SOURCES}._source_module_paths",
+            return_value=[f"{_SOURCES}.gone.source", f"{_SOURCES}.pypi.source"],
+        ),
+        patch(f"{_SOURCES}.capture_exception") as capture_exception,
+    ):
+        load_all_sources()
+
+    # Reads `_sources` rather than `get_all_sources()` so the assertion can't be satisfied by
+    # the real full load that `_ensure_loaded` would kick off.
+    assert ExternalDataSourceType.PYPI in SourceRegistry._sources
+    capture_exception.assert_called_once()
+
+
+def test_per_source_fallback_covers_every_source_the_bulk_import_loads():
+    bulk_import_list = ast.parse((Path(__file__).parent.parent / "_load_all.py").read_text())
+
+    assert set(_source_module_paths()) == {
+        f"{_SOURCES}.{node.module}"
+        for node in ast.walk(bulk_import_list)
+        if isinstance(node, ast.ImportFrom) and node.module
+    }


### PR DESCRIPTION
## Problem

`load_all_sources()` imports the whole source catalog through `_load_all`, which is a single flat list of 1265 `from .<vendor>.source import <Vendor>Source` lines. Python aborts a module on the first failing import, so one unimportable source module leaves *every* source unregistered.

Everything downstream of `SourceRegistry` then fails, no matter which source it is for:

- `GET /api/environments/:id/external_data_sources/wizard/` returns a bare `500 A server error occurred.`, so Data management → Sources will not load
- every running sync dies in `import_data_sync` / `external_data_job`, because those call `SourceRegistry.get_source()` and pay for the same all-or-nothing import

That is a 1265-way shared fate for a product where each source is otherwise independent. It happened today: two sources landed carrying an import of `...data_imports.pipelines.pipeline.typings`, a module that had moved to `...sources.common.typings` the day before. Both branches predated the move and merged without rebasing, so their own CI never saw the combination. The stale imports are already fixed in `e370063f`, but the amplification that turned two bad lines into a product-wide outage is still there.

## Changes

Keep the bulk import as the fast path. When it raises, fall back to importing module by module, reporting each failure through `capture_exception` so the broken source is visible in error tracking instead of silently missing.

A broken vendor module now costs only its own source. It is absent from the registry, `get_source()` reports it as an unknown type, and every other source keeps working.

```diff
 def load_all_sources() -> None:
-    from . import _load_all
+    try:
+        _bulk_load()
+    except Exception:
+        logger.exception("load_all_sources: bulk import failed, falling back to per-source import")
+        for module_path in _source_module_paths():
+            _load_source(module_path)
```

`_source_module_paths()` derives the list from the directory layout (`*/source.py`), which resolves to exactly the same 1265 modules `_load_all` imports. A test locks that equivalence in, since the fallback is only as complete as this enumeration and it would otherwise drift silently, only to be discovered during the next incident.

Second, smaller change in the same file: `__getattr__` resolved *any* non-underscore attribute by importing the entire catalog. All 1265 back-compat re-exports are `*Source`, so anything else is an attribute probe that should not cost 1200-odd vendor imports to answer. pytest probing packages for `pytest_plugins` was hitting this, which is also why it was the first thing to blow up while I was testing the fallback. Side effect: the new test file went from 13.9s to 1.0s once probes stopped pulling in every vendor SDK.

> [!NOTE]
> A source that cannot be imported is now missing rather than fatal, and its absence is reported to error tracking rather than raised at the call site. That is the intended trade: a scoped, visible failure over a total one.

## How did you test this code?

I (actually Claude) verified this by reproducing today's outage. With the exact stale import re-injected into `app_store_connect/source.py`:

<details>
<summary>Before vs after, same broken tree</summary>

```
RESULT OLD PATH (bulk import only): TOTAL FAILURE -> ModuleNotFoundError: No module named 'products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline'
RESULT NEW PATH: registered sources = 1264
RESULT AppStoreConnect registered: False
RESULT Stripe registered: True
```

</details>

Old path: nothing registers, so the wizard 500s and all syncs fail. New path: 1264 of 1265 register, only the genuinely broken source drops out, and Stripe (and everything else) syncs fine. That injected break and its scratch test were reverted before committing.

Automated, all run locally:

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/tests/` — 3828 passed
- `uv run mypy --cache-fine-grained .` repo-wide — `Success: no issues found in 17252 source files`
- `ruff check` and `ruff format --check` on the touched files

Two new tests, and the regression each catches:

- `test_broken_source_module_does_not_block_the_rest_of_the_catalog` — the outage itself. Fails if the fallback is dropped, or if it swallows failures without reporting them.
- `test_per_source_fallback_covers_every_source_the_bulk_import_loads` — fails if the glob enumeration and `_load_all` drift, which would make the fallback quietly under-register real sources.

I could not exercise the HTTP endpoint or a real sync end to end here: this sandbox has no Postgres or ClickHouse, so the DB-backed API tests do not run. The registry-level assertions above cover the shared code path all three surfaces go through.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel hit the 500 on the sources page and asked me to investigate. I traced it through PostHog error tracking to a `ModuleNotFoundError` on the wizard endpoint, then to the two source PRs that merged with stale imports against a module moved the day before. The import fix itself was already on master by then and just waiting on a deploy, so the interesting question became the one Daniel asked next: why does a broken App Store Connect module stop a Stripe sync at all?

Considered and rejected: adding a CI test that imports every source, which is the obvious guard but redundant here since sibling tests under `sources/tests/` already import `_load_all` at module scope. CI would have caught this on a rebased branch; the gap was a stale base, not missing coverage. So the useful change is runtime blast radius, not another test gate.

I chose a fallback over replacing `_load_all` with dynamic discovery outright. `_load_all` stays greppable and explicit, the healthy path keeps doing one bulk import, and enumeration cost is only paid when something is already broken. The drift test is what makes keeping two representations safe.

Skills invoked: the repo's `/writing-tests` and `/writing-code-comments` gates, plus the CLAUDE.md conventions for this product.
