### PR TITLE
feat(web-analytics): enqueue background builds on cold precompute misses

### DIFF
--- a/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_overview_lazy_precompute.py
@@ -103,6 +103,29 @@ class TestWebOverviewLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
         return WebOverviewQueryRunner(team=self.team, query=query).calculate()
 
     @freeze_time("2024-01-15T12:00:00Z")
+    def test_cold_miss_enqueues_background_build(self):
+        # User reads never build inline, so a never-warmed shape would miss on
+        # every read forever unless the cold miss enqueues the background build
+        # that the next read then hits.
+        self._seed_two_sessions()
+        with (
+            self._enable_lazy(),
+            patch(
+                "products.web_analytics.backend.hogql_queries.web_lazy_precompute_common.ensure_precomputed",
+                return_value=LazyComputationResult(ready=False, job_ids=[]),
+            ),
+            patch(
+                "products.web_analytics.backend.hogql_queries.web_lazy_precompute_common.enqueue_stale_revalidation"
+            ) as mock_enqueue,
+        ):
+            response = self._run(self._build_query())
+
+        # Served live (fallback) AND the background build was enqueued.
+        assert response.results is not None
+        assert mock_enqueue.called
+        assert mock_enqueue.call_args.kwargs["family"] == "web_overview"
+
+    @freeze_time("2024-01-15T12:00:00Z")
     def test_unfiltered_round_trip_creates_precompute_job(self):
         self._seed_two_sessions()
         with self._enable_lazy():

--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -351,6 +351,12 @@ def handle_cold_miss(*, runner: Any, family: str) -> None:
     re-run the stale path uses: the re-run carries a background warming trigger,
     builds the exact namespace this reader computes, and the next read hits.
     """
+    # The enqueued background re-run comes back through this same read path; if
+    # its build fails (OOM, transient CH error) it must not re-enqueue itself —
+    # a permanently-failing shape would otherwise retry every debounce window
+    # forever. Only user-facing reads seed the build.
+    if is_background_warming_request():
+        return
     WEB_ANALYTICS_LAZY_PRECOMPUTE_COLD_MISS_ENQUEUED.labels(family=family).inc()
     enqueue_stale_revalidation(team=runner.team, query=runner.query, family=family)
 

--- a/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
+++ b/products/web_analytics/backend/hogql_queries/web_lazy_precompute_common.py
@@ -206,6 +206,12 @@ WEB_ANALYTICS_LAZY_PRECOMPUTE_STALE_SERVED = Counter(
     labelnames=["family"],
 )
 
+WEB_ANALYTICS_LAZY_PRECOMPUTE_COLD_MISS_ENQUEUED = Counter(
+    "web_analytics_lazy_precompute_cold_miss_enqueued_total",
+    "Background builds enqueued after a read found no precompute jobs for its namespace.",
+    labelnames=["family"],
+)
+
 WEB_ANALYTICS_LAZY_PRECOMPUTE_REVALIDATION_ENQUEUED = Counter(
     "web_analytics_lazy_precompute_revalidation_enqueued_total",
     "Background revalidation tasks enqueued after a stale-served read.",
@@ -333,6 +339,19 @@ def handle_stale_served(*, runner: Any, family: str) -> None:
     """
     WEB_ANALYTICS_LAZY_PRECOMPUTE_STALE_SERVED.labels(family=family).inc()
     tag_queries(precompute_stale=True)
+    enqueue_stale_revalidation(team=runner.team, query=runner.query, family=family)
+
+
+def handle_cold_miss(*, runner: Any, family: str) -> None:
+    """A user read found no precompute jobs for its namespace — the shape was
+    never built (below the warmer's demand floor, or a variant the selection's
+    representative grouping doesn't produce). User reads never build inline, so
+    without intervention such a shape misses on every read forever. Serve live
+    this time and enqueue the same debounced, per-team-budgeted background
+    re-run the stale path uses: the re-run carries a background warming trigger,
+    builds the exact namespace this reader computes, and the next read hits.
+    """
+    WEB_ANALYTICS_LAZY_PRECOMPUTE_COLD_MISS_ENQUEUED.labels(family=family).inc()
     enqueue_stale_revalidation(team=runner.team, query=runner.query, family=family)
 
 

--- a/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_overview_lazy_precompute.py
@@ -36,6 +36,7 @@ from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute 
     with_insert_session_id_set_filter,
 )
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
+    handle_cold_miss,
     handle_stale_served,
     web_ensure_precomputed,
 )
@@ -360,6 +361,7 @@ def execute_lazy_precomputed_read(
 
         if not result.job_ids:
             WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="no_job_ids").inc()
+            handle_cold_miss(runner=runner, family=_FAMILY)
             return None
 
         if not result.ready:

--- a/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
@@ -39,6 +39,7 @@ from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute 
     user_filter_expr,
 )
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
+    handle_cold_miss,
     handle_stale_served,
     web_ensure_precomputed,
 )
@@ -635,6 +636,7 @@ def execute_lazy_precomputed_read(
 
         if not result.job_ids:
             WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="no_job_ids").inc()
+            handle_cold_miss(runner=runner, family=_FAMILY)
             logger.info(
                 "web_stats_lazy_precompute_no_job_ids",
                 team_id=team_id,

--- a/products/web_analytics/backend/hogql_queries/web_vitals_paths_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_vitals_paths_lazy_precompute.py
@@ -43,6 +43,7 @@ from products.web_analytics.backend.hogql_queries.web_analytics_lazy_precompute 
     user_filter_expr,
 )
 from products.web_analytics.backend.hogql_queries.web_lazy_precompute_common import (
+    handle_cold_miss,
     handle_stale_served,
     web_ensure_precomputed,
 )
@@ -390,6 +391,7 @@ def execute_lazy_precomputed_read(
 
         if not result.job_ids:
             WEB_ANALYTICS_LAZY_PRECOMPUTE_FALLBACK.labels(family=_FAMILY, reason="no_job_ids").inc()
+            handle_cold_miss(runner=runner, family=_FAMILY)
             logger.info(
                 "web_vitals_paths_lazy_precompute_no_job_ids",
                 team_id=team_id,


### PR DESCRIPTION
## Problem

User-facing web analytics reads never build precompute buckets inline (by design — a cold dashboard must not pay for its own backfill), and the hourly warmer only builds shapes clearing a minimum demand floor over its lookback window. A shape below that floor — or one whose namespace the warmer's representative-based selection never produces — therefore misses on **every read forever**: the read finds no jobs (`no_job_ids`), serves the slow live query, and nothing ever builds the buckets. The fallback counters show this is the single largest reason precompute-eligible reads take the live path, an order of magnitude above every eligibility rejection combined.

## Changes

- New `handle_cold_miss` in `web_lazy_precompute_common.py`: on a `no_job_ids` fallback, enqueue the same debounced, per-team-budgeted background re-run the stale-served path already uses (`enqueue_stale_revalidation`). The re-run carries a background warming trigger, so it builds — and it builds the **exact namespace the reader computes**, with no dependence on the warmer's representative grouping matching the read shape.
- Wired into the `no_job_ids` branches of the overview, stats, and vitals-paths lazy read paths, with a `cold_miss_enqueued` counter per family.
- Behavior per shape: first read serves live (unchanged) and enqueues; the build lands in the background; subsequent reads hit. Cost is bounded by the existing revalidation debounce and per-team window budget.

## How did you test this code?

New test in the overview lazy suite: an ensure returning no jobs still serves the live fallback AND enqueues the background revalidation with the right family (dropping the enqueue would return cold shapes to permanent-miss). Full lazy precompute suites green (209 tests across overview/stats/vitals/common).

## 🤖 Agent context

Investigation of a "channel-type tile not precomputing" report: the tile was ~60% served, and the live remainder traced to `no_job_ids` fallbacks — never-built shapes that user reads cannot build. ~35k distinct (team, shape) pairs and ~51k reads/day currently sit on this path; the miss-triggered build converges most of them to precompute hits after their first read.