### PR TITLE
fix(data-imports): tolerate Apple's misleading 400 on subscription reports

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/app_store_connect.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/app_store_connect.py
@@ -404,11 +404,12 @@ def _fetch_report(
         params=params,
         accept=REPORT_ACCEPT,
         timeout=REPORT_TIMEOUT_SECONDS,
-        tolerate=(404,),
+        tolerate=config.missing_report_status_codes,
     )
-    if response.status_code == 404:
+    if response.status_code in config.missing_report_status_codes:
         # Apple 404s any date with no activity at all — normal for quiet days and for dates before the
-        # app shipped — so a missing day is not an error.
+        # app shipped — so a missing day is not an error. Subscription-family report types 400 for the
+        # same condition instead (see `missing_report_status_codes`).
         return []
 
     return _parse_report(response.content, report_date)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/settings.py
@@ -51,6 +51,11 @@ class AppStoreConnectEndpointConfig:
     # the DAILY/SUMMARY combination of each report type.
     report_version: str = ""
     report_frequency: str = "DAILY"
+    # Apple 404s a SALES report request for a date with no data. Subscription-family report types
+    # (SUBSCRIPTION, SUBSCRIPTION_EVENT) instead 400 with a misleading "Invalid vendor number
+    # specified" error for that same condition — a longstanding, publicly reported Apple API quirk,
+    # not an actual credentials problem. Treat both as "no report for this day" for those types.
+    missing_report_status_codes: tuple[int, ...] = (404,)
 
 
 _REPORT_DATE_FIELD: IncrementalField = incremental_field("report_date", IncrementalFieldType.Date)
@@ -139,6 +144,7 @@ APP_STORE_CONNECT_ENDPOINTS: dict[str, AppStoreConnectEndpointConfig] = {
         incremental_fields=[_REPORT_DATE_FIELD],
         partition_key="report_date",
         should_sync_default=False,
+        missing_report_status_codes=(404, 400),
     ),
     # Daily subscription lifecycle events (renewals, cancellations, upgrades).
     "subscription_event_reports": AppStoreConnectEndpointConfig(
@@ -151,6 +157,7 @@ APP_STORE_CONNECT_ENDPOINTS: dict[str, AppStoreConnectEndpointConfig] = {
         incremental_fields=[_REPORT_DATE_FIELD],
         partition_key="report_date",
         should_sync_default=False,
+        missing_report_status_codes=(404, 400),
     ),
 }
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/app_store_connect/tests/test_app_store_connect.py
@@ -142,14 +142,15 @@ class _FakeApi:
 class _FakeReportApi:
     """Serves `/v1/salesReports` per requested report date; an unknown date 404s like Apple's does."""
 
-    def __init__(self, tsv_by_date: dict[str, str]) -> None:
+    def __init__(self, tsv_by_date: dict[str, str], missing_status_code: int = 404) -> None:
         self.tsv_by_date = tsv_by_date
+        self.missing_status_code = missing_status_code
         self.calls: list[tuple[str, dict[str, Any]]] = []
 
     def get(self, url: str, **kwargs: Any) -> MagicMock:
         params: dict[str, Any] = kwargs.get("params") or {}
         self.calls.append((url, params))
-        return _report_response(self.tsv_by_date.get(params["filter[reportDate]"]))
+        return _report_response(self.tsv_by_date.get(params["filter[reportDate]"]), self.missing_status_code)
 
 
 def _collect(
@@ -534,6 +535,48 @@ class TestSalesReports:
         # Yesterday (2026-03-04) is the newest date Apple has published; 03-03 404s and is skipped.
         assert [(row["report_date"], row["units"]) for row in rows] == [("2026-03-02", "1"), ("2026-03-04", "2")]
         assert [params["filter[reportDate]"] for _, params in api.calls] == ["2026-03-02", "2026-03-03", "2026-03-04"]
+
+    @freeze_time("2026-03-05 09:00:00")
+    def test_subscription_report_tolerates_apples_misleading_400(self) -> None:
+        # Apple 400s (instead of 404) a subscription-family report request for a date with no report
+        # available yet — a documented Apple API quirk, not a real credentials failure. It must not
+        # poison-pill the walk by raising on every retry of the same day.
+        api = _FakeReportApi({"2026-03-04": "SKU\tUnits\nacme\t1\n"}, missing_status_code=400)
+
+        rows = _collect(
+            "subscription_reports",
+            api,
+            _FakeManager(),
+            vendor_number="85234567",
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=date(2026, 3, 2),
+        )
+
+        assert [(row["report_date"], row["units"]) for row in rows] == [("2026-03-04", "1")]
+        assert [params["filter[reportDate]"] for _, params in api.calls] == ["2026-03-02", "2026-03-03", "2026-03-04"]
+
+    @freeze_time("2026-03-05 09:00:00")
+    def test_sales_report_400_is_not_tolerated(self) -> None:
+        # SALES reports don't carry the subscription-family quirk, so a 400 there is a real error and
+        # must still surface rather than being silently treated as an empty day.
+        session = MagicMock()
+        bad_request = _report_response(None, missing_status_code=400)
+        bad_request.raise_for_status.side_effect = Exception("400 Client Error: Bad Request")
+        session.get.return_value = bad_request
+
+        with patch(f"{MODULE}._make_session", return_value=session):
+            with pytest.raises(Exception, match="400"):
+                list(
+                    get_rows(
+                        issuer_id="issuer",
+                        key_id="KEY123",
+                        private_key=PRIVATE_KEY_PEM,
+                        vendor_number="85234567",
+                        endpoint="sales_reports",
+                        logger=MagicMock(),
+                        resumable_source_manager=_FakeManager(),
+                    )
+                )
 
     @freeze_time("2026-03-05 09:00:00")
     def test_sends_the_report_type_filters_from_settings(self) -> None:


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `HTTPError: 400 Client Error: Bad Request` for `https://api.appstoreconnect.apple.com/v1/salesReports` ([issue](https://us.posthog.com/project/2/error_tracking/019fb4fe-dcd7-7312-a62a-49f389165a2c)), always for `reportType=SUBSCRIPTION` or `SUBSCRIPTION_EVENT` at the exact oldest date of the sync's backfill window.

Apple's `/v1/salesReports` endpoint 404s a `SALES` report request for a date with no report available (which we already treat as "quiet day, keep going"). For `SUBSCRIPTION` and `SUBSCRIPTION_EVENT` reports it instead returns a 400 with a misleading `"Invalid vendor number specified"` message for that same condition — a longstanding, publicly documented Apple API quirk (see [Apple Developer Forums thread](https://developer.apple.com/forums/thread/704777)), not an actual credentials problem.

Since our code only tolerated 404, hitting this quirk raised on every retry of the same report date. That poison-pills the sync (Temporal keeps retrying the identical request and failing identically) and produces a stream of near-identical error-tracking events instead of ever making progress past that day.

## Changes

- Added `missing_report_status_codes` to `AppStoreConnectEndpointConfig`, defaulting to `(404,)`.
- Set it to `(404, 400)` for the `subscription_reports` and `subscription_event_reports` endpoints, since only those report types exhibit Apple's misleading-400 behavior.
- `_fetch_report` now checks against the endpoint's configured status codes instead of a hardcoded `404`, so `SALES` report requests still treat an unexpected 400 as a real error.

## How did you test this code?

Added two cases to `TestSalesReports` in `test_app_store_connect.py`:
- A subscription-report 400 for a day with no report is now tolerated and the walk continues past it (previously this would have raised) — guards the poison-pill this PR fixes.
- A `SALES`-report 400 still raises, since that report type doesn't carry the Apple quirk and a real 400 there shouldn't be silently swallowed.

Ran the full `app_store_connect` test suite locally (74 passed), `ruff check --fix` / `ruff format`, and `mypy` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live error-tracking issue in the App Store Connect data-imports pipeline. Investigated the stack trace and sampled exception events via PostHog's error-tracking MCP tools, read the shared and source-specific pipeline code, and cross-referenced Apple's own developer forums to confirm the 400 is a known Apple-side inconsistency for subscription-family reports rather than a bug in our date math or a customer credentials issue. No repo skills were invoked beyond `/writing-tests` before adding the regression tests.