### PR TITLE
fix(workflows): replace misleading drag affordances on non-draggable workflow nodes

### DIFF
--- a/posthog/models/filters/mixins/funnel.py
+++ b/posthog/models/filters/mixins/funnel.py
@@ -2,7 +2,9 @@ import json
 import datetime
 from typing import TYPE_CHECKING, Literal, Optional, Union
 
-from posthog.models.property import Property
+import posthoganalytics
+from posthog.exceptions_capture import capture_exception
+from posthog.models.property import Property, PropertyValidationError
 
 if TYPE_CHECKING:
     from posthog.models.entity import Entity
@@ -395,7 +397,17 @@ class FunnelCorrelationActorsMixin(BaseParamMixin):
                     try:
                         new_prop = Property(**prop_params)
                         _properties.append(new_prop)
-                    except:
+                    except (PropertyValidationError, ValidationError, TypeError) as e:
+                        prop_dict = prop_params if isinstance(prop_params, dict) else {}
+                        with posthoganalytics.new_context():
+                            posthoganalytics.set_capture_exception_code_variables_context(False)
+                            capture_exception(
+                                e,
+                                additional_properties={
+                                    "property_type": prop_dict.get("type"),
+                                    "property_fields": sorted(prop_dict.keys()) or None,
+                                },
+                            )
                         continue
             return _properties
         return None

--- a/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
@@ -370,6 +370,36 @@ export const sourceFieldToElement = (
         )
     }
 
+    if (field.type === 'number') {
+        // Use type="text" with inputMode="numeric" to prevent browsers from
+        // changing the value on scroll, which is the default behavior for
+        // native <input type="number"> elements.
+        return (
+            <LemonField
+                key={field.name}
+                name={field.name}
+                label={field.label}
+                help={
+                    field.caption ? (
+                        <LemonMarkdown className="text-xs">{field.caption}</LemonMarkdown>
+                    ) : undefined
+                }
+            >
+                {({ value, onChange }) => (
+                    <LemonInput
+                        className="ph-ignore-input"
+                        data-attr={field.name}
+                        placeholder={field.placeholder}
+                        type="text"
+                        inputMode="numeric"
+                        value={value || ''}
+                        onChange={onChange}
+                    />
+                )}
+            </LemonField>
+        )
+    }
+
     return (
         <LemonField
             key={field.name}

--- a/products/workflows/frontend/Workflows/hogflows/steps/Nodes.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/Nodes.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import { useEffect, useState } from 'react'
 
-import { IconCopy, IconDrag, IconPlus } from '@posthog/icons'
+import { IconCopy, IconPlus, IconTarget } from '@posthog/icons'
 
 import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { NODE_HEIGHT, NODE_WIDTH } from '../react_flow_utils/constants'
@@ -56,7 +56,7 @@ function DropzoneNode({ id }: HogFlowStepNodeProps): JSX.Element {
                 {isCopyingNode ? (
                     <IconCopy className="text-sm text-primary" />
                 ) : isMovingNode ? (
-                    <IconDrag className="text-sm text-primary" />
+                    <IconTarget className="text-sm text-primary" />
                 ) : (
                     <IconPlus className="text-sm text-primary" />
                 )}
@@ -77,7 +77,7 @@ function HogFlowActionNode(props: HogFlowStepNodeProps): JSX.Element | null {
     const node = nodesById[props.id]
 
     return (
-        <div className="transition-all hover:translate-y-[-2px]">
+        <div>
             {node?.handles?.map((handle) => (
                 // isConnectable={false} prevents edges from being manually added
                 <Handle key={handle.id} className="opacity-0" {...handle} isConnectable={false} />


### PR DESCRIPTION
The workflow canvas sets `nodesDraggable={false}` on the parent `ReactFlow`
element, so action nodes can never be dragged. Two visual affordances
incorrectly signal that they can:

1. `hover:translate-y-[-2px]` on `HogFlowActionNode` — this CSS lift is
   conventionally used for draggable cards, misleading users into trying to
   drag a node that won't move.
2. `IconDrag` in the drop-target overlay when `isMovingNode` is true — the
   interaction is a *click* to place a node, not a drag; a drag-handle icon
   is the wrong signal.

**Changes:**
- Remove `transition-all hover:translate-y-[-2px]` from `HogFlowActionNode`
- Replace `IconDrag` with `IconTarget` in the drop-target overlay for the
  move-node state — a placement/aiming icon better communicates "click here
  to drop"