### PR TITLE
feat(data-warehouse): promote Google Analytics source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/source.py
@@ -210,8 +210,7 @@ class GoogleAnalyticsSource(ResumableSource[GoogleAnalyticsSourceConfig, GoogleA
                 "devices, locations, traffic sources, and events). Requires a Google account with read access "
                 "to the GA4 property."
             ),
-            releaseStatus=ReleaseStatus.BETA,
-            featureFlag="dwh-google-analytics",
+            releaseStatus=ReleaseStatus.GA,
             iconPath="/static/services/google_analytics.png",
             docsUrl="https://posthog.com/docs/cdp/sources/google-analytics",
             fields=cast(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics_source.py
@@ -37,8 +37,8 @@ def test_get_source_config_fields():
     field_names = {field.name for field in cfg.fields}
     assert field_names == {"google_analytics_integration_id", "property_id"}
     assert cfg.label == "Google Analytics"
-    assert cfg.featureFlag == "dwh-google-analytics"
-    assert cfg.releaseStatus == ReleaseStatus.BETA
+    assert cfg.featureFlag is None
+    assert cfg.releaseStatus == ReleaseStatus.GA
     assert not cfg.unreleasedSource
 
 


### PR DESCRIPTION
## Problem

The **Google Analytics** (GA4) data-warehouse source has been in Beta and gated behind a `dwh-google-analytics` feature flag. It now meets the bar for general availability.

Current metrics (7-day window):
- **Adoption:** 140 teams · live ~1.4 months (bar: 100+ teams **or** 3+ months live).
- **Import error rate:** 0.1% (bar: < 2.5%).

## Changes

- Set the source's `releaseStatus` from `ReleaseStatus.BETA` to `ReleaseStatus.GA` (surfaced by `/api/public_source_configs/`).
- Removed the `featureFlag="dwh-google-analytics"` controlled-rollout gate. No GA source in the tree carries a `featureFlag` — it's a beta-only rollout mechanism, so a GA source ships visible to everyone. There are no other references to `dwh-google-analytics` in the codebase.

No changes to the connector's behavior, schemas, auth, or sync logic — this is a status promotion only.

## How did you test this code?

Updated the existing source-config test assertions to reflect GA status and the removed flag. Ran the source's test suite (`test_google_analytics_source.py`, 27 passed) and `ruff check` (clean). I did not run the connector against a live GA4 account — this change touches only release metadata.

## Docs update

No user-facing doc changes needed; `docsUrl` is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Invoked the `/implementing-warehouse-sources` skill to confirm where source release status and gating live and the convention around `releaseStatus`/`featureFlag`. Checked open PRs (including the maintainer's own) to rule out a duplicate promotion before opening this one; the closest, #75852, promotes the ClickHouse source, not Google Analytics. Decision worth flagging: removing the feature flag alongside the status bump, justified by the codebase-wide convention that no GA source retains a `featureFlag`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
