### PR TITLE
fix(endpoints): check access to the query's tables before materializing

### DIFF
--- a/products/endpoints/backend/logic/validation.py
+++ b/products/endpoints/backend/logic/validation.py
@@ -22,6 +22,7 @@ from posthog.hogql.errors import ExposedHogQLError, ResolutionError
 from posthog.hogql.parser import parse_select
 from posthog.hogql.printer import prepare_ast_for_printing
 from posthog.hogql.variables import replace_variables
+from posthog.hogql.visitor import CloningVisitor
 
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team, User
@@ -290,8 +291,51 @@ def validate_endpoint_request(data: EndpointRequest, team: Team, user: User, str
         sync_hogql_query_variables(query, team)
         validate_hogql_query(query, team, user)
 
+    if data.is_materialized is True and query is not None:
+        assert_user_can_materialize(query.model_dump(), team, user)
+
     validate_data_freshness(data.data_freshness_seconds)
     validate_optional_breakdown_properties(data.optional_breakdown_properties, query)
+
+
+class _NeutralizePlaceholders(CloningVisitor):
+    """Replace {variables.x} placeholders with NULL so the query resolves without the variable
+    machinery. Access depends on what the query reads, not on variable values - and stored
+    endpoints can carry legacy non-UUID variable ids that the substitution path chokes on."""
+
+    def visit_placeholder(self, node: ast.Placeholder) -> ast.Expr:
+        return ast.Constant(value=None)
+
+
+def assert_user_can_materialize(query: dict | None, team: Team, user: User) -> None:
+    """Materialized results are produced by a userless run and then served under the endpoint's own
+    access rules, so whoever turns materialization on must be able to read everything the query
+    reads. Resolves the query as the requester - structured kinds (Trends, Lifecycle, Retention)
+    are first converted to HogQL the same way the materialization workflow converts them.
+    """
+    from products.endpoints.backend.materialization_transforms import (
+        build_endpoint_hogql,  # noqa: PLC0415 — keeps the heavy conversion pipeline off this module's import path
+    )
+
+    if not query:
+        return  # a missing query is rejected by the callers' own validation
+
+    if query.get("kind") != "HogQLQuery":
+        query = build_endpoint_hogql(query, team, user=user)
+
+    sql = query.get("query")
+    if not isinstance(sql, str) or not sql.strip():
+        return
+
+    node = _NeutralizePlaceholders().visit(parse_select(sql))
+    context = HogQLContext(team_id=team.pk, user=user, enable_select_queries=True)
+    try:
+        # Resolution is where table and view access is enforced, so this doesn't need to print.
+        prepare_ast_for_printing(node=node, context=context, dialect="clickhouse")
+    except (ExposedHogQLError, ResolutionError) as err:
+        # Surfaces "You don't have access to table `X`." for a denial; a query that no longer
+        # resolves also can't be safely published, so it's refused the same way.
+        raise ValidationError({"query": f"Cannot materialize endpoint: {err}"}) from err
 
 
 def validate_update_request(
@@ -320,6 +364,7 @@ def validate_update_request(
             can_materialize, reason = can_materialize_query(effective_query)
             if not can_materialize:
                 raise ValidationError(f"Cannot materialize endpoint. Reason: {reason}")
+            assert_user_can_materialize(effective_query, team, user)
 
     if data.query and isinstance(data.query, HogQLQuery) and data.query.query:
         sync_hogql_query_variables(data.query, team)

--- a/products/endpoints/backend/tests/test_endpoint_materialization.py
+++ b/products/endpoints/backend/tests/test_endpoint_materialization.py
@@ -2325,3 +2325,78 @@ class TestEndpointMaterializationTemporal:
         schedule = await sync_to_async(get_saved_query_schedule)(saved_query)
         assert len(schedule.spec.calendars) == 1
         assert schedule.spec.jitter == timedelta(hours=1)
+
+
+@pytest.mark.ee
+@mock.patch("posthoganalytics.feature_enabled", new=mock.Mock(return_value=True))
+class TestMaterializationRequiresUnderlyingAccess(APIBaseTest):
+    """Enabling materialization publishes the query's rows under the endpoint's own access rules,
+    so it has to be gated on the requester's access to what the query reads - a payload that only
+    flips the flag never reaches the query validators."""
+
+    def setUp(self):
+        super().setUp()
+        from posthog.constants import AvailableFeature
+        from posthog.models.organization import OrganizationMembership
+
+        from products.warehouse_sources.backend.facade.models import DataWarehouseCredential, DataWarehouseTable
+
+        from ee.models.rbac.access_control import AccessControl
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+        ]
+        self.organization.save()
+
+        credential = DataWarehouseCredential.objects.create(access_key="key", access_secret="secret", team=self.team)
+        self.table = DataWarehouseTable.objects.create(
+            name="restricted_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=credential,
+            url_pattern="s3://bucket/restricted/*",
+            columns={"id": "String"},
+        )
+        # Authored by someone who could read the table; the restricted user only flips the flag.
+        self.endpoint = create_endpoint_with_version(
+            name="over_restricted_table",
+            team=self.team,
+            query={"kind": "HogQLQuery", "query": "select id from restricted_table"},
+            created_by=self.user,
+            is_active=True,
+        )
+        self.denied_user = self._create_user("denied@posthog.com")
+        membership = OrganizationMembership.objects.get(user=self.denied_user, organization=self.organization)
+        AccessControl.objects.create(
+            team=self.team,
+            resource="warehouse_table",
+            resource_id=str(self.table.id),
+            access_level="none",
+            organization_member=membership,
+        )
+        self.client.force_login(self.denied_user)
+
+    def _toggle(self):
+        return self.client.patch(
+            f"/api/environments/{self.team.id}/endpoints/{self.endpoint.name}/",
+            {"is_materialized": True},
+            format="json",
+        )
+
+    def test_toggle_denied_when_the_query_reads_a_denied_table(self):
+        # 400 rather than 403 to match how the create path reports a denied query.
+        response = self._toggle()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("access", str(response.json()))
+        version = self.endpoint.versions.first()
+        self.assertIsNone(version.saved_query)
+
+    def test_toggle_allowed_without_a_table_denial(self):
+        from ee.models.rbac.access_control import AccessControl
+
+        AccessControl.objects.all().delete()
+
+        response = self._toggle()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
## Problem

A materialized endpoint serves stored rows under the endpoint's own access rules - the underlying tables are no longer part of the query at read time. So enabling materialization publishes whatever the query reads.

The query is access-checked when it's written: create and query-updates resolve it under the author's access control and refuse on a denied table. But a payload that only flips the flag never reaches that check:

```
PATCH /endpoints/<name>/  {"is_materialized": true}
```

runs only `can_materialize_query`, which checks whether the query *type* is materializable, never who's asking. A teammate denied a warehouse table can take an existing endpoint over it, toggle materialization, and read the result.

This is the endpoints sibling of #75758, which closes the same gap for data-warehouse views. It's a separate PR because the fix here had to clear two obstacles specific to this product.

## Changes

One check, `assert_user_can_materialize`, applied at both doors that can turn materialization on - `validate_endpoint_request` (create) and `validate_update_request` (the toggle). It resolves the query as the requester; resolution is where table and view access is enforced, so a denied table fails it with the standard access error. Denials report as 400 with the same shape the create path already uses for a denied query.

The two obstacles, and how they're handled:

**Endpoints aren't always HogQL.** `can_materialize_query` also admits Trends, Lifecycle, and Retention - and a `TrendsQuery` can read warehouse tables through a `DataWarehouseNode`. A HogQL-only check would leave those open. Structured kinds are converted to HogQL first, using the same `build_endpoint_hogql` pipeline the materialization workflow itself runs, so the check resolves exactly what materialization would execute.

**Stored endpoints can carry legacy non-UUID variable ids.** The existing variable-substitution path (`replace_variables`) raises on them, which is why the naive fix 500s. The check sidesteps variables entirely: placeholders are neutralized to `NULL` before resolving, because access depends on what the query *reads*, not on variable values. A placeholder can't name a table, so nothing access-relevant is lost.

> [!NOTE]
> Not touched here: converging `_validate_query_access` (this file's write-path check) onto `posthog/rbac/query_access.py` from #75758. Worth doing, but it changes tested write-path behavior and belongs in its own change.

## How did you test this code?

Automated only. I did not exercise this in a running stack.

Two tests in `TestMaterializationRequiresUnderlyingAccess`: the toggle is refused with a 400 for a user denied a table the endpoint's query reads (and writes nothing: no saved query is created), and succeeds once the denial is removed. The denied case failed against the unfixed code, so it demonstrably exercises the gap. Warehouse access control is feature-flagged, so the class forces the flag on.

Full runs, all green:

- `products/endpoints/backend/tests/` - 711 passed, including the stored-variable fixtures that broke the naive versions of this fix
- `uv run mypy --cache-fine-grained .` - clean, 17,259 files
- `ruff check` / `ruff format --check`, `tach check --dependencies --interfaces`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. No user-facing surface changes; a user who could already materialize an endpoint still can.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while auditing materialization doors for #75758. Three earlier attempts at this fix are worth recording because they shaped the final one: reusing `validate_hogql_query` wholesale broke 32 tests (endpoints aren't always HogQL, and it validates variable ids that legacy data fails); narrowing to `_validate_query_access` still 500'd because `replace_variables` chokes on the same legacy ids; and running `build_endpoint_hogql` alone enforces nothing for HogQL kinds, which it returns untouched. The shipped version combines the conversion (for structured kinds) with direct resolution (for enforcement) and placeholder neutralization (for the legacy-variable data).

The `replace_variables` crash on non-UUID variable ids is arguably a bug on its own - any stored endpoint carrying one would 500 on paths that substitute variables. Not addressed here.

Skills invoked: `/writing-tests`.

