### PR TITLE
feat(mcp-store): allow configured internal endpoints

### DIFF
--- a/ee/hogai/tools/call_mcp_server/mcp_client.py
+++ b/ee/hogai/tools/call_mcp_server/mcp_client.py
@@ -22,9 +22,10 @@ CLIENT_TIMEOUT = 60.0
 class MCPClient:
     """MCP client wrapping the official SDK with Streamable HTTP → SSE fallback."""
 
-    def __init__(self, server_url: str, headers: dict[str, str] | None = None):
+    def __init__(self, server_url: str, headers: dict[str, str] | None = None, team_id: int | None = None):
         self._server_url = server_url
         self._headers = headers
+        self._team_id = team_id
         self._stack = AsyncExitStack()
         self._session: ClientSession | None = None
 
@@ -47,7 +48,7 @@ class MCPClient:
             httpx.AsyncClient(
                 headers=self._headers,
                 timeout=CLIENT_TIMEOUT,
-                trust_env=trust_environment_proxy(self._server_url),
+                trust_env=trust_environment_proxy(self._server_url, self._team_id),
             )
         )
         read, write, _get_session_id = await self._stack.enter_async_context(

--- a/ee/hogai/tools/call_mcp_server/mcp_client.py
+++ b/ee/hogai/tools/call_mcp_server/mcp_client.py
@@ -9,6 +9,8 @@ from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamable_http_client
 from mcp.types import TextContent
 
+from products.mcp_store.backend.url_policy import trust_environment_proxy
+
 
 class MCPClientError(Exception):
     pass
@@ -42,7 +44,11 @@ class MCPClient:
 
     async def _connect_streamable_http(self) -> None:
         http_client = await self._stack.enter_async_context(
-            httpx.AsyncClient(headers=self._headers, timeout=CLIENT_TIMEOUT)
+            httpx.AsyncClient(
+                headers=self._headers,
+                timeout=CLIENT_TIMEOUT,
+                trust_env=trust_environment_proxy(self._server_url),
+            )
         )
         read, write, _get_session_id = await self._stack.enter_async_context(
             streamable_http_client(self._server_url, http_client=http_client)

--- a/ee/hogai/tools/call_mcp_server/tool.py
+++ b/ee/hogai/tools/call_mcp_server/tool.py
@@ -13,6 +13,7 @@ from posthog.security.url_validation import is_url_allowed
 from posthog.sync import database_sync_to_async
 
 from products.mcp_store.backend.oauth import is_token_expiring
+from products.mcp_store.backend.url_policy import allow_internal_mcp_url
 
 from ee.hogai.context.context import AssistantContextManager
 from ee.hogai.tool import MaxTool
@@ -297,7 +298,7 @@ class CallMCPServerTool(MaxTool):
                 f"Server URL '{server_url}' is not in the user's installed MCP servers. "
                 f"Allowed URLs: {', '.join(sorted(self._allowed_server_urls))}"
             )
-        allowed, error = is_url_allowed(server_url)
+        allowed, error = allow_internal_mcp_url(server_url, *is_url_allowed(server_url))
         if not allowed:
             raise MaxToolFatalError(f"MCP server URL blocked by security policy")
 

--- a/ee/hogai/tools/call_mcp_server/tool.py
+++ b/ee/hogai/tools/call_mcp_server/tool.py
@@ -211,7 +211,7 @@ class CallMCPServerTool(MaxTool):
 
     async def _attempt_call(self, server_url: str, tool_name: str, arguments: dict | None) -> str:
         headers = self._server_headers.get(server_url)
-        client = MCPClient(server_url, headers=headers)
+        client = MCPClient(server_url, headers=headers, team_id=self._team.id)
         try:
             # We build up and tear down the client session with every request.
             # This lets us use the same code in cloud, our backend, and when proxying via the server.
@@ -298,7 +298,7 @@ class CallMCPServerTool(MaxTool):
                 f"Server URL '{server_url}' is not in the user's installed MCP servers. "
                 f"Allowed URLs: {', '.join(sorted(self._allowed_server_urls))}"
             )
-        allowed, error = allow_internal_mcp_url(server_url, *is_url_allowed(server_url))
+        allowed, error = allow_internal_mcp_url(server_url, self._team.id, *is_url_allowed(server_url))
         if not allowed:
             raise MaxToolFatalError(f"MCP server URL blocked by security policy")
 

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1,5 +1,6 @@
 # Web app specific settings/middleware/apps setup
 import os
+import json
 from datetime import timedelta
 
 import structlog
@@ -1183,7 +1184,9 @@ AI_GATEWAY_API_KEY = get_from_env("AI_GATEWAY_API_KEY", "")
 # internal dogfooding escape hatch, not a hostname or CIDR allowlist: callers must
 # match one of these complete URLs byte-for-byte. Internal endpoints also bypass
 # the process HTTP proxy so cluster-local traffic is not sent to Smokescreen.
-MCP_STORE_INTERNAL_ALLOWED_URLS: list[str] = get_list(get_from_env("MCP_STORE_INTERNAL_ALLOWED_URLS", ""))
+MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM: dict[str, list[str]] = get_from_env(
+    "MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM", "{}", type_cast=json.loads
+)
 
 # Sharing configuration settings
 SHARING_TOKEN_GRACE_PERIOD_SECONDS = 60 * 5  # 5 minutes

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -1178,6 +1178,13 @@ AI_GATEWAY_INTERNAL_TOKEN = get_from_env("AI_GATEWAY_INTERNAL_TOKEN", "")
 AI_GATEWAY_URL = get_from_env("AI_GATEWAY_URL", "")
 AI_GATEWAY_API_KEY = get_from_env("AI_GATEWAY_API_KEY", "")
 
+# Exact MCP endpoints that operators explicitly allow the MCP Store to reach even
+# when normal SSRF validation rejects their private/internal address. This is an
+# internal dogfooding escape hatch, not a hostname or CIDR allowlist: callers must
+# match one of these complete URLs byte-for-byte. Internal endpoints also bypass
+# the process HTTP proxy so cluster-local traffic is not sent to Smokescreen.
+MCP_STORE_INTERNAL_ALLOWED_URLS: list[str] = get_list(get_from_env("MCP_STORE_INTERNAL_ALLOWED_URLS", ""))
+
 # Sharing configuration settings
 SHARING_TOKEN_GRACE_PERIOD_SECONDS = 60 * 5  # 5 minutes
 

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -45,6 +45,28 @@ Can't be added:
 - Non-HTTP transports (WebSocket-only) and legacy HTTP+SSE dual-endpoint servers — the probe and proxy speak streamable HTTP only.
 - Any URL that fails the probe (`speaks_mcp: false`) — never ship an unprobed URL.
 
+### Internal endpoint escape hatch
+
+Cloud operators can allow a small number of private Streamable HTTP endpoints
+for internal dogfooding with the comma-separated
+`MCP_STORE_INTERNAL_ALLOWED_URLS` environment variable. Each entry must be the
+complete MCP URL, for example:
+
+```text
+MCP_STORE_INTERNAL_ALLOWED_URLS=http://grafana-mcp.monitoring.svc.cluster.local/mcp
+```
+
+Matching is byte-for-byte. Configuring an endpoint does not allow another path,
+host, port, trailing-slash variant, or any other private address. Requests to an
+allowed endpoint bypass the process HTTP proxy on this MCP-only code path so
+cluster-local traffic is not sent to Smokescreen; the process-wide `NO_PROXY`
+configuration is unchanged.
+
+This setting only makes the endpoint reachable. Operators must separately
+restrict it with a NetworkPolicy and application authentication, and create the
+internal installation explicitly. Internal endpoints do not belong in
+`backend/catalog.py` and are never made visible in the public marketplace.
+
 Known gap: API keys are sent as `Authorization: Bearer <key>`, so servers that require a custom header (`X-API-Key`, ...) or exotic auth (signed JWTs, mTLS, IP allowlists) pass the probe but fail at first real install.
 A real end-to-end install (Gate B in the skill) is the only check that catches these.
 

--- a/products/mcp_store/README.md
+++ b/products/mcp_store/README.md
@@ -49,16 +49,16 @@ Can't be added:
 
 Cloud operators can allow a small number of private Streamable HTTP endpoints
 for internal dogfooding with the comma-separated
-`MCP_STORE_INTERNAL_ALLOWED_URLS` environment variable. Each entry must be the
-complete MCP URL, for example:
+`MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM` environment variable. Its value is a
+JSON object keyed by team ID; every entry must be a complete MCP URL, for example:
 
 ```text
-MCP_STORE_INTERNAL_ALLOWED_URLS=http://grafana-mcp.monitoring.svc.cluster.local/mcp
+MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM={"2":["http://grafana-mcp.monitoring.svc.cluster.local/mcp"]}
 ```
 
-Matching is byte-for-byte. Configuring an endpoint does not allow another path,
-host, port, trailing-slash variant, or any other private address. Requests to an
-allowed endpoint bypass the process HTTP proxy on this MCP-only code path so
+Matching is byte-for-byte and team-scoped. Configuring an endpoint does not
+allow another team, path, host, port, trailing-slash variant, or any other
+private address. Requests to an allowed endpoint bypass the process HTTP proxy on this MCP-only code path so
 cluster-local traffic is not sent to Smokescreen; the process-wide `NO_PROXY`
 configuration is unchanged.
 

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -56,6 +56,7 @@ from ..oauth import (
 from ..proxy import proxy_mcp_request, validate_installation_auth
 from ..tasks import sync_installation_tools_task
 from ..tools import ToolsFetchError, sync_installation_tools
+from ..url_policy import allow_internal_mcp_url
 
 
 class MCPProxyRenderer(renderers.BaseRenderer):
@@ -343,7 +344,7 @@ class InstallCustomSerializer(serializers.Serializer):
     )
 
     def validate_url(self, value: str) -> str:
-        allowed, error = is_url_allowed(value)
+        allowed, error = allow_internal_mcp_url(value, *is_url_allowed(value))
         if not allowed:
             raise serializers.ValidationError(f"URL not allowed: {error}")
         return value
@@ -567,7 +568,7 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def _validate_mcp_url_or_error_response(self, mcp_url: str) -> Response | None:
-        allowed, reason = is_url_allowed(mcp_url)
+        allowed, reason = allow_internal_mcp_url(mcp_url, *is_url_allowed(mcp_url))
         if not allowed:
             logger.warning("SSRF blocked MCP server URL", url=mcp_url, reason=reason)
             return Response({"detail": "Server URL blocked by security policy"}, status=status.HTTP_400_BAD_REQUEST)

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -344,7 +344,8 @@ class InstallCustomSerializer(serializers.Serializer):
     )
 
     def validate_url(self, value: str) -> str:
-        allowed, error = allow_internal_mcp_url(value, *is_url_allowed(value))
+        team = self.context.get("team")
+        allowed, error = allow_internal_mcp_url(value, getattr(team, "id", None), *is_url_allowed(value))
         if not allowed:
             raise serializers.ValidationError(f"URL not allowed: {error}")
         return value
@@ -568,7 +569,7 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     def _validate_mcp_url_or_error_response(self, mcp_url: str) -> Response | None:
-        allowed, reason = allow_internal_mcp_url(mcp_url, *is_url_allowed(mcp_url))
+        allowed, reason = allow_internal_mcp_url(mcp_url, self.team_id, *is_url_allowed(mcp_url))
         if not allowed:
             logger.warning("SSRF blocked MCP server URL", url=mcp_url, reason=reason)
             return Response({"detail": "Server URL blocked by security policy"}, status=status.HTTP_400_BAD_REQUEST)
@@ -966,6 +967,7 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
 
     @validated_request(
         InstallCustomSerializer,
+        include_serializer_context=True,
         responses={
             200: OpenApiResponse(response=OAuthRedirectResponseSerializer),
             201: OpenApiResponse(response=MCPServerInstallationSerializer),

--- a/products/mcp_store/backend/proxy.py
+++ b/products/mcp_store/backend/proxy.py
@@ -17,6 +17,7 @@ from ee.hogai.utils.asgi import SyncIterableToAsync
 
 from .models import MCPServerInstallation, MCPServerInstallationTool
 from .oauth import TokenRefreshError, is_token_expiring, refresh_installation_token
+from .url_policy import allow_internal_mcp_url, trust_environment_proxy
 
 logger = structlog.get_logger(__name__)
 
@@ -319,7 +320,7 @@ def enforce_tool_approval(
 
 
 def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> HttpResponseBase:
-    allowed, error = is_url_allowed(installation.url)
+    allowed, error = allow_internal_mcp_url(installation.url, *is_url_allowed(installation.url))
     if not allowed:
         logger.warning("SSRF: blocked proxy request", url=installation.url, reason=error)
         return HttpResponse(
@@ -372,7 +373,7 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
     if mcp_session_id:
         headers["Mcp-Session-Id"] = mcp_session_id
 
-    client = httpx.Client(timeout=UPSTREAM_TIMEOUT)
+    client = httpx.Client(timeout=UPSTREAM_TIMEOUT, trust_env=trust_environment_proxy(installation.url))
     try:
         upstream_response, upstream_url = send_mcp_request_with_same_origin_redirect(
             client,

--- a/products/mcp_store/backend/proxy.py
+++ b/products/mcp_store/backend/proxy.py
@@ -320,7 +320,7 @@ def enforce_tool_approval(
 
 
 def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> HttpResponseBase:
-    allowed, error = allow_internal_mcp_url(installation.url, *is_url_allowed(installation.url))
+    allowed, error = allow_internal_mcp_url(installation.url, installation.team_id, *is_url_allowed(installation.url))
     if not allowed:
         logger.warning("SSRF: blocked proxy request", url=installation.url, reason=error)
         return HttpResponse(
@@ -373,7 +373,10 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
     if mcp_session_id:
         headers["Mcp-Session-Id"] = mcp_session_id
 
-    client = httpx.Client(timeout=UPSTREAM_TIMEOUT, trust_env=trust_environment_proxy(installation.url))
+    client = httpx.Client(
+        timeout=UPSTREAM_TIMEOUT,
+        trust_env=trust_environment_proxy(installation.url, installation.team_id),
+    )
     try:
         upstream_response, upstream_url = send_mcp_request_with_same_origin_redirect(
             client,

--- a/products/mcp_store/backend/test/test_url_policy.py
+++ b/products/mcp_store/backend/test/test_url_policy.py
@@ -1,0 +1,32 @@
+from django.test import override_settings
+
+from products.mcp_store.backend.url_policy import allow_internal_mcp_url, is_internal_mcp_url, trust_environment_proxy
+
+
+@override_settings(MCP_STORE_INTERNAL_ALLOWED_URLS=["http://grafana-mcp.monitoring.svc.cluster.local/mcp"])
+def test_internal_mcp_url_requires_an_exact_match() -> None:
+    configured = "http://grafana-mcp.monitoring.svc.cluster.local/mcp"
+
+    assert is_internal_mcp_url(configured)
+    assert not is_internal_mcp_url(f"{configured}/")
+    assert not is_internal_mcp_url("http://grafana-mcp.monitoring.svc.cluster.local/other")
+    assert not is_internal_mcp_url("http://other.monitoring.svc.cluster.local/mcp")
+
+
+@override_settings(MCP_STORE_INTERNAL_ALLOWED_URLS=["http://grafana-mcp.monitoring.svc.cluster.local/mcp"])
+def test_internal_mcp_url_can_override_a_failed_public_ssrf_check() -> None:
+    configured = "http://grafana-mcp.monitoring.svc.cluster.local/mcp"
+
+    assert allow_internal_mcp_url(configured, False, "Internal domain") == (True, None)
+    assert allow_internal_mcp_url("http://other.svc.cluster.local/mcp", False, "Internal domain") == (
+        False,
+        "Internal domain",
+    )
+
+
+@override_settings(MCP_STORE_INTERNAL_ALLOWED_URLS=["http://grafana-mcp.monitoring.svc.cluster.local/mcp"])
+def test_internal_mcp_url_bypasses_environment_proxy_only_for_exact_match() -> None:
+    configured = "http://grafana-mcp.monitoring.svc.cluster.local/mcp"
+
+    assert not trust_environment_proxy(configured)
+    assert trust_environment_proxy("https://mcp.example.com/mcp")

--- a/products/mcp_store/backend/test/test_url_policy.py
+++ b/products/mcp_store/backend/test/test_url_policy.py
@@ -3,30 +3,40 @@ from django.test import override_settings
 from products.mcp_store.backend.url_policy import allow_internal_mcp_url, is_internal_mcp_url, trust_environment_proxy
 
 
-@override_settings(MCP_STORE_INTERNAL_ALLOWED_URLS=["http://grafana-mcp.monitoring.svc.cluster.local/mcp"])
+@override_settings(
+    MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM={"42": ["http://grafana-mcp.monitoring.svc.cluster.local/mcp"]}
+)
 def test_internal_mcp_url_requires_an_exact_match() -> None:
     configured = "http://grafana-mcp.monitoring.svc.cluster.local/mcp"
 
-    assert is_internal_mcp_url(configured)
-    assert not is_internal_mcp_url(f"{configured}/")
-    assert not is_internal_mcp_url("http://grafana-mcp.monitoring.svc.cluster.local/other")
-    assert not is_internal_mcp_url("http://other.monitoring.svc.cluster.local/mcp")
+    assert is_internal_mcp_url(configured, 42)
+    assert not is_internal_mcp_url(configured, 43)
+    assert not is_internal_mcp_url(configured, None)
+    assert not is_internal_mcp_url(f"{configured}/", 42)
+    assert not is_internal_mcp_url("http://grafana-mcp.monitoring.svc.cluster.local/other", 42)
+    assert not is_internal_mcp_url("http://other.monitoring.svc.cluster.local/mcp", 42)
 
 
-@override_settings(MCP_STORE_INTERNAL_ALLOWED_URLS=["http://grafana-mcp.monitoring.svc.cluster.local/mcp"])
+@override_settings(
+    MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM={"42": ["http://grafana-mcp.monitoring.svc.cluster.local/mcp"]}
+)
 def test_internal_mcp_url_can_override_a_failed_public_ssrf_check() -> None:
     configured = "http://grafana-mcp.monitoring.svc.cluster.local/mcp"
 
-    assert allow_internal_mcp_url(configured, False, "Internal domain") == (True, None)
-    assert allow_internal_mcp_url("http://other.svc.cluster.local/mcp", False, "Internal domain") == (
+    assert allow_internal_mcp_url(configured, 42, False, "Internal domain") == (True, None)
+    assert allow_internal_mcp_url(configured, 43, False, "Internal domain") == (False, "Internal domain")
+    assert allow_internal_mcp_url("http://other.svc.cluster.local/mcp", 42, False, "Internal domain") == (
         False,
         "Internal domain",
     )
 
 
-@override_settings(MCP_STORE_INTERNAL_ALLOWED_URLS=["http://grafana-mcp.monitoring.svc.cluster.local/mcp"])
+@override_settings(
+    MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM={"42": ["http://grafana-mcp.monitoring.svc.cluster.local/mcp"]}
+)
 def test_internal_mcp_url_bypasses_environment_proxy_only_for_exact_match() -> None:
     configured = "http://grafana-mcp.monitoring.svc.cluster.local/mcp"
 
-    assert not trust_environment_proxy(configured)
-    assert trust_environment_proxy("https://mcp.example.com/mcp")
+    assert not trust_environment_proxy(configured, 42)
+    assert trust_environment_proxy(configured, 43)
+    assert trust_environment_proxy("https://mcp.example.com/mcp", 42)

--- a/products/mcp_store/backend/tools.py
+++ b/products/mcp_store/backend/tools.py
@@ -66,7 +66,7 @@ def fetch_upstream_tools(installation: MCPServerInstallation) -> list[dict[str, 
     Shares the proxy's SSRF guard + timeout + auth-header builder so behavior stays
     consistent between proxy traffic and sync traffic.
     """
-    allowed, reason = allow_internal_mcp_url(installation.url, *is_url_allowed(installation.url))
+    allowed, reason = allow_internal_mcp_url(installation.url, installation.team_id, *is_url_allowed(installation.url))
     if not allowed:
         raise ToolsFetchError(f"URL not allowed: {reason}")
 
@@ -80,7 +80,10 @@ def fetch_upstream_tools(installation: MCPServerInstallation) -> list[dict[str, 
     }
 
     try:
-        with httpx.Client(timeout=HANDSHAKE_TIMEOUT, trust_env=trust_environment_proxy(installation.url)) as client:
+        with httpx.Client(
+            timeout=HANDSHAKE_TIMEOUT,
+            trust_env=trust_environment_proxy(installation.url, installation.team_id),
+        ) as client:
             session_id, upstream_url = _mcp_initialize(client, installation.url, base_headers)
             session_headers = dict(base_headers)
             if session_id:

--- a/products/mcp_store/backend/tools.py
+++ b/products/mcp_store/backend/tools.py
@@ -18,6 +18,7 @@ from posthog.security.url_validation import is_url_allowed
 from .models import MCPServerInstallation, MCPServerInstallationTool
 from .oauth import TokenRefreshError, is_token_expiring, refresh_installation_token
 from .proxy import build_upstream_auth_headers, validated_same_origin_redirect_url
+from .url_policy import allow_internal_mcp_url, trust_environment_proxy
 
 logger = structlog.get_logger(__name__)
 
@@ -65,7 +66,7 @@ def fetch_upstream_tools(installation: MCPServerInstallation) -> list[dict[str, 
     Shares the proxy's SSRF guard + timeout + auth-header builder so behavior stays
     consistent between proxy traffic and sync traffic.
     """
-    allowed, reason = is_url_allowed(installation.url)
+    allowed, reason = allow_internal_mcp_url(installation.url, *is_url_allowed(installation.url))
     if not allowed:
         raise ToolsFetchError(f"URL not allowed: {reason}")
 
@@ -79,7 +80,7 @@ def fetch_upstream_tools(installation: MCPServerInstallation) -> list[dict[str, 
     }
 
     try:
-        with httpx.Client(timeout=HANDSHAKE_TIMEOUT) as client:
+        with httpx.Client(timeout=HANDSHAKE_TIMEOUT, trust_env=trust_environment_proxy(installation.url)) as client:
             session_id, upstream_url = _mcp_initialize(client, installation.url, base_headers)
             session_headers = dict(base_headers)
             if session_id:

--- a/products/mcp_store/backend/url_policy.py
+++ b/products/mcp_store/backend/url_policy.py
@@ -1,0 +1,25 @@
+"""Narrow operator-controlled URL policy for internal MCP dogfooding.
+
+Normal MCP Store URLs must pass PostHog's shared SSRF validation. Cloud operators
+may additionally configure complete internal endpoint URLs through
+``MCP_STORE_INTERNAL_ALLOWED_URLS``. Matching is deliberately exact: this is not
+a domain, suffix, origin, or CIDR allowlist and cannot authorize sibling paths.
+"""
+
+from django.conf import settings
+
+
+def is_internal_mcp_url(url: str) -> bool:
+    return url in settings.MCP_STORE_INTERNAL_ALLOWED_URLS
+
+
+def allow_internal_mcp_url(url: str, allowed: bool, reason: str | None) -> tuple[bool, str | None]:
+    if not allowed and is_internal_mcp_url(url):
+        return True, None
+    return allowed, reason
+
+
+def trust_environment_proxy(url: str) -> bool:
+    """Internal Services must be reached directly instead of via HTTP_PROXY."""
+
+    return not is_internal_mcp_url(url)

--- a/products/mcp_store/backend/url_policy.py
+++ b/products/mcp_store/backend/url_policy.py
@@ -1,25 +1,29 @@
 """Narrow operator-controlled URL policy for internal MCP dogfooding.
 
 Normal MCP Store URLs must pass PostHog's shared SSRF validation. Cloud operators
-may additionally configure complete internal endpoint URLs through
-``MCP_STORE_INTERNAL_ALLOWED_URLS``. Matching is deliberately exact: this is not
-a domain, suffix, origin, or CIDR allowlist and cannot authorize sibling paths.
+may additionally configure complete internal endpoint URLs per team through
+``MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM``. Matching is deliberately exact:
+this is not a domain, suffix, origin, or CIDR allowlist and cannot authorize
+sibling paths or grant another team access.
 """
 
 from django.conf import settings
 
 
-def is_internal_mcp_url(url: str) -> bool:
-    return url in settings.MCP_STORE_INTERNAL_ALLOWED_URLS
+def is_internal_mcp_url(url: str, team_id: int | None) -> bool:
+    if team_id is None:
+        return False
+    urls = settings.MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM.get(str(team_id), [])
+    return isinstance(urls, list) and url in urls
 
 
-def allow_internal_mcp_url(url: str, allowed: bool, reason: str | None) -> tuple[bool, str | None]:
-    if not allowed and is_internal_mcp_url(url):
+def allow_internal_mcp_url(url: str, team_id: int | None, allowed: bool, reason: str | None) -> tuple[bool, str | None]:
+    if not allowed and is_internal_mcp_url(url, team_id):
         return True, None
     return allowed, reason
 
 
-def trust_environment_proxy(url: str) -> bool:
+def trust_environment_proxy(url: str, team_id: int | None) -> bool:
     """Internal Services must be reached directly instead of via HTTP_PROXY."""
 
-    return not is_internal_mcp_url(url)
+    return not is_internal_mcp_url(url, team_id)

--- a/tach.toml
+++ b/tach.toml
@@ -867,6 +867,8 @@ expose = [
     "backend\\.admin.*",
     "backend\\.models.*",
     "backend\\.oauth.*",
+    "backend\\.url_policy\\.allow_internal_mcp_url",
+    "backend\\.url_policy\\.trust_environment_proxy",
 ]
 from = [
     "products.mcp_store",


### PR DESCRIPTION
## Problem

The MCP Store rejects private endpoints, preventing operators from connecting a specifically authorized team to a trusted in-cluster MCP service even when Kubernetes networking restricts its reachability.

## Changes

- Add `MCP_STORE_INTERNAL_ALLOWED_URLS_BY_TEAM`, mapping team IDs to exact internal MCP URLs.
- Require both the requesting team and the complete URL to match before allowing a private endpoint.
- Bypass environment HTTP proxies only for the matched team/URL pair across validation, tool refresh, the Django proxy, and Max’s direct MCP client.
- Preserve the existing SSRF policy for every other team and URL.
- Document configuration and required network controls. Example: `{"2":["http://sherlockhog-mcp.sherlockhog-mcp.svc.cluster.local/mcp"]}`.

**Why:** This enables controlled internal MCP access without making knowledge of an internal URL sufficient authorization or weakening the public custom-server boundary.

## How did you test this code?

- Ruff lint and formatting checks passed for all changed Python files.
- Focused URL/team policy tests passed: 3 tests.
- The wider MCP suites could not start because PostgreSQL was unavailable in this checkout; they stopped during database setup before running test bodies.

The focused tests cover exact team and URL matching, rejection for the wrong or missing team, rejection of sibling paths and hosts, scoped SSRF override, and proxy bypass only for authorized pairs.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The MCP Store README documents the team-scoped environment variable, exact-match semantics, proxy behavior, and required network controls.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex inspected the MCP Store proxy paths and deployment proxy policy, then implemented a team-scoped exact-URL operator escape hatch. Complete team and URL equality were chosen so unrelated teams, sibling paths, hosts, and private services remain unreachable.


## Related PRs

- [PostHog/SherlockHog PR 157](https://github.com/PostHog/SherlockHog/pull/157) — provides the authenticated MCP-only HTTP service.
- [PostHog/charts PR 13761](https://github.com/PostHog/charts/pull/13761) — deploys the private service and network policy.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

