### PR TITLE
fix(mcp-analytics): display incomplete intervals in tools calls and errors chart

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6482,6 +6482,10 @@ snapshots:
         hash: v1.k794b7964.2d8dc7d50a9b0bb18090a2e5c29368e12754c133f5029fba10515afca766c9a4.6cPWYhvNfeMHrXHSOz8R-IvwxmTOlpko0UXkl4g920I
     scenes-app-mcp-analytics-dashboard-cards--daily-calls-and-errors--light:
         hash: v1.k794b7964.036b64dbb324cf0163342f393e403c3e3b7feb97bb5e3b88983f168c06f5b5fd.-rT11S5Rw9G17WjI2cK8efHwq2nmUsIMIA1hNd4F3BY
+    scenes-app-mcp-analytics-dashboard-cards--daily-calls-and-errors-in-progress-bucket--dark:
+        hash: v1.k794b7964.c4311ba9e5d1feb336e3e96ca47bb48f400381487ea18793b537b59a8827b70c.wzmFcWI7LrsQOJ902hjl5cWWhJr1jktic0Faj5XskOs
+    scenes-app-mcp-analytics-dashboard-cards--daily-calls-and-errors-in-progress-bucket--light:
+        hash: v1.k794b7964.4eb5cb46f0e65dca7bb7e668bf513dd2d84cf1003529bbcb62e356ffacd8d6be.9_PJaqE7DKZQaS7FtnPEBS7rW3FkBNs3GeU6n8fO3aI
     scenes-app-mcp-analytics-dashboard-cards--daily-tool-breakdown--dark:
         hash: v1.k794b7964.accfc0a38802ff4dd38b7d92143b5bd3ca3e7b746a05efcfa31980810a6fe1f1.krPWvAaNVmgG9TLam2-YDPGIJtCMCXtQO3kk4Y5qPM4
     scenes-app-mcp-analytics-dashboard-cards--daily-tool-breakdown--light:

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -30,6 +30,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
         harnessRowsLoading,
         dailyActivity,
         activityRowsLoading,
+        activityIncompleteTail,
         toolDailySeries,
         toolDailyRowsLoading,
         toolRows,
@@ -102,6 +103,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
                                 theme={theme}
                                 timezone={timezone}
                                 interval={interval}
+                                incompleteTail={activityIncompleteTail}
                             />
                         </div>
                         <HarnessDonut rows={harnessRows} loading={harnessRowsLoading} theme={theme} />

--- a/products/mcp_analytics/frontend/dashboard/ActivityChart.tsx
+++ b/products/mcp_analytics/frontend/dashboard/ActivityChart.tsx
@@ -28,8 +28,10 @@ export function ActivityChart({
     timezone: string
     interval: TimeInterval
     // When true, the final bucket is the current in-progress interval — dash that segment so the
-    // partial period reads as "not finished yet" rather than a drop in tool calls.
-    incompleteTail?: boolean
+    // partial period reads as "not finished yet" rather than a drop in tool calls. Required rather
+    // than optional: an omitted prop silently renders a solid partial bucket, which is the failure
+    // this had.
+    incompleteTail: boolean
 }): JSX.Element {
     const series = useMemo<Series[]>(() => {
         const totals = daily.successes.map((s, i) => s + (daily.errors[i] ?? 0))

--- a/products/mcp_analytics/frontend/dashboard/DashboardCards.stories.tsx
+++ b/products/mcp_analytics/frontend/dashboard/DashboardCards.stories.tsx
@@ -28,6 +28,14 @@ const DAILY_ACTIVITY: DailyActivity = {
     errors: [120, 140, 160, 170, 180, 176, 168],
 }
 
+// The shape the in-progress stories exist for: the last bucket is a few hours into the day, so its
+// counts sit far below its neighbours. Dashing it is what stops that reading as a collapse.
+const DAILY_ACTIVITY_PARTIAL_TAIL: DailyActivity = {
+    labels: DAYS,
+    successes: [4180, 4360, 4560, 4430, 4720, 4920, 1680],
+    errors: [120, 140, 160, 170, 180, 176, 54],
+}
+
 const TOOL_DAILY: ToolDailySeries = {
     labels: DAYS,
     tools: [
@@ -154,7 +162,27 @@ export const KeyMetrics: Story = {
 
 export const DailyCallsAndErrors: Story = {
     render: withTheme((theme) => (
-        <ActivityChart daily={DAILY_ACTIVITY} loading={false} theme={theme} timezone="UTC" interval="day" />
+        <ActivityChart
+            daily={DAILY_ACTIVITY}
+            loading={false}
+            theme={theme}
+            timezone="UTC"
+            interval="day"
+            incompleteTail={false}
+        />
+    )),
+}
+
+export const DailyCallsAndErrorsInProgressBucket: Story = {
+    render: withTheme((theme) => (
+        <ActivityChart
+            daily={DAILY_ACTIVITY_PARTIAL_TAIL}
+            loading={false}
+            theme={theme}
+            timezone="UTC"
+            interval="day"
+            incompleteTail
+        />
     )),
 }
 

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -19,7 +19,6 @@ import {
     buildKpiWindow,
     buildToolDailySeries,
     deltaPct,
-    lastBucketIsInProgress,
     mcpDashboardOverviewLogic,
     pickNotableSessions,
     type SessionRow,
@@ -216,27 +215,6 @@ describe('mcpDashboardOverviewLogic', () => {
             expect(result.successes).toHaveLength(bucketKeys.length)
             expect(result.errors).toHaveLength(bucketKeys.length)
             expect(result.successes).toEqual([0, 5, 0])
-        })
-    })
-
-    describe('lastBucketIsInProgress', () => {
-        const tz = 'UTC'
-        const keys = ['2026-06-27 00:00:00', '2026-06-28 00:00:00', '2026-06-29 00:00:00']
-
-        it('flags the tail when the last bucket is the interval containing now', () => {
-            const now = dayjs.tz('2026-06-29 09:15:00', tz)
-            expect(lastBucketIsInProgress(keys, tz, 'day', now)).toBe(true)
-        })
-
-        it('leaves the tail solid when the window ends in the past', () => {
-            const now = dayjs.tz('2026-07-05 09:15:00', tz)
-            expect(lastBucketIsInProgress(keys, tz, 'day', now)).toBe(false)
-        })
-
-        it('does not dash when there is no segment to dash', () => {
-            const now = dayjs.tz('2026-06-29 09:15:00', tz)
-            expect(lastBucketIsInProgress(['2026-06-29 00:00:00'], tz, 'day', now)).toBe(false)
-            expect(lastBucketIsInProgress([], tz, 'day', now)).toBe(false)
         })
     })
 

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -4,7 +4,6 @@ import { actionToUrl, router, urlToAction } from 'kea-router'
 
 import api from 'lib/api'
 import { isValidPropertyFilter } from 'lib/components/PropertyFilters/utils'
-import { dayjs } from 'lib/dayjs'
 import { getDefaultInterval } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -22,7 +21,7 @@ import { AnyPropertyFilter, IntervalType, TeamType } from '~/types'
 import type { TeamPublicType } from '../../../frontend/src/types'
 import { mcpClusteringLogic } from './clustering/mcpClusteringLogic'
 import type { MCPIntentClusterApi } from './generated/api.schemas'
-import { BUCKET_FORMAT, buildBucketKeys, normalizeBucket, resolveWindow, startOfBucket } from './timeBuckets'
+import { BUCKET_FORMAT, buildBucketKeys, lastBucketIsInProgress, normalizeBucket, resolveWindow } from './timeBuckets'
 
 export interface DateFilter {
     dateFrom: string | null
@@ -269,24 +268,8 @@ export function deltaPct(current: number, previous: number): number | null {
 }
 
 // Window resolution, bucket keys, and the BUCKET_FORMAT contract are shared with the tab/detail
-// surfaces — see ./timeBuckets. The dashboard adds only the KPI-comparison window and in-progress
-// tail below, built on those shared primitives.
-
-// True when the final bucket is the current, still-running interval (open-ended window), so the
-// chart can dash that segment as "in progress" rather than letting the partial period read as data
-// loss. Needs ≥2 buckets to have a segment to dash; `now` is injectable so the logic stays testable.
-export function lastBucketIsInProgress(
-    bucketKeys: string[],
-    timezone: string,
-    interval: IntervalType,
-    now: dayjs.Dayjs = dayjs()
-): boolean {
-    if (bucketKeys.length < 2) {
-        return false
-    }
-    const currentBucket = startOfBucket(now.tz(timezone), interval).format(BUCKET_FORMAT)
-    return bucketKeys[bucketKeys.length - 1] === currentBucket
-}
+// surfaces — see ./timeBuckets. The dashboard adds only the KPI-comparison window below, built on
+// those shared primitives.
 
 // Project the daily success/error rows onto the full set of buckets, defaulting empty buckets to 0.
 export function buildDailyActivity(rows: ActivityRow[], bucketKeys: string[]): DailyActivity {

--- a/products/mcp_analytics/frontend/timeBuckets.test.ts
+++ b/products/mcp_analytics/frontend/timeBuckets.test.ts
@@ -1,6 +1,6 @@
 import { dayjs } from 'lib/dayjs'
 
-import { buildBucketKeys, formatBucketLabel, normalizeBucket } from './timeBuckets'
+import { buildBucketKeys, formatBucketLabel, lastBucketIsInProgress, normalizeBucket } from './timeBuckets'
 
 describe('timeBuckets', () => {
     describe('normalizeBucket', () => {
@@ -101,6 +101,36 @@ describe('timeBuckets', () => {
             expect(formatBucketLabel('2026-06-01 09:30:00', 'minute')).toBe('Jun 1, 09:30')
             expect(formatBucketLabel('2026-06-01 09:00:00', 'hour')).toBe('Jun 1, 09:00')
             expect(formatBucketLabel('2026-06-01 00:00:00', 'day')).toBe('Jun 1')
+        })
+    })
+
+    describe('lastBucketIsInProgress', () => {
+        const tz = 'UTC'
+        const keys = ['2026-06-27 00:00:00', '2026-06-28 00:00:00', '2026-06-29 00:00:00']
+
+        it('flags the tail when the last bucket is the interval containing now', () => {
+            const now = dayjs.tz('2026-06-29 09:15:00', tz)
+            expect(lastBucketIsInProgress(keys, tz, 'day', now)).toBe(true)
+        })
+
+        it('leaves the tail solid when the window ends in the past', () => {
+            const now = dayjs.tz('2026-07-05 09:15:00', tz)
+            expect(lastBucketIsInProgress(keys, tz, 'day', now)).toBe(false)
+        })
+
+        it('does not dash when there is no segment to dash', () => {
+            const now = dayjs.tz('2026-06-29 09:15:00', tz)
+            expect(lastBucketIsInProgress(['2026-06-29 00:00:00'], tz, 'day', now)).toBe(false)
+            expect(lastBucketIsInProgress([], tz, 'day', now)).toBe(false)
+        })
+
+        // The project timezone decides which bucket "now" falls in: at 23:15 UTC on the 29th it is
+        // already the 30th in Athens, so a window ending on the 29th is settled there but still
+        // collecting in UTC. Reading the browser's zone instead would dash the wrong tail.
+        it('resolves the current bucket in the project timezone, not the browser', () => {
+            const now = dayjs.tz('2026-06-29 23:15:00', tz)
+            expect(lastBucketIsInProgress(keys, tz, 'day', now)).toBe(true)
+            expect(lastBucketIsInProgress(keys, 'Europe/Athens', 'day', now)).toBe(false)
         })
     })
 })

--- a/products/mcp_analytics/frontend/timeBuckets.ts
+++ b/products/mcp_analytics/frontend/timeBuckets.ts
@@ -68,6 +68,22 @@ export function buildBucketKeys(
     return keys
 }
 
+// True when the final bucket is the current, still-running interval (open-ended window), so a chart
+// can dash that segment as "in progress" rather than letting the partial period read as a drop.
+// Needs ≥2 buckets to have a segment to dash; `now` is injectable so the logic stays testable.
+export function lastBucketIsInProgress(
+    bucketKeys: string[],
+    timezone: string,
+    interval: IntervalType,
+    now: dayjs.Dayjs = dayjs()
+): boolean {
+    if (bucketKeys.length < 2) {
+        return false
+    }
+    const currentBucket = startOfBucket(now.tz(timezone), interval).format(BUCKET_FORMAT)
+    return bucketKeys[bucketKeys.length - 1] === currentBucket
+}
+
 // Normalize a raw bucket string from a query (a date or datetime) to BUCKET_FORMAT so it joins the
 // generated keys regardless of how ClickHouse rendered it. The value always carries the project-tz
 // wall clock, in one of three shapes: naive (toString(dateTrunc)), Z-stamped (a raw DateTime


### PR DESCRIPTION
## Problem

The dashboard's activity chart ends on the current, still-collecting bucket and draws it solid, so a few hours of data plotted against full days reads as a collapse in tool calls. `activityIncompleteTail` was computed and `ActivityChart` already drew a dashed partial stroke from it — the scene just never passed the prop.

First of four, one surface per PR: tool quality, tool detail, and the KPI sparklines follow.

<img width="981" height="391" alt="Screenshot 2026-07-31 at 12 54 03" src="https://github.com/user-attachments/assets/670cc32d-0ce1-4afe-ad30-186f052a2f8f" />


## Changes

Pass the prop, and make it required so a call site can't drop it again. `lastBucketIsInProgress` moves to `timeBuckets` for the three surfaces that follow.

<img width="981" height="391" alt="Screenshot 2026-07-31 at 12 21 32" src="https://github.com/user-attachments/assets/7a339eb2-b88b-4a28-8139-bc80d16d9a30" />


## How did you test this code?

`184 passed  pnpm exec jest products/mcp_analytics`. The moved helper tests come along, plus one new case pinning that the current bucket resolves in the project timezone rather than the browser's — newly load-bearing now that three more logics pass a timezone in. Two stories show settled vs in-progress. Not exercised in a browser by me (Claude); the undashed drop was confirmed in the running app before this was written.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while reviewing #74544, deferred to its own PR, confirmed against the running dashboard first. Quill's renderer implements `stroke.partial.fromIndex`, so this is a real rendering change, not a no-op prop. Skills invoked: `/writing-tests`, `/writing-code-comments`.
