### PR TITLE
fix(redshift): stop reporting permission-denied row-count probes as bugs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/redshift.py
@@ -887,6 +887,14 @@ class RedshiftImplementation(SQLSourceImplementation[RedshiftSourceConfig, psyco
             return int(row[0] or 0)
         except psycopg.errors.QueryCanceled:
             raise
+        except psycopg.errors.InsufficientPrivilege as e:
+            # The connecting role can SELECT the table itself but Redshift also gates access to a
+            # materialized view's base relation(s) separately (SQLSTATE 42501). Row-count
+            # estimation is best-effort (the caller defaults to 0), so skip gracefully instead of
+            # reporting the expected, non-actionable error to error tracking. Mirrors
+            # `fetch_table_stats`.
+            logger.debug(f"get_rows_to_sync: no privilege to run count query, using 0 as rows to sync: {e}")
+            return 0
         except Exception as e:
             logger.debug(f"get_rows_to_sync: Error: {e}. Using 0 as rows to sync", exc_info=e)
             capture_exception(e)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
@@ -161,7 +161,21 @@ class RedshiftSource(SQLSource[RedshiftSourceConfig], SSHTunnelMixin, ValidateDa
             "TemporaryFileSizeExceedsLimitException": None,
             "Name or service not known": None,
             "Network is unreachable": None,
+            # `InsufficientPrivilege` is the psycopg exception class name. It only appears once
+            # Temporal wraps the activity failure (`ApplicationError` stringifies as
+            # "InsufficientPrivilege: ..."), so it matches at the workflow layer but NOT in the
+            # activity-level check, where `error_msg = str(e)` is the raw psycopg message —
+            # Redshift's SQLSTATE 42501 text "permission denied for ...". Match that message
+            # substring too so the role-lacks-SELECT case (including a materialized view whose
+            # base relation isn't separately granted) is caught at both layers instead of burning
+            # the activity's full retry budget on a denial that can't resolve itself.
             "InsufficientPrivilege": None,
+            "permission denied for": (
+                "PostHog's database role isn't allowed to read one or more of the tables you selected to sync "
+                '(Redshift reported "permission denied"). If this is a materialized view, Redshift also '
+                "requires the connecting role to have SELECT on its underlying base table(s), not just the "
+                "view. Grant the connecting role SELECT on those tables, then re-enable the sync."
+            ),
             "No route to host": None,
             "password authentication failed connection": None,
             "connection timeout expired": None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -360,6 +360,21 @@ class TestGetRowsToSync:
         with pytest.raises(TemporaryFileSizeExceedsLimitException):
             impl.get_rows_to_sync(cursor, self._inner(), None, logger)
 
+    def test_permission_denied_on_materialized_view_is_not_reported(self, impl, cursor, logger):
+        # A materialized view's base relation can be denied even when the view itself is
+        # selectable. That's an expected customer permission-config issue, not an actionable bug —
+        # row-count estimation is best-effort (the caller defaults to 0), so skip gracefully
+        # without reporting the non-actionable error to error tracking (the source of the reported
+        # noise).
+        cursor.execute.side_effect = psycopg.errors.InsufficientPrivilege(
+            'permission denied for materialized view base relation "Payment_Actions"'
+        )
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.redshift.redshift.capture_exception"
+        ) as mock_capture:
+            assert impl.get_rows_to_sync(cursor, self._inner(), None, logger) == 0
+        mock_capture.assert_not_called()
+
 
 class TestFetchTableStats:
     def test_returns_none_when_no_row(self, impl, cursor, logger):
@@ -834,6 +849,17 @@ class TestRedshiftSourceNonRetryableErrors:
             'connection failed: connection to server at "10.0.0.1", port 5439 failed: '
             "server does not support SSL, but SSL was required"
         )
+        non_retryable = RedshiftSource().get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable
+
+    def test_permission_denied_raw_message_is_non_retryable(self):
+        # The activity-level check matches the raw `str(exception)`, which for a psycopg
+        # `InsufficientPrivilege` never contains the class name — only the `InsufficientPrivilege`
+        # key (which only matches once Temporal's `ApplicationError` wraps the failure with the
+        # class name) would miss this, letting the activity burn its full retry budget on a
+        # permission denial that can't resolve itself.
+        error_msg = 'permission denied for materialized view base relation "Payment_Actions"'
         non_retryable = RedshiftSource().get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable


### PR DESCRIPTION
## Problem

Error tracking flagged a recurring `InsufficientPrivilege` issue from the Redshift import source: `permission denied for materialized view base relation ...`. Redshift requires a role to have SELECT not just on a materialized view but also on its underlying base table(s) — a customer permission-config gap, not a PostHog bug.

Two things made this worse than it should be:

1. `get_rows_to_sync`'s row-count estimate is best-effort (falls back to 0 on any failure), but its catch-all `except Exception` reported *every* failure to error tracking, including this expected, non-actionable permission denial.
2. The source's `get_non_retryable_errors()` already had an `InsufficientPrivilege` entry, but it only matches once Temporal wraps the activity failure with the exception's class name. The activity-level check compares against the raw psycopg message, which never contains that class name — so a deterministic permission denial on the real sync query would burn the activity's full retry budget instead of stopping immediately with actionable guidance.

## Changes

- `redshift.py`: catch `psycopg.errors.InsufficientPrivilege` in `get_rows_to_sync` before the generic exception handler and skip reporting it, mirroring the existing `fetch_table_stats` handling of the same exception in this file.
- `source.py`: add a `"permission denied for"` key to `get_non_retryable_errors()` so the raw psycopg message is recognized as non-retryable at the activity layer too (not just after Temporal wraps it), with guidance about granting SELECT on a materialized view's base tables. This mirrors the equivalent fix already in the Postgres source.

## How did you test this code?

Added two test cases:
- `test_permission_denied_on_materialized_view_is_not_reported` in `TestGetRowsToSync` — asserts `get_rows_to_sync` returns 0 without calling `capture_exception` when Redshift denies access to a materialized view's base relation. Catches the exact regression: without the new `except` clause, this exception reaches the catch-all and gets reported.
- `test_permission_denied_raw_message_is_non_retryable` in `TestRedshiftSourceNonRetryableErrors` — asserts the raw (unwrapped) `"permission denied for ..."` message matches a key in `get_non_retryable_errors()`. Catches the regression where only the `InsufficientPrivilege` key existed, which never matches this raw message shape.

Ran the full `test_redshift.py` suite locally (99 passed), plus `ruff check`/`ruff format` and a repo-wide `mypy` run — all clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Investigated a live error-tracking issue for the Redshift data-warehouse source, confirmed the failing frame was genuinely inside `products/warehouse_sources/backend/temporal/data_imports/sources/redshift/redshift.py` (not just referenced in serialized context), then traced the non-retryable-error matching logic across the activity and workflow layers to understand why the existing `InsufficientPrivilege` entry didn't stop retries.
- Found the Postgres source already has the equivalent fix (`permission denied for` variants) with an explanatory comment about the same activity-vs-workflow matching gap; mirrored that pattern here rather than inventing a new one.
- Searched open PRs (by exception type, message phrase, module path, and the maintainer's own recent PRs) and found no existing fix for this specific error.
- Skills invoked: `/writing-tests` before adding the regression tests.