### PR TITLE
fix(data-imports): retry queryable-folder copy after a concurrent vacuum race

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/common/load.py
@@ -377,6 +377,7 @@ async def _publish_queryable_files(
             delete_existing=True,
             existing_queryable_folder=existing_queryable_folder,
             logger=logger,
+            refresh_file_uris=delta_table_helper.get_file_uris,
         )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
@@ -59,6 +59,41 @@ class TestPrepareS3FilesForQuerying:
         assert s3._cp_file.await_count == 2
         s3._copy.assert_not_awaited()
 
+    async def test_retries_with_fresh_listing_when_source_file_vanishes_mid_copy(self):
+        # A concurrent compact/vacuum pass on the same Delta table can delete a source file
+        # between get_file_uris() listing it and this copy step reading it, raising
+        # FileNotFoundError. Regression for that race: https://github.com/PostHog/posthog
+        vanished_file = "s3://bucket/job/my_table/part-0.parquet"
+        cp_file = AsyncMock(side_effect=[FileNotFoundError(vanished_file), None])
+        s3 = _fake_s3(_cp_file=cp_file)
+        refresh_file_uris = AsyncMock(return_value=["s3://bucket/job/my_table/part-1.parquet"])
+
+        with patch.object(util_module, "aget_s3_client", return_value=_FakeS3CM(s3)):
+            await prepare_s3_files_for_querying(
+                folder_path="job",
+                table_name="my_table",
+                file_uris=[vanished_file],
+                delete_existing=False,
+                refresh_file_uris=refresh_file_uris,
+            )
+
+        refresh_file_uris.assert_awaited_once()
+        assert cp_file.await_args_list[-1].args[0] == "s3://bucket/job/my_table/part-1.parquet"
+
+    async def test_propagates_vanished_source_file_without_refresh_callback(self):
+        # Callers that don't pass refresh_file_uris keep today's behavior: the race still
+        # surfaces as an error instead of being retried blindly.
+        s3 = _fake_s3(_cp_file=AsyncMock(side_effect=FileNotFoundError("gone")))
+
+        with patch.object(util_module, "aget_s3_client", return_value=_FakeS3CM(s3)):
+            with pytest.raises(FileNotFoundError):
+                await prepare_s3_files_for_querying(
+                    folder_path="job",
+                    table_name="my_table",
+                    file_uris=["s3://bucket/job/my_table/part-0.parquet"],
+                    delete_existing=False,
+                )
+
 
 @parameterized.expand(
     [

--- a/products/warehouse_sources/backend/temporal/data_imports/util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/util.py
@@ -1,5 +1,6 @@
 import re
 import asyncio
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 from typing import Literal, Optional
 from uuid import uuid4
@@ -75,6 +76,7 @@ async def prepare_s3_files_for_querying(
     preserve_table_name_casing: Optional[bool] = False,
     delete_existing: bool = True,
     logger: Optional[FilteringBoundLogger] = None,
+    refresh_file_uris: Optional[Callable[[], Awaitable[list[str]]]] = None,
 ) -> str:
     """Async version that uses s3fs native async methods for concurrent file operations."""
 
@@ -182,7 +184,18 @@ async def prepare_s3_files_for_querying(
                 # S3's SlowDown rate limiting on the destination prefix.
                 await s3._cp_file(file, f"{s3_path_for_querying}/{file_name}")
 
-        await asyncio.gather(*[copy_file(file) for file in file_uris])
+        try:
+            await asyncio.gather(*[copy_file(file) for file in file_uris])
+        except FileNotFoundError as e:
+            if refresh_file_uris is None:
+                raise
+            # A concurrent compact/vacuum pass on the same Delta table (e.g. a zombie attempt
+            # from a heartbeat timeout still running) can physically delete a source file
+            # between our listing and this copy. Re-listing picks up wherever that pass left
+            # the table and retries once against the current file set.
+            await _log(f"Source file vanished mid-copy, retrying with a fresh file listing: {e}", level="error")
+            file_uris = await refresh_file_uris()
+            await asyncio.gather(*[copy_file(file) for file in file_uris])
 
         # Delete existing files after copying new ones
         if delete_existing and files_to_delete:


### PR DESCRIPTION
## Problem

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019fb735-5e13-7031-b7ce-0ae280e371b9) surfaced a `FileNotFoundError` during a Postgres sync's post-load step:

```
FileNotFoundError: .../subscription_acquisition_daily/part-00000-....snappy.parquet
```

Call path: `run_post_load_operations` -> `_publish_queryable_files` -> `prepare_s3_files_for_querying` -> `copy_file` -> `s3fs`'s `_cp_file`.

`_publish_queryable_files` lists the Delta table's current parquet files with `get_file_uris()` right after this sync's own compact/vacuum pass, then copies each listed file into a stable, timestamped folder that ClickHouse/DuckDB read via an S3 glob. Between that listing and the copy, a concurrent maintenance pass on the same table — typically a Temporal activity attempt that heartbeat-timed-out but is still running as a "zombie", a scenario already documented elsewhere in this pipeline (`RepartitionSupersededError`, `is_transient_delta_maintenance_error`) — can compact/vacuum away one of the listed files before the copy reads it.

This is a bug in the shared list-then-copy pattern, not a source-specific or transient-infra issue: the file is gone, so blindly retrying the same list would fail again, but the data isn't lost (compaction always merges forward), so a fresh listing has it.

## Changes

- `prepare_s3_files_for_querying` (`util.py`) now accepts an optional `refresh_file_uris` callback. If a copy fails with `FileNotFoundError`, it re-fetches the current file list and retries the copy once. Callers that don't pass it keep today's behavior (the error still propagates, so Temporal's existing retry is the fallback).
- `_publish_queryable_files` (`common/load.py`) wires this to `delta_table_helper.get_file_uris`, the same source used for the initial listing.

## How did you test this code?

- Added `test_retries_with_fresh_listing_when_source_file_vanishes_mid_copy` in `test_util.py`: `_cp_file` raises `FileNotFoundError` once, then a fresh listing is provided via `refresh_file_uris` — asserts the retry succeeds and copies the refreshed file. Regression: this exact race crashing the sync instead of self-healing.
- Added `test_propagates_vanished_source_file_without_refresh_callback`: without `refresh_file_uris`, the error still propagates — guards against silently swallowing a genuine missing-file bug for callers that don't opt in.
- Ran the full `test_util.py` and `common/test/test_load.py` suites locally — all pass.
- `ruff check` / `ruff format --check` clean on all changed files.
- Repo-wide `uv run mypy --cache-fine-grained .` — clean (17284 source files, no issues).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal pipeline reliability fix, no user-facing or API surface change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a live PostHog error-tracking issue (webhook-delivered) using Claude Code. Pulled the stack trace and `warehouse_sources_*` event properties via the PostHog MCP error-tracking tools, confirmed the exact failing frame (`util.py:copy_file` -> `s3fs.core._cp_file` -> `_info`), and traced the call path back through `_publish_queryable_files`/`run_post_load_operations` to identify the list-then-copy race.

Searched open PRs (by exception type, message phrase, module path, and the maintainer's own open PRs) before starting. Found two related-but-distinct open PRs: [#75240](https://github.com/PostHog/posthog/pull/75240) and [#75242](https://github.com/PostHog/posthog/pull/75242), both classifying a *different* `DeltaError` signature (a `_delta_log/*.json` commit file vanishing during `vacuum()`/`optimize.compact()` inside `delta_table_helper.py`) as transient/non-reported. Neither touches `util.py`, `copy_file`, or `prepare_s3_files_for_querying` — this PR fixes a plain `FileNotFoundError` on a data parquet file in a different code path (the queryable-folder publish step), so they don't overlap.

Skills invoked: `/writing-tests`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*