### PR TITLE
fix(warehouse): stop paddle pagination looping on its final page

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -448,7 +448,7 @@ the row lists both.
 | outbrain                         | HTTP                        | requests                                                        | ✅                          |
 | pabbly_subscriptions_billing     | HTTP                        | requests                                                        | ✅                          |
 | packagist                        | HTTP                        | requests                                                        | ✅                          |
-| paddle                           | HTTP                        | requests                                                        | ✅                          |
+| paddle                           | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | optimizely                       | HTTP                        | requests                                                        | ✅                          |
 | pagerduty                        | HTTP                        | requests                                                        | ✅                          |
 | pandadoc                         | HTTP                        | requests                                                        | ✅                          |

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/baserow/baserow.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/baserow/baserow.py
@@ -177,10 +177,10 @@ class BaserowPaginator(JSONResponsePaginator):
     def __init__(self, base_url: str) -> None:
         super().__init__(next_url_path="next")
         self._allowed_netloc = urlparse(normalize_base_url(base_url)).netloc.lower()
-        # Cycle guards: a host that keeps returning a `next` link can otherwise keep a
-        # resumable import issuing requests until its week-long activity timeout. Track the
-        # link we just followed to catch a repeated URL, and count pages as a coarse backstop.
-        self._previous_next_url: Optional[str] = None
+        # Page cap: a host that keeps returning fresh `next` links can otherwise keep a
+        # resumable import issuing requests until its week-long activity timeout. The
+        # repeated-URL case is caught by the base paginator's guard, hardened below to
+        # raise rather than silently stop.
         self._pages_followed = 0
 
     def _pin(self, url: str) -> None:
@@ -188,16 +188,18 @@ class BaserowPaginator(JSONResponsePaginator):
         if target.scheme != "https" or target.netloc.lower() != self._allowed_netloc:
             raise ValueError(f"Baserow pagination URL {url!r} is not on the configured instance")
 
+    def _handle_non_advancing_page(self, next_url: str) -> None:
+        # A repeated next link from a user-controlled host is treated as hostile, not as
+        # a benign end-of-data quirk, so fail the sync loudly instead of completing it.
+        raise ValueError(f"Baserow pagination is not advancing (repeated next URL {next_url!r})")
+
     def _guard_progress(self) -> None:
         if self._next_url is None:
             return
         self._pin(self._next_url)
-        if self._next_url == self._previous_next_url:
-            raise ValueError(f"Baserow pagination is not advancing (repeated next URL {self._next_url!r})")
         self._pages_followed += 1
         if self._pages_followed > MAX_PAGES_PER_SYNC:
             raise ValueError(f"Baserow sync exceeded the {MAX_PAGES_PER_SYNC}-page limit")
-        self._previous_next_url = self._next_url
 
     def update_state(self, response: requests.Response, data: Optional[list[Any]] = None) -> None:
         super().update_state(response, data)
@@ -205,12 +207,11 @@ class BaserowPaginator(JSONResponsePaginator):
             self._guard_progress()
 
     def set_resume_state(self, state: dict[str, Any]) -> None:
+        # The base class seeds the repeat guard from the resumed link; pin it here too
+        # (a tampered resume URL must not be followed).
         super().set_resume_state(state)
         if self._next_url is not None:
-            # Seed the repeat guard from the resumed link so a host that immediately echoes it
-            # back is caught, and pin it here too (a tampered resume URL must not be followed).
             self._pin(self._next_url)
-            self._previous_next_url = self._next_url
 
 
 def list_tables(base_url: Optional[str], database_token: str) -> list[dict[str, Any]]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
@@ -2,6 +2,7 @@ import re
 import logging
 from abc import ABC, abstractmethod
 from typing import Any, Literal, Optional
+from urllib.parse import urlsplit
 
 from requests import Request, Response
 
@@ -95,9 +96,12 @@ class BaseNextUrlPaginator(BasePaginator):
         the sync instead of looping. Subclasses that consider a repeated link
         hostile (e.g. Baserow's user-controlled hosts) override this to raise.
         """
+        # Log only scheme/host/path: pagination links are echoed by the remote API and
+        # can carry credentials in their query string for query-param-authenticated sources.
+        redacted_url = urlsplit(next_url)._replace(query="", fragment="").geturl()
         logger.warning(
             "Pagination is not advancing (repeated next URL); treating as last page",
-            extra={"paginator": str(self), "next_url": next_url},
+            extra={"paginator": str(self), "next_url": redacted_url},
         )
         self._has_next_page = False
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/paginators.py
@@ -1,10 +1,13 @@
 import re
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Literal, Optional
 
 from requests import Request, Response
 
 from .jsonpath_utils import TJsonPath, find_values
+
+logger = logging.getLogger(__name__)
 
 # Where a paginator writes its pagination fields. "query" (default) mutates request.params;
 # "json" mutates the POST body — for APIs that carry page/cursor/limit inside the JSON payload.
@@ -64,6 +67,39 @@ class BaseNextUrlPaginator(BasePaginator):
     def __init__(self) -> None:
         super().__init__()
         self._next_url: Optional[str] = None
+        self._previous_next_url: Optional[str] = None
+
+    def _advance_to(self, next_url: Optional[str]) -> None:
+        """Follow ``next_url`` as the next page, or stop when there is none.
+
+        A next URL identical to the one just followed is treated as the last page:
+        some APIs (e.g. Paddle) return a populated next link even on their final
+        page, and following it would refetch the same page forever. Without this
+        guard the sync loops until its Temporal activity timeout, which is a week
+        for resumable sources.
+        """
+        if not next_url:
+            self._has_next_page = False
+            return
+        if next_url == self._previous_next_url:
+            self._handle_non_advancing_page(next_url)
+            return
+        self._previous_next_url = next_url
+        self._next_url = next_url
+        self._has_next_page = True
+
+    def _handle_non_advancing_page(self, next_url: str) -> None:
+        """Called when a response's next link equals the one just followed.
+
+        Default: treat it as the last page and log, so end-of-data quirks complete
+        the sync instead of looping. Subclasses that consider a repeated link
+        hostile (e.g. Baserow's user-controlled hosts) override this to raise.
+        """
+        logger.warning(
+            "Pagination is not advancing (repeated next URL); treating as last page",
+            extra={"paginator": str(self), "next_url": next_url},
+        )
+        self._has_next_page = False
 
     def init_request(self, request: Request) -> None:
         # Apply a seeded resume URL to the first request so a resumed run starts at the
@@ -89,6 +125,9 @@ class BaseNextUrlPaginator(BasePaginator):
         next_url = state.get("next_url")
         if next_url is not None:
             self._next_url = next_url
+            # Seed the repeat guard so a resumed page whose response echoes the
+            # saved URL stops instead of looping on a poisoned checkpoint.
+            self._previous_next_url = next_url
             self._has_next_page = True
 
 
@@ -98,13 +137,8 @@ class HeaderLinkPaginator(BaseNextUrlPaginator):
         self.links_next_key = links_next_key
 
     def update_state(self, response: Response, data: Optional[list[Any]] = None) -> None:
-        links = response.links
-        next_link = links.get(self.links_next_key)
-        if next_link:
-            self._next_url = next_link.get("url")
-            self._has_next_page = True
-        else:
-            self._has_next_page = False
+        next_link = response.links.get(self.links_next_key)
+        self._advance_to(next_link.get("url") if next_link else None)
 
     def __str__(self) -> str:
         return f"HeaderLinkPaginator(links_next_key={self.links_next_key})"
@@ -122,11 +156,7 @@ class JSONResponsePaginator(BaseNextUrlPaginator):
             values = find_values(self.next_url_path, response.json())
         except Exception:
             values = []
-        if values and values[0]:
-            self._next_url = values[0]
-            self._has_next_page = True
-        else:
-            self._has_next_page = False
+        self._advance_to(values[0] if values else None)
 
     def __str__(self) -> str:
         return f"JSONResponsePaginator(next_url_path={self.next_url_path})"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
@@ -78,11 +78,11 @@ class TestJSONResponsePaginator:
         assert p.has_next_page is True
         with caplog.at_level(logging.WARNING):
             p.update_state(_make_response({"next": url, "data": []}))
-        assert p.has_next_page is False
         # The logged URL must not carry the query string, which can hold credentials.
         record = next(r for r in caplog.records if "not advancing" in r.getMessage())
         assert record.next_url == "https://api.example.com/page2"  # type: ignore[attr-defined]
         assert "secret-token" not in str(record.__dict__)
+        assert p.has_next_page is False
 
     def test_header_link_paginator_stops_when_next_url_repeats(self) -> None:
         p = HeaderLinkPaginator()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Any
 
 import pytest
@@ -68,14 +69,20 @@ class TestJSONResponsePaginator:
         p.update_state(resp)
         assert p.has_next_page is False
 
-    def test_stops_when_next_url_repeats(self) -> None:
+    def test_stops_when_next_url_repeats(self, caplog: pytest.LogCaptureFixture) -> None:
         # Some APIs (e.g. Paddle) populate `next` even on the last page, pointing at
         # the page just fetched. Following it verbatim loops forever.
         p = JSONResponsePaginator(next_url_path="next")
-        p.update_state(_make_response({"next": "https://api.example.com/page2", "data": []}))
+        url = "https://api.example.com/page2?api_key=secret-token"
+        p.update_state(_make_response({"next": url, "data": []}))
         assert p.has_next_page is True
-        p.update_state(_make_response({"next": "https://api.example.com/page2", "data": []}))
+        with caplog.at_level(logging.WARNING):
+            p.update_state(_make_response({"next": url, "data": []}))
         assert p.has_next_page is False
+        # The logged URL must not carry the query string, which can hold credentials.
+        record = next(r for r in caplog.records if "not advancing" in r.getMessage())
+        assert record.next_url == "https://api.example.com/page2"  # type: ignore[attr-defined]
+        assert "secret-token" not in str(record.__dict__)
 
     def test_header_link_paginator_stops_when_next_url_repeats(self) -> None:
         p = HeaderLinkPaginator()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
@@ -68,6 +68,24 @@ class TestJSONResponsePaginator:
         p.update_state(resp)
         assert p.has_next_page is False
 
+    def test_stops_when_next_url_repeats(self) -> None:
+        # Some APIs (e.g. Paddle) populate `next` even on the last page, pointing at
+        # the page just fetched. Following it verbatim loops forever.
+        p = JSONResponsePaginator(next_url_path="next")
+        p.update_state(_make_response({"next": "https://api.example.com/page2", "data": []}))
+        assert p.has_next_page is True
+        p.update_state(_make_response({"next": "https://api.example.com/page2", "data": []}))
+        assert p.has_next_page is False
+
+    def test_header_link_paginator_stops_when_next_url_repeats(self) -> None:
+        p = HeaderLinkPaginator()
+        resp = _make_response()
+        resp.headers["Link"] = '<https://api.example.com/page2>; rel="next"'
+        p.update_state(resp)
+        assert p.has_next_page is True
+        p.update_state(resp)
+        assert p.has_next_page is False
+
     def test_json_link_paginator_is_alias(self) -> None:
         assert JSONLinkPaginator is JSONResponsePaginator
 
@@ -246,6 +264,15 @@ class TestPaginatorResume:
         req = Request(method="GET", url="https://api.example.com/page1")
         resumed.init_request(req)
         assert req.url == "https://api.example.com/page2"
+
+    def test_next_url_paginator_stops_when_resumed_page_echoes_saved_url(self) -> None:
+        # A checkpoint saved on an API's final page points at that same page; when the
+        # resumed fetch echoes the saved URL back as `next`, the sync must complete
+        # rather than loop on the checkpoint.
+        resumed = JSONResponsePaginator(next_url_path="next")
+        resumed.set_resume_state({"next_url": "https://api.example.com/page9"})
+        resumed.update_state(_make_response({"next": "https://api.example.com/page9", "data": []}))
+        assert resumed.has_next_page is False
 
 
 class TestOffsetPaginatorTotalHeader:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_paginators.py
@@ -1,11 +1,12 @@
 import json
-import logging
 from typing import Any
 
 import pytest
+from unittest import mock
 
 from requests import PreparedRequest, Request, Response, Session
 
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source import paginators
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.paginators import (
     HeaderLinkPaginator,
     JSONLinkPaginator,
@@ -69,19 +70,20 @@ class TestJSONResponsePaginator:
         p.update_state(resp)
         assert p.has_next_page is False
 
-    def test_stops_when_next_url_repeats(self, caplog: pytest.LogCaptureFixture) -> None:
+    def test_stops_when_next_url_repeats(self) -> None:
         # Some APIs (e.g. Paddle) populate `next` even on the last page, pointing at
         # the page just fetched. Following it verbatim loops forever.
         p = JSONResponsePaginator(next_url_path="next")
         url = "https://api.example.com/page2?api_key=secret-token"
         p.update_state(_make_response({"next": url, "data": []}))
         assert p.has_next_page is True
-        with caplog.at_level(logging.WARNING):
+        # Patch the logger rather than use caplog: the suite's logging config can
+        # disable this module's logger, which would drop the record before capture.
+        with mock.patch.object(paginators.logger, "warning") as warning:
             p.update_state(_make_response({"next": url, "data": []}))
         # The logged URL must not carry the query string, which can hold credentials.
-        record = next(r for r in caplog.records if "not advancing" in r.getMessage())
-        assert record.next_url == "https://api.example.com/page2"  # type: ignore[attr-defined]
-        assert "secret-token" not in str(record.__dict__)
+        assert warning.call_args.kwargs["extra"]["next_url"] == "https://api.example.com/page2"
+        assert "secret-token" not in str(warning.call_args)
         assert p.has_next_page is False
 
     def test_header_link_paginator_stops_when_next_url_repeats(self) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/netlify/tests/test_netlify.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/netlify/tests/test_netlify.py
@@ -234,10 +234,12 @@ class TestPageCap:
         # Hitting the per-parent page cap must fail loudly rather than silently truncate the table.
         paginator = NetlifyCappedHeaderLinkPaginator(max_pages=2, context={"table": "builds"})
         page = [{"id": "x"}]
-        resp = _response(page, next_url=f"{BASE}/sites/s1/builds?page=2")
-        paginator.update_state(resp, page)  # page 1: under the cap
+        paginator.update_state(
+            _response(page, next_url=f"{BASE}/sites/s1/builds?page=2"), page
+        )  # page 1: under the cap
         with pytest.raises(NetlifyPageCapExceededError):
-            paginator.update_state(resp, page)  # page 2: cap reached with more pages remaining
+            # page 2: cap reached with more pages remaining
+            paginator.update_state(_response(page, next_url=f"{BASE}/sites/s1/builds?page=3"), page)
 
     def test_capped_paginator_stops_cleanly_when_no_more_pages(self) -> None:
         paginator = NetlifyCappedHeaderLinkPaginator(max_pages=2, context={"table": "builds"})

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/paddle/paddle.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/paddle/paddle.py
@@ -39,6 +39,29 @@ class PaddlePermissionError(Exception):
     pass
 
 
+class PaddlePaginator(JSONResponsePaginator):
+    """Follows ``meta.pagination.next``, gated on ``meta.pagination.has_more``.
+
+    Paddle populates ``next`` on every page, including the last one; per their
+    pagination docs, ``has_more`` is the only end-of-results signal. Following
+    ``next`` alone therefore refetches the final page forever.
+    """
+
+    def update_state(self, response: requests.Response, data: Optional[list[Any]] = None) -> None:
+        try:
+            body = response.json()
+        except Exception:
+            body = {}
+        meta = body.get("meta") if isinstance(body, dict) else None
+        pagination = meta.get("pagination") if isinstance(meta, dict) else None
+        if isinstance(pagination, dict) and pagination.get("has_more") is False:
+            self._has_next_page = False
+            return
+        # has_more missing or malformed: fall back to the next link, where the base
+        # class still stops on a repeated URL.
+        super().update_state(response, data)
+
+
 def _format_paddle_datetime_query_value(value: Any) -> str:
     if isinstance(value, datetime):
         parsed = value
@@ -99,7 +122,7 @@ def paddle_source(
             "base_url": PADDLE_BASE_URL,
             "headers": {"Content-Type": "application/json"},
             "auth": {"type": "bearer", "token": api_key},
-            "paginator": JSONResponsePaginator(next_url_path="meta.pagination.next"),
+            "paginator": PaddlePaginator(next_url_path="meta.pagination.next"),
         },
         "resources": [
             {

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/paddle/tests/test_paddle.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/paddle/tests/test_paddle.py
@@ -27,8 +27,18 @@ PADDLE_SESSION_PATCH = (
 )
 
 
-def _response(items: list[dict[str, Any]] | None, *, next_url: str | None = None, drop_data: bool = False) -> Response:
-    body: dict[str, Any] = {"meta": {"pagination": {"per_page": 200, "next": next_url}}}
+def _response(
+    items: list[dict[str, Any]] | None,
+    *,
+    next_url: str | None = None,
+    has_more: bool | None = None,
+    drop_data: bool = False,
+) -> Response:
+    # Real Paddle bodies always carry has_more; default it from next_url so fixture
+    # pages terminate the way real responses do (via has_more, not a null next).
+    if has_more is None:
+        has_more = next_url is not None
+    body: dict[str, Any] = {"meta": {"pagination": {"per_page": 200, "next": next_url, "has_more": has_more}}}
     if not drop_data:
         body["data"] = items or []
     resp = Response()
@@ -107,6 +117,27 @@ class TestPagination:
 
         assert [r["id"] for r in rows] == ["a", "b"]
         assert session.send.call_count == 1
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_terminates_when_last_page_repeats_next_url(self, MockSession) -> None:
+        # Real Paddle populates `next` on every page, including the last, where it
+        # points back at the page just fetched; has_more is the only stop signal.
+        # Following `next` alone refetches the final page forever.
+        session = MockSession.return_value
+        last_url = f"{PADDLE_BASE_URL}/customers?after=c_1"
+        _wire(
+            session,
+            [
+                _response([{"id": "c_1"}], next_url=last_url, has_more=True),
+                _response([{"id": "c_2"}], next_url=last_url, has_more=False),
+            ],
+        )
+
+        manager = _make_manager()
+        rows = _rows(_source("customers", manager))
+
+        assert [r["id"] for r in rows] == ["c_1", "c_2"]
+        assert session.send.call_count == 2
 
     @mock.patch(CLIENT_SESSION_PATCH)
     def test_missing_data_key_yields_no_rows(self, MockSession) -> None:
@@ -190,6 +221,23 @@ class TestResume:
         # A resumed run starts at the saved next-page URL with no re-appended list params.
         assert urls[0] == saved_url
         assert params[0] == {}
+
+    @mock.patch(CLIENT_SESSION_PATCH)
+    def test_checkpoint_saved_on_last_page_terminates_on_resume(self, MockSession) -> None:
+        # A checkpoint saved while looping on the final page points at that page.
+        # The resumed fetch sees has_more=false, completes, and writes the empty
+        # terminal marker instead of re-saving the same URL.
+        session = MockSession.return_value
+        saved_url = f"{PADDLE_BASE_URL}/customers?after=c_9"
+        _wire(session, [_response([], next_url=saved_url, has_more=False)])
+
+        manager = _make_manager(PaddleResumeConfig(next_url=saved_url))
+        rows = _rows(_source("customers", manager))
+
+        assert rows == []
+        assert session.send.call_count == 1
+        saved = [call.args[0] for call in manager.save_state.call_args_list]
+        assert saved == [PaddleResumeConfig(next_url="")]
 
     @mock.patch(CLIENT_SESSION_PATCH)
     def test_empty_saved_url_starts_fresh(self, MockSession) -> None:


### PR DESCRIPTION
## Problem

Paddle populates `meta.pagination.next` on every page, including the last one, where it points back at the page just fetched. Per [Paddle's pagination docs](https://developer.paddle.com/api-reference/about/pagination), `has_more` is the only end-of-results signal.

The bulk rest_source migration (#72023) replaced Paddle's hand-rolled pager, whose seen-URLs set guarded against exactly this, with a plain `JSONResponsePaginator` that follows `next` unconditionally. Any Paddle sync reaching the true end of a collection now refetches the same page in a tight loop until its week-long activity timeout, re-saving the same resume checkpoint after every page so retries and resumes re-enter the loop. In production this pinned `temporal-worker-data-warehouse` pods through their entire graceful-shutdown window on every deploy, piling up old-generation pods in both regions.

## Changes

- `PaddlePaginator` stops on `meta.pagination.has_more == false`, Paddle's documented contract (modeled on `GranolaCursorPaginator`). Falls back to the next link when `has_more` is missing or malformed.
- `BaseNextUrlPaginator` gains a generic guard: a next URL identical to the one just followed is treated as the last page (warning logged). This covers the ~30 sources using plain `JSONResponsePaginator`/`HeaderLinkPaginator` with no guard of their own. The guard is seeded from resume state, so a checkpoint poisoned by the loop terminates on its first resumed page rather than resuming the loop.
- `BaserowPaginator` keeps its raise-on-repeat posture (its hosts are user-controlled, so a repeated link is treated as hostile, not as an end-of-data quirk) by overriding the new hook; its duplicated inline check is removed.
- Paddle test fixtures now model the real response shape: `has_more` always present, `next` populated even on the last page. The old fixtures modeled a `next: null` terminal page real Paddle never sends, which is why no test caught this.
- One Netlify page-cap test reused a single response object for two pages (same next URL twice); updated to a realistically advancing URL sequence.
- `SOURCES.md`: Paddle row updated to reflect it now uses `rest_source.RESTClient`.

> [!NOTE]
> Behavior change for next-URL sources: a repeated next link now ends the sync cleanly with a warning instead of looping until the activity timeout. Baserow's stricter raise behavior is preserved.

Deploy-safe for in-flight workflows: activity-side helper code only, no `@workflow.defn` changes.

## How did you test this code?

Automated tests only (no manual/prod testing in this PR):

- `test_paginators.py`: repeated next URL stops `JSONResponsePaginator` and `HeaderLinkPaginator`; a resume-seeded paginator stops when the resumed page echoes the saved URL. Catches removal of the base-class guard, which no existing test covered.
- `test_paddle.py`: sync terminates when the last page has `has_more: false` with `next` still populated (the exact production failure shape); a resume from a checkpoint pointing at the final page completes and writes the empty terminal marker. Catches reverting `PaddlePaginator` to the plain paginator.
- Baserow suite unchanged and green, proving raise-on-repeat and the page cap behave identically after the refactor.
- Full warehouse sources tree: 41,966 passed. Repo-wide mypy clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected; `SOURCES.md` (internal inventory) updated in this PR.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code diagnosed the production symptom (worker pods stuck in their graceful-shutdown window across deploys), traced it to the pagination loop via worker logs, and confirmed the origin with git archaeology: the guard existed in the original source and was dropped in the #72023 bulk migration. Skills invoked: /writing-tests, /writing-code-comments.

Design choices: the base-class guard warns and stops rather than raising, because for Paddle-like APIs a repeated next link is normal end-of-data and raising would fail every completed sync; Baserow overrides the hook to keep raising since its pagination URLs come from user-controlled hosts. A global page cap in the base class was considered and rejected (risks truncating legitimately huge syncs); Baserow retains its own cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
