### PR TITLE
fix(visual-review): sync cli package-lock with sharp bump

### DIFF
--- a/products/visual_review/cli/package-lock.json
+++ b/products/visual_review/cli/package-lock.json
@@ -26,6 +26,29 @@
                 "node": ">=24 <25"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+            "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.3",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
@@ -33,6 +56,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -1615,7 +1639,6 @@
             "integrity": "sha512-YrT9ArrGaHForBaCNwFjoqJWmn8G1Pr7+BH/vwyLHciA9qT/wSiuOhxGCT50JA5xLvFBd6PIiGkE3afxcPE1nw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -2214,7 +2237,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2444,7 +2466,6 @@
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "~0.27.0",
                 "get-tsconfig": "^4.7.5"
@@ -2486,7 +2507,6 @@
             "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
@@ -2671,7 +2691,6 @@
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
             "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },


### PR DESCRIPTION
## Problem

`npm ci` in `products/visual_review/cli` fails with `Missing: @emnapi/runtime@1.11.3 from lock file` since #74334 bumped `sharp` without regenerating the CLI's `package-lock.json`. Every workflow that clean-installs the CLI is red — e.g. the `visual-regression` job in PostHog/code fails on all PR branches since ~21:48 UTC (example: https://github.com/PostHog/code/actions/runs/30584853603/job/91013738908).

## Changes

Regenerated `package-lock.json` with `npm install --package-lock-only`: adds the missing `@emnapi/core` / `@emnapi/runtime` entries pulled in by the new `sharp`, plus the accompanying peer-flag sync. No dependency versions change in `package.json`.

## How did you test this code?

- Reproduced the `npm ci` failure locally on master, regenerated the lock, then verified `npm ci` and `npm run build` (tsc) both pass in `products/visual_review/cli`.
- No manual testing beyond that; no test changes (lockfile-only sync).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — lockfile-only fix.

## 🤖 Agent context

Entered a PostHog/code PR's CI-fix loop, found its `visual-regression` job failing in the "Install Visual Review CLI" step for every branch while main's last pre-21:48 run passed, and traced it to this repo's CLI lockfile being out of sync after the sharp bump.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*