### PR TITLE
chore(hogql): add a snapshot-diff canary for the type-aware simplifier

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,11 @@
 import gc
 import warnings
+from contextlib import ExitStack
 
 import pytest
+
+# Session-scoped patches that pytest_configure opens and pytest_unconfigure closes.
+_session_patches = ExitStack()
 
 # Test-session boot — plugin imports and importing every collected test module —
 # allocates almost exclusively permanent objects, so automatic cyclic GC during that
@@ -206,12 +210,32 @@ def _cheapen_freezegun_module_hash() -> None:
     api._get_module_attributes_hash = _fast_module_attributes_hash  # ty: ignore[invalid-assignment]
 
 
+def pytest_addoption(parser) -> None:
+    parser.addoption(
+        "--simplifier-canary",
+        action="store_true",
+        default=False,
+        help=(
+            "Force the HogQL type-aware simplifier on for the whole session. The resulting snapshot "
+            "diff is the change report for enabling typeAwareCastSimplification in production. "
+            "Do not commit the churned snapshots."
+        ),
+    )
+
+
 def pytest_configure(config) -> None:
     _cache_reverse_rel_identity()
     _cache_select_masks()
     _cache_drf_field_info()
     _cache_url_resolution()
     _cheapen_freezegun_module_hash()
+
+    if config.getoption("--simplifier-canary"):
+        from posthog.hogql.test.simplifier_canary import (  # noqa: PLC0415 — only imported when the flag is set
+            type_aware_simplification_forced,
+        )
+
+        _session_patches.enter_context(type_aware_simplification_forced())
 
 
 def pytest_collection_finish() -> None:
@@ -226,6 +250,8 @@ def pytest_runtestloop() -> None:
 
 
 def pytest_unconfigure() -> None:
+    _session_patches.close()
+
     # Frozen objects skip the final cyclic collections of interpreter shutdown, so their
     # finalizers run in the late teardown phase where extension modules may already be
     # gone — observed as exit code 139 (SIGSEGV) on the Temporal CI shards. Restore the

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -57,6 +57,7 @@ from posthog.hogql.parser import parse_expr, parse_select
 from posthog.hogql.printer import prepare_and_print_ast, prepare_ast_for_printing, print_prepared_ast, to_printed_hogql
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.query import execute_hogql_query
+from posthog.hogql.test.simplifier_canary import type_aware_simplification_forced
 from posthog.hogql.visitor import clear_locations
 
 from posthog.clickhouse.client.execute import sync_execute
@@ -868,6 +869,26 @@ class TestPrinter(BaseTest):
 
         assert "assumeNotNull(" in sql
         assert "toString(" in sql
+
+    def test_simplifier_canary_forces_the_simplifier_on_and_restores_it(self):
+        # The canary's entire value is the snapshot diff it produces. If it silently stops forcing
+        # the simplifier the diff comes back empty, which reads as "nothing changes, safe to flip" —
+        # the exact wrong conclusion. The restore half matters just as much: a patch that leaked
+        # would enable the simplifier for every later test in the session.
+        query = "SELECT assumeNotNull(1) AS a, toString('x') AS b FROM events"
+
+        def print_query() -> str:
+            return self._select(query, HogQLContext(team_id=self.team.pk, enable_select_queries=True))
+
+        with type_aware_simplification_forced():
+            forced_sql = print_query()
+
+        assert "assumeNotNull(" not in forced_sql
+        assert "toString(" not in forced_sql
+
+        restored_sql = print_query()
+        assert "assumeNotNull(" in restored_sql
+        assert "toString(" in restored_sql
 
     def test_hogql_properties(self):
         self.assertEqual(

--- a/posthog/hogql/test/simplifier_canary.py
+++ b/posthog/hogql/test/simplifier_canary.py
@@ -1,0 +1,42 @@
+"""Force the HogQL type-aware simplifier on for a whole pytest session.
+
+The snapshot suites already encode hundreds of real product queries and the ClickHouse SQL they
+print to. Running them with the simplifier forced on turns that corpus into a change report: the
+snapshot diff is every emitted-SQL shape that would change if ``typeAwareCastSimplification`` were
+enabled in production.
+
+    pytest posthog/hogql/printer --simplifier-canary
+    git diff -- '*.ambr'
+
+The diff is the artifact. Do not commit the churned snapshots — an updated snapshot silently
+becomes the new expectation, which is the opposite of what this is for.
+"""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+
+@contextmanager
+def type_aware_simplification_forced() -> Iterator[None]:
+    """Opt every ``HogQLContext`` into the simplifier, however it was constructed.
+
+    Wraps ``__post_init__`` rather than the printer gate so this reaches contexts that tests build
+    directly as well as those built from team modifiers.
+
+    Sets the internal context flag rather than the modifier. Both feed the same gate and the same
+    transform, so the emitted SQL is identical either way, and the flag stays out of the serialized
+    modifier payload that keys the query cache.
+    """
+    from posthog.hogql.context import HogQLContext  # noqa: PLC0415 — keeps HogQL off pytest's boot import path
+
+    original_post_init = HogQLContext.__post_init__
+
+    def post_init(self: HogQLContext) -> None:
+        original_post_init(self)
+        self.enable_type_aware_cast_simplification = True
+
+    HogQLContext.__post_init__ = post_init  # type: ignore[method-assign] # ty: ignore[invalid-assignment]
+    try:
+        yield
+    finally:
+        HogQLContext.__post_init__ = original_post_init  # type: ignore[method-assign] # ty: ignore[invalid-assignment]


### PR DESCRIPTION
## Problem

`typeAwareCastSimplification` (#68901) is merged and defaults off. Before it can be enabled on a team, and long before the default can flip, we need to be able to answer one question: **what SQL actually changes?**

Today the only evidence is the argument that the simplifier is conservative by construction. The printer suite passing with zero churn proves the default is off, not that turning it on is safe.

The corpus to answer it with already exists. The repo carries 183 `.ambr` snapshot files encoding real product queries and the SQL they print to. Running those suites with the simplifier forced on turns that corpus into a change report.

## Changes

A `--simplifier-canary` pytest flag that forces the simplifier on for the whole session:

```bash
pytest posthog/hogql/printer --simplifier-canary
git diff -- '*.ambr'
```

The snapshot diff is the artifact. It is not a snapshot update, and the churn should never be committed.

Implementation notes:

- The hook wraps `HogQLContext.__post_init__` rather than the printer gate, so it reaches contexts tests build directly as well as those built from team modifiers.
- It sets the internal context flag rather than the modifier. Both feed the same gate and the same transform, so emitted SQL is identical either way, and the flag stays out of the serialized modifier payload that keys the query cache.
- `pytest_configure` opens it, `pytest_unconfigure` closes it, via a session-scoped `ExitStack`.

**No production code path changes.** The flag defaults off and nothing outside `pytest_configure` reads it.

## What it found immediately

Running it against the printer suite: **43 tests change, and 12 of them are not ClickHouse.**

| Printer | Changed |
| --- | --- |
| `TestPrinter` (ClickHouse) | 31 |
| `TestPostgresPrinter` | 6 |
| `TestSnowflakePrinter` | 4 |
| `TestMySQLPrinter` | 2 |

The ClickHouse changes look like what the simplifier advertises. The non-ClickHouse ones are the interesting part, and they are not all the same kind of change.

Some are correct simplifications whose tests simply encode the pre-simplification shape:

```diff
# TestSnowflakePrinter::test_snowflake_emit_60_ifNull
- COALESCE(1, 2)
+ 1
```

At least one is not:

```diff
# TestPostgresPrinter::test_postgres_style_cast — '2024-01-01'::date
- CAST(%(hogql_val_0)s AS date)
+ toDate('2024-01-01')
```

That emits `toDate(...)`, a ClickHouse function, into Postgres output, and inlines a literal that was previously a bound parameter.

> [!WARNING]
> The root cause looks structural rather than incidental: `simplify_redundant_type_operations` is called for **every** dialect, while the type facts backing its safety proofs are ClickHouse-centric. The sibling transform on the next lines is gated `if dialect == "clickhouse"`, and this one is not.

I have deliberately **not** fixed that here. This PR is the measuring instrument; changing the simplifier in the same change would mean the instrument and the thing it measures land together with no independent check. The finding needs a decision that is not mine to make: restrict the simplifier to ClickHouse matching the `simplify_argmax_over_non_nullable` precedent, or treat the non-ClickHouse output as a printer bug and fix it there.

Either way this is now a blocker for the pilot on any team using direct SQL sources, which is exactly the kind of thing the canary exists to surface before a rollout rather than after.

## How did you test this code?

I'm an agent (Claude Code); listing only automated checks I actually ran.

- `posthog/hogql/printer/test/test_printer.py`, `test_type_system.py`, `test_modifiers.py` on the default path: **964 passed, 186 snapshots passed**, no churn. This is the important one, since the conftest change is in every test session's path.
- The same printer suite with `--simplifier-canary`: 43 changed, as above.
- One new test, `test_simplifier_canary_forces_the_simplifier_on_and_restores_it`, added next to the two existing `typeAwareCastSimplification` tests.

On that test specifically: the canary's whole value is the diff it produces, so if it silently stopped forcing the simplifier the diff would come back empty and read as "nothing changes, safe to flip" — the exact wrong conclusion, and invisible. The restore half guards the opposite failure, a leaked patch enabling the simplifier for every later test in the session. No existing test covers either, because neither could exist before this flag did.

Local ClickHouse needed recovering first (the container was bound to a deleted worktree path); recreated from this checkout, unrelated to the diff.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @georgemunyoro. This is the first follow-through on #68901: the modifier is merged but nothing has measured its blast radius, and the pilot shouldn't start without that.

Skills invoked: `/writing-tests` before adding the test, which is what forced the single-test scope and the explicit regression statement above rather than a set of mechanical assertions about the flag.

Design decisions: (1) hooking `__post_init__` over the printer gate, because the gate would have needed a production refactor to become patchable and `__post_init__` is already a universal choke point; (2) forcing the context flag rather than the modifier, since they converge on the same transform and the flag avoids touching cache keys; (3) a pytest flag rather than an env var, so the toggle can't reach a non-test process; (4) leaving the dialect finding unfixed, per the reasoning above.
