### PR TITLE
fix(conversations): wrap long lines in the compose ticket editor

### DIFF
--- a/products/conversations/frontend/components/ComposeTicket/ComposeTicketModal.tsx
+++ b/products/conversations/frontend/components/ComposeTicket/ComposeTicketModal.tsx
@@ -57,7 +57,7 @@ export function ComposeTicketModal(): JSX.Element | null {
                 </>
             }
         >
-            <div className="flex flex-col gap-3 min-w-[500px]">
+            <div className="flex flex-col gap-3 w-[500px] max-w-full">
                 <div className="flex flex-col gap-1">
                     <label className="font-semibold text-xs">From</label>
                     <LemonSelect

--- a/products/conversations/frontend/components/Editor/SupportEditor.scss
+++ b/products/conversations/frontend/components/Editor/SupportEditor.scss
@@ -54,6 +54,10 @@
     .SupportEditor__content {
         display: flex;
         flex-direction: column;
+
+        // Break long unbreakable strings (URLs, tokens) so typing one can't grow the
+        // editor (and its modal) wider — matches .SupportRichContentPreview below.
+        overflow-wrap: anywhere;
         background-color: var(--color-bg-fill-input);
         border-top-left-radius: var(--radius);
         border-top-right-radius: var(--radius);

--- a/products/conversations/frontend/components/Editor/SupportEditor.scss
+++ b/products/conversations/frontend/components/Editor/SupportEditor.scss
@@ -54,9 +54,6 @@
     .SupportEditor__content {
         display: flex;
         flex-direction: column;
-
-        // Break long unbreakable strings (URLs, tokens) so typing one can't grow the
-        // editor (and its modal) wider — matches .SupportRichContentPreview below.
         overflow-wrap: anywhere;
         background-color: var(--color-bg-fill-input);
         border-top-left-radius: var(--radius);


### PR DESCRIPTION
## Problem

In the "New outbound ticket" compose modal (`ComposeTicketModal`), typing into the message editor grew the modal wider and wider until it hit its max width, instead of the text wrapping. This happens with **ordinary spaced text**, not just long unbreakable strings. Reported from a Slack thread.

Two things combined to cause it:

1. `LemonModal` is `width: fit-content` (capped at `max-width: 90%`), so it sizes to its content.
2. The compose wrapper used `min-w-[500px]` — a floor with no ceiling. With no bounded width, the message paragraph laid out at its max-content width (one long line), so the modal ballooned toward 90% of the viewport as you typed.

`overflow-wrap` alone wouldn't fix this, since spaced text can already break — the paragraph just had unlimited room to grow into.

## Changes

- **`ComposeTicketModal.tsx`** — give the content wrapper a definite width, `w-[500px] max-w-full`, instead of the floor-only `min-w-[500px]`. Now the modal stays ~500px and text wraps. `max-w-full` keeps it from overflowing narrow viewports.
- **`SupportEditor.scss`** — add `overflow-wrap: anywhere` to the editable `.SupportEditor__content`, so a long unbreakable token (like a URL) also breaks instead of overflowing the now-bounded box. This mirrors the rule already present on the read-only `.SupportRichContentPreview`.

## How did you test this code?

This is a layout/CSS change. I (the PostHog Slack app agent) could not run the full app here, so I did **not** do manual testing in the live product and added no automated tests.

To validate the fix without the app, I built a standalone HTML reproduction using the **real** rules from `LemonModal.scss` and `SupportEditor.scss` and the exact wrapper classes, and rendered it with headless Chromium. Measured modal widths at a 1280px viewport:

| State | Modal width |
| --- | --- |
| Empty | 534px |
| Long text — before fix | 1152px (= 90% cap, ballooned) |
| Long text — after fix | 534px (wraps) |

> [!NOTE]
> The screenshots below are from that **CSS reproduction**, not the live app — the width/wrapping behaviour is driven by the production CSS rules, but the theme (input chrome, colours) is approximated. Worth a quick manual confirm in the real modal before merge.

**Empty modal**

![Empty compose modal](https://raw.githubusercontent.com/PostHog/pr-assets/main/conversations-compose-modal/pr75904-empty.png)

**Long message — before (modal balloons to the 90% cap)**

![Before fix — modal expands horizontally](https://raw.githubusercontent.com/PostHog/pr-assets/main/conversations-compose-modal/pr75904-before-longtext.png)

**Long message — after (stays ~500px, wraps, long URL breaks)**

![After fix — modal stays bounded and wraps](https://raw.githubusercontent.com/PostHog/pr-assets/main/conversations-compose-modal/pr75904-after-longtext.png)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and fixed by the PostHog Slack app agent from a Slack thread. The reporter noticed the compose modal expanding horizontally as they typed. I first tried `overflow-wrap` on the editor, but the reporter pointed out spaced text also expands it — which pointed at the real cause: `fit-content` modal + a floor-only wrapper width. I traced widths through `LemonModal.scss`, bounded the wrapper, and kept `overflow-wrap` for unbreakable tokens. I verified both halves with a headless-Chromium reproduction built from the production CSS (numbers and screenshots above). No repo skills were invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1785490121337869?thread_ts=1785490121.337869&cid=C08S2L0S5MZ)*
