### PR TITLE
fix(dashboards): retry transient 404s before showing not found

### DIFF
--- a/frontend/src/scenes/dashboard/Dashboard.tsx
+++ b/frontend/src/scenes/dashboard/Dashboard.tsx
@@ -133,7 +133,12 @@ function DashboardScene({
     })
 
     if (!dashboard && !itemsLoading && !dashboardFailedToLoad) {
-        return <NotFound object="dashboard" />
+        return (
+            <NotFound
+                object="dashboard"
+                caption="We couldn't load this dashboard. It may have been deleted or its sharing settings may have changed. If you just opened or edited it, the load might have failed temporarily, so try refreshing the page."
+            />
+        )
     }
 
     if (accessDeniedToDashboard) {

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -1203,6 +1203,46 @@ describe('dashboardLogic', () => {
             })
             expect(attempts).toBe(2)
         })
+
+        it('recovers from a transient 404 on retry instead of showing not found', async () => {
+            let attempts = 0
+            useMocks({
+                get: {
+                    '/api/environments/:team_id/dashboards/5/': () => {
+                        attempts++
+                        return attempts === 1 ? [404, null] : [200, dashboards[5]]
+                    },
+                },
+            })
+
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+
+            await expectLogic(logic).toDispatchActions(['loadDashboardSuccess']).toMatchValues({
+                error404: false,
+            })
+            expect(attempts).toBe(2)
+        })
+
+        it('still shows not found when a 404 persists across every retry', async () => {
+            let attempts = 0
+            useMocks({
+                get: {
+                    '/api/environments/:team_id/dashboards/5/': () => {
+                        attempts++
+                        return [404, null]
+                    },
+                },
+            })
+
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+
+            await expectLogic(logic).toDispatchActions(['dashboardNotFound']).toMatchValues({
+                error404: true,
+            })
+            expect(attempts).toBe(3)
+        })
     })
 
     describe('when a dashboard item API errors', () => {

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1376,8 +1376,7 @@ export const dashboardLogic = kea<dashboardLogicType>([
                             try {
                                 return await api.getResponse(apiUrl)
                             } catch (error: any) {
-                                const retryable =
-                                    isRetryableDashboardLoadError(error) || error?.status === 404
+                                const retryable = isRetryableDashboardLoadError(error) || error?.status === 404
                                 if (attempt >= LOAD_DASHBOARD_MAX_ATTEMPTS || !retryable) {
                                     throw error
                                 }

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -1367,12 +1367,18 @@ export const dashboardLogic = kea<dashboardLogicType>([
 
                     // A single dropped fetch shouldn't replace the whole dashboard with an error
                     // state, so transient failures get a couple of attempts before we give up.
+                    // A 404 counts as transient here too: on a dashboard the user owns and just
+                    // navigated to, a one-off 404 is usually a blip that succeeds on retry, so we
+                    // retry to confirm rather than dead-ending on the not-found screen. A genuinely
+                    // deleted dashboard 404s on every attempt and still falls through to `return null`.
                     const getDashboardResponse = async (): Promise<Response> => {
                         for (let attempt = 1; ; attempt++) {
                             try {
                                 return await api.getResponse(apiUrl)
                             } catch (error: any) {
-                                if (attempt >= LOAD_DASHBOARD_MAX_ATTEMPTS || !isRetryableDashboardLoadError(error)) {
+                                const retryable =
+                                    isRetryableDashboardLoadError(error) || error?.status === 404
+                                if (attempt >= LOAD_DASHBOARD_MAX_ATTEMPTS || !retryable) {
                                     throw error
                                 }
                                 await breakpoint(LOAD_DASHBOARD_RETRY_DELAY_MS * attempt)


### PR DESCRIPTION
## Problem

Users hit a "Dashboard not found" screen on dashboards they own and just edited. Six replay sessions caught the same pattern: a dashboard that loads fine one moment renders the not-found screen the next, and in several the exact same navigation succeeds moments later on retry. So it's a transient 404, not a real deletion.

The classic loader in `dashboardLogic` collapses **any** 404 into `return null`, and `loadDashboardSuccess` then fires `dashboardNotFound()` purely because the dashboard came back null. There's no distinction between "this was deleted" and "one request failed." On top of that, the not-found copy tells the user the dashboard "has been deleted or its sharing settings have changed," which is wrong in these sessions.

This is the dominant path: the large majority of these renders happen with the streaming flag off, so they go through the classic loader. The SSE variant is handled separately by #70207.

**Why:** getting back to your own dashboard is a core flow, and a transient blip shouldn't dead-end it on a screen that tells you the thing was deleted.

## Changes

Stacks on #75342 (retry/backoff for transient load failures), which deliberately kept 404 failing immediately.

- Treat a 404 as retryable in the load loop alongside the existing transient failures. A one-off blip now recovers on retry; a genuinely deleted dashboard 404s on every attempt and still falls through to `return null` → the not-found scene. So the not-found screen only shows on a confirmed, persistent 404.
- Reword the dashboard not-found caption so it stops asserting deletion outright and points the user at a refresh.

The SSE streaming classifier (the `error?.message?.includes('404')` string match) is the minority path and is already targeted by #70207, so it's left to that PR rather than duplicated here.

## How did you test this code?

Added two unit tests in `dashboardLogic.test.ts`, siblings of the existing transient-failure retry test:

- A transient 404 (404 then 200) recovers via `loadDashboardSuccess` with `error404: false` and never shows not-found — catches the regression where a single 404 dead-ends a valid dashboard.
- A 404 that persists across every retry still dispatches `dashboardNotFound` with `error404: true` — guards against retries swallowing a genuine deletion.

I (the agent) was not able to run the frontend suite locally in this environment (no installed `node_modules`), so these run in CI. No manual browser testing was done.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A PostHog engineer asked me (the PostHog Slack app) to investigate an inbox report about transient dashboard 404s and fix it. I verified the report against current master, confirmed the classic loader is the dominant path that neither open draft PR closes, and chose to stack the fix on #75342 rather than open a third competing branch in `dashboardLogic.tsx`. I considered distinguishing transient from genuine 404s by inspecting the error, but retry-to-confirm is simpler and matches the observed behavior (the same request succeeds on retry). The tradeoff is ~2s of added latency before a genuinely deleted dashboard shows not-found, which is worth it to stop false not-founds on live dashboards.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C045L1VEG87/p1785440773927679?thread_ts=1785440773.927679&cid=C045L1VEG87)*
