### PR TITLE
fix(data-imports): bound the queryable-files copy retry to survive a longer vacuum race

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py
@@ -80,6 +80,63 @@ class TestPrepareS3FilesForQuerying:
         refresh_file_uris.assert_awaited_once()
         assert cp_file.await_args_list[-1].args[0] == "s3://bucket/job/my_table/part-1.parquet"
 
+    async def test_retries_past_a_second_consecutive_vanished_file(self):
+        # Regression for a race where a zombie compact/vacuum pass outlived a single retry:
+        # the source file vanished on both the first attempt and the retry (a different file
+        # each time), which a retry-once loop would give up on instead of trying a third time.
+        cp_file = AsyncMock(
+            side_effect=[
+                FileNotFoundError("s3://bucket/job/my_table/part-0.parquet"),
+                FileNotFoundError("s3://bucket/job/my_table/part-1.parquet"),
+                None,
+            ]
+        )
+        s3 = _fake_s3(_cp_file=cp_file)
+        refresh_file_uris = AsyncMock(
+            side_effect=[
+                ["s3://bucket/job/my_table/part-1.parquet"],
+                ["s3://bucket/job/my_table/part-2.parquet"],
+            ]
+        )
+
+        with (
+            patch.object(util_module, "aget_s3_client", return_value=_FakeS3CM(s3)),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await prepare_s3_files_for_querying(
+                folder_path="job",
+                table_name="my_table",
+                file_uris=["s3://bucket/job/my_table/part-0.parquet"],
+                delete_existing=False,
+                refresh_file_uris=refresh_file_uris,
+            )
+
+        assert refresh_file_uris.await_count == 2
+        assert cp_file.await_args_list[-1].args[0] == "s3://bucket/job/my_table/part-2.parquet"
+
+    async def test_gives_up_after_max_attempts_exhausted(self):
+        # The retry loop is bounded: a source file that keeps vanishing on every attempt must
+        # eventually raise instead of retrying forever.
+        cp_file = AsyncMock(side_effect=FileNotFoundError("s3://bucket/job/my_table/part-0.parquet"))
+        s3 = _fake_s3(_cp_file=cp_file)
+        refresh_file_uris = AsyncMock(return_value=["s3://bucket/job/my_table/part-0.parquet"])
+
+        with (
+            patch.object(util_module, "aget_s3_client", return_value=_FakeS3CM(s3)),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            with pytest.raises(FileNotFoundError):
+                await prepare_s3_files_for_querying(
+                    folder_path="job",
+                    table_name="my_table",
+                    file_uris=["s3://bucket/job/my_table/part-0.parquet"],
+                    delete_existing=False,
+                    refresh_file_uris=refresh_file_uris,
+                )
+
+        assert cp_file.await_count == util_module._COPY_FILES_MAX_ATTEMPTS
+        assert refresh_file_uris.await_count == util_module._COPY_FILES_MAX_ATTEMPTS - 1
+
     async def test_propagates_vanished_source_file_without_refresh_callback(self):
         # Callers that don't pass refresh_file_uris keep today's behavior: the race still
         # surfaces as an error instead of being retried blindly.

--- a/products/warehouse_sources/backend/temporal/data_imports/util.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/util.py
@@ -57,6 +57,12 @@ class PostHogInternalDatabaseError(Exception):
 # 10 mins buffer to avoid deleting files Clickhouse may be reading
 S3_DELETE_TIME_BUFFER = 600
 
+# A zombie compaction+vacuum pass (a heartbeat-timed-out activity attempt still running) can keep
+# deleting source files for as long as its own rewrite takes - documented up to ~45s for a
+# fragmented table in delta_table_helper.py - which can outlive a single retry. Bound the retries
+# with backoff instead, mirroring _purge_s3_prefix's approach to the same class of race.
+_COPY_FILES_MAX_ATTEMPTS = 4
+
 
 def is_posthog_team(team_id: int) -> bool:
     DEBUG: bool = get_from_env("DEBUG", False, type_cast=str_to_bool)
@@ -184,18 +190,27 @@ async def prepare_s3_files_for_querying(
                 # S3's SlowDown rate limiting on the destination prefix.
                 await s3._cp_file(file, f"{s3_path_for_querying}/{file_name}")
 
-        try:
-            await asyncio.gather(*[copy_file(file) for file in file_uris])
-        except FileNotFoundError as e:
-            if refresh_file_uris is None:
-                raise
-            # A concurrent compact/vacuum pass on the same Delta table (e.g. a zombie attempt
-            # from a heartbeat timeout still running) can physically delete a source file
-            # between our listing and this copy. Re-listing picks up wherever that pass left
-            # the table and retries once against the current file set.
-            await _log(f"Source file vanished mid-copy, retrying with a fresh file listing: {e}", level="error")
-            file_uris = await refresh_file_uris()
-            await asyncio.gather(*[copy_file(file) for file in file_uris])
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                await asyncio.gather(*[copy_file(file) for file in file_uris])
+                break
+            except FileNotFoundError as e:
+                if refresh_file_uris is None or attempt >= _COPY_FILES_MAX_ATTEMPTS:
+                    raise
+                # A concurrent compact/vacuum pass on the same Delta table (e.g. a zombie attempt
+                # from a heartbeat timeout still running) can physically delete a source file
+                # between our listing and this copy. Re-listing picks up wherever that pass left
+                # the table; back off first so a still-running pass has time to finish before we
+                # retry against it again.
+                await _log(
+                    f"Source file vanished mid-copy (attempt {attempt}/{_COPY_FILES_MAX_ATTEMPTS}), "
+                    f"retrying with a fresh file listing: {e}",
+                    level="error",
+                )
+                await asyncio.sleep(2**attempt)
+                file_uris = await refresh_file_uris()
 
         # Delete existing files after copying new ones
         if delete_existing and files_to_delete:


### PR DESCRIPTION
## Problem

Error tracking caught an unhandled `FileNotFoundError` during a Postgres incremental sync's post-load "publish queryable files" step, in `prepare_s3_files_for_querying` (`products/warehouse_sources/backend/temporal/data_imports/util.py`).

That function already retries once after a source file vanishes mid-copy — the documented cause is a concurrent Delta compact/vacuum pass on the same table (e.g. a "zombie" attempt from a heartbeat timeout that keeps running) physically deleting a file between listing and copy. In this event, the retry itself failed too, on a *different* file, meaning the same race was still in progress when the single retry ran.

This pipeline's own comments (`delta_table_helper.py`) document that a compaction/vacuum rewrite on a fragmented table can take up to ~45s in the observed pathological case — long enough to outlive a bare, immediate, single retry.

## Changes

Turned the retry-once-after-refresh into a bounded retry loop with exponential backoff (up to 4 attempts total), re-listing the current file set via `refresh_file_uris` before each retry. This mirrors the existing `_purge_s3_prefix` retry pattern in the same pipeline, which handles the same class of "let a concurrent operation finish" race.

Left retry classification and Temporal's own activity retry policy untouched — this only changes how many times, and how patiently, the in-process copy step itself retries before giving up.

## How did you test this code?

Extended `products/warehouse_sources/backend/temporal/data_imports/tests/test_util.py`:
- `test_retries_past_a_second_consecutive_vanished_file` — a source file vanishes on both the first attempt and the retry (different file each time); asserts the loop tries a third time and succeeds. This is the exact regression: a retry-once loop would have raised instead.
- `test_gives_up_after_max_attempts_exhausted` — a file that keeps vanishing on every attempt eventually raises rather than retrying forever, guarding the loop's bound.

Ran the full `test_util.py` suite locally (13 passed) plus `ruff check`/`ruff format --check` on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Investigated via PostHog's error tracking MCP tools (issue details, representative event with full exception chain, `warehouse_sources_*` properties) to identify the exact race and call path, then read the surrounding pipeline code (`util.py`, `pipelines/common/load.py`, `pipelines/core/delta_table_helper.py`) to confirm the retry logic and the vacuum/compaction mechanism creating the race window.
- Skills invoked: `/writing-tests` before adding the regression tests.
- Considered classifying the exhausted-retry failure as a `NonReportableError` (like the existing transient-object-store-error handling elsewhere in this pipeline) instead of, or in addition to, strengthening the retry. Chose the bounded-retry-loop fix as primary since it directly targets the documented insufficiency (single retry vs. a race that can run for tens of seconds), keeping the same class of failure retryable and reportable if it somehow still exhausts all attempts. Searched open PRs (by exception type, module path, and the reporting user's own open PRs) and found none addressing this call site — several existing PRs classify *other* delta-maintenance races as transient, but none touch this retry loop.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*