### PR TITLE
fix(mcp): disclose event discovery window

### DIFF
--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -588,7 +588,7 @@ export const ExecuteSQLSchema = z.object({
 })
 
 const ReadEventsQuerySchema = z.object({
-    kind: z.literal('events'),
+    kind: z.literal('events').describe('List events seen in the last 30 days, ranked by frequency.'),
     limit: z.number().int().min(1).max(500).default(500).optional().describe('Number of events to return per page.'),
     offset: z.number().int().min(0).default(0).optional().describe('Number of events to skip for pagination.'),
 })

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/read-data-schema.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/read-data-schema.json
@@ -8,6 +8,7 @@
                     "properties": {
                         "kind": {
                             "const": "events",
+                            "description": "List events seen in the last 30 days, ranked by frequency.",
                             "type": "string"
                         },
                         "limit": {

--- a/services/mcp/tests/unit/read-data-schema-schema.test.ts
+++ b/services/mcp/tests/unit/read-data-schema-schema.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+
+import { ReadDataSchemaSchema } from '@/schema/tool-inputs'
+
+describe('read-data-schema event discovery contract', () => {
+    it('discloses that event discovery only searches the last 30 days', () => {
+        const schema = JSON.stringify(z.toJSONSchema(ReadDataSchemaSchema, { io: 'input' }))
+
+        expect(schema).toContain('last 30 days')
+    })
+})


### PR DESCRIPTION
## Problem

MCP clients can interpret an empty `read-data-schema` events response as evidence that an event does not exist. The tool currently discovers only events observed in the last 30 days, but its input contract does not disclose that boundary.

Closes #75803

## Changes

Expose the 30-day discovery window in the `events` query-kind description returned by the MCP tool schema. The generated runtime schema snapshot is updated alongside the source contract.

## How did you test this code?

- Added `read-data-schema-schema.test.ts`, which fails unless the public input schema states the 30-day event-discovery window.
- `pnpm --filter=@posthog/mcp exec vitest run tests/unit/read-data-schema-schema.test.ts --pool=forks --no-file-parallelism`
- `pnpm --filter=@posthog/mcp exec vitest run tests/unit/tool-schema-snapshots.test.ts --pool=forks --no-file-parallelism`
- `pnpm --filter=@posthog/mcp exec oxfmt --check src/schema/tool-inputs.ts tests/unit/read-data-schema-schema.test.ts tests/unit/__snapshots__/tool-schemas/read-data-schema.json`

Both Vitest commands used Node 24, the repository-supported engine. `bin/hogli ci:preflight --fix` confirmed branch freshness, but its repository-wide lockfile/OpenAPI checks could not complete in this linked worktree because the borrowed dependency directory is non-interactive and the local Python settings discovery cannot parse the existing root configuration. It made no source changes beyond this PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update needed. This is an MCP JSON-schema clarification; the generated schema snapshot is included.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Codex traced the boundary to the taxonomy query runner before changing the MCP contract. I kept the existing 30-day behavior rather than broadening event search, because the issue requires clients to understand the documented discovery window. Skills invoked: none.
