### PR TITLE
fix(conversations): warn before closing a ticket tab with unsent draft

### DIFF
--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -289,6 +289,8 @@ describe('supportTicketSceneLogic sendMessage with statusAfterSend', () => {
 
     beforeEach(async () => {
         initKeaTests()
+        // draftContent/draftIsPrivate persist to local storage, so isolate cases from each other.
+        localStorage.clear()
         commentsCreateMock.mockReset().mockResolvedValue(undefined)
         ticketGetMock.mockReset().mockResolvedValue(loadedTicket())
         ticketUpdateMock.mockReset()

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -9,7 +9,12 @@ import type { CommentType } from '~/types'
 
 import type { TicketAssignee } from '../../components/Assignee'
 import type { Ticket, TicketStatus } from '../../types'
-import { EmailReplyBlockedReason, getEmailReplyBlockedReason, supportTicketSceneLogic } from './supportTicketSceneLogic'
+import {
+    draftStorageKey,
+    EmailReplyBlockedReason,
+    getEmailReplyBlockedReason,
+    supportTicketSceneLogic,
+} from './supportTicketSceneLogic'
 
 const FEEDBACK_STORAGE_KEY = 'conversations_ai_reply_feedback'
 
@@ -289,7 +294,8 @@ describe('supportTicketSceneLogic sendMessage with statusAfterSend', () => {
 
     beforeEach(async () => {
         initKeaTests()
-        // draftContent/draftIsPrivate persist to local storage, so isolate cases from each other.
+        // The draft persists to sessionStorage and feedback to localStorage, so isolate cases.
+        sessionStorage.clear()
         localStorage.clear()
         commentsCreateMock.mockReset().mockResolvedValue(undefined)
         ticketGetMock.mockReset().mockResolvedValue(loadedTicket())
@@ -363,6 +369,29 @@ describe('supportTicketSceneLogic sendMessage with statusAfterSend', () => {
         expect(logic.values.hasPendingWork).toBe(false)
         logic.actions.setDraftContent(draft)
         expect(logic.values.hasPendingWork).toBe(expected)
+    })
+
+    // The draft must persist to sessionStorage (session-scoped, keyed by user), NOT origin-wide
+    // localStorage, and be restored when the ticket is reopened in the same session.
+    it('persists the draft session-scoped and restores it when the ticket is reopened', () => {
+        const draft: JSONContent = {
+            type: 'doc',
+            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hi' }] }],
+        }
+        const userUuid = logic.values.user?.uuid
+
+        // Typing stores the draft in sessionStorage, not origin-wide localStorage
+        logic.actions.setDraftContent(draft)
+        const key = draftStorageKey(userUuid, 42)
+        expect(sessionStorage.getItem(key)).not.toBeNull()
+        expect(localStorage.getItem(key)).toBeNull()
+
+        // Reopening the ticket (a fresh mount) restores the stored draft
+        sessionStorage.setItem(draftStorageKey(userUuid, 99), JSON.stringify({ content: draft, isPrivate: true }))
+        const reopened = supportTicketSceneLogic({ id: 99 })
+        reopened.mount()
+        expect(reopened.values.draftContent).toEqual(draft)
+        expect(reopened.values.draftIsPrivate).toBe(true)
     })
 
     // Overlapping updates must serialize: the second PATCH waits for the first and carries the

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -13,6 +13,7 @@ import {
     draftStorageKey,
     EmailReplyBlockedReason,
     getEmailReplyBlockedReason,
+    shouldWarnBeforeLeave,
     supportTicketSceneLogic,
 } from './supportTicketSceneLogic'
 
@@ -369,6 +370,40 @@ describe('supportTicketSceneLogic sendMessage with statusAfterSend', () => {
         expect(logic.values.hasPendingWork).toBe(false)
         logic.actions.setDraftContent(draft)
         expect(logic.values.hasPendingWork).toBe(expected)
+    })
+
+    // The leave prompt must fire for a genuine tab close / hard navigation, but NOT for in-app
+    // navigation (link clicks or browser back/forward), since the draft survives the session.
+    // Guards the regression where back/forward (popstate reaches enabled() with no location, like
+    // a real unload) re-triggered the warning.
+    test.each<[string, Parameters<typeof shouldWarnBeforeLeave>[0], boolean]>([
+        [
+            'nothing pending',
+            { hasPendingWork: false, hasUnsavedChanges: false, isRealUnload: true, isSamePath: false },
+            false,
+        ],
+        [
+            'same-path move (side panel)',
+            { hasPendingWork: true, hasUnsavedChanges: false, isRealUnload: false, isSamePath: true },
+            false,
+        ],
+        [
+            'in-app nav (link or back/forward) with only a draft',
+            { hasPendingWork: true, hasUnsavedChanges: false, isRealUnload: false, isSamePath: false },
+            false,
+        ],
+        [
+            'in-app nav with unsaved metadata',
+            { hasPendingWork: true, hasUnsavedChanges: true, isRealUnload: false, isSamePath: false },
+            true,
+        ],
+        [
+            'real tab close with a draft',
+            { hasPendingWork: true, hasUnsavedChanges: false, isRealUnload: true, isSamePath: false },
+            true,
+        ],
+    ])('shouldWarnBeforeLeave: %s', (_name, args, expected) => {
+        expect(shouldWarnBeforeLeave(args)).toBe(expected)
     })
 
     // The draft must persist to sessionStorage (session-scoped, keyed by user), NOT origin-wide

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.test.ts
@@ -1,5 +1,6 @@
 import { MOCK_DEFAULT_USER } from 'lib/api.mock'
 
+import { JSONContent } from '@tiptap/core'
 import { expectLogic } from 'kea-test-utils'
 
 import { tagsModel } from '~/models/tagsModel'
@@ -349,6 +350,17 @@ describe('supportTicketSceneLogic sendMessage with statusAfterSend', () => {
     ])('unsavedTicketChanges lists %s', (_name, applyEdit, expected) => {
         applyEdit()
         expect(logic.values.unsavedTicketChanges).toEqual(expected)
+    })
+
+    // Unsent draft text is pending work: it must drive the beforeUnload guard so closing the tab
+    // or hard-navigating away with typed-but-unsent reply content prompts before discarding it.
+    test.each<[string, JSONContent | null, boolean]>([
+        ['no draft', null, false],
+        ['a draft with content', { type: 'doc', content: [{ type: 'paragraph' }] }, true],
+    ])('hasPendingWork reflects %s', (_name, draft, expected) => {
+        expect(logic.values.hasPendingWork).toBe(false)
+        logic.actions.setDraftContent(draft)
+        expect(logic.values.hasPendingWork).toBe(expected)
     })
 
     // Overlapping updates must serialize: the second PATCH waits for the first and carries the

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -189,6 +189,7 @@ export interface supportTicketSceneLogicValues {
     eventsQuery: DataTableNode | null
     exceptionsQuery: DataTableNode | null
     feedbackByMessageId: Record<string, AiReplyFeedbackRating>
+    hasDraftContent: boolean
     hasMoreMessages: boolean
     hasPendingWork: boolean
     hasUnsavedChanges: boolean
@@ -435,7 +436,8 @@ export interface supportTicketSceneLogicMeta {
             ticket: Ticket | null,
             unsavedTicketChanges: string[]
         ) => boolean
-        hasPendingWork: (hasUnsavedChanges: boolean) => boolean
+        hasDraftContent: (draftContent: JSONContent | null) => boolean
+        hasPendingWork: (hasUnsavedChanges: boolean, hasDraftContent: boolean) => boolean
         chatMessages: (messages: CommentType[], ticket: Ticket | null) => ChatMessage[]
         eventsQuery: (ticket: Ticket | null) => DataTableNode | null
         exceptionsQuery: (ticket: Ticket | null) => DataTableNode | null
@@ -873,7 +875,16 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 return status !== ticket.status || unsavedTicketChanges.length > 0
             },
         ],
-        hasPendingWork: [(s) => [s.hasUnsavedChanges], (hasUnsavedChanges: boolean): boolean => hasUnsavedChanges],
+        // A draft with any content counts as unsent work: handleUpdate normalizes an empty editor
+        // to null, so a non-null draft means the input has one or more characters.
+        hasDraftContent: [
+            (s) => [s.draftContent],
+            (draftContent: JSONContent | null): boolean => draftContent !== null,
+        ],
+        hasPendingWork: [
+            (s) => [s.hasUnsavedChanges, s.hasDraftContent],
+            (hasUnsavedChanges: boolean, hasDraftContent: boolean): boolean => hasUnsavedChanges || hasDraftContent,
+        ],
         chatPanelWidth: [
             () => [],
             () =>

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -451,6 +451,41 @@ export type supportTicketSceneLogicType = MakeLogicType<
     supportTicketSceneLogicMeta
 >
 
+interface StoredDraft {
+    content: JSONContent | null
+    isPrivate: boolean
+}
+
+// Drafts are kept in sessionStorage, scoped to the logged-in user, so they are bound to the
+// PostHog session: they survive reloads and in-app navigation but not the browser session ending,
+// and a draft (which can contain a private note) never leaks to another account on the same device.
+export function draftStorageKey(userUuid: string | undefined, ticketId: string | number): string {
+    return `conversations_ticket_draft.${userUuid ?? 'anonymous'}.${ticketId}`
+}
+
+function readStoredDraft(userUuid: string | undefined, ticketId: string | number): StoredDraft | null {
+    try {
+        const raw = sessionStorage.getItem(draftStorageKey(userUuid, ticketId))
+        return raw ? (JSON.parse(raw) as StoredDraft) : null
+    } catch {
+        return null
+    }
+}
+
+function writeStoredDraft(userUuid: string | undefined, ticketId: string | number, draft: StoredDraft): void {
+    try {
+        const key = draftStorageKey(userUuid, ticketId)
+        // An empty editor normalizes content to null, so clear the entry rather than storing a blank.
+        if (draft.content === null) {
+            sessionStorage.removeItem(key)
+        } else {
+            sessionStorage.setItem(key, JSON.stringify(draft))
+        }
+    } catch {
+        // sessionStorage may be unavailable (e.g. privacy settings); drafts just won't persist then.
+    }
+}
+
 export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
     path(['products', 'conversations', 'frontend', 'scenes', 'ticket', 'supportTicketSceneLogic']),
     props({ id: 'new' as string | number }),
@@ -517,8 +552,8 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         loadKnowledgeGaps: true,
         dismissKnowledgeGap: (suggestionId: string) => ({ suggestionId }),
 
-        // Draft message state (persisted to local storage, so it survives tab switches,
-        // reloads, and closing/reopening the tab)
+        // Draft message state (persisted to sessionStorage per logged-in user, so it survives tab
+        // switches, in-app navigation, and reloads within the session)
         setDraftContent: (content: JSONContent | null) => ({ content }),
         setDraftIsPrivate: (isPrivate: boolean) => ({ isPrivate }),
         // Per-ticket draft mode override, seeded from the browser-local default on open
@@ -745,18 +780,16 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 setMessageSending: (_, { sending }) => sending,
             },
         ],
-        // persist: true keys on the logic path, which includes the ticket id, so each ticket
-        // keeps its own draft in local storage and it is not lost on reload or tab close.
+        // In-memory here; persistence is handled via sessionStorage in afterMount/listeners so it
+        // can be scoped to the logged-in user (see draftStorageKey).
         draftContent: [
             null as JSONContent | null,
-            { persist: true },
             {
                 setDraftContent: (_, { content }) => content,
             },
         ],
         draftIsPrivate: [
             false,
-            { persist: true },
             {
                 setDraftIsPrivate: (_, { isPrivate }) => isPrivate,
             },
@@ -993,6 +1026,18 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         ],
     }),
     listeners(({ actions, values, props, cache }) => ({
+        setDraftContent: () => {
+            writeStoredDraft(values.user?.uuid, props.id, {
+                content: values.draftContent,
+                isPrivate: values.draftIsPrivate,
+            })
+        },
+        setDraftIsPrivate: () => {
+            writeStoredDraft(values.user?.uuid, props.id, {
+                content: values.draftContent,
+                isPrivate: values.draftIsPrivate,
+            })
+        },
         loadTicket: async () => {
             if (props.id === 'new') {
                 actions.setTicket(null)
@@ -1225,6 +1270,11 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
     })),
     afterMount(({ actions, props, values }) => {
         actions.setDraftModeEnabled(values.draftModeDefault)
+        const storedDraft = readStoredDraft(values.user?.uuid, props.id)
+        if (storedDraft?.content) {
+            actions.setDraftContent(storedDraft.content)
+            actions.setDraftIsPrivate(storedDraft.isPrivate)
+        }
         if (props.id !== 'new') {
             actions.loadTicket()
         }
@@ -1244,7 +1294,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             if (newLocation && newLocation.pathname === router.values.location.pathname) {
                 return false
             }
-            // The draft is persisted to local storage, so in-app navigation keeps it and there's
+            // The draft is persisted for the session, so in-app navigation keeps it and there's
             // nothing to warn about — only unsaved ticket metadata (which isn't persisted) still
             // guards a route change. A real tab close (no newLocation) always warns about the draft.
             if (newLocation && !values.hasUnsavedChanges) {
@@ -1256,7 +1306,7 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         onConfirm: () => {
             // Re-sync local form reducers to the last-known server ticket so hasUnsavedChanges
             // recomputes to false and the prompt does not re-fire on the next navigation. The
-            // draft is deliberately left intact: it is persisted to local storage, so it must
+            // draft is deliberately left intact: it is persisted for the session, so it must
             // survive the user leaving rather than be discarded here.
             if (values.ticket) {
                 actions.setTicket(values.ticket)

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -517,7 +517,8 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         loadKnowledgeGaps: true,
         dismissKnowledgeGap: (suggestionId: string) => ({ suggestionId }),
 
-        // Draft message state (persists across tab switches)
+        // Draft message state (persisted to local storage, so it survives tab switches,
+        // reloads, and closing/reopening the tab)
         setDraftContent: (content: JSONContent | null) => ({ content }),
         setDraftIsPrivate: (isPrivate: boolean) => ({ isPrivate }),
         // Per-ticket draft mode override, seeded from the browser-local default on open
@@ -744,14 +745,18 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 setMessageSending: (_, { sending }) => sending,
             },
         ],
+        // persist: true keys on the logic path, which includes the ticket id, so each ticket
+        // keeps its own draft in local storage and it is not lost on reload or tab close.
         draftContent: [
             null as JSONContent | null,
+            { persist: true },
             {
                 setDraftContent: (_, { content }) => content,
             },
         ],
         draftIsPrivate: [
             false,
+            { persist: true },
             {
                 setDraftIsPrivate: (_, { isPrivate }) => isPrivate,
             },
@@ -1241,12 +1246,10 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         },
         message: 'You have unsaved changes. Are you sure you want to leave?',
         onConfirm: () => {
-            // Re-sync guard-feeding state so hasPendingWork recomputes to false and the prompt
-            // does not re-fire on the next navigation: reset ticket metadata to the server copy
-            // and discard the unsent draft the user just agreed to leave behind.
-            if (values.draftContent !== null) {
-                actions.setDraftContent(null)
-            }
+            // Re-sync local form reducers to the last-known server ticket so hasUnsavedChanges
+            // recomputes to false and the prompt does not re-fire on the next navigation. The
+            // draft is deliberately left intact: it is persisted to local storage, so it must
+            // survive the user leaving rather than be discarded here.
             if (values.ticket) {
                 actions.setTicket(values.ticket)
             }

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -1234,12 +1234,20 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         impersonationNoticeLogic.findMounted()?.actions.setTicketContext(null)
     }),
     beforeUnload(({ values, actions }) => ({
+        // enabled receives newLocation for in-app (SPA) navigation and undefined for a real tab
+        // close / hard navigation.
         enabled: (newLocation) => {
             if (!values.hasPendingWork) {
                 return false
             }
             // Ignore in-page navigations (e.g. opening a side panel) that keep the same path
             if (newLocation && newLocation.pathname === router.values.location.pathname) {
+                return false
+            }
+            // The draft is persisted to local storage, so in-app navigation keeps it and there's
+            // nothing to warn about — only unsaved ticket metadata (which isn't persisted) still
+            // guards a route change. A real tab close (no newLocation) always warns about the draft.
+            if (newLocation && !values.hasUnsavedChanges) {
                 return false
             }
             return true

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -486,6 +486,29 @@ function writeStoredDraft(userUuid: string | undefined, ticketId: string | numbe
     }
 }
 
+// Whether leaving warrants the unsaved-changes prompt. Only a genuine tab close / hard navigation
+// (isRealUnload) warns about a session-persisted draft; in-app navigation — link/breadcrumb clicks
+// and browser back/forward — keeps the draft, so a draft alone doesn't warn there. Unsaved ticket
+// metadata (persisted nowhere) always guards a route change, and same-path moves (e.g. opening a
+// side panel) never do.
+export function shouldWarnBeforeLeave(args: {
+    hasPendingWork: boolean
+    hasUnsavedChanges: boolean
+    isRealUnload: boolean
+    isSamePath: boolean
+}): boolean {
+    if (!args.hasPendingWork) {
+        return false
+    }
+    if (args.isSamePath) {
+        return false
+    }
+    if (!args.isRealUnload && !args.hasUnsavedChanges) {
+        return false
+    }
+    return true
+}
+
 export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
     path(['products', 'conversations', 'frontend', 'scenes', 'ticket', 'supportTicketSceneLogic']),
     props({ id: 'new' as string | number }),
@@ -1268,8 +1291,21 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
             }
         },
     })),
-    afterMount(({ actions, props, values }) => {
+    afterMount(({ actions, props, values, cache }) => {
         actions.setDraftModeEnabled(values.draftModeDefault)
+        // A real page unload (tab close, reload, hard navigation) fires 'beforeunload'; in-app SPA
+        // navigation and browser back/forward (popstate) do not. kea-router consults our
+        // beforeUnload enabled() with no location for both a real unload and popstate, so we record
+        // genuine unloads here to tell them apart. Registered before kea-router's own handler (its
+        // builder runs after this afterMount), so the flag is set by the time enabled() is consulted.
+        cache.markRealUnload = () => {
+            cache.realUnload = true
+            // Clear it if the unload is cancelled, so a later in-app popstate isn't misread.
+            window.setTimeout(() => {
+                cache.realUnload = false
+            }, 0)
+        }
+        window.addEventListener('beforeunload', cache.markRealUnload)
         const storedDraft = readStoredDraft(values.user?.uuid, props.id)
         if (storedDraft?.content) {
             actions.setDraftContent(storedDraft.content)
@@ -1280,28 +1316,22 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         }
     }),
     beforeUnmount(({ cache }) => {
+        if (cache.markRealUnload) {
+            window.removeEventListener('beforeunload', cache.markRealUnload)
+        }
         cache.disposables.disposeAll()
         impersonationNoticeLogic.findMounted()?.actions.setTicketContext(null)
     }),
-    beforeUnload(({ values, actions }) => ({
-        // enabled receives newLocation for in-app (SPA) navigation and undefined for a real tab
-        // close / hard navigation.
-        enabled: (newLocation) => {
-            if (!values.hasPendingWork) {
-                return false
-            }
-            // Ignore in-page navigations (e.g. opening a side panel) that keep the same path
-            if (newLocation && newLocation.pathname === router.values.location.pathname) {
-                return false
-            }
-            // The draft is persisted for the session, so in-app navigation keeps it and there's
-            // nothing to warn about — only unsaved ticket metadata (which isn't persisted) still
-            // guards a route change. A real tab close (no newLocation) always warns about the draft.
-            if (newLocation && !values.hasUnsavedChanges) {
-                return false
-            }
-            return true
-        },
+    beforeUnload(({ values, actions, cache }) => ({
+        enabled: (newLocation) =>
+            shouldWarnBeforeLeave({
+                hasPendingWork: values.hasPendingWork,
+                hasUnsavedChanges: values.hasUnsavedChanges,
+                // Set by our beforeunload listener just before kea-router consults us; false for
+                // in-app SPA navigation and browser back/forward.
+                isRealUnload: cache.realUnload === true,
+                isSamePath: !!(newLocation && newLocation.pathname === router.values.location.pathname),
+            }),
         message: 'You have unsaved changes. Are you sure you want to leave?',
         onConfirm: () => {
             // Re-sync local form reducers to the last-known server ticket so hasUnsavedChanges

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -189,7 +189,6 @@ export interface supportTicketSceneLogicValues {
     eventsQuery: DataTableNode | null
     exceptionsQuery: DataTableNode | null
     feedbackByMessageId: Record<string, AiReplyFeedbackRating>
-    hasDraftContent: boolean
     hasMoreMessages: boolean
     hasPendingWork: boolean
     hasUnsavedChanges: boolean
@@ -436,8 +435,7 @@ export interface supportTicketSceneLogicMeta {
             ticket: Ticket | null,
             unsavedTicketChanges: string[]
         ) => boolean
-        hasDraftContent: (draftContent: JSONContent | null) => boolean
-        hasPendingWork: (hasUnsavedChanges: boolean, hasDraftContent: boolean) => boolean
+        hasPendingWork: (hasUnsavedChanges: boolean, draftContent: JSONContent | null) => boolean
         chatMessages: (messages: CommentType[], ticket: Ticket | null) => ChatMessage[]
         eventsQuery: (ticket: Ticket | null) => DataTableNode | null
         exceptionsQuery: (ticket: Ticket | null) => DataTableNode | null
@@ -875,15 +873,12 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
                 return status !== ticket.status || unsavedTicketChanges.length > 0
             },
         ],
-        // A draft with any content counts as unsent work: handleUpdate normalizes an empty editor
-        // to null, so a non-null draft means the input has one or more characters.
-        hasDraftContent: [
-            (s) => [s.draftContent],
-            (draftContent: JSONContent | null): boolean => draftContent !== null,
-        ],
+        // Unsent draft text is pending work too: the editor normalizes an empty document to null,
+        // so a non-null draft means there's at least one character to warn about before leaving.
         hasPendingWork: [
-            (s) => [s.hasUnsavedChanges, s.hasDraftContent],
-            (hasUnsavedChanges: boolean, hasDraftContent: boolean): boolean => hasUnsavedChanges || hasDraftContent,
+            (s) => [s.hasUnsavedChanges, s.draftContent],
+            (hasUnsavedChanges: boolean, draftContent: JSONContent | null): boolean =>
+                hasUnsavedChanges || draftContent !== null,
         ],
         chatPanelWidth: [
             () => [],

--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -1241,8 +1241,12 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         },
         message: 'You have unsaved changes. Are you sure you want to leave?',
         onConfirm: () => {
-            // Re-sync local form reducers to the last-known server ticket so hasUnsavedChanges
-            // recomputes to false and the prompt does not re-fire on the next navigation.
+            // Re-sync guard-feeding state so hasPendingWork recomputes to false and the prompt
+            // does not re-fire on the next navigation: reset ticket metadata to the server copy
+            // and discard the unsent draft the user just agreed to leave behind.
+            if (values.draftContent !== null) {
+                actions.setDraftContent(null)
+            }
             if (values.ticket) {
                 actions.setTicket(values.ticket)
             }


### PR DESCRIPTION
## Problem

In the conversations product, typing a reply into a ticket's editor and then closing the tab or hard-navigating away discarded the unsent text with no warning. Two gaps: the in-SPA `beforeUnload` guard only watched ticket-metadata edits (status, priority, assignee, tags, snooze) and never looked at the draft, and the draft lived only in memory — so a reload lost it even though in-SPA tab switches kept it.

## Changes

- The draft (`draftContent` + `draftIsPrivate`) is persisted to `sessionStorage`, keyed by the logged-in user's id. It's bound to the PostHog session: it survives reloads and in-app navigation, but doesn't linger on disk across the browser session, and a draft (which can be a private note) never leaks to another account signed in on the same device. Restored on mount and written on change via listeners (kea-localstorage can't scope a key per user, so this is handled directly). This reuses the existing `draftContent` state the editor already reads/writes.
- `hasPendingWork` now also reads the draft, so unsent text counts as pending work.
- The `beforeUnload` guard distinguishes a real tab close from in-app navigation (kea-router passes `newLocation` only for SPA route changes):
  - **Tab close / hard navigation:** warns when there's unsent text — the "under no circumstances close the tab with a draft" case.
  - **In-app navigation:** does not warn for a draft-only state, since the draft is kept for the session and restored when you come back. Unsaved ticket metadata (which isn't persisted) still guards a route change.
- `onConfirm` leaves the draft intact — it only re-syncs ticket metadata to the server copy.

This is a warning, not a hard block; browsers only allow surfacing the native confirm on close.

## How did you test this code?

Added kea-logic tests to `supportTicketSceneLogic.test.ts`: `hasPendingWork` flips with draft content (guards the leave-warning regression), and the draft round-trips through `sessionStorage` under a user-scoped key and is restored on a fresh mount — asserting it lands in `sessionStorage` and not `localStorage`, which guards the session-scoping requirement. Storage is cleared in that block's `beforeEach` for isolation. Ran the file locally (`jest`, all 37 pass) plus `tsgo` typecheck on the changed file (clean).

The full browser flow (persistence round-trip, tab-close-vs-SPA-nav behavior) still wants manual verification in local dev, which I (the PostHog Slack app) could not fully exercise here.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven from a Slack thread by a PostHog engineer who noticed a written ticket draft was lost when a tab closed. Iterated on their testing and review feedback: added the draft to the leave guard, made it persist, scoped the warning to real tab close (a persisted draft survives SPA navigation, so warning there was noise), and finally moved persistence from origin-wide localStorage to session-scoped, per-user sessionStorage after a review bot flagged that drafts (including private notes) persisted across logout. Along the way I reversed an earlier "clear the draft in `onConfirm`" change — clearing would delete the draft. Invoked the `/writing-tests` skill for the added tests.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1785494906080289?thread_ts=1785494906.080289&cid=C08S2L0S5MZ)*
