### PR TITLE
fix(llm-gateway): price Kimi K3 through routed provider

### DIFF
--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
@@ -27,6 +27,7 @@ COST_ALIASES: dict[str, tuple[str, str]] = {
     # Modal serves the same GLM checkpoint; billed at the CF rate until trued
     # up against Modal's GPU-time invoices.
     "openai/zai-org/GLM-5.2-FP8": ("cloudflare/@cf/zai-org/glm-5.2", "openai"),
+    "openai/moonshotai/kimi-k3": ("moonshotai/kimi-k3", "openai"),
 }
 
 # Map LiteLLM's provider and model labels to stable telemetry identifiers. This stays separate from

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_overrides.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_overrides.py
@@ -34,7 +34,6 @@ BASETEN_GLM_COST: Final[ModelCost] = {
 MODEL_COST_OVERRIDES: Final[dict[str, ModelCost]] = {
     "openai/zai-org/GLM-5.2": cast("ModelCost", dict(BASETEN_GLM_COST)),
     "moonshotai/kimi-k3": cast("ModelCost", dict(KIMI_K3_COST)),
-    "openai/moonshotai/kimi-k3": cast("ModelCost", dict(KIMI_K3_COST)),
     "claude-fable-5": {
         "litellm_provider": "anthropic",
         "mode": "chat",

--- a/services/llm-gateway/tests/test_cost_refresh.py
+++ b/services/llm-gateway/tests/test_cost_refresh.py
@@ -13,6 +13,7 @@ from llm_gateway.rate_limiting.cost_refresh import (
     apply_cost_aliases,
     normalize_metric_labels,
 )
+from llm_gateway.rate_limiting.model_cost_overrides import apply_model_cost_overrides
 from llm_gateway.rate_limiting.model_cost_service import ModelCostService
 
 
@@ -87,29 +88,42 @@ class TestApplyCostAliases:
         apply_cost_aliases(cost)
         mock_logger.warning.assert_not_called()
 
-    def test_canonicals_exist_in_litellm_cost_map(self) -> None:
-        """Lock in that every COST_ALIASES canonical is present in the pinned litellm
-        cost map. If a litellm bump drops the canonical, this fails in CI rather than
-        letting `apply_cost_aliases` log `cost_alias_canonical_missing` every refresh
-        in production and falling back to the default cost for those models.
-        """
-        missing = [canonical for canonical, _ in COST_ALIASES.values() if canonical not in litellm.model_cost]
+    def test_canonicals_exist_after_model_cost_overrides(self) -> None:
+        model_cost = dict(litellm.model_cost)
+        apply_model_cost_overrides(model_cost)
+
+        missing = [canonical for canonical, _ in COST_ALIASES.values() if canonical not in model_cost]
         assert not missing, f"COST_ALIASES canonicals missing from litellm.model_cost: {missing}"
 
-    def test_alias_is_priced_for_routed_provider(self) -> None:
+    @pytest.mark.parametrize(
+        ("model", "prompt_tokens", "completion_tokens", "expected_input_cost", "expected_output_cost"),
+        [
+            ("@cf/zai-org/glm-5.2", 1000, 100, 0.0014, 0.00044),
+            ("moonshotai/kimi-k3", 1000, 100, 0.003, 0.0015),
+        ],
+    )
+    def test_alias_is_priced_for_routed_provider(
+        self,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+        expected_input_cost: float,
+        expected_output_cost: float,
+    ) -> None:
         model_cost = dict(litellm.model_cost)
+        apply_model_cost_overrides(model_cost)
         apply_cost_aliases(model_cost)
         litellm.model_cost = model_cost
 
         input_cost, output_cost = litellm.cost_per_token(
-            model="@cf/zai-org/glm-5.2",
-            prompt_tokens=1000,
-            completion_tokens=100,
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
             custom_llm_provider="openai",
         )
 
-        assert input_cost == pytest.approx(0.0014)
-        assert output_cost == pytest.approx(0.00044)
+        assert input_cost == pytest.approx(expected_input_cost)
+        assert output_cost == pytest.approx(expected_output_cost)
 
 
 class TestNormalizeMetricLabels:


### PR DESCRIPTION
## Problem

Kimi K3 is served through an OpenAI-compatible route, but its routed cost entry declares the Modal provider. LiteLLM rejects that provider mismatch and reports a zero total cost for otherwise priced generations.

## Changes

- Keep the canonical Kimi K3 pricing override.
- Derive the OpenAI-routed model entry through the cost alias mechanism so its provider matches the request path.
- Cover both GLM and Kimi routed pricing with exact cost assertions.

## How did you test this code?

- `uv run pytest tests/test_cost_refresh.py tests/test_modal.py tests/test_model_registry.py` (99 passed). The Kimi case catches a routed provider mismatch producing an unpriced request.
- `uv run ruff check ...` and `uv run ruff format --check ...` passed for changed files.
- `uv run mypy ...` passed for changed files.
- Repository-wide Hogli preflight could not run because the root Hogli/Flox environment is unavailable in this workspace.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed because this corrects internal cost resolution without changing the documented API.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and tested this focused billing correction using the PostHog analytics and signed-commit tools. The `/querying-posthog-data`, `/writing-tests`, and `/writing-code-comments` skills were used. The canonical local override remains the pricing source; only the OpenAI-compatible routed identity now uses a provider-correct alias.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*