### PR TITLE
chore(cdp): remove cdp-microsoft-ads feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -262,7 +262,6 @@ export const FEATURE_FLAGS = {
     CDP_ACTIVITY_LOG_NOTIFICATIONS: 'cdp-activity-log-notifications', // owner: #team-workflows-cdp
     CDP_DWH_TABLE_SOURCE: 'cdp-dwh-table-source', // owner: #team-workflows-cdp
     CDP_HOG_SOURCES: 'cdp-hog-sources', // owner #team-workflows-cdp
-    CDP_MICROSOFT_ADS: 'cdp-microsoft-ads', // owner: #team-workflows-cdp
     CDP_NEW_PRICING: 'cdp-new-pricing', // owner: #team-workflows
     CDP_PERSON_UPDATES: 'cdp-person-updates', // owner: #team-workflows-cdp
     CDP_VERCEL_LOG_DRAIN: 'cdp-vercel-log-drain', // owner: #team-workflows-cdp

--- a/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
+++ b/frontend/src/scenes/hog-functions/list/hogFunctionTemplateListLogic.tsx
@@ -259,7 +259,6 @@ export const hogFunctionTemplateListLogic = kea<hogFunctionTemplateListLogicType
                             x.id !== 'template-native-push' ||
                             !!featureFlags[FEATURE_FLAGS.WORKFLOWS_PUSH_NOTIFICATIONS]
                     )
-                    .filter((x) => x.id !== 'template-microsoft-ads' || !!featureFlags[FEATURE_FLAGS.CDP_MICROSOFT_ADS])
                     .sort((a, b) => (a.name || '').localeCompare(b.name || ''))
             },
         ],


### PR DESCRIPTION
## Problem

The Microsoft Ads destination template has been gated behind the `cdp-microsoft-ads` feature flag (added in https://github.com/PostHog/posthog/pull/64210). It has been tested with users and is working, so the flag is no longer needed.

## Changes

- Removed `CDP_MICROSOFT_ADS` from `FEATURE_FLAGS` in `frontend/src/lib/constants.tsx`
- Removed the filter in `hogFunctionTemplateListLogic.tsx` that hid the `template-microsoft-ads` destination unless the flag was enabled

The template's `status: 'alpha'` (the Experimental badge) is intentionally left unchanged.

## How did you test this code?

- Verified zero remaining references to `cdp-microsoft-ads` / `CDP_MICROSOFT_ADS` repo-wide
- Ran `hogli ci:preflight --fix` (0 failures) and `pnpm --filter=@posthog/frontend fix`
- Ran the frontend TypeScript check and confirmed no errors in the two edited files (the environment has pre-existing unrelated failures from unbuilt workspace packages)
- I (Claude) did not manually test the UI

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (PostHog Code). The request was to un-gate the Microsoft Ads destination now that it's been validated with users. I confirmed the flag had exactly two code touchpoints and removed both. The user explicitly chose to keep `status: 'alpha'` on the template, so the Experimental badge stays for now. The remaining follow-up is deleting the `cdp-microsoft-ads` flag definition in PostHog itself once this ships.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*