### PR TITLE
feat(ducklake): add post-gate registration metrics

### DIFF
--- a/posthog/temporal/ducklake/ducklake_register_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_register_data_imports_workflow.py
@@ -57,12 +57,22 @@ DATA_IMPORTS_GENERATIONS_PREFIX = "_imports"
 DUCKLAKE_REGISTER_STAGE_DURATION_METRIC = "ducklake_register_data_imports_stage_duration"
 
 
-def _stage_timer(stage: str) -> ExecutionTimeRecorder:
+def _stage_timer(*, stage: str, team_id: int, schema_id: str) -> ExecutionTimeRecorder:
     return ExecutionTimeRecorder(
         DUCKLAKE_REGISTER_STAGE_DURATION_METRIC,
         "Execution duration of one post-gate DuckLake data import registration stage.",
-        {"stage": stage},
+        {"stage": stage, "team_id": str(team_id), "schema_id": schema_id},
+        log=True,
     )
+
+
+def _bind_registration_activity_context(*, team_id: int, schema_id: str, job_id: str) -> None:
+    identifiers = {"team_id": team_id, "schema_id": schema_id, "job_id": job_id}
+    if activity.in_activity():
+        workflow_id = activity.info().workflow_id
+        if workflow_id is not None:
+            identifiers["workflow_id"] = workflow_id
+    bind_contextvars(**identifiers)
 
 
 @dataclasses.dataclass
@@ -144,10 +154,11 @@ async def ducklake_register_data_imports_gate_activity(inputs: DuckLakeRegisterD
 async def prepare_ducklake_data_imports_registration_activity(
     inputs: DuckLakeRegisterDataImportsInputs,
 ) -> DuckLakeRegisterDataImportsMetadata | None:
-    bind_contextvars(team_id=inputs.team_id)
+    schema_id = str(inputs.schema_id)
+    _bind_registration_activity_context(team_id=inputs.team_id, schema_id=schema_id, job_id=inputs.job_id)
     logger = LOGGER.bind(schema_id=str(inputs.schema_id), job_id=inputs.job_id)
 
-    with _stage_timer("prepare") as timer:
+    with _stage_timer(stage="prepare", team_id=inputs.team_id, schema_id=schema_id) as timer:
         if not _is_valid_queryable_folder(inputs.prepared_queryable_folder):
             raise ApplicationError(
                 f"Invalid prepared queryable folder '{inputs.prepared_queryable_folder}'",
@@ -160,7 +171,9 @@ async def prepare_ducklake_data_imports_registration_activity(
         )
         if schema.table is None or schema.table.queryable_folder != inputs.prepared_queryable_folder:
             timer.set_status("STALE")
-            get_ducklake_register_data_imports_stale_metric(stage="prepare").add(1)
+            get_ducklake_register_data_imports_stale_metric(
+                team_id=inputs.team_id, schema_id=schema_id, stage="prepare"
+            ).add(1)
             await logger.ainfo(
                 "Skipping stale prepared Parquet generation before registration",
                 prepared_queryable_folder=inputs.prepared_queryable_folder,
@@ -189,9 +202,10 @@ async def prepare_ducklake_data_imports_registration_activity(
 
 @activity.defn
 def copy_and_register_ducklake_data_imports_activity(inputs: DuckLakeRegisterDataImportsActivityInputs) -> bool:
-    bind_contextvars(team_id=inputs.team_id)
+    schema_id = inputs.metadata.source_schema_id
+    _bind_registration_activity_context(team_id=inputs.team_id, schema_id=schema_id, job_id=inputs.job_id)
     logger = LOGGER.bind(
-        schema_id=inputs.metadata.source_schema_id,
+        schema_id=schema_id,
         job_id=inputs.job_id,
     )
     if not settings.TEST:
@@ -202,13 +216,15 @@ def copy_and_register_ducklake_data_imports_activity(inputs: DuckLakeRegisterDat
         logger=logger,
     )
     with heartbeater:
-        with _stage_timer("copy"):
+        with _stage_timer(stage="copy", team_id=inputs.team_id, schema_id=schema_id):
             landing_paths, copied_bytes = _copy_prepared_parquet_files(
                 inputs.metadata.prepared_source_uri,
                 inputs.metadata.landing_uri,
             )
         if not _prepared_generation_is_current(inputs):
-            get_ducklake_register_data_imports_stale_metric(stage="post_copy").add(1)
+            get_ducklake_register_data_imports_stale_metric(
+                team_id=inputs.team_id, schema_id=schema_id, stage="post_copy"
+            ).add(1)
             logger.info("Skipping stale prepared Parquet generation after object copy")
             return False
 
@@ -216,13 +232,21 @@ def copy_and_register_ducklake_data_imports_activity(inputs: DuckLakeRegisterDat
             with _connect_to_duckgres_for_team(inputs.team_id) as conn:
                 registered_rows = _register_prepared_parquet_files(inputs, conn, landing_paths)
         except _StalePreparedGenerationError:
-            get_ducklake_register_data_imports_stale_metric(stage="publish").add(1)
+            get_ducklake_register_data_imports_stale_metric(
+                team_id=inputs.team_id, schema_id=schema_id, stage="publish"
+            ).add(1)
             logger.info("Skipping stale prepared Parquet generation before catalog swap")
             return False
 
-    get_ducklake_register_data_imports_files_metric().record(float(len(landing_paths)))
-    get_ducklake_register_data_imports_rows_metric().record(float(registered_rows))
-    get_ducklake_register_data_imports_bytes_metric().record(float(copied_bytes))
+    get_ducklake_register_data_imports_files_metric(team_id=inputs.team_id, schema_id=schema_id).record(
+        float(len(landing_paths))
+    )
+    get_ducklake_register_data_imports_rows_metric(team_id=inputs.team_id, schema_id=schema_id).record(
+        float(registered_rows)
+    )
+    get_ducklake_register_data_imports_bytes_metric(team_id=inputs.team_id, schema_id=schema_id).record(
+        float(copied_bytes)
+    )
 
     logger.info(
         "Copied, verified, and registered prepared Parquet files in DuckLake",
@@ -367,7 +391,7 @@ def _register_prepared_parquet_files(
 
     setup_duckgres_session(conn, extensions=("ducklake", "httpfs"))
     with conn.transaction():
-        with _stage_timer("register"):
+        with _stage_timer(stage="register", team_id=inputs.team_id, schema_id=inputs.metadata.source_schema_id):
             conn.execute(psql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psql.Identifier(schema_name)))
             conn.execute(
                 psql.SQL("DROP TABLE IF EXISTS {}.{}").format(
@@ -406,7 +430,7 @@ def _register_prepared_parquet_files(
                     )
                 )
 
-        with _stage_timer("verify"):
+        with _stage_timer(stage="verify", team_id=inputs.team_id, schema_id=inputs.metadata.source_schema_id):
             source_row = conn.execute(
                 psql.SQL("SELECT count(*) FROM read_parquet({}, union_by_name=true, hive_partitioning=true)").format(
                     parquet_paths
@@ -428,7 +452,7 @@ def _register_prepared_parquet_files(
                 )
 
         generation_is_stale = False
-        with _stage_timer("publish") as timer:
+        with _stage_timer(stage="publish", team_id=inputs.team_id, schema_id=inputs.metadata.source_schema_id) as timer:
             if _prepared_generation_is_current(inputs):
                 conn.execute(
                     psql.SQL("DROP TABLE IF EXISTS {}.{}").format(
@@ -487,6 +511,8 @@ class DuckLakeRegisterDataImportsWorkflow(PostHogWorkflow):
     @workflow.run
     async def run(self, inputs: DuckLakeRegisterDataImportsInputs) -> None:
         logger = LOGGER.bind(**inputs.properties_to_log)
+        if workflow.in_workflow():
+            logger = logger.bind(workflow_id=workflow.info().workflow_id)
         workflow_started_at = workflow.now()
         logger.info("Starting DuckLakeRegisterDataImportsWorkflow")
 
@@ -500,7 +526,8 @@ class DuckLakeRegisterDataImportsWorkflow(PostHogWorkflow):
             logger.info("DuckLake data imports registration workflow disabled by feature flag")
             return
 
-        get_ducklake_register_data_imports_started_metric().add(1)
+        schema_id = str(inputs.schema_id)
+        get_ducklake_register_data_imports_started_metric(team_id=inputs.team_id, schema_id=schema_id).add(1)
         status = "failed"
         try:
             metadata = await workflow.execute_activity(
@@ -540,7 +567,13 @@ class DuckLakeRegisterDataImportsWorkflow(PostHogWorkflow):
                 status=status,
                 duration_seconds=duration_seconds,
             )
-            get_ducklake_register_data_imports_finished_metric(status=status).add(1)
-            get_ducklake_register_data_imports_duration_metric(status=status).record(duration_seconds)
+            get_ducklake_register_data_imports_finished_metric(
+                team_id=inputs.team_id, schema_id=schema_id, status=status
+            ).add(1)
+            get_ducklake_register_data_imports_duration_metric(
+                team_id=inputs.team_id, schema_id=schema_id, status=status
+            ).record(duration_seconds)
             if status == "completed":
-                get_ducklake_register_data_imports_last_success_metric().set(finished_at.timestamp())
+                get_ducklake_register_data_imports_last_success_metric(team_id=inputs.team_id, schema_id=schema_id).set(
+                    finished_at.timestamp()
+                )

--- a/posthog/temporal/ducklake/ducklake_register_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_register_data_imports_workflow.py
@@ -36,9 +36,16 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat_sync import HeartbeaterSync
 from posthog.temporal.common.logger import get_logger
+from posthog.temporal.common.metrics import ExecutionTimeRecorder
 from posthog.temporal.ducklake.metrics import (
+    get_ducklake_register_data_imports_bytes_metric,
     get_ducklake_register_data_imports_duration_metric,
+    get_ducklake_register_data_imports_files_metric,
     get_ducklake_register_data_imports_finished_metric,
+    get_ducklake_register_data_imports_last_success_metric,
+    get_ducklake_register_data_imports_rows_metric,
+    get_ducklake_register_data_imports_stale_metric,
+    get_ducklake_register_data_imports_started_metric,
 )
 
 from products.data_warehouse.backend.facade.api import get_s3_client
@@ -47,6 +54,15 @@ from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 LOGGER = get_logger(__name__)
 DUCKLAKE_DATA_IMPORTS_REGISTRATION_WORKFLOW_FLAG = "ducklake-data-imports-registration-workflow"
 DATA_IMPORTS_GENERATIONS_PREFIX = "_imports"
+DUCKLAKE_REGISTER_STAGE_DURATION_METRIC = "ducklake_register_data_imports_stage_duration"
+
+
+def _stage_timer(stage: str) -> ExecutionTimeRecorder:
+    return ExecutionTimeRecorder(
+        DUCKLAKE_REGISTER_STAGE_DURATION_METRIC,
+        "Execution duration of one post-gate DuckLake data import registration stage.",
+        {"stage": stage},
+    )
 
 
 @dataclasses.dataclass
@@ -131,41 +147,44 @@ async def prepare_ducklake_data_imports_registration_activity(
     bind_contextvars(team_id=inputs.team_id)
     logger = LOGGER.bind(schema_id=str(inputs.schema_id), job_id=inputs.job_id)
 
-    if not _is_valid_queryable_folder(inputs.prepared_queryable_folder):
-        raise ApplicationError(
-            f"Invalid prepared queryable folder '{inputs.prepared_queryable_folder}'",
-            non_retryable=True,
-        )
+    with _stage_timer("prepare") as timer:
+        if not _is_valid_queryable_folder(inputs.prepared_queryable_folder):
+            raise ApplicationError(
+                f"Invalid prepared queryable folder '{inputs.prepared_queryable_folder}'",
+                non_retryable=True,
+            )
 
-    schema = await database_sync_to_async(ExternalDataSchema.objects.select_related("table", "source").get)(
-        id=inputs.schema_id,
-        team_id=inputs.team_id,
-    )
-    if schema.table is None or schema.table.queryable_folder != inputs.prepared_queryable_folder:
-        await logger.ainfo(
-            "Skipping stale prepared Parquet generation before registration",
+        schema = await database_sync_to_async(ExternalDataSchema.objects.select_related("table", "source").get)(
+            id=inputs.schema_id,
+            team_id=inputs.team_id,
+        )
+        if schema.table is None or schema.table.queryable_folder != inputs.prepared_queryable_folder:
+            timer.set_status("STALE")
+            get_ducklake_register_data_imports_stale_metric(stage="prepare").add(1)
+            await logger.ainfo(
+                "Skipping stale prepared Parquet generation before registration",
+                prepared_queryable_folder=inputs.prepared_queryable_folder,
+            )
+            return None
+
+        prepared_source_uri = f"{settings.BUCKET_URL}/{schema.folder_path()}/{inputs.prepared_queryable_folder}"
+        ducklake_schema_name = await database_sync_to_async(duckgres_data_imports_schema)(inputs.team_id)
+        ducklake_table_name = duckgres_data_imports_table_name(schema)
+        landing_uri = await database_sync_to_async(_resolve_data_imports_landing_uri)(
+            team_id=inputs.team_id,
+            ducklake_schema_name=ducklake_schema_name,
+            ducklake_table_name=ducklake_table_name,
+            source_schema_id=str(inputs.schema_id),
+            job_id=inputs.job_id,
+        )
+        return DuckLakeRegisterDataImportsMetadata(
+            source_schema_id=str(schema.id),
             prepared_queryable_folder=inputs.prepared_queryable_folder,
+            prepared_source_uri=prepared_source_uri,
+            landing_uri=landing_uri,
+            ducklake_schema_name=ducklake_schema_name,
+            ducklake_table_name=ducklake_table_name,
         )
-        return None
-
-    prepared_source_uri = f"{settings.BUCKET_URL}/{schema.folder_path()}/{inputs.prepared_queryable_folder}"
-    ducklake_schema_name = await database_sync_to_async(duckgres_data_imports_schema)(inputs.team_id)
-    ducklake_table_name = duckgres_data_imports_table_name(schema)
-    landing_uri = await database_sync_to_async(_resolve_data_imports_landing_uri)(
-        team_id=inputs.team_id,
-        ducklake_schema_name=ducklake_schema_name,
-        ducklake_table_name=ducklake_table_name,
-        source_schema_id=str(inputs.schema_id),
-        job_id=inputs.job_id,
-    )
-    return DuckLakeRegisterDataImportsMetadata(
-        source_schema_id=str(schema.id),
-        prepared_queryable_folder=inputs.prepared_queryable_folder,
-        prepared_source_uri=prepared_source_uri,
-        landing_uri=landing_uri,
-        ducklake_schema_name=ducklake_schema_name,
-        ducklake_table_name=ducklake_table_name,
-    )
 
 
 @activity.defn
@@ -183,20 +202,27 @@ def copy_and_register_ducklake_data_imports_activity(inputs: DuckLakeRegisterDat
         logger=logger,
     )
     with heartbeater:
-        landing_paths = _copy_prepared_parquet_files(
-            inputs.metadata.prepared_source_uri,
-            inputs.metadata.landing_uri,
-        )
+        with _stage_timer("copy"):
+            landing_paths, copied_bytes = _copy_prepared_parquet_files(
+                inputs.metadata.prepared_source_uri,
+                inputs.metadata.landing_uri,
+            )
         if not _prepared_generation_is_current(inputs):
+            get_ducklake_register_data_imports_stale_metric(stage="post_copy").add(1)
             logger.info("Skipping stale prepared Parquet generation after object copy")
             return False
 
         try:
             with _connect_to_duckgres_for_team(inputs.team_id) as conn:
-                _register_prepared_parquet_files(inputs, conn, landing_paths)
+                registered_rows = _register_prepared_parquet_files(inputs, conn, landing_paths)
         except _StalePreparedGenerationError:
+            get_ducklake_register_data_imports_stale_metric(stage="publish").add(1)
             logger.info("Skipping stale prepared Parquet generation before catalog swap")
             return False
+
+    get_ducklake_register_data_imports_files_metric().record(float(len(landing_paths)))
+    get_ducklake_register_data_imports_rows_metric().record(float(registered_rows))
+    get_ducklake_register_data_imports_bytes_metric().record(float(copied_bytes))
 
     logger.info(
         "Copied, verified, and registered prepared Parquet files in DuckLake",
@@ -271,11 +297,11 @@ def _resolve_data_imports_landing_uri(
     )
 
 
-def _copy_prepared_parquet_files(source_uri: str, landing_uri: str) -> list[str]:
+def _copy_prepared_parquet_files(source_uri: str, landing_uri: str) -> tuple[list[str], int]:
     source_prefix = source_uri.removeprefix("s3://").rstrip("/")
     landing_prefix = landing_uri.removeprefix("s3://").rstrip("/")
     s3 = get_s3_client()
-    found = s3.find(source_prefix)
+    found = s3.find(source_prefix, detail=True)
     source_paths = list(found.keys()) if isinstance(found, dict) else list(found)
     parquet_paths = sorted(str(path) for path in source_paths if str(path).lower().endswith(".parquet"))
     if not parquet_paths:
@@ -291,7 +317,15 @@ def _copy_prepared_parquet_files(source_uri: str, landing_uri: str) -> list[str]
         s3.copy(source_path, landing_path)
         landing_paths.append(f"s3://{landing_path}")
 
-    return landing_paths
+    copied_bytes = 0
+    if isinstance(found, dict):
+        copied_bytes = sum(
+            int(details.get("Size", 0))
+            for path, details in found.items()
+            if str(path).lower().endswith(".parquet") and isinstance(details, dict)
+        )
+
+    return landing_paths, copied_bytes
 
 
 def _prepared_generation_is_current(inputs: DuckLakeRegisterDataImportsActivityInputs) -> bool:
@@ -324,7 +358,7 @@ def _register_prepared_parquet_files(
     inputs: DuckLakeRegisterDataImportsActivityInputs,
     conn: psycopg.Connection,
     landing_paths: list[str],
-) -> None:
+) -> int:
     schema_name = inputs.metadata.ducklake_schema_name
     table_name = inputs.metadata.ducklake_table_name
     shadow_name = _data_imports_shadow_table_name(inputs)
@@ -333,80 +367,90 @@ def _register_prepared_parquet_files(
 
     setup_duckgres_session(conn, extensions=("ducklake", "httpfs"))
     with conn.transaction():
-        conn.execute(psql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psql.Identifier(schema_name)))
-        conn.execute(
-            psql.SQL("DROP TABLE IF EXISTS {}.{}").format(
-                psql.Identifier(schema_name),
-                psql.Identifier(shadow_name),
-            )
-        )
-        conn.execute(
-            psql.SQL(
-                "CREATE TABLE {}.{} AS SELECT * FROM "
-                "read_parquet({}, union_by_name=true, hive_partitioning=true) LIMIT 0"
-            ).format(
-                psql.Identifier(schema_name),
-                psql.Identifier(shadow_name),
-                parquet_paths,
-            )
-        )
-        if partition_columns:
+        with _stage_timer("register"):
+            conn.execute(psql.SQL("CREATE SCHEMA IF NOT EXISTS {}").format(psql.Identifier(schema_name)))
             conn.execute(
-                psql.SQL("ALTER TABLE {}.{} SET PARTITIONED BY ({})").format(
+                psql.SQL("DROP TABLE IF EXISTS {}.{}").format(
                     psql.Identifier(schema_name),
                     psql.Identifier(shadow_name),
-                    psql.SQL(", ").join(psql.Identifier(column) for column in partition_columns),
                 )
             )
-        for landing_path in landing_paths:
             conn.execute(
                 psql.SQL(
-                    "CALL ducklake_add_data_files({}, {}, {}, schema => {}, "
-                    "allow_missing => true, hive_partitioning => true)"
+                    "CREATE TABLE {}.{} AS SELECT * FROM "
+                    "read_parquet({}, union_by_name=true, hive_partitioning=true) LIMIT 0"
                 ).format(
-                    psql.Literal("ducklake"),
-                    psql.Literal(shadow_name),
-                    psql.Literal(landing_path),
-                    psql.Literal(schema_name),
+                    psql.Identifier(schema_name),
+                    psql.Identifier(shadow_name),
+                    parquet_paths,
                 )
             )
+            if partition_columns:
+                conn.execute(
+                    psql.SQL("ALTER TABLE {}.{} SET PARTITIONED BY ({})").format(
+                        psql.Identifier(schema_name),
+                        psql.Identifier(shadow_name),
+                        psql.SQL(", ").join(psql.Identifier(column) for column in partition_columns),
+                    )
+                )
+            for landing_path in landing_paths:
+                conn.execute(
+                    psql.SQL(
+                        "CALL ducklake_add_data_files({}, {}, {}, schema => {}, "
+                        "allow_missing => true, hive_partitioning => true)"
+                    ).format(
+                        psql.Literal("ducklake"),
+                        psql.Literal(shadow_name),
+                        psql.Literal(landing_path),
+                        psql.Literal(schema_name),
+                    )
+                )
 
-        source_row = conn.execute(
-            psql.SQL("SELECT count(*) FROM read_parquet({}, union_by_name=true, hive_partitioning=true)").format(
-                parquet_paths
-            )
-        ).fetchone()
-        registered_row = conn.execute(
-            psql.SQL("SELECT count(*) FROM {}.{}").format(
-                psql.Identifier(schema_name),
-                psql.Identifier(shadow_name),
-            )
-        ).fetchone()
-        source_count = int(source_row[0]) if source_row else 0
-        registered_count = int(registered_row[0]) if registered_row else 0
-        if source_count != registered_count:
-            raise ApplicationError(
-                "DuckLake prepared-file registration row count mismatch: "
-                f"source={source_count}, registered={registered_count}",
-                non_retryable=True,
-            )
+        with _stage_timer("verify"):
+            source_row = conn.execute(
+                psql.SQL("SELECT count(*) FROM read_parquet({}, union_by_name=true, hive_partitioning=true)").format(
+                    parquet_paths
+                )
+            ).fetchone()
+            registered_row = conn.execute(
+                psql.SQL("SELECT count(*) FROM {}.{}").format(
+                    psql.Identifier(schema_name),
+                    psql.Identifier(shadow_name),
+                )
+            ).fetchone()
+            source_count = int(source_row[0]) if source_row else 0
+            registered_count = int(registered_row[0]) if registered_row else 0
+            if source_count != registered_count:
+                raise ApplicationError(
+                    "DuckLake prepared-file registration row count mismatch: "
+                    f"source={source_count}, registered={registered_count}",
+                    non_retryable=True,
+                )
 
-        if not _prepared_generation_is_current(inputs):
+        generation_is_stale = False
+        with _stage_timer("publish") as timer:
+            if _prepared_generation_is_current(inputs):
+                conn.execute(
+                    psql.SQL("DROP TABLE IF EXISTS {}.{}").format(
+                        psql.Identifier(schema_name),
+                        psql.Identifier(table_name),
+                    )
+                )
+                conn.execute(
+                    psql.SQL("ALTER TABLE {}.{} RENAME TO {}").format(
+                        psql.Identifier(schema_name),
+                        psql.Identifier(shadow_name),
+                        psql.Identifier(table_name),
+                    )
+                )
+            else:
+                timer.set_status("STALE")
+                generation_is_stale = True
+
+        if generation_is_stale:
             raise _StalePreparedGenerationError
 
-        conn.execute(
-            psql.SQL("DROP TABLE IF EXISTS {}.{}").format(
-                psql.Identifier(schema_name),
-                psql.Identifier(table_name),
-            )
-        )
-        conn.execute(
-            psql.SQL("ALTER TABLE {}.{} RENAME TO {}").format(
-                psql.Identifier(schema_name),
-                psql.Identifier(shadow_name),
-                psql.Identifier(table_name),
-            )
-        )
+    return registered_count
 
 
 def _data_imports_shadow_table_name(inputs: DuckLakeRegisterDataImportsActivityInputs) -> str:
@@ -456,6 +500,7 @@ class DuckLakeRegisterDataImportsWorkflow(PostHogWorkflow):
             logger.info("DuckLake data imports registration workflow disabled by feature flag")
             return
 
+        get_ducklake_register_data_imports_started_metric().add(1)
         status = "failed"
         try:
             metadata = await workflow.execute_activity(
@@ -488,7 +533,8 @@ class DuckLakeRegisterDataImportsWorkflow(PostHogWorkflow):
 
             status = "completed"
         finally:
-            duration_seconds = (workflow.now() - workflow_started_at).total_seconds()
+            finished_at = workflow.now()
+            duration_seconds = (finished_at - workflow_started_at).total_seconds()
             logger.info(
                 "Finished DuckLakeRegisterDataImportsWorkflow",
                 status=status,
@@ -496,3 +542,5 @@ class DuckLakeRegisterDataImportsWorkflow(PostHogWorkflow):
             )
             get_ducklake_register_data_imports_finished_metric(status=status).add(1)
             get_ducklake_register_data_imports_duration_metric(status=status).record(duration_seconds)
+            if status == "completed":
+                get_ducklake_register_data_imports_last_success_metric().set(finished_at.timestamp())

--- a/posthog/temporal/ducklake/ducklake_register_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_register_data_imports_workflow.py
@@ -36,7 +36,10 @@ from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat_sync import HeartbeaterSync
 from posthog.temporal.common.logger import get_logger
-from posthog.temporal.ducklake.metrics import get_ducklake_register_data_imports_finished_metric
+from posthog.temporal.ducklake.metrics import (
+    get_ducklake_register_data_imports_duration_metric,
+    get_ducklake_register_data_imports_finished_metric,
+)
 
 from products.data_warehouse.backend.facade.api import get_s3_client
 from products.warehouse_sources.backend.facade.models import ExternalDataSchema
@@ -440,6 +443,7 @@ class DuckLakeRegisterDataImportsWorkflow(PostHogWorkflow):
     @workflow.run
     async def run(self, inputs: DuckLakeRegisterDataImportsInputs) -> None:
         logger = LOGGER.bind(**inputs.properties_to_log)
+        workflow_started_at = workflow.now()
         logger.info("Starting DuckLakeRegisterDataImportsWorkflow")
 
         should_register = await workflow.execute_activity(
@@ -452,22 +456,24 @@ class DuckLakeRegisterDataImportsWorkflow(PostHogWorkflow):
             logger.info("DuckLake data imports registration workflow disabled by feature flag")
             return
 
-        metadata = await workflow.execute_activity(
-            prepare_ducklake_data_imports_registration_activity,
-            inputs,
-            start_to_close_timeout=dt.timedelta(minutes=5),
-            retry_policy=RetryPolicy(maximum_attempts=3),
-        )
-        if metadata is None:
-            logger.info("Prepared Parquet generation is stale; nothing to register")
-            return
-
-        activity_inputs = DuckLakeRegisterDataImportsActivityInputs(
-            team_id=inputs.team_id,
-            job_id=inputs.job_id,
-            metadata=metadata,
-        )
+        status = "failed"
         try:
+            metadata = await workflow.execute_activity(
+                prepare_ducklake_data_imports_registration_activity,
+                inputs,
+                start_to_close_timeout=dt.timedelta(minutes=5),
+                retry_policy=RetryPolicy(maximum_attempts=3),
+            )
+            if metadata is None:
+                status = "stale"
+                logger.info("Prepared Parquet generation is stale; nothing to register")
+                return
+
+            activity_inputs = DuckLakeRegisterDataImportsActivityInputs(
+                team_id=inputs.team_id,
+                job_id=inputs.job_id,
+                metadata=metadata,
+            )
             copy_applied = await workflow.execute_activity(
                 copy_and_register_ducklake_data_imports_activity,
                 activity_inputs,
@@ -476,12 +482,17 @@ class DuckLakeRegisterDataImportsWorkflow(PostHogWorkflow):
                 retry_policy=RetryPolicy(maximum_attempts=2),
             )
             if not copy_applied:
+                status = "stale"
                 logger.info("Prepared Parquet generation became stale; registration skipped")
-                get_ducklake_register_data_imports_finished_metric(status="stale").add(1)
                 return
 
-        except Exception:
-            get_ducklake_register_data_imports_finished_metric(status="failed").add(1)
-            raise
-
-        get_ducklake_register_data_imports_finished_metric(status="completed").add(1)
+            status = "completed"
+        finally:
+            duration_seconds = (workflow.now() - workflow_started_at).total_seconds()
+            logger.info(
+                "Finished DuckLakeRegisterDataImportsWorkflow",
+                status=status,
+                duration_seconds=duration_seconds,
+            )
+            get_ducklake_register_data_imports_finished_metric(status=status).add(1)
+            get_ducklake_register_data_imports_duration_metric(status=status).record(duration_seconds)

--- a/posthog/temporal/ducklake/metrics.py
+++ b/posthog/temporal/ducklake/metrics.py
@@ -1,5 +1,5 @@
 from temporalio import workflow
-from temporalio.common import MetricCounter
+from temporalio.common import MetricCounter, MetricHistogramFloat
 
 
 def get_ducklake_copy_data_modeling_finished_metric(status: str) -> MetricCounter:
@@ -53,5 +53,17 @@ def get_ducklake_register_data_imports_finished_metric(status: str) -> MetricCou
         .create_counter(
             "ducklake_register_data_imports_finished",
             "Number of DuckLake prepared data import registration workflows finished, including failures.",
+        )
+    )
+
+
+def get_ducklake_register_data_imports_duration_metric(status: str) -> MetricHistogramFloat:
+    return (
+        workflow.metric_meter()
+        .with_additional_attributes({"status": status})
+        .create_histogram_float(
+            "ducklake_register_data_imports_duration_seconds",
+            "End-to-end duration of DuckLake prepared data import registration workflows that passed the feature flag gate.",
+            "s",
         )
     )

--- a/posthog/temporal/ducklake/metrics.py
+++ b/posthog/temporal/ducklake/metrics.py
@@ -1,5 +1,9 @@
-from temporalio import workflow
-from temporalio.common import MetricCounter, MetricHistogramFloat
+from temporalio import activity, workflow
+from temporalio.common import MetricCounter, MetricGaugeFloat, MetricHistogramFloat, MetricMeter
+
+
+def _activity_meter() -> MetricMeter:
+    return activity.metric_meter() if activity.in_activity() else MetricMeter.noop
 
 
 def get_ducklake_copy_data_modeling_finished_metric(status: str) -> MetricCounter:
@@ -66,4 +70,52 @@ def get_ducklake_register_data_imports_duration_metric(status: str) -> MetricHis
             "End-to-end duration of DuckLake prepared data import registration workflows that passed the feature flag gate.",
             "s",
         )
+    )
+
+
+def get_ducklake_register_data_imports_started_metric() -> MetricCounter:
+    return workflow.metric_meter().create_counter(
+        "ducklake_register_data_imports_started",
+        "Number of DuckLake prepared data import registration workflows that passed the feature flag gate.",
+    )
+
+
+def get_ducklake_register_data_imports_last_success_metric() -> MetricGaugeFloat:
+    return workflow.metric_meter().create_gauge_float(
+        "ducklake_register_data_imports_last_success_timestamp_seconds",
+        "Unix timestamp of the last successful DuckLake prepared data import registration workflow.",
+        "s",
+    )
+
+
+def get_ducklake_register_data_imports_stale_metric(stage: str) -> MetricCounter:
+    return (
+        _activity_meter()
+        .with_additional_attributes({"stage": stage})
+        .create_counter(
+            "ducklake_register_data_imports_stale",
+            "Number of post-gate DuckLake registrations skipped because their prepared generation became stale.",
+        )
+    )
+
+
+def get_ducklake_register_data_imports_files_metric() -> MetricHistogramFloat:
+    return _activity_meter().create_histogram_float(
+        "ducklake_register_data_imports_files_registered",
+        "Number of Parquet files in a successful DuckLake data import registration.",
+    )
+
+
+def get_ducklake_register_data_imports_rows_metric() -> MetricHistogramFloat:
+    return _activity_meter().create_histogram_float(
+        "ducklake_register_data_imports_rows_registered",
+        "Number of rows in a successful DuckLake data import registration.",
+    )
+
+
+def get_ducklake_register_data_imports_bytes_metric() -> MetricHistogramFloat:
+    return _activity_meter().create_histogram_float(
+        "ducklake_register_data_imports_bytes_copied",
+        "Number of prepared Parquet bytes copied by a successful DuckLake data import registration.",
+        "By",
     )

--- a/posthog/temporal/ducklake/metrics.py
+++ b/posthog/temporal/ducklake/metrics.py
@@ -6,6 +6,10 @@ def _activity_meter() -> MetricMeter:
     return activity.metric_meter() if activity.in_activity() else MetricMeter.noop
 
 
+def _registration_attributes(team_id: int, schema_id: str) -> dict[str, str]:
+    return {"team_id": str(team_id), "schema_id": schema_id}
+
+
 def get_ducklake_copy_data_modeling_finished_metric(status: str) -> MetricCounter:
     return (
         workflow.metric_meter()
@@ -50,10 +54,10 @@ def get_ducklake_copy_data_imports_verification_metric(check_name: str, status: 
     )
 
 
-def get_ducklake_register_data_imports_finished_metric(status: str) -> MetricCounter:
+def get_ducklake_register_data_imports_finished_metric(*, team_id: int, schema_id: str, status: str) -> MetricCounter:
     return (
         workflow.metric_meter()
-        .with_additional_attributes({"status": status})
+        .with_additional_attributes({**_registration_attributes(team_id, schema_id), "status": status})
         .create_counter(
             "ducklake_register_data_imports_finished",
             "Number of DuckLake prepared data import registration workflows finished, including failures.",
@@ -61,10 +65,12 @@ def get_ducklake_register_data_imports_finished_metric(status: str) -> MetricCou
     )
 
 
-def get_ducklake_register_data_imports_duration_metric(status: str) -> MetricHistogramFloat:
+def get_ducklake_register_data_imports_duration_metric(
+    *, team_id: int, schema_id: str, status: str
+) -> MetricHistogramFloat:
     return (
         workflow.metric_meter()
-        .with_additional_attributes({"status": status})
+        .with_additional_attributes({**_registration_attributes(team_id, schema_id), "status": status})
         .create_histogram_float(
             "ducklake_register_data_imports_duration_seconds",
             "End-to-end duration of DuckLake prepared data import registration workflows that passed the feature flag gate.",
@@ -73,25 +79,33 @@ def get_ducklake_register_data_imports_duration_metric(status: str) -> MetricHis
     )
 
 
-def get_ducklake_register_data_imports_started_metric() -> MetricCounter:
-    return workflow.metric_meter().create_counter(
-        "ducklake_register_data_imports_started",
-        "Number of DuckLake prepared data import registration workflows that passed the feature flag gate.",
+def get_ducklake_register_data_imports_started_metric(*, team_id: int, schema_id: str) -> MetricCounter:
+    return (
+        workflow.metric_meter()
+        .with_additional_attributes(_registration_attributes(team_id, schema_id))
+        .create_counter(
+            "ducklake_register_data_imports_started",
+            "Number of DuckLake prepared data import registration workflows that passed the feature flag gate.",
+        )
     )
 
 
-def get_ducklake_register_data_imports_last_success_metric() -> MetricGaugeFloat:
-    return workflow.metric_meter().create_gauge_float(
-        "ducklake_register_data_imports_last_success_timestamp_seconds",
-        "Unix timestamp of the last successful DuckLake prepared data import registration workflow.",
-        "s",
+def get_ducklake_register_data_imports_last_success_metric(*, team_id: int, schema_id: str) -> MetricGaugeFloat:
+    return (
+        workflow.metric_meter()
+        .with_additional_attributes(_registration_attributes(team_id, schema_id))
+        .create_gauge_float(
+            "ducklake_register_data_imports_last_success_timestamp_seconds",
+            "Unix timestamp of the last successful DuckLake prepared data import registration workflow.",
+            "s",
+        )
     )
 
 
-def get_ducklake_register_data_imports_stale_metric(stage: str) -> MetricCounter:
+def get_ducklake_register_data_imports_stale_metric(*, team_id: int, schema_id: str, stage: str) -> MetricCounter:
     return (
         _activity_meter()
-        .with_additional_attributes({"stage": stage})
+        .with_additional_attributes({**_registration_attributes(team_id, schema_id), "stage": stage})
         .create_counter(
             "ducklake_register_data_imports_stale",
             "Number of post-gate DuckLake registrations skipped because their prepared generation became stale.",
@@ -99,23 +113,35 @@ def get_ducklake_register_data_imports_stale_metric(stage: str) -> MetricCounter
     )
 
 
-def get_ducklake_register_data_imports_files_metric() -> MetricHistogramFloat:
-    return _activity_meter().create_histogram_float(
-        "ducklake_register_data_imports_files_registered",
-        "Number of Parquet files in a successful DuckLake data import registration.",
+def get_ducklake_register_data_imports_files_metric(*, team_id: int, schema_id: str) -> MetricHistogramFloat:
+    return (
+        _activity_meter()
+        .with_additional_attributes(_registration_attributes(team_id, schema_id))
+        .create_histogram_float(
+            "ducklake_register_data_imports_files_registered",
+            "Number of Parquet files in a successful DuckLake data import registration.",
+        )
     )
 
 
-def get_ducklake_register_data_imports_rows_metric() -> MetricHistogramFloat:
-    return _activity_meter().create_histogram_float(
-        "ducklake_register_data_imports_rows_registered",
-        "Number of rows in a successful DuckLake data import registration.",
+def get_ducklake_register_data_imports_rows_metric(*, team_id: int, schema_id: str) -> MetricHistogramFloat:
+    return (
+        _activity_meter()
+        .with_additional_attributes(_registration_attributes(team_id, schema_id))
+        .create_histogram_float(
+            "ducklake_register_data_imports_rows_registered",
+            "Number of rows in a successful DuckLake data import registration.",
+        )
     )
 
 
-def get_ducklake_register_data_imports_bytes_metric() -> MetricHistogramFloat:
-    return _activity_meter().create_histogram_float(
-        "ducklake_register_data_imports_bytes_copied",
-        "Number of prepared Parquet bytes copied by a successful DuckLake data import registration.",
-        "By",
+def get_ducklake_register_data_imports_bytes_metric(*, team_id: int, schema_id: str) -> MetricHistogramFloat:
+    return (
+        _activity_meter()
+        .with_additional_attributes(_registration_attributes(team_id, schema_id))
+        .create_histogram_float(
+            "ducklake_register_data_imports_bytes_copied",
+            "Number of prepared Parquet bytes copied by a successful DuckLake data import registration.",
+            "By",
+        )
     )

--- a/posthog/temporal/tests/ducklake/test_ducklake_register_data_imports_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_register_data_imports_workflow.py
@@ -124,11 +124,12 @@ def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monke
         def __init__(self) -> None:
             self.copies: list[tuple[str, str]] = []
 
-        def find(self, prefix: str) -> list[str]:
-            return [
-                f"{prefix}/_ph_partition_key=2026-07/a.parquet",
-                f"{prefix}/_ph_partition_key=2026-08/b.parquet",
-            ]
+        def find(self, prefix: str, detail: bool = False):
+            files = {
+                f"{prefix}/_ph_partition_key=2026-07/a.parquet": {"Size": 100, "type": "file"},
+                f"{prefix}/_ph_partition_key=2026-08/b.parquet": {"Size": 200, "type": "file"},
+            }
+            return files if detail else list(files)
 
         def copy(self, source: str, destination: str) -> None:
             self.copies.append((source, destination))
@@ -161,6 +162,7 @@ def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monke
     heartbeater.__enter__ = MagicMock(return_value=heartbeater)
     heartbeater.__exit__ = MagicMock(return_value=False)
     monkeypatch.setattr(registration_module, "HeartbeaterSync", MagicMock(return_value=heartbeater))
+    workload_metrics = _mock_activity_workload_metrics(monkeypatch)
 
     inputs = _activity_inputs()
     applied = copy_and_register_ducklake_data_imports_activity(inputs)
@@ -191,13 +193,16 @@ def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monke
     assert max(registration_indexes) < min(verification_indexes)
     assert max(verification_indexes) < drop_live_index < rename_index
     assert any("SET PARTITIONED BY" in query for query in executed)
+    workload_metrics.files.record.assert_called_once_with(2.0)
+    workload_metrics.rows.record.assert_called_once_with(2.0)
+    workload_metrics.bytes.record.assert_called_once_with(300.0)
 
 
 def test_copy_activity_does_not_touch_catalog_for_stale_generation(monkeypatch):
     monkeypatch.setattr(
         registration_module,
         "_copy_prepared_parquet_files",
-        lambda source_uri, landing_uri: [f"{landing_uri}/file.parquet"],
+        lambda source_uri, landing_uri: ([f"{landing_uri}/file.parquet"], 100),
     )
     monkeypatch.setattr(registration_module, "_prepared_generation_is_current", lambda inputs: False)
     monkeypatch.setattr(
@@ -209,15 +214,24 @@ def test_copy_activity_does_not_touch_catalog_for_stale_generation(monkeypatch):
     heartbeater.__enter__ = MagicMock(return_value=heartbeater)
     heartbeater.__exit__ = MagicMock(return_value=False)
     monkeypatch.setattr(registration_module, "HeartbeaterSync", MagicMock(return_value=heartbeater))
+    stale_counter = MagicMock()
+    stale_metric = MagicMock(return_value=stale_counter)
+    monkeypatch.setattr(registration_module, "get_ducklake_register_data_imports_stale_metric", stale_metric)
+    workload_metrics = _mock_activity_workload_metrics(monkeypatch)
 
     assert copy_and_register_ducklake_data_imports_activity(_activity_inputs()) is False
+    stale_metric.assert_called_once_with(stage="post_copy")
+    stale_counter.add.assert_called_once_with(1)
+    workload_metrics.files.record.assert_not_called()
+    workload_metrics.rows.record.assert_not_called()
+    workload_metrics.bytes.record.assert_not_called()
 
 
 def test_copy_activity_does_not_publish_a_row_count_mismatch(monkeypatch):
     monkeypatch.setattr(
         registration_module,
         "_copy_prepared_parquet_files",
-        lambda source_uri, landing_uri: [f"{landing_uri}/file.parquet"],
+        lambda source_uri, landing_uri: ([f"{landing_uri}/file.parquet"], 100),
     )
     monkeypatch.setattr(registration_module, "_prepared_generation_is_current", lambda inputs: True)
     conn = MagicMock()
@@ -253,14 +267,16 @@ def test_copy_activity_does_not_publish_a_row_count_mismatch(monkeypatch):
 @pytest.mark.asyncio
 async def test_workflow_does_not_record_duration_when_disabled(monkeypatch):
     execute_activity = AsyncMock(return_value=False)
-    duration_metric, _, finished_metric, _ = _mock_workflow_metrics(monkeypatch)
+    metrics = _mock_workflow_metrics(monkeypatch)
     monkeypatch.setattr(registration_module.workflow, "execute_activity", execute_activity)
     monkeypatch.setattr(registration_module.workflow, "now", MagicMock(return_value=dt.datetime(2026, 7, 30)))
 
     await DuckLakeRegisterDataImportsWorkflow().run(_workflow_inputs())
 
-    duration_metric.assert_not_called()
-    finished_metric.assert_not_called()
+    metrics.started_getter.assert_not_called()
+    metrics.duration_getter.assert_not_called()
+    metrics.finished_getter.assert_not_called()
+    metrics.last_success_getter.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -268,16 +284,20 @@ async def test_workflow_records_end_to_end_duration_after_gate(monkeypatch):
     started_at = dt.datetime(2026, 7, 30, 12, 0, 0)
     finished_at = started_at + dt.timedelta(minutes=7, seconds=12)
     execute_activity = AsyncMock(side_effect=[True, _activity_inputs().metadata, True])
-    duration_metric, duration_histogram, finished_metric, finished_counter = _mock_workflow_metrics(monkeypatch)
+    metrics = _mock_workflow_metrics(monkeypatch)
     monkeypatch.setattr(registration_module.workflow, "execute_activity", execute_activity)
     monkeypatch.setattr(registration_module.workflow, "now", MagicMock(side_effect=[started_at, finished_at]))
 
     await DuckLakeRegisterDataImportsWorkflow().run(_workflow_inputs())
 
-    finished_metric.assert_called_once_with(status="completed")
-    finished_counter.add.assert_called_once_with(1)
-    duration_metric.assert_called_once_with(status="completed")
-    duration_histogram.record.assert_called_once_with(432.0)
+    metrics.started_getter.assert_called_once_with()
+    metrics.started.add.assert_called_once_with(1)
+    metrics.finished_getter.assert_called_once_with(status="completed")
+    metrics.finished.add.assert_called_once_with(1)
+    metrics.duration_getter.assert_called_once_with(status="completed")
+    metrics.duration.record.assert_called_once_with(432.0)
+    metrics.last_success_getter.assert_called_once_with()
+    metrics.last_success.set.assert_called_once_with(finished_at.timestamp())
 
 
 @pytest.mark.asyncio
@@ -285,35 +305,69 @@ async def test_workflow_records_end_to_end_duration_on_post_gate_failure(monkeyp
     started_at = dt.datetime(2026, 7, 30, 12, 0, 0)
     failed_at = started_at + dt.timedelta(seconds=5)
     execute_activity = AsyncMock(side_effect=[True, RuntimeError("prepare failed")])
-    duration_metric, duration_histogram, finished_metric, finished_counter = _mock_workflow_metrics(monkeypatch)
+    metrics = _mock_workflow_metrics(monkeypatch)
     monkeypatch.setattr(registration_module.workflow, "execute_activity", execute_activity)
     monkeypatch.setattr(registration_module.workflow, "now", MagicMock(side_effect=[started_at, failed_at]))
 
     with pytest.raises(RuntimeError, match="prepare failed"):
         await DuckLakeRegisterDataImportsWorkflow().run(_workflow_inputs())
 
-    finished_metric.assert_called_once_with(status="failed")
-    finished_counter.add.assert_called_once_with(1)
-    duration_metric.assert_called_once_with(status="failed")
-    duration_histogram.record.assert_called_once_with(5.0)
+    metrics.started_getter.assert_called_once_with()
+    metrics.started.add.assert_called_once_with(1)
+    metrics.finished_getter.assert_called_once_with(status="failed")
+    metrics.finished.add.assert_called_once_with(1)
+    metrics.duration_getter.assert_called_once_with(status="failed")
+    metrics.duration.record.assert_called_once_with(5.0)
+    metrics.last_success_getter.assert_not_called()
 
 
 def _mock_workflow_metrics(monkeypatch):
-    duration_histogram = MagicMock()
-    duration_metric = MagicMock(return_value=duration_histogram)
-    finished_counter = MagicMock()
-    finished_metric = MagicMock(return_value=finished_counter)
+    metrics = MagicMock()
+    metrics.duration_getter = MagicMock(return_value=metrics.duration)
+    metrics.finished_getter = MagicMock(return_value=metrics.finished)
+    metrics.started_getter = MagicMock(return_value=metrics.started)
+    metrics.last_success_getter = MagicMock(return_value=metrics.last_success)
     monkeypatch.setattr(
         registration_module,
         "get_ducklake_register_data_imports_duration_metric",
-        duration_metric,
+        metrics.duration_getter,
     )
     monkeypatch.setattr(
         registration_module,
         "get_ducklake_register_data_imports_finished_metric",
-        finished_metric,
+        metrics.finished_getter,
     )
-    return duration_metric, duration_histogram, finished_metric, finished_counter
+    monkeypatch.setattr(
+        registration_module,
+        "get_ducklake_register_data_imports_started_metric",
+        metrics.started_getter,
+    )
+    monkeypatch.setattr(
+        registration_module,
+        "get_ducklake_register_data_imports_last_success_metric",
+        metrics.last_success_getter,
+    )
+    return metrics
+
+
+def _mock_activity_workload_metrics(monkeypatch):
+    metrics = MagicMock()
+    monkeypatch.setattr(
+        registration_module,
+        "get_ducklake_register_data_imports_files_metric",
+        MagicMock(return_value=metrics.files),
+    )
+    monkeypatch.setattr(
+        registration_module,
+        "get_ducklake_register_data_imports_rows_metric",
+        MagicMock(return_value=metrics.rows),
+    )
+    monkeypatch.setattr(
+        registration_module,
+        "get_ducklake_register_data_imports_bytes_metric",
+        MagicMock(return_value=metrics.bytes),
+    )
+    return metrics
 
 
 def _activity_inputs() -> DuckLakeRegisterDataImportsActivityInputs:

--- a/posthog/temporal/tests/ducklake/test_ducklake_register_data_imports_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_register_data_imports_workflow.py
@@ -1,7 +1,9 @@
+import uuid
+import datetime as dt
 import contextlib
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from parameterized import parameterized
 from temporalio.exceptions import ApplicationError
@@ -15,6 +17,7 @@ from posthog.temporal.ducklake.ducklake_register_data_imports_workflow import (
     DuckLakeRegisterDataImportsGateInputs,
     DuckLakeRegisterDataImportsInputs,
     DuckLakeRegisterDataImportsMetadata,
+    DuckLakeRegisterDataImportsWorkflow,
     build_register_data_imports_workflow_id,
     copy_and_register_ducklake_data_imports_activity,
     ducklake_register_data_imports_gate_activity,
@@ -247,6 +250,72 @@ def test_copy_activity_does_not_publish_a_row_count_mismatch(monkeypatch):
     assert not any("RENAME TO" in query for query in executed)
 
 
+@pytest.mark.asyncio
+async def test_workflow_does_not_record_duration_when_disabled(monkeypatch):
+    execute_activity = AsyncMock(return_value=False)
+    duration_metric, _, finished_metric, _ = _mock_workflow_metrics(monkeypatch)
+    monkeypatch.setattr(registration_module.workflow, "execute_activity", execute_activity)
+    monkeypatch.setattr(registration_module.workflow, "now", MagicMock(return_value=dt.datetime(2026, 7, 30)))
+
+    await DuckLakeRegisterDataImportsWorkflow().run(_workflow_inputs())
+
+    duration_metric.assert_not_called()
+    finished_metric.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_workflow_records_end_to_end_duration_after_gate(monkeypatch):
+    started_at = dt.datetime(2026, 7, 30, 12, 0, 0)
+    finished_at = started_at + dt.timedelta(minutes=7, seconds=12)
+    execute_activity = AsyncMock(side_effect=[True, _activity_inputs().metadata, True])
+    duration_metric, duration_histogram, finished_metric, finished_counter = _mock_workflow_metrics(monkeypatch)
+    monkeypatch.setattr(registration_module.workflow, "execute_activity", execute_activity)
+    monkeypatch.setattr(registration_module.workflow, "now", MagicMock(side_effect=[started_at, finished_at]))
+
+    await DuckLakeRegisterDataImportsWorkflow().run(_workflow_inputs())
+
+    finished_metric.assert_called_once_with(status="completed")
+    finished_counter.add.assert_called_once_with(1)
+    duration_metric.assert_called_once_with(status="completed")
+    duration_histogram.record.assert_called_once_with(432.0)
+
+
+@pytest.mark.asyncio
+async def test_workflow_records_end_to_end_duration_on_post_gate_failure(monkeypatch):
+    started_at = dt.datetime(2026, 7, 30, 12, 0, 0)
+    failed_at = started_at + dt.timedelta(seconds=5)
+    execute_activity = AsyncMock(side_effect=[True, RuntimeError("prepare failed")])
+    duration_metric, duration_histogram, finished_metric, finished_counter = _mock_workflow_metrics(monkeypatch)
+    monkeypatch.setattr(registration_module.workflow, "execute_activity", execute_activity)
+    monkeypatch.setattr(registration_module.workflow, "now", MagicMock(side_effect=[started_at, failed_at]))
+
+    with pytest.raises(RuntimeError, match="prepare failed"):
+        await DuckLakeRegisterDataImportsWorkflow().run(_workflow_inputs())
+
+    finished_metric.assert_called_once_with(status="failed")
+    finished_counter.add.assert_called_once_with(1)
+    duration_metric.assert_called_once_with(status="failed")
+    duration_histogram.record.assert_called_once_with(5.0)
+
+
+def _mock_workflow_metrics(monkeypatch):
+    duration_histogram = MagicMock()
+    duration_metric = MagicMock(return_value=duration_histogram)
+    finished_counter = MagicMock()
+    finished_metric = MagicMock(return_value=finished_counter)
+    monkeypatch.setattr(
+        registration_module,
+        "get_ducklake_register_data_imports_duration_metric",
+        duration_metric,
+    )
+    monkeypatch.setattr(
+        registration_module,
+        "get_ducklake_register_data_imports_finished_metric",
+        finished_metric,
+    )
+    return duration_metric, duration_histogram, finished_metric, finished_counter
+
+
 def _activity_inputs() -> DuckLakeRegisterDataImportsActivityInputs:
     return DuckLakeRegisterDataImportsActivityInputs(
         team_id=1,
@@ -259,6 +328,15 @@ def _activity_inputs() -> DuckLakeRegisterDataImportsActivityInputs:
             ducklake_schema_name="posthog_data_imports_team_1",
             ducklake_table_name="postgres_customers",
         ),
+    )
+
+
+def _workflow_inputs() -> DuckLakeRegisterDataImportsInputs:
+    return DuckLakeRegisterDataImportsInputs(
+        team_id=1,
+        job_id="job",
+        schema_id=uuid.UUID("019ef5df-e4c7-0000-b543-8ef7f13b5f15"),
+        prepared_queryable_folder="customers__query",
     )
 
 

--- a/posthog/temporal/tests/ducklake/test_ducklake_register_data_imports_workflow.py
+++ b/posthog/temporal/tests/ducklake/test_ducklake_register_data_imports_workflow.py
@@ -193,6 +193,9 @@ def test_copy_activity_uses_s3_copy_and_local_duckgres_postgres_connection(monke
     assert max(registration_indexes) < min(verification_indexes)
     assert max(verification_indexes) < drop_live_index < rename_index
     assert any("SET PARTITIONED BY" in query for query in executed)
+    workload_metrics.files_getter.assert_called_once_with(team_id=1, schema_id="schema")
+    workload_metrics.rows_getter.assert_called_once_with(team_id=1, schema_id="schema")
+    workload_metrics.bytes_getter.assert_called_once_with(team_id=1, schema_id="schema")
     workload_metrics.files.record.assert_called_once_with(2.0)
     workload_metrics.rows.record.assert_called_once_with(2.0)
     workload_metrics.bytes.record.assert_called_once_with(300.0)
@@ -220,7 +223,7 @@ def test_copy_activity_does_not_touch_catalog_for_stale_generation(monkeypatch):
     workload_metrics = _mock_activity_workload_metrics(monkeypatch)
 
     assert copy_and_register_ducklake_data_imports_activity(_activity_inputs()) is False
-    stale_metric.assert_called_once_with(stage="post_copy")
+    stale_metric.assert_called_once_with(team_id=1, schema_id="schema", stage="post_copy")
     stale_counter.add.assert_called_once_with(1)
     workload_metrics.files.record.assert_not_called()
     workload_metrics.rows.record.assert_not_called()
@@ -290,13 +293,14 @@ async def test_workflow_records_end_to_end_duration_after_gate(monkeypatch):
 
     await DuckLakeRegisterDataImportsWorkflow().run(_workflow_inputs())
 
-    metrics.started_getter.assert_called_once_with()
+    metric_identifiers = {"team_id": 1, "schema_id": str(_workflow_inputs().schema_id)}
+    metrics.started_getter.assert_called_once_with(**metric_identifiers)
     metrics.started.add.assert_called_once_with(1)
-    metrics.finished_getter.assert_called_once_with(status="completed")
+    metrics.finished_getter.assert_called_once_with(**metric_identifiers, status="completed")
     metrics.finished.add.assert_called_once_with(1)
-    metrics.duration_getter.assert_called_once_with(status="completed")
+    metrics.duration_getter.assert_called_once_with(**metric_identifiers, status="completed")
     metrics.duration.record.assert_called_once_with(432.0)
-    metrics.last_success_getter.assert_called_once_with()
+    metrics.last_success_getter.assert_called_once_with(**metric_identifiers)
     metrics.last_success.set.assert_called_once_with(finished_at.timestamp())
 
 
@@ -312,11 +316,12 @@ async def test_workflow_records_end_to_end_duration_on_post_gate_failure(monkeyp
     with pytest.raises(RuntimeError, match="prepare failed"):
         await DuckLakeRegisterDataImportsWorkflow().run(_workflow_inputs())
 
-    metrics.started_getter.assert_called_once_with()
+    metric_identifiers = {"team_id": 1, "schema_id": str(_workflow_inputs().schema_id)}
+    metrics.started_getter.assert_called_once_with(**metric_identifiers)
     metrics.started.add.assert_called_once_with(1)
-    metrics.finished_getter.assert_called_once_with(status="failed")
+    metrics.finished_getter.assert_called_once_with(**metric_identifiers, status="failed")
     metrics.finished.add.assert_called_once_with(1)
-    metrics.duration_getter.assert_called_once_with(status="failed")
+    metrics.duration_getter.assert_called_once_with(**metric_identifiers, status="failed")
     metrics.duration.record.assert_called_once_with(5.0)
     metrics.last_success_getter.assert_not_called()
 
@@ -352,20 +357,23 @@ def _mock_workflow_metrics(monkeypatch):
 
 def _mock_activity_workload_metrics(monkeypatch):
     metrics = MagicMock()
+    metrics.files_getter = MagicMock(return_value=metrics.files)
+    metrics.rows_getter = MagicMock(return_value=metrics.rows)
+    metrics.bytes_getter = MagicMock(return_value=metrics.bytes)
     monkeypatch.setattr(
         registration_module,
         "get_ducklake_register_data_imports_files_metric",
-        MagicMock(return_value=metrics.files),
+        metrics.files_getter,
     )
     monkeypatch.setattr(
         registration_module,
         "get_ducklake_register_data_imports_rows_metric",
-        MagicMock(return_value=metrics.rows),
+        metrics.rows_getter,
     )
     monkeypatch.setattr(
         registration_module,
         "get_ducklake_register_data_imports_bytes_metric",
-        MagicMock(return_value=metrics.bytes),
+        metrics.bytes_getter,
     )
     return metrics
 


### PR DESCRIPTION
## Problem

DuckLake data import registration workflows need operational metrics that focus on work performed after the feature flag gate. Gate-disabled runs should not pollute throughput, latency, staleness, or workload series, and operators need enough context to find an individual post-gate run.

## Changes

- Emit every new registration metric only after the workflow passes the feature flag gate.
- Track post-gate starts, terminal status, end-to-end duration, and the last successful completion timestamp.
- Track execution duration for the `prepare`, `copy`, `register`, `verify`, and `publish` stages using the shared Temporal activity timing pattern.
- Count stale generations by the stage where they were detected.
- Record files, rows, and bytes for successful registrations.
- Add `team_id` and `schema_id` dimensions to registration metrics so dashboards can filter tenant and schema activity.
- Include team, schema, job, and workflow identifiers in structured post-gate timing logs. Job and workflow IDs remain out of metric labels to avoid unbounded series cardinality.

## How did you test this code?

- Extended the focused workflow and activity tests to guard against metrics from gate-disabled runs, verify completed and failed post-gate timing, verify team/schema dimensions, verify successful workload measurements, and ensure stale runs do not report successful workload.
- `.codex/with-flox pytest -q posthog/temporal/tests/ducklake/test_ducklake_register_data_imports_workflow.py -k 'not registration_gate and not prepare_registration'` - 9 passed, 3 database-backed tests deselected.
- `.codex/with-flox hogli ci:preflight --fix` - passed lint, format, branch freshness, and preflight checks.
- `.codex/with-flox uv run mypy --cache-fine-grained .` - no issues in 17,262 source files.
- The commit hook passed `ty check`. The full test file's three database-backed cases could not complete because local test database setup stalled.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing documentation change is needed for internal workflow instrumentation.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made this change in a local workspace session (no shareable session URL) and used the GitHub connector to publish it. Skills invoked: `instrumenting-first-party-metrics`, `writing-tests`, and `github:yeet`.

I used the Temporal workflow meter for workflow-level series and the shared `ExecutionTimeRecorder` for activity stages. Emitting only after the gate avoids a permanent filtering requirement and keeps disabled runs out of the registration dashboards. Metric dimensions are limited to team and schema; per-run job and workflow identifiers are carried by structured logs.