### PR TITLE
feat(inbox): use Opus for Create PR report tasks

### DIFF
--- a/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
+++ b/frontend/src/scenes/inbox/inboxTaskKickoffLogic.ts
@@ -41,6 +41,15 @@ const DISCUSS_RUNTIME: ClaudeRuntimeSelection = {
     reasoning_effort: ReasoningEffortEnumApi.High,
 }
 
+// Pressing "Create PR" is a strong engagement signal — the user is committing to a real
+// implementation run — so it pins the stronger model rather than taking the server-side default of
+// Sonnet, giving the change the best shot at landing.
+const CREATE_PR_RUNTIME: ClaudeRuntimeSelection = {
+    runtime_adapter: ClaudeRuntimeAdapterEnumApi.Claude,
+    model: 'claude-opus-5',
+    reasoning_effort: ReasoningEffortEnumApi.High,
+}
+
 function buildCreatePrReportPrompt(report: SignalReport, feedback?: string): string {
     const base = `Act on PostHog Inbox report "${report.title ?? report.id}" (id ${report.id}). Investigate the root cause using the report's contributing findings, implement the fix, and open a PR.${
         report.summary ? `\n\nReport summary:\n${report.summary}` : ''
@@ -226,7 +235,8 @@ export const inboxTaskKickoffLogic = kea<inboxTaskKickoffLogicType>([
                     report,
                     SIGNAL_REPORT_TASK_IMPLEMENTATION_RELATIONSHIP,
                     buildCreatePrReportPrompt(report),
-                    'Implement report fix'
+                    'Implement report fix',
+                    CREATE_PR_RUNTIME
                 )
                 actions.createPrSuccess()
             } catch (error: any) {


### PR DESCRIPTION
## Problem

Pressing "Create PR" on an Inbox report is one of the strongest engagement signals we have — the user is committing to a real implementation run and wants it to land. Today that run takes the server-side default model (Sonnet), so we're spending the least capable model on the moment the user cares most about.

## Changes

`Create PR` now pins `claude-opus-5` with high reasoning effort, instead of falling through to the server-side default. This mirrors the `Discuss` path, which already pins the stronger model for the same reason.

The change is a single-line addition of a `CREATE_PR_RUNTIME` selection passed into the existing `createReportTask` call in `inboxTaskKickoffLogic.ts` — no backend or API changes needed, since `model` / `runtime_adapter` / `reasoning_effort` are already plumbed end-to-end.

## How did you test this code?

No automated tests were added — this is a one-line config change wiring an already-supported runtime selection into an existing call path. I (the PostHog Slack app agent) did not run the app manually. The change reuses the same `ClaudeRuntimeSelection` shape and `claude-opus-5` model id already used by the sibling `Discuss` action, so it's covered by the same request plumbing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked (via Slack) why the Inbox "Create PR" button runs on Sonnet when pressing it is a strong engagement signal that deserves the stronger model. I traced the two Create-PR-from-Inbox paths: the user-facing button click goes through `createPrFromReport` in `inboxTaskKickoffLogic.ts`, which was calling `createReportTask` without a `runtimeSelection`, so the run defaulted to Sonnet server-side. The fix mirrors the existing `DISCUSS_RUNTIME` constant right above it, pinning `claude-opus-5` / high effort. The separate autonomous auto-start pipeline (`products/signals/backend/auto_start.py`) resolves its model independently and is intentionally left untouched.

No repo skills were required for this one-line frontend change.


---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1785449875038899?thread_ts=1785449875.038899&cid=C09SK2PAGKF)*
