### PR TITLE
fix: spill the archive export rollup join to disk

### DIFF
--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -106,7 +106,7 @@ ONE_GB = 1024 * 1024 * 1024
 
 class QueryLogArchiveExportConfig(dagster.Config):
     max_threads: int = pydantic.Field(
-        default=24,
+        default=12,
         ge=1,
         description="ClickHouse max_threads for the export scan. Must be ≥ 1 (0 means auto/all-cores in ClickHouse and will re-enable the OOM risk).",
     )
@@ -139,6 +139,9 @@ def export_query_log_archive_day(
     leaf_sums = ",\n        ".join(f"sum(`{column}`) AS `leaf_{column}`" for column in LEAF_SUM_COLUMNS)
     leaf_columns = ",\n    ".join(f"`leaf_{column}`" for column in LEAF_SUM_COLUMNS)
     # Leaf rows of a query straddling midnight land on the next event_date, hence the two-day window.
+    # The rollup GROUP BY holds millions of initial_query_id keys and the join builds a hash table of
+    # them, sharing the query memory cap with the log_comment-heavy scan; both must spill to disk or
+    # the query exceeds the cap.
     query = f"""
 INSERT INTO FUNCTION s3('{s3_url}', 'Parquet')
 SELECT
@@ -168,7 +171,9 @@ LEFT JOIN
     WHERE event_date >= toDate('{day}') AND event_date <= toDate('{day}') + 1 AND NOT is_initial_query
     GROUP BY leaf_initial_query_id
 ) AS leaf ON initial_rows.query_id = leaf.leaf_initial_query_id
-SETTINGS s3_truncate_on_insert = 1, max_threads = {config.max_threads}
+SETTINGS s3_truncate_on_insert = 1, max_threads = {config.max_threads},
+    join_algorithm = 'grace_hash', max_bytes_in_join = 1500000000,
+    max_bytes_before_external_group_by = 2000000000
 """
 
     def run(client: Client) -> str:


### PR DESCRIPTION
## Problem

The query log archive export died with `MEMORY_LIMIT_EXCEEDED` at the job's 20 GiB per-query cap, failing while deserializing the `log_comment` JSON column on the initial-rows scan.

The scan itself fit the cap before #75698; what changed is that the same query now also holds the leaf rollup's `GROUP BY` state (millions of `initial_query_id` keys over the two-day window) and the join hash table built from it, so the scan, the aggregation, and the join build all compete for one 20 GiB budget.

## Changes

Add query settings so the aggregation and join spill to disk instead of competing with the scan, and lower the default thread count:

- `join_algorithm = 'grace_hash'` with `max_bytes_in_join = 1500000000`: the join build side flushes buckets to disk once it exceeds the bound and processes them one at a time. The bound is essential: grace hash with the default unlimited `max_bytes_in_join` never spills and behaves like a plain hash join.
- `max_bytes_before_external_group_by = 2000000000`: the rollup aggregation spills partial states to disk and merges them back.
- `max_threads` default 24 -> 12: per-thread scan buffers and partial aggregation states are the remaining large memory term.

Verified on the US OPS node against the real failed day (full query as `SELECT ... FORMAT Null`, same 20 GiB cap, executed remotely via `cluster('ops', view(...))`):

- grace hash without the join bound reproduced the production OOM at 163 s.
- with the join bounded at 2 GB and external aggregation past 3 GB, the same query at 24 threads survived the phase that killed the original run and held a peak of 19.6 GiB, alive but with almost no margin, which is why the shipped thresholds are tighter and the thread count halved.

## How did you test this code?

- Ran the rendered SQL with the new settings end to end against a local dev ClickHouse (26.6.1), confirming the grace hash join accepts this LEFT JOIN shape, and exercised the spill behavior on the US OPS node against the real failed day as described above.


## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs page covers this export job; nothing to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Claude Fable 5) in a session driven by Andy Zhao, diagnosing the first post-merge run failure of the rollup export.
- Considered and rejected: raising the 20 GiB cap (masks growth and eats into node memory shared with the archive's ingest path) and shrinking the leaf window to one day (loses midnight-straddling leaves for a marginal memory saving).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

