### PR TITLE
feat(personhog): steer placement away from old-generation pods during rollouts

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8527,6 +8527,8 @@ dependencies = [
  "envconfig",
  "foyer",
  "health",
+ "k8s-awareness",
+ "kube",
  "lifecycle",
  "metrics",
  "personhog-common",

--- a/rust/common/k8s-awareness/src/watcher.rs
+++ b/rust/common/k8s-awareness/src/watcher.rs
@@ -66,6 +66,19 @@ impl K8sAwareness {
         Ok(pod_info)
     }
 
+    /// Start watching a controller known by reference — the entry point
+    /// for consumers that learn controllers from member registrations
+    /// rather than pod-name discovery (the coordinator sees each pod's
+    /// self-reported controller ref and has no pod of its own to
+    /// discover from). Idempotent: an already-watched controller is a
+    /// no-op.
+    pub async fn watch_controller(
+        &self,
+        controller: &ControllerRef,
+    ) -> Result<(), K8sAwarenessError> {
+        self.ensure_watching(controller).await
+    }
+
     /// Classify why a member is departing based on its controller's current intent.
     ///
     /// Returns `DepartureReason::Unknown` if the controller isn't being watched

--- a/rust/personhog-coordination/src/coordinator.rs
+++ b/rust/personhog-coordination/src/coordinator.rs
@@ -1322,6 +1322,22 @@ async fn filter_pods_for_k8s(
             continue;
         }
 
+        // Lazily start the controller watch from the registration's own
+        // ref — the coordinator has no pod of its own to discover from,
+        // and without a watch `classify_departure` has no intent to
+        // consult. Idempotent, so calling per evaluation is cheap; the
+        // first evaluation after a watch starts may still classify
+        // Unknown, which safely leaves the pod active until intent
+        // arrives.
+        if let Err(e) = k8s.watch_controller(controller).await {
+            tracing::warn!(
+                controller = %controller,
+                error = %e,
+                "failed to start controller watch; treating pod as active"
+            );
+            continue;
+        }
+
         let reason = k8s.classify_departure(controller, generation).await;
 
         match (&controller.kind, pod.status, reason) {

--- a/rust/personhog-coordination/tests/k3s_integration.rs
+++ b/rust/personhog-coordination/tests/k3s_integration.rs
@@ -473,14 +473,27 @@ async fn deployment_rollout_reassigns_partitions() {
 
     tokio::time::sleep(Duration::from_secs(3)).await;
 
-    // Set up etcd store and coordination
+    // Set up etcd store and coordination. The coordinator gets its own
+    // fresh K8sAwareness — NOT the instance the test scaffolding already
+    // primed with discover_controller above — so this test exercises the
+    // production bootstrap path: the coordinator must start controller
+    // watches itself, lazily, from the refs pods carry in their
+    // registrations. Sharing the scaffolding instance would mask a
+    // coordinator that never starts watches (classify would keep
+    // answering from the scaffolding's watch, which is exactly how this
+    // gap previously escaped the suite).
     let store = test_store("deploy-rollout-k3s").await;
     store.set_total_partitions(NUM_PARTITIONS).await.unwrap();
 
+    let coordinator_awareness = Arc::new(K8sAwareness::new(
+        k8s_client.clone(),
+        NAMESPACE.to_string(),
+        k8s_cancel.clone(),
+    ));
     let cancel = CancellationToken::new();
     let _coord = start_coordinator_k8s(
         Arc::clone(&store),
-        Some(Arc::clone(&awareness)),
+        Some(coordinator_awareness),
         cancel.clone(),
     );
     let _router = start_router(Arc::clone(&store), "router-0", cancel.clone());

--- a/rust/personhog-leader/Cargo.toml
+++ b/rust/personhog-leader/Cargo.toml
@@ -13,6 +13,8 @@ common-kafka = { path = "../common/kafka" }
 common-ingestion-warnings = { path = "../common/ingestion_warnings" }
 common-metrics = { path = "../common/metrics" }
 common-alloc = { path = "../common/alloc" }
+k8s-awareness = { path = "../common/k8s-awareness" }
+kube = { version = "0.98", features = ["client"] }
 lifecycle = { path = "../common/lifecycle" }
 
 async-trait = { workspace = true }
@@ -28,6 +30,7 @@ rdkafka = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/rust/personhog-leader/src/config.rs
+++ b/rust/personhog-leader/src/config.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -229,6 +230,20 @@ pub struct Config {
     #[envconfig(default = "")]
     pub pod_ip: String,
 
+    /// Enable K8s awareness: at startup the leader discovers its owning
+    /// controller (Deployment) and generation (pod-template-hash) and
+    /// registers them, so the coordinator can steer placement away from
+    /// old-generation pods during rollouts instead of handing partitions
+    /// to pods that are about to be replaced. Requires RBAC to read
+    /// pods, replicasets, and deployments in the pod's namespace.
+    #[envconfig(default = "false")]
+    pub k8s_awareness_enabled: bool,
+
+    /// Kubernetes namespace for controller discovery. If empty,
+    /// auto-reads from the service account mount.
+    #[envconfig(default = "")]
+    pub k8s_namespace: String,
+
     #[envconfig(default = "30")]
     pub lease_ttl: i64,
 
@@ -271,6 +286,18 @@ impl Config {
 
     pub fn heartbeat_interval(&self) -> Duration {
         Duration::from_secs(self.heartbeat_interval_secs)
+    }
+
+    /// Resolve the K8s namespace from config or the service account mount.
+    pub fn resolve_k8s_namespace(&self) -> Result<String, String> {
+        if !self.k8s_namespace.is_empty() {
+            return Ok(self.k8s_namespace.clone());
+        }
+        fs::read_to_string("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+            .map(|s| s.trim().to_string())
+            .map_err(|e| {
+                format!("k8s_namespace not set and failed to read from service account: {e}")
+            })
     }
 }
 

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -7,12 +7,15 @@ use common_kafka::kafka_producer::create_kafka_producer;
 use common_metrics::setup_metrics_routes;
 use dashmap::DashMap;
 use envconfig::Envconfig;
+use k8s_awareness::{K8sAwareness, PodInfo};
+use kube::Client;
 use lifecycle::{ComponentOptions, Manager};
 use personhog_common::async_gzip::{AsyncGzipConfig, AsyncGzipLayer};
 use personhog_common::grpc::{tracked_tcp_incoming, GrpcLoadShedLayer, GrpcMetricsLayer};
 use personhog_coordination::pod::{PodConfig, PodHandle};
 use personhog_coordination::store::PersonhogStore;
 use personhog_proto::personhog::leader::v1::person_hog_leader_server::PersonHogLeaderServer;
+use tokio_util::sync::CancellationToken;
 use tonic::codec::CompressionEncoding;
 use tonic::transport::Server;
 use tracing::level_filters::LevelFilter;
@@ -253,8 +256,37 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("Invalid advertise address configuration");
     tracing::info!(%advertise_address, "advertising gRPC address for routing");
 
+    // Discover this pod's owning controller and generation so the
+    // coordinator can steer placement away from old-generation pods
+    // during rollouts. Fail-open: without the discovery the leader
+    // registers exactly as before and only loses rollout awareness.
+    let (controller, generation, k8s_awareness) = if config.k8s_awareness_enabled {
+        match discover_own_controller(&config, coordination_handle.shutdown_token()).await {
+            Ok((awareness, info)) => {
+                tracing::info!(
+                    controller = %info.controller,
+                    generation = %info.generation,
+                    "K8s awareness enabled; controller discovered"
+                );
+                (Some(info.controller), info.generation, Some(awareness))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "K8s awareness enabled but controller discovery failed; \
+                     registering without rollout awareness"
+                );
+                (None, String::new(), None)
+            }
+        }
+    } else {
+        (None, String::new(), None)
+    };
+
     let pod_config = PodConfig {
         pod_name: config.pod_name.clone(),
+        generation,
+        controller,
         lease_ttl: config.lease_ttl,
         heartbeat_interval: config.heartbeat_interval(),
         advertise_address: Some(advertise_address),
@@ -277,7 +309,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 
-    let pod = PodHandle::new(store, pod_config, Arc::new(handler), None);
+    let pod = PodHandle::new(store, pod_config, Arc::new(handler), k8s_awareness);
 
     tokio::spawn(async move {
         let _guard = coordination_handle.process_scope();
@@ -450,4 +482,23 @@ async fn run_dirty_index_prune_loop(
             .set(lag as f64);
         }
     }
+}
+
+/// Build a K8s awareness client and discover this pod's owning controller
+/// and generation. The awareness handle is returned alongside so the pod
+/// can also classify its own departure at drain time.
+async fn discover_own_controller(
+    config: &Config,
+    cancel: CancellationToken,
+) -> Result<(Arc<K8sAwareness>, PodInfo), String> {
+    let namespace = config.resolve_k8s_namespace()?;
+    let client = Client::try_default()
+        .await
+        .map_err(|e| format!("failed to create K8s client: {e}"))?;
+    let awareness = Arc::new(K8sAwareness::new(client, namespace, cancel));
+    let info = awareness
+        .discover_controller(&config.pod_name)
+        .await
+        .map_err(|e| format!("controller discovery failed: {e}"))?;
+    Ok((awareness, info))
 }

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -15,6 +15,7 @@ use personhog_common::grpc::{tracked_tcp_incoming, GrpcLoadShedLayer, GrpcMetric
 use personhog_coordination::pod::{PodConfig, PodHandle};
 use personhog_coordination::store::PersonhogStore;
 use personhog_proto::personhog::leader::v1::person_hog_leader_server::PersonHogLeaderServer;
+use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 use tonic::codec::CompressionEncoding;
 use tonic::transport::Server;
@@ -258,11 +259,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Discover this pod's owning controller and generation so the
     // coordinator can steer placement away from old-generation pods
-    // during rollouts. Fail-open: without the discovery the leader
-    // registers exactly as before and only loses rollout awareness.
+    // during rollouts. Fail-open, and bounded: this runs before the pod
+    // handle and gRPC server exist, so an unresponsive API server must
+    // cost a few seconds of startup at worst — never availability.
     let (controller, generation, k8s_awareness) = if config.k8s_awareness_enabled {
-        match discover_own_controller(&config, coordination_handle.shutdown_token()).await {
-            Ok((awareness, info)) => {
+        let discovery = discover_own_controller(&config, coordination_handle.shutdown_token());
+        match timeout(K8S_DISCOVERY_TIMEOUT, discovery).await {
+            Ok(Ok((awareness, info))) => {
                 tracing::info!(
                     controller = %info.controller,
                     generation = %info.generation,
@@ -270,10 +273,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 );
                 (Some(info.controller), info.generation, Some(awareness))
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 tracing::warn!(
                     error = %e,
                     "K8s awareness enabled but controller discovery failed; \
+                     registering without rollout awareness"
+                );
+                (None, String::new(), None)
+            }
+            Err(_) => {
+                tracing::warn!(
+                    timeout = ?K8S_DISCOVERY_TIMEOUT,
+                    "K8s awareness enabled but controller discovery timed out; \
                      registering without rollout awareness"
                 );
                 (None, String::new(), None)
@@ -483,6 +494,11 @@ async fn run_dirty_index_prune_loop(
         }
     }
 }
+
+/// How long startup may spend on controller discovery before falling
+/// open. Generous against a healthy API server (three small reads);
+/// tight against an unresponsive one, which must not delay serving.
+const K8S_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Build a K8s awareness client and discover this pod's owning controller
 /// and generation. The awareness handle is returned alongside so the pod


### PR DESCRIPTION
## Problem

The coordinator has rollout awareness built in: `filter_pods_for_k8s` excludes old-generation Deployment pods from placement, so partitions move to surviving pods before the kubelet kills anything, instead of being handed to pods that are about to be replaced (the `dead_new_owner` mid-warm cancellations we see on every deploy). The machinery is complete and k3s-tested — and has never once engaged in a real cluster, for two reasons:                                                                                                                                                                           

  1. Leaders never report who owns them. `PodConfig.controller`/`generation` documented the intent ("Populated via K8s awareness before registration") but no binary ever populated them, so the filter skipped every pod.
  2. Nothing production-side ever started a controller watch. `discover_controller` is only called from the k3s tests, and `classify_departure` answers Unknown for unwatched controllers. The k3s rollout test masked this by priming the coordinator's awareness instance from test scaffolding.

## Changes

  - The leader discovers its own controller at startup (pod -> ReplicaSet -> Deployment walk from the chart-injected `POD_NAME`) behind a new `K8S_AWARENESS_ENABLED` flag, and registers the controller ref plus pod-template-hash. Fail-open: any discovery error logs a warning and registers exactly as today. The awareness handle also flows into `PodHandle`, activating its existing drain-time departure classification.
  - The awareness crate gains a public `watch_controller` (thin wrapper over the private `ensure_watching`) for consumers that learn controllers from member registrations rather than pod-name discovery.
  - The coordinator calls it lazily in `filter_pods_for_k8s` for each registered controller — idempotent, fail-open (watch error leaves the pod active).
  - The k3s rollout test now hands the coordinator a fresh awareness instance instead of the scaffolding-primed one, so the suite exercises the production bootstrap path and would have caught this gap.

The chart side (env flag + RBAC) ships separately in the charts repo; this change is inert until that lands.

## How did you test this code?

The modified k3s test is the regression guard: with the coordinator's lazy watch call removed it fails (old-generation pods are never excluded and the rollout times out at 132s); with it, it passes in 42s — I (or, actually Claude) verified both directions via a scratch-copy revert. Full `personhog-coordination` suites (41 + 52), `k8s-awareness` suites (25), and clippy with `-D warnings` across all touched crates are green.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session, follow-on from the deploy-window investigation: after fixing SIGTERM delivery and freeze liveness, the remaining deploy cost was handoffs targeting pods scheduled for replacement. Investigation found this exact feature fully built but unwired at both ends, and found the router-leader's chart half (namespace + cross-namespace RBAC) already merged and dormant. The `/writing-tests` discipline shaped the test change: rather than adding a new k3s case, the existing one was fixed to stop masking the production path, and red-checked.