### PR TITLE
fix(data-imports): prefetch schema source to stop lazy DB read in delta URI

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/import_data_sync.py
@@ -304,7 +304,11 @@ async def import_data_activity_sync(inputs: ImportDataActivityInputs) -> Pipelin
 def _get_models(
     job_id: str,
 ) -> tuple[ExternalDataJob, ExternalDataSchema, ExternalDataSource, DataWarehouseTable | None]:
-    job = ExternalDataJob.objects.select_related("schema", "schema__table").get(id=job_id)
+    # `schema__source` is prefetched so `job.folder_path()` (via `schema.source.source_type`, called
+    # repeatedly through the run by `DeltaTableHelper._get_delta_table_uri`) never triggers a lazy
+    # relation load later on a pooled connection the transaction pooler may have dropped mid-sync,
+    # which raises a transient `OperationalError`/DNS failure.
+    job = ExternalDataJob.objects.select_related("schema", "schema__table", "schema__source").get(id=job_id)
     schema: ExternalDataSchema | None = job.schema
     source: ExternalDataSource | None = job.pipeline
     if schema is None:

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_import_data_sync.py
@@ -1,12 +1,17 @@
 import uuid
 import contextlib
 from datetime import datetime
+from typing import Any, cast
 
 import pytest
+from posthog.test.base import BaseTest
 from unittest import mock
 
 from posthog.temporal.common.errors import NonReportableError
 
+from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.arrow_utils import (
     SchemaColumnTypeChangedException,
 )
@@ -88,6 +93,29 @@ def _inputs() -> ImportDataActivityInputs:
         run_id=str(uuid.uuid4()),
         reset_pipeline=True,
     )
+
+
+class TestGetModelsPrefetchesSource(BaseTest):
+    def test_folder_path_needs_no_query_after_load(self) -> None:
+        # folder_path() reads schema.source.source_type. If _get_models stops prefetching
+        # schema__source, that read fires a lazy SELECT later in the run, on a pooled app-DB
+        # connection the transaction pooler can drop mid-sync — surfacing as a spurious
+        # OperationalError/DNS failure far from where the real query would have been.
+        source = ExternalDataSource.objects.create(
+            source_id=str(uuid.uuid4()), connection_id=str(uuid.uuid4()), team=self.team, source_type="Stripe"
+        )
+        schema = ExternalDataSchema.objects.create(name="Invoice", team=self.team, source=source, sync_type_config={})
+        job = ExternalDataJob.objects.create(
+            team=self.team, pipeline=source, schema=schema, status=ExternalDataJob.Status.RUNNING
+        )
+
+        # Call the undecorated sync loader directly so the query capture runs on this thread.
+        # `.func` is the wrapped sync callable on database_sync_to_async_pool's DatabaseSyncToAsync
+        # (asgiref); it isn't on the decorator's static type, hence the cast.
+        loaded_job, _, _, _ = cast(Any, module._get_models).func(str(job.id))
+
+        with self.assertNumQueries(0):
+            loaded_job.folder_path()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError: [Errno -2] Name or service not known` during a warehouse sync, with the top frame in `psycopg`'s connection code. The stack trace showed it wasn't a source-connector issue at all — it was a lazy Django relation load hitting our own app database:

```
handle_corrupted_delta_log -> is_table_corrupted -> _get_delta_table_uri
  -> job.folder_path() -> schema.folder_path() -> self.source.source_type
  -> (lazy SELECT on schema.source) -> OperationalError
```

`_get_models` (the loader used by the import activity) only prefetches `schema` and `schema__table`. `DeltaTableHelper._get_delta_table_uri()` calls `job.folder_path()` repeatedly through a sync run (including from `handle_corrupted_delta_log`, which runs before every extraction), and `folder_path()` reads `schema.source.source_type`. Without `schema__source` prefetched, that access is a lazy DB query fired later in the run on a pooled connection — one the transaction pooler can drop mid-sync, surfacing as a transient `OperationalError`/DNS failure that looks unrelated to anything in the pipeline.

This exception is already caught and captured rather than crashing the sync, so the failure was cosmetic/noise rather than a broken sync, but it's still an avoidable extra round-trip to our own DB and a misleading error to triage.

## Changes

Add `schema__source` to the existing `select_related` call in `_get_models`, so the relation is resolved once up front alongside `schema` and `schema__table`, instead of lazily later in the run.

## How did you test this code?

Added a regression test (`TestGetModelsPrefetchesSource`) that creates a real source/schema/job, loads them through `_get_models`, and asserts `job.folder_path()` triggers zero additional queries (`assertNumQueries(0)`) — this fails without the prefetch and would have caught the bug.

Ran the full `test_import_data_sync.py` suite (15 passed) and `mypy --cache-fine-grained .` (repo-wide, per project convention) — both clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior changed; no docs to update.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude) triaged a PostHog error-tracking issue reporting an `OperationalError` during a Supabase sync, traced it through the shared pipeline code (not the Supabase connector), and found the root cause: a missing `select_related` prefetch causing a lazy DB read against our own app database, occasionally hitting a transient DNS/pooler blip.

Before implementing, I searched open PRs for duplicates. Two were relevant but neither covers this: [#75733](https://github.com/PostHog/posthog/pull/75733) reclassifies `OperationalError`/`InterfaceError` at the top-level activity error handler (a different code path — this exception is caught deep inside `handle_corrupted_delta_log` and never reaches that handler), and [#71934](https://github.com/PostHog/posthog/pull/71934) is a stale, months-old, unmerged attempt at the same root cause that targets a file path (`pipelines/pipeline/delta_table_helper.py`) that no longer exists after a pipeline reorg — it doesn't apply to current code.

Invoked `/writing-tests` before adding the regression test.