### PR TITLE
fix(warehouse): skip GitHub's code_frequency stats when a repo exceeds 10k commits

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -78,6 +78,15 @@ class GithubOrgNotFoundError(Exception):
     pass
 
 
+class GithubRepositoryTooLargeError(Exception):
+    """GitHub's /stats/code_frequency permanently 422s once a repository passes 10,000 commits — a
+    documented limit of that specific endpoint (other stats endpoints keep working, just with
+    zeroed addition/deletion counts for large repos). Retrying can never succeed, so `_fetch_page`
+    raises this and the caller syncs zero rows instead of failing the schema forever."""
+
+    pass
+
+
 @dataclasses.dataclass
 class GithubResumeConfig:
     next_url: str
@@ -243,6 +252,20 @@ def _is_empty_repository_response(response: requests.Response) -> bool:
     except (ValueError, TypeError):
         message = response.text or ""
     return isinstance(message, str) and "repository is empty" in message.lower()
+
+
+def _is_repository_too_large_for_code_frequency(response: requests.Response) -> bool:
+    """GitHub returns 422 on /stats/code_frequency with a stable "must have fewer than 10000
+    commits" message once a repository crosses that commit count — a hard, permanent limit of this
+    one endpoint, not a transient or credential problem."""
+    if response.status_code != 422:
+        return False
+    try:
+        body = response.json()
+        message = body.get("message", "") if isinstance(body, dict) else ""
+    except (ValueError, TypeError):
+        message = response.text or ""
+    return isinstance(message, str) and "fewer than 10000 commits" in message.lower()
 
 
 def _as_utc(dt: datetime) -> datetime:
@@ -676,6 +699,9 @@ def _fetch_page(
     if _is_empty_repository_response(response):
         raise GithubEmptyRepositoryError()
 
+    if _is_repository_too_large_for_code_frequency(response):
+        raise GithubRepositoryTooLargeError()
+
     # An org-scoped endpoint 404s when the repo owner is a user (no org) or the token lacks org
     # access. Signal it so the caller syncs zero rows rather than failing the schema — a benign skip
     # like an empty repository, not a real "repository not found".
@@ -995,6 +1021,9 @@ def get_rows(
             break
         except GithubOrgNotFoundError:
             logger.debug(f"Github: no accessible org teams for {endpoint}, syncing zero rows: url={url}")
+            break
+        except GithubRepositoryTooLargeError:
+            logger.debug(f"Github: repository too large for code frequency stats, syncing zero rows: url={url}")
             break
 
         # The /stats/* aggregates are computed asynchronously: GitHub answers 202 with no body

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_fetch_page.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from unittest import mock
 
@@ -60,6 +62,42 @@ def test_fetch_page_404_skips_only_for_org_scoped_endpoints(skip_on_not_found, e
             github._fetch_page(
                 "https://api.github.com/orgs/acme/teams", {}, mock.Mock(), skip_on_not_found=skip_on_not_found
             )
+
+
+def _unprocessable_response(message: str) -> mock.Mock:
+    response = mock.Mock(spec=requests.Response)
+    response.status_code = 422
+    response.ok = False
+    response.headers = {}
+    response.text = json.dumps({"message": message})
+    response.json.return_value = {"message": message}
+    response.request = None
+    response.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        "422 Client Error: Unprocessable Entity for url", response=response
+    )
+    return response
+
+
+def test_fetch_page_raises_repository_too_large_for_code_frequency_422():
+    # GitHub permanently 422s /stats/code_frequency once a repo passes 10,000 commits; the caller
+    # must treat this as a benign skip, not crash and retry the activity forever.
+    session = mock.Mock()
+    session.request.return_value = _unprocessable_response("repository must have fewer than 10000 commits")
+
+    with mock.patch.object(github, "make_tracked_session", return_value=session):
+        with pytest.raises(github.GithubRepositoryTooLargeError):
+            github._fetch_page("https://api.github.com/repos/o/r/stats/code_frequency", {}, mock.Mock())
+
+
+def test_fetch_page_reraises_other_422_errors():
+    # A generic 422 (e.g. malformed request params) is a real, fixable problem and must stay fatal
+    # rather than being swallowed by the too-large-repository check.
+    session = mock.Mock()
+    session.request.return_value = _unprocessable_response("Validation failed")
+
+    with mock.patch.object(github, "make_tracked_session", return_value=session):
+        with pytest.raises(requests.exceptions.HTTPError):
+            github._fetch_page("https://api.github.com/repos/o/r/stats/code_frequency", {}, mock.Mock())
 
 
 def test_fetch_page_retries_chunked_encoding_error():


### PR DESCRIPTION
## Problem

GitHub's `/repos/{owner}/{repo}/stats/code_frequency` endpoint has a documented, permanent limit: it returns `422 Unprocessable Entity` once a repository passes 10,000 commits. This is different from GitHub's other `/stats/*` endpoints, which keep working for large repos (just with zeroed addition/deletion counts).

PostHog's GitHub data warehouse source didn't account for this, so the sync let the 422 bubble up as an unhandled `HTTPError`. This surfaced in error tracking as a recurring failure on the `code_frequency_stats` table for large repositories, retried by the activity on every sync attempt with no chance of succeeding.

## Changes

`_fetch_page` now recognizes this specific 422 (matched on GitHub's stable response message, "repository must have fewer than 10000 commits") and raises a new `GithubRepositoryTooLargeError`. `get_rows` catches it and syncs zero rows for that table, the same graceful-skip pattern already used for "stats not ready yet" (202) and "empty repository" (409).

A generic 422 (e.g. a malformed request) still raises normally and fails the sync — only this specific, permanent GitHub limitation is treated as a skip.

## How did you test this code?

Added two cases to `test_github_fetch_page.py`:
- `test_fetch_page_raises_repository_too_large_for_code_frequency_422` — confirms the specific 422 message is now caught as `GithubRepositoryTooLargeError` instead of crashing.
- `test_fetch_page_reraises_other_422_errors` — confirms a generic 422 still raises `HTTPError`, so the fix doesn't over-broaden and swallow real request errors.

Ran the full `github` source test suite locally (`hogli test products/warehouse_sources/backend/temporal/data_imports/sources/github/`) — 169 passed (the 16 errors in `test_github_webhook_template.py` are pre-existing, unrelated to this change, and require a local Postgres connection not available in this environment). Also ran `ruff check`/`ruff format` and a repo-wide `mypy` check on the touched files, both clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal source implementation detail, no user-facing behavior or config change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

This PR was produced by an agent triaging a live error tracking issue for the GitHub data-warehouse source (HTTPError 422 on `/stats/code_frequency`). The agent confirmed the failure originated in this source's own stack frame, read GitHub's REST API docs to confirm the 422 is a documented, permanent limit tied to a 10,000-commit threshold (verified against a real large public repo), and implemented a graceful-skip fix mirroring the existing 202/409 handling already present in this file, rather than adding the error to `NonRetryableErrors` — since the fix improves the sync outcome (zero rows instead of a hard failure) rather than just silencing retries.

No repo-provided skills applied directly to the code change itself; `writing-tests` was consulted before adding the regression tests.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*