### PR TITLE
fix(access-control): resolve a table's inherited level through its source

### DIFF
--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -303,7 +303,7 @@ class AccessControlViewSetMixin(_GenericViewSet):
             # can spell out what removing the override means. Resolved server-side, next to the
             # runtime access resolution, so the two cannot drift; None means nothing sits above
             # this object and the UI must not offer "No override".
-            inherited = resolve_inherited_object_access(team, resource, obj)
+            inherited = resolve_inherited_object_access(user_access_control.user, team, resource, obj)
             payload["inherited_access"] = asdict(inherited) if inherited else None
 
         return Response(payload)

--- a/ee/api/rbac/access_control.py
+++ b/ee/api/rbac/access_control.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, cast
 
 from rest_framework import exceptions, serializers, status
@@ -14,8 +15,6 @@ from posthog.rbac.user_access_control import (
     ACCESS_CONTROL_LEVELS_RESOURCE,
     ACCESS_CONTROL_MAX_OBJECTS_PER_RESOURCE,
     ACCESS_CONTROL_RESOURCES,
-    RESOURCE_INHERITANCE_MAP,
-    RESOURCES_WITHOUT_RESOURCE_LEVEL_CONTROLS,
     AccessControlLevel,
     AccessSource,
     UserAccessControl,
@@ -25,6 +24,7 @@ from posthog.rbac.user_access_control import (
     highest_access_level,
     minimum_access_level,
     ordered_access_levels,
+    resolve_inherited_object_access,
 )
 from posthog.scopes import API_SCOPE_OBJECTS, INTERNAL_API_SCOPE_OBJECTS, APIScopeObject, APIScopeObjectOrNotSupported
 
@@ -300,32 +300,11 @@ class AccessControlViewSetMixin(_GenericViewSet):
 
         if not is_resource_level:
             # The level this object falls back to when it carries no default of its own, so the UI
-            # can spell out what removing the override means. Follows RESOURCE_INHERITANCE_MAP
-            # because that's the resource the runtime check consults — a warehouse view is gated by
-            # the warehouse_objects rules, not by its own.
-            #
-            # None for a project is load-bearing: it is what stops the UI offering "No override" on
-            # a project's own default, which has nothing above it to fall back to. "No override"
-            # belongs to object defaults only — project-level access is configured in its own
-            # panel, which has no inherited tier to fall back to.
-            inherited_resource = (
-                None
-                if resource in RESOURCES_WITHOUT_RESOURCE_LEVEL_CONTROLS
-                else RESOURCE_INHERITANCE_MAP.get(resource, resource)
-            )
-            payload["inherited_resource"] = inherited_resource
-            payload["inherited_access_level"] = None
-            if inherited_resource:
-                everyone_rule = AccessControl.objects.filter(
-                    team=team,
-                    resource=inherited_resource,
-                    resource_id=None,
-                    organization_member=None,
-                    role=None,
-                ).first()
-                payload["inherited_access_level"] = (
-                    everyone_rule.access_level if everyone_rule else default_access_level(inherited_resource)
-                )
+            # can spell out what removing the override means. Resolved server-side, next to the
+            # runtime access resolution, so the two cannot drift; None means nothing sits above
+            # this object and the UI must not offer "No override".
+            inherited = resolve_inherited_object_access(team, resource, obj)
+            payload["inherited_access"] = asdict(inherited) if inherited else None
 
         return Response(payload)
 

--- a/ee/api/rbac/test/test_access_control.py
+++ b/ee/api/rbac/test/test_access_control.py
@@ -17,6 +17,7 @@ from products.cohorts.backend.models.cohort import Cohort
 from products.dashboards.backend.models.dashboard import Dashboard
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.notebooks.backend.models import Notebook
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSource
 
 from ee.api.test.base import APILicensedTest
 from ee.models.rbac.role import Role, RoleMembership
@@ -265,9 +266,8 @@ class TestAccessControlResourceLevelAPI(BaseAccessControlTest):
             "user_can_edit_access_levels": True,
             "minimum_access_level": "none",
             "maximum_access_level": "manager",
-            "inherited_resource": "notebook",
             # No project-wide rule for notebooks, so the resource's built-in default applies
-            "inherited_access_level": "editor",
+            "inherited_access": {"access_level": "editor", "reason": "Based on the default for notebooks"},
         }
 
     def test_get_access_controls_resolves_the_project_wide_level_it_falls_back_to(self):
@@ -285,8 +285,10 @@ class TestAccessControlResourceLevelAPI(BaseAccessControlTest):
 
         res = self._get_access_controls()
         assert res.status_code == status.HTTP_200_OK, res.json()
-        assert res.json()["inherited_resource"] == "notebook"
-        assert res.json()["inherited_access_level"] == "viewer"
+        assert res.json()["inherited_access"] == {
+            "access_level": "viewer",
+            "reason": "Based on the default for notebooks",
+        }
 
     def test_inherited_resource_follows_the_resource_it_actually_inherits_from(self):
         self._org_membership(OrganizationMembership.Level.ADMIN)
@@ -297,8 +299,63 @@ class TestAccessControlResourceLevelAPI(BaseAccessControlTest):
         res = self.client.get(f"/api/projects/@current/session_recording_playlists/{playlist.short_id}/access_controls")
         assert res.status_code == status.HTTP_200_OK, res.json()
         # Playlists are gated by the session_recording rules, so that's what "no override" falls back to
-        assert res.json()["inherited_resource"] == "session_recording"
-        assert res.json()["inherited_access_level"] == "viewer"
+        assert res.json()["inherited_access"] == {
+            "access_level": "viewer",
+            "reason": "Based on the default for session recordings",
+        }
+
+    def test_a_synced_table_inherits_from_its_source_before_any_resource_wide_rule(self):
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+        source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id="src",
+            connection_id="conn",
+            destination_id="dest",
+            source_type="Stripe",
+            prefix="test",
+        )
+        table = DataWarehouseTable.objects.create(
+            name="brands", format="Parquet", team=self.team, external_data_source=source, columns={}
+        )
+        # A resource-wide rule that the source's own default must outrank
+        res = self._put_global_access_control({"resource": "warehouse_objects", "access_level": "editor"})
+        assert res.status_code == status.HTTP_200_OK, res.json()
+        res = self.client.put(
+            f"/api/projects/@current/external_data_sources/{source.id}/access_controls",
+            {"access_level": "viewer"},
+        )
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        res = self.client.get(f"/api/projects/@current/warehouse_tables/{table.id}/access_controls")
+        assert res.status_code == status.HTTP_200_OK, res.json()
+        assert res.json()["inherited_access"] == {
+            "access_level": "viewer",
+            "reason": "Based on default access to its external data source",
+        }
+
+    def test_a_table_without_a_source_default_falls_back_to_the_resource_wide_rules(self):
+        self._org_membership(OrganizationMembership.Level.ADMIN)
+        source = ExternalDataSource.objects.create(
+            team_id=self.team.pk,
+            source_id="src",
+            connection_id="conn",
+            destination_id="dest",
+            source_type="Stripe",
+            prefix="test",
+        )
+        table = DataWarehouseTable.objects.create(
+            name="brands", format="Parquet", team=self.team, external_data_source=source, columns={}
+        )
+        # No rule on the source itself: the sources-wide rule applies (the tables-wide tier is empty)
+        res = self._put_global_access_control({"resource": "external_data_source", "access_level": "viewer"})
+        assert res.status_code == status.HTTP_200_OK, res.json()
+
+        res = self.client.get(f"/api/projects/@current/warehouse_tables/{table.id}/access_controls")
+        assert res.status_code == status.HTTP_200_OK, res.json()
+        assert res.json()["inherited_access"] == {
+            "access_level": "viewer",
+            "reason": "Based on the default for data warehouse sources",
+        }
 
     def test_project_reports_no_inherited_level(self):
         self._org_membership(OrganizationMembership.Level.ADMIN)
@@ -306,8 +363,7 @@ class TestAccessControlResourceLevelAPI(BaseAccessControlTest):
         assert res.status_code == status.HTTP_200_OK, res.json()
         # Nothing sits above a project, so it must report no inherited level — that absence is what
         # keeps "No override" an object-default affordance rather than a project-level one
-        assert res.json()["inherited_resource"] is None
-        assert res.json()["inherited_access_level"] is None
+        assert res.json()["inherited_access"] is None
 
     def test_change_rejected_if_not_org_admin(self):
         self._org_membership(OrganizationMembership.Level.MEMBER)

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/accessControlLogic.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/access_control/accessControlLogic.ts
@@ -4,7 +4,7 @@ import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { upgradeModalLogic } from 'lib/components/UpgradeModal/upgradeModalLogic'
 import { OrganizationMembershipLevel } from 'lib/constants'
-import { AccessControlUIVersion, captureAccessControlEvent, pluralizeResource } from 'lib/utils/accessControlUtils'
+import { AccessControlUIVersion, captureAccessControlEvent } from 'lib/utils/accessControlUtils'
 import { membersLogic } from 'scenes/organization/membersLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
@@ -1298,16 +1298,13 @@ export const accessControlLogic = kea<accessControlLogicType>([
         inheritedAccess: [
             (s) => [s.accessControls],
             (accessControls: AccessControlResponseType | null): InheritedAccess | null => {
-                const inheritedResource = accessControls?.inherited_resource
-                const inheritedLevel = accessControls?.inherited_access_level
-                if (!inheritedResource || !inheritedLevel) {
+                const inherited = accessControls?.inherited_access
+                if (!inherited) {
                     return null
                 }
                 return {
-                    label: humanizeAccessControlLevel(inheritedLevel),
-                    // A configured project rule and the built-in fallback are both "the default
-                    // for <resource>", so one reason covers them without claiming someone set it
-                    reason: `Based on the default for ${pluralizeResource(inheritedResource)}`,
+                    label: humanizeAccessControlLevel(inherited.access_level),
+                    reason: inherited.reason,
                 }
             },
         ],

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5898,11 +5898,10 @@ export type AccessControlResponseType = {
     default_access_level: AccessControlLevel
     minimum_access_level?: AccessControlLevel
     user_can_edit_access_levels: boolean
-    /** Resource whose project-wide rules apply while the object carries no override of its own. */
-    inherited_resource?: APIScopeObject | null
-    /** The level that applies while the object carries no override: the project-wide rule for
-     * `inherited_resource`, or its built-in default when no rule is set. */
-    inherited_access_level?: AccessControlLevel | null
+    /** What applies while the object carries no default of its own, resolved server-side next to
+     * the runtime access resolution. `reason` is display copy, rendered verbatim. Null means
+     * nothing sits above this object, so there is no "No override" to offer. */
+    inherited_access?: { access_level: AccessControlLevel; reason: string } | null
 }
 
 export type InheritedAccessLevelReason = 'project_default' | 'role_override' | 'organization_admin'

--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -19,6 +19,7 @@ from posthog.rbac.user_access_control import (
     get_effective_access_level_for_role,
     get_field_access_control_map,
     model_to_resource,
+    resolve_inherited_object_access,
 )
 
 from products.dashboards.backend.models.dashboard import Dashboard
@@ -2126,6 +2127,50 @@ class TestUserAccessControlFallbackParent(BaseUserAccessControlTest):
         self._apply(rules, self.self_managed_table)
 
         assert self._level(self.self_managed_table) == expected
+
+    def _apply_for_everyone(self, rules, table):
+        # Same ladder as _apply, but rows that apply to every member — what the access panel's
+        # inherited level describes.
+        targets = {
+            "this_source": ("external_data_source", str(self.source.id)),
+            "all_tables": ("warehouse_objects", None),
+            "all_sources": ("external_data_source", None),
+        }
+        for target, level in rules.items():
+            resource, resource_id = targets[target]
+            self._create_access_control(resource=resource, resource_id=resource_id, access_level=level)
+        self._clear_uac_caches()
+
+    @parameterized.expand(
+        [
+            ("nothing_set", {}),
+            ("source_default", {"this_source": "viewer"}),
+            ("all_tables", {"all_tables": "viewer"}),
+            ("all_sources", {"all_sources": "viewer"}),
+            ("source_beats_all_tables", {"this_source": "viewer", "all_tables": "editor"}),
+            ("all_tables_beats_all_sources", {"all_tables": "viewer", "all_sources": "editor"}),
+            ("source_deny", {"this_source": "none"}),
+        ]
+    )
+    def test_inherited_access_matches_the_runtime_for_a_plain_member(self, _name, rules):
+        # The panel's inherited level must be the level the runtime actually grants a member with
+        # no roles and no rules of their own, whichever tier supplies it. Guards the two
+        # resolutions against drifting when a tier is added or reordered.
+        self._apply_for_everyone(rules, self.sourced_table)
+
+        inherited = resolve_inherited_object_access(self.team, "warehouse_table", self.sourced_table)
+        assert inherited is not None
+        assert inherited.access_level == self.user_with_no_role_access_control.get_user_access_level(self.sourced_table)
+
+    def test_inherited_access_matches_the_runtime_for_a_self_managed_table(self):
+        self._apply_for_everyone({"this_source": "none", "all_sources": "none"}, self.self_managed_table)
+
+        inherited = resolve_inherited_object_access(self.team, "warehouse_table", self.self_managed_table)
+        assert inherited is not None
+        assert inherited.access_level == self.user_with_no_role_access_control.get_user_access_level(
+            self.self_managed_table
+        )
+        assert inherited.access_level == "editor"
 
     def test_source_denial_does_not_leak_across_sources(self):
         other_source = ExternalDataSource.objects.create(

--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -2158,14 +2158,18 @@ class TestUserAccessControlFallbackParent(BaseUserAccessControlTest):
         # resolutions against drifting when a tier is added or reordered.
         self._apply_for_everyone(rules, self.sourced_table)
 
-        inherited = resolve_inherited_object_access(self.team, "warehouse_table", self.sourced_table)
+        inherited = resolve_inherited_object_access(
+            self.user_with_no_role, self.team, "warehouse_table", self.sourced_table
+        )
         assert inherited is not None
         assert inherited.access_level == self.user_with_no_role_access_control.get_user_access_level(self.sourced_table)
 
     def test_inherited_access_matches_the_runtime_for_a_self_managed_table(self):
         self._apply_for_everyone({"this_source": "none", "all_sources": "none"}, self.self_managed_table)
 
-        inherited = resolve_inherited_object_access(self.team, "warehouse_table", self.self_managed_table)
+        inherited = resolve_inherited_object_access(
+            self.user_with_no_role, self.team, "warehouse_table", self.self_managed_table
+        )
         assert inherited is not None
         assert inherited.access_level == self.user_with_no_role_access_control.get_user_access_level(
             self.self_managed_table

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -507,6 +507,63 @@ def fallback_parent_object_id(obj: Model, parent_resource: APIScopeObject) -> Op
     return str(parent_id) if parent_id is not None else None
 
 
+@dataclass(frozen=True)
+class InheritedObjectAccess:
+    access_level: AccessControlLevel
+    # User-facing one-liner naming the rule the level comes from, rendered verbatim by the UI
+    reason: str
+
+
+def resolve_inherited_object_access(
+    team: Team, resource: APIScopeObject, obj: Model
+) -> Optional[InheritedObjectAccess]:
+    """The level `obj` falls back to while it carries no default of its own, and where it comes from.
+
+    This is the everyone perspective of `_object_access_level_from_rows` — the same tier order,
+    restricted to rules that apply to all members: the object's parent default (a table's source),
+    then the resource-wide rule, then the parent's resource-wide rule, then the built-in default.
+    Keep the two in step; the UI renders this next to a "No override" option whose runtime effect
+    is that resolution.
+
+    None means nothing sits above this object to fall back to, and the UI must not offer
+    "No override" — a project's own default is the case that hits.
+    """
+    if resource in RESOURCES_WITHOUT_RESOURCE_LEVEL_CONTROLS:
+        return None
+    inherited_resource = RESOURCE_INHERITANCE_MAP.get(resource, resource)
+
+    def everyone_level(res: APIScopeObject, res_id: Optional[str]) -> Optional[AccessControlLevel]:
+        rule = AccessControl.objects.filter(
+            team=team, resource=res, resource_id=res_id, organization_member=None, role=None
+        ).first()
+        return cast(AccessControlLevel, rule.access_level) if rule else None
+
+    parent = RESOURCE_FALLBACK_MAP.get(resource)
+    parent_id = fallback_parent_object_id(obj, parent) if parent else None
+    if parent and parent_id:
+        parent_level = everyone_level(parent, parent_id)
+        if parent_level:
+            return InheritedObjectAccess(parent_level, f"Based on default access to its {parent.replace('_', ' ')}")
+
+    resource_level = everyone_level(inherited_resource, None)
+    if resource_level:
+        return InheritedObjectAccess(
+            resource_level, f"Based on the default for {resource_to_display_name(inherited_resource)}"
+        )
+
+    if parent and parent_id:
+        parent_resource_level = everyone_level(parent, None)
+        if parent_resource_level:
+            return InheritedObjectAccess(
+                parent_resource_level, f"Based on the default for {resource_to_display_name(parent)}"
+            )
+
+    return InheritedObjectAccess(
+        default_access_level(inherited_resource),
+        f"Based on the default for {resource_to_display_name(inherited_resource)}",
+    )
+
+
 class UserAccessControl:
     """
     UserAccessControl provides functions for checking unified access to all resources and objects from a Project level downwards.

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -514,54 +514,13 @@ class InheritedObjectAccess:
     reason: str
 
 
-def resolve_inherited_object_access(
-    team: Team, resource: APIScopeObject, obj: Model
-) -> Optional[InheritedObjectAccess]:
-    """The level `obj` falls back to while it carries no default of its own, and where it comes from.
+@dataclass(frozen=True)
+class InheritedTier:
+    """A resolved inherited level plus which tier supplied it, so the panel can attribute it."""
 
-    This is the everyone perspective of `_object_access_level_from_rows` — the same tier order,
-    restricted to rules that apply to all members: the object's parent default (a table's source),
-    then the resource-wide rule, then the parent's resource-wide rule, then the built-in default.
-    Keep the two in step; the UI renders this next to a "No override" option whose runtime effect
-    is that resolution.
-
-    None means nothing sits above this object to fall back to, and the UI must not offer
-    "No override" — a project's own default is the case that hits.
-    """
-    if resource in RESOURCES_WITHOUT_RESOURCE_LEVEL_CONTROLS:
-        return None
-    inherited_resource = RESOURCE_INHERITANCE_MAP.get(resource, resource)
-
-    def everyone_level(res: APIScopeObject, res_id: Optional[str]) -> Optional[AccessControlLevel]:
-        rule = AccessControl.objects.filter(
-            team=team, resource=res, resource_id=res_id, organization_member=None, role=None
-        ).first()
-        return cast(AccessControlLevel, rule.access_level) if rule else None
-
-    parent = RESOURCE_FALLBACK_MAP.get(resource)
-    parent_id = fallback_parent_object_id(obj, parent) if parent else None
-    if parent and parent_id:
-        parent_level = everyone_level(parent, parent_id)
-        if parent_level:
-            return InheritedObjectAccess(parent_level, f"Based on default access to its {parent.replace('_', ' ')}")
-
-    resource_level = everyone_level(inherited_resource, None)
-    if resource_level:
-        return InheritedObjectAccess(
-            resource_level, f"Based on the default for {resource_to_display_name(inherited_resource)}"
-        )
-
-    if parent and parent_id:
-        parent_resource_level = everyone_level(parent, None)
-        if parent_resource_level:
-            return InheritedObjectAccess(
-                parent_resource_level, f"Based on the default for {resource_to_display_name(parent)}"
-            )
-
-    return InheritedObjectAccess(
-        default_access_level(inherited_resource),
-        f"Based on the default for {resource_to_display_name(inherited_resource)}",
-    )
+    access_level: AccessControlLevel
+    tier: Literal["parent_object", "resource"]
+    resource: APIScopeObject
 
 
 class UserAccessControl:
@@ -1408,39 +1367,56 @@ class UserAccessControl:
         fallback_parent_id: Optional[str] = None,
     ) -> Optional[AccessControlLevel]:
         """Row-based object access resolution, most specific rule first: explicit (role/member) object
-        rows, then the fallback parent's object rows, then resource-level rows, then the parent's
-        resource-level rows, then default object rows, then the resource default. Shared by
-        `get_user_access_level` and `bulk_object_access_levels`.
+        rows, then the inherited tiers (see `inherited_object_access_level`), then default object
+        rows, then the resource default. Shared by `get_user_access_level` and
+        `bulk_object_access_levels`.
         """
-        parent = RESOURCE_FALLBACK_MAP.get(resource) if fallback_parent_id else None
-
         explicit_rows = [
             ac for ac in object_access_controls if ac.role_id is not None or ac.organization_member_id is not None
         ]
         if explicit_rows:
             return self._highest_access_level_from_rows(resource, explicit_rows)
 
-        if parent:
-            parent_rows = self._get_access_controls(
-                self._access_controls_filters_for_object(parent, cast(str, fallback_parent_id))
-            )
-            if parent_rows:
-                return self._highest_access_level_from_rows(parent, parent_rows)
-
-        if self.has_access_levels_for_resource(resource):
-            access_level_for_resource = self.access_level_for_resource(resource)
-            if access_level_for_resource:
-                return access_level_for_resource
-
-        if parent and self.has_access_levels_for_resource(parent):
-            access_level_for_parent = self.access_level_for_resource(parent)
-            if access_level_for_parent:
-                return access_level_for_parent
+        inherited = self.inherited_object_access_level(resource, fallback_parent_id)
+        if inherited:
+            return inherited.access_level
 
         if object_access_controls:
             return self._highest_access_level_from_rows(resource, object_access_controls)
 
         return None if explicit else default_access_level(resource)
+
+    def inherited_object_access_level(
+        self, resource: APIScopeObject, fallback_parent_id: Optional[str]
+    ) -> Optional["InheritedTier"]:
+        """The tiers between an object's own rows and the built-in default, most specific first:
+        the fallback parent's object rows (a table's source), then resource-level rows, then the
+        parent's resource-level rows. This is the single definition of what an object inherits —
+        enforcement consumes it above, and the access panel's "No override" display consumes it
+        through `resolve_inherited_object_access` with a baseline-member perspective.
+        """
+        parent = RESOURCE_FALLBACK_MAP.get(resource) if fallback_parent_id else None
+
+        if parent:
+            parent_rows = self._get_access_controls(
+                self._access_controls_filters_for_object(parent, cast(str, fallback_parent_id))
+            )
+            if parent_rows:
+                return InheritedTier(self._highest_access_level_from_rows(parent, parent_rows), "parent_object", parent)
+
+        if self.has_access_levels_for_resource(resource):
+            access_level_for_resource = self.access_level_for_resource(resource)
+            if access_level_for_resource:
+                return InheritedTier(
+                    access_level_for_resource, "resource", RESOURCE_INHERITANCE_MAP.get(resource, resource)
+                )
+
+        if parent and self.has_access_levels_for_resource(parent):
+            access_level_for_parent = self.access_level_for_resource(parent)
+            if access_level_for_parent:
+                return InheritedTier(access_level_for_parent, "resource", parent)
+
+        return None
 
     @staticmethod
     def _fallback_parent_id(obj: Model, resource: APIScopeObject) -> Optional[str]:
@@ -1505,6 +1481,54 @@ class UserAccessControl:
             results[object_id] = self._object_access_level_from_rows(resource, rows_by_object_id.get(object_id, []))
 
         return results
+
+
+class _BaselineMemberAccessControl(UserAccessControl):
+    """The perspective of a plain org member: no roles, no personal grants, no admin or creator
+    privileges. Only narrows what the parent class would return — every override below removes an
+    arm from the resolution, none adds one. Used solely to display what an object inherits; never
+    for enforcement.
+    """
+
+    def _filter_options(self, filters: dict[str, Any]) -> Q:
+        # Only the everyone-arm; the member and role arms don't exist for a baseline member
+        return Q(**filters, organization_member=None, role=None)
+
+    @property
+    def is_organization_admin(self) -> bool:
+        return False
+
+
+def resolve_inherited_object_access(
+    user: User, team: Team, resource: APIScopeObject, obj: Model
+) -> Optional[InheritedObjectAccess]:
+    """The level `obj` falls back to while it carries no default of its own, and where it comes from.
+
+    Resolved by the same `inherited_object_access_level` tiers that enforcement walks, through a
+    baseline-member perspective — so what the panel displays next to "No override" cannot drift
+    from what removing the override actually grants.
+
+    None means nothing sits above this object to fall back to, and the UI must not offer
+    "No override" — a project's own default is the case that hits.
+    """
+    if resource in RESOURCES_WITHOUT_RESOURCE_LEVEL_CONTROLS:
+        return None
+
+    baseline = _BaselineMemberAccessControl(user, team)
+    tier = baseline.inherited_object_access_level(resource, UserAccessControl._fallback_parent_id(obj, resource))
+    if tier is None:
+        inherited_resource = RESOURCE_INHERITANCE_MAP.get(resource, resource)
+        return InheritedObjectAccess(
+            default_access_level(inherited_resource),
+            f"Based on the default for {resource_to_display_name(inherited_resource)}",
+        )
+    if tier.tier == "parent_object":
+        return InheritedObjectAccess(
+            tier.access_level, f"Based on default access to its {tier.resource.replace('_', ' ')}"
+        )
+    return InheritedObjectAccess(
+        tier.access_level, f"Based on the default for {resource_to_display_name(tier.resource)}"
+    )
 
 
 class UserAccessControlSerializerMixin(serializers.Serializer):

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -515,12 +515,14 @@ class InheritedObjectAccess:
 
 
 @dataclass(frozen=True)
-class InheritedTier:
-    """A resolved inherited level plus which tier supplied it, so the panel can attribute it."""
+class ResolvedObjectAccess:
+    """An object access resolution plus which tier supplied it, so displays can attribute it."""
 
     access_level: AccessControlLevel
-    tier: Literal["parent_object", "resource"]
-    resource: APIScopeObject
+    tier: Literal["object_explicit", "parent_object", "resource", "object_default", "builtin_default"]
+    # The resource the winning tier belongs to — a table resolved through its source reports the
+    # source's resource, not its own
+    tier_resource: APIScopeObject
 
 
 class UserAccessControl:
@@ -1365,58 +1367,58 @@ class UserAccessControl:
         object_access_controls: list[_AccessControl],
         explicit: bool = False,
         fallback_parent_id: Optional[str] = None,
-    ) -> Optional[AccessControlLevel]:
+    ) -> Optional[ResolvedObjectAccess]:
         """Row-based object access resolution, most specific rule first: explicit (role/member) object
-        rows, then the inherited tiers (see `inherited_object_access_level`), then default object
-        rows, then the resource default. Shared by `get_user_access_level` and
-        `bulk_object_access_levels`.
+        rows, then the fallback parent's object rows, then resource-level rows, then the parent's
+        resource-level rows, then default object rows, then the resource default. Shared by
+        `get_user_access_level` and `bulk_object_access_levels`, which read only `.access_level`.
+
+        Returns the tier that supplied the level alongside it, so a display can attribute the
+        resolution without re-implementing it: `resolve_inherited_object_access` computes the
+        inherited level by calling this very walk with the object's own rows masked out of
+        `object_access_controls`.
         """
+        parent = RESOURCE_FALLBACK_MAP.get(resource) if fallback_parent_id else None
+
         explicit_rows = [
             ac for ac in object_access_controls if ac.role_id is not None or ac.organization_member_id is not None
         ]
         if explicit_rows:
-            return self._highest_access_level_from_rows(resource, explicit_rows)
-
-        inherited = self.inherited_object_access_level(resource, fallback_parent_id)
-        if inherited:
-            return inherited.access_level
-
-        if object_access_controls:
-            return self._highest_access_level_from_rows(resource, object_access_controls)
-
-        return None if explicit else default_access_level(resource)
-
-    def inherited_object_access_level(
-        self, resource: APIScopeObject, fallback_parent_id: Optional[str]
-    ) -> Optional["InheritedTier"]:
-        """The tiers between an object's own rows and the built-in default, most specific first:
-        the fallback parent's object rows (a table's source), then resource-level rows, then the
-        parent's resource-level rows. This is the single definition of what an object inherits —
-        enforcement consumes it above, and the access panel's "No override" display consumes it
-        through `resolve_inherited_object_access` with a baseline-member perspective.
-        """
-        parent = RESOURCE_FALLBACK_MAP.get(resource) if fallback_parent_id else None
+            return ResolvedObjectAccess(
+                self._highest_access_level_from_rows(resource, explicit_rows), "object_explicit", resource
+            )
 
         if parent:
             parent_rows = self._get_access_controls(
                 self._access_controls_filters_for_object(parent, cast(str, fallback_parent_id))
             )
             if parent_rows:
-                return InheritedTier(self._highest_access_level_from_rows(parent, parent_rows), "parent_object", parent)
+                return ResolvedObjectAccess(
+                    self._highest_access_level_from_rows(parent, parent_rows), "parent_object", parent
+                )
 
         if self.has_access_levels_for_resource(resource):
             access_level_for_resource = self.access_level_for_resource(resource)
             if access_level_for_resource:
-                return InheritedTier(
+                return ResolvedObjectAccess(
                     access_level_for_resource, "resource", RESOURCE_INHERITANCE_MAP.get(resource, resource)
                 )
 
         if parent and self.has_access_levels_for_resource(parent):
             access_level_for_parent = self.access_level_for_resource(parent)
             if access_level_for_parent:
-                return InheritedTier(access_level_for_parent, "resource", parent)
+                return ResolvedObjectAccess(access_level_for_parent, "resource", parent)
 
-        return None
+        if object_access_controls:
+            return ResolvedObjectAccess(
+                self._highest_access_level_from_rows(resource, object_access_controls), "object_default", resource
+            )
+
+        if explicit:
+            return None
+        return ResolvedObjectAccess(
+            default_access_level(resource), "builtin_default", RESOURCE_INHERITANCE_MAP.get(resource, resource)
+        )
 
     @staticmethod
     def _fallback_parent_id(obj: Model, resource: APIScopeObject) -> Optional[str]:
@@ -1436,12 +1438,13 @@ class UserAccessControl:
         object_access_controls = self._get_access_controls(
             self._access_controls_filters_for_object(resource, str(obj.id))  # type: ignore
         )
-        return self._object_access_level_from_rows(
+        resolution = self._object_access_level_from_rows(
             resource,
             object_access_controls,
             explicit=explicit,
             fallback_parent_id=self._fallback_parent_id(obj, resource),
         )
+        return resolution.access_level if resolution else None
 
     def bulk_object_access_levels(
         self,
@@ -1478,7 +1481,8 @@ class UserAccessControl:
                 for ac in self._get_access_controls(self._access_controls_filters_for_queryset(resource)):
                     rows_by_object_id[ac.resource_id].append(ac)
 
-            results[object_id] = self._object_access_level_from_rows(resource, rows_by_object_id.get(object_id, []))
+            resolution = self._object_access_level_from_rows(resource, rows_by_object_id.get(object_id, []))
+            results[object_id] = resolution.access_level if resolution else None
 
         return results
 
@@ -1502,11 +1506,12 @@ class _BaselineMemberAccessControl(UserAccessControl):
 def resolve_inherited_object_access(
     user: User, team: Team, resource: APIScopeObject, obj: Model
 ) -> Optional[InheritedObjectAccess]:
-    """The level `obj` falls back to while it carries no default of its own, and where it comes from.
+    """The level `obj` falls back to while it carries no rules of its own, and where it comes from.
 
-    Resolved by the same `inherited_object_access_level` tiers that enforcement walks, through a
-    baseline-member perspective — so what the panel displays next to "No override" cannot drift
-    from what removing the override actually grants.
+    Inherited access is the enforcement resolution itself, run for a baseline member with the
+    object's own rows masked out of the pool — not a re-implementation of the tier order. Whatever
+    `_object_access_level_from_rows` resolves to without those rows is what removing the override
+    grants, by construction.
 
     None means nothing sits above this object to fall back to, and the UI must not offer
     "No override" — a project's own default is the case that hits.
@@ -1515,19 +1520,22 @@ def resolve_inherited_object_access(
         return None
 
     baseline = _BaselineMemberAccessControl(user, team)
-    tier = baseline.inherited_object_access_level(resource, UserAccessControl._fallback_parent_id(obj, resource))
-    if tier is None:
-        inherited_resource = RESOURCE_INHERITANCE_MAP.get(resource, resource)
+    object_rows = baseline._get_access_controls(baseline._access_controls_filters_for_object(resource, str(obj.pk)))
+    # Masking the object's own rows is what turns "resolve access" into "resolve inherited access"
+    resolution = baseline._object_access_level_from_rows(
+        resource,
+        [row for row in object_rows if row.organization_member_id is not None or row.role_id is not None],
+        fallback_parent_id=UserAccessControl._fallback_parent_id(obj, resource),
+    )
+    if resolution is None:
+        return None
+
+    if resolution.tier == "parent_object":
         return InheritedObjectAccess(
-            default_access_level(inherited_resource),
-            f"Based on the default for {resource_to_display_name(inherited_resource)}",
-        )
-    if tier.tier == "parent_object":
-        return InheritedObjectAccess(
-            tier.access_level, f"Based on default access to its {tier.resource.replace('_', ' ')}"
+            resolution.access_level, f"Based on default access to its {resolution.tier_resource.replace('_', ' ')}"
         )
     return InheritedObjectAccess(
-        tier.access_level, f"Based on the default for {resource_to_display_name(tier.resource)}"
+        resolution.access_level, f"Based on the default for {resource_to_display_name(resolution.tier_resource)}"
     )
 
 


### PR DESCRIPTION
## Problem

Follow-up to #74399, after #74201 landed.

The object panel's `No override · Editor` reads the inherited level from **resource-wide rules only**. Since #74201, the runtime resolves a synced table's access through its **source object's rules first** (`RESOURCE_FALLBACK_MAP`) — so a table under a source set to Viewer still showed `No override · Editor`, and picking "No override" would actually land the table on Viewer, not the Editor the select promised.

The frontend also built the "Based on …" copy itself from resource names, which meant every change to the inheritance chain needed matching frontend logic — the two had already drifted once.

## Changes

- **Inherited access is the enforcement resolution itself, masked — not a second implementation.** `_object_access_level_from_rows` (the walker enforcement already uses, structurally unchanged) now reports which tier supplied the level alongside it. `resolve_inherited_object_access` runs that same walker for a baseline member with the object's own rows masked out of the pool: whatever it resolves to without those rows is what removing the override grants, by construction. The definition — "inherited = same resolution, minus the rule being edited" — survives any future change to the conflict rules, because masking re-runs whatever rule is current.
- **`_BaselineMemberAccessControl`** supplies the everyone-perspective — a `UserAccessControl` subclass that only narrows (everyone-arm of the row filter only, no admin bypass, never used for enforcement). The resolver returns `None` for resources with nothing above them (a project's own default), which keeps "No override" off the project panel.
- **Payload collapses to one field**: `inherited_resource` + `inherited_access_level` (+ the would-be `inherited_parent_resource`) become a single `inherited_access: { access_level, reason } | null`. The `reason` is display copy resolved server-side ("Based on default access to its external data source" vs "Based on the default for data warehouse tables & views"); the frontend renders it verbatim.
- `inheritedAccess` selector in `accessControlLogic.ts` is now a trivial mapping — no resource-name copy derivation left in the frontend.

> The reason string lives backend-side deliberately: the inheritance chain will keep changing, and this way those changes are backend-only. `resource_to_display_name` already sets the precedent for user-facing copy in that module.

## How did you test this code?

Tests — `pytest ee/api/rbac/test/test_access_control.py` (119 passed).

New cases in `TestAccessControlResourceLevelAPI`:
- a synced table with a source default of Viewer reports Viewer even when a tables-wide Editor rule exists (source outranks resource-wide — the reported bug)
- with no source default, the sources-wide rule applies
- a project still reports no inherited access

Conformance tests in `posthog/rbac/test/test_user_access_control.py`: for a member with no roles and no rules of their own, `resolve_inherited_object_access` must equal `get_user_access_level` — asserted across the rule ladder (source default / tables-wide / sources-wide / combinations / deny / self-managed table). With the tier walk single-sourced these verify the baseline projection equals a real plain member, rather than policing two implementations.

Also ran the full RBAC suite (158), the property-based suite, and repo-wide mypy — all green.

Not manually tested — the fix is payload-only and the select renders whatever the payload says.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Human-driven (agent-assisted).

This went through four shapes under Alex's direction. First: backend returned `inherited_resource` + a level + a discriminator, frontend picked the copy — rejected because the frontend shouldn't compute inheritance. Second: a standalone resolver mirroring the runtime chain, pinned by conformance tests — rejected because the tier order then existed twice. Third: the middle tiers extracted into a method both sides shared — rejected because the walk then existed in split form. Final (Alex's formulation): inherited access is the unmodified enforcement walker, run for a baseline member with the object's own rows masked out of the row pool, with the walker annotating which tier won so the panel can attribute it. One resolution, one tier order, masking as the only difference between "effective" and "inherited".

Why the panel can't just call `get_user_access_level`: every existing method resolves for the *requesting* user (`_filter_options` scopes all row fetches to their member/role rows, plus creator/org-admin short-circuits), and the panel viewer is nearly always an admin — the real resolver would answer "Manager" for everyone. The baseline subclass strips exactly those arms and nothing else. If reviewers prefer a structured reason (enum) over a display string, that's contained to `resolve_inherited_object_access` and the one selector.

Session: https://claude.ai/code/session_01FBfNfcw8LHPxsiEsGSzHGZ
