### PR TITLE
fix(replay-vision): collapse adjacent citations into one bracket group

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/visionActionRunSceneLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionRunSceneLogic.test.ts
@@ -12,24 +12,45 @@ const obs = (index: number, id: string): RunObservationApi => ({
     created_at: '2026-01-01T00:00:00Z',
 })
 
+const link = (id: string): string => urls.replayVisionObservation(id)
+
 describe('resolveObservationCitations', () => {
-    it('links resolvable [obs N] markers as [N] and drops the ones that no longer resolve', () => {
+    it('links a lone [obs N] marker as an [N] link and drops the ones that no longer resolve', () => {
         // obs 3 has no matching observation (deleted, or the model invented it) — it must be dropped, not
         // rendered as a dead `[3]` or misdirected to another row.
-        const out = resolveObservationCitations('Friction here [obs 1] [obs 2]. Gone [obs 3].', [
-            obs(1, 'aaa'),
-            obs(2, 'bbb'),
+        const out = resolveObservationCitations('Friction here [obs 1]. Gone [obs 3].', [obs(1, 'aaa'), obs(2, 'bbb')])
+        expect(out).toBe(`Friction here [\\[1\\]](${link('aaa')}). Gone .`)
+    })
+
+    it('collapses adjacent markers into one bracket group where every number is its own link', () => {
+        const out = resolveObservationCitations('Direct to the button [obs 2] [obs 5] [obs 33].', [
+            obs(2, 'aaa'),
+            obs(5, 'bbb'),
+            obs(33, 'ccc'),
         ])
-        expect(out).toBe(
-            `Friction here [[1]](${urls.replayVisionObservation('aaa')}) [[2]](${urls.replayVisionObservation(
-                'bbb'
-            )}). Gone .`
-        )
+        // Renders as `[2, 5, 33]`: brackets and commas live inside the link texts so the whole group
+        // gets the superscript citation styling.
+        expect(out).toBe(`Direct to the button [\\[2,](${link('aaa')}) [5,](${link('bbb')}) [33\\]](${link('ccc')}).`)
+    })
+
+    it('drops unresolvable markers from a group and keeps the brackets balanced', () => {
+        const out = resolveObservationCitations('Here [obs 1] [obs 3] [obs 2].', [obs(1, 'aaa'), obs(2, 'bbb')])
+        expect(out).toBe(`Here [\\[1,](${link('aaa')}) [2\\]](${link('bbb')}).`)
+    })
+
+    it('drops a group entirely when none of its markers resolve', () => {
+        const out = resolveObservationCitations('Nothing left [obs 3] [obs 4].', [obs(1, 'aaa')])
+        expect(out).toBe('Nothing left .')
+    })
+
+    it('does not collapse markers separated by other text or newlines', () => {
+        const out = resolveObservationCitations('One [obs 1], two [obs 2]\n[obs 1]', [obs(1, 'aaa'), obs(2, 'bbb')])
+        expect(out).toBe(`One [\\[1\\]](${link('aaa')}), two [\\[2\\]](${link('bbb')})\n[\\[1\\]](${link('aaa')})`)
     })
 
     it('maps a citation to its index, not its array position, after an earlier observation is deleted', () => {
         // obs 1 was deleted, so the array starts at index 2. `[obs 2]` must still resolve to id 'bbb'.
         const out = resolveObservationCitations('See [obs 2].', [obs(2, 'bbb'), obs(3, 'ccc')])
-        expect(out).toBe(`See [[2]](${urls.replayVisionObservation('bbb')}).`)
+        expect(out).toBe(`See [\\[2\\]](${link('bbb')}).`)
     })
 })

--- a/products/replay_vision/frontend/replay_scanners/visionActionRunSceneLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionRunSceneLogic.test.ts
@@ -14,6 +14,9 @@ const obs = (index: number, id: string): RunObservationApi => ({
 
 const link = (id: string): string => urls.replayVisionObservation(id)
 
+// Group members join on a no-break space so a `[2, 5, 33]` group can't wrap mid-bracket.
+const NBSP = '\u00a0'
+
 describe('resolveObservationCitations', () => {
     it('links a lone [obs N] marker as an [N] link and drops the ones that no longer resolve', () => {
         // obs 3 has no matching observation (deleted, or the model invented it) — it must be dropped, not
@@ -30,12 +33,19 @@ describe('resolveObservationCitations', () => {
         ])
         // Renders as `[2, 5, 33]`: brackets and commas live inside the link texts so the whole group
         // gets the superscript citation styling.
-        expect(out).toBe(`Direct to the button [\\[2,](${link('aaa')}) [5,](${link('bbb')}) [33\\]](${link('ccc')}).`)
+        expect(out).toBe(
+            `Direct to the button [\\[2,](${link('aaa')})${NBSP}[5,](${link('bbb')})${NBSP}[33\\]](${link('ccc')}).`
+        )
     })
 
     it('drops unresolvable markers from a group and keeps the brackets balanced', () => {
         const out = resolveObservationCitations('Here [obs 1] [obs 3] [obs 2].', [obs(1, 'aaa'), obs(2, 'bbb')])
-        expect(out).toBe(`Here [\\[1,](${link('aaa')}) [2\\]](${link('bbb')}).`)
+        expect(out).toBe(`Here [\\[1,](${link('aaa')})${NBSP}[2\\]](${link('bbb')}).`)
+    })
+
+    it('cites a duplicated marker once so it does not read as extra evidence', () => {
+        const out = resolveObservationCitations('Twice [obs 1] [obs 1] [obs 2].', [obs(1, 'aaa'), obs(2, 'bbb')])
+        expect(out).toBe(`Twice [\\[1,](${link('aaa')})${NBSP}[2\\]](${link('bbb')}).`)
     })
 
     it('drops a group entirely when none of its markers resolve', () => {

--- a/products/replay_vision/frontend/replay_scanners/visionActionRunSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionRunSceneLogic.ts
@@ -13,14 +13,28 @@ import type { RunObservationApi, VisionActionApi, VisionActionRunApi } from '../
 
 /**
  * Resolve the `[obs N]` citation markers the synthesizer leaves in a group summary into `[N]` links to
- * each observation. `N` is the observation's stable `index` (its position in the summary), so a deleted
+ * each observation. Adjacent markers collapse into one bracket group (`[2, 5, 33]`) where every number
+ * stays its own link. `N` is the observation's stable `index` (its position in the summary), so a deleted
  * observation drops its citation rather than misdirecting to a renumbered neighbor.
  */
 export function resolveObservationCitations(markdown: string, observations: readonly RunObservationApi[]): string {
     const byIndex = new Map(observations.map((obs) => [obs.index, obs]))
-    return markdown.replace(/\[obs (\d+)\]/g, (_match, n: string) => {
-        const obs = byIndex.get(Number(n))
-        return obs ? `[[${n}]](${urls.replayVisionObservation(obs.id)})` : ''
+    return markdown.replace(/\[obs \d+\](?:[ \t]*\[obs \d+\])*/g, (group) => {
+        const cited: { n: string; url: string }[] = []
+        for (const [, n] of group.matchAll(/\[obs (\d+)\]/g)) {
+            const obs = byIndex.get(Number(n))
+            if (obs) {
+                cited.push({ n, url: urls.replayVisionObservation(obs.id) })
+            }
+        }
+        // Brackets and commas sit inside the link texts (escaped) so the whole group inherits the
+        // superscript citation styling, which only targets the <a> elements (ScannerSummary.scss).
+        return cited
+            .map(({ n, url }, i) => {
+                const text = `${i === 0 ? '\\[' : ''}${n}${i === cited.length - 1 ? '\\]' : ','}`
+                return `[${text}](${url})`
+            })
+            .join(' ')
     })
 }
 

--- a/products/replay_vision/frontend/replay_scanners/visionActionRunSceneLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/visionActionRunSceneLogic.ts
@@ -23,18 +23,21 @@ export function resolveObservationCitations(markdown: string, observations: read
         const cited: { n: string; url: string }[] = []
         for (const [, n] of group.matchAll(/\[obs (\d+)\]/g)) {
             const obs = byIndex.get(Number(n))
-            if (obs) {
+            // Synthesizers often repeat a citation; a group citing the same observation twice would
+            // read as two distinct pieces of evidence.
+            if (obs && !cited.some((c) => c.n === n)) {
                 cited.push({ n, url: urls.replayVisionObservation(obs.id) })
             }
         }
         // Brackets and commas sit inside the link texts (escaped) so the whole group inherits the
         // superscript citation styling, which only targets the <a> elements (ScannerSummary.scss).
+        // Joined with no-break spaces so a group can't wrap mid-bracket (orphaning e.g. `[2,` at a line end).
         return cited
             .map(({ n, url }, i) => {
                 const text = `${i === 0 ? '\\[' : ''}${n}${i === cited.length - 1 ? '\\]' : ','}`
                 return `[${text}](${url})`
             })
-            .join(' ')
+            .join('\u00a0')
     })
 }
 


### PR DESCRIPTION
## Problem

A synthesized scanner summary cites every observation as its own superscript link, so a sentence backed by six observations trails off in a long row like [2] [5] [6] [11] [27] [33]. That reads as clutter and often wraps onto an extra line.

## Changes

Adjacent `[obs N]` markers now collapse into a single bracket group, and every number inside the group is still its own link to that observation.

![citation-before-after](https://raw.githubusercontent.com/PostHog/pr-assets/b158163df670a3761d65833eef26a89a081217e8/2026/07/25e5af1f-479a-4150-9a3a-510b479386ad.png)

How it works: the resolved markdown puts the group's brackets and commas inside the link texts (escaped), so the whole group inherits the superscript citation styling in `ScannerSummary.scss`, which only targets the `<a>` elements. Lone citations render exactly as before, markers separated by other text or newlines don't collapse, and unresolvable citations (deleted observations) drop out of the group while keeping the brackets balanced.

> [!NOTE]
> Display-only change. The stored `synthesized_markdown` is untouched, so existing runs and digests pick this up with no migration and nothing breaks on revert.

## How did you test this code?

- Extended the jest suite for `resolveObservationCitations` (6 tests, all passing locally). New regressions covered that no existing test did: adjacent markers collapse into one group, unresolved markers drop from a group without unbalancing the brackets, a fully unresolved group disappears entirely, and markers separated by other text or newlines stay separate.
- Verified the emitted markdown renders to the intended anchors with the repo's actual react-markdown + remark-gfm + remark-breaks versions (adjacent `<a>` elements reading `[2, 5, 33]`, lone citation unchanged as `[7]`).
- I did not run the full app. The screenshot above is a mock render of the output HTML with the real citation CSS applied.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (PostHog Code) at Arno's request. Considered wrapping the group in raw HTML (`<sup>`), but LemonMarkdown doesn't render raw HTML, and putting the separators outside the links would leave them at full text size. So the separators live inside the escaped link texts instead, keeping this a one-function change with no new CSS.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
