### PR TITLE
fix(workflows): stop email setup from touching root domain SPF

### DIFF
--- a/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-eu.json
+++ b/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-eu.json
@@ -3,7 +3,7 @@
     "providerName": "PostHog",
     "serviceId": "email-verification-eu",
     "serviceName": "PostHog Email Sending (EU)",
-    "version": 1,
+    "version": 2,
     "syncBlock": false,
     "logoUrl": "https://posthog.com/brand/posthog-logo.svg",
     "description": "Configures DNS records for PostHog email sending (domain verification, DKIM, SPF, MAIL FROM)",
@@ -33,7 +33,6 @@
             "pointsTo": "%dkim3%.dkim.amazonses.com",
             "ttl": 3600
         },
-        { "groupId": "spf", "type": "SPFM", "host": "@", "spfRules": "include:amazonses.com", "ttl": 3600 },
         {
             "groupId": "mailfrom",
             "type": "MX",

--- a/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-us.json
+++ b/frontend/src/lib/components/DomainConnect/templates/posthog.com.email-verification-us.json
@@ -3,7 +3,7 @@
     "providerName": "PostHog",
     "serviceId": "email-verification-us",
     "serviceName": "PostHog Email Sending (US)",
-    "version": 1,
+    "version": 2,
     "syncBlock": false,
     "logoUrl": "https://posthog.com/brand/posthog-logo.svg",
     "description": "Configures DNS records for PostHog email sending (domain verification, DKIM, SPF, MAIL FROM)",
@@ -33,7 +33,6 @@
             "pointsTo": "%dkim3%.dkim.amazonses.com",
             "ttl": 3600
         },
-        { "groupId": "spf", "type": "SPFM", "host": "@", "spfRules": "include:amazonses.com", "ttl": 3600 },
         {
             "groupId": "mailfrom",
             "type": "MX",

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7678,19 +7678,19 @@ export type OAuthApplicationPublicMetadata = {
     wildcard_read_scopes?: string[]
 }
 export interface EmailSenderDomainStatus {
-    status: 'pending' | 'success'
+    status: 'pending' | 'success' | 'failed'
     dnsRecords: (
         | {
-              type: 'dkim'
+              type: 'verification'
               recordType: 'TXT'
               recordHostname: string
               recordValue: string
               status: 'pending' | 'success'
           }
         | {
-              type: 'spf'
-              recordType: 'TXT'
-              recordHostname: '@'
+              type: 'dkim'
+              recordType: 'CNAME'
+              recordHostname: string
               recordValue: string
               status: 'pending' | 'success'
           }
@@ -7701,6 +7701,13 @@ export interface EmailSenderDomainStatus {
               recordValue: string
               status: 'pending' | 'success'
               priority?: number
+          }
+        | {
+              type: 'dmarc'
+              recordType: 'TXT'
+              recordHostname: string
+              recordValue: string
+              status: 'pending' | 'success'
           }
     )[]
 }

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -348,9 +348,9 @@ class TestEmailIntegration:
                     "status": "pending",
                 },
                 {
-                    "type": "spf",
+                    "type": "mail_from",
                     "recordType": "TXT",
-                    "recordHostname": "@",
+                    "recordHostname": "feedback.posthog.com",
                     "recordValue": "v=spf1 include:amazonses.com ~all",
                     "status": "pending",
                 },

--- a/products/workflows/backend/providers/maildev.py
+++ b/products/workflows/backend/providers/maildev.py
@@ -29,13 +29,6 @@ MAILDEV_MOCK_DNS_RECORDS = [
         "status": "success",
     },
     {
-        "type": "verification",
-        "recordType": "TXT",
-        "recordHostname": "@",
-        "recordValue": "v=spf1 include:amazonses.com ~all",
-        "status": "success",
-    },
-    {
         "type": "mail_from",
         "recordType": "MX",
         "recordHostname": "mail.example.com",

--- a/products/workflows/backend/providers/ses.py
+++ b/products/workflows/backend/providers/ses.py
@@ -217,15 +217,9 @@ class SESProvider:
                 }
             )
 
-        dns_records.append(
-            {
-                "type": "verification",
-                "recordType": "TXT",
-                "recordHostname": "@",
-                "recordValue": "v=spf1 include:amazonses.com ~all",
-                "status": "pending",
-            }
-        )
+        # Deliberately no SPF at the root domain — SPF is evaluated against the envelope MAIL FROM
+        # domain, which is the custom subdomain below, and it carries its own SPF. A root record
+        # would only collide with whatever else the domain already sends mail through.
 
         # Start/ensure MAIL FROM setup (MX + TXT) ---
         try:

--- a/products/workflows/backend/test/test_ses_provider.py
+++ b/products/workflows/backend/test/test_ses_provider.py
@@ -170,13 +170,6 @@ class TestSESProvider(TestCase):
                     "status": "pending",
                 },
                 {
-                    "type": "verification",
-                    "recordType": "TXT",
-                    "recordHostname": "@",
-                    "recordValue": "v=spf1 include:amazonses.com ~all",
-                    "status": "pending",
-                },
-                {
                     "recordHostname": "mail.test.posthog.com",
                     "recordType": "MX",
                     "recordValue": "feedback-smtp.us-east-1.amazonses.com",


### PR DESCRIPTION
## Problem

Setting up a sending domain for workflow emails asks for an SPF record at the root domain (host `@`). In the Domain Connect template that record is typed `SPFM`, an SPF merge, so a provider applying the template rewrites whatever SPF the domain already publishes. For a domain that already sends through another provider, that is a destructive change to a record it depends on, and it happens behind a one-click "configure automatically" button.

SES does not need it. The setup already provisions a custom MAIL FROM subdomain (for example `feedback.example.com`) with its own SPF and MX. SPF is evaluated against the envelope MAIL FROM domain, which is that subdomain, so nothing about sending or SPF depends on the root record. Relaxed DMARC alignment still holds two ways: the MAIL FROM subdomain is under the same organizational domain as the From header, and DKIM is signed on the root domain through the three CNAMEs we already ask for.

> [!NOTE]
> Domains that already applied the old record set keep their root SPF. Nothing removes it, it just stops being requested and stops being listed in the setup UI.

## Changes

- Drop the root `@` SPF record from the SES verification flow, the maildev mock, and both region Domain Connect templates (`email-verification-us` / `-eu`).
- Bump both template versions to `2`. These files are the copies of what gets submitted to [Domain-Connect/Templates](https://github.com/Domain-Connect/Templates), and the spec says the version should increase with each update to template content, so providers and their onboarding can tell the record set changed. Removing a record is backwards compatible, so no new template is needed.
- Correct `EmailSenderDomainStatus` in `frontend/src/types.ts`. The union was stale: it listed an `spf` record the backend never returned, typed DKIM records as `TXT` when they are `CNAME`, and had no `verification` or `dmarc` member even though the backend returns both. It now matches what `verify_email_domain` actually emits, including the `failed` overall status.

The MAIL FROM SPF and MX, the `_amazonses` verification TXT, the DKIM CNAMEs, and the DMARC TXT are all unchanged.

## How did you test this code?

I (Claude, driven by @dmarchuk) ran `products/workflows/backend/test/test_ses_provider.py` locally against a minimal virtualenv, 21 tests passing. That file pins the full record list `verify_email_domain` returns, so it is the test that would catch a root-domain record coming back.

I did not run `posthog/api/test/test_integration.py` or the frontend typecheck here, the sandbox has no working repo venv or frontend `node_modules`. Both are covered by CI. The `test_integration.py` change is a mock fixture that echoed a record shape the provider no longer produces, so it now describes a MAIL FROM record instead.

No new tests. The existing exact-match assertion already fails if a root-domain record is reintroduced, so a dedicated guard would not catch anything new.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs describe this record set.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus) wrote this. Starting point was a report that email auto-configuration wanted to drop DNS records a domain relied on. The root `SPFM` record is the only one in the set that modifies an existing record rather than adding a new one, which made it the obvious suspect.

Two options were on the table: make the merge non-destructive, or drop the record. Dropping it won because the record is redundant given the custom MAIL FROM subdomain, and a merge that has to preserve arbitrary existing SPF content is harder to get right than not writing to the root at all.

Two things were added beyond the minimal fix, both because the change is incomplete without them: the template version bump, since providers cache templates by version and these files are the submission source of truth, and the `EmailSenderDomainStatus` correction, since deleting one wrong member of a union while leaving three others wrong is half a fix. That type is handwritten rather than generated, this endpoint returns a plain dict rather than a serializer.

No skills were invoked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LwsWxdtMiDQfBdQ4yoojvR)_