### PR TITLE
chore: Document Trunk pause

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ Guarding it inside the workflow is worse: skipping the gate job cascades to the 
 #### Stacked PRs
 
 Restacking force-pushes every branch, and each push triggers a full CI fan-out.
-Never restack while any branch in the stack is sitting in the merge queue — the force-push removes it from the queue.
+If the Trunk merge queue is re-enabled (it is paused, see below), never restack while any branch in the stack is sitting in it: the force-push removes the PR from the queue.
 Pushing a deep stack at once can exceed GitHub's per-repo dispatch cap (500 workflow runs / 10s).
 The overflow fails as `startup_failure` and takes unrelated runs in the same window down too.
 Draft status doesn't help, since runs are dispatched before draft/skip logic applies.
@@ -112,14 +112,15 @@ In environments without hooks (no `node_modules`), run `hogli ci:preflight --fix
 
 ### Merging PRs
 
-All merges into `master` go through the Trunk merge queue.
-Never run `gh pr merge` or click the GitHub merge button — both are blocked by branch ruleset.
+Merges into `master` currently go through `gh pr merge <number> --squash`.
+Squash is the only merge method the repo allows, so `--merge` and `--rebase` are rejected.
 
-- Enqueue: `gh pr comment <number> --body "/trunk merge"`. Cancel: `gh pr comment <number> --body "/trunk cancel"`.
-- After enqueueing, babysit the PR until it merges or fails — follow [`.agents/skills/merging-prs/SKILL.md`](./.agents/skills/merging-prs/SKILL.md) for the preflight, watch, and failure-handling loop.
-- Queue progress is the `Trunk Merge Queue (master)` check run on the PR's head commit. The PR's own checks don't reflect the queue's testing — it runs CI on a `trunk-merge/**` branch.
-- On failure the Trunk bot comments with links to the failing workflows; fix, push, and re-enqueue.
-- Never force-push a branch while it is in the queue — it removes the PR from the queue.
+**The Trunk merge queue is paused.** Its ruleset is disabled, so `/trunk merge` and `/trunk cancel` comments and the `trunk-merge-queue-submit` label are no-ops: no `Trunk Merge Queue (master)` check run appears and the bot never replies. Don't reach for them.
+
+- Branch protection on `master` is unchanged and still enforced: an approving review, code owner review, the required status checks, and signed commits. `gh pr merge` refuses until all of those pass.
+- Shortly after a force-push or a label change, GitHub's mergeability cache can be stale and the first attempt fails with "the base branch policy prohibits the merge". Retrying a moment later works.
+- [`.agents/skills/merging-prs/SKILL.md`](./.agents/skills/merging-prs/SKILL.md) is still written for the Trunk flow, so it's stale pending a follow-up. Its preflight and CI failure-handling advice still applies; its enqueue and queue-watching steps don't.
+- If Trunk is re-enabled, the old flow was: enqueue with `gh pr comment <number> --body "/trunk merge"`, watch the `Trunk Merge Queue (master)` check run on the head commit rather than the PR's own checks, and never force-push while the PR sits in the queue.
 
 ### Public open source repo guidance
 
@@ -229,7 +230,7 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 
 **Invoke when in the area:**
 
-- `/merging-prs` — merging a PR, or babysitting one through the Trunk merge queue
+- `/merging-prs` — merging a PR, or babysitting one through CI (written for the Trunk queue, so partly stale while it's paused)
 - `/implementing-mcp-tools` — adding/modifying endpoints or `tools.yaml`
 - `/modifying-taxonomic-filter` — any TaxonomicFilter change
 - `/sending-notifications` — adding notification support


### PR DESCRIPTION
## Problem

Our root `AGENTS.md` (symlinked as `CLAUDE.md`) told everyone, humans and agents alike, that all merges into `master` go through the Trunk merge queue and that `gh pr merge` is forbidden because the branch ruleset blocks it. Neither is true right now. We've paused our use of Trunk, and the "Trunk merge" ruleset is disabled.

That stale instruction has a real cost. On a PR earlier today I burned about 45 minutes on the documented path: two `/trunk merge` comments and the `trunk-merge-queue-submit` label, all silently ignored. No `Trunk Merge Queue (master)` check run ever appeared and the bot never replied. `gh pr merge --squash` then merged it immediately.

## Changes

Rewrote the `### Merging PRs` section to describe what actually works today, and fixed the two other spots in the file that assumed the queue.

```diff
-All merges into `master` go through the Trunk merge queue.
-Never run `gh pr merge` or click the GitHub merge button — both are blocked by branch ruleset.
+Merges into `master` currently go through `gh pr merge <number> --squash`.
+Squash is the only merge method the repo allows, so `--merge` and `--rebase` are rejected.
```

- Calls out that Trunk is paused, so `/trunk merge`, `/trunk cancel`, and the `trunk-merge-queue-submit` label are no-ops.
- Keeps the branch protection context, which is unchanged and still enforced: approving review, code owner review, required status checks, signed commits.
- Notes the stale mergeability cache right after a force-push or label change, where the first `gh pr merge` can fail with "the base branch policy prohibits the merge" and a retry succeeds.
- Keeps the Trunk instructions as a single "if Trunk is re-enabled" line so we don't lose them.
- Flags that `.agents/skills/merging-prs/SKILL.md` is still written for the Trunk flow and is therefore partly stale. Deliberately not edited here, that's a follow-up.

> [!NOTE]
> Docs only. No behavior change, no code touched.

## How did you test this code?

Nothing to test automatically, this is a markdown-only change. I verified the claims against the live repo rather than assuming:

- `gh api repos/PostHog/posthog/rulesets` shows the "Trunk merge" ruleset with `enforcement: disabled`, while "Default branch", "Require signed commits", "Security Audit", and "master" are active.
- `repository.mergeQueue(branch: "master")` returns `null`, so there's no GitHub-native queue either.
- Repo merge settings: `allow_squash_merge=true`, `allow_merge_commit=false`, `allow_rebase_merge=false`, which is why `--squash` is the only valid method.
- `gh pr merge --squash` merged a PR today.

`hogli ci:preflight --fix` passes (staleness, markdown formatting), and the pre-push hook ran it in `--strict` mode too.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable, this is the agent instruction file itself.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I hit this myself while trying to merge a PR through the documented Trunk path, so I had Claude (Claude Code) write up the correction. No skills were invoked, the mandatory list doesn't cover agent instruction files.

Scope was deliberately kept to this one file. The tempting bigger change is rewriting `.agents/skills/merging-prs/SKILL.md` in the same PR, since it's the thing agents actually follow step by step. I left it alone so this stays a small, obviously-correct docs fix, and called out its staleness inline instead.

One judgment call: I kept the Trunk instructions rather than deleting them, framed as "if Trunk is re-enabled". The pause looks reversible, and re-deriving the enqueue and queue-watching mechanics later would be wasted work.
