### PR TITLE
fix(data-modeling): retry rate-limited teams in batch reconcile

### DIFF
--- a/products/data_modeling/backend/management/commands/batch_reconcile_teams.py
+++ b/products/data_modeling/backend/management/commands/batch_reconcile_teams.py
@@ -1,4 +1,5 @@
 import json
+import time
 import dataclasses
 from datetime import timedelta
 from pathlib import Path
@@ -7,6 +8,7 @@ from django.core.management.base import BaseCommand, CommandError
 
 import structlog
 from asgiref.sync import async_to_sync
+from temporalio.service import RPCError, RPCStatusCode
 
 from posthog.models.team import Team
 from posthog.temporal.common.client import async_connect
@@ -26,6 +28,9 @@ from products.data_modeling.backend.models.dag import DAG
 logger = structlog.get_logger(__name__)
 
 REPORT_MARKER = "=== BATCH RECONCILE REPORT JSON ==="
+
+RATE_LIMIT_RETRIES = 3
+RATE_LIMIT_BASE_WAIT_SECONDS = 10
 
 
 class Anomaly(Exception):
@@ -82,7 +87,7 @@ class Command(BaseCommand):
             record: dict = {"team_id": team_id, "status": "planned", "dags": [], "anomalies": []}
             report["teams"].append(record)
             try:
-                self._process_team(team_id, record, apply=apply)
+                self._process_team_with_retry(team_id, record, apply=apply)
                 if apply:
                     record["status"] = "applied"
                 self.stdout.write(f"team {team_id}: {record['status']}")
@@ -107,6 +112,23 @@ class Command(BaseCommand):
             Path(options["output"]).write_text(payload)
         self.stdout.write(REPORT_MARKER)
         self.stdout.write(payload)
+
+    def _process_team_with_retry(self, team_id: int, record: dict, *, apply: bool) -> None:
+        """Retry a rate-limited team instead of halting the batch: both phases are
+        idempotent per team (plan is read-only; re-applying converges on the same
+        tier set), so on RESOURCE_EXHAUSTED the whole team is safely re-run after
+        a backoff. Any other error propagates to the per-team handler."""
+        for attempt in range(RATE_LIMIT_RETRIES + 1):
+            try:
+                self._process_team(team_id, record, apply=apply)
+                return
+            except RPCError as err:
+                if err.status != RPCStatusCode.RESOURCE_EXHAUSTED or attempt == RATE_LIMIT_RETRIES:
+                    raise
+                wait = RATE_LIMIT_BASE_WAIT_SECONDS * (2**attempt)
+                self.stderr.write(f"team {team_id}: temporal rate limited, retrying in {wait}s")
+                record["dags"].clear()
+                time.sleep(wait)
 
     def _process_team(self, team_id: int, record: dict, *, apply: bool) -> None:
         team = Team.objects.filter(id=team_id).first()

--- a/products/data_modeling/backend/test/test_batch_reconcile_teams.py
+++ b/products/data_modeling/backend/test/test_batch_reconcile_teams.py
@@ -8,6 +8,8 @@ from unittest import mock
 
 from django.core.management import call_command
 
+from temporalio.service import RPCError, RPCStatusCode
+
 from posthog.models.team import Team
 
 from products.data_modeling.backend.logic.cohort_scheduling import tier_schedule_id
@@ -135,6 +137,33 @@ class TestBatchReconcileTeams(BaseTest):
         invalid = team_record["dags"][0]["invalid_targets"]
         assert [t["node_id"] for t in invalid] == [str(parent.id)]
         assert invalid[0]["consumer_ceiling"] == int(timedelta(hours=1).total_seconds())
+
+    def test_rate_limited_team_retries_instead_of_halting(self):
+        # a temporal namespace rate limit mid-batch must back off and retry the team,
+        # not halt the whole batch (halted a real 200-team production run)
+        dag, _node = self._legacy_dag(self.team)
+        listing = _temporal_listing([str(dag.id)])
+        rate_limit = RPCError("namespace rate limit exceeded", RPCStatusCode.RESOURCE_EXHAUSTED, b"")
+
+        out = StringIO()
+        with (
+            mock.patch(f"{BATCH}.tiered_schedules_enabled", return_value=True),
+            mock.patch(f"{BATCH}.time.sleep") as sleep,
+            mock.patch(f"{RECONCILE}.sync_connect"),
+            mock.patch(f"{RECONCILE}.delete_schedule"),
+            mock.patch(f"{RECONCILE}.async_connect", new=mock.AsyncMock(side_effect=[rate_limit, listing])),
+            mock.patch(f"{RECONCILE}.a_create_schedule", new=mock.AsyncMock()),
+            mock.patch(f"{RECONCILE}.a_delete_schedule", new=mock.AsyncMock()),
+            mock.patch(f"{BATCH}.async_connect", new=mock.AsyncMock()),
+            mock.patch(f"{BATCH}.a_schedule_exists", new=mock.AsyncMock(return_value=False)),
+        ):
+            call_command("batch_reconcile_teams", "--team-ids", str(self.team.pk), stdout=out, stderr=StringIO())
+        report = json.loads(out.getvalue().split(REPORT_MARKER, 1)[1])
+
+        assert report["halted"] is False
+        assert report["teams"][0]["status"] == "planned"
+        assert len(report["teams"][0]["dags"]) == 1
+        sleep.assert_called_once_with(10)
 
     def test_plan_only_writes_nothing(self):
         dag, node = self._legacy_dag(self.team)


### PR DESCRIPTION
## Problem

A 200-team `batch_reconcile_teams` run halted mid-plan when Temporal's namespace rate limit kicked in: the per-team schedule listings in quick succession exceeded the RPS budget, the `RPCError` surfaced as an "unexpected error", and the circuit breaker (correctly, but unhelpfully) stopped the batch. Rate limiting is backpressure, not an anomaly.

## Changes

`RESOURCE_EXHAUSTED` now retries the whole team up to 3 times with exponential backoff (10/20/40s) before counting as an anomaly. Retrying a full team is safe because both phases are idempotent: the plan is read-only, and re-applying converges on the same tier set (re-seed is a no-op, reconcile create/update converges) - this was demonstrated in production by deliberately re-running an already-converted team. Partial per-team report state is cleared before each retry. All other errors halt immediately, unchanged.

## How did you test this code?

Automated only (agent-run): one new test in `test_batch_reconcile_teams.py` reproducing the production event - the first Temporal listing raises `RPCError(RESOURCE_EXHAUSTED)`, the retry succeeds; asserts the team ends `planned`, the batch is not halted, exactly one backoff sleep happened, and the report has no duplicated DAG entries. Full file: 6 passed. No existing test covered a retryable-error path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I hit this during the tiered-scheduling fleet rollout; Claude (Claude Code) wrote the fix and test. Skills invoked: /writing-tests. Alternative considered and rejected: retrying only the individual Temporal calls inside the logic layer - more invasive across shared code paths, while the per-team retry keeps the change local to the batch command and leans on already-proven idempotency.
