### PR TITLE
chore(slack_app): remove slack-app-queue-workflow feature flag

### DIFF
--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -62,7 +62,6 @@ from products.slack_app.backend.feature_flags import (
     is_slack_app_assistant_enabled,
     is_slack_app_bot_prs_enabled,
     is_slack_app_oauth_enabled,
-    is_slack_app_queue_workflow_enabled,
     is_slack_app_untagged_thread_followups_enabled,
 )
 from products.slack_app.backend.helpers import local_dev_slack_email
@@ -2717,10 +2716,9 @@ def _start_mention_workflow(
         untagged_followup=untagged_followup,
         is_ext_shared_channel=is_ext_shared_channel,
     )
-    # Deriving the ID is free, the flag evaluation is remote — check in that
-    # order. Events without channel/ts fall back to the per-message workflow.
+    # Events without channel/ts fall back to the per-message workflow.
     queue_workflow_id = derive_slack_app_mention_workflow_id(workflow_inputs)
-    if queue_workflow_id is not None and is_slack_app_queue_workflow_enabled(integration, slack_team_id):
+    if queue_workflow_id is not None:
         _start_posthog_code_workflow(
             SlackAppMentionWorkflow,
             SlackAppMentionWorkflowInputs(),

--- a/products/slack_app/backend/feature_flags.py
+++ b/products/slack_app/backend/feature_flags.py
@@ -35,7 +35,6 @@ SLACK_APP_ASSISTANT_FLAG = "slack-app-assistant"
 SLACK_APP_BOT_PRS_FLAG = "slack-app-bot-prs"
 SLACK_APP_LIVING_ARTIFACTS_FLAG = "slack-app-living-artifacts"
 SLACK_APP_CANVAS_FILE_ARTIFACTS_FLAG = "slack-app-canvas-file-artifacts"
-SLACK_APP_QUEUE_WORKFLOW_FLAG = "slack-app-queue-workflow"
 UNTAGGED_THREAD_FOLLOWUPS_FLAG = "posthog-slack-app-untagged-thread-followups"
 
 
@@ -182,31 +181,6 @@ def is_slack_app_untagged_thread_followups_enabled(integration: Integration, sla
     except Exception:
         logger.exception(
             "slack_app_thread_message_feature_flag_check_failed",
-            slack_team_id=slack_team_id,
-            integration_id=integration.id,
-        )
-        return False
-
-
-def is_slack_app_queue_workflow_enabled(integration: Integration, slack_team_id: str) -> bool:
-    """Gate for the per-conversation queue workflow: when on, mention/followup/DM
-    dispatch signal-with-starts one ``SlackAppMentionWorkflow`` per thread that
-    processes messages serially, instead of one workflow per message. Keyed on
-    the Slack workspace + PostHog org."""
-    try:
-        return bool(
-            posthoganalytics.feature_enabled(
-                SLACK_APP_QUEUE_WORKFLOW_FLAG,
-                f"slack_workspace:{slack_team_id}",
-                groups={"organization": str(integration.team.organization_id)},
-                person_properties=_region_properties(),
-                only_evaluate_locally=False,
-                send_feature_flag_events=False,
-            )
-        )
-    except Exception:
-        logger.exception(
-            "slack_app_queue_workflow_flag_check_failed",
             slack_team_id=slack_team_id,
             integration_id=integration.id,
         )

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -529,7 +529,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
 
         mock_sync_connect.return_value.start_workflow.assert_called_once()
-        workflow_inputs = mock_sync_connect.return_value.start_workflow.call_args.args[1]
+        workflow_inputs = mock_sync_connect.return_value.start_workflow.call_args.kwargs["start_signal_args"][0]
         # The user belongs to ``self.organization`` only, so only that integration
         # should be the mention target — ``other_integration`` is filtered out.
         assert workflow_inputs.integration_id == self.posthog_code_integration.id
@@ -583,7 +583,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
 
         mock_sync_connect.return_value.start_workflow.assert_called_once()
-        workflow_inputs = mock_sync_connect.return_value.start_workflow.call_args.args[1]
+        workflow_inputs = mock_sync_connect.return_value.start_workflow.call_args.kwargs["start_signal_args"][0]
         assert workflow_inputs.integration_id == self.posthog_code_integration.id
         assert workflow_inputs.integration_id != private_integration.id
 
@@ -600,7 +600,7 @@ class TestRoutePostHogCodeEventToRelevantRegion(TestCase):
         route_posthog_code_event_to_relevant_region(request, self.event, "T12345")
 
         mock_sync_connect.return_value.start_workflow.assert_called_once()
-        workflow_inputs = mock_sync_connect.return_value.start_workflow.call_args.args[1]
+        workflow_inputs = mock_sync_connect.return_value.start_workflow.call_args.kwargs["start_signal_args"][0]
         assert workflow_inputs.user_id == self.user.id
 
     @patch("products.slack_app.backend.api.asyncio.run")

--- a/products/slack_app/backend/tests/test_posthog_code_event_handler.py
+++ b/products/slack_app/backend/tests/test_posthog_code_event_handler.py
@@ -1433,16 +1433,15 @@ class TestQueueWorkflowDispatch(TestCase):
         ]
     )
     @patch("products.slack_app.backend.api.SlackIntegration")
-    @patch("products.slack_app.backend.api.is_slack_app_queue_workflow_enabled", return_value=True)
     @patch("products.slack_app.backend.api.asyncio.run")
     @patch("products.slack_app.backend.api.sync_connect")
     @override_settings(DEBUG=False, CLOUD_DEPLOYMENT="US")
-    def test_flag_on_signal_with_starts_conversation_workflow(
-        self, _name, thread_ts, expected_anchor, mock_sync_connect, mock_asyncio_run, mock_flag, mock_slack
+    def test_signal_with_starts_conversation_workflow(
+        self, _name, thread_ts, expected_anchor, mock_sync_connect, mock_asyncio_run, mock_slack
     ):
-        # With the flag on, every message in a conversation must land in ONE
-        # per-thread workflow via signal-with-start — the conversation ID
-        # anchors on the thread root so followups reach the same instance.
+        # Every message in a conversation must land in ONE per-thread workflow
+        # via signal-with-start — the conversation ID anchors on the thread
+        # root so followups reach the same instance.
         from posthog.temporal.ai.slack_app.slack_app_mention import SlackAppMentionWorkflow
 
         from products.slack_app.backend.api import ROUTE_HANDLED_LOCALLY, route_posthog_code_event_to_relevant_region


### PR DESCRIPTION
## Problem

The `slack-app-queue-workflow` flag is fully rolled out. Keeping the gate around just leaves a dead branch and a remote flag check on the mention dispatch path.

## Changes

Remove the flag and its `is_slack_app_queue_workflow_enabled` check. Dispatch now always signal-with-starts the per-thread `SlackAppMentionWorkflow` whenever a queue workflow ID can be derived, falling back to the per-message workflow only for events without a channel/ts.

## How did you test this code?

Updated the existing `TestQueueWorkflowDispatch` tests to drop the flag patch since the queue path is now the default. Ran them locally, both pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed this; Claude did the removal. Straightforward flag cleanup across `feature_flags.py`, `api.py`, and the dispatch tests.
