### PR TITLE
chore(cyclotron): index parked jobs with no person anchor

### DIFF
--- a/rust/cyclotron-node-migrations/20260731000001_add_null_person_anchor_index.sql
+++ b/rust/cyclotron-node-migrations/20260731000001_add_null_person_anchor_index.sql
@@ -1,0 +1,7 @@
+-- no-transaction
+-- The matcher looks up parked waits with no person anchor on every distinct_id first mapping, which is a
+-- high-volume stream. Only a handful of jobs lack an anchor at any moment, so a partial index keeps that
+-- lookup to a few rows instead of leaning on the full (team_id, distinct_id) index.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cyclotron_jobs_null_person_anchor
+    ON cyclotron_jobs (team_id, distinct_id)
+    WHERE person_id IS NULL AND distinct_id IS NOT NULL;


### PR DESCRIPTION
## Problem

The hogflow subscription matcher is gaining a lookup for parked waits that carry no person anchor, on every distinct_id first mapping (see #75860). First mappings are a high-volume stream, and without an index that lookup leans on the full `(team_id, distinct_id)` index, which covers every parked job rather than the few that lack an anchor.

Measured on both regions, jobs with a null anchor are about 0.04% of parked waits — single digits at any moment out of roughly 6,000 per region.

## Changes

A partial index on `(team_id, distinct_id) WHERE person_id IS NULL AND distinct_id IS NOT NULL`, matching the shape of the existing `idx_cyclotron_jobs_distinct_id` and `idx_cyclotron_jobs_person_id` partial indexes. `CREATE INDEX CONCURRENTLY` with `-- no-transaction`, as the other index migrations here do.

Split out of #75860 so the migration lands on its own, which is also the right order: the index should exist before the code starts querying against it.

## How did you test this code?

Applied against a local `test_cyclotron_node` via `migrate-entry`, which reported `Applied 20260731000001/migrate add null person anchor index`. The querying code in #75860 was then exercised against that database by its E2E test and by a live reproduction on the local stack.

No behavior change on its own — this is an index addition with no reader until #75860 merges.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None — internal index, no user-facing or documented behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (Claude Code) at my direction.

Split out after CI's `migrations-separation` check correctly flagged the combined PR. There is a `skip-migration-service-check` label, but it is documented for DB-noop migrations (state-only renames), and this is a real `CREATE INDEX`, so splitting is the right response rather than labelling past it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
