### PR TITLE
fix(utils): resolve yEnd relative date to end of year

### DIFF
--- a/posthog/test/test_utils.py
+++ b/posthog/test/test_utils.py
@@ -396,6 +396,16 @@ class TestRelativeDateParse(TestCase):
             "2019-01-01",
         )
 
+        # yEnd is the end of the year (Dec 31), mirroring yStart being Jan 1.
+        self.assertEqual(
+            relative_date_parse("yEnd", ZoneInfo("UTC")).strftime("%Y-%m-%d"),
+            "2020-12-31",
+        )
+        self.assertEqual(
+            relative_date_parse("-1yEnd", ZoneInfo("UTC")).strftime("%Y-%m-%d"),
+            "2019-12-31",
+        )
+
     @parameterized.expand(
         [
             # 2020-01-31 is a Friday

--- a/posthog/utils.py
+++ b/posthog/utils.py
@@ -340,6 +340,7 @@ def get_delta_mapping_for(
             delta_mapping["month"] = 1
             delta_mapping["day"] = 1
         elif position == "End":
+            delta_mapping["month"] = 12
             delta_mapping["day"] = 31
 
     return delta_mapping


### PR DESCRIPTION
## Problem

`yEnd` resolves to the end of the current month, not the end of the year. In `get_delta_mapping_for` (`posthog/utils.py`), the `y` / `End` case sets only `day=31`, so `relativedelta(day=31)` lands on the current month's last day. `yStart` correctly sets `month=1` and `day=1`; `yEnd` was missing the matching `month=12`.

## Changes

Add `month=12` to the `y` / `End` branch so `yEnd` resolves to December 31, mirroring `yStart` resolving to January 1. Also added `yEnd` / `-1yEnd` assertions to `test_year` (there was no `yEnd` test before, which is why this slipped through).

## How did you test this code?

Unit tests in `posthog/test/test_utils.py::TestRelativeDateParse.test_year` (frozen at 2020-01-31): `yEnd` now returns `2020-12-31` and `-1yEnd` returns `2019-12-31`. Run `pytest posthog/test/test_utils.py::TestRelativeDateParse` to confirm.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found and fixed with Claude Code; I reviewed it and own the change.
