### PR TITLE
fix(clickhouse): classify mid-stream connection drops as retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -292,6 +292,13 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             "returned response code 502",
             "returned response code 503",
             "returned response code 504",
+            # urllib3 raises this when the source drops the connection mid-transfer while
+            # `get_rows` is iterating `query_arrow_stream` — the byte count varies, but the
+            # "Connection broken: IncompleteRead" wording is stable. Unlike the connect-time
+            # drops above, this happens after the client is already constructed, so
+            # `_get_client`'s in-process retry never sees it; Temporal's activity retry
+            # reopens a fresh tunnel + client and resumes from the last committed cursor.
+            "Connection broken: IncompleteRead",
         }
 
     @contextmanager

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -718,6 +718,11 @@ class TestClickHouseSourceRetryableErrors:
             "Tunnel connection failed: 504 Gateway Timeout",
             "EOF occurred in violation of protocol",
             "Connection reset by peer",
+            # The source dropped the connection mid-stream while reading Arrow batches
+            # (urllib3 ProtocolError wrapping http.client.IncompleteRead). Byte counts vary.
+            "('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))",
+            "('Connection broken: IncompleteRead(12345 bytes read, 67 more expected)', "
+            "IncompleteRead(12345 bytes read, 67 more expected))",
         ],
     )
     def test_transient_errors_are_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ProtocolError` from the `clickhouse` data-warehouse import source: `('Connection broken: IncompleteRead(0 bytes read)', IncompleteRead(0 bytes read))`, raised from `get_rows` while iterating `query_arrow_stream` in [`clickhouse.py`](https://github.com/PostHog/posthog/blob/master/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/clickhouse.py).

The source's connection dropped mid-transfer while streaming Arrow batches, after the client was already constructed. `_get_client`'s in-process retry only guards connection setup, so a drop this late in the read never gets its chance there and instead falls straight through to `_handle_import_error`, which today doesn't recognize it and captures it as tracked exception noise on every occurrence.

## Changes

This is the same class of transient network blip as the connection-reset/EOF entries already in `ClickHouseSource.get_retryable_errors()` (`source.py`), just surfacing at a later point in the pipeline. Added the stable `"Connection broken: IncompleteRead"` substring (the byte counts in the message vary, but this prefix doesn't) to that set, so the error is classified as retryable: Temporal still retries the activity (reopening a fresh tunnel + client and resuming from the last committed cursor), but it no longer gets reported to error tracking.

No code path changes, retry policy changes, or `NonRetryableErrors` changes — purely a classification fix scoped to this one error family.

## How did you test this code?

Added two parametrized cases to `TestClickHouseSourceRetryableErrors::test_transient_errors_are_retryable` in `test_clickhouse.py`, covering the exact wrapped message from error tracking and a variant with different byte counts, to confirm the new pattern matches without over-matching.

Ran the full `clickhouse` test module locally: `232 passed` (one pre-existing, unrelated failure in `TestClickHouseReconcileSchemaMetadata` requires a local Postgres connection this sandbox doesn't have). Also ran `ruff check` and `ruff format --check` on both changed files — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal retry classification only, no user-facing or documented behavior changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was authored autonomously by Claude Code, triggered off an error-tracking webhook for the linked issue. No skills were invoked (a straightforward, scoped classification change to an existing dict, following the file's own established pattern for similar errors). I confirmed the stack trace genuinely originates in this source's `clickhouse.py`/`source.py`, ruled out an existing fix by searching open PRs (by exception type, message substring, and module path, including the maintainer's own open PRs), and decided this belongs in `get_retryable_errors()` rather than `get_non_retryable_errors()` since a mid-stream connection drop is transient infrastructure noise, not a customer config/credential problem.