### PR TITLE
fix(llm-gateway): price Baseten GLM through routed provider

### DIFF
--- a/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/cost_refresh.py
@@ -27,6 +27,7 @@ COST_ALIASES: dict[str, tuple[str, str]] = {
     # Modal serves the same GLM checkpoint; billed at the CF rate until trued
     # up against Modal's GPU-time invoices.
     "openai/zai-org/GLM-5.2-FP8": ("cloudflare/@cf/zai-org/glm-5.2", "openai"),
+    "openai/zai-org/GLM-5.2": (BASETEN_METRIC_MODEL, "openai"),
     "openai/moonshotai/kimi-k3": ("moonshotai/kimi-k3", "openai"),
 }
 

--- a/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_overrides.py
+++ b/services/llm-gateway/src/llm_gateway/rate_limiting/model_cost_overrides.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Final, cast
 
+from llm_gateway.baseten import BASETEN_METRIC_MODEL
+
 if TYPE_CHECKING:
     from llm_gateway.rate_limiting.model_cost_service import ModelCost
 
@@ -32,7 +34,7 @@ BASETEN_GLM_COST: Final[ModelCost] = {
 }
 
 MODEL_COST_OVERRIDES: Final[dict[str, ModelCost]] = {
-    "openai/zai-org/GLM-5.2": cast("ModelCost", dict(BASETEN_GLM_COST)),
+    BASETEN_METRIC_MODEL: cast("ModelCost", dict(BASETEN_GLM_COST)),
     "moonshotai/kimi-k3": cast("ModelCost", dict(KIMI_K3_COST)),
     "claude-fable-5": {
         "litellm_provider": "anthropic",
@@ -86,7 +88,7 @@ MODEL_COST_OVERRIDES: Final[dict[str, ModelCost]] = {
 }
 
 # Provider-specific contract prices must not be replaced by a same-named LiteLLM entry.
-PINNED_MODEL_COST_OVERRIDES: Final[frozenset[str]] = frozenset({"openai/zai-org/GLM-5.2"})
+PINNED_MODEL_COST_OVERRIDES: Final[frozenset[str]] = frozenset({BASETEN_METRIC_MODEL})
 
 
 def apply_model_cost_overrides(model_cost: dict[str, ModelCost]) -> dict[str, ModelCost]:

--- a/services/llm-gateway/tests/test_baseten.py
+++ b/services/llm-gateway/tests/test_baseten.py
@@ -5,12 +5,13 @@ import pytest
 from fastapi import HTTPException
 
 from llm_gateway.baseten import (
+    BASETEN_METRIC_MODEL,
     _inject_baseten_params,
     ensure_baseten_configured,
     make_baseten_responses_call,
 )
 from llm_gateway.config import Settings
-from llm_gateway.rate_limiting.cost_refresh import normalize_metric_labels
+from llm_gateway.rate_limiting.cost_refresh import COST_ALIASES, normalize_metric_labels
 from llm_gateway.rate_limiting.model_cost_overrides import MODEL_COST_OVERRIDES
 
 GLM_MODEL = "@cf/zai-org/glm-5.2"
@@ -31,10 +32,10 @@ def test_inject_baseten_params_maps_model_and_pins_api_key() -> None:
     assert "headers" not in kwargs
     assert kwargs["extra_headers"] == {"Authorization": "Api-Key test-key"}
     assert kwargs["drop_params"] is True
-    assert BASETEN_MODEL in MODEL_COST_OVERRIDES
-    assert MODEL_COST_OVERRIDES[BASETEN_MODEL]["input_cost_per_token"] == 1.4e-06
-    assert MODEL_COST_OVERRIDES[BASETEN_MODEL]["cache_read_input_token_cost"] == 1.4e-07
-    assert MODEL_COST_OVERRIDES[BASETEN_MODEL]["output_cost_per_token"] == 4.4e-06
+    assert COST_ALIASES[BASETEN_MODEL] == (BASETEN_METRIC_MODEL, "openai")
+    assert MODEL_COST_OVERRIDES[BASETEN_METRIC_MODEL]["input_cost_per_token"] == 1.4e-06
+    assert MODEL_COST_OVERRIDES[BASETEN_METRIC_MODEL]["cache_read_input_token_cost"] == 1.4e-07
+    assert MODEL_COST_OVERRIDES[BASETEN_METRIC_MODEL]["output_cost_per_token"] == 4.4e-06
     assert normalize_metric_labels(BASETEN_MODEL, "openai") == ("baseten", "baseten/zai-org/glm-5.2")
 
 

--- a/services/llm-gateway/tests/test_cost_refresh.py
+++ b/services/llm-gateway/tests/test_cost_refresh.py
@@ -99,6 +99,7 @@ class TestApplyCostAliases:
         ("model", "prompt_tokens", "completion_tokens", "expected_input_cost", "expected_output_cost"),
         [
             ("@cf/zai-org/glm-5.2", 1000, 100, 0.0014, 0.00044),
+            ("zai-org/GLM-5.2", 1000, 100, 0.0014, 0.00044),
             ("moonshotai/kimi-k3", 1000, 100, 0.003, 0.0015),
         ],
     )

--- a/services/llm-gateway/tests/test_cost_refresh.py
+++ b/services/llm-gateway/tests/test_cost_refresh.py
@@ -99,6 +99,7 @@ class TestApplyCostAliases:
         ("model", "prompt_tokens", "completion_tokens", "expected_input_cost", "expected_output_cost"),
         [
             ("@cf/zai-org/glm-5.2", 1000, 100, 0.0014, 0.00044),
+            ("zai-org/GLM-5.2-FP8", 1000, 100, 0.0014, 0.00044),
             ("zai-org/GLM-5.2", 1000, 100, 0.0014, 0.00044),
             ("moonshotai/kimi-k3", 1000, 100, 0.003, 0.0015),
         ],


### PR DESCRIPTION
## Problem

Baseten serves GLM through an OpenAI-compatible route, but the routed cost entry declares the Baseten provider. LiteLLM rejects that provider mismatch and reports a zero total cost for otherwise priced generations.

This PR is stacked on [#75969](https://github.com/PostHog/posthog/pull/75969).

## Changes

- Keep the pinned Baseten GLM price under a canonical Baseten identity.
- Derive the OpenAI-routed request entry through the cost alias mechanism.
- Extend routed-provider cost coverage to Baseten GLM.

## How did you test this code?

- `uv run pytest tests/test_cost_refresh.py tests/test_model_cost_overrides.py tests/test_baseten.py tests/test_modal.py tests/test_model_registry.py` (127 passed). The Baseten case catches a routed provider mismatch producing an unpriced request.
- `uv run ruff check ...` and `uv run ruff format --check ...` passed for changed files.
- `uv run mypy ...` passed for changed files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No documentation update is needed because this corrects internal cost resolution without changing the documented API.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented and tested this focused billing correction using the PostHog analytics and signed-commit tools. The `/querying-posthog-data` and `/writing-tests` skills were used. The pinned Baseten price remains the source of truth; only its OpenAI-compatible routed identity now uses a provider-correct alias.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*