### PR TITLE
feat(aio): show prompt config usage in code snippets

### DIFF
--- a/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
+++ b/products/ai_observability/frontend/prompts/promptSceneComponents.tsx
@@ -530,10 +530,14 @@ function buildPythonSnippet(
     host: string,
     projectApiKey: string,
     variables: string[],
-    labelName?: string
+    labelName?: string,
+    showConfig?: boolean
 ): string {
     const compileLines = variables.length
         ? `\nsystem_prompt = prompts.compile(result.prompt, {${variables.map((v) => `${JSON.stringify(v)}: '...'`).join(', ')}})`
+        : ''
+    const configLines = showConfig
+        ? `\nmodel = (result.config or {}).get('model', 'your-default-model')  # config stored with this prompt version`
         : ''
     const labelArg = labelName ? `label=${JSON.stringify(labelName)}, ` : ''
     return `from posthog import Posthog
@@ -546,7 +550,7 @@ posthog = Posthog(
 )
 prompts = Prompts(posthog)
 
-result = prompts.get(${JSON.stringify(promptName)}, ${labelArg}with_metadata=True, fallback='You are a helpful assistant.')${compileLines}
+result = prompts.get(${JSON.stringify(promptName)}, ${labelArg}with_metadata=True, fallback='You are a helpful assistant.')${compileLines}${configLines}
 # result.name / result.version -> send as $ai_prompt_name / $ai_prompt_version on your LLM events`
 }
 
@@ -555,10 +559,14 @@ function buildNodeSnippet(
     host: string,
     projectApiKey: string,
     variables: string[],
-    labelName?: string
+    labelName?: string,
+    showConfig?: boolean
 ): string {
     const compileLines = variables.length
         ? `\nconst systemPrompt = prompts.compile(result.prompt, {${variables.map((v) => ` ${JSON.stringify(v)}: '...'`).join(',')} })`
+        : ''
+    const configLines = showConfig
+        ? `\nconst model = result.config?.model ?? 'your-default-model' // config stored with this prompt version`
         : ''
     const labelArg = labelName ? `label: '${labelName}', ` : ''
     return `import { Prompts } from '@posthog/ai'
@@ -570,7 +578,7 @@ const posthog = new PostHog('${projectApiKey}', {
 })
 const prompts = new Prompts({ posthog })
 
-const result = await prompts.get(${JSON.stringify(promptName)}, { ${labelArg}fallback: 'You are a helpful assistant.' })${compileLines}
+const result = await prompts.get(${JSON.stringify(promptName)}, { ${labelArg}fallback: 'You are a helpful assistant.' })${compileLines}${configLines}
 // result.name / result.version -> send as $ai_prompt_name / $ai_prompt_version on your LLM events`
 }
 
@@ -588,6 +596,8 @@ export function PromptCodeSnippets({ prompt }: { prompt: LLMPrompt }): JSX.Eleme
     const snippetLabel = labelsEnabled
         ? (promptLabels.find((label) => label.name === 'production') ?? promptLabels[0])?.name
         : undefined
+    // Same principle for config: only show the usage line once this prompt has one.
+    const showConfig = !!featureFlags[FEATURE_FLAGS.LLM_PROMPT_CONFIG] && prompt.config != null
 
     return (
         <div className="mb-6" data-attr="llma-prompt-code-snippets">
@@ -620,7 +630,14 @@ export function PromptCodeSnippets({ prompt }: { prompt: LLMPrompt }): JSX.Eleme
                         label: 'Python',
                         content: (
                             <CodeSnippet language={Language.Python}>
-                                {buildPythonSnippet(prompt.name, host, projectApiKey, variables, snippetLabel)}
+                                {buildPythonSnippet(
+                                    prompt.name,
+                                    host,
+                                    projectApiKey,
+                                    variables,
+                                    snippetLabel,
+                                    showConfig
+                                )}
                             </CodeSnippet>
                         ),
                     },
@@ -629,7 +646,14 @@ export function PromptCodeSnippets({ prompt }: { prompt: LLMPrompt }): JSX.Eleme
                         label: 'Node.js',
                         content: (
                             <CodeSnippet language={Language.JavaScript}>
-                                {buildNodeSnippet(prompt.name, host, projectApiKey, variables, snippetLabel)}
+                                {buildNodeSnippet(
+                                    prompt.name,
+                                    host,
+                                    projectApiKey,
+                                    variables,
+                                    snippetLabel,
+                                    showConfig
+                                )}
                             </CodeSnippet>
                         ),
                     },


### PR DESCRIPTION
## Problem

The prompt code snippets tab doesn't show how to use `prompt.config`, which shipped in posthog-python 7.35.0 and @posthog/ai 8.6.0.

## Changes

When the `llm-prompt-config` flag is on and the prompt has a config, the Python and Node snippets include a line reading a model parameter from `result.config`, with defensive access since config is unset when the fallback is used. Prompts without a config are unchanged.

## How did you test this code?

Typecheck passes. Snippet builders are plain string templates, no behavior beyond the rendered text.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Follow-up to #75423, per the prompt config rollout plan. /writing-user-facing-copy invoked for the snippet text.