### PR TITLE
chore(ci): bucket remaining per-PR setup-node/python calls

### DIFF
--- a/.depot/workflows/ci-backend.yml
+++ b/.depot/workflows/ci-backend.yml
@@ -821,8 +821,9 @@ jobs:
                     db redis7 clickhouse zookeeper kafka objectstorage \
                     temporal elasticsearch objectstorage-azure \
                     </dev/null >"${RUNNER_TEMP:-/tmp}/compose-launch.log" 2>&1
-            # Shadow trial: canonical threads a setup-action app token into
-            # pnpm-install; mint stripped here (secret not available on Depot).
+            # Shadow trial: canonical threads a setup-action app token into both
+            # pnpm-install and setup-python; mint stripped here (secret not
+            # available on Depot), so setup-python keeps the bot PAT.
             - name: Install pnpm dependencies
               uses: ./.depot/actions/pnpm-install
               with:

--- a/.github/workflows/auto-assign-labels.yml
+++ b/.github/workflows/auto-assign-labels.yml
@@ -42,10 +42,23 @@ jobs:
                   # MUST be `master` so we never execute untrusted PR code.
                   ref: master
 
+            # No fork guard: pull_request_target runs in base context, so org
+            # secrets are available even when the PR comes from a fork.
+            - name: Mint setup-action GitHub token
+              id: setup-gh-token
+              continue-on-error: true
+              uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+              with:
+                  client-id: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_APP_ID }}
+                  private-key: ${{ secrets.GH_APP_POSTHOG_SETUP_ACTIONS_PRIVATE_KEY }}
+                  skip-token-revoke: true
+
             - name: Setup Node.js
               uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
               with:
                   node-version-file: .nvmrc
+                  # Resolve the node-versions manifest on the app token, not the shared per-repo GITHUB_TOKEN bucket
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Run label assignment script
               env:

--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -56,6 +56,8 @@ jobs:
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: '3.13'
+                  # Same reasoning as the node manifest lookup above
+                  token: ${{ steps.app-token.outputs.token || github.token }}
 
             # Exact pin: this pull_request_target workflow runs with an app token,
             # so a floating version must not be able to pull fresh code at run time.

--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -829,7 +829,7 @@ jobs:
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: 3.13.13
-                  token: ${{ secrets.POSTHOG_BOT_PAT }}
+                  token: ${{ steps.setup-gh-token.outputs.token || github.token }}
 
             - name: Install uv
               id: setup-uv


### PR DESCRIPTION
## Problem

Three high-frequency `setup-node` / `setup-python` sites were still off the app-token buckets:

- `ci-backend` product-test matrix: [PR 75068](https://github.com/PostHog/posthog/pull/75068) gave it a `posthog-product-tests` app but threaded the token into setup-node only. Its `Set up Python` stayed on `POSTHOG_BOT_PAT`.
- `auto-assign-labels`: setup-node on the shared `GITHUB_TOKEN` bucket, runs on every PR open.
- `auto-assign-reviewers`: already mints an app token for setup-node, but its setup-python had none.

## Changes

- Point all three at an app token, keeping the `|| github.token` fallback.
- `auto-assign-reviewers` and `auto-assign-labels` need no new secrets: the first reuses its existing mint, the second uses the `posthog-setup-actions` app (17.5% peak utilization, plenty of headroom).
- Document the delta in the Depot shadow, which has no mint step and keeps the PAT.

Deliberately excluded: `trunk-impacted-targets`. That job runs PR-controlled code and is documented as secret-free, so it keeps `github.token`.

## How did you test this code?

- `bin/hogli lint:workflows` (7 checks, 106 workflows) and `hogli ci:preflight --strict` pass.
- Forced the full matrix with `run-ci-backend`: [27 product-test jobs](https://github.com/PostHog/posthog/actions/runs/30632244077), no failures. [One job's log](https://github.com/PostHog/posthog/actions/runs/30632244077/job/91161865099) shows the mint succeeding, then setup-python missing the tool cache and fetching the manifest under the new token.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

- None

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code; skills: /writing-code-comments.
- Grounded in the action sources: `token` pays only for the two `api.github.com` calls a tool-cache miss makes ([setup-python](https://github.com/actions/setup-python/blob/a309ff8b426b58ec0e2a45f0f869d46889d02405/src/install-python.ts#L75-L84), [tool-cache](https://github.com/actions/toolkit/blob/50ee743ceeee9a539b534aeaba271c0454fca1e3/packages/tool-cache/src/tool-cache.ts#L588-L618)). The tarball is a `github.com` release asset and costs no quota.
- A YAML audit of every setup site puts the rest of the unbucketed ones in release, publish, and cron workflows that run a few times a week. Not worth the churn.
- Next lever is `posthog-devex-general` at 53.7% peak, ~90% of which is the 38-job django matrix.
