### PR TITLE
fix(webflow): stop retrying syncs for deleted CMS collections

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/source.py
@@ -67,6 +67,11 @@ class WebflowSource(ResumableSource[WebflowSourceConfig, WebflowResumeConfig]):
             # the site has unpublished changes. Both are deterministic state/config issues
             # that retrying can't resolve, so stop retrying and tell the user how to fix it.
             "409 Client Error: Conflict": "Webflow returned a 409 Conflict. For the Products and Orders tables this means the connected site does not have ecommerce enabled — enable ecommerce in Webflow or remove those tables from the sync. For other resources it can mean the site has unpublished changes; publish your Webflow site, then try again.",
+            # A CMS collection discovered when the table was set up can later be deleted or have its
+            # slug renamed in Webflow, so at sync time the slug no longer resolves to a collection.
+            # That's a deterministic upstream state change retrying can't fix. Match the stable
+            # prefix, not the schema name and site id that follow it.
+            "Webflow collection for schema": "A Webflow CMS collection PostHog was syncing no longer exists on your site. It was deleted or renamed in Webflow. Refresh this source's schemas to pick up your current collections, then remove the table for the collection that's gone.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/tests/test_webflow_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/webflow/tests/test_webflow_source.py
@@ -59,6 +59,7 @@ class TestWebflowSource:
         assert "401 Client Error" in errors
         assert "403 Client Error" in errors
         assert "409 Client Error: Conflict" in errors
+        assert "Webflow collection for schema" in errors
 
     def test_409_conflict_message_is_recognised_as_non_retryable(self) -> None:
         # Webflow returns 409 on /products when the site has no ecommerce; the raised
@@ -71,6 +72,15 @@ class TestWebflowSource:
         )
         matches = [pattern for pattern in errors if pattern in raised_message]
         assert matches == ["409 Client Error: Conflict"]
+
+    def test_deleted_collection_message_is_recognised_as_non_retryable(self) -> None:
+        # _resolve_collection_id raises this when a collection's slug no longer resolves at sync
+        # time; the message embeds a volatile schema name and site id, so we must match on a stable
+        # substring that excludes them.
+        errors = WebflowSource().get_non_retryable_errors()
+        raised_message = "Webflow collection for schema 'collection_blog' was not found on site 'abc123'"
+        matches = [pattern for pattern in errors if pattern in raised_message]
+        assert matches == ["Webflow collection for schema"]
 
     def test_get_schemas_includes_static_and_dynamic_collections(self) -> None:
         with patch(


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ValueError` from the Webflow data warehouse source:

> Webflow collection for schema '<redacted>' was not found on site '<redacted>'

It's raised in `_resolve_collection_id` (`webflow.py:146`) on the sync path: `webflow_source` → `_endpoint_config_for_schema` → `_resolve_collection_id`.

When a Webflow table is set up, we discover the site's CMS collections and expose one schema per collection, keyed by the collection's slug. At sync time we re-list the site's collections and map the schema's slug back to a collection id. If the collection was deleted (or its slug renamed) in Webflow between setup and sync, the slug no longer resolves and we raise.

This is a deterministic upstream state change. The collection is gone, so retrying the sync can never succeed. Today it fails as a generic error and keeps retrying.

## Changes

Add the raised message to the Webflow source's `get_non_retryable_errors`, matching on the stable prefix `Webflow collection for schema` (the schema name and site id that follow are volatile, so they're excluded from the match). The sync now stops retrying and disables the affected schema with a clear, actionable message pointing the user to refresh their source's schemas and remove the table for the missing collection.

Scoped strictly to this error. No change to global retry policy.

## How did you test this code?

Automated only (I'm an agent, no manual sync run):

- Added `test_deleted_collection_message_is_recognised_as_non_retryable` — builds the exact message `_resolve_collection_id` raises and asserts only the stable `Webflow collection for schema` key matches, guarding against the message format drifting away from the key or the volatile schema name / site id leaking into the match.
- Extended `test_get_non_retryable_errors` to assert the new key is registered.
- Ran the source test suite (`test_webflow_source.py`, 11 passed) plus `ruff check` and `ruff format --check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. I confirmed the failure originates in this source (top in-app frame is `_resolve_collection_id`), traced the call path, and judged it an upstream state change (deleted/renamed collection) rather than a code bug — retrying can't help, so it belongs in `NonRetryableErrors` rather than a graceful-skip. Mirrored the existing Stripe / Webflow-409 pattern for the entry and its test. Checked open PRs (including the maintainer's own) for a duplicate fix and found none.

Skills invoked: `/writing-user-facing-copy` (the friendly message) and `/writing-tests` (the regression test gate).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
