### PR TITLE
fix(workflows): build tenant ARNs from the client region, not settings

### DIFF
--- a/posthog/management/commands/migrate_ses_tenants.py
+++ b/posthog/management/commands/migrate_ses_tenants.py
@@ -90,10 +90,18 @@ def migrate_ses_tenants(team_ids: list[int], domains: list[str], dry_run: bool =
         counts["tenant_failures"] = len(pairs)
         return counts
 
+    # ARN region must match the region the client actually calls, or SES rejects the
+    # association with "must be in the same region". settings.SES_REGION defaults to us-east-1
+    # when the env var is unset (true on some pods), while the bare boto3 client resolves the
+    # pod's real AWS region — so derive from the client, the one that cannot drift.
+    region = tenant_client.meta.region_name
+    if region != settings.SES_REGION:
+        print(f"Note: using client region '{region}' (settings.SES_REGION is '{settings.SES_REGION}')")  # noqa: T201
+
     for batch in _batched(pairs, 50):
         for team_id, domain in batch:
             tenant_name = f"team-{team_id}"
-            identity_arn = f"arn:aws:ses:{settings.SES_REGION}:{aws_account_id}:identity/{domain}"
+            identity_arn = f"arn:aws:ses:{region}:{aws_account_id}:identity/{domain}"
 
             # Create tenant if missing
             try:
@@ -121,7 +129,7 @@ def migrate_ses_tenants(team_ids: list[int], domains: list[str], dry_run: bool =
             # Associate the identity plus the configuration sets sends reference — an attributed
             # send fails unless EVERY resource it uses is associated with the tenant.
             resource_arns = [identity_arn] + [
-                f"arn:aws:ses:{settings.SES_REGION}:{aws_account_id}:configuration-set/{config_set}"
+                f"arn:aws:ses:{region}:{aws_account_id}:configuration-set/{config_set}"
                 for config_set in settings.SES_TENANT_CONFIGURATION_SETS
             ]
             for resource_arn in resource_arns:

--- a/posthog/management/commands/test/test_migrate_ses_tenants.py
+++ b/posthog/management/commands/test/test_migrate_ses_tenants.py
@@ -7,10 +7,17 @@ from posthog.management.commands.migrate_ses_tenants import migrate_ses_tenants
 from posthog.models.integration import Integration
 
 
+class _FakeClientMeta:
+    def __init__(self, region_name: str):
+        self.region_name = region_name
+
+
 class _FakeSESv2Client:
-    def __init__(self):
+    def __init__(self, region_name: str = "us-east-1"):
         self.created_tenants: list[str] = []
         self.associations: list[tuple[str, str]] = []
+        # Mirrors boto3's client.meta.region_name — the command derives ARN regions from it.
+        self.meta = _FakeClientMeta(region_name)
 
     def get_caller_identity(self):
         return {"Account": "123456789012"}
@@ -103,7 +110,7 @@ class TestMigrateSESTenants(BaseTest):
     @override_settings(SES_ACCESS_KEY_ID="test", SES_SECRET_ACCESS_KEY="test", SES_REGION="eu-west-1", SES_ENDPOINT="")
     @patch("posthog.management.commands.migrate_ses_tenants.boto3.client")
     def test_migrate_for_domain_filter(self, mock_boto_client):
-        sesv2 = _FakeSESv2Client()
+        sesv2 = _FakeSESv2Client(region_name="eu-west-1")
         mock_boto_client.side_effect = lambda service, **kwargs: sesv2
 
         # Use domains filter; should match example.com only
@@ -162,3 +169,16 @@ class TestMigrateSESTenants(BaseTest):
         # The identity succeeded; both config-set associations failed and must be reported so the
         # rollout can't mistake a partial pass for a complete one
         assert counts == {"tenants": 1, "associations_ok": 1, "tenant_failures": 0, "association_failures": 2}
+
+    @override_settings(SES_ACCESS_KEY_ID="test", SES_SECRET_ACCESS_KEY="test", SES_REGION="us-east-1", SES_ENDPOINT="")
+    @patch("posthog.management.commands.migrate_ses_tenants.boto3.client")
+    def test_arn_region_comes_from_the_client_not_settings(self, mock_boto_client):
+        # A pod without SES_REGION set falls back to us-east-1 in settings while the bare boto3
+        # client resolves the pod's real region — ARNs must follow the client or SES rejects the
+        # association with "must be in the same region" (hit on prod-eu).
+        sesv2 = _FakeSESv2Client(region_name="eu-central-1")
+        mock_boto_client.side_effect = lambda service, **kwargs: sesv2
+
+        migrate_ses_tenants(team_ids=[self.team.id], domains=[], dry_run=False)
+
+        assert all(arn.startswith("arn:aws:ses:eu-central-1:") for _, arn in sesv2.associations)


### PR DESCRIPTION
## Problem

Running `migrate_ses_tenants` on prod-EU failed every association with:

```
BadRequestException: Resource <arn:aws:ses:us-east-1:730758685644:identity/posthog.com> must be in the same region
```

The command's boto3 clients are created bare, so they resolve the **pod's** AWS region (eu-central-1, correct) — but the ARN strings were built from `settings.SES_REGION`, which defaults to `us-east-1` when the env var is unset on the pod. The two disagree and SES rejects the association. prod-US worked only because the default happens to match its real region.

## Changes

- ARNs (identity + configuration sets) are now built from `tenant_client.meta.region_name` — the region the client actually calls, which by construction can't drift from the request.
- When that differs from `settings.SES_REGION`, the command prints a note so the drift is visible.
- Fake client in tests grew a `meta.region_name`; new regression test pins client region `eu-central-1` against settings `us-east-1` and asserts every ARN follows the client.

## Interim workaround (already usable without this PR)

`SES_REGION=eu-central-1 python manage.py migrate_ses_tenants` on prod-EU, or run it on a web-django pod (its chart sets `SES_REGION`). The command is idempotent, so rerunning after the failed pass is safe.

## How did you test this code?

I'm an agent: 6/6 command tests pass including the new cross-region regression case; repo-wide mypy clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Root cause from the prod-EU rollout error: bare boto3 client region vs settings-derived ARN region. Note `providers/ses.py` does NOT have this bug — it passes `settings.SES_REGION` to its clients, so its ARNs and calls always agree (the request-path region config is validated by every domain-verification call).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*