### PR TITLE
chore(dags): cap query_log_archive export run concurrency

### DIFF
--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -193,7 +193,10 @@ SETTINGS s3_truncate_on_insert = 1, max_threads = {config.max_threads},
     resource_defs={
         "cluster": OpsClickhouseClusterResource(max_execution_time=2 * 60 * 60, max_memory_usage=20 * ONE_GB)
     },
-    tags={"owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value},
+    tags={
+        "owner": JobOwners.TEAM_ANALYTICS_PLATFORM.value,
+        "query_log_archive_backfill_concurrency": "query_log_archive_v1",
+    },
 )
 def export_query_log_archive_to_s3():
     export_query_log_archive_day()


### PR DESCRIPTION
## Problem

Backfills launch partitions in parallel (the only systemic cap is the backfill system tag's 50), and concurrent `export_query_log_archive_to_s3` can crash because of the total memory limit on the cluster.

## Changes

Tag export runs with `query_log_archive_backfill_concurrency: query_log_archive_v1`, the key the Dagster Cloud `tag_concurrency_limits` deployment setting targets, following the same pattern as the sessions and duckling backfill tags. The companion charts change adds the `limit: 1` entry to `managed_tag_concurrency_limits.yaml`.

## How did you test this code?

- `ruff check` passes; the tag follows the exact shape of the existing `sessions_backfill_concurrency` and `duckling_backfill_concurrency` tags. The limit only takes effect once the charts side deploys; until then the tag is inert metadata.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The dags README documents `tag_concurrency_limits` generically for local dev; no registry of tags exists to update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by Claude Code (Claude Fable 5) in a session driven by Andy Zhao, after a rollup export retry was killed by the OPS node's total-memory OvercommitTracker while concurrent runs were possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
