### PR TITLE
fix(personhog): install rustls provider before leader k8s discovery

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8536,6 +8536,7 @@ dependencies = [
  "personhog-proto",
  "prost 0.13.5",
  "rdkafka",
+ "rustls 0.23.37",
  "serde_json",
  "sqlx",
  "tokio",

--- a/rust/personhog-leader/Cargo.toml
+++ b/rust/personhog-leader/Cargo.toml
@@ -15,6 +15,10 @@ common-metrics = { path = "../common/metrics" }
 common-alloc = { path = "../common/alloc" }
 k8s-awareness = { path = "../common/k8s-awareness" }
 kube = { version = "0.98", features = ["client"] }
+# Direct dep only to install a process-wide rustls CryptoProvider at startup (see
+# main.rs): kube's HTTPS client uses rustls 0.23, which can't auto-pick a provider
+# with both aws-lc-rs and ring in the tree. Matches personhog-router/cymbal.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 lifecycle = { path = "../common/lifecycle" }
 
 async-trait = { workspace = true }

--- a/rust/personhog-leader/src/main.rs
+++ b/rust/personhog-leader/src/main.rs
@@ -42,6 +42,14 @@ common_alloc::used!();
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Install a process-wide rustls CryptoProvider before any TLS use. kube's
+    // HTTPS client (controller discovery) uses rustls 0.23, which can't
+    // auto-pick a provider with both aws-lc-rs and ring compiled in — it
+    // panics. Matches personhog-router / cymbal / ingestion-consumer.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install rustls ring CryptoProvider");
+
     let config = Config::init_from_env().expect("Invalid configuration");
     validate_table_name(&config.fallback_table).expect("Invalid FALLBACK_TABLE");
 


### PR DESCRIPTION
## Problem

The first leader rollout with Kubernetes awareness enabled crash-looped at startup: the binary panicked in rustls the moment controller discovery built its Kubernetes client.

thread 'main' panicked at rustls-0.23.37/src/crypto/mod.rs:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.

Adding kube to the leader pulled rustls's aws-lc-rs backend into a dependency graph that already links ring — with both compiled in, rustls refuses to auto-select a provider and panics at Client::try_default(). Feature unification is per-binary, which is why the coordination crate's k3s integration tests (single provider in their union) never caught it, and why the router — which installs a provider explicitly at startup — runs the same discovery stack fine. The failure is contained: startup panics before registration, so old-generation pods keep serving while the new ReplicaSet loops.

## Changes

The established fix for this exact collision, copied from personhog-router / cymbal / ingestion-consumer:

- rustls as a direct dependency of the leader (default-features = false, features = ["ring", "std"]) — present only so the binary can install a provider.
- rustls::crypto::ring::default_provider().install_default() as the first statement of main, before any TLS use, making the feature union irrelevant.

## How did you test this code?

Agent-authored; automated checks only: cargo build -p personhog-leader, cargo clippy --all-targets --all-features (clean), cargo shear (dep is used), cargo test -p personhog-leader (86 tests green). The panic itself only reproduces with in-cluster TLS config, so the real verification is the next rollout: the leader should log K8s awareness enabled; controller discovered at startup instead of restarting. No new tests — the provider install is process-global startup wiring the existing pattern already establishes in three other binaries.

## 🤖 Agent context

Autonomy: Human-driven (agent-assisted)

Claude Code session. Root-caused from the deploy's telemetry: the new ReplicaSet's pod logged normal startup through address advertisement, then a rustls panic with a container restart, while the awareness startup log lines (success, failure, and timeout arms) were all absent — placing the panic exactly at client construction. Verified the chart env was correctly rendered before suspecting code. The fix copies the repo's existingtion-consumer's comment names this exact kube/rustls collision); no newapproach was invented.