### PR TITLE
feat(replay-vision): expose vision action write MCP tools

### DIFF
--- a/frontend/src/lib/agentScopes.generated.ts
+++ b/frontend/src/lib/agentScopes.generated.ts
@@ -131,6 +131,7 @@ export const AGENT_USE_CASE_SCOPES = [
     'user_interview:read',
     'user_interview:write',
     'vision_action:read',
+    'vision_action:write',
     'visual_review:read',
     'visual_review:write',
     'warehouse_table:read',

--- a/products/replay_vision/mcp/tools.yaml
+++ b/products/replay_vision/mcp/tools.yaml
@@ -11,10 +11,51 @@ ui_apps: {}
 tools:
     vision-actions-create:
         operation: vision_actions_create
-        enabled: false
-    vision-actions-destroy:
+        enabled: true
+        scopes:
+            - vision_action:write
+            - session_recording:read
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Create vision action
+        description: >
+            Create a vision action, an "and then…" automation over a scanner's observations. Two modes: `group_summary`
+            (a scheduled report synthesized from the observations matching `selection`; set the cadence via
+            `trigger_config` `{rrule, timezone}`, an iCal RRULE without DTSTART, e.g. `FREQ=DAILY`) and `alert`
+            (evaluated continuously on the scanner's sweep; requires `alert_config`: `every_match` notifies about each
+            new matching observation, `on_breach` needs a `threshold` and fires when the `metric` (`count`, or
+            `avg_score` for scorer scanners) crosses it over `window_days` of 1/3/7/14/30). `selection` narrows which
+            observations count (verdict/tags/score bounds). Deliver to Slack or a webhook via `delivery_config`, e.g.
+            `[{type: 'slack', integration_id, channel}]`. Find the workspace's `integration_id` with `integrations-list`
+            (filter kind=slack) and the channel ID with `integrations-channels-retrieve`; without a delivery target,
+            results only appear in-app. Names must be unique within the team.
+        exclude_params:
+            - id
+            - next_run_at
+            - last_run_at
+            - hog_flow_id
+            - created_at
+            - created_by
+            - updated_at
+        requires_ai_consent: true
+        feature_flag: replay-vision
+    vision-actions-delete:
         operation: vision_actions_destroy
-        enabled: false
+        enabled: true
+        scopes:
+            - vision_action:write
+        annotations:
+            readOnly: false
+            destructive: true
+            idempotent: true
+        title: Delete vision action
+        description: >
+            Permanently delete a vision action by ID, along with its run history (past group summaries and alert
+            firings). Its delivery destinations stop firing. To stop an action without losing its history, set `enabled:
+            false` via `vision-actions-update` instead.
+        feature_flag: replay-vision
     vision-actions-list:
         operation: vision_actions_list
         enabled: true
@@ -34,9 +75,6 @@ tools:
             `trigger_type`, cadence, and `is_scanner_digest` (the built-in daily digest). Pass `?scanner=<id>` to filter
             to one scanner. To read a specific action's produced reports, list its runs with `vision-actions-runs-list`.
         feature_flag: replay-vision
-    vision-actions-partial-update:
-        operation: vision_actions_partial_update
-        enabled: false
     vision-actions-retrieve:
         operation: vision_actions_retrieve
         enabled: true
@@ -94,6 +132,34 @@ tools:
             markdown, `observations[N-1]` is the observation it cites, so you can check whether the cited observation
             actually supports the claim. Empty `synthesized_markdown`/`observations` means the run skipped, failed, or
             predates observation tracking.
+        feature_flag: replay-vision
+    vision-actions-update:
+        operation: vision_actions_partial_update
+        enabled: true
+        scopes:
+            - vision_action:write
+            - session_recording:read
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: true
+        title: Update vision action
+        description: >
+            Partially update a vision action by ID. Send only the fields you want to change. Common changes: toggle
+            `enabled` to pause/resume it, tune the `alert_config` threshold, change the `trigger_config` cadence, or
+            point `delivery_config` at a different Slack channel or webhook. Nested objects and lists you send replace
+            the stored value wholesale (e.g. `delivery_config` is the full new list), so fetch the action with
+            `vision-actions-retrieve` first and resend the parts you want to keep. `mode` cross-field rules apply as on
+            create: switching to `alert` requires an `alert_config`.
+        exclude_params:
+            - id
+            - next_run_at
+            - last_run_at
+            - hog_flow_id
+            - created_at
+            - created_by
+            - updated_at
+        requires_ai_consent: true
         feature_flag: replay-vision
     vision-observations-create-task-create:
         operation: vision_observations_create_task_create
@@ -236,7 +302,8 @@ tools:
             call `vision-scanners-estimate-create` to project its monthly observation volume and `vision-quota-retrieve`
             to check the org's remaining budget — an enabled scanner sweeps matching recordings every 5 minutes, and
             creation itself does not check quota, so a too-broad scanner can exhaust the monthly budget on its first
-            sweeps.
+            sweeps. To get notified about what the scanner finds (a Slack alert or a scheduled summary), create a vision
+            action bound to it with `vision-actions-create`.
         exclude_params:
             - id
             - scanner_version

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -9738,6 +9738,37 @@
             "readOnlyHint": false
         }
     },
+    "vision-actions-create": {
+        "description": "Create a vision action, an \"and then…\" automation over a scanner's observations. Two modes: `group_summary` (a scheduled report synthesized from the observations matching `selection`; set the cadence via `trigger_config` `{rrule, timezone}`, an iCal RRULE without DTSTART, e.g. `FREQ=DAILY`) and `alert` (evaluated continuously on the scanner's sweep; requires `alert_config`: `every_match` notifies about each new matching observation, `on_breach` needs a `threshold` and fires when the `metric` (`count`, or `avg_score` for scorer scanners) crosses it over `window_days` of 1/3/7/14/30). `selection` narrows which observations count (verdict/tags/score bounds). Deliver to Slack or a webhook via `delivery_config`, e.g. `[{type: 'slack', integration_id, channel}]`. Find the workspace's `integration_id` with `integrations-list` (filter kind=slack) and the channel ID with `integrations-channels-retrieve`; without a delivery target, results only appear in-app. Names must be unique within the team.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Create vision action",
+        "title": "Create vision action",
+        "required_scopes": ["vision_action:write", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "requires_ai_consent": true,
+        "feature_flag": "replay-vision"
+    },
+    "vision-actions-delete": {
+        "description": "Permanently delete a vision action by ID, along with its run history (past group summaries and alert firings). Its delivery destinations stop firing. To stop an action without losing its history, set `enabled: false` via `vision-actions-update` instead.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Delete vision action",
+        "title": "Delete vision action",
+        "required_scopes": ["vision_action:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "replay-vision"
+    },
     "vision-actions-list": {
         "description": "List the vision actions (the \"and then…\" automations that run over a scanner's observations) for the current project. A vision action in `mode: group_summary` produces the group summary shown on the \"Summaries and alerts\" tab — one report synthesized from up to `max_observations` observations of its bound scanner; `mode: alert` delivers only when its alert condition holds. Each row carries the bound `scanner`, `mode`, `trigger_type`, cadence, and `is_scanner_digest` (the built-in daily digest). Pass `?scanner=<id>` to filter to one scanner. To read a specific action's produced reports, list its runs with `vision-actions-runs-list`.",
         "category": "Replay vision",
@@ -9796,6 +9827,22 @@
             "openWorldHint": true,
             "readOnlyHint": true
         },
+        "feature_flag": "replay-vision"
+    },
+    "vision-actions-update": {
+        "description": "Partially update a vision action by ID. Send only the fields you want to change. Common changes: toggle `enabled` to pause/resume it, tune the `alert_config` threshold, change the `trigger_config` cadence, or point `delivery_config` at a different Slack channel or webhook. Nested objects and lists you send replace the stored value wholesale (e.g. `delivery_config` is the full new list), so fetch the action with `vision-actions-retrieve` first and resend the parts you want to keep. `mode` cross-field rules apply as on create: switching to `alert` requires an `alert_config`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Update vision action",
+        "title": "Update vision action",
+        "required_scopes": ["vision_action:write", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "requires_ai_consent": true,
         "feature_flag": "replay-vision"
     },
     "vision-observations-label-create": {
@@ -9889,7 +9936,7 @@
         "feature_flag": "replay-vision"
     },
     "vision-scanners-create": {
-        "description": "Create a replay vision scanner. Pick a `scanner_type` — `monitor` (open-ended observations), `classifier` (assign a tag from a fixed label set), `scorer` (numeric rubric), or `summarizer` (free-text summary with optional facet embeddings via `emits_embeddings`) — and fill `scanner_config` to match: all types need a `prompt`; classifiers also need `tags`; scorers also need `scale`; summarizers optionally set `length` and `emits_embeddings`. `query` is a `RecordingsQuery` shape that defines which sessions the scanner watches — `date_from` and `date_to` are ignored (the schedule controls time). `sampling_rate` is a 0..1 random downsample applied after the query matches (default 1.0). `model` chooses the LLM. Names must be unique within the team. Before creating a broad scanner (a permissive `query` and/or high `sampling_rate`), first call `vision-scanners-estimate-create` to project its monthly observation volume and `vision-quota-retrieve` to check the org's remaining budget — an enabled scanner sweeps matching recordings every 5 minutes, and creation itself does not check quota, so a too-broad scanner can exhaust the monthly budget on its first sweeps.",
+        "description": "Create a replay vision scanner. Pick a `scanner_type` — `monitor` (open-ended observations), `classifier` (assign a tag from a fixed label set), `scorer` (numeric rubric), or `summarizer` (free-text summary with optional facet embeddings via `emits_embeddings`) — and fill `scanner_config` to match: all types need a `prompt`; classifiers also need `tags`; scorers also need `scale`; summarizers optionally set `length` and `emits_embeddings`. `query` is a `RecordingsQuery` shape that defines which sessions the scanner watches — `date_from` and `date_to` are ignored (the schedule controls time). `sampling_rate` is a 0..1 random downsample applied after the query matches (default 1.0). `model` chooses the LLM. Names must be unique within the team. Before creating a broad scanner (a permissive `query` and/or high `sampling_rate`), first call `vision-scanners-estimate-create` to project its monthly observation volume and `vision-quota-retrieve` to check the org's remaining budget — an enabled scanner sweeps matching recordings every 5 minutes, and creation itself does not check quota, so a too-broad scanner can exhaust the monthly budget on its first sweeps. To get notified about what the scanner finds (a Slack alert or a scheduled summary), create a vision action bound to it with `vision-actions-create`.",
         "category": "Replay vision",
         "feature": "replay_vision",
         "summary": "Create replay vision scanner",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -10378,6 +10378,37 @@
             "readOnlyHint": false
         }
     },
+    "vision-actions-create": {
+        "description": "Create a vision action, an \"and then…\" automation over a scanner's observations. Two modes: `group_summary` (a scheduled report synthesized from the observations matching `selection`; set the cadence via `trigger_config` `{rrule, timezone}`, an iCal RRULE without DTSTART, e.g. `FREQ=DAILY`) and `alert` (evaluated continuously on the scanner's sweep; requires `alert_config`: `every_match` notifies about each new matching observation, `on_breach` needs a `threshold` and fires when the `metric` (`count`, or `avg_score` for scorer scanners) crosses it over `window_days` of 1/3/7/14/30). `selection` narrows which observations count (verdict/tags/score bounds). Deliver to Slack or a webhook via `delivery_config`, e.g. `[{type: 'slack', integration_id, channel}]`. Find the workspace's `integration_id` with `integrations-list` (filter kind=slack) and the channel ID with `integrations-channels-retrieve`; without a delivery target, results only appear in-app. Names must be unique within the team.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Create vision action",
+        "title": "Create vision action",
+        "required_scopes": ["vision_action:write", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "requires_ai_consent": true,
+        "feature_flag": "replay-vision"
+    },
+    "vision-actions-delete": {
+        "description": "Permanently delete a vision action by ID, along with its run history (past group summaries and alert firings). Its delivery destinations stop firing. To stop an action without losing its history, set `enabled: false` via `vision-actions-update` instead.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Delete vision action",
+        "title": "Delete vision action",
+        "required_scopes": ["vision_action:write"],
+        "annotations": {
+            "destructiveHint": true,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "replay-vision"
+    },
     "vision-actions-list": {
         "description": "List the vision actions (the \"and then…\" automations that run over a scanner's observations) for the current project. A vision action in `mode: group_summary` produces the group summary shown on the \"Summaries and alerts\" tab — one report synthesized from up to `max_observations` observations of its bound scanner; `mode: alert` delivers only when its alert condition holds. Each row carries the bound `scanner`, `mode`, `trigger_type`, cadence, and `is_scanner_digest` (the built-in daily digest). Pass `?scanner=<id>` to filter to one scanner. To read a specific action's produced reports, list its runs with `vision-actions-runs-list`.",
         "category": "Replay vision",
@@ -10436,6 +10467,22 @@
             "openWorldHint": true,
             "readOnlyHint": true
         },
+        "feature_flag": "replay-vision"
+    },
+    "vision-actions-update": {
+        "description": "Partially update a vision action by ID. Send only the fields you want to change. Common changes: toggle `enabled` to pause/resume it, tune the `alert_config` threshold, change the `trigger_config` cadence, or point `delivery_config` at a different Slack channel or webhook. Nested objects and lists you send replace the stored value wholesale (e.g. `delivery_config` is the full new list), so fetch the action with `vision-actions-retrieve` first and resend the parts you want to keep. `mode` cross-field rules apply as on create: switching to `alert` requires an `alert_config`.",
+        "category": "Replay vision",
+        "feature": "replay_vision",
+        "summary": "Update vision action",
+        "title": "Update vision action",
+        "required_scopes": ["vision_action:write", "session_recording:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "requires_ai_consent": true,
         "feature_flag": "replay-vision"
     },
     "vision-observations-label-create": {
@@ -10529,7 +10576,7 @@
         "feature_flag": "replay-vision"
     },
     "vision-scanners-create": {
-        "description": "Create a replay vision scanner. Pick a `scanner_type` — `monitor` (open-ended observations), `classifier` (assign a tag from a fixed label set), `scorer` (numeric rubric), or `summarizer` (free-text summary with optional facet embeddings via `emits_embeddings`) — and fill `scanner_config` to match: all types need a `prompt`; classifiers also need `tags`; scorers also need `scale`; summarizers optionally set `length` and `emits_embeddings`. `query` is a `RecordingsQuery` shape that defines which sessions the scanner watches — `date_from` and `date_to` are ignored (the schedule controls time). `sampling_rate` is a 0..1 random downsample applied after the query matches (default 1.0). `model` chooses the LLM. Names must be unique within the team. Before creating a broad scanner (a permissive `query` and/or high `sampling_rate`), first call `vision-scanners-estimate-create` to project its monthly observation volume and `vision-quota-retrieve` to check the org's remaining budget — an enabled scanner sweeps matching recordings every 5 minutes, and creation itself does not check quota, so a too-broad scanner can exhaust the monthly budget on its first sweeps.",
+        "description": "Create a replay vision scanner. Pick a `scanner_type` — `monitor` (open-ended observations), `classifier` (assign a tag from a fixed label set), `scorer` (numeric rubric), or `summarizer` (free-text summary with optional facet embeddings via `emits_embeddings`) — and fill `scanner_config` to match: all types need a `prompt`; classifiers also need `tags`; scorers also need `scale`; summarizers optionally set `length` and `emits_embeddings`. `query` is a `RecordingsQuery` shape that defines which sessions the scanner watches — `date_from` and `date_to` are ignored (the schedule controls time). `sampling_rate` is a 0..1 random downsample applied after the query matches (default 1.0). `model` chooses the LLM. Names must be unique within the team. Before creating a broad scanner (a permissive `query` and/or high `sampling_rate`), first call `vision-scanners-estimate-create` to project its monthly observation volume and `vision-quota-retrieve` to check the org's remaining budget — an enabled scanner sweeps matching recordings every 5 minutes, and creation itself does not check quota, so a too-broad scanner can exhaust the monthly budget on its first sweeps. To get notified about what the scanner finds (a Slack alert or a scheduled summary), create a vision action bound to it with `vision-actions-create`.",
         "category": "Replay vision",
         "feature": "replay_vision",
         "summary": "Create replay vision scanner",

--- a/services/mcp/src/generated/replay_vision/api.ts
+++ b/services/mcp/src/generated/replay_vision/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 25 enabled ops
+ * PostHog API - MCP 28 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -28,7 +28,396 @@ export const VisionActionsListQueryParams = /* @__PURE__ */ zod.object({
 /**
  * CRUD for Replay Vision actions — scheduled "and then…" automations over a scanner's observations.
  */
+export const VisionActionsCreateParams = /* @__PURE__ */ zod.object({
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const visionActionsCreateBodyNameMax = 255
+
+export const visionActionsCreateBodyTriggerConfigOneTimezoneDefault = `UTC`
+export const visionActionsCreateBodySynthesisConfigOnePromptGuideMax = 500
+
+export const visionActionsCreateBodyAlertConfigOneFrequencyDefault = `on_breach`
+export const visionActionsCreateBodyAlertConfigOneMetricDefault = `count`
+export const visionActionsCreateBodyAlertConfigOneDirectionDefault = `above`
+
+export const VisionActionsCreateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod
+            .string()
+            .max(visionActionsCreateBodyNameMax)
+            .describe('Human-readable action name. Unique within the team.'),
+        scanner: zod
+            .string()
+            .describe('Scanner whose observations this action operates on. Must belong to the same team.'),
+        enabled: zod.boolean().optional().describe('When false, the scheduler skips this action.'),
+        is_scanner_digest: zod
+            .boolean()
+            .optional()
+            .describe(
+                "Marks this action as the scanner's built-in daily digest, the one summary surfaced on the scanner overview. At most one digest per scanner."
+            ),
+        trigger_type: zod
+            .enum(['schedule', 'threshold'])
+            .describe('\* `schedule` - Schedule\n\* `threshold` - Threshold')
+            .optional()
+            .describe(
+                "What fires the action. MVP supports 'schedule' only.\n\n\* `schedule` - Schedule\n\* `threshold` - Threshold"
+            ),
+        mode: zod
+            .enum(['group_summary', 'alert', 'per_observation'])
+            .describe('\* `group_summary` - Group summary\n\* `alert` - Alert\n\* `per_observation` - Per observation')
+            .optional()
+            .describe(
+                "What the action produces. MVP supports 'group_summary' only.\n\n\* `group_summary` - Group summary\n\* `alert` - Alert\n\* `per_observation` - Per observation"
+            ),
+        trigger_config: zod
+            .object({
+                rrule: zod
+                    .string()
+                    .optional()
+                    .describe(
+                        'iCal RRULE string controlling the schedule cadence (no DTSTART — the start is managed separately).'
+                    ),
+                timezone: zod
+                    .string()
+                    .default(visionActionsCreateBodyTriggerConfigOneTimezoneDefault)
+                    .describe("IANA timezone name the RRULE is expanded in, e.g. 'Europe\/Prague'. Defaults to 'UTC'."),
+            })
+            .describe('Schedule trigger parameters. Threshold triggers are reserved and rejected at the API for now.')
+            .optional()
+            .describe('Trigger parameters. For schedule triggers: {rrule, timezone}.'),
+        selection: zod
+            .object({
+                scanner_ids: zod
+                    .array(zod.string())
+                    .optional()
+                    .describe('Restrict to observations produced by these scanner IDs. Defaults to the bound scanner.'),
+                verdict: zod
+                    .array(
+                        zod
+                            .enum(['yes', 'no', 'inconclusive'])
+                            .describe('\* `yes` - yes\n\* `no` - no\n\* `inconclusive` - inconclusive')
+                    )
+                    .optional()
+                    .describe('Only run on monitor observations with one of these verdicts (yes\/no\/inconclusive).'),
+                tags: zod
+                    .array(zod.string())
+                    .optional()
+                    .describe('Only run on classifier observations carrying any of these tags (fixed or freeform).'),
+                min_score: zod
+                    .number()
+                    .optional()
+                    .describe('Only run on scorer observations with a score at or above this value (inclusive).'),
+                max_score: zod
+                    .number()
+                    .optional()
+                    .describe('Only run on scorer observations with a score at or below this value (inclusive).'),
+            })
+            .describe(
+                'The action\'s targeting predicate (\"run this on…\") applied when gathering observations. All keys\noptional; this typed shape is the allowlist, so unknown input keys are dropped rather than persisted.'
+            )
+            .optional()
+            .describe("Targeting predicate: which of the scanner's observations this action runs on."),
+        synthesis_config: zod
+            .object({
+                prompt_guide: zod
+                    .string()
+                    .max(visionActionsCreateBodySynthesisConfigOnePromptGuideMax)
+                    .optional()
+                    .describe('Free-form guidance steering how the group summary is written.'),
+            })
+            .describe('Options for the group-summary synthesis step.')
+            .optional()
+            .describe('Synthesis options for the group summary, e.g. {prompt_guide}.'),
+        alert_config: zod
+            .object({
+                frequency: zod
+                    .enum(['every_match', 'on_breach'])
+                    .describe('\* `every_match` - Every new match\n\* `on_breach` - When a threshold is crossed')
+                    .default(visionActionsCreateBodyAlertConfigOneFrequencyDefault)
+                    .describe(
+                        "'every_match' notifies about every new matching observation (batched per check); 'on_breach' notifies once when the threshold condition starts holding. Defaults to 'on_breach'.\n\n\* `every_match` - Every new match\n\* `on_breach` - When a threshold is crossed"
+                    ),
+                metric: zod
+                    .enum(['count', 'avg_score'])
+                    .describe('\* `count` - Count of matching observations\n\* `avg_score` - Average score')
+                    .default(visionActionsCreateBodyAlertConfigOneMetricDefault)
+                    .describe(
+                        "What to measure over the window: 'count' of targeted observations, or 'avg_score' (the mean scorer score; scorer scanners only). every_match supports 'count' only.\n\n\* `count` - Count of matching observations\n\* `avg_score` - Average score"
+                    ),
+                threshold: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        "The alert fires when the metric is at or above ('above') or at or below ('below') this value, per 'direction'. Required for on_breach; ignored for every_match."
+                    ),
+                direction: zod
+                    .enum(['above', 'below'])
+                    .describe('\* `above` - At or above\n\* `below` - At or below')
+                    .default(visionActionsCreateBodyAlertConfigOneDirectionDefault)
+                    .describe(
+                        "Which side of the threshold breaches: 'above' fires when the metric is at or above it, 'below' when at or below (e.g. an average score dropping under a floor). Both inclusive. Defaults to 'above'; ignored for every_match.\n\n\* `above` - At or above\n\* `below` - At or below"
+                    ),
+                window_days: zod
+                    .union([zod.literal(1), zod.literal(3), zod.literal(7), zod.literal(14), zod.literal(30)])
+                    .describe('\* `1` - 1 day\n\* `3` - 3 days\n\* `7` - 7 days\n\* `14` - 14 days\n\* `30` - 30 days')
+                    .optional()
+                    .describe(
+                        "Rolling lookback window for on_breach conditions, ending at each check. Defaults to 1 day. every_match ignores it (each check covers what's new since the previous one).\n\n\* `1` - 1 day\n\* `3` - 3 days\n\* `7` - 7 days\n\* `14` - 14 days\n\* `30` - 30 days"
+                    ),
+            })
+            .describe(
+                "The alert condition for mode='alert', applied after `selection` targeting. 'every_match'\nnotifies about each new match since the previous check; 'on_breach' compares a metric to a\nthreshold over a rolling window and notifies on the transition into breach."
+            )
+            .optional()
+            .describe("Alert condition; required when mode is 'alert', ignored otherwise."),
+        delivery_config: zod
+            .array(
+                zod
+                    .object({
+                        type: zod
+                            .enum(['slack', 'webhook'])
+                            .describe('\* `slack` - Slack\n\* `webhook` - Webhook')
+                            .describe(
+                                "Destination type: 'slack' posts to a Slack channel; 'webhook' POSTs a JSON payload to a URL.\n\n\* `slack` - Slack\n\* `webhook` - Webhook"
+                            ),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                "ID of the Slack Integration on this team used to deliver. Required when type is 'slack'."
+                            ),
+                        channel: zod
+                            .string()
+                            .optional()
+                            .describe(
+                                "Slack channel ID or name the summary is posted to. Required when type is 'slack'."
+                            ),
+                        url: zod
+                            .url()
+                            .optional()
+                            .describe(
+                                "HTTPS endpoint the summary is POSTed to as JSON. Required when type is 'webhook'. Redacted to scheme+host in responses for users without editor access to the scanner."
+                            ),
+                    })
+                    .describe('A single delivery destination: a Slack channel or an HTTP webhook URL.')
+            )
+            .optional()
+            .describe('List of delivery destinations the synthesized summary is sent to.'),
+    })
+    .describe('A Replay Vision action: a scheduled \"and then…\" automation over a scanner\'s observations.')
+
+/**
+ * CRUD for Replay Vision actions — scheduled "and then…" automations over a scanner's observations.
+ */
 export const VisionActionsRetrieveParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this vision action.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+/**
+ * CRUD for Replay Vision actions — scheduled "and then…" automations over a scanner's observations.
+ */
+export const VisionActionsPartialUpdateParams = /* @__PURE__ */ zod.object({
+    id: zod.string().describe('A UUID string identifying this vision action.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to \/api\/projects\/."
+        ),
+})
+
+export const visionActionsPartialUpdateBodyNameMax = 255
+
+export const visionActionsPartialUpdateBodyTriggerConfigOneTimezoneDefault = `UTC`
+export const visionActionsPartialUpdateBodySynthesisConfigOnePromptGuideMax = 500
+
+export const visionActionsPartialUpdateBodyAlertConfigOneFrequencyDefault = `on_breach`
+export const visionActionsPartialUpdateBodyAlertConfigOneMetricDefault = `count`
+export const visionActionsPartialUpdateBodyAlertConfigOneDirectionDefault = `above`
+
+export const VisionActionsPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        name: zod
+            .string()
+            .max(visionActionsPartialUpdateBodyNameMax)
+            .optional()
+            .describe('Human-readable action name. Unique within the team.'),
+        scanner: zod
+            .string()
+            .optional()
+            .describe('Scanner whose observations this action operates on. Must belong to the same team.'),
+        enabled: zod.boolean().optional().describe('When false, the scheduler skips this action.'),
+        is_scanner_digest: zod
+            .boolean()
+            .optional()
+            .describe(
+                "Marks this action as the scanner's built-in daily digest, the one summary surfaced on the scanner overview. At most one digest per scanner."
+            ),
+        trigger_type: zod
+            .enum(['schedule', 'threshold'])
+            .describe('\* `schedule` - Schedule\n\* `threshold` - Threshold')
+            .optional()
+            .describe(
+                "What fires the action. MVP supports 'schedule' only.\n\n\* `schedule` - Schedule\n\* `threshold` - Threshold"
+            ),
+        mode: zod
+            .enum(['group_summary', 'alert', 'per_observation'])
+            .describe('\* `group_summary` - Group summary\n\* `alert` - Alert\n\* `per_observation` - Per observation')
+            .optional()
+            .describe(
+                "What the action produces. MVP supports 'group_summary' only.\n\n\* `group_summary` - Group summary\n\* `alert` - Alert\n\* `per_observation` - Per observation"
+            ),
+        trigger_config: zod
+            .object({
+                rrule: zod
+                    .string()
+                    .optional()
+                    .describe(
+                        'iCal RRULE string controlling the schedule cadence (no DTSTART — the start is managed separately).'
+                    ),
+                timezone: zod
+                    .string()
+                    .default(visionActionsPartialUpdateBodyTriggerConfigOneTimezoneDefault)
+                    .describe("IANA timezone name the RRULE is expanded in, e.g. 'Europe\/Prague'. Defaults to 'UTC'."),
+            })
+            .describe('Schedule trigger parameters. Threshold triggers are reserved and rejected at the API for now.')
+            .optional()
+            .describe('Trigger parameters. For schedule triggers: {rrule, timezone}.'),
+        selection: zod
+            .object({
+                scanner_ids: zod
+                    .array(zod.string())
+                    .optional()
+                    .describe('Restrict to observations produced by these scanner IDs. Defaults to the bound scanner.'),
+                verdict: zod
+                    .array(
+                        zod
+                            .enum(['yes', 'no', 'inconclusive'])
+                            .describe('\* `yes` - yes\n\* `no` - no\n\* `inconclusive` - inconclusive')
+                    )
+                    .optional()
+                    .describe('Only run on monitor observations with one of these verdicts (yes\/no\/inconclusive).'),
+                tags: zod
+                    .array(zod.string())
+                    .optional()
+                    .describe('Only run on classifier observations carrying any of these tags (fixed or freeform).'),
+                min_score: zod
+                    .number()
+                    .optional()
+                    .describe('Only run on scorer observations with a score at or above this value (inclusive).'),
+                max_score: zod
+                    .number()
+                    .optional()
+                    .describe('Only run on scorer observations with a score at or below this value (inclusive).'),
+            })
+            .describe(
+                'The action\'s targeting predicate (\"run this on…\") applied when gathering observations. All keys\noptional; this typed shape is the allowlist, so unknown input keys are dropped rather than persisted.'
+            )
+            .optional()
+            .describe("Targeting predicate: which of the scanner's observations this action runs on."),
+        synthesis_config: zod
+            .object({
+                prompt_guide: zod
+                    .string()
+                    .max(visionActionsPartialUpdateBodySynthesisConfigOnePromptGuideMax)
+                    .optional()
+                    .describe('Free-form guidance steering how the group summary is written.'),
+            })
+            .describe('Options for the group-summary synthesis step.')
+            .optional()
+            .describe('Synthesis options for the group summary, e.g. {prompt_guide}.'),
+        alert_config: zod
+            .object({
+                frequency: zod
+                    .enum(['every_match', 'on_breach'])
+                    .describe('\* `every_match` - Every new match\n\* `on_breach` - When a threshold is crossed')
+                    .default(visionActionsPartialUpdateBodyAlertConfigOneFrequencyDefault)
+                    .describe(
+                        "'every_match' notifies about every new matching observation (batched per check); 'on_breach' notifies once when the threshold condition starts holding. Defaults to 'on_breach'.\n\n\* `every_match` - Every new match\n\* `on_breach` - When a threshold is crossed"
+                    ),
+                metric: zod
+                    .enum(['count', 'avg_score'])
+                    .describe('\* `count` - Count of matching observations\n\* `avg_score` - Average score')
+                    .default(visionActionsPartialUpdateBodyAlertConfigOneMetricDefault)
+                    .describe(
+                        "What to measure over the window: 'count' of targeted observations, or 'avg_score' (the mean scorer score; scorer scanners only). every_match supports 'count' only.\n\n\* `count` - Count of matching observations\n\* `avg_score` - Average score"
+                    ),
+                threshold: zod
+                    .number()
+                    .optional()
+                    .describe(
+                        "The alert fires when the metric is at or above ('above') or at or below ('below') this value, per 'direction'. Required for on_breach; ignored for every_match."
+                    ),
+                direction: zod
+                    .enum(['above', 'below'])
+                    .describe('\* `above` - At or above\n\* `below` - At or below')
+                    .default(visionActionsPartialUpdateBodyAlertConfigOneDirectionDefault)
+                    .describe(
+                        "Which side of the threshold breaches: 'above' fires when the metric is at or above it, 'below' when at or below (e.g. an average score dropping under a floor). Both inclusive. Defaults to 'above'; ignored for every_match.\n\n\* `above` - At or above\n\* `below` - At or below"
+                    ),
+                window_days: zod
+                    .union([zod.literal(1), zod.literal(3), zod.literal(7), zod.literal(14), zod.literal(30)])
+                    .describe('\* `1` - 1 day\n\* `3` - 3 days\n\* `7` - 7 days\n\* `14` - 14 days\n\* `30` - 30 days')
+                    .optional()
+                    .describe(
+                        "Rolling lookback window for on_breach conditions, ending at each check. Defaults to 1 day. every_match ignores it (each check covers what's new since the previous one).\n\n\* `1` - 1 day\n\* `3` - 3 days\n\* `7` - 7 days\n\* `14` - 14 days\n\* `30` - 30 days"
+                    ),
+            })
+            .describe(
+                "The alert condition for mode='alert', applied after `selection` targeting. 'every_match'\nnotifies about each new match since the previous check; 'on_breach' compares a metric to a\nthreshold over a rolling window and notifies on the transition into breach."
+            )
+            .optional()
+            .describe("Alert condition; required when mode is 'alert', ignored otherwise."),
+        delivery_config: zod
+            .array(
+                zod
+                    .object({
+                        type: zod
+                            .enum(['slack', 'webhook'])
+                            .describe('\* `slack` - Slack\n\* `webhook` - Webhook')
+                            .describe(
+                                "Destination type: 'slack' posts to a Slack channel; 'webhook' POSTs a JSON payload to a URL.\n\n\* `slack` - Slack\n\* `webhook` - Webhook"
+                            ),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                "ID of the Slack Integration on this team used to deliver. Required when type is 'slack'."
+                            ),
+                        channel: zod
+                            .string()
+                            .optional()
+                            .describe(
+                                "Slack channel ID or name the summary is posted to. Required when type is 'slack'."
+                            ),
+                        url: zod
+                            .url()
+                            .optional()
+                            .describe(
+                                "HTTPS endpoint the summary is POSTed to as JSON. Required when type is 'webhook'. Redacted to scheme+host in responses for users without editor access to the scanner."
+                            ),
+                    })
+                    .describe('A single delivery destination: a Slack channel or an HTTP webhook URL.')
+            )
+            .optional()
+            .describe('List of delivery destinations the synthesized summary is sent to.'),
+    })
+    .describe('A Replay Vision action: a scheduled \"and then…\" automation over a scanner\'s observations.')
+
+/**
+ * CRUD for Replay Vision actions — scheduled "and then…" automations over a scanner's observations.
+ */
+export const VisionActionsDestroyParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this vision action.'),
     project_id: zod
         .string()

--- a/services/mcp/src/tools/generated/replay_vision.ts
+++ b/services/mcp/src/tools/generated/replay_vision.ts
@@ -3,7 +3,11 @@ import { z } from 'zod'
 
 import type { Schemas } from '@/api/generated'
 import {
+    VisionActionsCreateBody,
+    VisionActionsDestroyParams,
     VisionActionsListQueryParams,
+    VisionActionsPartialUpdateBody,
+    VisionActionsPartialUpdateParams,
     VisionActionsRetrieveParams,
     VisionActionsRunsListParams,
     VisionActionsRunsListQueryParams,
@@ -41,6 +45,71 @@ import {
 } from '@/generated/replay_vision/api'
 import { withPostHogUrl, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
+
+const VisionActionsCreateSchema = VisionActionsCreateBody
+
+const visionActionsCreate = (): ToolBase<typeof VisionActionsCreateSchema, Schemas.VisionAction> => ({
+    name: 'vision-actions-create',
+    schema: VisionActionsCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionActionsCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.scanner !== undefined) {
+            body['scanner'] = params.scanner
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        if (params.is_scanner_digest !== undefined) {
+            body['is_scanner_digest'] = params.is_scanner_digest
+        }
+        if (params.trigger_type !== undefined) {
+            body['trigger_type'] = params.trigger_type
+        }
+        if (params.mode !== undefined) {
+            body['mode'] = params.mode
+        }
+        if (params.trigger_config !== undefined) {
+            body['trigger_config'] = params.trigger_config
+        }
+        if (params.selection !== undefined) {
+            body['selection'] = params.selection
+        }
+        if (params.synthesis_config !== undefined) {
+            body['synthesis_config'] = params.synthesis_config
+        }
+        if (params.alert_config !== undefined) {
+            body['alert_config'] = params.alert_config
+        }
+        if (params.delivery_config !== undefined) {
+            body['delivery_config'] = params.delivery_config
+        }
+        const result = await context.api.request<Schemas.VisionAction>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/actions/`,
+            body,
+        })
+        return result
+    },
+})
+
+const VisionActionsDeleteSchema = VisionActionsDestroyParams.omit({ project_id: true })
+
+const visionActionsDelete = (): ToolBase<typeof VisionActionsDeleteSchema, unknown> => ({
+    name: 'vision-actions-delete',
+    schema: VisionActionsDeleteSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionActionsDeleteSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const result = await context.api.request<unknown>({
+            method: 'DELETE',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/actions/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
 
 const VisionActionsListSchema = VisionActionsListQueryParams
 
@@ -114,6 +183,58 @@ const visionActionsRunsRetrieve = (): ToolBase<typeof VisionActionsRunsRetrieveS
         const result = await context.api.request<Schemas.VisionActionRun>({
             method: 'GET',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/actions/${encodeURIComponent(String(params.vision_action_id))}/runs/${encodeURIComponent(String(params.id))}/`,
+        })
+        return result
+    },
+})
+
+const VisionActionsUpdateSchema = VisionActionsPartialUpdateParams.omit({ project_id: true }).extend(
+    VisionActionsPartialUpdateBody.shape
+)
+
+const visionActionsUpdate = (): ToolBase<typeof VisionActionsUpdateSchema, Schemas.VisionAction> => ({
+    name: 'vision-actions-update',
+    schema: VisionActionsUpdateSchema,
+    handler: async (context: Context, params: z.infer<typeof VisionActionsUpdateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.name !== undefined) {
+            body['name'] = params.name
+        }
+        if (params.scanner !== undefined) {
+            body['scanner'] = params.scanner
+        }
+        if (params.enabled !== undefined) {
+            body['enabled'] = params.enabled
+        }
+        if (params.is_scanner_digest !== undefined) {
+            body['is_scanner_digest'] = params.is_scanner_digest
+        }
+        if (params.trigger_type !== undefined) {
+            body['trigger_type'] = params.trigger_type
+        }
+        if (params.mode !== undefined) {
+            body['mode'] = params.mode
+        }
+        if (params.trigger_config !== undefined) {
+            body['trigger_config'] = params.trigger_config
+        }
+        if (params.selection !== undefined) {
+            body['selection'] = params.selection
+        }
+        if (params.synthesis_config !== undefined) {
+            body['synthesis_config'] = params.synthesis_config
+        }
+        if (params.alert_config !== undefined) {
+            body['alert_config'] = params.alert_config
+        }
+        if (params.delivery_config !== undefined) {
+            body['delivery_config'] = params.delivery_config
+        }
+        const result = await context.api.request<Schemas.VisionAction>({
+            method: 'PATCH',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/vision/actions/${encodeURIComponent(String(params.id))}/`,
+            body,
         })
         return result
     },
@@ -695,10 +816,13 @@ const visionScannersUpdate = (): ToolBase<typeof VisionScannersUpdateSchema, Sch
 })
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
+    'vision-actions-create': visionActionsCreate,
+    'vision-actions-delete': visionActionsDelete,
     'vision-actions-list': visionActionsList,
     'vision-actions-retrieve': visionActionsRetrieve,
     'vision-actions-runs-list': visionActionsRunsList,
     'vision-actions-runs-retrieve': visionActionsRunsRetrieve,
+    'vision-actions-update': visionActionsUpdate,
     'vision-observations-label-create': visionObservationsLabelCreate,
     'vision-observations-label-destroy': visionObservationsLabelDestroy,
     'vision-observations-list': visionObservationsList,


### PR DESCRIPTION
## Problem

An agent using the PostHog MCP could not set up a Slack alert (or a scheduled summary) for a Replay Vision scanner. The read-only vision action tools shipped already (`vision-actions-list`, `vision-actions-retrieve`, and the run tools), so an agent could see the "and then..." automations bound to a scanner but had no tool to create, edit, or remove one. Slack alerts and summaries live on the vision action, not the scanner itself, so there was no MCP path to configure them.

## Changes

Enable the three vision action write tools that were already scaffolded (disabled) in `products/replay_vision/mcp/tools.yaml`, add their scopes, annotations, and descriptions, and regenerate the MCP and type artifacts:

- `vision-actions-create` — create a group_summary or alert action bound to a scanner, with `delivery_config` routing to Slack (`{type: 'slack', integration_id, channel}`) or a webhook. The description points at `integrations-list` and `integrations-channels-retrieve` for resolving the Slack workspace and channel.
- `vision-actions-update` — partial update (toggle enabled, retune the alert threshold, change cadence, repoint delivery).
- `vision-actions-delete` — permanently delete an action and its run history.

Also added one sentence to the `vision-scanners-create` description pointing agents at `vision-actions-create` for wiring up notifications, so the "create a scanner, then get alerted" path is discoverable.

No backend changes. The endpoints, serializers, and RBAC already exist on master (`VisionActionViewSet`). Scopes match the viewset: `vision_action:write`, plus `session_recording:read` on create/update since configuring an action reads recording-derived observations. All three are gated behind the existing `replay-vision` feature flag. create/update carry `requires_ai_consent`, matching the other replay-vision write tools whose runs invoke an LLM. This mirrors how the read tools were enabled in #73296.

## How did you test this code?

I (the agent) did not exercise the tools against a live MCP connection — the deployed MCP does not serve them until this ships. I ran the automated checks that gate a tools.yaml enablement:

- `hogli build:openapi` to regenerate; codegen is idempotent (re-running produces no further diff).
- `pnpm --filter=@posthog/mcp run scaffold-yaml -- --sync-all` — clean, the renamed tool keys sync with no stubs re-added.
- Full MCP unit suite: `pnpm --filter=@posthog/mcp run test` — 95 files / 2449 tests pass (including the tool-schema snapshot test, tool-name validation, and generate-tools tests). Note: on a cold transform cache the snapshot test can flake on its 10s timeout; it passes once caches are warm, and it passes identically on clean master.
- `pnpm --filter=@posthog/mcp lint-tool-names` — passes (names, length, and cross-references to `integrations-list` / `integrations-channels-retrieve` / sibling vision tools all resolve).
- `pnpm --filter=@posthog/mcp run typecheck` and `lint` — both clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Claude Fable 5) from a Slack feature request noting that a new scanner's Slack alerts could not be set up via MCP. The agent explored the MCP codegen pipeline (`services/mcp`), the `VisionActionViewSet` REST API and its `delivery_config`/Slack provisioning, the frontend delivery payload shape, and the write-tool conventions across other products' `tools.yaml` before enabling the three tools. Chosen approach: pure `tools.yaml` enablement matching the existing read-tool precedent (#73296), with no backend change, since the API and RBAC already existed. Tool key names follow the product's `create`/`update`/`delete` convention (`vision-actions-delete`/`-update` rather than the raw `-destroy`/`-partial-update` operation ids).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*