### PR TITLE
fix(monday): retry 404s from the fixed GraphQL endpoint

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/monday/monday.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/monday/monday.py
@@ -137,7 +137,11 @@ def _execute(
         timeout=REQUEST_TIMEOUT_SECONDS,
     )
 
-    if response.status_code == 429 or response.status_code >= 500:
+    # MONDAY_API_URL is a fixed constant, never derived from customer input, so a 404 on it can't
+    # mean "this resource doesn't exist" — it's the edge/gateway dropping the request before it
+    # reaches the GraphQL engine (monday.com's own docs don't list 404 as a GraphQL response code).
+    # Treat it like the other transport-layer blips (429/5xx) instead of failing the sync outright.
+    if response.status_code in (404, 429) or response.status_code >= 500:
         raise MondayRetryableError(f"monday.com API error (retryable): status={response.status_code}")
 
     if not response.ok:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/monday/tests/test_monday.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/monday/tests/test_monday.py
@@ -95,6 +95,20 @@ class TestGetRowsPaged:
         with pytest.raises(MondayRetryableError):
             list(get_rows("token", "users", mock.MagicMock()))
 
+    @mock.patch("time.sleep")
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_404_status_is_retried_then_succeeds(self, mock_session, _mock_sleep):
+        not_found = mock.MagicMock(status_code=404, ok=False)
+        mock_session.return_value.post.side_effect = [
+            not_found,
+            _response({"users": [{"id": "1"}]}),
+        ]
+
+        batches = list(get_rows("token", "users", mock.MagicMock()))
+
+        assert batches == [[{"id": "1"}]]
+        assert mock_session.return_value.post.call_count == 2
+
     @mock.patch(f"{_MODULE}.make_tracked_session")
     def test_requests_carry_token_and_api_version(self, mock_session):
         mock_session.return_value.post.return_value = _response({"users": []})


### PR DESCRIPTION
## Problem

Error tracking surfaced an [issue](https://us.posthog.com/project/2/error_tracking/019fb6ba-8eb7-7af3-9a06-9dd387648f45) for the monday.com data warehouse source:

```
HTTPError: 404 Client Error: Not Found for url: https://api.monday.com/v2
```

raised from `_execute` in `monday.py`. The request URL (`MONDAY_API_URL`) is a hardcoded constant, never derived from anything a customer configures, so a 404 on it can't mean "this resource doesn't exist" the way a normal REST 404 would. monday.com's own [error-handling docs](https://developer.monday.com/api-reference/docs/error-handling) only document 401/403/429/415/500 as real GraphQL API responses — a 404 here looks like the edge/gateway dropping the request before it reaches the GraphQL engine, i.e. a transient infrastructure blip rather than a genuine client or auth error.

Previously, this status code fell through to `response.raise_for_status()`, which raises a plain `requests.HTTPError` that the retry decorator doesn't catch — so the sync failed outright on what's most likely a one-off routing hiccup on monday.com's side.

## Changes

- Treat HTTP 404 from `_execute` the same as the existing 429/5xx retryable path, so it goes through the same exponential backoff and retry budget instead of failing the sync immediately.

## How did you test this code?

Added `test_404_status_is_retried_then_succeeds` to `test_monday.py`, following the existing pattern for the internal-server-error retry test — it asserts a 404 response is retried and a subsequent success completes the batch. Ran the full `test_monday.py` suite locally (18 passed) plus `ruff check`/`ruff format` on the touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via the PostHog error-tracking MCP tools (issue details, sampled event with stack trace) to confirm the failure originates in `products/warehouse_sources/backend/temporal/data_imports/sources/monday/monday.py`, then read the source and settings to understand the fixed, non-configurable endpoint URL. Weighed non-retryable-error classification (per `stripe/source.py`'s `get_non_retryable_errors` pattern) against a retry-policy fix, and concluded this fits the "transient infrastructure error" case since the URL can never legitimately 404 for a real customer-side reason. Searched open PRs and the maintainer's recent PRs for a duplicate fix — found none. Used the `/writing-tests` skill before adding the regression test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*