### PR TITLE
fix(auth): import the paper desk stylesheet where the panel uses it

### DIFF
--- a/frontend/src/scenes/authentication/shared/paperDesk/DevLoginPanel.tsx
+++ b/frontend/src/scenes/authentication/shared/paperDesk/DevLoginPanel.tsx
@@ -1,3 +1,5 @@
+import './PaperDesk.scss'
+
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 


### PR DESCRIPTION
## Problem

Follow-up to #75943, which I only caught after it merged.

That PR pulled the paper card chrome out of duplicated Tailwind utilities and into a shared `.PaperDesk__card` class in `PaperDesk.scss`.
`DevLoginPanel` uses the class but doesn't import the stylesheet.
It only renders correctly because `PaperDeskScene` happens to import `PaperDesk.scss`, and in the app the panel is always inside that scene.

Standalone it isn't styled at all, which is what the `Scenes-Other/Authentication/DevLoginPanel` stories do.
On master those three stories render the panel with no card: transparent background, no border, no radius, no shadow, contents floating on the desk texture.

> [!NOTE]
> **The app is unaffected.** `DevLoginPanel` is only rendered by `PaperDeskScene`, which loads the stylesheet, so the real login page looks correct today. This is a Storybook-only defect plus an implicit dependency worth removing: the panel's styling shouldn't depend on a sibling component's import.

## Changes

Two lines: `import './PaperDesk.scss'` in the component that uses the class.
Side-effect imports are deduped, so this costs nothing where the scene already pulled it in.

## How did you test this code?

Loaded the standalone story in a browser on master, then again with the fix, and read the computed styles off the panel root:

| | master | with fix |
| --- | --- | --- |
| `.PaperDesk__card` rule present in any loaded stylesheet | **no** | yes |
| `background-color` | `rgba(0, 0, 0, 0)` | `rgb(255, 255, 255)` |
| `border` | `0px solid rgb(219, 222, 212)` | `1px solid rgb(224, 225, 217)` |
| `border-radius` | `0px` | `10px` |
| `box-shadow` | `none` | `rgba(40, 38, 30, 0.35) 0px 20px 44px -26px, rgb(224, 225, 217) 0px 3px 0px 0px` |

The right-hand column also matches the Tailwind utilities the class replaced in #75943, so the shared class is still pixel-identical to what it superseded.

Also ran `pnpm --filter=@posthog/frontend fix` and `typescript:check`.

No test added: the thing that would have caught this is a visual regression snapshot for the DevLoginPanel stories, and those are `test-skip` tagged.
Untagging them would cover the panel at the cost of three snapshots - worth considering separately, but not in this PR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed - dev-only tooling, no behavior change in the app.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude wrote this. Spotted while checking whether the `.PaperDesk__card` refactor in #75943 would move any visual regression snapshots.
The app-side answer was no, but the standalone Storybook render turned out to be broken, because the component was relying on a sibling to load its stylesheet.

Worth flagging on process: I first claimed this was broken from reasoning alone, and only verified it after being asked whether the change was actually needed.
The before/after table above is from actually loading master in a browser.
