### PR TITLE
fix(vercel): surface a clear error for unexpected token validation responses

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/tests/test_vercel.py
@@ -135,6 +135,19 @@ class TestValidateCredentials:
         assert ok is False
         assert error == "boom"
 
+    def test_unexpected_status_does_not_leak_raw_status_code(self) -> None:
+        response = requests.Response()
+        response.status_code = 404
+        session = MagicMock()
+        session.get.return_value = response
+        with patch.object(vercel, "make_tracked_session", lambda *a, **k: session):
+            ok, error = validate_credentials("token")
+
+        assert ok is False
+        assert error is not None
+        assert "Vercel API error" not in error
+        assert "404" not in error
+
 
 class TestGetRows:
     def test_full_refresh_follows_until_cursor_across_pages(self, monkeypatch: Any) -> None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/vercel/vercel.py
@@ -136,7 +136,10 @@ def validate_credentials(access_token: str) -> tuple[bool, str | None]:
         return True, None
     if response.status_code in (401, 403):
         return False, "Invalid or unauthorized Vercel access token"
-    return False, f"Vercel API error: {response.status_code}"
+    return (
+        False,
+        "Couldn't validate your Vercel access token. Check that it's a valid token from your Vercel account settings, then try again.",
+    )
 
 
 def get_rows(


### PR DESCRIPTION
## Problem

When a user connects a Vercel source, we validate their access token by probing `GET /v2/user`. For a valid token we get 200; for a bad or unauthorized one we get 401/403 and show a clear message. But for any *other* status, validation fell back to returning the raw upstream status code as the error, so users saw messages like `Vercel API error: 404`. That gives them nothing to act on and leaks an internal detail.

This showed up in real source-creation failures in the new-source wizard.

## Changes

Replace the raw-status fallback in `validate_credentials` with an actionable, user-facing message that tells the user to check their token. The 200 success path and the 401/403 "invalid or unauthorized" path are unchanged.

## How did you test this code?

Added a case to `TestValidateCredentials` asserting an unexpected status (404) no longer leaks the raw `Vercel API error` string or the status code into the returned message. Ran the `TestValidateCredentials` suite locally — all pass. I (Claude) did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a batch of data-warehouse source-creation failures and classified each error message as user-misconfiguration, internal-leak, or product bug. Most messages were already clear and actionable and needed no change. This Vercel fallback was a clear internal-leak case: it echoed the upstream HTTP status verbatim.

Kept the change minimal (single message string) rather than adding per-status branching for 429/5xx, since the validation session already retries those and the reported failures were the unhandled fallback path. Invoked `/writing-tests` before extending the test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
