### PR TITLE
fix(insights): show day-of-week exclusions everywhere the backend supports them

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightResultMetadata.tsx
@@ -2,7 +2,11 @@ import { useValues } from 'kea'
 
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { daysOfWeekLabel, getExcludedDaysOfWeek } from 'scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils'
+import {
+    daysOfWeekLabel,
+    getExcludedDaysOfWeek,
+    querySupportsDaysOfWeek,
+} from 'scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
@@ -18,12 +22,13 @@ export const InsightResultMetadata = ({
     disableLastComputationRefresh,
 }: InsightResultMetadataProps): JSX.Element => {
     const { insightProps } = useValues(insightLogic)
-    const { samplingFactor, trendsFilter, dateRange, isTrends } = useValues(insightVizDataLogic(insightProps))
+    const { samplingFactor, trendsFilter, dateRange, querySource } = useValues(insightVizDataLogic(insightProps))
     const { featureFlags } = useValues(featureFlagLogic)
 
     const quillDateFilterEnabled = featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_DATE_FILTER] === 'test'
-    // Only trends applies daysOfWeek server-side, so only trends gets the note
-    const excludedDays = quillDateFilterEnabled && isTrends ? getExcludedDaysOfWeek(dateRange) : []
+    // Only insights that apply daysOfWeek server-side get the note
+    const excludedDays =
+        quillDateFilterEnabled && querySupportsDaysOfWeek(querySource) ? getExcludedDaysOfWeek(dateRange) : []
     const excludedLabel = daysOfWeekLabel(excludedDays)
     const excludedText = ['Weekends', 'Weekdays'].includes(excludedLabel) ? excludedLabel.toLowerCase() : excludedLabel
 

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightDateFilter.tsx
@@ -11,13 +11,12 @@ import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
-import { FunnelVizType } from '~/types'
-
 import {
     computeDaysOfWeekUpdate,
     daysOfWeekSetsEqual,
     getExcludedDaysOfWeek,
     parseIsoDaysOfWeek,
+    querySupportsDaysOfWeek,
 } from './daysOfWeekFilterUtils'
 
 type InsightDateFilterProps = {
@@ -26,18 +25,14 @@ type InsightDateFilterProps = {
 
 export function InsightDateFilter({ disabled }: InsightDateFilterProps): JSX.Element {
     const { insightProps, editingDisabledReason } = useValues(insightLogic)
-    const { dateRange, interval, querySource, trendsFilter, funnelsFilter, isTrends, isFunnels, isLifecycle } =
-        useValues(insightVizDataLogic(insightProps))
+    const { dateRange, interval, querySource, trendsFilter, isTrends } = useValues(insightVizDataLogic(insightProps))
     const { updateDateRange, updateQuerySource } = useActions(insightVizDataLogic(insightProps))
     const { insightData } = useValues(insightVizDataLogic(insightProps))
     const { reportInsightDatePickerOpened } = useActions(eventUsageLogic)
 
     // The picker speaks excluded days; the query schema stores included days
     const excludedDaysOfWeek = getExcludedDaysOfWeek(dateRange)
-    // Funnel steps and time-to-convert deliberately lack backend daysOfWeek support: dropping
-    // mid-sequence events has ambiguous semantics (see funnel_event_query.py)
-    const supportsDaysOfWeek =
-        isTrends || isLifecycle || (isFunnels && funnelsFilter?.funnelVizType === FunnelVizType.Trends)
+    const supportsDaysOfWeek = querySupportsDaysOfWeek(querySource)
     // The backend rejects daysOfWeek together with smoothing, so don't offer it
     const smoothingActive = isTrends && (trendsFilter?.smoothingIntervals ?? 1) > 1
     const showDaysOfWeekExclusions = supportsDaysOfWeek && !smoothingActive

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightQuillDateFilter.test.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightQuillDateFilter.test.tsx
@@ -1,0 +1,90 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { BindLogic, Provider } from 'kea'
+
+import { insightDataLogic } from 'scenes/insights/insightDataLogic'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { FunnelsQuery, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { InsightShortId } from '~/types'
+
+import { InsightQuillDateFilter } from './InsightQuillDateFilter'
+
+const Insight123 = '123' as InsightShortId
+const insightProps = { dashboardItemId: Insight123 }
+
+function makeTrendsQuery(daysOfWeek: number[] | null = null): TrendsQuery {
+    return {
+        kind: NodeKind.TrendsQuery,
+        series: [{ kind: NodeKind.EventsNode, name: '$pageview', event: '$pageview' }],
+        dateRange: { date_from: '-7d', daysOfWeek },
+    }
+}
+
+function makeFunnelsStepsQuery(daysOfWeek: number[] | null = null): FunnelsQuery {
+    return {
+        kind: NodeKind.FunnelsQuery,
+        series: [{ kind: NodeKind.EventsNode, name: '$pageview', event: '$pageview' }],
+        dateRange: { date_from: '-7d', daysOfWeek },
+    }
+}
+
+describe('InsightQuillDateFilter', () => {
+    let vizDataLogic: ReturnType<typeof insightVizDataLogic.build>
+
+    beforeEach(() => {
+        useMocks({
+            get: {
+                '/api/environments/:team_id/insights/trend': [],
+                '/api/environments/:team_id/insights/': { results: [{}] },
+            },
+        })
+        initKeaTests()
+
+        insightLogic(insightProps).mount()
+        insightDataLogic(insightProps).mount()
+        vizDataLogic = insightVizDataLogic(insightProps)
+        vizDataLogic.mount()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    function setupAndRender(query: TrendsQuery | FunnelsQuery): void {
+        vizDataLogic.actions.updateQuerySource(query)
+
+        render(
+            <Provider>
+                <BindLogic logic={insightLogic} props={insightProps}>
+                    <InsightQuillDateFilter disabled={false} />
+                </BindLogic>
+            </Provider>
+        )
+    }
+
+    it('clears daysOfWeek when the insight changes to a kind that does not support it', async () => {
+        setupAndRender(makeTrendsQuery([1, 2, 3, 4, 5]))
+        expect(vizDataLogic.values.dateRange?.daysOfWeek).toEqual([1, 2, 3, 4, 5])
+
+        vizDataLogic.actions.updateQuerySource(makeFunnelsStepsQuery([1, 2, 3, 4, 5]))
+
+        await waitFor(() => {
+            expect(vizDataLogic.values.dateRange?.daysOfWeek ?? null).toBeNull()
+        })
+    })
+
+    it('leaves daysOfWeek untouched while the query kind keeps support for it', async () => {
+        setupAndRender(makeTrendsQuery([1, 2, 3, 4, 5]))
+
+        vizDataLogic.actions.updateQuerySource(makeTrendsQuery([1, 2, 3, 4, 5]))
+
+        await waitFor(() => {
+            expect(vizDataLogic.values.dateRange?.daysOfWeek).toEqual([1, 2, 3, 4, 5])
+        })
+    })
+})

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightQuillDateFilter.test.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightQuillDateFilter.test.tsx
@@ -12,12 +12,13 @@ import { FunnelsQuery, NodeKind, TrendsQuery } from '~/queries/schema/schema-gen
 import { initKeaTests } from '~/test/init'
 import { InsightShortId } from '~/types'
 
+import type { IsoDayOfWeek } from './daysOfWeekFilterUtils'
 import { InsightQuillDateFilter } from './InsightQuillDateFilter'
 
 const Insight123 = '123' as InsightShortId
 const insightProps = { dashboardItemId: Insight123 }
 
-function makeTrendsQuery(daysOfWeek: number[] | null = null): TrendsQuery {
+function makeTrendsQuery(daysOfWeek: IsoDayOfWeek[] | null = null): TrendsQuery {
     return {
         kind: NodeKind.TrendsQuery,
         series: [{ kind: NodeKind.EventsNode, name: '$pageview', event: '$pageview' }],
@@ -25,7 +26,7 @@ function makeTrendsQuery(daysOfWeek: number[] | null = null): TrendsQuery {
     }
 }
 
-function makeFunnelsStepsQuery(daysOfWeek: number[] | null = null): FunnelsQuery {
+function makeFunnelsStepsQuery(daysOfWeek: IsoDayOfWeek[] | null = null): FunnelsQuery {
     return {
         kind: NodeKind.FunnelsQuery,
         series: [{ kind: NodeKind.EventsNode, name: '$pageview', event: '$pageview' }],

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/InsightQuillDateFilter.tsx
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/InsightQuillDateFilter.tsx
@@ -28,7 +28,12 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { computeDaysOfWeekUpdate, getExcludedDaysOfWeek, type IsoDayOfWeek } from './daysOfWeekFilterUtils'
+import {
+    computeDaysOfWeekUpdate,
+    getExcludedDaysOfWeek,
+    querySupportsDaysOfWeek,
+    type IsoDayOfWeek,
+} from './daysOfWeekFilterUtils'
 
 // Chip labels double as dateMapping keys; filter at module load so a renamed chip can never
 // silently produce the wrong range.
@@ -72,12 +77,13 @@ export function InsightQuillDateFilter({ disabled }: InsightQuillDateFilterProps
     const excludedDays = getExcludedDaysOfWeek(dateRange)
     // The backend rejects daysOfWeek together with smoothing, so don't offer it
     const smoothingActive = isTrends && (trendsFilter?.smoothingIntervals ?? 1) > 1
-    const showExcludedDays = isTrends && !smoothingActive
+    const showExcludedDays = querySupportsDaysOfWeek(querySource) && !smoothingActive
     const showIncompletePeriod = !isRetention
 
-    // Hiding the exclusions control (smoothing turned on, or the insight type changed away from
-    // trends) must also clear any daysOfWeek already on the query — otherwise it lingers with no
-    // UI left to remove it, and the backend rejects daysOfWeek alongside smoothing.
+    // Hiding the exclusions control (smoothing turned on, or the insight changed to an
+    // unsupported kind) must also clear any daysOfWeek already on the query — otherwise it
+    // lingers with no UI left to remove it, and the backend rejects daysOfWeek alongside
+    // smoothing.
     useEffect(() => {
         if (!showExcludedDays && dateRange?.daysOfWeek?.length) {
             updateQuerySource(computeDaysOfWeekUpdate([], dateRange))
@@ -85,11 +91,11 @@ export function InsightQuillDateFilter({ disabled }: InsightQuillDateFilterProps
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [showExcludedDays])
     const exclusions: DateFilterExclusions = {
-        days: isTrends ? excludedDays.map(String) : [],
+        days: showExcludedDays ? excludedDays.map(String) : [],
         incomplete: !isRetention && !!dateRange?.excludeIncompletePeriods,
     }
     const handleExclusionsChange = (next: DateFilterExclusions): void => {
-        if (isTrends && next.days.join(',') !== exclusions.days.join(',')) {
+        if (showExcludedDays && next.days.join(',') !== exclusions.days.join(',')) {
             updateQuerySource(computeDaysOfWeekUpdate(next.days.map(Number) as IsoDayOfWeek[], dateRange))
         }
         if (!isRetention && next.incomplete !== exclusions.incomplete) {

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.test.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.test.ts
@@ -1,9 +1,11 @@
-import type { DateRange } from '~/queries/schema/schema-general'
+import { NodeKind, type DateRange } from '~/queries/schema/schema-general'
+import { FunnelVizType } from '~/types'
 
 import {
     computeDaysOfWeekUpdate,
     getExcludedDaysOfWeek,
     invertDaysOfWeek,
+    querySupportsDaysOfWeek,
     type IsoDayOfWeek,
 } from './daysOfWeekFilterUtils'
 
@@ -61,4 +63,23 @@ describe('daysOfWeekFilterUtils', () => {
         const update = computeDaysOfWeekUpdate([6, 7], { date_from: '-7d', date_to: null })
         expect(update.dateRange).toEqual({ date_from: '-7d', date_to: null, daysOfWeek: [1, 2, 3, 4, 5] })
     })
+
+    it.each([
+        [null, false],
+        [undefined, false],
+        [{ kind: NodeKind.TrendsQuery }, true],
+        [{ kind: NodeKind.StickinessQuery }, true],
+        [{ kind: NodeKind.LifecycleQuery }, true],
+        [{ kind: NodeKind.FunnelsQuery }, false],
+        [{ kind: NodeKind.FunnelsQuery, funnelsFilter: { funnelVizType: FunnelVizType.Steps } }, false],
+        [{ kind: NodeKind.FunnelsQuery, funnelsFilter: { funnelVizType: FunnelVizType.TimeToConvert } }, false],
+        [{ kind: NodeKind.FunnelsQuery, funnelsFilter: { funnelVizType: FunnelVizType.Trends } }, true],
+        [{ kind: NodeKind.RetentionQuery }, false],
+        [{ kind: NodeKind.PathsQuery }, false],
+    ] as [Record<string, any> | null | undefined, boolean][])(
+        'querySupportsDaysOfWeek(%j) → %s',
+        (querySource, expected) => {
+            expect(querySupportsDaysOfWeek(querySource)).toBe(expected)
+        }
+    )
 })

--- a/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.ts
+++ b/frontend/src/scenes/insights/filters/InsightDateFilter/daysOfWeekFilterUtils.ts
@@ -1,6 +1,17 @@
 import { DateRange } from '~/queries/schema/schema-general'
+import { isFunnelsQuery, isLifecycleQuery, isStickinessQuery, isTrendsQuery } from '~/queries/utils'
+import { FunnelVizType } from '~/types'
 
 export type IsoDayOfWeek = NonNullable<DateRange['daysOfWeek']>[number]
+
+/** Mirrors backend support: trends, stickiness, lifecycle, and funnels in the trends viz only
+ *  (dropping mid-sequence events from a step funnel has ambiguous semantics). */
+export function querySupportsDaysOfWeek(querySource: Record<string, any> | null | undefined): boolean {
+    if (isTrendsQuery(querySource) || isStickinessQuery(querySource) || isLifecycleQuery(querySource)) {
+        return true
+    }
+    return isFunnelsQuery(querySource) && querySource.funnelsFilter?.funnelVizType === FunnelVizType.Trends
+}
 
 const DAYS_IN_WEEK = 7
 const WEEKDAYS: IsoDayOfWeek[] = [1, 2, 3, 4, 5]


### PR DESCRIPTION
## Problem

The backend accepts `DateRange.daysOfWeek` for trends, stickiness, lifecycle, and funnel trends (extended in #70588), but the frontend never caught up:

- The quill date picker (`InsightQuillDateFilter`) still gated the day-of-week exclusion UI to `isTrends` only — stickiness, lifecycle, and funnel-trends users saw just the "Incomplete period" toggle in the Exclude flyout.
- The legacy picker (`InsightDateFilter`) had its own hand-rolled predicate that omitted **stickiness**.
- The results metadata note ("Excluding weekends") was also trends-only.

Three call sites, three different answers, none matching the backend.

## Changes

- Added `querySupportsDaysOfWeek(querySource)` to `daysOfWeekFilterUtils.ts`, mirroring backend support exactly: trends, stickiness, lifecycle, and funnels in the trends viz only (regular funnels/time-to-convert stay excluded — dropping mid-sequence events has ambiguous semantics, see `funnel_event_query.py`).
- Both date pickers and `InsightResultMetadata` now use the shared predicate.
- In the quill picker, the exclusions derivation, change handler, and the clear-on-hide effect now key off the same `showExcludedDays` flag, so `daysOfWeek` is still cleared when an insight changes to an unsupported kind (or funnel viz moves off trends) and can't linger with no UI to remove it.

## How did you test this code?

- Extended `daysOfWeekFilterUtils.test.ts` with cases for the new predicate across all insight kinds and funnel viz types (27 tests pass).
- `tsc --noEmit`, oxlint, and oxfmt all clean.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*