### PR TITLE
refactor(access-control): route property restrictions through facade

### DIFF
--- a/products/access_control/backend/facade/api.py
+++ b/products/access_control/backend/facade/api.py
@@ -27,7 +27,10 @@ from posthog.models import OrganizationMembership, PropertyDefinition, Team
 from ee.models.rbac.role import Role
 
 from ..models.property_access_control import PropertyAccessControl
-from ..property_access_control import is_property_access_control_enabled
+from ..property_access_control import (
+    get_restricted_property_names as _get_restricted_property_names,
+    is_property_access_control_enabled,
+)
 from . import contracts
 from .contracts import PropertyAccessLevel
 
@@ -114,6 +117,22 @@ def team_has_property_access_rules(*, team_id: int) -> bool:
     if not is_property_access_control_enabled(team_id=team_id):
         return False
     return PropertyAccessControl.objects.filter(team_id=team_id, property_definition__isnull=False).exists()
+
+
+def get_restricted_property_names(
+    *,
+    team_id: int,
+    user_id: int | None,
+    property_type: int,
+) -> frozenset[str]:
+    return frozenset(
+        _get_restricted_property_names(
+            team_id=team_id,
+            user=None,
+            user_id=user_id,
+            property_type=property_type,
+        )
+    )
 
 
 # --- Write API ---
@@ -226,5 +245,6 @@ __all__ = [
     "available_access_levels",
     "delete_property_access_control",
     "get_property_access_state",
+    "get_restricted_property_names",
     "upsert_property_access_control",
 ]

--- a/products/access_control/backend/property_access_control.py
+++ b/products/access_control/backend/property_access_control.py
@@ -192,6 +192,7 @@ def get_restricted_property_names(
     *,
     team_id: int,
     user: User | None,
+    user_id: int | None = None,
     property_type: int,
 ) -> set[str]:
     """
@@ -199,11 +200,13 @@ def get_restricted_property_names(
     restricted for a specific PropertyDefinition.Type (EVENT or PERSON).
 
     :param team_id: The team whose restrictions to check.
-    :param user: The user making the request.
+    :param user: The user making the request. Preferred when the instance is already loaded.
+    :param user_id: The requesting user's identifier for callers that should not depend on the model instance.
+        Pass at most one of ``user`` and ``user_id``.
     :param property_type: PropertyDefinition.Type value (e.g., PropertyDefinition.Type.EVENT).
     :returns: Set of restricted property name strings.
     """
-    restricted = get_restricted_properties_for_team(team_id=team_id, user=user)
+    restricted = get_restricted_properties_for_team(team_id=team_id, user=user, user_id=user_id)
     return {name for name, ptype in restricted if ptype == property_type}
 
 
@@ -279,6 +282,7 @@ def get_non_writable_property_names(
 def get_restricted_properties_for_team(
     *,
     user: User | SyntheticUser | SharedLinkUser | None,
+    user_id: int | None = None,
     team: Team | None = None,
     team_id: int | None = None,
 ) -> set[tuple[str, int]]:
@@ -292,7 +296,9 @@ def get_restricted_properties_for_team(
     with many insights doesn't trigger one ``PropertyAccessControl`` lookup per insight. Outside of an
     active scope (e.g. ad-hoc scripts) the lookup runs uncached so we never serve stale authorization data.
 
-    :param user: (optional) The user making the query. When not provided, only the default (property-level) rules apply.
+    :param user: The user making the query. Preferred when the instance is already loaded.
+    :param user_id: The user's id for callers that should not depend on the model instance. Pass at most one of
+        ``user`` and ``user_id``. When neither is provided, only the default property-level rules apply.
     :param team: The team whose property restrictions we are checking. Preferred over ``team_id`` when the
         instance is already loaded, as it lets the feature-availability check skip its per-call Team lookup.
     :param team_id: The team's id, for callers that don't have the instance loaded. Pass exactly one of
@@ -302,8 +308,13 @@ def get_restricted_properties_for_team(
     """
     # Shared-link user and synthetic user have no membership to resolve restrictions against;
     # treat them as userless so only the default rules apply.
+    if user is not None and user_id is not None:
+        raise ValueError("pass either user or user_id, not both")
+
     if isinstance(user, SyntheticUser | SharedLinkUser):
         user = None
+    elif user is not None:
+        user_id = user.pk
 
     if team is not None:
         if team_id is not None:
@@ -313,7 +324,7 @@ def get_restricted_properties_for_team(
         raise ValueError("one of team or team_id is required")
 
     cache = _restriction_cache_var.get()
-    cache_key = (team_id, user.pk if user is not None else None)
+    cache_key = (team_id, user_id)
     if cache is not None:
         cached = cache.get(cache_key)
         if cached is not None:
@@ -352,10 +363,10 @@ def get_restricted_properties_for_team(
     # resolve the user's membership and roles once
     membership = None
     user_role_ids: set[int] = set()
-    if user is not None:
+    if user_id is not None:
         org_id = Team.objects.values_list("organization_id", flat=True).get(id=team_id)
         membership_qs = OrganizationMembership.objects.filter(
-            user=user,
+            user_id=user_id,
             organization_id=org_id,
         ).only("id", "level")
         membership = membership_qs.first()

--- a/products/access_control/backend/tests/test_api.py
+++ b/products/access_control/backend/tests/test_api.py
@@ -1,0 +1,57 @@
+from posthog.test.base import BaseTest
+
+from posthog.constants import AvailableFeature
+from posthog.models import OrganizationMembership, PropertyDefinition
+
+from products.access_control.backend.facade.api import get_restricted_property_names
+from products.access_control.backend.facade.contracts import PropertyAccessLevel
+from products.access_control.backend.models.property_access_control import PropertyAccessControl
+
+
+class TestGetRestrictedPropertyNames(BaseTest):
+    def test_returns_immutable_names_for_requested_property_type(self) -> None:
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        self.organization.available_product_features = [
+            {
+                "name": AvailableFeature.PROPERTY_ACCESS_CONTROL,
+                "key": AvailableFeature.PROPERTY_ACCESS_CONTROL,
+            }
+        ]
+        self.organization.save()
+        event_property = PropertyDefinition.objects.create(
+            team=self.team,
+            name="restricted_event_property",
+            property_type="String",
+            type=PropertyDefinition.Type.EVENT,
+        )
+        person_property = PropertyDefinition.objects.create(
+            team=self.team,
+            name="restricted_person_property",
+            property_type="String",
+            type=PropertyDefinition.Type.PERSON,
+        )
+        PropertyAccessControl.objects.bulk_create(
+            [
+                PropertyAccessControl(
+                    team=self.team,
+                    property_definition=event_property,
+                    organization_member=self.organization_membership,
+                    access_level=PropertyAccessLevel.NONE.value,
+                ),
+                PropertyAccessControl(
+                    team=self.team,
+                    property_definition=person_property,
+                    access_level=PropertyAccessLevel.NONE.value,
+                ),
+            ]
+        )
+
+        restricted_names = get_restricted_property_names(
+            team_id=self.team.pk,
+            user_id=self.user.pk,
+            property_type=PropertyDefinition.Type.EVENT,
+        )
+
+        assert restricted_names == frozenset({"restricted_event_property"})
+        assert isinstance(restricted_names, frozenset)

--- a/products/access_control/backend/tests/test_property_access_control.py
+++ b/products/access_control/backend/tests/test_property_access_control.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from posthog.constants import AvailableFeature
 from posthog.models import PropertyDefinition
+from posthog.synthetic_user import SyntheticUser
 
 from products.access_control.backend.models.property_access_control import PropertyAccessControl
 from products.access_control.backend.property_access_control import (
@@ -413,6 +414,16 @@ class TestGetRestrictedPropertiesForTeam(BaseTest):
         )
         restricted = get_restricted_properties_for_team(team_id=self.team.pk, user=self.user)
         assert restricted == set()
+
+    def test_special_principal_and_user_id_are_mutually_exclusive(self) -> None:
+        synthetic_user = SyntheticUser(self.team, "test-principal")
+
+        with self.assertRaisesRegex(ValueError, "pass either user or user_id, not both"):
+            get_restricted_properties_for_team(
+                team_id=self.team.pk,
+                user=synthetic_user,
+                user_id=self.user.id,
+            )
 
 
 class TestRestrictionCacheScope(BaseTest):

--- a/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
+++ b/products/marketing_analytics/backend/hogql_queries/conversion_goal_processor.py
@@ -28,7 +28,8 @@ from posthog.hogql.timings import HogQLTimings
 
 from posthog.models import PropertyDefinition, Team, User
 
-from products.access_control.backend.property_access_control import get_restricted_property_names
+from products.access_control.backend.facade.api import get_restricted_property_names
+from products.actions.backend.models.action import Action
 from products.analytics_platform.backend.lazy_computation.lazy_computation_executor import (
     LazyComputationResult,
     LazyComputationTable,
@@ -524,7 +525,7 @@ class ConversionGoalProcessor:
         """
         restricted = get_restricted_property_names(
             team_id=self.team.pk,
-            user=self.user,
+            user_id=self.user.id if self.user is not None else None,
             property_type=PropertyDefinition.Type.EVENT,
         )
         return bool(restricted) and not restricted.isdisjoint(self._precompute_materialized_event_properties())

--- a/products/marketing_analytics/backend/hogql_queries/test_conversion_goal_processor_refactor.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_conversion_goal_processor_refactor.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from posthog.test.base import BaseTest
@@ -20,6 +20,9 @@ from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
 from posthog.hogql.printer import prepare_and_print_ast
 from posthog.hogql.test.utils import pretty_print_in_tests
+
+from posthog.models import PropertyDefinition, User
+from posthog.synthetic_user import SyntheticUser
 
 from products.marketing_analytics.backend.hogql_queries.conversion_goal_processor import ConversionGoalProcessor
 from products.marketing_analytics.backend.hogql_queries.marketing_analytics_config import MarketingAnalyticsConfig
@@ -136,11 +139,34 @@ class TestConversionGoalProcessorRefactor(BaseTest):
             "products.marketing_analytics.backend.hogql_queries.conversion_goal_processor.get_restricted_property_names"
         )
 
-        with patch(target, return_value=set()):
+        with patch(target, return_value=frozenset()):
             assert processor._should_use_precompute(date_from, date_to) is True
 
-        with patch(target, return_value={restricted_property}):
+        with patch(target, return_value=frozenset({restricted_property})):
             assert processor._should_use_precompute(date_from, date_to) is False
+
+    @parameterized.expand(
+        [
+            ("real_user", False),
+            ("synthetic_user", True),
+        ]
+    )
+    def test_property_restriction_user_id(self, _name: str, use_synthetic_user: bool) -> None:
+        processor = self._processor()
+        processor.user = cast(User, SyntheticUser(self.team, "test-principal")) if use_synthetic_user else self.user
+        expected_user_id = None if use_synthetic_user else self.user.id
+        target = (
+            "products.marketing_analytics.backend.hogql_queries.conversion_goal_processor.get_restricted_property_names"
+        )
+
+        with patch(target, return_value=frozenset()) as get_restricted_property_names_mock:
+            processor._precompute_properties_restricted_for_user()
+
+        get_restricted_property_names_mock.assert_called_once_with(
+            team_id=self.team.pk,
+            user_id=expected_user_id,
+            property_type=PropertyDefinition.Type.EVENT,
+        )
 
     def test_tracked_fields_match_touchpoints_table_schema(self):
         from posthog.clickhouse.preaggregation.marketing_touchpoints_sql import (


### PR DESCRIPTION
## Problem

Marketing analytics reads property restrictions by importing a legacy access-control implementation module directly. This keeps the caller coupled to access-control internals and makes further product isolation harder.

This PR is the first step in migrating property-restriction callers to the access-control facade. Other direct users of the legacy `get_restricted_property_names` helper remain in event and property-value query runners, taxonomy helpers, and person and event APIs. Those callers will be addressed in follow-up changes.

## Changes

- Added an ID-based `get_restricted_property_names` facade that returns an immutable `frozenset[str]`.
- Extended the legacy restriction helpers to accept either a user object or `user_id`, while keeping identity handling explicit and rejecting both inputs together.
- Migrated `ConversionGoalProcessor` to the facade.
- Preserved userless behavior for synthetic and shared-link principals by forwarding their nullable `id` instead of the synthetic `pk` sentinel.
- Added coverage for the facade contract, identity validation, and real and synthetic marketing analytics callers.

## How did you test this code?

- Ran the marketing analytics conversion-goal processor tests and the access-control facade and property-access-control suites. 167 tests passed.
- Ran the complete conversion-goal processor refactor suite after the final test changes. All 17 tests passed.
- Ran Ruff check and format verification for the changed Python files.
- Ran `tach check --dependencies --interfaces`.
- Ran `hogli product:lint access_control`.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is required. This changes an internal dependency boundary without changing the public API or user-facing behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored the implementation and PR description in a local session with human direction. Repo skills used: `/writing-tests`, `/writing-code-comments`, and `/writing-user-facing-copy`.

I kept the facade thin and ID-based, retained the primitive immutable return type, and limited this PR to the marketing analytics caller.

