### PR TITLE
fix(data-warehouse): preserve canonical source table slugs

### DIFF
--- a/posthog/ducklake/README.md
+++ b/posthog/ducklake/README.md
@@ -69,7 +69,7 @@ Every copy is written to a deterministic schema inside DuckLake. Each workflow n
 ### Data Imports and Data Import Registration
 
 - **Schema**: `posthog_data_imports_<cluster_schema_name>` for an onboarded team, or the legacy `posthog_data_imports_team_<team_id>` schema
-- **Table**: `<source_type>_<prefix>_<normalized_name>` using the same snake-case and 63-character shortening convention as the v3 Duckgres sink
+- **Table**: `<source_slug>_<prefix>_<normalized_name>` using the source's canonical slug when defined, then the same snake-case and 63-character shortening convention as the v3 Duckgres sink
 - **Example**: `ducklake.posthog_data_imports_team_123.stripe_prod_invoices`
 - **Registered files**: `s3://<ducklake-bucket>/<ducklake-schema>/<ducklake-table>/_imports/<source-schema-id>/<job-id>/<prepared-relative-path>`
 

--- a/posthog/ducklake/common.py
+++ b/posthog/ducklake/common.py
@@ -542,6 +542,11 @@ def duckgres_data_imports_schema(team_id: int) -> str:
     return team_state.data_imports_schema(team_id)
 
 
+_DATA_IMPORTS_CANONICAL_SOURCE_SLUGS: dict[str, str] = {
+    "TikTokAds": "tiktok_ads",
+}
+
+
 def duckgres_data_imports_table_name(schema: ExternalDataSchema) -> str:
     """Resolve the duckgres table name the data-import copy workflow writes a schema's snapshot into.
 
@@ -551,7 +556,8 @@ def duckgres_data_imports_table_name(schema: ExternalDataSchema) -> str:
     source_type = schema.source.source_type
     prefix = schema.source.prefix
     normalized_name = schema.normalized_name
-    raw_name = f"{source_type}_{prefix}_{normalized_name}" if prefix else f"{source_type}_{normalized_name}"
+    source_slug = _DATA_IMPORTS_CANONICAL_SOURCE_SLUGS.get(source_type, source_type)
+    raw_name = f"{source_slug}_{prefix}_{normalized_name}" if prefix else f"{source_slug}_{normalized_name}"
     return _normalize_duckgres_table_name(raw_name, max_length=63)
 
 

--- a/posthog/ducklake/test_common.py
+++ b/posthog/ducklake/test_common.py
@@ -60,6 +60,7 @@ class TestDuckgresTableNames:
         [
             ("mysql_with_prefix", "MySQL", "SalesEU", "customer_orders", "my_sql_sales_eu_customer_orders"),
             ("bigquery_without_prefix", "BigQuery", None, "daily_stats", "big_query_daily_stats"),
+            ("tiktok_ads_canonical_slug", "TikTokAds", "prod", "ad_report", "tiktok_ads_prod_ad_report"),
             (
                 "long_name",
                 "MySQL",


### PR DESCRIPTION
## Problem

Duckgres data-import table names are derived from the source type. Generic CamelCase normalization turns `TikTokAds` into `tik_tok_ads`, but the established source slug is `tiktok_ads`. This makes the physical name inconsistent with the source naming contract and can cause readers and writers to address a parallel table.

## Changes

- Map `TikTokAds` to its canonical `tiktok_ads` slug in the shared Duckgres data-import table-name builder.
- Keep the existing prefix, schema-name normalization, and 63-character shortening behavior unchanged.
- Document canonical source slugs and add a regression case for the physical table name.

## How did you test this code?

- `hogli test posthog/ducklake/test_common.py::TestDuckgresTableNames` – 6 passed. The added parameter catches canonical source slugs being split by generic CamelCase normalization.
- `hogli test posthog/ducklake/test_client.py::TestDuckLakeModelRedirect::test_non_materialized_view_resolves_its_source_to_cluster_table` – 1 passed.
- `ruff check posthog/ducklake/common.py posthog/ducklake/test_common.py`
- `ruff format --check posthog/ducklake/common.py posthog/ducklake/test_common.py`
- `markdownlint-cli2` and `oxfmt --check` on `posthog/ducklake/README.md`
- `hogli ci:preflight --strict` – no failures.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated the DuckLake README to describe canonical source slugs in physical data-import table names.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and validated this change using the local workspace and GitHub app. Skills invoked: `/writing-tests`, `/reviewing-distributed-systems`, `/running-ci-preflight`, and `github:yeet`.

I chose a targeted canonical-slug override in the shared naming helper instead of changing generic identifier normalization or loading the source registry. This keeps every other physical table name byte-identical and avoids adding heavy or circular imports to DuckLake's shared configuration path.