### PR TITLE
fix(capture): divert only allowlisted AI events to the AI topic

### DIFF
--- a/rust/capture/src/v0_request.rs
+++ b/rust/capture/src/v0_request.rs
@@ -184,6 +184,32 @@ pub enum DataType {
     AiEvents,
 }
 
+/// Event names diverted to the dedicated AI lane. Must stay in sync with the
+/// ingestion AI subpipeline's allowlist (`AI_EVENT_TYPES` in
+/// `nodejs/src/ingestion/common/subpipelines/ai-event-types.ts`), which DLQs
+/// anything it receives that isn't on the list. Matching on the `$ai_` prefix
+/// instead would divert prefixed-but-unlisted names (e.g. `$ai_call`) into the
+/// AI topic only for the ingestion pipeline to DLQ them.
+pub const AI_EVENT_NAMES: &[&str] = &[
+    "$ai_generation",
+    "$ai_embedding",
+    "$ai_evaluation",
+    "$ai_span",
+    "$ai_trace",
+    "$ai_metric",
+    "$ai_feedback",
+    "$ai_tag",
+    "$ai_generation_summary",
+    "$ai_trace_summary",
+    "$ai_evaluation_report",
+];
+
+/// Whether an event name is diverted to the dedicated AI lane. See
+/// [`AI_EVENT_NAMES`].
+pub fn is_ai_event(name: &str) -> bool {
+    AI_EVENT_NAMES.contains(&name)
+}
+
 impl DataType {
     /// Classify an event by its name (and historical-migration flag) into a
     /// `DataType`. Used by both v0's `process_single_event` and v1's
@@ -191,10 +217,11 @@ impl DataType {
     /// ingestion-warning split stays in one place.
     ///
     /// `route_ai_events` reflects the per-batch `AiRouting` decision,
-    /// mirroring v1's `destination_for_event_name`: when set, `$ai_*` events
-    /// divert to `AiEvents`, winning over historical (in v1 the historical
-    /// reroute only applies to the analytics-main destination). When unset
-    /// the mapping is a strict no-op relative to the pre-AI-lane behavior.
+    /// mirroring v1's `destination_for_event_name`: when set, AI events (per
+    /// [`is_ai_event`]) divert to `AiEvents`, winning over historical (in v1
+    /// the historical reroute only applies to the analytics-main destination).
+    /// When unset the mapping is a strict no-op relative to the pre-AI-lane
+    /// behavior.
     ///
     /// `SnapshotMain` is not produced here — replay events arrive on a
     /// separate endpoint and never flow through analytics processing.
@@ -207,7 +234,7 @@ impl DataType {
             "$$client_ingestion_warning" => Self::ClientIngestionWarning,
             "$exception" => Self::ExceptionErrorTracking,
             "$$heatmap" => Self::HeatmapMain,
-            _ if route_ai_events && event_name.starts_with("$ai_") => Self::AiEvents,
+            _ if route_ai_events && is_ai_event(event_name) => Self::AiEvents,
             _ if historical_migration => Self::AnalyticsHistorical,
             _ => Self::AnalyticsMain,
         }
@@ -337,13 +364,20 @@ mod tests {
     #[case("custom_event", false, true, DataType::AnalyticsMain)]
     #[case("$pageview", true, false, DataType::AnalyticsHistorical)]
     #[case("$pageview", true, true, DataType::AnalyticsHistorical)]
-    // $ai_* diverts only when AI routing is enabled, and wins over historical.
+    // Allowlisted AI events divert only when AI routing is enabled, and win over historical.
     #[case("$ai_generation", false, true, DataType::AiEvents)]
     #[case("$ai_span", false, true, DataType::AiEvents)]
     #[case("$ai_trace", false, true, DataType::AiEvents)]
+    #[case("$ai_generation_summary", false, true, DataType::AiEvents)]
     #[case("$ai_generation", true, true, DataType::AiEvents)]
     #[case("$ai_generation", false, false, DataType::AnalyticsMain)]
     #[case("$ai_generation", true, false, DataType::AnalyticsHistorical)]
+    // Names matching the $ai_ prefix but absent from the allowlist do NOT divert:
+    // the ingestion AI pipeline would DLQ them, so they stay on the main lane.
+    #[case("$ai_call", false, true, DataType::AnalyticsMain)]
+    #[case("$ai_generation_enriched", false, true, DataType::AnalyticsMain)]
+    #[case("$ai_model_failover", false, true, DataType::AnalyticsMain)]
+    #[case("$ai_model_failover", true, true, DataType::AnalyticsHistorical)]
     fn from_event_name_mapping(
         #[case] event_name: &str,
         #[case] historical_migration: bool,

--- a/rust/capture/src/v1/analytics/process.rs
+++ b/rust/capture/src/v1/analytics/process.rs
@@ -19,6 +19,7 @@ use super::response::BatchResponse;
 use super::types::{Batch, Event, EventResult, Options, WrappedEvent};
 use crate::event_restrictions::{EventContext, EventRestrictionService};
 use crate::global_rate_limiter::{GlobalRateLimitKey, GlobalRateLimiter};
+use crate::v0_request::is_ai_event;
 use limiters::overflow::{OverflowLimiter, OverflowLimiterResult};
 use tracing::Level;
 
@@ -43,16 +44,16 @@ use common_ingestion_warnings::{
 /// in Kafka headers — removing that fallback would break scroll-depth heatmaps for v1.
 ///
 /// When `route_ai_events` is set (this batch's token routes to the AI topic
-/// per the configured `AiRouting` policy: mode plus token allowlist), `$ai_*`
-/// events are diverted to `Destination::AiEvents`; otherwise they fall through
-/// to `AnalyticsMain` exactly as before, so an unconfigured AI topic or
-/// `primary` mode is a strict no-op.
+/// per the configured `AiRouting` policy: mode plus token allowlist), AI events
+/// (per [`is_ai_event`]) are diverted to `Destination::AiEvents`; otherwise they
+/// fall through to `AnalyticsMain` exactly as before, so an unconfigured AI
+/// topic or `primary` mode is a strict no-op.
 fn destination_for_event_name(name: &str, route_ai_events: bool) -> Destination {
     match name {
         "$exception" => Destination::ExceptionErrorTracking,
         "$$heatmap" => Destination::HeatmapMain,
         "$$client_ingestion_warning" => Destination::ClientIngestionWarning,
-        _ if route_ai_events && name.starts_with("$ai_") => Destination::AiEvents,
+        _ if route_ai_events && is_ai_event(name) => Destination::AiEvents,
         _ => Destination::AnalyticsMain,
     }
 }
@@ -2020,11 +2021,17 @@ mod tests {
     #[case("$pageview", true, Destination::AnalyticsMain)]
     #[case("custom_event", false, Destination::AnalyticsMain)]
     #[case("$autocapture", false, Destination::AnalyticsMain)]
-    // $ai_* diverts only when AI routing is enabled; otherwise stays on Main.
+    // Allowlisted AI events divert only when AI routing is enabled; otherwise stay on Main.
     #[case("$ai_generation", true, Destination::AiEvents)]
     #[case("$ai_span", true, Destination::AiEvents)]
     #[case("$ai_trace", true, Destination::AiEvents)]
+    #[case("$ai_generation_summary", true, Destination::AiEvents)]
     #[case("$ai_generation", false, Destination::AnalyticsMain)]
+    // $ai_ prefixed names absent from the allowlist stay on Main so the
+    // ingestion AI pipeline doesn't DLQ them.
+    #[case("$ai_call", true, Destination::AnalyticsMain)]
+    #[case("$ai_generation_enriched", true, Destination::AnalyticsMain)]
+    #[case("$ai_model_failover", true, Destination::AnalyticsMain)]
     fn destination_for_event_name_mapping(
         #[case] event_name: &str,
         #[case] route_ai_events: bool,


### PR DESCRIPTION
## Problem

Capture diverts events to the dedicated AI topic whenever the event name matches the `$ai_` prefix, but the ingestion AI subpipeline only accepts names on its `AI_EVENT_TYPES` allowlist (`nodejs/src/ingestion/common/subpipelines/ai-event-types.ts`) and DLQs everything else. So `$ai_`-prefixed names that aren't real AI telemetry types — e.g. `$ai_call`, `$ai_generation_enriched`, `$ai_model_failover` — get diverted into the AI topic only to be dropped in the DLQ.

**Why:** these events were showing up in the DLQ. The routing decision in capture and the accept/DLQ decision in the ingestion pipeline used different criteria (prefix vs allowlist), so the two could disagree.

## Changes

Both capture routing paths (`v0_request.rs::DataType::from_event_name` and `v1/analytics/process.rs::destination_for_event_name`) now divert an event to the AI lane only if its name is in a shared `AI_EVENT_NAMES` allowlist, which mirrors the ingestion pipeline's `AI_EVENT_TYPES`. `$ai_`-prefixed names not on the list stay on the main analytics lane instead of being diverted-then-DLQ'd.

If a new AI event type is added, it needs to be listed in both places to be diverted and ingested — a comment on each list points at the other.

## How did you test this code?

Extended the existing parameterized routing tests in both files to assert that the three prefixed-but-unlisted names stay on the main lane while the allowlisted types (including meta-events like `$ai_generation_summary`) still divert. Ran `cargo test -p capture --lib` — all routing tests pass. (One unrelated `event_restrictions` integration test fails locally only because it needs a Redis server.)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The requester noticed several `$ai_*` events DLQ'ing and asked to make capture divert only the events on the ingestion AI pipeline's allowlist rather than the whole `$ai_` prefix. Located the ingestion allowlist (`AI_EVENT_TYPES`) and the two capture routing functions, factored the names into a shared `AI_EVENT_NAMES` constant, and switched both from a prefix check to allowlist membership. No skills were invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C087XQ7K9K7/p1785502096541499?thread_ts=1785502096.541499&cid=C087XQ7K9K7)*
