### PR TITLE
fix(postgres): reject xmin as a plain incremental/append field

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -110,6 +110,14 @@ XMIN_PROJECTED_COLUMN = "_ph_xmin"
 # xmin replication relies on `pg_snapshot_xmin` / `xid8`, both PG13+.
 XMIN_MIN_SERVER_VERSION = 130000
 
+# Raised when `xmin` (type `IncrementalFieldType.XID`) is configured as a plain incremental/append
+# field instead of going through the dedicated xmin replication sync type. Matched verbatim in
+# `PostgresSource.get_non_retryable_errors`.
+XMIN_AS_INCREMENTAL_FIELD_ERROR = (
+    "'xmin' incremental field type is only valid for the xmin replication sync type, not for "
+    "incremental or append syncs"
+)
+
 # In-process retries for a recovery conflict before the abort (non-retryable, see source.py). The
 # read path counts these only once the chunk has shrunk to the floor.
 _MAX_SETUP_RECOVERY_CONFLICT_RETRIES = 10
@@ -1937,6 +1945,14 @@ def _build_query(
     if incremental_field is None or incremental_field_type is None:
         raise ValueError("incremental_field and incremental_field_type can't be None")
 
+    # `xmin` is a synthetic system column with no ordering operators against a plain integer
+    # (see `_xmin_predicate`) — it only works through the dedicated xmin replication sync type,
+    # which never reaches this generic path (it always sets `xmin_bounds` and returns above).
+    # Picking `xmin` as a plain incremental/append field builds `"xmin" >= 0`, which Postgres
+    # rejects with `UndefinedFunction`.
+    if incremental_field_type == IncrementalFieldType.XID:
+        raise ValueError(XMIN_AS_INCREMENTAL_FIELD_ERROR)
+
     if db_incremental_field_last_value is None:
         db_incremental_field_last_value = incremental_type_to_initial_value(incremental_field_type)
 
@@ -2060,6 +2076,9 @@ def _build_count_query(
 
     if incremental_field is None or incremental_field_type is None:
         raise ValueError("incremental_field and incremental_field_type can't be None")
+
+    if incremental_field_type == IncrementalFieldType.XID:
+        raise ValueError(XMIN_AS_INCREMENTAL_FIELD_ERROR)
 
     if db_incremental_field_last_value is None:
         db_incremental_field_last_value = incremental_type_to_initial_value(incremental_field_type)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -44,6 +44,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.c
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres import (
     _SSH_HANDSHAKE_EOF_ERROR,
+    XMIN_AS_INCREMENTAL_FIELD_ERROR,
     PostgresImplementation,
     SSLRequiredError,
     _rls_active_from_conn,
@@ -403,6 +404,15 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "This table is set to sync incrementally but has no incremental field configured, so "
                 "PostHog can't build its sync query. Choose an incremental field for the table in its "
                 "sync settings, or switch it to full table replication, then re-enable the sync."
+            ),
+            # `xmin` was picked as a plain incremental/append field instead of through the dedicated
+            # xmin replication sync type — `_build_query`/`_build_count_query` raise this before
+            # emitting SQL Postgres would reject (`xid >= integer` has no operator). The stored config
+            # is fixed until the customer changes it, so every retry re-hits the same wall.
+            XMIN_AS_INCREMENTAL_FIELD_ERROR: (
+                "This table's incremental field is set to Postgres's internal 'xmin' system column, "
+                "which only works with the dedicated xmin replication sync type. Switch this schema to "
+                "xmin replication, or choose a different incremental field, then re-enable the sync."
             ),
             "failed: timeout expired": None,
             # NOTE: "SSL connection has been closed unexpectedly" is intentionally NOT listed here.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -830,6 +830,32 @@ class TestPostgresSourceNonRetryableErrors:
         assert friendly, "Missing incremental field error should surface an actionable message"
         assert "incremental field" in friendly[0]
 
+    @pytest.mark.parametrize(
+        "builder",
+        [
+            # schema, table_name, should_use_incremental_field, table_type, incremental_field,
+            # incremental_field_type, db_incremental_field_last_value
+            lambda: _build_query("public", "my_table", True, None, "xmin", IncrementalFieldType.XID, None),
+            # _build_count_query has no `table_type` parameter
+            lambda: _build_count_query("public", "my_table", True, "xmin", IncrementalFieldType.XID, None),
+        ],
+    )
+    def test_xmin_as_incremental_field_is_non_retryable(self, source, builder):
+        # `xmin` is only valid through the dedicated xmin replication sync type. Picking it as a
+        # plain incremental/append field used to build `"xmin" >= 0`, which Postgres rejects with
+        # `UndefinedFunction: operator does not exist: xid >= integer`. Drive the real raise sites so
+        # a message change that breaks the classifier key is caught.
+        with pytest.raises(ValueError) as exc_info:
+            builder()
+        error_msg = str(exc_info.value)
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"xmin-as-incremental-field error should be non-retryable: {error_msg}"
+
+        friendly = [reason for pattern, reason in non_retryable.items() if pattern in error_msg and reason]
+        assert friendly, "xmin-as-incremental-field error should surface an actionable message"
+        assert "xmin replication" in friendly[0]
+
     def test_exhausted_recovery_conflict_retries_are_non_retryable(self, source):
         error_msg = str(_recovery_conflict_abort_error(10))
         non_retryable = source.get_non_retryable_errors()


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `UndefinedFunction` crash from the Postgres data warehouse source: `operator does not exist: xid >= integer`, raised from a `SELECT ... WHERE "xmin" >= 0 ...` query.

Postgres's `xmin` system column is exposed as a synthetic incremental-field option so it can back the dedicated "xmin replication" sync type, which captures a snapshot ceiling and always compares the column through an explicit `xmin::text::bigint` cast. When `xmin` is instead selected as the incremental field for a plain "Incremental" or "Append" sync (a combination nothing currently blocks), the generic query builder compares the raw `xid` column against an integer literal with no cast — SQL Postgres rejects outright, since `xid` has no `>=` operator against `integer`. Every retry re-hit the identical crash.

## Changes

- `_build_query` / `_build_count_query` in `postgres.py` now raise a clear, specific error as soon as `incremental_field_type` is `XID` outside the dedicated xmin-replication path (which never reaches this generic branch), instead of letting Postgres reject the malformed SQL.
- Registered that error message in `PostgresSource.get_non_retryable_errors`, mirroring the existing `incremental_field and incremental_field_type can't be None` entry, so a schema already stuck in this state stops retrying with an actionable message telling the customer to switch sync method or pick a different incremental field.

## How did you test this code?

Added `test_xmin_as_incremental_field_is_non_retryable`, which drives both `_build_query` and `_build_count_query` directly with `incremental_field="xmin"` / `incremental_field_type=XID`, asserts they raise, and asserts the raised message is classified non-retryable with an actionable reason mentioning xmin replication. This mirrors the existing `test_missing_incremental_field_is_non_retryable` sibling test and would have caught this exact failure mode.

Ran the full `test_postgres.py` suite locally (`pytest`); all tests that don't require a live Postgres connection pass (555 passed, plus the 53 pre-existing DB-connection-dependent tests error in this sandbox for lack of a database, unrelated to this change). Also ran `ruff check`/`ruff format` and `mypy` on the touched files with no issues.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triggered by an automated error-tracking triage prompt (Claude Code / PostHog Code) against a live error-tracking issue for the Postgres data warehouse source.
- Investigation traced the stack trace to `postgres.py`'s `get_rows` → `_build_query`, then to how the schema's `incremental_field` got set to `xmin` for a non-xmin sync type by reading `source.py`'s schema discovery and the frontend's `SyncMethodForm` field picker (which lists the synthetic `xmin` entry alongside real incremental fields).
- Considered also filtering the `xmin` entry out of the picker/serializer validation to prevent future occurrences, but scoped the fix to the query-builder layer to match the existing `incremental_field and incremental_field_type can't be None` precedent in this file, and to also self-heal already-misconfigured schemas rather than only blocking new ones.
- Searched open PRs (by exception type, message fragment, module path, and the maintainer's own recent PRs) for a duplicate fix; found none.