### PR TITLE
fix(insights): compute on cache miss when loading an insight with dashboard overrides

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightVizDisplay.tsx
@@ -96,7 +96,7 @@ function DashboardInsightRefreshHintOrLoading({
             />
         )
     }
-    return <InsightRefreshDataHint onRetry={onRetry} />
+    return <InsightRefreshDataHint onRetry={onRetry} insightProps={insightProps} />
 }
 
 /** Dashboard tile: show refresh when merged `result` is still nullish (empty success is `[]`, not `null`). */
@@ -304,7 +304,7 @@ export function InsightVizDisplay({
                     />
                 )
             }
-            return <InsightRefreshDataHint onRetry={onRetry} />
+            return <InsightRefreshDataHint onRetry={onRetry} insightProps={insightProps} />
         }
 
         if (activeView === InsightType.FUNNELS && !isFlowViz) {

--- a/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
+++ b/frontend/src/scenes/insights/EmptyStates/EmptyStates.tsx
@@ -27,7 +27,7 @@ import { humanFriendlyNumber, humanizeBytes } from 'lib/utils/numbers'
 import { isTrustedPostHogUrl } from 'lib/utils/trustedUrl'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { entityFilterLogic } from 'scenes/insights/filters/ActionFilter/entityFilterLogic'
-import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightLogic, insightOverridesPresent } from 'scenes/insights/insightLogic'
 import { autoRunMaxPrompt } from 'scenes/max/maxPrompt'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SavedInsightFilters } from 'scenes/saved-insights/savedInsightsLogic'
@@ -118,7 +118,27 @@ export function InsightEmptyState({
 }
 
 /** Shown when the chart area would otherwise be blank (e.g. cache miss + aborted refresh). */
-export function InsightRefreshDataHint({ onRetry }: { onRetry: () => void }): JSX.Element {
+export function InsightRefreshDataHint({
+    onRetry,
+    insightProps,
+}: {
+    onRetry: () => void
+    insightProps?: InsightLogicProps
+}): JSX.Element {
+    // This dead-end state used to be invisible outside session replay — capture it so blank
+    // tiles are measurable and can be sliced by dashboard context and override presence.
+    useOnMountEffect(() => {
+        posthog.capture('insight refresh hint shown', {
+            dashboard_id: insightProps?.dashboardId ?? null,
+            insight_short_id: typeof insightProps?.dashboardItemId === 'string' ? insightProps.dashboardItemId : null,
+            has_overrides: insightOverridesPresent(
+                insightProps?.filtersOverride,
+                insightProps?.variablesOverride,
+                insightProps?.tileFiltersOverride
+            ),
+        })
+    })
+
     return (
         <div
             data-attr="insight-refresh-data-hint"

--- a/frontend/src/scenes/insights/InsightSceneHeader.tsx
+++ b/frontend/src/scenes/insights/InsightSceneHeader.tsx
@@ -32,8 +32,8 @@ export function InsightSceneHeader({ insightLogicProps }: InsightSceneHeaderProp
                 <LemonBanner type="warning" className="mb-4">
                     <div className="flex flex-row items-center justify-between gap-2">
                         <span>
-                            You are viewing this insight with filter/variable overrides. Discard them to edit the
-                            insight.
+                            You're viewing this insight with a dashboard's filters applied, so it can't be edited.
+                            Discard the filters to edit the saved insight.
                         </span>
 
                         <LemonButton type="secondary" to={urls.insightView(insightId as InsightShortId)}>

--- a/frontend/src/scenes/insights/insightLogic.test.ts
+++ b/frontend/src/scenes/insights/insightLogic.test.ts
@@ -1069,6 +1069,70 @@ describe('insightLogic', () => {
         })
     })
 
+    describe('loadInsight refresh mode', () => {
+        // Overridden queries get their own cache key, which nothing warms — a cache-only-ish
+        // `async` read yields `result: null` and the scene shows "Chart data didn't load".
+        const seenRefreshParams: (string | null)[] = []
+
+        beforeEach(() => {
+            seenRefreshParams.length = 0
+            useMocks({
+                get: {
+                    '/api/environments/:team_id/insights/': ({ request }) => {
+                        const url = new URL(request.url)
+                        seenRefreshParams.push(url.searchParams.get('refresh'))
+                        return [
+                            200,
+                            {
+                                results: [
+                                    {
+                                        id: 42,
+                                        short_id: Insight42,
+                                        result: ['result from api'],
+                                        filters: API_FILTERS,
+                                        name: 'original name',
+                                    },
+                                ],
+                            },
+                        ]
+                    },
+                },
+            })
+        })
+
+        it('uses async without overrides', async () => {
+            logic = insightLogic({ dashboardItemId: Insight42 })
+            logic.mount()
+            await expectLogic(logic).toDispatchActions(['loadInsightSuccess'])
+
+            expect(seenRefreshParams).toEqual(['async'])
+        })
+
+        it('blocks on a cache miss when overrides are present', async () => {
+            logic = insightLogic({
+                dashboardItemId: Insight42,
+                dashboardId: 33,
+                filtersOverride: { date_from: '-14d' },
+            })
+            logic.mount()
+            await expectLogic(logic).toDispatchActions(['loadInsightSuccess'])
+
+            expect(seenRefreshParams).toEqual(['async_except_on_cache_miss'])
+        })
+
+        it('treats empty overrides as no overrides', async () => {
+            logic = insightLogic({
+                dashboardItemId: Insight42,
+                dashboardId: 33,
+                filtersOverride: {},
+            })
+            logic.mount()
+            await expectLogic(logic).toDispatchActions(['loadInsightSuccess'])
+
+            expect(seenRefreshParams).toEqual(['async'])
+        })
+    })
+
     describe('editingDisabledReason', () => {
         it.each([
             ['overrides present', { filtersOverride: { date_from: '-7d' } }, 'Discard overrides to edit the insight.'],

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -517,6 +517,18 @@ export type insightLogicType = MakeLogicType<
     insightLogicMeta
 >
 
+export function insightOverridesPresent(
+    filtersOverride?: DashboardFilter | null,
+    variablesOverride?: Record<string, HogQLVariable> | null,
+    tileFiltersOverride?: TileFilters | null
+): boolean {
+    return (
+        !isDashboardFilterEmpty(filtersOverride) ||
+        (isObject(variablesOverride) && !isEmptyObject(variablesOverride)) ||
+        !isDashboardFilterEmpty(tileFiltersOverride)
+    )
+}
+
 export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType>([
     props({ filtersOverride: null, variablesOverride: null, tileFiltersOverride: null } as InsightLogicProps),
     key((props) => keyForInsightLogicProps('new')(props)),
@@ -615,10 +627,21 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 ) => {
                     await breakpoint(100)
                     try {
+                        // Overrides are merged into the query before caching, giving the overridden
+                        // variant a cache key of its own that no scheduled refresh warms. A plain
+                        // `async` read returns `result: null` on that cold key, and in dashboard
+                        // context the data node won't load on its own — the scene dead-ends on
+                        // "Chart data didn't load". Block on a genuine miss instead; warm and stale
+                        // keys behave exactly as before.
+                        const hasOverrides = insightOverridesPresent(
+                            filtersOverride,
+                            variablesOverride,
+                            tileFiltersOverride
+                        )
                         const insight = await insightsApi.getByShortId(
                             shortId,
                             undefined,
-                            'async',
+                            hasOverrides ? 'async_except_on_cache_miss' : 'async',
                             filtersOverride,
                             variablesOverride,
                             tileFiltersOverride
@@ -1003,11 +1026,7 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                 variablesOverride: Record<string, HogQLVariable> | null,
                 tileFiltersOverride: TileFilters | null
             ) => {
-                return (
-                    !isDashboardFilterEmpty(filtersOverride) ||
-                    (isObject(variablesOverride) && !isEmptyObject(variablesOverride)) ||
-                    !isDashboardFilterEmpty(tileFiltersOverride)
-                )
+                return insightOverridesPresent(filtersOverride, variablesOverride, tileFiltersOverride)
             },
         ],
         editingDisabledReason: [

--- a/playwright/e2e/product-analytics/insights/funnels.spec.ts
+++ b/playwright/e2e/product-analytics/insights/funnels.spec.ts
@@ -434,7 +434,7 @@ test.describe('Funnel insights', () => {
             await insight.goToInsight(seededInsightId(), {
                 queryParams: { filters_override: { date_from: '-14d' }, dashboard: dashboardId },
             })
-            await expect(page.getByText('filter/variable overrides')).toBeVisible({ timeout: 20000 })
+            await expect(page.getByText("a dashboard's filters applied")).toBeVisible({ timeout: 20000 })
             await expect(
                 page
                     .getByRole('button', { name: 'Discard overrides' })
@@ -447,7 +447,7 @@ test.describe('Funnel insights', () => {
                 .getByRole('button', { name: 'Discard overrides' })
                 .or(page.getByRole('link', { name: 'Discard overrides' }))
                 .click()
-            await expect(page.getByText('filter/variable overrides')).not.toBeVisible()
+            await expect(page.getByText("a dashboard's filters applied")).not.toBeVisible()
             await expect(insight.editButton).toBeVisible()
         })
 


### PR DESCRIPTION
## TL;DR

Opening an insight from a dashboard applies the dashboard's filters, which gives the query its own cache key that nothing ever warms. The page could then show "Chart data didn't load" forever. Now that load asks the backend to compute when the cache misses, so the chart renders. The blank state also emits an analytics event (it was invisible before), and the overrides banner now reads like it's meant for users.

## Problem

An insight opened with dashboard filter/variable overrides (e.g. clicking through from a dashboard tile) can dead-end on "Chart data didn't load", with manual Refresh or "Discard overrides" as the only ways out. Traced in [this inbox report](https://us.posthog.com/project/2/inbox/reports/019fb3e4-d6dd-74e0-b161-30db34cd3346) from session replays; the state emits no telemetry, so it is invisible in product analytics.

The chain:

- Overrides are merged into the query before it is fingerprinted, so the overridden variant has a cache key of its own that no scheduled refresh warms.
- The insight scene loads via the insights endpoint with a hardcoded `refresh=async`. On a cold key that mode enqueues a background computation and returns `result: null` — the result lands in cache moments later, but nothing on the scene polls or reloads.
- The scene can't self-heal: with overrides it passes the loaded null-result insight as `cachedInsight`, and `dataNodeLogic` skips auto-loading when cached results exist on a dashboard-context key.

Replaces #75842, which escalated the execution mode in `refresh_policy.py` for override-carrying requests with **no** `refresh` param. Every in-app path sends one (dashboard load: `force_cache`; tile refresh: `blocking`; insight scene: `async`), so that change never touched the broken flow — and it escalated every compute surface, turning e.g. a `stream_tiles` request or an `/insights/?filters_override=…` list into per-insight blocking computes for API callers.

## Changes

- `insightLogic.loadInsight` sends `refresh=async_except_on_cache_miss` instead of `async` when overrides are present: warm and stale keys behave exactly as before, a genuine miss computes synchronously and returns real results. Override presence reuses the `hasOverrides` predicate, extracted as `insightOverridesPresent`, so empty override objects don't escalate.
- `InsightRefreshDataHint` captures `insight refresh hint shown` (dashboard id, insight short id, override presence) whenever the dead-end state renders.
- Overrides banner on the insight scene:

```diff
-You are viewing this insight with filter/variable overrides. Discard them to edit the insight.
+You're viewing this insight with a dashboard's filters applied, so it can't be edited. Discard the filters to edit the saved insight.
```

## How did you test this code?

Automated, run locally:

- `jest src/scenes/insights/insightLogic.test.ts` — 52 passed. The 3 new cases pin the refresh param the scene load sends: `async` without overrides, `async_except_on_cache_miss` with a filter override, and `async` again for an empty override object. No existing test covered the scene's refresh mode.
- `oxfmt --check` and `oxlint` — clean on the touched files.
- `pnpm --filter=@posthog/frontend typescript:check` — no errors in the touched files (pre-existing failures in quill-consuming products in this sandbox, unrelated).

Not done: no manual browser verification (no dev stack in this sandbox). To reproduce: open a dashboard tile's insight with a filter override whose combination has never been computed, and confirm the chart renders instead of "Chart data didn't load".

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs affected.

## 🤖 Agent context

Human-driven (agent-assisted): implemented from the inbox report linked above, after review of #75842 found its escalation only applied to requests no in-app surface makes.

Decisions along the way:

- Fixed the caller instead of the refresh-policy table: `async_except_on_cache_miss` is an existing, first-class refresh mode, and the "explicit `?refresh=` wins" contract stays intact for every other surface and API caller.
- Scoped the escalation to override-carrying loads. Without overrides the saved-query key is warmed by scheduled refreshes, and a miss there already self-heals via the data node's own load.
- The dashboard-tile variant of the blank state (tiles refresh through explicit-refresh paths with bounded concurrency and abort on filter changes) is a separate race — the new `insight refresh hint shown` event is there to measure it before fixing it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
