### PR TITLE
fix(data-imports): register binary Arrow columns in HogQLSchema

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/hogql_schema.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/hogql_schema.py
@@ -35,17 +35,11 @@ class HogQLSchema:
             if existing_type is not None and existing_type != StringDatabaseField.__name__:
                 continue
 
-            if pa.types.is_binary(field.type):
-                continue
-
             self.schema[field.name] = self._map_arrow_type(field.type).__name__
 
     def add_field(self, field: pa.Field, column: pa.ChunkedArray) -> None:
         existing_type = self.schema.get(field.name)
         if existing_type is not None and existing_type != StringDatabaseField.__name__:
-            return
-
-        if pa.types.is_binary(field.type):
             return
 
         hogql_type = self._map_arrow_type(field.type)
@@ -83,6 +77,11 @@ class HogQLSchema:
         elif pa.types.is_integer(arrow_type):
             return IntegerDatabaseField
         elif pa.types.is_string(arrow_type):
+            return StringDatabaseField
+        elif pa.types.is_binary(arrow_type) or pa.types.is_large_binary(arrow_type):
+            # ClickHouse's deltaLake()/Parquet readers surface binary columns as String, so
+            # db_columns always reports "String" for these — map to the same HogQL type or
+            # merge_columns can never find a match for them.
             return StringDatabaseField
         return DatabaseField
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_hogql_schema.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_hogql_schema.py
@@ -49,6 +49,8 @@ class TestAddPyarrowSchema:
             ("timestamp_us", pa.timestamp("us"), "DateTimeDatabaseField"),
             ("date32", pa.date32(), "DateDatabaseField"),
             ("decimal128", pa.decimal128(10, 2), "FloatDatabaseField"),
+            ("binary", pa.binary(), "StringDatabaseField"),
+            ("large_binary", pa.large_binary(), "StringDatabaseField"),
         ]
     )
     def test_maps_arrow_type(self, _name: str, arrow_type: pa.DataType, expected: str):
@@ -56,13 +58,6 @@ class TestAddPyarrowSchema:
         fields: list[pa.Field] = [pa.field("col", arrow_type)]
         schema.add_pyarrow_schema(pa.schema(fields))
         assert schema.schema["col"] == expected
-
-    def test_skips_binary_fields(self):
-        arrow_schema = pa.schema([pa.field("bin_col", pa.binary())])
-        schema = HogQLSchema()
-        schema.add_pyarrow_schema(arrow_schema)
-
-        assert "bin_col" not in schema.schema
 
     def test_does_not_overwrite_non_string_types(self):
         schema = HogQLSchema()
@@ -192,3 +187,16 @@ class TestMergeColumnsRaceCondition:
 
         assert "user_id" in result
         assert "new_col" not in result
+
+    def test_merge_columns_keeps_binary_column_registered_by_hogql_schema(self):
+        # A binary Arrow column (e.g. a BigQuery BYTES field) is read back by ClickHouse's
+        # deltaLake() reader as String, so HogQLSchema must register a type for it or this
+        # column is dropped from `columns` on every sync.
+        table = pa.table({"key": pa.array([b"abc"], type=pa.binary())})
+        schema = HogQLSchema()
+        schema.add_pyarrow_table(table)
+
+        db_columns = {"key": "String"}
+        result = merge_columns(db_columns, schema.to_hogql_types(), {})
+
+        assert result["key"] == {"clickhouse": "String", "hogql": "StringDatabaseField"}


### PR DESCRIPTION
## Problem

An error-tracking issue surfaced `Exception: HogQL type not found for column: key` from `merge_columns` in the data-imports pipeline, during a BigQuery `full_refresh` sync ([issue](https://us.posthog.com/project/2/error_tracking/019fb7fc-60b8-7b00-bca4-63d7c6fe9d69)).

`HogQLSchema` (the registry that maps a synced table's columns to HogQL types) explicitly skipped any Arrow column of type `binary`:

```python
if pa.types.is_binary(field.type):
    continue  # add_pyarrow_schema
    return    # add_field
```

That means a binary column never gets an entry in the type registry. But ClickHouse's `deltaLake()`/Parquet reader still reports the column back as a physical `String` type when introspecting the written table (`DataWarehouseTable.get_columns()`). `merge_columns` reconciles those two views by column name, so a column present in ClickHouse's introspection but absent from the registry raises `"HogQL type not found for column: {name}"` and gets dropped from the table's stored `columns`.

BigQuery `BYTES` columns come back from the Storage Read API as Arrow `binary`, so a `BYTES` column named `key` in the affected schema hit this every sync.

## Changes

- `hogql_schema.py`: map `binary`/`large_binary` Arrow types to `StringDatabaseField` in `_map_arrow_type`, instead of skipping them entirely in `add_pyarrow_schema`/`add_field`. This matches how ClickHouse actually reads these columns back.
- Updated the existing test that asserted the old (buggy) skip behavior, and added a regression test that exercises the full `HogQLSchema` → `merge_columns` chain for a binary column.

## How did you test this code?

Added `test_merge_columns_keeps_binary_column_registered_by_hogql_schema` to `test_hogql_schema.py`, wiring a binary-typed `HogQLSchema` output straight into `merge_columns` (mirroring how `pipeline_v2/pipeline.py` calls them) — this fails on master because the column is silently dropped, and passes with the fix. Also added `binary`/`large_binary` cases to the existing parameterized `test_maps_arrow_type`.

Ran:
- `pytest products/warehouse_sources/backend/temporal/data_imports/pipelines/core/test/test_hogql_schema.py` (29 passed)
- `ruff check` / `ruff format --check` on the changed files
- `uv run mypy --cache-fine-grained .` (repo-wide, no issues)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal pipeline bug fix, no user-facing behavior or documented workflow changed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Investigated via PostHog error tracking MCP tools (issue details, sampled event with stack trace and `warehouse_sources_*` properties) plus Explore subagents to trace the call chain from the raised exception back through `merge_columns` and `HogQLSchema`, and to confirm BigQuery `BYTES` columns surface as Arrow `binary` with no coercion step upstream. Checked for competing open PRs by exception message, module names, and the reporting maintainer's own open PRs — found none addressing this.

Considered whether this was upstream/user error (bad data, retryable), but the failure is a shared-pipeline type-registry gap independent of BigQuery specifically, so fixed the shared code rather than adding to `NonRetryableErrors`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*