### PR TITLE
fix(data-warehouse): explain why incremental sync is unavailable on a table

### DIFF
--- a/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SyncMethodForm.tsx
@@ -51,7 +51,8 @@ const getIncrementalSyncSupported = (
     if (schema.incremental_fields.length === 0) {
         return {
             disabled: true,
-            disabledReason: 'No incremental fields found on table',
+            disabledReason:
+                'Incremental replication needs a timestamp, date, or auto-incrementing numeric column to track new rows, and none was found on this table',
         }
     }
 
@@ -73,7 +74,8 @@ const getAppendOnlySyncSupported = (
     if (schema.incremental_fields.length === 0) {
         return {
             disabled: true,
-            disabledReason: 'No incremental fields found on table',
+            disabledReason:
+                'Append only replication needs a timestamp, date, or auto-incrementing numeric column to track new rows, and none was found on this table',
         }
     }
 


### PR DESCRIPTION
## Problem

Session recordings of the data-warehouse new-source flow show users repeatedly blocked when trying to switch a table to incremental (or append-only) replication. When a table has no column the source can track incrementally, the sync-method picker disables those options with the tooltip **"No incremental fields found on table"**.

That message doesn't say what an "incremental field" is or why none was available, so users cycle between the schema view, source health metrics, and the docs trying to work out what's wrong. In at least one observed session the user gave up and deleted the source.

## Changes

Reworded the disabled reason on both the incremental and append-only sync options to explain the requirement:

> Incremental replication needs a timestamp, date, or auto-incrementing numeric column to track new rows, and none was found on this table

(and the append-only equivalent). The message now names what qualifies as an incremental field, matching the timestamp / date / integer / numeric column types the sources actually surface, so the requirement is clear from the tooltip itself.

Copy-only change, no behavior change.

## How did you test this code?

No manual browser testing and no automated tests were run by the agent — `node_modules` isn't installed in this environment, so the frontend linters/typecheck couldn't run locally. This is a pure user-facing string change in `SyncMethodForm.tsx` with no type or logic impact; CI's lint/typecheck will cover it. No existing test asserted the old string.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found by reviewing summarized session recordings of the new-source onboarding flow for recurring friction. Invoked the `/writing-user-facing-copy` skill for the wording (sentence case, no em-dash, points at the next action). Confirmed the qualifying column types against `products/warehouse_sources/.../setting-up-a-data-warehouse-source/references/sync-types.md`.

Other themes from the same review were deliberately not actioned here: the widespread source-catalog `ModuleNotFoundError` is already fixed by #75756, and the database connection-error copy and the "couldn't load available sources" state are already handled.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
