### PR TITLE
fix(error-tracking): only ship suppression rules the SDK can evaluate

### DIFF
--- a/products/error_tracking/backend/logic/__init__.py
+++ b/products/error_tracking/backend/logic/__init__.py
@@ -34,6 +34,12 @@ from products.error_tracking.backend.models import (
 
 SERVER_ONLY_PROPERTIES = frozenset({"$exception_sources", "$exception_functions"})
 
+# Operators posthog-js implements in propertyComparisons. Anything outside this set is undefined when
+# the SDK looks it up and throws on call, which drops the exception rather than skipping the rule.
+CLIENT_EVALUABLE_OPERATORS = frozenset(
+    {"exact", "is_not", "regex", "not_regex", "icontains", "not_icontains", "gt", "lt"}
+)
+
 
 class ErrorTrackingReleaseHashInUseError(Exception):
     pass
@@ -815,16 +821,18 @@ def reorder_bypass_rules(team_id: int, orders: dict[str, int]) -> None:
 def get_client_safe_filters(filters: dict) -> dict | None:
     """Return the filters if every leaf is client-safe, otherwise None.
 
-    A filter that references a server-only property cannot be evaluated
-    client-side, so the whole rule is excluded.
+    A filter that references a server-only property, or an operator the SDK does not implement,
+    cannot be evaluated client-side, so the whole rule is excluded and left to server-side
+    evaluation during ingestion.
     """
     for value in filters.get("values", []):
-        if "key" in value:
-            if value.get("key") in SERVER_ONLY_PROPERTIES:
-                return None
-        elif "values" in value:
+        if "values" in value:
             if get_client_safe_filters(value) is None:
                 return None
+        elif value.get("key") in SERVER_ONLY_PROPERTIES:
+            return None
+        elif value.get("operator") not in CLIENT_EVALUABLE_OPERATORS:
+            return None
     return filters
 
 

--- a/products/error_tracking/backend/tests/api/test_suppression_rules.py
+++ b/products/error_tracking/backend/tests/api/test_suppression_rules.py
@@ -21,13 +21,13 @@ class TestGetClientSafeFilters(TestCase):
             # All client-safe: returned as-is
             (
                 "all_client_safe",
-                {"type": "AND", "values": [{"operator": "is", "key": "$exception_types", "value": "TypeError"}]},
-                {"type": "AND", "values": [{"operator": "is", "key": "$exception_types", "value": "TypeError"}]},
+                {"type": "AND", "values": [{"operator": "exact", "key": "$exception_types", "value": "TypeError"}]},
+                {"type": "AND", "values": [{"operator": "exact", "key": "$exception_types", "value": "TypeError"}]},
             ),
             (
                 "or_all_client_safe",
-                {"type": "OR", "values": [{"operator": "is", "key": "$exception_types", "value": "TypeError"}]},
-                {"type": "OR", "values": [{"operator": "is", "key": "$exception_types", "value": "TypeError"}]},
+                {"type": "OR", "values": [{"operator": "exact", "key": "$exception_types", "value": "TypeError"}]},
+                {"type": "OR", "values": [{"operator": "exact", "key": "$exception_types", "value": "TypeError"}]},
             ),
             (
                 "negative_operator_is_client_safe",
@@ -49,7 +49,7 @@ class TestGetClientSafeFilters(TestCase):
             # Any server-only property → entire rule returns None
             (
                 "server_only_property_returns_none",
-                {"type": "AND", "values": [{"operator": "is", "key": "$exception_sources", "value": "app.js"}]},
+                {"type": "AND", "values": [{"operator": "exact", "key": "$exception_sources", "value": "app.js"}]},
                 None,
             ),
             (
@@ -57,8 +57,8 @@ class TestGetClientSafeFilters(TestCase):
                 {
                     "type": "AND",
                     "values": [
-                        {"operator": "is", "key": "$exception_types", "value": "TypeError"},
-                        {"operator": "is", "key": "$exception_sources", "value": "app.js"},
+                        {"operator": "exact", "key": "$exception_types", "value": "TypeError"},
+                        {"operator": "exact", "key": "$exception_sources", "value": "app.js"},
                     ],
                 },
                 None,
@@ -68,8 +68,38 @@ class TestGetClientSafeFilters(TestCase):
                 {
                     "type": "OR",
                     "values": [
-                        {"operator": "is", "key": "$exception_types", "value": "TypeError"},
-                        {"operator": "is", "key": "$exception_sources", "value": "app.js"},
+                        {"operator": "exact", "key": "$exception_types", "value": "TypeError"},
+                        {"operator": "exact", "key": "$exception_sources", "value": "app.js"},
+                    ],
+                },
+                None,
+            ),
+            # Operators the SDK does not implement
+            (
+                "unimplemented_operator_returns_none",
+                {"type": "AND", "values": [{"operator": "is_not_set", "key": "$exception_types", "value": None}]},
+                None,
+            ),
+            (
+                "server_only_operator_returns_none",
+                {"type": "AND", "values": [{"operator": "starts_with", "key": "$exception_values", "value": "Cannot"}]},
+                None,
+            ),
+            (
+                "missing_operator_returns_none",
+                {"type": "AND", "values": [{"key": "$exception_types", "value": "TypeError"}]},
+                None,
+            ),
+            (
+                "nested_unimplemented_operator_returns_none",
+                {
+                    "type": "OR",
+                    "values": [
+                        {"operator": "exact", "key": "$exception_types", "value": "TypeError"},
+                        {
+                            "type": "AND",
+                            "values": [{"operator": "is_not_set", "key": "$exception_values", "value": None}],
+                        },
                     ],
                 },
                 None,
@@ -94,7 +124,7 @@ class TestGetClientSafeFilters(TestCase):
                         {
                             "type": "AND",
                             "values": [
-                                {"operator": "is", "key": "$exception_types", "value": "TypeError"},
+                                {"operator": "exact", "key": "$exception_types", "value": "TypeError"},
                                 {"operator": "regex", "key": "$exception_values", "value": ".*null.*"},
                             ],
                         }
@@ -106,7 +136,7 @@ class TestGetClientSafeFilters(TestCase):
                         {
                             "type": "AND",
                             "values": [
-                                {"operator": "is", "key": "$exception_types", "value": "TypeError"},
+                                {"operator": "exact", "key": "$exception_types", "value": "TypeError"},
                                 {"operator": "regex", "key": "$exception_values", "value": ".*null.*"},
                             ],
                         }
@@ -121,8 +151,8 @@ class TestGetClientSafeFilters(TestCase):
                         {
                             "type": "AND",
                             "values": [
-                                {"operator": "is", "key": "$exception_types", "value": "TypeError"},
-                                {"operator": "is", "key": "$exception_sources", "value": "app.js"},
+                                {"operator": "exact", "key": "$exception_types", "value": "TypeError"},
+                                {"operator": "exact", "key": "$exception_sources", "value": "app.js"},
                             ],
                         }
                     ],
@@ -134,11 +164,11 @@ class TestGetClientSafeFilters(TestCase):
                 {
                     "type": "OR",
                     "values": [
-                        {"operator": "is", "key": "$exception_types", "value": "TypeError"},
+                        {"operator": "exact", "key": "$exception_types", "value": "TypeError"},
                         {
                             "type": "AND",
                             "values": [
-                                {"operator": "is", "key": "$exception_sources", "value": "app.js"},
+                                {"operator": "exact", "key": "$exception_sources", "value": "app.js"},
                             ],
                         },
                     ],
@@ -153,7 +183,7 @@ class TestGetClientSafeFilters(TestCase):
 
 class TestGetClientSafeSuppressionRules(APIBaseTest):
     def test_returns_fully_client_safe_rule(self) -> None:
-        filters = {"values": [{"operator": "is", "key": "$exception_types", "value": "TypeError"}]}
+        filters = {"values": [{"operator": "exact", "key": "$exception_types", "value": "TypeError"}]}
         ErrorTrackingSuppressionRule.objects.create(team=self.team, filters=filters, bytecode=[], order_key=0)
 
         result = get_client_safe_suppression_rules(self.team.id)
@@ -165,8 +195,8 @@ class TestGetClientSafeSuppressionRules(APIBaseTest):
         filters = {
             "type": "AND",
             "values": [
-                {"operator": "is", "key": "$exception_types", "value": "TypeError"},
-                {"operator": "is", "key": "$exception_sources", "value": "app.js"},
+                {"operator": "exact", "key": "$exception_types", "value": "TypeError"},
+                {"operator": "exact", "key": "$exception_sources", "value": "app.js"},
             ],
         }
         ErrorTrackingSuppressionRule.objects.create(team=self.team, filters=filters, bytecode=[], order_key=0)
@@ -179,8 +209,8 @@ class TestGetClientSafeSuppressionRules(APIBaseTest):
         filters = {
             "type": "OR",
             "values": [
-                {"operator": "is", "key": "$exception_types", "value": "TypeError"},
-                {"operator": "is", "key": "$exception_sources", "value": "app.js"},
+                {"operator": "exact", "key": "$exception_types", "value": "TypeError"},
+                {"operator": "exact", "key": "$exception_sources", "value": "app.js"},
             ],
         }
         ErrorTrackingSuppressionRule.objects.create(team=self.team, filters=filters, bytecode=[], order_key=0)
@@ -193,7 +223,7 @@ class TestGetClientSafeSuppressionRules(APIBaseTest):
         filters = {
             "type": "OR",
             "values": [
-                {"operator": "is", "key": "$exception_sources", "value": "app.js"},
+                {"operator": "exact", "key": "$exception_sources", "value": "app.js"},
                 {"operator": "regex", "key": "$exception_functions", "value": "handleClick"},
             ],
         }
@@ -209,12 +239,12 @@ class TestGetClientSafeSuppressionRules(APIBaseTest):
         assert result == []
 
     def test_handles_mixed_rules(self) -> None:
-        safe_filters = {"values": [{"operator": "is", "key": "$exception_types", "value": "TypeError"}]}
+        safe_filters = {"values": [{"operator": "exact", "key": "$exception_types", "value": "TypeError"}]}
         has_server_only = {
             "type": "AND",
             "values": [
-                {"operator": "is", "key": "$exception_types", "value": "TypeError"},
-                {"operator": "is", "key": "$exception_sources", "value": "app.js"},
+                {"operator": "exact", "key": "$exception_types", "value": "TypeError"},
+                {"operator": "exact", "key": "$exception_sources", "value": "app.js"},
             ],
         }
         also_safe = {
@@ -236,7 +266,7 @@ class TestGetClientSafeSuppressionRules(APIBaseTest):
         assert also_safe in result
 
     def test_includes_sampling_rate_when_less_than_one(self) -> None:
-        filters = {"values": [{"operator": "is", "key": "$exception_types", "value": "TypeError"}]}
+        filters = {"values": [{"operator": "exact", "key": "$exception_types", "value": "TypeError"}]}
         ErrorTrackingSuppressionRule.objects.create(
             team=self.team, filters=filters, bytecode=[], order_key=0, sampling_rate=0.5
         )
@@ -247,7 +277,7 @@ class TestGetClientSafeSuppressionRules(APIBaseTest):
         assert result[0] == {**filters, "samplingRate": 0.5}
 
     def test_omits_sampling_rate_when_one(self) -> None:
-        filters = {"values": [{"operator": "is", "key": "$exception_types", "value": "TypeError"}]}
+        filters = {"values": [{"operator": "exact", "key": "$exception_types", "value": "TypeError"}]}
         ErrorTrackingSuppressionRule.objects.create(
             team=self.team, filters=filters, bytecode=[], order_key=0, sampling_rate=1.0
         )

--- a/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/EvaluationIndicator.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/suppression_rules/EvaluationIndicator.tsx
@@ -3,13 +3,28 @@ import { Tooltip } from '@posthog/lemon-ui'
 
 import { AnyPropertyFilter, FilterLogicalOperator, UniversalFiltersGroup } from '~/types'
 
+// Kept in sync with SERVER_ONLY_PROPERTIES and CLIENT_EVALUABLE_OPERATORS in
+// products/error_tracking/backend/logic/__init__.py, which decides what actually reaches the SDK.
+// Showing a rule as client-evaluated when the backend withholds it tells the user the wrong thing
+// about where their rule runs.
 const SERVER_ONLY_PROPERTIES = new Set(['$exception_sources', '$exception_functions'])
+const CLIENT_EVALUABLE_OPERATORS = new Set([
+    'exact',
+    'is_not',
+    'regex',
+    'not_regex',
+    'icontains',
+    'not_icontains',
+    'gt',
+    'lt',
+])
 
 function isFilterClientSafe(f: AnyPropertyFilter): boolean {
     if ('key' in f && f.key && SERVER_ONLY_PROPERTIES.has(f.key)) {
         return false
     }
-    return true
+    const operator = 'operator' in f ? f.operator : undefined
+    return !!operator && CLIENT_EVALUABLE_OPERATORS.has(operator)
 }
 
 export type EvalMode = 'client' | 'partial' | 'server'


### PR DESCRIPTION
## Problem

posthog-js implements eight comparison operators. Anything else (`is_not_set`, `starts_with`, `gte`, the date operators) is undefined when the SDK looks it up and throws on call, which drops the exception. We only checked keys before shipping a rule to the browser, so one such rule silently kills a team's entire browser exception capture.

## Changes

Gate on the operator too, per leaf and through nested groups. Withheld rules still run server-side during ingestion, which has the full HogQL operator set. The eval-mode indicator mirrors the gate. Server-side behavior unchanged.

## How did you test this code?

44 backend tests pass, plus `ci:preflight`, repo-wide mypy, frontend typecheck. No manual testing.

Four new cases: an unimplemented operator, a server-only operator, a missing operator, one nested in a group. Each currently ships to browsers and breaks capture. The fixtures also used `"operator": "is"`, which is not a value in `PropertyOperator` (the equality operator is `exact`), so those cases would now fail the gate on a value that cannot occur.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 5). Skills: `/writing-tests`, `/writing-code-comments`.

Out of scope: keys the SDK cannot resolve (`$lib`, `$host`) still ship, and fall back to an empty array that the negative operators match vacuously, so `$host not_regex ...` under `OR` suppresses everything. PostHog/posthog-js#4354 fixes that SDK-side for versions people upgrade to. Also unfixed: no `post_delete` receiver for `ErrorTrackingSuppressionRule`, so deleting a rule never invalidates the cached remote config.
