### PR TITLE
fix(data-imports): keep transient object-store blips out of error tracking on delta corruption check

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py
@@ -428,6 +428,17 @@ async def handle_corrupted_delta_log(
             if not await delta_table_helper.is_table_corrupted():
                 return False
         except Exception as e:
+            if is_transient_object_store_error(e):
+                # `is_table_corrupted` opens the table via `DeltaTable.is_deltatable`, which can hit
+                # the same IMDS/STS credential-provider or connectivity blips as any other delta-rs
+                # object-store call — not evidence the table is corrupt, just a blip talking to our
+                # own S3 bucket. Skip the revive check this sync rather than reporting a defect; the
+                # next sync's check runs fresh.
+                await logger.awarning(
+                    f"handle_corrupted_delta_log: is_table_corrupted transient object-store error, "
+                    f"skipping revive check schema_id={schema.id}: {e}"
+                )
+                return False
             capture_exception(e)
             return False
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py
@@ -422,6 +422,32 @@ class TestHandleCorruptedDeltaLog:
         job.refresh_from_db()
         assert job.billable is True
 
+    def test_is_table_corrupted_transient_object_store_error_skips_without_capturing(self, team):
+        # `is_table_corrupted` opens the table via `DeltaTable.is_deltatable`, which can raise the
+        # same IMDS/STS credential-provider blip as any other delta-rs object-store call. That isn't
+        # evidence of corruption — it must be treated like the reset-path blip above (skip, log a
+        # warning, no error-tracking capture) rather than unconditionally reported as a defect.
+        schema, job = self._schema_and_job(team)
+        corrupt_check_error = OSError(
+            "Operation not supported: an error occurred while loading credentials: dispatch failure: "
+            "timeout: client error (Connect): HTTP connect timeout occurred after 3.1s: timed out"
+        )
+        helper = MagicMock(is_table_corrupted=AsyncMock(side_effect=corrupt_check_error), reset_table=AsyncMock())
+        logger = self._logger()
+
+        with (
+            patch(f"{_EXTRACT_MODULE}.posthoganalytics"),
+            patch(f"{_EXTRACT_MODULE}.capture_exception") as mock_capture,
+        ):
+            result = async_to_sync(handle_corrupted_delta_log)(schema, job, helper, logger)
+
+        assert result is False
+        mock_capture.assert_not_called()
+        helper.reset_table.assert_not_awaited()
+        logger.awarning.assert_awaited()
+        job.refresh_from_db()
+        assert job.billable is True
+
     def test_revive_marker_resets_readable_table(self, team):
         # A hollow table — log opens fine but references data files gone from S3 — is invisible to
         # is_table_corrupted; the repartition scan marks it instead. The marker alone must trigger the


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OSError: Operation not supported: an error occurred while loading credentials: ... HTTP connect timeout occurred after 3.1s: timed out` from the data-imports pipeline, with the in-app frame in `DeltaTableHelper.is_table_corrupted` (occurred during a Supabase sync, but the failing code is shared across all sources).

`is_table_corrupted` opens the table via `DeltaTable.is_deltatable`, which talks to our own S3-backed data-warehouse bucket through delta-rs's Rust `object_store` crate. That call can hit the same IMDS/STS credential-provider or connectivity blips as any other delta-rs object-store call — a self-recovering infra hiccup, not evidence the table is actually corrupt.

The pipeline already has a classifier for exactly this shape of error (`is_transient_object_store_error`), and `handle_corrupted_delta_log`'s own `reset_table` exception handler a few lines further down already uses it to skip reporting a defect for the identical blip. The exception handler wrapping the `is_table_corrupted()` call, a few lines above, didn't — it unconditionally called `capture_exception` for any failure, turning a known, retryable blip into error-tracking noise.

## Changes

- In `handle_corrupted_delta_log`, classify the exception from `is_table_corrupted()` with the existing `is_transient_object_store_error` check before reporting it. A transient blip now logs a warning and skips the revive check for this sync (the check runs again fresh next sync); everything else still goes through `capture_exception` as before.

## How did you test this code?

Added `test_is_table_corrupted_transient_object_store_error_skips_without_capturing` to `TestHandleCorruptedDeltaLog` in `test_extract.py`, asserting `capture_exception` is not called, `reset_table` is never invoked, and the job stays billable — the exact regression this fixes, mirroring the existing `test_reset_transient_object_store_error_retries_next_sync` case for the sibling code path a few lines down.

Ran:
- `uv run pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/common/test/test_extract.py -k "TestHandleCorruptedDeltaLog or TestRunPreWriteDefensiveCompact"` — 18 passed
- `uv run mypy --cache-fine-grained .` (repo-wide) — clean
- `hogli ci:preflight --fix` — 0 failures

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal error-classification change, no user-facing or API behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged directly from the linked error-tracking issue via PostHog's error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`), which surfaced the full stack trace confirming the failure is in shared delta-table code, not the Supabase connector. Read `delta_table_helper.py`'s existing transient-error classifiers and their established usage pattern elsewhere in the same file (`run_pre_write_defensive_compact`, the `reset_table` handler in this same function) to confirm this exception handler was the outlier that hadn't adopted it.

Checked open PRs for a duplicate by exception type, message phrase, and module path, and reviewed the maintainer's own open PR queue — found several related-but-non-overlapping PRs applying the same "classify transient infra blip" pattern to other error classes and code paths in this pipeline. None cover this specific `is_table_corrupted` call site.

Invoked `/writing-tests` before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*