### PR TITLE
fix(mcp-analytics): dash the in-progress bucket on a tool's report

### DIFF
--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -228,6 +228,7 @@ function StatTiles({
     theme,
     dateRangeLabel,
     interval,
+    incompleteTail,
 }: {
     summary: ToolSummary | null
     loading: boolean
@@ -235,6 +236,10 @@ function StatTiles({
     theme: ChartTheme
     dateRangeLabel: string
     interval: TimeInterval
+    // When true, the final bucket is the current in-progress interval — dash the sparkline from
+    // there so a partial period doesn't read as a decline. Required rather than optional: an
+    // omitted prop silently renders the partial bucket as settled data.
+    incompleteTail: boolean
 }): JSX.Element {
     const calls = summary?.calls ?? 0
     const errors = summary?.errors ?? 0
@@ -311,6 +316,7 @@ function StatTiles({
                     theme={theme}
                     restingSubtitle={dateRangeLabel}
                     sparklineHeight={40}
+                    sparklineDashedFromIndex={incompleteTail ? sparkLabels.length - 1 : undefined}
                 />
             ))}
         </div>
@@ -410,12 +416,16 @@ const SERIES_META: Record<TrendSeriesKey, { label: string; colorIndex: number }>
     p95: { label: 'p95', colorIndex: 0 },
 }
 
-function seriesFor(data: DailyChartData, theme: ChartTheme, keys: TrendSeriesKey[]): Series[] {
+// `incompleteTail` is only true when the window has ≥2 buckets (lastBucketIsInProgress owns that
+// rule), and every series is filled to the bucket count, so the final segment exists.
+function seriesFor(data: DailyChartData, theme: ChartTheme, keys: TrendSeriesKey[], incompleteTail: boolean): Series[] {
+    const stroke = incompleteTail ? { partial: { fromIndex: data.labels.length - 1 } } : undefined
     return keys.map((key) => ({
         key,
         label: SERIES_META[key].label,
         color: theme.colors[SERIES_META[key].colorIndex],
         data: data[key],
+        stroke,
     }))
 }
 
@@ -493,18 +503,19 @@ function MCPAnalyticsToolDetailContent({ toolName }: { toolName: string }): JSX.
         dateRangeLabel,
         dateFilter,
         interval,
+        incompleteTail,
     } = useValues(mcpAnalyticsToolDetailLogic({ toolName }))
     const { selectFailure } = useActions(mcpAnalyticsToolDetailLogic({ toolName }))
     const { timezone } = useValues(teamLogic)
 
     const theme = useChartTheme()
     const callsSeries = useMemo<Series[]>(
-        () => seriesFor(dailyChartData, theme, ['calls', 'errors']),
-        [dailyChartData, theme]
+        () => seriesFor(dailyChartData, theme, ['calls', 'errors'], incompleteTail),
+        [dailyChartData, theme, incompleteTail]
     )
     const latencySeries = useMemo<Series[]>(
-        () => seriesFor(dailyChartData, theme, ['p50', 'p95']),
-        [dailyChartData, theme]
+        () => seriesFor(dailyChartData, theme, ['p50', 'p95'], incompleteTail),
+        [dailyChartData, theme, incompleteTail]
     )
     const countsConfig = useChartConfig(() => trendChartConfig(timezone, interval), [timezone, interval])
     const latencyConfig = useChartConfig(
@@ -534,6 +545,7 @@ function MCPAnalyticsToolDetailContent({ toolName }: { toolName: string }): JSX.
                     theme={theme}
                     dateRangeLabel={dateRangeLabel}
                     interval={interval}
+                    incompleteTail={incompleteTail}
                 />
             </div>
 

--- a/products/mcp_analytics/frontend/dashboard/MetricTile.tsx
+++ b/products/mcp_analytics/frontend/dashboard/MetricTile.tsx
@@ -26,6 +26,8 @@ export interface MetricTileProps {
     changeTooltip?: string
     hoverChangeFromPreviousPoint?: boolean
     sparklineHeight?: number
+    // Dash the sparkline from this index on, for a trailing bucket that is still collecting.
+    sparklineDashedFromIndex?: number
     className?: string
 }
 
@@ -44,6 +46,7 @@ export function MetricTile({
     changeTooltip,
     hoverChangeFromPreviousPoint = false,
     sparklineHeight,
+    sparklineDashedFromIndex,
     className,
 }: MetricTileProps): JSX.Element {
     const hasSparkline = data != null && data.length > 0
@@ -69,6 +72,7 @@ export function MetricTile({
                     hoverChangeFromPreviousPoint={hoverChangeFromPreviousPoint}
                     restingSubtitle={restingSubtitle}
                     sparklineHeight={sparklineHeight}
+                    sparklineDashedFromIndex={sparklineDashedFromIndex}
                 >
                     <MetricHeader>
                         <MetricTitle>{label}</MetricTitle>

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.test.ts
@@ -65,6 +65,32 @@ describe('buildDailyChartData', () => {
     })
 })
 
+describe('incompleteTail', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        initKeaTests()
+        jest.spyOn(mockApi, 'query').mockResolvedValue({ results: [] })
+    })
+
+    // An open-ended relative window always ends in the bucket that is still collecting, and a window
+    // that closed in the past never does, so this holds whenever the suite runs.
+    it.each([
+        ['an open-ended window', '-30d', null, true],
+        ['a window that already closed', '2026-06-01', '2026-06-10', false],
+    ])('is %s: %s', async (_label, dateFrom, dateTo, expected) => {
+        const logic = mcpAnalyticsToolDetailLogic({ toolName: 'query_run' })
+        logic.mount()
+        await expectLogic(logic, () => {
+            logic.actions.setDateFilter(dateFrom, dateTo)
+        }).toFinishAllListeners()
+        // Seeded directly: with no rows the chart data short-circuits to empty, and an empty axis
+        // has no tail to dash either way.
+        logic.actions.loadDailyStatsSuccess([stat({ day: '2026-06-02 00:00:00', calls: 1 })])
+
+        expect(logic.values.incompleteTail).toBe(expected)
+    })
+})
+
 describe('failure drill-down', () => {
     beforeEach(() => {
         jest.clearAllMocks()

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -23,7 +23,7 @@ import {
 } from '~/queries/schema/schema-general'
 import { IntervalType } from '~/types'
 
-import { buildBucketKeys, normalizeBucket } from './timeBuckets'
+import { buildBucketKeys, lastBucketIsInProgress, normalizeBucket } from './timeBuckets'
 export interface ToolSummary {
     calls: number
     errors: number
@@ -143,6 +143,7 @@ export interface mcpAnalyticsToolDetailLogicValues {
     failureBucketsLoading: boolean
     failureOccurrences: MCPToolFailureOccurrenceItem[]
     failureOccurrencesLoading: boolean
+    incompleteTail: boolean
     intentCoverage: IntentCoverage | null
     intentCoverageLoading: boolean
     interval: IntervalType
@@ -353,6 +354,7 @@ export interface mcpAnalyticsToolDetailLogicMeta {
             interval: IntervalType,
             timezone: string
         ) => DailyChartData
+        incompleteTail: (dailyChartData: DailyChartData, interval: IntervalType, timezone: string) => boolean
         interval: (dateFilter: DateFilter) => IntervalType
         dateRange: (dateFilter: DateFilter, timezone: string) => DateRange
         dateRangeLabel: (dateFilter: DateFilter) => string
@@ -614,6 +616,14 @@ export const mcpAnalyticsToolDetailLogic = kea<mcpAnalyticsToolDetailLogicType>(
                 const bucketKeys = buildBucketKeys(dateFilter.dateFrom, dateFilter.dateTo, timezone, interval)
                 return buildDailyChartData(dailyStats, bucketKeys)
             },
+        ],
+
+        // The trend charts and sparklines dash the final segment when it is the current, still-
+        // collecting interval, so a partial period doesn't read as a fall in calls or a latency win.
+        incompleteTail: [
+            (s) => [s.dailyChartData, s.interval, teamLogic.selectors.timezone],
+            (dailyChartData: DailyChartData, interval: IntervalType, timezone: string): boolean =>
+                lastBucketIsInProgress(dailyChartData.labels, timezone, interval),
         ],
 
         // Grouping interval for the daily series — PostHog's standard auto-choice, matching the query's


### PR DESCRIPTION
## Problem

Same as #75886, on a tool's report: both trend charts and all six stat sparklines draw the current, still-collecting bucket solid. This is the page where that drop gets read as a regression in the tool itself.

<img width="1471" height="613" alt="Screenshot 2026-07-31 at 13 07 41" src="https://github.com/user-attachments/assets/3a13e91e-9b84-4f8a-adcb-aff48df9f199" />


## Changes

An `incompleteTail` selector on the tool detail logic, applied to both trend charts and the sparklines. `MetricTile` gains a `sparklineDashedFromIndex` passthrough — quill's `Metric` already supports it, nothing was passing it.

<img width="1462" height="619" alt="Screenshot 2026-07-31 at 13 06 50" src="https://github.com/user-attachments/assets/a34bbf06-8a82-41ed-a48f-3352f74b0358" />


## How did you test this code?

`183 passed  pnpm exec jest products/mcp_analytics`. One parameterized logic test covers the selector on an open-ended vs a closed window — verified red by stubbing the selector to `false`. Not exercised in a browser by me (Claude).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Third of four. Stacked on #75887; retarget as the stack lands. Skills invoked: `/writing-tests`, `/writing-code-comments`.
