### PR TITLE
chore(usage-reports): compare decoded report, not gzip bytes

### DIFF
--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -207,6 +207,9 @@ class TestUsageReport(APIBaseTest, ClickhouseTestMixin, ClickhouseDestroyTablesM
 
         # make sure we don't collapse duplicate rows
         sync_execute("SYSTEM STOP MERGES")
+        # Server-global and not scoped to this database, so it outlives the process and would
+        # leave every later test on this ClickHouse unable to merge.
+        self.addCleanup(sync_execute, "SYSTEM START MERGES")
 
         materialize("events", "$exception_values")
 
@@ -4855,6 +4858,21 @@ class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
         TEST_clear_instance_license_cache()
         materialize("events", "$exception_values")
 
+    def _assert_queued_report(self, mock_producer: MagicMock, expected_report: dict[str, Any]) -> None:
+        # Assert on the decoded payload rather than the compressed bytes: `teams` is keyed by
+        # team id in whatever order Postgres hands the rows back, so two runs of an identical
+        # report serialize to different JSON — and therefore different gzip — bytes.
+        mock_producer.send_message.assert_called_once()
+        kwargs = mock_producer.send_message.call_args.kwargs
+        assert kwargs["message_attributes"] == {
+            "content_encoding": "gzip",
+            "content_type": "application/json",
+        }
+        assert json.loads(gzip.decompress(base64.b64decode(kwargs["message_body"]))) == {
+            "organization_id": str(self.organization.id),
+            "usage_report": expected_report,
+        }
+
     def _usage_report_response(self) -> Any:
         # A roughly correct billing response
         return {
@@ -4905,27 +4923,12 @@ class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
         full_report_as_dict = _get_full_org_usage_report_as_dict(
             _get_full_org_usage_report(all_reports[str(self.organization.id)], get_instance_metadata(period))
         )
-        json_data = json.dumps(
-            {
-                "organization_id": str(self.organization.id),
-                "usage_report": full_report_as_dict,
-            },
-            separators=(",", ":"),
-        )
-        compressed_bytes = gzip.compress(json_data.encode("utf-8"))
-        compressed_b64 = base64.b64encode(compressed_bytes).decode("ascii")
 
         send_all_org_usage_reports(dry_run=False)
         license = License.objects.first()
         assert license
 
-        mock_producer.send_message.assert_called_once_with(
-            message_attributes={
-                "content_encoding": "gzip",
-                "content_type": "application/json",
-            },
-            message_body=compressed_b64,
-        )
+        self._assert_queued_report(mock_producer, full_report_as_dict)
 
         # mock_posthog.capture.assert_any_call(
         #     get_machine_id(),
@@ -4959,27 +4962,11 @@ class TestSendUsage(LicensedTestMixin, ClickhouseDestroyTablesMixin, APIBaseTest
                     get_instance_metadata(period),
                 )
             )
-            json_data = json.dumps(
-                {
-                    "organization_id": str(self.organization.id),
-                    "usage_report": full_report_as_dict,
-                },
-                separators=(",", ":"),
-            )
-            compressed_bytes = gzip.compress(json_data.encode("utf-8"))
-            compressed_b64 = base64.b64encode(compressed_bytes).decode("ascii")
-
             send_all_org_usage_reports(dry_run=False)
             license = License.objects.first()
             assert license
 
-            mock_producer.send_message.assert_called_once_with(
-                message_attributes={
-                    "content_encoding": "gzip",
-                    "content_type": "application/json",
-                },
-                message_body=compressed_b64,
-            )
+            self._assert_queued_report(mock_producer, full_report_as_dict)
 
             # mock_posthog.capture.assert_any_call(
             #     self.user.distinct_id,


### PR DESCRIPTION
## Problem

`TestSendUsage::test_send_usage` and `test_send_usage_cloud` fail nondeterministically on master, so people rerun Backend CI on unrelated PRs to get past them.

Both recompute the usage report and compare **gzip bytes** against what `send_all_org_usage_reports` produced internally. `_get_teams_for_usage_reports()` has no `ORDER BY` and `Team` declares no `Meta.ordering`, so Postgres row order varies between the two runs. That order becomes dict insertion order in `org_report.teams`, and `json.dumps` serializes it positionally. Identical reports, different bytes.

Separately, `TestUsageReport.setUp` runs `SYSTEM STOP MERGES` and the class has no teardown. That switch is server-global, not database-scoped, so it leaks into every later test sharing that ClickHouse for the rest of the job.

## Changes

- Compare the decoded payload instead of the compressed bytes. Coverage is unchanged: the body still has to round-trip through base64 and gzip to be compared at all, `send_message` must still be called exactly once with exactly those attributes, and every counter is still asserted. The only thing dropped is JSON key *position*.
- Restore merges with `addCleanup`, which still runs when `setUp` fails partway through. Mirrors `test_ai_observability_usage_report.py:44-48`.

> [!NOTE]
> I deliberately did not add `ORDER BY` to `_get_teams_for_usage_reports()`. It is an unbounded scan of the teams table joined to organizations, run daily. Forcing a sort is a real production cost to satisfy a test, and JSON object key order is semantically irrelevant to the billing consumer.

## How did you test this code?

All automated, run by me (Claude), against a local ClickHouse, Postgres and Kafka stack. Both tests, same command, same box.

| | result |
| --- | --- |
| master | **2 failed of 5** |
| this branch | **20 passed of 20** |

No new tests, so no new regression to name. The regression the existing assertions catch is unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None. Test-only change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- I (Claude, via Claude Code) worked this at @rnegron's direction. Skills invoked: `/fixing-flaky-tests`, `/writing-tests`.
- The byte-comparison fix is lifted from a closed PostHog Code PR. What is new here is that it is now measured rather than argued, and that it ships **without** that PR's other half.
- That other half, a rework of the `usage_report_events_preagg` Kafka MV tests, **fails validation**: 13 of 20 runs red, every failure `never reached unique>=2, total>=2 ... last seen (0, 0)`, the same zero-rows signature as master. Its class-level readiness event lands and the flow test's events then do not. Deliberately excluded from this PR; that flake is still open.
- The `SYSTEM STOP MERGES` leak is unrelated to the byte comparison and was found while reading the file. It is one line and belongs with the other hygiene fix rather than in its own PR.
