### PR TITLE
fix(data-warehouse): make "sql" search surface all SQL databases

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -316,7 +316,7 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.BIG_QUERY,
             category=DataWarehouseSourceCategory.DATABASES,
-            keywords=["bq", "gbq"],
+            keywords=["bq", "gbq", "sql"],
             featured=True,
             iconPath="/static/services/bigquery.png",
             caption=(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -115,6 +115,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
         return SourceConfig(
             name=SchemaExternalDataSourceType.CLICK_HOUSE,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["sql"],
             releaseStatus=ReleaseStatus.GA,
             caption="Enter your ClickHouse connection details to pull data into the PostHog Data warehouse. ClickHouse databases can be very large — we stream the data in Arrow batches to keep memory bounded.",
             iconPath="/static/services/clickhouse.png",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/cockroachdb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/cockroachdb/source.py
@@ -25,6 +25,7 @@ class CockroachDBSource(SimpleSource[CockroachDBSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.COCKROACH_DB,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["sql"],
             label="CockroachDB",
             iconPath="/static/services/cockroachdb.png",
             fields=cast(list[FieldType], []),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/db2/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/db2/source.py
@@ -23,7 +23,7 @@ class Db2Source(SimpleSource[Db2SourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.DB2,
             category=DataWarehouseSourceCategory.DATABASES,
-            keywords=["ibm db2"],
+            keywords=["ibm db2", "sql"],
             label="IBM Db2",
             iconPath="/static/services/db2.png",
             fields=cast(list[FieldType], []),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/dremio/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/dremio/source.py
@@ -23,6 +23,7 @@ class DremioSource(SimpleSource[DremioSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.DREMIO,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["sql"],
             label="Dremio",
             iconPath="/static/services/dremio.png",
             fields=cast(list[FieldType], []),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/firebolt/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/firebolt/source.py
@@ -25,6 +25,7 @@ class FireboltSource(SimpleSource[FireboltSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.FIREBOLT,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["sql"],
             label="Firebolt",
             iconPath="/static/services/firebolt.png",
             fields=cast(list[FieldType], []),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/motherduck/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/motherduck/source.py
@@ -25,6 +25,7 @@ class MotherduckSource(SimpleSource[MotherduckSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.MOTHERDUCK,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["sql", "duckdb"],
             label="MotherDuck",
             iconPath="/static/services/motherduck.png",
             fields=cast(list[FieldType], []),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/oracle/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/oracle/source.py
@@ -23,6 +23,7 @@ class OracleSource(SimpleSource[OracleSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.ORACLE,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["sql"],
             label="Oracle",
             iconPath="/static/services/oracle.png",
             fields=cast(list[FieldType], []),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/planetscale/source.py
@@ -25,6 +25,7 @@ class PlanetScaleSource(SimpleSource[PlanetScaleSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.PLANET_SCALE,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["sql", "mysql"],
             label="PlanetScale",
             iconPath="/static/services/planetscale.svg",
             fields=cast(list[FieldType], []),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
@@ -71,7 +71,7 @@ class RedshiftSource(SQLSource[RedshiftSourceConfig], SSHTunnelMixin, ValidateDa
         return SourceConfig(
             name=SchemaExternalDataSourceType.REDSHIFT,
             category=DataWarehouseSourceCategory.DATABASES,
-            keywords=["aws redshift", "amazon redshift"],
+            keywords=["aws redshift", "amazon redshift", "sql"],
             caption="Enter your Redshift credentials to automatically pull your Redshift data into the PostHog Data warehouse",
             iconPath="/static/services/redshift.png",
             docsUrl="https://posthog.com/docs/cdp/sources/redshift",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/sap_hana/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/sap_hana/source.py
@@ -25,6 +25,7 @@ class SapHanaSource(SimpleSource[SapHanaSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.SAP_HANA,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["sql"],
             label="SAP HANA",
             iconPath="/static/services/sap_hana.png",
             fields=cast(list[FieldType], []),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/singlestore/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/singlestore/source.py
@@ -25,6 +25,7 @@ class SinglestoreSource(SimpleSource[SinglestoreSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.SINGLESTORE,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["sql"],
             label="SingleStore, Inc.",
             iconPath="/static/services/singlestore.png",
             fields=cast(list[FieldType], []),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -83,6 +83,7 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
         return SourceConfig(
             name=SchemaExternalDataSourceType.SNOWFLAKE,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["sql"],
             caption="Enter your Snowflake credentials to automatically pull your Snowflake data into the PostHog Data warehouse.",
             iconPath="/static/services/snowflake.png",
             docsUrl="https://posthog.com/docs/cdp/sources/snowflake",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
@@ -95,6 +95,7 @@ class SupabaseSource(PostgresSource):
         return SourceConfig(
             name=SchemaExternalDataSourceType.SUPABASE,
             category=DataWarehouseSourceCategory.DATABASES,
+            keywords=["sql", "postgresql", "postgres"],
             featured=True,
             iconPath="/static/services/supabase.png",
             caption="Enter your Supabase credentials to automatically pull your data into the PostHog Data warehouse",


### PR DESCRIPTION
## Problem

In the data warehouse new-source catalog, the search box matches your term against each connector's label, name, and keywords with a fuzzy substring matcher. Because "sql" is a substring of "postgresql", "mysql", and "mssql", those connectors turn up when you search "sql". But the other SQL databases and warehouses we support (Redshift, Snowflake, BigQuery, Oracle, Db2, SAP HANA, CockroachDB, SingleStore, PlanetScale, Supabase, Firebolt, Dremio, ClickHouse, MotherDuck) have no "sql" substring anywhere in their name or keywords, so they never matched.

The result is that someone browsing the catalog for "a SQL database" sees an arbitrary subset and can miss the connector they actually want. This came out of watching real onboarding sessions where a user searched "sql" before finding their database by another name.

## Changes

Added the `sql` keyword to the SQL database and warehouse connectors that were missing it, so a "sql" search surfaces them all consistently. Where a connector had an obvious extra alias worth carrying too, I added it alongside (`mysql` for PlanetScale, `postgres`/`postgresql` for Supabase, `duckdb` for MotherDuck).

No behavior changes beyond search discoverability. `keywords` is an existing field on `SourceConfig`, already used by other connectors.

## How did you test this code?

`ruff check` passes on all touched files. The change only adds strings to each connector's `keywords` list, a field already populated on other sources, so there is no new code path. I (Claude) did not stand up the full app to click through the catalog. Fuse is configured with `threshold: 0.3` and default location weighting, which is why "sql" already matched via the "postgresql"/"mysql" substrings and why the labels above did not.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude (Claude Code). The work started from a review of anonymized onboarding session summaries surfacing catalog-search friction. I traced the catalog search through `sourceCatalogLogic` and `createFuse`, confirmed the substring-match behavior that lets "sql" hit Postgres/MySQL/MSSQL but not the label-only connectors, then scoped the fix to the SQL database/warehouse connectors in the `DATABASES` category that lacked the keyword. Deliberately left NoSQL stores (DynamoDB, MongoDB, Cosmos DB) untouched, and skipped connectors that already match "sql" via a substring (e.g. Databricks' "sql warehouse", Turso's "sqlite"). No skills were needed for a keyword-only change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
