### PR TITLE
fix(data-imports): stop reporting transient S3 blips from pre-extraction repartition detection

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py
@@ -30,7 +30,10 @@ from posthog.temporal.common.logger import get_logger
 
 from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper import DeltaTableHelper
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.delta_table_helper import (
+    DeltaTableHelper,
+    is_transient_object_store_error,
+)
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.core.repartition import (
     RepartitionSupersededError,
     RepartitionTarget,
@@ -158,9 +161,15 @@ def _maybe_flag_pre_extraction(
             return None
         async_to_sync(maybe_flag_for_repartition)(schema, schema.source, job, delta_table, logger, enabled=enabled)
     except Exception as e:
-        # Detection is best-effort; a failure here must not block the sync.
-        logger.warning("repartition: pre-extraction detection failed", exc_info=True)
-        capture_exception(e)
+        # Detection is best-effort; a failure here must not block the sync. `get_delta_table` re-raises
+        # transient object-store blips (S3/credential-provider timeouts) rather than swallowing them —
+        # see its own docstring — so this is the layer that must apply is_transient_object_store_error
+        # before reporting, same as the other best-effort call sites around this table.
+        if is_transient_object_store_error(e):
+            logger.warning("repartition: pre-extraction detection failed with a transient object-store error")
+        else:
+            logger.warning("repartition: pre-extraction detection failed", exc_info=True)
+            capture_exception(e)
         return None
     return schema.repartition_pending
 

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_repartition_table.py
@@ -3,8 +3,11 @@ import uuid
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from parameterized import parameterized
+
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.repartition_table import (
     RepartitionActivityInputs,
+    _maybe_flag_pre_extraction,
     _maybe_repartition_table,
 )
 
@@ -83,3 +86,48 @@ class TestRepartitionActivityDeltaFolder:
         assert await_args is not None
         assert await_args.kwargs["helper"] is mock_helper_cls.return_value
         assert mock_job_model.objects.get.call_args.kwargs == {"id": JOB_ID}
+
+
+class TestMaybeFlagPreExtraction:
+    @parameterized.expand(
+        [
+            (
+                "generic_s3_error",
+                OSError(
+                    "Generic S3 error: Error getting list response body: HTTP error: "
+                    "request or response body error: operation timed out"
+                ),
+            ),
+            (
+                "credential_provider_timeout",
+                OSError(
+                    "Operation not supported: an error occurred while loading credentials: "
+                    "dispatch failure: timeout: client error (Connect): HTTP connect timeout occurred: timed out"
+                ),
+            ),
+        ]
+    )
+    @patch(f"{MODULE}.capture_exception")
+    def test_transient_object_store_error_is_not_reported(
+        self, _name: str, error: OSError, mock_capture: MagicMock
+    ) -> None:
+        schema = _schema(name="stripe_charge", s3_folder_name=None)
+        helper = MagicMock()
+        helper.get_delta_table = AsyncMock(side_effect=error)
+
+        result = _maybe_flag_pre_extraction(schema, MagicMock(), helper, MagicMock(), enabled=True)
+
+        assert result is None
+        mock_capture.assert_not_called()
+
+    @patch(f"{MODULE}.capture_exception")
+    def test_non_transient_error_is_still_reported(self, mock_capture: MagicMock) -> None:
+        schema = _schema(name="stripe_charge", s3_folder_name=None)
+        helper = MagicMock()
+        error = ValueError("unexpected schema drift")
+        helper.get_delta_table = AsyncMock(side_effect=error)
+
+        result = _maybe_flag_pre_extraction(schema, MagicMock(), helper, MagicMock(), enabled=True)
+
+        assert result is None
+        mock_capture.assert_called_once_with(error)


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OSError` ("Generic S3 error ... operation timed out") originating from `products/warehouse_sources/backend/temporal/data_imports/workflow_activities/repartition_table.py`.

The stack trace traces the failure to the pre-extraction repartition size check (`_maybe_flag_pre_extraction`), which calls `DeltaTableHelper.get_delta_table` to measure the on-disk Delta table before deciding whether a repartition is needed. `get_delta_table` deliberately re-raises S3/credential-provider blips rather than swallowing them (it can't safely report "no table" for a table that actually exists), so it's the caller's job to classify the error before deciding whether to report it.

`_maybe_flag_pre_extraction`'s except block called `capture_exception` unconditionally, even for a message that matches the codebase's own `is_transient_object_store_error` classifier (used everywhere else in this file and in `delta_table_helper.py` to recognize retriable object-store noise like "Generic S3 error" and "an error occurred while loading credentials"). The result: a transient, self-recovering network blip got reported as a fresh error-tracking issue, even though this detection path is explicitly best-effort and never blocks the sync — the same table is simply re-measured on the next run.

## Changes

- `repartition_table.py`: `_maybe_flag_pre_extraction`'s exception handler now checks `is_transient_object_store_error(e)` before calling `capture_exception`, mirroring the same check already applied inside `get_delta_table` and delta maintenance. Non-transient errors are still captured and logged as before.

## How did you test this code?

Added `TestMaybeFlagPreExtraction` in `test_repartition_table.py`:
- Two parameterized cases reproducing the exact error messages from the error-tracking issue (a generic S3 list timeout and a credential-provider connect timeout) assert `capture_exception` is *not* called.
- One case with an unrelated `ValueError` asserts `capture_exception` is still called, so a genuine bug in this path keeps surfacing.

Ran the full `test_repartition_table.py` file locally (5 passed) and `ruff check`/`ruff format` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-tracking noise fix, no user-facing behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (Claude Code) triaged an error-tracking issue for the warehouse import pipeline, traced the stack trace to `_maybe_flag_pre_extraction` in `repartition_table.py`, and found the transient-error classification gap described above by comparing this except block against the equivalent, already-correct handling in `delta_table_helper.get_delta_table` and `_maybe_repartition_table`'s own except block in the same file. No skills were mandatory for this change beyond `/writing-tests`, which was invoked before adding the regression test.

Decision: this is shared-pipeline-code noise, not a retry-policy or `NonRetryableErrors` question — the exception was already fully swallowed and never affected the sync; the only issue was over-reporting a known-transient class to error tracking.