### PR TITLE
feat: expand my open tickets with posthog

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
@@ -341,6 +341,9 @@ export function SidePanelSupport(): JSX.Element {
                             to={urls.myTickets()}
                             onClick={() => closeSidePanel()}
                             tooltip="View your tickets full screen"
+                            // LemonButton's tooltip→aria-label fallback only applies to plain buttons,
+                            // not links (`to` renders a Link), so an icon-only link needs it explicitly
+                            aria-label="View your tickets full screen"
                             data-attr="support-panel-expand-tickets"
                         />
                     )}

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/support/SidePanelSupport.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import React from 'react'
 
-import { IconFeatures, IconHelmet, IconMap, IconWarning } from '@posthog/icons'
+import { IconExpand45, IconFeatures, IconHelmet, IconMap, IconWarning } from '@posthog/icons'
 import { LemonButton, Link } from '@posthog/lemon-ui'
 
 import { incidentStatusLogic } from 'lib/components/HelpMenu/incidentStatusLogic'
@@ -307,7 +307,7 @@ export function SidePanelSupport(): JSX.Element {
         isSendSupportRequestSubmitting,
     } = useValues(supportLogic)
     const { closeEmailForm, openEmailForm, closeSupportForm, resetSendSupportRequest } = useActions(supportLogic)
-    const { openSidePanel } = useActions(sidePanelStateLogic)
+    const { openSidePanel, closeSidePanel } = useActions(sidePanelStateLogic)
     const { billing, billingLoading, billingPlan } = useValues(billingLogic)
     const { tickets, canCreateTicket } = useValues(sidepanelTicketsLogic)
 
@@ -333,7 +333,18 @@ export function SidePanelSupport(): JSX.Element {
     return (
         <div className="SidePanelSupport contents">
             <SidePanelContentContainer>
-                <SidePanelPaneHeader showCloseButton={false} title={isEmailFormOpen ? supportPanelTitle : 'Support'} />
+                <SidePanelPaneHeader showCloseButton={false} title={isEmailFormOpen ? supportPanelTitle : 'Support'}>
+                    {showTickets && (
+                        <LemonButton
+                            size="xsmall"
+                            icon={<IconExpand45 />}
+                            to={urls.myTickets()}
+                            onClick={() => closeSidePanel()}
+                            tooltip="View your tickets full screen"
+                            data-attr="support-panel-expand-tickets"
+                        />
+                    )}
+                </SidePanelPaneHeader>
                 <div className="p-0 justify-start flex-none px-1 max-w-160 w-full mx-auto flex flex-col">
                     {isEmailFormOpen && showEmailSupport && isBillingLoaded && !useProductSupportSidePanel ? (
                         <SupportFormBlock

--- a/frontend/src/productScenes.tsx
+++ b/frontend/src/productScenes.tsx
@@ -44,6 +44,7 @@ export const productScenes: Record<string, () => Promise<any>> = {
     SupportTickets: () => import('../../products/conversations/frontend/scenes/tickets/SupportTicketsScene'),
     SupportTicketDetail: () => import('../../products/conversations/frontend/scenes/ticket/SupportTicketScene'),
     SupportSettings: () => import('../../products/conversations/frontend/scenes/settings/SupportSettingsScene'),
+    MyTickets: () => import('../../products/conversations/frontend/scenes/myTickets/MyTicketsScene'),
     CustomerAnalytics: () => import('../../products/customer_analytics/frontend/CustomerAnalyticsScene'),
     CustomerAnalyticsConfiguration: () =>
         import('../../products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/CustomerAnalyticsConfigurationScene'),

--- a/frontend/src/products.tsx
+++ b/frontend/src/products.tsx
@@ -96,6 +96,7 @@ export const productRoutes: Record<string, [string, string]> = {
     '/support/tickets': ['SupportTickets', 'supportTickets'],
     '/support/tickets/:ticketId': ['SupportTicketDetail', 'supportTicketDetail'],
     '/support/settings': ['SupportSettings', 'supportSettings'],
+    '/my-tickets': ['MyTickets', 'myTickets'],
     '/customer_analytics/dashboard': ['CustomerAnalytics', 'customerAnalyticsDashboard'],
     '/customer_analytics/accounts': ['CustomerAnalytics', 'customerAnalyticsAccounts'],
     '/customer_analytics/accounts/:accountId': ['CustomerAnalytics', 'customerAnalyticsAccounts'],
@@ -526,6 +527,7 @@ export const productConfiguration: Record<string, any> = {
     SupportTickets: { name: 'Ticket list', projectBased: true, layout: 'app-container' },
     SupportTicketDetail: { name: 'Ticket detail', projectBased: true, layout: 'app-container' },
     SupportSettings: { name: 'Support settings', projectBased: true, layout: 'app-container' },
+    MyTickets: { name: 'Your tickets', projectBased: true, layout: 'app-container' },
     CustomerAnalytics: {
         projectBased: true,
         name: 'Customer analytics',
@@ -969,6 +971,7 @@ export const productUrls = {
     supportTickets: (): string => '/support/tickets',
     supportTicketDetail: (ticketId: string | number): string => `/support/tickets/${ticketId}`,
     supportSettings: (): string => '/support/settings',
+    myTickets: (): string => '/my-tickets',
     customerAnalytics: (): string => '/customer_analytics',
     customerAnalyticsDashboard: (): string => '/customer_analytics/dashboard',
     customerAnalyticsAccounts: (): string => '/customer_analytics/accounts',
@@ -2261,7 +2264,7 @@ export const getTreeItemsProducts = (): FileSystemImport[] => [
         iconType: 'conversations',
         iconColor: ['var(--color-product-support-light)'] as FileSystemIconColor,
         sceneKey: 'SupportTickets',
-        sceneKeys: ['SupportTickets', 'SupportTicketDetail', 'SupportSettings'],
+        sceneKeys: ['SupportTickets', 'SupportTicketDetail', 'SupportSettings', 'MyTickets'],
     },
     {
         path: 'Surveys',

--- a/products/conversations/frontend/components/SidePanel/Ticket.tsx
+++ b/products/conversations/frontend/components/SidePanel/Ticket.tsx
@@ -7,14 +7,27 @@ import { MessageInput } from '../Chat/MessageInput'
 import { MessageList } from '../Chat/MessageList'
 import { sidepanelTicketsLogic } from './sidepanelTicketsLogic'
 
-export function Ticket(): JSX.Element {
+interface TicketProps {
+    /** Hidden in master-detail layouts where the list stays visible alongside the thread */
+    showBackButton?: boolean
+    messagesMinHeight?: string
+    messagesMaxHeight?: string
+}
+
+export function Ticket({
+    showBackButton = true,
+    messagesMinHeight = '300px',
+    messagesMaxHeight = '400px',
+}: TicketProps): JSX.Element {
     const { messages, messagesLoading, messageSending, currentTicket } = useValues(sidepanelTicketsLogic)
     const { sendMessage, setView } = useActions(sidepanelTicketsLogic)
 
     return (
         <div className="flex flex-col h-full bg-surface-primary border rounded-lg p-2">
             <div className="flex items-center gap-2">
-                <LemonButton icon={<IconArrowLeft />} size="small" onClick={() => setView('list')} />
+                {showBackButton && (
+                    <LemonButton icon={<IconArrowLeft />} size="small" onClick={() => setView('list')} />
+                )}
                 {currentTicket?.ticket_number && (
                     <span className="text-xs font-mono text-muted-alt">#{currentTicket.ticket_number}</span>
                 )}
@@ -36,8 +49,8 @@ export function Ticket(): JSX.Element {
                 messages={messages}
                 messagesLoading={messagesLoading}
                 emptyMessage="No messages yet."
-                minHeight="300px"
-                maxHeight="400px"
+                minHeight={messagesMinHeight}
+                maxHeight={messagesMaxHeight}
                 className="mb-3"
                 isCustomerView
             />

--- a/products/conversations/frontend/components/SidePanel/Ticket.tsx
+++ b/products/conversations/frontend/components/SidePanel/Ticket.tsx
@@ -10,12 +10,15 @@ import { sidepanelTicketsLogic } from './sidepanelTicketsLogic'
 interface TicketProps {
     /** Hidden in master-detail layouts where the list stays visible alongside the thread */
     showBackButton?: boolean
+    /** Lets master-detail layouts show the back button only at widths where the panes stack */
+    backButtonClassName?: string
     messagesMinHeight?: string
     messagesMaxHeight?: string
 }
 
 export function Ticket({
     showBackButton = true,
+    backButtonClassName,
     messagesMinHeight = '300px',
     messagesMaxHeight = '400px',
 }: TicketProps): JSX.Element {
@@ -26,7 +29,12 @@ export function Ticket({
         <div className="flex flex-col h-full bg-surface-primary border rounded-lg p-2">
             <div className="flex items-center gap-2">
                 {showBackButton && (
-                    <LemonButton icon={<IconArrowLeft />} size="small" onClick={() => setView('list')} />
+                    <LemonButton
+                        icon={<IconArrowLeft />}
+                        size="small"
+                        className={backButtonClassName}
+                        onClick={() => setView('list')}
+                    />
                 )}
                 {currentTicket?.ticket_number && (
                     <span className="text-xs font-mono text-muted-alt">#{currentTicket.ticket_number}</span>

--- a/products/conversations/frontend/components/SidePanel/TicketsList.tsx
+++ b/products/conversations/frontend/components/SidePanel/TicketsList.tsx
@@ -11,7 +11,12 @@ import { stripMarkdown } from 'lib/utils/markdown'
 import type { ConversationTicket } from '../../types'
 import { sidepanelTicketsLogic } from './sidepanelTicketsLogic'
 
-export function TicketsList(): JSX.Element {
+interface TicketsListProps {
+    /** Highlights the matching row in master-detail layouts where the list stays visible */
+    selectedTicketId?: string | null
+}
+
+export function TicketsList({ selectedTicketId = null }: TicketsListProps): JSX.Element {
     const { tickets, ticketsLoading, canCreateTicket } = useValues(sidepanelTicketsLogic)
     const { setCurrentTicket, setView } = useActions(sidepanelTicketsLogic)
 
@@ -72,7 +77,7 @@ export function TicketsList(): JSX.Element {
                             key={ticket.id}
                             className={`flex items-center justify-between p-3 rounded border cursor-pointer hover:bg-surface-light transition-colors ${
                                 (ticket.unread_count ?? 0) > 0 ? 'bg-primary-alt-highlight' : 'bg-surface-primary'
-                            }`}
+                            } ${ticket.id === selectedTicketId ? 'border-accent' : ''}`}
                             onClick={() => {
                                 setCurrentTicket(ticket)
                             }}

--- a/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
+++ b/products/conversations/frontend/components/SidePanel/sidepanelTicketsLogic.ts
@@ -718,8 +718,10 @@ export const sidepanelTicketsLogic = kea<sidepanelTicketsLogicType>([
                 actions.openPendingTicket()
             }
         },
-        sidePanelOpen: () => {
-            if (values.isEnabled) {
+        sidePanelOpen: (open: boolean) => {
+            // Only on open — a close-triggered fetch is wasted (nothing renders the result), and the
+            // full-screen tickets scene closes the panel as it opens, which would double-fetch
+            if (open && values.isEnabled) {
                 actions.loadTickets()
             }
         },

--- a/products/conversations/frontend/scenes/myTickets/MyTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/myTickets/MyTicketsScene.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 
-import { Link } from '@posthog/lemon-ui'
+import { Link, Spinner } from '@posthog/lemon-ui'
 
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -24,7 +24,8 @@ const PANE_MIN_HEIGHT = 'min(400px, calc(100svh - 16rem))'
 const PANE_MAX_HEIGHT = 'calc(100svh - 16rem)'
 
 export function MyTicketsScene(): JSX.Element {
-    const { view, currentTicket, newTicketDraftRevision, isEnabled } = useValues(sidepanelTicketsLogic)
+    const { view, currentTicket, newTicketDraftRevision, isEnabled, isBillingResolved } =
+        useValues(sidepanelTicketsLogic)
     const { preflight } = useValues(preflightLogic)
 
     const hasIdentityMode = !!window.JS_POSTHOG_IDENTITY_DISTINCT_ID
@@ -49,6 +50,24 @@ export function MyTicketsScene(): JSX.Element {
         )
     }
 
+    // canCreateTicket (which gates the create button and empty-state copy inside TicketsList) reads
+    // as false until billing loads, so rendering earlier would flash the wrong eligibility state —
+    // the side panel guards on the same condition
+    if (!isBillingResolved) {
+        return (
+            <SceneContent>
+                <SceneTitleSection
+                    name="Your tickets"
+                    description="Support conversations with the PostHog team"
+                    resourceType={{ type: 'conversation' }}
+                />
+                <div className="flex items-center justify-center h-40">
+                    <Spinner />
+                </div>
+            </SceneContent>
+        )
+    }
+
     let pane: JSX.Element
     if (view === 'new') {
         // Key on the draft revision so a prefill injected while the composer is already open
@@ -57,7 +76,13 @@ export function MyTicketsScene(): JSX.Element {
     } else if (view === 'restore' && !hasIdentityMode) {
         pane = <RestoreTickets />
     } else if (view === 'ticket' && currentTicket) {
-        pane = <Ticket showBackButton={false} messagesMinHeight={PANE_MIN_HEIGHT} messagesMaxHeight={PANE_MAX_HEIGHT} />
+        pane = (
+            <Ticket
+                backButtonClassName="lg:hidden"
+                messagesMinHeight={PANE_MIN_HEIGHT}
+                messagesMaxHeight={PANE_MAX_HEIGHT}
+            />
+        )
     } else {
         pane = (
             <div className="flex items-center justify-center border border-dashed rounded-lg text-muted-alt min-h-[min(400px,calc(100svh-16rem))]">
@@ -73,11 +98,11 @@ export function MyTicketsScene(): JSX.Element {
                 description="Support conversations with the PostHog team"
                 resourceType={{ type: 'conversation' }}
             />
-            <div className="flex items-start gap-4">
-                <div className="w-96 shrink-0 overflow-y-auto max-h-[calc(100svh-16rem)]">
-                    <TicketsList />
+            <div className="flex flex-col lg:flex-row items-start gap-4">
+                <div className="w-full lg:w-96 shrink-0 overflow-y-auto max-h-[calc(100svh-16rem)]">
+                    <TicketsList selectedTicketId={view === 'ticket' ? (currentTicket?.id ?? null) : null} />
                 </div>
-                <div className="flex-1 min-w-0">{pane}</div>
+                <div className="flex-1 min-w-0 w-full">{pane}</div>
             </div>
         </SceneContent>
     )

--- a/products/conversations/frontend/scenes/myTickets/MyTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/myTickets/MyTicketsScene.tsx
@@ -1,0 +1,84 @@
+import { useValues } from 'kea'
+
+import { Link } from '@posthog/lemon-ui'
+
+import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
+import { SceneExport } from 'scenes/sceneTypes'
+
+import { SceneContent } from '~/layout/scenes/components/SceneContent'
+import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
+
+import { NewTicket } from '../../components/SidePanel/NewTicket'
+import { RestoreTickets } from '../../components/SidePanel/RestoreTickets'
+import { sidepanelTicketsLogic } from '../../components/SidePanel/sidepanelTicketsLogic'
+import { Ticket } from '../../components/SidePanel/Ticket'
+import { TicketsList } from '../../components/SidePanel/TicketsList'
+
+export const scene: SceneExport = {
+    component: MyTicketsScene,
+    logic: sidepanelTicketsLogic,
+}
+
+// Sized against the viewport so the thread fills the page without the scene itself scrolling
+const PANE_MIN_HEIGHT = 'min(400px, calc(100svh - 16rem))'
+const PANE_MAX_HEIGHT = 'calc(100svh - 16rem)'
+
+export function MyTicketsScene(): JSX.Element {
+    const { view, currentTicket, newTicketDraftRevision, isEnabled } = useValues(sidepanelTicketsLogic)
+    const { preflight } = useValues(preflightLogic)
+
+    const hasIdentityMode = !!window.JS_POSTHOG_IDENTITY_DISTINCT_ID
+    const isCloudOrDev = preflight?.cloud || process.env.NODE_ENV === 'development'
+
+    if (!isEnabled || !isCloudOrDev) {
+        return (
+            <SceneContent>
+                <SceneTitleSection
+                    name="Your tickets"
+                    description="Support conversations with the PostHog team"
+                    resourceType={{ type: 'conversation' }}
+                />
+                <p className="text-muted-alt">
+                    Support tickets aren't available on this instance. You can ask the{' '}
+                    <Link to="https://posthog.com/questions" target="_blank">
+                        community forum
+                    </Link>{' '}
+                    instead.
+                </p>
+            </SceneContent>
+        )
+    }
+
+    let pane: JSX.Element
+    if (view === 'new') {
+        // Key on the draft revision so a prefill injected while the composer is already open
+        // remounts the editor (it only reads initial content at creation)
+        pane = <NewTicket key={newTicketDraftRevision} />
+    } else if (view === 'restore' && !hasIdentityMode) {
+        pane = <RestoreTickets />
+    } else if (view === 'ticket' && currentTicket) {
+        pane = <Ticket showBackButton={false} messagesMinHeight={PANE_MIN_HEIGHT} messagesMaxHeight={PANE_MAX_HEIGHT} />
+    } else {
+        pane = (
+            <div className="flex items-center justify-center border border-dashed rounded-lg text-muted-alt min-h-[min(400px,calc(100svh-16rem))]">
+                Select a ticket to view the conversation
+            </div>
+        )
+    }
+
+    return (
+        <SceneContent>
+            <SceneTitleSection
+                name="Your tickets"
+                description="Support conversations with the PostHog team"
+                resourceType={{ type: 'conversation' }}
+            />
+            <div className="flex items-start gap-4">
+                <div className="w-96 shrink-0 overflow-y-auto max-h-[calc(100svh-16rem)]">
+                    <TicketsList />
+                </div>
+                <div className="flex-1 min-w-0">{pane}</div>
+            </div>
+        </SceneContent>
+    )
+}

--- a/products/conversations/manifest.tsx
+++ b/products/conversations/manifest.tsx
@@ -25,11 +25,20 @@ export const manifest: ProductManifest = {
             projectBased: true,
             layout: 'app-container',
         },
+        // The user's own tickets with PostHog support — unrelated to the Support product's
+        // agent inbox above, which shows tickets from *their* customers
+        MyTickets: {
+            name: 'Your tickets',
+            import: () => import('./frontend/scenes/myTickets/MyTicketsScene'),
+            projectBased: true,
+            layout: 'app-container',
+        },
     },
     routes: {
         '/support/tickets': ['SupportTickets', 'supportTickets'],
         '/support/tickets/:ticketId': ['SupportTicketDetail', 'supportTicketDetail'],
         '/support/settings': ['SupportSettings', 'supportSettings'],
+        '/my-tickets': ['MyTickets', 'myTickets'],
     },
     redirects: {
         '/support': '/support/tickets',
@@ -39,6 +48,7 @@ export const manifest: ProductManifest = {
         supportTickets: (): string => '/support/tickets',
         supportTicketDetail: (ticketId: string | number): string => `/support/tickets/${ticketId}`,
         supportSettings: (): string => '/support/settings',
+        myTickets: (): string => '/my-tickets',
     },
     fileSystemTypes: {},
     treeItemsNew: [],


### PR DESCRIPTION
## Problem

The support side panel is the only place to see your tickets with PostHog support, and it's a narrow column with a 400px-tall thread. There's no way to view a long ticket list or conversation comfortably. 

## Changes

- New `MyTickets` scene at `/my-tickets` (registered in the Conversations manifest, deliberately outside the `/support/*` namespace to avoid colliding with the agent inbox): ticket list on the left, selected conversation / composer / recovery flow filling the rest of the screen.
- Reuses the existing `TicketsList`, `Ticket`, `NewTicket`, `RestoreTickets` components and `sidepanelTicketsLogic`, so data flow and gating are identical to the panel.
- `Ticket` gained optional `showBackButton` and message-height props so the thread works in both surfaces. Panel defaults unchanged.
- New expand button in the support side panel header that opens the page and closes the panel.
- Shows a fallback pointing to the community forum when the conversations support flag is off or on self-hosted.

<img width="5120" height="2584" alt="image" src="https://github.com/user-attachments/assets/c6cc5182-954e-45a7-b801-2cc805fc236a" />


## How did you test this code?

Ran and confirmed locally 

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skills invoked: `/writing-kea-logics`, `/writing-user-facing-copy`.

Decisions: chose a dedicated scene over a panel "maximize" button (chosen by the human driver) for a proper full-screen home. Kept the singleton `sidepanelTicketsLogic` as the data layer rather than keying it, since shared selection state between panel and page is coherent. Skipped `/my-tickets/:ticketId` deep links for now: hydrating a ticket from just its id isn't supported by the widget data flow, left as a follow-up.
