### PR TITLE
fix(data-imports): stop blocking incremental syncs on expected report-source key collisions

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/README.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/README.md
@@ -93,7 +93,10 @@ If you can request how many rows are about to be imported (this is usually more 
 
 #### `has_duplicate_primary_keys`
 
-Also optional, setting this to `True` will stop the pipeline from syncing any data and give the user feedback that they can't sync until they no longer have duplicate primary keys. Again, this is more of a problem with database sources than API backed sources. But, the point of this is to ensure we don't try to merge incremental data with duplicate merge keys as this blows up the memory usage of our pods and kills them with OOM errors.
+Also optional, setting this to `True` will stop the pipeline from syncing any data and give the user feedback that they can't sync until they no longer have duplicate primary keys.
+This is for the case where duplicates signal a likely mistake the user can fix — e.g. a database source fell back to a declared key that turns out not to be unique on the live table, so a merge would silently keep an arbitrary row per key instead of the one the user expects.
+
+Don't set this for a source whose primary key is inherently non-unique by design and isn't user-configurable — e.g. an aggregated report API whose dimensions can collide on blank values (Adjust, AppsFlyer, Clari, Pingdom's alerts endpoint). There's no key the user could pick instead, so blocking the sync leaves it permanently unusable. The pipeline already dedupes a batch on its primary key before merging (keeping the last occurrence), which is exactly the right behavior for that case, so just leave `has_duplicate_primary_keys` unset and let the sync proceed normally.
 
 ### Partitioning
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/adjust.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/adjust.py
@@ -352,7 +352,10 @@ def adjust_source(
         partition_format="month",
         partition_keys=["day"],
         sort_mode="asc",
-        # Aggregated dimension keys can collide when a dimension value comes back blank
-        # (e.g. organic traffic with no campaign).
-        has_duplicate_primary_keys=True,
+        # Aggregated dimension keys can collide when a dimension value comes back blank (e.g.
+        # organic traffic with no campaign) — an expected trait of report data, not a data-quality
+        # problem the user can fix. Don't set has_duplicate_primary_keys: that flag tells
+        # validate_incremental_sync to block incremental syncing altogether, which would make
+        # `day` (the only incremental field this source offers) permanently unusable. The merge's
+        # own per-batch dedup (keep-last-per-key) already resolves the collision safely.
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/settings.py
@@ -42,8 +42,8 @@ class AdjustReportConfig:
     dimensions: list[str]
     metrics: list[str] = field(default_factory=lambda: list(_CORE_METRICS))
     # Aggregated reports have no row ids — the requested dimensions are the natural key. Blank
-    # dimension values (e.g. an unattributed campaign) can collide, so rows are merged with
-    # `has_duplicate_primary_keys=True`.
+    # dimension values (e.g. an unattributed campaign) can collide; the merge's per-batch dedup
+    # (keep-last-per-key) resolves that safely, so incremental syncing stays available.
     primary_keys: list[str] = field(default_factory=lambda: ["day", "app_token"])
     incremental_fields: list[IncrementalField] = field(default_factory=lambda: list(_DAY_INCREMENTAL_FIELDS))
     description: str | None = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/tests/test_adjust.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/adjust/tests/test_adjust.py
@@ -9,6 +9,7 @@ from unittest import mock
 import requests
 from parameterized import parameterized
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import validate_incremental_sync
 from products.warehouse_sources.backend.temporal.data_imports.sources.adjust import adjust
 from products.warehouse_sources.backend.temporal.data_imports.sources.adjust.adjust import (
     LOOKBACK_DAYS,
@@ -480,8 +481,12 @@ class TestAdjustSource:
         assert response.sort_mode == "asc"
         assert response.partition_mode == "datetime"
         assert response.partition_keys == ["day"]
-        # Blank dimension values (e.g. organic traffic with no campaign) can collide.
-        assert response.has_duplicate_primary_keys is True
+        # Blank dimension values (e.g. organic traffic with no campaign) can collide, but that's
+        # expected for report data and must not block incremental syncing (the only incremental
+        # field these reports offer is `day`) - regression test for the schema-wide incremental
+        # sync outage this caused when has_duplicate_primary_keys was set unconditionally.
+        assert not response.has_duplicate_primary_keys
+        validate_incremental_sync(True, response)
 
     def test_items_is_lazy(self) -> None:
         # Building the SourceResponse must not issue a request; the pipeline drives iteration.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/appsflyer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/appsflyer.py
@@ -212,6 +212,8 @@ def appsflyer_source(
         partition_format="month",
         partition_keys=["date"],
         sort_mode="asc",
-        # Dimension keys can collide (e.g. blank campaign values).
-        has_duplicate_primary_keys=True,
+        # Dimension keys can collide (e.g. blank campaign values) — an expected trait of report
+        # data, not something the user can fix. Don't set has_duplicate_primary_keys: that flag
+        # tells validate_incremental_sync to block incremental syncing altogether. The merge's own
+        # per-batch dedup (keep-last-per-key) already resolves the collision safely.
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/appsflyer/tests/test_appsflyer.py
@@ -4,6 +4,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from unittest import mock
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import validate_incremental_sync
 from products.warehouse_sources.backend.temporal.data_imports.sources.appsflyer.appsflyer import (
     CHUNK_SIZE,
     LOOKBACK_DAYS,
@@ -229,8 +230,11 @@ class TestAppsFlyerSourceResponse:
         assert response.sort_mode == "asc"
         assert response.partition_mode == "datetime"
         assert response.partition_keys == ["date"]
-        # Dimension keys can collide (blank campaigns etc).
-        assert response.has_duplicate_primary_keys is True
+        # Dimension keys can collide (blank campaigns etc), but that's expected for report data
+        # and must not block incremental syncing - regression test for the schema-wide incremental
+        # sync outage this caused when has_duplicate_primary_keys was set unconditionally.
+        assert not response.has_duplicate_primary_keys
+        validate_incremental_sync(True, response)
 
     def test_geo_report_key_includes_country(self):
         response = appsflyer_source("token", "id123", "geo_report", mock.MagicMock())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clari/clari.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clari/clari.py
@@ -198,14 +198,17 @@ def clari_source(
                 should_use_incremental_field=should_use_incremental_field,
                 db_incremental_field_last_value=db_incremental_field_last_value,
             ),
-            # Audit events carry no unique id — dedupe on the natural composite.
+            # Audit events carry no unique id — dedupe on the natural composite. This composite can
+            # still collide, but that's expected, not a data-quality problem the user can fix, so
+            # don't set has_duplicate_primary_keys: that flag tells validate_incremental_sync to
+            # block incremental syncing altogether. The merge's own per-batch dedup
+            # (keep-last-per-key) already resolves the collision safely.
             primary_keys=["eventTimestamp", "actorId", "sessionId", "event"],
             partition_count=1,
             partition_size=1,
             # Result ordering is undocumented, so only commit the watermark
             # once a sync completes.
             sort_mode="desc",
-            has_duplicate_primary_keys=True,
         )
 
     return SourceResponse(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clari/tests/test_clari.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clari/tests/test_clari.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 from unittest import mock
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import validate_incremental_sync
 from products.warehouse_sources.backend.temporal.data_imports.sources.clari.clari import (
     ClariResumeConfig,
     ClariRetryableError,
@@ -215,7 +216,11 @@ class TestClariSourceResponse:
         assert response.name == "audit_events"
         assert response.primary_keys == ["eventTimestamp", "actorId", "sessionId", "event"]
         assert response.sort_mode == "desc"
-        assert response.has_duplicate_primary_keys is True
+        # The composite key can collide, but that's expected for this data and must not block
+        # incremental syncing - regression test for the schema-wide incremental sync outage this
+        # caused when has_duplicate_primary_keys was set unconditionally.
+        assert not response.has_duplicate_primary_keys
+        validate_incremental_sync(True, response)
 
     def test_forecast_metadata(self):
         response = clari_source("key", "fc-1", "forecast", mock.MagicMock(), _make_manager())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pingdom/pingdom.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pingdom/pingdom.py
@@ -131,7 +131,6 @@ def pingdom_source(
         partition_format="month" if config.partition_key else None,
         partition_keys=[config.partition_key] if config.partition_key else None,
         sort_mode="asc",
-        has_duplicate_primary_keys=config.has_duplicate_primary_keys or None,
     )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pingdom/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pingdom/settings.py
@@ -18,8 +18,6 @@ class PingdomEndpointConfig:
     partition_key: Optional[str] = None
     # Max page size the endpoint accepts (checks allow 25000, actions 1000).
     page_size: int = 1000
-    # Composite keys on alerts may still collide (same check/user/second/channel).
-    has_duplicate_primary_keys: bool = False
 
 
 # Pingdom API 3.1 timestamps are UNIX epoch seconds. Only /actions exposes a
@@ -46,12 +44,13 @@ PINGDOM_ENDPOINTS: dict[str, PingdomEndpointConfig] = {
         name="alerts",
         path="/actions",
         data_key="actions.alerts",
-        # Alert rows carry no id; (checkid, time, userid, via) is the closest
-        # natural key and can still collide, so flag duplicates for the pipeline.
+        # Alert rows carry no id; (checkid, time, userid, via) is the closest natural key and can
+        # still collide — an expected trait of this data, not something the user can fix. The
+        # merge's own per-batch dedup (keep-last-per-key) resolves the collision safely, so
+        # incremental syncing (via `time` below) stays available.
         primary_keys=["checkid", "time", "userid", "via"],
         partition_key="time",
         page_size=1000,
-        has_duplicate_primary_keys=True,
         incremental_fields=[
             {
                 "label": "time",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/pingdom/tests/test_pingdom.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/pingdom/tests/test_pingdom.py
@@ -7,6 +7,7 @@ from unittest import mock
 
 from requests import Response
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.common.extract import validate_incremental_sync
 from products.warehouse_sources.backend.temporal.data_imports.sources.pingdom.pingdom import (
     PingdomResumeConfig,
     _to_epoch,
@@ -232,14 +233,14 @@ class TestPingdomSourceResponse:
             assert response.partition_keys is None
 
     @mock.patch(CLIENT_SESSION_PATCH)
-    def test_alerts_flag_duplicate_primary_keys(self, MockSession):
+    def test_alerts_duplicate_composite_key_does_not_block_incremental_sync(self, MockSession):
+        # Alert rows' composite key (checkid, time, userid, via) can collide, but that's expected
+        # for this data and must not block incremental syncing (the only incremental field this
+        # endpoint offers is `time`) - regression test for the schema-wide incremental sync outage
+        # this caused when has_duplicate_primary_keys was set unconditionally for this endpoint.
         response = pingdom_source("token", "alerts", team_id=1, job_id="j", resumable_source_manager=_make_manager())
-        assert response.has_duplicate_primary_keys is True
-
-    @mock.patch(CLIENT_SESSION_PATCH)
-    def test_checks_do_not_flag_duplicate_primary_keys(self, MockSession):
-        response = pingdom_source("token", "checks", team_id=1, job_id="j", resumable_source_manager=_make_manager())
-        assert response.has_duplicate_primary_keys is None
+        assert not response.has_duplicate_primary_keys
+        validate_incremental_sync(True, response)
 
     @pytest.mark.parametrize("config", list(PINGDOM_ENDPOINTS.values()))
     def test_partition_keys_are_stable_fields(self, config):


### PR DESCRIPTION
## Problem

Error tracking surfaced a `DuplicatePrimaryKeysException` firing repeatedly during an Adjust sync, raised from shared pipeline code (`validate_incremental_sync` in `products/warehouse_sources/backend/temporal/data_imports/pipelines/common/extract.py`), not the Adjust connector itself.

Tracing it back: Adjust declares `has_duplicate_primary_keys=True` unconditionally for every report schema, because its aggregated-report dimensions can legitimately collide on blank values (e.g. organic installs with no campaign). That flag has exactly one consumer, and its only effect is a hard block: any incremental sync where it's set raises immediately, gets classified non-retryable (the message already matches an entry in `Any_Source_Errors`), retries a few times, then gives up and disables the schema. Since the flag is set unconditionally, this means incremental sync for Adjust never had a chance to succeed - all six report schemas failed on the very first activity call.

The same pattern exists in three other connectors that declare the same trait for the same reason: AppsFlyer, Clari, and Pingdom's `alerts` endpoint. All four expose an incremental field (their report's date/time cursor), so incremental sync is clearly meant to work for them, but it never could.

## Changes

The write path already dedupes a batch on its primary key before merging into Delta (keeping the last occurrence per key) specifically to handle "the same key appears twice" - see the comment in `delta_table_helper.write_to_deltalake`. That's exactly the right behavior for these connectors' blank-dimension collisions. Unlike a database source where a dynamically-detected duplicate key usually signals a fixable mistake (wrong column chosen, no real primary key), these report APIs have no alternative key a user could pick instead, so blocking them left the sync permanently stuck with no path to recovery other than switching off incremental sync entirely.

Stopped setting `has_duplicate_primary_keys=True` for Adjust, AppsFlyer, Clari, and Pingdom's `alerts` endpoint, since the flag's only purpose is a block these connectors don't want. Also dropped the now-fully-unused `has_duplicate_primary_keys` field from Pingdom's per-endpoint config (it was only ever set for `alerts`), and updated the connector README's description of the flag to spell out this distinction for future sources.

Left the dynamic detection in BigQuery, Postgres, Redshift, and ClickHouse untouched - those cases genuinely benefit from stopping the sync and telling the user to pick a real primary key.

## How did you test this code?

Updated the existing per-connector tests (`test_adjust.py`, `test_appsflyer.py`, `test_clari.py`, `test_pingdom.py`) to assert the flag is no longer set and to call `validate_incremental_sync(True, response)` directly - this reproduces the exact failure path from production and would have caught the regression these connectors just shipped.

```
uv run pytest products/warehouse_sources/backend/temporal/data_imports/sources/{adjust,appsflyer,clari,pingdom}/tests/   197 passed
uv run mypy --cache-fine-grained .                                                                                       clean, 17288 files
tach check --dependencies --interfaces                                                                                    clean
ruff check / ruff format                                                                                                  clean
```

No manual sync against a live source - couldn't exercise the real Adjust/AppsFlyer/Clari/Pingdom APIs from this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found via an error-tracking issue for `DuplicatePrimaryKeysException` in the warehouse-sources import pipeline. Traced the stack trace into `validate_incremental_sync`, then read the four connectors that unconditionally set `has_duplicate_primary_keys=True` and the merge-side dedup logic that already handles this collision safely, to confirm the flag was blocking a feature these connectors otherwise support (they all declare an incremental field). Checked open PRs for a prior fix (search terms: `DuplicatePrimaryKeysException`, `has_duplicate_primary_keys`, `validate_incremental_sync`; scanned Gilbert09's open PRs) - found no overlap. Skills invoked: `/writing-tests`.

Decision worth flagging: I fixed the whole class (four connectors sharing the same unconditional-flag pattern) rather than patching Adjust alone, since the root cause and fix are identical for all four and the error tracking issue's own guidance pointed at shared pipeline code rather than the specific source.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*