### PR TITLE
fix(railway): keep exhausted read timeouts out of error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/railway/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/railway/source.py
@@ -83,6 +83,17 @@ Note that Railway rate limits API requests per plan (as low as 100 requests/hour
             "Railway API error: Not Authorized": "Your Railway API token is invalid, revoked, or lacks access to this resource. Create a new account or workspace token in your Railway account settings, then reconnect.",
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_execute` already retries 429/5xx (as the "Railway API error (retryable)" sentinel),
+        # connection failures, and read timeouts in-process. Once that budget exhausts, Temporal
+        # retries the whole activity and the failure is transient and self-recovering, so don't
+        # surface it as tracked exception noise. The host is a constant, not user input, so
+        # matching on it doesn't risk swallowing an unrelated failure.
+        return {
+            "Railway API error (retryable)",
+            "HTTPSConnectionPool(host='backboard.railway.com', port=443)",
+        }
+
     def get_schemas(
         self,
         config: RailwaySourceConfig,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/railway/tests/test_railway_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/railway/tests/test_railway_source.py
@@ -80,6 +80,29 @@ class TestRailwaySource:
         assert error_message == expected_message
         mock_validate.assert_called_once_with("railway-token")
 
+    @parameterized.expand(
+        [
+            ("rate_limit", "Railway API error (retryable): status=429, retry_after=60"),
+            ("server_error", "Railway API error (retryable): status=500, retry_after=None"),
+            (
+                "connection_error",
+                "HTTPSConnectionPool(host='backboard.railway.com', port=443): Max retries exceeded with url: "
+                '/graphql/v2 (Caused by ReadTimeoutError("HTTPSConnectionPool'
+                "(host='backboard.railway.com', port=443): Read timed out. (read timeout=60)\"))",
+            ),
+            (
+                "read_timeout",
+                "HTTPSConnectionPool(host='backboard.railway.com', port=443): Read timed out. (read timeout=60)",
+            ),
+        ]
+    )
+    def test_retryable_errors_match_transient_failures(self, _name, observed_error):
+        # `_execute` already retries these in-process; once that budget exhausts, this keeps the
+        # benign, self-recovering failure out of error tracking (see the ReadTimeout that used to
+        # slip through and get reported as a tracked exception).
+        retryable_errors = self.source.get_retryable_errors()
+        assert any(key in observed_error for key in retryable_errors)
+
     def test_get_resumable_source_manager_binds_resume_config(self):
         inputs = mock.MagicMock()
 


### PR DESCRIPTION
## Problem

An error tracking issue surfaced a `ReadTimeout` from the Railway data-warehouse import source (`HTTPSConnectionPool(host='backboard.railway.com', port=443): Read timed out.`), raised while paging Railway's `projects` connection to enumerate project IDs for fan-out endpoints.

Railway's `_execute` helper already retries `ReadTimeout`, `ConnectionError`, `ChunkedEncodingError`, and rate-limit/5xx responses in-process (tenacity, 5 attempts with exponential backoff). Once that budget exhausts, the raw exception re-raises and Temporal retries the whole activity — a transient, self-recovering failure. But `RailwaySource` didn't override `get_retryable_errors()`, so the import pipeline's error handler logged it at `exception` level (tracked in error tracking) instead of `warning` (the treatment reserved for failures a source already retries internally).

This is not a user/credential error — the token and request are fine, Railway's API was just slow to respond. So it belongs in `get_retryable_errors()`, not `get_non_retryable_errors()`.

## Changes

Added `get_retryable_errors()` to `RailwaySource`, matching:
- The stable `HTTPSConnectionPool(host='backboard.railway.com', port=443)` prefix shared by exhausted `ReadTimeout`/`ConnectionError` retries (the host is a constant, not user input, so matching on it is safe).
- The existing `"Railway API error (retryable)"` sentinel raised for exhausted 429/5xx retries, which was also falling through to `exception`-level logging.

This mirrors the same pattern already used by the Vercel and Notion sources for their own internally-retried transport errors.

No change to the retry/backoff policy itself — retries, timeouts, and Temporal's activity-level retry all stay as they are.

## How did you test this code?

Added `test_retryable_errors_match_transient_failures` (parameterized: rate limit, server error, connection error, read timeout) to `test_railway_source.py`, asserting `get_retryable_errors()` matches each of these observed failure message shapes. This is the regression an existing test didn't catch — before this change, none of these strings matched any entry in `get_retryable_errors()` (it returned the empty base-class default), so they'd all have been logged as tracked exceptions.

Ran the full `test_railway_source.py` and `test_railway.py` suites locally (all passing), plus `ruff check --fix`, `ruff format --check`, and `mypy` on the changed file (no issues).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — no user-facing behavior or config change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the Railway data-warehouse source (a `ReadTimeout` against Railway's API), confirmed the failure originates in `railway.py`'s connection-page pagination, and traced it to a missing `get_retryable_errors()` override on `RailwaySource` — the mechanism this codebase already uses (see Vercel, Notion, Stripe) to keep failures a source already retries internally out of error tracking once the internal retry budget exhausts. Verified no open PR already addressed this before opening.