### PR TITLE
feat(data-warehouse): promote ClickHouse source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -8,6 +8,7 @@ from sshtunnel import BaseSSHTunnelForwarderError
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -114,7 +115,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
         return SourceConfig(
             name=SchemaExternalDataSourceType.CLICK_HOUSE,
             category=DataWarehouseSourceCategory.DATABASES,
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             caption="Enter your ClickHouse connection details to pull data into the PostHog Data warehouse. ClickHouse databases can be very large — we stream the data in Arrow batches to keep memory bounded.",
             iconPath="/static/services/clickhouse.png",
             docsUrl="https://posthog.com/docs/cdp/sources/clickhouse",


### PR DESCRIPTION
## Problem

The ClickHouse data-warehouse source has been shipping as beta. It now clears our promotion bar, so it should be marked generally available.

Current metrics (7-day window):
- Import error rate 1.7%, below the 2.5% threshold.
- Live for 3.3 months.

## Changes

- Set `releaseStatus` on the ClickHouse `SourceConfig` from beta to GA.
- Switch from the bare string `"beta"` to the `ReleaseStatus` enum (`ReleaseStatus.GA`), matching the convention every other source follows.

This is a status promotion only. No connector behavior, schema, or sync logic changes. ClickHouse has no feature-flag or `unreleasedSource` gating, so there was nothing else to remove.

## How did you test this code?

`ruff check` passes on the changed file. No test asserted the old beta status, so nothing needed updating. I (Claude) did not run a live sync or exercise the connector, since this is a metadata-only change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code). Invoked the `/implementing-warehouse-sources` skill to confirm the release-status convention (the `ReleaseStatus` enum over a bare string) and where source config lives. Checked open PRs from several angles, including the maintainer's own, to rule out a duplicate promotion before opening this.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
