### PR TITLE
chore(skills): fix dead dashboard uids in the monitoring skills

### DIFF
--- a/.agents/skills/monitoring-capture-service/SKILL.md
+++ b/.agents/skills/monitoring-capture-service/SKILL.md
@@ -186,19 +186,27 @@ Profile types: `process_cpu:cpu:nanoseconds:cpu:nanoseconds`,
 
 ### Grafana dashboards
 
-| UID                                    | Title                                                                    |
-| -------------------------------------- | ------------------------------------------------------------------------ |
-| `capture`                              | Capture (golden-chart backend overview)                                  |
-| `ddfkdj56ds11xce`                      | Capture Golden (Synced folder)                                           |
-| `dffkdlee8ub5s0a`                      | Ingestion - Capture Golden                                               |
-| `capture-3000-envoy-codes`             | Capture 3000 — Envoy Response Code Investigation                         |
-| `ingestion-general`                    | Cross-service ingestion overview                                         |
-| `ingestion-analytics`                  | Ingestion - Analytics (per-pipeline breakdown)                           |
-| `ingestion-reliability`                | Error rates and reliability signals                                      |
-| `ingestion-pipeline-performance`       | End-to-end pipeline latency                                              |
-| `b2348f37-f276-498e-b72e-7cc2b5ec1455` | New capture (legacy)                                                     |
-| `contour`                              | Envoy L7 proxy (set `envoy_cluster_name=posthog_capture-analytics_3000`) |
-| `ingestion-session-recordings`         | Session Replay ingestion                                                 |
+| UID                       | Title                      | Use for                                                                    |
+| ------------------------- | -------------------------- | -------------------------------------------------------------------------- |
+| `capture`                 | Capture                    | Overview across capture deployments — start here                           |
+| `capture-v1-details`      | V1 Details                 | Per-panel detail for the v1 pipeline (`/i/v1/analytics/events`)            |
+| `ddfkdj56ds11xce`         | Legacy Details             | Per-panel detail for the legacy v0 pipeline (`/e/`, `/batch/`, `/i/v0/e/`) |
+| `ingestion-health`        | Ingestion - Health         | Cross-service ingestion health                                             |
+| `ingestion-analytics`     | Ingestion - Analytics      | Downstream analytics pipeline, per lane                                    |
+| `ingestion-pipelines`     | Ingestion - Pipelines      | End-to-end pipeline throughput and lag                                     |
+| `ingestion-reliability`   | Ingestion - Reliability    | Ingested-event trends, processing-lag SLOs, pod restarts                   |
+| `ingestion-sessionreplay` | Ingestion - Session Replay | Session replay ingestion                                                   |
+| `contour`                 | Contour Ingress            | Envoy L7 proxy (set `envoy_cluster_name=posthog_capture-analytics_3000`)   |
+| `AWSRedis`                | AWS ElastiCache Redis      | Per-cluster CloudWatch Redis metrics (filter `cacheclusterId`)             |
+
+The two details boards live under `Capture/Ingestion/` and cross-link each other
+plus the overview. Sections for machinery shared by both pipelines (Global Rate
+Limiter, Event restrictions, Hyper server, Contour, billing/quota) appear on
+**both** details boards, so use whichever one you are already on.
+
+One board you will find via `search_dashboards` but should not rely on:
+`capture-3000-envoy-codes` is a personal, US-only Envoy investigation board (not
+synced to EU).
 
 ## Discovery workflows
 

--- a/.agents/skills/monitoring-ingestion-pipeline/SKILL.md
+++ b/.agents/skills/monitoring-ingestion-pipeline/SKILL.md
@@ -297,33 +297,31 @@ Profile types: `process_cpu:cpu:nanoseconds:cpu:nanoseconds`,
 
 ### Grafana dashboards
 
-| UID                                    | Title                                       | Focus                                                |
-| -------------------------------------- | ------------------------------------------- | ---------------------------------------------------- |
-| `ingestion-analytics`                  | Ingestion - Analytics                       | Per-pipeline analytics breakdown                     |
-| `ingestion-health`                     | Ingestion - Health                          | Health overview across all ingestion services        |
-| `ingestion-pipelines`                  | Ingestion - Pipelines                       | Per-lane pipeline step breakdown                     |
-| `ingestion-reliability`                | Ingestion - Reliability                     | Event trends, processing-lag SLOs, restarts, E2E lag |
-| `ingestion-person-processing`          | Ingestion -- Person Processing              | Person store, merge, cache                           |
-| `ingestion-group-processing`           | Ingestion -- Group Processing               | Group store                                          |
-| `ingestion-sessionreplay`              | Ingestion - Session Replay                  | Replay blob pipeline                                 |
-| `capture`                              | Capture                                     | Capture-side ingestion metrics (overview)            |
-| `cesaxfujkyl8gf`                       | Ingestion - Deduplication                   | Event deduplication pipeline                         |
-| `pl-ingestion-slas`                    | Ingestion — SLIs / SLOs / SLAs              | Dynamic SLI/SLO view from `ingestion_sli_*` metrics  |
-| `warpstream`                           | Warpstream Agent Overview                   | Agent health, control plane ops, file cache          |
-| `dbfj5c31spa1ogf`                      | MSK vs Warpstream — Active Produce Topics   | Side-by-side produce volume comparison               |
-| `8e93b023-a544-4a3b-8fac-123459d4eb84` | WarpStream: ClickHouse Consumer Lag         | CH consumer lag on WarpStream topics (US only)       |
-| `ws-coarse-lag-explore`                | WarpStream Coarse Lag — Explore             | Agent-reported lag (US only, personal dashboard)     |
-| `ceef2kuqw66tca`                       | Ingestion copy for warpstream               | Legacy WarpStream migration view                     |
-| `personhog-service`                    | Personhog service                           | PersonHog latency decomposition                      |
-| `dbfgkwxs3gw8owd`                      | KMinion Consumer Group Lag                  | Consumer lag by group (including CH groups)          |
-| `logs`                                 | Logs (product)                              | Logs ingestion                                       |
-| `vm-clickhouse-cluster-overview`       | ClickHouse (cluster overview)               | QPS, memory, disk, replication, parts, merges        |
-| `8aa35a4a-091a-4645-ac8f-ae46901f0060` | ClickHouse Ingestion Layer - Resource Usage | K8s resources for `chi-ingestion-*` pods             |
-| `ddpxkllwxg268e`                       | ClickHouse - Kafka consumption              | CH Kafka engine consumption stats                    |
-| `clickhouse-keeper`                    | ClickHouse Keeper                           | ZooKeeper replacement health                         |
-| `ef7h2todfg4xsd`                       | New ClickHouse Cluster Merge Overview       | Merge throughput                                     |
-| `cdzv7o1635n9ca`                       | Kafka Connect                               | Kafka Connect tasks, lag, DuckLake sink              |
-| `deoz13wy08wsga`                       | ClickHouse - Disk capacity (EU ONLY)        | EU-specific disk dashboard                           |
+| UID                                      | Title                                     | Focus                                                 |
+| ---------------------------------------- | ----------------------------------------- | ----------------------------------------------------- |
+| `ingestion-analytics`                    | Ingestion - Analytics                     | Per-pipeline analytics breakdown                      |
+| `ingestion-health`                       | Ingestion - Health                        | Health overview across all ingestion services         |
+| `ingestion-pipelines`                    | Ingestion - Pipelines                     | Per-lane pipeline step breakdown                      |
+| `ingestion-reliability`                  | Ingestion - Reliability                   | Event trends, processing-lag SLOs, restarts, E2E lag  |
+| `ingestion-person-processing`            | Ingestion -- Person Processing            | Person store, merge, cache                            |
+| `ingestion-group-processing`             | Ingestion -- Group Processing             | Group store                                           |
+| `ingestion-sessionreplay`                | Ingestion - Session Replay                | Replay blob pipeline                                  |
+| `capture`                                | Capture                                   | Capture-side ingestion metrics (overview)             |
+| `bexr9fnja75z4f`                         | Kafka Deduplicator                        | Event deduplication pipeline                          |
+| `pl-ingestion-slas`                      | Ingestion — SLIs / SLOs / SLAs            | SLI/SLO view from `ingestion_sli_*` metrics (US only) |
+| `warpstream`                             | Warpstream Agent Overview                 | Agent health, control plane ops, file cache           |
+| `dbfj5c31spa1ogf`                        | MSK vs Warpstream — Active Produce Topics | Side-by-side produce volume comparison                |
+| `8e93b023-a544-4a3b-8fac-123459d4eb84`   | WarpStream: ClickHouse Consumer Lag       | CH consumer lag on WarpStream topics (US only)        |
+| `ws-coarse-lag-explore`                  | WarpStream Coarse Lag — Explore           | Agent-reported lag (US only, personal dashboard)      |
+| `personhog-service`                      | Personhog service                         | PersonHog latency decomposition                       |
+| `dbfgkwxs3gw8owd`                        | KMinion Consumer Group Lag                | Consumer lag by group (including CH groups)           |
+| `logs`                                   | Logs (product)                            | Logs ingestion                                        |
+| `vm-clickhouse-cluster-overview`         | ClickHouse (cluster overview)             | QPS, memory, disk, replication, parts, merges         |
+| `clickhouse-ingestion-overview-20260615` | ClickHouse Ingestion Layer Overview       | Ingestion-layer CH cluster health and resources       |
+| `clickhouse-keeper`                      | ClickHouse Keeper                         | ZooKeeper replacement health                          |
+| `fe469e59-e10a-465a-9dac-ac8f6f82dc9a`   | ClickHouse Stuck Merge Loop Investigation | Merges that stop making progress                      |
+| `cdzv7o1635n9ca`                         | Kafka Connect                             | Kafka Connect tasks, lag, DuckLake sink               |
+| `fdrcd04np3hfkf`                         | ClickHouse - Kafka consumption            | CH Kafka engine consumption stats (EU only)           |
 
 ## Discovery workflows
 
@@ -382,7 +380,7 @@ Repeat with other prefixes: `consumed_batch_*`, `person_*`, `personhog_*`,
   **Important:** scope with `app_kubernetes_io_instance="kminion-warpstream-ingestion"` for the
   WarpStream path (primary) or `"kminion-msk-analytics"` for the MSK path.
 - Logs: `{namespace="clickhouse"} |= "Exception"` or `{namespace="kafka-connect"}`
-- Dashboards: `vm-clickhouse-cluster-overview`, `8aa35a4a-091a-4645-ac8f-ae46901f0060`,
+- Dashboards: `vm-clickhouse-cluster-overview`, `clickhouse-ingestion-overview-20260615`,
   `cdzv7o1635n9ca`, `8e93b023-a544-4a3b-8fac-123459d4eb84` (WarpStream CH consumer lag)
 
 ## Key metric domains

--- a/.agents/skills/monitoring-ingestion-pipeline/SKILL.md
+++ b/.agents/skills/monitoring-ingestion-pipeline/SKILL.md
@@ -297,36 +297,33 @@ Profile types: `process_cpu:cpu:nanoseconds:cpu:nanoseconds`,
 
 ### Grafana dashboards
 
-| UID                                    | Title                                       | Focus                                               |
-| -------------------------------------- | ------------------------------------------- | --------------------------------------------------- |
-| `ingestion-general`                    | Ingestion - General                         | Cross-service overview, E2E lag, topic flow         |
-| `ingestion-analytics`                  | Ingestion - Analytics                       | Per-pipeline analytics breakdown                    |
-| `ingestion-health`                     | Ingestion - Health                          | Health overview across all ingestion services       |
-| `ingestion-pipelines`                  | Ingestion - Pipelines                       | Per-lane pipeline step breakdown                    |
-| `ingestion-pipeline-performance`       | Ingestion - Pipeline Performance            | Step latency, batch utilization                     |
-| `ingestion-reliability`                | Ingestion - Reliability                     | Error rates, DLQ, drop causes                       |
-| `ingestion-autoscaling`                | Ingestion - Autoscaling                     | HPA/KEDA scaling                                    |
-| `ingestion-person-processing`          | Ingestion -- Person Processing              | Person store, merge, cache                          |
-| `ingestion-group-processing`           | Ingestion -- Group Processing               | Group store                                         |
-| `ingestion-session-recordings`         | Session Replay -- Ingestion                 | Replay blob pipeline                                |
-| `dffkdlee8ub5s0a`                      | Ingestion - Capture Golden                  | Capture-specific ingestion metrics (golden chart)   |
-| `cesaxfujkyl8gf`                       | Ingestion - Deduplication                   | Event deduplication pipeline                        |
-| `pl-ingestion-slas`                    | Ingestion — SLIs / SLOs / SLAs              | Dynamic SLI/SLO view from `ingestion_sli_*` metrics |
-| `warpstream`                           | Warpstream Agent Overview                   | Agent health, control plane ops, file cache         |
-| `dbfj5c31spa1ogf`                      | MSK vs Warpstream — Active Produce Topics   | Side-by-side produce volume comparison              |
-| `8e93b023-a544-4a3b-8fac-123459d4eb84` | WarpStream: ClickHouse Consumer Lag         | CH consumer lag on WarpStream topics (US only)      |
-| `ws-coarse-lag-explore`                | WarpStream Coarse Lag — Explore             | Agent-reported lag (US only, personal dashboard)    |
-| `ceef2kuqw66tca`                       | Ingestion copy for warpstream               | Legacy WarpStream migration view                    |
-| `personhog-service`                    | Personhog service                           | PersonHog latency decomposition                     |
-| `dbfgkwxs3gw8owd`                      | KMinion Consumer Group Lag                  | Consumer lag by group (including CH groups)         |
-| `logs`                                 | Logs (product)                              | Logs ingestion                                      |
-| `vm-clickhouse-cluster-overview`       | ClickHouse (cluster overview)               | QPS, memory, disk, replication, parts, merges       |
-| `8aa35a4a-091a-4645-ac8f-ae46901f0060` | ClickHouse Ingestion Layer - Resource Usage | K8s resources for `chi-ingestion-*` pods            |
-| `ddpxkllwxg268e`                       | ClickHouse - Kafka consumption              | CH Kafka engine consumption stats                   |
-| `clickhouse-keeper`                    | ClickHouse Keeper                           | ZooKeeper replacement health                        |
-| `ef7h2todfg4xsd`                       | New ClickHouse Cluster Merge Overview       | Merge throughput                                    |
-| `cdzv7o1635n9ca`                       | Kafka Connect                               | Kafka Connect tasks, lag, DuckLake sink             |
-| `deoz13wy08wsga`                       | ClickHouse - Disk capacity (EU ONLY)        | EU-specific disk dashboard                          |
+| UID                                    | Title                                       | Focus                                                |
+| -------------------------------------- | ------------------------------------------- | ---------------------------------------------------- |
+| `ingestion-analytics`                  | Ingestion - Analytics                       | Per-pipeline analytics breakdown                     |
+| `ingestion-health`                     | Ingestion - Health                          | Health overview across all ingestion services        |
+| `ingestion-pipelines`                  | Ingestion - Pipelines                       | Per-lane pipeline step breakdown                     |
+| `ingestion-reliability`                | Ingestion - Reliability                     | Event trends, processing-lag SLOs, restarts, E2E lag |
+| `ingestion-person-processing`          | Ingestion -- Person Processing              | Person store, merge, cache                           |
+| `ingestion-group-processing`           | Ingestion -- Group Processing               | Group store                                          |
+| `ingestion-sessionreplay`              | Ingestion - Session Replay                  | Replay blob pipeline                                 |
+| `capture`                              | Capture                                     | Capture-side ingestion metrics (overview)            |
+| `cesaxfujkyl8gf`                       | Ingestion - Deduplication                   | Event deduplication pipeline                         |
+| `pl-ingestion-slas`                    | Ingestion — SLIs / SLOs / SLAs              | Dynamic SLI/SLO view from `ingestion_sli_*` metrics  |
+| `warpstream`                           | Warpstream Agent Overview                   | Agent health, control plane ops, file cache          |
+| `dbfj5c31spa1ogf`                      | MSK vs Warpstream — Active Produce Topics   | Side-by-side produce volume comparison               |
+| `8e93b023-a544-4a3b-8fac-123459d4eb84` | WarpStream: ClickHouse Consumer Lag         | CH consumer lag on WarpStream topics (US only)       |
+| `ws-coarse-lag-explore`                | WarpStream Coarse Lag — Explore             | Agent-reported lag (US only, personal dashboard)     |
+| `ceef2kuqw66tca`                       | Ingestion copy for warpstream               | Legacy WarpStream migration view                     |
+| `personhog-service`                    | Personhog service                           | PersonHog latency decomposition                      |
+| `dbfgkwxs3gw8owd`                      | KMinion Consumer Group Lag                  | Consumer lag by group (including CH groups)          |
+| `logs`                                 | Logs (product)                              | Logs ingestion                                       |
+| `vm-clickhouse-cluster-overview`       | ClickHouse (cluster overview)               | QPS, memory, disk, replication, parts, merges        |
+| `8aa35a4a-091a-4645-ac8f-ae46901f0060` | ClickHouse Ingestion Layer - Resource Usage | K8s resources for `chi-ingestion-*` pods             |
+| `ddpxkllwxg268e`                       | ClickHouse - Kafka consumption              | CH Kafka engine consumption stats                    |
+| `clickhouse-keeper`                    | ClickHouse Keeper                           | ZooKeeper replacement health                         |
+| `ef7h2todfg4xsd`                       | New ClickHouse Cluster Merge Overview       | Merge throughput                                     |
+| `cdzv7o1635n9ca`                       | Kafka Connect                               | Kafka Connect tasks, lag, DuckLake sink              |
+| `deoz13wy08wsga`                       | ClickHouse - Disk capacity (EU ONLY)        | EU-specific disk dashboard                           |
 
 ## Discovery workflows
 
@@ -356,7 +353,7 @@ Repeat with other prefixes: `consumed_batch_*`, `person_*`, `personhog_*`,
 ### Dashboards
 
 1. `search_dashboards` — query `"ingestion"` or `"clickhouse"` or a specific deployment name
-2. `get_dashboard_by_uid` — use a known UID (e.g. `"ingestion-general"`) to get panel details
+2. `get_dashboard_by_uid` — use a known UID (e.g. `"ingestion-health"`) to get panel details
 3. `get_dashboard_panel_queries` — extract PromQL from existing panels
 
 ### Redis / ElastiCache

--- a/.agents/skills/monitoring-ingestion-pipeline/references/investigation-playbooks.md
+++ b/.agents/skills/monitoring-ingestion-pipeline/references/investigation-playbooks.md
@@ -7,7 +7,7 @@ construct PromQL live using the discovery workflow from the main skill doc.
 ## 1. "Is ingestion healthy?" — quick health check
 
 Start by pulling up the main dashboard:
-`get_dashboard_by_uid` with uid `"ingestion-general"`.
+`get_dashboard_by_uid` with uid `"ingestion-health"`.
 
 Then verify these signals in order:
 
@@ -195,7 +195,7 @@ Then check infrastructure health:
 
 ## 9. "Session replay ingestion issues" — replay pipeline
 
-1. **Replay-specific dashboard** — `get_dashboard_by_uid` with uid `"ingestion-session-recordings"`.
+1. **Replay-specific dashboard** — `get_dashboard_by_uid` with uid `"ingestion-sessionreplay"`.
 2. **Consumer lag** — `kminion_kafka_consumer_group_topic_lag_seconds{group_id="session-recordings-blob-v2"}`.
 3. **Replay metrics** — `list_prometheus_metric_names` regex `"recording_blob_ingestion_v2_.*"`.
    Key: batch size, S3 upload latency, session manager operations.

--- a/.agents/skills/monitoring-ingestion-pipeline/references/investigation-playbooks.md
+++ b/.agents/skills/monitoring-ingestion-pipeline/references/investigation-playbooks.md
@@ -226,7 +226,7 @@ ClickHouse lag means users see stale data even if ingestion workers are healthy.
 4. **Part count growth** — `ClickHouseAsyncMetrics_MaxPartCountForPartition{type="events"}`.
    Rising steadily = merge thread can't keep up with insert rate.
    CH hard-limits at 300 parts per partition — approaching this causes insert rejects.
-   Dashboard: `ef7h2todfg4xsd` (merge overview).
+   Dashboard: `fe469e59-e10a-465a-9dac-ac8f6f82dc9a` (stuck merge loop investigation).
 
 5. **Merge pressure** — `ClickHouseMetrics_BackgroundMergesAndMutationsPoolTask{type="events"}`.
    Compare to pool size. Also `ClickHouseProfileEvents_MergedRows` rate.
@@ -243,7 +243,7 @@ ClickHouse lag means users see stale data even if ingestion workers are healthy.
    and `ducklake_errant_record_count` for DLQ'd records.
    Dashboard: `cdzv7o1635n9ca` (Kafka Connect).
 
-9. **CH ingestion pod resources** — dashboard `8aa35a4a-091a-4645-ac8f-ae46901f0060`.
+9. **CH ingestion pod resources** — dashboard `clickhouse-ingestion-overview-20260615`.
    CPU throttling, memory pressure, disk usage on `chi-ingestion-*` pods in the
    `clickhouse` namespace.
 
@@ -323,9 +323,10 @@ For cross-environment comparison:
 
 1. **Same queries, different Grafana** — run the same PromQL against both environments
    by switching the Grafana MCP connection (requires a new session).
-2. **Dashboard UIDs are synced** — all dashboards above exist in both environments
-   with the same UIDs (deployed from shared `Synced` folder).
-   Exception: `deoz13wy08wsga` (ClickHouse disk capacity EU ONLY).
+2. **Dashboard UIDs are mostly synced** — boards from the shared `Synced` folder carry the
+   same UID in both environments. The exceptions are boards that live in a personal or
+   team folder: `pl-ingestion-slas`, `8e93b023-a544-4a3b-8fac-123459d4eb84` and
+   `ws-coarse-lag-explore` are US only, `fdrcd04np3hfkf` is EU only.
 3. **Label values are identical** — `ingestion_pipeline`, `ingestion_lane`, ClickHouse `type`
    values are the same across envs.
 4. **CloudWatch cluster IDs differ** — use the env-specific names from the topology sections:


### PR DESCRIPTION
## Problem

The capture and ingestion monitoring skills carry tables of Grafana dashboard uids, and an agent following either one calls `get_dashboard_by_uid` on them first. Eleven of those uids 404 in prod-us and prod-eu, so the first tool call in the investigation dead-ends. The capture table also predated [grafana-dashboards#337](https://github.com/PostHog/grafana-dashboards/pull/337): it named the legacy details board "Capture Golden" and did not list the v1 details board at all.

## Changes

Checked every uid in both tables against `/api/dashboards/uid` in both regions, then replaced or dropped the dead ones.

Capture table: Legacy Details and V1 Details are now named as they appear in Grafana, with a note that the sections for machinery shared by both pipelines appear on both boards, and that `capture-3000-envoy-codes` is a personal US-only board. The Contour row records that the envoy cluster name is `posthog_capture-analytics_3000`.

Ingestion table, dead in both regions:

| Was | Now |
| --- | --- |
| `ingestion-general`, `ingestion-pipeline-performance`, `ingestion-session-recordings`, `ingestion-autoscaling`, `dffkdlee8ub5s0a` | the boards that carry that content today |
| `cesaxfujkyl8gf` (Ingestion - Deduplication) | `bexr9fnja75z4f`, Kafka Deduplicator |
| `8aa35a4a-091a-4645-ac8f-ae46901f0060` (CH Ingestion Layer - Resource Usage) | `clickhouse-ingestion-overview-20260615` |
| `ef7h2todfg4xsd` (New CH Cluster Merge Overview) | `fe469e59-e10a-465a-9dac-ac8f6f82dc9a`, Stuck Merge Loop Investigation |
| `ddpxkllwxg268e` (CH - Kafka consumption) | `fdrcd04np3hfkf`, EU only |
| `ceef2kuqw66tca` (Ingestion copy for warpstream), `deoz13wy08wsga` (CH disk capacity) | dropped |

The last two are dropped rather than replaced: the first was a WarpStream migration-era view, and the second no longer exists in the one region it was labeled for.

The cross-environment section claimed every board carries the same uid in both regions with a single exception. That is wrong in both directions, so it now names the real ones: `pl-ingestion-slas`, `8e93b023-a544-4a3b-8fac-123459d4eb84` and `ws-coarse-lag-explore` resolve in prod-us only, `fdrcd04np3hfkf` in prod-eu only. Each sits in a personal or team folder rather than `Synced`, which is why the pattern holds for everything else.

> [!NOTE]
> The replacement boards were matched by title and confirmed to resolve in both regions. Their panel content was not audited beyond the title, so a follow-up may want to retitle a row if the closest live board turns out to cover less than the old one did.

## How did you test this code?

No automated tests. These are skill markdown files.

Every uid in both tables was fetched from `/api/dashboards/uid/<uid>` in prod-us and prod-eu, and replacements were found through `/api/search` by title and confirmed to resolve in both regions. The playbook references to the removed uids were updated too, so nothing in either skill points at a 404 any more.

I have not run an agent end to end through either skill against live Grafana.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Cursor agent (Claude), directed by me, using the Grafana MCP server (`get_dashboard_property`, `search_dashboards`, `query_prometheus`) and the Grafana HTTP API over Tailscale for the bulk uid sweep. No repo skills were invoked; this is documentation for agents rather than code.

This started as a fix for the capture table after the details boards moved. The first pass only verified the uids it removed, which left six more dead ones a few rows down, so the second pass checked every uid in both tables instead of the ones that looked suspect. Worth remembering for the next edit: a board disappearing is not visible from the table itself.

Companion PR [runbooks#585](https://github.com/PostHog/runbooks/pull/585) covers the human-facing docs for the same boards.
