### PR TITLE
fix(data-warehouse): salt schedule buckets per interval to de-align cadence tiers

### DIFF
--- a/products/data_modeling/backend/schedule.py
+++ b/products/data_modeling/backend/schedule.py
@@ -155,7 +155,9 @@ def _short_interval_spec(entity_id: uuid.UUID, interval: timedelta, timezone: st
     """
     interval_mins = int(interval.total_seconds() // 60)
     num_windows = 60 // interval_mins
-    base_min = _deterministic_int(entity_id, "minute") % interval_mins
+    # The interval must participate in the salt: with a shared salt, a coarser tier's fire
+    # minutes are always a subset of every finer tier's, so all tiers of a DAG fire together.
+    base_min = _deterministic_int(entity_id, f"minute-{interval_mins}") % interval_mins
     mins = [(base_min + i * interval_mins) % 60 for i in range(num_windows)]
     return ScheduleSpec(
         calendars=[
@@ -181,7 +183,9 @@ def _medium_interval_spec(entity_id: uuid.UUID, interval: timedelta, timezone: s
     """
     interval_hours = int(interval.total_seconds() // 3600)
     num_windows = 24 // interval_hours
-    base_hour = _deterministic_int(entity_id, "hour") % interval_hours
+    # Interval in the salt keeps tiers of one DAG de-aligned from each other (and the plain
+    # "hour" salt of the weekly/monthly specs).
+    base_hour = _deterministic_int(entity_id, f"hour-{interval_hours}") % interval_hours
     hours = [(base_hour + i * interval_hours) % 24 for i in range(num_windows)]
     return ScheduleSpec(
         calendars=[

--- a/products/data_modeling/backend/test/test_schedule.py
+++ b/products/data_modeling/backend/test/test_schedule.py
@@ -6,6 +6,7 @@ import pytest
 from posthog.test.base import BaseTest
 from unittest import mock
 
+from parameterized import parameterized
 from temporalio.client import ScheduleCalendarSpec, ScheduleListActionStartWorkflow
 
 from products.data_modeling.backend.models import Node
@@ -219,6 +220,49 @@ class TestMonthlySpec:
             spec = build_schedule_spec(entity_id, timedelta(days=30))
             days[spec.calendars[0].day_of_month[0].start] += 1
         assert len(days) == 28
+
+
+class TestTierPhaseAlignment:
+    """Cadence tiers of one DAG must not be phase-aligned.
+
+    All tiers of a DAG derive their bucket from the same entity_id, so unless the
+    interval participates in the salt, a coarser tier's fire times are a subset of
+    every finer tier's — every tier of a DAG piles onto the same minute/hour.
+    """
+
+    N = 500
+
+    @staticmethod
+    def _minute_set(spec) -> set[int]:
+        return {r.start for r in spec.calendars[0].minute}
+
+    @staticmethod
+    def _hour_set(spec) -> set[int]:
+        return {r.start for r in spec.calendars[0].hour}
+
+    @parameterized.expand(
+        [
+            ("15min_vs_30min", timedelta(minutes=15), timedelta(minutes=30), "_minute_set"),
+            ("15min_vs_1hr", timedelta(minutes=15), timedelta(hours=1), "_minute_set"),
+            ("30min_vs_1hr", timedelta(minutes=30), timedelta(hours=1), "_minute_set"),
+            ("6hr_vs_12hr", timedelta(hours=6), timedelta(hours=12), "_hour_set"),
+            ("6hr_vs_24hr", timedelta(hours=6), timedelta(hours=24), "_hour_set"),
+            ("12hr_vs_24hr", timedelta(hours=12), timedelta(hours=24), "_hour_set"),
+            ("24hr_vs_weekly", timedelta(hours=24), timedelta(days=7), "_hour_set"),
+        ]
+    )
+    def test_coarser_tier_not_contained_in_finer(self, _name, finer, coarser, extractor):
+        buckets = getattr(self, extractor)
+        aligned = 0
+        for i in range(self.N):
+            entity_id = uuid.UUID(int=i)
+            finer_set = buckets(build_schedule_spec(entity_id, finer))
+            coarser_set = buckets(build_schedule_spec(entity_id, coarser))
+            if coarser_set <= finer_set:
+                aligned += 1
+        # Incidental overlap is fine (expected ~1/interval-ratio of ids); systematic
+        # alignment is the defect.
+        assert aligned < self.N // 2, f"{aligned}/{self.N} ids have the coarser tier phase-aligned into the finer"
 
 
 class TestBuildScheduleSpecEdgeCases:


### PR DESCRIPTION
## Problem

Every cadence tier of a data-modeling DAG derives its fire bucket from the same deterministic salt (`_deterministic_int(dag_id, "minute")` / `"hour"` in `products/data_modeling/backend/schedule.py`).
Because a coarser interval's window count divides a finer one's, the coarser tier's fire times are always a subset of every finer tier's, and the daily tier always shares the weekly tier's hour (both use the bare `"hour"` salt).
Result: all tiers of one DAG fire on the same minute, piling their runs onto the same moment instead of load-spreading.
Verified: 500/500 deterministic ids phase-aligned across every tier pair (15/30/60min, 6/12/24h, 24h/weekly).

Since tier preemption became node-scoped this is no longer destructive, just a thundering herd - but multi-tier DAGs are exactly the ones the tiered-schedule rollout is now converting, so it's worth fixing before they multiply.

## Changes

- Include the interval in the bucket salt (`minute-{interval_mins}`, `hour-{interval_hours}`) so each tier of a DAG lands in an independent bucket. Weekly/monthly keep their existing salts and are de-aligned from the daily tier by the medium-tier change.

> [!NOTE]
> This changes the computed spec for every short/medium interval, so an existing schedule re-cadences (shifts its fire minute/hour once) the next time a reconcile touches it. Fire times stay deterministic per (id, interval). Schedule ids and verification logic are unaffected.

## How did you test this code?

Red-first: added `TestTierPhaseAlignment`, a parameterized pure-function test over 7 tier pairs asserting the coarser tier's fire set is not systematically contained in the finer tier's (500 fixed uuids per pair; incidental overlap allowed, systematic alignment fails).
All 7 cases failed at 500/500 aligned before the fix and pass after.
It catches any future regression that drops the interval from the salt - no existing test looks across intervals.
Full `test_schedule.py` run: 49 passed (5 pre-existing environment-dependent DB test errors on my machine, identical on master).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed - internal scheduling behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code session. Skills invoked: /writing-tests, /quick-fix-pr.
The defect was diagnosed earlier during the tiered-schedules rollout (phase alignment was defect 1 of the tier-preemption investigation; defect 2 was fixed in #73567).
Deliberately scoped to the two salts only: weekly/monthly stay on their existing salts to avoid re-cadencing those schedules for no alignment gain.
