### PR TITLE
fix(workflows): anchor parked waits when their distinct_id first gets a person

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-hogflow-subscription-matcher.consumer.test.ts
+++ b/nodejs/src/cdp/consumers/cdp-hogflow-subscription-matcher.consumer.test.ts
@@ -1351,11 +1351,16 @@ describe('CdpHogflowSubscriptionMatcherConsumer', () => {
             expect(result).toEqual([{ teamId: 1, distinctId: 'anon-did', newPersonId: 'survivor-uuid', version: 2 }])
         })
 
-        it('drops version-0 inserts, deletions, missing-id and malformed messages', () => {
+        it('admits a version-0 first mapping, which a wait parked with no person needs', () => {
+            const result = (matcher as any)._parsePersonDistinctIdBatch([rawMove({ version: 0 })])
+            expect(result).toEqual([{ teamId: 1, distinctId: 'anon-did', newPersonId: 'survivor-uuid', version: 0 }])
+        })
+
+        it('drops deletions, missing-id, versionless and malformed messages', () => {
             const result = (matcher as any)._parsePersonDistinctIdBatch([
-                rawMove({ version: 0 }), // brand-new distinct_id (person creation), not a repoint
                 rawMove({ is_deleted: 1 }), // distinct_id being deleted
-                rawMove({ person_id: '' }), // no survivor to point at
+                rawMove({ person_id: '' }), // no person to point at
+                rawMove({ version: null }), // no version to order against
                 { value: Buffer.from('not json') }, // malformed
                 rawMove(),
             ])
@@ -1457,6 +1462,60 @@ describe('CdpHogflowSubscriptionMatcherConsumer', () => {
                 c.sql.includes('SELECT id, team_id, distinct_id, function_id, action_id, state')
             )!
             expect(select.params[3]).toEqual(['wait_node'])
+        })
+
+        it('anchors a wait that parked before its distinct_id had a person', async () => {
+            // The gap this closes: person wakes are keyed on person_id alone, so a wait parked with a null
+            // anchor is unwakeable by any person-property change and only the polling re-check advances it.
+            // The distinct_id's first mapping (version 0) is the one chance to give it an anchor.
+            matcher.moveRows = [parkedWaitRow({ person_id: null, state: Buffer.from(JSON.stringify({ state: {} })) })]
+
+            await matcher.processMoveBatch([
+                { teamId: 1, distinctId: 'anon-did', newPersonId: 'first-person-uuid', version: 0 },
+            ])
+
+            const update = lastUpdate()
+            expect(update).toBeDefined()
+            expect(update!.params[1]).toEqual(['first-person-uuid'])
+            const newState = parseJSON((update!.params[2][0] as Buffer).toString('utf-8')) as any
+            expect(newState.state.personId).toBe('first-person-uuid')
+            // Waking it here is the point: it re-checks against the now-resolvable person immediately, and
+            // re-parks with an anchor that later person updates can address.
+            expect(update!.sql).toContain('scheduled = NOW()')
+        })
+
+        it('scopes a first mapping to jobs with no anchor, leaving anchored waits alone', async () => {
+            // A first mapping says "this distinct_id now has a person". That tells us nothing about a job
+            // already anchored elsewhere, so it must not rewrite one — and the null-anchor scope is also
+            // what keeps this off the insert firehose.
+            matcher.moveRows = [parkedWaitRow({ person_id: null, state: Buffer.from(JSON.stringify({ state: {} })) })]
+
+            await matcher.processMoveBatch([
+                { teamId: 1, distinctId: 'anon-did', newPersonId: 'first-person-uuid', version: 0 },
+            ])
+
+            const select = matcher.calls.find(
+                (c) =>
+                    c.sql.includes('SELECT id, team_id, distinct_id, function_id, action_id, state') &&
+                    c.sql.includes('person_id IS NULL')
+            )
+            expect(select).toBeDefined()
+        })
+
+        it('keeps a repoint able to rewrite an existing anchor', async () => {
+            // The complement of the scoping above: a merge must still move an anchored wait, so the
+            // null-anchor restriction has to apply to first mappings only.
+            matcher.moveRows = [parkedWaitRow()]
+
+            await matcher.processMoveBatch([
+                { teamId: 1, distinctId: 'anon-did', newPersonId: 'survivor-uuid', version: 2 },
+            ])
+
+            const select = matcher.calls.find((c) =>
+                c.sql.includes('SELECT id, team_id, distinct_id, function_id, action_id, state')
+            )!
+            expect(select.sql).not.toContain('person_id IS NULL')
+            expect(lastUpdate()!.params[1]).toEqual(['survivor-uuid'])
         })
     })
 

--- a/nodejs/src/cdp/consumers/cdp-hogflow-subscription-matcher.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-hogflow-subscription-matcher.consumer.ts
@@ -72,6 +72,17 @@ const counterHogflowMatcherJobsRekeyedOnMove = new Counter({
     help: 'Parked wait_until_condition jobs re-keyed to the surviving person after a distinct_id was repointed by a merge.',
 })
 
+// A wait parked before its distinct_id had a person keeps a null person_id, and person wakes are keyed on
+// person_id alone, so nothing can ever wake it — only the polling re-check advances it. The distinct_id's
+// first mapping (version 0) is where that anchor becomes available. 'seen' is every first mapping admitted
+// for a team with a wait flow, which is the load this path adds; 'filled' is the jobs it actually anchored.
+// A 'seen' rate far above 'filled' is expected — watch the gap for query cost, not correctness.
+const counterHogflowMatcherFirstMapping = new Counter({
+    name: 'cdp_hogflow_matcher_first_mapping_total',
+    help: 'distinct_id first mappings processed for parked waits with no person anchor, by outcome.',
+    labelNames: ['outcome'],
+})
+
 // Latency of the cyclotron lookup for parked jobs. Watch this for cyclotron-node
 // read pressure as the wait-until-event feature ramps.
 const histogramHogflowMatcherFindParkedJobs = new Histogram({
@@ -684,9 +695,12 @@ export class CdpHogflowSubscriptionMatcherConsumer<
         for (const message of messages) {
             try {
                 const data = parseJSON(message.value!.toString()) as ClickHousePersonDistinctId2
-                // Only repoints matter. version 0 is a brand-new distinct_id (person creation) that no
-                // parked wait can be keyed on yet — skipping it also keeps this off the insert firehose.
-                if (!data.version || data.version <= 0) {
+                // version > 0 is a repoint (identify/merge). version 0 is the distinct_id's first mapping
+                // to a person, which a wait parked before the person resolved needs to acquire its anchor:
+                // person wakes are keyed on person_id alone, so a job left with a null anchor is
+                // unwakeable by any person-property change. processMoveBatch scopes version 0 to exactly
+                // those jobs, which is what keeps this off the insert firehose.
+                if (data.version === undefined || data.version === null || data.version < 0) {
                     continue
                 }
                 // A distinct_id being deleted can't wake anything, and must never re-point a wait at a
@@ -712,18 +726,32 @@ export class CdpHogflowSubscriptionMatcherConsumer<
         return moves
     }
 
-    // Re-key parked wait_until_condition jobs whose distinct_id was repointed by a merge onto the
-    // surviving person. We only rewrite the person_id anchor (column + state.personId) and leave the
-    // schedule alone: the survivor's clickhouse_person / event updates then wake the wait through the
-    // existing person/event streams (matched by the new person_id), and the worker takes the matched
-    // branch via the eventMatched flag without re-resolving the person. Waking here instead would make
-    // the worker re-resolve the distinct_id against PersonsManager's ~1-minute cache, which can return
-    // the stale pre-merge person and, on re-park, write the old person_id back — undoing this re-key.
+    // Point parked wait_until_condition jobs at the person their distinct_id now belongs to, for the two
+    // ways that can change: a merge repointing it onto a survivor, or the distinct_id acquiring a person
+    // for the first time. Either way the job's existing anchor can no longer be woken — person and event
+    // wakes are keyed on person_id — so we rewrite the anchor (column + state.personId) and wake it.
     public async processMoveBatch(moves: PersonDistinctIdMove[]): Promise<void> {
         if (moves.length === 0) {
             return
         }
 
+        // A repoint (version > 0) may rewrite any parked wait's anchor. A first mapping (version 0) may
+        // only fill an anchor that is missing: it says "this distinct_id now has a person", which tells us
+        // nothing about a job already anchored elsewhere, and the null-anchor scope is what keeps the
+        // insert firehose off the whole flow set.
+        const repoints = moves.filter((m) => m.version > 0)
+        const firstMappings = moves.filter((m) => m.version === 0)
+
+        if (repoints.length > 0) {
+            await this.applyMoves(repoints, false)
+        }
+        if (firstMappings.length > 0) {
+            counterHogflowMatcherFirstMapping.labels({ outcome: 'seen' }).inc(firstMappings.length)
+            await this.applyMoves(firstMappings, true)
+        }
+    }
+
+    private async applyMoves(moves: PersonDistinctIdMove[], onlyNullAnchor: boolean): Promise<void> {
         // Only flows with a wait_until_condition step can have a parked wait to re-key. Scope the
         // function_id filter to them so the cyclotron query stays index-friendly and skips repoints for
         // teams with no such flow.
@@ -774,6 +802,7 @@ export class CdpHogflowSubscriptionMatcherConsumer<
                  WHERE status = 'available'
                    AND function_id = ANY($3::uuid[])
                    AND action_id = ANY($4::text[])
+                   ${onlyNullAnchor ? 'AND person_id IS NULL' : ''}
                    AND (team_id, distinct_id) IN (SELECT * FROM unnest($1::int[], $2::text[]))
                  ORDER BY id
                  FOR UPDATE`,
@@ -795,7 +824,13 @@ export class CdpHogflowSubscriptionMatcherConsumer<
                 if (!newPerson || !row.state) {
                     continue
                 }
-                const newState = rewriteStatePersonId(row.state, newPerson.personId, newPerson.version, row.id)
+                const newState = rewriteStatePersonId(
+                    row.state,
+                    newPerson.personId,
+                    newPerson.version,
+                    row.id,
+                    onlyNullAnchor
+                )
                 if (!newState) {
                     continue
                 }
@@ -816,7 +851,11 @@ export class CdpHogflowSubscriptionMatcherConsumer<
                      WHERE cj.id = u.id AND cj.status = 'available'`,
                     [updates.map((u) => u.id), updates.map((u) => u.personId), updates.map((u) => u.state)]
                 )
-                counterHogflowMatcherJobsRekeyedOnMove.inc(result.rowCount ?? 0)
+                if (onlyNullAnchor) {
+                    counterHogflowMatcherFirstMapping.labels({ outcome: 'filled' }).inc(result.rowCount ?? 0)
+                } else {
+                    counterHogflowMatcherJobsRekeyedOnMove.inc(result.rowCount ?? 0)
+                }
             }
             await client.query('COMMIT')
         } catch (err) {
@@ -1040,7 +1079,8 @@ function rewriteStatePersonId(
     stateBuffer: Buffer,
     newPersonId: string,
     newVersion: number,
-    jobId: string
+    jobId: string,
+    fillingNullAnchor = false
 ): Buffer | null {
     try {
         const parsed = parseJSON(stateBuffer.toString('utf-8'))
@@ -1048,8 +1088,10 @@ function rewriteStatePersonId(
         // delayed lower-version move (anon → A, v2) can arrive in a later batch than a higher one already
         // applied (anon → B, v3); without this watermark it would rewind the wait onto the obsolete
         // person A, and B's person-stream updates would no longer address the parked job.
+        // A first mapping is exempt: it carries version 0, which no watermark can beat, and there is no
+        // anchor to rewind — the caller has already scoped it to jobs with none.
         const appliedVersion = parsed.state?.personIdRepointVersion ?? 0
-        if (newVersion <= appliedVersion) {
+        if (!fillingNullAnchor && newVersion <= appliedVersion) {
             return null
         }
         // Flag the re-key so the worker resolves the person by this survivor personId, not the repointed

--- a/nodejs/src/cdp/workflows-e2e.test.ts
+++ b/nodejs/src/cdp/workflows-e2e.test.ts
@@ -1453,7 +1453,7 @@ describe.each(['postgres-v2' as const, 'postgres' as const])('Workflows E2E (%s)
             last_seen_at: null,
             distinct_id: 'distinct_id',
         })
-        const distinctIdMoveMessage = (): any => ({
+        const distinctIdMoveMessage = (overrides: Record<string, any> = {}): any => ({
             value: Buffer.from(
                 JSON.stringify({
                     team_id: team.id,
@@ -1461,6 +1461,7 @@ describe.each(['postgres-v2' as const, 'postgres' as const])('Workflows E2E (%s)
                     person_id: 'new-uuid',
                     version: 2,
                     is_deleted: 0,
+                    ...overrides,
                 })
             ),
         })
@@ -1496,6 +1497,39 @@ describe.each(['postgres-v2' as const, 'postgres' as const])('Workflows E2E (%s)
             // survivor's plan=enterprise, and advances down the matched branch, firing the fetch.
             mockPersonRepo.fetchPersonsByPersonIds.mockResolvedValue([survivorPersonRow()])
             await matcher.processMoveBatch(matcher._parsePersonDistinctIdBatch([distinctIdMoveMessage() as any]))
+
+            await waitForExpect(() => {
+                expect(mockFetch).toHaveBeenCalledTimes(1)
+            }, 10000)
+            expect(mockFetch).toHaveBeenCalledWith('https://example.com/condition-matched', expect.anything())
+        })
+
+        it('anchors and wakes a wait that parked before its distinct_id had a person', async () => {
+            // Production shape: an event arrives for a distinct_id with no person yet, so the wait parks
+            // with person_id NULL. Person wakes are keyed on person_id alone, so nothing can address that
+            // job — before this was fixed, only the 10-minute polling re-check ever advanced it.
+            await createWaitUntilWorkflow({
+                condition: { filters: personPropertyConditionFilters('plan', 'enterprise') },
+                max_wait_duration: '5m',
+            })
+            mockPersonRepo.fetchPersonsByDistinctIds.mockResolvedValue([])
+            await triggerWorkflow(createGlobals())
+            await expectParked()
+
+            // The premise of the test: no anchor to wake.
+            const parked = await cyclotronPool.query(
+                `SELECT person_id FROM cyclotron_jobs WHERE ${statusColumn} = 'available'`
+            )
+            expect(parked.rows).toHaveLength(1)
+            expect(parked.rows[0].person_id).toBeNull()
+
+            // The distinct_id acquires a person for the first time (version 0), and that person already
+            // satisfies the condition. The matcher fills the missing anchor and wakes the wait, which then
+            // resolves by personId and advances down the matched branch.
+            mockPersonRepo.fetchPersonsByPersonIds.mockResolvedValue([survivorPersonRow()])
+            await matcher.processMoveBatch(
+                matcher._parsePersonDistinctIdBatch([distinctIdMoveMessage({ version: 0 }) as any])
+            )
 
             await waitForExpect(() => {
                 expect(mockFetch).toHaveBeenCalledTimes(1)

--- a/rust/cyclotron-node-migrations/20260731000001_add_null_person_anchor_index.sql
+++ b/rust/cyclotron-node-migrations/20260731000001_add_null_person_anchor_index.sql
@@ -1,0 +1,7 @@
+-- no-transaction
+-- The matcher looks up parked waits with no person anchor on every distinct_id first mapping, which is a
+-- high-volume stream. Only a handful of jobs lack an anchor at any moment, so a partial index keeps that
+-- lookup to a few rows instead of leaning on the full (team_id, distinct_id) index.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cyclotron_jobs_null_person_anchor
+    ON cyclotron_jobs (team_id, distinct_id)
+    WHERE person_id IS NULL AND distinct_id IS NOT NULL;

--- a/rust/cyclotron-node-migrations/20260731000001_add_null_person_anchor_index.sql
+++ b/rust/cyclotron-node-migrations/20260731000001_add_null_person_anchor_index.sql
@@ -1,7 +1,0 @@
--- no-transaction
--- The matcher looks up parked waits with no person anchor on every distinct_id first mapping, which is a
--- high-volume stream. Only a handful of jobs lack an anchor at any moment, so a partial index keeps that
--- lookup to a few rows instead of leaning on the full (team_id, distinct_id) index.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cyclotron_jobs_null_person_anchor
-    ON cyclotron_jobs (team_id, distinct_id)
-    WHERE person_id IS NULL AND distinct_id IS NOT NULL;


### PR DESCRIPTION
## Problem

A parked `wait_until_condition` is woken when a message arrives on one of the matcher's streams. For a person-property condition, that means the `clickhouse_person` stream, and a person mutation carries **no distinct_id** - the handler sets `distinct_id: ''` deliberately, because a person row doesn't have one. So person wakes are matched on `person_id` alone.

That leaves a hole, and personless events walk straight into it. An event captured with `$process_person_profile: false` creates no person row at all - it only records the distinct_id in `posthog_personlessdistinctid` (see `processPersonlessDistinctIdsChunkStep`). The same applies to `$feature_flag_called` on teams where it defaults to personless.

So a personless event triggers the workflow, the trigger resolves no person, and the run parks with `person_id` NULL. Nothing can ever address that job: no person mutation can match a null anchor, and no later message supplies one. Only the 10-minute polling re-check advances it, which is why removing the poll (#72541) would turn those runs into silent wrong-branch outcomes - they would ride to `max_wait_duration` and take the timeout edge instead of the matched one.

Then the visitor identifies or signs up, and a person is created. That is the distinct_id's **first** mapping, and it is the one moment the anchor becomes available - which the matcher was throwing away:

```ts
// Only repoints matter. version 0 is a brand-new distinct_id (person creation) that no
// parked wait can be keyed on yet - skipping it also keeps this off the insert firehose.
if (!data.version || data.version <= 0) {
    continue
}
```

The reasoning holds for the merge re-keying this consumer was written for, but "no parked wait can be keyed on yet" is not true: a wait can already be parked on that distinct_id, waiting for exactly this.

**How narrow this is, measured rather than assumed.** Most personless-parked runs are fine without this fix, because the identify itself arrives as an *event* for that distinct_id, and the events stream wakes the wait keyed on distinct_id regardless of the anchor. I reproduced exactly that on a local stack: a personless event parked with `person_id` NULL, then a personful `$set` event woke it with `(woken by [Event:...])`.

So the gap is specifically **a person-property change that arrives with no event for that distinct_id** - which is precisely what the `clickhouse_person` stream exists to carry. In practice that means properties set from somewhere other than the person's own activity: a CRM or warehouse sync, a server-side API update, or a merge originating from a different distinct_id. For those, the null anchor makes the wait unwakeable and only the polling re-check advances it.

## Changes

Admit `version = 0` and route it separately. `processMoveBatch` splits its batch:

- **repoints** (`version > 0`) take the existing path unchanged
- **first mappings** (`version = 0`) run the same lock-and-update scoped with `AND person_id IS NULL`, so they can only *fill* a missing anchor, never rewrite one. A first mapping says "this distinct_id now has a person", which tells us nothing about a job already anchored elsewhere.

`rewriteStatePersonId` skips its version watermark when filling. Version 0 can't beat any watermark, and there is no anchor to rewind - the caller has already scoped it.

Plus **`cdp_hogflow_matcher_first_mapping_total{outcome}`**, where `seen` is the load this path adds and `filled` is the jobs it anchored. A `seen` rate far above `filled` is expected; the gap is what to watch for query cost.

**Depends on #75861**, which adds the partial index this lookup needs: `(team_id, distinct_id) WHERE person_id IS NULL`. Merge that first, so the index exists before this starts querying against it. The two were one PR until CI's `migrations-separation` check correctly refused to ship a migration alongside service code.

## How did you test this code?

**Reproduced on the local stack first**, against a real workflow, real captured event and a real Kafka message produced via `create_person_distinct_id(..., version=0)`. The parked job's anchor was nulled to match the production shape and its poll tick pushed 45 minutes out, so any fill is attributable to the matcher rather than a re-check. All data is made up.

| | anchor | scheduled | transitions |
|---|---|---|---|
| Before the fix | `NULL` | unchanged | 2 |
| After | filled | pulled forward | 4 |

The counter read `seen=1, filled=1`, confirming the new path ran rather than something else advancing the job.

**Tests, verified to fail without the fix** (production file reverted, tests kept):

| Test | Without the fix |
|---|---|
| E2E `anchors and wakes a wait that parked before its distinct_id had a person` | fails - 0 wake calls after 10s |
| admits a version-0 first mapping | fails |
| anchors a wait that parked before its distinct_id had a person | fails |
| scopes a first mapping to jobs with no anchor | fails |
| keeps a repoint able to rewrite an existing anchor | passes - regression guard, by design |

The E2E asserts `person_id IS NULL` on the parked row before acting, so it cannot pass for the wrong reason. It runs against real Postgres, which is what covers the `person_id IS NULL` scoping that a mocked pool can't.

Suites: 64/64 in the matcher consumer tests. In `workflows-e2e.test.ts` two tests fail (`rate-limits dequeue when the bucket drains`, `bulk-captures every asset when multiple workflow runs share a batch`); both also fail on clean master with these changes stashed, so they are pre-existing flakes and not from this change.

**One existing test changed rather than added to.** `drops version-0 inserts, deletions, missing-id and malformed messages` asserted the behavior this PR reverses. It's split into a version-0 admission case and a `drops deletions, missing-id, versionless and malformed messages` case, which also closes a gap the old name papered over: `!data.version` silently dropped `null` and `undefined` too.

## Scale of what this fixes

Over 14 days, roughly 2-3 runs per day across both regions park with no person on a wait whose condition reads person properties (from `log_entries`, by whether the trigger line carries a `[Person:…]` clause). Waits that are event-based or `event_metadata` are unaffected and were the large majority of person-less runs.

That figure is an upper bound on the exposure, not the broken count. As above, any later event for the same distinct_id wakes those runs anyway, so the genuinely-stuck subset is the ones whose person property changes without accompanying activity. The observed signal for that is small - a low single-digit number of poll-only advances per region per week on person-property waits, which is what `cdp_hogflow_wait_poll_only_advance` shows once clock-based flows are excluded.

I'd rather state that than overclaim: this is a narrow correctness gap, and its main value is that it removes a blocker for #72541 rather than that it fixes something happening at volume.

Today the poll rescues those runs late. This makes them wake on the signal instead, and it is a prerequisite for removing the poll.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior or documented workflow changes - this closes a wake path that was silently missing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Claude Code) at my direction.

Skills invoked: `/writing-tests` (the value gate for each new case, and why the repoint case is kept as a regression guard even though it passes without the fix) and `/posthog-local-e2e-qa` (the local reproduction, its test-DB isolation, and cleaning up the flow and parked job afterwards).

Found while auditing what still depends on the polling re-check for #72541. Two things I got wrong along the way and corrected against evidence rather than argument. First, the metric built for that question, `cdp_hogflow_wait_poll_only_advance`, cannot see a null-anchor wait whose condition never turns true - it times out and is counted nowhere - so raw exposure had to come from run logs instead. Second, an earlier version of this description claimed the identify was usually the signal the wait was waiting for; reproducing it showed the events stream already covers that, which is why the scope above is narrower than it first read.

The comment above the old filter stated the assumption this PR disproves, so it is rewritten rather than left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

