### PR TITLE
fix(customer_io): retry transient 5xx/429 on list-endpoint syncs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/api_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/api_client.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import requests
 import structlog
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
     ExternalWebhookInfo,
@@ -31,6 +32,14 @@ LOGGER = structlog.get_logger(__name__)
 REPORTING_WEBHOOKS_PATH = "/v1/reporting_webhooks"
 WORKSPACES_PATH = "/v1/workspaces"
 REQUEST_TIMEOUT_SECONDS = 30
+
+# Stable sentinel prefix — matched by `CustomerIOSource.get_retryable_errors` so an exhausted
+# retry budget doesn't get tracked as a bug.
+LIST_ENDPOINT_RETRYABLE_ERROR_PREFIX = "Customer.io API error (retryable)"
+
+
+class ListEndpointRetryableError(Exception):
+    pass
 
 
 def _base_url(region: str | None) -> str:
@@ -106,6 +115,23 @@ def validate_credentials(api_key: str, region: str | None) -> tuple[bool, str | 
     return True, None
 
 
+@retry(
+    retry=retry_if_exception_type((ListEndpointRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _get_list_page(session: requests.Session, url: str, params: dict[str, Any]) -> dict[str, Any]:
+    response = session.get(url, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
+    # Customer.io's list endpoints occasionally return a transient 429/5xx (e.g. a brief
+    # `503 Service Unavailable`); back off and retry in-process rather than failing the whole
+    # sync on a blip Temporal would just retry anyway.
+    if response.status_code == 429 or response.status_code >= 500:
+        raise ListEndpointRetryableError(f"{LIST_ENDPOINT_RETRYABLE_ERROR_PREFIX}: status={response.status_code}")
+    response.raise_for_status()
+    return response.json() or {}
+
+
 def iterate_list_endpoint(
     api_key: str,
     region: str | None,
@@ -126,9 +152,7 @@ def iterate_list_endpoint(
         params["limit"] = endpoint.page_size
 
     while True:
-        response = session.get(base, params=params, timeout=REQUEST_TIMEOUT_SECONDS)
-        response.raise_for_status()
-        payload = response.json() or {}
+        payload = _get_list_page(session, base, params)
 
         rows = payload.get(endpoint.response_key) or []
         if isinstance(rows, list):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/source.py
@@ -198,6 +198,17 @@ class CustomerIOSource(
             ),
         }
 
+    def get_retryable_errors(self) -> set[str]:
+        # `_get_list_page` already retries 429/5xx and connection/read-timeout errors with
+        # backoff (see api_client.py); if that budget still exhausts, Temporal retries the
+        # whole activity and the failure is transient and self-recovering, so don't surface it
+        # as tracked exception noise.
+        return {
+            api_client.LIST_ENDPOINT_RETRYABLE_ERROR_PREFIX,
+            "HTTPSConnectionPool(host='api.customer.io', port=443)",
+            "HTTPSConnectionPool(host='api-eu.customer.io', port=443)",
+        }
+
     def get_canonical_descriptions(self) -> CanonicalDescriptions:
         from products.warehouse_sources.backend.temporal.data_imports.sources.customer_io.canonical_descriptions import (
             CANONICAL_DESCRIPTIONS,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/tests/test_api_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/tests/test_api_client.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import MagicMock, patch
 
 import requests
@@ -402,6 +403,35 @@ class TestGetExternalWebhookInfo:
         assert info.exists is False
         assert info.error is not None
         assert "App API Key" in info.error
+
+
+class TestGetListPage:
+    @parameterized.expand(
+        [
+            ("rate_limited", 429),
+            ("internal_server_error", 500),
+            ("service_unavailable", 503),
+        ]
+    )
+    def test_transient_statuses_raise_retryable(self, _name, status_code):
+        response = MagicMock()
+        response.status_code = status_code
+        session = MagicMock()
+        session.get.return_value = response
+
+        # Call the undecorated function so tenacity's exponential backoff doesn't sleep in tests.
+        with pytest.raises(api_client.ListEndpointRetryableError):
+            api_client._get_list_page.__wrapped__(session, f"{CIO_US_BASE_URL}/v1/collections", {})  # type: ignore[attr-defined]
+
+    def test_non_transient_error_status_raises_http_error(self):
+        response = MagicMock()
+        response.status_code = 401
+        response.raise_for_status.side_effect = requests.HTTPError(response=response)
+        session = MagicMock()
+        session.get.return_value = response
+
+        with pytest.raises(requests.HTTPError):
+            api_client._get_list_page.__wrapped__(session, f"{CIO_US_BASE_URL}/v1/collections", {})  # type: ignore[attr-defined]
 
 
 class TestIterateListEndpoint:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/tests/test_customer_io_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/tests/test_customer_io_source.py
@@ -14,6 +14,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.bas
     WebhookDeletionResult,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.customer_io import api_client
 from products.warehouse_sources.backend.temporal.data_imports.sources.customer_io.constants import (
     CIO_API_SCHEMA_NAMES,
     CIO_WEBHOOK_SCHEMA_NAMES,
@@ -95,6 +96,16 @@ class TestCustomerIOSourceGetSchemas:
         # this is what keeps one-shot setup from enabling them as broken full-refresh syncs.
         webhook_only = {s.name for s in schemas if s.webhook_only}
         assert webhook_only == set(CIO_WEBHOOK_SCHEMA_NAMES)
+
+
+class TestCustomerIOSourceGetRetryableErrors:
+    def test_matches_list_endpoint_retryable_sentinel(self):
+        source = CustomerIOSource()
+        retryable_errors = source.get_retryable_errors()
+
+        error_message = f"{api_client.LIST_ENDPOINT_RETRYABLE_ERROR_PREFIX}: status=503"
+
+        assert any(pattern in error_message for pattern in retryable_errors)
 
 
 class TestCustomerIOSourceCreateWebhook:


### PR DESCRIPTION
## Problem

Error tracking surfaced a `HTTPError: 503 Server Error: Service Unavailable` from the Customer.io data warehouse source, raised in `iterate_list_endpoint` ([issue](https://us.posthog.com/project/2/error_tracking/019fb884-9f51-7fc2-ab3c-c3597793a292)). Customer.io's App API list endpoints (`/v1/collections`, `/v1/object_types`, etc.) occasionally return a transient 503/429, and the source had no in-process retry for that — every occurrence raised straight through as a plain `requests.HTTPError`, got fully exception-logged (creating error tracking noise), and only then fell back on Temporal's activity-level retry.

## Changes

This is a transient infrastructure error, not a customer credential/config problem, so it shouldn't go in `get_non_retryable_errors`. Instead I added in-process retry with backoff, matching the pattern already used by sibling sources (UptimeRobot, Railway, Vercel, Notion):

- `iterate_list_endpoint` now fetches each page through `_get_list_page`, which is wrapped in a `tenacity` retry (exponential backoff + jitter, 5 attempts) on 429/5xx responses and on connection/read-timeout errors.
- If that retry budget still exhausts, `CustomerIOSource.get_retryable_errors()` classifies the resulting error so it's logged as a warning instead of a tracked exception before Temporal retries the whole activity — the failure is transient and self-recovering, so it shouldn't page anyone.

## How did you test this code?

Added tests for the new behavior:
- `TestGetListPage` in `test_api_client.py` — asserts 429/500/503 responses raise the new retryable error (calling `.__wrapped__` to skip tenacity's actual sleep), and that non-transient statuses (e.g. 401) still raise a plain `HTTPError` unchanged.
- `TestCustomerIOSourceGetRetryableErrors` in `test_customer_io_source.py` — asserts the retryable-error sentinel is recognized by `get_retryable_errors()`.

Ran the full `customer_io` test suite locally (`pytest products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/tests/test_api_client.py test_customer_io_source.py`, all passing) plus `ruff check`/`ruff format` and a scoped `mypy` check on the touched module.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — no user-facing or documented-behavior change.

## 🤖 Agent context

**Autonomy:** Fully autonomous

I (an agent) triaged this directly from an error tracking webhook. Investigated the issue via PostHog's error tracking MCP tools to confirm the failure genuinely originates in `products/warehouse_sources/backend/temporal/data_imports/sources/customer_io/api_client.py`, read the sibling sources' retry conventions (`products/warehouse_sources/backend/temporal/data_imports/sources/README.md` § Retryable Errors, and the UptimeRobot/Railway/Vercel implementations) to match established style, then implemented and tested the fix. Ran `/writing-tests` before adding test coverage. Searched open PRs and the maintainer's own PRs for a duplicate fix; found none.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*